### PR TITLE
Added support for Gemini 1.5 Flash 8B and updated available versions for Google AI and Vertex AI Gemini models

### DIFF
--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -87,7 +87,11 @@ export const geminiPro = modelRef({
       tools: true,
       systemRole: true,
     },
-    versions: ['gemini-1.0-pro', 'gemini-1.0-pro-latest', 'gemini-1.0-pro-001'],
+    versions: [
+      'gemini-1.0-pro',
+      'gemini-1.0-pro-latest',
+      'gemini-1.0-pro-001'
+    ],
   },
   configSchema: GeminiConfigSchema,
 });
@@ -113,7 +117,7 @@ export const geminiProVision = modelRef({
 });
 
 export const gemini15Pro = modelRef({
-  name: 'googleai/gemini-1.5-pro',
+  name: 'googleai/gemini-1.5-pro-latest',
   info: {
     label: 'Google AI - Gemini 1.5 Pro',
     supports: {
@@ -124,7 +128,7 @@ export const gemini15Pro = modelRef({
       output: ['text', 'json'],
     },
     versions: [
-      'gemini-1.5-pro-latest',
+      'gemini-1.5-pro',
       'gemini-1.5-pro-001',
       'gemini-1.5-pro-002',
       'gemini-1.5-pro-exp-0827',
@@ -134,7 +138,7 @@ export const gemini15Pro = modelRef({
 });
 
 export const gemini15Flash = modelRef({
-  name: 'googleai/gemini-1.5-flash',
+  name: 'googleai/gemini-1.5-flash-latest',
   info: {
     label: 'Google AI - Gemini 1.5 Flash',
     supports: {
@@ -145,7 +149,7 @@ export const gemini15Flash = modelRef({
       output: ['text', 'json'],
     },
     versions: [
-      'gemini-1.5-flash-latest',
+      'gemini-1.5-flash',
       'gemini-1.5-flash-001',
       'gemini-1.5-flash-002',
       'gemini-1.5-flash-8b-exp-0924',
@@ -157,7 +161,7 @@ export const gemini15Flash = modelRef({
 });
 
 export const gemini15Flash8B = modelRef({
-  name: 'googleai/gemini-1.5-flash-8b',
+  name: 'googleai/gemini-1.5-flash-8b-latest',
   info: {
     label: 'Google AI - Gemini 1.5 Flash-8B',
     supports: {
@@ -167,7 +171,7 @@ export const gemini15Flash8B = modelRef({
       systemRole: true,
       output: ['text', 'json'],
     },
-    versions: ['gemini-1.5-flash-8b-latest', 'gemini-1.5-flash-8b-001'],
+    versions: ['gemini-1.5-flash-8b', 'gemini-1.5-flash-8b-001'],
   },
   configSchema: GeminiConfigSchema,
 });
@@ -200,9 +204,9 @@ export const SUPPORTED_V15_MODELS: Record<
   string,
   ModelReference<z.ZodTypeAny>
 > = {
-  'gemini-1.5-pro': gemini15Pro,
-  'gemini-1.5-flash': gemini15Flash,
-  'gemini-1.5-flash-8b': gemini15Flash8B,
+  'gemini-1.5-pro-latest': gemini15Pro,
+  'gemini-1.5-flash-latest': gemini15Flash,
+  'gemini-1.5-flash-8b-latest': gemini15Flash8B,
 };
 
 const SUPPORTED_MODELS = {

--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -81,19 +81,19 @@ export const geminiPro = modelRef({
   name: 'googleai/gemini-pro',
   info: {
     label: 'Google AI - Gemini Pro',
-    versions: ['gemini-1.0-pro', 'gemini-1.0-pro-latest', 'gemini-1.0-pro-001'],
     supports: {
       multiturn: true,
       media: false,
       tools: true,
       systemRole: true,
     },
+    versions: ['gemini-1.0-pro', 'gemini-1.0-pro-latest', 'gemini-1.0-pro-001'],
   },
   configSchema: GeminiConfigSchema,
 });
 
 /**
- * @deprecated Use `gemini15Pro` or `gemini15Flash` instead.
+ * @deprecated Use `gemini15Pro`, `gemini15Flash`, or `gemini15flash8B` instead.
  */
 export const geminiProVision = modelRef({
   name: 'googleai/gemini-pro-vision',
@@ -113,7 +113,7 @@ export const geminiProVision = modelRef({
 });
 
 export const gemini15Pro = modelRef({
-  name: 'googleai/gemini-1.5-pro-latest',
+  name: 'googleai/gemini-1.5-pro',
   info: {
     label: 'Google AI - Gemini 1.5 Pro',
     supports: {
@@ -123,13 +123,18 @@ export const gemini15Pro = modelRef({
       systemRole: true,
       output: ['text', 'json'],
     },
-    versions: ['gemini-1.5-pro-001'],
+    versions: [
+      'gemini-1.5-pro-latest',
+      'gemini-1.5-pro-001',
+      'gemini-1.5-pro-002',
+      'gemini-1.5-pro-exp-0827',
+    ],
   },
   configSchema: GeminiConfigSchema,
 });
 
 export const gemini15Flash = modelRef({
-  name: 'googleai/gemini-1.5-flash-latest',
+  name: 'googleai/gemini-1.5-flash',
   info: {
     label: 'Google AI - Gemini 1.5 Flash',
     supports: {
@@ -139,7 +144,30 @@ export const gemini15Flash = modelRef({
       systemRole: true,
       output: ['text', 'json'],
     },
-    versions: ['gemini-1.5-flash-001'],
+    versions: [
+      'gemini-1.5-flash-latest',
+      'gemini-1.5-flash-001',
+      'gemini-1.5-flash-002',
+      'gemini-1.5-flash-8b-exp-0924',
+      'gemini-1.5-flash-8b-exp-0827',
+      'gemini-1.5-flash-exp-0827',
+    ],
+  },
+  configSchema: GeminiConfigSchema,
+});
+
+export const gemini15Flash8B = modelRef({
+  name: 'googleai/gemini-1.5-flash-8b',
+  info: {
+    label: 'Google AI - Gemini 1.5 Flash-8B',
+    supports: {
+      multiturn: true,
+      media: true,
+      tools: true,
+      systemRole: true,
+      output: ['text', 'json'],
+    },
+    versions: ['gemini-1.5-flash-8b-latest', 'gemini-1.5-flash-8b-001'],
   },
   configSchema: GeminiConfigSchema,
 });
@@ -172,8 +200,9 @@ export const SUPPORTED_V15_MODELS: Record<
   string,
   ModelReference<z.ZodTypeAny>
 > = {
-  'gemini-1.5-pro-latest': gemini15Pro,
-  'gemini-1.5-flash-latest': gemini15Flash,
+  'gemini-1.5-pro': gemini15Pro,
+  'gemini-1.5-flash': gemini15Flash,
+  'gemini-1.5-flash-8b': gemini15Flash8B,
 };
 
 const SUPPORTED_MODELS = {

--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -87,11 +87,7 @@ export const geminiPro = modelRef({
       tools: true,
       systemRole: true,
     },
-    versions: [
-      'gemini-1.0-pro',
-      'gemini-1.0-pro-latest',
-      'gemini-1.0-pro-001'
-    ],
+    versions: ['gemini-1.0-pro', 'gemini-1.0-pro-latest', 'gemini-1.0-pro-001'],
   },
   configSchema: GeminiConfigSchema,
 });

--- a/js/plugins/googleai/src/index.ts
+++ b/js/plugins/googleai/src/index.ts
@@ -22,6 +22,7 @@ import {
 } from './embedder.js';
 import {
   gemini15Flash,
+  gemini15Flash8B,
   gemini15Pro,
   geminiPro,
   geminiProVision,
@@ -31,6 +32,7 @@ import {
 } from './gemini.js';
 export {
   gemini15Flash,
+  gemini15Flash8B,
   gemini15Pro,
   geminiPro,
   geminiProVision,

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -80,7 +80,7 @@ export const geminiPro = modelRef({
   name: 'vertexai/gemini-1.0-pro',
   info: {
     label: 'Vertex AI - Gemini Pro',
-    versions: ['gemini-1.0-pro', 'gemini-1.0-pro-001'],
+    versions: ['gemini-1.0-pro', 'gemini-1.0-pro-001', 'gemini-1.0-pro-002'],
     supports: {
       multiturn: true,
       media: false,
@@ -113,7 +113,11 @@ export const gemini15Pro = modelRef({
   name: 'vertexai/gemini-1.5-pro',
   info: {
     label: 'Vertex AI - Gemini 1.5 Pro',
-    versions: ['gemini-1.5-pro-001'],
+    versions: [
+      'gemini-1.5-pro-001',
+      'gemini-1.5-pro-002',
+      'gemini-pro-experimental',
+    ],
     supports: {
       multiturn: true,
       media: true,
@@ -160,7 +164,11 @@ export const gemini15Flash = modelRef({
   name: 'vertexai/gemini-1.5-flash',
   info: {
     label: 'Vertex AI - Gemini 1.5 Flash',
-    versions: ['gemini-1.5-flash-001'],
+    versions: [
+      'gemini-1.5-flash-001',
+      'gemini-1.5-flash-002',
+      'gemini-flash-experimental',
+    ],
     supports: {
       multiturn: true,
       media: true,


### PR DESCRIPTION
PR does the following:

- Adds support for Gemini 1.5 Flash 8B to the Google AI plugin
- Adds all available versions to all Gemini models in the Google AI plugin based on https://ai.google.dev/gemini-api/docs/models/gemini
- Adds all available versions to all Gemini models in the Vertex AI plugin based on https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models

Tested Gemini 1.5 Flash 8B manually in the DevUI and it works based on test apps: https://screenshot.googleplex.com/ryTsEwLtx4J2Amc

Checklist (if applicable):
- [ x] Tested (manually, unit tested, etc.)
- [ ] Docs updated
