### PR TITLE
Avoid race condition in user engagement collection

### DIFF
--- a/js/core/src/tracing/instrumentation.ts
+++ b/js/core/src/tracing/instrumentation.ts
@@ -128,12 +128,14 @@ export async function runInNewSpan<T>(
  * Creates a new child span and attaches it to a previously created trace. This
  * is useful, for example, for adding deferred user engagement metadata.
  */
-export function appendSpan(
+export async function appendSpan(
   traceId: string,
   parentSpanId: string,
   metadata: SpanMetadata,
   labels?: Record<string, string>
 ) {
+  await ensureBasicTelemetryInstrumentation();
+
   const tracer = trace.getTracer(TRACER_NAME, TRACER_VERSION);
 
   const spanContext = trace.setSpanContext(ROOT_CONTEXT, {

--- a/js/plugins/firebase/src/user_engagement.ts
+++ b/js/plugins/firebase/src/user_engagement.ts
@@ -67,7 +67,9 @@ export type FirebaseUserEngagement = z.infer<
 >;
 
 /** Associates user engagement metadata with the specified flow execution. */
-export function collectUserEngagement(userEngagement: FirebaseUserEngagement) {
+export async function collectUserEngagement(
+  userEngagement: FirebaseUserEngagement
+) {
   // Collect user feedback, if provided
   if (userEngagement.feedback?.value) {
     const metadata = {
@@ -78,7 +80,7 @@ export function collectUserEngagement(userEngagement: FirebaseUserEngagement) {
       metadata['textFeedback'] = userEngagement.feedback.text;
     }
 
-    appendSpan(
+    await appendSpan(
       userEngagement.traceId,
       userEngagement.spanId,
       {
@@ -94,7 +96,7 @@ export function collectUserEngagement(userEngagement: FirebaseUserEngagement) {
 
   // Collect user acceptance, if provided
   if (userEngagement.acceptance?.value) {
-    appendSpan(
+    await appendSpan(
       userEngagement.traceId,
       userEngagement.spanId,
       {

--- a/js/plugins/firebase/tests/user_engagement_test.ts
+++ b/js/plugins/firebase/tests/user_engagement_test.ts
@@ -38,7 +38,7 @@ describe('User Engagement', () => {
   });
 
   it('handles user feedback', async () => {
-    collectUserEngagement(
+    await collectUserEngagement(
       FirebaseUserEngagementSchema.parse({
         ...baseInput,
         feedback: {
@@ -65,7 +65,7 @@ describe('User Engagement', () => {
   });
 
   it('handles user acceptance', async () => {
-    collectUserEngagement(
+    await collectUserEngagement(
       FirebaseUserEngagementSchema.parse({
         ...baseInput,
         acceptance: {
@@ -90,7 +90,7 @@ describe('User Engagement', () => {
   });
 
   it('handles multiple engagement types', async () => {
-    collectUserEngagement(
+    await collectUserEngagement(
       FirebaseUserEngagementSchema.parse({
         ...baseInput,
         acceptance: {
@@ -106,7 +106,7 @@ describe('User Engagement', () => {
   });
 
   it('skips empty input', async () => {
-    collectUserEngagement(FirebaseUserEngagementSchema.parse(baseInput));
+    await collectUserEngagement(FirebaseUserEngagementSchema.parse(baseInput));
 
     expect(appendSpan as jest.Mock).not.toHaveBeenCalled();
   });

--- a/js/plugins/google-cloud/tests/logs_test.ts
+++ b/js/plugins/google-cloud/tests/logs_test.ts
@@ -197,7 +197,7 @@ describe('GoogleCloudLogs', () => {
   });
 
   it('writes user feedback log', async () => {
-    appendSpan(
+    await appendSpan(
       'trace1',
       'parent1',
       {
@@ -218,7 +218,7 @@ describe('GoogleCloudLogs', () => {
   });
 
   it('writes user acceptance log', async () => {
-    appendSpan(
+    await appendSpan(
       'trace1',
       'parent1',
       {

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -721,7 +721,7 @@ describe('GoogleCloudMetrics', () => {
   }, 10000); //timeout
 
   it('writes user feedback metrics', async () => {
-    appendSpan(
+    await appendSpan(
       'trace1',
       'parent1',
       {
@@ -750,7 +750,7 @@ describe('GoogleCloudMetrics', () => {
   });
 
   it('writes user acceptance metrics', async () => {
-    appendSpan(
+    await appendSpan(
       'trace1',
       'parent1',
       {

--- a/js/plugins/google-cloud/tests/traces_test.ts
+++ b/js/plugins/google-cloud/tests/traces_test.ts
@@ -207,7 +207,7 @@ describe('GoogleCloudTracing', () => {
   });
 
   it('attaches additional span', async () => {
-    appendSpan(
+    await appendSpan(
       'trace1',
       'parent1',
       { name: 'span-name', metadata: { metadata_key: 'metadata_value' } },

--- a/js/testapps/firebase-functions-sample1/functions/src/index.ts
+++ b/js/testapps/firebase-functions-sample1/functions/src/index.ts
@@ -155,7 +155,7 @@ export const triggerJokeFlow = onRequest(
 export const collectEngagement = onRequest(
   { memory: '512MiB' },
   async (req, res) => {
-    collectUserEngagement(FirebaseUserEngagementSchema.parse(req.body));
+    await collectUserEngagement(FirebaseUserEngagementSchema.parse(req.body));
     res.send({});
   }
 );


### PR DESCRIPTION
Avoid race condition when appending a span by waiting for telemetry initialization.

Checklist (if applicable):
- [X] Tested (manually, unit tested)
