### PR TITLE
[Go] generate calls are always actions

### DIFF
--- a/go/core/action.go
+++ b/go/core/action.go
@@ -77,6 +77,16 @@ func defineAction[In, Out any](r *registry, name string, atype ActionType, metad
 	return a
 }
 
+func DefineStreamingAction[In, Out, Stream any](name string, atype ActionType, metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
+	return defineStreamingAction(globalRegistry, name, atype, metadata, fn)
+}
+
+func defineStreamingAction[In, Out, Stream any](r *registry, name string, atype ActionType, metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
+	a := NewStreamingAction(name, atype, metadata, fn)
+	r.registerAction(name, a)
+	return a
+}
+
 // NewAction creates a new Action with the given name and non-streaming function.
 func NewAction[In, Out any](name string, atype ActionType, metadata map[string]any, fn func(context.Context, In) (Out, error)) *Action[In, Out, struct{}] {
 	return NewStreamingAction(name, atype, metadata, func(ctx context.Context, in In, cb NoStream) (Out, error) {

--- a/go/plugins/dotprompt/dotprompt.go
+++ b/go/plugins/dotprompt/dotprompt.go
@@ -68,9 +68,6 @@ type Prompt struct {
 
 	// A hash of the prompt contents.
 	hash string
-
-	// A Generator to use. If not nil, this is used to execute the prompt.
-	generator ai.Generator
 }
 
 // Config is optional configuration for a [Prompt].
@@ -78,7 +75,12 @@ type Config struct {
 	// The prompt variant.
 	Variant string
 	// The name of the model for which the prompt is input.
+	// If this is non-empty, Generator should be nil.
 	Model string
+
+	// The Generator to use.
+	// If this is non-nil, Model should be the empty string.
+	Generator ai.Generator
 
 	// TODO(iant): document
 	Tools []*ai.ToolDefinition
@@ -267,7 +269,7 @@ func parseFrontmatter(data []byte) (name string, c Config, rest []byte, err erro
 
 // Define creates and registers a new Prompt. This can be called from code that
 // doesn't have a prompt file.
-func Define(name, templateText string, cfg *Config) (*Prompt, error) {
+func Define(name, templateText string, cfg Config) (*Prompt, error) {
 	p, err := New(name, templateText, cfg)
 	if err != nil {
 		return nil, err
@@ -279,12 +281,15 @@ func Define(name, templateText string, cfg *Config) (*Prompt, error) {
 // New creates a new Prompt without registering it.
 // This may be used for testing or for direct calls not using the
 // genkit action and flow mechanisms.
-func New(name, templateText string, cfg *Config) (*Prompt, error) {
-	if cfg == nil {
-		cfg = &Config{}
+func New(name, templateText string, cfg Config) (*Prompt, error) {
+	if cfg.Model == "" && cfg.Generator == nil {
+		return nil, errors.New("dotprompt.New: config must specify either Model or Generator")
+	}
+	if cfg.Model != "" && cfg.Generator != nil {
+		return nil, errors.New("dotprompt.New: config must specify exactly one of Model and Generator")
 	}
 	hash := fmt.Sprintf("%02x", sha256.Sum256([]byte(templateText)))
-	return newPrompt(name, templateText, hash, *cfg)
+	return newPrompt(name, templateText, hash, cfg)
 }
 
 // sortSchemaSlices sorts the slices in a jsonschema to permit

--- a/go/plugins/dotprompt/genkit.go
+++ b/go/plugins/dotprompt/genkit.go
@@ -142,7 +142,7 @@ func (p *Prompt) Generate(ctx context.Context, pr *ai.PromptRequest, cb func(con
 		return nil, err
 	}
 
-	generator := p.generator
+	generator := p.Generator
 	if generator == nil {
 		model := p.Model
 		if pr.Model != "" {
@@ -156,7 +156,7 @@ func (p *Prompt) Generate(ctx context.Context, pr *ai.PromptRequest, cb func(con
 			return nil, errors.New("dotprompt model not in provider/name format")
 		}
 
-		generator, err = ai.LookupGeneratorAction(provider, name)
+		generator, err = ai.LookupGenerator(provider, name)
 		if err != nil {
 			return nil, err
 		}

--- a/go/plugins/dotprompt/genkit_test.go
+++ b/go/plugins/dotprompt/genkit_test.go
@@ -30,7 +30,7 @@ func (testGenerator) Generate(ctx context.Context, req *ai.GenerateRequest, cb f
 
 	r := &ai.GenerateResponse{
 		Candidates: []*ai.Candidate{
-			&ai.Candidate{
+			{
 				Message: &ai.Message{
 					Content: []*ai.Part{
 						ai.NewTextPart(output),
@@ -44,11 +44,10 @@ func (testGenerator) Generate(ctx context.Context, req *ai.GenerateRequest, cb f
 }
 
 func TestExecute(t *testing.T) {
-	p, err := New("TestExecute", "TestExecute", nil)
+	p, err := New("TestExecute", "TestExecute", Config{Generator: testGenerator{}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.generator = testGenerator{}
 	resp, err := p.Generate(context.Background(), &ai.PromptRequest{}, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/go/plugins/googleai/googleai.go
+++ b/go/plugins/googleai/googleai.go
@@ -193,26 +193,14 @@ func NewGenerator(ctx context.Context, model, apiKey string) (ai.Generator, erro
 	if err != nil {
 		return nil, err
 	}
-	return &generator{
-		model:  model,
-		client: client,
-	}, nil
-}
-
-// Init registers all the actions in this package with [ai]'s Register calls.
-func Init(ctx context.Context, model, apiKey string) error {
-	g, err := NewGenerator(ctx, model, apiKey)
-	if err != nil {
-		return err
-	}
-	ai.RegisterGenerator("google-genai", model, &ai.GeneratorMetadata{
+	meta := &ai.GeneratorMetadata{
 		Label: "Google AI - " + model,
 		Supports: ai.GeneratorCapabilities{
 			Multiturn: true,
 		},
-	}, g)
-
-	return nil
+	}
+	g := generator{model: model, client: client}
+	return ai.DefineGenerator("google-genai", model, meta, g.Generate), nil
 }
 
 // convertParts converts a slice of *ai.Part to a slice of genai.Part.

--- a/go/plugins/vertexai/vertexai.go
+++ b/go/plugins/vertexai/vertexai.go
@@ -169,26 +169,14 @@ func NewGenerator(ctx context.Context, model, projectID, location string) (ai.Ge
 	if err != nil {
 		return nil, err
 	}
-	return &generator{
-		model:  model,
-		client: client,
-	}, nil
-}
-
-// Init registers all the actions in this package with [ai]'s Register calls.
-func Init(ctx context.Context, model, projectID, location string) error {
-	g, err := NewGenerator(ctx, model, projectID, location)
-	if err != nil {
-		return err
-	}
-	ai.RegisterGenerator("google-vertexai", model, &ai.GeneratorMetadata{
+	g := &generator{model: model, client: client}
+	meta := &ai.GeneratorMetadata{
 		Label: "Vertex AI - " + model,
 		Supports: ai.GeneratorCapabilities{
 			Multiturn: true,
 		},
-	}, g)
-
-	return nil
+	}
+	return ai.DefineGenerator("google-vertexai", model, meta, g.Generate), nil
 }
 
 // convertParts converts a slice of *ai.Part to a slice of genai.Part.

--- a/go/samples/coffee-shop/main.go
+++ b/go/samples/coffee-shop/main.go
@@ -105,13 +105,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := googleai.Init(context.Background(), "gemini-1.5-pro", apiKey); err != nil {
+	g, err := googleai.NewGenerator(context.Background(), "gemini-1.5-pro", apiKey)
+	if err != nil {
 		log.Fatal(err)
 	}
 
 	simpleGreetingPrompt, err := dotprompt.Define("simpleGreeting", simpleGreetingPromptTemplate,
-		&dotprompt.Config{
-			Model:        "google-genai/gemini-1.5-pro",
+		dotprompt.Config{
+			Generator:    g,
 			InputSchema:  jsonschema.Reflect(simpleGreetingInput{}),
 			OutputFormat: ai.OutputFormatText,
 		},
@@ -145,8 +146,8 @@ func main() {
 	})
 
 	greetingWithHistoryPrompt, err := dotprompt.Define("greetingWithHistory", greetingWithHistoryPromptTemplate,
-		&dotprompt.Config{
-			Model:        "google-genai/gemini-1.5-pro",
+		dotprompt.Config{
+			Generator:    g,
 			InputSchema:  jsonschema.Reflect(customerTimeAndHistoryInput{}),
 			OutputFormat: ai.OutputFormatText,
 		},
@@ -189,8 +190,8 @@ func main() {
 	}
 
 	simpleStructuredGreetingPrompt, err := dotprompt.Define("simpleStructuredGreeting", simpleStructuredGreetingPromptTemplate,
-		&dotprompt.Config{
-			Model:        "google-genai/gemini-1.5-pro",
+		dotprompt.Config{
+			Generator:    g,
 			InputSchema:  jsonschema.Reflect(simpleGreetingInput{}),
 			OutputFormat: ai.OutputFormatJSON,
 			OutputSchema: outputSchema,

--- a/go/samples/menu/main.go
+++ b/go/samples/menu/main.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/localvec"
 	"github.com/firebase/genkit/go/plugins/vertexai"
@@ -81,23 +80,21 @@ func main() {
 		location = env
 	}
 
-	if err := vertexai.Init(context.Background(), geminiPro, projectID, location); err != nil {
-		log.Fatal(err)
-	}
-
-	ctx := context.Background()
-	if err := setup01(ctx); err != nil {
-		log.Fatal(err)
-	}
-	if err := setup02(ctx); err != nil {
-		log.Fatal(err)
-	}
-
-	generator, err := ai.LookupGeneratorAction("google-vertexai", geminiPro)
+	gen, err := vertexai.NewGenerator(context.Background(), geminiPro, projectID, location)
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := setup03(ctx, generator); err != nil {
+	genVision, err := vertexai.NewGenerator(context.Background(), geminiPro+"-vision", projectID, location)
+
+	ctx := context.Background()
+	if err := setup01(ctx, gen); err != nil {
+		log.Fatal(err)
+	}
+	if err := setup02(ctx, gen); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := setup03(ctx, gen); err != nil {
 		log.Fatal(err)
 	}
 
@@ -109,11 +106,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := setup04(ctx, ds); err != nil {
+	if err := setup04(ctx, ds, gen); err != nil {
 		log.Fatal(err)
 	}
 
-	if err := setup05(ctx); err != nil {
+	if err := setup05(ctx, gen, genVision); err != nil {
 		log.Fatal(err)
 	}
 

--- a/go/samples/menu/s01.go
+++ b/go/samples/menu/s01.go
@@ -21,13 +21,13 @@ import (
 	"github.com/firebase/genkit/go/plugins/dotprompt"
 )
 
-func setup01(ctx context.Context) error {
+func setup01(ctx context.Context, g ai.Generator) error {
 	_, err := dotprompt.Define("s01_vanillaPrompt",
 		`You are acting as a helpful AI assistant named "Walt" that can answer
 		 questions about the food available on the menu at Walt's Burgers.
 		 Customer says: ${input.question}`,
-		&dotprompt.Config{
-			Model:       "google-vertexai/gemini-1.0-pro",
+		dotprompt.Config{
+			Generator:   g,
 			InputSchema: menuQuestionInputSchema,
 		},
 	)
@@ -66,8 +66,8 @@ func setup01(ctx context.Context) error {
 
 		 Question:
 		 {{question}} ?`,
-		&dotprompt.Config{
-			Model:        "google-vertexai/gemini-1.0-pro",
+		dotprompt.Config{
+			Generator:    g,
 			InputSchema:  menuQuestionInputSchema,
 			OutputFormat: ai.OutputFormatText,
 		},

--- a/go/samples/menu/s02.go
+++ b/go/samples/menu/s02.go
@@ -46,7 +46,7 @@ func menu(ctx context.Context, input map[string]any) (map[string]any, error) {
 	return map[string]any{"menu": s}, nil
 }
 
-func setup02(ctx context.Context) error {
+func setup02(ctx context.Context, g ai.Generator) error {
 	ai.RegisterTool("menu", menuToolDef, nil, menu)
 
 	dataMenuPrompt, err := dotprompt.Define("s02_dataMenu",
@@ -60,8 +60,8 @@ func setup02(ctx context.Context) error {
 
 		 Question:
 		 {{question}} ?`,
-		&dotprompt.Config{
-			Model:        "google-vertexai/gemini-1.0-pro",
+		dotprompt.Config{
+			Generator:    g,
 			InputSchema:  menuQuestionInputSchema,
 			OutputFormat: ai.OutputFormatText,
 			Tools: []*ai.ToolDefinition{

--- a/go/samples/menu/s03.go
+++ b/go/samples/menu/s03.go
@@ -71,8 +71,8 @@ func setup03(ctx context.Context, generator ai.Generator) error {
 		    {{this.description}}
 		  {{~/each}}
 		  Do you have any questions about the menu?`,
-		&dotprompt.Config{
-			Model:        "google-vertexai/gemini-1.0-pro",
+		dotprompt.Config{
+			Generator:    generator,
 			InputSchema:  dataMenuQuestionInputSchema,
 			OutputFormat: ai.OutputFormatText,
 			GenerationConfig: &ai.GenerationCommonConfig{

--- a/go/samples/menu/s04.go
+++ b/go/samples/menu/s04.go
@@ -24,7 +24,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/localvec"
 )
 
-func setup04(ctx context.Context, docstore ai.DocumentStore) error {
+func setup04(ctx context.Context, docstore ai.DocumentStore, gen ai.Generator) error {
 	ragDataMenuPrompt, err := dotprompt.Define("s04_ragDataMenu",
 		`
 		  You are acting as Walt, a helpful AI assistant here at the restaurant.
@@ -40,8 +40,8 @@ func setup04(ctx context.Context, docstore ai.DocumentStore) error {
 
 		  Answer this customer's question:
 		  {{question}}?`,
-		&dotprompt.Config{
-			Model:        "google-vertexai/gemini-1.0-pro",
+		dotprompt.Config{
+			Generator:    gen,
 			InputSchema:  dataMenuQuestionInputSchema,
 			OutputFormat: ai.OutputFormatText,
 			GenerationConfig: &ai.GenerationCommonConfig{

--- a/go/samples/menu/s05.go
+++ b/go/samples/menu/s05.go
@@ -29,15 +29,15 @@ type imageURLInput struct {
 	ImageURL string `json:"imageUrl"`
 }
 
-func setup05(ctx context.Context) error {
+func setup05(ctx context.Context, gen, genVision ai.Generator) error {
 	readMenuPrompt, err := dotprompt.Define("s05_readMenu",
 		`
 		  Extract _all_ of the text, in order,
 		  from the following image of a restaurant menu.
 
 		  {{media url=imageUrl}}`,
-		&dotprompt.Config{
-			Model:        "google-vertexai/gemini-1.0-pro-vision",
+		dotprompt.Config{
+			Generator:    genVision,
 			InputSchema:  jsonschema.Reflect(imageURLInput{}),
 			OutputFormat: ai.OutputFormatText,
 			GenerationConfig: &ai.GenerationCommonConfig{
@@ -61,8 +61,8 @@ func setup05(ctx context.Context) error {
 		  Answer this customer's question:
 		  {{question}}?
 		`,
-		&dotprompt.Config{
-			Model:        "google-vertexai/gemini-1.0-pro",
+		dotprompt.Config{
+			Generator:    gen,
 			InputSchema:  textMenuQuestionInputSchema,
 			OutputFormat: ai.OutputFormatText,
 			GenerationConfig: &ai.GenerationCommonConfig{

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -76,14 +76,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := googleai.Init(context.Background(), "gemini-1.0-pro", apiKey); err != nil {
+	g, err := googleai.NewGenerator(context.Background(), "gemini-1.0-pro", apiKey)
+	if err != nil {
 		log.Fatal(err)
 	}
 
 	simpleQaPrompt, err := dotprompt.Define("simpleQaPrompt",
 		simpleQaPromptTemplate,
-		&dotprompt.Config{
-			Model:        "google-genai/gemini-1.0-pro",
+		dotprompt.Config{
+			Generator:    g,
 			InputSchema:  jsonschema.Reflect(simpleQaPromptInput{}),
 			OutputFormat: ai.OutputFormatText,
 		},


### PR DESCRIPTION
Add ai.DefineGenerator, which wraps a generate function in an action.

This allowed some simplification and deduplication in the ai package's
generate code.

- Rename LookupGeneratorAction to LookupGenerator.

- Add a Generator config option to dotprompt so that model
  lookup by string can be avoided.
