### PR TITLE
Docs/firebase fixes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,7 @@ public/
 .prettierrc.yaml
 pnpm-lock.yaml
 docs/_guides.yaml
+docs/firebase.md
+docs/auth.md
+docs/plugins/firebase.md
 genkit-tools/genkit-schema.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,4 @@ public/
 .prettierrc.yaml
 pnpm-lock.yaml
 docs/_guides.yaml
-docs/firebase.md
-docs/auth.md
-docs/plugins/firebase.md
 genkit-tools/genkit-schema.json

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -117,6 +117,7 @@ long as your app client is also using the
 [Firebase Auth SDK](https://firebase.google.com/docs/auth).
 You can use Firebase Auth to protect your flows defined with `onFlow()`:
 
+<!-- prettier-ignore -->
 ```ts
 import {firebaseAuth} from "@genkit-ai/firebase/auth";
 import {onFlow} from "@genkit-ai/firebase/functions";
@@ -148,6 +149,7 @@ client, but in cases where you wish to allow unauthenticated access with special
 handling for authenticated users (upselling features, say), then you can
 configure the policy like so:
 
+<!-- prettier-ignore -->
 ```ts
 authPolicy: firebaseAuth((user) => {
   if (user && !user.email_verified) {
@@ -166,6 +168,7 @@ your Function is not world-callable but instead is protected by
 indicate to the library that you are forgoing authorization checks by using the
 `noAuth()` function:
 
+<!-- prettier-ignore -->
 ```ts
 import {onFlow, noAuth} from "@genkit-ai/firebase/functions";
 
@@ -187,6 +190,7 @@ Firebase plugin for genkit includes first-class support for
 [Firebase App Check](https://firebase.google.com/docs/app-check). Simply add
 the following configuration options to your `onFlow()`:
 
+<!-- prettier-ignore -->
 ```ts
 import {onFlow} from "@genkit-ai/firebase/functions";
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -118,16 +118,16 @@ long as your app client is also using the
 You can use Firebase Auth to protect your flows defined with `onFlow()`:
 
 ```ts
-import { firebaseAuth } from '@genkit-ai/firebase/auth';
-import { onFlow } from '@genkit-ai/firebase/functions';
+import {firebaseAuth} from "@genkit-ai/firebase/auth";
+import {onFlow} from "@genkit-ai/firebase/functions";
 
 export const selfSummaryFlow = onFlow({
-    name: 'selfSummaryFlow',
+    name: "selfSummaryFlow",
     inputSchema: z.string(),
     outputSchema: z.string(),
     authPolicy: firebaseAuth((user) => {
       if (!user.email_verified && !user.admin) {
-        throw new Error('Email not verified');
+        throw new Error("Email not verified");
       }
     }),
   }, (subject) => {...})
@@ -151,7 +151,7 @@ configure the policy like so:
 ```ts
 authPolicy: firebaseAuth((user) => {
   if (user && !user.email_verified) {
-    throw new Error('Logged in users must have verified emails');
+    throw new Error("Logged in users must have verified emails");
   }
 }, {required: false}),
 ```
@@ -167,10 +167,10 @@ indicate to the library that you are forgoing authorization checks by using the
 `noAuth()` function:
 
 ```ts
-import { onFlow, noAuth } from '@genkit-ai/firebase/functions';
+import {onFlow, noAuth} from "@genkit-ai/firebase/functions";
 
 export const selfSummaryFlow = onFlow({
-    name: 'selfSummaryFlow',
+    name: "selfSummaryFlow",
     inputSchema: z.string(),
     outputSchema: z.string(),
     // WARNING: Only do this if you have some other gatekeeping in place, like
@@ -188,10 +188,10 @@ Firebase plugin for genkit includes first-class support for
 the following configuration options to your `onFlow()`:
 
 ```ts
-import { onFlow } from '@genkit-ai/firebase/functions';
+import {onFlow} from "@genkit-ai/firebase/functions";
 
 export const selfSummaryFlow = onFlow({
-    name: 'selfSummaryFlow',
+    name: "selfSummaryFlow",
     inputSchema: z.string(),
     outputSchema: z.string(),
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,3 +1,6 @@
+<!-- NOTE: prettier-ignore used in some snippets to allow copy/paste into Firebase Functions which
+use https://github.com/firebase/firebase-tools/blob/master/templates/init/functions/javascript/_eslintrc -->
+
 # Authorization and integrity
 
 When building any public-facing application, it's extremely important to protect
@@ -117,7 +120,8 @@ long as your app client is also using the
 [Firebase Auth SDK](https://firebase.google.com/docs/auth).
 You can use Firebase Auth to protect your flows defined with `onFlow()`:
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore: see note above -->
+
 ```ts
 import {firebaseAuth} from "@genkit-ai/firebase/auth";
 import {onFlow} from "@genkit-ai/firebase/functions";
@@ -149,7 +153,8 @@ client, but in cases where you wish to allow unauthenticated access with special
 handling for authenticated users (upselling features, say), then you can
 configure the policy like so:
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore: see note above  -->
+
 ```ts
 authPolicy: firebaseAuth((user) => {
   if (user && !user.email_verified) {
@@ -168,7 +173,8 @@ your Function is not world-callable but instead is protected by
 indicate to the library that you are forgoing authorization checks by using the
 `noAuth()` function:
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore: see note above -->
+
 ```ts
 import {onFlow, noAuth} from "@genkit-ai/firebase/functions";
 
@@ -190,7 +196,8 @@ Firebase plugin for genkit includes first-class support for
 [Firebase App Check](https://firebase.google.com/docs/app-check). Simply add
 the following configuration options to your `onFlow()`:
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore: see note above -->
+
 ```ts
 import {onFlow} from "@genkit-ai/firebase/functions";
 

--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -69,14 +69,15 @@ deploying the default sample flow to Firebase.
 
       1.  Edit `src/index.ts` and add the following after the existing imports:
 
-          ```js
-          import {defineSecret} from "firebase-functions/params";
-          defineSecret("GOOGLE_GENAI_API_KEY");
-          ```
+      <!-- prettier-ignore -->
+      ```js
+      import {defineSecret} from "firebase-functions/params";
+      defineSecret("GOOGLE_GENAI_API_KEY");
+      ```
 
-          Now, when you deploy this function, your API key will be stored in
-          Cloud Secret Manager, and available from the Cloud Functions
-          environment.
+      Now, when you deploy this function, your API key will be stored in
+      Cloud Secret Manager, and available from the Cloud Functions
+      environment.
 
     - {Gemini (Vertex AI)}
 
@@ -107,11 +108,11 @@ deploying the default sample flow to Firebase.
 
 1.  If you'll access your flow from a web app (which you will be doing in the
     next section), in the `httpsOptions` parameter, set a CORS policy:
-
+    <!-- prettier-ignore -->
     ```js
     export const menuSuggestionFlow = onFlow(
       {
-        name: 'menuSuggestionFlow',
+        name: "menuSuggestionFlow",
         // ...
         httpsOptions: {cors: true}, // Add this line.
       },

--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -1,3 +1,6 @@
+<!-- NOTE: prettier-ignore used in some snippets to allow copy/paste into Firebase Functions which
+use https://github.com/firebase/firebase-tools/blob/master/templates/init/functions/javascript/_eslintrc -->
+
 # Genkit with Firebase Cloud Functions
 
 Firebase Genkit includes a plugin that helps you deploy your flows to Firebase
@@ -69,6 +72,7 @@ deploying the default sample flow to Firebase.
 
       1.  Edit `src/index.ts` and add the following after the existing imports:
 
+      <!--See note above on prettier-ignore -->
       <!-- prettier-ignore -->
       ```js
       import {defineSecret} from "firebase-functions/params";
@@ -108,6 +112,7 @@ deploying the default sample flow to Firebase.
 
 1.  If you'll access your flow from a web app (which you will be doing in the
     next section), in the `httpsOptions` parameter, set a CORS policy:
+    <!--See note above on prettier-ignore -->
     <!-- prettier-ignore -->
     ```js
     export const menuSuggestionFlow = onFlow(

--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -70,8 +70,8 @@ deploying the default sample flow to Firebase.
       1.  Edit `src/index.ts` and add the following after the existing imports:
 
           ```js
-          import { defineSecret } from 'firebase-functions/params';
-          defineSecret('GOOGLE_GENAI_API_KEY');
+          import {defineSecret} from "firebase-functions/params";
+          defineSecret("GOOGLE_GENAI_API_KEY");
           ```
 
           Now, when you deploy this function, your API key will be stored in
@@ -113,7 +113,7 @@ deploying the default sample flow to Firebase.
       {
         name: 'menuSuggestionFlow',
         // ...
-        httpsOptions: { cors: '*' }, // Add this line.
+        httpsOptions: {cors: true}, // Add this line.
       },
       async (subject) => {
         // ...
@@ -229,7 +229,7 @@ app:
         </div>
         <div id="callGenkit" hidden>
           Subject: <input type="text" id="subject" />
-          <button id="suggestMenuItem">Suggest a menu item</button>
+          <button id="suggestMenuItem">Suggest a menu theme</button>
           <p id="menuItem"></p>
         </div>
         <script type="module">

--- a/docs/plugins/firebase.md
+++ b/docs/plugins/firebase.md
@@ -20,10 +20,10 @@ npm i --save @genkit-ai/firebase
 To use this plugin, specify it when you call `configureGenkit()`:
 
 ```js
-import { firebase } from '@genkit-ai/firebase';
+import {firebase} from "@genkit-ai/firebase";
 
 configureGenkit({
-  plugins: [firebase({ projectId: 'your-firebase-project' })],
+  plugins: [firebase({projectId: "your-firebase-project"})],
 });
 ```
 
@@ -67,21 +67,21 @@ The `firebase` plugin provides a convenience function for defining Firestore
 retrievers, `defineFirestoreRetriever()`:
 
 ```js
-import { defineFirestoreRetriever } from '@genkit-ai/firebase';
-import { initializeApp } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
+import {defineFirestoreRetriever} from "@genkit-ai/firebase";
+import {initializeApp} from "firebase-admin/app";
+import {getFirestore} from "firebase-admin/firestore";
 
 const app = initializeApp();
 const firestore = getFirestore(app);
 
 const yourRetrieverRef = defineFirestoreRetriever({
-  name: 'yourRetriever',
+  name: "yourRetriever",
   firestore: getFirestore(app),
-  collection: 'yourCollection',
-  contentField: 'yourDataChunks',
-  vectorField: 'embedding',
+  collection: "yourCollection",
+  contentField: "yourDataChunks",
+  vectorField: "embedding",
   embedder: textEmbeddingGecko,
-  distanceMeasure: 'COSINE', // 'EUCLIDEAN', 'DOT_PRODUCT', or 'COSINE' (default)
+  distanceMeasure: "COSINE", // "EUCLIDEAN", "DOT_PRODUCT", or "COSINE" (default)
 });
 ```
 
@@ -90,26 +90,26 @@ To use it, pass it to the `retrieve()` function:
 ```js
 const docs = await retrieve({
   retriever: yourRetrieverRef,
-  query: 'look for something',
-  config: { limit: 5 },
+  query: "look for something",
+  config: {limit: 5},
 });
 ```
 
 For indexing, use an embedding generator along with the Admin SDK:
 
 ```js
-import { initializeApp } from 'firebase-admin';
-import { getFirestore, FieldValue } from 'firebase-admin/firestore';
-import { textEmbeddingGecko } from '@genkit-ai/vertexai';
-import { embed } from '@genkit-ai/ai/embedder';
+import {initializeApp} from "firebase-admin";
+import {getFirestore, FieldValue} from "firebase-admin/firestore";
+import {textEmbeddingGecko} from "@genkit-ai/vertexai";
+import {embed} from "@genkit-ai/ai/embedder";
 
 const app = initializeApp();
 const firestore = getFirestore(app);
 
 const indexConfig = {
-  collection: 'yourCollection',
-  contentField: 'yourDataChunks',
-  vectorField: 'embedding',
+  collection: "yourCollection",
+  contentField: "yourDataChunks",
+  vectorField: "embedding",
   embedder: textEmbeddingGecko,
 };
 
@@ -139,11 +139,11 @@ discussion on indexers and retrievers.
 You can use Cloud Firestore to store traces:
 
 ```js
-import { firebase } from '@genkit-ai/firebase';
+import { firebase } from "@genkit-ai/firebase";
 
 configureGenkit({
   plugins: [firebase()],
-  traceStore: 'firebase',
+  traceStore: "firebase",
   enableTracingAndMetrics: true,
 });
 ```
@@ -154,8 +154,8 @@ the project's default database. To change either setting:
 ```js
 firebase({
   traceStore: {
-    collection: 'your-collection';
-    databaseId: 'your-db';
+    collection: "your-collection";
+    databaseId: "your-db";
   }
 })
 ```
@@ -166,14 +166,14 @@ When using Firestore-based trace storage you will want to enable TTL for the tra
 
 The plugin provides the `onFlow()` constructor, which creates a flow backed by a
 Cloud Functions for Firebase HTTPS-triggered function. These functions conform
-to Firebase's
+to Firebase"s
 [callable function interface](https://firebase.google.com/docs/functions/callable-reference) and you can use the
 [Cloud Functions client SDKs](https://firebase.google.com/docs/functions/callable?gen=2nd#call_the_function)
 to call them.
 
 ```js
-import { firebase } from '@genkit-ai/firebase';
-import { onFlow, noAuth } from '@genkit-ai/firebase/functions';
+import {firebase} from "@genkit-ai/firebase";
+import {onFlow, noAuth} from "@genkit-ai/firebase/functions";
 
 configureGenkit({
   plugins: [firebase()],
@@ -181,7 +181,7 @@ configureGenkit({
 
 export const exampleFlow = onFlow(
   {
-    name: 'exampleFlow',
+    name: "exampleFlow",
     authPolicy: noAuth(), // WARNING: noAuth() creates an open endpoint!
   },
   async (prompt) => {
@@ -206,9 +206,9 @@ The `onFlow()` function has some options not present in `defineFlow()`:
   ```js
   export const exampleFlow = onFlow(
     {
-      name: 'exampleFlow',
+      name: "exampleFlow",
       httpsOptions: {
-        cors: '*',
+        cors: true,
       },
       // ...
     },
@@ -231,13 +231,13 @@ This plugin provides a helper function to create authorization policies around
 Firebase Auth:
 
 ```js
-import { firebaseAuth } from '@genkit-ai/firebase/auth';
+import {firebaseAuth} from "@genkit-ai/firebase/auth";
 
 export const exampleFlow = onFlow(
   {
-    name: 'exampleFlow',
+    name: "exampleFlow",
     authPolicy: firebaseAuth((user) => {
-      if (!user.email_verified) throw new Error('Requires verification!');
+      if (!user.email_verified) throw new Error("Requires verification!");
     }),
   },
   async (prompt) => {

--- a/docs/plugins/firebase.md
+++ b/docs/plugins/firebase.md
@@ -19,6 +19,7 @@ npm i --save @genkit-ai/firebase
 
 To use this plugin, specify it when you call `configureGenkit()`:
 
+<!-- prettier-ignore -->
 ```js
 import {firebase} from "@genkit-ai/firebase";
 
@@ -66,6 +67,7 @@ You can use Cloud Firestore as a vector store for RAG indexing and retrieval.
 The `firebase` plugin provides a convenience function for defining Firestore
 retrievers, `defineFirestoreRetriever()`:
 
+<!-- prettier-ignore -->
 ```js
 import {defineFirestoreRetriever} from "@genkit-ai/firebase";
 import {initializeApp} from "firebase-admin/app";
@@ -87,6 +89,7 @@ const yourRetrieverRef = defineFirestoreRetriever({
 
 To use it, pass it to the `retrieve()` function:
 
+<!-- prettier-ignore -->
 ```js
 const docs = await retrieve({
   retriever: yourRetrieverRef,
@@ -97,6 +100,7 @@ const docs = await retrieve({
 
 For indexing, use an embedding generator along with the Admin SDK:
 
+<!-- prettier-ignore -->
 ```js
 import {initializeApp} from "firebase-admin";
 import {getFirestore, FieldValue} from "firebase-admin/firestore";
@@ -138,8 +142,9 @@ discussion on indexers and retrievers.
 
 You can use Cloud Firestore to store traces:
 
+<!-- prettier-ignore -->
 ```js
-import { firebase } from "@genkit-ai/firebase";
+import {firebase} from "@genkit-ai/firebase";
 
 configureGenkit({
   plugins: [firebase()],
@@ -151,6 +156,7 @@ configureGenkit({
 By default, the plugin stores traces in a collection called `genkit-traces` in
 the project's default database. To change either setting:
 
+<!-- prettier-ignore -->
 ```js
 firebase({
   traceStore: {
@@ -166,11 +172,12 @@ When using Firestore-based trace storage you will want to enable TTL for the tra
 
 The plugin provides the `onFlow()` constructor, which creates a flow backed by a
 Cloud Functions for Firebase HTTPS-triggered function. These functions conform
-to Firebase"s
+to Firebase's
 [callable function interface](https://firebase.google.com/docs/functions/callable-reference) and you can use the
 [Cloud Functions client SDKs](https://firebase.google.com/docs/functions/callable?gen=2nd#call_the_function)
 to call them.
 
+<!-- prettier-ignore -->
 ```js
 import {firebase} from "@genkit-ai/firebase";
 import {onFlow, noAuth} from "@genkit-ai/firebase/functions";
@@ -203,6 +210,7 @@ The `onFlow()` function has some options not present in `defineFlow()`:
 - `httpsOptions`: an [`HttpsOptions`](https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.https.httpsoptions)
   object used to configure your Cloud Function:
 
+  <!-- prettier-ignore -->
   ```js
   export const exampleFlow = onFlow(
     {
@@ -230,6 +238,7 @@ The `onFlow()` function has some options not present in `defineFlow()`:
 This plugin provides a helper function to create authorization policies around
 Firebase Auth:
 
+<!-- prettier-ignore -->
 ```js
 import {firebaseAuth} from "@genkit-ai/firebase/auth";
 

--- a/docs/plugins/firebase.md
+++ b/docs/plugins/firebase.md
@@ -1,3 +1,6 @@
+<!-- NOTE: prettier-ignore used in some snippets to allow copy/paste into Firebase Functions which
+use https://github.com/firebase/firebase-tools/blob/master/templates/init/functions/javascript/_eslintrc -->
+
 # Firebase plugin
 
 The Firebase plugin provides several integrations with Firebase services:
@@ -19,6 +22,7 @@ npm i --save @genkit-ai/firebase
 
 To use this plugin, specify it when you call `configureGenkit()`:
 
+<!--See note above on prettier-ignore -->
 <!-- prettier-ignore -->
 ```js
 import {firebase} from "@genkit-ai/firebase";
@@ -67,6 +71,7 @@ You can use Cloud Firestore as a vector store for RAG indexing and retrieval.
 The `firebase` plugin provides a convenience function for defining Firestore
 retrievers, `defineFirestoreRetriever()`:
 
+<!--See note above on prettier-ignore -->
 <!-- prettier-ignore -->
 ```js
 import {defineFirestoreRetriever} from "@genkit-ai/firebase";
@@ -89,6 +94,7 @@ const yourRetrieverRef = defineFirestoreRetriever({
 
 To use it, pass it to the `retrieve()` function:
 
+<!--See note above on prettier-ignore -->
 <!-- prettier-ignore -->
 ```js
 const docs = await retrieve({
@@ -100,6 +106,7 @@ const docs = await retrieve({
 
 For indexing, use an embedding generator along with the Admin SDK:
 
+<!--See note above on prettier-ignore -->
 <!-- prettier-ignore -->
 ```js
 import {initializeApp} from "firebase-admin";
@@ -142,6 +149,7 @@ discussion on indexers and retrievers.
 
 You can use Cloud Firestore to store traces:
 
+<!--See note above on prettier-ignore -->
 <!-- prettier-ignore -->
 ```js
 import {firebase} from "@genkit-ai/firebase";
@@ -156,6 +164,7 @@ configureGenkit({
 By default, the plugin stores traces in a collection called `genkit-traces` in
 the project's default database. To change either setting:
 
+<!--See note above on prettier-ignore -->
 <!-- prettier-ignore -->
 ```js
 firebase({
@@ -177,6 +186,7 @@ to Firebase's
 [Cloud Functions client SDKs](https://firebase.google.com/docs/functions/callable?gen=2nd#call_the_function)
 to call them.
 
+<!--See note above on prettier-ignore -->
 <!-- prettier-ignore -->
 ```js
 import {firebase} from "@genkit-ai/firebase";
@@ -209,7 +219,7 @@ The `onFlow()` function has some options not present in `defineFlow()`:
 
 - `httpsOptions`: an [`HttpsOptions`](https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.https.httpsoptions)
   object used to configure your Cloud Function:
-
+  <!--See note above on prettier-ignore -->
   <!-- prettier-ignore -->
   ```js
   export const exampleFlow = onFlow(
@@ -238,6 +248,7 @@ The `onFlow()` function has some options not present in `defineFlow()`:
 This plugin provides a helper function to create authorization policies around
 Firebase Auth:
 
+<!--See note above on prettier-ignore -->
 <!-- prettier-ignore -->
 ```js
 import {firebaseAuth} from "@genkit-ai/firebase/auth";


### PR DESCRIPTION
Modify prettier rules for docs/firebase since Firebase Lint requires strings use doublequotes and no spaces next to curly braces