### PR TITLE
add openai init go plugin from yukinagae, add vision pro model for ve…

### DIFF
--- a/genkit-tools/cli/src/commands/init/init-go.ts
+++ b/genkit-tools/cli/src/commands/init/init-go.ts
@@ -38,6 +38,19 @@ const templatePath = '../../../config/main.go.template';
 
 /** Model to plugin name. */
 const modelOptions: Record<ModelProvider, ModelOption> = {
+  openai: {
+    label: 'OpenAI',
+    package: 'github.com/yukinagae/genkit-go-plugins/plugins/openai',
+    init: `// Initialize the OpenAI plugin. When you pass an empty string for the
+\t// apiKey parameter, the OpenAI plugin will use the value from the
+\t// OPENAI_API_KEY environment variable, which is the recommended practice.
+\tif err := openai.Init(ctx, nil); err != nil {
+\t\tlog.Fatal(err)
+\t}`,
+    lookup: `// The OpenAI API provides access to several generative models. Here,
+\t\t// we specify the 4o mini model.
+\t\tm := openai.Model("gpt-4o-mini")`,
+  },
   googleai: {
     label: 'Google AI',
     package: 'github.com/firebase/genkit/go/plugins/googleai',

--- a/go/plugins/vertexai/vertexai.go
+++ b/go/plugins/vertexai/vertexai.go
@@ -40,9 +40,10 @@ const (
 
 var (
 	knownCaps = map[string]ai.ModelCapabilities{
-		"gemini-1.0-pro":   gemini.BasicText,
-		"gemini-1.5-pro":   gemini.Multimodal,
-		"gemini-1.5-flash": gemini.Multimodal,
+		"gemini-1.0-pro":    gemini.BasicText,
+		"gemini-1.5-pro":    gemini.Multimodal,
+		"gemini-1.5-flash":  gemini.Multimodal,
+		"gemini-pro-vision": gemini.Multimodal,
 	}
 
 	knownEmbedders = []string{

--- a/go/samples/menu/main.go
+++ b/go/samples/menu/main.go
@@ -73,6 +73,7 @@ func main() {
 	}
 	model := vertexai.Model("gemini-1.5-flash")
 	visionModel := vertexai.Model("gemini-1.5-flash")
+	visionModelPro := vertexai.Model("gemini-pro-vision")
 	embedder := vertexai.Embedder("text-embedding-004")
 	if err := setup01(ctx, model); err != nil {
 		log.Fatal(err)
@@ -100,6 +101,10 @@ func main() {
 	}
 
 	if err := setup05(ctx, model, visionModel); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := setup05(ctx, model, visionModelPro); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
* Integrate https://github.com/yukinagae/genkit-go-plugins plugin
* add vertexai pro vision model to be consistent with JS 

Checklist (if applicable):
- [ ] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
