### PR TITLE
refactor: [Go] embedder is an interface and ai.Embed is a veneer

### DIFF
--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -30,9 +30,9 @@ type Embedder interface {
 	Embed(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error)
 }
 
-// An EmbedderActionDef is used to convert a document to a
+// An embedderActionDef is used to convert a document to a
 // multidimensional vector.
-type EmbedderActionDef core.Action[*EmbedRequest, *EmbedResponse, struct{}]
+type embedderActionDef core.Action[*EmbedRequest, *EmbedResponse, struct{}]
 
 type embedderAction = core.Action[*EmbedRequest, *EmbedResponse, struct{}]
 
@@ -57,7 +57,7 @@ type DocumentEmbedding struct {
 // DefineEmbedder registers the given embed function as an action, and returns an
 // [Embedder] that runs it.
 func DefineEmbedder(provider, name string, embed func(context.Context, *EmbedRequest) (*EmbedResponse, error)) Embedder {
-	return (*EmbedderActionDef)(core.DefineAction(provider, name, atype.Embedder, nil, embed))
+	return (*embedderActionDef)(core.DefineAction(provider, name, atype.Embedder, nil, embed))
 }
 
 // IsDefinedEmbedder reports whether an embedder is defined.
@@ -72,11 +72,11 @@ func LookupEmbedder(provider, name string) Embedder {
 	if action == nil {
 		return nil
 	}
-	return (*EmbedderActionDef)(action)
+	return (*embedderActionDef)(action)
 }
 
 // Embed runs the given [Embedder].
-func (e *EmbedderActionDef) Embed(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+func (e *embedderActionDef) Embed(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 	if e == nil {
 		return nil, errors.New("Embed called on a nil Embedder; check that all embedders are defined")
 	}
@@ -84,7 +84,7 @@ func (e *EmbedderActionDef) Embed(ctx context.Context, req *EmbedRequest) (*Embe
 	return a.Run(ctx, req, nil)
 }
 
-func (e *EmbedderActionDef) Name() string {
+func (e *embedderActionDef) Name() string {
 	return (*embedderAction)(e).Name()
 }
 

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -91,6 +91,34 @@ func (e *embedderActionDef) Name() string {
 // EmbedOption configures params of the Embed call.
 type EmbedOption func(req *EmbedRequest) error
 
+// WithEmbedOptions set embedder options on [EmbedRequest]
+func WithEmbedOptions(opts any) EmbedOption {
+	return func(req *EmbedRequest) error {
+		req.Options = opts
+		return nil
+	}
+}
+
+// WithEmbedText adds simple text documents to [EmbedRequest]
+func WithEmbedText(text ...string) EmbedOption {
+	return func(req *EmbedRequest) error {
+		var docs []*Document
+		for _, p := range text {
+			docs = append(docs, DocumentFromText(p, nil))
+		}
+		req.Documents = append(req.Documents, docs...)
+		return nil
+	}
+}
+
+// WithEmbedDocs adds documents to [EmbedRequest]
+func WithEmbedDocs(docs ...*Document) EmbedOption {
+	return func(req *EmbedRequest) error {
+		req.Documents = append(req.Documents, docs...)
+		return nil
+	}
+}
+
 // Embed invokes the embedder with provided options.
 func Embed(ctx context.Context, e Embedder, opts ...EmbedOption) (*EmbedResponse, error) {
 	req := &EmbedRequest{}

--- a/go/internal/doc-snippets/googleai.go
+++ b/go/internal/doc-snippets/googleai.go
@@ -57,9 +57,7 @@ func googleaiEx(ctx context.Context) error {
 	// [END embedder]
 
 	// [START embed]
-	embedRes, err := embeddingModel.Embed(ctx, &ai.EmbedRequest{
-		Documents: []*ai.Document{ai.DocumentFromText(userInput, nil)},
-	})
+	embedRes, err := ai.Embed(ctx, embeddingModel, ai.WithEmbedText(userInput))
 	if err != nil {
 		return err
 	}

--- a/go/internal/doc-snippets/vertexai.go
+++ b/go/internal/doc-snippets/vertexai.go
@@ -63,9 +63,7 @@ func vertexaiEx(ctx context.Context) error {
 	// [END embedder]
 
 	// [START embed]
-	embedRes, err := embeddingModel.Embed(ctx, &ai.EmbedRequest{
-		Documents: []*ai.Document{ai.DocumentFromText(userInput, nil)},
-	})
+	embedRes, err := ai.Embed(ctx, embeddingModel, ai.WithEmbedText(userInput))
 	if err != nil {
 		return err
 	}

--- a/go/internal/fakeembedder/fakeembedder_test.go
+++ b/go/internal/fakeembedder/fakeembedder_test.go
@@ -30,11 +30,8 @@ func TestFakeEmbedder(t *testing.T) {
 	vals := []float32{1, 2}
 	embed.Register(d, vals)
 
-	req := &ai.EmbedRequest{
-		Documents: []*ai.Document{d},
-	}
 	ctx := context.Background()
-	res, err := emb.Embed(ctx, req)
+	res, err := ai.Embed(ctx, emb, ai.WithEmbedDocs(d))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,8 +40,7 @@ func TestFakeEmbedder(t *testing.T) {
 		t.Errorf("lookup returned %v, want %v", got, vals)
 	}
 
-	req.Documents[0] = ai.DocumentFromText("missing document", nil)
-	if _, err = emb.Embed(ctx, req); err == nil {
+	if _, err = ai.Embed(ctx, emb, ai.WithEmbedText("missing document")); err == nil {
 		t.Error("embedding unknown document succeeded unexpectedly")
 	}
 }

--- a/go/plugins/googleai/googleai.go
+++ b/go/plugins/googleai/googleai.go
@@ -166,7 +166,7 @@ func IsDefinedModel(name string) bool {
 //copy:start vertexai.go defineEmbedder
 
 // DefineEmbedder defines an embedder with a given name.
-func DefineEmbedder(name string) *ai.Embedder {
+func DefineEmbedder(name string) ai.Embedder {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 	if !state.initted {
@@ -183,7 +183,7 @@ func IsDefinedEmbedder(name string) bool {
 //copy:stop
 
 // requires state.mu
-func defineEmbedder(name string) *ai.Embedder {
+func defineEmbedder(name string) ai.Embedder {
 	return ai.DefineEmbedder(provider, name, func(ctx context.Context, input *ai.EmbedRequest) (*ai.EmbedResponse, error) {
 		em := state.pclient.EmbeddingModel(name)
 		// TODO: set em.TaskType from EmbedRequest.Options?
@@ -217,7 +217,7 @@ func Model(name string) ai.Model {
 
 // Embedder returns the [ai.Embedder] with the given name.
 // It returns nil if the embedder was not defined.
-func Embedder(name string) *ai.Embedder {
+func Embedder(name string) ai.Embedder {
 	return ai.LookupEmbedder(provider, name)
 }
 

--- a/go/plugins/googleai/googleai_test.go
+++ b/go/plugins/googleai/googleai_test.go
@@ -66,9 +66,7 @@ func TestLive(t *testing.T) {
 		},
 	)
 	t.Run("embedder", func(t *testing.T) {
-		res, err := embedder.Embed(ctx, &ai.EmbedRequest{
-			Documents: []*ai.Document{ai.DocumentFromText("yellow banana", nil)},
-		})
+		res, err := ai.Embed(ctx, embedder, ai.WithEmbedText("yellow banana"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -39,7 +39,7 @@ const provider = "devLocalVectorStore"
 type Config struct {
 	// Where to store the data. Defaults to os.TempDir.
 	Dir             string
-	Embedder        *ai.Embedder
+	Embedder        ai.Embedder
 	EmbedderOptions any
 }
 
@@ -83,7 +83,7 @@ func Retriever(name string) *ai.Retriever {
 // This is based on js/plugins/dev-local-vectorstore/src/index.ts.
 type docStore struct {
 	filename        string
-	embedder        *ai.Embedder
+	embedder        ai.Embedder
 	embedderOptions any
 	data            map[string]dbValue
 }
@@ -95,7 +95,7 @@ type dbValue struct {
 }
 
 // newDocStore returns a new ai.DocumentStore to register.
-func newDocStore(dir, name string, embedder *ai.Embedder, embedderOptions any) (*docStore, error) {
+func newDocStore(dir, name string, embedder ai.Embedder, embedderOptions any) (*docStore, error) {
 	if dir == "" {
 		dir = os.TempDir()
 	}

--- a/go/plugins/pinecone/genkit.go
+++ b/go/plugins/pinecone/genkit.go
@@ -75,7 +75,7 @@ type Config struct {
 	// The index ID to use.
 	IndexID string
 	// Embedder to use. Required.
-	Embedder        *ai.Embedder
+	Embedder        ai.Embedder
 	EmbedderOptions any
 	// The metadata key to use to store document text
 	// in Pinecone; the default is "_content".
@@ -170,7 +170,7 @@ type RetrieverOptions struct {
 // docStore implements the genkit [ai.DocumentStore] interface.
 type docStore struct {
 	index           *index
-	embedder        *ai.Embedder
+	embedder        ai.Embedder
 	embedderOptions any
 	textKey         string
 }

--- a/go/plugins/vertexai/vertexai.go
+++ b/go/plugins/vertexai/vertexai.go
@@ -186,7 +186,7 @@ func IsDefinedModel(name string) bool {
 // DO NOT MODIFY below vvvv
 
 // DefineEmbedder defines an embedder with a given name.
-func DefineEmbedder(name string) *ai.Embedder {
+func DefineEmbedder(name string) ai.Embedder {
 	state.mu.Lock()
 	defer state.mu.Unlock()
 	if !state.initted {
@@ -204,7 +204,7 @@ func IsDefinedEmbedder(name string) bool {
 //copy:endsink defineEmbedder
 
 // requires state.mu
-func defineEmbedder(name string) *ai.Embedder {
+func defineEmbedder(name string) ai.Embedder {
 	fullName := fmt.Sprintf("projects/%s/locations/%s/publishers/google/models/%s", state.projectID, state.location, name)
 	return ai.DefineEmbedder(provider, name, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
 		return embed(ctx, fullName, state.pclient, req)
@@ -222,7 +222,7 @@ func Model(name string) ai.Model {
 
 // Embedder returns the [ai.Embedder] with the given name.
 // It returns nil if the embedder was not defined.
-func Embedder(name string) *ai.Embedder {
+func Embedder(name string) ai.Embedder {
 	return ai.LookupEmbedder(provider, name)
 }
 

--- a/go/plugins/vertexai/vertexai_test.go
+++ b/go/plugins/vertexai/vertexai_test.go
@@ -120,12 +120,10 @@ func TestLive(t *testing.T) {
 		}
 	})
 	t.Run("embedder", func(t *testing.T) {
-		res, err := embedder.Embed(ctx, &ai.EmbedRequest{
-			Documents: []*ai.Document{
-				ai.DocumentFromText("time flies like an arrow", nil),
-				ai.DocumentFromText("fruit flies like a banana", nil),
-			},
-		})
+		res, err := ai.Embed(ctx, embedder, ai.WithEmbedDocs(
+			ai.DocumentFromText("time flies like an arrow", nil),
+			ai.DocumentFromText("fruit flies like a banana", nil),
+		))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/go/samples/pgvector/main.go
+++ b/go/samples/pgvector/main.go
@@ -114,7 +114,7 @@ func run() error {
 const provider = "pgvector"
 
 // [START retr]
-func defineRetriever(db *sql.DB, embedder *ai.Embedder) *ai.Retriever {
+func defineRetriever(db *sql.DB, embedder ai.Embedder) *ai.Retriever {
 	f := func(ctx context.Context, req *ai.RetrieverRequest) (*ai.RetrieverResponse, error) {
 		eres, err := embedder.Embed(ctx, &ai.EmbedRequest{Documents: []*ai.Document{req.Document}})
 		if err != nil {
@@ -159,7 +159,7 @@ func defineRetriever(db *sql.DB, embedder *ai.Embedder) *ai.Retriever {
 
 // [END retr]
 
-func defineIndexer(db *sql.DB, embedder *ai.Embedder) *ai.Indexer {
+func defineIndexer(db *sql.DB, embedder ai.Embedder) *ai.Indexer {
 	// The indexer assumes that each Document has a single part, to be embedded, and metadata fields
 	// for the table primary key: show_id, season_number, episode_id.
 	const query = `

--- a/go/samples/pgvector/main.go
+++ b/go/samples/pgvector/main.go
@@ -116,7 +116,7 @@ const provider = "pgvector"
 // [START retr]
 func defineRetriever(db *sql.DB, embedder ai.Embedder) *ai.Retriever {
 	f := func(ctx context.Context, req *ai.RetrieverRequest) (*ai.RetrieverResponse, error) {
-		eres, err := embedder.Embed(ctx, &ai.EmbedRequest{Documents: []*ai.Document{req.Document}})
+		eres, err := ai.Embed(ctx, embedder, ai.WithEmbedDocs(req.Document))
 		if err != nil {
 			return nil, err
 		}
@@ -168,7 +168,7 @@ func defineIndexer(db *sql.DB, embedder ai.Embedder) *ai.Indexer {
 			WHERE show_id = $1 AND season_number = $2 AND episode_id = $3
 		`
 	return ai.DefineIndexer(provider, "shows", func(ctx context.Context, req *ai.IndexerRequest) error {
-		res, err := embedder.Embed(ctx, &ai.EmbedRequest{Documents: req.Documents})
+		res, err := ai.Embed(ctx, embedder, ai.WithEmbedDocs(req.Documents...))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
```go
res, err := ai.Embed(ctx, embedder, ai.WithEmbedText(userInput))
```