### PR TITLE
feat: made registry hierarchical, allowing ephemeral child registries for testing and isolated ones for libraries

### DIFF
--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import * as z from 'zod';
 import { Action } from './action.js';
 import { FlowStateStore } from './flowTypes.js';
@@ -25,45 +26,7 @@ import { TraceStore } from './tracing/types.js';
 
 export type AsyncProvider<T> = () => Promise<T>;
 
-const ACTIONS_BY_ID = 'genkit__ACTIONS_BY_ID';
-const TRACE_STORES_BY_ENV = 'genkit__TRACE_STORES_BY_ENV';
-const FLOW_STATE_STORES_BY_ENV = 'genkit__FLOW_STATE_STORES_BY_ENV';
-const PLUGINS_BY_NAME = 'genkit__PLUGINS_BY_NAME';
-const SCHEMAS_BY_NAME = 'genkit__SCHEMAS_BY_NAME';
-
-function actionsById(): Record<string, Action<z.ZodTypeAny, z.ZodTypeAny>> {
-  if (global[ACTIONS_BY_ID] === undefined) {
-    global[ACTIONS_BY_ID] = {};
-  }
-  return global[ACTIONS_BY_ID];
-}
-function traceStoresByEnv(): Record<string, AsyncProvider<TraceStore>> {
-  if (global[TRACE_STORES_BY_ENV] === undefined) {
-    global[TRACE_STORES_BY_ENV] = {};
-  }
-  return global[TRACE_STORES_BY_ENV];
-}
-function flowStateStoresByEnv(): Record<string, AsyncProvider<FlowStateStore>> {
-  if (global[FLOW_STATE_STORES_BY_ENV] === undefined) {
-    global[FLOW_STATE_STORES_BY_ENV] = {};
-  }
-  return global[FLOW_STATE_STORES_BY_ENV];
-}
-function pluginsByName(): Record<string, PluginProvider> {
-  if (global[PLUGINS_BY_NAME] === undefined) {
-    global[PLUGINS_BY_NAME] = {};
-  }
-  return global[PLUGINS_BY_NAME];
-}
-function schemasByName(): Record<
-  string,
-  { schema?: z.ZodTypeAny; jsonSchema?: JSONSchema }
-> {
-  if (global[SCHEMAS_BY_NAME] === undefined) {
-    global[SCHEMAS_BY_NAME] = {};
-  }
-  return global[SCHEMAS_BY_NAME];
-}
+const REGISTRY_KEY = 'genkit__REGISTRY';
 
 /**
  * Type of a runnable action.
@@ -82,17 +45,12 @@ export type ActionType =
 /**
  * Looks up a registry key (action type and key) in the registry.
  */
-export async function lookupAction<
+export function lookupAction<
   I extends z.ZodTypeAny,
   O extends z.ZodTypeAny,
   R extends Action<I, O>,
 >(key: string): Promise<R> {
-  // If we don't see the key in the registry we try to initialize the plugin first.
-  const pluginName = parsePluginName(key);
-  if (!actionsById()[key] && pluginName) {
-    await initializePlugin(pluginName);
-  }
-  return actionsById()[key] as R;
+  return getRegistryInstance().lookupAction(key);
 }
 
 function parsePluginName(registryKey: string) {
@@ -110,14 +68,7 @@ export function registerAction<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
   type: ActionType,
   action: Action<I, O>
 ) {
-  logger.info(`Registering ${type}: ${action.__action.name}`);
-  const key = `/${type}/${action.__action.name}`;
-  if (actionsById().hasOwnProperty(key)) {
-    logger.warn(
-      `WARNING: ${key} already has an entry in the registry. Overwriting.`
-    );
-  }
-  actionsById()[key] = action;
+  return getRegistryInstance().registerAction(type, action);
 }
 
 type ActionsRecord = Record<string, Action<z.ZodTypeAny, z.ZodTypeAny>>;
@@ -125,11 +76,8 @@ type ActionsRecord = Record<string, Action<z.ZodTypeAny, z.ZodTypeAny>>;
 /**
  * Returns all actions in the registry.
  */
-export async function listActions(): Promise<ActionsRecord> {
-  for (const pluginName of Object.keys(pluginsByName())) {
-    await initializePlugin(pluginName);
-  }
-  return Object.assign({}, actionsById());
+export function listActions(): Promise<ActionsRecord> {
+  return getRegistryInstance().listActions();
 }
 
 /**
@@ -139,27 +87,14 @@ export function registerTraceStore(
   env: string,
   traceStoreProvider: AsyncProvider<TraceStore>
 ) {
-  traceStoresByEnv()[env] = traceStoreProvider;
+  return getRegistryInstance().registerTraceStore(env, traceStoreProvider);
 }
-
-const traceStoresByEnvCache: Record<any, Promise<TraceStore>> = {};
 
 /**
  * Looks up the trace store for the given environment.
  */
-export async function lookupTraceStore(
-  env: string
-): Promise<TraceStore | undefined> {
-  if (!traceStoresByEnv()[env]) {
-    return undefined;
-  }
-  const cached = traceStoresByEnvCache[env];
-  if (!cached) {
-    const newStore = traceStoresByEnv()[env]();
-    traceStoresByEnvCache[env] = newStore;
-    return newStore;
-  }
-  return cached;
+export function lookupTraceStore(env: string): Promise<TraceStore | undefined> {
+  return getRegistryInstance().lookupTraceStore(env);
 }
 
 /**
@@ -169,68 +104,48 @@ export function registerFlowStateStore(
   env: string,
   flowStateStoreProvider: AsyncProvider<FlowStateStore>
 ) {
-  flowStateStoresByEnv()[env] = flowStateStoreProvider;
+  return getRegistryInstance().registerFlowStateStore(
+    env,
+    flowStateStoreProvider
+  );
 }
 
-const flowStateStoresByEnvCache: Record<any, Promise<FlowStateStore>> = {};
 /**
  * Looks up the flow state store for the given environment.
  */
 export async function lookupFlowStateStore(
   env: string
 ): Promise<FlowStateStore | undefined> {
-  if (!flowStateStoresByEnv()[env]) {
-    return undefined;
-  }
-  const cached = flowStateStoresByEnvCache[env];
-  if (!cached) {
-    const newStore = flowStateStoresByEnv()[env]();
-    flowStateStoresByEnvCache[env] = newStore;
-    return newStore;
-  }
-  return cached;
+  return getRegistryInstance().lookupFlowStateStore(env);
 }
 
 /**
  * Registers a flow state store for the given environment.
  */
 export function registerPluginProvider(name: string, provider: PluginProvider) {
-  let cached;
-  pluginsByName()[name] = {
-    name: provider.name,
-    initializer: () => {
-      if (cached) {
-        return cached;
-      }
-      cached = provider.initializer();
-      return cached;
-    },
-  };
+  return getRegistryInstance().registerPluginProvider(name, provider);
 }
 
 export function lookupPlugin(name: string) {
-  return pluginsByName()[name];
+  return getRegistryInstance().lookupFlowStateStore(name);
 }
 
 /**
- *
+ * Initialize plugin -- calls the plugin initialization function.
  */
 export async function initializePlugin(name: string) {
-  if (pluginsByName()[name]) {
-    return await pluginsByName()[name].initializer();
-  }
-  return undefined;
+  return getRegistryInstance().initializePlugin(name);
 }
 
 export function registerSchema(
   name: string,
   data: { schema?: z.ZodTypeAny; jsonSchema?: JSONSchema }
 ) {
-  schemasByName()[name] = data;
+  return getRegistryInstance().registerSchema(name, data);
 }
 
 export function lookupSchema(name: string) {
-  return schemasByName()[name];
+  return getRegistryInstance().lookupSchema(name);
 }
 
 /**
@@ -241,14 +156,186 @@ if (process.env.GENKIT_ENV === 'dev') {
 }
 
 export function __hardResetRegistryForTesting() {
-  delete global[ACTIONS_BY_ID];
-  delete global[TRACE_STORES_BY_ENV];
-  delete global[FLOW_STATE_STORES_BY_ENV];
-  delete global[PLUGINS_BY_NAME];
-  deleteAll(flowStateStoresByEnvCache);
-  deleteAll(traceStoresByEnvCache);
+  delete global[REGISTRY_KEY];
+  global[REGISTRY_KEY] = new Registry();
 }
 
-function deleteAll(map: Record<any, any>) {
-  Object.keys(map).forEach((key) => delete map[key]);
+export class Registry {
+  private actionsById: Record<string, Action<z.ZodTypeAny, z.ZodTypeAny>> = {};
+  private traceStoresByEnv: Record<string, AsyncProvider<TraceStore>> = {};
+  private flowStateStoresByEnv: Record<string, AsyncProvider<FlowStateStore>> =
+    {};
+  private pluginsByName: Record<string, PluginProvider> = {};
+  private schemasByName: Record<
+    string,
+    { schema?: z.ZodTypeAny; jsonSchema?: JSONSchema }
+  > = {};
+
+  private traceStoresByEnvCache: Record<any, Promise<TraceStore>> = {};
+  private flowStateStoresByEnvCache: Record<any, Promise<FlowStateStore>> = {};
+
+  constructor(public parent?: Registry) {}
+
+  static withParent(parent: Registry) {
+    return new Registry(parent);
+  }
+
+  async lookupAction<
+    I extends z.ZodTypeAny,
+    O extends z.ZodTypeAny,
+    R extends Action<I, O>,
+  >(key: string): Promise<R> {
+    return (await this._lookupAction(key)) || this.parent?.lookupAction(key);
+  }
+
+  private async _lookupAction<
+    I extends z.ZodTypeAny,
+    O extends z.ZodTypeAny,
+    R extends Action<I, O>,
+  >(key: string): Promise<R> {
+    // If we don't see the key in the registry we try to initialize the plugin first.
+    const pluginName = parsePluginName(key);
+    if (!this.actionsById[key] && pluginName) {
+      await this.initializePlugin(pluginName);
+    }
+    return this.actionsById[key] as R;
+  }
+
+  registerAction<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
+    type: ActionType,
+    action: Action<I, O>
+  ) {
+    logger.info(`Registering ${type}: ${action.__action.name}`);
+    const key = `/${type}/${action.__action.name}`;
+    if (this.actionsById.hasOwnProperty(key)) {
+      logger.warn(
+        `WARNING: ${key} already has an entry in the registry. Overwriting.`
+      );
+    }
+    this.actionsById[key] = action;
+  }
+
+  async listActions(): Promise<ActionsRecord> {
+    for (const pluginName of Object.keys(this.pluginsByName)) {
+      await this.initializePlugin(pluginName);
+    }
+    return {
+      ...(await this.parent?.listActions()),
+      ...this.actionsById,
+    };
+  }
+
+  registerTraceStore(
+    env: string,
+    traceStoreProvider: AsyncProvider<TraceStore>
+  ) {
+    this.traceStoresByEnv[env] = traceStoreProvider;
+  }
+
+  async lookupTraceStore(env: string): Promise<TraceStore | undefined> {
+    return (
+      (await this._lookupTraceStore(env)) || this.parent?.lookupTraceStore(env)
+    );
+  }
+
+  private async _lookupTraceStore(
+    env: string
+  ): Promise<TraceStore | undefined> {
+    if (!this.traceStoresByEnv[env]) {
+      return undefined;
+    }
+    const cached = this.traceStoresByEnvCache[env];
+    if (!cached) {
+      const newStore = this.traceStoresByEnv[env]();
+      this.traceStoresByEnvCache[env] = newStore;
+      return newStore;
+    }
+    return cached;
+  }
+
+  registerFlowStateStore(
+    env: string,
+    flowStateStoreProvider: AsyncProvider<FlowStateStore>
+  ) {
+    this.flowStateStoresByEnv[env] = flowStateStoreProvider;
+  }
+
+  async lookupFlowStateStore(env: string): Promise<FlowStateStore | undefined> {
+    return (
+      (await this._lookupFlowStateStore(env)) ||
+      this.parent?.lookupFlowStateStore(env)
+    );
+  }
+
+  private async _lookupFlowStateStore(
+    env: string
+  ): Promise<FlowStateStore | undefined> {
+    if (!this.flowStateStoresByEnv[env]) {
+      return undefined;
+    }
+    const cached = this.flowStateStoresByEnvCache[env];
+    if (!cached) {
+      const newStore = this.flowStateStoresByEnv[env]();
+      this.flowStateStoresByEnvCache[env] = newStore;
+      return newStore;
+    }
+    return cached;
+  }
+
+  registerPluginProvider(name: string, provider: PluginProvider) {
+    let cached;
+    this.pluginsByName[name] = {
+      name: provider.name,
+      initializer: () => {
+        if (cached) {
+          return cached;
+        }
+        cached = provider.initializer();
+        return cached;
+      },
+    };
+  }
+
+  lookupPlugin(name: string) {
+    return this.pluginsByName[name] || this.parent?.lookupPlugin(name);
+  }
+
+  async initializePlugin(name: string) {
+    if (this.pluginsByName[name]) {
+      return await this.pluginsByName[name].initializer();
+    }
+    return undefined;
+  }
+
+  registerSchema(
+    name: string,
+    data: { schema?: z.ZodTypeAny; jsonSchema?: JSONSchema }
+  ) {
+    this.schemasByName[name] = data;
+  }
+
+  lookupSchema(name: string) {
+    return this.schemasByName[name] || this.parent?.lookupSchema(name);
+  }
+}
+
+// global regustry instance
+global[REGISTRY_KEY] = new Registry();
+
+const registryAls = new AsyncLocalStorage<Registry>();
+
+/**
+ * Executes provided function with within the provided registry.
+ */
+export function runWithRegistry<O>(registry: Registry, fn: () => O): O {
+  return registryAls.run(registry, fn);
+}
+
+/**
+ * Returns the current registry instance:
+ *  - if running within `runWithRegistry` then return that registry
+ *  - else return the global registry.
+ */
+export function getRegistryInstance(): Registry {
+  return registryAls.getStore() || global[REGISTRY_KEY];
 }

--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -176,6 +176,10 @@ export class Registry {
 
   constructor(public parent?: Registry) {}
 
+  static withCurrent() {
+    return new Registry(getRegistryInstance());
+  }
+
   static withParent(parent: Registry) {
     return new Registry(parent);
   }
@@ -336,6 +340,6 @@ export function runWithRegistry<O>(registry: Registry, fn: () => O): O {
  *  - if running within `runWithRegistry` then return that registry
  *  - else return the global registry.
  */
-export function getRegistryInstance(): Registry {
+function getRegistryInstance(): Registry {
   return registryAls.getStore() || global[REGISTRY_KEY];
 }

--- a/js/core/tests/registry_test.ts
+++ b/js/core/tests/registry_test.ts
@@ -18,6 +18,7 @@ import assert from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
 import { action } from '../src/action.js';
 import {
+  Registry,
   __hardResetRegistryForTesting,
   listActions,
   lookupAction,
@@ -25,7 +26,7 @@ import {
   registerPluginProvider,
 } from '../src/registry.js';
 
-describe('registry', () => {
+describe('global registry', () => {
   beforeEach(__hardResetRegistryForTesting);
 
   describe('listActions', () => {
@@ -167,5 +168,219 @@ describe('registry', () => {
 
   it('returns undefined for unknown action', async () => {
     assert.strictEqual(await lookupAction('/model/foo/something'), undefined);
+  });
+});
+
+describe('registry class', () => {
+  var registry: Registry;
+  beforeEach(() => {
+    registry = new Registry();
+  });
+
+  describe('listActions', () => {
+    it('returns all registered actions', async () => {
+      const fooSomethingAction = action(
+        { name: 'foo_something' },
+        async () => null
+      );
+      registry.registerAction('model', fooSomethingAction);
+      const barSomethingAction = action(
+        { name: 'bar_something' },
+        async () => null
+      );
+      registry.registerAction('model', barSomethingAction);
+
+      assert.deepEqual(await registry.listActions(), {
+        '/model/foo_something': fooSomethingAction,
+        '/model/bar_something': barSomethingAction,
+      });
+    });
+
+    it('returns all registered actions by plugins', async () => {
+      registry.registerPluginProvider('foo', {
+        name: 'foo',
+        async initializer() {
+          registry.registerAction('model', fooSomethingAction);
+          return {};
+        },
+      });
+      const fooSomethingAction = action(
+        {
+          name: {
+            pluginId: 'foo',
+            actionId: 'something',
+          },
+        },
+        async () => null
+      );
+      registry.registerPluginProvider('bar', {
+        name: 'bar',
+        async initializer() {
+          registry.registerAction('model', barSomethingAction);
+          return {};
+        },
+      });
+      const barSomethingAction = action(
+        {
+          name: {
+            pluginId: 'bar',
+            actionId: 'something',
+          },
+        },
+        async () => null
+      );
+
+      assert.deepEqual(await registry.listActions(), {
+        '/model/foo/something': fooSomethingAction,
+        '/model/bar/something': barSomethingAction,
+      });
+    });
+
+    it('returns all registered actions, including parent', async () => {
+      const child = Registry.withParent(registry);
+
+      const fooSomethingAction = action(
+        { name: 'foo_something' },
+        async () => null
+      );
+      registry.registerAction('model', fooSomethingAction);
+      const barSomethingAction = action(
+        { name: 'bar_something' },
+        async () => null
+      );
+      child.registerAction('model', barSomethingAction);
+
+      assert.deepEqual(await child.listActions(), {
+        '/model/foo_something': fooSomethingAction,
+        '/model/bar_something': barSomethingAction,
+      });
+      assert.deepEqual(await registry.listActions(), {
+        '/model/foo_something': fooSomethingAction,
+      });
+    });
+  });
+
+  describe('lookupAction', () => {
+    it('initializes plugin for action first', async () => {
+      let fooInitialized = false;
+      registry.registerPluginProvider('foo', {
+        name: 'foo',
+        async initializer() {
+          fooInitialized = true;
+          return {};
+        },
+      });
+      let barInitialized = false;
+      registry.registerPluginProvider('bar', {
+        name: 'bar',
+        async initializer() {
+          barInitialized = true;
+          return {};
+        },
+      });
+
+      await registry.lookupAction('/model/foo/something');
+
+      assert.strictEqual(fooInitialized, true);
+      assert.strictEqual(barInitialized, false);
+
+      await registry.lookupAction('/model/bar/something');
+
+      assert.strictEqual(fooInitialized, true);
+      assert.strictEqual(barInitialized, true);
+    });
+
+    it('returns registered action', async () => {
+      const fooSomethingAction = action(
+        { name: 'foo_something' },
+        async () => null
+      );
+      registry.registerAction('model', fooSomethingAction);
+      const barSomethingAction = action(
+        { name: 'bar_something' },
+        async () => null
+      );
+      registry.registerAction('model', barSomethingAction);
+
+      assert.strictEqual(
+        await registry.lookupAction('/model/foo_something'),
+        fooSomethingAction
+      );
+      assert.strictEqual(
+        await registry.lookupAction('/model/bar_something'),
+        barSomethingAction
+      );
+    });
+
+    it('returns action registered by plugin', async () => {
+      registry.registerPluginProvider('foo', {
+        name: 'foo',
+        async initializer() {
+          registry.registerAction('model', somethingAction);
+          return {};
+        },
+      });
+      const somethingAction = action(
+        {
+          name: {
+            pluginId: 'foo',
+            actionId: 'something',
+          },
+        },
+        async () => null
+      );
+
+      assert.strictEqual(
+        await registry.lookupAction('/model/foo/something'),
+        somethingAction
+      );
+    });
+
+    it('returns undefined for unknown action', async () => {
+      assert.strictEqual(
+        await registry.lookupAction('/model/foo/something'),
+        undefined
+      );
+    });
+
+    it('should lookup parent registry when child missing action', async () => {
+      const childRegistry = new Registry(registry);
+
+      const fooSomethingAction = action(
+        { name: 'foo_something' },
+        async () => null
+      );
+      registry.registerAction('model', fooSomethingAction);
+
+      assert.strictEqual(
+        await registry.lookupAction('/model/foo_something'),
+        fooSomethingAction
+      );
+      assert.strictEqual(
+        await childRegistry.lookupAction('/model/foo_something'),
+        fooSomethingAction
+      );
+    });
+
+    it('registration on the child registry should not modify parent', async () => {
+      const childRegistry = Registry.withParent(registry);
+
+      assert.strictEqual(childRegistry.parent, registry);
+
+      const fooSomethingAction = action(
+        { name: 'foo_something' },
+        async () => null
+      );
+      childRegistry.registerAction('model', fooSomethingAction);
+
+      assert.strictEqual(
+        await registry.lookupAction('/model/foo_something'),
+        undefined
+      );
+      assert.strictEqual(
+        await childRegistry.lookupAction('/model/foo_something'),
+        fooSomethingAction
+      );
+    });
   });
 });


### PR DESCRIPTION
For testing:
```ts
runInEphemeralRegistry(async () => {
  // these will not pollute the global registry
  defineFlow(...)
  defineModel(...)
  // etc.

  // these will have access to parent app actions and actions defined within
  listActions(...)
  lookupAction(...)
  // etc.
})
```

for libraries:
```ts
const myLibRegistry = new Registry();

runWithRegistry(myLibRegistry, async () => {
  // these will not pollute the global registry
  defineFlow(...)
  defineModel(...)
  // etc.

  // these will not have access to parent app actions
  // only actions above will be listed.
  listActions()
  lookupAction(...)
  // etc.
})
```
