### PR TITLE
feat: allow specifying middleware on the `generate` function

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -626,9 +626,15 @@ export async function generate<
     async () => {
       var modelAction = model;
       if (resolvedOptions.use) {
-        modelAction = actionWithMiddleware(modelAction, resolvedOptions.use) as ModelAction;
+        modelAction = actionWithMiddleware(
+          modelAction,
+          resolvedOptions.use
+        ) as ModelAction;
       }
-      return new GenerateResponse<z.infer<O>>(await modelAction(request), request)
+      return new GenerateResponse<z.infer<O>>(
+        await modelAction(request),
+        request
+      );
     }
   );
 

--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -269,6 +269,7 @@ export function defineModel<
     configSchema?: CustomOptionsSchema;
     /** Descriptive name for this model e.g. 'Google AI - Gemini Pro'. */
     label?: string;
+    /** Middlewera to be used with this model. */
     use?: ModelMiddleware[];
   },
   runner: (

--- a/js/ai/tests/generate/generate_test.ts
+++ b/js/ai/tests/generate/generate_test.ts
@@ -20,19 +20,19 @@ import { beforeEach, describe, it } from 'node:test';
 import { z } from 'zod';
 import {
   Candidate,
-  generate,
   GenerateOptions,
   GenerateResponse,
   Message,
+  generate,
   toGenerateRequest,
 } from '../../src/generate.js';
 import {
   CandidateData,
-  defineModel,
   GenerateRequest,
   MessageData,
   ModelAction,
   ModelMiddleware,
+  defineModel,
 } from '../../src/model.js';
 import { defineTool } from '../../src/tool.js';
 

--- a/js/ai/tests/generate/generate_test.ts
+++ b/js/ai/tests/generate/generate_test.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import { __hardResetRegistryForTesting } from '@genkit-ai/core/registry';
 import assert from 'node:assert';
-import { describe, it } from 'node:test';
+import { beforeEach, describe, it } from 'node:test';
 import { z } from 'zod';
 import {
   Candidate,
+  generate,
   GenerateOptions,
   GenerateResponse,
   Message,
@@ -26,8 +28,11 @@ import {
 } from '../../src/generate.js';
 import {
   CandidateData,
+  defineModel,
   GenerateRequest,
   MessageData,
+  ModelAction,
+  ModelMiddleware,
 } from '../../src/model.js';
 import { defineTool } from '../../src/tool.js';
 
@@ -505,4 +510,96 @@ describe('toGenerateRequest', () => {
       );
     });
   }
+});
+
+describe('generate', () => {
+  beforeEach(__hardResetRegistryForTesting);
+
+  var echoModel: ModelAction;
+
+  beforeEach(() => {
+    echoModel = defineModel(
+      {
+        name: 'echoModel',
+      },
+      async (request) => {
+        return {
+          candidates: [
+            {
+              index: 0,
+              finishReason: 'stop',
+              message: {
+                role: 'model',
+                content: [
+                  {
+                    text:
+                      'Echo: ' +
+                      request.messages
+                        .map((m) => m.content.map((c) => c.text).join())
+                        .join(),
+                  },
+                ],
+              },
+            },
+          ],
+        };
+      }
+    );
+  });
+
+  it('applies middleware', async () => {
+    const wrapRequest: ModelMiddleware = async (req, next) => {
+      return next({
+        ...req,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                text:
+                  '(' +
+                  req.messages
+                    .map((m) => m.content.map((c) => c.text).join())
+                    .join() +
+                  ')',
+              },
+            ],
+          },
+        ],
+      });
+    };
+    const wrapResponse: ModelMiddleware = async (req, next) => {
+      const res = await next(req);
+      return {
+        candidates: [
+          {
+            index: 0,
+            finishReason: 'stop',
+            message: {
+              role: 'model',
+              content: [
+                {
+                  text:
+                    '[' +
+                    res.candidates[0].message.content
+                      .map((c) => c.text)
+                      .join() +
+                    ']',
+                },
+              ],
+            },
+          },
+        ],
+      };
+    };
+
+    const response = await generate({
+      prompt: 'banana',
+      model: echoModel,
+      use: [wrapRequest, wrapResponse],
+    });
+
+    const want = '[Echo: (banana)]';
+    assert.deepStrictEqual(response.text(), want);
+  });
 });

--- a/js/plugins/dotprompt/src/prompt.ts
+++ b/js/plugins/dotprompt/src/prompt.ts
@@ -188,6 +188,7 @@ export class Dotprompt<Variables = unknown> implements PromptMetadata {
       tools: (options.tools || []).concat(this.tools || []),
       streamingCallback: options.streamingCallback,
       returnToolRequests: options.returnToolRequests,
+      use: options.use,
     };
   }
 

--- a/js/plugins/dotprompt/tests/prompt_test.ts
+++ b/js/plugins/dotprompt/tests/prompt_test.ts
@@ -95,7 +95,7 @@ describe('Prompt', () => {
       const prompt = testPrompt(`Hello {{name}}, how are you?`);
 
       const streamingCallback = (c) => console.log(c);
-      const middleware = []
+      const middleware = [];
 
       const rendered = await prompt.render({
         input: { name: 'Michael' },

--- a/js/plugins/dotprompt/tests/prompt_test.ts
+++ b/js/plugins/dotprompt/tests/prompt_test.ts
@@ -95,14 +95,17 @@ describe('Prompt', () => {
       const prompt = testPrompt(`Hello {{name}}, how are you?`);
 
       const streamingCallback = (c) => console.log(c);
+      const middleware = []
 
       const rendered = await prompt.render({
         input: { name: 'Michael' },
         streamingCallback,
         returnToolRequests: true,
+        use: middleware,
       });
       assert.strictEqual(rendered.streamingCallback, streamingCallback);
       assert.strictEqual(rendered.returnToolRequests, true);
+      assert.strictEqual(rendered.use, middleware);
     });
   });
 


### PR DESCRIPTION
The idea is to be able to do things like

```ts
await generate({
  prompt: prompt,
  model: model,
  use: [
    retry({ maxRetries: 2 }),
    smoothStreaming({ cadence: 25, randomize: true })
  ],
})