### PR TITLE
feat: add npx create-genkit alias

### DIFF
--- a/genkit-tools/cli/package.json
+++ b/genkit-tools/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "genkit",
+  "name": "genkit-cli",
   "version": "0.5.10",
   "description": "CLI for interacting with the Google GenKit AI framework",
   "license": "Apache-2.0",

--- a/genkit-tools/cli/package.json
+++ b/genkit-tools/cli/package.json
@@ -11,7 +11,8 @@
   ],
   "author": "genkit",
   "bin": {
-    "genkit": "dist/bin/genkit.js"
+    "genkit": "dist/bin/genkit.js",
+    "create-genkit": "dist/bin/create-genkit.js"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/genkit-tools/cli/src/bin/create-genkit.ts
+++ b/genkit-tools/cli/src/bin/create-genkit.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { spawnSync } from 'child_process';
+import { join } from 'path';
+
+// Resolve the path to the genkit.js file
+const genkitPath = join(__dirname, 'genkit.js');
+
+// Execute the genkit script with "init" as the argument
+const result = spawnSync('node', [genkitPath, 'init'], { stdio: 'inherit' });
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
This PR renames genkit to genkit-cli, and adds the alias `npx create-genkit`

resolves part of https://github.com/firebase/genkit/issues/783

Checklist (if applicable):
- [x] Tested (manually)
- [ ] Changelog updated
- [ ] Docs updated
