### PR TITLE
chore: pin package versions in `genkit init` in prep for next release

### DIFF
--- a/genkit-tools/cli/src/commands/init/init-go.ts
+++ b/genkit-tools/cli/src/commands/init/init-go.ts
@@ -191,7 +191,7 @@ export async function initGo(options: InitOptions, isNew: boolean) {
 function installPackages(packages: string[]) {
   const spinner = ora('Installing Go packages').start();
   try {
-    execSync(`go get ${packages.map((p) => p + '@latest').join(' ')}`, {
+    execSync(`go get ${packages.map((p) => p + '@v0.1').join(' ')}`, {
       stdio: 'ignore',
     });
     spinner.succeed('Successfully installed Go packages');

--- a/genkit-tools/cli/src/commands/init/init-nodejs.ts
+++ b/genkit-tools/cli/src/commands/init/init-nodejs.ts
@@ -240,8 +240,8 @@ export async function initNodejs(options: InitOptions, isNew: boolean) {
   // Compile NPM packages list.
   const packages = [...externalPackages];
   if (!distArchive) {
-    packages.push(...internalPackages);
-    packages.push(...plugins);
+    packages.push(...internalPackages.map((p) => `${p}@^0.5`));
+    packages.push(...plugins.map((p) => `${p}@^0.5`));
   }
 
   // Initialize and configure.


### PR DESCRIPTION
Fixes #1074