### PR TITLE
Fixes history rendering of Dotprompt system role.

### DIFF
--- a/js/ai/tests/generate/generate_test.ts
+++ b/js/ai/tests/generate/generate_test.ts
@@ -17,7 +17,7 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import { z } from 'zod';
-import { generate, GenerateResponseChunk } from '../../src/generate';
+import { GenerateResponseChunk, generate } from '../../src/generate';
 import {
   Candidate,
   GenerateOptions,
@@ -25,7 +25,7 @@ import {
   Message,
   toGenerateRequest,
 } from '../../src/generate.js';
-import { defineModel, GenerateResponseChunkData } from '../../src/model';
+import { GenerateResponseChunkData, defineModel } from '../../src/model';
 import {
   CandidateData,
   GenerateRequest,

--- a/js/plugins/dotprompt/src/template.ts
+++ b/js/plugins/dotprompt/src/template.ts
@@ -115,11 +115,15 @@ function toMessages(
   )
     return messages;
 
-  return [
-    ...messages.slice(0, -1),
-    ...options.history,
-    messages.at(-1),
-  ] as MessageData[];
+  if (messages.at(-1)?.role === 'user') {
+    return [
+      ...messages.slice(0, -1),
+      ...options.history,
+      messages.at(-1),
+    ] as MessageData[];
+  }
+
+  return [...messages, ...options.history] as MessageData[];
 }
 
 const PART_REGEX = /(<<<dotprompt:(?:media:url|section).*?)>>>/g;

--- a/js/plugins/dotprompt/tests/prompt_test.ts
+++ b/js/plugins/dotprompt/tests/prompt_test.ts
@@ -105,6 +105,25 @@ describe('Prompt', () => {
       assert.strictEqual(rendered.streamingCallback, streamingCallback);
       assert.strictEqual(rendered.returnToolRequests, true);
     });
+
+    it('should support system prompt with history', async () => {
+      const prompt = testPrompt(`{{ role "system" }}Testing system {{name}}`);
+
+      const rendered = await prompt.render({
+        input: { name: 'Michael' },
+        history: [
+          { role: 'user', content: [{ text: 'history 1' }] },
+          { role: 'model', content: [{ text: 'history 2' }] },
+          { role: 'user', content: [{ text: 'history 3' }] },
+        ],
+      });
+      assert.deepStrictEqual(rendered.history, [
+        { role: 'system', content: [{ text: 'Testing system Michael' }] },
+        { role: 'user', content: [{ text: 'history 1' }] },
+        { role: 'model', content: [{ text: 'history 2' }] },
+      ]);
+      assert.deepStrictEqual(rendered.prompt, [{ text: 'history 3' }]);
+    });
   });
 
   describe('#generate', () => {


### PR DESCRIPTION
There was a bug in the handling of Dotprompt's history rendering such that if a system message (and only a system message) was rendered, history would be inserted in a weird order. The new behavior adds a check:

- If the last message is a `user` role message, insert history just before it.
- Otherwise, append history to the end of the list of messages.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
