### PR TITLE
Add vertex ai summarization metrics

### DIFF
--- a/docs/plugins/vertex-ai.md
+++ b/docs/plugins/vertex-ai.md
@@ -14,6 +14,9 @@ It also provides access to subset of evaluation metrics through the Vertex AI [R
 - [Fluency](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations/evaluateInstances#fluencyinput)
 - [Safety](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations/evaluateInstances#safetyinput)
 - [Groundeness](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations/evaluateInstances#groundednessinput)
+- [Summarization Quality](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations/evaluateInstances#summarizationqualityinput)
+- [Summarization Helpfulness](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations/evaluateInstances#summarizationhelpfulnessinput)
+- [Summarization Verbosity](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations/evaluateInstances#summarizationverbosityinput)
 
 ## Installation
 

--- a/js/plugins/vertexai/src/evaluation.ts
+++ b/js/plugins/vertexai/src/evaluation.ts
@@ -10,7 +10,7 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specix c language governing permissions and
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 


### PR DESCRIPTION
Also, remove metric specific validation on datapoint fields. Instead, rely on API calls to fail if the input is missing a field. 

![Screenshot 2024-05-02 at 4 29 33 PM](https://github.com/firebase/genkit/assets/401051/82d38ff9-9709-4561-abb0-f5d69d064378)
