### PR TITLE
chore(js/plugins/vertexai): remove unused variable req

### DIFF
--- a/js/plugins/vertexai/src/imagen.ts
+++ b/js/plugins/vertexai/src/imagen.ts
@@ -269,11 +269,6 @@ export function imagenModel(
         };
       }
 
-      const req: any = {
-        instances: [instance],
-        parameters: toParameters(request),
-      };
-
       const predictClient = predictClientFactory(request);
       const response = await predictClient([instance], toParameters(request));
 


### PR DESCRIPTION
The req object is not being used.
Since `const response = await predictClient([instance], toParameters(request));` utilizes the contents of the req object, I believe the req object is not necessary at this point.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
