### PR TITLE
Updates isRoot logic to no longer assume root when calling newTrace.

### DIFF
--- a/js/core/src/tracing/instrumentation.ts
+++ b/js/core/src/tracing/instrumentation.ts
@@ -43,6 +43,7 @@ export async function newTrace<T>(
   },
   fn: (metadata: SpanMetadata, rootSpan: ApiSpan) => Promise<T>
 ) {
+  const isRoot = traceMetadataAls.getStore() ? false : true;
   const traceMetadata = traceMetadataAls.getStore() || {
     paths: new Set<PathMetadata>(),
     timestamp: performance.now(),
@@ -55,7 +56,7 @@ export async function newTrace<T>(
       {
         metadata: {
           name: opts.name,
-          isRoot: true,
+          isRoot,
         },
         labels: opts.labels,
         links: opts.links,
@@ -83,7 +84,7 @@ export async function runInNewSpan<T>(
   const isInRoot = parentStep?.isRoot === true;
   return await tracer.startActiveSpan(
     opts.metadata.name,
-    { links: opts.links },
+    { links: opts.links, root: opts.metadata.isRoot },
     async (otSpan) => {
       if (opts.labels) otSpan.setAttributes(opts.labels);
       try {

--- a/js/core/src/tracing/instrumentation.ts
+++ b/js/core/src/tracing/instrumentation.ts
@@ -43,6 +43,7 @@ export async function newTrace<T>(
   },
   fn: (metadata: SpanMetadata, rootSpan: ApiSpan) => Promise<T>
 ) {
+  // This is the root node only if we haven't previously started a trace.
   const isRoot = traceMetadataAls.getStore() ? false : true;
   const traceMetadata = traceMetadataAls.getStore() || {
     paths: new Set<PathMetadata>(),


### PR DESCRIPTION
This can be called multiple times when running child flows.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
