### PR TITLE
fix: rag docs missing lib

### DIFF
--- a/docs/rag.md
+++ b/docs/rag.md
@@ -128,7 +128,7 @@ into a vector database and retrieve them for use in a flow that determines what 
 ### Install dependencies for processing PDFs
 
 ```posix-terminal
-npm install llm-chunk pdf-parse
+npm install llm-chunk pdf-parse @genkit-ai/dev-local-vectorstore
 
 npm i -D --save @types/pdf-parse
 ```


### PR DESCRIPTION
Yesterday I was running a the docs example and this lib was missing from the tutorial!

Checklist (if applicable):
- [ ] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [x] Docs updated
