### PR TITLE
Add ability to optionally disable collection of traces/metrics

### DIFF
--- a/js/plugins/google-cloud/src/index.ts
+++ b/js/plugins/google-cloud/src/index.ts
@@ -35,6 +35,12 @@ export interface TelemetryConfig {
   metricExportIntervalMillis?: number;
   metricExportTimeoutMillis?: number;
   instrumentations?: Instrumentation[];
+
+  /** When true, metrics are not sent to GCP. */
+  disableMetrics?: boolean;
+
+  /** When true, traces are not sent to GCP. */
+  disableTraces?: boolean;
 }
 
 /**

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -273,24 +273,24 @@ describe('GoogleCloudMetrics', () => {
   });
 
   describe('Configuration', () => {
-    it('should export only traces', async() => {
+    it('should export only traces', async () => {
       const telemetry = new GcpOpenTelemetry({
         forceDevExport: true,
         telemetryConfig: {
-          disableMetrics: true
-        }
+          disableMetrics: true,
+        },
       });
       assert.equal(telemetry['shouldExportTraces'](), true);
       assert.equal(telemetry['shouldExportMetrics'](), false);
     });
 
-    it('should export only metrics', async() => {
+    it('should export only metrics', async () => {
       const telemetry = new GcpOpenTelemetry({
         forceDevExport: true,
         telemetryConfig: {
           disableTraces: true,
-          disableMetrics: false
-        }
+          disableMetrics: false,
+        },
       });
       assert.equal(telemetry['shouldExportTraces'](), false);
       assert.equal(telemetry['shouldExportMetrics'](), true);

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -27,6 +27,7 @@ import {
 import { registerFlowStateStore } from '@genkit-ai/core/registry';
 import { defineFlow, runAction, runFlow } from '@genkit-ai/flow';
 import {
+  GcpOpenTelemetry,
   __getMetricExporterForTesting,
   googleCloud,
 } from '@genkit-ai/google-cloud';
@@ -269,6 +270,31 @@ describe('GoogleCloudMetrics', () => {
     assert.equal(requestCounter.attributes.source, 'ts');
     assert.equal(requestCounter.attributes.error, 'TypeError');
     assert.ok(requestCounter.attributes.sourceVersion);
+  });
+
+  describe('Configuration', () => {
+    it('should export only traces', async() => {
+      const telemetry = new GcpOpenTelemetry({
+        forceDevExport: true,
+        telemetryConfig: {
+          disableMetrics: true
+        }
+      });
+      assert.equal(telemetry['shouldExportTraces'](), true);
+      assert.equal(telemetry['shouldExportMetrics'](), false);
+    });
+
+    it('should export only metrics', async() => {
+      const telemetry = new GcpOpenTelemetry({
+        forceDevExport: true,
+        telemetryConfig: {
+          disableTraces: true,
+          disableMetrics: false
+        }
+      });
+      assert.equal(telemetry['shouldExportTraces'](), false);
+      assert.equal(telemetry['shouldExportMetrics'](), true);
+    });
   });
 
   /** Polls the in memory metric exporter until the genkit scope is found. */


### PR DESCRIPTION
Add ability to optionally disable collection of traces/metrics via Google Cloud plugin options.

Checklist (if applicable):
- [X] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
