### PR TITLE
[Go] fix panic when registering indexer

### DIFF
--- a/go/genkit/action.go
+++ b/go/genkit/action.go
@@ -200,11 +200,16 @@ func (a *Action[I, O, S]) desc() actionDesc {
 	return ad
 }
 
-func inferJSONSchema(x any) *jsonschema.Schema {
+func inferJSONSchema(x any) (s *jsonschema.Schema) {
 	var r jsonschema.Reflector
-	// If x is a struct, put its definition at the "top level" of the schema,
-	// instead of nested inside a "$defs" object.
-	if reflect.TypeOf(x).Kind() == reflect.Struct {
+	t := reflect.TypeOf(x)
+	if t.Kind() == reflect.Struct {
+		if t.NumField() == 0 {
+			// Make struct{} correspond to ZodVoid.
+			return &jsonschema.Schema{Type: "null"}
+		}
+		// Put a struct definition at the "top level" of the schema,
+		// instead of nested inside a "$defs" object.
 		r.ExpandedStruct = true
 	}
 	return r.Reflect(x)

--- a/go/genkit/action_test.go
+++ b/go/genkit/action_test.go
@@ -49,6 +49,11 @@ func TestActionRunJSON(t *testing.T) {
 	}
 }
 
+func TestNewAction(t *testing.T) {
+	// Verify that struct{} can occur in the function signature.
+	_ = NewAction("f", nil, func(context.Context, int) (struct{}, error) { return struct{}{}, nil })
+}
+
 // count streams the numbers from 0 to n-1, then returns n.
 func count(ctx context.Context, n int, cb StreamingCallback[int]) (int, error) {
 	if cb != nil {


### PR DESCRIPTION
invopop panics when inferring the schema for `struct{}`.
Handle that case specially.
