### PR TITLE
fix(go): remove unnecessary nil check for lookup model

### DIFF
--- a/genkit-tools/cli/config/main.go.template
+++ b/genkit-tools/cli/config/main.go.template
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 
@@ -20,9 +19,6 @@ func $GENKIT_FUNC_NAME() {
 	// Define a simple flow that prompts an LLM to generate menu suggestions.
 	genkit.DefineFlow("menuSuggestionFlow", func(ctx context.Context, input string) (string, error) {
 		$GENKIT_MODEL_LOOKUP
-		if m == nil {
-			return "", errors.New("menuSuggestionFlow: failed to find model")
-		}
 
 		// Construct a request and send it to the model API.
 		resp, err := m.Generate(ctx,

--- a/go/internal/doc-snippets/init/main.go
+++ b/go/internal/doc-snippets/init/main.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 
@@ -43,9 +42,6 @@ func main() {
 		// The Google AI API provides access to several generative models. Here,
 		// we specify gemini-1.5-flash.
 		m := googleai.Model("gemini-1.5-flash")
-		if m == nil {
-			return "", errors.New("menuSuggestionFlow: failed to find model")
-		}
 
 		// Construct a request and send it to the model API (Google AI).
 		resp, err := ai.Generate(ctx, m,

--- a/go/plugins/ollama/ollama_live_test.go
+++ b/go/plugins/ollama/ollama_live_test.go
@@ -52,9 +52,6 @@ func TestLive(t *testing.T) {
 
 	// Use the Ollama model
 	m := ollamaPlugin.Model(*modelName)
-	if m == nil {
-		t.Fatalf(`failed to find model: %s`, *modelName)
-	}
 
 	// Generate a response from the model
 	resp, err := m.Generate(ctx,


### PR DESCRIPTION
Remove unnecessary nil check as lookup model (`ai.LookupModel(provider, name)`) returns `(*ai.modelActionDef)(nil)` when no model is found, which is different from `nil` in this case.

The below playground shows how it looks like:
https://go.dev/play/p/u-OvxaXc3aZ

Also, this article explains this problem.
https://vitaneri.com/posts/check-for-nil-interface-in-go 

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [x] Docs updated
