### PR TITLE
Setting root span status explicitly

### DIFF
--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -337,6 +337,8 @@ class AdjustingTraceExporter implements SpanExporter {
       featuresTelemetry.tick(span, unused, this.logIO, this.projectId);
       // Report executions and latency for all flow paths only on the root span
       pathsTelemetry.tick(span, paths, this.logIO, this.projectId);
+      // Set root status explicitly
+      span.attributes['genkit:rootState'] = span.attributes['genkit:state'];
     }
     if (type === 'action' && subtype === 'model') {
       // Report generate metrics () for all model actions

--- a/js/plugins/google-cloud/tests/traces_test.ts
+++ b/js/plugins/google-cloud/tests/traces_test.ts
@@ -152,6 +152,8 @@ describe('GoogleCloudTracing', () => {
       spans[0].attributes['genkit/failedPath'],
       '/{badFlow,t:flow}/{badStep,t:flowStep}'
     );
+    assert.equal(spans[1].attributes['genkit/isRoot'], true);
+    assert.equal(spans[1].attributes['genkit/rootState'], 'error');
   });
 
   it('labels the root feature', async () => {
@@ -165,6 +167,7 @@ describe('GoogleCloudTracing', () => {
     assert.equal(spans[0].attributes['genkit/feature'], undefined);
     assert.equal(spans[1].name, 'niceFlow');
     assert.equal(spans[1].attributes['genkit/feature'], 'niceFlow');
+    assert.equal(spans[1].attributes['genkit/rootState'], 'success');
   });
 
   it('adds the genkit/model label for model actions', async () => {


### PR DESCRIPTION
Enable unambiguous queries for traces with root successes or failures
