### PR TITLE
Requiring manual Firebase app initialization to use admin sdk features

### DIFF
--- a/js/plugins/firebase/src/auth.ts
+++ b/js/plugins/firebase/src/auth.ts
@@ -19,7 +19,7 @@ import { Response } from 'express';
 import { DecodedIdToken, getAuth } from 'firebase-admin/auth';
 import * as z from 'zod';
 import { FunctionFlowAuth } from './functions.js';
-import { initializeAppIfNecessary } from './helpers.js';
+import { requireDefaultFirebaseApp } from './helpers.js';
 
 export function firebaseAuth<I extends z.ZodTypeAny>(
   policy: (user: DecodedIdToken, input: z.infer<I>) => void | Promise<void>
@@ -39,7 +39,7 @@ export function firebaseAuth<I extends z.ZodTypeAny>(
   policy: (user: DecodedIdToken, input: z.infer<I>) => void | Promise<void>,
   config?: { required: boolean }
 ): FunctionFlowAuth<I> {
-  initializeAppIfNecessary();
+  requireDefaultFirebaseApp('Firebase authorization');
   const required = config?.required || true;
   return {
     async policy(auth: unknown | undefined, input: z.infer<I>) {

--- a/js/plugins/firebase/src/functions.ts
+++ b/js/plugins/firebase/src/functions.ts
@@ -34,7 +34,7 @@ import * as z from 'zod';
 import {
   callHttpsFunction,
   getLocation,
-  initializeAppIfNecessary,
+  requireDefaultFirebaseApp,
 } from './helpers.js';
 
 export type FunctionFlow<
@@ -157,7 +157,7 @@ async function appCheckValid(
   consume: boolean
 ): Promise<boolean> {
   if (typeof tok !== 'string') return false;
-  initializeAppIfNecessary();
+  requireDefaultFirebaseApp('Firebase app check');
   try {
     const appCheckClaims = await getAppCheck().verifyToken(tok, { consume });
 

--- a/js/plugins/firebase/src/helpers.ts
+++ b/js/plugins/firebase/src/helpers.ts
@@ -15,7 +15,7 @@
  */
 
 import { StreamingCallback } from '@genkit-ai/core';
-import { getApps, initializeApp } from 'firebase-admin/app';
+import { App, getApps } from 'firebase-admin/app';
 import { GoogleAuth } from 'google-auth-library';
 
 // cached `GoogleAuth` client.
@@ -131,8 +131,16 @@ export function getLocation() {
   return process.env['GCLOUD_LOCATION'] || 'us-central1';
 }
 
-export function initializeAppIfNecessary() {
-  if (!getApps().length) {
-    initializeApp();
+export function requireDefaultFirebaseApp(
+  feature: string = 'Firebase plugin'
+): App {
+  const apps: App[] = getApps();
+  if (apps.length) {
+    return apps[0];
+  } else {
+    const errorMessage =
+      `A Firebase application must be initialized first.` +
+      `Call initializeApp() before configuring the ${feature}.`;
+    throw new Error(errorMessage);
   }
 }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -742,8 +742,8 @@ importers:
         specifier: workspace:*
         version: link:../../plugins/vertexai
       firebase-admin:
-        specifier: ^12.1.0
-        version: 12.1.0(encoding@0.1.13)
+        specifier: ^12.2.0
+        version: 12.2.0(encoding@0.1.13)
       genkitx-chromadb:
         specifier: workspace:*
         version: link:../../plugins/chroma
@@ -936,6 +936,9 @@ importers:
       '@genkit-ai/flow':
         specifier: workspace:*
         version: link:../../flow
+      firebase-admin:
+        specifier: ^12.2.0
+        version: 12.2.0(encoding@0.1.13)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -974,8 +977,8 @@ importers:
         specifier: ^1.22.0
         version: 1.22.0(@opentelemetry/api@1.8.0)
       firebase-admin:
-        specifier: ^12.1.0
-        version: 12.1.0(encoding@0.1.13)
+        specifier: ^12.2.0
+        version: 12.2.0(encoding@0.1.13)
       partial-json:
         specifier: ^0.1.7
         version: 0.1.7
@@ -5041,7 +5044,7 @@ snapshots:
       fast-deep-equal: 3.1.3
       functional-red-black-tree: 1.0.1
       google-gax: 4.3.7(encoding@0.1.13)
-      protobufjs: 7.2.6
+      protobufjs: 7.3.2
     transitivePeerDependencies:
       - encoding
       - supports-color

--- a/js/testapps/dev-ui-gallery/package.json
+++ b/js/testapps/dev-ui-gallery/package.json
@@ -27,7 +27,7 @@
     "@genkit-ai/flow": "workspace:*",
     "@genkit-ai/googleai": "workspace:*",
     "@genkit-ai/vertexai": "workspace:*",
-    "firebase-admin": "^12.1.0",
+    "firebase-admin": "^12.2.0",
     "genkitx-chromadb": "workspace:*",
     "genkitx-ollama": "workspace:*",
     "genkitx-pinecone": "workspace:*",

--- a/js/testapps/dev-ui-gallery/src/index.ts
+++ b/js/testapps/dev-ui-gallery/src/index.ts
@@ -28,6 +28,7 @@ import {
   vertexAI,
   VertexAIEvaluationMetricType,
 } from '@genkit-ai/vertexai';
+import { initializeApp } from 'firebase-admin/app';
 import { chroma } from 'genkitx-chromadb';
 import { ollama } from 'genkitx-ollama';
 import { pinecone } from 'genkitx-pinecone';
@@ -54,6 +55,9 @@ export const PERMISSIVE_SAFETY_SETTINGS: any = {
     },
   ],
 };
+
+// Initialize Firebase SDKs
+initializeApp();
 
 export default configureGenkit({
   // settings

--- a/js/testapps/firebase-functions-sample1/functions/package.json
+++ b/js/testapps/firebase-functions-sample1/functions/package.json
@@ -19,7 +19,7 @@
     "@genkit-ai/firebase": "*",
     "@genkit-ai/flow": "*",
     "@genkit-ai/vertexai": "*",
-    "firebase-admin": "^11.8.0",
+    "firebase-admin": "^12.2.0",
     "firebase-functions": "^4.8.0 || ^5.0.0",
     "zod": "^3.22.4"
   },

--- a/js/testapps/firebase-functions-sample1/functions/src/index.ts
+++ b/js/testapps/firebase-functions-sample1/functions/src/index.ts
@@ -21,8 +21,11 @@ import { firebaseAuth } from '@genkit-ai/firebase/auth';
 import { noAuth, onFlow } from '@genkit-ai/firebase/functions';
 import { run, runFlow, streamFlow } from '@genkit-ai/flow';
 import { geminiPro, vertexAI } from '@genkit-ai/vertexai';
+import { initializeApp } from 'firebase-admin';
 import { onRequest } from 'firebase-functions/v2/https';
 import * as z from 'zod';
+
+initializeApp();
 
 configureGenkit({
   plugins: [firebase(), vertexAI()],

--- a/js/testapps/flow-sample1/package.json
+++ b/js/testapps/flow-sample1/package.json
@@ -18,6 +18,7 @@
     "@genkit-ai/core": "workspace:^",
     "@genkit-ai/flow": "workspace:*",
     "@genkit-ai/firebase": "workspace:^",
+    "firebase-admin": "^12.2.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/js/testapps/flow-sample1/src/index.ts
+++ b/js/testapps/flow-sample1/src/index.ts
@@ -30,7 +30,10 @@ import {
   sleep,
   waitFor,
 } from '@genkit-ai/flow/experimental';
+import { initializeApp } from 'firebase-admin';
 import * as z from 'zod';
+
+initializeApp();
 
 configureGenkit({
   plugins: [firebase()],

--- a/js/testapps/flow-simple-ai/package.json
+++ b/js/testapps/flow-simple-ai/package.json
@@ -24,7 +24,7 @@
     "@genkit-ai/googleai": "workspace:*",
     "@genkit-ai/vertexai": "workspace:*",
     "@opentelemetry/sdk-trace-base": "^1.22.0",
-    "firebase-admin": "^12.1.0",
+    "firebase-admin": "^12.2.0",
     "partial-json": "^0.1.7",
     "zod": "^3.22.4"
   },

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -34,14 +34,14 @@ import { getFirestore } from 'firebase-admin/firestore';
 import { Allow, parse } from 'partial-json';
 import * as z from 'zod';
 
+const app = initializeApp();
+
 configureGenkit({
   plugins: [
     firebase(),
     googleAI(),
     vertexAI(),
     googleCloud({
-      // Forces telemetry export in 'dev'
-      forceDevExport: true,
       // These are configured for demonstration purposes. Sensible defaults are
       // in place in the event that telemetryConfig is absent.
       telemetryConfig: {
@@ -66,8 +66,6 @@ configureGenkit({
     logger: 'googleCloud',
   },
 });
-
-const app = initializeApp();
 
 export const jokeFlow = defineFlow(
   {


### PR DESCRIPTION
- Removing opportunistic, automatic application initialization where the admin SDK is used in the Firebase plugin.
- Customer code will _always_ be required to call initializeApp() before configuring features that require the admin SDK.
- Updating test apps that use flow auth or functions

Checklist (if applicable):
- [ ] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
