### PR TITLE
[Go] shell scripts for Cloud Run

### DIFF
--- a/go/samples/cloud_run_deploy.sh
+++ b/go/samples/cloud_run_deploy.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# This script deploys a sample to Cloud Run.
+# Run it from this directory (go/samples).
+# For example
+#
+#    cloud_run_deploy.sh coffee-shop
+#
+# will deploy the coffee-shop sample as a Cloud Run service
+# named genkit-coffee-shop.
+
+sample="$1"
+
+if [ -z "$sample" ]; then
+  echo >&2 "usage: $0 SAMPLE"
+  exit 1
+fi
+
+if [ ! -d "$sample" ]; then
+  echo >&2 "$sample is not a subdirectory of the samples directory."
+  exit 1
+fi 
+
+if [ -z "$GCLOUD_PROJECT" ]; then
+  echo >&2 "Set GCLOUD_PROJECT to your project name."
+  exit 1
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+if [ -z "repo_root" ]; then
+  echo >&2 "Could not determine git repo root directory; are you in a git repo?"
+  exit 1
+fi
+
+location=${GCLOUD_LOCATION:-us-central1}
+
+image=${location}-docker.pkg.dev/$GCLOUD_PROJECT/cloud-run-source-deploy/genkit-${sample}
+
+gcloud --project "$GCLOUD_PROJECT" builds submit \
+  --pack image=${image},env=GOOGLE_BUILDABLE=./samples/${sample} \
+  "${repo_root}/go"

--- a/go/samples/cloud_run_request.sh
+++ b/go/samples/cloud_run_request.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# This script makes a request to a sample application deployed
+# to cloud run.
+# Run it from this directory.
+#
+# For example, after deploying the coffee-shop example (see
+# cloud_run_deploy.sh):
+#
+#    cloud_run_request.sh coffee-shop simpleGreeting '{"customerName": "Pat"}'   
+#
+# will request the genkit-coffee-shop Cloud Run service to invoke the simpleGreeting flow
+# with the third argument as input.
+
+if [ $# -ne 3 ]; then 
+  echo >&2 "usage: $0 SAMPLE FLOW INPUT"
+  exit 1
+fi
+
+sample=$1
+flow=$2
+input=$3
+
+if [ ! -d "$sample" ]; then
+  echo >&2 "$sample is not a subdirectory of the samples directory."
+  exit 1
+fi 
+
+if [ -z "$GCLOUD_PROJECT" ]; then
+  echo >&2 "Set GCLOUD_PROJECT to your project name."
+  exit 1
+fi
+
+token=$(gcloud auth print-identity-token)
+if [ -z "$token" ]; then
+  echo >&2 "could not obtain identity token; have you logged in with 'gcloud auth'?"
+  exit 1
+fi
+
+url=$(gcloud run services describe genkit-${sample} --format 'value(status.url)')
+if [ -z "$url}" ]; then
+  echo >&2 "could not get URL of Cloud Run service genkit-${sample}; are you sure it is deployed?"
+  exit 1
+fi
+
+curl -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $token" \
+  -d  "$input" \
+  "$url/$flow"


### PR DESCRIPTION
Cloud Run deployment is more complicated in Go than Javascript,
so provide a shell script to simplify it and serve as a working
example.

Also add a shell script to make a request to a deployed service.
