### PR TITLE
[Go] proposal: vector DB Inits return actions

### DIFF
--- a/go/plugins/localvec/localvec_test.go
+++ b/go/plugins/localvec/localvec_test.go
@@ -17,6 +17,7 @@ package localvec
 import (
 	"context"
 	"math"
+	"slices"
 	"strings"
 	"testing"
 
@@ -185,4 +186,31 @@ func TestSimilarity(t *testing.T) {
 	if math.Abs(got-want) > 0.001 {
 		t.Errorf("got %f, want %f", got, want)
 	}
+}
+
+func TestInit(t *testing.T) {
+	embedder := ai.DefineEmbedder("fake", "e", fakeembedder.New().Embed)
+	is, rs, err := Init(context.Background(), Config{Stores: []StoreConfig{
+		{Name: "a", Embedder: embedder},
+		{Name: "b", Embedder: embedder},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"a", "b"}
+
+	if got := names(is); !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got := names(rs); !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func names[T interface{ Name() string }](xs []T) []string {
+	var ns []string
+	for _, x := range xs {
+		ns = append(ns, x.Name())
+	}
+	return ns
 }

--- a/go/samples/menu/main.go
+++ b/go/samples/menu/main.go
@@ -100,14 +100,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	indexer, retriever, err := localvec.Init(ctx, localvec.Config{
-		Name:     "go-menu-items",
-		Embedder: vertexai.Embedder(embeddingGecko),
+	indexers, retrievers, err := localvec.Init(ctx, localvec.Config{
+		Stores: []localvec.StoreConfig{
+			{Name: "go-menu-items", Embedder: vertexai.Embedder(embeddingGecko)},
+		},
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := setup04(ctx, indexer, retriever, model); err != nil {
+	if err := setup04(ctx, indexers[0], retrievers[0], model); err != nil {
 		log.Fatal(err)
 	}
 

--- a/go/samples/menu/main.go
+++ b/go/samples/menu/main.go
@@ -100,14 +100,14 @@ func main() {
 		log.Fatal(err)
 	}
 
-	const localvecName = "go-menu-items"
-	if err := localvec.Init(ctx, localvec.Config{
-		Name:     localvecName,
+	indexer, retriever, err := localvec.Init(ctx, localvec.Config{
+		Name:     "go-menu-items",
 		Embedder: vertexai.Embedder(embeddingGecko),
-	}); err != nil {
+	})
+	if err != nil {
 		log.Fatal(err)
 	}
-	if err := setup04(ctx, localvec.Indexer(localvecName), localvec.Retriever(localvecName), model); err != nil {
+	if err := setup04(ctx, indexer, retriever, model); err != nil {
 		log.Fatal(err)
 	}
 

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -91,11 +91,11 @@ func main() {
 		log.Fatal(err)
 	}
 
-	const localvecName = "simpleQa"
-	if err := localvec.Init(context.Background(), localvec.Config{
-		Name:     localvecName,
+	indexer, retriever, err := localvec.Init(context.Background(), localvec.Config{
+		Name:     "simpleQa",
 		Embedder: googleai.Embedder("embedding-001"),
-	}); err != nil {
+	})
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -107,7 +107,7 @@ func main() {
 		indexerReq := &ai.IndexerRequest{
 			Documents: []*ai.Document{d1, d2, d3},
 		}
-		err := ai.Index(ctx, localvec.Indexer(localvecName), indexerReq)
+		err := ai.Index(ctx, indexer, indexerReq)
 		if err != nil {
 			return "", err
 		}
@@ -116,7 +116,7 @@ func main() {
 		retrieverReq := &ai.RetrieverRequest{
 			Document: dRequest,
 		}
-		response, err := ai.Retrieve(ctx, localvec.Retriever(localvecName), retrieverReq)
+		response, err := ai.Retrieve(ctx, retriever, retrieverReq)
 		if err != nil {
 			return "", err
 		}

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -91,9 +91,13 @@ func main() {
 		log.Fatal(err)
 	}
 
-	indexer, retriever, err := localvec.Init(context.Background(), localvec.Config{
-		Name:     "simpleQa",
-		Embedder: googleai.Embedder("embedding-001"),
+	indexers, retrievers, err := localvec.Init(context.Background(), localvec.Config{
+		Stores: []localvec.StoreConfig{
+			{
+				Name:     "simpleQa",
+				Embedder: googleai.Embedder("embedding-001"),
+			},
+		},
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -107,7 +111,7 @@ func main() {
 		indexerReq := &ai.IndexerRequest{
 			Documents: []*ai.Document{d1, d2, d3},
 		}
-		err := ai.Index(ctx, indexer, indexerReq)
+		err := ai.Index(ctx, indexers[0], indexerReq)
 		if err != nil {
 			return "", err
 		}
@@ -116,7 +120,7 @@ func main() {
 		retrieverReq := &ai.RetrieverRequest{
 			Document: dRequest,
 		}
-		response, err := ai.Retrieve(ctx, retriever, retrieverReq)
+		response, err := ai.Retrieve(ctx, retrievers[0], retrieverReq)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Vector DBs only register two actions: an indexer and a retriever.
Continue to allow users to look up these actions by name.
But also return them from Init.
