### PR TITLE
[Go] align Embedder API with JS

### DIFF
--- a/go/internal/fakeembedder/fakeembedder.go
+++ b/go/internal/fakeembedder/fakeembedder.go
@@ -43,10 +43,14 @@ func (e *Embedder) Register(d *ai.Document, vals []float32) {
 	e.registry[d] = vals
 }
 
-func (e *Embedder) Embed(ctx context.Context, req *ai.EmbedRequest) ([]float32, error) {
-	vals, ok := e.registry[req.Document]
-	if !ok {
-		return nil, errors.New("fake embedder called with unregistered document")
+func (e *Embedder) Embed(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+	res := &ai.EmbedResponse{}
+	for _, doc := range req.Documents {
+		vals, ok := e.registry[doc]
+		if !ok {
+			return nil, errors.New("fake embedder called with unregistered document")
+		}
+		res.Embeddings = append(res.Embeddings, &ai.DocumentEmbedding{Embedding: vals})
 	}
-	return vals, nil
+	return res, nil
 }

--- a/go/internal/fakeembedder/fakeembedder_test.go
+++ b/go/internal/fakeembedder/fakeembedder_test.go
@@ -31,18 +31,19 @@ func TestFakeEmbedder(t *testing.T) {
 	embed.Register(d, vals)
 
 	req := &ai.EmbedRequest{
-		Document: d,
+		Documents: []*ai.Document{d},
 	}
 	ctx := context.Background()
-	got, err := emb.Embed(ctx, req)
+	res, err := emb.Embed(ctx, req)
 	if err != nil {
 		t.Fatal(err)
 	}
+	got := res.Embeddings[0].Embedding
 	if !slices.Equal(got, vals) {
 		t.Errorf("lookup returned %v, want %v", got, vals)
 	}
 
-	req.Document = ai.DocumentFromText("missing document", nil)
+	req.Documents[0] = ai.DocumentFromText("missing document", nil)
 	if _, err = emb.Embed(ctx, req); err == nil {
 		t.Error("embedding unknown document succeeded unexpectedly")
 	}

--- a/go/plugins/googleai/googleai_test.go
+++ b/go/plugins/googleai/googleai_test.go
@@ -46,8 +46,8 @@ func TestLive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	embedder := googleai.DefineEmbedder("embedding-001")
-	model, err := googleai.DefineModel("gemini-1.0-pro", nil)
+	embedder := googleai.Embedder("embedding-001")
+	model := googleai.Model("gemini-1.0-pro")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,13 +85,13 @@ func TestLive(t *testing.T) {
 		},
 	)
 	t.Run("embedder", func(t *testing.T) {
-		out, err := embedder.Embed(ctx, &ai.EmbedRequest{
-			Document: ai.DocumentFromText("yellow banana", nil),
+		res, err := embedder.Embed(ctx, &ai.EmbedRequest{
+			Documents: []*ai.Document{ai.DocumentFromText("yellow banana", nil)},
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
-
+		out := res.Embeddings[0].Embedding
 		// There's not a whole lot we can test about the result.
 		// Just do a few sanity checks.
 		if len(out) < 100 {
@@ -137,7 +137,7 @@ func TestLive(t *testing.T) {
 			Candidates: 1,
 			Messages: []*ai.Message{
 				{
-					Content: []*ai.Part{ai.NewTextPart("Write one paragraph about the Golden State Warriors.")},
+					Content: []*ai.Part{ai.NewTextPart("Write one paragraph about the North Pole.")},
 					Role:    ai.RoleUser,
 				},
 			},
@@ -160,7 +160,7 @@ func TestLive(t *testing.T) {
 		if out != out2 {
 			t.Errorf("streaming and final should contain the same text.\nstreaming:%s\nfinal:%s", out, out2)
 		}
-		const want = "Golden"
+		const want = "North"
 		if !strings.Contains(out, want) {
 			t.Errorf("got %q, expecting it to contain %q", out, want)
 		}

--- a/go/plugins/vertexai/vertexai.go
+++ b/go/plugins/vertexai/vertexai.go
@@ -177,7 +177,7 @@ func DefineEmbedder(name string) *ai.Embedder {
 		panic("vertexai.Init not called")
 	}
 	fullName := fmt.Sprintf("projects/%s/locations/%s/publishers/google/models/%s", state.projectID, state.location, name)
-	return ai.DefineEmbedder(provider, name, func(ctx context.Context, req *ai.EmbedRequest) ([]float32, error) {
+	return ai.DefineEmbedder(provider, name, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
 		return embed(ctx, fullName, state.pclient, req)
 	})
 }


### PR DESCRIPTION
- An EmbedRequest takes a slice of Documents instead of a single Document.

- An EmbedResponse contains embeddings for each document. The []float32
  containing the embedding is inside a struct, to accommodate future
  additions (and to match the JS).

- The googleai embedder works on multiple documents sequentially.
  It should be changed to use the BatchEmbed RPC.

- The vertexai embedder always handled multiple "instances". Now an
  instance is the concatenated text parts of a document; before it
  was one text part of the sole document. (This is the only behavioral
  change.)

There is one unrelated change: the prompt of a generation test
was changed because the previous prompt is now blocked for the
"recitation" reason.
