### PR TITLE
feat(js/plugins/googleai): adds gemini() function for unspecified model support

### DIFF
--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -88,6 +88,7 @@ export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
     })
     .optional(),
 });
+export type GeminiConfig = z.infer<typeof GeminiConfigSchema>;
 
 export const gemini10Pro = modelRef({
   name: 'googleai/gemini-1.0-pro',
@@ -195,10 +196,13 @@ function longestMatchingPrefix(version: string, potentialMatches: string[]) {
       ''
     );
 }
+export type GeminiVersionString =
+  | keyof typeof SUPPORTED_GEMINI_MODELS
+  | (string & {});
 
 export function gemini(
-  version: keyof typeof SUPPORTED_GEMINI_MODELS | (string & {}),
-  options: z.infer<typeof GeminiConfigSchema> = {}
+  version: GeminiVersionString,
+  options: GeminiConfig = {}
 ): ModelReference<typeof GeminiConfigSchema> {
   const matchingKey = longestMatchingPrefix(
     version,
@@ -511,7 +515,7 @@ export function defineGoogleAIModel(
   apiVersion?: string,
   baseUrl?: string,
   info?: ModelInfo,
-  defaultConfig?: z.infer<typeof GeminiConfigSchema>
+  defaultConfig?: GeminiConfig
 ): ModelAction {
   if (!apiKey) {
     apiKey = process.env.GOOGLE_GENAI_API_KEY || process.env.GOOGLE_API_KEY;

--- a/js/plugins/googleai/src/index.ts
+++ b/js/plugins/googleai/src/index.ts
@@ -22,14 +22,22 @@ import {
   textEmbeddingGecko001,
 } from './embedder.js';
 import {
+  GENERIC_GEMINI_MODEL,
   SUPPORTED_V15_MODELS,
   SUPPORTED_V1_MODELS,
   defineGoogleAIModel,
+  gemini,
   gemini10Pro,
   gemini15Flash,
   gemini15Pro,
 } from './gemini.js';
-export { gemini10Pro, gemini15Flash, gemini15Pro, textEmbeddingGecko001 };
+export {
+  gemini,
+  gemini10Pro,
+  gemini15Flash,
+  gemini15Pro,
+  textEmbeddingGecko001,
+};
 
 export interface PluginOptions {
   apiKey?: string;
@@ -48,6 +56,15 @@ export function googleAI(options?: PluginOptions): GenkitPlugin {
         apiVersions = [options?.apiVersion];
       }
     }
+
+    defineGoogleAIModel(
+      ai,
+      GENERIC_GEMINI_MODEL.name,
+      options?.apiKey,
+      'v1beta',
+      options?.baseUrl
+    );
+
     if (apiVersions.includes('v1beta')) {
       Object.keys(SUPPORTED_V15_MODELS).forEach((name) =>
         defineGoogleAIModel(

--- a/js/plugins/googleai/src/index.ts
+++ b/js/plugins/googleai/src/index.ts
@@ -62,7 +62,8 @@ export function googleAI(options?: PluginOptions): GenkitPlugin {
       GENERIC_GEMINI_MODEL.name,
       options?.apiKey,
       'v1beta',
-      options?.baseUrl
+      options?.baseUrl,
+      GENERIC_GEMINI_MODEL.info
     );
 
     if (apiVersions.includes('v1beta')) {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -1009,6 +1009,12 @@ importers:
       '@opentelemetry/sdk-trace-base':
         specifier: ^1.25.0
         version: 1.25.1(@opentelemetry/api@1.9.0)
+      body-parser:
+        specifier: ^1.20.3
+        version: 1.20.3
+      express:
+        specifier: ^4.21.0
+        version: 4.21.0
       firebase-admin:
         specifier: '>=12.2'
         version: 12.3.1(encoding@0.1.13)
@@ -1022,6 +1028,9 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      tsx:
+        specifier: ^4.19.2
+        version: 4.19.2
       typescript:
         specifier: ^5.3.3
         version: 5.4.5

--- a/js/testapps/flow-simple-ai/package.json
+++ b/js/testapps/flow-simple-ai/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "lib/index.js",
   "scripts": {
-    "start": "node lib/index.js",
+    "start": "pnpm exec genkit start -- pnpm exec tsx --watch src/index.ts",
     "compile": "tsc",
     "build": "pnpm build:clean && pnpm compile",
     "build:clean": "rimraf ./lib",
@@ -15,18 +15,21 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "genkit": "workspace:*",
     "@genkit-ai/firebase": "workspace:*",
     "@genkit-ai/google-cloud": "workspace:*",
     "@genkit-ai/googleai": "workspace:*",
     "@genkit-ai/vertexai": "workspace:*",
     "@google/generative-ai": "^0.15.0",
     "@opentelemetry/sdk-trace-base": "^1.25.0",
+    "body-parser": "^1.20.3",
+    "express": "^4.21.0",
     "firebase-admin": ">=12.2",
+    "genkit": "workspace:*",
     "partial-json": "^0.1.7"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",
+    "tsx": "^4.19.2",
     "typescript": "^5.3.3"
   }
 }

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -50,7 +50,7 @@ enableGoogleCloudTelemetry({
 });
 
 const ai = genkit({
-  plugins: [googleAI({ apiVersion: 'v1beta' }), vertexAI()],
+  plugins: [googleAI(), vertexAI()],
 });
 
 const app = initializeApp();

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -50,7 +50,7 @@ enableGoogleCloudTelemetry({
 });
 
 const ai = genkit({
-  plugins: [googleAI(), vertexAI()],
+  plugins: [googleAI({ apiVersion: 'v1beta' }), vertexAI()],
 });
 
 const app = initializeApp();


### PR DESCRIPTION
This allows use of Gemini models using a stringly typed `gemini()` function from the Google AI plugin:

```ts
const geminiExp = gemini('gemini-exp-1114');
```

It supports string autocomplete for the model families:

![image](https://github.com/user-attachments/assets/3e6d8f34-c582-440c-81db-c8063aa3b3dc)

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [ ] Docs updated
