### PR TITLE
Update metrics export defaults and truncate metric labels

### DIFF
--- a/js/core/src/metrics.ts
+++ b/js/core/src/metrics.ts
@@ -101,7 +101,7 @@ export class MetricHistogram extends Metric<Histogram> {
  */
 function truncateDimensions(opts?: any) {
   if (opts) {
-    Object.keys(opts).forEach(k => {
+    Object.keys(opts).forEach((k) => {
       if (typeof opts[k] == 'string') {
         opts[k] = opts[k].substring(0, METRIC_DIMENSION_MAX_CHARS);
       }

--- a/js/core/src/metrics.ts
+++ b/js/core/src/metrics.ts
@@ -18,6 +18,7 @@ import { Counter, Histogram, Meter, metrics } from '@opentelemetry/api';
 
 export const METER_NAME = 'genkit';
 export const METRIC_NAME_PREFIX = 'genkit';
+const METRIC_DIMENSION_MAX_CHARS = 32;
 
 export function internalMetricNamespaceWrap(...namespaces) {
   return [METRIC_NAME_PREFIX, ...namespaces].join('/');
@@ -68,6 +69,7 @@ export class MetricCounter extends Metric<Counter> {
 
   add(val?: number, opts?: any) {
     if (val) {
+      truncateDimensions(opts);
       this.get().add(val, opts);
     }
   }
@@ -87,7 +89,22 @@ export class MetricHistogram extends Metric<Histogram> {
 
   record(val?: number, opts?: any) {
     if (val) {
+      truncateDimensions(opts);
       this.get().record(val, opts);
     }
+  }
+}
+
+/**
+ * Truncates all of the metric dimensions to avoid long, high-cardinality
+ * dimensions being added to metrics.
+ */
+function truncateDimensions(opts?: any) {
+  if (opts) {
+    Object.keys(opts).forEach(k => {
+      if (typeof opts[k] == 'string') {
+        opts[k] = opts[k].substring(0, METRIC_DIMENSION_MAX_CHARS);
+      }
+    });
   }
 }

--- a/js/core/src/metrics.ts
+++ b/js/core/src/metrics.ts
@@ -102,7 +102,9 @@ export class MetricHistogram extends Metric<Histogram> {
 function truncateDimensions(opts?: any) {
   if (opts) {
     Object.keys(opts).forEach((k) => {
-      if (typeof opts[k] == 'string') {
+      // We don't want to truncate paths. They are known to be long but with
+      // relatively low cardinality, and are useful for downstream monitoring.
+      if (!k.startsWith('path') && typeof opts[k] == 'string') {
         opts[k] = opts[k].substring(0, METRIC_DIMENSION_MAX_CHARS);
       }
     });

--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -150,9 +150,9 @@ export class GcpOpenTelemetry implements TelemetryConfig {
       : new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
     return new PeriodicExportingMetricReader({
       exportIntervalMillis:
-        this.options?.telemetryConfig?.metricExportIntervalMillis || 10_000,
+        this.options?.telemetryConfig?.metricExportIntervalMillis || 60_000,
       exportTimeoutMillis:
-        this.options?.telemetryConfig?.metricExportTimeoutMillis || 10_000,
+        this.options?.telemetryConfig?.metricExportTimeoutMillis || 60_000,
       exporter: metricExporter,
     });
   }

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -136,8 +136,14 @@ describe('GoogleCloudMetrics', () => {
 
     const requestCounter = await getCounterMetric('genkit/flow/requests');
     const latencyHistogram = await getHistogramMetric('genkit/flow/latency');
-    assert.equal(requestCounter.attributes.name, 'anExtremelyLongFlowNameThatIsToo');
-    assert.equal(latencyHistogram.attributes.name, 'anExtremelyLongFlowNameThatIsToo');
+    assert.equal(
+      requestCounter.attributes.name,
+      'anExtremelyLongFlowNameThatIsToo'
+    );
+    assert.equal(
+      latencyHistogram.attributes.name,
+      'anExtremelyLongFlowNameThatIsToo'
+    );
   });
 
   it('writes action failure metrics', async () => {

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -129,6 +129,17 @@ describe('GoogleCloudMetrics', () => {
     assert.ok(latencyHistogram.attributes.sourceVersion);
   });
 
+  it('truncates metric dimensions', async () => {
+    const testFlow = createFlow('anExtremelyLongFlowNameThatIsTooBig');
+
+    await runFlow(testFlow);
+
+    const requestCounter = await getCounterMetric('genkit/flow/requests');
+    const latencyHistogram = await getHistogramMetric('genkit/flow/latency');
+    assert.equal(requestCounter.attributes.name, 'anExtremelyLongFlowNameThatIsToo');
+    assert.equal(latencyHistogram.attributes.name, 'anExtremelyLongFlowNameThatIsToo');
+  });
+
   it('writes action failure metrics', async () => {
     const testAction = createAction('testActionWithFailure', async () => {
       const nothing = null;


### PR DESCRIPTION
* Update default metric export frequency from 10s to 60s
* Truncate metric dimensions to 32 characters

These changes are to prevent unexpected large metric dimensions and frequent exports from running up metrics ingestion costs.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
