### PR TITLE
[Go] POC: redo dotprompt API

### DIFF
--- a/go/genkit/dotprompt/dotprompt_test.go
+++ b/go/genkit/dotprompt/dotprompt_test.go
@@ -110,23 +110,23 @@ func TestPrompts(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if prompt.Frontmatter.Model != test.model {
-				t.Errorf("got model %q want %q", prompt.Frontmatter.Model, test.model)
+			if prompt.Model != test.model {
+				t.Errorf("got model %q want %q", prompt.Model, test.model)
 			}
-			if diff := cmpSchema(t, prompt.Frontmatter.Input.Schema, test.input); diff != "" {
+			if diff := cmpSchema(t, prompt.InputSchema, test.input); diff != "" {
 				t.Errorf("input schema mismatch (-want, +got):\n%s", diff)
 			}
 
 			if test.output == "" {
-				if prompt.Frontmatter.Output != nil && prompt.Frontmatter.Output.Schema != nil {
-					t.Errorf("unexpected output schema: %v", prompt.Frontmatter.Output.Schema)
+				if prompt.OutputSchema != nil {
+					t.Errorf("unexpected output schema: %v", prompt.OutputSchema)
 				}
 			} else {
 				var output map[string]any
 				if err := json.Unmarshal([]byte(test.output), &output); err != nil {
 					t.Fatalf("JSON unmarshal of %q failed: %v", test.output, err)
 				}
-				if diff := cmp.Diff(output, prompt.Frontmatter.Output.Schema); diff != "" {
+				if diff := cmp.Diff(output, prompt.OutputSchema); diff != "" {
 					t.Errorf("output schema mismatch (-want, +got):\n%s", diff)
 				}
 			}

--- a/go/genkit/dotprompt/genkit.go
+++ b/go/genkit/dotprompt/genkit.go
@@ -98,24 +98,19 @@ func (p *Prompt) buildRequest(input *ActionInput) (*ai.GenerateRequest, error) {
 	}
 
 	req.Candidates = input.Candidates
-	if req.Candidates == 0 && p.Frontmatter != nil {
-		req.Candidates = p.Frontmatter.Candidates
+	if req.Candidates == 0 {
+		req.Candidates = p.Candidates
 	}
 	if req.Candidates == 0 {
 		req.Candidates = 1
 	}
 
-	if p.Frontmatter != nil {
-		req.Config = p.Frontmatter.Config
+	req.Config = p.GenerationConfig
+	req.Output = &ai.GenerateRequestOutput{
+		Format: p.OutputFormat,
+		Schema: p.OutputSchema,
 	}
-
-	if p.Frontmatter != nil {
-		req.Output = p.Frontmatter.Output
-	}
-
-	if p.Frontmatter != nil {
-		req.Tools = p.Frontmatter.Tools
-	}
+	req.Tools = p.Tools
 
 	return req, nil
 }
@@ -174,10 +169,7 @@ func (p *Prompt) Execute(ctx context.Context, input *ActionInput) (*ai.GenerateR
 
 	generator := p.generator
 	if generator == nil {
-		var model string
-		if p.Frontmatter != nil {
-			model = p.Frontmatter.Model
-		}
+		model := p.Model
 		if input.Model != "" {
 			model = input.Model
 		}

--- a/go/genkit/dotprompt/genkit_test.go
+++ b/go/genkit/dotprompt/genkit_test.go
@@ -45,10 +45,11 @@ func (testGenerator) Generate(ctx context.Context, req *ai.GenerateRequest, cb g
 }
 
 func TestExecute(t *testing.T) {
-	p, err := Define("TestExecute", &Frontmatter{}, "TestExecute", testGenerator{})
+	p, err := New("TestExecute", "TestExecute", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	p.generator = testGenerator{}
 	resp, err := p.Execute(context.Background(), &ActionInput{})
 	if err != nil {
 		t.Fatal(err)

--- a/go/genkit/dotprompt/render.go
+++ b/go/genkit/dotprompt/render.go
@@ -48,9 +48,9 @@ func (p *Prompt) RenderText(variables map[string]any) (string, error) {
 
 // RenderMessages executes the prompt's template and converts it into messages.
 func (p *Prompt) RenderMessages(variables map[string]any) ([]*ai.Message, error) {
-	if p.Frontmatter != nil && p.Frontmatter.Input.Default != nil {
+	if p.VariableDefaults != nil {
 		nv := make(map[string]any)
-		maps.Copy(nv, p.Frontmatter.Input.Default)
+		maps.Copy(nv, p.VariableDefaults)
 		maps.Copy(nv, variables)
 		variables = nv
 	}

--- a/go/samples/coffee-shop/main.go
+++ b/go/samples/coffee-shop/main.go
@@ -83,19 +83,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	simpleGreetingPrompt, err := dotprompt.Define("simpleGreeting",
-		&dotprompt.Frontmatter{
-			Name:  "simpleGreeting",
-			Model: "google-genai/gemini-1.0-pro",
-			Input: dotprompt.FrontmatterInput{
-				Schema: jsonschema.Reflect(simpleGreetingInput{}),
-			},
-			Output: &ai.GenerateRequestOutput{
-				Format: ai.OutputFormatText,
-			},
+	simpleGreetingPrompt, err := dotprompt.Define("simpleGreeting", simpleGreetingPromptTemplate,
+		&dotprompt.Config{
+			Model:        "google-genai/gemini-1.0-pro",
+			InputSchema:  jsonschema.Reflect(simpleGreetingInput{}),
+			OutputFormat: ai.OutputFormatText,
 		},
-		simpleGreetingPromptTemplate,
-		nil,
 	)
 	if err != nil {
 		log.Fatal(err)
@@ -118,19 +111,12 @@ func main() {
 		return text, nil
 	})
 
-	greetingWithHistoryPrompt, err := dotprompt.Define("greetingWithHistory",
-		&dotprompt.Frontmatter{
-			Name:  "greetingWithHistory",
-			Model: "google-genai/gemini-1.0-pro",
-			Input: dotprompt.FrontmatterInput{
-				Schema: jsonschema.Reflect(customerTimeAndHistoryInput{}),
-			},
-			Output: &ai.GenerateRequestOutput{
-				Format: ai.OutputFormatText,
-			},
+	greetingWithHistoryPrompt, err := dotprompt.Define("greetingWithHistory", greetingWithHistoryPromptTemplate,
+		&dotprompt.Config{
+			Model:        "google-genai/gemini-1.0-pro",
+			InputSchema:  jsonschema.Reflect(customerTimeAndHistoryInput{}),
+			OutputFormat: ai.OutputFormatText,
 		},
-		greetingWithHistoryPromptTemplate,
-		nil,
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Attempt to make the dotprompt API a little more user-friendly.

The main change is to replace the exported Frontmatter type
with a type (called Config) that is easier to write a literal for.

Miscellaneous other changes:

- Unexport the Prompt.Hash field.

- Add `New` to create a prompt without registering it,
  and use `Define` to mean create + register, as it does elsewhere.

- Remove the generator as an argument; I believe it would only be
  used for tests.
