### PR TITLE
[JS] Support multiple imagen models in VertexAI

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -43,11 +43,11 @@ import { gemini15Flash } from '@genkit-ai/vertexai';
 Genkit provides model support through its plugin system. The following plugins
 are officially supported:
 
-| Plugin                    | Models                                                                   |
-| ------------------------- | ------------------------------------------------------------------------ |
-| [Google Generative AI][1] | Gemini Pro, Gemini Pro Vision                                            |
-| [Google Vertex AI][2]     | Gemini Pro, Gemini Pro Vision, Gemini 1.5 Flash, Gemini 1.5 Pro, Imagen2 |
-| [Ollama][3]               | Many local models, including Gemma, Llama 2, Mistral, and more           |
+| Plugin                    | Models                                                                            |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| [Google Generative AI][1] | Gemini Pro, Gemini Pro Vision                                                     |
+| [Google Vertex AI][2]     | Gemini Pro, Gemini Pro Vision, Gemini 1.5 Flash, Gemini 1.5 Pro, Imagen2, Imagen3 |
+| [Ollama][3]               | Many local models, including Gemma, Llama 2, Mistral, and more                    |
 
 [1]: plugins/google-genai.md
 [2]: plugins/vertex-ai.md

--- a/js/plugins/vertexai/src/imagen.ts
+++ b/js/plugins/vertexai/src/imagen.ts
@@ -34,23 +34,40 @@ const ImagenConfigSchema = GenerationCommonConfigSchema.extend({
     .enum(['auto', 'en', 'es', 'hi', 'ja', 'ko', 'pt', 'zh-TW', 'zh', 'zh-CN'])
     .optional(),
   /** Desired aspect ratio of output image. */
-  aspectRatio: z.enum(['1:1', '9:16', '16:9']).optional(),
-  /** A negative prompt to help generate the images. For example: "animals" (removes animals), "blurry" (makes the image clearer), "text" (removes text), or "cropped" (removes cropped images). */
+  aspectRatio: z.enum(['1:1', '9:16', '16:9', '3:4', '4:3']).optional(),
+  /**
+   * A negative prompt to help generate the images. For example: "animals"
+   * (removes animals), "blurry" (makes the image clearer), "text" (removes
+   * text), or "cropped" (removes cropped images).
+   **/
   negativePrompt: z.string().optional(),
-  /** Any non-negative integer you provide to make output images deterministic. Providing the same seed number always results in the same output images. Accepted integer values: 1 - 2147483647. */
+  /**
+   * Any non-negative integer you provide to make output images deterministic.
+   * Providing the same seed number always results in the same output images.
+   * Accepted integer values: 1 - 2147483647.
+   **/
   seed: z.number().optional(),
+  /** Your GCP project's region. e.g.) us-central1, europe-west2, etc. **/
   location: z.string().optional(),
+  /** Allow generation of people by the model. */
+  personGeneration: z
+    .enum(['dont_allow', 'allow_adult', 'allow_all'])
+    .optional(),
+  /** Adds a filter level to safety filtering. */
+  safetySetting: z
+    .enum(['block_most', 'block_some', 'block_few', 'block_fewest'])
+    .optional(),
+  /** Add an invisible watermark to the generated images. */
+  addWatermark: z.boolean().optional(),
+  /** Cloud Storage URI to store the generated images. **/
+  storageUri: z.string().optional(),
 });
 
 export const imagen2 = modelRef({
   name: 'vertexai/imagen2',
   info: {
     label: 'Vertex AI - Imagen2',
-    versions: [
-      'imagegeneration@006',
-      'imagegeneration@005',
-      'imagegeneration@002',
-    ],
+    versions: ['imagegeneration@006', 'imagegeneration@005'],
     supports: {
       media: false,
       multiturn: false,
@@ -116,6 +133,10 @@ interface ImagenParameters {
   negativePrompt?: string;
   seed?: number;
   language?: string;
+  personGeneration?: string;
+  safetySetting?: string;
+  addWatermark?: boolean;
+  storageUri?: string;
 }
 
 function toParameters(
@@ -127,6 +148,10 @@ function toParameters(
     negativePrompt: request.config?.negativePrompt,
     seed: request.config?.seed,
     language: request.config?.language,
+    personGeneration: request.config?.personGeneration,
+    safetySetting: request.config?.safetySetting,
+    addWatermark: request.config?.addWatermark,
+    storageUri: request.config?.storageUri,
   };
 
   for (const k in out) {

--- a/js/plugins/vertexai/src/index.ts
+++ b/js/plugins/vertexai/src/index.ts
@@ -55,7 +55,13 @@ import {
   geminiPro,
   geminiProVision,
 } from './gemini.js';
-import { imagen2, imagen2Model } from './imagen.js';
+import {
+  SUPPORTED_IMAGEN_MODELS,
+  imagen2,
+  imagen3,
+  imagen3Fast,
+  imagenModel,
+} from './imagen.js';
 import {
   SUPPORTED_OPENAI_FORMAT_MODELS,
   llama3,
@@ -94,6 +100,8 @@ export {
   geminiPro,
   geminiProVision,
   imagen2,
+  imagen3,
+  imagen3Fast,
   llama3,
   llama31,
   textEmbedding004,
@@ -175,7 +183,9 @@ export const vertexAI: Plugin<[PluginOptions] | []> = genkitPlugin(
         : [];
 
     const models = [
-      imagen2Model(authClient, { projectId, location }),
+      ...Object.keys(SUPPORTED_IMAGEN_MODELS).map((name) =>
+        imagenModel(name, authClient, { projectId, location })
+      ),
       ...Object.keys(SUPPORTED_GEMINI_MODELS).map((name) =>
         geminiModel(name, vertexClientFactory, { projectId, location })
       ),


### PR DESCRIPTION
Also adds Imagen3 and Imagen3 Fast. Both are currently allowlist only - I'm still waiting access to try these specific models.

![image](https://github.com/user-attachments/assets/b7cf6d16-50af-4eed-85b9-90034313d79c)

Checklist (if applicable):
- [X] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [x] Docs updated
