### PR TITLE
Follow up on prompt exporter

### DIFF
--- a/genkit-tools/common/src/server/router.ts
+++ b/genkit-tools/common/src/server/router.ts
@@ -138,9 +138,9 @@ export const TOOLS_SERVER_ROUTER = (runner: Runner) =>
       .input(apis.CreatePromptRequestSchema)
       .mutation(async ({ input }) => {
         const frontmatter: PromptFrontmatter = {
-          model: input.model,
+          model: input.model.replace('/model/', ''),
           config: input.config,
-          tools: input.toolNames,
+          tools: input.tools?.map((toolDefinition) => toolDefinition.name),
         };
         return fromMessages(frontmatter, input.messages);
       }),

--- a/genkit-tools/common/src/types/apis.ts
+++ b/genkit-tools/common/src/types/apis.ts
@@ -17,7 +17,11 @@
 import { z } from 'zod';
 import { EvalRunKeySchema } from './eval';
 import { FlowStateSchema } from './flow';
-import { GenerationCommonConfigSchema, MessageSchema } from './model';
+import {
+  GenerationCommonConfigSchema,
+  MessageSchema,
+  ToolDefinitionSchema,
+} from './model';
 import { TraceDataSchema } from './trace';
 
 /**
@@ -93,7 +97,7 @@ export const CreatePromptRequestSchema = z.object({
   model: z.string(),
   messages: z.array(MessageSchema),
   config: GenerationCommonConfigSchema.passthrough().optional(),
-  toolNames: z.array(z.string()).optional(),
+  tools: z.array(ToolDefinitionSchema).optional(),
 });
 
 export type CreatePromptRequest = z.infer<typeof CreatePromptRequestSchema>;


### PR DESCRIPTION
Modify the CreatePromptRequest to use the `tools` property sent via the front end's buildPrompt function rather than send tools data twice. This should be an non-breaking change to the UI, but will create a review ready PR when that's been tested.

Checklist (if applicable):
- [ ] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
