### PR TITLE
Update the flow name extraction regex to support the scenario where there is a parent span.

### DIFF
--- a/js/plugins/google-cloud/src/utils.ts
+++ b/js/plugins/google-cloud/src/utils.ts
@@ -22,7 +22,7 @@ export function extractOuterFlowNameFromPath(path: string) {
     return '<unknown>';
   }
 
-  const flowName = path.match('/{(.+),t:flow}+');
+  const flowName = path.match('/{([^,}]+),t:flow}+');
   return flowName ? flowName[1] : '<unknown>';
 }
 

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -25,6 +25,7 @@ import {
   FlowStateStore,
 } from '@genkit-ai/core';
 import { registerFlowStateStore } from '@genkit-ai/core/registry';
+import { newTrace } from '@genkit-ai/core/tracing';
 import { defineFlow, run, runAction, runFlow } from '@genkit-ai/flow';
 import {
   __forceFlushSpansForTesting,
@@ -370,7 +371,9 @@ describe('GoogleCloudMetrics', () => {
       });
     });
 
-    await runFlow(flow);
+    await newTrace({ name: 'dev-run-action-wrapper' }, async (_, span) => {
+      await runFlow(flow);
+    });
 
     await getExportedSpans();
 


### PR DESCRIPTION
When running locally, there is a parent `dev-run-action-wrapper` span, and this results in an extracted flow name that looks like `dev-run-action-wrapper/{<flowName>`.


Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
