### PR TITLE
Update GCP metric exporter to use an ExponentialHistogramAggregation

### DIFF
--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -196,7 +196,7 @@ export class GcpOpenTelemetry implements TelemetryConfig {
       : new InMemoryMetricExporter(AggregationTemporality.DELTA);
     exporter.selectAggregation = (instrumentType: InstrumentType) => {
       if (instrumentType === InstrumentType.HISTOGRAM) {
-        return new ExponentialHistogramAggregation(100, true);
+        return new ExponentialHistogramAggregation();
       }
       return new DefaultAggregation();
     };


### PR DESCRIPTION
Also switch to using DELTA temporality and reduce export frequency to 5m intervals by default.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
