### PR TITLE
refactor(go/plugins/ollama): use ollama go client in plugin

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -329,6 +329,16 @@ func conformOutput(req *GenerateRequest) error {
 // It will strip JSON markdown delimiters from the response.
 func validCandidates(ctx context.Context, resp *GenerateResponse) ([]*Candidate, error) {
 	var candidates []*Candidate
+
+	if resp.Request == nil {
+		return nil, errors.New("cannot validate candidates, response has no request information")
+	}
+
+	// check if resp.Request.Output is nil first. if it is then just respond with the candidates
+	if resp.Request.Output == nil {
+		return resp.Candidates, nil
+	}
+
 	for i, c := range resp.Candidates {
 		c, err := validCandidate(c, resp.Request.Output)
 		if err == nil {

--- a/go/ai/request_helpers.go
+++ b/go/ai/request_helpers.go
@@ -14,13 +14,27 @@
 
 package ai
 
-// NewGenerateRequest create a new GenerateRequest with provided config and
+import "errors"
+
+// NewGenerateRequest create a new GenerateRequest with provided config, output and
 // messages.
 func NewGenerateRequest(config any, messages ...*Message) *GenerateRequest {
 	return &GenerateRequest{
 		Config:   config,
 		Messages: messages,
 	}
+}
+
+func NewGenerateRequestWithOutput(config any, output *GenerateRequestOutput, messages ...*Message) (*GenerateRequest, error) {
+
+	if output == nil {
+		return nil, errors.New("output cannot be nil")
+	}
+	return &GenerateRequest{
+		Config:   config,
+		Messages: messages,
+		Output:   output,
+	}, nil
 }
 
 // NewUserMessage creates a new Message with role "user" and provided parts.

--- a/go/go.mod
+++ b/go/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/invopop/jsonschema v0.12.0
 	github.com/jba/slog v0.2.0
 	github.com/lib/pq v1.10.9
+	github.com/ollama/ollama v0.3.4
 	github.com/pgvector/pgvector-go v0.2.0
 	github.com/weaviate/weaviate v1.26.0-rc.1
 	github.com/weaviate/weaviate-go-client/v4 v4.15.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -223,6 +223,8 @@ github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJ
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/ollama/ollama v0.3.4 h1:WHXyMmDZ+c0OQVQV9FKj4PrKLB5IB522dKA0X0tbYa4=
+github.com/ollama/ollama v0.3.4/go.mod h1:USAVO5xFaXAoVWJ0rkPYgCVhTxE/oJ81o7YGcJxvyp8=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pgvector/pgvector-go v0.2.0 h1:NZdW4NxUxdSCzaev3LVHb9ORf+LdX+uZOQVqQ6s2Zyg=
 github.com/pgvector/pgvector-go v0.2.0/go.mod h1:OQpvU5QZGQOPI9quIXAyHaRZ5yGk/RGUDbs9C3DPUNE=

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -223,6 +223,9 @@ func (g *generator) handleSingleResponse(ctx context.Context, payload any, isCha
 			resp = r
 			return nil
 		})
+		if err != nil {
+			return nil, err
+		}
 		body, err = json.Marshal(resp)
 	} else {
 		var request *api.GenerateRequest = payload.(*api.GenerateRequest)
@@ -231,6 +234,9 @@ func (g *generator) handleSingleResponse(ctx context.Context, payload any, isCha
 			resp = r
 			return nil
 		})
+		if err != nil {
+			return nil, err
+		}
 		body, err = json.Marshal(resp)
 	}
 	if err != nil {

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -78,6 +78,14 @@ func Model(name string) ai.Model {
 	return ai.LookupModel(provider, name)
 }
 
+func uninit() {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.initted = false
+	state.serverAddress = ""
+	state.client = nil
+}
+
 // ModelDefinition represents a model with its name and type.
 type ModelDefinition struct {
 	Name string
@@ -449,7 +457,6 @@ func IsDefinedEmbedder(name string) bool {
 	return ai.IsDefinedEmbedder(provider, name)
 }
 
-// requires state.mu
 func defineEmbedder(name string) ai.Embedder {
 	return ai.DefineEmbedder(provider, name, func(ctx context.Context, input *ai.EmbedRequest) (*ai.EmbedResponse, error) {
 		em := &embedder{model: ModelDefinition{Name: name, Type: "embedding"}, client: state.client}

--- a/go/plugins/ollama/ollama_embedding_live_test.go
+++ b/go/plugins/ollama/ollama_embedding_live_test.go
@@ -1,0 +1,75 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ollama
+
+import (
+	"context"
+	"flag"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+)
+
+var embedderName = flag.String("embedder-name", "nomic-embed-text", "embedder name")
+
+func TestLiveEmbedding(t *testing.T) {
+	if !*testLive {
+		t.Skip("skipping go/plugins/ollama live test")
+	}
+
+	ctx := context.Background()
+
+	// Initialize the Ollama plugin
+	err := Init(ctx, &Config{
+		ServerAddress: *serverAddress,
+	})
+	defer uninit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	DefineEmbedder(*embedderName)
+
+	// Define and use the embedder
+	embedder := Embedder(*embedderName)
+	if embedder == nil {
+		t.Fatalf("failed to find embedder: %s", *embedderName)
+	}
+
+	t.Run("embedder", func(t *testing.T) {
+
+		res, err := ai.Embed(ctx, embedder, ai.WithEmbedDocs(
+			ai.DocumentFromText("time flies like an arrow", nil),
+			ai.DocumentFromText("fruit flies like a banana", nil),
+		))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Sanity checks on the embedding results
+		for _, de := range res.Embeddings {
+			out := de.Embedding
+			if len(out) < 100 { // Assuming embeddings should have a length > 100
+				t.Errorf("embedding vector looks too short: len(out)=%d", len(out))
+			}
+			var normSquared float32
+			for _, x := range out {
+				normSquared += x * x
+			}
+			if normSquared < 0.9 || normSquared > 1.1 {
+				t.Errorf("embedding vector not unit length: %f", normSquared)
+			}
+		}
+	})
+}

--- a/go/plugins/ollama/ollama_live_test.go
+++ b/go/plugins/ollama/ollama_live_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ollama_test
+package ollama
 
 import (
 	"context"
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
-	ollamaPlugin "github.com/firebase/genkit/go/plugins/ollama"
 )
 
 var serverAddress = flag.String("server-address", "http://localhost:11434", "Ollama server address")
@@ -30,6 +29,8 @@ var testLive = flag.Bool("test-live", false, "run live tests")
 /*
 To run this test, you need to have the Ollama server running. You can set the server address using the OLLAMA_SERVER_ADDRESS environment variable.
 If the environment variable is not set, the test will default to http://localhost:11434 (the default address for the Ollama server).
+
+Note sometimes this test will fail because the model isn't responding in the correct format.
 */
 func TestLive(t *testing.T) {
 	if !*testLive {
@@ -39,18 +40,20 @@ func TestLive(t *testing.T) {
 	ctx := context.Background()
 
 	// Initialize the Ollama plugin
-	err := ollamaPlugin.Init(ctx, &ollamaPlugin.Config{
+	err := Init(ctx, &Config{
 		ServerAddress: *serverAddress,
 	})
+	defer uninit()
+
 	if err != nil {
 		t.Fatalf("failed to initialize Ollama plugin: %s", err)
 	}
 
 	// Define the model
-	ollamaPlugin.DefineModel(ollamaPlugin.ModelDefinition{Name: *modelName}, nil)
+	DefineModel(ModelDefinition{Name: *modelName}, nil)
 
 	// Use the Ollama model
-	m := ollamaPlugin.Model(*modelName)
+	m := Model(*modelName)
 	if m == nil {
 		t.Fatalf("failed to find model: %s", *modelName)
 	}


### PR DESCRIPTION
This PR refactors the existing ollama plugin to use the ollama go client (which is used by ollama itself)

This will keep us in sync with ollama better, and make adding additional features easier as ollama adds them.

The PR also adds in embedders for ollama, resolving https://github.com/firebase/genkit/issues/728

During testing I also found some logic which could use a nil pointer check (in the validateCandidate logic, e.g called by generate.go in the `ai` package)

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
