### PR TITLE
fix: default to json format if not explicitly specified

### DIFF
--- a/js/ai/src/formats/index.ts
+++ b/js/ai/src/formats/index.ts
@@ -16,6 +16,7 @@
 
 import { JSONSchema } from '@genkit-ai/core';
 import { Registry } from '@genkit-ai/core/registry';
+import { OutputOptions } from '../generate.js';
 import { MessageData, TextPart } from '../model.js';
 import { arrayFormatter } from './array';
 import { enumFormatter } from './enum';
@@ -37,20 +38,23 @@ export function defineFormat(
 
 export type FormatArgument =
   | keyof typeof DEFAULT_FORMATS
-  | Formatter
   | Omit<string, keyof typeof DEFAULT_FORMATS>
   | undefined
   | null;
 
 export async function resolveFormat(
   registry: Registry,
-  arg: FormatArgument
+  outputOpts: OutputOptions | undefined
 ): Promise<Formatter<any, any> | undefined> {
-  if (!arg) return undefined;
-  if (typeof arg === 'string') {
-    return registry.lookupValue<Formatter>('format', arg);
+  if (!outputOpts) return undefined;
+  // If schema is set but no explicit format is set we default to json.
+  if (outputOpts.schema && !outputOpts.format) {
+    return registry.lookupValue<Formatter>('format', 'json');
   }
-  return arg as Formatter;
+  if (outputOpts.format) {
+    return registry.lookupValue<Formatter>('format', outputOpts.format);
+  }
+  return undefined;
 }
 
 export function resolveInstructions(

--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -46,6 +46,14 @@ import { ExecutablePrompt } from './prompt.js';
 import { resolveTools, ToolArgument, toToolDefinition } from './tool.js';
 export { GenerateResponse, GenerateResponseChunk };
 
+export interface OutputOptions<O extends z.ZodTypeAny = z.ZodTypeAny> {
+  format?: string;
+  contentType?: string;
+  instructions?: boolean | string;
+  schema?: O;
+  jsonSchema?: any;
+}
+
 export interface GenerateOptions<
   O extends z.ZodTypeAny = z.ZodTypeAny,
   CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
@@ -65,13 +73,7 @@ export interface GenerateOptions<
   /** Configuration for the generation request. */
   config?: z.infer<CustomOptions>;
   /** Configuration for the desired output of the request. Defaults to the model's default output if unspecified. */
-  output?: {
-    format?: string;
-    contentType?: string;
-    instructions?: boolean | string;
-    schema?: O;
-    jsonSchema?: any;
-  };
+  output?: OutputOptions<O>;
   /** When true, return tool calls for manual processing instead of automatically resolving them. */
   returnToolRequests?: boolean;
   /** When provided, models supporting streaming will call the provided callback with chunks as generation progresses. */
@@ -116,7 +118,7 @@ export async function toGenerateRequest(
     jsonSchema: options.output?.jsonSchema,
   });
 
-  const resolvedFormat = await resolveFormat(registry, options.output?.format);
+  const resolvedFormat = await resolveFormat(registry, options.output);
   const instructions = resolveInstructions(
     resolvedFormat,
     resolvedSchema,
@@ -246,10 +248,7 @@ export async function generate<
     jsonSchema: resolvedOptions.output?.jsonSchema,
   });
 
-  const resolvedFormat = await resolveFormat(
-    registry,
-    resolvedOptions.output?.format
-  );
+  const resolvedFormat = await resolveFormat(registry, resolvedOptions.output);
   const instructions = resolveInstructions(
     resolvedFormat,
     resolvedSchema,

--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -116,7 +116,7 @@ async function generate(
   const tools = await resolveTools(registry, rawRequest.tools);
 
   const resolvedFormat = rawRequest.output?.format
-    ? await resolveFormat(registry, rawRequest.output?.format)
+    ? await resolveFormat(registry, rawRequest.output)
     : undefined;
 
   const request = await actionToGenerateRequest(

--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -115,9 +115,7 @@ async function generate(
 
   const tools = await resolveTools(registry, rawRequest.tools);
 
-  const resolvedFormat = rawRequest.output?.format
-    ? await resolveFormat(registry, rawRequest.output)
-    : undefined;
+  const resolvedFormat = await resolveFormat(registry, rawRequest.output);
 
   const request = await actionToGenerateRequest(
     rawRequest,

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -160,6 +160,39 @@ describe('definePrompt - dotprompt', () => {
       assert.deepStrictEqual(foo, { bar: 'baz' });
     });
 
+    it('defaults to json format', async () => {
+      const Foo = z.object({
+        bar: z.string(),
+      });
+      const model = defineStaticResponseModel(ai, {
+        role: 'model',
+        content: [
+          {
+            text: '```json\n{bar: "baz"}\n```',
+          },
+        ],
+      });
+      const hi = ai.definePrompt(
+        {
+          name: 'hi',
+          model,
+          input: {
+            schema: z.object({
+              name: z.string(),
+            }),
+          },
+          output: {
+            schema: Foo,
+          },
+        },
+        'hi {{ name }}'
+      );
+
+      const response = await hi({ name: 'Genkit' });
+      const foo: z.infer<typeof Foo> = response.output;
+      assert.deepStrictEqual(foo, { bar: 'baz' });
+    });
+
     it('streams dotprompt with default model', async () => {
       const hi = ai.definePrompt(
         {

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -182,6 +182,7 @@ describe('definePrompt - dotprompt', () => {
             }),
           },
           output: {
+            // no format specified
             schema: Foo,
           },
         },


### PR DESCRIPTION
```ts
import { gemini15Flash, googleAI } from '@genkit-ai/googleai';
import { genkit, z } from 'genkit';

const ai = genkit({
  plugins: [googleAI()],
  model: gemini15Flash,
});
const MenuItemSchema = z.object({
  dishname: z.string(),
  description: z.string(),
});

const helloFlow = ai.defineFlow('hello', async (restaurantTheme) => {
  const { output } = await ai.generate({
    model: gemini15Flash,
    prompt: `Invent a menu item for a ${restaurantTheme} themed restaurant.`,
    output: {
      // format: 'json', //// <------ SHOULD NOT BE REQUIRED
      schema: MenuItemSchema,
    },
  });
  return output;
});

(async () => {
  console.log(await helloFlow('banana'));
})();
```