### PR TITLE
Remove Google Auth Access Token Caching in PredictModel

### DIFF
--- a/js/plugins/vertexai/src/predict.ts
+++ b/js/plugins/vertexai/src/predict.ts
@@ -31,26 +31,18 @@ interface PredictionResponse<R> {
   predictions: R[];
 }
 
-const ACCESS_TOKEN_TTL = 50 * 60 * 1000; // cache access token for 50 minutes
-
 export function predictModel<I = unknown, R = unknown, P = unknown>(
   auth: GoogleAuth,
   { location, projectId }: PluginOptions,
   model: string
 ) {
-  let accessToken: string | null | undefined;
-  let accessTokenFetchTime = 0;
-
   return async (
     instances: I[],
     parameters?: P
   ): Promise<PredictionResponse<R>> => {
     const fetch = (await import('node-fetch')).default;
 
-    if (!accessToken || accessTokenFetchTime + ACCESS_TOKEN_TTL < Date.now()) {
-      accessToken = await auth.getAccessToken();
-      accessTokenFetchTime = Date.now();
-    }
+    const accessToken = await auth.getAccessToken();
 
     const req = {
       instances,


### PR DESCRIPTION
The changes in this PR remove caching of the google auth access token to fix a token expiration issue mentioned in: https://github.com/firebase/genkit/issues/662

Example issue scenario: Google auth access token has a default 1 hour TTL before it expires. When the auth token is generated and the Predict Model is called, the PredictModel caches the token for 50 mins and then requests to get a new token after 50 mins. However, the auth token cached in Google Auth Library hasn't expired yet and it will expire in 10 mins in this case. The PredictModel now caches a token that's about to be expired in 10 mins for another 50 mins.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
