### PR TITLE
chore(js): update genkit-tools types to align with candidate changes

### DIFF
--- a/genkit-tools/genkit-schema.json
+++ b/genkit-tools/genkit-schema.json
@@ -452,31 +452,44 @@
     "GenerateResponseChunk": {
       "type": "object",
       "properties": {
-        "index": {
-          "type": "number"
-        },
         "content": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/Part"
           }
         },
-        "custom": {}
+        "custom": {},
+        "aggregated": {
+          "type": "boolean"
+        },
+        "index": {
+          "type": "number"
+        }
       },
       "required": [
-        "index",
-        "content"
+        "content",
+        "index"
       ],
       "additionalProperties": false
     },
     "GenerateResponse": {
       "type": "object",
       "properties": {
-        "candidates": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Candidate"
-          }
+        "message": {
+          "$ref": "#/$defs/Message"
+        },
+        "finishReason": {
+          "type": "string",
+          "enum": [
+            "stop",
+            "length",
+            "blocked",
+            "other",
+            "unknown"
+          ]
+        },
+        "finishMessage": {
+          "type": "string"
         },
         "latencyMs": {
           "type": "number"
@@ -487,11 +500,14 @@
         "custom": {},
         "request": {
           "$ref": "#/$defs/GenerateRequest"
+        },
+        "candidates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Candidate"
+          }
         }
       },
-      "required": [
-        "candidates"
-      ],
       "additionalProperties": false
     },
     "GenerationCommonConfig": {
@@ -543,6 +559,18 @@
           "type": "number"
         },
         "outputImages": {
+          "type": "number"
+        },
+        "inputVideos": {
+          "type": "number"
+        },
+        "outputVideos": {
+          "type": "number"
+        },
+        "inputAudioFiles": {
+          "type": "number"
+        },
+        "outputAudioFiles": {
           "type": "number"
         },
         "custom": {
@@ -654,6 +682,88 @@
           "additionalProperties": false
         }
       },
+      "additionalProperties": false
+    },
+    "ModelRequest": {
+      "type": "object",
+      "properties": {
+        "messages": {
+          "$ref": "#/$defs/GenerateRequest/properties/messages"
+        },
+        "config": {
+          "$ref": "#/$defs/GenerateRequest/properties/config"
+        },
+        "tools": {
+          "$ref": "#/$defs/GenerateRequest/properties/tools"
+        },
+        "output": {
+          "$ref": "#/$defs/GenerateRequest/properties/output"
+        },
+        "context": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GenerateRequest/properties/context/items"
+          }
+        }
+      },
+      "required": [
+        "messages"
+      ],
+      "additionalProperties": false
+    },
+    "ModelResponseChunk": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "$ref": "#/$defs/GenerateResponseChunk/properties/content"
+        },
+        "custom": {
+          "$ref": "#/$defs/GenerateResponseChunk/properties/custom"
+        },
+        "aggregated": {
+          "$ref": "#/$defs/GenerateResponseChunk/properties/aggregated"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "additionalProperties": false
+    },
+    "ModelResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "$ref": "#/$defs/GenerateResponse/properties/message"
+        },
+        "finishReason": {
+          "type": "string",
+          "enum": [
+            "stop",
+            "length",
+            "blocked",
+            "other",
+            "unknown"
+          ]
+        },
+        "finishMessage": {
+          "$ref": "#/$defs/GenerateResponse/properties/finishMessage"
+        },
+        "latencyMs": {
+          "$ref": "#/$defs/GenerateResponse/properties/latencyMs"
+        },
+        "usage": {
+          "$ref": "#/$defs/GenerateResponse/properties/usage"
+        },
+        "custom": {
+          "$ref": "#/$defs/GenerateResponse/properties/custom"
+        },
+        "request": {
+          "$ref": "#/$defs/GenerateResponse/properties/request"
+        }
+      },
+      "required": [
+        "finishReason"
+      ],
       "additionalProperties": false
     },
     "Part": {

--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -266,7 +266,7 @@ export const ModelResponseSchema = z.object({
 export type ModelResponseData = z.infer<typeof ModelResponseSchema>;
 
 export const GenerateResponseSchema = ModelResponseSchema.extend({
-  /** @deprecated All responses now return a single candidate. Only the first candidate will be used if supplied. Return `message`, `finisheReason`, and `finishMessage` instead. */
+  /** @deprecated All responses now return a single candidate. Only the first candidate will be used if supplied. Return `message`, `finishReason`, and `finishMessage` instead. */
   candidates: z.array(CandidateSchema).optional(),
   finishReason: z
     .enum(['stop', 'length', 'blocked', 'other', 'unknown'])


### PR DESCRIPTION
Brings the genkit-tools version of models up to date with the `js/ai/src/model.ts` changes from https://github.com/firebase/genkit/pull/959.

Part 1 of addressing https://github.com/firebase/genkit/issues/960. Dev UI PR to be merged right after this.