### PR TITLE
feat: allow overriding location per request in vertex ai plugin

### DIFF
--- a/js/plugins/vertexai/src/anthropic.ts
+++ b/js/plugins/vertexai/src/anthropic.ts
@@ -46,7 +46,7 @@ import z from 'zod';
 
 export const AnthropicConfigSchema = GenerationCommonConfigSchema.extend({
   locationOverride: z.string().optional(),
-})
+});
 
 export const claude35Sonnet = modelRef({
   name: 'vertexai/claude-3-5-sonnet',
@@ -370,7 +370,7 @@ export function anthropicModel(
   projectId: string,
   region: string
 ) {
-  const clients: Record<string, AnthropicVertex> = {  }
+  const clients: Record<string, AnthropicVertex> = {};
   const clientFactory = (region: string): AnthropicVertex => {
     if (!clients[region]) {
       clients[region] = new AnthropicVertex({
@@ -382,7 +382,7 @@ export function anthropicModel(
       });
     }
     return clients[region];
-  }
+  };
   const model = SUPPORTED_ANTHROPIC_MODELS[modelName];
   if (!model) {
     throw new Error(`unsupported Anthropic model name ${modelName}`);
@@ -397,7 +397,7 @@ export function anthropicModel(
       versions: model.info?.versions,
     },
     async (input, streamingCallback) => {
-      const client = clientFactory(input.config?.locationOverride || region)
+      const client = clientFactory(input.config?.locationOverride || region);
       if (!streamingCallback) {
         const response = await client.messages.create({
           ...toAnthropicRequest(input.config?.version ?? modelName, input),

--- a/js/plugins/vertexai/src/anthropic.ts
+++ b/js/plugins/vertexai/src/anthropic.ts
@@ -45,7 +45,7 @@ import { GENKIT_CLIENT_HEADER } from '@genkit-ai/core';
 import z from 'zod';
 
 export const AnthropicConfigSchema = GenerationCommonConfigSchema.extend({
-  locationOverride: z.string().optional(),
+  location: z.string().optional(),
 });
 
 export const claude35Sonnet = modelRef({
@@ -397,7 +397,7 @@ export function anthropicModel(
       versions: model.info?.versions,
     },
     async (input, streamingCallback) => {
-      const client = clientFactory(input.config?.locationOverride || region);
+      const client = clientFactory(input.config?.location || region);
       if (!streamingCallback) {
         const response = await client.messages.create({
           ...toAnthropicRequest(input.config?.version ?? modelName, input),

--- a/js/plugins/vertexai/src/embedder.ts
+++ b/js/plugins/vertexai/src/embedder.ts
@@ -22,7 +22,7 @@ import {
 import { GoogleAuth } from 'google-auth-library';
 import { z } from 'zod';
 import { PluginOptions } from './index.js';
-import { predictModel } from './predict.js';
+import { PredictClient, predictModel } from './predict.js';
 
 export const TaskTypeSchema = z.enum([
   'RETRIEVAL_DOCUMENT',
@@ -40,6 +40,7 @@ export const TextEmbeddingGeckoConfigSchema = z.object({
    **/
   taskType: TaskTypeSchema.optional(),
   title: z.string().optional(),
+  locationOverride: z.string().optional(),
 });
 export type TextEmbeddingGeckoConfig = z.infer<
   typeof TextEmbeddingGeckoConfigSchema
@@ -149,12 +150,31 @@ export function textEmbeddingGeckoEmbedder(
   options: PluginOptions
 ) {
   const embedder = SUPPORTED_EMBEDDER_MODELS[name];
-  // TODO: Figure out how to allow different versions while still sharing a single implementation.
-  const predict = predictModel<EmbeddingInstance, EmbeddingPrediction>(
-    client,
-    options,
-    name
-  );
+  const predictClients: Record<
+    string,
+    PredictClient<EmbeddingInstance, EmbeddingPrediction>
+  > = {};
+  const predictClientFactory = (
+    config: TextEmbeddingGeckoConfig
+  ): PredictClient<EmbeddingInstance, EmbeddingPrediction> => {
+    const requestLocation = config?.locationOverride || options.location;
+    if (!predictClients[requestLocation]) {
+      // TODO: Figure out how to allow different versions while still sharing a single implementation.
+      predictClients[requestLocation] = predictModel<
+        EmbeddingInstance,
+        EmbeddingPrediction
+      >(
+        client,
+        {
+          ...options,
+          location: requestLocation,
+        },
+        name
+      );
+    }
+    return predictClients[requestLocation];
+  };
+
   return defineEmbedder(
     {
       name: embedder.name,
@@ -162,7 +182,8 @@ export function textEmbeddingGeckoEmbedder(
       info: embedder.info!,
     },
     async (input, options) => {
-      const response = await predict(
+      const predictClient = predictClientFactory(options);
+      const response = await predictClient(
         input.map((i) => {
           return {
             content: i.text(),

--- a/js/plugins/vertexai/src/embedder.ts
+++ b/js/plugins/vertexai/src/embedder.ts
@@ -40,7 +40,7 @@ export const TextEmbeddingGeckoConfigSchema = z.object({
    **/
   taskType: TaskTypeSchema.optional(),
   title: z.string().optional(),
-  locationOverride: z.string().optional(),
+  location: z.string().optional(),
 });
 export type TextEmbeddingGeckoConfig = z.infer<
   typeof TextEmbeddingGeckoConfigSchema
@@ -157,7 +157,7 @@ export function textEmbeddingGeckoEmbedder(
   const predictClientFactory = (
     config: TextEmbeddingGeckoConfig
   ): PredictClient<EmbeddingInstance, EmbeddingPrediction> => {
-    const requestLocation = config?.locationOverride || options.location;
+    const requestLocation = config?.location || options.location;
     if (!predictClients[requestLocation]) {
       // TODO: Figure out how to allow different versions while still sharing a single implementation.
       predictClients[requestLocation] = predictModel<

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -56,7 +56,7 @@ const SafetySettingsSchema = z.object({
 
 export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
   safetySettings: z.array(SafetySettingsSchema).optional(),
-  locationOverride: z.string().optional(),
+  location: z.string().optional(),
 });
 
 export const geminiPro = modelRef({

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -38,12 +38,12 @@ import {
   Content,
   FunctionDeclaration,
   FunctionDeclarationSchemaType,
+  Part as GeminiPart,
   GenerateContentCandidate,
   GenerateContentResponse,
   GenerateContentResult,
   HarmBlockThreshold,
   HarmCategory,
-  Part as GeminiPart,
   StartChatParams,
   VertexAI,
 } from '@google-cloud/vertexai';
@@ -468,7 +468,7 @@ export function geminiModel(
       use: middlewares,
     },
     async (request, streamingCallback) => {
-      const vertex = vertexClientFactory(request)
+      const vertex = vertexClientFactory(request);
       const client = vertex.preview.getGenerativeModel(
         {
           model: request.config?.version || model.version || name,

--- a/js/plugins/vertexai/src/imagen.ts
+++ b/js/plugins/vertexai/src/imagen.ts
@@ -38,7 +38,7 @@ const ImagenConfigSchema = GenerationCommonConfigSchema.extend({
   negativePrompt: z.string().optional(),
   /** Any non-negative integer you provide to make output images deterministic. Providing the same seed number always results in the same output images. Accepted integer values: 1 - 2147483647. */
   seed: z.number().optional(),
-  locationOverride: z.string().optional(),
+  location: z.string().optional(),
 });
 
 export const imagen2 = modelRef({
@@ -114,8 +114,7 @@ export function imagen2Model(client: GoogleAuth, options: PluginOptions) {
   const predictClientFactory = (
     request: GenerateRequest<typeof ImagenConfigSchema>
   ): PredictClient<ImagenInstance, ImagenPrediction, ImagenParameters> => {
-    const requestLocation =
-      request.config?.locationOverride || options.location;
+    const requestLocation = request.config?.location || options.location;
     if (!predictClients[requestLocation]) {
       predictClients[requestLocation] = predictModel<
         ImagenInstance,

--- a/js/plugins/vertexai/src/index.ts
+++ b/js/plugins/vertexai/src/index.ts
@@ -16,17 +16,17 @@
 
 import { GenerateRequest, ModelReference } from '@genkit-ai/ai/model';
 import { IndexerAction, RetrieverAction } from '@genkit-ai/ai/retriever';
-import { genkitPlugin, Plugin } from '@genkit-ai/core';
+import { Plugin, genkitPlugin } from '@genkit-ai/core';
 import { VertexAI } from '@google-cloud/vertexai';
 import { GoogleAuth, GoogleAuthOptions } from 'google-auth-library';
 import z from 'zod';
 import {
+  SUPPORTED_ANTHROPIC_MODELS,
   anthropicModel,
   claude35Sonnet,
   claude3Haiku,
   claude3Opus,
   claude3Sonnet,
-  SUPPORTED_ANTHROPIC_MODELS,
 } from './anthropic.js';
 import {
   SUPPORTED_EMBEDDER_MODELS,
@@ -45,21 +45,21 @@ import {
   vertexEvaluators,
 } from './evaluation.js';
 import {
+  GeminiConfigSchema,
+  SUPPORTED_GEMINI_MODELS,
   gemini15Flash,
   gemini15FlashPreview,
   gemini15Pro,
   gemini15ProPreview,
-  GeminiConfigSchema,
   geminiModel,
   geminiPro,
   geminiProVision,
-  SUPPORTED_GEMINI_MODELS,
 } from './gemini.js';
 import { imagen2, imagen2Model } from './imagen.js';
 import {
+  SUPPORTED_OPENAI_FORMAT_MODELS,
   llama3,
   modelGardenOpenaiCompatibleModel,
-  SUPPORTED_OPENAI_FORMAT_MODELS,
 } from './model_garden.js';
 import {
   VectorSearchOptions,
@@ -69,12 +69,12 @@ import {
 export {
   DocumentIndexer,
   DocumentRetriever,
+  Neighbor,
+  VectorSearchOptions,
   getBigQueryDocumentIndexer,
   getBigQueryDocumentRetriever,
   getFirestoreDocumentIndexer,
   getFirestoreDocumentRetriever,
-  Neighbor,
-  VectorSearchOptions,
   vertexAiIndexerRef,
   vertexAiIndexers,
   vertexAiRetrieverRef,
@@ -153,7 +153,7 @@ export const vertexAI: Plugin<[PluginOptions] | []> = genkitPlugin(
       throw confError('project', 'GCLOUD_PROJECT');
     }
 
-    const vertexClientFactoryCache: Record<string, VertexAI> = {}
+    const vertexClientFactoryCache: Record<string, VertexAI> = {};
     const vertexClientFactory = (
       request: GenerateRequest<typeof GeminiConfigSchema>
     ): VertexAI => {
@@ -163,7 +163,7 @@ export const vertexAI: Plugin<[PluginOptions] | []> = genkitPlugin(
           project: projectId,
           location: requestLocation,
           googleAuthOptions: options?.googleAuth,
-        })
+        });
       }
       return vertexClientFactoryCache[requestLocation];
     };

--- a/js/plugins/vertexai/src/index.ts
+++ b/js/plugins/vertexai/src/index.ts
@@ -157,7 +157,7 @@ export const vertexAI: Plugin<[PluginOptions] | []> = genkitPlugin(
     const vertexClientFactory = (
       request: GenerateRequest<typeof GeminiConfigSchema>
     ): VertexAI => {
-      const requestLocation = request.config?.locationOverride || location;
+      const requestLocation = request.config?.location || location;
       if (!vertexClientFactoryCache[requestLocation]) {
         vertexClientFactoryCache[requestLocation] = new VertexAI({
           project: projectId,

--- a/js/plugins/vertexai/src/model_garden.ts
+++ b/js/plugins/vertexai/src/model_garden.ts
@@ -14,17 +14,22 @@
  * limitations under the License.
  */
 
-import { ModelAction, modelRef } from '@genkit-ai/ai/model';
+import { GenerateRequest, ModelAction, modelRef } from '@genkit-ai/ai/model';
 import { GENKIT_CLIENT_HEADER } from '@genkit-ai/core';
 import { GoogleAuth } from 'google-auth-library';
 import OpenAI from 'openai';
 
+import z from 'zod';
 import {
   openaiCompatibleModel,
   OpenAIConfigSchema,
 } from './openai_compatibility.js';
 
 const ACCESS_TOKEN_TTL = 50 * 60 * 1000; // cache access token for 50 minutes
+
+export const ModelGardenModelConfigSchema = OpenAIConfigSchema.extend({
+  locationOverride: z.string().optional(),
+});
 
 export const llama3 = modelRef({
   name: 'vertexai/llama3-405b',
@@ -39,7 +44,7 @@ export const llama3 = modelRef({
     },
     versions: ['meta/llama3-405b-instruct-maas'],
   },
-  configSchema: OpenAIConfigSchema,
+  configSchema: ModelGardenModelConfigSchema,
   version: 'meta/llama3-405b-instruct-maas',
 });
 
@@ -47,13 +52,18 @@ export const SUPPORTED_OPENAI_FORMAT_MODELS = {
   'llama3-405b': llama3,
 };
 
+interface OpenAIClient {
+  accessTokenFetchTime;
+  client: OpenAI;
+}
+
 export function modelGardenOpenaiCompatibleModel(
   name: string,
   projectId: string,
   location: string,
   googleAuth: GoogleAuth,
   baseUrlTemplate: string | undefined
-): ModelAction<typeof OpenAIConfigSchema> {
+): ModelAction<typeof ModelGardenModelConfigSchema> {
   const model = SUPPORTED_OPENAI_FORMAT_MODELS[name];
   if (!model) throw new Error(`Unsupported model: ${name}`);
   if (!baseUrlTemplate) {
@@ -61,29 +71,30 @@ export function modelGardenOpenaiCompatibleModel(
       'https://{location}-aiplatform.googleapis.com/v1beta1/projects/{projectId}/locations/{location}/endpoints/openapi';
   }
 
-  let accessToken: string | null | undefined;
-  let accessTokenFetchTime = 0;
-  var clientCache: OpenAI;
-  const clientFactory = async () => {
+  const clientCache: Record<string, OpenAIClient> = {};
+  const clientFactory = async (
+    request: GenerateRequest<typeof ModelGardenModelConfigSchema>
+  ): Promise<OpenAI> => {
+    const requestLocation = request.config?.locationOverride || location;
     if (
-      !clientCache ||
-      !accessToken ||
-      accessTokenFetchTime + ACCESS_TOKEN_TTL < Date.now()
+      !clientCache[requestLocation] ||
+      clientCache[requestLocation].accessTokenFetchTime + ACCESS_TOKEN_TTL <
+        Date.now()
     ) {
-      accessToken = await googleAuth.getAccessToken();
-      accessTokenFetchTime = Date.now();
-      clientCache = new OpenAI({
-        baseURL: baseUrlTemplate!
-          .replace(/{location}/g, location)
-          .replace(/{projectId}/g, projectId),
-        apiKey: accessToken!,
-        defaultHeaders: {
-          'X-Goog-Api-Client': GENKIT_CLIENT_HEADER,
-        },
-      });
+      clientCache[requestLocation] = {
+        accessTokenFetchTime: Date.now(),
+        client: new OpenAI({
+          baseURL: baseUrlTemplate!
+            .replace(/{location}/g, requestLocation)
+            .replace(/{projectId}/g, projectId),
+          apiKey: (await googleAuth.getAccessToken())!,
+          defaultHeaders: {
+            'X-Goog-Api-Client': GENKIT_CLIENT_HEADER,
+          },
+        }),
+      };
     }
-
-    return clientCache;
+    return clientCache[requestLocation].client;
   };
   return openaiCompatibleModel(model, clientFactory);
 }

--- a/js/plugins/vertexai/src/model_garden.ts
+++ b/js/plugins/vertexai/src/model_garden.ts
@@ -28,7 +28,7 @@ import {
 const ACCESS_TOKEN_TTL = 50 * 60 * 1000; // cache access token for 50 minutes
 
 export const ModelGardenModelConfigSchema = OpenAIConfigSchema.extend({
-  locationOverride: z.string().optional(),
+  location: z.string().optional(),
 });
 
 export const llama3 = modelRef({
@@ -75,7 +75,7 @@ export function modelGardenOpenaiCompatibleModel(
   const clientFactory = async (
     request: GenerateRequest<typeof ModelGardenModelConfigSchema>
   ): Promise<OpenAI> => {
-    const requestLocation = request.config?.locationOverride || location;
+    const requestLocation = request.config?.location || location;
     if (
       !clientCache[requestLocation] ||
       clientCache[requestLocation].accessTokenFetchTime + ACCESS_TOKEN_TTL <

--- a/js/plugins/vertexai/src/openai_compatibility.ts
+++ b/js/plugins/vertexai/src/openai_compatibility.ts
@@ -298,10 +298,10 @@ export function toRequestBody(
   return body;
 }
 
-export function openaiCompatibleModel(
+export function openaiCompatibleModel<C extends typeof OpenAIConfigSchema>(
   model: ModelReference<any>,
-  clientFactory: () => Promise<OpenAI>
-): ModelAction<typeof OpenAIConfigSchema> {
+  clientFactory: (request: GenerateRequest<C>) => Promise<OpenAI>
+): ModelAction<C> {
   const modelId = model.name;
   if (!model) throw new Error(`Unsupported model: ${name}`);
 
@@ -312,11 +312,11 @@ export function openaiCompatibleModel(
       configSchema: model.configSchema,
     },
     async (
-      request: GenerateRequest<typeof OpenAIConfigSchema>,
+      request: GenerateRequest<C>,
       streamingCallback?: StreamingCallback<GenerateResponseChunkData>
     ): Promise<GenerateResponseData> => {
       let response: ChatCompletion;
-      const client = await clientFactory();
+      const client = await clientFactory(request);
       const body = toRequestBody(model, request);
       if (streamingCallback) {
         const stream = client.beta.chat.completions.stream({

--- a/js/plugins/vertexai/src/predict.ts
+++ b/js/plugins/vertexai/src/predict.ts
@@ -33,11 +33,16 @@ interface PredictionResponse<R> {
 
 const ACCESS_TOKEN_TTL = 50 * 60 * 1000; // cache access token for 50 minutes
 
+export type PredictClient<I = unknown, R = unknown, P = unknown> = (
+  instances: I[],
+  parameters?: P
+) => Promise<PredictionResponse<R>>;
+
 export function predictModel<I = unknown, R = unknown, P = unknown>(
   auth: GoogleAuth,
   { location, projectId }: PluginOptions,
   model: string
-) {
+): PredictClient<I, R, P> {
   let accessToken: string | null | undefined;
   let accessTokenFetchTime = 0;
 

--- a/js/plugins/vertexai/src/predict.ts
+++ b/js/plugins/vertexai/src/predict.ts
@@ -43,20 +43,13 @@ export function predictModel<I = unknown, R = unknown, P = unknown>(
   { location, projectId }: PluginOptions,
   model: string
 ): PredictClient<I, R, P> {
-  let accessToken: string | null | undefined;
-  let accessTokenFetchTime = 0;
-
   return async (
     instances: I[],
     parameters?: P
   ): Promise<PredictionResponse<R>> => {
     const fetch = (await import('node-fetch')).default;
 
-    if (!accessToken || accessTokenFetchTime + ACCESS_TOKEN_TTL < Date.now()) {
-      accessToken = await auth.getAccessToken();
-      accessTokenFetchTime = Date.now();
-    }
-
+    const accessToken = await auth.getAccessToken();
     const req = {
       instances,
       parameters: parameters || {},

--- a/js/plugins/vertexai/tests/anthropic_test.ts
+++ b/js/plugins/vertexai/tests/anthropic_test.ts
@@ -18,21 +18,21 @@ import {
   Message,
   MessageCreateParamsBase,
 } from '@anthropic-ai/sdk/resources/messages.mjs';
-import {
-  GenerateRequest,
-  GenerateResponseData,
-  GenerationCommonConfigSchema,
-} from '@genkit-ai/ai/model';
+import { GenerateRequest, GenerateResponseData } from '@genkit-ai/ai/model';
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
-import { fromAnthropicResponse, toAnthropicRequest } from '../src/anthropic.js';
+import {
+  AnthropicConfigSchema,
+  fromAnthropicResponse,
+  toAnthropicRequest,
+} from '../src/anthropic.js';
 
 const MODEL_ID = 'modelid';
 
 describe('toAnthropicRequest', () => {
   const testCases: {
     should: string;
-    input: GenerateRequest<typeof GenerationCommonConfigSchema>;
+    input: GenerateRequest<typeof AnthropicConfigSchema>;
     expectedOutput: MessageCreateParamsBase;
   }[] = [
     {
@@ -136,7 +136,7 @@ describe('toAnthropicRequest', () => {
 describe('fromAnthropicResponse', () => {
   const testCases: {
     should: string;
-    input: GenerateRequest<typeof GenerationCommonConfigSchema>;
+    input: GenerateRequest<typeof AnthropicConfigSchema>;
     response: Message;
     expectedOutput: GenerateResponseData;
   }[] = [


### PR DESCRIPTION
```ts

configureGenkit({
  plugins: [
    vertextAI({
      location: 'us-central1',
      modelGarden: {
        models: [claude35Sonnet]
      }
    })
  ]
})

generate({
  model: claude35Sonnet,
  prompt: 'banana',
  config: {
    location: 'us-east5',
  }
})
```