### PR TITLE
Fixed filename not being valid for all platforms

### DIFF
--- a/js/core/src/reflection.ts
+++ b/js/core/src/reflection.ts
@@ -296,10 +296,12 @@ export class ReflectionServer {
     try {
       const rootDir = await findProjectRoot();
       const runtimesDir = path.join(rootDir, '.genkit', 'runtimes');
-      const timestamp = new Date().toISOString();
+      const date = new Date();
+      const time = date.getTime();
+      const timestamp = date.toISOString();
       this.runtimeFilePath = path.join(
         runtimesDir,
-        `${process.pid}-${timestamp}.json`
+        `${process.pid}-${time}.json`
       );
       const fileContent = JSON.stringify(
         {


### PR DESCRIPTION
This PR should solve the issue #1318.
I have noticed that in the latest version of Genkit (0.9.X), the filename of runtime follows the format `${process.pid}-${timestamp}.json` as in the writeRuntimeFile(). However, the produced filename is not a valid name on Windows due to the timestamp part which contains reserved characters such as ":".

What happens next is that when you try to run any kind of script using genkit library, the runtime file won't be generated due to 
invalid filename: "Error writing runtime file: Error: ENOENT: no such file or directory, open '<hidden>\.genkit\runtimes\42744-2024-11-18T12:17:25.549Z.json'

As I don't know exactly the purpose of the ISO format in the filename, I've replaced that format with the milliseconds.

Checklist (if applicable):
- [X] Tested (manually, unit tested, etc.)
- [ ] Changelog  #updated
- [ ] Docs updated