### PR TITLE
Properly ensure reflection API is never started more than once

### DIFF
--- a/js/core/src/reflectionApi.ts
+++ b/js/core/src/reflectionApi.ts
@@ -58,6 +58,7 @@ export async function startReflectionApi(port?: number | undefined) {
   if (!port) {
     port = Number(process.env.GENKIT_REFLECTION_PORT) || 3100;
   }
+  global[GLOBAL_REFLECTION_API_PORT_KEY] = port;
 
   const api = express();
 
@@ -300,7 +301,6 @@ export async function startReflectionApi(port?: number | undefined) {
 
   server = api.listen(port, () => {
     console.log(`Reflection API running on http://localhost:${port}`);
-    global[GLOBAL_REFLECTION_API_PORT_KEY] = port;
   });
 
   server.on('error', (error) => {


### PR DESCRIPTION
this sometimes may happen when nodejs gets confused normalizing imports and imports core multiple times