### PR TITLE
fix: googleai import typo in docs

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -34,7 +34,7 @@ const ai = genkit({
 ```
 
 **Note:** The configuration above requires installing the `genkit`,
-`@genkit-ai/google-ai`, `@genkit-ai/evaluator` and `@genkit-ai/vertexai`
+`@genkit-ai/googleai`, `@genkit-ai/evaluator` and `@genkit-ai/vertexai`
 packages.
 
 ```posix-terminal

--- a/docs/templates/pgvector.md
+++ b/docs/templates/pgvector.md
@@ -6,7 +6,7 @@ schema.
 
 ```ts
 import { genkit, z } from 'genkit';
-import { googleAI, textEmbedding004 } from '@genkit-ai/google-ai';
+import { googleAI, textEmbedding004 } from '@genkit-ai/googleai';
 import { toSql } from 'pgvector';
 import postgres from 'postgres';
 

--- a/docs/tool-calling.md
+++ b/docs/tool-calling.md
@@ -96,7 +96,7 @@ Use the Genkit instance's `defineTool()` function to write tool definitions:
 
 ```ts
 import { genkit, z } from 'genkit';
-import { googleAI, gemini15Flash } from '@genkit-ai/google-ai';
+import { googleAI, gemini15Flash } from '@genkitai/google-ai';
 
 const ai = genkit({
   plugins: [googleAI()],


### PR DESCRIPTION
This seems to be a typo - the npm package is hosted at https://www.npmjs.com/package/@genkit-ai/googleai.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
