### PR TITLE
[Go] improve core action API

### DIFF
--- a/go/core/action_test.go
+++ b/go/core/action_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
-func inc(_ context.Context, x int) (int, error) {
+func inc(_ context.Context, x int, _ noStream) (int, error) {
 	return x + 1, nil
 }
 
 func TestActionRun(t *testing.T) {
-	a := NewAction("inc", atype.Custom, nil, inc)
+	a := newAction("inc", atype.Custom, nil, nil, inc)
 	got, err := a.Run(context.Background(), 3, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +41,7 @@ func TestActionRun(t *testing.T) {
 }
 
 func TestActionRunJSON(t *testing.T) {
-	a := NewAction("inc", atype.Custom, nil, inc)
+	a := newAction("inc", atype.Custom, nil, nil, inc)
 	input := []byte("3")
 	want := []byte("4")
 	got, err := a.RunJSON(context.Background(), input, nil)
@@ -51,11 +51,6 @@ func TestActionRunJSON(t *testing.T) {
 	if !bytes.Equal(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
-}
-
-func TestNewAction(t *testing.T) {
-	// Verify that struct{} can occur in the function signature.
-	_ = NewAction("f", atype.Custom, nil, func(context.Context, int) (struct{}, error) { return struct{}{}, nil })
 }
 
 // count streams the numbers from 0 to n-1, then returns n.
@@ -72,7 +67,7 @@ func count(ctx context.Context, n int, cb func(context.Context, int) error) (int
 
 func TestActionStreaming(t *testing.T) {
 	ctx := context.Background()
-	a := NewStreamingAction("count", atype.Custom, nil, count)
+	a := newAction("count", atype.Custom, nil, nil, count)
 	const n = 3
 
 	// Non-streaming.
@@ -105,7 +100,7 @@ func TestActionStreaming(t *testing.T) {
 func TestActionTracing(t *testing.T) {
 	ctx := context.Background()
 	const actionName = "TestTracing-inc"
-	a := NewAction(actionName, atype.Custom, nil, inc)
+	a := newAction(actionName, atype.Custom, nil, nil, inc)
 	if _, err := a.Run(context.Background(), 3, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/go/genkit/servers_test.go
+++ b/go/genkit/servers_test.go
@@ -33,11 +33,11 @@ import (
 	"github.com/invopop/jsonschema"
 )
 
-func inc(_ context.Context, x int) (int, error) {
+func inc(_ context.Context, x int, _ noStream) (int, error) {
 	return x + 1, nil
 }
 
-func dec(_ context.Context, x int) (int, error) {
+func dec(_ context.Context, x int, _ noStream) (int, error) {
 	return x - 1, nil
 }
 
@@ -46,12 +46,12 @@ func TestDevServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.RegisterAction(atype.Custom, core.NewAction("devServer/inc", atype.Custom, map[string]any{
+	core.DefineActionInRegistry(r, "devServer", "inc", atype.Custom, map[string]any{
 		"foo": "bar",
-	}, inc))
-	r.RegisterAction(atype.Custom, core.NewAction("devServer/dec", atype.Custom, map[string]any{
+	}, nil, inc)
+	core.DefineActionInRegistry(r, "devServer", "dec", atype.Custom, map[string]any{
 		"bar": "baz",
-	}, dec))
+	}, nil, dec)
 	srv := httptest.NewServer(newDevServeMux(r))
 	defer srv.Close()
 


### PR DESCRIPTION
Define a single, general newAction function.

Define a single fully general method for defining an action
in a registry. All other Define functions call it.
Export it so the genkit package can use it to define flows.
It's unfortunate that we have to export it, but code outside the
module can't call it anyway because it takes a registry, which
has an internal type.
