### PR TITLE
Add a first_open even after GA ack to track new users

### DIFF
--- a/genkit-tools/common/src/utils/analytics.ts
+++ b/genkit-tools/common/src/utils/analytics.ts
@@ -58,6 +58,15 @@ export class PageViewEvent extends GAEvent {
   }
 }
 
+export class FirstUsageEvent extends GAEvent {
+  name = 'first_visit';
+  duration = 1;
+
+  constructor() {
+    super();
+  }
+}
+
 export class ToolsRequestEvent extends GAEvent {
   name = 'tools_request';
   duration = 1;
@@ -121,6 +130,9 @@ export async function notifyAnalyticsIfFirstRun(): Promise<void> {
   await readline.question('Press "Enter" to continue');
 
   configstore.set(NOTIFICATION_ACKED, true);
+
+  await record( new FirstUsageEvent());
+
 }
 
 /** Gets session information for the UI. */

--- a/genkit-tools/common/src/utils/analytics.ts
+++ b/genkit-tools/common/src/utils/analytics.ts
@@ -131,8 +131,7 @@ export async function notifyAnalyticsIfFirstRun(): Promise<void> {
 
   configstore.set(NOTIFICATION_ACKED, true);
 
-  await record( new FirstUsageEvent());
-
+  await record(new FirstUsageEvent());
 }
 
 /** Gets session information for the UI. */


### PR DESCRIPTION
Add a first-open event after GA acknowledgement so we can track new vs returning users

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)

