### PR TITLE
Add array of toolNames to CreatePromptRequest

### DIFF
--- a/genkit-tools/common/src/server/router.ts
+++ b/genkit-tools/common/src/server/router.ts
@@ -140,6 +140,7 @@ export const TOOLS_SERVER_ROUTER = (runner: Runner) =>
         const frontmatter: PromptFrontmatter = {
           model: input.model,
           config: input.config,
+          tools: input.toolNames,
         };
         return fromMessages(frontmatter, input.messages);
       }),

--- a/genkit-tools/common/src/types/apis.ts
+++ b/genkit-tools/common/src/types/apis.ts
@@ -93,6 +93,7 @@ export const CreatePromptRequestSchema = z.object({
   model: z.string(),
   messages: z.array(MessageSchema),
   config: GenerationCommonConfigSchema.passthrough().optional(),
+  toolNames: z.array(z.string()).optional(),
 });
 
 export type CreatePromptRequest = z.infer<typeof CreatePromptRequestSchema>;


### PR DESCRIPTION
Adding the `toolNames` property to `CreatePromptRequestSchema` which will then get passed to the PromptFormatter used to export prompts from the Prompt Runner and Model Runner. I used the property `toolNames` instead of `tools` to prevent incompatibility with the `main` branch of the genkit-ui which sends `tools` as a `ToolDefinitionSchema` object.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
Manually tested without UI changes to ensure this is a non-breaking change
- [ ] Changelog updated
- [ ] Docs updated
