### PR TITLE
fix(js/genkit): export defineTool

### DIFF
--- a/js/genkit/src/tool.ts
+++ b/js/genkit/src/tool.ts
@@ -16,6 +16,7 @@
 
 export {
   asTool,
+  defineTool,
   toToolDefinition,
   type ToolAction,
   type ToolArgument,


### PR DESCRIPTION
This should probably be exported from `genkit/tool` 

Should resolve https://github.com/firebase/genkit/issues/1106

Checklist (if applicable):
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated
