### PR TITLE
chore: add missing `rimraf` depDependency to package.json that use it

### DIFF
--- a/genkit-tools/common/package.json
+++ b/genkit-tools/common/package.json
@@ -49,6 +49,7 @@
     "@types/uuid": "^9.0.8",
     "genversion": "^3.2.0",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
   },

--- a/genkit-tools/plugins/firebase/package.json
+++ b/genkit-tools/plugins/firebase/package.json
@@ -11,6 +11,7 @@
     "@genkit-ai/tools-common": "workspace:*",
     "@types/node": "^20.11.19",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "typescript": "^4.9.0"
   },
   "types": "lib/types/index.d.ts",

--- a/genkit-tools/plugins/google/package.json
+++ b/genkit-tools/plugins/google/package.json
@@ -11,6 +11,7 @@
     "@genkit-ai/tools-common": "workspace:*",
     "@types/node": "^20.11.19",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "typescript": "^4.9.0"
   },
   "types": "lib/types/index.d.ts",

--- a/genkit-tools/pnpm-lock.yaml
+++ b/genkit-tools/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.5))
       ts-jest:
         specifier: ^29.1.2
-        version: 29.1.2(@babel/core@7.24.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.5))(jest@29.7.0(@types/node@20.12.7))(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.5))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.5)))(typescript@5.4.5)
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -193,9 +193,12 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       ts-jest:
         specifier: ^29.1.2
-        version: 29.1.2(@babel/core@7.24.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.5))(jest@29.7.0(@types/node@20.12.7))(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.24.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.5))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
@@ -218,6 +221,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^4.9.0
         version: 4.9.5
@@ -237,6 +243,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^4.9.0
         version: 4.9.5
@@ -289,6 +298,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsx:
         specifier: ^4.7.0
         version: 4.9.3
@@ -6365,7 +6377,7 @@ snapshots:
 
   triple-beam@1.4.1: {}
 
-  ts-jest@29.1.2(@babel/core@7.24.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.5))(jest@29.7.0(@types/node@20.12.7))(typescript@5.4.5):
+  ts-jest@29.1.2(@babel/core@7.24.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.5))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0

--- a/genkit-tools/telemetry-server/package.json
+++ b/genkit-tools/telemetry-server/package.json
@@ -41,6 +41,7 @@
     "@types/node": "^20.11.30",
     "@types/express": "~4.17.21",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"
   },

--- a/js/ai/package.json
+++ b/js/ai/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.1",
     "typescript": "^4.9.0"

--- a/js/core/package.json
+++ b/js/core/package.json
@@ -48,6 +48,7 @@
     "@types/node": "^20.11.30",
     "genversion": "^3.2.0",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"

--- a/js/genkit/package.json
+++ b/js/genkit/package.json
@@ -34,6 +34,7 @@
     "@types/express": "^4.17.21",
     "@types/uuid": "^9.0.6",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "typescript": "^4.9.0",
     "tsx": "^4.7.1",

--- a/js/plugins/chroma/package.json
+++ b/js/plugins/chroma/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@types/node": "^20.11.16",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"

--- a/js/plugins/dev-local-vectorstore/package.json
+++ b/js/plugins/dev-local-vectorstore/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@types/node": "^20.11.16",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"

--- a/js/plugins/dotprompt/package.json
+++ b/js/plugins/dotprompt/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@types/node": "^20.11.16",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0",

--- a/js/plugins/evaluators/package.json
+++ b/js/plugins/evaluators/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/node": "^20.11.16",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"

--- a/js/plugins/firebase/package.json
+++ b/js/plugins/firebase/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@types/node": "^20.11.16",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"

--- a/js/plugins/google-cloud/package.json
+++ b/js/plugins/google-cloud/package.json
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@types/node": "^20.11.16",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"

--- a/js/plugins/googleai/package.json
+++ b/js/plugins/googleai/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@types/node": "^20.11.16",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"

--- a/js/plugins/langchain/package.json
+++ b/js/plugins/langchain/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/node": "^20.11.16",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"

--- a/js/plugins/ollama/package.json
+++ b/js/plugins/ollama/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@types/node": "^20.11.16",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"

--- a/js/plugins/pinecone/package.json
+++ b/js/plugins/pinecone/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@types/node": "^20.11.16",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"

--- a/js/plugins/vertexai/package.json
+++ b/js/plugins/vertexai/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@types/node": "^20.11.16",
     "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "tsx": "^4.7.0",
     "typescript": "^4.9.0"

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -118,6 +121,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -152,6 +158,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -180,6 +189,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -208,6 +220,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -242,6 +257,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -276,6 +294,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -316,6 +337,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -392,6 +416,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -423,6 +450,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -457,6 +487,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -479,6 +512,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -507,6 +543,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -560,6 +599,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(postcss@8.4.47)(typescript@4.9.5)
@@ -641,6 +683,9 @@ importers:
         specifier: ^0.12.7
         version: 0.12.7
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -693,6 +738,9 @@ importers:
       '@types/pdf-parse':
         specifier: ^1.1.4
         version: 1.1.4
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -730,6 +778,9 @@ importers:
         specifier: workspace:*
         version: link:../../plugins/pinecone
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -749,6 +800,9 @@ importers:
         specifier: workspace:*
         version: link:../../genkit
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -777,6 +831,9 @@ importers:
       '@types/pdf-parse':
         specifier: ^1.1.4
         version: 1.1.4
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -796,6 +853,9 @@ importers:
         specifier: workspace:*
         version: link:../../genkit
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -821,6 +881,9 @@ importers:
         specifier: workspace:*
         version: link:../../genkit
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -849,6 +912,9 @@ importers:
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -862,6 +928,9 @@ importers:
         specifier: workspace:^
         version: link:../../genkit
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -896,6 +965,9 @@ importers:
         specifier: ^0.1.7
         version: 0.1.7
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -964,6 +1036,9 @@ importers:
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -989,6 +1064,9 @@ importers:
         specifier: workspace:*
         version: link:../../genkit
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -1017,6 +1095,9 @@ importers:
         specifier: ^0.10.1
         version: 0.10.1(@genkit-ai/ai@0.6.0-dev.2)(@genkit-ai/core@0.6.0-dev.2)
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.3.3
         version: 5.5.3
@@ -1113,6 +1194,9 @@ importers:
         specifier: ^9.11.0
         version: 9.11.0(encoding@0.1.13)
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.5.2
         version: 5.5.3
@@ -1159,6 +1243,9 @@ importers:
         specifier: ^9.11.0
         version: 9.11.0(encoding@0.1.13)
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.5.2
         version: 5.5.3
@@ -1205,6 +1292,9 @@ importers:
         specifier: ^9.11.0
         version: 9.11.0(encoding@0.1.13)
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.5.2
         version: 5.5.3
@@ -1251,6 +1341,9 @@ importers:
         specifier: ^9.11.0
         version: 9.11.0(encoding@0.1.13)
     devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: ^5.5.2
         version: 5.5.3
@@ -3325,6 +3418,11 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  glob@11.0.0:
+    resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -3607,6 +3705,10 @@ packages:
   jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
     engines: {node: '>=14'}
+
+  jackspeak@4.0.2:
+    resolution: {integrity: sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==}
+    engines: {node: 20 || >=22}
 
   jake@10.9.1:
     resolution: {integrity: sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==}
@@ -3915,6 +4017,10 @@ packages:
     resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@11.0.1:
+    resolution: {integrity: sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@4.0.2:
     resolution: {integrity: sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==}
 
@@ -3991,6 +4097,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -4015,6 +4125,10 @@ packages:
 
   minipass@7.0.4:
     resolution: {integrity: sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@2.1.2:
@@ -4208,6 +4322,9 @@ packages:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parents@1.0.1:
     resolution: {integrity: sha512-mXKF3xkoUt5td2DoxpLmtOmZvko9VfFpwRwkKDHSNvgmpLAeBo18YDhcPbBzJq+QLCHMbGOfzia2cX4U+0v9Mg==}
 
@@ -4244,6 +4361,10 @@ packages:
   path-scurry@1.10.2:
     resolution: {integrity: sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
 
   path-to-regexp@0.1.10:
     resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
@@ -4488,6 +4609,11 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@6.0.1:
+    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   rollup@4.13.2:
@@ -7372,6 +7498,15 @@ snapshots:
       minipass: 7.0.4
       path-scurry: 1.10.2
 
+  glob@11.0.0:
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 4.0.2
+      minimatch: 10.0.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -7745,6 +7880,10 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.0.2:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
   jake@10.9.1:
     dependencies:
       async: 3.2.5
@@ -7996,6 +8135,8 @@ snapshots:
 
   lru-cache@10.2.0: {}
 
+  lru-cache@11.0.1: {}
+
   lru-cache@4.0.2:
     dependencies:
       pseudomap: 1.0.2
@@ -8058,6 +8199,10 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  minimatch@10.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -8081,6 +8226,8 @@ snapshots:
     optional: true
 
   minipass@7.0.4: {}
+
+  minipass@7.1.2: {}
 
   minizlib@2.1.2:
     dependencies:
@@ -8279,6 +8426,8 @@ snapshots:
     dependencies:
       p-finally: 1.0.0
 
+  package-json-from-dist@1.0.1: {}
+
   parents@1.0.1:
     dependencies:
       path-platform: 0.11.15
@@ -8307,6 +8456,11 @@ snapshots:
     dependencies:
       lru-cache: 10.2.0
       minipass: 7.0.4
+
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.0.1
+      minipass: 7.1.2
 
   path-to-regexp@0.1.10: {}
 
@@ -8573,6 +8727,11 @@ snapshots:
     dependencies:
       glob: 7.2.3
     optional: true
+
+  rimraf@6.0.1:
+    dependencies:
+      glob: 11.0.0
+      package-json-from-dist: 1.0.1
 
   rollup@4.13.2:
     dependencies:

--- a/js/testapps/byo-evaluator/package.json
+++ b/js/testapps/byo-evaluator/package.json
@@ -23,6 +23,7 @@
     "path": "^0.12.7"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }

--- a/js/testapps/cat-eval/package.json
+++ b/js/testapps/cat-eval/package.json
@@ -30,6 +30,7 @@
     "pdfjs-dist-legacy": "^1.0.1"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "@types/pdf-parse": "^1.1.4",
     "typescript": "^5.3.3"
   }

--- a/js/testapps/dev-ui-gallery/package.json
+++ b/js/testapps/dev-ui-gallery/package.json
@@ -15,6 +15,7 @@
   "author": "Google, LLC",
   "license": "ISC",
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   },
   "dependencies": {

--- a/js/testapps/docs-menu-basic/package.json
+++ b/js/testapps/docs-menu-basic/package.json
@@ -21,6 +21,7 @@
     "express": "^4.21.0"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }

--- a/js/testapps/docs-menu-rag/package.json
+++ b/js/testapps/docs-menu-rag/package.json
@@ -23,6 +23,7 @@
     "pdf-parse": "^1.1.1"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "@types/pdf-parse": "^1.1.4",
     "typescript": "^5.3.3"
   }

--- a/js/testapps/eval/package.json
+++ b/js/testapps/eval/package.json
@@ -21,6 +21,7 @@
     "@genkit-ai/vertexai": "workspace:*"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }

--- a/js/testapps/evaluator-gut-check/package.json
+++ b/js/testapps/evaluator-gut-check/package.json
@@ -22,6 +22,7 @@
     "@genkit-ai/vertexai": "workspace:*"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }

--- a/js/testapps/express/package.json
+++ b/js/testapps/express/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }

--- a/js/testapps/flow-sample1/package.json
+++ b/js/testapps/flow-sample1/package.json
@@ -19,6 +19,7 @@
     "@genkit-ai/firebase": "workspace:^"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }

--- a/js/testapps/flow-simple-ai/package.json
+++ b/js/testapps/flow-simple-ai/package.json
@@ -26,6 +26,7 @@
     "partial-json": "^0.1.7"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }

--- a/js/testapps/langchain/package.json
+++ b/js/testapps/langchain/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }

--- a/js/testapps/menu/package.json
+++ b/js/testapps/menu/package.json
@@ -23,6 +23,7 @@
     "@genkit-ai/vertexai": "workspace:*"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   },
   "type": "module"

--- a/js/testapps/model-tester/package.json
+++ b/js/testapps/model-tester/package.json
@@ -24,6 +24,7 @@
     "genkitx-openai": "^0.10.1"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }

--- a/js/testapps/vertexai-reranker/package.json
+++ b/js/testapps/vertexai-reranker/package.json
@@ -24,6 +24,7 @@
     "google-auth-library": "^9.11.0"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.5.2"
   }
 }

--- a/js/testapps/vertexai-vector-search-bigquery/package.json
+++ b/js/testapps/vertexai-vector-search-bigquery/package.json
@@ -29,6 +29,7 @@
     "google-auth-library": "^9.11.0"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.5.2"
   }
 }

--- a/js/testapps/vertexai-vector-search-custom/package.json
+++ b/js/testapps/vertexai-vector-search-custom/package.json
@@ -29,6 +29,7 @@
     "google-auth-library": "^9.11.0"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.5.2"
   }
 }

--- a/js/testapps/vertexai-vector-search-firestore/package.json
+++ b/js/testapps/vertexai-vector-search-firestore/package.json
@@ -29,6 +29,7 @@
     "google-auth-library": "^9.11.0"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.5.2"
   }
 }

--- a/samples/js-coffee-shop/package.json
+++ b/samples/js-coffee-shop/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "genkit": "^0.5.0",
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }

--- a/samples/js-menu/package.json
+++ b/samples/js-menu/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "genkit": "^0.5.0",
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }

--- a/tests/test_js_app/package.json
+++ b/tests/test_js_app/package.json
@@ -18,6 +18,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "rimraf": "^6.0.1",
     "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
This fixes running `pnpm build` from any of the subdirectory packages that now use `rimraf` instead of `rm`.

Follow-up from https://github.com/firebase/genkit/pull/998.