### PR TITLE
Using features in telemetry

### DIFF
--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -26,7 +26,7 @@ import {
 import { parseSchema } from './schema.js';
 import {
   SPAN_TYPE_ATTR,
-  runInNewSpan,
+  newTrace,
   setCustomMetadataAttributes,
 } from './tracing.js';
 
@@ -129,11 +129,9 @@ export function action<
       schema: config.inputSchema,
       jsonSchema: config.inputJsonSchema,
     });
-    let output = await runInNewSpan(
+    let output = await newTrace(
       {
-        metadata: {
-          name: actionName,
-        },
+        name: actionName,
         labels: {
           [SPAN_TYPE_ATTR]: 'action',
         },

--- a/js/core/src/tracing/instrumentation.ts
+++ b/js/core/src/tracing/instrumentation.ts
@@ -46,13 +46,11 @@ export async function newTrace<T>(
   fn: (metadata: SpanMetadata, rootSpan: ApiSpan) => Promise<T>
 ) {
   ensureBasicTelemetryInstrumentation();
-  const traceMetadata = traceMetadataAls.getStore() || {
+  const traceMetadata: TraceMetadata = traceMetadataAls.getStore() || {
     paths: new Set<PathMetadata>(),
     timestamp: performance.now(),
+    featureName: opts.name,
   };
-  if (opts.labels && opts.labels[SPAN_TYPE_ATTR] === 'flow') {
-    traceMetadata.flowName = opts.name;
-  }
   return await traceMetadataAls.run(traceMetadata, () =>
     runInNewSpan(
       {

--- a/js/core/src/tracing/types.ts
+++ b/js/core/src/tracing/types.ts
@@ -29,7 +29,7 @@ export const PathMetadataSchema = z.object({
 export type PathMetadata = z.infer<typeof PathMetadataSchema>;
 
 export const TraceMetadataSchema = z.object({
-  flowName: z.string().optional(),
+  featureName: z.string().optional(),
   paths: z.set(PathMetadataSchema).optional(),
   timestamp: z.number(),
 });

--- a/js/core/src/utils.ts
+++ b/js/core/src/utils.ts
@@ -50,3 +50,10 @@ export function isDevEnv(): boolean {
 export function flowMetadataPrefix(name: string) {
   return `flow:${name}`;
 }
+
+/**
+ * Adds flow-specific prefix for OpenTelemetry span attributes.
+ */
+export function featureMetadataPrefix(name: string) {
+  return `feature:${name}`;
+}

--- a/js/plugins/google-cloud/src/telemetry/action.ts
+++ b/js/plugins/google-cloud/src/telemetry/action.ts
@@ -26,7 +26,7 @@ import {
   Telemetry,
   internalMetricNamespaceWrap,
 } from '../metrics.js';
-import { extractErrorName, extractOuterFlowNameFromPath } from '../utils';
+import { extractErrorName, extractOuterFeatureNameFromPath } from '../utils';
 
 class ActionTelemetry implements Telemetry {
   /**
@@ -55,9 +55,11 @@ class ActionTelemetry implements Telemetry {
 
     const actionName = (attributes['genkit:name'] as string) || '<unknown>';
     const path = (attributes['genkit:path'] as string) || '<unknown>';
-    const flowName =
-      (attributes['genkit:metadata:flow:name'] as string) ||
-      extractOuterFlowNameFromPath(path);
+    let featureName = (attributes['genkit:metadata:flow:name'] ||
+      extractOuterFeatureNameFromPath(path)) as string;
+    if (!featureName || featureName === '<unknown>') {
+      featureName = actionName;
+    }
     const state = attributes['genkit:state'] || 'success';
     const latencyMs = hrTimeToMilliseconds(
       hrTimeDuration(span.startTime, span.endTime)
@@ -65,11 +67,11 @@ class ActionTelemetry implements Telemetry {
     const errorName = extractErrorName(span.events);
 
     if (state === 'success') {
-      this.writeSuccess(actionName, flowName, path, latencyMs);
+      this.writeSuccess(actionName, featureName, path, latencyMs);
       return;
     }
     if (state === 'error') {
-      this.writeFailure(actionName, flowName, path, latencyMs, errorName);
+      this.writeFailure(actionName, featureName, path, latencyMs, errorName);
     }
 
     logger.warn(`Unknown action state; ${state}`);
@@ -77,13 +79,13 @@ class ActionTelemetry implements Telemetry {
 
   private writeSuccess(
     actionName: string,
-    flowName: string,
+    featureName: string,
     path: string,
     latencyMs: number
   ) {
     const dimensions = {
       name: actionName,
-      flowName,
+      featureName,
       path,
       status: 'success',
       source: 'ts',
@@ -95,14 +97,14 @@ class ActionTelemetry implements Telemetry {
 
   private writeFailure(
     actionName: string,
-    flowName: string,
+    featureName: string,
     path: string,
     latencyMs: number,
     errorName?: string
   ) {
     const dimensions = {
       name: actionName,
-      flowName,
+      featureName,
       path,
       source: 'ts',
       sourceVersion: GENKIT_VERSION,

--- a/js/plugins/google-cloud/src/utils.ts
+++ b/js/plugins/google-cloud/src/utils.ts
@@ -26,6 +26,20 @@ export function extractOuterFlowNameFromPath(path: string) {
   return flowName ? flowName[1] : '<unknown>';
 }
 
+/**
+ * Extract first feature name from a path
+ * e.g. for /{myFlow,t:flow}/{myStep,t:flowStep}/{googleai/gemini-pro,t:action,s:model}
+ * returns "myFlow"
+ */
+export function extractOuterFeatureNameFromPath(path: string) {
+  if (!path || path === '<unknown>') {
+    return '<unknown>';
+  }
+  const first = path.split('/')[1];
+  const featureName = first?.match('{(.+),t:(flow|action|prompt|helper)');
+  return featureName ? featureName[1] : '<unknown>';
+}
+
 export function extractErrorName(events: TimedEvent[]): string | undefined {
   return events
     .filter((event) => event.name === 'exception')

--- a/js/plugins/google-cloud/tests/logs_no_io_test.ts
+++ b/js/plugins/google-cloud/tests/logs_no_io_test.ts
@@ -15,8 +15,8 @@
  */
 
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { Genkit, generate, genkit, run, z } from 'genkit';
-import { GenerateResponseData, defineModel } from 'genkit/model';
+import { generate, Genkit, genkit, run, z } from 'genkit';
+import { defineModel, GenerateResponseData } from 'genkit/model';
 import { runWithRegistry } from 'genkit/registry';
 import assert from 'node:assert';
 import { after, before, beforeEach, describe, it } from 'node:test';

--- a/js/plugins/google-cloud/tests/logs_test.ts
+++ b/js/plugins/google-cloud/tests/logs_test.ts
@@ -15,10 +15,10 @@
  */
 
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { Genkit, generate, genkit, run, z } from 'genkit';
-import { GenerateResponseData, defineModel } from 'genkit/model';
+import { generate, Genkit, genkit, run, z } from 'genkit';
+import { defineModel, GenerateResponseData } from 'genkit/model';
 import { runWithRegistry } from 'genkit/registry';
-import { SPAN_TYPE_ATTR, appendSpan } from 'genkit/tracing';
+import { appendSpan, SPAN_TYPE_ATTR } from 'genkit/tracing';
 import assert from 'node:assert';
 import { after, before, beforeEach, describe, it } from 'node:test';
 import { Writable } from 'stream';


### PR DESCRIPTION
Enabling top level actions such as prompts or generate calls to be used for telemetry as effectively as those wrapped in flows.

- Switching actions to use newTrace, which starts a trace similar to a flow if it is not currently inside something.
- Improving instrumentation to always assign a feature name
- Renaming metric dimensions from flowName -> featureName