### PR TITLE
refactor: [Go] retriever/indexer are interfaces, ai.Retrieve/Index are veneers

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -95,8 +95,8 @@ func LookupModel(provider, name string) Model {
 	return (*modelActionDef)(core.LookupActionFor[*GenerateRequest, *GenerateResponse, *GenerateResponseChunk](atype.Model, provider, name))
 }
 
-// GenerateParams represents various params of the Generate call.
-type GenerateParams struct {
+// generateParams represents various params of the Generate call.
+type generateParams struct {
 	Request      *GenerateRequest
 	Stream       ModelStreamingCallback
 	History      []*Message
@@ -104,11 +104,11 @@ type GenerateParams struct {
 }
 
 // GenerateOption configures params of the Generate call.
-type GenerateOption func(req *GenerateParams) error
+type GenerateOption func(req *generateParams) error
 
 // WithTextPrompt adds a simple text user prompt to GenerateRequest.
 func WithTextPrompt(prompt string) GenerateOption {
-	return func(req *GenerateParams) error {
+	return func(req *generateParams) error {
 		req.Request.Messages = append(req.Request.Messages, NewUserTextMessage(prompt))
 		return nil
 	}
@@ -117,7 +117,7 @@ func WithTextPrompt(prompt string) GenerateOption {
 // WithSystemPrompt adds a simple text system prompt as the first message in GenerateRequest.
 // System prompt will always be put first in the list of messages.
 func WithSystemPrompt(prompt string) GenerateOption {
-	return func(req *GenerateParams) error {
+	return func(req *generateParams) error {
 		if req.SystemPrompt != nil {
 			return errors.New("cannot set system prompt (WithSystemPrompt) more than once")
 		}
@@ -128,7 +128,7 @@ func WithSystemPrompt(prompt string) GenerateOption {
 
 // WithMessages adds provided messages to GenerateRequest.
 func WithMessages(messages ...*Message) GenerateOption {
-	return func(req *GenerateParams) error {
+	return func(req *generateParams) error {
 		req.Request.Messages = append(req.Request.Messages, messages...)
 		return nil
 	}
@@ -139,7 +139,7 @@ func WithMessages(messages ...*Message) GenerateOption {
 // exception of system prompt which will always be first.
 // [WithMessages] and [WithTextPrompt] will insert messages after system prompt and history.
 func WithHistory(history ...*Message) GenerateOption {
-	return func(req *GenerateParams) error {
+	return func(req *generateParams) error {
 		if req.History != nil {
 			return errors.New("cannot set history (WithHistory) more than once")
 		}
@@ -150,7 +150,7 @@ func WithHistory(history ...*Message) GenerateOption {
 
 // WithConfig adds provided config to GenerateRequest.
 func WithConfig(config any) GenerateOption {
-	return func(req *GenerateParams) error {
+	return func(req *generateParams) error {
 		if req.Request.Config != nil {
 			return errors.New("cannot set Request.Config (WithConfig) more than once")
 		}
@@ -161,7 +161,7 @@ func WithConfig(config any) GenerateOption {
 
 // WithCandidates adds provided candidate count to GenerateRequest.
 func WithCandidates(c int) GenerateOption {
-	return func(req *GenerateParams) error {
+	return func(req *generateParams) error {
 		req.Request.Candidates = c
 		return nil
 	}
@@ -169,7 +169,7 @@ func WithCandidates(c int) GenerateOption {
 
 // WithContext adds provided context to GenerateRequest.
 func WithContext(c ...any) GenerateOption {
-	return func(req *GenerateParams) error {
+	return func(req *generateParams) error {
 		req.Request.Context = append(req.Request.Context, c...)
 		return nil
 	}
@@ -177,7 +177,7 @@ func WithContext(c ...any) GenerateOption {
 
 // WithTools adds provided tools to GenerateRequest.
 func WithTools(tools ...Tool) GenerateOption {
-	return func(req *GenerateParams) error {
+	return func(req *generateParams) error {
 		var toolDefs []*ToolDefinition
 		for _, t := range tools {
 			toolDefs = append(toolDefs, t.Definition())
@@ -189,7 +189,7 @@ func WithTools(tools ...Tool) GenerateOption {
 
 // WithOutputSchema adds provided output schema to GenerateRequest.
 func WithOutputSchema(schema any) GenerateOption {
-	return func(req *GenerateParams) error {
+	return func(req *generateParams) error {
 		if req.Request.Output != nil && req.Request.Output.Schema != nil {
 			return errors.New("cannot set Request.Output.Schema (WithOutputSchema) more than once")
 		}
@@ -204,7 +204,7 @@ func WithOutputSchema(schema any) GenerateOption {
 
 // WithOutputFormat adds provided output format to GenerateRequest.
 func WithOutputFormat(format OutputFormat) GenerateOption {
-	return func(req *GenerateParams) error {
+	return func(req *generateParams) error {
 		if req.Request.Output == nil {
 			req.Request.Output = &GenerateRequestOutput{}
 		}
@@ -215,7 +215,7 @@ func WithOutputFormat(format OutputFormat) GenerateOption {
 
 // WithStreaming adds a streaming callback to the generate request.
 func WithStreaming(cb ModelStreamingCallback) GenerateOption {
-	return func(req *GenerateParams) error {
+	return func(req *generateParams) error {
 		if req.Stream != nil {
 			return errors.New("cannot set streaming callback (WithStreaming) more than once")
 		}
@@ -226,7 +226,7 @@ func WithStreaming(cb ModelStreamingCallback) GenerateOption {
 
 // Generate run generate request for this model. Returns GenerateResponse struct.
 func Generate(ctx context.Context, m Model, opts ...GenerateOption) (*GenerateResponse, error) {
-	req := &GenerateParams{
+	req := &generateParams{
 		Request: &GenerateRequest{},
 	}
 	for _, with := range opts {

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -190,9 +190,9 @@ func WithIndexerText(prompts ...string) indexerOption {
 }
 
 // WithIndexerDoc adds a document to IndexRequest.
-func WithIndexerDocs(doc []*Document) indexerOption {
+func WithIndexerDocs(docs ...*Document) indexerOption {
 	return func(req *indexerParams) error {
-		req.request.Documents = doc
+		req.request.Documents = docs
 		return nil
 	}
 }

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -119,88 +119,74 @@ func (r *retrieverActionDef) Retrieve(ctx context.Context, req *RetrieverRequest
 	return (*retrieverAction)(r).Run(ctx, req, nil)
 }
 
-// retrieveParams represents various params of the Retrieve call.
-type retrieveParams struct {
-	request *RetrieverRequest
-}
-
-// generateOption configures params of the Retrieve call.
-type retrieveOption func(req *retrieveParams) error
+// RetrieveOption configures params of the Retrieve call.
+type RetrieveOption func(req *RetrieverRequest) error
 
 // WithRetrieverText adds a simple text as document to RetrieveRequest.
-func WithRetrieverText(prompt string) retrieveOption {
-	return func(req *retrieveParams) error {
-		req.request.Document = DocumentFromText(prompt, nil)
+func WithRetrieverText(text string) RetrieveOption {
+	return func(req *RetrieverRequest) error {
+		req.Document = DocumentFromText(text, nil)
 		return nil
 	}
 }
 
 // WithRetrieverDoc adds a document to RetrieveRequest.
-func WithRetrieverDoc(doc *Document) retrieveOption {
-	return func(req *retrieveParams) error {
-		req.request.Document = doc
+func WithRetrieverDoc(doc *Document) RetrieveOption {
+	return func(req *RetrieverRequest) error {
+		req.Document = doc
 		return nil
 	}
 }
 
 // WithRetrieverOpts retriever options to RetrieveRequest.
-func WithRetrieverOpts(opts any) retrieveOption {
-	return func(req *retrieveParams) error {
-		req.request.Options = opts
+func WithRetrieverOpts(opts any) RetrieveOption {
+	return func(req *RetrieverRequest) error {
+		req.Options = opts
 		return nil
 	}
 }
 
 // Retrieve calls the retrivers with provided options.
-func Retrieve(ctx context.Context, r Retriever, opts ...retrieveOption) (*RetrieverResponse, error) {
-	req := &retrieveParams{
-		request: &RetrieverRequest{},
-	}
+func Retrieve(ctx context.Context, r Retriever, opts ...RetrieveOption) (*RetrieverResponse, error) {
+	req := &RetrieverRequest{}
 	for _, with := range opts {
 		err := with(req)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return r.Retrieve(ctx, req.request)
+	return r.Retrieve(ctx, req)
 }
 
-// indexerParams represents various params of the Index call.
-type indexerParams struct {
-	request *IndexerRequest
-}
-
-// generateOption configures params of the Index call.
-type indexerOption func(req *indexerParams) error
+// IndexerOption configures params of the Index call.
+type IndexerOption func(req *IndexerRequest) error
 
 // WithIndexerDoc adds a document to IndexRequest.
-func WithIndexerDocs(docs ...*Document) indexerOption {
-	return func(req *indexerParams) error {
-		req.request.Documents = docs
+func WithIndexerDocs(docs ...*Document) IndexerOption {
+	return func(req *IndexerRequest) error {
+		req.Documents = docs
 		return nil
 	}
 }
 
 // WithIndexerOpts sets indexer options on IndexRequest.
-func WithIndexerOpts(opts any) indexerOption {
-	return func(req *indexerParams) error {
-		req.request.Options = opts
+func WithIndexerOpts(opts any) IndexerOption {
+	return func(req *IndexerRequest) error {
+		req.Options = opts
 		return nil
 	}
 }
 
 // Index calls the retrivers with provided options.
-func Index(ctx context.Context, r Indexer, opts ...indexerOption) error {
-	req := &indexerParams{
-		request: &IndexerRequest{},
-	}
+func Index(ctx context.Context, r Indexer, opts ...IndexerOption) error {
+	req := &IndexerRequest{}
 	for _, with := range opts {
 		err := with(req)
 		if err != nil {
 			return err
 		}
 	}
-	return r.Index(ctx, req.request)
+	return r.Index(ctx, req)
 }
 
 func (i *indexerActionDef) Name() string { return (*indexerAction)(i).Name() }

--- a/go/internal/doc-snippets/googleai.go
+++ b/go/internal/doc-snippets/googleai.go
@@ -67,12 +67,10 @@ func googleaiEx(ctx context.Context) error {
 
 	_ = embedRes
 
-	var myRetriever *ai.Retriever
+	var myRetriever ai.Retriever
 
 	// [START retrieve]
-	retrieveRes, err := myRetriever.Retrieve(ctx, &ai.RetrieverRequest{
-		Document: ai.DocumentFromText(userInput, nil),
-	})
+	retrieveRes, err := ai.Retrieve(ctx, myRetriever, ai.WithRetrieverText(userInput))
 	if err != nil {
 		return err
 	}
@@ -80,7 +78,7 @@ func googleaiEx(ctx context.Context) error {
 
 	_ = retrieveRes
 
-	var myIndexer *ai.Indexer
+	var myIndexer ai.Indexer
 	var docsToIndex []*ai.Document
 
 	// [START index]

--- a/go/internal/doc-snippets/googleai.go
+++ b/go/internal/doc-snippets/googleai.go
@@ -82,7 +82,7 @@ func googleaiEx(ctx context.Context) error {
 	var docsToIndex []*ai.Document
 
 	// [START index]
-	if err := myIndexer.Index(ctx, &ai.IndexerRequest{Documents: docsToIndex}); err != nil {
+	if err := ai.Index(ctx, myIndexer, ai.WithIndexerDocs(docsToIndex...)); err != nil {
 		return err
 	}
 	// [END index]

--- a/go/internal/doc-snippets/pinecone.go
+++ b/go/internal/doc-snippets/pinecone.go
@@ -51,10 +51,10 @@ func pineconeEx(ctx context.Context) error {
 	var docChunks []*ai.Document
 
 	// [START index]
-	if err := menuIndexer.Index(
+	if err := ai.Index(
 		ctx,
-		&ai.IndexerRequest{Documents: docChunks, Options: nil},
-	); err != nil {
+		menuIndexer,
+		ai.WithIndexerDocs(docChunks...)); err != nil {
 		return err
 	}
 	// [END index]

--- a/go/internal/doc-snippets/rag/main.go
+++ b/go/internal/doc-snippets/rag/main.go
@@ -91,7 +91,7 @@ func main() {
 			}
 
 			// Add chunks to the index.
-			err = menuPDFIndexer.Index(ctx, &ai.IndexerRequest{Documents: docs})
+			err = ai.Index(ctx, menuPDFIndexer, ai.WithIndexerDocs(docs...))
 			return nil, err
 		},
 	)

--- a/go/internal/doc-snippets/vertexai.go
+++ b/go/internal/doc-snippets/vertexai.go
@@ -73,12 +73,10 @@ func vertexaiEx(ctx context.Context) error {
 
 	_ = embedRes
 
-	var myRetriever *ai.Retriever
+	var myRetriever ai.Retriever
 
 	// [START retrieve]
-	retrieveRes, err := myRetriever.Retrieve(ctx, &ai.RetrieverRequest{
-		Document: ai.DocumentFromText(userInput, nil),
-	})
+	retrieveRes, err := ai.Retrieve(ctx, myRetriever, ai.WithRetrieverText(userInput))
 	if err != nil {
 		return err
 	}
@@ -86,7 +84,7 @@ func vertexaiEx(ctx context.Context) error {
 
 	_ = retrieveRes
 
-	var myIndexer *ai.Indexer
+	var myIndexer ai.Indexer
 	var docsToIndex []*ai.Document
 
 	// [START index]

--- a/go/internal/doc-snippets/vertexai.go
+++ b/go/internal/doc-snippets/vertexai.go
@@ -88,7 +88,7 @@ func vertexaiEx(ctx context.Context) error {
 	var docsToIndex []*ai.Document
 
 	// [START index]
-	if err := myIndexer.Index(ctx, &ai.IndexerRequest{Documents: docsToIndex}); err != nil {
+	if err := ai.Index(ctx, myIndexer, ai.WithIndexerDocs(docsToIndex...)); err != nil {
 		return err
 	}
 	// [END index]

--- a/go/plugins/googleai/googleai.go
+++ b/go/plugins/googleai/googleai.go
@@ -209,7 +209,7 @@ func defineEmbedder(name string) *ai.Embedder {
 
 //copy:start vertexai.go lookups
 
-// Model returns the [ai.ModelAction] with the given name.
+// Model returns the [ai.Model] with the given name.
 // It returns nil if the model was not defined.
 func Model(name string) ai.Model {
 	return ai.LookupModel(provider, name)

--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -48,7 +48,7 @@ func Init() error { return nil }
 
 // DefineIndexerAndRetriever defines an Indexer and Retriever that share the same underlying storage.
 // The name uniquely identifies the the Indexer and Retriever in the registry.
-func DefineIndexerAndRetriever(name string, cfg Config) (*ai.Indexer, *ai.Retriever, error) {
+func DefineIndexerAndRetriever(name string, cfg Config) (ai.Indexer, ai.Retriever, error) {
 	ds, err := newDocStore(cfg.Dir, name, cfg.Embedder, cfg.EmbedderOptions)
 	if err != nil {
 		return nil, nil, err
@@ -64,7 +64,7 @@ func IsDefinedIndexer(name string) bool {
 }
 
 // Indexer returns the registered indexer with the given name.
-func Indexer(name string) *ai.Indexer {
+func Indexer(name string) ai.Indexer {
 	return ai.LookupIndexer(provider, name)
 }
 
@@ -75,7 +75,7 @@ func IsDefinedRetriever(name string) bool {
 
 // Retriever returns the retriever with the given name.
 // The name must match the [Config.Name] value passed to [Init].
-func Retriever(name string) *ai.Retriever {
+func Retriever(name string) ai.Retriever {
 	return ai.LookupRetriever(provider, name)
 }
 

--- a/go/plugins/pinecone/genkit.go
+++ b/go/plugins/pinecone/genkit.go
@@ -83,7 +83,7 @@ type Config struct {
 }
 
 // DefineIndexer defines an Indexer with the given configuration.
-func DefineIndexer(ctx context.Context, cfg Config) (*ai.Indexer, error) {
+func DefineIndexer(ctx context.Context, cfg Config) (ai.Indexer, error) {
 	ds, err := newDocStore(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func DefineIndexer(ctx context.Context, cfg Config) (*ai.Indexer, error) {
 }
 
 // DefineRetriever defines a Retriever with the given configuration.
-func DefineRetriever(ctx context.Context, cfg Config) (*ai.Retriever, error) {
+func DefineRetriever(ctx context.Context, cfg Config) (ai.Retriever, error) {
 	ds, err := newDocStore(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -143,12 +143,12 @@ func newDocStore(ctx context.Context, cfg Config) (*docStore, error) {
 }
 
 // Indexer returns the indexer with the given index name.
-func Indexer(name string) *ai.Indexer {
+func Indexer(name string) ai.Indexer {
 	return ai.LookupIndexer(provider, name)
 }
 
 // Retriever returns the retriever with the given index name.
-func Retriever(name string) *ai.Retriever {
+func Retriever(name string) ai.Retriever {
 	return ai.LookupRetriever(provider, name)
 }
 

--- a/go/plugins/pinecone/genkit_test.go
+++ b/go/plugins/pinecone/genkit_test.go
@@ -92,12 +92,8 @@ func TestGenkit(t *testing.T) {
 		Namespace: namespace,
 	}
 
-	indexerReq := &ai.IndexerRequest{
-		Documents: []*ai.Document{d1, d2, d3},
-		Options:   indexerOptions,
-	}
 	t.Logf("index flag = %q, indexData.Host = %q", *testIndex, indexData.Host)
-	err = indexer.Index(ctx, indexerReq)
+	err = ai.Index(ctx, indexer, ai.WithIndexerOpts(indexerOptions), ai.WithIndexerDocs(d1, d2, d3))
 	if err != nil {
 		t.Fatalf("Index operation failed: %v", err)
 	}
@@ -129,12 +125,9 @@ func TestGenkit(t *testing.T) {
 		Count:     2,
 		Namespace: namespace,
 	}
-
-	retrieverReq := &ai.RetrieverRequest{
-		Document: d1,
-		Options:  retrieverOptions,
-	}
-	retrieverResp, err := retriever.Retrieve(ctx, retrieverReq)
+	retrieverResp, err := ai.Retrieve(ctx, retriever,
+		ai.WithRetrieverDoc(d1),
+		ai.WithRetrieverOpts(retrieverOptions))
 	if err != nil {
 		t.Fatalf("Retrieve operation failed: %v", err)
 	}

--- a/go/plugins/vertexai/vertexai.go
+++ b/go/plugins/vertexai/vertexai.go
@@ -214,7 +214,7 @@ func defineEmbedder(name string) *ai.Embedder {
 //copy:sink lookups from ../googleai/googleai.go
 // DO NOT MODIFY below vvvv
 
-// Model returns the [ai.ModelAction] with the given name.
+// Model returns the [ai.Model] with the given name.
 // It returns nil if the model was not defined.
 func Model(name string) ai.Model {
 	return ai.LookupModel(provider, name)

--- a/go/samples/menu/s04.go
+++ b/go/samples/menu/s04.go
@@ -67,10 +67,7 @@ func setup04(ctx context.Context, indexer ai.Indexer, retriever ai.Retriever, mo
 				}
 				docs = append(docs, ai.DocumentFromText(s, metadata))
 			}
-			req := &ai.IndexerRequest{
-				Documents: docs,
-			}
-			if err := indexer.Index(ctx, req); err != nil {
+			if err := ai.Index(ctx, indexer, ai.WithIndexerDocs(docs...)); err != nil {
 				return nil, err
 			}
 

--- a/go/samples/menu/s04.go
+++ b/go/samples/menu/s04.go
@@ -24,7 +24,7 @@ import (
 	"github.com/firebase/genkit/go/plugins/localvec"
 )
 
-func setup04(ctx context.Context, indexer *ai.Indexer, retriever *ai.Retriever, model ai.Model) error {
+func setup04(ctx context.Context, indexer ai.Indexer, retriever ai.Retriever, model ai.Model) error {
 	ragDataMenuPrompt, err := dotprompt.Define("s04_ragDataMenu",
 		`
 		  You are acting as Walt, a helpful AI assistant here at the restaurant.
@@ -83,13 +83,11 @@ func setup04(ctx context.Context, indexer *ai.Indexer, retriever *ai.Retriever, 
 
 	genkit.DefineFlow("s04_ragMenuQuestion",
 		func(ctx context.Context, input *menuQuestionInput) (*answerOutput, error) {
-			req := &ai.RetrieverRequest{
-				Document: ai.DocumentFromText(input.Question, nil),
-				Options: &localvec.RetrieverOptions{
+			resp, err := ai.Retrieve(ctx, retriever,
+				ai.WithRetrieverText(input.Question),
+				ai.WithRetrieverOpts(&localvec.RetrieverOptions{
 					K: 3,
-				},
-			}
-			resp, err := retriever.Retrieve(ctx, req)
+				}))
 			if err != nil {
 				return nil, err
 			}

--- a/go/samples/pgvector/main.go
+++ b/go/samples/pgvector/main.go
@@ -114,7 +114,7 @@ func run() error {
 const provider = "pgvector"
 
 // [START retr]
-func defineRetriever(db *sql.DB, embedder *ai.Embedder) *ai.Retriever {
+func defineRetriever(db *sql.DB, embedder *ai.Embedder) ai.Retriever {
 	f := func(ctx context.Context, req *ai.RetrieverRequest) (*ai.RetrieverResponse, error) {
 		eres, err := embedder.Embed(ctx, &ai.EmbedRequest{Documents: []*ai.Document{req.Document}})
 		if err != nil {
@@ -159,7 +159,7 @@ func defineRetriever(db *sql.DB, embedder *ai.Embedder) *ai.Retriever {
 
 // [END retr]
 
-func defineIndexer(db *sql.DB, embedder *ai.Embedder) *ai.Indexer {
+func defineIndexer(db *sql.DB, embedder *ai.Embedder) ai.Indexer {
 	// The indexer assumes that each Document has a single part, to be embedded, and metadata fields
 	// for the table primary key: show_id, season_number, episode_id.
 	const query = `
@@ -193,7 +193,7 @@ func defineIndexer(db *sql.DB, embedder *ai.Embedder) *ai.Indexer {
 	})
 }
 
-func indexExistingRows(ctx context.Context, db *sql.DB, indexer *ai.Indexer) error {
+func indexExistingRows(ctx context.Context, db *sql.DB, indexer ai.Indexer) error {
 	rows, err := db.QueryContext(ctx, `SELECT show_id, season_number, episode_id, chunk FROM embeddings`)
 	if err != nil {
 		return err

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -98,19 +98,13 @@ func main() {
 		d2 := ai.DocumentFromText("USA is the largest importer of coffee", nil)
 		d3 := ai.DocumentFromText("Water exists in 3 states - solid, liquid and gas", nil)
 
-		indexerReq := &ai.IndexerRequest{
-			Documents: []*ai.Document{d1, d2, d3},
-		}
-		err := indexer.Index(ctx, indexerReq)
+		err := ai.Index(ctx, indexer, ai.WithIndexerDocs(d1, d2, d3))
 		if err != nil {
 			return "", err
 		}
 
 		dRequest := ai.DocumentFromText(input.Question, nil)
-		retrieverReq := &ai.RetrieverRequest{
-			Document: dRequest,
-		}
-		response, err := retriever.Retrieve(ctx, retrieverReq)
+		response, err := ai.Retrieve(ctx, retriever, ai.WithRetrieverDoc(dRequest))
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
```go

resp, err := ai.Retrieve(ctx, retriever,
	ai.WithRetrieverText(userQuery),
	ai.WithRetrieverOpts(&localvec.RetrieverOptions{
		K: 3,
	}))

err = ai.Index(ctx, indexer,
	ai.WithIndexerOpts(&pinecone.IndexerOptions{
		Namespace: namespace,
	}),
	ai.WithIndexerDocs(d1, d2, d3))
```