### PR TITLE
[Go] rename localvec.DefineStore

### DIFF
--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -46,9 +46,9 @@ type Config struct {
 // Init initializes the plugin.
 func Init() error { return nil }
 
-// DefineStore defines an indexer and retriever that share the same underlying storage.
-// The name uniquely identifies the the indexer and retriever in the registry.
-func DefineStore(name string, cfg Config) (*ai.Indexer, *ai.Retriever, error) {
+// DefineIndexerAndRetriever defines an Indexer and Retriever that share the same underlying storage.
+// The name uniquely identifies the the Indexer and Retriever in the registry.
+func DefineIndexerAndRetriever(name string, cfg Config) (*ai.Indexer, *ai.Retriever, error) {
 	ds, err := newDocStore(cfg.Dir, name, cfg.Embedder, cfg.EmbedderOptions)
 	if err != nil {
 		return nil, nil, err

--- a/go/plugins/localvec/localvec_test.go
+++ b/go/plugins/localvec/localvec_test.go
@@ -193,7 +193,7 @@ func TestInit(t *testing.T) {
 		t.Fatal(err)
 	}
 	const name = "mystore"
-	ind, ret, err := DefineStore(name, Config{Embedder: embedder})
+	ind, ret, err := DefineIndexerAndRetriever(name, Config{Embedder: embedder})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/plugins/pinecone/genkit.go
+++ b/go/plugins/pinecone/genkit.go
@@ -82,6 +82,7 @@ type Config struct {
 	TextKey string
 }
 
+// DefineIndexer defines an Indexer with the given configuration.
 func DefineIndexer(ctx context.Context, cfg Config) (*ai.Indexer, error) {
 	ds, err := newDocStore(ctx, cfg)
 	if err != nil {
@@ -90,6 +91,7 @@ func DefineIndexer(ctx context.Context, cfg Config) (*ai.Indexer, error) {
 	return ai.DefineIndexer(provider, cfg.IndexID, ds.Index), nil
 }
 
+// DefineRetriever defines a Retriever with the given configuration.
 func DefineRetriever(ctx context.Context, cfg Config) (*ai.Retriever, error) {
 	ds, err := newDocStore(ctx, cfg)
 	if err != nil {

--- a/go/samples/menu/main.go
+++ b/go/samples/menu/main.go
@@ -96,7 +96,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	indexer, retriever, err := localvec.DefineStore("go-menu_items", localvec.Config{
+	indexer, retriever, err := localvec.DefineIndexerAndRetriever("go-menu_items", localvec.Config{
 		Embedder: embedder,
 	})
 	if err := setup04(ctx, indexer, retriever, model); err != nil {

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -87,7 +87,7 @@ func main() {
 	if err := localvec.Init(); err != nil {
 		log.Fatal(err)
 	}
-	indexer, retriever, err := localvec.DefineStore("simpleQa", localvec.Config{Embedder: embedder})
+	indexer, retriever, err := localvec.DefineIndexerAndRetriever("simpleQa", localvec.Config{Embedder: embedder})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
I tried to separate DefineStore into DefineIndexer and DefineRetriever,
but I didn't see a good way to share the in-memory state of the store.
Although DefineIndexerAndRetriever is cumbersome, it at least
removes the otherwise unused term "Store".
