### PR TITLE
Recursively look for `.prompt` files in specified dir

### DIFF
--- a/js/plugins/dotprompt/src/index.ts
+++ b/js/plugins/dotprompt/src/index.ts
@@ -28,6 +28,11 @@ import { loadPromptFolder, lookupPrompt } from './registry.js';
 export { defineDotprompt, Dotprompt };
 
 export interface DotpromptPluginOptions {
+  // Directory to look for .prompt files.
+  //
+  // Note: This directory will be searched recursively, and any sub-directory
+  // paths will be included in the prompt name. E.g. - if a prompt file is
+  // located at `<dir>/foo/bar.prompt`, the prompt name will be `foo-bar`.
   dir: string;
 }
 


### PR DESCRIPTION
Recursively looks for any `.prompt` file within the configured prompt directory, instead of just in the immediate folder.

<img width="244" alt="image" src="https://github.com/firebase/genkit/assets/844249/0959a7d1-f55d-4b02-b26c-330fc66a4f9b">

<img width="343" alt="image" src="https://github.com/firebase/genkit/assets/844249/72ef103e-54ae-43d8-acb2-069349ae7ca6">

Fixes https://github.com/firebase/genkit/issues/210.