### PR TITLE
Update usage metrics capture for gemini to include returned token counts

### DIFF
--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -191,6 +191,10 @@ export const GenerationUsageSchema = z.object({
   outputCharacters: z.number().optional(),
   inputImages: z.number().optional(),
   outputImages: z.number().optional(),
+  inputVideos: z.number().optional(),
+  outputVideos: z.number().optional(),
+  inputAudioFiles: z.number().optional(),
+  outputAudioFiles: z.number().optional(),
   custom: z.record(z.number()).optional(),
 });
 export type GenerationUsage = z.infer<typeof GenerationUsageSchema>;
@@ -344,6 +348,8 @@ export function modelRef<
 type PartCounts = {
   characters: number;
   images: number;
+  videos: number;
+  audio: number;
 };
 
 /**
@@ -363,8 +369,12 @@ export function getBasicUsageStats(
   return {
     inputCharacters: inputCounts.characters,
     inputImages: inputCounts.images,
+    inputVideos: inputCounts.videos,
+    inputAudioFiles: inputCounts.audio,
     outputCharacters: outputCounts.characters,
     outputImages: outputCounts.images,
+    outputVideos: outputCounts.videos,
+    outputAudioFiles: outputCounts.audio,
   };
 }
 
@@ -373,10 +383,17 @@ function getPartCounts(parts: Part[]): PartCounts {
     (counts, part) => {
       return {
         characters: counts.characters + (part.text?.length || 0),
-        images: counts.images + (part.media ? 1 : 0),
+        images:
+          counts.images +
+          (part.media?.contentType?.startsWith('image') ? 1 : 0),
+        videos:
+          counts.videos +
+          (part.media?.contentType?.startsWith('video') ? 1 : 0),
+        audio:
+          counts.audio + (part.media?.contentType?.startsWith('audio') ? 1 : 0),
       };
     },
-    { characters: 0, images: 0 }
+    { characters: 0, images: 0, videos: 0, audio: 0 }
   );
 }
 

--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -500,7 +500,12 @@ export function googleAIModel(
         return {
           candidates: responseCandidates,
           custom: result.response,
-          usage: getBasicUsageStats(request.messages, responseCandidates),
+          usage: {
+            ...getBasicUsageStats(request.messages, responseCandidates),
+            inputTokens: result.response.usageMetadata?.promptTokenCount,
+            outputTokens: result.response.usageMetadata?.candidatesTokenCount,
+            totalTokens: result.response.usageMetadata?.totalTokenCount,
+          },
         };
       }
     }

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -513,7 +513,12 @@ export function geminiModel(name: string, vertex: VertexAI): ModelAction {
         return {
           candidates: responseCandidates,
           custom: result.response,
-          usage: getBasicUsageStats(request.messages, responseCandidates),
+          usage: {
+            ...getBasicUsageStats(request.messages, responseCandidates),
+            inputTokens: result.response.usageMetadata?.promptTokenCount,
+            outputTokens: result.response.usageMetadata?.candidatesTokenCount,
+            totalTokens: result.response.usageMetadata?.totalTokenCount,
+          },
         };
       }
     }


### PR DESCRIPTION
Gemini usage metrics now include returned token counts and correctly counts different media types (images, video and audio files). This was previously counting any media type as an image.

Description here... 

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
