### PR TITLE
Update path variant logic to store paths in a new trace-scoped async local storage

### DIFF
--- a/js/core/src/tracing/instrumentation.ts
+++ b/js/core/src/tracing/instrumentation.ts
@@ -99,13 +99,13 @@ export async function runInNewSpan<T>(
 
         opts.metadata.path = decoratePathWithSubtype(opts.metadata);
         if (pathCount == getCurrentPathCount()) {
-          getCurrentTrace().paths?.add(opts.metadata.path);
+          traceMetadataAls.getStore()?.paths?.add(opts.metadata.path);
         }
 
         return output;
       } catch (e) {
         opts.metadata.path = decoratePathWithSubtype(opts.metadata);
-        getCurrentTrace().paths?.add(opts.metadata.path);
+        traceMetadataAls.getStore()?.paths?.add(opts.metadata.path);
         opts.metadata.state = 'error';
         otSpan.setStatus({
           code: SpanStatusCode.ERROR,
@@ -188,16 +188,8 @@ function getCurrentSpan(): SpanMetadata {
   return step;
 }
 
-function getCurrentTrace(): TraceMetadata {
-  const trace = traceMetadataAls.getStore();
-  if (!trace) {
-    throw new Error('running outside trace context');
-  }
-  return trace;
-}
-
 function getCurrentPathCount(): number {
-  return getCurrentTrace().paths?.size || 0;
+  return traceMetadataAls.getStore()?.paths?.size || 0;
 }
 
 function decoratePathWithSubtype(metadata: SpanMetadata): string {

--- a/js/core/src/tracing/types.ts
+++ b/js/core/src/tracing/types.ts
@@ -35,6 +35,11 @@ export interface TraceStore {
   list(query?: TraceQuery): Promise<TraceQueryResponse>;
 }
 
+export const TraceMetadataSchema = z.object({
+  paths: z.set(z.string()).optional(),
+});
+export type TraceMetadata = z.infer<typeof TraceMetadataSchema>;
+
 export const SpanMetadataSchema = z.object({
   name: z.string(),
   state: z.enum(['success', 'error']).optional(),

--- a/js/flow/src/flow.ts
+++ b/js/flow/src/flow.ts
@@ -64,7 +64,6 @@ import {
   runWithActiveContext,
 } from './utils.js';
 
-
 const streamDelimiter = '\n';
 
 const CREATED_FLOWS = 'genkit__CREATED_FLOWS';

--- a/js/flow/src/flow.ts
+++ b/js/flow/src/flow.ts
@@ -64,7 +64,6 @@ import {
   runWithActiveContext,
 } from './utils.js';
 
-import { pathVariants } from '@genkit-ai/core/tracing';
 
 const streamDelimiter = '\n';
 
@@ -451,7 +450,6 @@ export class Flow<
             setCustomMetadataAttribute(metadataPrefix('state'), 'done');
             telemetry.writeFlowSuccess(
               ctx.flow.name,
-              pathVariants,
               performance.now() - startTimeMs
             );
             return output;
@@ -482,7 +480,6 @@ export class Flow<
               telemetry.recordError(e);
               telemetry.writeFlowFailure(
                 ctx.flow.name,
-                pathVariants,
                 performance.now() - startTimeMs,
                 e
               );


### PR DESCRIPTION
This allows us to keep the path variants written to metrics to be scoped to a single trace.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated

Co-authored-by: Konstantin Mandrika <kmandrika@google.com>