### PR TITLE
refactor: [Go] updated the ai.Generate API

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -357,6 +357,15 @@ func (gr *GenerateResponse) Text() string {
 	return gr.Candidates[0].Text()
 }
 
+// History returns messages from the request combined with the reponse message
+// to represent the conversation history.
+func (gr *GenerateResponse) History() []*Message {
+	if len(gr.Candidates) == 0 {
+		return gr.Request.Messages
+	}
+	return append(gr.Request.Messages, gr.Candidates[0].Message)
+}
+
 // UnmarshalOutput unmarshals structured JSON output into the provided
 // struct pointer.
 func (gr *GenerateResponse) UnmarshalOutput(v any) error {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -241,8 +241,8 @@ func (m *Model) Generate(ctx context.Context, opts ...generateOption) (*Generate
 }
 
 // GenerateText run generate request for this model. Returns generated text only.
-func (m *Model) GenerateText(ctx context.Context, withs ...generateOption) (string, error) {
-	res, err := m.Generate(ctx, withs...)
+func (m *Model) GenerateText(ctx context.Context, opts ...generateOption) (string, error) {
+	res, err := m.Generate(ctx, opts...)
 	if err != nil {
 		return "", err
 	}
@@ -252,9 +252,9 @@ func (m *Model) GenerateText(ctx context.Context, withs ...generateOption) (stri
 
 // Generate run generate request for this model. Returns GenerateResponse struct.
 // TODO: Stream GenerateData with partial JSON
-func (m *Model) GenerateData(ctx context.Context, value any, withs ...generateOption) (*GenerateResponse, error) {
-	withs = append(withs, WithOutputSchema(value))
-	resp, err := m.Generate(ctx, withs...)
+func (m *Model) GenerateData(ctx context.Context, value any, opts ...generateOption) (*GenerateResponse, error) {
+	opts = append(opts, WithOutputSchema(value))
+	resp, err := m.Generate(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -135,7 +135,7 @@ func WithTools(tools ...Tool) generateRequestEditor {
 }
 
 // WithConfig adds provided output schema to GenerateRequest
-func WithOutputSchema(schema struct{}) generateRequestEditor {
+func WithOutputSchema[T any](schema T) generateRequestEditor {
 	return func(req *GenerateRequest) {
 		req.Output.Schema = base.SchemaAsMap(base.InferJSONSchema(schema))
 	}
@@ -354,6 +354,12 @@ func (gr *GenerateResponse) Text() (string, error) {
 		return "", errors.New("no candidates returned")
 	}
 	return gr.Candidates[0].Text()
+}
+
+// UnmarshalOutput unmarshals structured JSON output into the provided
+// struct pointer.
+func (gr *GenerateResponse) UnmarshalOutput(v any) error {
+	return fmt.Errorf("implement me!")
 }
 
 // Text returns the text content of the [GenerateResponseChunk]

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -106,6 +106,7 @@ func WithTextPrompt(prompt string) generateOption {
 }
 
 // WithSystemPrompt adds a simple text system prompt as the first message in GenerateRequest.
+// System prompt will always be put first in the list of messages.
 func WithSystemPrompt(prompt string) generateOption {
 	return func(req *generateParams) error {
 		if req.SystemPrompt != nil {
@@ -125,6 +126,9 @@ func WithMessages(messages ...*Message) generateOption {
 }
 
 // WithHistory adds provided history messages to the begining of GenerateRequest.Messages.
+// History messages will always be put first in the list of messages, with the
+// exception of system prompt which will always be first.
+// [WithMessages] and [WithTextPrompt] will insert messages after system prompt and history.
 func WithHistory(history ...*Message) generateOption {
 	return func(req *generateParams) error {
 		if req.History != nil {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -86,45 +86,53 @@ func LookupModel(provider, name string) *Model {
 	return (*Model)(core.LookupActionFor[*GenerateRequest, *GenerateResponse, *GenerateResponseChunk](atype.Model, provider, name))
 }
 
-type generateRequestEditor func(req *GenerateRequest)
+// GenerateRequestBuilder adds
+type GenerateRequestBuilder func(req *GenerateRequest)
 
 // WithTextPrompt adds a simple text user prompt to GenerateRequest
-func WithTextPrompt(prompt string) generateRequestEditor {
+func WithTextPrompt(prompt string) GenerateRequestBuilder {
 	return func(req *GenerateRequest) {
 		req.Messages = append(req.Messages, NewUserTextMessage(prompt))
 	}
 }
 
+// WithSystemPrompt adds a simple text system prompt to GenerateRequest
+func WithSystemPrompt(prompt string) GenerateRequestBuilder {
+	return func(req *GenerateRequest) {
+		req.Messages = append(req.Messages, NewSystemTextMessage(prompt))
+	}
+}
+
 // WithMessages adds provided messages to GenerateRequest
-func WithMessages(messages ...*Message) generateRequestEditor {
+func WithMessages(messages ...*Message) GenerateRequestBuilder {
 	return func(req *GenerateRequest) {
 		req.Messages = append(req.Messages, messages...)
 	}
 }
 
 // WithConfig adds provided config to GenerateRequest
-func WithConfig(config any) generateRequestEditor {
+func WithConfig(config any) GenerateRequestBuilder {
 	return func(req *GenerateRequest) {
 		req.Config = config
 	}
 }
 
 // WithConfig adds provided candidate count to GenerateRequest
-func WithCandidates(c int) generateRequestEditor {
+func WithCandidates(c int) GenerateRequestBuilder {
 	return func(req *GenerateRequest) {
 		req.Candidates = c
 	}
 }
 
 // WithConfig adds provided context to GenerateRequest
-func WithContext(c ...any) generateRequestEditor {
+func WithContext(c ...any) GenerateRequestBuilder {
 	return func(req *GenerateRequest) {
 		req.Context = c
 	}
 }
 
 // WithConfig adds provided tools to GenerateRequest
-func WithTools(tools ...Tool) generateRequestEditor {
+func WithTools(tools ...Tool) GenerateRequestBuilder {
 	return func(req *GenerateRequest) {
 		var toolDefs []*ToolDefinition
 		for _, t := range tools {
@@ -135,31 +143,31 @@ func WithTools(tools ...Tool) generateRequestEditor {
 }
 
 // WithConfig adds provided output schema to GenerateRequest
-func WithOutputSchema[T any](schema T) generateRequestEditor {
+func WithOutputSchema[T any](schema T) GenerateRequestBuilder {
 	return func(req *GenerateRequest) {
 		req.Output.Schema = base.SchemaAsMap(base.InferJSONSchema(schema))
 	}
 }
 
 // WithConfig adds provided output format to GenerateRequest
-func WithOutputFormat(format OutputFormat) generateRequestEditor {
+func WithOutputFormat(format OutputFormat) GenerateRequestBuilder {
 	return func(req *GenerateRequest) {
 		req.Output.Format = format
 	}
 }
 
 // Generate run generate request for this model. Returns GenerateResponse struct.
-func (m *Model) Generate(ctx context.Context, withs ...generateRequestEditor) (*GenerateResponse, error) {
+func (m *Model) Generate(ctx context.Context, withs ...GenerateRequestBuilder) (*GenerateResponse, error) {
 	return m.StreamGenerate(ctx, nil, withs...)
 }
 
 // GenerateText run generate request for this model. Returns generated text only.
-func (m *Model) GenerateText(ctx context.Context, withs ...generateRequestEditor) (string, error) {
+func (m *Model) GenerateText(ctx context.Context, withs ...GenerateRequestBuilder) (string, error) {
 	return m.StreamGenerateText(ctx, nil, withs...)
 }
 
 // StreamGenerate run generate request for this model, handles streaming.
-func (m *Model) StreamGenerate(ctx context.Context, cb ModelStreamingCallback, withs ...generateRequestEditor) (*GenerateResponse, error) {
+func (m *Model) StreamGenerate(ctx context.Context, cb ModelStreamingCallback, withs ...GenerateRequestBuilder) (*GenerateResponse, error) {
 	req := &GenerateRequest{}
 	for _, with := range withs {
 		with(req)
@@ -169,7 +177,7 @@ func (m *Model) StreamGenerate(ctx context.Context, cb ModelStreamingCallback, w
 }
 
 // StreamGenerateText run generate request for this model and returns text output, handles streaming.
-func (m *Model) StreamGenerateText(ctx context.Context, cb ModelStreamingCallback, withs ...generateRequestEditor) (string, error) {
+func (m *Model) StreamGenerateText(ctx context.Context, cb ModelStreamingCallback, withs ...GenerateRequestBuilder) (string, error) {
 	req := &GenerateRequest{}
 	for _, with := range withs {
 		with(req)

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -86,39 +86,45 @@ func LookupModel(provider, name string) *Model {
 	return (*Model)(core.LookupActionFor[*GenerateRequest, *GenerateResponse, *GenerateResponseChunk](atype.Model, provider, name))
 }
 
-type GenerateRequestEditor func(req *GenerateRequest)
+type generateRequestEditor func(req *GenerateRequest)
 
-func WithSimpleTextPrompt(prompt string) GenerateRequestEditor {
+// WithSimpleTextPrompt adds a simple text user prompt to GenerateRequest
+func WithSimpleTextPrompt(prompt string) generateRequestEditor {
 	return func(req *GenerateRequest) {
 		req.Messages = append(req.Messages, NewUserTextMessage(prompt))
 	}
 }
 
-func WithMessages(messages ...*Message) GenerateRequestEditor {
+// WithMessages adds provided messages to GenerateRequest
+func WithMessages(messages ...*Message) generateRequestEditor {
 	return func(req *GenerateRequest) {
 		req.Messages = append(req.Messages, messages...)
 	}
 }
 
-func WithConfig(config any) GenerateRequestEditor {
+// WithConfig adds provided config to GenerateRequest
+func WithConfig(config any) generateRequestEditor {
 	return func(req *GenerateRequest) {
 		req.Config = config
 	}
 }
 
-func WithCandidates(c int) GenerateRequestEditor {
+// WithConfig adds provided candidate count to GenerateRequest
+func WithCandidates(c int) generateRequestEditor {
 	return func(req *GenerateRequest) {
 		req.Candidates = c
 	}
 }
 
-func WithContext(c ...any) GenerateRequestEditor {
+// WithConfig adds provided context to GenerateRequest
+func WithContext(c ...any) generateRequestEditor {
 	return func(req *GenerateRequest) {
 		req.Context = c
 	}
 }
 
-func WithTools(tools ...Tool) GenerateRequestEditor {
+// WithConfig adds provided tools to GenerateRequest
+func WithTools(tools ...Tool) generateRequestEditor {
 	return func(req *GenerateRequest) {
 		var toolDefs []*ToolDefinition
 		for _, t := range tools {
@@ -128,27 +134,32 @@ func WithTools(tools ...Tool) GenerateRequestEditor {
 	}
 }
 
-func WithOutputSchema(schema struct{}) GenerateRequestEditor {
+// WithConfig adds provided output schema to GenerateRequest
+func WithOutputSchema(schema struct{}) generateRequestEditor {
 	return func(req *GenerateRequest) {
 		req.Output.Schema = base.SchemaAsMap(base.InferJSONSchema(schema))
 	}
 }
 
-func WithOutputFormat(format OutputFormat) GenerateRequestEditor {
+// WithConfig adds provided output format to GenerateRequest
+func WithOutputFormat(format OutputFormat) generateRequestEditor {
 	return func(req *GenerateRequest) {
 		req.Output.Format = format
 	}
 }
 
-func (m *Model) Generate(ctx context.Context, withs ...GenerateRequestEditor) (*GenerateResponse, error) {
+// Generate run generate request for this model. Returns GenerateResponse struct.
+func (m *Model) Generate(ctx context.Context, withs ...generateRequestEditor) (*GenerateResponse, error) {
 	return m.StreamGenerate(ctx, nil, withs...)
 }
 
-func (m *Model) GenerateText(ctx context.Context, withs ...GenerateRequestEditor) (string, error) {
+// GenerateText run generate request for this model. Returns generated text only.
+func (m *Model) GenerateText(ctx context.Context, withs ...generateRequestEditor) (string, error) {
 	return m.StreamGenerateText(ctx, nil, withs...)
 }
 
-func (m *Model) StreamGenerate(ctx context.Context, cb ModelStreamingCallback, withs ...GenerateRequestEditor) (*GenerateResponse, error) {
+// StreamGenerate run generate request for this model, handles streaming.
+func (m *Model) StreamGenerate(ctx context.Context, cb ModelStreamingCallback, withs ...generateRequestEditor) (*GenerateResponse, error) {
 	req := &GenerateRequest{}
 	for _, with := range withs {
 		with(req)
@@ -157,7 +168,8 @@ func (m *Model) StreamGenerate(ctx context.Context, cb ModelStreamingCallback, w
 	return m.StreamGenerateRaw(ctx, req, cb)
 }
 
-func (m *Model) StreamGenerateText(ctx context.Context, cb ModelStreamingCallback, withs ...GenerateRequestEditor) (string, error) {
+// StreamGenerateText run generate request for this model and returns text output, handles streaming.
+func (m *Model) StreamGenerateText(ctx context.Context, cb ModelStreamingCallback, withs ...generateRequestEditor) (string, error) {
 	req := &GenerateRequest{}
 	for _, with := range withs {
 		with(req)
@@ -175,12 +187,12 @@ func (m *Model) StreamGenerateText(ctx context.Context, cb ModelStreamingCallbac
 	return res.Text()
 }
 
-// GenerateRaw applies the [Model] to some input, handling tool requests.
+// GenerateRaw applies the [Model] to provided request, handling tool requests.
 func (m *Model) GenerateRaw(ctx context.Context, req *GenerateRequest) (*GenerateResponse, error) {
 	return m.StreamGenerateRaw(ctx, req, nil)
 }
 
-// StreamGenerateRaw applies the [Model] to some input, handling tool requests and handles streaming.
+// StreamGenerateRaw applies the [Model] to provided request, handling tool requests and handles streaming.
 func (m *Model) StreamGenerateRaw(ctx context.Context, req *GenerateRequest, cb ModelStreamingCallback) (*GenerateResponse, error) {
 	if m == nil {
 		return nil, errors.New("Generate called on a nil Model; check that all models are defined")

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -157,7 +157,7 @@ func WithCandidates(c int) GenerateOption {
 // WithContext adds provided context to GenerateRequest.
 func WithContext(c ...any) GenerateOption {
 	return func(req *GenerateParams) error {
-		req.Request.Context = append(req.Request.Context, c)
+		req.Request.Context = append(req.Request.Context, c...)
 		return nil
 	}
 }

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -86,6 +86,7 @@ func LookupModel(provider, name string) *Model {
 	return (*Model)(core.LookupActionFor[*GenerateRequest, *GenerateResponse, *GenerateResponseChunk](atype.Model, provider, name))
 }
 
+// GenerateParams represents various params of the Generate call.
 type GenerateParams struct {
 	Request      *GenerateRequest
 	Stream       ModelStreamingCallback
@@ -107,6 +108,9 @@ func WithTextPrompt(prompt string) GenerateOption {
 // WithSystemPrompt adds a simple text system prompt as the first message in GenerateRequest.
 func WithSystemPrompt(prompt string) GenerateOption {
 	return func(req *GenerateParams) error {
+		if req.SystemPrompt != nil {
+			return errors.New("cannot set system prompt (WithSystemPrompt) more than once")
+		}
 		req.SystemPrompt = NewSystemTextMessage(prompt)
 		return nil
 	}
@@ -123,6 +127,9 @@ func WithMessages(messages ...*Message) GenerateOption {
 // WithHistory adds provided history messages to the begining of GenerateRequest.Messages.
 func WithHistory(history ...*Message) GenerateOption {
 	return func(req *GenerateParams) error {
+		if req.History != nil {
+			return errors.New("cannot set history (WithHistory) more than once")
+		}
 		req.History = history
 		return nil
 	}
@@ -131,6 +138,9 @@ func WithHistory(history ...*Message) GenerateOption {
 // WithConfig adds provided config to GenerateRequest.
 func WithConfig(config any) GenerateOption {
 	return func(req *GenerateParams) error {
+		if req.Request.Config != nil {
+			return errors.New("cannot set Request.Config (WithConfig) more than once")
+		}
 		req.Request.Config = config
 		return nil
 	}
@@ -147,7 +157,7 @@ func WithCandidates(c int) GenerateOption {
 // WithContext adds provided context to GenerateRequest.
 func WithContext(c ...any) GenerateOption {
 	return func(req *GenerateParams) error {
-		req.Request.Context = c
+		req.Request.Context = append(req.Request.Context, c)
 		return nil
 	}
 }
@@ -193,6 +203,9 @@ func WithOutputFormat(format OutputFormat) GenerateOption {
 // WithStreaming adds a streaming callback to the generate request.
 func WithStreaming(cb ModelStreamingCallback) GenerateOption {
 	return func(req *GenerateParams) error {
+		if req.Stream != nil {
+			return errors.New("cannot set streaming callback (WithStreaming) more than once")
+		}
 		req.Stream = cb
 		return nil
 	}

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -86,28 +86,28 @@ func LookupModel(provider, name string) *Model {
 	return (*Model)(core.LookupActionFor[*GenerateRequest, *GenerateResponse, *GenerateResponseChunk](atype.Model, provider, name))
 }
 
-// GenerateParams represents various params of the Generate call.
-type GenerateParams struct {
+// generateParams represents various params of the Generate call.
+type generateParams struct {
 	Request      *GenerateRequest
 	Stream       ModelStreamingCallback
 	History      []*Message
 	SystemPrompt *Message
 }
 
-// GenerateOption configures params of the Generate call.
-type GenerateOption func(req *GenerateParams) error
+// generateOption configures params of the Generate call.
+type generateOption func(req *generateParams) error
 
 // WithTextPrompt adds a simple text user prompt to GenerateRequest.
-func WithTextPrompt(prompt string) GenerateOption {
-	return func(req *GenerateParams) error {
+func WithTextPrompt(prompt string) generateOption {
+	return func(req *generateParams) error {
 		req.Request.Messages = append(req.Request.Messages, NewUserTextMessage(prompt))
 		return nil
 	}
 }
 
 // WithSystemPrompt adds a simple text system prompt as the first message in GenerateRequest.
-func WithSystemPrompt(prompt string) GenerateOption {
-	return func(req *GenerateParams) error {
+func WithSystemPrompt(prompt string) generateOption {
+	return func(req *generateParams) error {
 		if req.SystemPrompt != nil {
 			return errors.New("cannot set system prompt (WithSystemPrompt) more than once")
 		}
@@ -117,16 +117,16 @@ func WithSystemPrompt(prompt string) GenerateOption {
 }
 
 // WithMessages adds provided messages to GenerateRequest.
-func WithMessages(messages ...*Message) GenerateOption {
-	return func(req *GenerateParams) error {
+func WithMessages(messages ...*Message) generateOption {
+	return func(req *generateParams) error {
 		req.Request.Messages = append(req.Request.Messages, messages...)
 		return nil
 	}
 }
 
 // WithHistory adds provided history messages to the begining of GenerateRequest.Messages.
-func WithHistory(history ...*Message) GenerateOption {
-	return func(req *GenerateParams) error {
+func WithHistory(history ...*Message) generateOption {
+	return func(req *generateParams) error {
 		if req.History != nil {
 			return errors.New("cannot set history (WithHistory) more than once")
 		}
@@ -136,8 +136,8 @@ func WithHistory(history ...*Message) GenerateOption {
 }
 
 // WithConfig adds provided config to GenerateRequest.
-func WithConfig(config any) GenerateOption {
-	return func(req *GenerateParams) error {
+func WithConfig(config any) generateOption {
+	return func(req *generateParams) error {
 		if req.Request.Config != nil {
 			return errors.New("cannot set Request.Config (WithConfig) more than once")
 		}
@@ -147,24 +147,24 @@ func WithConfig(config any) GenerateOption {
 }
 
 // WithCandidates adds provided candidate count to GenerateRequest.
-func WithCandidates(c int) GenerateOption {
-	return func(req *GenerateParams) error {
+func WithCandidates(c int) generateOption {
+	return func(req *generateParams) error {
 		req.Request.Candidates = c
 		return nil
 	}
 }
 
 // WithContext adds provided context to GenerateRequest.
-func WithContext(c ...any) GenerateOption {
-	return func(req *GenerateParams) error {
+func WithContext(c ...any) generateOption {
+	return func(req *generateParams) error {
 		req.Request.Context = append(req.Request.Context, c...)
 		return nil
 	}
 }
 
 // WithTools adds provided tools to GenerateRequest.
-func WithTools(tools ...Tool) GenerateOption {
-	return func(req *GenerateParams) error {
+func WithTools(tools ...Tool) generateOption {
+	return func(req *generateParams) error {
 		var toolDefs []*ToolDefinition
 		for _, t := range tools {
 			toolDefs = append(toolDefs, t.Definition())
@@ -175,8 +175,8 @@ func WithTools(tools ...Tool) GenerateOption {
 }
 
 // WithOutputSchema adds provided output schema to GenerateRequest.
-func WithOutputSchema(schema any) GenerateOption {
-	return func(req *GenerateParams) error {
+func WithOutputSchema(schema any) generateOption {
+	return func(req *generateParams) error {
 		if req.Request.Output != nil && req.Request.Output.Schema != nil {
 			return errors.New("cannot set Request.Output.Schema (WithOutputSchema) more than once")
 		}
@@ -190,8 +190,8 @@ func WithOutputSchema(schema any) GenerateOption {
 }
 
 // WithOutputFormat adds provided output format to GenerateRequest.
-func WithOutputFormat(format OutputFormat) GenerateOption {
-	return func(req *GenerateParams) error {
+func WithOutputFormat(format OutputFormat) generateOption {
+	return func(req *generateParams) error {
 		if req.Request.Output == nil {
 			req.Request.Output = &GenerateRequestOutput{}
 		}
@@ -201,8 +201,8 @@ func WithOutputFormat(format OutputFormat) GenerateOption {
 }
 
 // WithStreaming adds a streaming callback to the generate request.
-func WithStreaming(cb ModelStreamingCallback) GenerateOption {
-	return func(req *GenerateParams) error {
+func WithStreaming(cb ModelStreamingCallback) generateOption {
+	return func(req *generateParams) error {
 		if req.Stream != nil {
 			return errors.New("cannot set streaming callback (WithStreaming) more than once")
 		}
@@ -212,8 +212,8 @@ func WithStreaming(cb ModelStreamingCallback) GenerateOption {
 }
 
 // Generate run generate request for this model. Returns GenerateResponse struct.
-func (m *Model) Generate(ctx context.Context, opts ...GenerateOption) (*GenerateResponse, error) {
-	req := &GenerateParams{
+func (m *Model) Generate(ctx context.Context, opts ...generateOption) (*GenerateResponse, error) {
+	req := &generateParams{
 		Request: &GenerateRequest{},
 	}
 	for _, with := range opts {
@@ -237,7 +237,7 @@ func (m *Model) Generate(ctx context.Context, opts ...GenerateOption) (*Generate
 }
 
 // GenerateText run generate request for this model. Returns generated text only.
-func (m *Model) GenerateText(ctx context.Context, withs ...GenerateOption) (string, error) {
+func (m *Model) GenerateText(ctx context.Context, withs ...generateOption) (string, error) {
 	res, err := m.Generate(ctx, withs...)
 	if err != nil {
 		return "", err
@@ -248,7 +248,7 @@ func (m *Model) GenerateText(ctx context.Context, withs ...GenerateOption) (stri
 
 // Generate run generate request for this model. Returns GenerateResponse struct.
 // TODO: Stream GenerateData with partial JSON
-func (m *Model) GenerateData(ctx context.Context, value any, withs ...GenerateOption) (*GenerateResponse, error) {
+func (m *Model) GenerateData(ctx context.Context, value any, withs ...generateOption) (*GenerateResponse, error) {
 	withs = append(withs, WithOutputSchema(value))
 	resp, err := m.Generate(ctx, withs...)
 	if err != nil {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -88,8 +88,8 @@ func LookupModel(provider, name string) *Model {
 
 type generateRequestEditor func(req *GenerateRequest)
 
-// WithSimpleTextPrompt adds a simple text user prompt to GenerateRequest
-func WithSimpleTextPrompt(prompt string) generateRequestEditor {
+// WithTextPrompt adds a simple text user prompt to GenerateRequest
+func WithTextPrompt(prompt string) generateRequestEditor {
 	return func(req *GenerateRequest) {
 		req.Messages = append(req.Messages, NewUserTextMessage(prompt))
 	}

--- a/go/ai/generator_test.go
+++ b/go/ai/generator_test.go
@@ -85,7 +85,7 @@ func TestValidCandidate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if text != json {
+		if strings.TrimSpace(text) != strings.TrimSpace(json) {
 			t.Fatalf("got %q, want %q", json, text)
 		}
 	})

--- a/go/ai/generator_test.go
+++ b/go/ai/generator_test.go
@@ -15,8 +15,46 @@
 package ai
 
 import (
+	"context"
+	"math"
 	"strings"
 	"testing"
+
+	test_utils "github.com/firebase/genkit/go/tests/utils"
+	"github.com/google/go-cmp/cmp"
+)
+
+// structured output
+type GameCharacter struct {
+	Name      string
+	Backstory string
+}
+
+var echoModel = DefineModel("test", "echo", nil, func(ctx context.Context, gr *GenerateRequest, msc ModelStreamingCallback) (*GenerateResponse, error) {
+	if msc != nil {
+		msc(ctx, &GenerateResponseChunk{
+			Index:   0,
+			Content: []*Part{NewTextPart("stream!")},
+		})
+	}
+	return &GenerateResponse{
+		Request: gr,
+		Candidates: []*Candidate{
+			{
+				Message: NewUserTextMessage(gr.Messages[0].Content[0].Text),
+			},
+		},
+	}, nil
+})
+
+// with tools
+var gablorkenTool = DefineTool("gablorken", "use when need to calculate a gablorken",
+	func(ctx context.Context, input struct {
+		Value float64
+		Over  float64
+	}) (float64, error) {
+		return math.Pow(input.Value, input.Over), nil
+	},
 )
 
 func TestValidCandidate(t *testing.T) {
@@ -81,10 +119,7 @@ func TestValidCandidate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		text, err := candidate.Text()
-		if err != nil {
-			t.Fatal(err)
-		}
+		text := candidate.Text()
 		if strings.TrimSpace(text) != strings.TrimSpace(json) {
 			t.Fatalf("got %q, want %q", json, text)
 		}
@@ -186,6 +221,92 @@ func TestValidCandidate(t *testing.T) {
 		}
 		_, err := validCandidate(candidate, outputSchema)
 		errorContains(t, err, "failed to validate data against expected schema")
+	})
+}
+
+func TestGenerate(t *testing.T) {
+	t.Run("constructs request", func(t *testing.T) {
+		charJson := "{\"Name\": \"foo\", \"Backstory\": \"bar\"}"
+		wantText := charJson
+		wantRequest := &GenerateRequest{
+			Messages: []*Message{
+				{
+					Content: []*Part{
+						{ContentType: "plain/text", Text: charJson},
+						{
+							ContentType: "plain/text",
+							Text:        "!!Ignored!!", // structured output prompt, noisy, ignored
+						},
+					}, Role: "user"},
+			},
+			Config:     GenerationCommonConfig{Temperature: 1},
+			Candidates: 3,
+			Context:    []any{[]any{string("Banana")}},
+			Output: &GenerateRequestOutput{
+				Format: "json",
+				Schema: map[string]any{
+					"$id":                  string("https://github.com/firebase/genkit/go/ai/game-character"),
+					"additionalProperties": bool(false),
+					"properties": map[string]any{
+						"Backstory": map[string]any{"type": string("string")},
+						"Name":      map[string]any{"type": string("string")},
+					},
+					"required": []any{string("Name"), string("Backstory")},
+					"type":     string("object"),
+				},
+			},
+			Tools: []*ToolDefinition{
+				{
+					Description: "use when need to calculate a gablorken",
+					InputSchema: map[string]any{
+						"additionalProperties": bool(false),
+						"properties": map[string]any{
+							"Over":  map[string]any{"type": string("number")},
+							"Value": map[string]any{"type": string("number")},
+						},
+						"required": []any{
+							string("Value"),
+							string("Over"),
+						},
+						"type": string("object"),
+					},
+					Name:         "gablorken",
+					OutputSchema: map[string]any{"type": string("number")},
+				},
+			},
+		}
+
+		wantStreamText := "stream!"
+		streamText := ""
+		res, err := echoModel.Generate(context.Background(),
+			WithTextPrompt(charJson),
+			WithConfig(GenerationCommonConfig{
+				Temperature: 1,
+			}),
+			WithCandidates(3),
+			WithContext([]any{"Banana"}),
+			WithOutputSchema(&GameCharacter{}),
+			WithTools(gablorkenTool),
+			WithStreaming(func(ctx context.Context, grc *GenerateResponseChunk) error {
+				streamText += grc.Text()
+				return nil
+			}),
+		)
+		if err != nil {
+			t.Error(err)
+		}
+		gotText := res.Text()
+		if diff := cmp.Diff(gotText, wantText); diff != "" {
+			t.Errorf("Text() diff (+got -want):\n%s", diff)
+		}
+		if diff := cmp.Diff(streamText, wantStreamText); diff != "" {
+			t.Errorf("Text() diff (+got -want):\n%s", diff)
+		}
+		if diff := cmp.Diff(res.Request, wantRequest, test_utils.IgnoreNoisyParts([]string{
+			"{*ai.GenerateRequest}.Messages[0].Content[1].Text",
+		})); diff != "" {
+			t.Errorf("Request diff (+got -want):\n%s", diff)
+		}
 	})
 }
 

--- a/go/internal/base/json.go
+++ b/go/internal/base/json.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 
 	"github.com/invopop/jsonschema"
 )
@@ -100,4 +101,15 @@ func SchemaAsMap(s *jsonschema.Schema) map[string]any {
 		log.Panicf("failed to unmarshal schema: %v", err)
 	}
 	return m
+}
+
+var jsonMarkdownRegex = regexp.MustCompile("```(json)?((\n|.)*?)```")
+
+func ExtractJsonFromMarkdown(md string) string {
+	// TODO: improve this
+	matches := jsonMarkdownRegex.FindStringSubmatch(md)
+	if matches == nil {
+		return md
+	}
+	return matches[2]
 }

--- a/go/internal/base/json_test.go
+++ b/go/internal/base/json_test.go
@@ -1,0 +1,100 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExtractJsonFromMarkdown(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   string
+		want string
+	}{
+		{
+			desc: "no markdown",
+			in:   "abcdefg",
+			want: "abcdefg",
+		},
+		{
+			desc: "no markdown (with line breaks)",
+			in:   "ab\ncd\nfg",
+			want: "ab\ncd\nfg",
+		},
+		{
+			desc: "simple markdown",
+			in:   "```foo bar```",
+			want: "foo bar",
+		},
+		{
+			desc: "json markdown",
+			in:   "```json{\"a\":1}```",
+			want: "{\"a\":1}",
+		},
+		{
+			desc: "json multipline markdown",
+			in:   "```json\n{\"a\": 1}\n```",
+			want: "\n{\"a\": 1}\n",
+		},
+		{
+			desc: "returns first of multiple blocks",
+			in:   "```json{\"a\":\n1}```\n```json\n{\"b\":\n1}```",
+			want: "{\"a\":\n1}",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if diff := cmp.Diff(ExtractJsonFromMarkdown(tc.in), tc.want); diff != "" {
+				t.Errorf("ExtractJsonFromMarkdown diff (+got -want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSchemaAsMap(t *testing.T) {
+	type Bar struct {
+		Bar string
+	}
+	type Foo struct {
+		BarField Bar
+		Str      string
+	}
+
+	want := map[string]any{
+		"$id":                  string("https://github.com/firebase/genkit/go/internal/base/foo"),
+		"additionalProperties": bool(false),
+		"properties": map[string]any{
+			"BarField": map[string]any{
+				"additionalProperties": bool(false),
+				"properties": map[string]any{
+					"Bar": map[string]any{"type": string("string")},
+				},
+				"required": []any{string("Bar")},
+				"type":     string("object"),
+			},
+			"Str": map[string]any{"type": string("string")},
+		},
+		"required": []any{string("BarField"), string("Str")},
+		"type":     string("object"),
+	}
+
+	got := SchemaAsMap(InferJSONSchemaNonReferencing(Foo{}))
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("SchemaAsMap diff (+got -want):\n%s", diff)
+	}
+}

--- a/go/internal/doc-snippets/dotprompt.go
+++ b/go/internal/doc-snippets/dotprompt.go
@@ -68,9 +68,7 @@ func dot01() error {
 		return err
 	}
 
-	if responseText, err := response.Text(); err == nil {
-		fmt.Println(responseText)
-	}
+	fmt.Println(response.Text())
 	// [END dot01_2]
 
 	// [START dot01_3]

--- a/go/internal/doc-snippets/googleai.go
+++ b/go/internal/doc-snippets/googleai.go
@@ -42,7 +42,7 @@ func googleaiEx(ctx context.Context) error {
 	// [END model]
 
 	// [START gen]
-	text, err := langModel.GenerateText(ctx, ai.WithSimpleTextPrompt("Tell me a joke."))
+	text, err := langModel.GenerateText(ctx, ai.WithTextPrompt("Tell me a joke."))
 	if err != nil {
 		return err
 	}

--- a/go/internal/doc-snippets/googleai.go
+++ b/go/internal/doc-snippets/googleai.go
@@ -42,14 +42,13 @@ func googleaiEx(ctx context.Context) error {
 	// [END model]
 
 	// [START gen]
-	genRes, err := langModel.Generate(ctx, ai.NewGenerateRequest(
-		nil, ai.NewUserTextMessage("Tell me a joke.")), nil)
+	text, err := langModel.GenerateText(ctx, ai.WithSimpleTextPrompt("Tell me a joke."))
 	if err != nil {
 		return err
 	}
 	// [END gen]
 
-	_ = genRes
+	_ = text
 
 	var userInput string
 

--- a/go/internal/doc-snippets/init/main.go
+++ b/go/internal/doc-snippets/init/main.go
@@ -50,8 +50,7 @@ func main() {
 		// Construct a request and send it to the model API (Google AI).
 		resp, err := m.Generate(ctx,
 			ai.WithConfig(&ai.GenerationCommonConfig{Temperature: 1}),
-			ai.WithSimpleTextPrompt(fmt.Sprintf(`Suggest an item for the menu of a %s themed restaurant`, input)),
-		)
+			ai.WithSimpleTextPrompt(fmt.Sprintf(`Suggest an item for the menu of a %s themed restaurant`, input)))
 		if err != nil {
 			return "", err
 		}

--- a/go/internal/doc-snippets/init/main.go
+++ b/go/internal/doc-snippets/init/main.go
@@ -50,7 +50,7 @@ func main() {
 		// Construct a request and send it to the model API (Google AI).
 		resp, err := m.Generate(ctx,
 			ai.WithConfig(&ai.GenerationCommonConfig{Temperature: 1}),
-			ai.WithSimpleTextPrompt(fmt.Sprintf(`Suggest an item for the menu of a %s themed restaurant`, input)))
+			ai.WithTextPrompt(fmt.Sprintf(`Suggest an item for the menu of a %s themed restaurant`, input)))
 		if err != nil {
 			return "", err
 		}

--- a/go/internal/doc-snippets/init/main.go
+++ b/go/internal/doc-snippets/init/main.go
@@ -59,10 +59,7 @@ func main() {
 		// convert it to a string. but more complicated flows might coerce the
 		// response into structured output or chain the response into another
 		// LLM call.
-		text, err := resp.Text()
-		if err != nil {
-			return "", fmt.Errorf("menuSuggestionFlow: %v", err)
-		}
+		text := resp.Text()
 		return text, nil
 	})
 

--- a/go/internal/doc-snippets/init/main.go
+++ b/go/internal/doc-snippets/init/main.go
@@ -49,10 +49,9 @@ func main() {
 
 		// Construct a request and send it to the model API (Google AI).
 		resp, err := m.Generate(ctx,
-			ai.NewGenerateRequest(
-				&ai.GenerationCommonConfig{Temperature: 1},
-				ai.NewUserTextMessage(fmt.Sprintf(`Suggest an item for the menu of a %s themed restaurant`, input))),
-			nil)
+			ai.WithConfig(&ai.GenerationCommonConfig{Temperature: 1}),
+			ai.WithSimpleTextPrompt(fmt.Sprintf(`Suggest an item for the menu of a %s themed restaurant`, input)),
+		)
 		if err != nil {
 			return "", err
 		}

--- a/go/internal/doc-snippets/models.go
+++ b/go/internal/doc-snippets/models.go
@@ -46,7 +46,7 @@ func m1() error {
 	// [END model]
 
 	// [START call]
-	responseText, err := model.GenerateText(ctx, ai.WithSimpleTextPrompt("Tell me a joke."))
+	responseText, err := model.GenerateText(ctx, ai.WithTextPrompt("Tell me a joke."))
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func streaming() error {
 			}
 			fmt.Printf("Chunk: %s\n", text)
 			return nil
-		}, ai.WithSimpleTextPrompt("Tell a long story about robots and ninjas."))
+		}, ai.WithTextPrompt("Tell a long story about robots and ninjas."))
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func tools() error {
 	)
 
 	response, err := gemini15pro.Generate(ctx,
-		ai.WithSimpleTextPrompt("Tell me a joke."),
+		ai.WithTextPrompt("Tell me a joke."),
 		ai.WithTools(myJokeTool))
 	// [END tools]
 	_ = response

--- a/go/internal/doc-snippets/models.go
+++ b/go/internal/doc-snippets/models.go
@@ -74,27 +74,21 @@ func opts() error {
 
 func streaming() error {
 	// [START streaming]
-	response, err := gemini15pro.StreamGenerate(
+	response, err := gemini15pro.Generate(
 		ctx,
+		ai.WithTextPrompt("Tell a long story about robots and ninjas."),
 		// stream callback
-		func(ctx context.Context, grc *ai.GenerateResponseChunk) error {
-			text, err := grc.Text()
-			if err != nil {
-				return err
-			}
-			fmt.Printf("Chunk: %s\n", text)
-			return nil
-		}, ai.WithTextPrompt("Tell a long story about robots and ninjas."))
+		ai.WithStreaming(
+			func(ctx context.Context, grc *ai.GenerateResponseChunk) error {
+				fmt.Printf("Chunk: %s\n", grc.Text())
+				return nil
+			}))
 	if err != nil {
 		return err
 	}
 
 	// You can also still get the full response.
-	responseText, err := response.Text()
-	if err != nil {
-		return err
-	}
-	fmt.Println(responseText)
+	fmt.Println(response.Text())
 
 	// [END streaming]
 	return nil

--- a/go/internal/doc-snippets/models.go
+++ b/go/internal/doc-snippets/models.go
@@ -108,11 +108,15 @@ func multi() error {
 	}
 	encodedImage := base64.StdEncoding.EncodeToString(imageBytes)
 
-	gemini15pro.Generate(ctx, ai.WithMessages(&ai.Message{Content: []*ai.Part{
-		ai.NewTextPart("Describe the following image."),
-		ai.NewMediaPart("", "data:image/jpeg;base64,"+encodedImage),
-	}}))
+	resp, err := gemini15pro.Generate(ctx, ai.WithMessages(
+		ai.NewUserMessage(
+			ai.NewTextPart("Describe the following image."),
+			ai.NewMediaPart("", "data:image/jpeg;base64,"+encodedImage))))
 	// [END multimodal]
+	if err != nil {
+		return err
+	}
+	_ = resp
 	return nil
 }
 

--- a/go/internal/doc-snippets/ollama.go
+++ b/go/internal/doc-snippets/ollama.go
@@ -49,7 +49,7 @@ func ollamaEx(ctx context.Context) error {
 	// [END definemodel]
 
 	// [START gen]
-	text, err := model.GenerateText(ctx, ai.WithSimpleTextPrompt("Tell me a joke."))
+	text, err := model.GenerateText(ctx, ai.WithTextPrompt("Tell me a joke."))
 	if err != nil {
 		return err
 	}

--- a/go/internal/doc-snippets/ollama.go
+++ b/go/internal/doc-snippets/ollama.go
@@ -49,14 +49,13 @@ func ollamaEx(ctx context.Context) error {
 	// [END definemodel]
 
 	// [START gen]
-	genRes, err := model.Generate(ctx, ai.NewGenerateRequest(
-		nil, ai.NewUserTextMessage("Tell me a joke.")), nil)
+	text, err := model.GenerateText(ctx, ai.WithSimpleTextPrompt("Tell me a joke."))
 	if err != nil {
 		return err
 	}
 	// [END gen]
 
-	_ = genRes
+	_ = text
 
 	return nil
 }

--- a/go/internal/doc-snippets/prompts.go
+++ b/go/internal/doc-snippets/prompts.go
@@ -84,7 +84,7 @@ func pr03() error {
 	if err != nil {
 		return err
 	}
-	response, err := model.GenerateRaw(context.Background(), request)
+	response, err := model.GenerateRaw(context.Background(), request, nil)
 	// [END pr03_2]
 
 	_ = response

--- a/go/internal/doc-snippets/prompts.go
+++ b/go/internal/doc-snippets/prompts.go
@@ -27,7 +27,7 @@ func pr01() {
 	model := ai.Model{}
 
 	// [START pr01]
-	model.Generate(context.Background(), ai.WithSimpleTextPrompt("You are a helpful AI assistant named Walt."))
+	model.Generate(context.Background(), ai.WithTextPrompt("You are a helpful AI assistant named Walt."))
 	// [END pr01]
 }
 

--- a/go/internal/doc-snippets/prompts.go
+++ b/go/internal/doc-snippets/prompts.go
@@ -27,10 +27,7 @@ func pr01() {
 	model := ai.Model{}
 
 	// [START pr01]
-	request := ai.GenerateRequest{Messages: []*ai.Message{
-		{Content: []*ai.Part{ai.NewTextPart("You are a helpful AI assistant named Walt.")}},
-	}}
-	model.Generate(context.Background(), &request, nil)
+	model.Generate(context.Background(), ai.WithSimpleTextPrompt("You are a helpful AI assistant named Walt."))
 	// [END pr01]
 }
 
@@ -46,10 +43,8 @@ func pr02() {
 	model := ai.Model{}
 
 	// [START pr02]
-	request := ai.GenerateRequest{Messages: []*ai.Message{
-		{Content: []*ai.Part{helloPrompt("Fred")}},
-	}}
-	response, err := model.Generate(context.Background(), &request, nil)
+	response, err := model.GenerateText(context.Background(),
+		ai.WithMessages(&ai.Message{Content: []*ai.Part{helloPrompt("Fred")}}))
 	// [END pr02]
 
 	if err == nil {
@@ -89,7 +84,7 @@ func pr03() error {
 	if err != nil {
 		return err
 	}
-	response, err := model.Generate(context.Background(), request, nil)
+	response, err := model.GenerateRaw(context.Background(), request)
 	// [END pr03_2]
 
 	_ = response

--- a/go/internal/doc-snippets/prompts.go
+++ b/go/internal/doc-snippets/prompts.go
@@ -44,7 +44,7 @@ func pr02() {
 
 	// [START pr02]
 	response, err := model.GenerateText(context.Background(),
-		ai.WithMessages(&ai.Message{Content: []*ai.Part{helloPrompt("Fred")}}))
+		ai.WithMessages(ai.NewUserMessage(helloPrompt("Fred"))))
 	// [END pr02]
 
 	if err == nil {

--- a/go/internal/doc-snippets/rag/main.go
+++ b/go/internal/doc-snippets/rag/main.go
@@ -174,12 +174,14 @@ func menuQA() {
 
 			// Call Generate, including the menu information in your prompt.
 			return model.GenerateText(ctx,
-				ai.WithMessages(ai.NewUserTextMessage(`
+				ai.WithMessages(
+					ai.NewSystemTextMessage(`
 You are acting as a helpful AI assistant that can answer questions about the
 food available on the menu at Genkit Grub Pub.
 Use only the context provided to answer the question. If you don't know, do not
 make up an answer. Do not add or change items on the menu.`),
-					menuInfo, ai.NewUserTextMessage(question)))
+					menuInfo,
+					ai.NewUserTextMessage(question)))
 		})
 	// [END retrieve]
 }

--- a/go/internal/doc-snippets/rag/main.go
+++ b/go/internal/doc-snippets/rag/main.go
@@ -173,22 +173,13 @@ func menuQA() {
 			}
 
 			// Call Generate, including the menu information in your prompt.
-			resp, err := model.Generate(ctx, &ai.GenerateRequest{
-				Messages: []*ai.Message{
-					ai.NewSystemTextMessage(`
+			return model.GenerateText(ctx,
+				ai.WithMessages(ai.NewUserTextMessage(`
 You are acting as a helpful AI assistant that can answer questions about the
 food available on the menu at Genkit Grub Pub.
 Use only the context provided to answer the question. If you don't know, do not
 make up an answer. Do not add or change items on the menu.`),
-					menuInfo,
-					ai.NewUserTextMessage(question),
-				},
-			}, nil)
-			if err != nil {
-				return "", err
-			}
-
-			return resp.Text()
+					menuInfo, ai.NewUserTextMessage(question)))
 		})
 	// [END retrieve]
 }

--- a/go/internal/doc-snippets/vertexai.go
+++ b/go/internal/doc-snippets/vertexai.go
@@ -48,7 +48,7 @@ func vertexaiEx(ctx context.Context) error {
 	// [END model]
 
 	// [START gen]
-	genRes, err := langModel.GenerateText(ctx, ai.WithSimpleTextPrompt("Tell me a joke."))
+	genRes, err := langModel.GenerateText(ctx, ai.WithTextPrompt("Tell me a joke."))
 	if err != nil {
 		return err
 	}

--- a/go/internal/doc-snippets/vertexai.go
+++ b/go/internal/doc-snippets/vertexai.go
@@ -48,8 +48,7 @@ func vertexaiEx(ctx context.Context) error {
 	// [END model]
 
 	// [START gen]
-	genRes, err := langModel.Generate(ctx, ai.NewGenerateRequest(
-		nil, ai.NewUserTextMessage("Tell me a joke.")), nil)
+	genRes, err := langModel.GenerateText(ctx, ai.WithSimpleTextPrompt("Tell me a joke."))
 	if err != nil {
 		return err
 	}

--- a/go/plugins/dotprompt/genkit.go
+++ b/go/plugins/dotprompt/genkit.go
@@ -224,7 +224,7 @@ func (p *Prompt) Generate(ctx context.Context, pr *PromptRequest, cb func(contex
 		}
 	}
 
-	resp, err := model.Generate(ctx, genReq, cb)
+	resp, err := model.StreamGenerateRaw(ctx, genReq, cb)
 	if err != nil {
 		return nil, err
 	}

--- a/go/plugins/dotprompt/genkit.go
+++ b/go/plugins/dotprompt/genkit.go
@@ -224,7 +224,7 @@ func (p *Prompt) Generate(ctx context.Context, pr *PromptRequest, cb func(contex
 		}
 	}
 
-	resp, err := model.StreamGenerateRaw(ctx, genReq, cb)
+	resp, err := model.GenerateRaw(ctx, genReq, cb)
 	if err != nil {
 		return nil, err
 	}

--- a/go/plugins/googleai/googleai_test.go
+++ b/go/plugins/googleai/googleai_test.go
@@ -106,11 +106,14 @@ func TestLive(t *testing.T) {
 	t.Run("streaming", func(t *testing.T) {
 		out := ""
 		parts := 0
-		final, err := model.StreamGenerate(ctx, func(ctx context.Context, c *ai.GenerateResponseChunk) error {
-			parts++
-			out += c.Content[0].Text
-			return nil
-		}, ai.WithCandidates(1), ai.WithTextPrompt("Write one paragraph about the North Pole."))
+		final, err := model.Generate(ctx,
+			ai.WithCandidates(1),
+			ai.WithTextPrompt("Write one paragraph about the North Pole."),
+			ai.WithStreaming(func(ctx context.Context, c *ai.GenerateResponseChunk) error {
+				parts++
+				out += c.Content[0].Text
+				return nil
+			}))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/go/plugins/googleai/googleai_test.go
+++ b/go/plugins/googleai/googleai_test.go
@@ -87,7 +87,7 @@ func TestLive(t *testing.T) {
 		}
 	})
 	t.Run("generate", func(t *testing.T) {
-		resp, err := model.Generate(ctx, ai.WithCandidates(1), ai.WithSimpleTextPrompt("Which country was Napoleon the emperor of?"))
+		resp, err := model.Generate(ctx, ai.WithCandidates(1), ai.WithTextPrompt("Which country was Napoleon the emperor of?"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -110,7 +110,7 @@ func TestLive(t *testing.T) {
 			parts++
 			out += c.Content[0].Text
 			return nil
-		}, ai.WithCandidates(1), ai.WithSimpleTextPrompt("Write one paragraph about the North Pole."))
+		}, ai.WithCandidates(1), ai.WithTextPrompt("Write one paragraph about the North Pole."))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -136,7 +136,7 @@ func TestLive(t *testing.T) {
 	t.Run("tool", func(t *testing.T) {
 		resp, err := model.Generate(ctx,
 			ai.WithCandidates(1),
-			ai.WithSimpleTextPrompt("what is a gablorken of 2 over 3.5?"),
+			ai.WithTextPrompt("what is a gablorken of 2 over 3.5?"),
 			ai.WithTools(gablorkenTool))
 
 		if err != nil {
@@ -168,7 +168,7 @@ func TestHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	model := googleai.Model("gemini-1.0-pro")
-	_, _ = model.Generate(ctx, ai.WithSimpleTextPrompt("hi"))
+	_, _ = model.Generate(ctx, ai.WithTextPrompt("hi"))
 	got := header.Get("x-goog-api-client")
 	want := regexp.MustCompile(fmt.Sprintf(`\bgenkit-go/%s\b`, internal.Version))
 	if !want.MatchString(got) {

--- a/go/plugins/vertexai/vertexai_test.go
+++ b/go/plugins/vertexai/vertexai_test.go
@@ -72,13 +72,16 @@ func TestLive(t *testing.T) {
 		out := ""
 		parts := 0
 		model := vertexai.Model(modelName)
-		final, err := model.StreamGenerate(ctx, func(ctx context.Context, c *ai.GenerateResponseChunk) error {
-			parts++
-			for _, p := range c.Content {
-				out += p.Text
-			}
-			return nil
-		}, ai.WithCandidates(1), ai.WithTextPrompt("Write one paragraph about the Golden State Warriors."))
+		final, err := model.Generate(ctx,
+			ai.WithCandidates(1),
+			ai.WithTextPrompt("Write one paragraph about the Golden State Warriors."),
+			ai.WithStreaming(func(ctx context.Context, c *ai.GenerateResponseChunk) error {
+				parts++
+				for _, p := range c.Content {
+					out += p.Text
+				}
+				return nil
+			}))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/go/plugins/vertexai/vertexai_test.go
+++ b/go/plugins/vertexai/vertexai_test.go
@@ -53,7 +53,7 @@ func TestLive(t *testing.T) {
 		},
 	)
 	t.Run("model", func(t *testing.T) {
-		resp, err := model.Generate(ctx, ai.WithCandidates(1), ai.WithSimpleTextPrompt("Which country was Napoleon the emperor of?"))
+		resp, err := model.Generate(ctx, ai.WithCandidates(1), ai.WithTextPrompt("Which country was Napoleon the emperor of?"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -78,7 +78,7 @@ func TestLive(t *testing.T) {
 				out += p.Text
 			}
 			return nil
-		}, ai.WithCandidates(1), ai.WithSimpleTextPrompt("Write one paragraph about the Golden State Warriors."))
+		}, ai.WithCandidates(1), ai.WithTextPrompt("Write one paragraph about the Golden State Warriors."))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -105,7 +105,7 @@ func TestLive(t *testing.T) {
 	t.Run("tool", func(t *testing.T) {
 		resp, err := model.Generate(ctx,
 			ai.WithCandidates(1),
-			ai.WithSimpleTextPrompt("what is a gablorken of 2 over 3.5?"),
+			ai.WithTextPrompt("what is a gablorken of 2 over 3.5?"),
 			ai.WithTools(gablorkenTool))
 		if err != nil {
 			t.Fatal(err)

--- a/go/plugins/vertexai/vertexai_test.go
+++ b/go/plugins/vertexai/vertexai_test.go
@@ -53,17 +53,7 @@ func TestLive(t *testing.T) {
 		},
 	)
 	t.Run("model", func(t *testing.T) {
-		req := &ai.GenerateRequest{
-			Candidates: 1,
-			Messages: []*ai.Message{
-				{
-					Content: []*ai.Part{ai.NewTextPart("Which country was Napoleon the emperor of?")},
-					Role:    ai.RoleUser,
-				},
-			},
-		}
-
-		resp, err := model.Generate(ctx, req, nil)
+		resp, err := model.Generate(ctx, ai.WithCandidates(1), ai.WithSimpleTextPrompt("Which country was Napoleon the emperor of?"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -71,7 +61,7 @@ func TestLive(t *testing.T) {
 		if !strings.Contains(out, "France") {
 			t.Errorf("got \"%s\", expecting it would contain \"France\"", out)
 		}
-		if resp.Request != req {
+		if resp.Request == nil {
 			t.Error("Request field not set properly")
 		}
 		if resp.Usage.InputTokens == 0 || resp.Usage.OutputTokens == 0 || resp.Usage.TotalTokens == 0 {
@@ -79,26 +69,16 @@ func TestLive(t *testing.T) {
 		}
 	})
 	t.Run("streaming", func(t *testing.T) {
-		req := &ai.GenerateRequest{
-			Candidates: 1,
-			Messages: []*ai.Message{
-				{
-					Content: []*ai.Part{ai.NewTextPart("Write one paragraph about the Golden State Warriors.")},
-					Role:    ai.RoleUser,
-				},
-			},
-		}
-
 		out := ""
 		parts := 0
 		model := vertexai.Model(modelName)
-		final, err := model.Generate(ctx, req, func(ctx context.Context, c *ai.GenerateResponseChunk) error {
+		final, err := model.StreamGenerate(ctx, func(ctx context.Context, c *ai.GenerateResponseChunk) error {
 			parts++
 			for _, p := range c.Content {
 				out += p.Text
 			}
 			return nil
-		})
+		}, ai.WithCandidates(1), ai.WithSimpleTextPrompt("Write one paragraph about the Golden State Warriors."))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -123,18 +103,10 @@ func TestLive(t *testing.T) {
 		}
 	})
 	t.Run("tool", func(t *testing.T) {
-		req := &ai.GenerateRequest{
-			Candidates: 1,
-			Messages: []*ai.Message{
-				{
-					Content: []*ai.Part{ai.NewTextPart("what is a gablorken of 2 over 3.5?")},
-					Role:    ai.RoleUser,
-				},
-			},
-			Tools: []*ai.ToolDefinition{gablorkenTool.Definition()},
-		}
-
-		resp, err := model.Generate(ctx, req, nil)
+		resp, err := model.Generate(ctx,
+			ai.WithCandidates(1),
+			ai.WithSimpleTextPrompt("what is a gablorken of 2 over 3.5?"),
+			ai.WithTools(gablorkenTool))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/go/samples/coffee-shop/main.go
+++ b/go/samples/coffee-shop/main.go
@@ -36,7 +36,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/firebase/genkit/go/ai"
@@ -120,11 +119,7 @@ func main() {
 		var callback func(context.Context, *ai.GenerateResponseChunk) error
 		if cb != nil {
 			callback = func(ctx context.Context, c *ai.GenerateResponseChunk) error {
-				text, err := c.Text()
-				if err != nil {
-					return err
-				}
-				return cb(ctx, text)
+				return cb(ctx, c.Text())
 			}
 		}
 		resp, err := simpleGreetingPrompt.Generate(ctx,
@@ -136,11 +131,7 @@ func main() {
 		if err != nil {
 			return "", err
 		}
-		text, err := resp.Text()
-		if err != nil {
-			return "", fmt.Errorf("simpleGreeting: %v", err)
-		}
-		return text, nil
+		return resp.Text(), nil
 	})
 
 	greetingWithHistoryPrompt, err := dotprompt.Define("greetingWithHistory", greetingWithHistoryPromptTemplate,
@@ -164,11 +155,7 @@ func main() {
 		if err != nil {
 			return "", err
 		}
-		text, err := resp.Text()
-		if err != nil {
-			return "", fmt.Errorf("greetingWithHistory: %v", err)
-		}
-		return text, nil
+		return resp.Text(), nil
 	})
 
 	simpleStructuredGreetingPrompt, err := dotprompt.Define("simpleStructuredGreeting", simpleStructuredGreetingPromptTemplate,
@@ -187,11 +174,7 @@ func main() {
 		var callback func(context.Context, *ai.GenerateResponseChunk) error
 		if cb != nil {
 			callback = func(ctx context.Context, c *ai.GenerateResponseChunk) error {
-				text, err := c.Text()
-				if err != nil {
-					return err
-				}
-				return cb(ctx, text)
+				return cb(ctx, c.Text())
 			}
 		}
 		resp, err := simpleStructuredGreetingPrompt.Generate(ctx,
@@ -203,11 +186,7 @@ func main() {
 		if err != nil {
 			return "", err
 		}
-		text, err := resp.Text()
-		if err != nil {
-			return "", fmt.Errorf("simpleStructuredGreeting: %v", err)
-		}
-		return text, nil
+		return resp.Text(), nil
 	})
 
 	genkit.DefineFlow("testAllCoffeeFlows", func(ctx context.Context, _ struct{}) (*testAllCoffeeFlowsOutput, error) {

--- a/go/samples/menu/s02.go
+++ b/go/samples/menu/s02.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 
 	"github.com/firebase/genkit/go/ai"
@@ -75,11 +74,7 @@ func setup02(_ context.Context, m *ai.Model) error {
 				return nil, err
 			}
 
-			text, err := resp.Text()
-			if err != nil {
-				return nil, fmt.Errorf("s02MenuQuestionFlow: %v", err)
-			}
-			return &answerOutput{Answer: text}, nil
+			return &answerOutput{Answer: resp.Text()}, nil
 		},
 	)
 

--- a/go/samples/menu/s03.go
+++ b/go/samples/menu/s03.go
@@ -112,10 +112,7 @@ func setup03(ctx context.Context, model *ai.Model) error {
 				Role: ai.RoleUser,
 			}
 			messages := append(slices.Clip(history), msg)
-			req := &ai.GenerateRequest{
-				Messages: messages,
-			}
-			resp, err := model.Generate(ctx, req, nil)
+			resp, err := model.Generate(ctx, ai.WithMessages(messages...))
 			if err != nil {
 				return nil, err
 			}

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -36,7 +36,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 
@@ -136,11 +135,7 @@ func main() {
 		if err != nil {
 			return "", err
 		}
-		text, err := resp.Text()
-		if err != nil {
-			return "", fmt.Errorf("simpleQa: %v", err)
-		}
-		return text, nil
+		return resp.Text(), nil
 	})
 
 	if err := genkit.Init(context.Background(), nil); err != nil {

--- a/go/tests/test_app/main.go
+++ b/go/tests/test_app/main.go
@@ -28,7 +28,7 @@ import (
 func main() {
 	model := ai.DefineModel("", "customReflector", nil, echo)
 	genkit.DefineFlow("testFlow", func(ctx context.Context, in string) (string, error) {
-		res, err := model.Generate(ctx, ai.WithSimpleTextPrompt(in))
+		res, err := model.Generate(ctx, ai.WithTextPrompt(in))
 		if err != nil {
 			return "", err
 		}

--- a/go/tests/test_app/main.go
+++ b/go/tests/test_app/main.go
@@ -28,7 +28,7 @@ import (
 func main() {
 	model := ai.DefineModel("", "customReflector", nil, echo)
 	genkit.DefineFlow("testFlow", func(ctx context.Context, in string) (string, error) {
-		res, err := model.Generate(ctx, ai.NewGenerateRequest(nil, ai.NewUserTextMessage(in)), nil)
+		res, err := model.Generate(ctx, ai.WithSimpleTextPrompt(in))
 		if err != nil {
 			return "", err
 		}

--- a/go/tests/utils/utils.go
+++ b/go/tests/utils/utils.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package test_utils
 
 import (

--- a/go/tests/utils/utils.go
+++ b/go/tests/utils/utils.go
@@ -1,0 +1,22 @@
+package test_utils
+
+import (
+	"slices"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// IgnoreNoisyParts is a go-cmp/cmp package Option that allows specifying paths to ignore
+// in the comparison.
+func IgnoreNoisyParts(ignoredPaths []string) cmp.Option {
+	return cmp.FilterPath(func(ps cmp.Path) bool {
+		path := ""
+		for _, p := range ps {
+			if p.String() != "*" {
+				path += p.String()
+			}
+		}
+
+		return slices.Contains(ignoredPaths, path)
+	}, cmp.Ignore())
+}


### PR DESCRIPTION
```go
model := googleai.Model("gemini-1.5-flash")

// simple text
text, err := model.GenerateText(ctx,
	ai.WithConfig(&ai.GenerationCommonConfig{Temperature: 1}),
	ai.WithTextPrompt("Tell me a joke"))

// with tools
gablorkenTool := ai.DefineTool("gablorken", "use when need to calculate a gablorken",
	func(ctx context.Context, input struct {
		Value float64
		Over  float64
	}) (float64, error) {
		return math.Pow(input.Value, input.Over), nil
	},
)

text, err := model.GenerateText(ctx,
	ai.WithCandidates(1),
	ai.WithTextPrompt("what is a gablorken of 2 over 3.5?"),
	ai.WithTools(gablorkenTool))

// with mesages
response, err = model.Generate(ctx,
	ai.WithMessages(history...),
	ai.WithTextPrompt("What were we talking about?"))

// with history
resp1, err := m.Generate(ctx, ai.WithTextPrompt("hi, my name is Heisenberg!"))

resp2, err := m.Generate(ctx,
    ai.WithMessages(resp1.History()...),
    ai.WithTextPrompt("Say my name!"))

// multimodal
resp, err := model.Generate(ctx, ai.WithMessages(
	ai.NewUserMessage(
		ai.NewTextPart("Describe the following image."),
		ai.NewMediaPart("", "data:image/jpeg;base64,"+encodedImage))))

// structured output
type GameCharacter struct {
	Name      string
	Backstory string
}

character := &GameCharacter{}
_, err = m.GenerateData(ctx, character,
	ai.WithTextPrompt("generate a game character"))

// streaming
resp, err := model.Generate(ctx,
	ai.WithTextPrompt("tell me a VERY long joke"),
	ai.WithStreaming(func(ctx context.Context, c *ai.GenerateResponseChunk) error {
		fmt.Printf("got stream chunk %v\n", c)
		return nil
	}))
```


variants to work with "raw" request are still available

```go
	resp, err := model.GenerateRaw(ctx, &ai.GenerateRequest{
		Messages: []*ai.Message{
			// ....
		},
	}, streamingCallback)
```