### PR TITLE
Fix issue where failed paths are written with parent path due to rethrows

### DIFF
--- a/js/core/src/tracing/instrumentation.ts
+++ b/js/core/src/tracing/instrumentation.ts
@@ -195,10 +195,6 @@ function getCurrentSpan(): SpanMetadata {
   return step;
 }
 
-function getCurrentPathCount(): number {
-  return traceMetadataAls.getStore()?.paths?.size || 0;
-}
-
 function buildPath(
   name: string,
   parentPath: string,


### PR DESCRIPTION
* Updates logic for determining whether or not to add a path to the traceMetadata to be based on the presence of any children paths as opposed to checking the path length. This both solves the rethrow problem and cleans up some of the code.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
