### PR TITLE
chore: update to pnpm v9.7

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -9,3 +9,8 @@ link-workspace-packages=false
 # This option will cause pnpm to fail if its version doesn't exactly match the
 # version specified in the `packageManager` field of package.json.
 package-manager-strict-version=true
+
+# This option will cause pnpm to automatically download and run the version of
+# pnpm specified in the `packageManager` field of package.json. This is the same
+# field used by Corepack.
+manage-package-manager-versions=true

--- a/genkit-tools/package.json
+++ b/genkit-tools/package.json
@@ -20,5 +20,5 @@
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.22.4"
   },
-  "packageManager": "pnpm@9.6.0+sha256.dae0f7e822c56b20979bb5965e3b73b8bdabb6b8b8ef121da6d857508599ca35"
+  "packageManager": "pnpm@9.7.0+sha256.b35018fbfa8f583668b2649e407922a721355cd81f61beeb4ac1d4258e585559"
 }

--- a/js/package.json
+++ b/js/package.json
@@ -19,5 +19,5 @@
     "only-allow": "^1.2.1",
     "typescript": "^4.9.0"
   },
-  "packageManager": "pnpm@9.6.0+sha256.dae0f7e822c56b20979bb5965e3b73b8bdabb6b8b8ef121da6d857508599ca35"
+  "packageManager": "pnpm@9.7.0+sha256.b35018fbfa8f583668b2649e407922a721355cd81f61beeb4ac1d4258e585559"
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.7.1"
   },
-  "packageManager": "pnpm@9.6.0+sha256.dae0f7e822c56b20979bb5965e3b73b8bdabb6b8b8ef121da6d857508599ca35"
+  "packageManager": "pnpm@9.7.0+sha256.b35018fbfa8f583668b2649e407922a721355cd81f61beeb4ac1d4258e585559"
 }


### PR DESCRIPTION
https://github.com/pnpm/pnpm/releases/tag/v9.7.0

Also sets the new [`manage-package-manager-versions`](https://pnpm.io/npmrc#manage-package-manager-versions) option to `true` in .npmrc to have pnpm automatically install the specified version in package.json to prevent weird installation issues (woot!).