### PR TITLE
feat: turned flow second param into a destructurable side channel object (backwards compatible)

### DIFF
--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -16,6 +16,7 @@
 
 import { JSONSchema7 } from 'json-schema';
 import * as z from 'zod';
+import { getContext } from './context.js';
 import { ActionType, Registry } from './registry.js';
 import { parseSchema } from './schema.js';
 import {
@@ -23,7 +24,6 @@ import {
   newTrace,
   setCustomMetadataAttributes,
 } from './tracing.js';
-import { getContext } from './context.js';
 
 export { Status, StatusCodes, StatusSchema } from './statusTypes.js';
 export { JSONSchema7 };

--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -23,6 +23,7 @@ import {
   newTrace,
   setCustomMetadataAttributes,
 } from './tracing.js';
+import { getContext } from './context.js';
 
 export { Status, StatusCodes, StatusSchema } from './statusTypes.js';
 export { JSONSchema7 };
@@ -277,7 +278,8 @@ export function action<
 
         try {
           const output = await fn(input, {
-            context: options?.context,
+            // Context can either be explicitly set, or inherited from the parent action.
+            context: options?.context ?? getContext(registry),
             sendChunk: options?.onChunk ?? ((c) => {}),
           });
 

--- a/js/core/src/context.ts
+++ b/js/core/src/context.ts
@@ -43,16 +43,16 @@ export function runWithContext<R>(
  * @deprecated use {@link getFlowContext}
  */
 export function getFlowAuth(registry?: Registry | HasRegistry): any {
-  return getFlowContext(registry);
+  if (!registry) {
+    return legacyContextAsyncLocalStorage.getStore();
+  }
+  return getContext(registry);
 }
 
 /**
  * Gets the runtime context of the current flow.
  */
-export function getFlowContext(registry?: Registry | HasRegistry): any {
-  if (!registry) {
-    return legacyContextAsyncLocalStorage.getStore();
-  }
+export function getContext(registry: Registry | HasRegistry): any {
   if ((registry as HasRegistry).registry) {
     registry = (registry as HasRegistry).registry;
   }

--- a/js/core/src/flow.ts
+++ b/js/core/src/flow.ts
@@ -26,7 +26,7 @@ import {
   defineAction,
   StreamingCallback,
 } from './action.js';
-import { runWithContext } from './auth.js';
+import { runWithContext } from './context.js';
 import { getErrorMessage, getErrorStack } from './error.js';
 import { logger } from './logging.js';
 import { HasRegistry, Registry } from './registry.js';
@@ -137,6 +137,25 @@ interface StreamingResponse<
 }
 
 /**
+ * Flow execution context for flow to access the streaming callback and 
+ * side-channel context data. The context itself is a function, a short-cut
+ * for streaming callback.
+ */
+export interface FlowSideChannel<S> {
+  (chunk: S): void;
+
+  /**
+   * Streaming callback (optional).
+   */
+  sendChunk: StreamingCallback<S>;
+
+  /**
+   * Additional runtime context data (ex. auth context data).
+   */
+  context?: any;
+}
+
+/**
  * Function to be executed in the flow.
  */
 export type FlowFn<
@@ -147,7 +166,7 @@ export type FlowFn<
   /** Input to the flow. */
   input: z.infer<I>,
   /** Callback for streaming functions only. */
-  streamingCallback: StreamingCallback<z.infer<S>>
+  streamingCallback: FlowSideChannel<z.infer<S>>
 ) => Promise<z.infer<O>> | z.infer<O>;
 
 export class Flow<
@@ -550,9 +569,14 @@ function defineFlowAction<
     },
     async (input, { sendChunk, context }) => {
       await config.authPolicy?.(context, input);
-      return await legacyRegistryAls.run(registry, () =>
-        runWithContext(registry, context, () => fn(input, sendChunk))
-      );
+      return await legacyRegistryAls.run(registry, () => {
+        const ctx = sendChunk;
+        (ctx as FlowSideChannel<z.infer<S>>).sendChunk = sendChunk;
+        (ctx as FlowSideChannel<z.infer<S>>).context = context;
+        return runWithContext(registry, context, () =>
+          fn(input, ctx as FlowSideChannel<z.infer<S>>)
+        );
+      });
     }
   );
 }

--- a/js/core/src/flow.ts
+++ b/js/core/src/flow.ts
@@ -137,7 +137,7 @@ interface StreamingResponse<
 }
 
 /**
- * Flow execution context for flow to access the streaming callback and 
+ * Flow execution context for flow to access the streaming callback and
  * side-channel context data. The context itself is a function, a short-cut
  * for streaming callback.
  */

--- a/js/core/src/index.ts
+++ b/js/core/src/index.ts
@@ -22,7 +22,7 @@ export const GENKIT_REFLECTION_API_SPEC_VERSION = 1;
 
 export { z } from 'zod';
 export * from './action.js';
-export { getFlowAuth } from './auth.js';
+export { getFlowAuth } from './context.js';
 export { GenkitError } from './error.js';
 export {
   Flow,

--- a/js/plugins/express/tests/express_test.ts
+++ b/js/plugins/express/tests/express_test.ts
@@ -22,7 +22,6 @@ import getPort from 'get-port';
 import * as http from 'http';
 import assert from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
-import { getFlowContext } from '../../../core/lib/auth.js';
 import { RequestWithAuth, handler } from '../src/index.js';
 
 describe('telemetry', async () => {
@@ -76,8 +75,8 @@ describe('telemetry', async () => {
         name: 'flowWithContext',
         inputSchema: z.object({ question: z.string() }),
       },
-      async (input) => {
-        return `${input.question} - ${JSON.stringify(getFlowContext())}`;
+      async (input, { context }) => {
+        return `${input.question} - ${JSON.stringify(context)}`;
       }
     );
 


### PR DESCRIPTION
```ts
      const myFlow = ai.defineFlow(
        {
          name: 'myFlow',
          inputSchema: z.string(),
          outputSchema: z.string(),
        },
        async (input, { sendChunk, context }) => {
          sendChunk(1);
          sendChunk(2);
          sendChunk(3);
          return `${input} ${JSON.stringify(context)}`;
        }
      );
```

old way still works

```ts
      const myFlow = ai.defineFlow(
        {
          name: 'myFlow',
          inputSchema: z.string(),
          outputSchema: z.string(),
        },
        async (input, sendChunk) => {
          sendChunk(1);
          sendChunk(2);
          sendChunk(3);
          return `${input} ${JSON.stringify(getFlowAuth())}`;
        }
      );
```


Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [IOU] Docs updated (updated docs or a docs bug required)
