### PR TITLE
fix: correctly pass auth when invoking streaming flow

### DIFF
--- a/js/core/src/flow.ts
+++ b/js/core/src/flow.ts
@@ -301,6 +301,7 @@ export class Flow<
             }) as S extends z.ZodVoid
               ? undefined
               : StreamingCallback<z.infer<S>>,
+            auth: opts?.withLocalAuthContext,
           }
         ).then((s) => s.result)
       )


### PR DESCRIPTION
Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
