### PR TITLE
Update action names to match JS SDK

### DIFF
--- a/go/core/action.go
+++ b/go/core/action.go
@@ -73,7 +73,8 @@ func DefineAction[In, Out any](provider, name string, atype atype.ActionType, me
 }
 
 func defineAction[In, Out any](r *registry, provider, name string, atype atype.ActionType, metadata map[string]any, fn func(context.Context, In) (Out, error)) *Action[In, Out, struct{}] {
-	a := newAction(name, atype, metadata, fn)
+	actionName := fmt.Sprintf("%s/%s", provider, name)
+	a := newAction(actionName, atype, metadata, fn)
 	r.registerAction(provider, a)
 	return a
 }
@@ -83,7 +84,8 @@ func DefineStreamingAction[In, Out, Stream any](provider, name string, atype aty
 }
 
 func defineStreamingAction[In, Out, Stream any](r *registry, provider, name string, atype atype.ActionType, metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
-	a := newStreamingAction(name, atype, metadata, fn)
+	actionName := fmt.Sprintf("%s/%s", provider, name)
+	a := newStreamingAction(actionName, atype, metadata, fn)
 	r.registerAction(provider, a)
 	return a
 }
@@ -101,7 +103,8 @@ func DefineActionWithInputSchema[Out any](provider, name string, atype atype.Act
 }
 
 func defineActionWithInputSchema[Out any](r *registry, provider, name string, atype atype.ActionType, metadata map[string]any, fn func(context.Context, any) (Out, error), inputSchema *jsonschema.Schema) *Action[any, Out, struct{}] {
-	a := newActionWithInputSchema(name, atype, metadata, fn, inputSchema)
+	actionName := fmt.Sprintf("%s/%s", provider, name)
+	a := newActionWithInputSchema(actionName, atype, metadata, fn, inputSchema)
 	r.registerAction(provider, a)
 	return a
 }

--- a/go/core/conformance_test.go
+++ b/go/core/conformance_test.go
@@ -97,7 +97,7 @@ func TestFlowConformance(t *testing.T) {
 				t.Fatal(err)
 			}
 			_ = defineFlow(r, test.Name, flowFunction(test.Commands))
-			key := fmt.Sprintf("/flow/%s/%[1]s", test.Name)
+			key := fmt.Sprintf("/flow/%s", test.Name)
 			resp, err := runAction(context.Background(), r, key, test.Input, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/go/core/registry.go
+++ b/go/core/registry.go
@@ -17,6 +17,7 @@ package core
 import (
 	"context"
 	"crypto/md5"
+	"encoding/json"
 	"fmt"
 	"log"
 	"log/slog"
@@ -113,6 +114,8 @@ func (r *registry) registerAction(provider string, a action) {
 func (r *registry) lookupAction(key string) action {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	bs, _ := json.Marshal(r.actions)
+	fmt.Println(string(bs))
 	return r.actions[key]
 }
 

--- a/go/core/registry.go
+++ b/go/core/registry.go
@@ -95,7 +95,7 @@ const (
 // It panics if an action with the same type, provider and name is already
 // registered.
 func (r *registry) registerAction(provider string, a action) {
-	key := fmt.Sprintf("/%s/%s/%s", a.actionType(), provider, a.Name())
+	key := fmt.Sprintf("/%s/%s", a.actionType(), a.Name())
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, ok := r.actions[key]; ok {

--- a/go/core/registry.go
+++ b/go/core/registry.go
@@ -17,7 +17,6 @@ package core
 import (
 	"context"
 	"crypto/md5"
-	"encoding/json"
 	"fmt"
 	"log"
 	"log/slog"
@@ -114,8 +113,6 @@ func (r *registry) registerAction(provider string, a action) {
 func (r *registry) lookupAction(key string) action {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	bs, _ := json.Marshal(r.actions)
-	fmt.Println(string(bs))
 	return r.actions[key]
 }
 

--- a/go/core/servers_test.go
+++ b/go/core/servers_test.go
@@ -39,10 +39,10 @@ func TestDevServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.registerAction("devServer", newAction("inc", atype.Custom, map[string]any{
+	r.registerAction("devServer", newAction("devServer/inc", atype.Custom, map[string]any{
 		"foo": "bar",
 	}, inc))
-	r.registerAction("devServer", newAction("dec", atype.Custom, map[string]any{
+	r.registerAction("devServer", newAction("devServer/dec", atype.Custom, map[string]any{
 		"bar": "baz",
 	}, dec))
 	srv := httptest.NewServer(newDevServeMux(r))
@@ -87,7 +87,7 @@ func TestDevServer(t *testing.T) {
 		want := map[string]actionDesc{
 			"/custom/devServer/inc": {
 				Key:          "/custom/devServer/inc",
-				Name:         "inc",
+				Name:         "devServer/inc",
 				InputSchema:  &jsonschema.Schema{Type: "integer"},
 				OutputSchema: &jsonschema.Schema{Type: "integer"},
 				Metadata:     map[string]any{"foo": "bar"},
@@ -96,7 +96,7 @@ func TestDevServer(t *testing.T) {
 				Key:          "/custom/devServer/dec",
 				InputSchema:  &jsonschema.Schema{Type: "integer"},
 				OutputSchema: &jsonschema.Schema{Type: "integer"},
-				Name:         "dec",
+				Name:         "devServer/dec",
 				Metadata:     map[string]any{"bar": "baz"},
 			},
 		}

--- a/go/plugins/localvec/localvec_test.go
+++ b/go/plugins/localvec/localvec_test.go
@@ -197,7 +197,7 @@ func TestInit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"a", "b"}
+	want := []string{"devLocalVectorStore/a", "devLocalVectorStore/b"}
 
 	if got := names(is); !slices.Equal(got, want) {
 		t.Errorf("got %v, want %v", got, want)


### PR DESCRIPTION
Using `provider/name` as the action name, instead of `name`. This matches the JS SDK.

Checklist (if applicable):
- [x] Tested (manually, unit tests)
