### PR TITLE
fix(js/plugins/vertexai): fix subplugin names

### DIFF
--- a/js/plugins/vertexai/src/evaluation/index.ts
+++ b/js/plugins/vertexai/src/evaluation/index.ts
@@ -25,7 +25,7 @@ export { PluginOptions };
  * Add Google Cloud Vertex AI Rerankers API to Genkit.
  */
 export function vertexAIEvaluation(options: PluginOptions): GenkitPlugin {
-  return genkitPlugin('vertexai', async (ai: Genkit) => {
+  return genkitPlugin('vertexAIEvaluation', async (ai: Genkit) => {
     const { projectId, location, authClient } = await getDerivedParams(options);
 
     const metrics =

--- a/js/plugins/vertexai/src/modelgarden/index.ts
+++ b/js/plugins/vertexai/src/modelgarden/index.ts
@@ -27,7 +27,7 @@ import { PluginOptions } from './types.js';
  * Add Google Cloud Vertex AI Rerankers API to Genkit.
  */
 export function vertexAIModelGarden(options: PluginOptions): GenkitPlugin {
-  return genkitPlugin('vertexai', async (ai: Genkit) => {
+  return genkitPlugin('vertexAIModelGarden', async (ai: Genkit) => {
     const { projectId, location, authClient } = await getDerivedParams(options);
 
     const mgModels = options?.modelGardenModels || options?.modelGarden?.models;

--- a/js/plugins/vertexai/src/rerankers/index.ts
+++ b/js/plugins/vertexai/src/rerankers/index.ts
@@ -29,7 +29,7 @@ export interface PluginOptions extends CommonPluginOptions, RerankerOptions {}
  * Add Google Cloud Vertex AI Rerankers API to Genkit.
  */
 export function vertexAIRerankers(options: PluginOptions): GenkitPlugin {
-  return genkitPlugin('vertexai', async (ai: Genkit) => {
+  return genkitPlugin('vertexAIRerankers', async (ai: Genkit) => {
     const { projectId, location, authClient } = await getDerivedParams(options);
 
     await vertexAiRerankers(ai, {

--- a/js/plugins/vertexai/src/vectorsearch/index.ts
+++ b/js/plugins/vertexai/src/vectorsearch/index.ts
@@ -38,7 +38,7 @@ export {
  * Add Google Cloud Vertex AI to Genkit. Includes Gemini and Imagen models and text embedder.
  */
 export function vertexAIVectorSearch(options?: PluginOptions): GenkitPlugin {
-  return genkitPlugin('vertexai', async (ai: Genkit) => {
+  return genkitPlugin('vertexAIVectorSearch', async (ai: Genkit) => {
     const { projectId, location, vertexClientFactory, authClient } =
       await getDerivedParams(options);
 


### PR DESCRIPTION
This PR gives subplugins unique names, as not to clash in the registry

Checklist (if applicable):
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated
