### PR TITLE
Return project name with runtime info

### DIFF
--- a/genkit-tools/common/src/manager/manager.ts
+++ b/genkit-tools/common/src/manager/manager.ts
@@ -27,7 +27,12 @@ import {
 import * as apis from '../types/apis';
 import { TraceData } from '../types/trace';
 import { logger } from '../utils/logger';
-import { checkServerHealth, findRuntimesDir, retriable } from '../utils/utils';
+import {
+  checkServerHealth,
+  findRuntimesDir,
+  projectNameFromGenkitFilePath,
+  retriable,
+} from '../utils/utils';
 import {
   GenkitToolsError,
   RuntimeEvent,
@@ -312,6 +317,7 @@ export class RuntimeManager {
         async () => {
           const content = await fs.readFile(filePath, 'utf-8');
           const runtimeInfo = JSON.parse(content) as RuntimeInfo;
+          runtimeInfo.projectName = projectNameFromGenkitFilePath(filePath);
           return { content, runtimeInfo };
         },
         { maxRetries: 10, delayMs: 500 }

--- a/genkit-tools/common/src/manager/types.ts
+++ b/genkit-tools/common/src/manager/types.ts
@@ -36,6 +36,8 @@ export interface RuntimeInfo {
   reflectionServerUrl: string;
   /** Timestamp when the runtime was started. */
   timestamp: string;
+  /** Display name for the project, typically basename of the root folder */
+  projectName?: string;
 }
 
 export enum RuntimeEvent {

--- a/genkit-tools/common/src/utils/utils.ts
+++ b/genkit-tools/common/src/utils/utils.ts
@@ -65,6 +65,29 @@ export async function findServersDir(projectRoot?: string): Promise<string> {
 }
 
 /**
+ * Extract project name (i.e. basename of the project root folder) from the
+ * path to a runtime file.
+ *
+ * e.g.) /path/to/<basename>/.genkit/runtimes/123.json returns <basename>.
+ *
+ * @param filePath path to a runtime file
+ * @returns project name
+ */
+export function projectNameFromGenkitFilePath(filePath: string): string {
+  const parts = filePath.split('/');
+  const basePath = parts
+    .slice(
+      0,
+      Math.max(
+        parts.findIndex((value) => value === '.genkit'),
+        0
+      )
+    )
+    .join('/');
+  return basePath === '' ? 'unknown' : path.basename(basePath);
+}
+
+/**
  * Detects what runtime is used in the current directory.
  * @returns Runtime of the project directory.
  */

--- a/genkit-tools/common/tests/utils/utils_test.ts
+++ b/genkit-tools/common/tests/utils/utils_test.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import { projectNameFromGenkitFilePath } from '../../src/utils';
+
+describe('utils', () => {
+  describe('projectNameFromGenkitFilePath', () => {
+    it('returns unknown for empty string', () => {
+      expect(projectNameFromGenkitFilePath('')).toEqual('unknown');
+    });
+
+    it('returns unknown for an invalid path', () => {
+      expect(projectNameFromGenkitFilePath('/path/to/nowhere')).toEqual(
+        'unknown'
+      );
+    });
+
+    it('returns project name from a typical runtime file path', () => {
+      expect(
+        projectNameFromGenkitFilePath(
+          '/path/to/test-project/.genkit/runtimes/123.json'
+        )
+      ).toEqual('test-project');
+    });
+
+    it('returns project name from any path that contains a .genkit dir', () => {
+      expect(
+        projectNameFromGenkitFilePath(
+          '/path/to/test-project/.genkit/unexpected/but/valid/location'
+        )
+      ).toEqual('test-project');
+    });
+  });
+});


### PR DESCRIPTION
We'll show project name in the breadcrumbs on the dev ui (my-ai-app in the screenshot below).

![image](https://github.com/user-attachments/assets/f200fbde-544b-4ecb-9744-3d332561003b)

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [na] Changelog updated
- [na] Docs updated
