### PR TITLE
Use the same names from modelRefs as keys in SUPPORTED_GEMINI_MODELS

### DIFF
--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -104,8 +104,8 @@ export const gemini15ProPreview = modelRef({
 });
 
 export const SUPPORTED_V1_MODELS = {
-  'gemini-pro': geminiPro,
-  'gemini-pro-vision': geminiProVision,
+  'gemini-1.0-pro': geminiPro,
+  'gemini-1.0-pro-vision': geminiProVision,
   // 'gemini-ultra': geminiUltra,
 };
 


### PR DESCRIPTION
Somewhat of an edge case, but you should be able to take `model.name` and look it back up in the registry. 