### PR TITLE
fixes #1338 corrects links to plugins

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -90,10 +90,10 @@ you get started:
 Genkit supports additional evaluators through plugins:
 
 *   VertexAI Rapid Evaluators via the [VertexAI
-    Plugin](http://plugins/vertex-ai#evaluation).
+    Plugin](plugins/vertex-ai#evaluation).
 *   [LangChain Criteria
     Evaluation](https://python.langchain.com/docs/guides/productionization/evaluation/string/criteria_eval_chain/)
-    via the [LangChain plugin](http://plugins/langchain.md).
+    via the [LangChain plugin](plugins/langchain.md).
 
 ## Advanced use
 


### PR DESCRIPTION
replaces `http://plugins/` with `plugins/` to correct links to vertex ai and langchain plugins.

Checklist (if applicable):
- [ ] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [X] Docs updated
