### PR TITLE
Revamped get started guide to be more similar to typical libraries

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -25,7 +25,7 @@ npm install genkit @genkit-ai/ai @genkit-ai/core @genkit-ai/googleai
 
 ## Configure your model API key
 
-For this tutorial, we’ll use the Gemini API which provides a generous free tier and does not require a credit card to get started. To use the Gemini API, you'll need an API key. If you don't already have one, create a key in Google AI Studio.
+For this guide, we’ll show you how to use the Gemini API which provides a generous free tier and does not require a credit card to get started. To use the Gemini API, you'll need an API key. If you don't already have one, create a key in Google AI Studio.
 
 <a class="button" href="https://makersuite.google.com/app/apikey" target="_blank" rel="noopener noreferrer">Get an API key from Google AI Studio</a>
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -19,7 +19,7 @@ Install the following Genkit dependencies to use Genkit in your project:
 * `@genkit-ai/ai` and `@genkit-ai/core` provide Genkit core capabilities  
 * `@genkit-ai/googleai` provide access to the Google AI Gemini models
 
-```
+```posix-terminal
 npm install genkit @genkit-ai/ai @genkit-ai/core @genkit-ai/googleai
 ```
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -8,7 +8,7 @@ This guide assumes that you're familiar with building applications with Node.js.
 
 To complete this quickstart, make sure that your development environment meets the following requirements:
 
-* Node.js v18+  
+* Node.js v20+  
 * npm
 
 ## Install Genkit dependencies

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -52,11 +52,6 @@ import { googleAI, gemini15Flash } from '@genkit-ai/googleai';
 Use the `generate` method to generate a text response.
 
 ```javascript
-// Make sure to include these imports:
-// import { generate } from '@genkit-ai/ai';
-// import { configureGenkit } from '@genkit-ai/core';
-// import { googleAI, gemini15Flash } from '@genkit-ai/googleai';
-
 configureGenkit({ plugins: [googleAI()] });
 
 const result = await generate({

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -15,12 +15,13 @@ To complete this quickstart, make sure that your development environment meets t
 
 Install the following Genkit dependencies to use Genkit in your project:
 
-* `genkit` provides the Genkit CLI and tooling  
-* `@genkit-ai/ai` and `@genkit-ai/core` provide Genkit core capabilities  
-* `@genkit-ai/googleai` provide access to the Google AI Gemini models
+* `@genkit-ai/ai` and `@genkit-ai/core` provide Genkit core capabilities. 
+* `@genkit-ai/googleai` provide access to the Google AI Gemini models.
+* `genkit` provides the Genkit CLI and tooling to help you test and debug your solution later.
 
 ```posix-terminal
-npm install genkit @genkit-ai/ai @genkit-ai/core @genkit-ai/googleai
+npm install @genkit-ai/ai @genkit-ai/core @genkit-ai/googleai
+npm install -g genkit
 ```
 
 ## Configure your model API key


### PR DESCRIPTION
Currently, our Get started guide uses `genkit init` to set up a new Genkit project from scratch, but I think this is too magical. We should show that it's extremely simple to add Genkit to your project. This version of the Get started guide is much more similar to that of the [Gemini API](https://ai.google.dev/gemini-api/docs/quickstart?lang=node
), and more similar to typical library / API quickstart guides.
