### PR TITLE
[JS] feat: add path prefix option to startFlowsServer

### DIFF
--- a/js/flow/src/flow.ts
+++ b/js/flow/src/flow.ts
@@ -847,7 +847,7 @@ export function startFlowsServer(params?: {
   const flows = params?.flows || createdFlows();
   logger.info(`Starting flows server on port ${port}`);
   flows.forEach((f) => {
-    const flowPath = `${pathPrefix}/${f.name}`;
+    const flowPath = `/${pathPrefix}${f.name}`;
     logger.info(` - ${flowPath}`);
     // Add middlware
     f.middleware?.forEach((m) => {

--- a/js/flow/src/flow.ts
+++ b/js/flow/src/flow.ts
@@ -378,7 +378,7 @@ export class Flow<
 
     throw new Error(
       'Unexpected envelope message case, must set one of: ' +
-      'start, schedule, runScheduled, resume, retry, state'
+        'start, schedule, runScheduled, resume, retry, state'
     );
   }
 
@@ -710,8 +710,8 @@ export function streamFlow<
     start(controller) {
       chunkStreamController = controller;
     },
-    pull() { },
-    cancel() { },
+    pull() {},
+    cancel() {},
   });
 
   const operationPromise = flow
@@ -839,7 +839,7 @@ export function startFlowsServer(params?: {
 }) {
   const port =
     params?.port || (process.env.PORT ? parseInt(process.env.PORT) : 0) || 3400;
-  const pathPrefix = params?.pathPrefix ? `/${params?.pathPrefix}` : "";
+  const pathPrefix = params?.pathPrefix ? `/${params?.pathPrefix}` : '';
   const app = express();
   app.use(bodyParser.json());
   app.use(cors(params?.cors));

--- a/js/flow/src/flow.ts
+++ b/js/flow/src/flow.ts
@@ -378,7 +378,7 @@ export class Flow<
 
     throw new Error(
       'Unexpected envelope message case, must set one of: ' +
-        'start, schedule, runScheduled, resume, retry, state'
+      'start, schedule, runScheduled, resume, retry, state'
     );
   }
 
@@ -710,8 +710,8 @@ export function streamFlow<
     start(controller) {
       chunkStreamController = controller;
     },
-    pull() {},
-    cancel() {},
+    pull() { },
+    cancel() { },
   });
 
   const operationPromise = flow
@@ -835,9 +835,11 @@ export function startFlowsServer(params?: {
   flows?: Flow<any, any, any>[];
   port?: number;
   cors?: CorsOptions;
+  pathPrefix?: string;
 }) {
   const port =
     params?.port || (process.env.PORT ? parseInt(process.env.PORT) : 0) || 3400;
+  const pathPrefix = params?.pathPrefix ? `/${params?.pathPrefix}` : "";
   const app = express();
   app.use(bodyParser.json());
   app.use(cors(params?.cors));
@@ -845,12 +847,12 @@ export function startFlowsServer(params?: {
   const flows = params?.flows || createdFlows();
   logger.info(`Starting flows server on port ${port}`);
   flows.forEach((f) => {
-    logger.info(` - /${f.name}`);
+    logger.info(` - ${pathPrefix}/${f.name}`);
     // Add middlware
     f.middleware?.forEach((m) => {
-      app.post(`/${f.name}`, m);
+      app.post(`${pathPrefix}/${f.name}`, m);
     });
-    app.post(`/${f.name}`, f.expressHandler);
+    app.post(`${pathPrefix}/${f.name}`, f.expressHandler);
   });
 
   app.listen(port, () => {

--- a/js/flow/src/flow.ts
+++ b/js/flow/src/flow.ts
@@ -839,7 +839,7 @@ export function startFlowsServer(params?: {
 }) {
   const port =
     params?.port || (process.env.PORT ? parseInt(process.env.PORT) : 0) || 3400;
-  const pathPrefix = params?.pathPrefix ? `/${params?.pathPrefix}` : '';
+  const pathPrefix = params?.pathPrefix ?? '';
   const app = express();
   app.use(bodyParser.json());
   app.use(cors(params?.cors));
@@ -847,12 +847,13 @@ export function startFlowsServer(params?: {
   const flows = params?.flows || createdFlows();
   logger.info(`Starting flows server on port ${port}`);
   flows.forEach((f) => {
-    logger.info(` - ${pathPrefix}/${f.name}`);
+    const flowPath = `${pathPrefix}/${f.name}`;
+    logger.info(` - ${flowPath}`);
     // Add middlware
     f.middleware?.forEach((m) => {
-      app.post(`${pathPrefix}/${f.name}`, m);
+      app.post(flowPath, m);
     });
-    app.post(`${pathPrefix}/${f.name}`, f.expressHandler);
+    app.post(flowPath, f.expressHandler);
   });
 
   app.listen(port, () => {


### PR DESCRIPTION
Allows you to specify an optional path prefix for flows server.

if the flow name is `suggestMenuItems` and path prefix is `flows` then the server will be available on `/flows/suggestMenuItems`

Applies to all flows