### PR TITLE
fix: moved core lib deps to peer deps for plugins

### DIFF
--- a/js/plugins/chroma/package.json
+++ b/js/plugins/chroma/package.json
@@ -30,11 +30,13 @@
   "author": "genkit",
   "license": "Apache-2.0",
   "dependencies": {
-    "@genkit-ai/ai": "workspace:*",
-    "@genkit-ai/core": "workspace:*",
-    "chromadb": "^1.7.3",
     "ts-md5": "^1.3.1",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "chromadb": "^1.7.3"
+  },
+  "peerDependencies": {
+    "@genkit-ai/ai": "workspace:*",
+    "@genkit-ai/core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/js/plugins/dev-local-vectorstore/package.json
+++ b/js/plugins/dev-local-vectorstore/package.json
@@ -27,11 +27,13 @@
   "author": "genkit",
   "license": "Apache-2.0",
   "dependencies": {
-    "@genkit-ai/ai": "workspace:*",
-    "@genkit-ai/core": "workspace:*",
     "compute-cosine-similarity": "^1.1.0",
     "ts-md5": "^1.3.1",
     "zod": "^3.22.4"
+  },
+  "peerDependencies": {
+    "@genkit-ai/ai": "workspace:*",
+    "@genkit-ai/core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/js/plugins/dotprompt/package.json
+++ b/js/plugins/dotprompt/package.json
@@ -27,12 +27,14 @@
   "author": "genkit",
   "license": "Apache-2.0",
   "dependencies": {
-    "@genkit-ai/ai": "workspace:*",
-    "@genkit-ai/core": "workspace:*",
     "front-matter": "^4.0.2",
     "handlebars": "^4.7.8",
     "node-fetch": "^3.3.2",
     "zod": "^3.22.4"
+  },
+  "peerDependencies": {
+    "@genkit-ai/ai": "workspace:*",
+    "@genkit-ai/core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/js/plugins/evaluators/package.json
+++ b/js/plugins/evaluators/package.json
@@ -30,13 +30,15 @@
   "author": "genkit",
   "license": "Apache-2.0",
   "dependencies": {
-    "@genkit-ai/ai": "workspace:*",
-    "@genkit-ai/core": "workspace:*",
     "@genkit-ai/dotprompt": "workspace:*",
     "compute-cosine-similarity": "^1.1.0",
     "node-fetch": "^3.3.2",
     "path": "^0.12.7",
     "zod": "^3.22.4"
+  },
+  "peerDependencies": {
+    "@genkit-ai/ai": "workspace:*",
+    "@genkit-ai/core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/js/plugins/firebase/package.json
+++ b/js/plugins/firebase/package.json
@@ -31,9 +31,6 @@
   "author": "genkit",
   "license": "Apache-2.0",
   "dependencies": {
-    "@genkit-ai/ai": "workspace:*",
-    "@genkit-ai/core": "workspace:*",
-    "@genkit-ai/flow": "workspace:*",
     "@genkit-ai/google-cloud": "workspace:*",
     "express": "^4.19.2",
     "google-auth-library": "^9.6.3",
@@ -42,7 +39,10 @@
   "peerDependencies": {
     "@google-cloud/firestore": "^7.6.0",
     "firebase-admin": "^12.2.0",
-    "firebase-functions": "^4.8.0 || ^5.0.0"
+    "firebase-functions": "^4.8.0 || ^5.0.0",
+    "@genkit-ai/ai": "workspace:*",
+    "@genkit-ai/core": "workspace:*",
+    "@genkit-ai/flow": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/js/plugins/google-cloud/package.json
+++ b/js/plugins/google-cloud/package.json
@@ -31,8 +31,6 @@
   "author": "genkit",
   "license": "Apache-2.0",
   "dependencies": {
-    "@genkit-ai/ai": "workspace:*",
-    "@genkit-ai/core": "workspace:*",
     "@google-cloud/logging-winston": "^6.0.0",
     "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.19.0",
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^2.1.0",
@@ -51,6 +49,10 @@
     "node-fetch": "^3.3.2",
     "prettier-plugin-organize-imports": "^3.2.4",
     "winston": "^3.12.0"
+  },
+  "peerDependencies": {
+    "@genkit-ai/ai": "workspace:*",
+    "@genkit-ai/core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/js/plugins/googleai/package.json
+++ b/js/plugins/googleai/package.json
@@ -31,12 +31,14 @@
   "author": "genkit",
   "license": "Apache-2.0",
   "dependencies": {
-    "@genkit-ai/ai": "workspace:*",
-    "@genkit-ai/core": "workspace:*",
     "@google/generative-ai": "^0.14.1",
     "google-auth-library": "^9.6.3",
     "node-fetch": "^3.3.2",
     "zod": "^3.22.4"
+  },
+  "peerDependencies": {
+    "@genkit-ai/ai": "workspace:*",
+    "@genkit-ai/core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/js/plugins/langchain/package.json
+++ b/js/plugins/langchain/package.json
@@ -26,14 +26,16 @@
   "author": "genkit",
   "license": "Apache-2.0",
   "dependencies": {
+    "@langchain/community": "^0.0.53",
+    "@langchain/core": "^0.1.61",
+    "@opentelemetry/api": "^1.7.0",
+    "zod": "^3.22.4"
+  },
+  "peerDependencies": {
     "@genkit-ai/ai": "workspace:*",
     "@genkit-ai/core": "workspace:*",
     "@genkit-ai/flow": "workspace:*",
-    "zod": "^3.22.4",
-    "langchain": "^0.1.36",
-    "@langchain/community": "^0.0.53",
-    "@langchain/core": "^0.1.61",
-    "@opentelemetry/api": "^1.7.0"
+    "langchain": "^0.1.36"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/js/plugins/ollama/package.json
+++ b/js/plugins/ollama/package.json
@@ -26,7 +26,7 @@
   },
   "author": "genkit",
   "license": "Apache-2.0",
-  "dependencies": {
+  "peerDependencies": {
     "@genkit-ai/ai": "workspace:*",
     "@genkit-ai/core": "workspace:*"
   },

--- a/js/plugins/pinecone/package.json
+++ b/js/plugins/pinecone/package.json
@@ -30,11 +30,13 @@
   "author": "genkit",
   "license": "Apache-2.0",
   "dependencies": {
-    "@genkit-ai/ai": "workspace:*",
-    "@genkit-ai/core": "workspace:*",
     "@pinecone-database/pinecone": "^2.0.1",
     "ts-md5": "^1.3.1",
     "zod": "^3.22.4"
+  },
+  "peerDependencies": {
+    "@genkit-ai/ai": "workspace:*",
+    "@genkit-ai/core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/js/plugins/vertexai/package.json
+++ b/js/plugins/vertexai/package.json
@@ -37,13 +37,15 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.24.3",
     "@anthropic-ai/vertex-sdk": "^0.4.0",
-    "@genkit-ai/ai": "workspace:*",
-    "@genkit-ai/core": "workspace:*",
-    "@genkit-ai/flow": "workspace:*",
     "@google-cloud/vertexai": "^1.1.0",
     "google-auth-library": "^9.6.3",
     "node-fetch": "^3.3.2",
     "zod": "^3.22.4"
+  },
+  "peerDependencies": {
+    "@genkit-ai/ai": "workspace:*",
+    "@genkit-ai/core": "workspace:*",
+    "@genkit-ai/flow": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",


### PR DESCRIPTION
core lib need to be in peer deps to avoid situations when mismatched plugin and core lib versions in the app package.json cause AsyncLocalStorage and global state issues.