### PR TITLE
fix: [Go] action name must include provider

### DIFF
--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -38,7 +38,6 @@ func DefinePrompt(provider, name string, metadata map[string]any, render func(co
 		mm = make(map[string]any)
 	}
 	mm["type"] = "prompt"
-	mm["prompt"] = true // required by genkit ui
 	return core.DefineActionWithInputSchema(provider, name, atype.Prompt, mm, render, inputSchema)
 }
 

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -73,8 +73,8 @@ func DefineAction[In, Out any](provider, name string, atype atype.ActionType, me
 }
 
 func defineAction[In, Out any](r *registry, provider, name string, atype atype.ActionType, metadata map[string]any, fn func(context.Context, In) (Out, error)) *Action[In, Out, struct{}] {
-	a := newAction(name, atype, metadata, fn)
-	r.registerAction(provider, a)
+	a := newAction(provider+"/"+name, atype, metadata, fn)
+	r.registerAction(a)
 	return a
 }
 
@@ -83,8 +83,8 @@ func DefineStreamingAction[In, Out, Stream any](provider, name string, atype aty
 }
 
 func defineStreamingAction[In, Out, Stream any](r *registry, provider, name string, atype atype.ActionType, metadata map[string]any, fn Func[In, Out, Stream]) *Action[In, Out, Stream] {
-	a := newStreamingAction(name, atype, metadata, fn)
-	r.registerAction(provider, a)
+	a := newStreamingAction(provider+"/"+name, atype, metadata, fn)
+	r.registerAction(a)
 	return a
 }
 
@@ -101,8 +101,8 @@ func DefineActionWithInputSchema[Out any](provider, name string, atype atype.Act
 }
 
 func defineActionWithInputSchema[Out any](r *registry, provider, name string, atype atype.ActionType, metadata map[string]any, fn func(context.Context, any) (Out, error), inputSchema *jsonschema.Schema) *Action[any, Out, struct{}] {
-	a := newActionWithInputSchema(name, atype, metadata, fn, inputSchema)
-	r.registerAction(provider, a)
+	a := newActionWithInputSchema(provider+"/"+name, atype, metadata, fn, inputSchema)
+	r.registerAction(a)
 	return a
 }
 

--- a/go/core/conformance_test.go
+++ b/go/core/conformance_test.go
@@ -97,7 +97,7 @@ func TestFlowConformance(t *testing.T) {
 				t.Fatal(err)
 			}
 			_ = defineFlow(r, test.Name, flowFunction(test.Commands))
-			key := fmt.Sprintf("/flow/%s/%[1]s", test.Name)
+			key := fmt.Sprintf("/flow/%s", test.Name)
 			resp, err := runAction(context.Background(), r, key, test.Input, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/go/core/flow.go
+++ b/go/core/flow.go
@@ -119,7 +119,7 @@ func defineFlow[In, Out, Stream any](r *registry, name string, fn Func[In, Out, 
 		// TODO(jba): set stateStore?
 	}
 	a := f.action()
-	r.registerAction(name, a)
+	r.registerAction(a)
 	// TODO(jba): this is a roundabout way to transmit the tracing state. Is there a cleaner way?
 	f.tstate = a.tstate
 	r.registerFlow(f)

--- a/go/core/registry.go
+++ b/go/core/registry.go
@@ -94,8 +94,8 @@ const (
 // registerAction records the action in the registry.
 // It panics if an action with the same type, provider and name is already
 // registered.
-func (r *registry) registerAction(provider string, a action) {
-	key := fmt.Sprintf("/%s/%s/%s", a.actionType(), provider, a.Name())
+func (r *registry) registerAction(a action) {
+	key := fmt.Sprintf("/%s/%s", a.actionType(), a.Name())
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, ok := r.actions[key]; ok {
@@ -105,7 +105,6 @@ func (r *registry) registerAction(provider string, a action) {
 	r.actions[key] = a
 	slog.Info("RegisterAction",
 		"type", a.actionType(),
-		"provider", provider,
 		"name", a.Name())
 }
 

--- a/go/core/servers_test.go
+++ b/go/core/servers_test.go
@@ -39,10 +39,10 @@ func TestDevServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.registerAction("devServer", newAction("devServer/inc", atype.Custom, map[string]any{
+	r.registerAction(newAction("devServer/inc", atype.Custom, map[string]any{
 		"foo": "bar",
 	}, inc))
-	r.registerAction("devServer", newAction("devServer/dec", atype.Custom, map[string]any{
+	r.registerAction(newAction("devServer/dec", atype.Custom, map[string]any{
 		"bar": "baz",
 	}, dec))
 	srv := httptest.NewServer(newDevServeMux(r))

--- a/go/core/servers_test.go
+++ b/go/core/servers_test.go
@@ -39,10 +39,10 @@ func TestDevServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.registerAction("devServer", newAction("inc", atype.Custom, map[string]any{
+	r.registerAction("devServer", newAction("devServer/inc", atype.Custom, map[string]any{
 		"foo": "bar",
 	}, inc))
-	r.registerAction("devServer", newAction("dec", atype.Custom, map[string]any{
+	r.registerAction("devServer", newAction("devServer/dec", atype.Custom, map[string]any{
 		"bar": "baz",
 	}, dec))
 	srv := httptest.NewServer(newDevServeMux(r))
@@ -87,7 +87,7 @@ func TestDevServer(t *testing.T) {
 		want := map[string]actionDesc{
 			"/custom/devServer/inc": {
 				Key:          "/custom/devServer/inc",
-				Name:         "inc",
+				Name:         "devServer/inc",
 				InputSchema:  &jsonschema.Schema{Type: "integer"},
 				OutputSchema: &jsonschema.Schema{Type: "integer"},
 				Metadata:     map[string]any{"foo": "bar"},
@@ -96,7 +96,7 @@ func TestDevServer(t *testing.T) {
 				Key:          "/custom/devServer/dec",
 				InputSchema:  &jsonschema.Schema{Type: "integer"},
 				OutputSchema: &jsonschema.Schema{Type: "integer"},
-				Name:         "dec",
+				Name:         "devServer/dec",
 				Metadata:     map[string]any{"bar": "baz"},
 			},
 		}

--- a/go/plugins/dotprompt/dotprompt.go
+++ b/go/plugins/dotprompt/dotprompt.go
@@ -63,8 +63,11 @@ type Prompt struct {
 
 	Config
 
-	// The template for the prompt.
+	// The parsed prompt template.
 	Template *raymond.Template
+
+	// The original prompt template text.
+	TemplateText string
 
 	// A hash of the prompt contents.
 	hash string
@@ -197,10 +200,11 @@ func newPrompt(name, templateText, hash string, config Config) (*Prompt, error) 
 	}
 	template.RegisterHelpers(templateHelpers)
 	return &Prompt{
-		Name:     name,
-		Config:   config,
-		hash:     hash,
-		Template: template,
+		Name:         name,
+		Config:       config,
+		hash:         hash,
+		Template:     template,
+		TemplateText: templateText,
 	}, nil
 }
 

--- a/go/plugins/localvec/localvec_test.go
+++ b/go/plugins/localvec/localvec_test.go
@@ -197,7 +197,7 @@ func TestInit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"a", "b"}
+	want := []string{"devLocalVectorStore/a", "devLocalVectorStore/b"}
 
 	if got := names(is); !slices.Equal(got, want) {
 		t.Errorf("got %v, want %v", got, want)

--- a/go/samples/coffee-shop/main.go
+++ b/go/samples/coffee-shop/main.go
@@ -109,11 +109,15 @@ func main() {
 		log.Fatal(err)
 	}
 
+	r := &jsonschema.Reflector{
+		AllowAdditionalProperties: false,
+		DoNotReference:            true,
+	}
 	g := googleai.Model("gemini-1.5-pro")
 	simpleGreetingPrompt, err := dotprompt.Define("simpleGreeting", simpleGreetingPromptTemplate,
 		dotprompt.Config{
 			ModelAction:  g,
-			InputSchema:  jsonschema.Reflect(simpleGreetingInput{}),
+			InputSchema:  r.Reflect(simpleGreetingInput{}),
 			OutputFormat: ai.OutputFormatText,
 		},
 	)
@@ -176,10 +180,6 @@ func main() {
 		return text, nil
 	})
 
-	r := &jsonschema.Reflector{
-		AllowAdditionalProperties: false,
-		DoNotReference:            true,
-	}
 	schema := r.Reflect(simpleGreetingOutput{})
 	jsonBytes, err := schema.MarshalJSON()
 	if err != nil {


### PR DESCRIPTION
Action names are fully qualified (which includes provider id). Action name are used downstream in tracing and being fully qualified is important when loading traces in the Dev UI.