### PR TITLE
fix(docs/dotprompt/schema): use correct schemas to type inference

### DIFF
--- a/docs/dotprompt.md
+++ b/docs/dotprompt.md
@@ -151,11 +151,19 @@ a schema registered with `defineSchema` by name. To register a schema:
 import { defineSchema } from '@genkit-ai/core';
 import { z } from 'zod';
 
-const MySchema = defineSchema(
-  'MySchema',
+const MyOutputSchema = defineSchema(
+  'MyOutputSchema',
   z.object({
     field1: z.string(),
     field2: z.number(),
+  })
+);
+
+const MyInputSchema = defineSchema(
+  'MyInputSchema',
+  z.object({
+    field3: z.string(),
+    field4: z.number(),
   })
 );
 ```
@@ -167,7 +175,9 @@ Within your prompt, you can provide the name of the registered schema:
 ---
 model: vertexai/gemini-1.5-flash
 output:
-  schema: MySchema
+  schema: MyOutputSchema
+input:
+  schema: MyInputSchema
 ---
 ```
 
@@ -180,9 +190,9 @@ import { promptRef } from "@genkit-ai/dotprompt";
 
 const myPrompt = promptRef("myPrompt");
 
-const result = await myPrompt.generate<typeof MySchema>({...});
+const result = await myPrompt.generate<typeof MyInputSchema, typeof MyOutputSchema>({...});
 
-// now strongly typed as MySchema
+// now strongly typed as MyOutputSchema
 result.output();
 ```
 


### PR DESCRIPTION
Current example is wrong and does't correctly infer schema for the output. It sends only one schema, where 2 are expected, one for input, one for output.

I have followed the current docs, but replaced the single schema with 2 schemas, one for output and one for input, that would produce correctly working snippet. 

Related Discord chat: https://discord.com/channels/1255578482214305893/1255934063173435402/1291469593235296439


Checklist (if applicable):
- [ ] Tested (manually, unit tested, etc.)
- [x] Docs updated
