### PR TITLE
Fix broken rendering of code snippet on DevSite

### DIFF
--- a/docs/plugins/firebase.md
+++ b/docs/plugins/firebase.md
@@ -339,6 +339,7 @@ The `onFlow()` function has some options not present in `defineFlow()`:
 
 - `httpsOptions`: an [`HttpsOptions`](https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.https.httpsoptions)
   object used to configure your Cloud Function:
+
   <!--See note above on prettier-ignore -->
   <!-- prettier-ignore -->
   ```js


### PR DESCRIPTION
This is an attempt to fix the broken rendering of the `httpsOptions` code snippet in on this page: https://firebase.google.com/docs/genkit/plugins/firebase

This is related to #739.