### PR TITLE
feat: [Go] added middleware framework for actions and models

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -50,7 +50,7 @@ type ModelMetadata struct {
 
 // DefineModel registers the given generate function as an action, and returns a
 // [ModelAction] that runs it.
-func DefineModel(provider, name string, metadata *ModelMetadata, generate func(context.Context, *GenerateRequest, ModelStreamingCallback) (*GenerateResponse, error)) *ModelAction {
+func DefineModel(provider, name string, metadata *ModelMetadata, middleware []core.Middleware[*GenerateRequest, *GenerateResponse], generate func(context.Context, *GenerateRequest, ModelStreamingCallback) (*GenerateResponse, error)) *ModelAction {
 	metadataMap := map[string]any{}
 	if metadata != nil {
 		if metadata.Label != "" {
@@ -66,7 +66,7 @@ func DefineModel(provider, name string, metadata *ModelMetadata, generate func(c
 	}
 	return core.DefineStreamingAction(provider, name, atype.Model, map[string]any{
 		"model": metadataMap,
-	}, generate)
+	}, middleware, generate)
 }
 
 // LookupModel looks up a [ModelAction] registered by [DefineModel].

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -48,9 +48,12 @@ type ModelMetadata struct {
 	Supports ModelCapabilities
 }
 
+type ModelMiddleware = core.Middleware[*GenerateRequest, *GenerateResponse, *GenerateResponseChunk]
+type ModelFunc = core.Func[*GenerateRequest, *GenerateResponse, *GenerateResponseChunk]
+
 // DefineModel registers the given generate function as an action, and returns a
 // [ModelAction] that runs it.
-func DefineModel(provider, name string, metadata *ModelMetadata, middleware []core.Middleware[*GenerateRequest, *GenerateResponse], generate func(context.Context, *GenerateRequest, ModelStreamingCallback) (*GenerateResponse, error)) *ModelAction {
+func DefineModel(provider, name string, metadata *ModelMetadata, middleware []ModelMiddleware, generate ModelFunc) *ModelAction {
 	metadataMap := map[string]any{}
 	if metadata != nil {
 		if metadata.Label != "" {

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -215,7 +215,7 @@ func (a *Action[In, Out, Stream]) Run(ctx context.Context, input In, cb func(con
 			}
 			var output Out
 			if err == nil {
-				dispatch := ChainMiddleware(a.middleware...)
+				dispatch := chainMiddleware(a.middleware...)
 				output, err = dispatch(func(ctx context.Context, di In) (Out, error) {
 					return a.fn(ctx, di, cb)
 				})(ctx, input)

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -213,7 +213,6 @@ func (a *Action[In, Out, Stream]) Run(ctx context.Context, input In, cb func(con
 			}
 			var output Out
 			if err == nil {
-
 				dispatch := ChainMiddleware(a.middleware...)
 				output, err = dispatch(func(ctx context.Context, di In) (Out, error) {
 					return a.fn(ctx, di, cb)

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -47,10 +47,10 @@ func Middlewares[I, O any](ms ...Middleware[I, O]) []Middleware[I, O] {
 	return ms
 }
 
-// Chain creates a new Middleware that applies a sequence of Middlewares, so
-// that they execute in the given order when handling action request.
-//
-// In other words, Chain(m1, m2)(handler) = m1(m2(handler))
+// ChainMiddleware creates a new Middleware that applies a sequence of
+// Middlewares, so that they execute in the given order when handling action
+// request.
+// In other words, ChainMiddleware(m1, m2)(handler) = m1(m2(handler))
 func ChainMiddleware[I, O any](middlewares ...Middleware[I, O]) Middleware[I, O] {
 	return func(h MiddlewareHandler[I, O]) MiddlewareHandler[I, O] {
 		for i := range middlewares {

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -37,13 +37,13 @@ import (
 //   - terminate response by returning a response (or error);
 //   - call the next middleware function.
 //
-// If the current middleware function does not terminate the middlware chain it
-// must call next middlware in the chain to pass control to the next middleware
+// If the current middleware function does not terminate the middleware chain it
+// must call next middleware in the chain to pass control to the next middleware
 // function, otherwise the request will be left hanging.
 type Middleware[I, O any] func(context.Context, I, func(ctx context.Context, input I) (O, error)) (O, error)
 
 // Middlewares returns an array of middlewares that are passes in as an argument.
-// `core.Middlewares(apple, banana)` is identical to `[]core.Middleware[InputType, OutputType]{apple, banana}`
+// core.Middlewares(apple, banana) is identical to []core.Middleware[InputType, OutputType]{apple, banana}
 func Middlewares[I, O any](ms ...Middleware[I, O]) []Middleware[I, O] {
 	return ms
 }

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -39,6 +39,8 @@ import (
 //   - call the next middleware function.
 type Middleware[I, O any] func(MiddlewareHandler[I, O]) MiddlewareHandler[I, O]
 
+// MiddlewareHandler is a function used as part of middleware definition that
+// contains input handling logic.
 type MiddlewareHandler[I, O any] func(ctx context.Context, input I) (O, error)
 
 // Middlewares returns an array of middlewares that are passes in as an argument.
@@ -47,11 +49,11 @@ func Middlewares[I, O any](ms ...Middleware[I, O]) []Middleware[I, O] {
 	return ms
 }
 
-// ChainMiddleware creates a new Middleware that applies a sequence of
+// chainMiddleware creates a new Middleware that applies a sequence of
 // Middlewares, so that they execute in the given order when handling action
 // request.
-// In other words, ChainMiddleware(m1, m2)(handler) = m1(m2(handler))
-func ChainMiddleware[I, O any](middlewares ...Middleware[I, O]) Middleware[I, O] {
+// In other words, chainMiddleware(m1, m2)(handler) = m1(m2(handler))
+func chainMiddleware[I, O any](middlewares ...Middleware[I, O]) Middleware[I, O] {
 	return func(h MiddlewareHandler[I, O]) MiddlewareHandler[I, O] {
 		for i := range middlewares {
 			h = middlewares[len(middlewares)-1-i](h)

--- a/go/core/action_test.go
+++ b/go/core/action_test.go
@@ -143,7 +143,7 @@ func TestActionTracing(t *testing.T) {
 	t.Fatalf("did not find trace named %q", actionName)
 }
 
-func TestActionMiddlware(t *testing.T) {
+func TestActionMiddleware(t *testing.T) {
 	ctx := context.Background()
 
 	sayHello := newStreamingAction("hello", atype.Custom, nil, Middlewares(wrapRequest, wrapResponse), func(ctx context.Context, input string, _ NoStream) (string, error) {
@@ -160,7 +160,7 @@ func TestActionMiddlware(t *testing.T) {
 	}
 }
 
-func TestActionInterruptedMiddlware(t *testing.T) {
+func TestActionInterruptedMiddleware(t *testing.T) {
 	ctx := context.Background()
 
 	interrupt := func(next MiddlewareHandler[string, string]) MiddlewareHandler[string, string] {

--- a/go/core/action_test.go
+++ b/go/core/action_test.go
@@ -169,7 +169,7 @@ func TestActionInterruptedMiddlware(t *testing.T) {
 
 	interrupt := func(next MiddlewareHandler[string, string]) MiddlewareHandler[string, string] {
 		return func(ctx context.Context, request string) (string, error) {
-			return "banana", nil
+			return "interrupt (request: \"" + request + "\")", nil
 		}
 	}
 
@@ -181,7 +181,7 @@ func TestActionInterruptedMiddlware(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "banana"
+	want := "interrupt (request: \"(Pavel)\")"
 	if got != want {
 		t.Fatalf("got %v, want %v", got, want)
 	}

--- a/go/core/action_test.go
+++ b/go/core/action_test.go
@@ -29,11 +29,7 @@ func inc(_ context.Context, x int) (int, error) {
 
 func wrapRequest(next MiddlewareHandler[string, string]) MiddlewareHandler[string, string] {
 	return func(ctx context.Context, request string) (string, error) {
-		nextResponse, err := next(ctx, "("+request+")")
-		if err != nil {
-			return "", err
-		}
-		return nextResponse, nil
+		return next(ctx, "("+request+")")
 	}
 }
 

--- a/go/core/action_test.go
+++ b/go/core/action_test.go
@@ -27,15 +27,15 @@ func inc(_ context.Context, x int) (int, error) {
 	return x + 1, nil
 }
 
-func wrapRequest(next MiddlewareHandler[string, string]) MiddlewareHandler[string, string] {
-	return func(ctx context.Context, request string) (string, error) {
-		return next(ctx, "("+request+")")
+func wrapRequest(next Func[string, string, struct{}]) Func[string, string, struct{}] {
+	return func(ctx context.Context, request string, _ NoStream) (string, error) {
+		return next(ctx, "("+request+")", nil)
 	}
 }
 
-func wrapResponse(next MiddlewareHandler[string, string]) MiddlewareHandler[string, string] {
-	return func(ctx context.Context, request string) (string, error) {
-		nextResponse, err := next(ctx, request)
+func wrapResponse(next Func[string, string, struct{}]) Func[string, string, struct{}] {
+	return func(ctx context.Context, request string, _ NoStream) (string, error) {
+		nextResponse, err := next(ctx, request, nil)
 		if err != nil {
 			return "", err
 		}
@@ -163,8 +163,8 @@ func TestActionMiddleware(t *testing.T) {
 func TestActionInterruptedMiddleware(t *testing.T) {
 	ctx := context.Background()
 
-	interrupt := func(next MiddlewareHandler[string, string]) MiddlewareHandler[string, string] {
-		return func(ctx context.Context, request string) (string, error) {
+	interrupt := func(next Func[string, string, struct{}]) Func[string, string, struct{}] {
+		return func(ctx context.Context, request string, _ NoStream) (string, error) {
 			return "interrupt (request: \"" + request + "\")", nil
 		}
 	}

--- a/go/core/flow.go
+++ b/go/core/flow.go
@@ -260,7 +260,7 @@ func (f *Flow[In, Out, Stream]) action() *Action[*flowInstruction[In], *flowStat
 		tracing.SetCustomMetadataAttr(ctx, "flow:wrapperAction", "true")
 		return f.runInstruction(ctx, inst, streamingCallback[Stream](cb))
 	}
-	return newStreamingAction(f.name, atype.Flow, metadata, cback)
+	return newStreamingAction(f.name, atype.Flow, metadata, nil, cback)
 }
 
 // runInstruction performs one of several actions on a flow, as determined by msg.

--- a/go/plugins/dotprompt/genkit_test.go
+++ b/go/plugins/dotprompt/genkit_test.go
@@ -42,7 +42,7 @@ func testGenerate(ctx context.Context, req *ai.GenerateRequest, cb func(context.
 }
 
 func TestExecute(t *testing.T) {
-	testModel := ai.DefineModel("test", "test", nil, testGenerate)
+	testModel := ai.DefineModel("test", "test", nil, nil, testGenerate)
 	p, err := New("TestExecute", "TestExecute", Config{ModelAction: testModel})
 	if err != nil {
 		t.Fatal(err)

--- a/go/plugins/googleai/googleai.go
+++ b/go/plugins/googleai/googleai.go
@@ -97,7 +97,7 @@ func defineModel(name string, client *genai.Client) {
 		},
 	}
 	g := generator{model: name, client: client}
-	ai.DefineModel(provider, name, meta, g.generate)
+	ai.DefineModel(provider, name, meta, nil, g.generate)
 }
 
 func defineEmbedder(name string, client *genai.Client) {

--- a/go/plugins/vertexai/vertexai.go
+++ b/go/plugins/vertexai/vertexai.go
@@ -81,7 +81,7 @@ func initModels(ctx context.Context, cfg Config) error {
 			},
 		}
 		g := &generator{model: name, client: gclient}
-		ai.DefineModel(provider, name, meta, g.generate)
+		ai.DefineModel(provider, name, meta, nil, g.generate)
 	}
 	return nil
 }

--- a/js/flow/src/flow.ts
+++ b/js/flow/src/flow.ts
@@ -850,7 +850,7 @@ export function startFlowsServer(params?: {
   flows.forEach((f) => {
     const flowPath = `/${pathPrefix}${f.name}`;
     logger.info(` - ${flowPath}`);
-    // Add middlware
+    // Add middleware
     f.middleware?.forEach((m) => {
       app.post(flowPath, m);
     });


### PR DESCRIPTION
Middleware allows providing reusable request/response pre/post processors. On the JS side we use middleware for polyfiling various model behaviours like system prompt and fetching media from URLs.