### PR TITLE
Fix action schema validation

### DIFF
--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -28,6 +28,8 @@ import {
 export { Status, StatusCodes, StatusSchema } from './statusTypes.js';
 export { JSONSchema7 };
 
+export const GENKIT_SESSION_STATE_INPUT_KEY = '__genkit__sessionState';
+
 export interface ActionMetadata<
   I extends z.ZodTypeAny,
   O extends z.ZodTypeAny,
@@ -120,6 +122,10 @@ export function action<
       ? config.name
       : `${config.name.pluginId}/${config.name.actionId}`;
   const actionFn = async (input: I) => {
+    if (input?.hasOwnProperty(GENKIT_SESSION_STATE_INPUT_KEY)) {
+      input = { ...input };
+      delete input[GENKIT_SESSION_STATE_INPUT_KEY];
+    }
     input = parseSchema(input, {
       schema: config.inputSchema,
       jsonSchema: config.inputJsonSchema,

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -475,8 +475,8 @@ export class Genkit {
         // ignore, no model on a render is OK?
       }
       const promptResult = await p({
-        // this feels a litte hacky, but we need to pass session state as action input
-        // to make it replayable from trace view in the dev ui.
+        // this feels a litte hacky, but we need to pass session state as action
+        // input to make it replayable from trace view in the dev ui.
         __genkit__sessionState: { state: getCurrentSession()?.state },
         ...opt.input,
       });


### PR DESCRIPTION
Prune the session state from the input just prior to validation (at the action level), similar to what we're doing for rendering prompts.

See also:
https://github.com/firebase/genkit/blob/next/js/plugins/dotprompt/src/prompt.ts#L182-L198

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated
