### PR TITLE
Adds context as first-class feature of Model.

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -175,13 +175,13 @@ Documents from a retriever can be passed directly to `generate` to provide
 grounding context:
 
 ```javascript
-const docs = await companyPolicyRetriever({query: question});
+const docs = await companyPolicyRetriever({ query: question });
 
 await generate({
   model: geminiPro,
   prompt: `Answer using the available context from company policy: ${question}`,
   context: docs,
-})
+});
 ```
 
 The document context is automatically appended to the content of the prompt

--- a/docs/models.md
+++ b/docs/models.md
@@ -169,6 +169,24 @@ await generate({
 });
 ```
 
+## Retriever context
+
+Documents from a retriever can be passed directly to `generate` to provide
+grounding context:
+
+```javascript
+const docs = await companyPolicyRetriever({query: question});
+
+await generate({
+  model: geminiPro,
+  prompt: `Answer using the available context from company policy: ${question}`,
+  context: docs,
+})
+```
+
+The document context is automatically appended to the content of the prompt
+sent to the model.
+
 ## Message history
 
 Genkit models support maintaining a history of the messages sent to the model

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -181,7 +181,6 @@ import { configureGenkit } from '@genkit-ai/core';
 import { defineFlow } from '@genkit-ai/flow';
 import { generate } from '@genkit-ai/ai/generate';
 import { retrieve } from '@genkit-ai/ai/retriever';
-import { definePrompt } from '@genkit-ai/dotprompt';
 import {
   devLocalRetrieverRef,
   devLocalVectorstore,
@@ -211,31 +210,11 @@ export const ragFlow = defineFlow(
       query: input,
       options: { k: 3 },
     });
-    const facts = docs.map((d) => d.text());
-
-    const promptGenerator = definePrompt(
-      {
-        name: 'bob-facts',
-        model: 'google-vertex/gemini-pro',
-        input: {
-          schema: z.object({
-            facts: z.array(z.string()),
-            question: z.string(),
-          }),
-        },
-      },
-      '{{#each people}}{{this}}\n\n{{/each}}\n{{question}}'
-    );
-    const prompt = await promptGenerator.generate({
-      input: {
-        facts,
-        question: input,
-      },
-    });
 
     const llmResponse = await generate({
       model: geminiPro,
-      prompt: prompt.text(),
+      prompt: `Answer this question: ${input}`,
+      context: docs,
     });
 
     const output = llmResponse.text();

--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -22,6 +22,7 @@ import {
 } from '@genkit-ai/core';
 import { lookupAction } from '@genkit-ai/core/registry';
 import { toJsonSchema, validateSchema } from '@genkit-ai/core/schema';
+import { DocumentData } from '@google-cloud/firestore';
 import { z } from 'zod';
 import { extractJson } from './extract.js';
 import {
@@ -46,7 +47,6 @@ import {
   ToolArgument,
   toToolDefinition,
 } from './tool.js';
-import { DocumentData } from '@google-cloud/firestore';
 
 /**
  * Message represents a single role's contribution to a generation. Each message
@@ -413,7 +413,9 @@ export async function toGenerateRequest(
     output: {
       format:
         options.output?.format ||
-        (options.output?.schema || options.output?.jsonSchema ? 'json' : 'text'),
+        (options.output?.schema || options.output?.jsonSchema
+          ? 'json'
+          : 'text'),
       schema: toJsonSchema({
         schema: options.output?.schema,
         jsonSchema: options.output?.jsonSchema,
@@ -433,7 +435,7 @@ export interface GenerateOptions<
   /** The prompt for which to generate a response. Can be a string for a simple text prompt or one or more parts for multi-modal prompts. */
   prompt: string | Part | Part[];
   /** Retrieved documents to be used as context for this generation. */
-  context?: DocumentData[],
+  context?: DocumentData[];
   /** Conversation history for multi-turn prompting when supported by the underlying model. */
   history?: MessageData[];
   /** List of registered tool names or actions to treat as a tool for this generation if supported by the underlying model. */
@@ -551,7 +553,11 @@ export async function generate<
   }
 
   const request = await toGenerateRequest(resolvedOptions);
-  telemetry.recordGenerateActionInputLogs(model.__action.name, resolvedOptions, request);
+  telemetry.recordGenerateActionInputLogs(
+    model.__action.name,
+    resolvedOptions,
+    request
+  );
   const response = await runWithStreamingCallback(
     resolvedOptions.streamingCallback
       ? (chunk: GenerateResponseChunkData) =>

--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -25,7 +25,11 @@ import { toJsonSchema } from '@genkit-ai/core/schema';
 import { performance } from 'node:perf_hooks';
 import { z } from 'zod';
 import { DocumentDataSchema } from './document.js';
-import { augmentWithContext, conformOutput, validateSupport } from './model/middleware.js';
+import {
+  augmentWithContext,
+  conformOutput,
+  validateSupport,
+} from './model/middleware.js';
 import * as telemetry from './telemetry.js';
 
 //

--- a/js/ai/src/model/middleware.ts
+++ b/js/ai/src/model/middleware.ts
@@ -218,7 +218,7 @@ export function augmentWithContext(
     req.context?.forEach((d, i) => {
       out += itemTemplate(new Document(d), i, options);
     });
-    out += "\n";
+    out += '\n';
     userMessage.content.push({ text: out, metadata: { purpose: 'context' } });
     return next(req);
   };

--- a/js/ai/src/model/middleware.ts
+++ b/js/ai/src/model/middleware.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Document } from '../document.js';
 import { ModelInfo, ModelMiddleware, Part } from '../model.js';
 
 /**
@@ -169,5 +170,55 @@ export function simulateSystemPrompt(options?: {
       }
     }
     return next({ ...req, messages });
+  };
+}
+
+export interface AugmentWithContextOptions {
+  /** Preceding text to place before the rendered context documents. */
+  preface?: string | null;
+  /** A function to render a document into a text part to be included in the message. */
+  itemTemplate?: (d: Document, options?: AugmentWithContextOptions) => string;
+  /** The metadata key to use for citation reference. Pass `null` to provide no citations. */
+  citationKey?: string | null;
+}
+
+const CONTEXT_PREFACE =
+  'Use the following information to complete your task:\n\n';
+const CONTEXT_ITEM_TEMPLATE = (
+  d: Document,
+  index: number,
+  options?: AugmentWithContextOptions
+) => {
+  let out = '- ';
+  if (options?.citationKey) {
+    out += `[${d.metadata![options.citationKey]}]: `;
+  } else if (options?.citationKey === undefined) {
+    out += `[${d.metadata?.['ref'] || d.metadata?.['id'] || index}]: `;
+  }
+  out += d.text() + '\n';
+  return out;
+};
+export function augmentWithContext(
+  options?: AugmentWithContextOptions
+): ModelMiddleware {
+  const preface =
+    typeof options?.preface === 'undefined' ? CONTEXT_PREFACE : options.preface;
+  const itemTemplate = options?.itemTemplate || CONTEXT_ITEM_TEMPLATE;
+  const citationKey = options?.citationKey;
+  return (req, next) => {
+    // if there is no context in the request, no-op
+    if (!req.context?.length) return next(req);
+    const userMessage = req.messages.at(-1);
+    // if there are no messages, no-op
+    if (!userMessage) return next(req);
+    // if there is already a context part, no-op
+    if (userMessage?.content.find((p) => p.metadata?.purpose === 'context'))
+      return next(req);
+    let out = `${preface || ''}`;
+    req.context?.forEach((d, i) => {
+      out += itemTemplate(new Document(d), i, options);
+    });
+    userMessage.content.push({ text: out, metadata: { purpose: 'context' } });
+    return next(req);
   };
 }

--- a/js/ai/src/model/middleware.ts
+++ b/js/ai/src/model/middleware.ts
@@ -182,8 +182,8 @@ export interface AugmentWithContextOptions {
   citationKey?: string | null;
 }
 
-const CONTEXT_PREFACE =
-  'Use the following information to complete your task:\n\n';
+export const CONTEXT_PREFACE =
+  '\n\nUse the following information to complete your task:\n\n';
 const CONTEXT_ITEM_TEMPLATE = (
   d: Document,
   index: number,
@@ -218,6 +218,7 @@ export function augmentWithContext(
     req.context?.forEach((d, i) => {
       out += itemTemplate(new Document(d), i, options);
     });
+    out += "\n";
     userMessage.content.push({ text: out, metadata: { purpose: 'context' } });
     return next(req);
   };

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -16,10 +16,10 @@
 
 import { Action, defineAction, JSONSchema7 } from '@genkit-ai/core';
 import { lookupAction } from '@genkit-ai/core/registry';
+import { DocumentData } from '@google-cloud/firestore';
 import z from 'zod';
 import { GenerateOptions } from './generate';
 import { GenerateRequest, GenerateRequestSchema, ModelArgument } from './model';
-import { DocumentData } from '@google-cloud/firestore';
 
 export type PromptFn<I extends z.ZodTypeAny = z.ZodTypeAny> = (
   input: z.infer<I>
@@ -87,7 +87,7 @@ export async function renderPrompt<
 >(params: {
   prompt: PromptArgument<I>;
   input: z.infer<I>;
-  context?: DocumentData[],
+  context?: DocumentData[];
   model: ModelArgument<CustomOptions>;
   config?: z.infer<CustomOptions>;
 }): Promise<GenerateOptions> {

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -35,6 +35,10 @@ export type PromptAction<I extends z.ZodTypeAny = z.ZodTypeAny> = Action<
   };
 };
 
+export function isPrompt(arg: any): boolean {
+  return typeof arg === 'function' && (arg as any).__action?.metadata?.type === 'prompt';
+}
+
 export function definePrompt<I extends z.ZodTypeAny>(
   {
     name,

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -19,6 +19,7 @@ import { lookupAction } from '@genkit-ai/core/registry';
 import z from 'zod';
 import { GenerateOptions } from './generate';
 import { GenerateRequest, GenerateRequestSchema, ModelArgument } from './model';
+import { DocumentData } from '@google-cloud/firestore';
 
 export type PromptFn<I extends z.ZodTypeAny = z.ZodTypeAny> = (
   input: z.infer<I>
@@ -86,6 +87,7 @@ export async function renderPrompt<
 >(params: {
   prompt: PromptArgument<I>;
   input: z.infer<I>;
+  context?: DocumentData[],
   model: ModelArgument<CustomOptions>;
   config?: z.infer<CustomOptions>;
 }): Promise<GenerateOptions> {
@@ -101,5 +103,6 @@ export async function renderPrompt<
     config: { ...(rendered.config || {}), ...params.config },
     history: rendered.messages.slice(0, rendered.messages.length - 1),
     prompt: rendered.messages[rendered.messages.length - 1].content,
+    context: params.context,
   };
 }

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -36,7 +36,10 @@ export type PromptAction<I extends z.ZodTypeAny = z.ZodTypeAny> = Action<
 };
 
 export function isPrompt(arg: any): boolean {
-  return typeof arg === 'function' && (arg as any).__action?.metadata?.type === 'prompt';
+  return (
+    typeof arg === 'function' &&
+    (arg as any).__action?.metadata?.type === 'prompt'
+  );
 }
 
 export function definePrompt<I extends z.ZodTypeAny>(

--- a/js/ai/tests/model/middleware_test.ts
+++ b/js/ai/tests/model/middleware_test.ts
@@ -379,22 +379,19 @@ describe('augmentWithContext', () => {
     const messages: MessageData[] = [
       { role: 'user', content: [{ text: 'first part' }] },
     ];
-    const result = await testRequest(
-      messages,
-      [
-        {
-          content: [{ text: 'i am context' }],
-          metadata: { ref: 'first', id: 'wrong' },
-        },
-        {
-          content: [{ text: 'i am more context' }],
-          metadata: { id: 'second' },
-        },
-        {
-          content: [{ text: 'i am even more context' }],
-        },
-      ]
-    );
+    const result = await testRequest(messages, [
+      {
+        content: [{ text: 'i am context' }],
+        metadata: { ref: 'first', id: 'wrong' },
+      },
+      {
+        content: [{ text: 'i am more context' }],
+        metadata: { id: 'second' },
+      },
+      {
+        content: [{ text: 'i am even more context' }],
+      },
+    ]);
     assert.deepEqual(result[0].content.at(-1), {
       text: 'Use the following information to complete your task:\n\n- [first]: i am context\n- [second]: i am more context\n- [2]: i am even more context\n',
       metadata: { purpose: 'context' },
@@ -414,11 +411,11 @@ describe('augmentWithContext', () => {
           metadata: { uid: 'second' },
         },
       ],
-      { itemTemplate: (d) => `* (${d.metadata!.uid}) -- ${d.text()}\n`}
+      { itemTemplate: (d) => `* (${d.metadata!.uid}) -- ${d.text()}\n` }
     );
     assert.deepEqual(result[0].content.at(-1), {
       text: 'Use the following information to complete your task:\n\n* (first) -- i am context\n* (second) -- i am more context\n',
       metadata: { purpose: 'context' },
     });
-  })
+  });
 });

--- a/js/ai/tests/model/middleware_test.ts
+++ b/js/ai/tests/model/middleware_test.ts
@@ -26,6 +26,7 @@ import {
 } from '../../src/model.js';
 import {
   AugmentWithContextOptions,
+  CONTEXT_PREFACE,
   augmentWithContext,
   simulateSystemPrompt,
   validateSupport,
@@ -313,7 +314,7 @@ describe('augmentWithContext', () => {
       { content: [{ text: 'i am more context' }] },
     ]);
     assert.deepEqual(result[0].content.at(-1), {
-      text: 'Use the following information to complete your task:\n\n- [0]: i am context\n- [1]: i am more context\n',
+      text: `${CONTEXT_PREFACE}- [0]: i am context\n- [1]: i am more context\n\n`,
       metadata: { purpose: 'context' },
     });
   });
@@ -328,10 +329,10 @@ describe('augmentWithContext', () => {
         { content: [{ text: 'i am context' }] },
         { content: [{ text: 'i am more context' }] },
       ],
-      { preface: 'Check this out:\n\n' }
+      { preface: '\n\nCheck this out:\n\n' }
     );
     assert.deepEqual(result[0].content.at(-1), {
-      text: 'Check this out:\n\n- [0]: i am context\n- [1]: i am more context\n',
+      text: '\n\nCheck this out:\n\n- [0]: i am context\n- [1]: i am more context\n\n',
       metadata: { purpose: 'context' },
     });
   });
@@ -349,7 +350,7 @@ describe('augmentWithContext', () => {
       { preface: null }
     );
     assert.deepEqual(result[0].content.at(-1), {
-      text: '- [0]: i am context\n- [1]: i am more context\n',
+      text: '- [0]: i am context\n- [1]: i am more context\n\n',
       metadata: { purpose: 'context' },
     });
   });
@@ -370,7 +371,7 @@ describe('augmentWithContext', () => {
       { citationKey: 'uid' }
     );
     assert.deepEqual(result[0].content.at(-1), {
-      text: 'Use the following information to complete your task:\n\n- [first]: i am context\n- [second]: i am more context\n',
+      text: `${CONTEXT_PREFACE}- [first]: i am context\n- [second]: i am more context\n\n`,
       metadata: { purpose: 'context' },
     });
   });
@@ -393,7 +394,7 @@ describe('augmentWithContext', () => {
       },
     ]);
     assert.deepEqual(result[0].content.at(-1), {
-      text: 'Use the following information to complete your task:\n\n- [first]: i am context\n- [second]: i am more context\n- [2]: i am even more context\n',
+      text: `${CONTEXT_PREFACE}- [first]: i am context\n- [second]: i am more context\n- [2]: i am even more context\n\n`,
       metadata: { purpose: 'context' },
     });
   });
@@ -414,7 +415,7 @@ describe('augmentWithContext', () => {
       { itemTemplate: (d) => `* (${d.metadata!.uid}) -- ${d.text()}\n` }
     );
     assert.deepEqual(result[0].content.at(-1), {
-      text: 'Use the following information to complete your task:\n\n* (first) -- i am context\n* (second) -- i am more context\n',
+      text: `${CONTEXT_PREFACE}* (first) -- i am context\n* (second) -- i am more context\n\n`,
       metadata: { purpose: 'context' },
     });
   });

--- a/js/dotprompt/src/prompt.ts
+++ b/js/dotprompt/src/prompt.ts
@@ -25,9 +25,9 @@ import {
   toGenerateRequest,
 } from '@genkit-ai/ai';
 import { GenerationCommonConfigSchema, MessageData } from '@genkit-ai/ai/model';
-import { DocumentData, DocumentDataSchema } from '@genkit-ai/ai/retriever';
+import { DocumentData } from '@genkit-ai/ai/retriever';
 import { GenkitError } from '@genkit-ai/core';
-import { parseSchema, toJsonSchema } from '@genkit-ai/core/schema';
+import { parseSchema } from '@genkit-ai/core/schema';
 import { createHash } from 'crypto';
 import fm, { FrontMatterResult } from 'front-matter';
 import z from 'zod';
@@ -153,7 +153,7 @@ export class Dotprompt<Variables = unknown> implements PromptMetadata {
           prompt: this.toJSON(),
         },
       },
-      async (input?: Variables) => toGenerateRequest(this.render({input}))
+      async (input?: Variables) => toGenerateRequest(this.render({ input }))
     );
   }
 

--- a/js/dotprompt/src/prompt.ts
+++ b/js/dotprompt/src/prompt.ts
@@ -47,7 +47,6 @@ export type PromptGenerateOptions<V = unknown> = Omit<
 > & {
   model?: string;
   input?: V;
-  context?: DocumentData[];
 };
 
 export class Dotprompt<Variables = unknown> implements PromptMetadata {
@@ -147,36 +146,14 @@ export class Dotprompt<Variables = unknown> implements PromptMetadata {
       {
         name: `${this.name}${this.variant ? `.${this.variant}` : ''}`,
         description: 'Defined by Dotprompt',
-        inputSchema: this.input?.schema
-          ? z.object({
-              input: this.input.schema,
-              context: z.array(DocumentDataSchema).optional(),
-            })
-          : undefined,
-        inputJsonSchema: this.input?.jsonSchema
-          ? {
-              type: 'object',
-              properties: {
-                input: this.input?.jsonSchema,
-                context: {
-                  type: 'array',
-                  items: toJsonSchema({ schema: DocumentDataSchema }),
-                },
-              },
-            }
-          : undefined,
+        inputSchema: this.input?.schema,
+        inputJsonSchema: this.input?.jsonSchema,
         metadata: {
           type: 'prompt',
           prompt: this.toJSON(),
         },
       },
-      async ({
-        input,
-        context,
-      }: {
-        input?: Variables;
-        context?: DocumentData[];
-      }) => toGenerateRequest(this.render({ input, context }))
+      async (input?: Variables) => toGenerateRequest(this.render({input}))
     );
   }
 
@@ -197,6 +174,7 @@ export class Dotprompt<Variables = unknown> implements PromptMetadata {
       config: { ...this.config, ...options.config } || {},
       history: messages.slice(0, messages.length - 1),
       prompt: messages[messages.length - 1].content,
+      context: options.context,
       candidates: options.candidates || this.candidates || 1,
       output: {
         format: options.output?.format || this.output?.format || undefined,

--- a/js/dotprompt/src/prompt.ts
+++ b/js/dotprompt/src/prompt.ts
@@ -9,7 +9,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
-cd * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */

--- a/js/dotprompt/src/template.ts
+++ b/js/dotprompt/src/template.ts
@@ -48,22 +48,22 @@ function mediaHelper(options: Handlebars.HelperOptions) {
 }
 Promptbars.registerHelper('media', mediaHelper);
 
-function contextHelper(options: Handlebars.HelperOptions) {
-  const context = options.data?.metadata?.context || [];
-  const items = context.map((d: DocumentData, i) => {
-    let text = new Document(d).text();
-    if (options.hash.cite === true) {
-      text += `[${i}]`;
-    } else if (d.metadata?.[options.hash.cite]) {
-      text += `[${d.metadata[options.hash.cite]}]`;
-    }
-    return Promptbars.escapeExpression(text);
-  });
+// function contextHelper(options: Handlebars.HelperOptions) {
+//   const context = options.data?.metadata?.context || [];
+//   const items = context.map((d: DocumentData, i) => {
+//     let text = new Document(d).text();
+//     if (options.hash.cite === true) {
+//       text += `[${i}]`;
+//     } else if (d.metadata?.[options.hash.cite]) {
+//       text += `[${d.metadata[options.hash.cite]}]`;
+//     }
+//     return Promptbars.escapeExpression(text);
+//   });
 
-  return new Promptbars.SafeString(`<<<dotprompt:section context>>>
-- ${items.join('\n- ')}`);
-}
-Promptbars.registerHelper('context', contextHelper);
+//   return new Promptbars.SafeString(`<<<dotprompt:section context>>>
+// - ${items.join('\n- ')}`);
+// }
+// Promptbars.registerHelper('context', contextHelper);
 
 const ROLE_REGEX = /(<<<dotprompt:role:[a-z]+)>>>/g;
 
@@ -134,9 +134,9 @@ export function compile<Variables = any>(
       media: true,
       role: true,
       history: true,
-      context: true,
+      // context: true,
     },
-    // knownHelpersOnly: true,
+    knownHelpersOnly: true,
   });
 
   return (

--- a/js/dotprompt/src/template.ts
+++ b/js/dotprompt/src/template.ts
@@ -48,23 +48,6 @@ function mediaHelper(options: Handlebars.HelperOptions) {
 }
 Promptbars.registerHelper('media', mediaHelper);
 
-// function contextHelper(options: Handlebars.HelperOptions) {
-//   const context = options.data?.metadata?.context || [];
-//   const items = context.map((d: DocumentData, i) => {
-//     let text = new Document(d).text();
-//     if (options.hash.cite === true) {
-//       text += `[${i}]`;
-//     } else if (d.metadata?.[options.hash.cite]) {
-//       text += `[${d.metadata[options.hash.cite]}]`;
-//     }
-//     return Promptbars.escapeExpression(text);
-//   });
-
-//   return new Promptbars.SafeString(`<<<dotprompt:section context>>>
-// - ${items.join('\n- ')}`);
-// }
-// Promptbars.registerHelper('context', contextHelper);
-
 const ROLE_REGEX = /(<<<dotprompt:role:[a-z]+)>>>/g;
 
 function toMessages(renderedString: string): MessageData[] {
@@ -134,7 +117,6 @@ export function compile<Variables = any>(
       media: true,
       role: true,
       history: true,
-      // context: true,
     },
     knownHelpersOnly: true,
   });

--- a/js/dotprompt/src/template.ts
+++ b/js/dotprompt/src/template.ts
@@ -21,7 +21,7 @@ import {
   Role,
   TextPart,
 } from '@genkit-ai/ai/model';
-import { Document, DocumentData } from '@genkit-ai/ai/retriever';
+import { DocumentData } from '@genkit-ai/ai/retriever';
 import Handlebars from 'handlebars';
 import { PromptMetadata } from './metadata.js';
 

--- a/js/dotprompt/tests/template_test.ts
+++ b/js/dotprompt/tests/template_test.ts
@@ -106,75 +106,73 @@ describe('compile', () => {
       template: '{{json . indent=2}}',
       want: [{ role: 'user', content: [{ text: '{\n  "test": true\n}' }] }],
     },
-    {
-      should: 'allow defining context',
-      input: {},
-      context: [
-        { content: [{ text: 'abc' }, { text: 'def' }] },
-        { content: [{ text: 'hgi' }] },
-      ],
-      template: '{{context}}',
-      want: [
-        {
-          role: 'user',
-          content: [
-            { text: '\n- abcdef\n- hgi', metadata: { purpose: 'context' } },
-          ],
-        },
-      ],
-    },
-    {
-      should: 'allow defining context with custom citations',
-      input: {},
-      context: [
-        {
-          content: [{ text: 'abc' }, { text: 'def' }],
-          metadata: { ref: 'first' },
-        },
-        { content: [{ text: 'hgi' }], metadata: { ref: 'second' } },
-      ],
-      template: '{{context cite="ref"}}',
-      want: [
-        {
-          role: 'user',
-          content: [
-            {
-              text: '\n- abcdef[first]\n- hgi[second]',
-              metadata: { purpose: 'context' },
-            },
-          ],
-        },
-      ],
-    },
-    {
-      should: 'allow defining context with numbered citations',
-      input: {},
-      context: [
-        {
-          content: [{ text: 'abc' }, { text: 'def' }],
-          metadata: { ref: 'first' },
-        },
-        { content: [{ text: 'hgi' }], metadata: { ref: 'second' } },
-      ],
-      template: '{{context cite=true}}',
-      want: [
-        {
-          role: 'user',
-          content: [
-            {
-              text: '\n- abcdef[0]\n- hgi[1]',
-              metadata: { purpose: 'context' },
-            },
-          ],
-        },
-      ],
-    },
+    // {
+    //   should: 'allow defining context',
+    //   input: {},
+    //   context: [
+    //     { content: [{ text: 'abc' }, { text: 'def' }] },
+    //     { content: [{ text: 'hgi' }] },
+    //   ],
+    //   template: '{{context}}',
+    //   want: [
+    //     {
+    //       role: 'user',
+    //       content: [
+    //         { text: '\n- abcdef\n- hgi', metadata: { purpose: 'context' } },
+    //       ],
+    //     },
+    //   ],
+    // },
+    // {
+    //   should: 'allow defining context with custom citations',
+    //   input: {},
+    //   context: [
+    //     {
+    //       content: [{ text: 'abc' }, { text: 'def' }],
+    //       metadata: { ref: 'first' },
+    //     },
+    //     { content: [{ text: 'hgi' }], metadata: { ref: 'second' } },
+    //   ],
+    //   template: '{{context cite="ref"}}',
+    //   want: [
+    //     {
+    //       role: 'user',
+    //       content: [
+    //         {
+    //           text: '\n- abcdef[first]\n- hgi[second]',
+    //           metadata: { purpose: 'context' },
+    //         },
+    //       ],
+    //     },
+    //   ],
+    // },
+    // {
+    //   should: 'allow defining context with numbered citations',
+    //   input: {},
+    //   context: [
+    //     {
+    //       content: [{ text: 'abc' }, { text: 'def' }],
+    //       metadata: { ref: 'first' },
+    //     },
+    //     { content: [{ text: 'hgi' }], metadata: { ref: 'second' } },
+    //   ],
+    //   template: '{{context cite=true}}',
+    //   want: [
+    //     {
+    //       role: 'user',
+    //       content: [
+    //         {
+    //           text: '\n- abcdef[0]\n- hgi[1]',
+    //           metadata: { purpose: 'context' },
+    //         },
+    //       ],
+    //     },
+    //   ],
+    // },
   ]) {
     it(test.should, () => {
       assert.deepEqual(
-        compile(test.template, { model: 'test/example' })(test.input, {
-          context: test.context,
-        }),
+        compile(test.template, { model: 'test/example' })(test.input),
         test.want
       );
     });

--- a/js/dotprompt/tests/template_test.ts
+++ b/js/dotprompt/tests/template_test.ts
@@ -106,10 +106,75 @@ describe('compile', () => {
       template: '{{json . indent=2}}',
       want: [{ role: 'user', content: [{ text: '{\n  "test": true\n}' }] }],
     },
+    {
+      should: 'allow defining context',
+      input: {},
+      context: [
+        { content: [{ text: 'abc' }, { text: 'def' }] },
+        { content: [{ text: 'hgi' }] },
+      ],
+      template: '{{context}}',
+      want: [
+        {
+          role: 'user',
+          content: [
+            { text: '\n- abcdef\n- hgi', metadata: { purpose: 'context' } },
+          ],
+        },
+      ],
+    },
+    {
+      should: 'allow defining context with custom citations',
+      input: {},
+      context: [
+        {
+          content: [{ text: 'abc' }, { text: 'def' }],
+          metadata: { ref: 'first' },
+        },
+        { content: [{ text: 'hgi' }], metadata: { ref: 'second' } },
+      ],
+      template: '{{context cite="ref"}}',
+      want: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: '\n- abcdef[first]\n- hgi[second]',
+              metadata: { purpose: 'context' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      should: 'allow defining context with numbered citations',
+      input: {},
+      context: [
+        {
+          content: [{ text: 'abc' }, { text: 'def' }],
+          metadata: { ref: 'first' },
+        },
+        { content: [{ text: 'hgi' }], metadata: { ref: 'second' } },
+      ],
+      template: '{{context cite=true}}',
+      want: [
+        {
+          role: 'user',
+          content: [
+            {
+              text: '\n- abcdef[0]\n- hgi[1]',
+              metadata: { purpose: 'context' },
+            },
+          ],
+        },
+      ],
+    },
   ]) {
     it(test.should, () => {
       assert.deepEqual(
-        compile(test.template, { model: 'test/example' })(test.input),
+        compile(test.template, { model: 'test/example' })(test.input, {
+          context: test.context,
+        }),
         test.want
       );
     });

--- a/js/dotprompt/tests/template_test.ts
+++ b/js/dotprompt/tests/template_test.ts
@@ -106,69 +106,6 @@ describe('compile', () => {
       template: '{{json . indent=2}}',
       want: [{ role: 'user', content: [{ text: '{\n  "test": true\n}' }] }],
     },
-    // {
-    //   should: 'allow defining context',
-    //   input: {},
-    //   context: [
-    //     { content: [{ text: 'abc' }, { text: 'def' }] },
-    //     { content: [{ text: 'hgi' }] },
-    //   ],
-    //   template: '{{context}}',
-    //   want: [
-    //     {
-    //       role: 'user',
-    //       content: [
-    //         { text: '\n- abcdef\n- hgi', metadata: { purpose: 'context' } },
-    //       ],
-    //     },
-    //   ],
-    // },
-    // {
-    //   should: 'allow defining context with custom citations',
-    //   input: {},
-    //   context: [
-    //     {
-    //       content: [{ text: 'abc' }, { text: 'def' }],
-    //       metadata: { ref: 'first' },
-    //     },
-    //     { content: [{ text: 'hgi' }], metadata: { ref: 'second' } },
-    //   ],
-    //   template: '{{context cite="ref"}}',
-    //   want: [
-    //     {
-    //       role: 'user',
-    //       content: [
-    //         {
-    //           text: '\n- abcdef[first]\n- hgi[second]',
-    //           metadata: { purpose: 'context' },
-    //         },
-    //       ],
-    //     },
-    //   ],
-    // },
-    // {
-    //   should: 'allow defining context with numbered citations',
-    //   input: {},
-    //   context: [
-    //     {
-    //       content: [{ text: 'abc' }, { text: 'def' }],
-    //       metadata: { ref: 'first' },
-    //     },
-    //     { content: [{ text: 'hgi' }], metadata: { ref: 'second' } },
-    //   ],
-    //   template: '{{context cite=true}}',
-    //   want: [
-    //     {
-    //       role: 'user',
-    //       content: [
-    //         {
-    //           text: '\n- abcdef[0]\n- hgi[1]',
-    //           metadata: { purpose: 'context' },
-    //         },
-    //       ],
-    //     },
-    //   ],
-    // },
   ]) {
     it(test.should, () => {
       assert.deepEqual(


### PR DESCRIPTION
This adds the ability to pass context (an array of `DocumentData[]`) to a model and adds default support for prompt augmentation if a model does not declare specific support for context. Usage:

```ts
const query = "What do cats like to eat?";
const docs = await retrieveStuff({query});

generate({
  prompt: `Answer this question: ${query}`,
  context: docs
});
```

This will augment the prompt to look something like this:

```
Answer this question: What do cats like to eat?

Use the following information to complete your task:

- [0]: Cats eat a variety of foods including dry kibble and wet foods that can be purchased at a pet store.
- [1]: Cats will hunt mice and birds for fun and for food.
```