### PR TITLE
Labeling failed spans

### DIFF
--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -247,6 +247,7 @@ class AdjustingTraceExporter implements SpanExporter {
 
       span = this.redactPii(span);
       span = this.markErrorSpanAsError(span);
+      span = this.markFailedAction(span);
       span = this.normalizeLabels(span);
       return span;
     });
@@ -321,6 +322,18 @@ class AdjustingTraceExporter implements SpanExporter {
       spanContext: span.spanContext,
       attributes: normalized,
     };
+  }
+
+  private markFailedAction(span: ReadableSpan): ReadableSpan {
+    if (
+      span.attributes['genkit:state'] === 'error' &&
+      (span.attributes['genkit:type'] === 'action' ||
+        span.attributes['genkit:type'] === 'flowStep') &&
+      span.attributes['genkit:name']
+    ) {
+      span.attributes['genkit:failedSpan'] = span.attributes['genkit:name'];
+    }
+    return span;
   }
 }
 

--- a/js/plugins/google-cloud/tests/traces_test.ts
+++ b/js/plugins/google-cloud/tests/traces_test.ts
@@ -117,6 +117,22 @@ describe('GoogleCloudTracing', () => {
     assert.equal(spans[1].parentSpanId, undefined);
   });
 
+  it('labels failed actions', async () => {
+    const testFlow = createFlow(ai, 'badFlow', async () => {
+      return await run('badAction', async () => {
+        throw new Error('oh no!');
+      });
+    });
+    try {
+      await testFlow();
+    } catch (e) {}
+
+    const spans = await getExportedSpans();
+    assert.equal(spans.length, 2);
+    assert.equal(spans[0].name, 'badAction');
+    assert.equal(spans[0].attributes['genkit/failedSpan'], 'badAction');
+  });
+
   /** Helper to create a flow with no inputs or outputs */
   function createFlow(
     ai: Genkit,


### PR DESCRIPTION
Adding a new "failedSpan" attribute on flow step or action spans which have failed. This makes it much easier for the GCP trace api to find them.
