### PR TITLE
[Go] fix go generate

### DIFF
--- a/go/ai/gen.go
+++ b/go/ai/gen.go
@@ -28,6 +28,20 @@ type Candidate struct {
 	Usage         *GenerationUsage `json:"usage,omitempty"`
 }
 
+type CandidateError struct {
+	Code    CandidateErrorCode `json:"code,omitempty"`
+	Index   float64            `json:"index,omitempty"`
+	Message string             `json:"message,omitempty"`
+}
+
+type CandidateErrorCode string
+
+const (
+	CandidateErrorCodeBlocked CandidateErrorCode = "blocked"
+	CandidateErrorCodeOther   CandidateErrorCode = "other"
+	CandidateErrorCodeUnknown CandidateErrorCode = "unknown"
+)
+
 // FinishReason is the reason why a model stopped generating tokens.
 type FinishReason string
 
@@ -39,10 +53,16 @@ const (
 	FinishReasonUnknown FinishReason = "unknown"
 )
 
+type DataPart struct {
+	Data     any            `json:"data,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
 // A GenerateRequest is a request to generate completions from a model.
 type GenerateRequest struct {
-	Candidates int `json:"candidates,omitempty"`
-	Config     any `json:"config,omitempty"`
+	Candidates int   `json:"candidates,omitempty"`
+	Config     any   `json:"config,omitempty"`
+	Context    []any `json:"context,omitempty"`
 	// Messages is a list of messages to pass to the model. The first n-1 Messages
 	// are treated as history. The last Message is the current request.
 	Messages []*Message             `json:"messages,omitempty"`
@@ -62,16 +82,24 @@ type GenerateRequestOutput struct {
 type OutputFormat string
 
 const (
-	OutputFormatJSON OutputFormat = "json"
-	OutputFormatText OutputFormat = "text"
+	OutputFormatJSON  OutputFormat = "json"
+	OutputFormatText  OutputFormat = "text"
+	OutputFormatMedia OutputFormat = "media"
 )
 
 // A GenerateResponse is a model's response to a [GenerateRequest].
 type GenerateResponse struct {
 	Candidates []*Candidate     `json:"candidates,omitempty"`
 	Custom     any              `json:"custom,omitempty"`
+	LatencyMs  float64          `json:"latencyMs,omitempty"`
 	Request    *GenerateRequest `json:"request,omitempty"`
 	Usage      *GenerationUsage `json:"usage,omitempty"`
+}
+
+type GenerateResponseChunk struct {
+	Content []*Part `json:"content,omitempty"`
+	Custom  any     `json:"custom,omitempty"`
+	Index   float64 `json:"index,omitempty"`
 }
 
 // GenerationCommonConfig holds configuration for generation.
@@ -86,14 +114,20 @@ type GenerationCommonConfig struct {
 
 // GenerationUsage provides information about the generation process.
 type GenerationUsage struct {
-	Custom       map[string]float64 `json:"custom,omitempty"`
-	InputTokens  float64            `json:"inputTokens,omitempty"`
-	OutputTokens float64            `json:"outputTokens,omitempty"`
-	TotalTokens  float64            `json:"totalTokens,omitempty"`
+	Custom           map[string]float64 `json:"custom,omitempty"`
+	InputCharacters  float64            `json:"inputCharacters,omitempty"`
+	InputImages      float64            `json:"inputImages,omitempty"`
+	InputTokens      float64            `json:"inputTokens,omitempty"`
+	OutputCharacters float64            `json:"outputCharacters,omitempty"`
+	OutputImages     float64            `json:"outputImages,omitempty"`
+	OutputTokens     float64            `json:"outputTokens,omitempty"`
+	TotalTokens      float64            `json:"totalTokens,omitempty"`
 }
 
 type mediaPart struct {
-	Media *mediaPartMedia `json:"media,omitempty"`
+	Data     any             `json:"data,omitempty"`
+	Media    *mediaPartMedia `json:"media,omitempty"`
+	Metadata map[string]any  `json:"metadata,omitempty"`
 }
 
 type mediaPartMedia struct {
@@ -105,6 +139,21 @@ type mediaPartMedia struct {
 type Message struct {
 	Content []*Part `json:"content,omitempty"`
 	Role    Role    `json:"role,omitempty"`
+}
+
+type ModelInfo struct {
+	Label    string             `json:"label,omitempty"`
+	Supports *ModelInfoSupports `json:"supports,omitempty"`
+	Versions []string           `json:"versions,omitempty"`
+}
+
+type ModelInfoSupports struct {
+	Context    bool         `json:"context,omitempty"`
+	Media      bool         `json:"media,omitempty"`
+	Multiturn  bool         `json:"multiturn,omitempty"`
+	Output     OutputFormat `json:"output,omitempty"`
+	SystemRole bool         `json:"systemRole,omitempty"`
+	Tools      bool         `json:"tools,omitempty"`
 }
 
 // Role indicates which entity is responsible for the content of a message.
@@ -123,11 +172,13 @@ const (
 )
 
 type textPart struct {
-	Text string `json:"text,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+	Text     string         `json:"text,omitempty"`
 }
 
 // A ToolDefinition describes a tool.
 type ToolDefinition struct {
+	Description string `json:"description,omitempty"`
 	// Valid JSON Schema representing the input of the tool.
 	InputSchema map[string]any `json:"inputSchema,omitempty"`
 	Name        string         `json:"name,omitempty"`

--- a/go/genkit/schemas.config
+++ b/go/genkit/schemas.config
@@ -124,9 +124,13 @@ by the model in a [ToolRequest].
 .
 
 Candidate						pkg ai
+CandidateError					pkg ai
+CandidateErrorCode				pkg ai
 CandidateFinishReason			pkg ai
+DataPart						pkg ai
 DocumentData					pkg ai
 GenerateResponse				pkg ai
+GenerateResponseChunk			pkg ai
 GenerateRequest					pkg ai
 GenerateRequestOutput			pkg ai
 GenerateRequestOutputFormat		pkg ai
@@ -144,14 +148,25 @@ ToolResponsePartToolResponse	pkg ai
 Part							pkg ai
 TextPart						pkg ai
 TextPart						name textPart
+TextPart.data					omit
+TextPart.media					omit
+TextPart.toolRequest			omit
+TextPart.toolResponse			omit
 MediaPart						pkg ai
 MediaPart						name mediaPart
+MediaPart.text					omit
+MediaPart.toolRequest			omit
+MediaPart.toolResponse			omit
 MediaPartMedia					pkg ai
 MediaPartMedia					name mediaPartMedia
+ModelInfo						pkg ai
+ModelInfoSupports				pkg ai
+ModelInfoSupports.output  		type OutputFormat
 Role							pkg ai
 RoleUser						pkg ai
 RoleModel						pkg ai
 RoleTool						pkg ai
+
 
 
 GenerateRequestOutput doc
@@ -180,3 +195,4 @@ ToolDefinition doc
 A ToolDefinition describes a tool.
 .
 
+DataPart/properties/metadata	name map[string]any


### PR DESCRIPTION
Some new types were added, and a new aspect of JSON Schema
that the code generator didn't know about.

The new aspect is that a "$ref" can refer to a property
inside a schema. The code generator still doesn't understand
these, but the config file handles them by ignoring them or
replacing them with another type.
