### PR TITLE
Simplified firebase init instructions

### DIFF
--- a/docs/cloud-run.md
+++ b/docs/cloud-run.md
@@ -6,7 +6,7 @@ flow.
 
 1.  Install the required tools:
 
-    1.  Make sure you are using Node.js version 18 or higher (run
+    1.  Make sure you are using Node.js version 20 or higher (run
         `node --version` to check).
 
     1.  Install the

--- a/docs/deploy-node.md
+++ b/docs/deploy-node.md
@@ -10,7 +10,7 @@ sample flow.
 
 1.  Install the required tools:
 
-    - Make sure you are using node version 18 or higher (run `node --version` to
+    - Make sure you are using node version 20 or higher (run `node --version` to
       check).
 
 1.  Create a directory for the Genkit sample project:
@@ -113,7 +113,7 @@ sample flow.
 
     | Setting               | Value                                                               |
     | --------------------- | ------------------------------------------------------------------- |
-    | Runtime               | Node.js 18 or newer                                                 |
+    | Runtime               | Node.js 20 or newer                                                 |
     | Build command         | `npm run build`                                                     |
     | Start command         | `npm run start`                                                     |
     | Environment variables | `GOOGLE_API_KEY=<your-api-key>` (or whichever secrets are required) |

--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -8,7 +8,7 @@ deploying the default sample flow to Firebase.
 
 1.  Install the required tools:
 
-    1.  Make sure you are using Node.js version 18 or higher (run `node --version` to
+    1.  Make sure you are using Node.js version 20 or higher (run `node --version` to
         check).
 
     1.  Install the [Firebase CLI](https://firebase.google.com/docs/cli).
@@ -36,29 +36,15 @@ deploying the default sample flow to Firebase.
     mkdir -p $PROJECT_ROOT
     ```
 
-1.  Initialize a Firebase project in the folder:
+1.  Initialize a Firebase project with Genkit in the folder:
 
     ```posix-terminal
     cd $PROJECT_ROOT
 
-    firebase init
+    firebase init genkit
     ```
 
-    - Select **Functions** as the only feature to set up (for now).
     - Select the project you created earlier.
-    - Select **TypeScript** as the functions language.
-
-    Accept the defaults for the remaining prompts.
-
-1.  Initialize Genkit in your Firebase project:
-
-    ```posix-terminal
-    cd $PROJECT_ROOT/functions
-
-    genkit init
-    ```
-
-    - Select **Firebase** as the deployment platform.
     - Select the model provider you want to use.
 
     Accept the defaults for the remaining prompts. The `genkit` tool will create

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -5,7 +5,7 @@ To get started with Firebase Genkit, install the Genkit CLI and run
 
 ## Requirements
 
-Node.js 18 or later.
+Node.js 20 or later.
 
 ## Procedure
 


### PR DESCRIPTION
Using `firebase init genkit` instead of separate `firebase init && genkit init`