### PR TITLE
[Go] proposal: AI types have methods

### DIFF
--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -48,7 +48,7 @@ func Init() error { return nil }
 
 // DefineStore defines an indexer and retriever that share the same underlying storage.
 // The name uniquely identifies the the indexer and retriever in the registry.
-func DefineStore(name string, cfg Config) (*ai.IndexerAction, *ai.RetrieverAction, error) {
+func DefineStore(name string, cfg Config) (*ai.Indexer, *ai.Retriever, error) {
 	ds, err := newDocStore(cfg.Dir, name, cfg.Embedder, cfg.EmbedderOptions)
 	if err != nil {
 		return nil, nil, err
@@ -59,13 +59,13 @@ func DefineStore(name string, cfg Config) (*ai.IndexerAction, *ai.RetrieverActio
 }
 
 // Indexer returns the registered indexer with the given name.
-func Indexer(name string) *ai.IndexerAction {
+func Indexer(name string) *ai.Indexer {
 	return ai.LookupIndexer(provider, name)
 }
 
 // Retriever returns the retriever with the given name.
 // The name must match the [Config.Name] value passed to [Init].
-func Retriever(name string) *ai.RetrieverAction {
+func Retriever(name string) *ai.Retriever {
 	return ai.LookupRetriever(provider, name)
 }
 

--- a/go/plugins/localvec/localvec_test.go
+++ b/go/plugins/localvec/localvec_test.go
@@ -205,11 +205,3 @@ func TestInit(t *testing.T) {
 		t.Errorf("got %q, want %q", g, want)
 	}
 }
-
-func names[T interface{ Name() string }](xs []T) []string {
-	var ns []string
-	for _, x := range xs {
-		ns = append(ns, x.Name())
-	}
-	return ns
-}

--- a/go/plugins/pinecone/genkit.go
+++ b/go/plugins/pinecone/genkit.go
@@ -82,7 +82,7 @@ type Config struct {
 	TextKey string
 }
 
-func DefineIndexer(ctx context.Context, cfg Config) (*ai.IndexerAction, error) {
+func DefineIndexer(ctx context.Context, cfg Config) (*ai.Indexer, error) {
 	ds, err := newDocStore(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func DefineIndexer(ctx context.Context, cfg Config) (*ai.IndexerAction, error) {
 	return ai.DefineIndexer(provider, cfg.IndexID, ds.Index), nil
 }
 
-func DefineRetriever(ctx context.Context, cfg Config) (*ai.RetrieverAction, error) {
+func DefineRetriever(ctx context.Context, cfg Config) (*ai.Retriever, error) {
 	ds, err := newDocStore(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -131,12 +131,12 @@ func newDocStore(ctx context.Context, cfg Config) (*docStore, error) {
 }
 
 // Indexer returns the indexer with the given index name.
-func Indexer(name string) *ai.IndexerAction {
+func Indexer(name string) *ai.Indexer {
 	return ai.LookupIndexer(provider, name)
 }
 
 // Retriever returns the retriever with the given index name.
-func Retriever(name string) *ai.RetrieverAction {
+func Retriever(name string) *ai.Retriever {
 	return ai.LookupRetriever(provider, name)
 }
 

--- a/go/plugins/pinecone/genkit_test.go
+++ b/go/plugins/pinecone/genkit_test.go
@@ -97,7 +97,7 @@ func TestGenkit(t *testing.T) {
 		Options:   indexerOptions,
 	}
 	t.Logf("index flag = %q, indexData.Host = %q", *testIndex, indexData.Host)
-	err = ai.Index(ctx, indexer, indexerReq)
+	err = indexer.Index(ctx, indexerReq)
 	if err != nil {
 		t.Fatalf("Index operation failed: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestGenkit(t *testing.T) {
 		Document: d1,
 		Options:  retrieverOptions,
 	}
-	retrieverResp, err := ai.Retrieve(ctx, retriever, retrieverReq)
+	retrieverResp, err := retriever.Retrieve(ctx, retrieverReq)
 	if err != nil {
 		t.Fatalf("Retrieve operation failed: %v", err)
 	}

--- a/go/samples/menu/s04.go
+++ b/go/samples/menu/s04.go
@@ -24,7 +24,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/localvec"
 )
 
-func setup04(ctx context.Context, indexer *ai.IndexerAction, retriever *ai.RetrieverAction, model *ai.ModelAction) error {
+func setup04(ctx context.Context, indexer *ai.Indexer, retriever *ai.Retriever, model *ai.ModelAction) error {
 	ragDataMenuPrompt, err := dotprompt.Define("s04_ragDataMenu",
 		`
 		  You are acting as Walt, a helpful AI assistant here at the restaurant.
@@ -70,7 +70,7 @@ func setup04(ctx context.Context, indexer *ai.IndexerAction, retriever *ai.Retri
 			req := &ai.IndexerRequest{
 				Documents: docs,
 			}
-			if err := ai.Index(ctx, indexer, req); err != nil {
+			if err := indexer.Index(ctx, req); err != nil {
 				return nil, err
 			}
 
@@ -89,7 +89,7 @@ func setup04(ctx context.Context, indexer *ai.IndexerAction, retriever *ai.Retri
 					K: 3,
 				},
 			}
-			resp, err := ai.Retrieve(ctx, retriever, req)
+			resp, err := retriever.Retrieve(ctx, req)
 			if err != nil {
 				return nil, err
 			}

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -109,7 +109,7 @@ func main() {
 		indexerReq := &ai.IndexerRequest{
 			Documents: []*ai.Document{d1, d2, d3},
 		}
-		err := ai.Index(ctx, indexer, indexerReq)
+		err := indexer.Index(ctx, indexerReq)
 		if err != nil {
 			return "", err
 		}
@@ -118,7 +118,7 @@ func main() {
 		retrieverReq := &ai.RetrieverRequest{
 			Document: dRequest,
 		}
-		response, err := ai.Retrieve(ctx, retriever, retrieverReq)
+		response, err := retriever.Retrieve(ctx, retrieverReq)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Calling Retriever on a retriever as a method is more natural
in Go than calling a top-level function, as we currently have.

This PR changes Indexer and Retriever from being aliases of Actions
to being their own types, allowing methods.

If we like this, then a followup PR would do the same for
Model, Embedder and possibly Tool.
