### PR TITLE
Removing overly dimensional generate metrics

### DIFF
--- a/js/plugins/google-cloud/src/telemetry/generate.ts
+++ b/js/plugins/google-cloud/src/telemetry/generate.ts
@@ -207,10 +207,6 @@ class GenerateTelemetry implements Telemetry {
     }
   ) {
     this.doRecordGenerateActionMetrics(modelName, opts.response?.usage || {}, {
-      temperature: input.config?.temperature,
-      topK: input.config?.topK,
-      topP: input.config?.topP,
-      maxOutputTokens: input.config?.maxOutputTokens,
       featureName,
       path,
       latencyMs: opts.response?.latencyMs,
@@ -342,7 +338,7 @@ class GenerateTelemetry implements Telemetry {
   }
 
   private xOfY(x: number, y: number): string {
-    return `${x} of ${y}`;
+    return `${x + 1} of ${y}`;
   }
 
   private toPartLogContent(part: Part): string {
@@ -415,10 +411,6 @@ class GenerateTelemetry implements Telemetry {
     dimensions: {
       featureName?: string;
       path?: string;
-      temperature?: number;
-      maxOutputTokens?: number;
-      topK?: number;
-      topP?: number;
       latencyMs?: number;
       errName?: string;
       source?: string;
@@ -429,16 +421,12 @@ class GenerateTelemetry implements Telemetry {
       modelName: modelName,
       featureName: dimensions.featureName,
       path: dimensions.path,
-      temperature: dimensions.temperature,
-      topK: dimensions.topK,
-      topP: dimensions.topP,
       source: dimensions.source,
       sourceVersion: dimensions.sourceVersion,
       status: dimensions.errName ? 'failure' : 'success',
     };
 
     this.actionCounter.add(1, {
-      maxOutputTokens: dimensions.maxOutputTokens,
       error: dimensions.errName,
       ...shared,
     });

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -342,7 +342,6 @@ describe('GoogleCloudMetrics', () => {
       'genkit/ai/generate/latency'
     );
     assert.equal(requestCounter.value, 1);
-    assert.equal(requestCounter.attributes.maxOutputTokens, 7);
     assert.equal(inputTokenCounter.value, 10);
     assert.equal(outputTokenCounter.value, 14);
     assert.equal(inputCharacterCounter.value, 8);
@@ -361,9 +360,6 @@ describe('GoogleCloudMetrics', () => {
       latencyHistogram,
     ]) {
       assert.equal(metric.attributes.modelName, 'testModel');
-      assert.equal(metric.attributes.temperature, 1.0);
-      assert.equal(metric.attributes.topK, 3);
-      assert.equal(metric.attributes.topP, 5);
       assert.equal(metric.attributes.source, 'ts');
       assert.equal(metric.attributes.status, 'success');
       assert.equal(metric.attributes.featureName, 'generate');
@@ -398,9 +394,6 @@ describe('GoogleCloudMetrics', () => {
     );
     assert.equal(requestCounter.value, 1);
     assert.equal(requestCounter.attributes.modelName, 'failingTestModel');
-    assert.equal(requestCounter.attributes.temperature, 1.0);
-    assert.equal(requestCounter.attributes.topK, 3);
-    assert.equal(requestCounter.attributes.topP, 5);
     assert.equal(requestCounter.attributes.source, 'ts');
     assert.equal(requestCounter.attributes.status, 'failure');
     assert.equal(requestCounter.attributes.error, 'TypeError');


### PR DESCRIPTION
Removing the numerical dimensions from generation metrics which are expensive to store and query.