### PR TITLE
Update to pnpm v9.3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,3 +5,7 @@ publish-branch=main
 # This option tells pnpm to only resolve local deps to the local files when
 # the `workspace:` protocol is used, and to otherwise download published versions.
 link-workspace-packages=false
+
+# This option will cause pnpm to fail if its version doesn't exactly match the
+# version specified in the `packageManager` field of package.json.
+package-manager-strict-version=true

--- a/genkit-tools/package.json
+++ b/genkit-tools/package.json
@@ -20,5 +20,5 @@
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.22.4"
   },
-  "packageManager": "pnpm@9.1.3+sha256.7f63001edc077f1cff96cacba901f350796287a2800dfa83fe898f94183e4f5f"
+  "packageManager": "pnpm@9.3.0+sha256.e1f9e8d1a16607a46dd3c158b5f7a7dc7945501d1c6222d454d63d033d1d918f"
 }

--- a/js/package.json
+++ b/js/package.json
@@ -19,5 +19,5 @@
     "only-allow": "^1.2.1",
     "typescript": "^4.9.0"
   },
-  "packageManager": "pnpm@9.1.3+sha256.7f63001edc077f1cff96cacba901f350796287a2800dfa83fe898f94183e4f5f"
+  "packageManager": "pnpm@9.3.0+sha256.e1f9e8d1a16607a46dd3c158b5f7a7dc7945501d1c6222d454d63d033d1d918f"
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "prettier-plugin-organize-imports": "^3.2.4",
     "ts-node": "^10.9.2"
   },
-  "packageManager": "pnpm@9.1.3+sha256.7f63001edc077f1cff96cacba901f350796287a2800dfa83fe898f94183e4f5f"
+  "packageManager": "pnpm@9.3.0+sha256.e1f9e8d1a16607a46dd3c158b5f7a7dc7945501d1c6222d454d63d033d1d918f"
 }


### PR DESCRIPTION
Also incorporates the new `package-manager-strict-version` npmrc settings from pnpm 9.2.0 so enforce that everyone uses the same version (useful to prevent lockfile thrashing).

See https://github.com/pnpm/pnpm/releases/tag/v9.3.0 for full release notes.