### PR TITLE
Respect config.required for auth

### DIFF
--- a/js/plugins/firebase/src/auth.ts
+++ b/js/plugins/firebase/src/auth.ts
@@ -40,7 +40,7 @@ export function firebaseAuth<I extends z.ZodTypeAny>(
   config?: { required: boolean }
 ): FunctionFlowAuth<I> {
   initializeAppIfNecessary();
-  const required = config?.required || true;
+  const required = config?.required ?? true;
   return {
     async policy(auth: unknown | undefined, input: z.infer<I>) {
       // If required is true, then auth will always be set when called from

--- a/js/plugins/firebase/tests/auth_test.ts
+++ b/js/plugins/firebase/tests/auth_test.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { firebaseAuth } from '../src/auth';
+
+describe('firebaseAuth', () => {
+  it('config unset throws', async () => {
+    const auth = firebaseAuth((user, input) => {});
+
+    await assert.rejects(async () => {
+      await auth.policy(undefined, undefined);
+    }, new Error('Auth is required'));
+  });
+
+  it('not required ok', async () => {
+    const auth = firebaseAuth((user, input) => {}, { required: false });
+
+    await assert.doesNotReject(async () => {
+      await auth.policy(undefined, undefined);
+    });
+  });
+
+  it('required throws', async () => {
+    const auth = firebaseAuth((user, input) => {}, { required: true });
+
+    await assert.rejects(async () => {
+      await auth.policy(undefined, undefined);
+    }, new Error('Auth is required'));
+  });
+
+  it('config unset present ok', async () => {
+    const auth = firebaseAuth((user, input) => {});
+
+    await assert.doesNotReject(async () => {
+      await auth.policy({}, undefined);
+    });
+  });
+
+  it('required present ok', async () => {
+    const auth = firebaseAuth((user, input) => {}, { required: true });
+
+    await assert.doesNotReject(async () => {
+      await auth.policy({}, undefined);
+    });
+  });
+});


### PR DESCRIPTION
I think the original intention of the author was to default to true if `config.required` isn't specified, but `||true` will just always evaluate to true. This blocks me when I was following the onboarding flow of https://firebase.google.com/docs/genkit/get-started#gemini-google-ai

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.) -- there were no previous unit tests for this bit.
- [ ] Changelog updated
- [ ] Docs updated
