### PR TITLE
Add reference to genkit object to firebase retriever docs

### DIFF
--- a/docs/plugins/firebase.md
+++ b/docs/plugins/firebase.md
@@ -138,15 +138,17 @@ import {getFirestore} from "firebase-admin/firestore";
 const app = initializeApp();
 const firestore = getFirestore(app);
 
-const yourRetrieverRef = defineFirestoreRetriever({
-  name: "yourRetriever",
-  firestore: getFirestore(app),
-  collection: "yourCollection",
-  contentField: "yourDataChunks",
-  vectorField: "embedding",
-  embedder: textEmbeddingGecko, // Import from '@genkit-ai/googleai' or '@genkit-ai/vertexai'
-  distanceMeasure: "COSINE", // "EUCLIDEAN", "DOT_PRODUCT", or "COSINE" (default)
-});
+const yourRetrieverRef = defineFirestoreRetriever(
+  ai,
+  {
+    name: "yourRetriever",
+    firestore: getFirestore(app),
+    collection: "yourCollection",
+    contentField: "yourDataChunks",
+    vectorField: "embedding",
+    embedder: textEmbeddingGecko, // Import from '@genkit-ai/googleai' or '@genkit-ai/vertexai'
+    distanceMeasure: "COSINE", // "EUCLIDEAN", "DOT_PRODUCT", or "COSINE" (default)
+  });
 ```
 
 To use it, pass it to the `ai.retrieve()` function:


### PR DESCRIPTION
defineFirestoreRetriever requires a reference to a genkit object.

I didn't add the import / initializiation, since that is covered in a snippet above.
