### PR TITLE
Marking the correct feature when failing in subflows

### DIFF
--- a/js/plugins/google-cloud/src/telemetry/action.ts
+++ b/js/plugins/google-cloud/src/telemetry/action.ts
@@ -55,8 +55,7 @@ class ActionTelemetry implements Telemetry {
 
     const actionName = (attributes['genkit:name'] as string) || '<unknown>';
     const path = (attributes['genkit:path'] as string) || '<unknown>';
-    let featureName = (attributes['genkit:metadata:flow:name'] ||
-      extractOuterFeatureNameFromPath(path)) as string;
+    let featureName = extractOuterFeatureNameFromPath(path);
     if (!featureName || featureName === '<unknown>') {
       featureName = actionName;
     }
@@ -68,13 +67,11 @@ class ActionTelemetry implements Telemetry {
 
     if (state === 'success') {
       this.writeSuccess(actionName, featureName, path, latencyMs);
-      return;
-    }
-    if (state === 'error') {
+    } else if (state === 'error') {
       this.writeFailure(actionName, featureName, path, latencyMs, errorName);
+    } else {
+      logger.warn(`Unknown action state; ${state}`);
     }
-
-    logger.warn(`Unknown action state; ${state}`);
   }
 
   private writeSuccess(

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -184,11 +184,13 @@ describe('GoogleCloudMetrics', () => {
     assert.equal(requestCounter.attributes.source, 'ts');
     assert.equal(requestCounter.attributes.status, 'success');
     assert.ok(requestCounter.attributes.sourceVersion);
+    assert.equal(requestCounter.attributes.featureName, 'testFlowWithActions');
     assert.equal(latencyHistogram.value.count, 6);
     assert.equal(latencyHistogram.attributes.name, 'testAction');
     assert.equal(latencyHistogram.attributes.source, 'ts');
     assert.equal(latencyHistogram.attributes.status, 'success');
     assert.ok(latencyHistogram.attributes.sourceVersion);
+    assert.equal(requestCounter.attributes.featureName, 'testFlowWithActions');
   });
 
   it('writes feature metrics for an action', async () => {


### PR DESCRIPTION
- Always using top level feature name for action metrics
- Fixing spurious error logging