### PR TITLE
fix(cli): on windows use shell option to spawn runtime process

### DIFF
--- a/genkit-tools/cli/src/commands/start.ts
+++ b/genkit-tools/cli/src/commands/start.ts
@@ -40,7 +40,7 @@ export const start = new Command('start')
       runtimePromise = new Promise((urlResolver, reject) => {
         const appProcess = spawn(start.args[0], start.args.slice(1), {
           env: { ...process.env, GENKIT_ENV: 'dev' },
-          shell: process.platform == 'win32',
+          shell: process.platform === 'win32',
         });
 
         const originalStdIn = process.stdin;


### PR DESCRIPTION
https://stackoverflow.com/questions/37459717/error-spawn-enoent-on-windows

This is a quick fix that seems to work in my testing.

As a follow up we should explore: https://www.npmjs.com/package/cross-spawn

Filed https://github.com/firebase/genkit/issues/1332 to track

Checklist (if applicable):
- [x] Tested (manually))
