### PR TITLE
Adds generateText and generateOutput convenience methods.

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -713,6 +713,29 @@ export async function generate<
   return await generate(resolvedOptions);
 }
 
+export async function generateText<
+  CustomOptions extends z.ZodTypeAny = typeof GenerationCommonConfigSchema,
+>(
+  options:
+    | GenerateOptions<z.ZodString, CustomOptions>
+    | PromiseLike<GenerateOptions<z.ZodString, CustomOptions>>
+): Promise<{ text: string; response: GenerateResponse<string> }> {
+  const response = await generate(options);
+  return { text: response.text(), response };
+}
+
+export async function generateOutput<
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  CustomOptions extends z.ZodTypeAny = typeof GenerationCommonConfigSchema,
+>(
+  options:
+    | GenerateOptions<O, CustomOptions>
+    | PromiseLike<GenerateOptions<O, CustomOptions>>
+): Promise<{ output: O; response: GenerateResponse<z.infer<O>> }> {
+  const response = await generate(options);
+  return { output: response.output()!, response };
+}
+
 export type GenerateStreamOptions<
   O extends z.ZodTypeAny = z.ZodTypeAny,
   CustomOptions extends z.ZodTypeAny = typeof GenerationCommonConfigSchema,

--- a/js/ai/src/index.ts
+++ b/js/ai/src/index.ts
@@ -23,11 +23,13 @@ export {
 } from './evaluator.js';
 export {
   Candidate,
+  generate,
+  generateOutput,
   GenerateResponse,
+  generateStream,
+  generateText,
   Message,
   NoValidCandidatesError,
-  generate,
-  generateStream,
   toGenerateRequest,
   type GenerateOptions,
   type GenerateStreamOptions,

--- a/js/ai/src/index.ts
+++ b/js/ai/src/index.ts
@@ -23,13 +23,13 @@ export {
 } from './evaluator.js';
 export {
   Candidate,
-  generate,
-  generateOutput,
   GenerateResponse,
-  generateStream,
-  generateText,
   Message,
   NoValidCandidatesError,
+  generate,
+  generateOutput,
+  generateStream,
+  generateText,
   toGenerateRequest,
   type GenerateOptions,
   type GenerateStreamOptions,


### PR DESCRIPTION
This adds new `generateText` and `generateOutput` convenience methods that return like so:

```
const {text, response} = await generateText({prompt: "Tell me a joke"});

const {output, response} = await generateOutput({
  prompt: "Create a creature",
  output: {
    schema: z.object({
      name: z.string(),
      hitPoints: z.number()
    })
  }
});
```

It's a small ergonomic change but it prevents needing to assign the response to a variable if you don't care about it.