### PR TITLE
feat: Write OTel GenAI semantic convention client-side metrics for token usage

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -34,6 +34,7 @@ import { GenerateUtilParamSchema, generateHelper } from './generate/action.js';
 import { GenerateResponseChunk } from './generate/chunk.js';
 import { GenerateResponse } from './generate/response.js';
 import { Message } from './message.js';
+import { writeMetrics } from './metrics.js';
 import {
   GenerateRequest,
   GenerationCommonConfigSchema,
@@ -300,10 +301,12 @@ export async function generate<
         ...resolvedOptions,
         tools,
       });
-      return new GenerateResponse<O>(response, {
+      const generateResponse = new GenerateResponse<O>(response, {
         request: response.request ?? request,
         parser: resolvedFormat?.handler(request.output?.schema).parseMessage,
       });
+      writeMetrics(generateResponse);
+      return generateResponse;
     }
   );
 }

--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -292,6 +292,7 @@ export async function generate<
     registry,
     stripNoop(resolvedOptions.onChunk ?? resolvedOptions.streamingCallback),
     async () => {
+      const startTime = performance.now();
       const response = await generateHelper(
         registry,
         params,
@@ -305,7 +306,8 @@ export async function generate<
         request: response.request ?? request,
         parser: resolvedFormat?.handler(request.output?.schema).parseMessage,
       });
-      writeMetrics(generateResponse);
+      const endTime = performance.now();
+      writeMetrics(generateResponse, endTime - startTime);
       return generateResponse;
     }
   );

--- a/js/ai/src/generate/response.ts
+++ b/js/ai/src/generate/response.ts
@@ -24,6 +24,7 @@ import {
   GenerateRequest,
   GenerateResponseData,
   GenerationUsage,
+  GenerateClientTelemetry,
   MessageData,
   ModelResponseData,
   ToolRequestPart,
@@ -48,6 +49,8 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
   request?: GenerateRequest;
   /** The parser for output parsing of this response. */
   parser?: MessageParser<O>;
+  /** Client telemetry information associated with this request */
+  clientTelemetry?: GenerateClientTelemetry;
 
   constructor(
     response: GenerateResponseData,
@@ -71,6 +74,7 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
     this.usage = response.usage || {};
     this.custom = response.custom || {};
     this.request = options?.request;
+    this.clientTelemetry = response.clientTelemetry;
   }
 
   private get assertMessage(): Message<O> {
@@ -196,9 +200,11 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
       usage: this.usage,
       custom: (this.custom as { toJSON?: () => any }).toJSON?.() || this.custom,
       request: this.request,
+      clientTelemetry: this.clientTelemetry,
     };
     if (!out.finishMessage) delete out.finishMessage;
     if (!out.request) delete out.request;
+    if (!out.clientTelemetry) delete out.clientTelemetry;
     return out;
   }
 }

--- a/js/ai/src/generate/response.ts
+++ b/js/ai/src/generate/response.ts
@@ -21,10 +21,10 @@ import {
 } from '../generate.js';
 import { Message, MessageParser } from '../message.js';
 import {
+  GenerateClientTelemetry,
   GenerateRequest,
   GenerateResponseData,
   GenerationUsage,
-  GenerateClientTelemetry,
   MessageData,
   ModelResponseData,
   ToolRequestPart,

--- a/js/ai/src/metrics.ts
+++ b/js/ai/src/metrics.ts
@@ -74,13 +74,16 @@ const tokenUsage = new MetricHistogram('gen_ai.client.token.usage', {
   unit: 'token',
 });
 
-const operationDuration = new MetricHistogram('gen_ai.client.operation.duration', {
-  description: 'Time taken for GenAI operations',
-  valueType: ValueType.DOUBLE,
-  unit: 'token',
-});
+const operationDuration = new MetricHistogram(
+  'gen_ai.client.operation.duration',
+  {
+    description: 'Time taken for GenAI operations',
+    valueType: ValueType.DOUBLE,
+    unit: 'token',
+  }
+);
 
-export function writeMetrics(resp: GenerateResponse, durationMs: double): void {
+export function writeMetrics(resp: GenerateResponse, durationMs: number): void {
   const commonDimensions = {
     'gen_ai.client.framework': 'genkit',
     'gen_ai.operation.name': resp.clientTelemetry?.operationName,

--- a/js/ai/src/metrics.ts
+++ b/js/ai/src/metrics.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Histogram, Meter, metrics, ValueType } from '@opentelemetry/api';
+import { GenerateResponse } from './generate/response.js';
+
+type MetricCreateFn<T> = (meter: Meter) => T;
+export const METER_NAME = 'genkit';
+
+/**
+ * Wrapper for OpenTelemetry metrics.
+ *
+ * The OpenTelemetry {MeterProvider} can only be accessed through the metrics
+ * API after the NodeSDK library has been initialized. To prevent race
+ * conditions we defer the instantiation of the metric to when it is first
+ * ticked.
+ */
+class Metric<T> {
+  readonly createFn: MetricCreateFn<T>;
+  readonly meterName: string;
+  metric?: T;
+
+  constructor(createFn: MetricCreateFn<T>, meterName: string = METER_NAME) {
+    this.meterName = meterName;
+    this.createFn = createFn;
+  }
+
+  get(): T {
+    if (!this.metric) {
+      this.metric = this.createFn(
+        metrics.getMeterProvider().getMeter(this.meterName)
+      );
+    }
+
+    return this.metric;
+  }
+}
+
+/**
+ * Wrapper for an OpenTelemetry Histogram.
+ *
+ * By using this wrapper, we defer initialization of the counter until it is
+ * need, which ensures that the OpenTelemetry SDK has been initialized before
+ * the metric has been defined.
+ */
+export class MetricHistogram extends Metric<Histogram> {
+  constructor(name: string, options: any) {
+    super((meter) => meter.createHistogram(name, options));
+  }
+
+  record(val?: number, opts?: any) {
+    if (val) {
+      this.get().record(val, opts);
+    }
+  }
+}
+
+const tokenUsage = new MetricHistogram('gen_ai.client.token.usage', {
+  description: 'Usage of GenAI tokens.',
+  valueType: ValueType.INT,
+  unit: 'token',
+});
+
+export function writeMetrics(resp: GenerateResponse): void {
+  const commonDimensions = {
+    'gen_ai.client.framework': 'genkit',
+    'gen_ai.operation.name': resp.clientTelemetry?.operationName,
+    'gen_ai.system': resp.clientTelemetry?.system,
+    'gen_ai.request.model': resp.clientTelemetry?.requestModel,
+    'server.port': resp.clientTelemetry?.serverPort,
+    'gen_ai.response.model': resp.clientTelemetry?.responseModel,
+    'server.address': resp.clientTelemetry?.serverAddress,
+  };
+  tokenUsage.record(resp.usage?.inputTokens || 0, {
+    ...commonDimensions,
+    'gen_ai.token.type': 'input',
+  });
+  tokenUsage.record(resp.usage?.outputTokens || 0, {
+    ...commonDimensions,
+    'gen_ai.token.type': 'output',
+  });
+}

--- a/js/ai/src/metrics.ts
+++ b/js/ai/src/metrics.ts
@@ -74,7 +74,13 @@ const tokenUsage = new MetricHistogram('gen_ai.client.token.usage', {
   unit: 'token',
 });
 
-export function writeMetrics(resp: GenerateResponse): void {
+const operationDuration = new MetricHistogram('gen_ai.client.operation.duration', {
+  description: 'Time taken for GenAI operations',
+  valueType: ValueType.DOUBLE,
+  unit: 'token',
+});
+
+export function writeMetrics(resp: GenerateResponse, durationMs: double): void {
   const commonDimensions = {
     'gen_ai.client.framework': 'genkit',
     'gen_ai.operation.name': resp.clientTelemetry?.operationName,
@@ -92,4 +98,5 @@ export function writeMetrics(resp: GenerateResponse): void {
     ...commonDimensions,
     'gen_ai.token.type': 'output',
   });
+  operationDuration.record(durationMs, commonDimensions);
 }

--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -376,7 +376,9 @@ export const GenerateClientTelemetrySchema = z.object({
   serverPort: z.number().optional(),
   serverAddress: z.string().optional(),
 });
-export type GenerateClientTelemetry = z.infer<typeof GenerateClientTelemetrySchema>;
+export type GenerateClientTelemetry = z.infer<
+  typeof GenerateClientTelemetrySchema
+>;
 
 /**
  * Zod schema of a model response.

--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -363,6 +363,22 @@ export const CandidateErrorSchema = z.object({
 export type CandidateError = z.infer<typeof CandidateErrorSchema>;
 
 /**
+ * Additional telemetry information associated with a Generate request.
+ * See
+ * https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#generative-ai-client-metrics
+ * for details.
+ */
+export const GenerateClientTelemetrySchema = z.object({
+  system: z.string().optional(),
+  requestModel: z.string().optional(),
+  responseModel: z.string().optional(),
+  operationName: z.string().optional(),
+  serverPort: z.number().optional(),
+  serverAddress: z.string().optional(),
+});
+export type GenerateClientTelemetry = z.infer<typeof GenerateClientTelemetrySchema>;
+
+/**
  * Zod schema of a model response.
  */
 export const ModelResponseSchema = z.object({
@@ -375,6 +391,7 @@ export const ModelResponseSchema = z.object({
   custom: z.unknown(),
   raw: z.unknown(),
   request: GenerateRequestSchema.optional(),
+  clientTelemetry: GenerateClientTelemetrySchema.optional(),
 });
 
 /**

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -422,7 +422,7 @@ describe('GoogleCloudMetrics', () => {
     );
   });
 
-  it('writes feature label to generate and action metrics when running inside an action', async () => {
+  it.only('writes feature label to generate and action metrics when running inside an action', async () => {
     const testModel = createTestModel(ai, 'testModel');
 
     const testAction = createAction(ai, 'testGenerateAction', async () => {
@@ -800,7 +800,11 @@ describe('GoogleCloudMetrics', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
       const found = __getMetricExporterForTesting()
         .getMetrics()
-        .find((e) => e.scopeMetrics.map((sm) => sm.scope.name).includes(name));
+        .find((e) =>
+          e.scopeMetrics.find((sm) =>
+            sm.metrics.find((m) => m.descriptor.name.includes(name))
+          )
+        );
       if (found) {
         return found.scopeMetrics.find((e) => e.scope.name === name);
       }

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -422,7 +422,7 @@ describe('GoogleCloudMetrics', () => {
     );
   });
 
-  it.only('writes feature label to generate and action metrics when running inside an action', async () => {
+  it('writes feature label to generate and action metrics when running inside an action', async () => {
     const testModel = createTestModel(ai, 'testModel');
 
     const testAction = createAction(ai, 'testGenerateAction', async () => {

--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -15,9 +15,10 @@
  */
 
 import {
+  EnhancedGenerateContentResponse,
   FileDataPart,
-  FunctionCallingMode,
   FunctionCallPart,
+  FunctionCallingMode,
   FunctionDeclaration,
   FunctionResponsePart,
   GenerateContentCandidate as GeminiCandidate,
@@ -33,32 +34,31 @@ import {
   StartChatParams,
   Tool,
   ToolConfig,
-  EnhancedGenerateContentResponse,
 } from '@google/generative-ai';
 import {
-  Genkit,
   GENKIT_CLIENT_HEADER,
+  Genkit,
   GenkitError,
   JSONSchema,
   z,
 } from 'genkit';
 import {
   CandidateData,
+  GenerateRequestData,
+  GenerateResponseData,
   GenerationCommonConfigSchema,
-  getBasicUsageStats,
   MediaPart,
   MessageData,
   ModelAction,
   ModelInfo,
   ModelMiddleware,
-  modelRef,
   ModelReference,
   Part,
   ToolDefinitionSchema,
   ToolRequestPart,
   ToolResponsePart,
-  GenerateRequestData,
-  GenerateResponseData,
+  getBasicUsageStats,
+  modelRef,
 } from 'genkit/model';
 import {
   downloadRequestMedia,
@@ -796,12 +796,22 @@ export function defineGoogleAIModel(
             message: 'No valid candidates returned.',
           });
         }
-        return toModelResponseData(modelVersion, request, response, fromJSONModeScopedGeminiCandidate);
+        return toModelResponseData(
+          modelVersion,
+          request,
+          response,
+          fromJSONModeScopedGeminiCandidate
+        );
       } else {
         const result = await genModel
           .startChat(updatedChatRequest)
           .sendMessage(msg.parts, options);
-        return toModelResponseData(modelVersion, request, result.response, fromJSONModeScopedGeminiCandidate);
+        return toModelResponseData(
+          modelVersion,
+          request,
+          result.response,
+          fromJSONModeScopedGeminiCandidate
+        );
       }
     }
   );
@@ -835,7 +845,7 @@ function toModelResponseData(
   modelName: string,
   request: GenerateRequestData,
   response: EnhancedGenerateContentResponse,
-  fromJSONModeScopedGeminiCandidate: (GeminiCandidate) => CandidateData,
+  fromJSONModeScopedGeminiCandidate: (GeminiCandidate) => CandidateData
 ): GenerateResponseData {
   if (!response.candidates?.length)
     throw new Error('No valid candidates returned.');

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -35,14 +35,14 @@ import { GENKIT_CLIENT_HEADER, Genkit, JSONSchema, z } from 'genkit';
 import {
   CandidateData,
   GenerateRequest,
+  GenerateRequestData,
+  GenerateResponseData,
   GenerationCommonConfigSchema,
   MediaPart,
   MessageData,
   ModelAction,
   ModelMiddleware,
   ModelReference,
-  GenerateRequestData,
-  GenerateResponseData,
   Part,
   ToolDefinitionSchema,
   getBasicUsageStats,
@@ -765,9 +765,16 @@ export function defineGeminiModel(
         if (!response.candidates?.length) {
           throw new Error('No valid candidates returned.');
         }
-        const candidates =
-          response.candidates.map((c) => fromGeminiCandidate(c, jsonMode));
-        return toModelResponseData(modelVersion, chatRequest, request, response, candidates);
+        const candidates = response.candidates.map((c) =>
+          fromGeminiCandidate(c, jsonMode)
+        );
+        return toModelResponseData(
+          modelVersion,
+          chatRequest,
+          request,
+          response,
+          candidates
+        );
       } else {
         const result = await genModel
           .startChat(updatedChatRequest)
@@ -777,8 +784,16 @@ export function defineGeminiModel(
           throw new Error('No valid candidates returned.');
         }
         const candidates =
-          result.response.candidates.map((c) => fromGeminiCandidate(c, jsonMode)) || [];
-        return toModelResponseData(modelVersion, chatRequest, request, result.response, candidates);
+          result.response.candidates.map((c) =>
+            fromGeminiCandidate(c, jsonMode)
+          ) || [];
+        return toModelResponseData(
+          modelVersion,
+          chatRequest,
+          request,
+          result.response,
+          candidates
+        );
       }
     }
   );
@@ -813,7 +828,7 @@ function toModelResponseData(
   chatRequest: StartChatParams,
   requestData: GenerateRequestData,
   response: GenerateContentResponse,
-  candidates: CandidateData[],
+  candidates: CandidateData[]
 ): GenerateResponseData {
   return {
     candidates,

--- a/js/plugins/vertexai/src/imagen.ts
+++ b/js/plugins/vertexai/src/imagen.ts
@@ -25,7 +25,7 @@ import {
 } from 'genkit/model';
 import { GoogleAuth } from 'google-auth-library';
 import { PluginOptions } from './common/types.js';
-import { PredictClient, predictModel, endpoint } from './predict.js';
+import { PredictClient, endpoint, predictModel } from './predict.js';
 
 const ImagenConfigSchema = GenerationCommonConfigSchema.extend({
   /** Language of the prompt text. */
@@ -312,10 +312,10 @@ export function imagenModel(
           serverAddress: endpoint({
             projectId: options.projectId || '',
             location: request.config?.location || options.location,
-            model: request.config?.version || model.version || name
+            model: request.config?.version || model.version || name,
           }),
           serverPort: 80,
-        }
+        },
       };
     }
   );

--- a/js/plugins/vertexai/src/predict.ts
+++ b/js/plugins/vertexai/src/predict.ts
@@ -18,7 +18,7 @@ import { GENKIT_CLIENT_HEADER } from 'genkit';
 import { GoogleAuth } from 'google-auth-library';
 import { PluginOptions } from './common/types.js';
 
-function endpoint(options: {
+export function endpoint(options: {
   projectId: string;
   location: string;
   model: string;


### PR DESCRIPTION
Adds support for writing the `gen_ai.client.token.usage` metric as described by the OpenTelemetry GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage

I added this directly to the framework instead of in the google-cloud plugin since they seem generally useful. So far I have only added support to the Gemini and Imagen models to see if this approach looks good. If it does, I will carry it through to the other models in the vertex model garden and add the `gen_ai.client.operation.duration` metric.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
