### PR TITLE
[Go] replace IsKnownModel with IsDefinedModel

### DIFF
--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -50,6 +50,11 @@ func DefineEmbedder(provider, name string, embed func(context.Context, *EmbedReq
 	return (*Embedder)(core.DefineAction(provider, name, atype.Embedder, nil, embed))
 }
 
+// IsDefinedEmbedder reports whether an embedder is defined.
+func IsDefinedEmbedder(provider, name string) bool {
+	return LookupEmbedder(provider, name) != nil
+}
+
 // LookupEmbedder looks up an [EmbedderAction] registered by [DefineEmbedder].
 // It returns nil if the embedder was not defined.
 func LookupEmbedder(provider, name string) *Embedder {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -50,7 +50,7 @@ type ModelMetadata struct {
 }
 
 // DefineModel registers the given generate function as an action, and returns a
-// [ModelAction] that runs it.
+// [Model] that runs it.
 func DefineModel(provider, name string, metadata *ModelMetadata, generate func(context.Context, *GenerateRequest, ModelStreamingCallback) (*GenerateResponse, error)) *Model {
 	metadataMap := map[string]any{}
 	if metadata == nil {
@@ -75,7 +75,12 @@ func DefineModel(provider, name string, metadata *ModelMetadata, generate func(c
 	}, generate))
 }
 
-// LookupModel looks up a [ModelAction] registered by [DefineModel].
+// IsDefinedModel reports whether a model is defined.
+func IsDefinedModel(provider, name string) bool {
+	return LookupModel(provider, name) != nil
+}
+
+// LookupModel looks up a [Model] registered by [DefineModel].
 // It returns nil if the model was not defined.
 func LookupModel(provider, name string) *Model {
 	return (*Model)(core.LookupActionFor[*GenerateRequest, *GenerateResponse, *GenerateResponseChunk](atype.Model, provider, name))

--- a/go/plugins/googleai/googleai.go
+++ b/go/plugins/googleai/googleai.go
@@ -110,15 +110,15 @@ func Init(ctx context.Context, cfg *Config) (err error) {
 	return nil
 }
 
-// IsKnownModel reports whether a model is known to this plugin.
-func IsKnownModel(name string) bool {
-	_, ok := knownCaps[name]
-	return ok
+// IsDefinedModel reports whether a model is defined in this plugin.
+func IsDefinedModel(name string) bool {
+	return ai.IsDefinedModel(provider, name)
 }
 
 // DefineModel defines an unknown model with the given name.
 // The second argument describes the capability of the model.
-// Use [IsKnownModel] to determine if a model is known.
+// Use [IsDefinedModel] to determine if a model is already defined.
+// After [Init] is called, only the known models are defined.
 func DefineModel(name string, caps *ai.ModelCapabilities) (*ai.Model, error) {
 	state.mu.Lock()
 	defer state.mu.Unlock()
@@ -136,17 +136,6 @@ func DefineModel(name string, caps *ai.ModelCapabilities) (*ai.Model, error) {
 		mc = *caps
 	}
 	return defineModel(name, mc), nil
-}
-
-// KnownModels returns a slice of all known model names.
-func KnownModels() []string {
-	keys := make([]string, len(knownCaps))
-	i := 0
-	for k := range knownCaps {
-		keys[i] = k
-		i++
-	}
-	return keys
 }
 
 // requires state.mu
@@ -167,6 +156,11 @@ func DefineEmbedder(name string) *ai.Embedder {
 		panic("googleai.Init not called")
 	}
 	return defineEmbedder(name)
+}
+
+// IsDefinedEmbedder reports whether a model is defined in this plugin.
+func IsDefinedEmbedder(name string) bool {
+	return ai.IsDefinedEmbedder(provider, name)
 }
 
 // requires state.mu


### PR DESCRIPTION
IsDefinedModel is more general. You can call it right after Init
to determine if a model is known, or any time to see if you've already
defined a model, and avoid the panic from DefineModel.

Also remove KnownModels. It's unclear if it's useful. If it is, we can
always add it later.

Do the same for embedders.
