### PR TITLE
Added metricExportTimeoutMillis to google-cloud.md

### DIFF
--- a/docs/plugins/google-cloud.md
+++ b/docs/plugins/google-cloud.md
@@ -88,6 +88,7 @@ googleCloud({
       '@opentelemetry/instrumentation-net': { enabled: false },
     },
     metricExportIntervalMillis: 5_000,
+    metricExportTimeoutMillis: 5_000,
   },
 });
 ```


### PR DESCRIPTION
Added `metricExportTimeoutMillis: 5_000,` to the telemetryConfig. This is needed when you define `metricExportIntervalMillis` like in the example. Without it won't run due to errors.
