### PR TITLE
[Go] use "dotprompt" as the provider for dotprompt actions

### DIFF
--- a/go/plugins/dotprompt/genkit.go
+++ b/go/plugins/dotprompt/genkit.go
@@ -153,7 +153,7 @@ func (p *Prompt) Register() error {
 		return err
 	}
 
-	core.RegisterAction(name, action)
+	core.RegisterAction("dotprompt", action)
 	return nil
 }
 


### PR DESCRIPTION
Corresponds to TypeScript PR #231.
