### PR TITLE
feat: simplified syntax for defining super-simple flows

### DIFF
--- a/js/core/src/flow.ts
+++ b/js/core/src/flow.ts
@@ -153,7 +153,7 @@ export type FlowFn<
   streamingCallback?: S extends z.ZodVoid
     ? undefined
     : StreamingCallback<z.infer<S>>
-) => Promise<z.infer<O>>;
+) => Promise<z.infer<O>> | z.infer<O>;
 
 /**
  * Represents the result of a flow execution.
@@ -556,8 +556,14 @@ export class FlowServer {
 export function defineFlow<
   I extends z.ZodTypeAny = z.ZodTypeAny,
   O extends z.ZodTypeAny = z.ZodTypeAny,
->(config: FlowConfig<I, O>, fn: FlowFn<I, O, z.ZodVoid>): CallableFlow<I, O> {
-  const flow = new Flow<I, O, z.ZodVoid>(config, fn);
+>(
+  config: FlowConfig<I, O> | string,
+  fn: FlowFn<I, O, z.ZodVoid>
+): CallableFlow<I, O> {
+  const resolvedConfig: FlowConfig<I, O> =
+    typeof config === 'string' ? { name: config } : config;
+
+  const flow = new Flow<I, O, z.ZodVoid>(resolvedConfig, fn);
   registerFlowAction(flow);
   const registry = getRegistryInstance();
   const callableFlow: CallableFlow<I, O> = async (input, opts) => {

--- a/js/core/tests/flow_test.ts
+++ b/js/core/tests/flow_test.ts
@@ -70,6 +70,18 @@ describe('flow', () => {
       assert.equal(result, 'bar foo');
     });
 
+    it('should run simple sync flow', async () => {
+      const testFlow = runWithRegistry(registry, () => {
+        return defineFlow('testFlow', (input) => {
+          return `bar ${input}`;
+        });
+      });
+
+      const result = await testFlow('foo');
+
+      assert.equal(result, 'bar foo');
+    });
+
     it('should rethrow the error', async () => {
       const testFlow = runWithRegistry(registry, () =>
         defineFlow(

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -143,7 +143,7 @@ export class Genkit {
   defineFlow<
     I extends z.ZodTypeAny = z.ZodTypeAny,
     O extends z.ZodTypeAny = z.ZodTypeAny,
-  >(config: FlowConfig<I, O>, fn: FlowFn<I, O>): CallableFlow<I, O> {
+  >(config: FlowConfig<I, O> | string, fn: FlowFn<I, O>): CallableFlow<I, O> {
     const flow = runWithRegistry(this.registry, () => defineFlow(config, fn));
     this.registeredFlows.push(flow.flow);
     return flow;


### PR DESCRIPTION
this allows:

```ts
ai.defineFlow('banana', () => {
  return 'banana'
})
```

vs 

```ts
ai.defineFlow({ name: 'banana' }, async () => {
  return 'banana'
})
```
