### PR TITLE
Adds 'any' scalar, nullable optionals, wildcards to Picoschema.

### DIFF
--- a/docs/dotprompt.md
+++ b/docs/dotprompt.md
@@ -125,6 +125,10 @@ by `?`, and do not allow additional properties. When a property is marked as opt
 it is also made nullable to provide more leniency for LLMs to return null instead of
 omitting a field.
 
+In an object definition, the special key `(*)` can be used to declare a "wildcard"
+field definition. This will match any additional properties not supplied by an
+explicit key.
+
 Picoschema does not support many of the capabilities of full JSON schema. If you
 require more robust schemas, you may supply a JSON Schema instead:
 

--- a/docs/dotprompt.md
+++ b/docs/dotprompt.md
@@ -82,6 +82,7 @@ schema:
   metadata?(object): # objects are also denoted via parentheses
     updatedAt?: string, ISO timestamp of last update
     approvedBy?: integer, id of approver
+  extra?: any, arbitrary extra data
 ```
 
 The above schema is equivalent to the following TypeScript interface:
@@ -89,33 +90,37 @@ The above schema is equivalent to the following TypeScript interface:
 ```ts
 interface Article {
   title: string;
-  subtitle?: string;
+  subtitle?: string | null;
   /** true when in draft state */
-  draft?: boolean;
+  draft?: boolean | null;
   /** approval status */
-  status?: 'PENDING' | 'APPROVED';
+  status?: 'PENDING' | 'APPROVED' | null;
   /** the date of publication e.g. '2024-04-09' */
   date: string;
   /** relevant tags for article */
   tags: string[];
   authors: {
     name: string;
-    email?: string;
+    email?: string | null;
   }[];
   metadata?: {
     /** ISO timestamp of last update */
-    updatedAt?: string;
+    updatedAt?: string | null;
     /** id of approver */
-    approvedBy?: number;
-  };
+    approvedBy?: number | null;
+  } | null;
+  /** arbitrary extra data */
+  extra?: any;
 }
 ```
 
-Picoschema supports scalar types `string`, `integer`, `number`, and `boolean`. For
-objects, arrays, and enums they are denoted by a parenthetical after the field name.
+Picoschema supports scalar types `string`, `integer`, `number`, `boolean`, and `any`.
+For objects, arrays, and enums they are denoted by a parenthetical after the field name.
 
 Objects defined by Picoschema have all properties as required unless denoted optional
-by `?`, and do not allow additional properties.
+by `?`, and do not allow additional properties. When a property is marked as optional,
+it is also made nullable to provide more leniency for LLMs to return null instead of
+omitting a field.
 
 Picoschema does not support many of the capabilities of full JSON schema. If you
 require more robust schemas, you may supply a JSON Schema instead:

--- a/docs/dotprompt.md
+++ b/docs/dotprompt.md
@@ -83,6 +83,7 @@ schema:
     updatedAt?: string, ISO timestamp of last update
     approvedBy?: integer, id of approver
   extra?: any, arbitrary extra data
+  (*): string, wildcard field
 ```
 
 The above schema is equivalent to the following TypeScript interface:
@@ -111,6 +112,8 @@ interface Article {
   } | null;
   /** arbitrary extra data */
   extra?: any;
+  /** wildcard field */
+  [additionalField: string]: string;
 }
 ```
 

--- a/js/plugins/dotprompt/src/picoschema.ts
+++ b/js/plugins/dotprompt/src/picoschema.ts
@@ -23,6 +23,8 @@ const JSON_SCHEMA_SCALAR_TYPES = [
   'any',
 ];
 
+const WILDCARD_PROPERTY_NAME = '(*)';
+
 import { JSONSchema } from '@genkit-ai/core/schema';
 
 export function picoschema(schema: unknown): JSONSchema | null {
@@ -77,9 +79,16 @@ function parsePico(obj: any, path: string[] = []): JSONSchema {
   };
 
   for (const key in obj) {
+    // wildcard property
+    if (key === WILDCARD_PROPERTY_NAME) {
+      schema.additionalProperties = parsePico(obj[key], [...path, key]);
+      continue;
+    }
+
     const [name, typeInfo] = key.split('(');
     const isOptional = name.endsWith('?');
     const propertyName = isOptional ? name.slice(0, -1) : name;
+
     if (!isOptional) {
       schema.required.push(propertyName);
     }

--- a/js/plugins/dotprompt/tests/picoschema_test.ts
+++ b/js/plugins/dotprompt/tests/picoschema_test.ts
@@ -74,7 +74,7 @@ describe('picoschema()', () => {
         additionalProperties: false,
         properties: {
           req: { type: 'string', description: 'required field' },
-          nonreq: { type: 'boolean', description: 'optional field' },
+          nonreq: { type: ['boolean', 'null'], description: 'optional field' },
         },
         required: ['req'],
       },
@@ -110,10 +110,10 @@ describe('picoschema()', () => {
         additionalProperties: false,
         properties: {
           obj: {
-            type: 'object',
+            type: ['object', 'null'],
             description: 'a nested object',
             additionalProperties: false,
-            properties: { nest1: { type: 'string' } },
+            properties: { nest1: { type: ['string', 'null'] } },
           },
           arr: {
             type: 'array',
@@ -121,7 +121,7 @@ describe('picoschema()', () => {
             items: {
               type: 'object',
               additionalProperties: false,
-              properties: { nest2: { type: 'boolean' } },
+              properties: { nest2: { type: ['boolean', 'null'] } },
             },
           },
         },
@@ -154,9 +154,24 @@ describe('picoschema()', () => {
       want: {
         type: 'object',
         properties: {
-          color: { description: 'the enum', enum: ['RED', 'BLUE', 'GREEN'] },
+          color: {
+            description: 'the enum',
+            enum: ['RED', 'BLUE', 'GREEN', null],
+          },
         },
         additionalProperties: false,
+      },
+    },
+    {
+      description: 'any field',
+      yaml: `schema:
+  first: any
+  second?: any, could be anything`,
+      want: {
+        type: 'object',
+        properties: { first: {}, second: { description: 'could be anything' } },
+        additionalProperties: false,
+        required: ['first'],
       },
     },
   ];

--- a/js/plugins/dotprompt/tests/picoschema_test.ts
+++ b/js/plugins/dotprompt/tests/picoschema_test.ts
@@ -174,6 +174,38 @@ describe('picoschema()', () => {
         required: ['first'],
       },
     },
+    {
+      description: 'wildcard fields with other fields',
+      yaml: `schema:
+  otherField: string, another string
+  (*): any, whatever you want`,
+      want: {
+        additionalProperties: {
+          description: 'whatever you want',
+        },
+        properties: {
+          otherField: {
+            description: 'another string',
+            type: 'string',
+          },
+        },
+        required: ['otherField'],
+        type: 'object',
+      },
+    },
+    {
+      description: 'wildcard fields with other fields',
+      yaml: `schema:
+  (*): number, lucky number`,
+      want: {
+        additionalProperties: {
+          type: 'number',
+          description: 'lucky number',
+        },
+        properties: {},
+        type: 'object',
+      },
+    },
   ];
 
   for (const test of tests) {

--- a/js/plugins/dotprompt/tests/prompt_test.ts
+++ b/js/plugins/dotprompt/tests/prompt_test.ts
@@ -192,7 +192,10 @@ output:
           additionalProperties: false,
           properties: {
             name: { type: 'string', description: 'the name of the person' },
-            date: { type: 'string', description: "ISO date like '2024-04-09'" },
+            date: {
+              type: ['string', 'null'],
+              description: "ISO date like '2024-04-09'",
+            },
           },
         },
       });


### PR DESCRIPTION
Three quality-of-life improvements for Picoschema:

1. You can now specify `any` as a scalar type and it will allow anything.
2. When a field is marked as optional, Picoschema will *also* mark it as nullable. This fixes an annoying situation where LLMs return `null` values instead of omitting keys.
3. You can have a wildcard field in an object using `(*)` as a key.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [x] Docs updated
