### PR TITLE
Update I/O metrics to be counters instead of histograms

### DIFF
--- a/js/ai/src/telemetry.ts
+++ b/js/ai/src/telemetry.ts
@@ -52,50 +52,50 @@ const generateActionLatencies = new MetricHistogram(_N('generate/latency'), {
   unit: 'ms',
 });
 
-const generateActionInputCharacters = new MetricHistogram(
-  _N('generate/input_characters'),
+const generateActionInputCharacters = new MetricCounter(
+  _N('generate/input/characters'),
   {
-    description: 'Histogram of input characters to a Genkit model.',
+    description: 'Counts input characters to any Genkit model.',
     valueType: ValueType.INT,
   }
 );
 
-const generateActionInputTokens = new MetricHistogram(
-  _N('generate/input_tokens'),
+const generateActionInputTokens = new MetricCounter(
+  _N('generate/input/tokens'),
   {
-    description: 'Histogram of input tokens to a Genkit model.',
+    description: 'Counts input tokens to a Genkit model.',
     valueType: ValueType.INT,
   }
 );
 
-const generateActionInputImages = new MetricHistogram(
-  _N('generate/input_images'),
+const generateActionInputImages = new MetricCounter(
+  _N('generate/input/images'),
   {
-    description: 'Histogram of input images to a Genkit model.',
+    description: 'Counts input images to a Genkit model.',
     valueType: ValueType.INT,
   }
 );
 
-const generateActionOutputCharacters = new MetricHistogram(
-  _N('generate/output_characters'),
+const generateActionOutputCharacters = new MetricCounter(
+  _N('generate/output/characters'),
   {
-    description: 'Histogram of output characters to a Genkit model.',
+    description: 'Counts output characters from a Genkit model.',
     valueType: ValueType.INT,
   }
 );
 
-const generateActionOutputTokens = new MetricHistogram(
-  _N('generate/output_tokens'),
+const generateActionOutputTokens = new MetricCounter(
+  _N('generate/output/tokens'),
   {
-    description: 'Histogram of output tokens to a Genkit model.',
+    description: 'Counts output tokens from a Genkit model.',
     valueType: ValueType.INT,
   }
 );
 
-const generateActionOutputImages = new MetricHistogram(
-  _N('generate/output_images'),
+const generateActionOutputImages = new MetricCounter(
+  _N('generate/output/images'),
   {
-    description: 'Histogram of output images to a Genkit model.',
+    description: 'Count output images from a Genkit model.',
     valueType: ValueType.INT,
   }
 );
@@ -319,12 +319,12 @@ function doRecordGenerateActionMetrics(
   generateActionLatencies.record(dimensions.latencyMs, shared);
 
   // inputs
-  generateActionInputTokens.record(dimensions.inputTokens, shared);
-  generateActionInputCharacters.record(dimensions.inputCharacters, shared);
-  generateActionInputImages.record(dimensions.inputImages, shared);
+  generateActionInputTokens.add(dimensions.inputTokens, shared);
+  generateActionInputCharacters.add(dimensions.inputCharacters, shared);
+  generateActionInputImages.add(dimensions.inputImages, shared);
 
   // outputs
-  generateActionOutputTokens.record(dimensions.outputTokens, shared);
-  generateActionOutputCharacters.record(dimensions.outputCharacters, shared);
-  generateActionOutputImages.record(dimensions.outputImages, shared);
+  generateActionOutputTokens.add(dimensions.outputTokens, shared);
+  generateActionOutputCharacters.add(dimensions.outputCharacters, shared);
+  generateActionOutputImages.add(dimensions.outputImages, shared);
 }


### PR DESCRIPTION
Also move the metrics into separate input and output namespaces.

Counters are more useful for these metrics because they are cost-proxies and so getting the overall sum is more imporant than understanding the per-request rate.