### PR TITLE
Update GCP Trace exporter to avoid ':' in span attributes.

### DIFF
--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -45,6 +45,8 @@ import {
 import { PluginOptions } from './index.js';
 
 let metricExporter: PushMetricExporter;
+let spanProcessor: BatchSpanProcessor;
+let spanExporter: AdjustingTraceExporter;
 
 /**
  * Provides a {TelemetryConfig} for exporting OpenTelemetry data (Traces,
@@ -53,60 +55,6 @@ let metricExporter: PushMetricExporter;
 export class GcpOpenTelemetry implements TelemetryConfig {
   private readonly options: PluginOptions;
   private readonly resource: Resource;
-
-  /**
-   * Adjusts spans before exporting to GCP. In particular, redacts PII
-   * (input prompts and outputs), and adds a workaround attribute to
-   * error spans that marks them as error in GCP.
-   */
-  private AdjustingTraceExporter = class extends TraceExporter {
-    export(
-      spans: ReadableSpan[],
-      resultCallback: (result: ExportResult) => void
-    ): Promise<void> {
-      return super.export(this.adjust(spans), resultCallback);
-    }
-
-    private adjust(spans: ReadableSpan[]): ReadableSpan[] {
-      return spans.map((span) => {
-        span = this.redactPii(span);
-        span = this.markErrorSpanAsError(span);
-        return span;
-      });
-    }
-
-    private redactPii(span: ReadableSpan): ReadableSpan {
-      const hasInput = 'genkit:input' in span.attributes;
-      const hasOutput = 'genkit:output' in span.attributes;
-
-      return !hasInput && !hasOutput
-        ? span
-        : {
-            ...span,
-            spanContext: span.spanContext,
-            attributes: {
-              ...span.attributes,
-              'genkit:input': '<redacted>',
-              'genkit:output': '<redacted>',
-            },
-          };
-    }
-
-    // This is a workaround for GCP Trace to mark a span with a red
-    // exclamation mark indicating that it is an error.
-    private markErrorSpanAsError(span: ReadableSpan): ReadableSpan {
-      return span.status.code !== SpanStatusCode.ERROR
-        ? span
-        : {
-            ...span,
-            spanContext: span.spanContext,
-            attributes: {
-              ...span.attributes,
-              '/http/status_code': '599',
-            },
-          };
-    }
-  };
 
   /**
    * Log hook for writing trace and span metadata to log messages in the format
@@ -129,9 +77,10 @@ export class GcpOpenTelemetry implements TelemetryConfig {
   }
 
   getConfig(): Partial<NodeSDKConfiguration> {
+    spanProcessor = new BatchSpanProcessor(this.createSpanExporter());
     return {
       resource: this.resource,
-      spanProcessor: new BatchSpanProcessor(this.createSpanExporter()),
+      spanProcessor: spanProcessor,
       sampler: this.options?.telemetryConfig?.sampler || new AlwaysOnSampler(),
       instrumentations: this.getInstrumentations(),
       metricReader: this.createMetricReader(),
@@ -139,9 +88,12 @@ export class GcpOpenTelemetry implements TelemetryConfig {
   }
 
   private createSpanExporter(): SpanExporter {
-    return this.shouldExportTraces()
-      ? new this.AdjustingTraceExporter()
-      : new InMemorySpanExporter();
+    spanExporter = new AdjustingTraceExporter(
+      this.shouldExportTraces()
+        ? new TraceExporter()
+        : new InMemorySpanExporter()
+    );
+    return spanExporter;
   }
 
   /**
@@ -211,6 +163,99 @@ export class GcpOpenTelemetry implements TelemetryConfig {
   }
 }
 
+/**
+ * Adjusts spans before exporting to GCP. In particular, redacts PII
+ * (input prompts and outputs), and adds a workaround attribute to
+ * error spans that marks them as error in GCP.
+ */
+class AdjustingTraceExporter implements SpanExporter {
+  constructor(private exporter: SpanExporter) {}
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void
+  ): void {
+    this.exporter?.export(this.adjust(spans), resultCallback);
+  }
+
+  shutdown(): Promise<void> {
+    return this.exporter?.shutdown();
+  }
+
+  getExporter(): SpanExporter {
+    return this.exporter;
+  }
+
+  forceFlush(): Promise<void> {
+    if (this.exporter?.forceFlush) {
+      return this.exporter.forceFlush();
+    }
+    return Promise.resolve();
+  }
+
+  private adjust(spans: ReadableSpan[]): ReadableSpan[] {
+    return spans.map((span) => {
+      span = this.redactPii(span);
+      span = this.markErrorSpanAsError(span);
+      span = this.normalizeLabels(span);
+      return span;
+    });
+  }
+
+  private redactPii(span: ReadableSpan): ReadableSpan {
+    const hasInput = 'genkit:input' in span.attributes;
+    const hasOutput = 'genkit:output' in span.attributes;
+
+    return !hasInput && !hasOutput
+      ? span
+      : {
+          ...span,
+          spanContext: span.spanContext,
+          attributes: {
+            ...span.attributes,
+            'genkit:input': '<redacted>',
+            'genkit:output': '<redacted>',
+          },
+        };
+  }
+
+  // This is a workaround for GCP Trace to mark a span with a red
+  // exclamation mark indicating that it is an error.
+  private markErrorSpanAsError(span: ReadableSpan): ReadableSpan {
+    return span.status.code !== SpanStatusCode.ERROR
+      ? span
+      : {
+          ...span,
+          spanContext: span.spanContext,
+          attributes: {
+            ...span.attributes,
+            '/http/status_code': '599',
+          },
+        };
+  }
+
+  // This is a workaround for GCP Trace to mark a span with a red
+  // exclamation mark indicating that it is an error.
+  private normalizeLabels(span: ReadableSpan): ReadableSpan {
+    const normalized = {} as Record<string, any>;
+    for (const [key, value] of Object.entries(span.attributes)) {
+      normalized[key.replace(/\:/g, '/')] = value;
+    }
+    return {
+      ...span,
+      attributes: normalized,
+    };
+  }
+}
+
 export function __getMetricExporterForTesting(): InMemoryMetricExporter {
   return metricExporter as InMemoryMetricExporter;
+}
+
+export function __getSpanExporterForTesting(): InMemorySpanExporter {
+  return spanExporter.getExporter() as InMemorySpanExporter;
+}
+
+export function __forceFlushSpansForTesting() {
+  spanProcessor.forceFlush();
 }

--- a/js/plugins/google-cloud/tests/traces_test.ts
+++ b/js/plugins/google-cloud/tests/traces_test.ts
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  FlowState,
+  FlowStateQuery,
+  FlowStateQueryResponse,
+  FlowStateStore,
+  configureGenkit,
+} from '@genkit-ai/core';
+import { registerFlowStateStore } from '@genkit-ai/core/registry';
+import { defineFlow, run, runFlow } from '@genkit-ai/flow';
+import {
+  __forceFlushSpansForTesting,
+  __getSpanExporterForTesting,
+  googleCloud,
+} from '@genkit-ai/google-cloud';
+import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import assert from 'node:assert';
+import { before, beforeEach, describe, it } from 'node:test';
+import { z } from 'zod';
+
+describe('GoogleCloudTracing', () => {
+  before(async () => {
+    process.env.GENKIT_ENV = 'dev';
+    const config = configureGenkit({
+      // Force GCP Plugin to use in-memory metrics exporter
+      plugins: [
+        googleCloud({
+          telemetryConfig: {
+            forceDevExport: false,
+          },
+        }),
+      ],
+      enableTracingAndMetrics: true,
+      telemetry: {
+        instrumentation: 'googleCloud',
+      },
+    });
+    registerFlowStateStore('dev', async () => new NoOpFlowStateStore());
+    // Wait for the telemetry plugin to be initialized
+    await config.getTelemetryConfig();
+  });
+  beforeEach(async () => {
+    __getSpanExporterForTesting().reset();
+  });
+
+  it('writes traces', async () => {
+    const testFlow = createFlow('testFlow');
+
+    await runFlow(testFlow);
+
+    const spans = await getExportedSpans();
+    assert.equal(spans.length, 1);
+    assert.equal(spans[0].name, 'testFlow');
+  });
+
+  it('Adjusts attributes to support GCP trace filtering', async () => {
+    const testFlow = createFlow('testFlow');
+
+    await runFlow(testFlow);
+
+    const spans = await getExportedSpans();
+    // Check some common attributes
+    assert.equal(spans[0].attributes['genkit/name'], 'testFlow');
+    assert.equal(spans[0].attributes['genkit/type'], 'flow');
+    // Ensure we have no attributes with ':' because these are awkward to use in
+    // Cloud Trace.
+    const spanAttrKeys = Object.entries(spans[0].attributes).map(([k, v]) => k);
+    for (key in spanAttrKeys) {
+      assert.equal(key.indexOf(':'), -1);
+    }
+  });
+
+  it('sub actions are contained within flows', async () => {
+    const testFlow = createFlow('testFlow', async () => {
+      return await run('subAction', async () => {
+        return await run('subAction2', async () => {
+          return 'done';
+        });
+      });
+    });
+
+    await runFlow(testFlow);
+
+    const spans = await getExportedSpans();
+    assert.equal(spans.length, 3);
+    assert.equal(spans[2].name, 'testFlow');
+    assert.equal(spans[2].parentSpanId, undefined);
+    assert.equal(spans[1].name, 'subAction');
+    assert.equal(spans[1].parentSpanId, spans[2].spanContext().spanId);
+    assert.equal(spans[0].name, 'subAction2');
+    assert.equal(spans[0].parentSpanId, spans[1].spanContext().spanId);
+  });
+
+  it('different flows run independently', async () => {
+    const testFlow1 = createFlow('testFlow1');
+    const testFlow2 = createFlow('testFlow2');
+
+    await runFlow(testFlow1);
+    await runFlow(testFlow2);
+
+    const spans = await getExportedSpans();
+    assert.equal(spans.length, 2);
+    assert.equal(spans[0].parentSpanId, undefined);
+    assert.equal(spans[1].parentSpanId, undefined);
+  });
+
+  /** Helper to create a flow with no inputs or outputs */
+  function createFlow(name: string, fn: () => Promise<void> = async () => {}) {
+    return defineFlow(
+      {
+        name,
+        inputSchema: z.void(),
+        outputSchema: z.void(),
+      },
+      fn
+    );
+  }
+
+  /** Polls the in memory metric exporter until the genkit scope is found. */
+  async function getExportedSpans(
+    name: string = 'genkit',
+    maxAttempts: number = 100
+  ): promise<ReadableSpan[]> {
+    __forceFlushSpansForTesting();
+    var attempts = 0;
+    while (attempts++ < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const found = __getSpanExporterForTesting().getFinishedSpans();
+      if (found.length > 0) {
+        return found;
+      }
+    }
+    assert.fail(`Waiting for metric ${name} but it has not been written.`);
+  }
+});
+
+class NoOpFlowStateStore implements FlowStateStore {
+  state: Record<string, string> = {};
+
+  load(id: string): Promise<FlowState | undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  save(id: string, state: FlowState): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async list(
+    query?: FlowStateQuery | undefined
+  ): Promise<FlowStateQueryResponse> {
+    return {};
+  }
+}


### PR DESCRIPTION
Using colons in span attributes make filtering by these labels difficult in the Trace Explorer.

* Add tests for GCP exported traces
* Modify AdjustingTraceExporter to facilitate testing

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
