### PR TITLE
Fixes DocumentData imports.

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -22,8 +22,8 @@ import {
 } from '@genkit-ai/core';
 import { lookupAction } from '@genkit-ai/core/registry';
 import { toJsonSchema, validateSchema } from '@genkit-ai/core/schema';
-import { DocumentData } from '@google-cloud/firestore';
 import { z } from 'zod';
+import { DocumentData } from './document.js';
 import { extractJson } from './extract.js';
 import {
   CandidateData,

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -16,8 +16,8 @@
 
 import { Action, defineAction, JSONSchema7 } from '@genkit-ai/core';
 import { lookupAction } from '@genkit-ai/core/registry';
-import { DocumentData } from '@google-cloud/firestore';
 import z from 'zod';
+import { DocumentData } from './document';
 import { GenerateOptions } from './generate';
 import { GenerateRequest, GenerateRequestSchema, ModelArgument } from './model';
 


### PR DESCRIPTION
Trigger happy Enter-pressing led to importing the wrong type for DocumentData in a couple places. Luckily Firestore DocumentData is very loose (basically `Record<string, any>`) so it's not broken, just not typed correctly.