### PR TITLE
chore: fix pnpm version used in workflows

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: pnpm/action-setup@v3
-      with:
-        version: 8
     - name: Set up node v20
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: pnpm/action-setup@v3
-      with:
-        version: 8
     - name: Set up node v20
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
We shouldn't be hard-coding pnpm version in the workflow config, it will automatically use the correct version based on the `packageManager` field in package.json.