### PR TITLE
[Go] expose mock embedder

### DIFF
--- a/go/plugins/localvec/localvec_test.go
+++ b/go/plugins/localvec/localvec_test.go
@@ -21,14 +21,14 @@ import (
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/internal/fakeembedder"
+	"github.com/firebase/genkit/go/testing/mockembedder"
 )
 
 func TestLocalVec(t *testing.T) {
 	ctx := context.Background()
 
 	// Make two very similar vectors and one different vector.
-	// Arrange for a fake embedder to return those vector
+	// Arrange for a mock embedder to return those vector
 	// when provided with documents.
 
 	const dim = 32
@@ -46,11 +46,11 @@ func TestLocalVec(t *testing.T) {
 	d2 := ai.DocumentFromText("hello2", nil)
 	d3 := ai.DocumentFromText("goodbye", nil)
 
-	embedder := fakeembedder.New()
+	embedder := mockembedder.New()
 	embedder.Register(d1, v1)
 	embedder.Register(d2, v2)
 	embedder.Register(d3, v3)
-	embedAction := ai.DefineEmbedder("fake", "embedder1", embedder.Embed)
+	embedAction := ai.DefineEmbedder("mock", "embedder1", embedder.Embed)
 	ds, err := newDocStore(t.TempDir(), "testLocalVec", embedAction, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -106,11 +106,11 @@ func TestPersistentIndexing(t *testing.T) {
 	d2 := ai.DocumentFromText("hello2", nil)
 	d3 := ai.DocumentFromText("goodbye", nil)
 
-	embedder := fakeembedder.New()
+	embedder := mockembedder.New()
 	embedder.Register(d1, v1)
 	embedder.Register(d2, v2)
 	embedder.Register(d3, v3)
-	embedAction := ai.DefineEmbedder("fake", "embedder2", embedder.Embed)
+	embedAction := ai.DefineEmbedder("mock", "embedder2", embedder.Embed)
 
 	tDir := t.TempDir()
 
@@ -188,7 +188,7 @@ func TestSimilarity(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
-	embedder := ai.DefineEmbedder("fake", "e", fakeembedder.New().Embed)
+	embedder := ai.DefineEmbedder("mock", "e", mockembedder.New().Embed)
 	if err := Init(); err != nil {
 		t.Fatal(err)
 	}

--- a/go/plugins/pinecone/genkit_test.go
+++ b/go/plugins/pinecone/genkit_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/internal/fakeembedder"
+	"github.com/firebase/genkit/go/testing/mockembedder"
 )
 
 func TestGenkit(t *testing.T) {
@@ -50,7 +50,7 @@ func TestGenkit(t *testing.T) {
 	dim := indexData.Dimension
 
 	// Make two very similar vectors and one different vector.
-	// Arrange for a fake embedder to return those vector
+	// Arrange for a mock embedder to return those vector
 	// when provided with documents.
 
 	v1 := make([]float32, dim)
@@ -67,7 +67,7 @@ func TestGenkit(t *testing.T) {
 	d2 := ai.DocumentFromText("hello2", nil)
 	d3 := ai.DocumentFromText("goodbye", nil)
 
-	embedder := fakeembedder.New()
+	embedder := mockembedder.New()
 	embedder.Register(d1, v1)
 	embedder.Register(d2, v2)
 	embedder.Register(d3, v3)
@@ -77,7 +77,7 @@ func TestGenkit(t *testing.T) {
 	}
 	cfg := Config{
 		IndexID:  *testIndex,
-		Embedder: ai.DefineEmbedder("fake", "embedder3", embedder.Embed),
+		Embedder: ai.DefineEmbedder("mock", "embedder3", embedder.Embed),
 	}
 	indexer, err := DefineIndexer(ctx, cfg)
 	if err != nil {

--- a/go/testing/mockembedder/mockembedder.go
+++ b/go/testing/mockembedder/mockembedder.go
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package fakeembedder provides a fake implementation of
-// genkit.Embedder for testing purposes.
+// Package mockembedder provides a mock implementation of
+// ai.Embedder for testing purposes.
 // The caller must register the values that the fake embedder should
 // return for each document. Asking for the values of an unregistered
-// document panics.
-package fakeembedder
+// document returns an error.
+package mockembedder
 
 import (
 	"context"
@@ -26,12 +26,12 @@ import (
 	"github.com/firebase/genkit/go/ai"
 )
 
-// Embedder is a fake implementation of genkit.Embedder.
+// Embedder is a mock implementation of genkit.Embedder.
 type Embedder struct {
 	registry map[*ai.Document][]float32
 }
 
-// New returns a new fake embedder.
+// New returns a new mock embedder.
 func New() *Embedder {
 	return &Embedder{
 		registry: make(map[*ai.Document][]float32),
@@ -46,7 +46,7 @@ func (e *Embedder) Register(d *ai.Document, vals []float32) {
 func (e *Embedder) Embed(ctx context.Context, req *ai.EmbedRequest) ([]float32, error) {
 	vals, ok := e.registry[req.Document]
 	if !ok {
-		return nil, errors.New("fake embedder called with unregistered document")
+		return nil, errors.New("mock embedder called with unregistered document")
 	}
 	return vals, nil
 }

--- a/go/testing/mockembedder/mockembedder_test.go
+++ b/go/testing/mockembedder/mockembedder_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fakeembedder
+package mockembedder
 
 import (
 	"context"
@@ -22,13 +22,13 @@ import (
 	"github.com/firebase/genkit/go/ai"
 )
 
-func TestFakeEmbedder(t *testing.T) {
-	embed := New()
-	embedAction := ai.DefineEmbedder("fake", "embed", embed.Embed)
-	d := ai.DocumentFromText("fakeembedder test", nil)
+func TestMockEmbedder(t *testing.T) {
+	mock := New()
+	embedAction := ai.DefineEmbedder("mock", "embed", mock.Embed)
+	d := ai.DocumentFromText("mockembedder test", nil)
 
 	vals := []float32{1, 2}
-	embed.Register(d, vals)
+	mock.Register(d, vals)
 
 	req := &ai.EmbedRequest{
 		Document: d,


### PR DESCRIPTION
Move the fakeembedder package out of internal so anyone can
use it for testing.

Also, somewhat pedantically, rename it because it's actually
a mock.

(Hyperpedantically, it's a stub
(https://testing.googleblog.com/2013/07/testing-on-toilet-know-your-test-doubles.html),
but I don't think anyone observes that distinction.)
