### PR TITLE
Adds telemetry export support to Firebase plugin

### DIFF
--- a/docs/plugins/google-cloud.md
+++ b/docs/plugins/google-cloud.md
@@ -62,7 +62,6 @@ The `googleCloud()` plugin takes an optional configuration object:
 ```ts
 {
     projectId?: string,
-    forceDevExport?: boolean,
     telemetryConfig?: TelemetryConfig
 }
 ```
@@ -70,12 +69,6 @@ The `googleCloud()` plugin takes an optional configuration object:
 ### projectId
 
 This option allows specifying the Google Cloud project ID explicitly. In most cases, this is unnecessary.
-
-### forceDevExport
-
-This option will force Genkit to export telemetry and log data when running in the `dev` environment (e.g. locally).
-
-> Note: When running locally, internal telemetry buffers may not fully flush prior to the process exiting, resulting in an incomplete telemetry export.
 
 ### telemetryConfig
 
@@ -85,8 +78,8 @@ This option configures the [OpenTelemetry NodeSDK](https://open-telemetry.github
 import { AlwaysOnSampler } from '@opentelemetry/sdk-trace-base';
 
 googleCloud({
-  forceDevExport: false, // Set this to true to export telemetry for local runs
   telemetryConfig: {
+    forceDevExport: false, // Set this to true to export telemetry for local runs
     sampler: new AlwaysOnSampler(),
     autoInstrumentation: true,
     autoInstrumentationConfig: {
@@ -98,6 +91,12 @@ googleCloud({
   },
 });
 ```
+
+#### forceDevExport
+
+This option will force Genkit to export telemetry and log data when running in the `dev` environment (e.g. locally).
+
+> Note: When running locally, internal telemetry buffers may not fully flush prior to the process exiting, resulting in an incomplete telemetry export.
 
 #### sampler
 

--- a/js/plugins/firebase/package.json
+++ b/js/plugins/firebase/package.json
@@ -34,6 +34,7 @@
     "@genkit-ai/ai": "workspace:*",
     "@genkit-ai/core": "workspace:*",
     "@genkit-ai/flow": "workspace:*",
+    "@genkit-ai/google-cloud": "workspace:*",
     "express": "^4.19.2",
     "google-auth-library": "^9.6.3",
     "zod": "^3.22.4"

--- a/js/plugins/firebase/src/index.ts
+++ b/js/plugins/firebase/src/index.ts
@@ -16,6 +16,11 @@
 
 import { genkitPlugin, Plugin } from '@genkit-ai/core';
 import { FirestoreStateStore } from '@genkit-ai/flow';
+import {
+  GcpLogger,
+  GcpOpenTelemetry,
+  TelemetryConfig,
+} from '@genkit-ai/google-cloud';
 import { FirestoreTraceStore } from './firestoreTraceStore.js';
 export { defineFirestoreRetriever } from './firestoreRetriever.js';
 
@@ -29,6 +34,7 @@ interface FirestorePluginParams {
     collection?: string;
     databaseId?: string;
   };
+  telemetryConfig?: TelemetryConfig;
 }
 
 export const firebase: Plugin<[FirestorePluginParams] | []> = genkitPlugin(
@@ -41,6 +47,16 @@ export const firebase: Plugin<[FirestorePluginParams] | []> = genkitPlugin(
     traceStore: {
       id: 'firestore',
       value: new FirestoreTraceStore(params?.traceStore),
+    },
+    telemetry: {
+      instrumentation: {
+        id: 'firebase',
+        value: new GcpOpenTelemetry(params),
+      },
+      logger: {
+        id: 'firebase',
+        value: new GcpLogger(params),
+      },
     },
   })
 );

--- a/js/plugins/google-cloud/src/gcpLogger.ts
+++ b/js/plugins/google-cloud/src/gcpLogger.ts
@@ -60,6 +60,6 @@ export class GcpLogger implements LoggerConfig {
   }
 
   private shouldExport(env: string) {
-    return this.options.forceDevExport || env !== 'dev';
+    return this.options.telemetryConfig?.forceDevExport || env !== 'dev';
   }
 }

--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -170,14 +170,16 @@ export class GcpOpenTelemetry implements TelemetryConfig {
 
   private shouldExportTraces(): boolean {
     return (
-      (this.options.forceDevExport || process.env.GENKIT_ENV !== 'dev') &&
+      (this.options.telemetryConfig?.forceDevExport ||
+        process.env.GENKIT_ENV !== 'dev') &&
       !this.options.telemetryConfig?.disableTraces
     );
   }
 
   private shouldExportMetrics(): boolean {
     return (
-      (this.options.forceDevExport || process.env.GENKIT_ENV !== 'dev') &&
+      (this.options.telemetryConfig?.forceDevExport ||
+        process.env.GENKIT_ENV !== 'dev') &&
       !this.options.telemetryConfig?.disableMetrics
     );
   }

--- a/js/plugins/google-cloud/src/index.ts
+++ b/js/plugins/google-cloud/src/index.ts
@@ -24,7 +24,6 @@ import { GcpOpenTelemetry } from './gcpOpenTelemetry.js';
 
 export interface PluginOptions {
   projectId?: string;
-  forceDevExport?: boolean;
   telemetryConfig?: TelemetryConfig;
 }
 
@@ -41,6 +40,9 @@ export interface TelemetryConfig {
 
   /** When true, traces are not sent to GCP. */
   disableTraces?: boolean;
+
+  /** When true, telemetry data will be exported, even for local runs */
+  forceDevExport?: boolean;
 }
 
 /**
@@ -72,4 +74,5 @@ export const googleCloud: Plugin<[PluginOptions] | []> = genkitPlugin(
 );
 
 export default googleCloud;
+export * from './gcpLogger.js';
 export * from './gcpOpenTelemetry.js';

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -49,8 +49,8 @@ describe('GoogleCloudMetrics', () => {
       // Force GCP Plugin to use in-memory metrics exporter
       plugins: [
         googleCloud({
-          forceDevExport: false,
           telemetryConfig: {
+            forceDevExport: false,
             metricExportIntervalMillis: 100,
             metricExportTimeoutMillis: 100,
           },
@@ -390,8 +390,8 @@ describe('GoogleCloudMetrics', () => {
   describe('Configuration', () => {
     it('should export only traces', async () => {
       const telemetry = new GcpOpenTelemetry({
-        forceDevExport: true,
         telemetryConfig: {
+          forceDevExport: true,
           disableMetrics: true,
         },
       });
@@ -401,8 +401,8 @@ describe('GoogleCloudMetrics', () => {
 
     it('should export only metrics', async () => {
       const telemetry = new GcpOpenTelemetry({
-        forceDevExport: true,
         telemetryConfig: {
+          forceDevExport: true,
           disableTraces: true,
           disableMetrics: false,
         },

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
       '@genkit-ai/flow':
         specifier: workspace:*
         version: link:../../flow
+      '@genkit-ai/google-cloud':
+        specifier: workspace:*
+        version: link:../google-cloud
       '@google-cloud/firestore':
         specifier: ^7.6.0
         version: 7.6.0(encoding@0.1.13)


### PR DESCRIPTION
Adds dependency from Firebase plugin to GCP plugin, and moves the 'forceDevExport' config option under  TelemetryConfig since it is specific to telemetry data export.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [x] Docs updated
