### PR TITLE
Makes inputSchema optional for tools.

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -16,10 +16,10 @@
 
 import {
   Action,
-  GenkitError,
-  StreamingCallback,
   config as genkitConfig,
+  GenkitError,
   runWithStreamingCallback,
+  StreamingCallback,
 } from '@genkit-ai/core';
 import { lookupAction } from '@genkit-ai/core/registry';
 import { toJsonSchema, validateSchema } from '@genkit-ai/core/schema';
@@ -27,8 +27,8 @@ import { z } from 'zod';
 import { DocumentData } from './document.js';
 import { extractJson } from './extract.js';
 import {
-  GenerateUtilParamSchema,
   generateAction,
+  GenerateUtilParamSchema,
   inferRoleFromParts,
 } from './generateAction.js';
 import {
@@ -47,7 +47,7 @@ import {
   ToolRequestPart,
   ToolResponsePart,
 } from './model.js';
-import { ToolArgument, resolveTools, toToolDefinition } from './tool.js';
+import { resolveTools, ToolArgument, toToolDefinition } from './tool.js';
 
 /**
  * Message represents a single role's contribution to a generation. Each message
@@ -610,7 +610,11 @@ export async function generate<
 
   return await runWithStreamingCallback(
     resolvedOptions.streamingCallback,
-    async () => new GenerateResponse<O>(await generateAction(params))
+    async () =>
+      new GenerateResponse<O>(
+        await generateAction(params),
+        await toGenerateRequest(resolvedOptions)
+      )
   );
 }
 

--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -154,11 +154,11 @@ export const ToolDefinitionSchema = z.object({
   inputSchema: z
     .record(z.any())
     .describe('Valid JSON Schema representing the input of the tool.')
-    .optional(),
+    .nullish(),
   outputSchema: z
     .record(z.any())
     .describe('Valid JSON Schema describing the output of the tool.')
-    .optional(),
+    .nullish(),
 });
 export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;
 

--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -153,7 +153,8 @@ export const ToolDefinitionSchema = z.object({
   description: z.string(),
   inputSchema: z
     .record(z.any())
-    .describe('Valid JSON Schema representing the input of the tool.'),
+    .describe('Valid JSON Schema representing the input of the tool.')
+    .optional(),
   outputSchema: z
     .record(z.any())
     .describe('Valid JSON Schema describing the output of the tool.')

--- a/js/ai/tests/generate/generate_test.ts
+++ b/js/ai/tests/generate/generate_test.ts
@@ -17,7 +17,7 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import { z } from 'zod';
-import { GenerateResponseChunk } from '../../src/generate';
+import { generate, GenerateResponseChunk } from '../../src/generate';
 import {
   Candidate,
   GenerateOptions,
@@ -25,7 +25,7 @@ import {
   Message,
   toGenerateRequest,
 } from '../../src/generate.js';
-import { GenerateResponseChunkData } from '../../src/model';
+import { defineModel, GenerateResponseChunkData } from '../../src/model';
 import {
   CandidateData,
   GenerateRequest,
@@ -579,5 +579,28 @@ describe('GenerateResponseChunk', () => {
         });
       }
     }
+  });
+});
+
+const echo = defineModel(
+  { name: 'echo', supports: { tools: true } },
+  async (input) => ({
+    candidates: [
+      { index: 0, message: input.messages[0], finishReason: 'stop' },
+    ],
+  })
+);
+
+describe('generate', () => {
+  it('should preserve the request in the returned response, enabling toHistory()', async () => {
+    const response = await generate({
+      model: echo,
+      prompt: 'Testing toHistory',
+    });
+
+    assert.deepEqual(
+      response.toHistory().map((m) => m.content[0].text),
+      ['Testing toHistory', 'Testing toHistory']
+    );
   });
 });

--- a/js/plugins/vertexai/src/openai_compatibility.ts
+++ b/js/plugins/vertexai/src/openai_compatibility.ts
@@ -75,7 +75,7 @@ function toOpenAiTool(tool: ToolDefinition): ChatCompletionTool {
     type: 'function',
     function: {
       name: tool.name,
-      parameters: tool.inputSchema,
+      parameters: tool.inputSchema || undefined,
     },
   };
 }

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -480,7 +480,7 @@ export const testTools = [
         'indigo',
         'violet',
       ];
-      return [Math.floor(Math.random() * colors.length)];
+      return colors[Math.floor(Math.random() * colors.length)];
     }
   ),
 ];

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -22,8 +22,8 @@ import { defineFlow, run } from '@genkit-ai/flow';
 import { googleCloud } from '@genkit-ai/google-cloud';
 import {
   gemini15Flash,
-  geminiPro as googleGeminiPro,
   googleAI,
+  geminiPro as googleGeminiPro,
 } from '@genkit-ai/googleai';
 import {
   gemini15ProPreview,


### PR DESCRIPTION
Fixes #814 and also fixes a nasty regression with the new `generateAction` that caused `response.toHistory()` to stop working.

There's still an issue with tool calling and `toHistory`, which is that the tool request / responses are elided from history once the LLM comes back with a full response. We should fix that.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
