### PR TITLE
Set span type to prompt when rendering a dotprompt

### DIFF
--- a/js/plugins/dotprompt/src/prompt.ts
+++ b/js/plugins/dotprompt/src/prompt.ts
@@ -234,7 +234,7 @@ export class Dotprompt<I = unknown> implements PromptMetadata<z.ZodTypeAny> {
           input: opt,
         },
         labels: {
-          [SPAN_TYPE_ATTR]: 'dotprompt',
+          [SPAN_TYPE_ATTR]: 'prompt',
         },
       },
       async (metadata) => {


### PR DESCRIPTION
This will enable the Dev UI to properly deal with prompts in a more generic way when rendering badges, loading traces into the runner, etc, versus having to check for each different type of prompt ['prompt', 'DOTprompt', 'FOOprompt'] etc.

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/1ec7ec51-cc9f-496e-8e98-b26b7b28017e">

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
