### PR TITLE
fix: handle (and rethrow) exceptions during `generateStream`

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -426,10 +426,19 @@ export async function generateStream<
             ({ resolve: provideNextChunk, promise: nextChunk } =
               createPromise<GenerateResponseChunk | null>());
           },
-        }).then((result) => {
-          provideNextChunk(null);
-          finalResolve(result);
-        });
+        })
+          .then((result) => {
+            provideNextChunk(null);
+            finalResolve(result);
+          })
+          .catch((e) => {
+            if (!firstChunkSent) {
+              initialReject(e);
+              return;
+            }
+            provideNextChunk(null);
+            finalReject(e);
+          });
       } catch (e) {
         if (!firstChunkSent) {
           initialReject(e);

--- a/js/genkit/tests/generate_test.ts
+++ b/js/genkit/tests/generate_test.ts
@@ -18,7 +18,7 @@ import assert from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
 import { modelRef } from '../../ai/src/model';
 import { Genkit, genkit } from '../src/genkit';
-import { defineEchoModel } from './helpers';
+import { defineEchoModel, runAsync } from './helpers';
 
 describe('generate', () => {
   describe('default model', () => {
@@ -65,7 +65,7 @@ describe('generate', () => {
         messages: [
           {
             role: 'system',
-            content: 'talk like a pirate',
+            content: [{ text: 'talk like a pirate' }],
           },
           {
             role: 'user',
@@ -91,7 +91,7 @@ describe('generate', () => {
     });
   });
 
-  describe('default model', () => {
+  describe('explicit model', () => {
     let ai: Genkit;
 
     beforeEach(() => {
@@ -105,6 +105,71 @@ describe('generate', () => {
         prompt: 'hi',
       });
       assert.strictEqual(response.text, 'Echo: hi; config: {}');
+    });
+  });
+
+  describe('streaming', () => {
+    let ai: Genkit;
+
+    beforeEach(() => {
+      ai = genkit({});
+    });
+
+    it('rethrows errors', async () => {
+      ai.defineModel(
+        {
+          name: 'blockingModel',
+        },
+        async (request, streamingCallback) => {
+          if (streamingCallback) {
+            await runAsync(() => {
+              streamingCallback({
+                content: [
+                  {
+                    text: '3',
+                  },
+                ],
+              });
+            });
+            await runAsync(() => {
+              streamingCallback({
+                content: [
+                  {
+                    text: '2',
+                  },
+                ],
+              });
+            });
+            await runAsync(() => {
+              streamingCallback({
+                content: [
+                  {
+                    text: '1',
+                  },
+                ],
+              });
+            });
+          }
+          return await runAsync(() => ({
+            message: {
+              role: 'model',
+              content: [],
+            },
+            finishReason: 'blocked',
+          }));
+        }
+      );
+
+      assert.rejects(async () => {
+        const { response, stream } = await ai.generateStream({
+          prompt: 'hi',
+          model: 'blockingModel',
+        });
+        for await (const chunk of stream) {
+          // nothing
+        }
+        await response;
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #1183