### PR TITLE
Use span's recordException to record Errors

### DIFF
--- a/js/core/src/tracing/instrumentation.ts
+++ b/js/core/src/tracing/instrumentation.ts
@@ -89,8 +89,11 @@ export async function runInNewSpan<T>(
         opts.metadata.state = 'error';
         otSpan.setStatus({
           code: SpanStatusCode.ERROR,
-          message: formatError(e),
+          message: getErrorMessage(e),
         });
+        if (e instanceof Error) {
+          otSpan.recordException(e);
+        }
         throw e;
       } finally {
         otSpan.setAttributes(metadataToAttributes(opts.metadata));
@@ -100,9 +103,9 @@ export async function runInNewSpan<T>(
   );
 }
 
-function formatError(e: any): string {
+function getErrorMessage(e: any): string {
   if (e instanceof Error) {
-    return `${e.message}\n${e.stack}`;
+    return e.message;
   }
   return `${e}`;
 }


### PR DESCRIPTION
This follows the [recommendations](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/#recording-an-exception) of Open Telemetry and will solve two outstanding issues for us.

1. Currently stacktraces are not appearing in Cloud Trace.
2. We need a nice normalized `message` and `stacktrace` for the dev ui.

### Genkit Trace Store (AFTER)

```
"status": {
  "code": 2,
  "message": "Error: Got an error!"
 },
"timeEvents": {
  "timeEvent": [
    {
      "time": 1714531849038.1628,
      "annotation": {
        "attributes": {
          "exception.type": "Error",
          "exception.message": "Got an error!",
          "exception.stacktrace": "Error: Got an error!\n    at /Users/michaeldoyle/repos/src/genkit/js/samples/dev-ui-gallery/lib/main/flows.js:148:23\n    at Context.<anonymous> (/Users/michaeldoyle/repos/src/genkit/js/flow/lib/context.js:71:27)\n    at Generator.next (<anonymous>)\n    at /Users/michaeldoyle/repos/src/genkit/js/flow/lib/context.js:36:61\n    at new Promise (<anonymous>)\n    at __async (/Users/michaeldoyle/repos/src/genkit/js/flow/lib/context.js:20:10)\n    at Context.memoize (/Users/michaeldoyle/repos/src/genkit/js/flow/lib/context.js:67:12)\n    at Context.<anonymous> (/Users/michaeldoyle/repos/src/genkit/js/flow/lib/context.js:105:58)\n    at Generator.next (<anonymous>)\n    at /Users/michaeldoyle/repos/src/genkit/js/flow/lib/context.js:36:61"
        },
        "description": "exception"
      }
    }
  ]
}
```

### Cloud Trace (BEFORE)

#### Caught Errors

<img width="1178" alt="image" src="https://github.com/firebase/genkit/assets/2858322/dec4be5a-7160-470f-98ee-f5e7961e18b4">

#### Uncaught Errors

<img width="1165" alt="image" src="https://github.com/firebase/genkit/assets/2858322/cb49f3a7-af3a-4c4a-a7cd-57efd8bbea8b">

### Cloud Trace (AFTER)

#### Caught Errors

<img width="1183" alt="image" src="https://github.com/firebase/genkit/assets/2858322/9fc29d53-b8e3-4681-a241-e9ab7d0bf437">

#### Uncaught Errors

<img width="1169" alt="image" src="https://github.com/firebase/genkit/assets/2858322/e1a05ef1-4a99-41d2-b961-51dff76745c2">
