### PR TITLE
Return a proper 400 error when a trace is not found in the trace store

### DIFF
--- a/js/core/src/reflectionApi.ts
+++ b/js/core/src/reflectionApi.ts
@@ -191,7 +191,7 @@ export async function startReflectionApi(port?: number | undefined) {
       const trace = await tracestore?.load(traceId);
       return trace
         ? response.json(trace)
-        : response.status(400).send({
+        : response.status(404).send({
             code: StatusCodes.NOT_FOUND,
             message: `Trace with traceId=${traceId} not found.`,
           });

--- a/js/core/src/reflectionApi.ts
+++ b/js/core/src/reflectionApi.ts
@@ -188,7 +188,13 @@ export async function startReflectionApi(port?: number | undefined) {
     // TODO: Remove try/catch when upgrading to Express 5; error is sent to `next` automatically
     // in that version
     try {
-      response.json(await tracestore?.load(traceId));
+      const trace = await tracestore?.load(traceId);
+      return trace
+        ? response.json(trace)
+        : response.status(400).send({
+            code: StatusCodes.NOT_FOUND,
+            message: `Trace with traceId=${traceId} not found.`,
+          });
     } catch (err) {
       const error = err as Error;
       const { message, stack } = error;


### PR DESCRIPTION
Will make it easier on the front-end to know definitively when a trace wasn't found, versus an error.

Checklist (if applicable):
- [X] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
