### PR TITLE
Logging I/O for tool spans

### DIFF
--- a/js/plugins/google-cloud/tests/logs_test.ts
+++ b/js/plugins/google-cloud/tests/logs_test.ts
@@ -115,7 +115,7 @@ describe('GoogleCloudLogs', () => {
     await getExportedSpans();
 
     const logMessages = await getLogs(1, 100, logLines);
-    console.log(logMessages);
+
     assert.equal(
       logMessages.includes(
         "[error] Error[testFlow, TypeError] Cannot read properties of undefined (reading 'explode')"
@@ -232,6 +232,18 @@ describe('GoogleCloudLogs', () => {
     await getExportedSpans();
     const logMessages = await getLogs(1, 100, logLines);
     assert.equal(logMessages.includes('[info] UserAcceptance[flowName]'), true);
+  });
+
+  it('writes tool input and output logs', async () => {
+    const echoTool = ai.defineTool(
+      { name: 'echoTool', description: 'echo' },
+      async (input) => input
+    );
+    await echoTool('Helllooooo!');
+    await getExportedSpans();
+    const logMessages = await getLogs(2, 100, logLines);
+    assert.ok(logMessages.includes('[info] Input[echoTool, echoTool]'));
+    assert.ok(logMessages.includes('[info] Output[echoTool, echoTool]'));
   });
 });
 

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -175,8 +175,7 @@ describe('GoogleCloudMetrics', () => {
     assert.equal(requestCounter.attributes.status, 'failure');
   }, 10000); //timeout
 
-  // SKIPPED -- we don't allow defining arbitrary actions anymore....
-  it.skip('writes action metrics', async () => {
+  it('writes action metrics', async () => {
     const testAction = createAction(ai, 'testAction');
     const testFlow = createFlow(ai, 'testFlowWithActions', async () => {
       await Promise.all([
@@ -279,13 +278,15 @@ describe('GoogleCloudMetrics', () => {
     );
   });
 
-  // SKIPPED -- we don't allow defining arbitrary actions anymore....
-  it.skip('writes action failure metrics', async () => {
-    const testAction = createAction(ai, 'testActionWithFailure', async () => {
-      const nothing: { missing?: any } = { missing: 1 };
-      delete nothing.missing;
-      return nothing.missing.explode;
-    });
+  it('writes action failure metrics', async () => {
+    const testAction = ai.defineTool(
+      { name: 'testActionWithFailure', description: 'Just a test' },
+      async () => {
+        const nothing: { missing?: any } = { missing: 1 };
+        delete nothing.missing;
+        return nothing.missing.explode;
+      }
+    );
 
     assert.rejects(async () => {
       return testAction(null);
@@ -406,8 +407,7 @@ describe('GoogleCloudMetrics', () => {
     assert.ok(requestCounter.attributes.sourceVersion);
   }, 10000); //timeout
 
-  // SKIPPED -- we don't allow defining arbitrary actions anymore....
-  it.skip('writes flow label to action metrics when running inside flow', async () => {
+  it('writes flow label to action metrics when running inside flow', async () => {
     const testAction = createAction(ai, 'testAction');
     const flow = createFlow(ai, 'flowNameLabelTestFlow', async () => {
       return await testAction(undefined);
@@ -927,9 +927,10 @@ describe('GoogleCloudMetrics', () => {
     name: string,
     fn: () => Promise<void> = async () => {}
   ) {
-    return ai.defineFlow(
+    return ai.defineTool(
       {
         name,
+        description: "I don't do much...",
       },
       fn
     );


### PR DESCRIPTION
- Adding input and output logs for tool calls.
- Restoring skipped action tests
