### PR TITLE
refactor: [Go] Model is an interface and ai.Generate/Text/Data are veneers

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -29,7 +29,9 @@ import (
 	"github.com/firebase/genkit/go/internal/base"
 )
 
+// Model represents a model that can perform content generation tasks.
 type Model interface {
+	// Generate applies the [Model] to provided request, handling tool requests and handles streaming.
 	Generate(ctx context.Context, req *GenerateRequest, cb ModelStreamingCallback) (*GenerateResponse, error)
 }
 
@@ -54,7 +56,7 @@ type ModelMetadata struct {
 }
 
 // DefineModel registers the given generate function as an action, and returns a
-// [ModelAction] that runs it.
+// [Model] that runs it.
 func DefineModel(provider, name string, metadata *ModelMetadata, generate func(context.Context, *GenerateRequest, ModelStreamingCallback) (*GenerateResponse, error)) Model {
 	metadataMap := map[string]any{}
 	if metadata == nil {

--- a/go/ai/generator_test.go
+++ b/go/ai/generator_test.go
@@ -313,7 +313,7 @@ func TestGenerate(t *testing.T) {
 
 		wantStreamText := "stream!"
 		streamText := ""
-		res, err := echoModel.Generate(context.Background(),
+		res, err := Generate(context.Background(), echoModel,
 			WithTextPrompt(charJsonMd),
 			WithMessages(NewModelTextMessage("banana again")),
 			WithSystemPrompt("you are"),
@@ -344,6 +344,19 @@ func TestGenerate(t *testing.T) {
 			"{*ai.GenerateRequest}.Messages[4].Content[1].Text",
 		})); diff != "" {
 			t.Errorf("Request diff (+got -want):\n%s", diff)
+		}
+	})
+}
+
+func TestIsDefinedModel(t *testing.T) {
+	t.Run("should return true", func(t *testing.T) {
+		if IsDefinedModel("test", "echo") != true {
+			t.Errorf("IsDefinedModel did not return true")
+		}
+	})
+	t.Run("should return false", func(t *testing.T) {
+		if IsDefinedModel("foo", "bar") != false {
+			t.Errorf("IsDefinedModel did not return false")
 		}
 	})
 }

--- a/go/internal/doc-snippets/googleai.go
+++ b/go/internal/doc-snippets/googleai.go
@@ -38,11 +38,11 @@ func googleaiEx(ctx context.Context) error {
 	// [END initkey]
 
 	// [START model]
-	langModel := googleai.Model("gemini-1.5-flash")
+	model := googleai.Model("gemini-1.5-flash")
 	// [END model]
 
 	// [START gen]
-	text, err := langModel.GenerateText(ctx, ai.WithTextPrompt("Tell me a joke."))
+	text, err := ai.GenerateText(ctx, model, ai.WithTextPrompt("Tell me a joke."))
 	if err != nil {
 		return err
 	}

--- a/go/internal/doc-snippets/init/main.go
+++ b/go/internal/doc-snippets/init/main.go
@@ -48,7 +48,7 @@ func main() {
 		}
 
 		// Construct a request and send it to the model API (Google AI).
-		resp, err := m.Generate(ctx,
+		resp, err := ai.Generate(ctx, m,
 			ai.WithConfig(&ai.GenerationCommonConfig{Temperature: 1}),
 			ai.WithTextPrompt(fmt.Sprintf(`Suggest an item for the menu of a %s themed restaurant`, input)))
 		if err != nil {

--- a/go/internal/doc-snippets/models.go
+++ b/go/internal/doc-snippets/models.go
@@ -29,7 +29,7 @@ import (
 // Globals for simplification only.
 // Bad style: don't do this.
 var ctx = context.Background()
-var gemini15pro *ai.Model
+var gemini15pro ai.Model
 
 func m1() error {
 	// [START init]
@@ -46,7 +46,7 @@ func m1() error {
 	// [END model]
 
 	// [START call]
-	responseText, err := model.GenerateText(ctx, ai.WithTextPrompt("Tell me a joke."))
+	responseText, err := ai.GenerateText(ctx, model, ai.WithTextPrompt("Tell me a joke."))
 	if err != nil {
 		return err
 	}
@@ -74,8 +74,7 @@ func opts() error {
 
 func streaming() error {
 	// [START streaming]
-	response, err := gemini15pro.Generate(
-		ctx,
+	response, err := ai.Generate(ctx, gemini15pro,
 		ai.WithTextPrompt("Tell a long story about robots and ninjas."),
 		// stream callback
 		ai.WithStreaming(
@@ -102,7 +101,7 @@ func multi() error {
 	}
 	encodedImage := base64.StdEncoding.EncodeToString(imageBytes)
 
-	resp, err := gemini15pro.Generate(ctx, ai.WithMessages(
+	resp, err := ai.Generate(ctx, gemini15pro, ai.WithMessages(
 		ai.NewUserMessage(
 			ai.NewTextPart("Describe the following image."),
 			ai.NewMediaPart("", "data:image/jpeg;base64,"+encodedImage))))
@@ -124,7 +123,7 @@ func tools() error {
 		},
 	)
 
-	response, err := gemini15pro.Generate(ctx,
+	response, err := ai.Generate(ctx, gemini15pro,
 		ai.WithTextPrompt("Tell me a joke."),
 		ai.WithTools(myJokeTool))
 	// [END tools]
@@ -140,7 +139,7 @@ func history() error {
 		Role:    ai.RoleUser,
 	}}
 
-	response, err := gemini15pro.Generate(context.Background(), ai.WithMessages(history...))
+	response, err := ai.Generate(context.Background(), gemini15pro, ai.WithMessages(history...))
 	// [END hist1]
 	_ = err
 	// [START hist2]
@@ -153,7 +152,7 @@ func history() error {
 		Role:    ai.RoleUser,
 	})
 
-	response, err = gemini15pro.Generate(ctx, ai.WithMessages(history...))
+	response, err = ai.Generate(ctx, gemini15pro, ai.WithMessages(history...))
 	// [END hist3]
 	// [START hist4]
 	history = []*ai.Message{{

--- a/go/internal/doc-snippets/ollama.go
+++ b/go/internal/doc-snippets/ollama.go
@@ -49,7 +49,7 @@ func ollamaEx(ctx context.Context) error {
 	// [END definemodel]
 
 	// [START gen]
-	text, err := model.GenerateText(ctx, ai.WithTextPrompt("Tell me a joke."))
+	text, err := ai.GenerateText(ctx, model, ai.WithTextPrompt("Tell me a joke."))
 	if err != nil {
 		return err
 	}

--- a/go/internal/doc-snippets/prompts.go
+++ b/go/internal/doc-snippets/prompts.go
@@ -24,10 +24,10 @@ import (
 )
 
 func pr01() {
-	model := ai.Model{}
+	model := ai.LookupModel("googleai", "gemini-1.5-flash")
 
 	// [START pr01]
-	model.Generate(context.Background(), ai.WithTextPrompt("You are a helpful AI assistant named Walt."))
+	ai.Generate(context.Background(), model, ai.WithTextPrompt("You are a helpful AI assistant named Walt."))
 	// [END pr01]
 }
 
@@ -40,10 +40,10 @@ func helloPrompt(name string) *ai.Part {
 // [END hello]
 
 func pr02() {
-	model := ai.Model{}
+	model := ai.LookupModel("googleai", "gemini-1.5-flash")
 
 	// [START pr02]
-	response, err := model.GenerateText(context.Background(),
+	response, err := ai.GenerateText(context.Background(), model,
 		ai.WithMessages(ai.NewUserMessage(helloPrompt("Fred"))))
 	// [END pr02]
 
@@ -53,7 +53,7 @@ func pr02() {
 }
 
 func pr03() error {
-	model := ai.Model{}
+	model := ai.LookupModel("googleai", "gemini-1.5-flash")
 
 	// [START pr03_1]
 	type HelloPromptInput struct {
@@ -84,7 +84,7 @@ func pr03() error {
 	if err != nil {
 		return err
 	}
-	response, err := model.GenerateRaw(context.Background(), request, nil)
+	response, err := model.Generate(context.Background(), request, nil)
 	// [END pr03_2]
 
 	_ = response

--- a/go/internal/doc-snippets/rag/main.go
+++ b/go/internal/doc-snippets/rag/main.go
@@ -173,7 +173,7 @@ func menuQA() {
 			}
 
 			// Call Generate, including the menu information in your prompt.
-			return model.GenerateText(ctx,
+			return ai.GenerateText(ctx, model,
 				ai.WithMessages(
 					ai.NewSystemTextMessage(`
 You are acting as a helpful AI assistant that can answer questions about the

--- a/go/internal/doc-snippets/vertexai.go
+++ b/go/internal/doc-snippets/vertexai.go
@@ -48,7 +48,7 @@ func vertexaiEx(ctx context.Context) error {
 	// [END model]
 
 	// [START gen]
-	genRes, err := langModel.GenerateText(ctx, ai.WithTextPrompt("Tell me a joke."))
+	genRes, err := ai.GenerateText(ctx, langModel, ai.WithTextPrompt("Tell me a joke."))
 	if err != nil {
 		return err
 	}

--- a/go/plugins/dotprompt/dotprompt.go
+++ b/go/plugins/dotprompt/dotprompt.go
@@ -86,7 +86,7 @@ type Config struct {
 
 	// The Model to use.
 	// If this is non-nil, Model should be the empty string.
-	Model *ai.Model
+	Model ai.Model
 
 	// TODO: document
 	Tools []ai.Tool

--- a/go/plugins/dotprompt/genkit.go
+++ b/go/plugins/dotprompt/genkit.go
@@ -224,7 +224,7 @@ func (p *Prompt) Generate(ctx context.Context, pr *PromptRequest, cb func(contex
 		}
 	}
 
-	resp, err := model.GenerateRaw(ctx, genReq, cb)
+	resp, err := model.Generate(ctx, genReq, cb)
 	if err != nil {
 		return nil, err
 	}

--- a/go/plugins/googleai/googleai.go
+++ b/go/plugins/googleai/googleai.go
@@ -122,7 +122,7 @@ func Init(ctx context.Context, cfg *Config) (err error) {
 // The second argument describes the capability of the model.
 // Use [IsDefinedModel] to determine if a model is already defined.
 // After [Init] is called, only the known models are defined.
-func DefineModel(name string, caps *ai.ModelCapabilities) (*ai.Model, error) {
+func DefineModel(name string, caps *ai.ModelCapabilities) (ai.Model, error) {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 	if !state.initted {
@@ -142,7 +142,7 @@ func DefineModel(name string, caps *ai.ModelCapabilities) (*ai.Model, error) {
 }
 
 // requires state.mu
-func defineModel(name string, caps ai.ModelCapabilities) *ai.Model {
+func defineModel(name string, caps ai.ModelCapabilities) ai.Model {
 	meta := &ai.ModelMetadata{
 		Label:    labelPrefix + " - " + name,
 		Supports: caps,
@@ -209,9 +209,9 @@ func defineEmbedder(name string) *ai.Embedder {
 
 //copy:start vertexai.go lookups
 
-// Model returns the [ai.Model] with the given name.
+// Model returns the [ai.ModelAction] with the given name.
 // It returns nil if the model was not defined.
-func Model(name string) *ai.Model {
+func Model(name string) ai.Model {
 	return ai.LookupModel(provider, name)
 }
 

--- a/go/plugins/googleai/googleai_test.go
+++ b/go/plugins/googleai/googleai_test.go
@@ -87,7 +87,7 @@ func TestLive(t *testing.T) {
 		}
 	})
 	t.Run("generate", func(t *testing.T) {
-		resp, err := model.Generate(ctx, ai.WithCandidates(1), ai.WithTextPrompt("Which country was Napoleon the emperor of?"))
+		resp, err := ai.Generate(ctx, model, ai.WithCandidates(1), ai.WithTextPrompt("Which country was Napoleon the emperor of?"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -106,7 +106,7 @@ func TestLive(t *testing.T) {
 	t.Run("streaming", func(t *testing.T) {
 		out := ""
 		parts := 0
-		final, err := model.Generate(ctx,
+		final, err := ai.Generate(ctx, model,
 			ai.WithCandidates(1),
 			ai.WithTextPrompt("Write one paragraph about the North Pole."),
 			ai.WithStreaming(func(ctx context.Context, c *ai.GenerateResponseChunk) error {
@@ -137,7 +137,7 @@ func TestLive(t *testing.T) {
 		}
 	})
 	t.Run("tool", func(t *testing.T) {
-		resp, err := model.Generate(ctx,
+		resp, err := ai.Generate(ctx, model,
 			ai.WithCandidates(1),
 			ai.WithTextPrompt("what is a gablorken of 2 over 3.5?"),
 			ai.WithTools(gablorkenTool))
@@ -171,7 +171,7 @@ func TestHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	model := googleai.Model("gemini-1.0-pro")
-	_, _ = model.Generate(ctx, ai.WithTextPrompt("hi"))
+	_, _ = ai.Generate(ctx, model, ai.WithTextPrompt("hi"))
 	got := header.Get("x-goog-api-client")
 	want := regexp.MustCompile(fmt.Sprintf(`\bgenkit-go/%s\b`, internal.Version))
 	if !want.MatchString(got) {

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -47,7 +47,7 @@ var state struct {
 	serverAddress string
 }
 
-func DefineModel(model ModelDefinition, caps *ai.ModelCapabilities) *ai.Model {
+func DefineModel(model ModelDefinition, caps *ai.ModelCapabilities) ai.Model {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 	if !state.initted {
@@ -79,7 +79,7 @@ func IsDefinedModel(name string) bool {
 
 // Model returns the [ai.Model] with the given name.
 // It returns nil if the model was not configured.
-func Model(name string) *ai.Model {
+func Model(name string) ai.Model {
 	return ai.LookupModel(provider, name)
 }
 

--- a/go/plugins/vertexai/vertexai.go
+++ b/go/plugins/vertexai/vertexai.go
@@ -140,7 +140,7 @@ func Init(ctx context.Context, cfg *Config) error {
 // The second argument describes the capability of the model.
 // Use [IsDefinedModel] to determine if a model is already defined.
 // After [Init] is called, only the known models are defined.
-func DefineModel(name string, caps *ai.ModelCapabilities) (*ai.Model, error) {
+func DefineModel(name string, caps *ai.ModelCapabilities) (ai.Model, error) {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 	if !state.initted {
@@ -160,7 +160,7 @@ func DefineModel(name string, caps *ai.ModelCapabilities) (*ai.Model, error) {
 }
 
 // requires state.mu
-func defineModel(name string, caps ai.ModelCapabilities) *ai.Model {
+func defineModel(name string, caps ai.ModelCapabilities) ai.Model {
 	meta := &ai.ModelMetadata{
 		Label:    labelPrefix + " - " + name,
 		Supports: caps,
@@ -214,9 +214,9 @@ func defineEmbedder(name string) *ai.Embedder {
 //copy:sink lookups from ../googleai/googleai.go
 // DO NOT MODIFY below vvvv
 
-// Model returns the [ai.Model] with the given name.
+// Model returns the [ai.ModelAction] with the given name.
 // It returns nil if the model was not defined.
-func Model(name string) *ai.Model {
+func Model(name string) ai.Model {
 	return ai.LookupModel(provider, name)
 }
 

--- a/go/plugins/vertexai/vertexai_test.go
+++ b/go/plugins/vertexai/vertexai_test.go
@@ -53,7 +53,7 @@ func TestLive(t *testing.T) {
 		},
 	)
 	t.Run("model", func(t *testing.T) {
-		resp, err := model.Generate(ctx, ai.WithCandidates(1), ai.WithTextPrompt("Which country was Napoleon the emperor of?"))
+		resp, err := ai.Generate(ctx, model, ai.WithCandidates(1), ai.WithTextPrompt("Which country was Napoleon the emperor of?"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -72,7 +72,7 @@ func TestLive(t *testing.T) {
 		out := ""
 		parts := 0
 		model := vertexai.Model(modelName)
-		final, err := model.Generate(ctx,
+		final, err := ai.Generate(ctx, model,
 			ai.WithCandidates(1),
 			ai.WithTextPrompt("Write one paragraph about the Golden State Warriors."),
 			ai.WithStreaming(func(ctx context.Context, c *ai.GenerateResponseChunk) error {
@@ -106,7 +106,7 @@ func TestLive(t *testing.T) {
 		}
 	})
 	t.Run("tool", func(t *testing.T) {
-		resp, err := model.Generate(ctx,
+		resp, err := ai.Generate(ctx, model,
 			ai.WithCandidates(1),
 			ai.WithTextPrompt("what is a gablorken of 2 over 3.5?"),
 			ai.WithTools(gablorkenTool))

--- a/go/samples/menu/s01.go
+++ b/go/samples/menu/s01.go
@@ -21,7 +21,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/dotprompt"
 )
 
-func setup01(ctx context.Context, g *ai.Model) error {
+func setup01(ctx context.Context, g ai.Model) error {
 	_, err := dotprompt.Define("s01_vanillaPrompt",
 		`You are acting as a helpful AI assistant named "Walt" that can answer
 		 questions about the food available on the menu at Walt's Burgers.

--- a/go/samples/menu/s02.go
+++ b/go/samples/menu/s02.go
@@ -37,7 +37,7 @@ func menu(ctx context.Context, _ *any) ([]*menuItem, error) {
 	return s, nil
 }
 
-func setup02(_ context.Context, m *ai.Model) error {
+func setup02(_ context.Context, m ai.Model) error {
 	menuTool := ai.DefineTool("todaysMenu", "Use this tool to retrieve all the items on today's menu", menu)
 
 	dataMenuPrompt, err := dotprompt.Define("s02_dataMenu",

--- a/go/samples/menu/s03.go
+++ b/go/samples/menu/s03.go
@@ -55,7 +55,7 @@ func (ch *chatHistoryStore) Retrieve(sessionID string) chatHistory {
 	return ch.preamble
 }
 
-func setup03(ctx context.Context, model *ai.Model) error {
+func setup03(ctx context.Context, model ai.Model) error {
 	chatPreamblePrompt, err := dotprompt.Define("s03_chatPreamble",
 		`
 		  {{ role "user" }}
@@ -112,7 +112,7 @@ func setup03(ctx context.Context, model *ai.Model) error {
 				Role: ai.RoleUser,
 			}
 			messages := append(slices.Clip(history), msg)
-			resp, err := model.Generate(ctx, ai.WithMessages(messages...))
+			resp, err := ai.Generate(ctx, model, ai.WithMessages(messages...))
 			if err != nil {
 				return nil, err
 			}

--- a/go/samples/menu/s04.go
+++ b/go/samples/menu/s04.go
@@ -24,7 +24,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/localvec"
 )
 
-func setup04(ctx context.Context, indexer *ai.Indexer, retriever *ai.Retriever, model *ai.Model) error {
+func setup04(ctx context.Context, indexer *ai.Indexer, retriever *ai.Retriever, model ai.Model) error {
 	ragDataMenuPrompt, err := dotprompt.Define("s04_ragDataMenu",
 		`
 		  You are acting as Walt, a helpful AI assistant here at the restaurant.

--- a/go/samples/menu/s05.go
+++ b/go/samples/menu/s05.go
@@ -29,7 +29,7 @@ type imageURLInput struct {
 	ImageURL string `json:"imageUrl"`
 }
 
-func setup05(ctx context.Context, gen, genVision *ai.Model) error {
+func setup05(ctx context.Context, gen, genVision ai.Model) error {
 	readMenuPrompt, err := dotprompt.Define("s05_readMenu",
 		`
 		  Extract _all_ of the text, in order,

--- a/go/tests/test_app/main.go
+++ b/go/tests/test_app/main.go
@@ -28,7 +28,7 @@ import (
 func main() {
 	model := ai.DefineModel("", "customReflector", nil, echo)
 	genkit.DefineFlow("testFlow", func(ctx context.Context, in string) (string, error) {
-		res, err := model.Generate(ctx, ai.WithTextPrompt(in))
+		res, err := ai.Generate(ctx, model, ai.WithTextPrompt(in))
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
```go
model := googleai.Model("gemini-1.5-flash")

resp, err := ai.Generate(ctx, model, ai.WithTextPrompt("tell me a joke"))

text, err := ai.GenerateText(ctx, model, ai.WithTextPrompt("tell me a joke"))

// structured output
type GameCharacter struct {
	Name      string
	Backstory string
}

character := &GameCharacter{}
_, err = ai.GenerateData(ctx, model, character,
	ai.WithTextPrompt("generate a game character"))

// model raw interface
resp, err := model.Generate(ctx, &ai.GenerateRequest{
	Messages: []*ai.Message{
		// ....
	},
}, streamingCallback)

```