### PR TITLE
Reduce duplicate codepaths for resolving models and tools.

### DIFF
--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -17,6 +17,7 @@
 import {
   Action,
   defineAction,
+  GenkitError,
   getStreamingCallback,
   Middleware,
   StreamingCallback,
@@ -479,3 +480,54 @@ function getPartCounts(parts: Part[]): PartCounts {
 export type ModelArgument<
   CustomOptions extends z.ZodTypeAny = typeof GenerationCommonConfigSchema,
 > = ModelAction<CustomOptions> | ModelReference<CustomOptions> | string;
+
+export interface ResolvedModel<
+  CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
+> {
+  modelAction: ModelAction;
+  config?: z.infer<CustomOptions>;
+  version?: string;
+}
+
+export async function resolveModel<C extends z.ZodTypeAny = z.ZodTypeAny>(
+  registry: Registry,
+  model: ModelArgument<C> | undefined
+): Promise<ResolvedModel<C>> {
+  let out: ResolvedModel<C>;
+  let modelId: string;
+
+  if (!model) {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: 'Must supply a `model` to `generate()` calls.',
+    });
+  }
+  if (typeof model === 'string') {
+    modelId = model;
+    out = { modelAction: await registry.lookupAction(`/model/${model}`) };
+  } else if (model.hasOwnProperty('__action')) {
+    modelId = (model as ModelAction).__action.name;
+    out = { modelAction: model as ModelAction };
+  } else {
+    const ref = model as ModelReference<any>;
+    modelId = ref.name;
+    out = {
+      modelAction: (await registry.lookupAction(
+        `/model/${ref.name}`
+      )) as ModelAction,
+      config: {
+        ...ref.config,
+      },
+      version: ref.version,
+    };
+  }
+
+  if (!out.modelAction) {
+    throw new GenkitError({
+      status: 'NOT_FOUND',
+      message: `Model ${modelId} not found`,
+    });
+  }
+
+  return out;
+}

--- a/js/ai/src/tool.ts
+++ b/js/ai/src/tool.ts
@@ -95,7 +95,11 @@ export function asTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
 export async function resolveTools<
   O extends z.ZodTypeAny = z.ZodTypeAny,
   CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
->(registry: Registry, tools: ToolArgument[] = []): Promise<ToolAction[]> {
+>(registry: Registry, tools?: ToolArgument[]): Promise<ToolAction[]> {
+  if (!tools || tools.length === 0) {
+    return [];
+  }
+
   return await Promise.all(
     tools.map(async (ref): Promise<ToolAction> => {
       if (typeof ref === 'string') {

--- a/js/testapps/format-tester/src/tools.ts
+++ b/js/testapps/format-tester/src/tools.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gemini15Flash, googleAI } from '@genkit-ai/googleai';
+import { genkit, z } from 'genkit';
+
+const ai = genkit({ plugins: [googleAI()], model: gemini15Flash });
+
+const lookupUsers = ai.defineTool(
+  {
+    name: 'lookupUsers',
+    description: 'use this tool to list users',
+    outputSchema: z.array(z.object({ name: z.string(), id: z.number() })),
+  },
+  async () => [
+    { id: 123, name: 'Michael Bleigh' },
+    { id: 456, name: 'Pavel Jbanov' },
+    { id: 789, name: 'Chris Gill' },
+    { id: 1122, name: 'Marissa Christy' },
+  ]
+);
+
+async function main() {
+  const { stream } = await ai.generateStream({
+    prompt:
+      'use the lookupUsers tool and generate silly nicknames for each, then generate 50 fake users in the same format. return a JSON array.',
+    output: {
+      format: 'json',
+      schema: z.array(
+        z.object({ id: z.number(), name: z.string(), nickname: z.string() })
+      ),
+    },
+    tools: [lookupUsers],
+  });
+
+  for await (const chunk of stream) {
+    console.log('raw:', chunk);
+    console.log('output:', chunk.output);
+  }
+}
+main();


### PR DESCRIPTION
Extracts `resolveModel` into a common helper in `model.ts`, use `resolveTools` instead of duplicating tool resolution.