### PR TITLE
fix(js): disabled explicit json mode when using tools

### DIFF
--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -533,18 +533,6 @@ export function googleAIModel(
           systemInstruction = toGeminiSystemInstruction(systemMessage);
         }
       }
-      const generationConfig: GenerationConfig = {
-        candidateCount: request.candidates || undefined,
-        temperature: request.config?.temperature,
-        maxOutputTokens: request.config?.maxOutputTokens,
-        topK: request.config?.topK,
-        topP: request.config?.topP,
-        stopSequences: request.config?.stopSequences,
-        responseMimeType:
-          request.output?.format === 'json' || request.output?.schema
-            ? 'application/json'
-            : undefined,
-      };
 
       const tools: Tool[] = [];
 
@@ -563,6 +551,21 @@ export function googleAIModel(
         });
       }
 
+      //  cannot use tools with json mode
+      const jsonMode =
+        (request.output?.format === 'json' || !!request.output?.schema) &&
+        tools.length === 0;
+
+      const generationConfig: GenerationConfig = {
+        candidateCount: request.candidates || undefined,
+        temperature: request.config?.temperature,
+        maxOutputTokens: request.config?.maxOutputTokens,
+        topK: request.config?.topK,
+        topP: request.config?.topP,
+        stopSequences: request.config?.stopSequences,
+        responseMimeType: jsonMode ? 'application/json' : undefined,
+      };
+
       const chatRequest = {
         systemInstruction,
         generationConfig,
@@ -573,8 +576,6 @@ export function googleAIModel(
         safetySettings: request.config?.safetySettings,
       } as StartChatParams;
       const msg = toGeminiMessage(messages[messages.length - 1], model);
-      const jsonMode =
-        request.output?.format === 'json' || !!request.output?.schema;
       const fromJSONModeScopedGeminiCandidate = (
         candidate: GeminiCandidate
       ) => {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -592,6 +592,31 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
 
+  testapps/basic-gemini:
+    dependencies:
+      '@genkit-ai/firebase':
+        specifier: workspace:*
+        version: link:../../plugins/firebase
+      '@genkit-ai/google-cloud':
+        specifier: workspace:*
+        version: link:../../plugins/google-cloud
+      '@genkit-ai/googleai':
+        specifier: workspace:*
+        version: link:../../plugins/googleai
+      '@genkit-ai/vertexai':
+        specifier: workspace:*
+        version: link:../../plugins/vertexai
+      express:
+        specifier: ^4.20.0
+        version: 4.21.0
+      genkit:
+        specifier: workspace:*
+        version: link:../../genkit
+    devDependencies:
+      typescript:
+        specifier: ^5.6.2
+        version: 5.6.2
+
   testapps/byo-evaluator:
     dependencies:
       '@genkit-ai/dev-local-vectorstore':
@@ -4811,6 +4836,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uglify-js@3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
@@ -8980,6 +9010,8 @@ snapshots:
   typescript@5.4.5: {}
 
   typescript@5.5.3: {}
+
+  typescript@5.6.2: {}
 
   uglify-js@3.17.4:
     optional: true

--- a/js/testapps/basic-gemini/package.json
+++ b/js/testapps/basic-gemini/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "basic-gemini",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node lib/index.js",
+    "build": "tsc",
+    "build:watch": "tsc --watch"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "genkit": "workspace:*",
+    "@genkit-ai/firebase": "workspace:*",
+    "@genkit-ai/google-cloud": "workspace:*",
+    "@genkit-ai/googleai": "workspace:*",
+    "@genkit-ai/vertexai": "workspace:*",
+    "express": "^4.20.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.2"
+  }
+}

--- a/js/testapps/basic-gemini/src/index.ts
+++ b/js/testapps/basic-gemini/src/index.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gemini15Flash, googleAI } from '@genkit-ai/googleai';
+import { vertexAI } from '@genkit-ai/vertexai';
+import { defineTool, generate, genkit, z } from 'genkit';
+import { runWithRegistry } from 'genkit/registry';
+
+const ai = genkit({
+  plugins: [googleAI(), vertexAI()],
+});
+
+const jokeSubjectGenerator = runWithRegistry(ai.registry, () =>
+  defineTool(
+    {
+      name: 'jokeSubjectGenerator',
+      description: 'Can be called to generate a subject for a joke',
+    },
+    async () => {
+      return 'banana';
+    }
+  )
+);
+
+export const jokeFlow = ai.defineFlow(
+  {
+    name: 'jokeFlow',
+    inputSchema: z.void(),
+    outputSchema: z.any(),
+  },
+  async () => {
+    const llmResponse = await generate({
+      model: gemini15Flash,
+      config: {
+        temperature: 2,
+      },
+      output: {
+        schema: z.object({ jokeSubject: z.string() }),
+      },
+      tools: [jokeSubjectGenerator],
+      prompt: `come up with a subject to joke about (using the function provided)`,
+    });
+    return llmResponse.output();
+  }
+);

--- a/js/testapps/basic-gemini/tsconfig.json
+++ b/js/testapps/basic-gemini/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compileOnSave": true,
+  "include": ["src"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitReturns": true,
+    "outDir": "lib",
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2017",
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
This PR disables using tools AND explicit json mode for Google AI, to match `main`


Checklist (if applicable):
- [ ] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
