### PR TITLE
fix(js/genkit): correctly handle function prompt output schema

### DIFF
--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -136,6 +136,7 @@ import { BaseEvalDataPointSchema } from './evaluator.js';
 import { logger } from './logging.js';
 import { GenkitPlugin, genkitPlugin } from './plugin.js';
 import { Registry } from './registry.js';
+import { toJsonSchema } from './schema.js';
 import { toToolDefinition } from './tool.js';
 
 /**
@@ -465,7 +466,12 @@ export class Genkit {
             ).map(toToolDefinition);
           }
           if (!response.output && options.output) {
-            response.output = options.output;
+            response.output = {
+              schema: toJsonSchema({
+                schema: options.output.schema,
+                jsonSchema: options.output.jsonSchema,
+              }),
+            };
           }
           return response;
         }

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -715,6 +715,7 @@ describe('definePrompt', () => {
 
 describe('prompt', () => {
   let ai: Genkit;
+  let pm: ProgrammableModel;
 
   beforeEach(() => {
     ai = genkit({
@@ -722,6 +723,7 @@ describe('prompt', () => {
       promptDir: './tests/prompts',
     });
     defineEchoModel(ai);
+    pm = defineProgrammableModel(ai);
   });
 
   it('loads from from the folder', async () => {
@@ -770,6 +772,49 @@ describe('prompt', () => {
     const { text } = await testPrompt({ name: 'banana' });
 
     assert.strictEqual(text, 'Echo: hi banana; config: {"temperature":11}');
+  });
+
+  it('passes in output options to the model', async () => {
+    const hi = ai.definePrompt(
+      {
+        name: 'hi',
+        model: 'programmableModel',
+        input: {
+          schema: z.object({
+            name: z.string(),
+          }),
+        },
+        output: {
+          schema: z.object({
+            message: z.string(),
+          }),
+          format: 'json',
+        },
+      },
+      async (input) => {
+        return {
+          messages: [{ role: 'user', content: [{ text: `hi ${input.name}` }] }],
+          config: {
+            temperature: 11,
+          },
+        };
+      }
+    );
+
+    pm.handleResponse = async (req, sc) => {
+      return {
+        message: {
+          role: 'model',
+          content: [{ text: '```json\n{"message": "hello"}\n```' }],
+        },
+      };
+    };
+
+    const { output } = await hi({
+      name: 'Pavel'
+    });
+
+    assert.deepStrictEqual(output, {message: 'hello'});
   });
 });
 


### PR DESCRIPTION
```ts
import { genkit, z } from 'genkit';
import { googleAI, gemini15Flash } from '@genkit-ai/googleai'

const ai = genkit({
  plugins: [googleAI()],
  model: gemini15Flash,
});

const helloPrompt = ai.definePrompt(
  {
    name: 'helloPrompt',
    input: z.object({
      name: z.string(),
    }),
    output: {
      schema: z.object({
        message: z.string()
      })
    }
  }, async (input) => ({
    messages: [{
      role: 'user',
      content: [{text: `say hello to ${input.name}`}]
    }]
  })
);


export const helloFlow = ai.defineFlow('hello', async () => {
  const { text } = await helloPrompt({name: "Pavel"});
  return text;
});
```


Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)
