### PR TITLE
fix: firebase documentation after 0.9 upgrade

### DIFF
--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -416,27 +416,11 @@ Firebase offers a
 [suite of emulators for local development](/docs/emulator-suite), which you can
 use with Genkit.
 
-First, You will need to launch the Genkit Dev UI:
-
-```posix-terminal
-cd $PROJECT_ROOT/functions
-
-npx genkit start -- npx tsx --watch src/index.ts
-```
-
-or
-  
-```posix-terminal
-cd $PROJECT_ROOT/functions
-
-npm run genkit:start
-```
-
-To use Genkit with the Firebase Emulator Suite, start the Firebase emulators
+To use the Genkit Dev UI with the Firebase Emulator Suite, start the Firebase emulators
 like this:
 
 ```posix-terminal
-firebase emulators:start --inspect-functions
+npx genkit start -- firebase emulators:start --inspect-functions
 ```
 
 This will run your code in the emulator and run the Genkit framework in

--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -400,29 +400,48 @@ cd $PROJECT_ROOT/functions
 npx genkit start -- npx tsx --watch src/index.ts
 ```
 
+or
+  
+```posix-terminal
+cd $PROJECT_ROOT/functions
+
+npm run genkit:start
+```
+
+You can now navigate to the URL printed by the `genkit start` command to access.
+
 ## Optional: Developing using Firebase Local Emulator Suite
 
 Firebase offers a
 [suite of emulators for local development](/docs/emulator-suite), which you can
 use with Genkit.
 
+First, You will need to launch the Genkit Dev UI:
+
+```posix-terminal
+cd $PROJECT_ROOT/functions
+
+npx genkit start -- npx tsx --watch src/index.ts
+```
+
+or
+  
+```posix-terminal
+cd $PROJECT_ROOT/functions
+
+npm run genkit:start
+```
+
 To use Genkit with the Firebase Emulator Suite, start the Firebase emulators
 like this:
 
 ```posix-terminal
-GENKIT_ENV=dev firebase emulators:start --inspect-functions
+firebase emulators:start --inspect-functions
 ```
 
 This will run your code in the emulator and run the Genkit framework in
 development mode, which launches and exposes the Genkit reflection API (but not
 the Dev UI).
-
-Then, launch the Genkit Dev UI with the `--attach` option to connect it to your
-code running inside the Firebase Emulator:
-
-```posix-terminal
-npx genkit start --attach http://localhost:3100 --port 4001
-```
 
 To see traces from Firestore in the Dev UI you can navigate to the Inspect tab
 and toggle the "Dev/Prod" switch. When toggled to "prod" it will be loading

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -51,7 +51,9 @@ logger.setLogLevel('debug');
 
 ## Trace Storage and Developer UI
 Traces are automatically captured and can be viewed in the Genkit Developer UI. To start the UI:
+
 ```posix-terminal
 npx genkit start -- <command to run your code>
 ```
+
 When using Firebase, trace data is automatically stored in Firestore. It's recommended to enable [TTL (Time To Live)](https://firebase.google.com/docs/firestore/ttl) for trace documents to manage storage costs and data retention.

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -507,8 +507,7 @@ export function defineGeminiModel(
       }
       // Cannot use tools and function calling at the same time
       const jsonMode =
-        (request.output?.format === 'json' || !!request.output?.schema ||
-          request.output?.contentType === 'application/json') &&
+        (request.output?.format === 'json' || !!request.output?.schema) &&
         tools.length === 0;
 
       const chatRequest: StartChatParams = {

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -507,7 +507,8 @@ export function defineGeminiModel(
       }
       // Cannot use tools and function calling at the same time
       const jsonMode =
-        (request.output?.format === 'json' || !!request.output?.schema) &&
+        (request.output?.format === 'json' || !!request.output?.schema || ||
+          request.output?.contentType === 'application/json') &&
         tools.length === 0;
 
       const chatRequest: StartChatParams = {

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -507,7 +507,7 @@ export function defineGeminiModel(
       }
       // Cannot use tools and function calling at the same time
       const jsonMode =
-        (request.output?.format === 'json' || !!request.output?.schema || ||
+        (request.output?.format === 'json' || !!request.output?.schema ||
           request.output?.contentType === 'application/json') &&
         tools.length === 0;
 


### PR DESCRIPTION
This PR updates the docs after upgrading to 0.9.0:
1. Since the firebase emulator and the genkit UI uses by default the same port (4000), it is better to start first the genkit UI and then the firebase emulator. The firebase emulator autodetect that the port 4000 is in use and uses another one.
2. Added the npm command provided by the firebase template `npm run genkit:start`
3. fixes this visualization problem: https://firebase.google.com/docs/genkit/monitoring#trace_storage_and_developer_ui

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [x] Docs updated
