### PR TITLE
chore: rename 'prompt' to 'preamble' in chat

### DIFF
--- a/js/genkit/src/chat.ts
+++ b/js/genkit/src/chat.ts
@@ -42,7 +42,7 @@ export type ChatGenerateOptions<
 > = GenerateOptions<O, CustomOptions>;
 
 export interface PromptRenderOptions<I> {
-  prompt: ExecutablePrompt<I>;
+  preamble: ExecutablePrompt<I>;
   input?: I;
 }
 

--- a/js/genkit/src/session.ts
+++ b/js/genkit/src/session.ts
@@ -168,9 +168,9 @@ export class Session<S = any> {
         }
       }
       let requestBase: Promise<BaseGenerateOptions>;
-      if (!!(options as PromptRenderOptions<I>)?.prompt?.render) {
+      if (!!(options as PromptRenderOptions<I>)?.preamble?.render) {
         const renderOptions = options as PromptRenderOptions<I>;
-        requestBase = renderOptions.prompt
+        requestBase = renderOptions.preamble
           .render({
             input: renderOptions.input,
           })

--- a/js/genkit/tests/chat_test.ts
+++ b/js/genkit/tests/chat_test.ts
@@ -120,12 +120,12 @@ describe('chat', () => {
   });
 
   it('can start chat from a prompt', async () => {
-    const prompt = ai.definePrompt(
+    const preamble = ai.definePrompt(
       { name: 'hi', config: { version: 'abc' } },
       'hi {{ name }} from template'
     );
     const session = await ai.chat({
-      prompt,
+      preamble,
       input: { name: 'Genkit' },
     });
     const response = await session.send('send it');
@@ -208,7 +208,7 @@ describe('preabmle', () => {
     };
 
     const session = ai.chat({
-      prompt: agentA,
+      preamble: agentA,
     });
     let { text } = await session.send('hi');
     assert.strictEqual(text, 'hi from agent a');

--- a/js/genkit/tests/generate_test.ts
+++ b/js/genkit/tests/generate_test.ts
@@ -65,7 +65,7 @@ describe('generate', () => {
         messages: [
           {
             role: 'system',
-            content: 'talk like a pirate',
+            content: [{ text: 'talk like a pirate' }],
           },
           {
             role: 'user',

--- a/js/genkit/tests/session_test.ts
+++ b/js/genkit/tests/session_test.ts
@@ -347,7 +347,7 @@ describe('session', () => {
         foo: 'bar',
       },
     });
-    const chat = session.chat({ prompt: agent });
+    const chat = session.chat({ preamble: agent });
     const respose = await chat.send('hi');
     assert.deepStrictEqual(respose.messages, [
       {

--- a/js/package.json
+++ b/js/package.json
@@ -15,7 +15,7 @@
     "pack:ai": "cd ai && pnpm pack --pack-destination ../../dist",
     "pack:genkit": "cd genkit && pnpm pack --pack-destination ../../dist",
     "pack:plugins": "for i in plugins/*/; do cd $i && pnpm pack --pack-destination ../../../dist && cd ../..; done",
-    "test:all": "pnpm -r --workspace-concurrency 0 -F \"./(ai|core|plugins)/**\" test"
+    "test:all": "pnpm -r --workspace-concurrency 0 -F \"./(ai|core|plugins|genkit)/**\" test"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
```ts
const chat = session.chat({ preamble: agent });
```

Fixes #1117