### PR TITLE
Minor cli cleanup: show help when no command provided, hide login/deploy unless plugins installed

### DIFF
--- a/genkit-tools/cli/src/cli.ts
+++ b/genkit-tools/cli/src/cli.ts
@@ -57,7 +57,7 @@ const commands: Command[] = [
 export async function startCLI(): Promise<void> {
   program
     .name('genkit')
-    .description('Google Genkit CLI')
+    .description('Firebase Genkit CLI')
     .version(version)
     .hook('preAction', async (_, actionCommand) => {
       await notifyAnalyticsIfFirstRun();
@@ -84,12 +84,18 @@ export async function startCLI(): Promise<void> {
   for (const command of await getPluginCommands()) program.addCommand(command);
 
   for (const cmd of ToolPluginSubCommandsSchema.keyof().options) {
-    program.addCommand(await getPluginSubCommand(cmd));
+    const command = await getPluginSubCommand(cmd);
+    if (command) {
+      program.addCommand(command);
+    }
   }
-
+  program.addCommand(new Command('help').action(() => {
+    logger.info(program.help());    
+  }));
   // Default action to catch unknown commands.
-  program.action((_, { args }: { args: string[] }) => {
-    logger.error(`"${clc.bold(args[0])}" is not a known Genkit command.`);
+  program.action(() => {
+    // print help
+    logger.info(program.help());
   });
 
   await program.parseAsync();

--- a/genkit-tools/cli/src/cli.ts
+++ b/genkit-tools/cli/src/cli.ts
@@ -21,7 +21,6 @@ import {
   notifyAnalyticsIfFirstRun,
   record,
 } from '@genkit-ai/tools-common/utils';
-import * as clc from 'colorette';
 import { Command, program } from 'commander';
 import { config } from './commands/config';
 import { evalExtractData } from './commands/eval-extract-data';
@@ -89,9 +88,11 @@ export async function startCLI(): Promise<void> {
       program.addCommand(command);
     }
   }
-  program.addCommand(new Command('help').action(() => {
-    logger.info(program.help());    
-  }));
+  program.addCommand(
+    new Command('help').action(() => {
+      logger.info(program.help());
+    })
+  );
   // Default action to catch unknown commands.
   program.action(() => {
     // print help

--- a/genkit-tools/cli/src/commands/config.ts
+++ b/genkit-tools/cli/src/commands/config.ts
@@ -43,7 +43,7 @@ const CONFIG_TAGS: Record<
 export const config = new Command('config');
 
 config
-  .description('set development environemnt configuration')
+  .description('set development environment configuration')
   .command('get')
   .argument('<tag>', `The config tag to get. One of [${readableTagsHint()}]`)
   .action((tag) => {

--- a/genkit-tools/cli/src/commands/config.ts
+++ b/genkit-tools/cli/src/commands/config.ts
@@ -43,6 +43,7 @@ const CONFIG_TAGS: Record<
 export const config = new Command('config');
 
 config
+  .description('set development environemnt configuration')
   .command('get')
   .argument('<tag>', `The config tag to get. One of [${readableTagsHint()}]`)
   .action((tag) => {

--- a/genkit-tools/cli/src/commands/eval-extract-data.ts
+++ b/genkit-tools/cli/src/commands/eval-extract-data.ts
@@ -33,6 +33,7 @@ interface EvalDatasetOptions {
 
 /** Command to extract evaluation data. */
 export const evalExtractData = new Command('eval:extractData')
+  .description('extract evaludation data for a given flow from the trace store')
   .argument('<flowName>', 'name of the flow to run')
   .option('--env <env>', 'environment (dev/prod)', 'dev')
   .option(

--- a/genkit-tools/cli/src/commands/eval-flow.ts
+++ b/genkit-tools/cli/src/commands/eval-flow.ts
@@ -56,6 +56,9 @@ const EVAL_FLOW_SCHEMA = '{samples: Array<{input: any; reference?: any;}>}';
 
 /** Command to run a flow and evaluate the output */
 export const evalFlow = new Command('eval:flow')
+  .description(
+    'evaluate a flow against configured evaluators using provided data as input'
+  )
   .argument('<flowName>', 'Name of the flow to run')
   .argument('[data]', 'JSON data to use to start the flow')
   .option('--input <filename>', 'JSON batch data to use to run the flow')

--- a/genkit-tools/cli/src/commands/eval-run.ts
+++ b/genkit-tools/cli/src/commands/eval-run.ts
@@ -41,6 +41,7 @@ interface EvalRunOptions {
 }
 /** Command to run evaluation on a dataset. */
 export const evalRun = new Command('eval:run')
+  .description('evaluate provided dataset against configured evaluators')
   .argument(
     '<dataset>',
     'Dataset to evaluate on (currently only supports JSON)'

--- a/genkit-tools/cli/src/commands/flow-batch-run.ts
+++ b/genkit-tools/cli/src/commands/flow-batch-run.ts
@@ -36,6 +36,9 @@ interface FlowBatchRunOptions {
 
 /** Command to run flows with batch input. */
 export const flowBatchRun = new Command('flow:batchRun')
+  .description(
+    'batch run a flow using provided set of data from a file as input'
+  )
   .argument('<flowName>', 'name of the flow to run')
   .argument('<inputFileName>', 'JSON batch data to use to run the flow')
   .option('-w, --wait', 'Wait for the flow to complete', false)

--- a/genkit-tools/cli/src/commands/flow-resume.ts
+++ b/genkit-tools/cli/src/commands/flow-resume.ts
@@ -20,6 +20,7 @@ import { Command } from 'commander';
 
 /** Command to start GenKit server, optionally without static file serving */
 export const flowResume = new Command('flow:resume')
+  .description('resume an interrupted flow (experimental)')
   .argument('<flowName>', 'name of the flow to resume')
   .argument('<flowId>', 'ID of the flow to resume')
   .argument('<data>', 'JSON data to use to resume the flow')

--- a/genkit-tools/cli/src/commands/flow-run.ts
+++ b/genkit-tools/cli/src/commands/flow-run.ts
@@ -32,6 +32,7 @@ interface FlowRunOptions {
 
 /** Command to start GenKit server, optionally without static file serving */
 export const flowRun = new Command('flow:run')
+  .description('run a flow using provided data as input')
   .argument('<flowName>', 'name of the flow to run')
   .argument('[data]', 'JSON data to use to start the flow')
   .option('-w, --wait', 'Wait for the flow to complete', false)

--- a/genkit-tools/cli/src/commands/init.ts
+++ b/genkit-tools/cli/src/commands/init.ts
@@ -154,7 +154,7 @@ const sampleTemplatePaths: Record<Platform, string> = {
 const supportedRuntimes: Runtime[] = ['node'];
 
 export const init = new Command('init')
-  .description('Initialize a project directory with Genkit')
+  .description('initialize a project directory with Genkit')
   .option(
     '-p, --platform <platform>',
     'Deployment platform (firebase, googlecloud, or nodejs)'

--- a/genkit-tools/cli/src/commands/plugins.ts
+++ b/genkit-tools/cli/src/commands/plugins.ts
@@ -34,7 +34,7 @@ export async function getPluginCommands(): Promise<Command[]> {
 /** Gets special-case commands for plugins in the config file. */
 export async function getPluginSubCommand(
   commandString: SpecialAction
-): Promise<Command> {
+): Promise<Command | undefined> {
   const config = await findToolsConfig();
   const actions = (config?.cliPlugins || [])
     .filter((p) => !!p.subCommands?.[commandString])
@@ -48,12 +48,7 @@ export async function getPluginSubCommand(
   );
 
   if (!actions.length) {
-    return command.action(() => {
-      logger.error(
-        `No plugins installed that support ${commandString}. Add a supported ` +
-          `plugin to your ${clc.bold('genkit-tools.conf.js')} file.`
-      );
-    });
+    return undefined;
   }
 
   for (const a of actions) {

--- a/genkit-tools/cli/src/commands/start.ts
+++ b/genkit-tools/cli/src/commands/start.ts
@@ -28,6 +28,7 @@ interface StartOptions {
 
 /** Command to start GenKit server, optionally without static file serving */
 export const start = new Command('start')
+  .description('run the app in dev mode and start a Developer UI')
   .option(
     '-x, --headless',
     'Do not serve static UI files (for development)',


### PR DESCRIPTION
```
$ genkit help
Usage: genkit [options] [command]

Firebase Genkit CLI

Options:
  -V, --version                                       output the version number
  -h, --help                                          display help for command

Commands:
  start [options]
  flow:run [options] <flowName> [data]
  flow:batchRun [options] <flowName> <inputFileName>
  flow:resume <flowName> <flowId> <data>
  eval:extractData [options] <flowName>
  eval:run [options] <dataset>
  eval:flow [options] <flowName> [data]
  init [options]                                      Initialize a project directory with Genkit
  config
  help
```