### PR TITLE
feat(evals): New data format for evals IO

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -46,25 +46,30 @@ called `testInputs.json`. This input dataset represents the test cases you will
 use to generate output for evaluation.
 
 ```json
-["Cheese", "Broccoli", "Spinach and Kale"]
+[
+  {
+    "input": "What is the French word for Cheese?"
+  },
+  {
+    "input": "What green vegetable looks like cauliflower?"
+  }
+]
 ```
 
 If the evaluator requires a reference output for evaluating a flow, you can pass both 
 input and reference output using this format instead:
 
 ```json
-{
-  "samples": [
-    {
-      "input": "What is the French word for Cheese?",
-      "reference": "Fromage"
-    },
-    {
-      "input": "What green vegetable looks like cauliflower?",
-      "reference": "Broccoli"
-    }
-  ]
-}
+[
+  {
+    "input": "What is the French word for Cheese?",
+    "reference": "Fromage"
+  },
+  {
+    "input": "What green vegetable looks like cauliflower?",
+    "reference": "Broccoli"
+  }
+]
 ```
 
 Note that you can use any JSON data type in the input JSON file. Genkit will pass them along with the same data type to your flow.

--- a/genkit-tools/cli/src/commands/eval-extract-data.ts
+++ b/genkit-tools/cli/src/commands/eval-extract-data.ts
@@ -58,12 +58,10 @@ export const evalExtractData = new Command('eval:extractData')
           .map((t) => {
             const rootSpan = Object.values(t.spans).find(
               (s) =>
-                s.attributes['genkit:type'] === 'flow' &&
+                s.attributes['genkit:metadata:subtype'] === 'flow' &&
                 (!options.label ||
-                  s.attributes['genkit:metadata:flow:label:batchRun'] ===
-                    options.label) &&
-                s.attributes['genkit:metadata:flow:name'] === flowName &&
-                s.attributes['genkit:metadata:flow:state'] === 'done'
+                  s.attributes['batchRun'] === options.label) &&
+                s.attributes['genkit:name'] === flowName
             );
             if (!rootSpan) {
               return undefined;

--- a/genkit-tools/cli/src/commands/eval-flow.ts
+++ b/genkit-tools/cli/src/commands/eval-flow.ts
@@ -42,7 +42,7 @@ interface EvalFlowRunCliOptions {
   outputFormat: string;
 }
 
-const EVAL_FLOW_SCHEMA = '{samples: Array<{input: any; reference?: any;}>}';
+const EVAL_FLOW_SCHEMA = 'Array<{input: any; reference?: any;}>';
 enum SourceType {
   DATA = 'data',
   FILE = 'file',
@@ -177,8 +177,7 @@ async function readInputs(
     case SourceType.DATASET:
       const datasetStore = await getDatasetStore();
       const data = await datasetStore.getDataset(input!);
-      // Format to match EvalInferenceInputSchema
-      parsedData = { samples: data };
+      parsedData = data;
       break;
   }
 

--- a/genkit-tools/cli/src/commands/flow-batch-run.ts
+++ b/genkit-tools/cli/src/commands/flow-batch-run.ts
@@ -49,12 +49,17 @@ export const flowBatchRun = new Command('flow:batchRun')
     ) => {
       await runWithManager(async (manager) => {
         const inputData = JSON.parse(await readFile(fileName, 'utf8')) as any[];
-        if (!Array.isArray(inputData)) {
-          throw new Error('batch input data must be an array');
+        let input = inputData;
+        if (inputData.length === 0) {
+          throw new Error('batch input data must be a non-empty array');
+        }
+        if (Object.hasOwn(inputData[0], 'input')) {
+          // If object has "input" field, use that instead.
+          input = inputData.map((d) => d.input);
         }
 
         const outputValues = [] as { input: any; output: any }[];
-        for (const data of inputData) {
+        for (const data of input) {
           logger.info(`Running '/flow/${flowName}'...`);
           let response = await manager.runAction({
             key: `/flow/${flowName}`,

--- a/genkit-tools/common/src/eval/evaluate.ts
+++ b/genkit-tools/common/src/eval/evaluate.ts
@@ -80,7 +80,7 @@ export async function runNewEvaluation(
   const evalDataset = await runInference({
     manager,
     actionRef,
-    evalFlowInput: EvalInferenceInputSchema.parse({ samples: dataset }),
+    evalFlowInput: EvalInferenceInputSchema.parse(dataset),
     auth: request.options?.auth,
     actionConfig: request.options?.actionConfig,
   });
@@ -209,16 +209,11 @@ async function bulkRunAction(params: {
 }): Promise<EvalInput[]> {
   const { manager, actionRef, evalFlowInput, auth, actionConfig } = params;
   const isModelAction = actionRef.startsWith('/model');
-  let testCases: TestCase[] = Array.isArray(evalFlowInput)
-    ? (evalFlowInput as any[]).map((i) => ({
-        input: i,
-        testCaseId: generateTestCaseId(),
-      }))
-    : evalFlowInput.samples.map((c) => ({
-        input: c.input,
-        reference: c.reference,
-        testCaseId: c.testCaseId ?? generateTestCaseId(),
-      }));
+  let testCases: TestCase[] = evalFlowInput.map((c) => ({
+    input: c.input,
+    reference: c.reference,
+    testCaseId: c.testCaseId ?? generateTestCaseId(),
+  }));
 
   let states: InferenceRunState[] = [];
   let evalInputs: EvalInput[] = [];

--- a/genkit-tools/common/src/eval/localFileDatasetStore.ts
+++ b/genkit-tools/common/src/eval/localFileDatasetStore.ts
@@ -241,18 +241,10 @@ export class LocalFileDatasetStore implements DatasetStore {
   }
 
   private getDatasetFromInferenceInput(data: EvalInferenceInput): Dataset {
-    if (Array.isArray(data)) {
-      return data.map((d) => ({
-        testCaseId: d.testCaseId ?? generateTestCaseId(),
-        input: d,
-      }));
-    } else if (!!data.samples) {
-      return data.samples.map((d) => ({
-        testCaseId: d.testCaseId ?? generateTestCaseId(),
-        ...d,
-      }));
-    }
-    return [];
+    return data.map((d) => ({
+      testCaseId: d.testCaseId ?? generateTestCaseId(),
+      ...d,
+    }));
   }
 
   private async patchDataset(

--- a/genkit-tools/common/src/types/eval.ts
+++ b/genkit-tools/common/src/types/eval.ts
@@ -30,22 +30,6 @@ import { GenerateRequestSchema } from './model';
  */
 
 /**
- * Structured input for inference part of evaluation
- */
-export const EvalInferenceStructuredInputSchema = z.object({
-  samples: z.array(
-    z.object({
-      testCaseId: z.string().optional(),
-      input: z.any(),
-      reference: z.any().optional(),
-    })
-  ),
-});
-export type EvalInferenceStructuredInput = z.infer<
-  typeof EvalInferenceStructuredInputSchema
->;
-
-/**
  * Supported datatype when running eval-inference using models
  */
 export const ModelInferenceInputSchema = z.union([
@@ -60,15 +44,19 @@ export const ModelInferenceInputJSONSchema = zodToJsonSchema(
     removeAdditionalStrategy: 'strict',
   }
 ) as JSONSchema7;
+
 /**
  * A set of samples that is ready for inference.
  *
  * This should be used in user-facing surfaces (CLI/API inputs) to accommodate various user input formats. For internal wire-transfer/storage, prefer {@link Dataset}.
  */
-export const EvalInferenceInputSchema = z.union([
-  z.array(z.any()),
-  EvalInferenceStructuredInputSchema,
-]);
+export const EvalInferenceInputSchema = z.array(
+  z.object({
+    testCaseId: z.string().optional(),
+    input: z.any(),
+    reference: z.any().optional(),
+  })
+);
 export type EvalInferenceInput = z.infer<typeof EvalInferenceInputSchema>;
 
 /**

--- a/genkit-tools/common/tests/eval/localFileDatasetStore_test.ts
+++ b/genkit-tools/common/tests/eval/localFileDatasetStore_test.ts
@@ -88,12 +88,12 @@ const SAMPLE_DATASET_METADATA_1_V2 = {
 };
 
 const CREATE_DATASET_REQUEST = CreateDatasetRequestSchema.parse({
-  data: { samples: SAMPLE_DATASET_1_V1 },
+  data: SAMPLE_DATASET_1_V1,
   datasetType: 'UNKNOWN',
 });
 
 const CREATE_DATASET_REQUEST_WITH_SCHEMA = CreateDatasetRequestSchema.parse({
-  data: { samples: SAMPLE_DATASET_1_V1 },
+  data: SAMPLE_DATASET_1_V1,
   datasetType: 'UNKNOWN',
   schema: {
     inputSchema: {
@@ -109,7 +109,7 @@ const CREATE_DATASET_REQUEST_WITH_SCHEMA = CreateDatasetRequestSchema.parse({
 });
 
 const UPDATE_DATASET_REQUEST = UpdateDatasetRequestSchema.parse({
-  data: { samples: SAMPLE_DATASET_1_V2 },
+  data: SAMPLE_DATASET_1_V2,
   datasetId: SAMPLE_DATASET_ID_1,
 });
 
@@ -205,7 +205,7 @@ describe('localFileDatasetStore', () => {
 
       const datasetMetadata = await DatasetStore.createDataset({
         ...CREATE_DATASET_REQUEST,
-        data: { samples: dataset },
+        data: dataset,
         datasetId: SAMPLE_DATASET_ID_1,
       });
 
@@ -304,13 +304,11 @@ describe('localFileDatasetStore', () => {
         .mockImplementation(() => Promise.resolve(dataset));
 
       const datasetMetadata = await DatasetStore.updateDataset({
-        data: {
-          samples: [
-            {
-              input: 'A new information on cat dog',
-            },
-          ],
-        },
+        data: [
+          {
+            input: 'A new information on cat dog',
+          },
+        ],
         datasetId: SAMPLE_DATASET_ID_1,
       });
 
@@ -357,17 +355,15 @@ describe('localFileDatasetStore', () => {
         .mockImplementation(() => Promise.resolve(dataset));
 
       const datasetMetadata = await DatasetStore.updateDataset({
-        data: {
-          samples: [
-            {
-              input: 'A new information on cat dog',
-            },
-            {
-              testCaseId: '1',
-              input: 'Other information on hot dog',
-            },
-          ],
-        },
+        data: [
+          {
+            input: 'A new information on cat dog',
+          },
+          {
+            testCaseId: '1',
+            input: 'Other information on hot dog',
+          },
+        ],
         datasetId: SAMPLE_DATASET_ID_1,
       });
 

--- a/js/testapps/evals/data/cat_adoption_questions.json
+++ b/js/testapps/evals/data/cat_adoption_questions.json
@@ -1,6 +1,14 @@
 [
-  "What are typical cat behaviors?",
-  "What supplies do you need when bringing home a new cat?",
-  "How often should you trim your cat's nails?",
-  "What are some plants that are toxic to cats?"
+  {
+    "input": "What are typical cat behaviors?"
+  },
+  {
+    "input": "What supplies do you need when bringing home a new cat?"
+  },
+  {
+    "input": "How often should you trim your cat's nails?"
+  },
+  {
+    "input": "What are some plants that are toxic to cats?"
+  }
 ]

--- a/js/testapps/evals/data/cat_adoption_questions_with_reference.json
+++ b/js/testapps/evals/data/cat_adoption_questions_with_reference.json
@@ -1,20 +1,18 @@
-{
-  "samples": [
-    {
-      "input": "What are typical cat behaviors?",
-      "reference": "Cats like to purr, push things away and cuddle."
-    },
-    {
-      "input": "What supplies do you need when bringing home a new cat?",
-      "reference": "Litter box, cat food and plenty of yarn"
-    },
-    {
-      "input": "How often should you trim your cat's nails?",
-      "reference": "Trim your cat's nails only when you feel like they're overgrown"
-    },
-    {
-      "input": "What are some plants that are toxic to cats?",
-      "reference": "I don't know, maybe poison ivy?"
-    }
-  ]
-}
+[
+  {
+    "input": "What are typical cat behaviors?",
+    "reference": "Cats like to purr, push things away and cuddle."
+  },
+  {
+    "input": "What supplies do you need when bringing home a new cat?",
+    "reference": "Litter box, cat food and plenty of yarn"
+  },
+  {
+    "input": "How often should you trim your cat's nails?",
+    "reference": "Trim your cat's nails only when you feel like they're overgrown"
+  },
+  {
+    "input": "What are some plants that are toxic to cats?",
+    "reference": "I don't know, maybe poison ivy?"
+  }
+]


### PR DESCRIPTION
This PR implements the changes discussed with AIM to support a more coherent dataset IO format.

Changes:
 - `{samples: [{input, reference}]}`  is no longer a valid format. All IO will be using `[{input, reference}]`.
 - As a consequence `any[]` is not allowed anymore. i.e. users cannot use an array of inputs for evals. They have to use the format above.
 - On the upside, the result of `eval:extractData` can be used for both `eval:run` and `eval:flow`. (In other words, `eval:flow` input format is a strict subset of `eval:run` input format -- which is the same as the output format of `eval:extractData`). Users can use the same `.json` file for multiple evaluation tasks, provided they have the right fields present.
 - Formats like JSONL can be supported as a follow-up.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
