### PR TITLE
[Go] change embedder plugins to use Init and New

### DIFF
--- a/go/ai/document.go
+++ b/go/ai/document.go
@@ -31,101 +31,80 @@ type Document struct {
 // A Part is one part of a [Document]. This may be plain text or it
 // may be a URL (possibly a "data:" URL with embedded data).
 type Part struct {
-	kind         partKind
-	contentType  string        // valid for kind==blob
-	text         string        // valid for kind∈{text,blob}
-	toolRequest  *ToolRequest  // valid for kind==partToolRequest
-	toolResponse *ToolResponse // valid for kind==partToolResponse
+	Kind         PartKind      `json:"kind,omitempty"`
+	ContentType  string        `json:"contentType,omitempty"` // valid for kind==blob
+	Text         string        `json:"text,omitempty"`        // valid for kind∈{text,blob}
+	ToolRequest  *ToolRequest  `json:"toolreq,omitempty"`     // valid for kind==partToolRequest
+	ToolResponse *ToolResponse `json:"toolresp,omitempty"`    // valid for kind==partToolResponse
 }
 
-type partKind int8
+type PartKind int8
 
 const (
-	partText partKind = iota
-	partMedia
-	partData
-	partToolRequest
-	partToolResponse
+	PartText PartKind = iota
+	PartMedia
+	PartData
+	PartToolRequest
+	PartToolResponse
 )
 
 // NewTextPart returns a Part containing text.
 func NewTextPart(text string) *Part {
-	return &Part{kind: partText, text: text}
+	return &Part{Kind: PartText, ContentType: "plain/text", Text: text}
+}
+
+// NewJSONPart returns a Part containing JSON.
+func NewJSONPart(text string) *Part {
+	return &Part{Kind: PartText, ContentType: "application/json", Text: text}
 }
 
 // NewMediaPart returns a Part containing structured data described
 // by the given mimeType.
 func NewMediaPart(mimeType, contents string) *Part {
-	return &Part{kind: partMedia, contentType: mimeType, text: contents}
+	return &Part{Kind: PartMedia, ContentType: mimeType, Text: contents}
 }
 
 // NewDataPart returns a Part containing raw string data.
 func NewDataPart(contents string) *Part {
-	return &Part{kind: partData, text: contents}
+	return &Part{Kind: PartData, Text: contents}
 }
 
 // NewToolRequestPart returns a Part containing a request from
 // the model to the client to run a Tool.
 // (Only genkit plugins should need to use this function.)
 func NewToolRequestPart(r *ToolRequest) *Part {
-	return &Part{kind: partToolRequest, toolRequest: r}
+	return &Part{Kind: PartToolRequest, ToolRequest: r}
 }
 
 // NewToolResponsePart returns a Part containing the results
 // of applying a Tool that the model requested.
 func NewToolResponsePart(r *ToolResponse) *Part {
-	return &Part{kind: partToolResponse, toolResponse: r}
+	return &Part{Kind: PartToolResponse, ToolResponse: r}
 }
 
 // IsText reports whether the [Part] contains plain text.
 func (p *Part) IsText() bool {
-	return p.kind == partText
+	return p.Kind == PartText
 }
 
 // IsMedia reports whether the [Part] contains structured media data.
 func (p *Part) IsMedia() bool {
-	return p.kind == partMedia
+	return p.Kind == PartMedia
 }
 
 // IsData reports whether the [Part] contains unstructured data.
 func (p *Part) IsData() bool {
-	return p.kind == partData
+	return p.Kind == PartData
 }
 
 // IsToolRequest reports whether the [Part] contains a request to run a tool.
 func (p *Part) IsToolRequest() bool {
-	return p.kind == partToolRequest
+	return p.Kind == PartToolRequest
 }
 
 // IsToolResponse reports whether the [Part] contains the result of running a tool.
 func (p *Part) IsToolResponse() bool {
-	return p.kind == partToolResponse
-}
-
-// Text returns the text. This is either plain text or a URL.
-func (p *Part) Text() string {
-	return p.text
-}
-
-// ContentType returns the type of the content.
-// This is only interesting if IsBlob() is true.
-func (p *Part) ContentType() string {
-	if p.kind == partText {
-		return "text/plain"
-	}
-	return p.contentType
-}
-
-// ToolRequest returns a request from the model for the client to run a tool.
-// Valid only if [IsToolRequest] is true.
-func (p *Part) ToolRequest() *ToolRequest {
-	return p.toolRequest
-}
-
-// ToolResponse returns the tool response the client is sending to the model.
-// Valid only if [IsToolResponse] is true.
-func (p *Part) ToolResponse() *ToolResponse {
-	return p.toolResponse
+	return p.Kind == PartToolResponse
 }
 
 // MarshalJSON is called by the JSON marshaler to write out a Part.
@@ -133,44 +112,44 @@ func (p *Part) MarshalJSON() ([]byte, error) {
 	// This is not handled by the schema generator because
 	// Part is defined in TypeScript as a union.
 
-	switch p.kind {
-	case partText:
+	switch p.Kind {
+	case PartText:
 		v := textPart{
-			Text: p.text,
+			Text: p.Text,
 		}
 		return json.Marshal(v)
-	case partMedia:
+	case PartMedia:
 		v := mediaPart{
 			Media: &mediaPartMedia{
-				ContentType: p.contentType,
-				Url:         p.text,
+				ContentType: p.ContentType,
+				Url:         p.Text,
 			},
 		}
 		return json.Marshal(v)
-	case partData:
+	case PartData:
 		v := dataPart{
-			Data: p.text,
+			Data: p.Text,
 		}
 		return json.Marshal(v)
-	case partToolRequest:
+	case PartToolRequest:
 		// TODO: make sure these types marshal/unmarshal nicely
 		// between Go and javascript. At the very least the
 		// field name needs to change (here and in UnmarshalJSON).
 		v := struct {
 			ToolReq *ToolRequest `json:"toolreq,omitempty"`
 		}{
-			ToolReq: p.toolRequest,
+			ToolReq: p.ToolRequest,
 		}
 		return json.Marshal(v)
-	case partToolResponse:
+	case PartToolResponse:
 		v := struct {
 			ToolResp *ToolResponse `json:"toolresp,omitempty"`
 		}{
-			ToolResp: p.toolResponse,
+			ToolResp: p.ToolResponse,
 		}
 		return json.Marshal(v)
 	default:
-		return nil, fmt.Errorf("invalid part kind %v", p.kind)
+		return nil, fmt.Errorf("invalid part kind %v", p.Kind)
 	}
 }
 
@@ -193,23 +172,23 @@ func (p *Part) UnmarshalJSON(b []byte) error {
 
 	switch {
 	case s.Media != nil:
-		p.kind = partMedia
-		p.text = s.Media.Url
-		p.contentType = s.Media.ContentType
+		p.Kind = PartMedia
+		p.Text = s.Media.Url
+		p.ContentType = s.Media.ContentType
 	case s.ToolReq != nil:
-		p.kind = partToolRequest
-		p.toolRequest = s.ToolReq
+		p.Kind = PartToolRequest
+		p.ToolRequest = s.ToolReq
 	case s.ToolResp != nil:
-		p.kind = partToolResponse
-		p.toolResponse = s.ToolResp
+		p.Kind = PartToolResponse
+		p.ToolResponse = s.ToolResp
 	default:
-		p.kind = partText
-		p.text = s.Text
-		p.contentType = ""
+		p.Kind = PartText
+		p.Text = s.Text
+		p.ContentType = ""
 		if s.Data != "" {
 			// Note: if part is completely empty, we use text by default.
-			p.kind = partData
-			p.text = s.Data
+			p.Kind = PartData
+			p.Text = s.Data
 		}
 	}
 	return nil
@@ -220,9 +199,9 @@ func (p *Part) UnmarshalJSON(b []byte) error {
 func DocumentFromText(text string, metadata map[string]any) *Document {
 	return &Document{
 		Content: []*Part{
-			&Part{
-				kind: partText,
-				text: text,
+			{
+				Kind: PartText,
+				Text: text,
 			},
 		},
 		Metadata: metadata,

--- a/go/ai/document_test.go
+++ b/go/ai/document_test.go
@@ -32,7 +32,7 @@ func TestDocumentFromText(t *testing.T) {
 	if !p.IsText() {
 		t.Errorf("IsText() == %t, want %t", p.IsText(), true)
 	}
-	if got := p.Text(); got != data {
+	if got := p.Text; got != data {
 		t.Errorf("Data() == %q, want %q", got, data)
 	}
 }
@@ -42,28 +42,28 @@ func TestDocumentJSON(t *testing.T) {
 	d := Document{
 		Content: []*Part{
 			&Part{
-				kind: partText,
-				text: "hi",
+				Kind: PartText,
+				Text: "hi",
 			},
 			&Part{
-				kind:        partMedia,
-				contentType: "text/plain",
-				text:        "data:,bye",
+				Kind:        PartMedia,
+				ContentType: "text/plain",
+				Text:        "data:,bye",
 			},
 			&Part{
-				kind: partData,
-				text: "somedata\x00string",
+				Kind: PartData,
+				Text: "somedata\x00string",
 			},
 			&Part{
-				kind: partToolRequest,
-				toolRequest: &ToolRequest{
+				Kind: PartToolRequest,
+				ToolRequest: &ToolRequest{
 					Name:  "tool1",
 					Input: map[string]any{"arg1": 3.3, "arg2": "foo"},
 				},
 			},
 			&Part{
-				kind: partToolResponse,
-				toolResponse: &ToolResponse{
+				Kind: PartToolResponse,
+				ToolResponse: &ToolResponse{
 					Name:   "tool1",
 					Output: map[string]any{"res1": 4.4, "res2": "bar"},
 				},
@@ -83,22 +83,22 @@ func TestDocumentJSON(t *testing.T) {
 	}
 
 	cmpPart := func(a, b *Part) bool {
-		if a.kind != b.kind {
+		if a.Kind != b.Kind {
 			return false
 		}
-		switch a.kind {
-		case partText:
-			return a.text == b.text
-		case partMedia:
-			return a.contentType == b.contentType && a.text == b.text
-		case partData:
-			return a.text == b.text
-		case partToolRequest:
-			return reflect.DeepEqual(a.toolRequest, b.toolRequest)
-		case partToolResponse:
-			return reflect.DeepEqual(a.toolResponse, b.toolResponse)
+		switch a.Kind {
+		case PartText:
+			return a.Text == b.Text
+		case PartMedia:
+			return a.ContentType == b.ContentType && a.Text == b.Text
+		case PartData:
+			return a.Text == b.Text
+		case PartToolRequest:
+			return reflect.DeepEqual(a.ToolRequest, b.ToolRequest)
+		case PartToolResponse:
+			return reflect.DeepEqual(a.ToolResponse, b.ToolResponse)
 		default:
-			t.Fatalf("bad part kind %v", a.kind)
+			t.Fatalf("bad part kind %v", a.Kind)
 			return false
 		}
 	}

--- a/go/ai/generator.go
+++ b/go/ai/generator.go
@@ -16,12 +16,15 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/logger"
 )
 
 // Generator is the interface used to query an AI model.
@@ -70,14 +73,24 @@ func RegisterGenerator(provider, name string, metadata *GeneratorMetadata, gener
 }
 
 // Generate applies a [Generator] to some input, handling tool requests.
-func Generate(ctx context.Context, g Generator, input *GenerateRequest, cb func(context.Context, *Candidate) error) (*GenerateResponse, error) {
+func Generate(ctx context.Context, g Generator, req *GenerateRequest, cb func(context.Context, *Candidate) error) (*GenerateResponse, error) {
+	if err := conformOutput(req); err != nil {
+		return nil, err
+	}
+
 	for {
-		resp, err := g.Generate(ctx, input, cb)
+		resp, err := g.Generate(ctx, req, cb)
 		if err != nil {
 			return nil, err
 		}
 
-		newReq, err := handleToolRequest(ctx, input, resp)
+		candidates, err := validCandidates(ctx, resp)
+		if err != nil {
+			return nil, err
+		}
+		resp.Candidates = candidates
+
+		newReq, err := handleToolRequest(ctx, req, resp)
 		if err != nil {
 			return nil, err
 		}
@@ -85,7 +98,7 @@ func Generate(ctx context.Context, g Generator, input *GenerateRequest, cb func(
 			return resp, nil
 		}
 
-		input = newReq
+		req = newReq
 	}
 }
 
@@ -115,14 +128,24 @@ type generatorAction struct {
 // Generate implements Generator. This is like the [Generate] function,
 // but invokes the [core.Action] rather than invoking the Generator
 // directly.
-func (ga *generatorAction) Generate(ctx context.Context, input *GenerateRequest, cb func(context.Context, *Candidate) error) (*GenerateResponse, error) {
+func (ga *generatorAction) Generate(ctx context.Context, req *GenerateRequest, cb func(context.Context, *Candidate) error) (*GenerateResponse, error) {
+	if err := conformOutput(req); err != nil {
+		return nil, err
+	}
+
 	for {
-		resp, err := ga.action.Run(ctx, input, cb)
+		resp, err := ga.action.Run(ctx, req, cb)
 		if err != nil {
 			return nil, err
 		}
 
-		newReq, err := handleToolRequest(ctx, input, resp)
+		candidates, err := validCandidates(ctx, resp)
+		if err != nil {
+			return nil, err
+		}
+		resp.Candidates = candidates
+
+		newReq, err := handleToolRequest(ctx, req, resp)
 		if err != nil {
 			return nil, err
 		}
@@ -130,8 +153,83 @@ func (ga *generatorAction) Generate(ctx context.Context, input *GenerateRequest,
 			return resp, nil
 		}
 
-		input = newReq
+		req = newReq
 	}
+}
+
+// conformOutput appends a message to the request indicating conformance to the expected schema.
+func conformOutput(req *GenerateRequest) error {
+	if req.Output.Format == OutputFormatJSON && len(req.Messages) > 0 {
+		jsonBytes, err := json.Marshal(req.Output.Schema)
+		if err != nil {
+			return fmt.Errorf("expected schema is not valid: %w", err)
+		}
+
+		escapedJSON := strconv.Quote(string(jsonBytes))
+		part := NewTextPart(fmt.Sprintf("Output should be in JSON format and conform to the following schema:\n\n```%s```", escapedJSON))
+		req.Messages[len(req.Messages)-1].Content = append(req.Messages[len(req.Messages)-1].Content, part)
+	}
+	return nil
+}
+
+// validCandidates finds all candidates that match the expected schema.
+// It will strip JSON markdown delimiters from the response.
+func validCandidates(ctx context.Context, resp *GenerateResponse) ([]*Candidate, error) {
+	var candidates []*Candidate
+	for i, c := range resp.Candidates {
+		c, err := validCandidate(c, resp.Request.Output)
+		if err == nil {
+			candidates = append(candidates, c)
+		} else {
+			logger.FromContext(ctx).Debug("candidate did not match expected schema", "index", i, "error", err.Error())
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, errors.New("generation resulted in no candidates matching expected schema")
+	}
+	return candidates, nil
+}
+
+// validCandidate will validate the candidate's response against the expected schema.
+// It will return an error if it does not match, otherwise it will return a candidate with JSON content and type.
+func validCandidate(c *Candidate, output *GenerateRequestOutput) (*Candidate, error) {
+	if output.Format == OutputFormatJSON {
+		text, err := c.Text()
+		if err != nil {
+			return nil, err
+		}
+		text = stripJSONDelimiters(text)
+		var schemaBytes []byte
+		schemaBytes, err = json.Marshal(output.Schema)
+		if err != nil {
+			return nil, fmt.Errorf("expected schema is not valid: %w", err)
+		}
+		if err = core.ValidateRaw([]byte(text), schemaBytes); err != nil {
+			return nil, err
+		}
+		// TODO: Verify that it okay to replace all content with JSON.
+		c.Message.Content = []*Part{NewJSONPart(text)}
+	}
+	return c, nil
+}
+
+// stripJSONDelimiters strips Markdown JSON delimiters that may come back in the response.
+func stripJSONDelimiters(s string) string {
+	s = strings.TrimSpace(s)
+	delimiters := []string{"```", "~~~"}
+	for _, delimiter := range delimiters {
+		if strings.HasPrefix(s, delimiter) && strings.HasSuffix(s, delimiter) {
+			s = strings.TrimPrefix(s, delimiter)
+			s = strings.TrimSuffix(s, delimiter)
+			s = strings.TrimSpace(s)
+			if strings.HasPrefix(s, "json") {
+				s = strings.TrimPrefix(s, "json")
+				s = strings.TrimSpace(s)
+			}
+			break
+		}
+	}
+	return s
 }
 
 // handleToolRequest checks if a tool was requested by a generator.
@@ -150,7 +248,7 @@ func handleToolRequest(ctx context.Context, req *GenerateRequest, resp *Generate
 		return nil, nil
 	}
 
-	toolReq := part.ToolRequest()
+	toolReq := part.ToolRequest
 	output, err := RunTool(ctx, toolReq.Name, toolReq.Input)
 	if err != nil {
 		return nil, err
@@ -180,19 +278,25 @@ func (gr *GenerateResponse) Text() (string, error) {
 	if len(gr.Candidates) == 0 {
 		return "", errors.New("no candidates returned")
 	}
-	msg := gr.Candidates[0].Message
+	return gr.Candidates[0].Text()
+}
+
+// Text returns the contents of a [Candidate] as a string. It
+// returns an error if the candidate has no message.
+func (c *Candidate) Text() (string, error) {
+	msg := c.Message
 	if msg == nil {
-		return "", errors.New("candidate with no message")
+		return "", errors.New("candidate has no message")
 	}
 	if len(msg.Content) == 0 {
 		return "", errors.New("candidate message has no content")
 	}
 	if len(msg.Content) == 1 {
-		return msg.Content[0].Text(), nil
+		return msg.Content[0].Text, nil
 	} else {
 		var sb strings.Builder
 		for _, p := range msg.Content {
-			sb.WriteString(p.Text())
+			sb.WriteString(p.Text)
 		}
 		return sb.String(), nil
 	}

--- a/go/ai/generator_test.go
+++ b/go/ai/generator_test.go
@@ -1,0 +1,203 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ai
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidCandidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Valid candidate with text format", func(t *testing.T) {
+		candidate := &Candidate{
+			Message: &Message{
+				Content: []*Part{
+					NewTextPart("Hello, World!"),
+				},
+			},
+		}
+		outputSchema := &GenerateRequestOutput{
+			Format: OutputFormatText,
+		}
+		_, err := validCandidate(candidate, outputSchema)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Valid candidate with JSON format and matching schema", func(t *testing.T) {
+		json := `{
+			"name": "John",
+			"age": 30,
+			"address": {
+				"street": "123 Main St",
+				"city": "New York",
+				"country": "USA"
+			}
+		}`
+		candidate := &Candidate{
+			Message: &Message{
+				Content: []*Part{
+					NewTextPart(JSONMarkdown(json)),
+				},
+			},
+		}
+		outputSchema := &GenerateRequestOutput{
+			Format: OutputFormatJSON,
+			Schema: map[string]any{
+				"type":     "object",
+				"required": []string{"name", "age", "address"},
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+					"age":  map[string]any{"type": "integer"},
+					"address": map[string]any{
+						"type":     "object",
+						"required": []string{"street", "city", "country"},
+						"properties": map[string]any{
+							"street":  map[string]any{"type": "string"},
+							"city":    map[string]any{"type": "string"},
+							"country": map[string]any{"type": "string"},
+						},
+					},
+					"phone": map[string]any{"type": "string"},
+				},
+			},
+		}
+		candidate, err := validCandidate(candidate, outputSchema)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text, err := candidate.Text()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if text != json {
+			t.Fatalf("got %q, want %q", json, text)
+		}
+	})
+
+	t.Run("Invalid candidate with JSON format and non-matching schema", func(t *testing.T) {
+		candidate := &Candidate{
+			Message: &Message{
+				Content: []*Part{
+					NewTextPart(JSONMarkdown(`{"name": "John", "age": "30"}`)),
+				},
+			},
+		}
+		outputSchema := &GenerateRequestOutput{
+			Format: OutputFormatJSON,
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+					"age":  map[string]any{"type": "integer"},
+				},
+			},
+		}
+		_, err := validCandidate(candidate, outputSchema)
+		errorContains(t, err, "data did not match expected schema")
+	})
+
+	t.Run("Candidate with invalid JSON", func(t *testing.T) {
+		candidate := &Candidate{
+			Message: &Message{
+				Content: []*Part{
+					NewTextPart(JSONMarkdown(`{"name": "John", "age": 30`)), // Missing trailing }.
+				},
+			},
+		}
+		outputSchema := &GenerateRequestOutput{
+			Format: OutputFormatJSON,
+		}
+		_, err := validCandidate(candidate, outputSchema)
+		errorContains(t, err, "data is not valid JSON")
+	})
+
+	t.Run("Candidate with no message", func(t *testing.T) {
+		candidate := &Candidate{}
+		outputSchema := &GenerateRequestOutput{
+			Format: OutputFormatJSON,
+		}
+		_, err := validCandidate(candidate, outputSchema)
+		errorContains(t, err, "candidate has no message")
+	})
+
+	t.Run("Candidate with message but no content", func(t *testing.T) {
+		candidate := &Candidate{
+			Message: &Message{},
+		}
+		outputSchema := &GenerateRequestOutput{
+			Format: OutputFormatJSON,
+		}
+		_, err := validCandidate(candidate, outputSchema)
+		errorContains(t, err, "candidate message has no content")
+	})
+
+	t.Run("Candidate contains unexpected field", func(t *testing.T) {
+		candidate := &Candidate{
+			Message: &Message{
+				Content: []*Part{
+					NewTextPart(JSONMarkdown(`{"name": "John", "height": 190}`)),
+				},
+			},
+		}
+		outputSchema := &GenerateRequestOutput{
+			Format: OutputFormatJSON,
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+					"age":  map[string]any{"type": "integer"},
+				},
+				"additionalProperties": false,
+			},
+		}
+		_, err := validCandidate(candidate, outputSchema)
+		errorContains(t, err, "data did not match expected schema")
+	})
+
+	t.Run("Invalid expected schema", func(t *testing.T) {
+		candidate := &Candidate{
+			Message: &Message{
+				Content: []*Part{
+					NewTextPart(JSONMarkdown(`{"name": "John", "age": 30}`)),
+				},
+			},
+		}
+		outputSchema := &GenerateRequestOutput{
+			Format: OutputFormatJSON,
+			Schema: map[string]any{
+				"type": "invalid",
+			},
+		}
+		_, err := validCandidate(candidate, outputSchema)
+		errorContains(t, err, "failed to validate data against expected schema")
+	})
+}
+
+func JSONMarkdown(text string) string {
+	return "```json\n" + text + "\n```"
+}
+
+func errorContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Error("got nil, want error")
+	} else if !strings.Contains(err.Error(), want) {
+		t.Errorf("got error message %q, want it to contain %q", err, want)
+	}
+}

--- a/go/core/validation.go
+++ b/go/core/validation.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/invopop/jsonschema"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// ValidateValue will validate any value against the expected schema.
+// It will return an error if it doesn't match the schema, otherwise it will return nil.
+func ValidateValue(data any, schema *jsonschema.Schema) error {
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("data is not a valid JSON type: %w", err)
+	}
+	return ValidateJSON(dataBytes, schema)
+}
+
+// ValidateJSON will validate JSON against the expected schema.
+// It will return an error if it doesn't match the schema, otherwise it will return nil.
+func ValidateJSON(dataBytes json.RawMessage, schema *jsonschema.Schema) error {
+	schemaBytes, err := schema.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("expected schema is not valid: %w", err)
+	}
+	return ValidateRaw(dataBytes, schemaBytes)
+}
+
+// ValidateRaw will validate JSON data against the JSON schema.
+// It will return an error if it doesn't match the schema, otherwise it will return nil.
+func ValidateRaw(dataBytes json.RawMessage, schemaBytes json.RawMessage) error {
+	var data any
+	// Do this check separately from below to get a better error message.
+	if err := json.Unmarshal(dataBytes, &data); err != nil {
+		return fmt.Errorf("data is not valid JSON: %w", err)
+	}
+
+	schemaLoader := gojsonschema.NewBytesLoader(schemaBytes)
+	documentLoader := gojsonschema.NewBytesLoader(dataBytes)
+
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		return fmt.Errorf("failed to validate data against expected schema: %w", err)
+	}
+
+	if !result.Valid() {
+		var errors []string
+		for _, err := range result.Errors() {
+			errors = append(errors, fmt.Sprintf("- %s", err))
+		}
+		return fmt.Errorf("data did not match expected schema:\n%s", strings.Join(errors, "\n"))
+	}
+
+	return nil
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/invopop/jsonschema v0.12.0
 	github.com/jba/slog v0.2.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8
+	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/metric v1.26.0
 	go.opentelemetry.io/otel/sdk v1.26.0
@@ -49,6 +50,8 @@ require (
 	github.com/googleapis/gax-go/v2 v2.12.3 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -93,8 +93,6 @@ github.com/googleapis/gax-go/v2 v2.12.3 h1:5/zPPDvw8Q1SuXjrqrZslrqT7dL/uJT2CQii/
 github.com/googleapis/gax-go/v2 v2.12.3/go.mod h1:AKloxT6GtNbaLm8QTNSidHUVsHYcBHwWRvkNFJUQcS4=
 github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=
 github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
-github.com/jba/slog v0.1.0 h1:m7pbPxGRvFcQy4vONykm/9X+0Fx4FGEDl7A6E/C/z9Q=
-github.com/jba/slog v0.1.0/go.mod h1:R9u+1Qbl7LcDnJaFNIPer+AJa3yK9eZ8SQUE4waKFiw=
 github.com/jba/slog v0.2.0 h1:jI0U5NRR3EJKGsbeEVpItJNogk0c4RMeCl7vJmogCJI=
 github.com/jba/slog v0.2.0/go.mod h1:0Dh7Vyz3Td68Z1OwzadfincHwr7v+PpzadrS2Jua338=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -112,6 +110,7 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -119,6 +118,12 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 h1:4Pp6oUg3+e/6M4C0A/3kJ2VYa++dsWVTtGgLVj5xtHg=

--- a/go/plugins/dotprompt/genkit_test.go
+++ b/go/plugins/dotprompt/genkit_test.go
@@ -25,7 +25,7 @@ import (
 type testGenerator struct{}
 
 func (testGenerator) Generate(ctx context.Context, req *ai.GenerateRequest, cb func(context.Context, *ai.Candidate) error) (*ai.GenerateResponse, error) {
-	input := req.Messages[0].Content[0].Text()
+	input := req.Messages[0].Content[0].Text
 	output := fmt.Sprintf("AI reply to %q", input)
 
 	r := &ai.GenerateResponse{
@@ -69,7 +69,7 @@ func TestExecute(t *testing.T) {
 			t.FailNow()
 		}
 	}
-	got := msg.Content[0].Text()
+	got := msg.Content[0].Text
 	want := `AI reply to "TestExecute"`
 	if got != want {
 		t.Errorf("fake generator replied with %q, want %q", got, want)

--- a/go/plugins/dotprompt/render.go
+++ b/go/plugins/dotprompt/render.go
@@ -41,7 +41,7 @@ func (p *Prompt) RenderText(variables map[string]any) (string, error) {
 		if !part.IsText() {
 			return "", errors.New("RenderText: multi-modal prompt can't be rendered as text")
 		}
-		sb.WriteString(part.Text())
+		sb.WriteString(part.Text)
 	}
 	return sb.String(), nil
 }

--- a/go/plugins/dotprompt/render_test.go
+++ b/go/plugins/dotprompt/render_test.go
@@ -201,10 +201,10 @@ func TestRenderMessages(t *testing.T) {
 		if a.IsText() != b.IsText() {
 			return false
 		}
-		if a.Text() != b.Text() {
+		if a.Text != b.Text {
 			return false
 		}
-		if a.ContentType() != b.ContentType() {
+		if a.ContentType != b.ContentType {
 			return false
 		}
 		return true

--- a/go/plugins/googleai/embed.go
+++ b/go/plugins/googleai/embed.go
@@ -36,7 +36,7 @@ func (e *embedder) Embed(ctx context.Context, input *ai.EmbedRequest) ([]float32
 	return res.Embedding.Values, nil
 }
 
-// NewEmbedder returns an embedder which can compute the embedding
+// NewEmbedder returns an [ai.Embedder] that can compute the embedding
 // of an input document given the Google AI model.
 func NewEmbedder(ctx context.Context, model, apiKey string) (ai.Embedder, error) {
 	client, err := newClient(ctx, apiKey)

--- a/go/plugins/googleai/googleai.go
+++ b/go/plugins/googleai/googleai.go
@@ -235,19 +235,19 @@ func convertParts(parts []*ai.Part) []genai.Part {
 func convertPart(p *ai.Part) genai.Part {
 	switch {
 	case p.IsText():
-		return genai.Text(p.Text())
+		return genai.Text(p.Text)
 	case p.IsMedia():
-		return genai.Blob{MIMEType: p.ContentType(), Data: []byte(p.Text())}
+		return genai.Blob{MIMEType: p.ContentType, Data: []byte(p.Text)}
 	case p.IsData():
 		panic("googleai does not support Data parts")
 	case p.IsToolResponse():
-		toolResp := p.ToolResponse()
+		toolResp := p.ToolResponse
 		return genai.FunctionResponse{
 			Name:     toolResp.Name,
 			Response: toolResp.Output,
 		}
 	case p.IsToolRequest():
-		toolReq := p.ToolRequest()
+		toolReq := p.ToolRequest
 		return genai.FunctionCall{
 			Name: toolReq.Name,
 			Args: toolReq.Input,

--- a/go/plugins/googleai/googleai.go
+++ b/go/plugins/googleai/googleai.go
@@ -188,7 +188,7 @@ func translateResponse(resp *genai.GenerateContentResponse) *ai.GenerateResponse
 	return r
 }
 
-// NewGenerator returns an action which sends a request to
+// NewGenerator returns an [ai.Generator] which sends a request to
 // the google AI model and returns the response.
 func NewGenerator(ctx context.Context, model, apiKey string) (ai.Generator, error) {
 	client, err := newClient(ctx, apiKey)
@@ -201,7 +201,7 @@ func NewGenerator(ctx context.Context, model, apiKey string) (ai.Generator, erro
 	}, nil
 }
 
-// Init registers all the actions in this package with ai.
+// Init registers all the actions in this package with [ai]'s Register calls.
 func Init(ctx context.Context, model, apiKey string) error {
 	e, err := NewEmbedder(ctx, model, apiKey)
 	if err != nil {

--- a/go/plugins/googleai/googleai_test.go
+++ b/go/plugins/googleai/googleai_test.go
@@ -83,7 +83,7 @@ func TestGenerator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	out := resp.Candidates[0].Message.Content[0].Text()
+	out := resp.Candidates[0].Message.Content[0].Text
 	if out != "France" {
 		t.Errorf("got \"%s\", expecting \"France\"", out)
 	}
@@ -115,7 +115,7 @@ func TestGeneratorStreaming(t *testing.T) {
 	parts := 0
 	_, err = g.Generate(ctx, req, func(ctx context.Context, c *ai.Candidate) error {
 		parts++
-		out += c.Message.Content[0].Text()
+		out += c.Message.Content[0].Text
 		return nil
 	})
 	if err != nil {
@@ -193,7 +193,7 @@ func TestGeneratorTool(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out := resp.Candidates[0].Message.Content[0].Text()
+	out := resp.Candidates[0].Message.Content[0].Text
 	if !strings.Contains(out, "12.25") {
 		t.Errorf("got %s, expecting it to contain \"12.25\"", out)
 	}

--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -34,6 +34,16 @@ import (
 	"github.com/firebase/genkit/go/core/logger"
 )
 
+// Init register an action to be used with ai.
+func Init(ctx context.Context, dir, name string, embedder ai.Embedder, embedderOptions any) error {
+	r, err := New(ctx, dir, name, embedder, embedderOptions)
+	if err != nil {
+		return err
+	}
+	ai.RegisterRetriever("devLocalVectorStore/"+name, r)
+	return nil
+}
+
 // New returns a new local vector database. This will register a new
 // retriever with genkit, and also return it.
 // This retriever may only be used by a single goroutine at a time.
@@ -43,7 +53,6 @@ func New(ctx context.Context, dir, name string, embedder ai.Embedder, embedderOp
 	if err != nil {
 		return nil, err
 	}
-	ai.RegisterRetriever("devLocalVectorStore/"+name, r)
 	return r, nil
 }
 

--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -34,7 +34,7 @@ import (
 	"github.com/firebase/genkit/go/core/logger"
 )
 
-// Init register an action to be used with ai.
+// Init registers all the actions in this package with [ai]'s Register calls.
 func Init(ctx context.Context, dir, name string, embedder ai.Embedder, embedderOptions any) error {
 	r, err := New(ctx, dir, name, embedder, embedderOptions)
 	if err != nil {

--- a/go/plugins/localvec/localvec_test.go
+++ b/go/plugins/localvec/localvec_test.go
@@ -82,7 +82,7 @@ func TestLocalVec(t *testing.T) {
 		t.Errorf("got %d results, expected 2", len(docs))
 	}
 	for _, d := range docs {
-		text := d.Content[0].Text()
+		text := d.Content[0].Text
 		if !strings.HasPrefix(text, "hello") {
 			t.Errorf("returned doc text %q does not start with %q", text, "hello")
 		}

--- a/go/plugins/pinecone/genkit.go
+++ b/go/plugins/pinecone/genkit.go
@@ -36,7 +36,19 @@ import (
 // documents in pinecone.
 const defaultTextKey = "_content"
 
-// Init registers actions to be used with ai.
+// Init registers an action to be used with ai.
+//
+// The arguments are as for [New].
+func Init(ctx context.Context, apiKey, host string, embedder ai.Embedder, embedderOptions any, textKey string) error {
+	r, err := New(ctx, apiKey, host, embedder, embedderOptions, textKey)
+	if err != nil {
+		return err
+	}
+	ai.RegisterRetriever("pinecone", r)
+	return nil
+}
+
+// New returns an [ai.Retriever] that uses Pinecone.
 //
 // apiKey is the API key to use to access Pinecone.
 // If it is the empty string, it is read from the PINECONE_API_INDEX
@@ -50,17 +62,7 @@ const defaultTextKey = "_content"
 //
 // The textKey parameter is the metadata key to use to store document text
 // in Pinecone; the default is "_content".
-func Init(ctx context.Context, apiKey, host string, embedder ai.Embedder, embedderOptions any, textKey string) error {
-	r, err := newRetriever(ctx, apiKey, host, embedder, embedderOptions, textKey)
-	if err != nil {
-		return err
-	}
-	ai.RegisterRetriever("pinecone", r)
-	return nil
-}
-
-// newRetriever returns a new ai.Retriever to register.
-func newRetriever(ctx context.Context, apiKey, host string, embedder ai.Embedder, embedderOptions any, textKey string) (ai.Retriever, error) {
+func New(ctx context.Context, apiKey, host string, embedder ai.Embedder, embedderOptions any, textKey string) (ai.Retriever, error) {
 	client, err := NewClient(ctx, apiKey)
 	if err != nil {
 		return nil, err

--- a/go/plugins/pinecone/genkit.go
+++ b/go/plugins/pinecone/genkit.go
@@ -36,7 +36,7 @@ import (
 // documents in pinecone.
 const defaultTextKey = "_content"
 
-// Init registers an action to be used with ai.
+// Init registers all the actions in this package with [ai]'s Register calls.
 //
 // The arguments are as for [New].
 func Init(ctx context.Context, apiKey, host string, embedder ai.Embedder, embedderOptions any, textKey string) error {

--- a/go/plugins/pinecone/genkit.go
+++ b/go/plugins/pinecone/genkit.go
@@ -151,7 +151,7 @@ func (r *retriever) Index(ctx context.Context, req *ai.IndexerRequest) error {
 		// but it loses the structure of the document.
 		var sb strings.Builder
 		for _, p := range doc.Content {
-			sb.WriteString(p.Text())
+			sb.WriteString(p.Text)
 		}
 		metadata[r.textKey] = sb.String()
 

--- a/go/plugins/pinecone/genkit_test.go
+++ b/go/plugins/pinecone/genkit_test.go
@@ -72,7 +72,7 @@ func TestGenkit(t *testing.T) {
 	embedder.Register(d2, v2)
 	embedder.Register(d3, v3)
 
-	r, err := newRetriever(ctx, *testAPIKey, indexData.Host, embedder, nil, "")
+	r, err := New(ctx, *testAPIKey, indexData.Host, embedder, nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/plugins/pinecone/genkit_test.go
+++ b/go/plugins/pinecone/genkit_test.go
@@ -132,7 +132,7 @@ func TestGenkit(t *testing.T) {
 		t.Errorf("got %d results, expected 2", len(docs))
 	}
 	for _, d := range docs {
-		text := d.Content[0].Text()
+		text := d.Content[0].Text
 		if !strings.HasPrefix(text, "hello") {
 			t.Errorf("returned doc text %q does not start with %q", text, "hello")
 		}

--- a/go/plugins/vertexai/embed.go
+++ b/go/plugins/vertexai/embed.go
@@ -35,8 +35,8 @@ type embedder struct {
 	client    *aiplatform.PredictionClient
 }
 
-// EmbedOptions is options for the Vertex AI embedder.
-// Set [ai.EmbedRequest].Options to a value of type &EmbedOptions.
+// EmbedOptions are options for the Vertex AI embedder.
+// Set [ai.EmbedRequest.Options] to a value of type *[EmbedOptions].
 type EmbedOptions struct {
 	// Document title.
 	Title string `json:"title,omitempty"`

--- a/go/plugins/vertexai/embed.go
+++ b/go/plugins/vertexai/embed.go
@@ -59,7 +59,7 @@ func (e *embedder) Embed(ctx context.Context, req *ai.EmbedRequest) ([]float32, 
 	instances := make([]*structpb.Value, 0, len(req.Document.Content))
 	for _, part := range req.Document.Content {
 		fields := map[string]any{
-			"content": part.Text(),
+			"content": part.Text,
 		}
 		if title != "" {
 			fields["title"] = title

--- a/go/plugins/vertexai/vertexai.go
+++ b/go/plugins/vertexai/vertexai.go
@@ -161,7 +161,7 @@ func translateResponse(resp *genai.GenerateContentResponse) *ai.GenerateResponse
 	return r
 }
 
-// NewGenerator returns an action which sends a request to
+// NewGenerator returns an [ai.Generator] which sends a request to
 // the vertex AI model and returns the response.
 func NewGenerator(ctx context.Context, model, projectID, location string) (ai.Generator, error) {
 	client, err := newClient(ctx, projectID, location)
@@ -174,7 +174,7 @@ func NewGenerator(ctx context.Context, model, projectID, location string) (ai.Ge
 	}, nil
 }
 
-// Init registers all the actions in this package with ai.
+// Init registers all the actions in this package with [ai]'s Register calls.
 func Init(ctx context.Context, model, projectID, location string) error {
 	g, err := NewGenerator(ctx, model, projectID, location)
 	if err != nil {

--- a/go/plugins/vertexai/vertexai.go
+++ b/go/plugins/vertexai/vertexai.go
@@ -203,19 +203,19 @@ func convertParts(parts []*ai.Part) []genai.Part {
 func convertPart(p *ai.Part) genai.Part {
 	switch {
 	case p.IsText():
-		return genai.Text(p.Text())
+		return genai.Text(p.Text)
 	case p.IsMedia():
-		return genai.Blob{MIMEType: p.ContentType(), Data: []byte(p.Text())}
+		return genai.Blob{MIMEType: p.ContentType, Data: []byte(p.Text)}
 	case p.IsData():
 		panic("vertexai does not support Data parts")
 	case p.IsToolResponse():
-		toolResp := p.ToolResponse()
+		toolResp := p.ToolResponse
 		return genai.FunctionResponse{
 			Name:     toolResp.Name,
 			Response: toolResp.Output,
 		}
 	case p.IsToolRequest():
-		toolReq := p.ToolRequest()
+		toolReq := p.ToolRequest
 		return genai.FunctionCall{
 			Name: toolReq.Name,
 			Args: toolReq.Input,

--- a/go/plugins/vertexai/vertexai_test.go
+++ b/go/plugins/vertexai/vertexai_test.go
@@ -56,7 +56,7 @@ func TestGenerator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	out := resp.Candidates[0].Message.Content[0].Text()
+	out := resp.Candidates[0].Message.Content[0].Text
 	if !strings.Contains(out, "France") {
 		t.Errorf("got \"%s\", expecting it would contain \"France\"", out)
 	}
@@ -128,7 +128,7 @@ func TestGeneratorTool(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out := resp.Candidates[0].Message.Content[0].Text()
+	out := resp.Candidates[0].Message.Content[0].Text
 	if !strings.Contains(out, "12.25") {
 		t.Errorf("got %s, expecting it to contain \"12.25\"", out)
 	}

--- a/go/samples/coffee-shop/main.go
+++ b/go/samples/coffee-shop/main.go
@@ -19,12 +19,7 @@
 //
 //	go run . &
 //
-// Tell it to run an action. Here are some examples:
-//
-//  Flow without input:
-//
-//	curl -d '{"key":"/flow/testAllCoffeeFlows/testAllCoffeeFlows", "input":{"start": {"input":null}}}'  http://localhost:3100/api/runAction
-//  Flow with input:
+// Tell it to run a flow:
 //
 //	curl -d '{"key":"/flow/simpleGreeting/simpleGreeting", "input":{"start": {"input":{"customerName": "John Doe"}}}}' http://localhost:3100/api/runAction
 //

--- a/go/samples/flow-sample1/main.go
+++ b/go/samples/flow-sample1/main.go
@@ -17,9 +17,19 @@
 //
 //	go run . &
 //
-// Tell it to run an action:
+// Tell it to run a flow:
 //
-//	curl -d '{"key":"/flow/parent/parent", "input":{"start": {"input":null}}}'  http://localhost:3100/api/runAction
+//	curl -d '{"key":"/flow/parent/parent", "input":{"start": {"input":null}}}' http://localhost:3100/api/runAction
+//
+// In production mode (GENKIT_ENV missing or set to "prod"):
+// Start the server listening on port 3400:
+//
+//	go run . &
+//
+// Tell it to run a flow:
+//
+// curl -d '{}' http://localhost:3400/parent
+
 package main
 
 import (

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -1,0 +1,156 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This program can be manually tested like so:
+//
+// In development mode (with the environment variable GENKIT_ENV="dev"):
+// Start the server listening on port 3100:
+//
+//	go run . &
+//
+// Tell it to run a flow:
+//
+//	curl -d '{"key":"/flow/simpleQaFlow/simpleQaFlow", "input":{"start": {"input":{"question": "What is the capital of UK?"}}}}' http://localhost:3100/api/runAction
+//
+// In production mode (GENKIT_ENV missing or set to "prod"):
+// Start the server listening on port 3400:
+//
+//	go run . &
+//
+// Tell it to run a flow:
+//
+//   curl -d '{"question": "What is the capital of UK?"}' http://localhost:3400/simpleQaFlow
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/dotprompt"
+	"github.com/firebase/genkit/go/plugins/googleai"
+	"github.com/firebase/genkit/go/plugins/localvec"
+	"github.com/invopop/jsonschema"
+)
+
+const simpleQaPromptTemplate = `
+You're a helpful agent that answers the user's common questions based on the context provided.
+
+Here is the user's query: {{query}}
+
+Here is the context you should use: {{context}}
+
+Please provide the best answer you can.
+`
+
+type simpleQaInput struct {
+	Question string `json:"question"`
+}
+
+type simpleQaPromptInput struct {
+	Query   string `json:"query"`
+	Context string `json:"context"`
+}
+
+func main() {
+	apiKey := os.Getenv("GOOGLE_GENAI_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "rag example requires setting GOOGLE_GENAI_API_KEY in the environment.")
+		fmt.Fprintln(os.Stderr, "You can get an API key at https://ai.google.dev.")
+		os.Exit(1)
+	}
+
+	if err := googleai.Init(context.Background(), "gemini-1.0-pro", apiKey); err != nil {
+		log.Fatal(err)
+	}
+
+	simpleQaPrompt, err := dotprompt.Define("simpleQaPrompt",
+		simpleQaPromptTemplate,
+		&dotprompt.Config{
+			Model:        "google-genai/gemini-1.0-pro",
+			InputSchema:  jsonschema.Reflect(simpleQaPromptInput{}),
+			OutputFormat: ai.OutputFormatText,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	embedder, err := googleai.NewEmbedder(context.Background(), "embedding-001", apiKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	localDb, err := localvec.New(context.Background(), os.TempDir(), "simpleQa", embedder, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	genkit.DefineFlow("simpleQaFlow", func(ctx context.Context, input *simpleQaInput, _ genkit.NoStream) (string, error) {
+		d1 := ai.DocumentFromText("Paris is the capital of France", nil)
+		d2 := ai.DocumentFromText("USA is the largest importer of coffee", nil)
+		d3 := ai.DocumentFromText("Water exists in 3 states - solid, liquid and gas", nil)
+
+		indexerReq := &ai.IndexerRequest{
+			Documents: []*ai.Document{d1, d2, d3},
+		}
+		err := localDb.Index(ctx, indexerReq)
+		if err != nil {
+			return "", err
+		}
+
+		dRequest := ai.DocumentFromText(input.Question, nil)
+		retrieverReq := &ai.RetrieverRequest{
+			Document: dRequest,
+		}
+		response, err := localDb.Retrieve(ctx, retrieverReq)
+		if err != nil {
+			return "", err
+		}
+
+		var sb strings.Builder
+		for _, d := range response.Documents {
+			sb.WriteString(d.Content[0].Text())
+			sb.WriteByte('\n')
+		}
+
+		promptInput := &simpleQaPromptInput{
+			Query:   input.Question,
+			Context: sb.String(),
+		}
+
+		vars, err := simpleQaPrompt.BuildVariables(promptInput)
+		if err != nil {
+			return "", err
+		}
+		ai := &dotprompt.ActionInput{Variables: vars}
+		resp, err := simpleQaPrompt.Execute(ctx, ai)
+		if err != nil {
+			return "", err
+		}
+		text, err := resp.Text()
+		if err != nil {
+			return "", fmt.Errorf("simpleQa: %v", err)
+		}
+		return text, nil
+	})
+
+	if err := genkit.StartFlowServer(""); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Change the pinecone and localvec plugins to use a `New` function that
returns an `ai.Retriever`, and an `Init` function that registers one with genkit.

This makes the pinecone and localvec plugins consistent with each other,
and with other plugins such as googleai.
