### PR TITLE
Re-initializing GCP logger after it experiences a failure.

### DIFF
--- a/js/plugins/google-cloud/src/gcpLogger.ts
+++ b/js/plugins/google-cloud/src/gcpLogger.ts
@@ -15,6 +15,7 @@
  */
 
 import { LoggingWinston } from '@google-cloud/logging-winston';
+import { getCurrentEnv } from 'genkit';
 import { logger } from 'genkit/logging';
 import { Writable } from 'stream';
 import { GcpTelemetryConfig } from './types';
@@ -56,6 +57,7 @@ export class GcpLogger {
             prefix: 'genkit',
             logName: 'genkit_log',
             credentials: this.config.credentials,
+            autoRetry: true,
             defaultCallback: await this.getErrorHandler(),
           })
         : new winston.transports.Console()
@@ -89,6 +91,13 @@ export class GcpLogger {
         }
       } else if (err) {
         defaultLogger.error(`Unable to send logs to Google Cloud: ${err}`);
+      }
+
+      if (err) {
+        // Assume the logger is compromised, and we need a new one
+        // Reinitialize the genkit logger with a new instance with the same config
+        logger.init(new GcpLogger(this.config).getLogger(getCurrentEnv()));
+        defaultLogger.info('Initialized a new GcpLogger.');
       }
     };
   }


### PR DESCRIPTION
When deployed on Cloud Run, the winston logger stops sending logs after a connection error.
This change creates a new logger when the error handler detects a problem.
