### PR TITLE
fix: passthrough streaming callback on dotprompt render

### DIFF
--- a/js/plugins/dotprompt/src/prompt.ts
+++ b/js/plugins/dotprompt/src/prompt.ts
@@ -175,6 +175,7 @@ export class Dotprompt<Variables = unknown> implements PromptMetadata {
         jsonSchema: options.output?.jsonSchema || this.output?.jsonSchema,
       },
       tools: (options.tools || []).concat(this.tools || []),
+      streamingCallback: options.streamingCallback,
     };
   }
 

--- a/js/plugins/dotprompt/tests/prompt_test.ts
+++ b/js/plugins/dotprompt/tests/prompt_test.ts
@@ -90,6 +90,16 @@ describe('Prompt', () => {
         await invalidSchemaPrompt.render({ input: { foo: 'baz' } });
       }, ValidationError);
     });
+
+    it('should render with streaming callback', async () => {
+      const prompt = testPrompt(`Hello {{name}}, how are you?`);
+
+      const streamingCallback = (c) => console.log(c);
+
+      const rendered = await prompt.render({ input: { name: 'Michael' }, streamingCallback});
+      assert.strictEqual(rendered.streamingCallback, streamingCallback);
+    });
+
   });
 
   describe('#generate', () => {


### PR DESCRIPTION
Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
