### PR TITLE
[Go] more API and doc changes

### DIFF
--- a/go/genkit/action.go
+++ b/go/genkit/action.go
@@ -96,11 +96,11 @@ func (a *Action[I, O, S]) setTracingState(tstate *tracingState) { a.tstate = tst
 func (a *Action[I, O, S]) Run(ctx context.Context, input I, cb StreamingCallback[S]) (output O, err error) {
 	// TODO: validate input against JSONSchema for I.
 	// TODO: validate output against JSONSchema for O.
-	logger(ctx).Debug("Action.Run",
+	Logger(ctx).Debug("Action.Run",
 		"name", a.name,
 		"input", fmt.Sprintf("%#v", input))
 	defer func() {
-		logger(ctx).Debug("Action.Run",
+		Logger(ctx).Debug("Action.Run",
 			"name", a.name,
 			"output", fmt.Sprintf("%#v", output),
 			"err", err)

--- a/go/genkit/dev_server.go
+++ b/go/genkit/dev_server.go
@@ -160,7 +160,7 @@ func (s *devServer) handleRunAction(w http.ResponseWriter, r *http.Request) erro
 			return err
 		}
 	}
-	logger(ctx).Debug("running action",
+	Logger(ctx).Debug("running action",
 		"key", body.Key,
 		"stream", stream)
 	var callback StreamingCallback[json.RawMessage]
@@ -286,7 +286,7 @@ func writeJSON(ctx context.Context, w http.ResponseWriter, value any) error {
 	}
 	_, err = w.Write(data)
 	if err != nil {
-		logger(ctx).Error("writing output", "err", err)
+		Logger(ctx).Error("writing output", "err", err)
 	}
 	return nil
 }

--- a/go/genkit/flow.go
+++ b/go/genkit/flow.go
@@ -176,7 +176,7 @@ type flowState[I, O any] struct {
 	EventsTriggered map[string]any             `json:"eventsTriggered,omitempty"`
 	Executions      []*flowExecution           `json:"executions,omitempty"`
 	// The operation is the user-visible part of the state.
-	Operation    *Operation[O] `json:"operation,omitempty"`
+	Operation    *operation[O] `json:"operation,omitempty"`
 	TraceContext string        `json:"traceContext,omitempty"`
 }
 
@@ -187,7 +187,7 @@ func newFlowState[I, O any](id, name string, input I) *flowState[I, O] {
 		Input:     input,
 		StartTime: gtime.ToMilliseconds(time.Now()),
 		Cache:     map[string]json.RawMessage{},
-		Operation: &Operation[O]{
+		Operation: &operation[O]{
 			FlowID: id,
 			Done:   false,
 		},
@@ -208,8 +208,8 @@ func (fs *flowState[I, O]) lock()                             { fs.mu.Lock() }
 func (fs *flowState[I, O]) unlock()                           { fs.mu.Unlock() }
 func (fs *flowState[I, O]) cache() map[string]json.RawMessage { return fs.Cache }
 
-// An Operation describes the state of a Flow that may still be in progress.
-type Operation[O any] struct {
+// An operation describes the state of a Flow that may still be in progress.
+type operation[O any] struct {
 	FlowID string `json:"name,omitempty"`
 	// The step that the flow is blocked on, if any.
 	BlockedOnStep *struct {
@@ -524,7 +524,7 @@ func StreamFlow[I, O, S any](ctx context.Context, flow *Flow[I, O, S], input I) 
 	}
 }
 
-func finishedOpResponse[O any](op *Operation[O]) (O, error) {
+func finishedOpResponse[O any](op *operation[O]) (O, error) {
 	if !op.Done {
 		return internal.Zero[O](), fmt.Errorf("flow %s did not finish execution", op.FlowID)
 	}

--- a/go/genkit/flow.go
+++ b/go/genkit/flow.go
@@ -210,8 +210,11 @@ func (fs *flowState[I, O]) cache() map[string]json.RawMessage { return fs.Cache 
 
 // An Operation describes the state of a Flow that may still be in progress.
 type Operation[O any] struct {
-	FlowID        string         `json:"name,omitempty"`
-	BlockedOnStep *blockedOnStep `json:"blockedOnStep,omitempty"`
+	FlowID        string `json:"name,omitempty"`
+	BlockedOnStep *struct {
+		Name   string `json:"name"`
+		Schema string `json:"schema"`
+	} `json:"blockedOnStep,omitempty"`
 	// Whether the operation is completed.
 	// If true Result will be non-nil.
 	Done bool `json:"done,omitempty"`

--- a/go/genkit/flow.go
+++ b/go/genkit/flow.go
@@ -210,7 +210,8 @@ func (fs *flowState[I, O]) cache() map[string]json.RawMessage { return fs.Cache 
 
 // An Operation describes the state of a Flow that may still be in progress.
 type Operation[O any] struct {
-	FlowID        string `json:"name,omitempty"`
+	FlowID string `json:"name,omitempty"`
+	// The step that the flow is blocked on, if any.
 	BlockedOnStep *struct {
 		Name   string `json:"name"`
 		Schema string `json:"schema"`

--- a/go/genkit/flow_test.go
+++ b/go/genkit/flow_test.go
@@ -40,13 +40,13 @@ func TestFlowStart(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := state.Operation
-	want := &Operation[int]{
+	want := &operation[int]{
 		Done: true,
 		Result: &FlowResult[int]{
 			Response: 2,
 		},
 	}
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Operation[int]{}, "FlowID")); diff != "" {
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(operation[int]{}, "FlowID")); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
 	}
 }
@@ -137,7 +137,7 @@ func TestFlowState(t *testing.T) {
 		Cache:           map[string]json.RawMessage{"x": json.RawMessage([]byte("3"))},
 		EventsTriggered: map[string]any{"a": "b"},
 		Executions:      []*flowExecution{{StartTime: 4, EndTime: 5, TraceIDs: []string{"c"}}},
-		Operation: &Operation[int]{
+		Operation: &operation[int]{
 			FlowID: "id",
 			BlockedOnStep: &struct {
 				Name   string `json:"name"`

--- a/go/genkit/flow_test.go
+++ b/go/genkit/flow_test.go
@@ -138,10 +138,13 @@ func TestFlowState(t *testing.T) {
 		EventsTriggered: map[string]any{"a": "b"},
 		Executions:      []*flowExecution{{StartTime: 4, EndTime: 5, TraceIDs: []string{"c"}}},
 		Operation: &Operation[int]{
-			FlowID:        "id",
-			BlockedOnStep: &blockedOnStep{Name: "bos", Schema: "s"},
-			Done:          true,
-			Metadata:      "meta",
+			FlowID: "id",
+			BlockedOnStep: &struct {
+				Name   string `json:"name"`
+				Schema string `json:"schema"`
+			}{Name: "bos", Schema: "s"},
+			Done:     true,
+			Metadata: "meta",
 			Result: &FlowResult[int]{
 				Response:   6,
 				Error:      "err",

--- a/go/genkit/flow_test.go
+++ b/go/genkit/flow_test.go
@@ -16,6 +16,7 @@ package genkit
 
 import (
 	"context"
+	"encoding/json"
 	"slices"
 	"testing"
 
@@ -122,4 +123,43 @@ func TestStreamFlow(t *testing.T) {
 		want++
 		return true
 	})
+}
+
+func TestFlowState(t *testing.T) {
+	// A flowState is an action output, so it must support JSON marshaling.
+	// Verify that a fully populated flowState can round-trip via JSON.
+
+	fs := &flowState[int, int]{
+		FlowID:          "id",
+		FlowName:        "name",
+		StartTime:       1,
+		Input:           2,
+		Cache:           map[string]json.RawMessage{"x": json.RawMessage([]byte("3"))},
+		EventsTriggered: map[string]any{"a": "b"},
+		Executions:      []*flowExecution{{StartTime: 4, EndTime: 5, TraceIDs: []string{"c"}}},
+		Operation: &Operation[int]{
+			FlowID:        "id",
+			BlockedOnStep: &blockedOnStep{Name: "bos", Schema: "s"},
+			Done:          true,
+			Metadata:      "meta",
+			Result: &FlowResult[int]{
+				Response:   6,
+				Error:      "err",
+				StackTrace: "st",
+			},
+		},
+		TraceContext: "tc",
+	}
+	data, err := json.Marshal(fs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got *flowState[int, int]
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	diff := cmp.Diff(fs, got, cmpopts.IgnoreUnexported(flowState[int, int]{}))
+	if diff != "" {
+		t.Errorf("mismatch (-want, +got):\n%s", diff)
+	}
 }

--- a/go/genkit/gen.go
+++ b/go/genkit/gen.go
@@ -30,9 +30,3 @@ type flowExecution struct {
 	StartTime gtime.Milliseconds `json:"startTime,omitempty"`
 	TraceIDs  []string           `json:"traceIds,omitempty"`
 }
-
-// blockedOnStep describes the step of the flow that the flow is blocked on.
-type blockedOnStep struct {
-	Name   string `json:"name,omitempty"`
-	Schema string `json:"schema,omitempty"`
-}

--- a/go/genkit/gen.go
+++ b/go/genkit/gen.go
@@ -23,11 +23,7 @@ type flowError struct {
 	Stacktrace string `json:"stacktrace,omitempty"`
 }
 
-type FlowInvokeEnvelopeMessageRunScheduled struct {
-	FlowID string `json:"flowId,omitempty"`
-}
-
-type FlowExecution struct {
+type flowExecution struct {
 	// end time in milliseconds since the epoch
 	EndTime gtime.Milliseconds `json:"endTime,omitempty"`
 	// start time in milliseconds since the epoch
@@ -35,8 +31,8 @@ type FlowExecution struct {
 	TraceIDs  []string           `json:"traceIds,omitempty"`
 }
 
-// BlockedOnStep describes the step of the flow that the flow is blocked on.
-type BlockedOnStep struct {
+// blockedOnStep describes the step of the flow that the flow is blocked on.
+type blockedOnStep struct {
 	Name   string `json:"name,omitempty"`
 	Schema string `json:"schema,omitempty"`
 }

--- a/go/genkit/logging.go
+++ b/go/genkit/logging.go
@@ -31,16 +31,11 @@ func init() {
 
 var loggerKey = newContextKey[*slog.Logger]()
 
-// logger returns the Logger in ctx, or the default Logger
+// Logger returns the Logger in ctx, or the default Logger
 // if there is none.
-func logger(ctx context.Context) *slog.Logger {
+func Logger(ctx context.Context) *slog.Logger {
 	if l := loggerKey.fromContext(ctx); l != nil {
 		return l
 	}
 	return slog.Default()
-}
-
-// DebugLog is a helper function for plugins to log debugging info.
-func DebugLog(ctx context.Context, msg string, args ...any) {
-	logger(ctx).Debug(msg, args...)
 }

--- a/go/genkit/metrics.go
+++ b/go/genkit/metrics.go
@@ -37,7 +37,7 @@ var fetchInstruments = sync.OnceValue(func() *metricInstruments {
 	insts, err := initInstruments()
 	if err != nil {
 		// Do not stop the program because we can't collect metrics.
-		logger(context.Background()).Error("metric initialization failed; no metrics will be collected", "err", err)
+		Logger(context.Background()).Error("metric initialization failed; no metrics will be collected", "err", err)
 		return nil
 	}
 	return insts

--- a/go/genkit/registry.go
+++ b/go/genkit/registry.go
@@ -67,7 +67,7 @@ func newRegistry() (*registry, error) {
 	return r, nil
 }
 
-// An Environment is the execution context that the program is running in.
+// An Environment is the execution context in which the program is running.
 type Environment string
 
 const (

--- a/go/genkit/schemas.config
+++ b/go/genkit/schemas.config
@@ -46,9 +46,9 @@ GenerationCommonConfig.topK	type int
 
 GenerateRequestOutputFormat	name OutputFormat
 
-OperationBlockedOnStep			name BlockedOnStep
+OperationBlockedOnStep			name blockedOnStep
 OperationBlockedOnStep			doc
-BlockedOnStep describes the step of the flow that the flow is blocked on.
+blockedOnStep describes the step of the flow that the flow is blocked on.
 .
 
 OutputFormatJson				name OutputFormatJSON
@@ -66,9 +66,10 @@ FlowInvokeEnvelopeMessageRetry		omit
 FlowInvokeEnvelopeMessageSchedule	omit
 FlowInvokeEnvelopeMessageStart		omit
 FlowInvokeEnvelopeMessageState		omit
+FlowInvokeEnvelopeMessageRunScheduled omit
 Operation						omit
 
-FlowStateExecution				name FlowExecution
+FlowStateExecution				name flowExecution
 FlowStateExecution.startTime	type gtime.Milliseconds
 FlowStateExecution.endTime		type gtime.Milliseconds
 

--- a/go/genkit/schemas.config
+++ b/go/genkit/schemas.config
@@ -46,10 +46,7 @@ GenerationCommonConfig.topK	type int
 
 GenerateRequestOutputFormat	name OutputFormat
 
-OperationBlockedOnStep			name blockedOnStep
-OperationBlockedOnStep			doc
-blockedOnStep describes the step of the flow that the flow is blocked on.
-.
+OperationBlockedOnStep			omit
 
 OutputFormatJson				name OutputFormatJSON
 

--- a/go/genkit/tracing.go
+++ b/go/genkit/tracing.go
@@ -103,7 +103,7 @@ func runInNewSpan[I, O any](
 	f func(context.Context, I) (O, error),
 ) (O, error) {
 	// TODO(jba): support span links.
-	log := logger(ctx)
+	log := Logger(ctx)
 	log.Debug("span start", "name", name)
 	defer log.Debug("span end", "name", name)
 	sm := &spanMetadata{

--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -110,7 +110,7 @@ func (r *retriever) Index(ctx context.Context, req *ai.IndexerRequest) error {
 		}
 
 		if _, ok := r.data[id]; ok {
-			genkit.DebugLog(ctx, "localvec skipping document because already present", "id", id)
+			genkit.Logger(ctx).Debug("localvec skipping document because already present", "id", id)
 			continue
 		}
 


### PR DESCRIPTION
- Export Logger, remove DebugLog.

- Simplify the doc for Flow.

- Unexport more symbols that users shouldn't need.
