### PR TITLE
[Go] Reuse the same file in localvec when indexing

### DIFF
--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -134,7 +134,7 @@ func (r *retriever) Index(ctx context.Context, req *ai.IndexerRequest) error {
 	}
 
 	// Update the file every time we add documents.
-	tmpname := r.filename + ".tmp"
+	tmpname := r.filename
 	f, err := os.Create(tmpname)
 	if err != nil {
 		return err

--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -134,7 +134,9 @@ func (r *retriever) Index(ctx context.Context, req *ai.IndexerRequest) error {
 	}
 
 	// Update the file every time we add documents.
-	tmpname := r.filename
+	// We use a temporary file to avoid losing the original
+	// file, in case of a crash.
+	tmpname := r.filename + ".tmp"
 	f, err := os.Create(tmpname)
 	if err != nil {
 		return err
@@ -144,6 +146,9 @@ func (r *retriever) Index(ctx context.Context, req *ai.IndexerRequest) error {
 		return err
 	}
 	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpname, r.filename); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Make LocalVec use the same DB file across runs.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
