### PR TITLE
feat(js/plugins): added custom dimensions parameter to text-embedding

### DIFF
--- a/js/plugins/googleai/src/embedder.ts
+++ b/js/plugins/googleai/src/embedder.ts
@@ -37,13 +37,13 @@ export const GeminiEmbeddingConfigSchema = z.object({
   title: z.string().optional(),
   version: z.string().optional(),
   /**
-   * The `dimensions` parameter allows you to specify the dimensionality of the embedding output.
+   * The `outputDimensionality` parameter allows you to specify the dimensionality of the embedding output.
    * By default, the model generates embeddings with 768 dimensions. Models such as
    * `text-embedding-004`, `text-embedding-005`, and `text-multilingual-embedding-002`
    * allow the output dimensionality to be adjusted between 1 and 768.
    * By selecting a smaller output dimensionality, users can save memory and storage space, leading to more efficient computations.
    **/
-  dimensions: z.number().min(1).max(768).optional(),
+  outputDimensionality: z.number().min(1).max(768).optional(),
 });
 
 export type GeminiEmbeddingConfig = z.infer<typeof GeminiEmbeddingConfigSchema>;
@@ -76,8 +76,6 @@ export const SUPPORTED_MODELS = {
   'embedding-001': textEmbeddingGecko001,
   'text-embedding-004': textEmbedding004,
 };
-
-const customDimensionsSupportedModelNames = [textEmbedding004.name];
 
 export function defineGoogleAIEmbedder(
   ai: Genkit,
@@ -116,11 +114,6 @@ export function defineGoogleAIEmbedder(
       info: embedder.info!,
     },
     async (input, options) => {
-      const dimensions =
-        customDimensionsSupportedModelNames.includes(embedder.name) &&
-        options?.dimensions
-          ? options.dimensions
-          : undefined;
       const client = new GoogleGenerativeAI(apiKey!).getGenerativeModel({
         model:
           options?.version ||
@@ -137,7 +130,7 @@ export function defineGoogleAIEmbedder(
               role: '',
               parts: [{ text: doc.text }],
             },
-            outputDimensionality: dimensions,
+            outputDimensionality: options?.outputDimensionality,
           } as EmbedContentRequest);
           const values = response.embedding.values;
           return { embedding: values };

--- a/js/plugins/vertexai/src/embedder.ts
+++ b/js/plugins/vertexai/src/embedder.ts
@@ -39,6 +39,14 @@ export const VertexEmbeddingConfigSchema = z.object({
   title: z.string().optional(),
   location: z.string().optional(),
   version: z.string().optional(),
+  /**
+   * The `dimensions` parameter allows you to specify the dimensionality of the embedding output.
+   * By default, the model generates embeddings with 768 dimensions. Models such as
+   * `text-embedding-004`, `text-embedding-005`, and `text-multilingual-embedding-002`
+   * allow the output dimensionality to be adjusted between 1 and 768.
+   * By selecting a smaller output dimensionality, users can save memory and storage space, leading to more efficient computations.
+   **/
+  dimensions: z.number().min(1).max(768).optional(),
 });
 
 export type VertexEmbeddingConfig = z.infer<typeof VertexEmbeddingConfigSchema>;
@@ -82,6 +90,12 @@ export const SUPPORTED_EMBEDDER_MODELS: Record<string, EmbedderReference> = {
   //   'text',
   // ]),
 };
+
+const customDimensionsSupportedModelNames = [
+  textEmbedding004.name,
+  textEmbedding005.name,
+  textMultilingualEmbedding002.name,
+];
 
 interface EmbeddingInstance {
   task_type?: TaskType;
@@ -137,6 +151,11 @@ export function defineVertexAIEmbedder(
       info: embedder.info!,
     },
     async (input, options) => {
+      const dimensions =
+        customDimensionsSupportedModelNames.includes(embedder.name) &&
+        options?.dimensions
+          ? options.dimensions
+          : undefined;
       const predictClient = predictClientFactory(options);
       const response = await predictClient(
         input.map((i) => {
@@ -145,7 +164,8 @@ export function defineVertexAIEmbedder(
             task_type: options?.taskType,
             title: options?.title,
           };
-        })
+        }),
+        dimensions ? { outputDimensionality: dimensions } : {}
       );
       return {
         embeddings: response.predictions.map((p) => ({

--- a/js/plugins/vertexai/src/embedder.ts
+++ b/js/plugins/vertexai/src/embedder.ts
@@ -40,13 +40,13 @@ export const VertexEmbeddingConfigSchema = z.object({
   location: z.string().optional(),
   version: z.string().optional(),
   /**
-   * The `dimensions` parameter allows you to specify the dimensionality of the embedding output.
+   * The `outputDimensionality` parameter allows you to specify the dimensionality of the embedding output.
    * By default, the model generates embeddings with 768 dimensions. Models such as
    * `text-embedding-004`, `text-embedding-005`, and `text-multilingual-embedding-002`
    * allow the output dimensionality to be adjusted between 1 and 768.
    * By selecting a smaller output dimensionality, users can save memory and storage space, leading to more efficient computations.
    **/
-  dimensions: z.number().min(1).max(768).optional(),
+  outputDimensionality: z.number().min(1).max(768).optional(),
 });
 
 export type VertexEmbeddingConfig = z.infer<typeof VertexEmbeddingConfigSchema>;
@@ -90,12 +90,6 @@ export const SUPPORTED_EMBEDDER_MODELS: Record<string, EmbedderReference> = {
   //   'text',
   // ]),
 };
-
-const customDimensionsSupportedModelNames = [
-  textEmbedding004.name,
-  textEmbedding005.name,
-  textMultilingualEmbedding002.name,
-];
 
 interface EmbeddingInstance {
   task_type?: TaskType;
@@ -151,11 +145,6 @@ export function defineVertexAIEmbedder(
       info: embedder.info!,
     },
     async (input, options) => {
-      const dimensions =
-        customDimensionsSupportedModelNames.includes(embedder.name) &&
-        options?.dimensions
-          ? options.dimensions
-          : undefined;
       const predictClient = predictClientFactory(options);
       const response = await predictClient(
         input.map((i) => {
@@ -165,7 +154,7 @@ export function defineVertexAIEmbedder(
             title: options?.title,
           };
         }),
-        { outputDimensionality: dimensions }
+        { outputDimensionality: options?.outputDimensionality }
       );
       return {
         embeddings: response.predictions.map((p) => ({

--- a/js/plugins/vertexai/src/embedder.ts
+++ b/js/plugins/vertexai/src/embedder.ts
@@ -165,7 +165,7 @@ export function defineVertexAIEmbedder(
             title: options?.title,
           };
         }),
-        dimensions ? { outputDimensionality: dimensions } : {}
+        { outputDimensionality: dimensions }
       );
       return {
         embeddings: response.predictions.map((p) => ({

--- a/js/plugins/vertexai/src/predict.ts
+++ b/js/plugins/vertexai/src/predict.ts
@@ -50,7 +50,7 @@ export function predictModel<I = unknown, R = unknown, P = unknown>(
     const accessToken = await auth.getAccessToken();
     const req = {
       instances,
-      parameters: parameters || {},
+      parameters,
     };
 
     const response = await fetch(

--- a/js/plugins/vertexai/src/predict.ts
+++ b/js/plugins/vertexai/src/predict.ts
@@ -33,7 +33,7 @@ interface PredictionResponse<R> {
 
 export type PredictClient<I = unknown, R = unknown, P = unknown> = (
   instances: I[],
-  parameters?: P
+  parameters: P
 ) => Promise<PredictionResponse<R>>;
 
 export function predictModel<I = unknown, R = unknown, P = unknown>(
@@ -43,7 +43,7 @@ export function predictModel<I = unknown, R = unknown, P = unknown>(
 ): PredictClient<I, R, P> {
   return async (
     instances: I[],
-    parameters?: P
+    parameters: P
   ): Promise<PredictionResponse<R>> => {
     const fetch = (await import('node-fetch')).default;
 


### PR DESCRIPTION
How to use
```typescript
ai.embed({
  embedder: textEmbedding005,
  content: 'String to be embedded',
  options: {
    outputDimensionality: 500 // Between 1 and 768, inclusive
  }
})
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
