### PR TITLE
feat(js/core): added a way to run actions with side-channel data and streaming

### DIFF
--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -19,7 +19,7 @@ import {
   defineAction,
   GenkitError,
   getStreamingCallback,
-  Middleware,
+  SimpleMiddleware,
   StreamingCallback,
   z,
 } from '@genkit-ai/core';
@@ -304,7 +304,7 @@ export type ModelAction<
   __configSchema: CustomOptionsSchema;
 };
 
-export type ModelMiddleware = Middleware<
+export type ModelMiddleware = SimpleMiddleware<
   z.infer<typeof GenerateRequestSchema>,
   z.infer<typeof GenerateResponseSchema>
 >;

--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -299,7 +299,7 @@ export type ModelAction<
 > = Action<
   typeof GenerateRequestSchema,
   typeof GenerateResponseSchema,
-  { model: ModelInfo }
+  typeof GenerateResponseChunkSchema
 > & {
   __configSchema: CustomOptionsSchema;
 };

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -25,6 +25,7 @@ import {
 import {
   GenerateRequest,
   GenerateRequestSchema,
+  GenerateResponseChunkSchema,
   ModelArgument,
 } from './model.js';
 import { ToolAction } from './tool.js';
@@ -36,7 +37,8 @@ export type PromptFn<
 
 export type PromptAction<I extends z.ZodTypeAny = z.ZodTypeAny> = Action<
   I,
-  typeof GenerateRequestSchema
+  typeof GenerateRequestSchema,
+  typeof GenerateResponseChunkSchema
 > & {
   __action: {
     metadata: {

--- a/js/ai/src/reranker.ts
+++ b/js/ai/src/reranker.ts
@@ -78,11 +78,7 @@ export const RerankerInfoSchema = z.object({
 export type RerankerInfo = z.infer<typeof RerankerInfoSchema>;
 
 export type RerankerAction<CustomOptions extends z.ZodTypeAny = z.ZodTypeAny> =
-  Action<
-    typeof RerankerRequestSchema,
-    typeof RerankerResponseSchema,
-    { model: RerankerInfo }
-  > & {
+  Action<typeof RerankerRequestSchema, typeof RerankerResponseSchema> & {
     __configSchema?: CustomOptions;
   };
 

--- a/js/ai/src/retriever.ts
+++ b/js/ai/src/retriever.ts
@@ -67,11 +67,7 @@ export const RetrieverInfoSchema = z.object({
 export type RetrieverInfo = z.infer<typeof RetrieverInfoSchema>;
 
 export type RetrieverAction<CustomOptions extends z.ZodTypeAny = z.ZodTypeAny> =
-  Action<
-    typeof RetrieverRequestSchema,
-    typeof RetrieverResponseSchema,
-    { model: RetrieverInfo }
-  > & {
+  Action<typeof RetrieverRequestSchema, typeof RetrieverResponseSchema> & {
     __configSchema?: CustomOptions;
   };
 


### PR DESCRIPTION
```ts
    const act = action(
      {
        name: 'foo',
        inputSchema: z.string(),
        outputSchema: z.number(),
      },
      async (input, { sendChunk, context }) => {
        checkAuth(context);
        sendChunk(1);
        sendChunk(2);
        sendChunk(3);
        return input.length;
      }
    );

    const chunks: any[] = [];
    await act('1234', {
      context: { user: 'pavel' },
      onChunk: (c) => chunks.push(c),
    });
```

Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
