### PR TITLE
Clear trace metadata from logs not used by GCP plugin.

### DIFF
--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -97,6 +97,15 @@ export class GcpOpenTelemetry {
       `projects/${projectId}/traces/${spanContext.traceId}`;
     record['logging.googleapis.com/trace_sampled'] ??= isSampled ? '1' : '0';
     record['logging.googleapis.com/spanId'] ??= spanContext.spanId;
+
+    // Clear out the duplicate trace and span information in the log metadata.
+    // These will be incorrect for logs written during span export time since
+    // the logs are written after the span has fully executed. Those logs are
+    // explicitly tied to the correct span in createCommonLogAttributes in
+    // utils.ts.
+    delete record['span_id'];
+    delete record['trace_id'];
+    delete record['trace_flags'];
   };
 
   async getConfig(): Promise<Partial<NodeSDKConfiguration>> {


### PR DESCRIPTION
For logs written during span export in the GCP plugin, these default Otel trace fields are incorrect because the log is being written at a different time than during span execution.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated
