### PR TITLE
chore: removed generate/generateStream from executable prompts

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -83,10 +83,10 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns the model response as a promise of `GenerateStreamResponse`.
    */
-  <In extends I, Out extends O, Opts extends CustomOptions>(
-    input?: In,
-    opts?: PromptGenerateOptions<Out, Opts>
-  ): Promise<GenerateResponse<z.infer<Out>>>;
+  (
+    input?: I,
+    opts?: PromptGenerateOptions<O, CustomOptions>
+  ): Promise<GenerateResponse<z.infer<O>>>;
 
   /**
    * Generates a response by rendering the prompt template with given user input and then calling the model.
@@ -94,10 +94,10 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns the model response as a promise of `GenerateStreamResponse`.
    */
-  stream<In extends I, Out extends O, Opts extends CustomOptions>(
-    input?: In,
-    opts?: PromptGenerateOptions<Out, Opts>
-  ): Promise<GenerateStreamResponse<z.infer<Out>>>;
+  stream(
+    input?: I,
+    opts?: PromptGenerateOptions<O, CustomOptions>
+  ): Promise<GenerateStreamResponse<z.infer<O>>>;
 
   /**
    * Renders the prompt template based on user input.
@@ -105,11 +105,11 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns a `GenerateOptions` object to be used with the `generate()` function from @genkit-ai/ai.
    */
-  render<In extends I, Out extends O, Opts extends CustomOptions>(
-    opt: PromptGenerateOptions<Out, Opts> & {
-      input?: In;
+  render(
+    opt: PromptGenerateOptions<O, CustomOptions> & {
+      input?: I;
     }
-  ): Promise<GenerateOptions<Out, Opts>>;
+  ): Promise<GenerateOptions<O, CustomOptions>>;
 
   /**
    * Returns the prompt usable as a tool.

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -64,7 +64,6 @@ export function isPrompt(arg: any): boolean {
 }
 
 export type PromptGenerateOptions<
-  I = undefined,
   CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
 > = Omit<GenerateOptions<z.ZodTypeAny, CustomOptions>, 'prompt' | 'model'> & {
   model?: ModelArgument<CustomOptions>;
@@ -85,9 +84,9 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns the model response as a promise of `GenerateStreamResponse`.
    */
-  <Out extends O>(
-    input?: I,
-    opts?: PromptGenerateOptions<I, CustomOptions>
+  <In extends I, Out extends O, Opts extends CustomOptions>(
+    input?: In,
+    opts?: PromptGenerateOptions<Opts>
   ): Promise<GenerateResponse<z.infer<Out>>>;
 
   /**
@@ -96,9 +95,9 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns the model response as a promise of `GenerateStreamResponse`.
    */
-  stream<Out extends O>(
-    input?: I,
-    opts?: PromptGenerateOptions<I, CustomOptions>
+  stream<In extends I, Out extends O, Opts extends CustomOptions>(
+    input?: In,
+    opts?: PromptGenerateOptions<Opts>
   ): Promise<GenerateStreamResponse<z.infer<Out>>>;
 
   /**
@@ -107,11 +106,11 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns a `GenerateOptions` object to be used with the `generate()` function from @genkit-ai/ai.
    */
-  render<Out extends O>(
-    opt: PromptGenerateOptions<I, CustomOptions> & {
-      input?: I;
+  render<In extends I, Out extends O, Opts extends CustomOptions>(
+    opt: PromptGenerateOptions<Opts> & {
+      input?: In;
     }
-  ): Promise<GenerateOptions<Out, CustomOptions>>;
+  ): Promise<GenerateOptions<Out, Opts>>;
 
   /**
    * Returns the prompt usable as a tool.

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -85,10 +85,10 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns the model response as a promise of `GenerateStreamResponse`.
    */
-  <Out extends O>(
+  (
     input?: I,
     opts?: PromptGenerateOptions<I, CustomOptions>
-  ): Promise<GenerateResponse<z.infer<Out>>>;
+  ): Promise<GenerateResponse<z.infer<O>>>;
 
   /**
    * Generates a response by rendering the prompt template with given user input and then calling the model.
@@ -96,10 +96,10 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns the model response as a promise of `GenerateStreamResponse`.
    */
-  stream<Out extends O>(
+  stream(
     input?: I,
     opts?: PromptGenerateOptions<I, CustomOptions>
-  ): Promise<GenerateStreamResponse<z.infer<Out>>>;
+  ): Promise<GenerateStreamResponse<z.infer<O>>>;
 
   /**
    * Renders the prompt template based on user input.
@@ -107,11 +107,11 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns a `GenerateOptions` object to be used with the `generate()` function from @genkit-ai/ai.
    */
-  render<Out extends O>(
+  render(
     opt: PromptGenerateOptions<I, CustomOptions> & {
       input?: I;
     }
-  ): Promise<GenerateOptions<CustomOptions, Out>>;
+  ): Promise<GenerateOptions<CustomOptions, O>>;
 
   /**
    * Returns the prompt usable as a tool.

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -64,10 +64,9 @@ export function isPrompt(arg: any): boolean {
 }
 
 export type PromptGenerateOptions<
+  O extends z.ZodTypeAny = z.ZodTypeAny,
   CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
-> = Omit<GenerateOptions<z.ZodTypeAny, CustomOptions>, 'prompt' | 'model'> & {
-  model?: ModelArgument<CustomOptions>;
-};
+> = Omit<GenerateOptions<O, CustomOptions>, 'prompt'>;
 
 /**
  * A prompt that can be executed as a function.
@@ -86,7 +85,7 @@ export interface ExecutablePrompt<
    */
   <In extends I, Out extends O, Opts extends CustomOptions>(
     input?: In,
-    opts?: PromptGenerateOptions<Opts>
+    opts?: PromptGenerateOptions<Out, Opts>
   ): Promise<GenerateResponse<z.infer<Out>>>;
 
   /**
@@ -97,7 +96,7 @@ export interface ExecutablePrompt<
    */
   stream<In extends I, Out extends O, Opts extends CustomOptions>(
     input?: In,
-    opts?: PromptGenerateOptions<Opts>
+    opts?: PromptGenerateOptions<Out, Opts>
   ): Promise<GenerateStreamResponse<z.infer<Out>>>;
 
   /**
@@ -107,7 +106,7 @@ export interface ExecutablePrompt<
    * @returns a `GenerateOptions` object to be used with the `generate()` function from @genkit-ai/ai.
    */
   render<In extends I, Out extends O, Opts extends CustomOptions>(
-    opt: PromptGenerateOptions<Opts> & {
+    opt: PromptGenerateOptions<Out, Opts> & {
       input?: In;
     }
   ): Promise<GenerateOptions<Out, Opts>>;

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -85,10 +85,10 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns the model response as a promise of `GenerateStreamResponse`.
    */
-  (
+  <Out extends O>(
     input?: I,
     opts?: PromptGenerateOptions<I, CustomOptions>
-  ): Promise<GenerateResponse<z.infer<O>>>;
+  ): Promise<GenerateResponse<z.infer<Out>>>;
 
   /**
    * Generates a response by rendering the prompt template with given user input and then calling the model.
@@ -96,10 +96,10 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns the model response as a promise of `GenerateStreamResponse`.
    */
-  stream(
+  stream<Out extends O>(
     input?: I,
     opts?: PromptGenerateOptions<I, CustomOptions>
-  ): Promise<GenerateStreamResponse<z.infer<O>>>;
+  ): Promise<GenerateStreamResponse<z.infer<Out>>>;
 
   /**
    * Renders the prompt template based on user input.
@@ -107,11 +107,11 @@ export interface ExecutablePrompt<
    * @param opt Options for the prompt template, including user input variables and custom model configuration options.
    * @returns a `GenerateOptions` object to be used with the `generate()` function from @genkit-ai/ai.
    */
-  render(
+  render<Out extends O>(
     opt: PromptGenerateOptions<I, CustomOptions> & {
       input?: I;
     }
-  ): Promise<GenerateOptions<CustomOptions, O>>;
+  ): Promise<GenerateOptions<Out, CustomOptions>>;
 
   /**
    * Returns the prompt usable as a tool.

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -66,12 +66,8 @@ export function isPrompt(arg: any): boolean {
 export type PromptGenerateOptions<
   I = undefined,
   CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
-> = Omit<
-  GenerateOptions<z.ZodTypeAny, CustomOptions>,
-  'prompt' | 'input' | 'model'
-> & {
+> = Omit<GenerateOptions<z.ZodTypeAny, CustomOptions>, 'prompt' | 'model'> & {
   model?: ModelArgument<CustomOptions>;
-  input?: I;
 };
 
 /**
@@ -91,7 +87,7 @@ export interface ExecutablePrompt<
    */
   <Out extends O>(
     input?: I,
-    opts?: Omit<PromptGenerateOptions<I, CustomOptions>, 'input'>
+    opts?: PromptGenerateOptions<I, CustomOptions>
   ): Promise<GenerateResponse<z.infer<Out>>>;
 
   /**
@@ -102,27 +98,7 @@ export interface ExecutablePrompt<
    */
   stream<Out extends O>(
     input?: I,
-    opts?: Omit<PromptGenerateOptions<I, CustomOptions>, 'input'>
-  ): Promise<GenerateStreamResponse<z.infer<Out>>>;
-
-  /**
-   * Generates a response by rendering the prompt template with given user input and additional generate options and then calling the model.
-   *
-   * @param opt Options for the prompt template, including user input variables and custom model configuration options.
-   * @returns the model response as a promise of `GenerateResponse`.
-   */
-  generate<Out extends O>(
-    opt: PromptGenerateOptions<I, CustomOptions>
-  ): Promise<GenerateResponse<z.infer<Out>>>;
-
-  /**
-   * Generates a streaming response by rendering the prompt template with given user input and additional generate options and then calling the model.
-   *
-   * @param opt Options for the prompt template, including user input variables and custom model configuration options.
-   * @returns the model response as a promise of `GenerateStreamResponse`.
-   */
-  generateStream<Out extends O>(
-    opt: PromptGenerateOptions<I, CustomOptions>
+    opts?: PromptGenerateOptions<I, CustomOptions>
   ): Promise<GenerateStreamResponse<z.infer<Out>>>;
 
   /**
@@ -132,7 +108,9 @@ export interface ExecutablePrompt<
    * @returns a `GenerateOptions` object to be used with the `generate()` function from @genkit-ai/ai.
    */
   render<Out extends O>(
-    opt: PromptGenerateOptions<I, CustomOptions>
+    opt: PromptGenerateOptions<I, CustomOptions> & {
+      input?: I;
+    }
   ): Promise<GenerateOptions<CustomOptions, Out>>;
 
   /**

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -91,7 +91,7 @@ export interface ExecutablePrompt<
    */
   <Out extends O>(
     input?: I,
-    opts?: PromptGenerateOptions<I, CustomOptions>
+    opts?: Omit<PromptGenerateOptions<I, CustomOptions>, 'input'>
   ): Promise<GenerateResponse<z.infer<Out>>>;
 
   /**
@@ -102,7 +102,7 @@ export interface ExecutablePrompt<
    */
   stream<Out extends O>(
     input?: I,
-    opts?: PromptGenerateOptions<I, CustomOptions>
+    opts?: Omit<PromptGenerateOptions<I, CustomOptions>, 'input'>
   ): Promise<GenerateStreamResponse<z.infer<Out>>>;
 
   /**

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -493,7 +493,7 @@ export class Genkit {
           ...opt.config,
         },
         model,
-      } as GenerateOptions<CustomOptions, Out>;
+      } as GenerateOptions<Out, CustomOptions>;
       delete (resultOptions as any).input;
       return resultOptions;
     };

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -438,7 +438,7 @@ export class Genkit {
   ): ExecutablePrompt<I, O, CustomOptions> {
     const executablePrompt = async (
       input?: z.infer<I>,
-      opts?: PromptGenerateOptions<I, CustomOptions>
+      opts?: PromptGenerateOptions<O, CustomOptions>
     ): Promise<GenerateResponse> => {
       const renderedOpts = await (
         executablePrompt as ExecutablePrompt<I, O, CustomOptions>
@@ -461,12 +461,14 @@ export class Genkit {
       return this.generateStream(renderedOpts);
     };
     (executablePrompt as ExecutablePrompt<I, O, CustomOptions>).render = async <
+      In extends I,
       Out extends O,
+      Opts extends CustomOptions,
     >(
-      opt: PromptGenerateOptions<I, CustomOptions> & {
-        input?: I;
+      opt: PromptGenerateOptions<Out, Opts> & {
+        input?: In;
       }
-    ): Promise<GenerateOptions<Out, CustomOptions>> => {
+    ): Promise<GenerateOptions<Out, Opts>> => {
       let model: ModelAction | undefined;
       options = await options;
       try {
@@ -493,7 +495,7 @@ export class Genkit {
           ...opt.config,
         },
         model,
-      } as GenerateOptions<Out, CustomOptions>;
+      } as GenerateOptions<Out, Opts>;
       delete (resultOptions as any).input;
       return resultOptions;
     };

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -460,28 +460,12 @@ export class Genkit {
       });
       return this.generateStream(renderedOpts);
     };
-    (executablePrompt as ExecutablePrompt<I, O, CustomOptions>).generate =
-      async (
-        opt: PromptGenerateOptions<I, CustomOptions>
-      ): Promise<GenerateResponse<O>> => {
-        const renderedOpts = await (
-          executablePrompt as ExecutablePrompt<I, O, CustomOptions>
-        ).render(opt);
-        return this.generate(renderedOpts);
-      };
-    (executablePrompt as ExecutablePrompt<I, O, CustomOptions>).generateStream =
-      async (
-        opt: PromptGenerateOptions<I, CustomOptions>
-      ): Promise<GenerateStreamResponse<O>> => {
-        const renderedOpts = await (
-          executablePrompt as ExecutablePrompt<I, O, CustomOptions>
-        ).render(opt);
-        return this.generateStream(renderedOpts);
-      };
     (executablePrompt as ExecutablePrompt<I, O, CustomOptions>).render = async <
       Out extends O,
     >(
-      opt: PromptGenerateOptions<I, CustomOptions>
+      opt: PromptGenerateOptions<I, CustomOptions> & {
+        input?: I;
+      }
     ): Promise<GenerateOptions<CustomOptions, Out>> => {
       let model: ModelAction | undefined;
       options = await options;
@@ -510,7 +494,7 @@ export class Genkit {
         },
         model,
       } as GenerateOptions<CustomOptions, Out>;
-      delete (resultOptions as PromptGenerateOptions<I, CustomOptions>).input;
+      delete (resultOptions as any).input;
       return resultOptions;
     };
     (executablePrompt as ExecutablePrompt<I, O, CustomOptions>).asTool =

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -460,15 +460,11 @@ export class Genkit {
       });
       return this.generateStream(renderedOpts);
     };
-    (executablePrompt as ExecutablePrompt<I, O, CustomOptions>).render = async <
-      In extends I,
-      Out extends O,
-      Opts extends CustomOptions,
-    >(
-      opt: PromptGenerateOptions<Out, Opts> & {
-        input?: In;
+    (executablePrompt as ExecutablePrompt<I, O, CustomOptions>).render = async (
+      opt: PromptGenerateOptions<O, CustomOptions> & {
+        input?: I;
       }
-    ): Promise<GenerateOptions<Out, Opts>> => {
+    ): Promise<GenerateOptions<O, CustomOptions>> => {
       let model: ModelAction | undefined;
       options = await options;
       try {
@@ -495,7 +491,7 @@ export class Genkit {
           ...opt.config,
         },
         model,
-      } as GenerateOptions<Out, Opts>;
+      } as GenerateOptions<O, CustomOptions>;
       delete (resultOptions as any).input;
       return resultOptions;
     };

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -466,7 +466,7 @@ export class Genkit {
       opt: PromptGenerateOptions<I, CustomOptions> & {
         input?: I;
       }
-    ): Promise<GenerateOptions<CustomOptions, Out>> => {
+    ): Promise<GenerateOptions<Out, CustomOptions>> => {
       let model: ModelAction | undefined;
       options = await options;
       try {

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -77,32 +77,6 @@ describe('definePrompt - dotprompt', () => {
       );
     });
 
-    it('calls dotprompt with .generate', async () => {
-      const hi = ai.definePrompt(
-        {
-          name: 'hi',
-          input: {
-            schema: z.object({
-              name: z.string(),
-            }),
-          },
-          config: {
-            temperature: 11,
-          },
-        },
-        'hi {{ name }}'
-      );
-
-      const response = await hi.generate({
-        input: { name: 'Genkit' },
-        config: { version: 'abc' },
-      });
-      assert.strictEqual(
-        response.text,
-        'Echo: hi Genkit; config: {"version":"abc","temperature":11}'
-      );
-    });
-
     it('calls dotprompt with default model via retrieved prompt', async () => {
       ai.definePrompt(
         {
@@ -211,39 +185,6 @@ describe('definePrompt - dotprompt', () => {
       assert.strictEqual(
         responseText,
         'Echo: hi Genkit; config: {"temperature":11}'
-      );
-      assert.deepStrictEqual(chunks, ['3', '2', '1']);
-    });
-
-    it('streams dotprompt .generateStream', async () => {
-      const hi = ai.definePrompt(
-        {
-          name: 'hi',
-          input: {
-            schema: z.object({
-              name: z.string(),
-            }),
-          },
-          config: {
-            temperature: 11,
-          },
-        },
-        'hi {{ name }}'
-      );
-
-      const { response, stream } = await hi.generateStream({
-        input: { name: 'Genkit' },
-        config: { version: 'abc' },
-      });
-      const chunks: string[] = [];
-      for await (const chunk of stream) {
-        chunks.push(chunk.text);
-      }
-      const responseText = (await response).text;
-
-      assert.strictEqual(
-        responseText,
-        'Echo: hi Genkit; config: {"version":"abc","temperature":11}'
       );
       assert.deepStrictEqual(chunks, ['3', '2', '1']);
     });
@@ -620,70 +561,6 @@ describe('definePrompt', () => {
         response.text,
         'Echo: hi Genkit; config: {"version":"abc","temperature":11}'
       );
-    });
-
-    it('works with .generate', async () => {
-      const hi = ai.definePrompt(
-        {
-          name: 'hi',
-          model: 'echoModel',
-          input: {
-            schema: z.object({
-              name: z.string(),
-            }),
-          },
-        },
-        async (input) => {
-          return {
-            messages: [
-              { role: 'user', content: [{ text: `hi ${input.name}` }] },
-            ],
-          };
-        }
-      );
-
-      const response = await hi.generate({ input: { name: 'Genkit' } });
-      assert.strictEqual(response.text, 'Echo: hi Genkit; config: {}');
-    });
-
-    it('streams dotprompt with .generateStream', async () => {
-      const hi = ai.definePrompt(
-        {
-          name: 'hi',
-          input: {
-            schema: z.object({
-              name: z.string(),
-            }),
-          },
-          config: {
-            temperature: 11,
-          },
-        },
-        async (input) => {
-          return {
-            messages: [
-              { role: 'user', content: [{ text: `hi ${input.name}` }] },
-            ],
-          };
-        }
-      );
-
-      const { response, stream } = await hi.generateStream({
-        model: 'echoModel',
-        input: { name: 'Genkit' },
-        config: { version: 'abc' },
-      });
-      const chunks: string[] = [];
-      for await (const chunk of stream) {
-        chunks.push(chunk.text);
-      }
-      const responseText = (await response).text;
-
-      assert.strictEqual(
-        responseText,
-        'Echo: hi Genkit; config: {"version":"abc","temperature":11}'
-      );
-      assert.deepStrictEqual(chunks, ['3', '2', '1']);
     });
   });
 

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -338,10 +338,12 @@ export const dotpromptContext = ai.defineFlow(
       },
     ];
 
-    const result = await ai.prompt('dotpromptContext').generate({
-      input: { question: question },
-      docs,
-    });
+    const result = await ai.prompt('dotpromptContext')(
+      { question: question },
+      {
+        docs,
+      }
+    );
     return result.output as any;
   }
 );

--- a/js/testapps/menu/src/02/flows.ts
+++ b/js/testapps/menu/src/02/flows.ts
@@ -27,12 +27,8 @@ export const s02_menuQuestionFlow = ai.defineFlow(
     outputSchema: AnswerOutputSchema,
   },
   async (input) => {
-    return s02_dataMenuPrompt
-      .generate({
-        input: { question: input.question },
-      })
-      .then((response) => {
-        return { answer: response.text };
-      });
+    return s02_dataMenuPrompt({ question: input.question }).then((response) => {
+      return { answer: response.text };
+    });
   }
 );

--- a/js/testapps/menu/src/04/flows.ts
+++ b/js/testapps/menu/src/04/flows.ts
@@ -74,11 +74,9 @@ export const s04_ragMenuQuestionFlow = ai.defineFlow(
     );
 
     // Generate the response
-    const response = await s04_ragDataMenuPrompt.generate({
-      input: {
-        menuData: menuData,
-        question: input.question,
-      },
+    const response = await s04_ragDataMenuPrompt({
+      menuData: menuData,
+      question: input.question,
     });
     return { answer: response.text };
   }

--- a/js/testapps/menu/src/05/flows.ts
+++ b/js/testapps/menu/src/05/flows.ts
@@ -38,10 +38,8 @@ export const s05_readMenuFlow = ai.defineFlow(
   },
   async (unused) => {
     const imageDataUrl = await inlineDataUrl('menu.jpeg', 'image/jpeg');
-    const response = await s05_readMenuPrompt.generate({
-      input: {
-        imageUrl: imageDataUrl,
-      },
+    const response = await s05_readMenuPrompt({
+      imageUrl: imageDataUrl,
     });
     return { menuText: response.text };
   }
@@ -57,11 +55,9 @@ export const s05_textMenuQuestionFlow = ai.defineFlow(
     outputSchema: AnswerOutputSchema,
   },
   async (input) => {
-    const response = await s05_textMenuPrompt.generate({
-      input: {
-        menuText: input.menuText,
-        question: input.question,
-      },
+    const response = await s05_textMenuPrompt({
+      menuText: input.menuText,
+      question: input.question,
     });
     return { answer: response.text };
   }

--- a/js/testapps/prompt-file/src/index.ts
+++ b/js/testapps/prompt-file/src/index.ts
@@ -60,8 +60,7 @@ ai.defineFlow(
     outputSchema: RecipeSchema,
   },
   async (input) =>
-    (await ai.prompt('recipe').generate<typeof RecipeSchema>({ input: input }))
-      .output!
+    (await ai.prompt('recipe')<typeof RecipeSchema>(input)).output!
 );
 
 ai.defineFlow(
@@ -73,8 +72,7 @@ ai.defineFlow(
     outputSchema: z.any(),
   },
   async (input) =>
-    (await ai.prompt('recipe', { variant: 'robot' }).generate({ input: input }))
-      .output
+    (await ai.prompt('recipe', { variant: 'robot' })(input)).output
 );
 
 // A variation that supports streaming, optionally
@@ -92,15 +90,16 @@ ai.defineStreamingFlow(
   async ({ subject, personality }, streamingCallback) => {
     const storyPrompt = ai.prompt('story');
     if (streamingCallback) {
-      const { response, stream } = await storyPrompt.generateStream({
-        input: { subject, personality },
+      const { response, stream } = await storyPrompt.stream({
+        subject,
+        personality,
       });
       for await (const chunk of stream) {
         streamingCallback(chunk.content[0]?.text!);
       }
       return (await response).text;
     } else {
-      const response = await storyPrompt.generate({ input: { subject } });
+      const response = await storyPrompt({ subject });
       return response.text;
     }
   }

--- a/js/testapps/prompt-file/src/index.ts
+++ b/js/testapps/prompt-file/src/index.ts
@@ -60,7 +60,7 @@ ai.defineFlow(
     outputSchema: RecipeSchema,
   },
   async (input) =>
-    (await ai.prompt('recipe')<typeof RecipeSchema>(input)).output!
+    (await ai.prompt<any, typeof RecipeSchema>('recipe')(input)).output!
 );
 
 ai.defineFlow(

--- a/js/testapps/rag/src/pdf_rag.ts
+++ b/js/testapps/rag/src/pdf_rag.ts
@@ -45,15 +45,15 @@ export const pdfQA = ai.defineFlow(
       options: { k: 3 },
     });
 
-    return augmentedPrompt
-      .generate({
-        input: {
-          question: query,
-          context: docs.map((d) => d.text),
-        },
+    return augmentedPrompt(
+      {
+        question: query,
+        context: docs.map((d) => d.text),
+      },
+      {
         streamingCallback,
-      })
-      .then((r) => r.text);
+      }
+    ).then((r) => r.text);
   }
 );
 

--- a/js/testapps/rag/src/simple_rag.ts
+++ b/js/testapps/rag/src/simple_rag.ts
@@ -62,14 +62,10 @@ export const askQuestionsAboutCatsFlow = ai.defineFlow(
       query,
       options: { k: 3 },
     });
-    return augmentedPrompt
-      .generate({
-        input: {
-          question: query,
-          context: docs.map((d) => d.text),
-        },
-      })
-      .then((r) => r.text);
+    return augmentedPrompt({
+      question: query,
+      context: docs.map((d) => d.text),
+    }).then((r) => r.text);
   }
 );
 
@@ -87,14 +83,10 @@ export const askQuestionsAboutDogsFlow = ai.defineFlow(
       query,
       options: { k: 3 },
     });
-    return augmentedPrompt
-      .generate({
-        input: {
-          question: query,
-          context: docs.map((d) => d.text),
-        },
-      })
-      .then((r) => r.text);
+    return augmentedPrompt({
+      question: query,
+      context: docs.map((d) => d.text),
+    }).then((r) => r.text);
   }
 );
 


### PR DESCRIPTION
unnecessary/redundant as everything can be done with ()/.stream()