### PR TITLE
fix(js): fix no pluginOptions logic in vertexai rerankers

### DIFF
--- a/js/plugins/vertexai/src/reranker.ts
+++ b/js/plugins/vertexai/src/reranker.ts
@@ -79,9 +79,7 @@ export async function vertexAiRerankers(
   params: VertexRerankOptions
 ): Promise<RerankerAction<z.ZodTypeAny>[]> {
   if (!params.pluginOptions) {
-    throw new Error(
-      'Plugin options are required to create Vertex AI rerankers'
-    );
+    return [];
   }
   const pluginOptions = params.pluginOptions;
   if (!params.pluginOptions.rerankOptions) {


### PR DESCRIPTION
This PR prevents rerankers from throwing if no options are provided to the vertex ai plugin.


Checklist (if applicable):
- [x] Tested (manually)
- [ ] Docs updated
