### PR TITLE
[VertexAI] Fix Gemini 1.5 Pro model version

### DIFF
--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -91,7 +91,7 @@ export const gemini15Pro = modelRef({
   name: 'vertexai/gemini-1.5-pro',
   info: {
     label: 'Vertex AI - Gemini 1.5 Pro',
-    versions: ['gemini-1.0-pro-001'],
+    versions: ['gemini-1.5-pro-001'],
     supports: {
       multiturn: true,
       media: true,


### PR DESCRIPTION
Originally reported [here](https://github.com/TheFireCo/genkit-plugins/issues/85) (wrong repo).
Gemini 1.5 Pro available model version was incorrectly set to Gemini 1.0 Pro instead.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
