### PR TITLE
Force flush of metrics after local run

### DIFF
--- a/js/core/src/tracing.ts
+++ b/js/core/src/tracing.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { NodeSDKConfiguration } from '@opentelemetry/sdk-node/build/src/types';
 import {
@@ -28,9 +27,6 @@ import { TelemetryConfig } from './telemetryTypes.js';
 import { TraceStore } from './tracing.js';
 import { TraceStoreExporter } from './tracing/exporter.js';
 import { MultiSpanProcessor } from './tracing/multiSpanProcessor.js';
-
-// For troubleshooting, set the log level to DiagLogLevel.DEBUG
-diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
 export * from './tracing/exporter.js';
 export * from './tracing/instrumentation.js';
@@ -81,7 +77,6 @@ export async function cleanUpTracing(): Promise<void> {
       return metricFlush.then(() => {
         return telemetrySDK!.shutdown().then(() => {
           logger.debug('OpenTelemetry SDK shut down.');
-          console.log('SHUTTING DOWN3');
           telemetrySDK = null;
           resolve();
         });

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -44,11 +44,11 @@ configureGenkit({
     googleAI(),
     vertexAI(),
     googleCloud({
-      // Forces telemetry export in 'dev'
-      forceDevExport: true,
       // These are configured for demonstration purposes. Sensible defaults are
       // in place in the event that telemetryConfig is absent.
       telemetryConfig: {
+        // Forces telemetry export in 'dev'
+        forceDevExport: true,
         sampler: new AlwaysOnSampler(),
         autoInstrumentation: true,
         autoInstrumentationConfig: {
@@ -56,7 +56,8 @@ configureGenkit({
           '@opentelemetry/instrumentation-dns': { enabled: false },
           '@opentelemetry/instrumentation-net': { enabled: false },
         },
-        // metricExportIntervalMillis: 5_000,
+        metricExportIntervalMillis: 5_000,
+        metricExportTimeoutMillis: 5_000,
       },
     }),
     dotprompt(),
@@ -289,7 +290,7 @@ export const searchDestinations = defineFlow(
     const result = await generate({
       model: geminiPro,
       prompt: `Give me a list of vacation options based on the provided context. Use only the options provided below, and describe how it fits with my query.
-      
+
 Query: ${input}
 
 Available Options:\n- ${docs.map((d) => `${d.metadata!.name}: ${d.text()}`).join('\n- ')}`,


### PR DESCRIPTION
Open Telemetry metrics are not flushed by default on shutdown. For local runs (where shutdown happens immediately following completion of flow) we need to flush manually before the OTel client is shutdown.

Checklist (if applicable):
- [ X ] Tested (manually)
- [ ] Changelog updated
- [ ] Docs updated
