### PR TITLE
Update retrieverName in pgvector template

### DIFF
--- a/docs/templates/pgvector.md
+++ b/docs/templates/pgvector.md
@@ -22,7 +22,7 @@ const QueryOptions = z.object({
 
 const sqlRetriever = defineRetriever(
   {
-    name: 'pgvector/myTable',
+    name: 'pgvector-myTable',
     configSchema: QueryOptions,
   },
   async (input, options) => {


### PR DESCRIPTION
- Should not use `<abc>/<xyz>` format since it is reserved for plugins.