### PR TITLE
[Docs] Fix config -> options for  firestore retriever

### DIFF
--- a/docs/plugins/firebase.md
+++ b/docs/plugins/firebase.md
@@ -100,7 +100,7 @@ To use it, pass it to the `retrieve()` function:
 const docs = await retrieve({
   retriever: yourRetrieverRef,
   query: "look for something",
-  config: {limit: 5},
+  options: {limit: 5},
 });
 ```
 


### PR DESCRIPTION
The correct field for passing custom options is `options`. For Issue #212 

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [X] Docs updated
