### PR TITLE
[Go] rename to follow Go initialism rules

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -349,7 +349,7 @@ func validCandidate(c *Candidate, output *GenerateRequestOutput) (*Candidate, er
 			return nil, errors.New("candidate message has no content")
 		}
 
-		text := base.ExtractJsonFromMarkdown(c.Text())
+		text := base.ExtractJSONFromMarkdown(c.Text())
 		var schemaBytes []byte
 		schemaBytes, err := json.Marshal(output.Schema)
 		if err != nil {
@@ -431,7 +431,7 @@ func (gr *GenerateResponse) History() []*Message {
 // UnmarshalOutput unmarshals structured JSON output into the provided
 // struct pointer.
 func (gr *GenerateResponse) UnmarshalOutput(v any) error {
-	j := base.ExtractJsonFromMarkdown(gr.Text())
+	j := base.ExtractJSONFromMarkdown(gr.Text())
 	if j == "" {
 		return errors.New("unable to parse JSON from response text")
 	}

--- a/go/ai/generator_test.go
+++ b/go/ai/generator_test.go
@@ -232,9 +232,9 @@ func TestValidCandidate(t *testing.T) {
 
 func TestGenerate(t *testing.T) {
 	t.Run("constructs request", func(t *testing.T) {
-		charJson := "{\"Name\": \"foo\", \"Backstory\": \"bar\"}"
-		charJsonMd := "```json" + charJson + "```"
-		wantText := charJson
+		charJSON := "{\"Name\": \"foo\", \"Backstory\": \"bar\"}"
+		charJSONmd := "```json" + charJSON + "```"
+		wantText := charJSON
 		wantRequest := &GenerateRequest{
 			Messages: []*Message{
 				// system prompt -- always first
@@ -259,7 +259,7 @@ func TestGenerate(t *testing.T) {
 				{
 					Role: "user",
 					Content: []*Part{
-						{ContentType: "plain/text", Text: charJsonMd},
+						{ContentType: "plain/text", Text: charJSONmd},
 					},
 				},
 				{
@@ -314,7 +314,7 @@ func TestGenerate(t *testing.T) {
 		wantStreamText := "stream!"
 		streamText := ""
 		res, err := Generate(context.Background(), echoModel,
-			WithTextPrompt(charJsonMd),
+			WithTextPrompt(charJSONmd),
 			WithMessages(NewModelTextMessage("banana again")),
 			WithSystemPrompt("you are"),
 			WithConfig(GenerationCommonConfig{

--- a/go/internal/base/json.go
+++ b/go/internal/base/json.go
@@ -105,7 +105,9 @@ func SchemaAsMap(s *jsonschema.Schema) map[string]any {
 
 var jsonMarkdownRegex = regexp.MustCompile("```(json)?((\n|.)*?)```")
 
-func ExtractJsonFromMarkdown(md string) string {
+// ExtractJSONFromMarkdown returns the contents of the first fenced code block in
+// the markdown text md. If there is none, it returns md.
+func ExtractJSONFromMarkdown(md string) string {
 	// TODO: improve this
 	matches := jsonMarkdownRegex.FindStringSubmatch(md)
 	if matches == nil {

--- a/go/internal/base/json_test.go
+++ b/go/internal/base/json_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestExtractJsonFromMarkdown(t *testing.T) {
+func TestExtractJSONFromMarkdown(t *testing.T) {
 	tests := []struct {
 		desc string
 		in   string
@@ -59,8 +59,8 @@ func TestExtractJsonFromMarkdown(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			if diff := cmp.Diff(ExtractJsonFromMarkdown(tc.in), tc.want); diff != "" {
-				t.Errorf("ExtractJsonFromMarkdown diff (+got -want):\n%s", diff)
+			if diff := cmp.Diff(ExtractJSONFromMarkdown(tc.in), tc.want); diff != "" {
+				t.Errorf("ExtractJSONFromMarkdown diff (+got -want):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Keep same case for acronyms and other initialisms.
