### PR TITLE
Update firebase peer dependencies to have a minimum version

### DIFF
--- a/js/plugins/firebase/package.json
+++ b/js/plugins/firebase/package.json
@@ -31,7 +31,7 @@
   "author": "genkit",
   "license": "Apache-2.0",
   "dependencies": {
-    "@genkit-ai/google-cloud": "workspace:*",
+    "@genkit-ai/google-cloud": "workspace:^0.5.7",
     "express": "^4.19.2",
     "google-auth-library": "^9.6.3",
     "zod": "^3.22.4"
@@ -40,9 +40,9 @@
     "@google-cloud/firestore": "^7.6.0",
     "firebase-admin": "^12.2.0",
     "firebase-functions": "^4.8.0 || ^5.0.0",
-    "@genkit-ai/ai": "workspace:*",
-    "@genkit-ai/core": "workspace:*",
-    "@genkit-ai/flow": "workspace:*"
+    "@genkit-ai/ai": "workspace:^0.5.7",
+    "@genkit-ai/core": "workspace:^0.5.7",
+    "@genkit-ai/flow": "workspace:^0.5.7"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -325,16 +325,16 @@ importers:
   plugins/firebase:
     dependencies:
       '@genkit-ai/ai':
-        specifier: workspace:*
+        specifier: workspace:^0.5.7
         version: link:../../ai
       '@genkit-ai/core':
-        specifier: workspace:*
+        specifier: workspace:^0.5.7
         version: link:../../core
       '@genkit-ai/flow':
-        specifier: workspace:*
+        specifier: workspace:^0.5.7
         version: link:../../flow
       '@genkit-ai/google-cloud':
-        specifier: workspace:*
+        specifier: workspace:^0.5.7
         version: link:../google-cloud
       '@google-cloud/firestore':
         specifier: ^7.6.0
@@ -3604,6 +3604,7 @@ packages:
   google-p12-pem@4.0.1:
     resolution: {integrity: sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==}
     engines: {node: '>=12.0.0'}
+    deprecated: Package is no longer maintained
     hasBin: true
 
   google-proto-files@3.0.3:


### PR DESCRIPTION
AI Monitoring in Firebase requires a minimum version in other genkit plugins to function properly. 

With this change developers will now see a warning message if a peer dependency is not met.

pnpm and workspace dependencies behave somewhat oddly with this (see https://github.com/pnpm/pnpm/issues/7087), but once released it should work for vanilla npm.
