### PR TITLE
feat: added json parser options to startFlowsServer

### DIFF
--- a/js/flow/package.json
+++ b/js/flow/package.json
@@ -44,7 +44,8 @@
     "npm-run-all": "^4.1.5",
     "tsup": "^8.0.2",
     "typescript": "^4.9.0",
-    "tsx": "^4.7.1"
+    "tsx": "^4.7.1",
+    "@types/body-parser": "^1.19.5"
   },
   "files": [
     "genkit-ui",

--- a/js/flow/src/flow.ts
+++ b/js/flow/src/flow.ts
@@ -16,28 +16,28 @@
 
 import {
   Action,
+  defineAction,
   FlowError,
   FlowState,
   FlowStateSchema,
   FlowStateStore,
-  Operation,
-  StreamingCallback,
-  defineAction,
   getStreamingCallback,
   config as globalConfig,
   isDevEnv,
+  Operation,
+  StreamingCallback,
 } from '@genkit-ai/core';
 import { logger } from '@genkit-ai/core/logging';
 import { toJsonSchema } from '@genkit-ai/core/schema';
 import {
-  SPAN_TYPE_ATTR,
   newTrace,
   setCustomMetadataAttribute,
   setCustomMetadataAttributes,
+  SPAN_TYPE_ATTR,
 } from '@genkit-ai/core/tracing';
 import { SpanStatusCode } from '@opentelemetry/api';
 import * as bodyParser from 'body-parser';
-import { CorsOptions, default as cors } from 'cors';
+import { default as cors, CorsOptions } from 'cors';
 import express from 'express';
 import { performance } from 'node:perf_hooks';
 import * as z from 'zod';
@@ -45,9 +45,9 @@ import { Context } from './context.js';
 import {
   FlowExecutionError,
   FlowStillRunningError,
-  InterruptError,
   getErrorMessage,
   getErrorStack,
+  InterruptError,
 } from './errors.js';
 import * as telemetry from './telemetry.js';
 import {
@@ -844,12 +844,13 @@ export function startFlowsServer(params?: {
   port?: number;
   cors?: CorsOptions;
   pathPrefix?: string;
+  jsonParserOptions?: bodyParser.OptionsJson;
 }) {
   const port =
     params?.port || (process.env.PORT ? parseInt(process.env.PORT) : 0) || 3400;
   const pathPrefix = params?.pathPrefix ?? '';
   const app = express();
-  app.use(bodyParser.json());
+  app.use(bodyParser.json(params?.jsonParserOptions));
   app.use(cors(params?.cors));
 
   const flows = params?.flows || createdFlows();

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
         specifier: ^3.22.4
         version: 3.22.4
     devDependencies:
+      '@types/body-parser':
+        specifier: ^1.19.5
+        version: 1.19.5
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21


### PR DESCRIPTION
this just a cleanup of #193

this allows

```ts
startFlowsServer({
  jsonParserOptions: {
    limit: '32mb',
  }
})
```

Co-authored-by: tzahush