### PR TITLE
[Go] suggestion: associate type params with Action Types

### DIFF
--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -25,6 +25,8 @@ import (
 // multidimensional vector.
 type EmbedderAction = core.Action[*EmbedRequest, []float32, struct{}]
 
+const embedderAssoc = atype.Assoc[EmbedderAction](atype.Embedder)
+
 // EmbedRequest is the data we pass to convert a document
 // to a multidimensional vector.
 type EmbedRequest struct {
@@ -35,13 +37,13 @@ type EmbedRequest struct {
 // DefineEmbedder registers the given embed function as an action, and returns an
 // [EmbedderAction] that runs it.
 func DefineEmbedder(provider, name string, embed func(context.Context, *EmbedRequest) ([]float32, error)) *EmbedderAction {
-	return core.DefineAction(provider, name, atype.Embedder, nil, embed)
+	return core.DefineAction(provider, name, embedderAssoc, nil, embed)
 }
 
 // LookupEmbedder looks up an [EmbedderAction] registered by [DefineEmbedder].
 // It returns nil if the embedder was not defined.
 func LookupEmbedder(provider, name string) *EmbedderAction {
-	action := core.LookupActionFor[*EmbedRequest, []float32, struct{}](atype.Embedder, provider, name)
+	action := core.LookupAction(embedderAssoc, provider, name)
 	if action == nil {
 		return nil
 	}

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -31,6 +31,8 @@ import (
 // A ModelAction is used to generate content from an AI model.
 type ModelAction = core.Action[*GenerateRequest, *GenerateResponse, *GenerateResponseChunk]
 
+const modelAssoc = atype.Assoc[ModelAction](atype.Model)
+
 // ModelStreamingCallback is the type for the streaming callback of a model.
 type ModelStreamingCallback = func(context.Context, *GenerateResponseChunk) error
 
@@ -64,7 +66,7 @@ func DefineModel(provider, name string, metadata *ModelMetadata, generate func(c
 		}
 		metadataMap["supports"] = supports
 	}
-	return core.DefineStreamingAction(provider, name, atype.Model, map[string]any{
+	return core.DefineStreamingAction(provider, name, modelAssoc, map[string]any{
 		"model": metadataMap,
 	}, generate)
 }
@@ -72,7 +74,7 @@ func DefineModel(provider, name string, metadata *ModelMetadata, generate func(c
 // LookupModel looks up a [ModelAction] registered by [DefineModel].
 // It returns nil if the model was not defined.
 func LookupModel(provider, name string) *ModelAction {
-	return core.LookupActionFor[*GenerateRequest, *GenerateResponse, *GenerateResponseChunk](atype.Model, provider, name)
+	return core.LookupAction(modelAssoc, provider, name)
 }
 
 // Generate applies a [ModelAction] to some input, handling tool requests.

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -27,6 +27,8 @@ import (
 // producing a [GenerateRequest] that may be passed to a [ModelAction].
 type PromptAction = core.Action[any, *GenerateRequest, struct{}]
 
+const promptAssoc = atype.Assoc[PromptAction](atype.Prompt)
+
 // DefinePrompt takes a function that renders a prompt template
 // into a [GenerateRequest] that may be passed to a [ModelAction].
 // The prompt expects some input described by inputSchema.
@@ -39,13 +41,13 @@ func DefinePrompt(provider, name string, metadata map[string]any, render func(co
 	}
 	mm["type"] = "prompt"
 	mm["prompt"] = true // required by genkit ui
-	return core.DefineActionWithInputSchema(provider, name, atype.Prompt, mm, render, inputSchema)
+	return core.DefineActionWithInputSchema(provider, name, promptAssoc, mm, render, inputSchema)
 }
 
 // LookupPrompt looks up a [PromptAction] registered by [DefinePrompt].
 // It returns nil if the prompt was not defined.
 func LookupPrompt(provider, name string) *PromptAction {
-	return core.LookupActionFor[any, *GenerateRequest, struct{}](atype.Prompt, provider, name)
+	return core.LookupAction(promptAssoc, provider, name)
 }
 
 // Render renders a [PromptAction] with some input data.

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -28,6 +28,11 @@ type (
 	RetrieverAction = core.Action[*RetrieverRequest, *RetrieverResponse, struct{}]
 )
 
+const (
+	indexerAssoc   = atype.Assoc[IndexerAction](atype.Indexer)
+	retrieverAssoc = atype.Assoc[RetrieverAction](atype.Retriever)
+)
+
 // IndexerRequest is the data we pass to add documents to the database.
 // The Options field is specific to the actual retriever implementation.
 type IndexerRequest struct {
@@ -53,25 +58,25 @@ func DefineIndexer(provider, name string, index func(context.Context, *IndexerRe
 	f := func(ctx context.Context, req *IndexerRequest) (struct{}, error) {
 		return struct{}{}, index(ctx, req)
 	}
-	return core.DefineAction(provider, name, atype.Indexer, nil, f)
+	return core.DefineAction(provider, name, indexerAssoc, nil, f)
 }
 
 // LookupIndexer looks up a [IndexerAction] registered by [DefineIndexer].
 // It returns nil if the model was not defined.
 func LookupIndexer(provider, name string) *IndexerAction {
-	return core.LookupActionFor[*IndexerRequest, struct{}, struct{}](atype.Indexer, provider, name)
+	return core.LookupAction(indexerAssoc, provider, name)
 }
 
 // DefineRetriever registers the given retrieve function as an action, and returns a
 // [RetrieverAction] that runs it.
 func DefineRetriever(provider, name string, ret func(context.Context, *RetrieverRequest) (*RetrieverResponse, error)) *RetrieverAction {
-	return core.DefineAction(provider, name, atype.Retriever, nil, ret)
+	return core.DefineAction(provider, name, retrieverAssoc, nil, ret)
 }
 
 // LookupRetriever looks up a [RetrieverAction] registered by [DefineRetriever].
 // It returns nil if the model was not defined.
 func LookupRetriever(provider, name string) *RetrieverAction {
-	return core.LookupActionFor[*RetrieverRequest, *RetrieverResponse, struct{}](atype.Retriever, provider, name)
+	return core.LookupAction(retrieverAssoc, provider, name)
 }
 
 // Index runs the given [IndexerAction].

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -34,6 +34,10 @@ type Tool struct {
 	Fn         func(context.Context, map[string]any) (map[string]any, error)
 }
 
+type toolAction = core.Action[map[string]any, map[string]any, struct{}]
+
+const toolAssoc = atype.Assoc[toolAction](atype.Tool)
+
 // DefineTool defines a tool function.
 func DefineTool(definition *ToolDefinition, metadata map[string]any, fn func(ctx context.Context, input map[string]any) (map[string]any, error)) {
 	if len(metadata) > 0 {
@@ -44,13 +48,13 @@ func DefineTool(definition *ToolDefinition, metadata map[string]any, fn func(ctx
 	}
 	metadata["type"] = "tool"
 
-	core.DefineAction(provider, definition.Name, atype.Tool, metadata, fn)
+	core.DefineAction(provider, definition.Name, toolAssoc, metadata, fn)
 }
 
 // RunTool looks up a tool registered by [DefineTool],
 // runs it with the given input, and returns the result.
 func RunTool(ctx context.Context, name string, input map[string]any) (map[string]any, error) {
-	action := core.LookupActionFor[map[string]any, map[string]any, struct{}](atype.Tool, provider, name)
+	action := core.LookupAction(toolAssoc, provider, name)
 	if action == nil {
 		return nil, fmt.Errorf("no tool named %q", name)
 	}

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -68,8 +68,8 @@ type Action[In, Out, Stream any] struct {
 // See js/core/src/action.ts
 
 // DefineAction creates a new Action and registers it.
-func DefineAction[In, Out any](provider, name string, atype atype.ActionType, metadata map[string]any, fn func(context.Context, In) (Out, error)) *Action[In, Out, struct{}] {
-	return defineAction(globalRegistry, provider, name, atype, metadata, fn)
+func DefineAction[In, Out any](provider, name string, assoc atype.Assoc[Action[In, Out, struct{}]], metadata map[string]any, fn func(context.Context, In) (Out, error)) *Action[In, Out, struct{}] {
+	return defineAction(globalRegistry, provider, name, atype.ActionType(assoc), metadata, fn)
 }
 
 func defineAction[In, Out any](r *registry, provider, name string, atype atype.ActionType, metadata map[string]any, fn func(context.Context, In) (Out, error)) *Action[In, Out, struct{}] {
@@ -78,8 +78,8 @@ func defineAction[In, Out any](r *registry, provider, name string, atype atype.A
 	return a
 }
 
-func DefineStreamingAction[In, Out, Stream any](provider, name string, atype atype.ActionType, metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
-	return defineStreamingAction(globalRegistry, provider, name, atype, metadata, fn)
+func DefineStreamingAction[In, Out, Stream any](provider, name string, assoc atype.Assoc[Action[In, Out, Stream]], metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
+	return defineStreamingAction(globalRegistry, provider, name, atype.ActionType(assoc), metadata, fn)
 }
 
 func defineStreamingAction[In, Out, Stream any](r *registry, provider, name string, atype atype.ActionType, metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
@@ -89,15 +89,15 @@ func defineStreamingAction[In, Out, Stream any](r *registry, provider, name stri
 }
 
 func DefineCustomAction[In, Out, Stream any](provider, name string, metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
-	return DefineStreamingAction(provider, name, atype.Custom, metadata, fn)
+	return defineStreamingAction(globalRegistry, provider, name, atype.Custom, metadata, fn)
 }
 
 // DefineActionWithInputSchema creates a new Action and registers it.
 // This differs from DefineAction in that the input schema is
 // defined dynamically; the static input type is "any".
 // This is used for prompts.
-func DefineActionWithInputSchema[Out any](provider, name string, atype atype.ActionType, metadata map[string]any, fn func(context.Context, any) (Out, error), inputSchema *jsonschema.Schema) *Action[any, Out, struct{}] {
-	return defineActionWithInputSchema(globalRegistry, provider, name, atype, metadata, fn, inputSchema)
+func DefineActionWithInputSchema[Out any](provider, name string, assoc atype.Assoc[Action[any, Out, struct{}]], metadata map[string]any, fn func(context.Context, any) (Out, error), inputSchema *jsonschema.Schema) *Action[any, Out, struct{}] {
+	return defineActionWithInputSchema(globalRegistry, provider, name, atype.ActionType(assoc), metadata, fn, inputSchema)
 }
 
 func defineActionWithInputSchema[Out any](r *registry, provider, name string, atype atype.ActionType, metadata map[string]any, fn func(context.Context, any) (Out, error), inputSchema *jsonschema.Schema) *Action[any, Out, struct{}] {

--- a/go/core/action_test.go
+++ b/go/core/action_test.go
@@ -28,7 +28,7 @@ func inc(_ context.Context, x int) (int, error) {
 }
 
 func TestActionRun(t *testing.T) {
-	a := NewAction("inc", atype.Custom, nil, inc)
+	a := newAction("inc", atype.Custom, nil, inc)
 	got, err := a.Run(context.Background(), 3, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -39,7 +39,7 @@ func TestActionRun(t *testing.T) {
 }
 
 func TestActionRunJSON(t *testing.T) {
-	a := NewAction("inc", atype.Custom, nil, inc)
+	a := newAction("inc", atype.Custom, nil, inc)
 	input := []byte("3")
 	want := []byte("4")
 	got, err := a.runJSON(context.Background(), input, nil)
@@ -53,7 +53,7 @@ func TestActionRunJSON(t *testing.T) {
 
 func TestNewAction(t *testing.T) {
 	// Verify that struct{} can occur in the function signature.
-	_ = NewAction("f", atype.Custom, nil, func(context.Context, int) (struct{}, error) { return struct{}{}, nil })
+	_ = newAction("f", atype.Custom, nil, func(context.Context, int) (struct{}, error) { return struct{}{}, nil })
 }
 
 // count streams the numbers from 0 to n-1, then returns n.
@@ -70,7 +70,7 @@ func count(ctx context.Context, n int, cb func(context.Context, int) error) (int
 
 func TestActionStreaming(t *testing.T) {
 	ctx := context.Background()
-	a := NewStreamingAction("count", atype.Custom, nil, count)
+	a := newStreamingAction("count", atype.Custom, nil, count)
 	const n = 3
 
 	// Non-streaming.
@@ -103,7 +103,7 @@ func TestActionStreaming(t *testing.T) {
 func TestActionTracing(t *testing.T) {
 	ctx := context.Background()
 	const actionName = "TestTracing-inc"
-	a := NewAction(actionName, atype.Custom, nil, inc)
+	a := newAction(actionName, atype.Custom, nil, inc)
 	if _, err := a.Run(context.Background(), 3, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/go/core/conformance_test.go
+++ b/go/core/conformance_test.go
@@ -69,7 +69,7 @@ func (c *command) run(ctx context.Context, input string) (string, error) {
 	case c.Append != nil:
 		return input + *c.Append, nil
 	case c.Run != nil:
-		return Run(ctx, c.Run.Name, func() (string, error) {
+		return InternalRun(ctx, c.Run.Name, func() (string, error) {
 			return c.Run.Command.run(ctx, input)
 		})
 	default:

--- a/go/core/core.go
+++ b/go/core/core.go
@@ -20,6 +20,6 @@
 //go:generate go run ../internal/cmd/jsonschemagen -outdir .. -config schemas.config ../../genkit-tools/genkit-schema.json core
 
 // Package core implements Genkit actions, flows and other essential machinery.
-// This package is primarily intended for genkit internals and for plugins.
-// Applications using genkit should use the genkit package.
+// This package is primarily intended for Genkit internals and for plugins.
+// Genkit applications should use the genkit package.
 package core

--- a/go/core/flow_test.go
+++ b/go/core/flow_test.go
@@ -30,7 +30,7 @@ func incFlow(_ context.Context, i int, _ NoStream) (int, error) {
 }
 
 func TestFlowStart(t *testing.T) {
-	f := DefineFlow("inc", incFlow)
+	f := InternalDefineFlow("inc", incFlow)
 	ss, err := NewFileFlowStateStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -62,12 +62,12 @@ func TestFlowRun(t *testing.T) {
 		return n, nil
 	}
 
-	flow := DefineFlow("run", func(ctx context.Context, s string, _ NoStream) ([]int, error) {
-		g1, err := Run(ctx, "s1", stepf)
+	flow := InternalDefineFlow("run", func(ctx context.Context, s string, _ NoStream) ([]int, error) {
+		g1, err := InternalRun(ctx, "s1", stepf)
 		if err != nil {
 			return nil, err
 		}
-		g2, err := Run(ctx, "s2", stepf)
+		g2, err := InternalRun(ctx, "s2", stepf)
 		if err != nil {
 			return nil, err
 		}
@@ -94,7 +94,7 @@ func TestRunFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 	f := defineFlow(reg, "inc", incFlow)
-	got, err := RunFlow(context.Background(), f, 2)
+	got, err := InternalRunFlow(context.Background(), f, 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/core/registry.go
+++ b/go/core/registry.go
@@ -116,10 +116,18 @@ func (r *registry) lookupAction(key string) action {
 	return r.actions[key]
 }
 
-// LookupActionFor returns the action for the given key in the global registry,
+func LookupAction[In, Out, Stream any](assoc atype.Assoc[Action[In, Out, Stream]], provider, name string) *Action[In, Out, Stream] {
+	return lookupAction[In, Out, Stream](atype.ActionType(assoc), provider, name)
+}
+
+func LookupCustomAction[In, Out, Stream any](provider, name string) *Action[In, Out, Stream] {
+	return lookupAction[In, Out, Stream](atype.Custom, provider, name)
+}
+
+// lookupAction returns the action for the given key in the global registry,
 // or nil if there is none.
 // It panics if the action is of the wrong type.
-func LookupActionFor[In, Out, Stream any](typ atype.ActionType, provider, name string) *Action[In, Out, Stream] {
+func lookupAction[In, Out, Stream any](typ atype.ActionType, provider, name string) *Action[In, Out, Stream] {
 	key := fmt.Sprintf("/%s/%s/%s", typ, provider, name)
 	a := globalRegistry.lookupAction(key)
 	if a == nil {

--- a/go/core/servers_test.go
+++ b/go/core/servers_test.go
@@ -39,10 +39,10 @@ func TestDevServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.registerAction("devServer", NewAction("inc", atype.Custom, map[string]any{
+	r.registerAction("devServer", newAction("inc", atype.Custom, map[string]any{
 		"foo": "bar",
 	}, inc))
-	r.registerAction("devServer", NewAction("dec", atype.Custom, map[string]any{
+	r.registerAction("devServer", newAction("dec", atype.Custom, map[string]any{
 		"bar": "baz",
 	}, dec))
 	srv := httptest.NewServer(newDevServeMux(r))

--- a/go/core/validation.go
+++ b/go/core/validation.go
@@ -23,19 +23,19 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-// ValidateValue will validate any value against the expected schema.
+// validateValue will validate any value against the expected schema.
 // It will return an error if it doesn't match the schema, otherwise it will return nil.
-func ValidateValue(data any, schema *jsonschema.Schema) error {
+func validateValue(data any, schema *jsonschema.Schema) error {
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("data is not a valid JSON type: %w", err)
 	}
-	return ValidateJSON(dataBytes, schema)
+	return validateJSON(dataBytes, schema)
 }
 
-// ValidateJSON will validate JSON against the expected schema.
+// validateJSON will validate JSON against the expected schema.
 // It will return an error if it doesn't match the schema, otherwise it will return nil.
-func ValidateJSON(dataBytes json.RawMessage, schema *jsonschema.Schema) error {
+func validateJSON(dataBytes json.RawMessage, schema *jsonschema.Schema) error {
 	schemaBytes, err := schema.MarshalJSON()
 	if err != nil {
 		return fmt.Errorf("expected schema is not valid: %w", err)

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -37,7 +37,7 @@ func DefineFlow[In, Out, Stream any](
 	name string,
 	fn func(ctx context.Context, input In, callback func(context.Context, Stream) error) (Out, error),
 ) *core.Flow[In, Out, Stream] {
-	return core.DefineFlow(name, core.Func[In, Out, Stream](fn))
+	return core.InternalDefineFlow(name, core.Func[In, Out, Stream](fn))
 }
 
 // Run runs the function f in the context of the current flow
@@ -48,13 +48,13 @@ func DefineFlow[In, Out, Stream any](
 // A step has its own span in the trace, and its result is cached so that if the flow
 // is restarted, f will not be called a second time.
 func Run[Out any](ctx context.Context, name string, f func() (Out, error)) (Out, error) {
-	return core.Run(ctx, name, f)
+	return core.InternalRun(ctx, name, f)
 }
 
 // RunFlow runs flow in the context of another flow. The flow must run to completion when started
 // (that is, it must not have interrupts).
 func RunFlow[In, Out, Stream any](ctx context.Context, flow *core.Flow[In, Out, Stream], input In) (Out, error) {
-	return core.RunFlow(ctx, flow, input)
+	return core.InternalRunFlow(ctx, flow, input)
 }
 
 // NoStream indicates that a flow does not support streaming.

--- a/go/internal/atype/atype.go
+++ b/go/internal/atype/atype.go
@@ -31,3 +31,9 @@ const (
 	Tool      ActionType = "tool"
 	Custom    ActionType = "custom"
 )
+
+// An Assoc associates the type parameters of an Action with an ActionType.
+//
+// Most ActionTypes correspond to Actions with a particular set of type
+// parameters. An Assoc makes that association explicit.
+type Assoc[A any] ActionType


### PR DESCRIPTION
Define a type called Assoc that links the Go type of an action
to a value of the ActionType enum. That is, a line like

   const fooAssoc = atype.Assoc[Action[int, bool, string]](atype.Foo)

encodes the relationship between the ActionType enum value Foo and
actions with type parameters [int, bool, string].

The main benefit is that the relationship needs to be written only once
in the program. Previously it appeared twice: in the Define function and
in the Lookup function.
