### PR TITLE
fix: fixed gemini model handling of nullish optional fields in response schema

### DIFF
--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -459,9 +459,11 @@ export function cleanSchema(schema: JSONSchema): JSONSchema {
     if (typeof out[key] === 'object') {
       out[key] = cleanSchema(out[key]);
     }
+    // Zod nullish() and picoschema optional fields will produce type `["string", "null"]`
+    // which is not supported by the model API. Convert them to just `"string"`.
     if (key === 'type' && Array.isArray(out[key])) {
       // find the first that's not `null`.
-      out[key] = out[key].find(t => t !== 'null');
+      out[key] = out[key].find((t) => t !== 'null');
     }
   }
   return out;

--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -449,7 +449,7 @@ export function fromGeminiCandidate(
   };
 }
 
-function cleanSchema(schema: JSONSchema): JSONSchema {
+export function cleanSchema(schema: JSONSchema): JSONSchema {
   const out = structuredClone(schema);
   for (const key in out) {
     if (key === '$schema' || key === 'additionalProperties') {
@@ -458,6 +458,10 @@ function cleanSchema(schema: JSONSchema): JSONSchema {
     }
     if (typeof out[key] === 'object') {
       out[key] = cleanSchema(out[key]);
+    }
+    if (key === 'type' && Array.isArray(out[key])) {
+      // find the first that's not `null`.
+      out[key] = out[key].find(t => t !== 'null');
     }
   }
   return out;

--- a/js/plugins/googleai/tests/gemini_test.ts
+++ b/js/plugins/googleai/tests/gemini_test.ts
@@ -364,7 +364,6 @@ describe('cleanSchema', () => {
       $schema: 'http://json-schema.org/draft-07/schema#',
     });
 
-    console.log(JSON.stringify(cleaned, undefined, 2));
     assert.deepStrictEqual(cleaned, {
       type: 'object',
       properties: {

--- a/js/plugins/googleai/tests/gemini_test.ts
+++ b/js/plugins/googleai/tests/gemini_test.ts
@@ -19,6 +19,7 @@ import { GenerateContentCandidate } from '@google/generative-ai';
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import {
+  cleanSchema,
   fromGeminiCandidate,
   toGeminiMessage,
   toGeminiSystemInstruction,
@@ -344,4 +345,37 @@ describe('fromGeminiCandidate', () => {
       );
     });
   }
+});
+
+describe('cleanSchema', () => {
+  it('strips nulls from type', () => {
+    const cleaned = cleanSchema({
+      type: 'object',
+      properties: {
+        title: {
+          type: 'string',
+        },
+        subtitle: {
+          type: ['string', 'null'],
+        },
+      },
+      required: ['title'],
+      additionalProperties: true,
+      $schema: 'http://json-schema.org/draft-07/schema#',
+    });
+
+    console.log(JSON.stringify(cleaned, undefined, 2));
+    assert.deepStrictEqual(cleaned, {
+      type: 'object',
+      properties: {
+        title: {
+          type: 'string',
+        },
+        subtitle: {
+          type: 'string',
+        },
+      },
+      required: ['title'],
+    });
+  });
 });

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -415,7 +415,7 @@ const convertSchemaProperty = (property) => {
   }
 };
 
-function cleanSchema(schema: JSONSchema): JSONSchema {
+export function cleanSchema(schema: JSONSchema): JSONSchema {
   const out = structuredClone(schema);
   for (const key in out) {
     if (key === '$schema' || key === 'additionalProperties') {
@@ -424,6 +424,10 @@ function cleanSchema(schema: JSONSchema): JSONSchema {
     }
     if (typeof out[key] === 'object') {
       out[key] = cleanSchema(out[key]);
+    }
+    if (key === 'type' && Array.isArray(out[key])) {
+      // find the first that's not `null`.
+      out[key] = out[key].find(t => t !== 'null');
     }
   }
   return out;

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -425,9 +425,11 @@ export function cleanSchema(schema: JSONSchema): JSONSchema {
     if (typeof out[key] === 'object') {
       out[key] = cleanSchema(out[key]);
     }
+    // Zod nullish() and picoschema optional fields will produce type `["string", "null"]`
+    // which is not supported by the model API. Convert them to just `"string"`.
     if (key === 'type' && Array.isArray(out[key])) {
       // find the first that's not `null`.
-      out[key] = out[key].find(t => t !== 'null');
+      out[key] = out[key].find((t) => t !== 'null');
     }
   }
   return out;

--- a/js/plugins/vertexai/tests/gemini_test.ts
+++ b/js/plugins/vertexai/tests/gemini_test.ts
@@ -19,6 +19,7 @@ import { MessageData } from 'genkit';
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import {
+  cleanSchema,
   fromGeminiCandidate,
   toGeminiMessage,
   toGeminiSystemInstruction,
@@ -347,4 +348,37 @@ describe('fromGeminiCandidate', () => {
       );
     });
   }
+});
+
+describe('cleanSchema', () => {
+  it('strips nulls from type', () => {
+    const cleaned = cleanSchema({
+      type: 'object',
+      properties: {
+        title: {
+          type: 'string',
+        },
+        subtitle: {
+          type: ['string', 'null'],
+        },
+      },
+      required: ['title'],
+      additionalProperties: true,
+      $schema: 'http://json-schema.org/draft-07/schema#',
+    });
+
+    console.log(JSON.stringify(cleaned, undefined, 2));
+    assert.deepStrictEqual(cleaned, {
+      type: 'object',
+      properties: {
+        title: {
+          type: 'string',
+        },
+        subtitle: {
+          type: 'string',
+        },
+      },
+      required: ['title'],
+    });
+  });
 });

--- a/js/plugins/vertexai/tests/gemini_test.ts
+++ b/js/plugins/vertexai/tests/gemini_test.ts
@@ -367,7 +367,6 @@ describe('cleanSchema', () => {
       $schema: 'http://json-schema.org/draft-07/schema#',
     });
 
-    console.log(JSON.stringify(cleaned, undefined, 2));
     assert.deepStrictEqual(cleaned, {
       type: 'object',
       properties: {


### PR DESCRIPTION
Zod schema like this:

```ts
schema: z.object({
  title: z.string(),
  subtitle: z.string().nulish(),
}),
```

and  picoschema like this:

```yaml
output:
  schema:
    title: string
    subtitle?: string
```

produce schema:
```json
{
  "type": "object",
  "properties": {
    "title": {
      "type": "string"
    },
    "subtitle": {
      "type": [
        "string",
        "null"
      ]
    }
  },
  "required": [
    "title"
  ],
  "additionalProperties": false
}
```

which is not a valid schema in Gemini API request for constrained generation.

```
  status: 400,
  statusText: 'Bad Request',
  errorDetails: [
    {
      '@type': 'type.googleapis.com/google.rpc.BadRequest',
      fieldViolations: [
        {
          field: 'generation_config.response_schema.properties[1].value',
          description: `Invalid JSON payload received. Unknown name "type" at 'generation_config.response_schema.properties[1].value': Proto field is not repeating, cannot start list.`
        }
      ]
    }
  ]
```

convert
```
      "type": [
        "string",
        "null"
      ]
```

to

```
      "type": "string",
```


Checklist (if applicable):
- [x] Tested (manually, unit tested, etc.)

