### PR TITLE
fix(js/plugins/vertexai): remove throw in reranker

### DIFF
--- a/js/plugins/vertexai/src/reranker.ts
+++ b/js/plugins/vertexai/src/reranker.ts
@@ -79,9 +79,7 @@ export async function vertexAiRerankers(
   params: VertexRerankOptions
 ): Promise<RerankerAction<z.ZodTypeAny>[]> {
   if (!params.pluginOptions) {
-    throw new Error(
-      'Plugin options are required to create Vertex AI rerankers'
-    );
+    return [];
   }
   const pluginOptions = params.pluginOptions;
   if (!params.pluginOptions.rerankOptions) {

--- a/js/testapps/vertexai-test/package.json
+++ b/js/testapps/vertexai-test/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "vertex-ai-plugin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node lib/index.js",
+    "build": "tsc",
+    "build:watch": "tsc --watch"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "genkit": "workspace:^",
+    "@genkit-ai/vertexai": "workspace:^",
+    "express": "^4.21.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.2"
+  }
+}

--- a/js/testapps/vertexai-test/src/index.ts
+++ b/js/testapps/vertexai-test/src/index.ts
@@ -1,0 +1,54 @@
+import * as z from 'zod';
+
+// Import the Genkit core libraries and plugins.
+import { claude35Sonnet, vertexAI } from '@genkit-ai/vertexai';
+// TODO: make this work
+// import { vertexAIModelGarden } from '@genkit-ai/vertexai/modelgarden';
+import { generate, genkit } from 'genkit';
+// TODO: make this work
+
+const ai = genkit({
+  plugins: [
+    vertexAI({ location: 'us-central1' }),
+    // TODO: make this work
+    // vertexAIModelGarden({
+    // some params here
+    // }),
+  ],
+});
+
+// Define a simple flow that prompts an LLM to generate menu suggestions.
+export const menuSuggestionFlow = ai.defineFlow(
+  {
+    name: 'menuSuggestionFlow',
+    inputSchema: z.object({ subject: z.string() }),
+    outputSchema: z.object({ output: z.string() }),
+  },
+  async ({ subject }) => {
+    // Construct a request and send it to the model API.
+    const llmResponse = await generate({
+      prompt: `Suggest an item for the menu of a ${subject} themed restaurant`,
+      model: claude35Sonnet,
+      output: {
+        format: 'json',
+        schema: z.object({
+          output: z.string(),
+        }),
+      },
+      config: {
+        temperature: 1,
+      },
+    });
+
+    const output = llmResponse.output();
+
+    if (output === null) {
+      throw new Error('Failed to generate menu suggestion');
+    }
+
+    // Handle the response from the model API. In this sample, we just convert
+    // it to a string, but more complicated flows might coerce the response into
+    // structured output or chain the response into another LLM call, etc.
+    return llmResponse.output()!;
+  }
+);

--- a/js/testapps/vertexai-test/tsconfig.json
+++ b/js/testapps/vertexai-test/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compileOnSave": true,
+  "include": [
+    "src"
+  ],
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitReturns": true,
+    "outDir": "lib",
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2017",
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
This PR stops the reranker throwing if no Vertex AI plugin options are provided.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated
