### PR TITLE
Include model in options for executable prompts

### DIFF
--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -279,18 +279,21 @@ export class Genkit {
     name: string,
     options?: { variant?: string }
   ): Promise<ExecutablePrompt<z.infer<I>, O, CustomOptions>> {
-    // check if functional prompt exists.
+    // check the registry first as not all prompt types can be
+    // loaded by dotprompt (e.g. functional)
     let action = (await this.registry.lookupAction(
       `/prompt/${name}`
     )) as PromptAction<I>;
-    // if not, lookup with dotprompt.
+    // nothing in registry - check for dotprompt file.
     if (!action) {
       action = (await prompt(this.registry, name, options))
         .promptAction as PromptAction<I>;
     }
+    // make sure we get configuration such as model name if applicable
+    const { template, ...opts } = action.__action.metadata!.prompt;
     return this.wrapPromptActionInExecutablePrompt(
       action as PromptAction<I>,
-      {}
+      opts
     ) as ExecutablePrompt<I, O, CustomOptions>;
   }
 


### PR DESCRIPTION
When wrapping prompt actions as ExecutablePrompt, we need to include the model in the options. This is because the PromptAction returns GenerateRequest, which in turn does not actually include model. This is particularly a problem for dotprompt files.

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [NA] Docs updated

cc @pavelgj 

Fixes #1119
