### PR TITLE
Provide service account creds to gcloud from environment variables

### DIFF
--- a/docs/plugins/firebase.md
+++ b/docs/plugins/firebase.md
@@ -56,6 +56,8 @@ your Firebase project ID in either of the following ways:
   If you set `GCLOUD_PROJECT`, you can omit the configuration parameter:
   `firebase()`
 
+### Credentials
+
 To provide Firebase credentials, you also need to set up Google Cloud
 Application Default Credentials. To specify your credentials:
 
@@ -69,7 +71,7 @@ Application Default Credentials. To specify your credentials:
       [Service account](https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk)
       page of the Firebase console.
   1.  Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the file
-      path of the JSON file that contains your service account key.
+      path of the JSON file that contains your service account key, or you can set the environment variable `GCLOUD_SERVICE_ACCOUNT` to the content of the JSON file.
 
 ### Telemetry
 
@@ -106,6 +108,26 @@ This section contains information specific to the `firebase` plugin and Cloud
 Firestore's vector search feature.
 See the [Retrieval-augmented generation](../rag.md) page for a more detailed
 discussion on implementing RAG using Genkit.
+
+#### Using GCLOUD_SERVICE_ACCOUNT and Firestore 
+
+If you are using service account credentials by passing credentials directly via `GCLOUD_SERVICE_ACCOUNT` and are also using Firestore as a vector store, you will need to pass credentials directly to the Firestore instance during initialization or the singleton may be initialized with application default credentials depending on plugin initialization order.
+
+```
+import {initializeApp} from "firebase-admin/app";
+import {getFirestore} from "firebase-admin/firestore";
+
+const app = initializeApp();
+let firestore = getFirestore(app);
+
+if (process.env.GCLOUD_SERVICE_ACCOUNT) {
+  const serviceAccountCreds = JSON.parse(process.env.GCLOUD_SERVICE_ACCOUNT);
+  const authOptions = { credentials: serviceAccountCreds };
+  firestore.settings(authOptions);
+}
+```
+
+#### Retrievers
 
 The `firebase` plugin provides a convenience function for defining Firestore
 retrievers, `defineFirestoreRetriever()`:
@@ -150,6 +172,8 @@ Available retrieval options include:
 - `limit`: Specify the number of matching results to return.
 - `where`: Field/value pairs to match (e.g. `{category: 'food'}`) in addition to vector search.
 - `collection`: Override the default collection to search for e.g. subcollection search.
+
+#### Indexing and Embedding
 
 To populate your Firestore collection, use an embedding generator along with the
 Admin SDK. For example, the menu ingestion script from the

--- a/docs/plugins/firebase.md
+++ b/docs/plugins/firebase.md
@@ -71,7 +71,7 @@ Application Default Credentials. To specify your credentials:
       [Service account](https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk)
       page of the Firebase console.
   1.  Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the file
-      path of the JSON file that contains your service account key, or you can set the environment variable `GCLOUD_SERVICE_ACCOUNT` to the content of the JSON file.
+      path of the JSON file that contains your service account key, or you can set the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDS` to the content of the JSON file.
 
 ### Telemetry
 
@@ -109,9 +109,9 @@ Firestore's vector search feature.
 See the [Retrieval-augmented generation](../rag.md) page for a more detailed
 discussion on implementing RAG using Genkit.
 
-#### Using GCLOUD_SERVICE_ACCOUNT and Firestore 
+#### Using GCLOUD_SERVICE_ACCOUNT_CREDS and Firestore 
 
-If you are using service account credentials by passing credentials directly via `GCLOUD_SERVICE_ACCOUNT` and are also using Firestore as a vector store, you will need to pass credentials directly to the Firestore instance during initialization or the singleton may be initialized with application default credentials depending on plugin initialization order.
+If you are using service account credentials by passing credentials directly via `GCLOUD_SERVICE_ACCOUNT_CREDS` and are also using Firestore as a vector store, you will need to pass credentials directly to the Firestore instance during initialization or the singleton may be initialized with application default credentials depending on plugin initialization order.
 
 ```
 import {initializeApp} from "firebase-admin/app";
@@ -120,8 +120,8 @@ import {getFirestore} from "firebase-admin/firestore";
 const app = initializeApp();
 let firestore = getFirestore(app);
 
-if (process.env.GCLOUD_SERVICE_ACCOUNT) {
-  const serviceAccountCreds = JSON.parse(process.env.GCLOUD_SERVICE_ACCOUNT);
+if (process.env.GCLOUD_SERVICE_ACCOUNT_CREDS) {
+  const serviceAccountCreds = JSON.parse(process.env.GCLOUD_SERVICE_ACCOUNT_CREDS);
   const authOptions = { credentials: serviceAccountCreds };
   firestore.settings(authOptions);
 }

--- a/docs/plugins/google-cloud.md
+++ b/docs/plugins/google-cloud.md
@@ -47,13 +47,48 @@ export default configureGenkit({
 
 When running in production, your telemetry gets automatically exported.
 
-The plugin requires the Google Cloud project ID and your Google Cloud project credentials. If you're running your flow from a Google Cloud environment (Cloud Functions, Cloud Run, etc), the project ID and credentials are set automatically. Running in other environments requires setting the `GCLOUD_PROJECT` environment variable to your Google Cloud project and authenticating using the `gcloud` tool:
+### Authentication
+
+The plugin requires the Google Cloud project ID and your Google Cloud project credentials. If you're running your flow from a Google Cloud environment (Cloud Functions, Cloud Run, etc), the project ID and credentials are set automatically. 
+
+#### Application Default Credentials
+
+Running in other environments requires setting the `GCLOUD_PROJECT` environment variable to your Google Cloud project and authenticating using the `gcloud` tool:
 
 ```posix-terminal
 gcloud auth application-default login
 ```
 
 For more information, see the [Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc) docs.
+
+#### Service Account Credentials
+
+If you are using a service account and running outside of a Google Cloud environment, you can set your credentials as an environment variable. Follow instructions here to [set up your Google Cloud Service Account Key](https://cloud.google.com/iam/docs/keys-create-delete#creating).
+
+Once you have downloaded the key file, you can specify the credentials in two ways a file location using the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or directly copy the contents of the json file to the environment variable `GCLOUD_SERVICE_ACCOUNT`.
+
+File path:
+
+```
+GOOGLE_APPLICATION_CREDENTIALS = "path/to/your/key/file"
+```
+
+Direct copy:
+
+```
+GCLOUD_SERVICE_ACCOUNT='{
+  "type": "service_account",
+  "project_id": "your-project-id",
+  "private_key_id": "your-private-key-id",
+  "private_key": "your-private-key",
+  "client_email": "your-client-email",
+  "client_id": "your-client-id",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "your-cert-url"
+}'
+```
 
 ## Plugin configuration
 

--- a/docs/plugins/google-cloud.md
+++ b/docs/plugins/google-cloud.md
@@ -65,7 +65,7 @@ For more information, see the [Application Default Credentials](https://cloud.go
 
 If you are using a service account and running outside of a Google Cloud environment, you can set your credentials as an environment variable. Follow instructions here to [set up your Google Cloud Service Account Key](https://cloud.google.com/iam/docs/keys-create-delete#creating).
 
-Once you have downloaded the key file, you can specify the credentials in two ways a file location using the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or directly copy the contents of the json file to the environment variable `GCLOUD_SERVICE_ACCOUNT`.
+Once you have downloaded the key file, you can specify the credentials in two ways a file location using the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or directly copy the contents of the json file to the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDS`.
 
 File path:
 
@@ -76,7 +76,7 @@ GOOGLE_APPLICATION_CREDENTIALS = "path/to/your/key/file"
 Direct copy:
 
 ```
-GCLOUD_SERVICE_ACCOUNT='{
+GCLOUD_SERVICE_ACCOUNT_CREDS='{
   "type": "service_account",
   "project_id": "your-project-id",
   "private_key_id": "your-private-key-id",

--- a/js/flow/src/firestoreStateStore.ts
+++ b/js/flow/src/firestoreStateStore.ts
@@ -24,6 +24,12 @@ import {
 import { logger } from '@genkit-ai/core/logging';
 import { Firestore } from '@google-cloud/firestore';
 
+/** Allow customers to set service account credentials via an environment variable. */
+interface Credentials {
+  client_email?: string;
+  private_key?: string;
+}
+
 /**
  * Implementation of flow state store that persistes flow state in Firestore.
  */
@@ -37,6 +43,7 @@ export class FirestoreStateStore implements FlowStateStore {
       collection?: string;
       databaseId?: string;
       projectId?: string;
+      credentials?: Credentials;
     } = {}
   ) {
     this.collection = params.collection || 'genkit-flows';
@@ -44,6 +51,7 @@ export class FirestoreStateStore implements FlowStateStore {
     this.db = new Firestore({
       databaseId: this.databaseId,
       ignoreUndefinedProperties: true,
+      credentials: params.credentials,
     });
   }
 

--- a/js/plugins/firebase/src/firestoreTraceStore.ts
+++ b/js/plugins/firebase/src/firestoreTraceStore.ts
@@ -29,6 +29,12 @@ import { randomUUID } from 'crypto';
 
 const DOC_MAX_SIZE = 1_000_000;
 
+/** Allow customers to set service account credentials via an environment variable. */
+interface Credentials {
+  client_email?: string;
+  private_key?: string;
+}
+
 /**
  * Firestore implementation of a trace store.
  */
@@ -44,6 +50,7 @@ export class FirestoreTraceStore implements TraceStore {
       databaseId?: string;
       projectId?: string;
       expireAfterDays?: number;
+      credentials?: Credentials;
     } = {}
   ) {
     this.collection = params.collection || 'genkit-traces';
@@ -52,6 +59,7 @@ export class FirestoreTraceStore implements TraceStore {
     this.db = new Firestore({
       databaseId: this.databaseId,
       ignoreUndefinedProperties: true,
+      credentials: params.credentials,
     });
   }
 

--- a/js/plugins/firebase/src/index.ts
+++ b/js/plugins/firebase/src/index.ts
@@ -42,24 +42,24 @@ interface FirestorePluginParams {
 export const firebase: Plugin<[FirestorePluginParams] | []> = genkitPlugin(
   'firebase',
   async (params?: FirestorePluginParams) => {
-    let projectId;
+    let authClient;
     let credentials;
 
     // Allow customers to pass in cloud credentials from environment variables
     // following: https://github.com/googleapis/google-auth-library-nodejs?tab=readme-ov-file#loading-credentials-from-environment-variables
-    if (process.env.GCLOUD_SERVICE_ACCOUNT) {
+    if (process.env.GCLOUD_SERVICE_ACCOUNT_CREDS) {
       const serviceAccountCreds = JSON.parse(
-        process.env.GCLOUD_SERVICE_ACCOUNT
+        process.env.GCLOUD_SERVICE_ACCOUNT_CREDS
       );
       const authOptions = { credentials: serviceAccountCreds };
-      const authClient = new GoogleAuth(authOptions);
+      authClient = new GoogleAuth(authOptions);
 
-      projectId = await authClient.getProjectId();
       credentials = await authClient.getCredentials();
     } else {
-      const authClient = new GoogleAuth();
-      projectId = params?.projectId || (await getProjectId(authClient));
+      authClient = new GoogleAuth();
     }
+
+    const projectId = params?.projectId || (await authClient.getProjectId());
 
     const gcpOptions = {
       projectId,

--- a/js/plugins/google-cloud/package.json
+++ b/js/plugins/google-cloud/package.json
@@ -48,7 +48,8 @@
     "google-auth-library": "^9.6.3",
     "node-fetch": "^3.3.2",
     "prettier-plugin-organize-imports": "^3.2.4",
-    "winston": "^3.12.0"
+    "winston": "^3.12.0",
+    "zod": "^3.22.4"
   },
   "peerDependencies": {
     "@genkit-ai/ai": "workspace:*",

--- a/js/plugins/google-cloud/src/gcpLogger.ts
+++ b/js/plugins/google-cloud/src/gcpLogger.ts
@@ -58,6 +58,7 @@ export class GcpLogger implements LoggerConfig {
             labels: { module: 'genkit' },
             prefix: 'genkit',
             logName: 'genkit_log',
+            credentials: this.options.credentials,
           })
         : new winston.transports.Console()
     );
@@ -66,7 +67,6 @@ export class GcpLogger implements LoggerConfig {
         new winston.transports.Stream({ stream: additionalStream })
       );
     }
-
     return winston.createLogger({
       transports: transports,
       ...format,

--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -90,7 +90,9 @@ export class GcpOpenTelemetry implements TelemetryConfig {
   private createSpanExporter(): SpanExporter {
     spanExporter = new AdjustingTraceExporter(
       this.shouldExportTraces()
-        ? new TraceExporter()
+        ? new TraceExporter({
+            credentials: this.options.credentials,
+          })
         : new InMemorySpanExporter()
     );
     return spanExporter;
@@ -152,6 +154,7 @@ export class GcpOpenTelemetry implements TelemetryConfig {
             product: 'genkit',
             version: GENKIT_VERSION,
           },
+          credentials: this.options.credentials,
         })
       : new InMemoryMetricExporter(AggregationTemporality.DELTA);
     exporter.selectAggregation = (instrumentType: InstrumentType) => {

--- a/js/plugins/google-cloud/src/index.ts
+++ b/js/plugins/google-cloud/src/index.ts
@@ -18,13 +18,14 @@ import { genkitPlugin, Plugin } from '@genkit-ai/core';
 import { InstrumentationConfigMap } from '@opentelemetry/auto-instrumentations-node';
 import { Instrumentation } from '@opentelemetry/instrumentation';
 import { Sampler } from '@opentelemetry/sdk-trace-base';
-import { GoogleAuth } from 'google-auth-library';
+import { GoogleAuth, JWTInput } from 'google-auth-library';
 import { GcpLogger } from './gcpLogger.js';
 import { GcpOpenTelemetry } from './gcpOpenTelemetry.js';
 
 export interface PluginOptions {
   projectId?: string;
   telemetryConfig?: TelemetryConfig;
+  credentials?: JWTInput;
 }
 
 export interface TelemetryConfig {
@@ -51,22 +52,40 @@ export interface TelemetryConfig {
 export const googleCloud: Plugin<[PluginOptions] | []> = genkitPlugin(
   'googleCloud',
   async (options?: PluginOptions) => {
-    const authClient = new GoogleAuth();
-    const projectId = options?.projectId || (await authClient.getProjectId());
-    const optionsWithProjectId = {
+    let projectId;
+    let credentials;
+
+    // Allow customers to pass in cloud credentials from environment variables
+    // following: https://github.com/googleapis/google-auth-library-nodejs?tab=readme-ov-file#loading-credentials-from-environment-variables
+    if (process.env.GCLOUD_SERVICE_ACCOUNT) {
+      const serviceAccountCreds = JSON.parse(
+        process.env.GCLOUD_SERVICE_ACCOUNT
+      );
+      const authOptions = { credentials: serviceAccountCreds };
+      const authClient = new GoogleAuth(authOptions);
+
+      projectId = await authClient.getProjectId();
+      credentials = await authClient.getCredentials();
+    } else {
+      const authClient = new GoogleAuth();
+      projectId = options?.projectId || (await authClient.getProjectId());
+    }
+
+    const optionsWithProjectIdAndCreds = {
       ...options,
       projectId,
+      credentials,
     };
 
     return {
       telemetry: {
         instrumentation: {
           id: 'googleCloud',
-          value: new GcpOpenTelemetry(optionsWithProjectId),
+          value: new GcpOpenTelemetry(optionsWithProjectIdAndCreds),
         },
         logger: {
           id: 'googleCloud',
-          value: new GcpLogger(optionsWithProjectId),
+          value: new GcpLogger(optionsWithProjectIdAndCreds),
         },
       },
     };

--- a/js/plugins/google-cloud/src/index.ts
+++ b/js/plugins/google-cloud/src/index.ts
@@ -52,24 +52,24 @@ export interface TelemetryConfig {
 export const googleCloud: Plugin<[PluginOptions] | []> = genkitPlugin(
   'googleCloud',
   async (options?: PluginOptions) => {
-    let projectId;
+    let authClient;
     let credentials;
 
     // Allow customers to pass in cloud credentials from environment variables
     // following: https://github.com/googleapis/google-auth-library-nodejs?tab=readme-ov-file#loading-credentials-from-environment-variables
-    if (process.env.GCLOUD_SERVICE_ACCOUNT) {
+    if (process.env.GCLOUD_SERVICE_ACCOUNT_CREDS) {
       const serviceAccountCreds = JSON.parse(
-        process.env.GCLOUD_SERVICE_ACCOUNT
+        process.env.GCLOUD_SERVICE_ACCOUNT_CREDS
       );
       const authOptions = { credentials: serviceAccountCreds };
-      const authClient = new GoogleAuth(authOptions);
+      authClient = new GoogleAuth(authOptions);
 
-      projectId = await authClient.getProjectId();
       credentials = await authClient.getCredentials();
     } else {
-      const authClient = new GoogleAuth();
-      projectId = options?.projectId || (await authClient.getProjectId());
+      authClient = new GoogleAuth();
     }
+
+    const projectId = options?.projectId || (await authClient.getProjectId());
 
     const optionsWithProjectIdAndCreds = {
       ...options,

--- a/js/plugins/vertexai/src/index.ts
+++ b/js/plugins/vertexai/src/index.ts
@@ -142,9 +142,9 @@ export const vertexAI: Plugin<[PluginOptions] | []> = genkitPlugin(
 
     // Allow customers to pass in cloud credentials from environment variables
     // following: https://github.com/googleapis/google-auth-library-nodejs?tab=readme-ov-file#loading-credentials-from-environment-variables
-    if (process.env.GCLOUD_SERVICE_ACCOUNT) {
+    if (process.env.GCLOUD_SERVICE_ACCOUNT_CREDS) {
       const serviceAccountCreds = JSON.parse(
-        process.env.GCLOUD_SERVICE_ACCOUNT
+        process.env.GCLOUD_SERVICE_ACCOUNT_CREDS
       );
       authOptions = {
         credentials: serviceAccountCreds,

--- a/js/plugins/vertexai/src/index.ts
+++ b/js/plugins/vertexai/src/index.ts
@@ -137,9 +137,26 @@ const CLOUD_PLATFROM_OAUTH_SCOPE =
 export const vertexAI: Plugin<[PluginOptions] | []> = genkitPlugin(
   'vertexai',
   async (options?: PluginOptions) => {
-    const authClient = new GoogleAuth(
-      options?.googleAuth ?? { scopes: [CLOUD_PLATFROM_OAUTH_SCOPE] }
-    );
+    let authClient;
+    let authOptions = options?.googleAuth;
+
+    // Allow customers to pass in cloud credentials from environment variables
+    // following: https://github.com/googleapis/google-auth-library-nodejs?tab=readme-ov-file#loading-credentials-from-environment-variables
+    if (process.env.GCLOUD_SERVICE_ACCOUNT) {
+      const serviceAccountCreds = JSON.parse(
+        process.env.GCLOUD_SERVICE_ACCOUNT
+      );
+      authOptions = {
+        credentials: serviceAccountCreds,
+        scopes: [CLOUD_PLATFROM_OAUTH_SCOPE],
+      };
+      authClient = new GoogleAuth(authOptions);
+    } else {
+      authClient = new GoogleAuth(
+        authOptions ?? { scopes: [CLOUD_PLATFROM_OAUTH_SCOPE] }
+      );
+    }
+
     const projectId = options?.projectId || (await authClient.getProjectId());
 
     const location = options?.location || 'us-central1';
@@ -164,7 +181,7 @@ export const vertexAI: Plugin<[PluginOptions] | []> = genkitPlugin(
         vertexClientFactoryCache[requestLocation] = new VertexAI({
           project: projectId,
           location: requestLocation,
-          googleAuthOptions: options?.googleAuth,
+          googleAuthOptions: authOptions,
         });
       }
       return vertexClientFactoryCache[requestLocation];

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -436,6 +436,9 @@ importers:
       winston:
         specifier: ^3.12.0
         version: 3.13.0
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
     devDependencies:
       '@types/node':
         specifier: ^20.11.16
@@ -503,7 +506,7 @@ importers:
         version: link:../../flow
       '@langchain/community':
         specifier: ^0.0.53
-        version: 0.0.53(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(firebase-admin@12.2.0(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(jsonwebtoken@9.0.2)
+        version: 0.0.53(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(firebase-admin@12.3.1(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(jsonwebtoken@9.0.2)
       '@langchain/core':
         specifier: ^0.1.61
         version: 0.1.61
@@ -512,7 +515,7 @@ importers:
         version: 1.9.0
       langchain:
         specifier: ^0.1.36
-        version: 0.1.36(@google-cloud/storage@7.10.1(encoding@0.1.13))(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(fast-xml-parser@4.3.6)(firebase-admin@12.2.0(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(handlebars@4.7.8)(ignore@5.3.1)(jsonwebtoken@9.0.2)(pdf-parse@1.1.1)
+        version: 0.1.36(@google-cloud/storage@7.10.1(encoding@0.1.13))(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(fast-xml-parser@4.3.6)(firebase-admin@12.3.1(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(handlebars@4.7.8)(ignore@5.3.1)(jsonwebtoken@9.0.2)(pdf-parse@1.1.1)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -754,12 +757,24 @@ importers:
       '@genkit-ai/vertexai':
         specifier: workspace:*
         version: link:../../plugins/vertexai
+      '@google-cloud/firestore':
+        specifier: ^7.9.0
+        version: 7.9.0(encoding@0.1.13)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.22.0
+        version: 1.25.1(@opentelemetry/api@1.9.0)
+      firebase-admin:
+        specifier: ^12.3.0
+        version: 12.3.1(encoding@0.1.13)
       genkitx-pinecone:
         specifier: workspace:*
         version: link:../../plugins/pinecone
       llm-chunk:
         specifier: ^0.0.1
         version: 0.0.1
+      pdf-parse:
+        specifier: ^1.1.1
+        version: 1.1.1
       pdfjs-dist:
         specifier: ^4.0.379
         version: 4.2.67(encoding@0.1.13)
@@ -770,6 +785,9 @@ importers:
         specifier: ^3.22.4
         version: 3.22.4
     devDependencies:
+      '@types/pdf-parse':
+        specifier: ^1.1.4
+        version: 1.1.4
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -1108,7 +1126,7 @@ importers:
         version: link:../../plugins/vertexai
       '@langchain/community':
         specifier: ^0.0.53
-        version: 0.0.53(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(firebase-admin@12.2.0(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(jsonwebtoken@9.0.2)
+        version: 0.0.53(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(firebase-admin@12.3.1(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(jsonwebtoken@9.0.2)
       '@langchain/core':
         specifier: ^0.1.61
         version: 0.1.61
@@ -1126,7 +1144,7 @@ importers:
         version: link:../../plugins/ollama
       langchain:
         specifier: ^0.1.36
-        version: 0.1.36(@google-cloud/storage@7.10.1(encoding@0.1.13))(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(fast-xml-parser@4.3.6)(firebase-admin@12.2.0(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(handlebars@4.7.8)(ignore@5.3.1)(jsonwebtoken@9.0.2)(pdf-parse@1.1.1)
+        version: 0.1.36(@google-cloud/storage@7.10.1(encoding@0.1.13))(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(fast-xml-parser@4.3.6)(firebase-admin@12.3.1(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(handlebars@4.7.8)(ignore@5.3.1)(jsonwebtoken@9.0.2)(pdf-parse@1.1.1)
       pdf-parse:
         specifier: ^1.1.1
         version: 1.1.1
@@ -1623,6 +1641,9 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
+  '@fastify/busboy@3.0.0':
+    resolution: {integrity: sha512-83rnH2nCvclWaPQQKvkJ2pdOjG4TZyEVuFDnlOF6KP08lDaaceVyw/W63mDuafQT+MKHCvXIPpE5uYWeM0rT4w==}
+
   '@firebase/app-check-interop-types@0.3.1':
     resolution: {integrity: sha512-NILZbe6RH3X1pZmJnfOfY2gLIrlKmrkUMMrrK6VSXHcSE0eQv28xFEcw16D198i9JYZpy5Kwq394My62qCMaIw==}
 
@@ -1668,6 +1689,10 @@ packages:
 
   '@google-cloud/firestore@7.8.0':
     resolution: {integrity: sha512-m21BWVZLz7H7NF8HZ5hCGUSCEJKNwYB5yzQqDTuE9YUzNDRMDei3BwVDht5k4xF636sGlnobyBL+dcbthSGONg==}
+    engines: {node: '>=14.0.0'}
+
+  '@google-cloud/firestore@7.9.0':
+    resolution: {integrity: sha512-c4ALHT3G08rV7Zwv8Z2KG63gZh66iKdhCBeDfCpIkLrjX6EAjTD/szMdj14M+FnQuClZLFfW5bAgoOjfNmLtJg==}
     engines: {node: '>=14.0.0'}
 
   '@google-cloud/logging-winston@6.0.0':
@@ -2703,6 +2728,9 @@ packages:
   '@types/node@20.11.30':
     resolution: {integrity: sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==}
 
+  '@types/node@22.4.1':
+    resolution: {integrity: sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==}
+
   '@types/pdf-parse@1.1.4':
     resolution: {integrity: sha512-+gbBHbNCVGGYw1S9lAIIvrHW47UYOhMIFUsJcMkMrzy1Jf0vulBN3XQIjPgnoOXveMuHnF3b57fXROnY/Or7eg==}
 
@@ -3356,6 +3384,10 @@ packages:
 
   firebase-admin@12.2.0:
     resolution: {integrity: sha512-R9xxENvPA/19XJ3mv0Kxfbz9kPXd9/HrM4083LZWOO0qAQGheRzcCQamYRe+JSrV2cdKXP3ZsfFGTYMrFM0pJg==}
+    engines: {node: '>=14'}
+
+  firebase-admin@12.3.1:
+    resolution: {integrity: sha512-vEr3s3esl8nPIA9r/feDT4nzIXCfov1CyyCSpMQWp6x63Q104qke0MEGZlrHUZVROtl8FLus6niP/M9I1s4VBA==}
     engines: {node: '>=14'}
 
   firebase-functions@4.8.1:
@@ -5015,6 +5047,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -5295,6 +5330,8 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
+  '@fastify/busboy@3.0.0': {}
+
   '@firebase/app-check-interop-types@0.3.1': {}
 
   '@firebase/app-types@0.9.1': {}
@@ -5398,6 +5435,16 @@ snapshots:
       - encoding
       - supports-color
     optional: true
+
+  '@google-cloud/firestore@7.9.0(encoding@0.1.13)':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      functional-red-black-tree: 1.0.1
+      google-gax: 4.3.7(encoding@0.1.13)
+      protobufjs: 7.3.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@google-cloud/logging-winston@6.0.0(encoding@0.1.13)(winston@3.13.0)':
     dependencies:
@@ -5580,7 +5627,7 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@langchain/community@0.0.53(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(firebase-admin@12.2.0(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(jsonwebtoken@9.0.2)':
+  '@langchain/community@0.0.53(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(firebase-admin@12.3.1(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(jsonwebtoken@9.0.2)':
     dependencies:
       '@langchain/core': 0.1.61
       '@langchain/openai': 0.0.28(encoding@0.1.13)
@@ -5593,7 +5640,7 @@ snapshots:
     optionalDependencies:
       '@pinecone-database/pinecone': 2.2.0
       chromadb: 1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13))
-      firebase-admin: 12.2.0(encoding@0.1.13)
+      firebase-admin: 12.3.1(encoding@0.1.13)
       google-auth-library: 8.9.0(encoding@0.1.13)
       jsonwebtoken: 9.0.2
     transitivePeerDependencies:
@@ -6422,6 +6469,10 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@22.4.1':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/pdf-parse@1.1.4': {}
 
   '@types/pg-pool@2.0.4':
@@ -7222,6 +7273,24 @@ snapshots:
       - encoding
       - supports-color
 
+  firebase-admin@12.3.1(encoding@0.1.13):
+    dependencies:
+      '@fastify/busboy': 3.0.0
+      '@firebase/database-compat': 1.0.4
+      '@firebase/database-types': 1.0.2
+      '@types/node': 22.4.1
+      farmhash-modern: 1.1.0
+      jsonwebtoken: 9.0.2
+      jwks-rsa: 3.1.0
+      node-forge: 1.3.1
+      uuid: 10.0.0
+    optionalDependencies:
+      '@google-cloud/firestore': 7.9.0(encoding@0.1.13)
+      '@google-cloud/storage': 7.10.1(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   firebase-functions@4.8.1(encoding@0.1.13)(firebase-admin@12.2.0(encoding@0.1.13)):
     dependencies:
       '@types/cors': 2.8.17
@@ -7918,10 +7987,10 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  langchain@0.1.36(@google-cloud/storage@7.10.1(encoding@0.1.13))(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(fast-xml-parser@4.3.6)(firebase-admin@12.2.0(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(handlebars@4.7.8)(ignore@5.3.1)(jsonwebtoken@9.0.2)(pdf-parse@1.1.1):
+  langchain@0.1.36(@google-cloud/storage@7.10.1(encoding@0.1.13))(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(fast-xml-parser@4.3.6)(firebase-admin@12.3.1(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(handlebars@4.7.8)(ignore@5.3.1)(jsonwebtoken@9.0.2)(pdf-parse@1.1.1):
     dependencies:
       '@anthropic-ai/sdk': 0.9.1(encoding@0.1.13)
-      '@langchain/community': 0.0.53(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(firebase-admin@12.2.0(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(jsonwebtoken@9.0.2)
+      '@langchain/community': 0.0.53(@pinecone-database/pinecone@2.2.0)(chromadb@1.8.1(encoding@0.1.13)(openai@4.53.0(encoding@0.1.13)))(encoding@0.1.13)(firebase-admin@12.3.1(encoding@0.1.13))(google-auth-library@8.9.0(encoding@0.1.13))(jsonwebtoken@9.0.2)
       '@langchain/core': 0.1.61
       '@langchain/openai': 0.0.28(encoding@0.1.13)
       '@langchain/textsplitters': 0.0.0
@@ -9055,6 +9124,8 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   undici-types@5.26.5: {}
+
+  undici-types@6.19.8: {}
 
   unpipe@1.0.0: {}
 

--- a/js/testapps/cat-eval/package.json
+++ b/js/testapps/cat-eval/package.json
@@ -23,13 +23,18 @@
     "@genkit-ai/flow": "workspace:*",
     "@genkit-ai/googleai": "workspace:*",
     "@genkit-ai/vertexai": "workspace:*",
+    "@google-cloud/firestore": "^7.9.0",
+    "@opentelemetry/sdk-trace-base": "^1.22.0",
+    "firebase-admin": "^12.3.0",
     "genkitx-pinecone": "workspace:*",
     "llm-chunk": "^0.0.1",
+    "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^4.0.379",
     "pdfjs-dist-legacy": "^1.0.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/pdf-parse": "^1.1.4",
     "typescript": "^5.3.3"
   }
 }

--- a/js/testapps/cat-eval/src/pdf_rag_firebase.ts
+++ b/js/testapps/cat-eval/src/pdf_rag_firebase.ts
@@ -63,7 +63,7 @@ Helpful Answer:`;
 export const pdfChatRetrieverFirebase = defineFirestoreRetriever({
   name: 'pdfChatRetrieverFirebase',
   firestore,
-  collection: 'pdfQA',
+  collection: 'pdf-qa',
   contentField: 'facts',
   vectorField: 'embedding',
   embedder: textEmbeddingGecko,

--- a/js/testapps/cat-eval/src/pdf_rag_firebase.ts
+++ b/js/testapps/cat-eval/src/pdf_rag_firebase.ts
@@ -38,9 +38,11 @@ let firestore = getFirestore(app);
 // There's a race condition in initializing the Firestore singleton.
 // To avoid that, explicitly create an instance using the service account
 // from the environment variable.
-if (process.env.GCLOUD_SERVICE_ACCOUNT) {
+if (process.env.GCLOUD_SERVICE_ACCOUNT_CREDS) {
   console.log(`Using service account credentials.`);
-  const serviceAccountCreds = JSON.parse(process.env.GCLOUD_SERVICE_ACCOUNT);
+  const serviceAccountCreds = JSON.parse(
+    process.env.GCLOUD_SERVICE_ACCOUNT_CREDS
+  );
   const authOptions = { credentials: serviceAccountCreds };
   firestore.settings(authOptions);
 }

--- a/js/testapps/cat-eval/src/pdf_rag_firebase.ts
+++ b/js/testapps/cat-eval/src/pdf_rag_firebase.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { generate } from '@genkit-ai/ai';
+import { retrieve } from '@genkit-ai/ai/retriever';
+import { defineFirestoreRetriever } from '@genkit-ai/firebase';
+import { defineFlow, run } from '@genkit-ai/flow';
+import { geminiPro } from '@genkit-ai/googleai';
+import { initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { readFile } from 'fs/promises';
+import { chunk } from 'llm-chunk';
+import path from 'path';
+
+import pdf from 'pdf-parse';
+
+import { embed } from '@genkit-ai/ai/embedder';
+import { textEmbeddingGecko } from '@genkit-ai/vertexai';
+import { FieldValue } from '@google-cloud/firestore';
+import * as z from 'zod';
+
+const app = initializeApp();
+let firestore = getFirestore(app);
+
+// There's a race condition in initializing the Firestore singleton.
+// To avoid that, explicitly create an instance using the service account
+// from the environment variable.
+if (process.env.GCLOUD_SERVICE_ACCOUNT) {
+  console.log(`Using service account credentials.`);
+  const serviceAccountCreds = JSON.parse(process.env.GCLOUD_SERVICE_ACCOUNT);
+  const authOptions = { credentials: serviceAccountCreds };
+  firestore.settings(authOptions);
+}
+
+function ragTemplate({
+  context,
+  question,
+}: {
+  context: string;
+  question: string;
+}) {
+  return `Use the following pieces of context to answer the question at the end.
+ If you don't know the answer, just say that you don't know, don't try to make up an answer.
+
+${context}
+Question: ${question}
+Helpful Answer:`;
+}
+
+export const pdfChatRetrieverFirebase = defineFirestoreRetriever({
+  name: 'pdfChatRetrieverFirebase',
+  firestore,
+  collection: 'pdfQA',
+  contentField: 'facts',
+  vectorField: 'embedding',
+  embedder: textEmbeddingGecko,
+  distanceMeasure: 'COSINE',
+});
+
+// Define a simple RAG flow, we will evaluate this flow
+export const pdfQAFirebase = defineFlow(
+  {
+    name: 'pdfQAFirebase',
+    inputSchema: z.string(),
+    outputSchema: z.string(),
+  },
+  async (query) => {
+    const docs = await retrieve({
+      retriever: pdfChatRetrieverFirebase,
+      query,
+      options: { limit: 3 },
+    });
+    console.log(docs);
+
+    const augmentedPrompt = ragTemplate({
+      question: query,
+      context: docs.map((d) => d.text()).join('\n\n'),
+    });
+    const llmResponse = await generate({
+      model: geminiPro,
+      prompt: augmentedPrompt,
+    });
+    return llmResponse.text();
+  }
+);
+
+// Firebase index config for pdfQA flow
+const indexConfig = {
+  collection: 'pdf-qa',
+  contentField: 'facts',
+  vectorField: 'embedding',
+  embedder: textEmbeddingGecko,
+};
+
+const chunkingConfig = {
+  minLength: 1000, // number of minimum characters into chunk
+  maxLength: 2000, // number of maximum characters into chunk
+  splitter: 'sentence', // paragraph | sentence
+  overlap: 100, // number of overlap chracters
+  delimiters: '', // regex for base split method
+} as any;
+
+// Define a flow to index documents into the "vector store"
+// genkit flow:run indexPdf '"./docs/sfspca-cat-adoption-handbook-2023.pdf"'
+export const indexPdfFirebase = defineFlow(
+  {
+    name: 'indexPdfFirestore',
+    inputSchema: z.string().describe('PDF file path'),
+  },
+  async (filePath) => {
+    filePath = path.resolve(filePath);
+    const pdfTxt = await run('extract-text', () =>
+      extractTextFromPdf(filePath)
+    );
+
+    const chunks = await run('chunk-it', async () =>
+      chunk(pdfTxt, chunkingConfig)
+    );
+
+    // Add chunks to the index.
+    await run('index-chunks', async () => indexToFirestore(chunks));
+  }
+);
+
+async function indexToFirestore(data: string[]) {
+  for (const text of data) {
+    const embedding = await embed({
+      embedder: indexConfig.embedder,
+      content: text,
+    });
+    await firestore.collection(indexConfig.collection).add({
+      [indexConfig.vectorField]: FieldValue.vector(embedding),
+      [indexConfig.contentField]: text,
+    });
+    // await firestore.collection(indexConfig.collection).add({ 'a': 'b' });
+  }
+}
+
+async function extractTextFromPdf(filePath: string) {
+  const pdfFile = path.resolve(filePath);
+  const dataBuffer = await readFile(pdfFile);
+  const data = await pdf(dataBuffer);
+  return data.text;
+}

--- a/js/testapps/cat-eval/src/setup.ts
+++ b/js/testapps/cat-eval/src/setup.ts
@@ -17,6 +17,7 @@
 import { defineFlow, runFlow } from '@genkit-ai/flow';
 import * as z from 'zod';
 import { indexPdf } from './pdf_rag.js';
+import { indexPdfFirebase } from './pdf_rag_firebase.js';
 
 const catFacts = ['./docs/sfspca-cat-adoption-handbook-2023.pdf'];
 
@@ -38,6 +39,26 @@ export const setup = defineFlow(
       documentArr.map(async (document) => {
         console.log(`Indexed ${document}`);
         return runFlow(indexPdf, document);
+      })
+    );
+  }
+);
+
+export const setupFirebase = defineFlow(
+  {
+    name: 'setupFirebase',
+    inputSchema: z.array(z.string()).optional(),
+  },
+  async (documentArr) => {
+    if (!documentArr) {
+      documentArr = catFacts;
+    } else {
+      documentArr.concat(catFacts);
+    }
+
+    await Promise.all(
+      documentArr.map(async (document) => {
+        return runFlow(indexPdfFirebase, document);
       })
     );
   }


### PR DESCRIPTION
Allow customers to pass Google Service Account credentials directly via an environment variable following https://github.com/googleapis/google-auth-library-nodejs?tab=readme-ov-file#loading-credentials-from-environment-variables

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
   Updated the cat-eval example to validate Firestore, GCloud, and Vertex
- [ ] Changelog updated
- [x] Docs updated
   Added docs around the new option to pass in credentials directly via environment variable
