### PR TITLE
Fixing bugs in prompt rendering

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -48,6 +48,15 @@ export function isPrompt(arg: any): boolean {
   );
 }
 
+/**
+ * Defines and registers a prompt action. The action can be called to obtain
+ * a `GenerateRequest` which can be passed to a model action. The given
+ * `PromptFn` can perform any action needed to create the request such as rendering
+ * a template or fetching a prompt from a database.
+ *
+ * @returns The new `PromptAction`.
+ */
+
 export function definePrompt<I extends z.ZodTypeAny>(
   {
     name,
@@ -78,14 +87,15 @@ export function definePrompt<I extends z.ZodTypeAny>(
   return a as PromptAction<I>;
 }
 
-/**
- * A veneer for rendering a prompt action to GenerateOptions.
- */
-
 export type PromptArgument<I extends z.ZodTypeAny = z.ZodTypeAny> =
   | string
   | PromptAction<I>;
 
+/**
+ * This veneer renders a `PromptAction` into a `GenerateOptions` object.
+ *
+ * @returns A promise of an options object for use with the `generate()` function.
+ */
 export async function renderPrompt<
   I extends z.ZodTypeAny = z.ZodTypeAny,
   O extends z.ZodTypeAny = z.ZodTypeAny,

--- a/js/ai/tests/prompt/prompt_test.ts
+++ b/js/ai/tests/prompt/prompt_test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import * as z from 'zod';
+import { definePrompt, renderPrompt } from '../../src/prompt.ts';
+
+describe('prompt', () => {
+  describe('render()', () => {
+    it('respects output schema in the definition', async () => {
+      const schema1 = z.object({
+        puppyName: z.string({ description: 'A cute name for a puppy' }),
+      });
+      const prompt1 = definePrompt(
+        {
+          name: 'prompt1',
+          inputSchema: z.string({ description: 'Dog breed' }),
+        },
+        async (breed) => {
+          return {
+            messages: [
+              {
+                role: 'user',
+                content: [{ text: `Pick a name for a ${breed} puppy` }],
+              },
+            ],
+            output: {
+              format: 'json',
+              schema: schema1,
+            },
+          };
+        }
+      );
+      const generateRequest = await renderPrompt({
+        prompt: prompt1,
+        input: 'poodle',
+        model: 'geminiPro',
+      });
+      assert.equal(generateRequest.output?.schema, schema1);
+    });
+  });
+});

--- a/js/ai/tests/prompt/prompt_test.ts
+++ b/js/ai/tests/prompt/prompt_test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import * as z from 'zod';

--- a/js/testapps/dev-ui-gallery/src/main/prompts.ts
+++ b/js/testapps/dev-ui-gallery/src/main/prompts.ts
@@ -46,26 +46,24 @@ export const codeDefinedPrompt = defineDotprompt(
       topK: 16,
       topP: 0.95,
       stopSequences: ['STAWP!'],
-      custom: {
-        safetySettings: [
-          {
-            category: 'HARM_CATEGORY_HATE_SPEECH',
-            threshold: 'BLOCK_ONLY_HIGH',
-          },
-          {
-            category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
-            threshold: 'BLOCK_ONLY_HIGH',
-          },
-          {
-            category: 'HARM_CATEGORY_HARASSMENT',
-            threshold: 'BLOCK_ONLY_HIGH',
-          },
-          {
-            category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-            threshold: 'BLOCK_ONLY_HIGH',
-          },
-        ],
-      },
+      safetySettings: [
+        {
+          category: 'HARM_CATEGORY_HATE_SPEECH',
+          threshold: 'BLOCK_ONLY_HIGH',
+        },
+        {
+          category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+          threshold: 'BLOCK_ONLY_HIGH',
+        },
+        {
+          category: 'HARM_CATEGORY_HARASSMENT',
+          threshold: 'BLOCK_ONLY_HIGH',
+        },
+        {
+          category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+          threshold: 'BLOCK_ONLY_HIGH',
+        },
+      ],
     },
   },
   template


### PR DESCRIPTION
This fixes the bug reported in https://github.com/firebase/genkit/issues/422 where `renderPrompt` does not preserve the output schema that the prompt function returns.

This also fixes the bug reported in https://github.com/firebase/genkit/issues/757 where `Dotprompt.render()` only accepts default options. With this change, the `render` and `generate` methods will accept any options, unless a model is also passed in the method, in which case it requires the custom options defined by that model.
