### PR TITLE
Add ajv-formats to schema validation

### DIFF
--- a/js/core/package.json
+++ b/js/core/package.json
@@ -32,6 +32,7 @@
     "@opentelemetry/sdk-node": "^0.49.0",
     "@opentelemetry/sdk-trace-base": "^1.22.0",
     "ajv": "^8.12.0",
+    "ajv-formats": "^3.0.1",
     "async-mutex": "^0.5.0",
     "express": "^4.19.2",
     "json-schema": "^0.4.0",

--- a/js/core/src/schema.ts
+++ b/js/core/src/schema.ts
@@ -15,10 +15,12 @@
  */
 
 import Ajv, { ErrorObject, JSONSchemaType } from 'ajv';
+import addFormats from 'ajv-formats';
 import { z } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 import { GenkitError } from './error.js';
 const ajv = new Ajv();
+addFormats(ajv);
 
 export { z }; // provide a consistent zod to use throughout genkit
 export type JSONSchema = JSONSchemaType<any> | any;

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -67,6 +67,12 @@ describe('validate()', () => {
       errors: [{ path: 'foo', message: 'must be boolean' }],
     },
     {
+      it: 'should allow for date types',
+      schema: z.object({ date: z.string().datetime() }),
+      data: { date: "2024-05-22T17:00:00Z" },
+      valid: true,
+    },
+    {
       it: 'should return dotted path for errors',
       schema: z.object({ foo: z.array(z.object({ bar: z.boolean() })) }),
       data: { foo: [{ bar: 123 }] },


### PR DESCRIPTION
Adds ajv-format to support JSON schema types. Fixes #227

Checklist (if applicable):
- [X ] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
