### PR TITLE
fix: reload the preamble every time a 'fresh' chat session is created

### DIFF
--- a/js/ai/src/session.ts
+++ b/js/ai/src/session.ts
@@ -224,6 +224,8 @@ export class Session<S = any> {
         requestBase = preamble
           .render({
             input: renderOptions?.input,
+            model: (renderOptions as BaseGenerateOptions)?.model,
+            config: (renderOptions as BaseGenerateOptions)?.config,
           })
           .then((rb) => {
             return {

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -308,35 +308,6 @@ export class Genkit {
   }
 
   /**
-   * Defines and registers a dotprompt.
-   *
-   * This is an alternative to defining and importing a .prompt file.
-   *
-   * ```ts
-   * const hi = ai.definePrompt(
-   *   {
-   *     name: 'hi',
-   *     input: {
-   *       schema: z.object({
-   *         name: z.string(),
-   *       }),
-   *     },
-   *   },
-   *   'hi {{ name }}'
-   * );
-   * const { text } = await hi({ name: 'Genkit' });
-   * ```
-   */
-  definePrompt<
-    I extends z.ZodTypeAny = z.ZodTypeAny,
-    O extends z.ZodTypeAny = z.ZodTypeAny,
-    CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
-  >(
-    options: PromptMetadata<I, CustomOptions>,
-    template: string
-  ): ExecutablePrompt<z.infer<I>, O, CustomOptions>;
-
-  /**
    * Defines and registers a function-based prompt.
    *
    * ```ts
@@ -368,6 +339,35 @@ export class Genkit {
   >(
     options: PromptMetadata<I, CustomOptions>,
     fn: PromptFn<I>
+  ): ExecutablePrompt<z.infer<I>, O, CustomOptions>;
+
+  /**
+   * Defines and registers a dotprompt.
+   *
+   * This is an alternative to defining and importing a .prompt file.
+   *
+   * ```ts
+   * const hi = ai.definePrompt(
+   *   {
+   *     name: 'hi',
+   *     input: {
+   *       schema: z.object({
+   *         name: z.string(),
+   *       }),
+   *     },
+   *   },
+   *   'hi {{ name }}'
+   * );
+   * const { text } = await hi({ name: 'Genkit' });
+   * ```
+   */
+  definePrompt<
+    I extends z.ZodTypeAny = z.ZodTypeAny,
+    O extends z.ZodTypeAny = z.ZodTypeAny,
+    CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
+  >(
+    options: PromptMetadata<I, CustomOptions>,
+    template: string
   ): ExecutablePrompt<z.infer<I>, O, CustomOptions>;
 
   definePrompt<

--- a/js/genkit/tests/chat_test.ts
+++ b/js/genkit/tests/chat_test.ts
@@ -178,6 +178,7 @@ describe('preamble', () => {
       model: 'programmableModel',
     });
     pm = defineProgrammableModel(ai);
+    defineEchoModel(ai);
   });
 
   it('swaps out preamble on prompt tool invocation', async () => {
@@ -461,5 +462,91 @@ describe('preamble', () => {
         },
       ],
     });
+  });
+
+  it('updates the preabmle on fresh chat instance', async () => {
+    const agent = ai.definePrompt(
+      {
+        name: 'agent',
+        config: { temperature: 2 },
+        description: 'Agent A description',
+      },
+      '{{ role "system"}} greet {{ @state.name }}'
+    );
+
+    const session = ai.createSession({ initialState: { name: 'Pavel' } });
+
+    const chat = session.chat(agent, { model: 'echoModel' });
+    let response = await chat.send('hi');
+
+    assert.deepStrictEqual(response.messages, [
+      {
+        content: [
+          {
+            text: ' greet Pavel',
+          },
+        ],
+        metadata: {
+          preamble: true,
+        },
+        role: 'system',
+      },
+      {
+        content: [
+          {
+            text: 'hi',
+          },
+        ],
+        role: 'user',
+      },
+      {
+        content: [
+          {
+            text: 'Echo: system:  greet Pavel,hi',
+          },
+          {
+            text: '; config: {"temperature":2}',
+          },
+        ],
+        role: 'model',
+      },
+    ]);
+
+    await session.updateState({ name: 'Michael' });
+
+    const freshChat = session.chat(agent, { model: 'echoModel' });
+    response = await freshChat.send('hi');
+
+    assert.deepStrictEqual(response.messages, [
+      {
+        role: 'system',
+        content: [{ text: ' greet Michael' }],
+        metadata: { preamble: true },
+      },
+      {
+        role: 'user',
+        content: [{ text: 'hi' }],
+      },
+      {
+        role: 'model',
+        content: [
+          { text: 'Echo: system:  greet Pavel,hi' },
+          { text: '; config: {"temperature":2}' },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ text: 'hi' }],
+      },
+      {
+        role: 'model',
+        content: [
+          {
+            text: 'Echo: system:  greet Michael,hi,Echo: system:  greet Pavel,hi,; config: {"temperature":2},hi',
+          },
+          { text: '; config: {"temperature":2}' },
+        ],
+      },
+    ]);
   });
 });

--- a/js/genkit/tests/chat_test.ts
+++ b/js/genkit/tests/chat_test.ts
@@ -481,34 +481,20 @@ describe('preamble', () => {
 
     assert.deepStrictEqual(response.messages, [
       {
-        content: [
-          {
-            text: ' greet Pavel',
-          },
-        ],
-        metadata: {
-          preamble: true,
-        },
         role: 'system',
+        content: [{ text: ' greet Pavel' }],
+        metadata: { preamble: true },
       },
       {
-        content: [
-          {
-            text: 'hi',
-          },
-        ],
         role: 'user',
+        content: [{ text: 'hi' }],
       },
       {
-        content: [
-          {
-            text: 'Echo: system:  greet Pavel,hi',
-          },
-          {
-            text: '; config: {"temperature":2}',
-          },
-        ],
         role: 'model',
+        content: [
+          { text: 'Echo: system:  greet Pavel,hi' },
+          { text: '; config: {"temperature":2}' },
+        ],
       },
     ]);
 

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -786,7 +786,7 @@ describe('prompt', () => {
   });
 });
 
-describe.only('asTool', () => {
+describe('asTool', () => {
   let ai: Genkit;
   let pm: ProgrammableModel;
 
@@ -798,9 +798,8 @@ describe.only('asTool', () => {
     pm = defineProgrammableModel(ai);
   });
 
-  it.only('swaps out preamble on .prompt file tool invocation', async () => {
+  it('swaps out preamble on .prompt file tool invocation', async () => {
     const session = ai.createSession({ initialState: { name: 'Genkit' } });
-
     const agentA = ai.definePrompt(
       {
         name: 'agentA',


### PR DESCRIPTION
Parent PR: https://github.com/firebase/genkit/pull/1215

```ts
const greeting = ai.definePrompt(
  { name: 'greeter' },
  `{{ role "system"}} user's name is {{ @state.userName}}. Important: greet them by this name.`
);

(async () => {
  const session = ai.createSession({
    initialState: {
      userName: 'Pavel',
    },
  });

  let chat = session.chat(greeting);

  let response = await chat.send('hi');
  console.log(response.text); // hi Pavel

  await session.updateState({
    userName: 'Chris',
  })
  chat = session.chat(greeting); // <----- important: causes the preamble to refresh
  response = await chat.send('hi');
  console.log(response.text); // hi Chris
})();
```

Fixes: #1116