### PR TITLE
Normalize to type/provider/name pattern for action names.

### DIFF
--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -35,8 +35,8 @@ type EmbedRequest struct {
 
 // DefineEmbedder registers the given embed function as an action, and returns an
 // [Embedder] whose Embed method runs it.
-func DefineEmbedder(name string, embed func(context.Context, *EmbedRequest) ([]float32, error)) Embedder {
-	return embedder{core.DefineAction(name, core.ActionTypeEmbedder, nil, embed)}
+func DefineEmbedder(provider, name string, embed func(context.Context, *EmbedRequest) ([]float32, error)) Embedder {
+	return embedder{core.DefineAction(provider, name, core.ActionTypeEmbedder, nil, embed)}
 }
 
 type embedder struct {

--- a/go/ai/generator.go
+++ b/go/ai/generator.go
@@ -70,7 +70,7 @@ func DefineGenerator(provider, name string, metadata *GeneratorMetadata, generat
 		}
 		metadataMap["supports"] = supports
 	}
-	a := core.DefineStreamingAction(provider+"/"+name, core.ActionTypeModel, map[string]any{
+	a := core.DefineStreamingAction(provider, name, core.ActionTypeModel, map[string]any{
 		"model": metadataMap,
 	}, generate)
 	return generator{a}

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -56,10 +56,10 @@ func DefineDocumentStore(
 	index func(context.Context, *IndexerRequest) error,
 	retrieve func(context.Context, *RetrieverRequest) (*RetrieverResponse, error),
 ) DocumentStore {
-	ia := core.DefineAction(name, core.ActionTypeIndexer, nil, func(ctx context.Context, req *IndexerRequest) (struct{}, error) {
+	ia := core.DefineAction("indexer", name, core.ActionTypeIndexer, nil, func(ctx context.Context, req *IndexerRequest) (struct{}, error) {
 		return struct{}{}, index(ctx, req)
 	})
-	ra := core.DefineAction(name, core.ActionTypeRetriever, nil, retrieve)
+	ra := core.DefineAction("retreiver", name, core.ActionTypeRetriever, nil, retrieve)
 	return &docStore{ia, ra}
 }
 

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -32,7 +32,7 @@ type Tool struct {
 }
 
 // RegisterTool registers a tool function.
-func RegisterTool(name string, definition *ToolDefinition, metadata map[string]any, fn func(ctx context.Context, input map[string]any) (map[string]any, error)) {
+func RegisterTool(definition *ToolDefinition, metadata map[string]any, fn func(ctx context.Context, input map[string]any) (map[string]any, error)) {
 	if len(metadata) > 0 {
 		metadata = maps.Clone(metadata)
 	}
@@ -41,7 +41,7 @@ func RegisterTool(name string, definition *ToolDefinition, metadata map[string]a
 	}
 	metadata["type"] = "tool"
 
-	core.DefineAction(definition.Name, core.ActionTypeTool, metadata, fn)
+	core.DefineAction("tool", definition.Name, core.ActionTypeTool, metadata, fn)
 }
 
 // toolActionType is the instantiated core.Action type registered

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -41,7 +41,7 @@ func RegisterTool(definition *ToolDefinition, metadata map[string]any, fn func(c
 	}
 	metadata["type"] = "tool"
 
-	core.DefineAction("tool", definition.Name, core.ActionTypeTool, metadata, fn)
+	core.DefineAction("local", definition.Name, core.ActionTypeTool, metadata, fn)
 }
 
 // toolActionType is the instantiated core.Action type registered
@@ -51,7 +51,7 @@ type toolActionType = core.Action[map[string]any, map[string]any, struct{}]
 // RunTool looks up a tool registered by [RegisterTool],
 // runs it with the given input, and returns the result.
 func RunTool(ctx context.Context, name string, input map[string]any) (map[string]any, error) {
-	action := core.LookupAction(core.ActionTypeTool, "tool", name)
+	action := core.LookupAction(core.ActionTypeTool, "local", name)
 	if action == nil {
 		return nil, fmt.Errorf("no tool named %q", name)
 	}

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -67,23 +67,23 @@ type Action[In, Out, Stream any] struct {
 // See js/core/src/action.ts
 
 // DefineAction creates a new Action and registers it.
-func DefineAction[In, Out any](name string, atype ActionType, metadata map[string]any, fn func(context.Context, In) (Out, error)) *Action[In, Out, struct{}] {
-	return defineAction(globalRegistry, name, atype, metadata, fn)
+func DefineAction[In, Out any](provider, name string, atype ActionType, metadata map[string]any, fn func(context.Context, In) (Out, error)) *Action[In, Out, struct{}] {
+	return defineAction(globalRegistry, provider, name, atype, metadata, fn)
 }
 
-func defineAction[In, Out any](r *registry, name string, atype ActionType, metadata map[string]any, fn func(context.Context, In) (Out, error)) *Action[In, Out, struct{}] {
+func defineAction[In, Out any](r *registry, provider, name string, atype ActionType, metadata map[string]any, fn func(context.Context, In) (Out, error)) *Action[In, Out, struct{}] {
 	a := NewAction(name, atype, metadata, fn)
-	r.registerAction(name, a)
+	r.registerAction(provider, a)
 	return a
 }
 
-func DefineStreamingAction[In, Out, Stream any](name string, atype ActionType, metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
-	return defineStreamingAction(globalRegistry, name, atype, metadata, fn)
+func DefineStreamingAction[In, Out, Stream any](provider, name string, atype ActionType, metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
+	return defineStreamingAction(globalRegistry, provider, name, atype, metadata, fn)
 }
 
-func defineStreamingAction[In, Out, Stream any](r *registry, name string, atype ActionType, metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
+func defineStreamingAction[In, Out, Stream any](r *registry, provider, name string, atype ActionType, metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
 	a := NewStreamingAction(name, atype, metadata, fn)
-	r.registerAction(name, a)
+	r.registerAction(provider, a)
 	return a
 }
 

--- a/go/plugins/googleai/embed.go
+++ b/go/plugins/googleai/embed.go
@@ -27,7 +27,7 @@ func NewEmbedder(ctx context.Context, model, apiKey string) (ai.Embedder, error)
 	if err != nil {
 		return nil, err
 	}
-	e := ai.DefineEmbedder("google-genai", func(ctx context.Context, input *ai.EmbedRequest) ([]float32, error) {
+	e := ai.DefineEmbedder("google-genai", model, func(ctx context.Context, input *ai.EmbedRequest) ([]float32, error) {
 		em := client.EmbeddingModel(model)
 		parts := convertParts(input.Document.Content)
 		res, err := em.EmbedContent(ctx, parts...)

--- a/go/plugins/googleai/googleai_test.go
+++ b/go/plugins/googleai/googleai_test.go
@@ -137,8 +137,7 @@ var toolDef = &ai.ToolDefinition{
 }
 
 func init() {
-	ai.RegisterTool("exponentiation",
-		toolDef, nil,
+	ai.RegisterTool(toolDef, nil,
 		func(ctx context.Context, input map[string]any) (map[string]any, error) {
 			baseAny, ok := input["base"]
 			if !ok {

--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -43,7 +43,7 @@ func New(ctx context.Context, dir, name string, embedder ai.Embedder, embedderOp
 	if err != nil {
 		return nil, err
 	}
-	return ai.DefineDocumentStore("devLocalVectorStore/"+name, r.Index, r.Retrieve), nil
+	return ai.DefineDocumentStore("devLocalVectorStore-"+name, r.Index, r.Retrieve), nil
 }
 
 // docStore implements the [ai.DocumentStore] interface

--- a/go/plugins/vertexai/embed.go
+++ b/go/plugins/vertexai/embed.go
@@ -54,7 +54,7 @@ func NewEmbedder(ctx context.Context, model, projectID, location string) (ai.Emb
 
 	reqEndpoint := fmt.Sprintf("projects/%s/locations/%s/publishers/google/models/%s", projectID, location, model)
 
-	e := ai.DefineEmbedder("google-vertexai", func(ctx context.Context, req *ai.EmbedRequest) ([]float32, error) {
+	e := ai.DefineEmbedder("google-vertexai", "embed", func(ctx context.Context, req *ai.EmbedRequest) ([]float32, error) {
 		preq, err := newPredictRequest(reqEndpoint, req)
 		if err != nil {
 			return nil, err

--- a/go/plugins/vertexai/embed.go
+++ b/go/plugins/vertexai/embed.go
@@ -54,7 +54,7 @@ func NewEmbedder(ctx context.Context, model, projectID, location string) (ai.Emb
 
 	reqEndpoint := fmt.Sprintf("projects/%s/locations/%s/publishers/google/models/%s", projectID, location, model)
 
-	e := ai.DefineEmbedder("google-vertexai", "embed", func(ctx context.Context, req *ai.EmbedRequest) ([]float32, error) {
+	e := ai.DefineEmbedder("google-vertexai", model, func(ctx context.Context, req *ai.EmbedRequest) ([]float32, error) {
 		preq, err := newPredictRequest(reqEndpoint, req)
 		if err != nil {
 			return nil, err

--- a/go/plugins/vertexai/vertexai_test.go
+++ b/go/plugins/vertexai/vertexai_test.go
@@ -72,8 +72,7 @@ var toolDef = &ai.ToolDefinition{
 }
 
 func init() {
-	ai.RegisterTool("exponentiation",
-		toolDef, nil,
+	ai.RegisterTool(toolDef, nil,
 		func(ctx context.Context, input map[string]any) (map[string]any, error) {
 			baseAny, ok := input["base"]
 			if !ok {

--- a/go/samples/menu/s02.go
+++ b/go/samples/menu/s02.go
@@ -47,7 +47,7 @@ func menu(ctx context.Context, input map[string]any) (map[string]any, error) {
 }
 
 func setup02(ctx context.Context, g ai.Generator) error {
-	ai.RegisterTool("menu", menuToolDef, nil, menu)
+	ai.RegisterTool(menuToolDef, nil, menu)
 
 	dataMenuPrompt, err := dotprompt.Define("s02_dataMenu",
 		`You are acting as a helpful AI assistant named Walt that can answer


### PR DESCRIPTION
Tools were not working because they were being inserted as
tool/tool/name and looked up as tool/name/name.