### PR TITLE
breaking(go): update flow streaming protocol to SSE

### DIFF
--- a/go/genkit/servers.go
+++ b/go/genkit/servers.go
@@ -418,7 +418,7 @@ func nonDurableFlowHandler(f flow) func(http.ResponseWriter, *http.Request) erro
 		out, err := f.runJSON(r.Context(), r.Header.Get("Authorization"), body.Data, callback)
 		if err != nil {
 			if r.Header.Get("Accept") == "text/event-stream" || stream {
-				_, err = fmt.Fprintf(w, `data: {"error": {"status": "INTERNAL", "message": "stream flow error", "details": %s}}\n\n`, err)
+				_, err = fmt.Fprintf(w, `data: {"error": {"status": "INTERNAL", "message": "stream flow error", "details": "%s"}}\n\n`, err)
 				return err
 			}
 			return err

--- a/go/genkit/servers.go
+++ b/go/genkit/servers.go
@@ -399,12 +399,12 @@ func nonDurableFlowHandler(f flow) func(http.ResponseWriter, *http.Request) erro
 			return err
 		}
 		var callback streamingCallback[json.RawMessage]
-		if stream {
+		if r.Header.Get("Accept") == "text/event-stream" || stream {
 			w.Header().Set("Content-Type", "text/plain")
 			w.Header().Set("Transfer-Encoding", "chunked")
 			// Stream results are newline-separated JSON.
 			callback = func(ctx context.Context, msg json.RawMessage) error {
-				_, err := fmt.Fprintf(w, "%s\n", msg)
+				_, err := fmt.Fprintf(w, "data: %s\n\n", msg)
 				if err != nil {
 					return err
 				}
@@ -421,7 +421,7 @@ func nonDurableFlowHandler(f flow) func(http.ResponseWriter, *http.Request) erro
 		}
 		// Responses for non-streaming, non-durable flows are passed back
 		// with the flow result stored in a field called "result."
-		_, err = fmt.Fprintf(w, `{"result": %s}\n`, out)
+		_, err = fmt.Fprintf(w, `data: {"result": %s}\n`, out)
 		return err
 	}
 }

--- a/go/samples/flow-sample1/main.go
+++ b/go/samples/flow-sample1/main.go
@@ -37,7 +37,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"log"
 	"strconv"
 
@@ -98,6 +97,21 @@ func main() {
 		i := 0
 		if cb != nil {
 			for ; i < count; i++ {
+				if err := cb(ctx, chunk{i}); err != nil {
+					return "", err
+				}
+			}
+		}
+		return fmt.Sprintf("done: %d, streamed: %d times", count, i), nil
+	})
+
+	genkit.DefineStreamingFlow(g, "streamyThrowy", func(ctx context.Context, count int, cb func(context.Context, chunk) error) (string, error) {
+		i := 0
+		if cb != nil {
+			for ; i < count; i++ {
+				if i == 3 {
+					return "", errors.New("boom!")
+				}
 				if err := cb(ctx, chunk{i}); err != nil {
 					return "", err
 				}

--- a/go/tests/api_test.go
+++ b/go/tests/api_test.go
@@ -45,7 +45,7 @@ type test struct {
 const hostPort = "http://localhost:3100"
 
 func TestReflectionAPI(t *testing.T) {
-	filenames, err := filepath.Glob(filepath.FromSlash("../../tests/*.yaml"))
+	filenames, err := filepath.Glob(filepath.FromSlash("../../tests/reflection_api_tests.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/tests/api_test.go
+++ b/go/tests/api_test.go
@@ -45,8 +45,7 @@ type test struct {
 const hostPort = "http://localhost:3100"
 
 func TestReflectionAPI(t *testing.T) {
-	filenames, err := filepath.Glob(filepath.FromSlash("../../tests/*.yaml"))
-
+	filenames, err := filepath.Glob(filepath.FromSlash("../../tests/reflection_api_tests.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/tests/api_test.go
+++ b/go/tests/api_test.go
@@ -45,7 +45,7 @@ type test struct {
 const hostPort = "http://localhost:3100"
 
 func TestReflectionAPI(t *testing.T) {
-	filenames, err := filepath.Glob(filepath.FromSlash("../../tests/reflection_api_tests.yaml"))
+	filenames, err := filepath.Glob(filepath.FromSlash("../../tests/*.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/tests/test_app/main.go
+++ b/go/tests/test_app/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 
@@ -61,21 +60,6 @@ func main() {
 			}
 		}
 		return fmt.Sprintf("done %d, streamed: %d times", count, i), nil
-	})
-
-	genkit.DefineStreamingFlow(g, "streamyThrowy", func(ctx context.Context, count int, cb func(context.Context, chunk) error) (string, error) {
-		i := 0
-		if cb != nil {
-			for ; i < count; i++ {
-				if i == 3 {
-					return "", errors.New("boom!")
-				}
-				if err := cb(ctx, chunk{i}); err != nil {
-					return "", err
-				}
-			}
-		}
-		return fmt.Sprintf("done: %d, streamed: %d times", count, i), nil
 	})
 
 	if err := g.Start(context.Background(), &opts); err != nil {

--- a/go/tests/test_app/main.go
+++ b/go/tests/test_app/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 
@@ -60,6 +61,21 @@ func main() {
 			}
 		}
 		return fmt.Sprintf("done %d, streamed: %d times", count, i), nil
+	})
+
+	genkit.DefineStreamingFlow(g, "streamyThrowy", func(ctx context.Context, count int, cb func(context.Context, chunk) error) (string, error) {
+		i := 0
+		if cb != nil {
+			for ; i < count; i++ {
+				if i == 3 {
+					return "", errors.New("boom!")
+				}
+				if err := cb(ctx, chunk{i}); err != nil {
+					return "", err
+				}
+			}
+		}
+		return fmt.Sprintf("done: %d, streamed: %d times", count, i), nil
 	})
 
 	if err := g.Start(context.Background(), &opts); err != nil {

--- a/js/testapps/flow-sample1/src/index.ts
+++ b/js/testapps/flow-sample1/src/index.ts
@@ -160,7 +160,7 @@ export const flowMultiStepCaughtError = ai.defineFlow(
         }
         return `${result1} ${i++},`;
       });
-    } catch (e) { }
+    } catch (e) {}
 
     return await ai.run('step3', async () => {
       return `${result2} ${i++}`;

--- a/js/testapps/flow-sample1/src/index.ts
+++ b/js/testapps/flow-sample1/src/index.ts
@@ -160,7 +160,7 @@ export const flowMultiStepCaughtError = ai.defineFlow(
         }
         return `${result1} ${i++},`;
       });
-    } catch (e) {}
+    } catch (e) { }
 
     return await ai.run('step3', async () => {
       return `${result2} ${i++}`;
@@ -223,7 +223,3 @@ function generateString(length: number) {
   }
   return str.substring(0, length);
 }
-
-ai.startFlowServer({
-  flows: [basic, streamy, streamyThrowy, throwy],
-});

--- a/js/testapps/flow-sample1/src/index.ts
+++ b/js/testapps/flow-sample1/src/index.ts
@@ -223,3 +223,7 @@ function generateString(length: number) {
   }
   return str.substring(0, length);
 }
+
+ai.startFlowServer({
+  flows: [basic, streamy, streamyThrowy, throwy],
+});

--- a/tests/flow_server_tests.yaml
+++ b/tests/flow_server_tests.yaml
@@ -5,6 +5,9 @@
 
 app: flow_server
 tests:
-  - path: /streamy
+  - path: streamy
     post:
-      data: 2
+      data: 5
+  - path: streamyThrowy
+    post:
+      data: 4

--- a/tests/flow_server_tests.yaml
+++ b/tests/flow_server_tests.yaml
@@ -5,11 +5,6 @@
 
 app: flow_server
 tests:
-  - path: /flow/streamy
-    key: /flow/streamy
-    name: streamy
-    metadata:
-      inputSchema:
-        type: string
-      outputSchema:
-        type: string
+  - path: /streamy
+  - post:
+      data: 5

--- a/tests/flow_server_tests.yaml
+++ b/tests/flow_server_tests.yaml
@@ -1,0 +1,15 @@
+# This file describes the responses to HTTP requests made
+# to the flow server
+
+# TODO: add more test cases
+
+app: flow_server
+tests:
+  - path: /flow/streamy
+    key: /flow/streamy
+    name: streamy
+    metadata:
+      inputSchema:
+        type: string
+      outputSchema:
+        type: string

--- a/tests/flow_server_tests.yaml
+++ b/tests/flow_server_tests.yaml
@@ -6,5 +6,5 @@
 app: flow_server
 tests:
   - path: /streamy
-  - post:
-      data: 5
+    post:
+      data: 2

--- a/tests/flow_server_tests.yaml
+++ b/tests/flow_server_tests.yaml
@@ -10,4 +10,4 @@ tests:
       data: 5
     response:
       message: '{"count":{count}}'
-      result: "done {count}, streamed: {count} times"
+      result: 'done {count}, streamed: {count} times'

--- a/tests/flow_server_tests.yaml
+++ b/tests/flow_server_tests.yaml
@@ -8,6 +8,6 @@ tests:
   - path: streamy
     post:
       data: 5
-  - path: streamyThrowy
-    post:
-      data: 4
+    response:
+      message: '{"count":{count}}'
+      result: "done {count}, streamed: {count} times"

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,9 +4,10 @@
   "description": "",
   "main": "lib/e2e.js",
   "scripts": {
-    "test": "npm-run-all test:reflection_api",
+    "test": "npm-run-all test:reflection_api test:flow_server",
     "test:dev_ui_test": "node --import tsx src/dev_ui_test.ts",
-    "test:reflection_api": "node --import tsx src/reflection_api_test.ts"
+    "test:reflection_api": "node --import tsx src/reflection_api_test.ts",
+    "test:flow_server": "node --import tsx src/flow_server_test.ts"
   },
   "keywords": [],
   "author": "",

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "lib/e2e.js",
   "scripts": {
-    "test": "npm-run-all test:reflection_api test:flow_server",
+    "test": "npm-run-all test:flow_server test:reflection_api",
     "test:dev_ui_test": "node --import tsx src/dev_ui_test.ts",
     "test:reflection_api": "node --import tsx src/reflection_api_test.ts",
     "test:flow_server": "node --import tsx src/flow_server_test.ts"

--- a/tests/reflection_api_tests.yaml
+++ b/tests/reflection_api_tests.yaml
@@ -876,3 +876,7 @@ tests:
       /flow/testFlow:
         key: /flow/testFlow
         name: testFlow
+
+      /flow/streamy:
+        key: /flow/streamy
+        name: streamy

--- a/tests/src/flow_server_test.ts
+++ b/tests/src/flow_server_test.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'fs';
+import * as yaml from 'yaml';
+import {
+  runTestsForApp,
+  retriable
+} from './utils.js';
+
+(async () => {
+  // TODO: Add NodeJS tests
+  // Run the tests for go test app
+  await runTestsForApp('../go/tests/test_app', 'go run main.go', async () => {
+    await testFlowServer();
+  });
+})();
+
+async function testFlowServer() {
+  const url = 'http://localhost:3400';
+
+  const t = yaml.parse(readFileSync('flow_server_tests.yaml', 'utf8'));
+  for (const test of t.tests) {
+    console.log('path', test.path)
+    let fetchopts = {
+      method: 'GET',
+    } as RequestInit;
+    if (test.hasOwnProperty('post')) {
+      fetchopts.method = 'POST';
+      fetchopts.headers = { 'Content-Type': 'text/event-stream' }
+      fetchopts.headers = { 'Access-Control-Allow-Origin': '*' }
+      fetchopts.body = JSON.stringify(test.post)
+    }
+    const res = await fetch(url + test.path)
+    if (res.status != 200) {
+      throw new Error(`${test.path}: got status ${res.status}`);
+    }
+
+  }
+  console.log('Flow server tests done! \\o/')
+}

--- a/tests/src/flow_server_test.ts
+++ b/tests/src/flow_server_test.ts
@@ -33,17 +33,17 @@ import {
 
 async function testFlowServer() {
   const url = 'http://localhost:3400';
-  let data = new FormData()
-  data.append("data", "5")
   await retriable(
     async () => {
-      const res = await fetch(`${url}/flow/testFlow`,
+      const res = await fetch(`${url}/streamy`,
         {
-          method: 'post',
-          body: data,
+          method: 'POST',
+          body: JSON.stringify({
+            data: 1
+          },),
         });
       if (res.status != 200) {
-        throw new Error(`timed out waiting for code to become healthy`)
+        throw new Error(`timed out waiting for flow server to become healthy`)
       }
     },
     {
@@ -57,7 +57,7 @@ async function testFlowServer() {
   for (const test of t.tests) {
     console.log('path', test.path)
     let fetchopts = {
-      method: 'GET',
+      method: 'POST',
     } as RequestInit;
     if (test.hasOwnProperty('post')) {
       fetchopts.method = 'POST';

--- a/tests/src/flow_server_test.ts
+++ b/tests/src/flow_server_test.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import { streamFlow } from 'genkit/client';
 import { readFileSync } from 'fs';
+import { streamFlow } from 'genkit/client';
 import * as yaml from 'yaml';
 import { retriable, runTestsForApp } from './utils.js';
-
 
 (async () => {
   // TODO: Add NodeJS tests
@@ -57,7 +56,7 @@ async function testFlowServer() {
   const t = yaml.parse(readFileSync('flow_server_tests.yaml', 'utf8'));
   for (const test of t.tests) {
     let chunkCount = 0;
-    let expected: string = ""
+    let expected: string = '';
     let want: TestResults = {
       message: test.response.message,
       result: test.response.result,
@@ -70,20 +69,26 @@ async function testFlowServer() {
       });
 
       for await (const chunk of response.stream()) {
-        expected = want.message.replace("{count}", chunkCount.toString())
-        let chunkJSON = JSON.stringify(await chunk)
+        expected = want.message.replace('{count}', chunkCount.toString());
+        let chunkJSON = JSON.stringify(await chunk);
         if (chunkJSON != expected) {
-          throw new Error(`unexpected chunk data received, got: ${chunkJSON}, want: ${want.message}`)
+          throw new Error(
+            `unexpected chunk data received, got: ${chunkJSON}, want: ${want.message}`
+          );
         }
-        chunkCount++
+        chunkCount++;
       }
       if (chunkCount != test.post.data) {
-        throw new Error(`unexpected number of stream chunks received: got ${chunkCount}, want: ${test.post.data}`)
+        throw new Error(
+          `unexpected number of stream chunks received: got ${chunkCount}, want: ${test.post.data}`
+        );
       }
-      let out = await response.output()
-      want.result = want.result.replace(/\{count\}/g, chunkCount.toString())
+      let out = await response.output();
+      want.result = want.result.replace(/\{count\}/g, chunkCount.toString());
       if (out != want.result) {
-        throw new Error(`unexpected output received, got: ${out}, want: ${want.result}`)
+        throw new Error(
+          `unexpected output received, got: ${out}, want: ${want.result}`
+        );
       }
     })();
   }

--- a/tests/src/flow_server_test.ts
+++ b/tests/src/flow_server_test.ts
@@ -25,13 +25,13 @@ import { retriable, runTestsForApp } from './utils.js';
   // Run the tests for go test app
   await runTestsForApp('../go/tests/test_app', 'go run main.go', async () => {
     await testFlowServer();
+    console.log('Flow server tests done! \\o/');
   });
 })();
 
 type TestResults = {
   message: string;
   result: string;
-  error: string;
 };
 
 async function testFlowServer() {
@@ -61,7 +61,6 @@ async function testFlowServer() {
     let want: TestResults = {
       message: test.response.message,
       result: test.response.result,
-      error: test.response.error,
     };
     console.log(`checking stream for: ${test.path}`);
     (async () => {

--- a/tests/test_js_app/src/index.ts
+++ b/tests/test_js_app/src/index.ts
@@ -60,3 +60,23 @@ export const testFlow = ai.defineFlow(
     return 'Test flow passed';
   }
 );
+
+// genkit flow:run streamy 5 -s
+export const streamy = ai.defineStreamingFlow(
+  {
+    name: 'streamy',
+    inputSchema: z.number(),
+    outputSchema: z.string(),
+    streamSchema: z.object({ count: z.number() }),
+  },
+  async (count, streamingCallback) => {
+    let i = 0;
+    if (streamingCallback) {
+      for (; i < count; i++) {
+        await new Promise((r) => setTimeout(r, 1000));
+        streamingCallback({ count: i });
+      }
+    }
+    return `done: ${count}, streamed: ${i} times`;
+  }
+);


### PR DESCRIPTION
OK
```shell
curl -X POST -H "Accept: text/event-stream" http://localhost:3400/streamy -d '{"data":5}'
data: {"count":0}\n\n
data: {"count":1}\n\n
data: {"count":2}\n\n
data: {"count":3}\n\n
data: {"count":4}\n\n
data: {"result": "done: 5, streamed: 5 times"}\n\n
```

ERROR
```shell
curl -X POST -H "Accept: text/event-stream" http://localhost:3400/streamy -d '{"data":5}'                                                                       
data: {"message": {"count":0}}\n\n
data: {"message": {"count":1}}\n\n
data: {"message": {"count":2}}\n\n
data: {"message": {"count":3}}\n\n
data: {"message": {"count":4}}\n\n
data: {"error": {"status": "INTERNAL", "message": "stream flow error", "details": "this is a dummy error"}}\n\n         
```