### PR TITLE
fix(cli): fixed `genkit start` port option to accept the port value

### DIFF
--- a/genkit-tools/cli/src/commands/start.ts
+++ b/genkit-tools/cli/src/commands/start.ts
@@ -32,7 +32,7 @@ interface RunOptions {
 export const start = new Command('start')
   .description('runs a command in Genkit dev mode')
   .option('-n, --noui', 'do not start the Dev UI', false)
-  .option('-p, --port', 'port for the Dev UI')
+  .option('-p, --port <port>', 'port for the Dev UI')
   .option('-o, --open', 'Open the browser on UI start up')
   .action(async (options: RunOptions) => {
     let runtimePromise = Promise.resolve();


### PR DESCRIPTION
Checklist (if applicable):
- [x] Tested (manually)
