### PR TITLE
fix: text formatting in docs

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -292,7 +292,7 @@ alongside the native flows. You have two options:
     });  // Registers the middleware
     ```
 
-    For more information about using Express, see the [Cloud Run](/genkit/express)
+    For more information about using Express, see the [Cloud Run](/genkit/cloud-run)
     instructions.
 
 Please note, if you go with (1), you the `middleware` configuration option will

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -87,7 +87,7 @@ you get started:
 
 ### Evaluator plugins
 
-Genkit supports additional evaluators through plugins like the VertexAI Rapid Evaluators via the [VertexAI Plugin](./plugins/vertex-ai#evaluation).
+Genkit supports additional evaluators through plugins like the VertexAI Rapid Evaluators via the [VertexAI Plugin](./plugins/vertex-ai#evaluators).
 
 ## Advanced use
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -85,5 +85,5 @@ with additional Genkit capabilities, see the following guides:
 *   [Creating flows](/docs/genkit/flows): Learn how to use special Genkit
     functions, called flows, that provide end-to-end observability for workflows
     and rich debugging from Genkit tooling.
-*   [Managing prompts](/docs/genkit/dotprompt)): Learn how Genkit helps you manage
-*   your prompts and configuration together as code.
+*   [Managing prompts](/docs/genkit/dotprompt): Learn how Genkit helps you manage
+    your prompts and configuration together as code.

--- a/docs/plugin-authoring-evaluator.md
+++ b/docs/plugin-authoring-evaluator.md
@@ -63,6 +63,7 @@ const DELICIOUSNESS_PROMPT = ai.definePrompt(
 Now, define the function that will take an example which includes `output` as is required by the prompt and score the result. Genkit test cases include `input` as required a required field, with optional fields for `output` and `context`. It is the responsibility of the evaluator to validate that all fields required for evaluation are present.
 
 ```ts
+import { ModelArgument, z } from 'genkit';
 import { BaseEvalDataPoint, Score } from 'genkit/evaluator';
 
 /**


### PR DESCRIPTION
Fixed:
- formatting in intro
- broken link 
- correct target heading [Evaluation](https://firebase.google.com/docs/genkit/evaluation#evaluator_plugins)

Relevant Discord link: https://discord.com/channels/1255578482214305893/1309810547302338570/1309810551223877634


Checklist (if applicable):
- [ ] Tested (manually, unit tested, etc.)
- [ ] Changelog updated
- [x] Docs updated
