### PR TITLE
Checks testapp for evaluators

### DIFF
--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -847,6 +847,37 @@ importers:
         specifier: ^5.3.3
         version: 5.4.5
 
+  testapps/checks-evaluation:
+    dependencies:
+      '@genkit-ai/checks':
+        specifier: workspace:*
+        version: link:../../plugins/checks
+      '@genkit-ai/dev-local-vectorstore':
+        specifier: workspace:*
+        version: link:../../plugins/dev-local-vectorstore
+      '@genkit-ai/evaluator':
+        specifier: workspace:*
+        version: link:../../plugins/evaluators
+      '@genkit-ai/firebase':
+        specifier: workspace:*
+        version: link:../../plugins/firebase
+      '@genkit-ai/googleai':
+        specifier: workspace:*
+        version: link:../../plugins/googleai
+      genkit:
+        specifier: workspace:*
+        version: link:../../genkit
+      path:
+        specifier: ^0.12.7
+        version: 0.12.7
+    devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.6.2
+
   testapps/dev-ui-gallery:
     dependencies:
       '@genkit-ai/dev-local-vectorstore':

--- a/js/testapps/checks-evaluation/package.json
+++ b/js/testapps/checks-evaluation/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "checks-evaluators",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "start": "node lib/index.js",
+    "compile": "tsc",
+    "build": "pnpm build:clean && pnpm compile",
+    "build:clean": "rimraf ./lib",
+    "build:watch": "tsc --watch"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@genkit-ai/checks": "workspace:*",
+    "genkit": "workspace:*",
+    "path": "^0.12.7"
+  },
+  "devDependencies": {
+    "rimraf": "^6.0.1",
+    "typescript": "^5.3.3"
+  }
+}

--- a/js/testapps/checks-evaluation/src/index.ts
+++ b/js/testapps/checks-evaluation/src/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { checks, ChecksEvaluationMetricType } from '@genkit-ai/checks';
+import { genkit } from 'genkit';
+
+export const ai = genkit({
+  plugins: [
+    checks({
+      // Project to charge quota to.
+      // Note: If your credentials have a quota project associated with them.
+      //       That value will take precedence over this.
+      projectId: 'your-project-id',
+      evaluation: {
+        metrics: [
+          // Policies configured with the default threshold.
+          ChecksEvaluationMetricType.DANGEROUS_CONTENT,
+          ChecksEvaluationMetricType.HARASSMENT,
+          ChecksEvaluationMetricType.HATE_SPEECH,
+          ChecksEvaluationMetricType.MEDICAL_INFO,
+          ChecksEvaluationMetricType.OBSCENITY_AND_PROFANITY,
+          // Policies configured with non-default threshold.
+          {
+            type: ChecksEvaluationMetricType.PII_SOLICITING_RECITING,
+            threshold: 0.6,
+          },
+          {
+            type: ChecksEvaluationMetricType.SEXUALLY_EXPLICIT,
+            threshold: 0.3,
+          },
+          {
+            type: ChecksEvaluationMetricType.VIOLENCE_AND_GORE,
+            threshold: 0.55,
+          },
+        ],
+      },
+    }),
+  ],
+});

--- a/js/testapps/checks-evaluation/tsconfig.json
+++ b/js/testapps/checks-evaluation/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noImplicitReturns": true,
+    "noUnusedLocals": false,
+    "outDir": "lib",
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2017",
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "compileOnSave": true,
+  "include": ["src"]
+}


### PR DESCRIPTION
Just adding a test application which configures the Checks evaluators.

run `genkit eval:run input-file.json --evaluators=checks/dangerous_content,checks/pii_soliciting_reciting,checks/harassment,checks/sexually_explicit,checks/hate_speech,checks/medical_info,checks/violence_and_gore,checks/obscenity_and_profanity`

Where `input-file.json` is a file of this format:
```json
[
  {
    "testCaseId": "test_case_id_1",
    "input": "The input to your model.",
    "output": "Example model output which. This is what will be evaluated."
  }
]
```


Checklist (if applicable):
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated
