### PR TITLE
Adds additional logs for output candidates

### DIFF
--- a/js/ai/src/telemetry.ts
+++ b/js/ai/src/telemetry.ts
@@ -216,6 +216,18 @@ export function recordGenerateActionOutputLogs(
   const candidates = output.candidates.length;
   output.candidates.forEach((cand, candIdx) => {
     const parts = cand.message.content.length;
+    const candCounts = parts > 1 ? ` (${candIdx + 1} of ${parts})` : '';
+    logger.logStructured(`Output Candidate[${path}, ${model}]${candCounts}`, {
+      ...sharedMetadata,
+      candidateIndex: candIdx,
+      totalCandidates: candidates,
+      messageIndex: cand.index,
+      finishReason: cand.finishReason,
+      finishMessage: cand.finishMessage,
+      role: cand.message.role,
+      usage: cand.usage,
+      custom: cand.custom,
+    });
     cand.message.content.forEach((part, partIdx) => {
       const partCounts = toPartCounts(partIdx, parts, candIdx, candidates);
       const initial = cand.finishMessage
@@ -234,6 +246,12 @@ export function recordGenerateActionOutputLogs(
         role: cand.message.role,
       });
     });
+    if (output.usage) {
+      logger.logStructured(`Usage[${path}, ${model}]`, {
+        ...sharedMetadata,
+        usage: output.usage,
+      });
+    }
   });
 }
 

--- a/js/plugins/google-cloud/tests/logs_test.ts
+++ b/js/plugins/google-cloud/tests/logs_test.ts
@@ -166,6 +166,12 @@ describe('GoogleCloudLogs', () => {
       ),
       true
     );
+    assert.equal(
+      logMessages.includes(
+        '[info] Output Candidate[testFlow > sub1 > sub2 > testModel, testModel]'
+      ),
+      true
+    );
   });
 
   /** Helper to create a flow with no inputs or outputs */

--- a/js/plugins/google-cloud/tests/logs_test.ts
+++ b/js/plugins/google-cloud/tests/logs_test.ts
@@ -172,6 +172,12 @@ describe('GoogleCloudLogs', () => {
       ),
       true
     );
+    assert.equal(
+      logMessages.includes(
+        '[info] Usage[testFlow > sub1 > sub2 > testModel, testModel]'
+      ),
+      true
+    );
   });
 
   /** Helper to create a flow with no inputs or outputs */


### PR DESCRIPTION
Output logs now include:
* usage information (tokens, images, etc) overall and by candidate
* custom output candidate metadata - this includes the safety scores for gemini

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
