### PR TITLE
fix(docs): replace obsolete package name (Firebase plugin)

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -31,7 +31,7 @@ want to enable TTL for the trace documents:
 https://firebase.google.com/docs/firestore/ttl
 
 ```ts
-import { firebase } from '@genkit-ai/plugin-firebase';
+import { firebase } from '@genkit-ai/firebase';
 
 configureGenkit({
   plugins: [firebase()],


### PR DESCRIPTION
Replacing obsolete package name in documentation to current version [genkit-ai/firebase](https://www.npmjs.com/package/@genkit-ai/firebase)

Checklist (if applicable):
- [ ] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [x] Docs updated
