### PR TITLE
[Go] retrieve and index calls are always actions

### DIFF
--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -34,16 +34,6 @@ import (
 	"github.com/firebase/genkit/go/core/logger"
 )
 
-// Init registers all the actions in this package with [ai]'s Register calls.
-func Init(ctx context.Context, dir, name string, embedder ai.Embedder, embedderOptions any) error {
-	r, err := New(ctx, dir, name, embedder, embedderOptions)
-	if err != nil {
-		return err
-	}
-	ai.RegisterRetriever("devLocalVectorStore/"+name, r)
-	return nil
-}
-
 // New returns a new local vector database. This will register a new
 // retriever with genkit, and also return it.
 // This retriever may only be used by a single goroutine at a time.
@@ -53,7 +43,7 @@ func New(ctx context.Context, dir, name string, embedder ai.Embedder, embedderOp
 	if err != nil {
 		return nil, err
 	}
-	return r, nil
+	return ai.DefineRetriever("devLocalVectorStore/"+name, r.Index, r.Retrieve), nil
 }
 
 // retriever implements the [ai.Retriever] interface

--- a/go/plugins/pinecone/genkit.go
+++ b/go/plugins/pinecone/genkit.go
@@ -36,18 +36,6 @@ import (
 // documents in pinecone.
 const defaultTextKey = "_content"
 
-// Init registers all the actions in this package with [ai]'s Register calls.
-//
-// The arguments are as for [New].
-func Init(ctx context.Context, apiKey, host string, embedder ai.Embedder, embedderOptions any, textKey string) error {
-	r, err := New(ctx, apiKey, host, embedder, embedderOptions, textKey)
-	if err != nil {
-		return err
-	}
-	ai.RegisterRetriever("pinecone", r)
-	return nil
-}
-
 // New returns an [ai.Retriever] that uses Pinecone.
 //
 // apiKey is the API key to use to access Pinecone.
@@ -80,7 +68,9 @@ func New(ctx context.Context, apiKey, host string, embedder ai.Embedder, embedde
 		embedderOptions: embedderOptions,
 		textKey:         textKey,
 	}
-	return r, nil
+
+	// index := func(ctx context.Context, req *ai.IndexerRequest) error {
+	return ai.DefineRetriever("pinecone", r.Index, r.Retrieve), nil
 }
 
 // IndexerOptions may be passed in the Options field


### PR DESCRIPTION
Add ai.DefineRetriever, which creates and registers core.Actions for
the index and retrieve methods of a vector DB.

Remove RegisterRetriever.

Remove the Init functions from our vector DB plugins.
Instead, the New functions return a Retriever that supports
actions directly.

There is no longer a way to create a Retriever that doesn't
use actions.
