### PR TITLE
docs(eval): fix evaluator plugin docs so code compiles

### DIFF
--- a/docs/plugin-authoring-evaluator.md
+++ b/docs/plugin-authoring-evaluator.md
@@ -31,6 +31,7 @@ const DeliciousnessDetectionResponseSchema = z.object({
   reason: z.string(),
   verdict: z.enum(DELICIOUSNESS_VALUES),
 });
+
 type DeliciousnessDetectionResponse = z.infer<typeof DeliciousnessDetectionResponseSchema>;
 
 const DELICIOUSNESS_PROMPT = ai.definePrompt(

--- a/docs/plugin-authoring-evaluator.md
+++ b/docs/plugin-authoring-evaluator.md
@@ -31,7 +31,6 @@ const DeliciousnessDetectionResponseSchema = z.object({
   reason: z.string(),
   verdict: z.enum(DELICIOUSNESS_VALUES),
 });
-
 type DeliciousnessDetectionResponse = z.infer<typeof DeliciousnessDetectionResponseSchema>;
 
 const DELICIOUSNESS_PROMPT = ai.definePrompt(


### PR DESCRIPTION
Fix some errors and mismatched types so that if someone copy/pastes all the code from the doc, it will at least compile and run

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
