### PR TITLE
Rendering dotprompts in a new trace span

### DIFF
--- a/js/plugins/dotprompt/src/prompt.ts
+++ b/js/plugins/dotprompt/src/prompt.ts
@@ -28,6 +28,11 @@ import { MessageData, ModelArgument } from '@genkit-ai/ai/model';
 import { DocumentData } from '@genkit-ai/ai/retriever';
 import { GenkitError } from '@genkit-ai/core';
 import { parseSchema } from '@genkit-ai/core/schema';
+import {
+  runInNewSpan,
+  setCustomMetadataAttribute,
+  SPAN_TYPE_ATTR,
+} from '@genkit-ai/core/tracing';
 import { createHash } from 'crypto';
 import fm, { FrontMatterResult } from 'front-matter';
 import z from 'zod';
@@ -220,6 +225,29 @@ export class Dotprompt<I = unknown> implements PromptMetadata<z.ZodTypeAny> {
     return this._generateOptions(opt);
   }
 
+  async renderInNewSpan<
+    CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
+    O extends z.ZodTypeAny = z.ZodTypeAny,
+  >(opt: PromptGenerateOptions<I>): Promise<GenerateOptions<CustomOptions, O>> {
+    return runInNewSpan(
+      {
+        metadata: {
+          name: this.name,
+          input: opt,
+        },
+        labels: {
+          [SPAN_TYPE_ATTR]: 'dotprompt',
+        },
+      },
+      async (metadata) => {
+        setCustomMetadataAttribute('prompt_fingerprint', this.hash);
+        const generateOptions = this._generateOptions<CustomOptions, O>(opt);
+        metadata.output = generateOptions;
+        return generateOptions;
+      }
+    );
+  }
+
   /**
    * Generates a response by rendering the prompt template with given user input and then calling the model.
    *
@@ -232,7 +260,9 @@ export class Dotprompt<I = unknown> implements PromptMetadata<z.ZodTypeAny> {
   >(
     opt: PromptGenerateOptions<I, CustomOptions>
   ): Promise<GenerateResponse<z.infer<O>>> {
-    return generate<CustomOptions, O>(this.render<CustomOptions, O>(opt));
+    return this.renderInNewSpan<CustomOptions, O>(opt).then((generateOptions) =>
+      generate<CustomOptions, O>(generateOptions)
+    );
   }
 
   /**
@@ -244,7 +274,9 @@ export class Dotprompt<I = unknown> implements PromptMetadata<z.ZodTypeAny> {
   async generateStream<CustomOptions extends z.ZodTypeAny = z.ZodTypeAny>(
     opt: PromptGenerateOptions<I, CustomOptions>
   ): Promise<GenerateStreamResponse> {
-    return generateStream(this.render<CustomOptions>(opt));
+    return this.renderInNewSpan<CustomOptions>(opt).then((generateOptions) =>
+      generateStream(generateOptions)
+    );
   }
 }
 

--- a/js/plugins/dotprompt/src/prompt.ts
+++ b/js/plugins/dotprompt/src/prompt.ts
@@ -229,10 +229,11 @@ export class Dotprompt<I = unknown> implements PromptMetadata<z.ZodTypeAny> {
     CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
     O extends z.ZodTypeAny = z.ZodTypeAny,
   >(opt: PromptGenerateOptions<I>): Promise<GenerateOptions<CustomOptions, O>> {
+    const spanName = this.variant ? `${this.name}.${this.variant}` : this.name;
     return runInNewSpan(
       {
         metadata: {
-          name: this.name,
+          name: spanName,
           input: opt,
         },
         labels: {


### PR DESCRIPTION
Rendering dotprompts in a new trace span for better observability.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)

![image](https://github.com/user-attachments/assets/dd12f497-7ed4-46ff-81f0-173b18d10038)

