### PR TITLE
fix: when detecting runtime in the CLI favor Go over nodejs when both are present

### DIFF
--- a/genkit-tools/common/src/utils/utils.ts
+++ b/genkit-tools/common/src/utils/utils.ts
@@ -57,9 +57,6 @@ export function getEntryPoint(directory: string): string | undefined {
  * @returns Runtime of the project directory.
  */
 export function detectRuntime(directory: string): Runtime {
-  if (fs.existsSync(path.join(directory, 'package.json'))) {
-    return 'nodejs';
-  }
   const files = fs.readdirSync(directory);
   for (const file of files) {
     const filePath = path.join(directory, file);
@@ -67,6 +64,9 @@ export function detectRuntime(directory: string): Runtime {
     if (stat.isFile() && (path.extname(file) === '.go' || file === 'go.mod')) {
       return 'go';
     }
+  }
+  if (fs.existsSync(path.join(directory, 'package.json'))) {
+    return 'nodejs';
   }
   return undefined;
 }


### PR DESCRIPTION
a common use case is when genkit cli is installed locally (to be used with `npx`) but using Go as runtime. In cases when there's both Go  files and `package.json` prefer Go runtime.