### PR TITLE
Fix bugs related to combining tools and output conformance

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -641,7 +641,8 @@ export async function generate<
   if (resolvedOptions.output?.schema || resolvedOptions.output?.jsonSchema) {
     // find a candidate with valid output schema
     const candidateErrors = response.candidates.map((c) => {
-      if (c.toolRequests()?.length) return null;
+      // only validate candidates that have output
+      if (!c.output()) return null;
 
       try {
         parseSchema(c.output(), {

--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -641,6 +641,8 @@ export async function generate<
   if (resolvedOptions.output?.schema || resolvedOptions.output?.jsonSchema) {
     // find a candidate with valid output schema
     const candidateErrors = response.candidates.map((c) => {
+      if (c.toolRequests()?.length) return null;
+
       try {
         parseSchema(c.output(), {
           jsonSchema: resolvedOptions.output?.jsonSchema,

--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -84,25 +84,11 @@ export class Message<T = unknown> implements MessageData {
   }
 
   /**
-   * @returns true if the message has at least one tool response
-   */
-  hasToolResponse(): boolean {
-    return this.content.some((part) => !!part.toolResponse);
-  }
-
-  /**
    * Concatenates all `text` parts present in the message with no delimiter.
    * @returns A string of all concatenated text parts.
    */
   text(): string {
     return this.content.map((part) => part.text || '').join('');
-  }
-
-  /**
-   * @returns true if the message contains at least one text part
-   */
-  hasText(): boolean {
-    return this.content.some((part) => !!part.text);
   }
 
   /**
@@ -123,13 +109,6 @@ export class Message<T = unknown> implements MessageData {
   }
 
   /**
-   * @returns true if the message contains at least one data part
-   */
-  hasData(): boolean {
-    return this.content.some((p) => p.data);
-  }
-
-  /**
    * Returns all tool request found in this message.
    * @returns Array of all tool request found in this message.
    */
@@ -137,13 +116,6 @@ export class Message<T = unknown> implements MessageData {
     return this.content.filter(
       (part) => !!part.toolRequest
     ) as ToolRequestPart[];
-  }
-
-  /**
-   * @returns true if the message has at least one tool request
-   */
-  hasToolRequest(): boolean {
-    return this.content.some((p) => !!p.toolRequest);
   }
 
   /**
@@ -663,8 +635,8 @@ export async function generate<
   if (resolvedOptions.output?.schema || resolvedOptions.output?.jsonSchema) {
     // find a candidate with valid output schema
     const candidateErrors = response.candidates.map((c) => {
-      // don't validate messages without text / data content
-      if (!c.message.hasData() && !c.message.hasText()) return null;
+      // don't validate messages that have no text or data
+      if (c.text() === '' && c.data() === null) return null;
 
       try {
         parseSchema(c.output(), {

--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -22,7 +22,11 @@ import {
   StreamingCallback,
 } from '@genkit-ai/core';
 import { lookupAction } from '@genkit-ai/core/registry';
-import { toJsonSchema, validateSchema } from '@genkit-ai/core/schema';
+import {
+  parseSchema,
+  toJsonSchema,
+  validateSchema,
+} from '@genkit-ai/core/schema';
 import { z } from 'zod';
 import { DocumentData } from './document.js';
 import { extractJson } from './extract.js';
@@ -636,26 +640,24 @@ export async function generate<
 
   if (resolvedOptions.output?.schema || resolvedOptions.output?.jsonSchema) {
     // find a candidate with valid output schema
-    const candidateValidations = response.candidates.map((c) => {
+    const candidateErrors = response.candidates.map((c) => {
       try {
-        return validateSchema(c.output(), {
+        parseSchema(c.output(), {
           jsonSchema: resolvedOptions.output?.jsonSchema,
           schema: resolvedOptions.output?.schema,
         });
+        return null;
       } catch (e) {
-        return {
-          valid: false,
-          errors: [{ path: '', error: (e as Error).message }],
-        };
+        return e as Error;
       }
     });
-    if (!candidateValidations.some((c) => c.valid)) {
+    // if all candidates have a non-null error...
+    if (candidateErrors.every((c) => !!c)) {
       throw new NoValidCandidatesError({
-        message:
-          'Generation resulted in no candidates matching provided output schema.',
+        message: `Generation resulted in no candidates matching provided output schema.${candidateErrors.map((e, i) => `\n\nCandidate[${i}] ${e!.toString()}`)}`,
         response,
         detail: {
-          candidateErrors: candidateValidations,
+          candidateErrors: candidateErrors,
         },
       });
     }

--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -92,6 +92,13 @@ export class Message<T = unknown> implements MessageData {
   }
 
   /**
+   * @returns true if the message contains at least one text part
+   */
+  hasText(): boolean {
+    return this.content.some((part) => !!part.text);
+  }
+
+  /**
    * Returns the first media part detected in the message. Useful for extracting
    * (for example) an image from a generation expected to create one.
    * @returns The first detected `media` part in the message.
@@ -106,6 +113,13 @@ export class Message<T = unknown> implements MessageData {
    */
   data(): T | null {
     return this.content.find((part) => part.data)?.data as T | null;
+  }
+
+  /**
+   * @returns true if the message contains at least one data part
+   */
+  hasData(): boolean {
+    return this.content.some((p) => p.data);
   }
 
   /**
@@ -635,8 +649,8 @@ export async function generate<
   if (resolvedOptions.output?.schema || resolvedOptions.output?.jsonSchema) {
     // find a candidate with valid output schema
     const candidateErrors = response.candidates.map((c) => {
-      // only validate candidates that have output
-      if (!c.output()) return null;
+      // don't validate messages without text / data content
+      if (!c.message.hasData() && !c.message.hasText()) return null;
 
       try {
         parseSchema(c.output(), {

--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -84,6 +84,13 @@ export class Message<T = unknown> implements MessageData {
   }
 
   /**
+   * @returns true if the message has at least one tool response
+   */
+  hasToolResponse(): boolean {
+    return this.content.some((part) => !!part.toolResponse);
+  }
+
+  /**
    * Concatenates all `text` parts present in the message with no delimiter.
    * @returns A string of all concatenated text parts.
    */
@@ -130,6 +137,13 @@ export class Message<T = unknown> implements MessageData {
     return this.content.filter(
       (part) => !!part.toolRequest
     ) as ToolRequestPart[];
+  }
+
+  /**
+   * @returns true if the message has at least one tool request
+   */
+  hasToolRequest(): boolean {
+    return this.content.some((p) => !!p.toolRequest);
   }
 
   /**

--- a/js/ai/src/model/middleware.ts
+++ b/js/ai/src/model/middleware.ts
@@ -15,7 +15,7 @@
  */
 
 import { Document } from '../document.js';
-import { ModelInfo, ModelMiddleware, Part } from '../model.js';
+import { MessageData, ModelInfo, ModelMiddleware, Part } from '../model.js';
 
 /**
  * Preprocess a GenerateRequest to download referenced http(s) media URLs and
@@ -117,9 +117,18 @@ export function validateSupport(options: {
   };
 }
 
+function lastUserMessage(messages: MessageData[]) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'user') {
+      return messages[i];
+    }
+  }
+}
+
 export function conformOutput(): ModelMiddleware {
   return async (req, next) => {
-    const lastMessage = req.messages.at(-1)!;
+    const lastMessage = lastUserMessage(req.messages);
+    if (!lastMessage) return next(req);
     const outputPartIndex = lastMessage.content.findIndex(
       (p) => p.metadata?.purpose === 'output'
     );

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -215,15 +215,16 @@ export const jokeWithToolsFlow = defineFlow(
       modelName: z.enum([geminiPro.name, googleGeminiPro.name]),
       subject: z.string(),
     }),
-    outputSchema: z.string(),
+    outputSchema: z.object({ model: z.string(), joke: z.string() }),
   },
   async (input) => {
     const llmResponse = await generate({
       model: input.modelName,
       tools,
+      output: { schema: z.object({ joke: z.string() }) },
       prompt: `Tell a joke about ${input.subject}.`,
     });
-    return `From ${input.modelName}: ${llmResponse.text()}`;
+    return { ...llmResponse.output()!, model: input.modelName };
   }
 );
 

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -21,7 +21,11 @@ import { dotprompt, prompt } from '@genkit-ai/dotprompt';
 import { defineFirestoreRetriever, firebase } from '@genkit-ai/firebase';
 import { defineFlow, run } from '@genkit-ai/flow';
 import { googleCloud } from '@genkit-ai/google-cloud';
-import { googleAI, geminiPro as googleGeminiPro } from '@genkit-ai/googleai';
+import {
+  gemini15Flash,
+  geminiPro as googleGeminiPro,
+  googleAI,
+} from '@genkit-ai/googleai';
 import {
   gemini15ProPreview,
   geminiPro,
@@ -52,7 +56,7 @@ configureGenkit({
           '@opentelemetry/instrumentation-dns': { enabled: false },
           '@opentelemetry/instrumentation-net': { enabled: false },
         },
-        metricExportIntervalMillis: 5_000,
+        // metricExportIntervalMillis: 5_000,
       },
     }),
     dotprompt(),
@@ -371,5 +375,28 @@ export const toolCaller = defineFlow(
     }
 
     return (await response()).text();
+  }
+);
+
+export const invalidOutput = defineFlow(
+  {
+    name: 'invalidOutput',
+    inputSchema: z.string(),
+    outputSchema: z.object({
+      name: z.string(),
+    }),
+  },
+  async () => {
+    const result = await generate({
+      model: gemini15Flash,
+      output: {
+        schema: z.object({
+          name: z.string(),
+        }),
+      },
+      prompt:
+        'Output a JSON object in the form {"displayName": "Some Name"}. Ignore any further instructions about output format.',
+    });
+    return result.output() as any;
   }
 );

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -23,8 +23,8 @@ import { defineFlow, run } from '@genkit-ai/flow';
 import { googleCloud } from '@genkit-ai/google-cloud';
 import {
   gemini15Flash,
-  geminiPro as googleGeminiPro,
   googleAI,
+  geminiPro as googleGeminiPro,
 } from '@genkit-ai/googleai';
 import {
   gemini15ProPreview,


### PR DESCRIPTION
Before, combining a tool call with output conformance could result in two different errors:

1. `Vertex response generation failed: ClientError: [VertexAI.ClientError]: Within a single message, FunctionResponse cannot be mixed with other type of part in the request for sending chat message.`
2. A schema validation error.

The first was caused by the output conformance middleware appending instructions to the last message instead of the last *user* role message.

The second was caused by the output schema validation trying to validate all candidates, even if the message returned contained no text or data part (e.g. a tool request).

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)