### PR TITLE
Update pnpm to v9.1.1

### DIFF
--- a/genkit-tools/cli/package.json
+++ b/genkit-tools/cli/package.json
@@ -41,6 +41,5 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "typescript": "^5.3.3"
-  },
-  "packageManager": "pnpm@9.1.0+sha256.22e36fba7f4880ecf749a5ca128b8435da085ecd49575e7fb9e64d6bf4fad394"
+  }
 }

--- a/genkit-tools/package.json
+++ b/genkit-tools/package.json
@@ -20,5 +20,5 @@
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.22.4"
   },
-  "packageManager": "pnpm@9.1.0+sha256.22e36fba7f4880ecf749a5ca128b8435da085ecd49575e7fb9e64d6bf4fad394"
+  "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b"
 }

--- a/js/package.json
+++ b/js/package.json
@@ -19,5 +19,5 @@
     "only-allow": "^1.2.1",
     "typescript": "^4.9.0"
   },
-  "packageManager": "pnpm@9.1.0+sha256.22e36fba7f4880ecf749a5ca128b8435da085ecd49575e7fb9e64d6bf4fad394"
+  "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b"
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "prettier-plugin-organize-imports": "^3.2.4",
     "ts-node": "^10.9.2"
   },
-  "packageManager": "pnpm@9.1.0+sha256.22e36fba7f4880ecf749a5ca128b8435da085ecd49575e7fb9e64d6bf4fad394"
+  "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b"
 }


### PR DESCRIPTION
Also removes superfluous `packageManager` field from `genkit-tools/cli/` since this is handled by `genkit-tools/`'s package.json.

https://github.com/pnpm/pnpm/releases/tag/v9.1.1