### PR TITLE
[Go] replace ai.DocumentStore with indexer and retriever actions

### DIFF
--- a/go/core/registry.go
+++ b/go/core/registry.go
@@ -147,7 +147,11 @@ func LookupAction(typ ActionType, provider, name string) action {
 // or nil if there is none.
 // It panics if the action is of the wrong type.
 func LookupActionFor[In, Out, Stream any](typ ActionType, provider, name string) *Action[In, Out, Stream] {
-	return LookupAction(typ, provider, name).(*Action[In, Out, Stream])
+	a := LookupAction(typ, provider, name)
+	if a == nil {
+		return nil
+	}
+	return a.(*Action[In, Out, Stream])
 }
 
 // listActions returns a list of descriptions of all registered actions.

--- a/go/plugins/localvec/localvec_test.go
+++ b/go/plugins/localvec/localvec_test.go
@@ -51,7 +51,7 @@ func TestLocalVec(t *testing.T) {
 	embedder.Register(d2, v2)
 	embedder.Register(d3, v3)
 	embedAction := ai.DefineEmbedder("fake", "embedder1", embedder.Embed)
-	ds, err := newDocStore(ctx, t.TempDir(), "testLocalVec", embedAction, nil)
+	ds, err := newDocStore(t.TempDir(), "testLocalVec", embedAction, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func TestLocalVec(t *testing.T) {
 	indexerReq := &ai.IndexerRequest{
 		Documents: []*ai.Document{d1, d2, d3},
 	}
-	err = ds.Index(ctx, indexerReq)
+	err = ds.index(ctx, indexerReq)
 	if err != nil {
 		t.Fatalf("Index operation failed: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestLocalVec(t *testing.T) {
 		Document: d1,
 		Options:  retrieverOptions,
 	}
-	retrieverResp, err := ds.Retrieve(ctx, retrieverReq)
+	retrieverResp, err := ds.retrieve(ctx, retrieverReq)
 	if err != nil {
 		t.Fatalf("Retrieve operation failed: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestPersistentIndexing(t *testing.T) {
 
 	tDir := t.TempDir()
 
-	ds, err := newDocStore(ctx, tDir, "testLocalVec", embedAction, nil)
+	ds, err := newDocStore(tDir, "testLocalVec", embedAction, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestPersistentIndexing(t *testing.T) {
 	indexerReq := &ai.IndexerRequest{
 		Documents: []*ai.Document{d1, d2},
 	}
-	err = ds.Index(ctx, indexerReq)
+	err = ds.index(ctx, indexerReq)
 	if err != nil {
 		t.Fatalf("Index operation failed: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestPersistentIndexing(t *testing.T) {
 		Document: d1,
 		Options:  retrieverOptions,
 	}
-	retrieverResp, err := ds.Retrieve(ctx, retrieverReq)
+	retrieverResp, err := ds.retrieve(ctx, retrieverReq)
 	if err != nil {
 		t.Fatalf("Retrieve operation failed: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestPersistentIndexing(t *testing.T) {
 		t.Errorf("got %d results, expected 2", len(docs))
 	}
 
-	dsAnother, err := newDocStore(ctx, tDir, "testLocalVec", embedAction, nil)
+	dsAnother, err := newDocStore(tDir, "testLocalVec", embedAction, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestPersistentIndexing(t *testing.T) {
 	indexerReq = &ai.IndexerRequest{
 		Documents: []*ai.Document{d3},
 	}
-	err = dsAnother.Index(ctx, indexerReq)
+	err = dsAnother.index(ctx, indexerReq)
 	if err != nil {
 		t.Fatalf("Index operation failed: %v", err)
 	}
@@ -166,7 +166,7 @@ func TestPersistentIndexing(t *testing.T) {
 		Document: d1,
 		Options:  retrieverOptions,
 	}
-	retrieverResp, err = dsAnother.Retrieve(ctx, retrieverReq)
+	retrieverResp, err = dsAnother.retrieve(ctx, retrieverReq)
 	if err != nil {
 		t.Fatalf("Retrieve operation failed: %v", err)
 	}

--- a/go/plugins/pinecone/genkit_test.go
+++ b/go/plugins/pinecone/genkit_test.go
@@ -71,10 +71,13 @@ func TestGenkit(t *testing.T) {
 	embedder.Register(d1, v1)
 	embedder.Register(d2, v2)
 	embedder.Register(d3, v3)
-	embedAction := ai.DefineEmbedder("fake", "embedder3", embedder.Embed)
 
-	r, err := New(ctx, *testAPIKey, indexData.Host, embedAction, nil, "")
-	if err != nil {
+	cfg := Config{
+		APIKey:   *testAPIKey,
+		Host:     indexData.Host,
+		Embedder: ai.DefineEmbedder("fake", "embedder3", embedder.Embed),
+	}
+	if err := Init(ctx, cfg); err != nil {
 		t.Fatal(err)
 	}
 
@@ -86,7 +89,8 @@ func TestGenkit(t *testing.T) {
 		Documents: []*ai.Document{d1, d2, d3},
 		Options:   indexerOptions,
 	}
-	err = r.Index(ctx, indexerReq)
+	t.Logf("index flag = %q, indexData.Host = %q", *testIndex, indexData.Host)
+	err = ai.Index(ctx, Indexer(indexData.Host), indexerReq)
 	if err != nil {
 		t.Fatalf("Index operation failed: %v", err)
 	}
@@ -123,7 +127,7 @@ func TestGenkit(t *testing.T) {
 		Document: d1,
 		Options:  retrieverOptions,
 	}
-	retrieverResp, err := r.Retrieve(ctx, retrieverReq)
+	retrieverResp, err := ai.Retrieve(ctx, Retriever(indexData.Host), retrieverReq)
 	if err != nil {
 		t.Fatalf("Retrieve operation failed: %v", err)
 	}

--- a/go/samples/menu/main.go
+++ b/go/samples/menu/main.go
@@ -85,7 +85,9 @@ func main() {
 		Models:    []string{geminiPro, geminiPro + "-vision"},
 		Embedders: []string{embeddingGecko},
 	})
-
+	if err != nil {
+		log.Fatal(err)
+	}
 	model := vertexai.Model(geminiPro)
 	if err := setup01(ctx, model); err != nil {
 		log.Fatal(err)
@@ -98,12 +100,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	embedder := vertexai.Embedder(embeddingGecko)
-	ds, err := localvec.New(ctx, os.TempDir(), "go-menu-items", embedder, nil)
-	if err != nil {
+	const localvecName = "go-menu-items"
+	if err := localvec.Init(ctx, localvec.Config{
+		Dir:      os.TempDir(),
+		Name:     localvecName,
+		Embedder: vertexai.Embedder(embeddingGecko),
+	}); err != nil {
 		log.Fatal(err)
 	}
-	if err := setup04(ctx, ds, model); err != nil {
+	if err := setup04(ctx, localvec.Indexer(localvecName), localvec.Retriever(localvecName), model); err != nil {
 		log.Fatal(err)
 	}
 

--- a/go/samples/menu/s04.go
+++ b/go/samples/menu/s04.go
@@ -24,7 +24,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/localvec"
 )
 
-func setup04(ctx context.Context, docstore ai.DocumentStore, model *ai.ModelAction) error {
+func setup04(ctx context.Context, indexer *ai.IndexerAction, retriever *ai.RetrieverAction, model *ai.ModelAction) error {
 	ragDataMenuPrompt, err := dotprompt.Define("s04_ragDataMenu",
 		`
 		  You are acting as Walt, a helpful AI assistant here at the restaurant.
@@ -70,7 +70,7 @@ func setup04(ctx context.Context, docstore ai.DocumentStore, model *ai.ModelActi
 			req := &ai.IndexerRequest{
 				Documents: docs,
 			}
-			if err := docstore.Index(ctx, req); err != nil {
+			if err := ai.Index(ctx, indexer, req); err != nil {
 				return nil, err
 			}
 
@@ -89,7 +89,7 @@ func setup04(ctx context.Context, docstore ai.DocumentStore, model *ai.ModelActi
 					K: 3,
 				},
 			}
-			resp, err := docstore.Retrieve(ctx, req)
+			resp, err := ai.Retrieve(ctx, retriever, req)
 			if err != nil {
 				return nil, err
 			}

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -91,8 +91,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	localDb, err := localvec.New(context.Background(), os.TempDir(), "simpleQa", googleai.Embedder("embedding-001"), nil)
-	if err != nil {
+	const localvecName = "simpleQa"
+	if err := localvec.Init(context.Background(), localvec.Config{
+		Dir:      os.TempDir(),
+		Name:     localvecName,
+		Embedder: googleai.Embedder("embedding-001"),
+	}); err != nil {
 		log.Fatal(err)
 	}
 
@@ -104,7 +108,7 @@ func main() {
 		indexerReq := &ai.IndexerRequest{
 			Documents: []*ai.Document{d1, d2, d3},
 		}
-		err := localDb.Index(ctx, indexerReq)
+		err := ai.Index(ctx, localvec.Indexer(localvecName), indexerReq)
 		if err != nil {
 			return "", err
 		}
@@ -113,7 +117,7 @@ func main() {
 		retrieverReq := &ai.RetrieverRequest{
 			Document: dRequest,
 		}
-		response, err := localDb.Retrieve(ctx, retrieverReq)
+		response, err := ai.Retrieve(ctx, localvec.Retriever(localvecName), retrieverReq)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Continue the redesign in which interfaces are replaced by
aliases to action types.

Remove DocumentStore, and replace it with two separate actions,
one for indexers and one for retrievers.
