### PR TITLE
refactor(js/flows): made flow be actually actions, actions can stream, moved flow server to express plugin

### DIFF
--- a/docs/cloud-run.md
+++ b/docs/cloud-run.md
@@ -55,7 +55,9 @@ endpoints.
 When you make the call, specify the flows you want to serve:
 
 ```ts
-ai.startFlowServer({
+import { startFlowServer } from '@genkit-ai/express';
+
+startFlowServer({
   flows: [menuSuggestionFlow],
 });
 ```

--- a/docs/deploy-node.md
+++ b/docs/deploy-node.md
@@ -48,6 +48,7 @@ sample flow.
   ```typescript
   import { genkit } from 'genkit';
   import { googleAI, gemini15Flash } from '@genkit-ai/googleai';
+  import { startFlowServer } from '@genkit-ai/express';
 
   const ai = genkit({
     plugins: [googleAI()],
@@ -66,7 +67,7 @@ sample flow.
     }
   );
 
-  ai.startFlowServer({
+  startFlowServer({
     flows: [menuSuggestionFlow],
   });
   ```

--- a/js/core/src/flow.ts
+++ b/js/core/src/flow.ts
@@ -14,52 +14,29 @@
  * limitations under the License.
  */
 
-import * as bodyParser from 'body-parser';
-import cors, { CorsOptions } from 'cors';
-import express from 'express';
-import { Server } from 'http';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { z } from 'zod';
-import {
-  Action,
-  ActionResult,
-  defineAction,
-  sentinelNoopStreamingCallback,
-  StreamingCallback,
-} from './action.js';
+import { Action, defineAction, StreamingCallback } from './action.js';
 import { runWithContext } from './context.js';
-import { getErrorMessage, getErrorStack } from './error.js';
-import { logger } from './logging.js';
 import { HasRegistry, Registry } from './registry.js';
 import { runInNewSpan, SPAN_TYPE_ATTR } from './tracing.js';
 
-const streamDelimiter = '\n\n';
-
 /**
- * Flow Auth policy. Consumes the authorization context of the flow and
- * performs checks before the flow runs. If this throws, the flow will not
- * be executed.
+ * Flow is an observable, streamable, (optionally) strongly typed function.
  */
-export interface FlowAuthPolicy<I extends z.ZodTypeAny = z.ZodTypeAny> {
-  (auth: any | undefined, input: z.infer<I>): void | Promise<void>;
-}
+export interface Flow<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  S extends z.ZodTypeAny = z.ZodTypeAny,
+> extends Action<I, O, S> {}
 
 /**
- * For express-based flows, req.auth should contain the value to bepassed into
- * the flow context.
- *
- * @hidden
- */
-export interface __RequestWithAuth extends express.Request {
-  auth?: unknown;
-}
-
-/**
- * Configuration for a flow.
+ * Configuration for a streaming flow.
  */
 export interface FlowConfig<
   I extends z.ZodTypeAny = z.ZodTypeAny,
   O extends z.ZodTypeAny = z.ZodTypeAny,
+  S extends z.ZodTypeAny = z.ZodTypeAny,
 > {
   /** Name of the flow. */
   name: string;
@@ -67,76 +44,8 @@ export interface FlowConfig<
   inputSchema?: I;
   /** Schema of the output from the flow. */
   outputSchema?: O;
-  /** Auth policy. */
-  authPolicy?: FlowAuthPolicy<I>;
-  /** Middleware for HTTP requests. Not called for direct invocations. */
-  middleware?: express.RequestHandler[];
-}
-
-/**
- * Configuration for a streaming flow.
- */
-export interface StreamingFlowConfig<
-  I extends z.ZodTypeAny = z.ZodTypeAny,
-  O extends z.ZodTypeAny = z.ZodTypeAny,
-  S extends z.ZodTypeAny = z.ZodTypeAny,
-> extends FlowConfig<I, O> {
   /** Schema of the streaming chunks from the flow. */
   streamSchema?: S;
-}
-
-export interface FlowCallOptions<S> {
-  /** @deprecated use {@link context} instead. */
-  withLocalAuthContext?: unknown;
-  context?: unknown;
-  onChunk?: StreamingCallback<S>;
-}
-
-/**
- * Non-streaming flow that can be called directly like a function.
- */
-export interface CallableFlow<
-  I extends z.ZodTypeAny = z.ZodTypeAny,
-  O extends z.ZodTypeAny = z.ZodTypeAny,
-  S extends z.ZodTypeAny = z.ZodTypeAny,
-> {
-  (input?: z.infer<I>, opts?: FlowCallOptions<z.infer<S>>): Promise<z.infer<O>>;
-
-  stream(
-    input?: z.infer<I>,
-    opts?: FlowCallOptions<z.infer<S>>
-  ): StreamingResponse<O, S>;
-
-  flow: Flow<I, O, S>;
-}
-
-/**
- * Streaming flow that can be called directly like a function.
- * @deprecated use {@link CallableFlow}
- */
-export interface StreamableFlow<
-  I extends z.ZodTypeAny = z.ZodTypeAny,
-  O extends z.ZodTypeAny = z.ZodTypeAny,
-  S extends z.ZodTypeAny = z.ZodTypeAny,
-> {
-  (
-    input?: z.infer<I>,
-    opts?: FlowCallOptions<z.infer<S>>
-  ): StreamingResponse<O, S>;
-  flow: Flow<I, O, S>;
-}
-
-/**
- * Response from a streaming flow.
- */
-interface StreamingResponse<
-  O extends z.ZodTypeAny = z.ZodTypeAny,
-  S extends z.ZodTypeAny = z.ZodTypeAny,
-> {
-  /** Iterator over the streaming chunks. */
-  stream: AsyncGenerator<z.infer<S>>;
-  /** Final output of the flow. */
-  output: Promise<z.infer<O>>;
 }
 
 /**
@@ -172,331 +81,6 @@ export type FlowFn<
   streamingCallback: FlowSideChannel<z.infer<S>>
 ) => Promise<z.infer<O>> | z.infer<O>;
 
-export class Flow<
-  I extends z.ZodTypeAny = z.ZodTypeAny,
-  O extends z.ZodTypeAny = z.ZodTypeAny,
-  S extends z.ZodTypeAny = z.ZodTypeAny,
-> {
-  readonly name: string;
-  readonly inputSchema?: I;
-  readonly outputSchema?: O;
-  readonly streamSchema?: S;
-  readonly authPolicy?: FlowAuthPolicy<I>;
-  readonly middleware?: express.RequestHandler[];
-  readonly action: Action<I, O, S>;
-
-  constructor(
-    readonly registry: Registry,
-    config: FlowConfig<I, O> | StreamingFlowConfig<I, O, S>,
-    action: Action<I, O, S>
-  ) {
-    this.name = config.name;
-    this.inputSchema = config.inputSchema;
-    this.outputSchema = config.outputSchema;
-    this.streamSchema =
-      'streamSchema' in config ? config.streamSchema : undefined;
-    this.authPolicy = config.authPolicy;
-    this.middleware = config.middleware;
-    this.action = action;
-  }
-
-  /**
-   * Executes the flow with the input directly.
-   */
-  async invoke(
-    input: unknown,
-    opts: {
-      onChunk?: StreamingCallback<z.infer<S>>;
-      labels?: Record<string, string>;
-      context?: unknown;
-    }
-  ): Promise<ActionResult<z.infer<O>>> {
-    await this.registry.initializeAllPlugins();
-    return await this.action.run(input, {
-      context: opts.context,
-      telemetryLabels: opts.labels,
-      onChunk: opts.onChunk ?? sentinelNoopStreamingCallback,
-    });
-  }
-
-  /**
-   * Runs the flow. This is used when calling a flow from another flow.
-   */
-  async run(
-    payload?: z.infer<I>,
-    opts?: FlowCallOptions<z.infer<S>>
-  ): Promise<z.infer<O>> {
-    const input = this.inputSchema ? this.inputSchema.parse(payload) : payload;
-    await this.authPolicy?.(opts?.withLocalAuthContext, payload);
-
-    if (this.middleware) {
-      logger.warn(
-        `Flow (${this.name}) middleware won't run when invoked with runFlow.`
-      );
-    }
-
-    const result = await this.invoke(input, {
-      context: opts?.context || opts?.withLocalAuthContext,
-      onChunk: opts?.onChunk,
-    });
-    return result.result;
-  }
-
-  /**
-   * Runs the flow and streams results. This is used when calling a flow from another flow.
-   */
-  stream(
-    payload?: z.infer<I>,
-    opts?: Omit<FlowCallOptions<z.infer<S>>, 'onChunk'>
-  ): StreamingResponse<O, S> {
-    let chunkStreamController: ReadableStreamController<z.infer<S>>;
-    const chunkStream = new ReadableStream<z.infer<S>>({
-      start(controller) {
-        chunkStreamController = controller;
-      },
-      pull() {},
-      cancel() {},
-    });
-
-    const authPromise =
-      this.authPolicy?.(opts?.context || opts?.withLocalAuthContext, payload) ??
-      Promise.resolve();
-
-    const invocationPromise = authPromise
-      .then(() =>
-        this.invoke(
-          this.inputSchema ? this.inputSchema.parse(payload) : payload,
-          {
-            onChunk: ((chunk: z.infer<S>) => {
-              chunkStreamController.enqueue(chunk);
-            }) as S extends z.ZodVoid
-              ? undefined
-              : StreamingCallback<z.infer<S>>,
-            context: opts?.context || opts?.withLocalAuthContext,
-          }
-        ).then((s) => s.result)
-      )
-      .finally(() => {
-        chunkStreamController.close();
-      });
-
-    return {
-      output: invocationPromise,
-      stream: (async function* () {
-        const reader = chunkStream.getReader();
-        while (true) {
-          const chunk = await reader.read();
-          if (chunk.value) {
-            yield chunk.value;
-          }
-          if (chunk.done) {
-            break;
-          }
-        }
-        return await invocationPromise;
-      })(),
-    };
-  }
-
-  async expressHandler(
-    request: __RequestWithAuth,
-    response: express.Response
-  ): Promise<void> {
-    const { stream } = request.query;
-    const auth = request.auth;
-
-    let input = request.body.data;
-
-    try {
-      await this.authPolicy?.(auth, input);
-    } catch (e: any) {
-      const respBody = {
-        error: {
-          status: 'PERMISSION_DENIED',
-          message: e.message || 'Permission denied to resource',
-        },
-      };
-      response.status(403).send(respBody).end();
-      return;
-    }
-
-    if (request.get('Accept') === 'text/event-stream' || stream === 'true') {
-      response.writeHead(200, {
-        'Content-Type': 'text/plain',
-        'Transfer-Encoding': 'chunked',
-      });
-      try {
-        const result = await this.invoke(input, {
-          onChunk: (chunk: z.infer<S>) => {
-            response.write(
-              'data: ' + JSON.stringify({ message: chunk }) + streamDelimiter
-            );
-          },
-          context: auth,
-        });
-        response.write(
-          'data: ' + JSON.stringify({ result: result.result }) + streamDelimiter
-        );
-        response.end();
-      } catch (e) {
-        console.log(e);
-        response.write(
-          'data: ' +
-            JSON.stringify({
-              error: {
-                status: 'INTERNAL',
-                message: getErrorMessage(e),
-                details: getErrorStack(e),
-              },
-            }) +
-            streamDelimiter
-        );
-        response.end();
-      }
-    } else {
-      try {
-        const result = await this.invoke(input, { context: auth });
-        response.setHeader('x-genkit-trace-id', result.telemetry.traceId);
-        response.setHeader('x-genkit-span-id', result.telemetry.spanId);
-        // Responses for non-streaming flows are passed back with the flow result stored in a field called "result."
-        response
-          .status(200)
-          .send({
-            result: result.result,
-          })
-          .end();
-      } catch (e) {
-        // Errors for non-streaming flows are passed back as standard API errors.
-        response
-          .status(500)
-          .send({
-            error: {
-              status: 'INTERNAL',
-              message: getErrorMessage(e),
-              details: getErrorStack(e),
-            },
-          })
-          .end();
-      }
-    }
-  }
-}
-
-/**
- * Options to configure the flow server.
- */
-export interface FlowServerOptions {
-  /** List of flows to expose via the flow server. */
-  flows: (CallableFlow<any, any> | StreamableFlow<any, any>)[];
-  /** Port to run the server on. Defaults to env.PORT or 3400. */
-  port?: number;
-  /** CORS options for the server. */
-  cors?: CorsOptions;
-  /** HTTP method path prefix for the exposed flows. */
-  pathPrefix?: string;
-  /** JSON body parser options. */
-  jsonParserOptions?: bodyParser.OptionsJson;
-}
-
-/**
- * Flow server exposes registered flows as HTTP endpoints.
- *
- * This is for use in production environments.
- *
- * @hidden
- */
-export class FlowServer {
-  /** List of all running servers needed to be cleaned up on process exit. */
-  private static RUNNING_SERVERS: FlowServer[] = [];
-
-  /** Registry instance to be used for API calls. */
-  private registry: Registry;
-  /** Options for the flow server configured by the developer. */
-  private options: FlowServerOptions;
-  /** Port the server is actually running on. This may differ from `options.port` if the original was occupied. Null is server is not running. */
-  private port: number | null = null;
-  /** Express server instance. Null if server is not running. */
-  private server: Server | null = null;
-
-  constructor(registry: Registry, options: FlowServerOptions) {
-    this.registry = registry;
-    this.options = {
-      ...options,
-    };
-  }
-
-  /**
-   * Starts the server and adds it to the list of running servers to clean up on exit.
-   */
-  async start() {
-    const server = express();
-
-    server.use(bodyParser.json(this.options.jsonParserOptions));
-    server.use(cors(this.options.cors));
-
-    if (!!this.options.flows) {
-      logger.debug('Running flow server with flow paths:');
-      const pathPrefix = this.options.pathPrefix ?? '';
-      this.options.flows?.forEach((flow) => {
-        const flowPath = `/${pathPrefix}${flow.flow.name}`;
-        logger.debug(` - ${flowPath}`);
-        flow.flow.middleware?.forEach((middleware) =>
-          server.post(flowPath, middleware)
-        );
-        server.post(flowPath, (req, res) => flow.flow.expressHandler(req, res));
-      });
-    } else {
-      logger.warn('No flows registered in flow server.');
-    }
-    this.port =
-      this.options?.port ||
-      (process.env.PORT ? parseInt(process.env.PORT) : 0) ||
-      3400;
-    this.server = server.listen(this.port, () => {
-      logger.debug(`Flow server running on http://localhost:${this.port}`);
-      FlowServer.RUNNING_SERVERS.push(this);
-    });
-  }
-
-  /**
-   * Stops the server and removes it from the list of running servers to clean up on exit.
-   */
-  async stop(): Promise<void> {
-    if (!this.server) {
-      return;
-    }
-    return new Promise<void>((resolve, reject) => {
-      this.server!.close((err) => {
-        if (err) {
-          logger.error(
-            `Error shutting down flow server on port ${this.port}: ${err}`
-          );
-          reject(err);
-        }
-        const index = FlowServer.RUNNING_SERVERS.indexOf(this);
-        if (index > -1) {
-          FlowServer.RUNNING_SERVERS.splice(index, 1);
-        }
-        logger.debug(
-          `Flow server on port ${this.port} has successfully shut down.`
-        );
-        this.port = null;
-        this.server = null;
-        resolve();
-      });
-    });
-  }
-
-  /**
-   * Stops all running servers.
-   */
-  static async stopAll() {
-    return Promise.all(
-      FlowServer.RUNNING_SERVERS.map((server) => server.stop())
-    );
-  }
-}
-
 /**
  * Defines a non-streaming flow. This operates on the currently active registry.
  */
@@ -506,46 +90,13 @@ export function defineFlow<
   S extends z.ZodTypeAny = z.ZodTypeAny,
 >(
   registry: Registry,
-  config: StreamingFlowConfig<I, O, S> | string,
+  config: FlowConfig<I, O, S> | string,
   fn: FlowFn<I, O, S>
-): CallableFlow<I, O, S> {
-  const resolvedConfig: StreamingFlowConfig<I, O, S> =
+): Flow<I, O, S> {
+  const resolvedConfig: FlowConfig<I, O, S> =
     typeof config === 'string' ? { name: config } : config;
 
-  const flowAction = defineFlowAction(registry, resolvedConfig, fn);
-  const flow = new Flow<I, O, S>(registry, resolvedConfig, flowAction);
-  const callableFlow = async (input, opts) => {
-    return flow.run(input, opts);
-  };
-  (callableFlow as CallableFlow<I, O, S>).flow = flow;
-  (callableFlow as CallableFlow<I, O, S>).stream = (
-    input: z.infer<I>,
-    opts: Omit<FlowCallOptions<z.infer<S>>, 'onChunk'>
-  ): StreamingResponse<O, S> => {
-    return flow.stream(input, opts);
-  };
-  return callableFlow as CallableFlow<I, O, S>;
-}
-
-/**
- * Defines a streaming flow. This operates on the currently active registry.
- */
-export function defineStreamingFlow<
-  I extends z.ZodTypeAny = z.ZodTypeAny,
-  O extends z.ZodTypeAny = z.ZodTypeAny,
-  S extends z.ZodTypeAny = z.ZodTypeAny,
->(
-  registry: Registry,
-  config: StreamingFlowConfig<I, O, S>,
-  fn: FlowFn<I, O, S>
-): StreamableFlow<I, O, S> {
-  const flowAction = defineFlowAction(registry, config, fn);
-  const flow = new Flow(registry, config, flowAction);
-  const streamableFlow: StreamableFlow<I, O, S> = (input, opts) => {
-    return flow.stream(input, opts);
-  };
-  streamableFlow.flow = flow;
-  return streamableFlow;
+  return defineFlowAction(registry, resolvedConfig, fn);
 }
 
 /**
@@ -557,9 +108,9 @@ function defineFlowAction<
   S extends z.ZodTypeAny = z.ZodTypeAny,
 >(
   registry: Registry,
-  config: StreamingFlowConfig<I, O, S>,
+  config: FlowConfig<I, O, S>,
   fn: FlowFn<I, O, S>
-): Action<I, O, S> {
+): Flow<I, O, S> {
   return defineAction(
     registry,
     {
@@ -568,12 +119,8 @@ function defineFlowAction<
       inputSchema: config.inputSchema,
       outputSchema: config.outputSchema,
       streamSchema: config.streamSchema,
-      metadata: {
-        requiresAuth: !!config.authPolicy,
-      },
     },
     async (input, { sendChunk, context }) => {
-      await config.authPolicy?.(context, input);
       return await legacyRegistryAls.run(registry, () => {
         const ctx = sendChunk;
         (ctx as FlowSideChannel<z.infer<S>>).sendChunk = sendChunk;
@@ -660,13 +207,4 @@ export function run<T>(
       return output;
     }
   );
-}
-
-// TODO: Verify that this works.
-if (typeof module !== 'undefined' && 'hot' in module) {
-  (module as any).hot.accept();
-  (module as any).hot.dispose(async () => {
-    logger.debug('Cleaning up flow server(s) before module reload...');
-    await FlowServer.stopAll();
-  });
 }

--- a/js/core/src/index.ts
+++ b/js/core/src/index.ts
@@ -32,19 +32,11 @@ export * from './action.js';
 export { getFlowAuth } from './context.js';
 export { GenkitError } from './error.js';
 export {
-  Flow,
-  FlowServer,
   defineFlow,
-  defineStreamingFlow,
   run,
-  type CallableFlow,
-  type FlowAuthPolicy,
+  type Flow,
   type FlowConfig,
   type FlowFn,
-  type FlowServerOptions,
-  type StreamableFlow,
-  type StreamingFlowConfig,
-  type __RequestWithAuth,
 } from './flow.js';
 export * from './plugin.js';
 export * from './reflection.js';

--- a/js/doc-snippets/package.json
+++ b/js/doc-snippets/package.json
@@ -16,6 +16,7 @@
     "@genkit-ai/googleai": "workspace:*",
     "@genkit-ai/vertexai": "workspace:*",
     "@genkit-ai/firebase": "workspace:*",
+    "@genkit-ai/express": "workspace:*",
     "data-urls": "^5.0.0"
   },
   "devDependencies": {

--- a/js/doc-snippets/src/flows/express.ts
+++ b/js/doc-snippets/src/flows/express.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { startFlowServer } from '@genkit-ai/express';
 import { genkit } from 'genkit';
 
 const ai = genkit({});
@@ -28,7 +29,7 @@ export const menuSuggestionFlow = ai.defineFlow(
   }
 );
 
-ai.startFlowServer({
+startFlowServer({
   flows: [menuSuggestionFlow],
 });
 // [END ex01]
@@ -42,7 +43,7 @@ export const flowB = ai.defineFlow({ name: 'flowB' }, async (subject) => {
   // ...
 });
 
-ai.startFlowServer({
+startFlowServer({
   flows: [flowB],
   port: 4567,
   cors: {

--- a/js/doc-snippets/src/flows/index.ts
+++ b/js/doc-snippets/src/flows/index.ts
@@ -15,7 +15,7 @@
  */
 
 import { gemini15Flash, googleAI } from '@genkit-ai/googleai';
-import { genkit, run, z } from 'genkit';
+import { genkit, z } from 'genkit';
 
 const ai = genkit({
   plugins: [googleAI()],
@@ -84,7 +84,7 @@ export const menuSuggestionFlowMarkdown = ai.defineFlow(
 // [END ex03]
 
 // [START ex06]
-export const menuSuggestionStreamingFlow = ai.defineStreamingFlow(
+export const menuSuggestionStreamingFlow = ai.defineFlow(
   {
     name: 'menuSuggestionFlow',
     inputSchema: z.string(),
@@ -159,22 +159,25 @@ export const menuQuestionFlow = ai.defineFlow(
     outputSchema: z.string(),
   },
   async (input: string): Promise<string> => {
-    const menu = await run('retrieve-daily-menu', async (): Promise<string> => {
-      // Retrieve today's menu. (This could be a database access or simply
-      // fetching the menu from your website.)
+    const menu = await ai.run(
+      'retrieve-daily-menu',
+      async (): Promise<string> => {
+        // Retrieve today's menu. (This could be a database access or simply
+        // fetching the menu from your website.)
 
-      // [START_EXCLUDE]
-      const menu = `
+        // [START_EXCLUDE]
+        const menu = `
 Today's menu
 
 - Breakfast: spam and eggs
 - Lunch: spam sandwich with a cup of spam soup
 - Dinner: spam roast with a side of spammed potatoes
       `;
-      // [END_EXCLUDE]
+        // [END_EXCLUDE]
 
-      return menu;
-    });
+        return menu;
+      }
+    );
     const { text } = await ai.generate({
       model: gemini15Flash,
       system: "Help the user answer questions about today's menu.",
@@ -197,7 +200,7 @@ async function fn() {
   // [END ex05]
 
   // [START ex07]
-  const response = menuSuggestionStreamingFlow('Danube');
+  const response = menuSuggestionStreamingFlow.stream('Danube');
   // [END ex07]
   // [START ex08]
   for await (const chunk of response.stream) {

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -104,21 +104,17 @@ import {
 } from '@genkit-ai/ai/session';
 import { resolveTools } from '@genkit-ai/ai/tool';
 import {
-  CallableFlow,
+  Action,
   defineFlow,
   defineJsonSchema,
   defineSchema,
-  defineStreamingFlow,
-  Flow,
+  FlowConfig,
   FlowFn,
-  FlowServer,
-  FlowServerOptions,
   isDevEnv,
   JSONSchema,
   ReflectionServer,
-  StreamableFlow,
+  run,
   StreamingCallback,
-  StreamingFlowConfig,
   z,
 } from '@genkit-ai/core';
 import { HasRegistry } from '@genkit-ai/core/registry';
@@ -182,10 +178,8 @@ export class Genkit implements HasRegistry {
   readonly registry: Registry;
   /** Reflection server for this registry. May be null if not started. */
   private reflectionServer: ReflectionServer | null = null;
-  /** Flow server. May be null if the flow server is not enabled in configuration or not started. */
-  private flowServer: FlowServer | null = null;
   /** List of flows that have been registered in this instance. */
-  readonly flows: Flow<any, any, any>[] = [];
+  readonly flows: Action<any, any, any>[] = [];
 
   constructor(options?: GenkitOptions) {
     this.options = options || {};
@@ -209,33 +203,11 @@ export class Genkit implements HasRegistry {
     O extends z.ZodTypeAny = z.ZodTypeAny,
     S extends z.ZodTypeAny = z.ZodTypeAny,
   >(
-    config: StreamingFlowConfig<I, O, S> | string,
+    config: FlowConfig<I, O, S> | string,
     fn: FlowFn<I, O, S>
-  ): CallableFlow<I, O, S> {
+  ): Action<I, O, S> {
     const flow = defineFlow(this.registry, config, fn);
-    this.flows.push(flow.flow);
-    return flow;
-  }
-
-  /**
-   * Defines and registers a streaming flow.
-   *
-   * @deprecated use {@link defineFlow}
-   */
-  defineStreamingFlow<
-    I extends z.ZodTypeAny = z.ZodTypeAny,
-    O extends z.ZodTypeAny = z.ZodTypeAny,
-    S extends z.ZodTypeAny = z.ZodTypeAny,
-  >(
-    config: StreamingFlowConfig<I, O, S> | string,
-    fn: FlowFn<I, O, S>
-  ): StreamableFlow<I, O, S> {
-    const flow = defineStreamingFlow(
-      this.registry,
-      typeof config === 'string' ? { name: config } : config,
-      fn
-    );
-    this.flows.push(flow.flow);
+    this.flows.push(flow);
     return flow;
   }
 
@@ -1076,6 +1048,54 @@ export class Genkit implements HasRegistry {
   }
 
   /**
+   * A flow step that executes the provided function. Each run step is recorded separately in the trace.
+   *
+   * ```ts
+   * ai.defineFlow('hello', async() => {
+   *   await ai.run('step1', async () => {
+   *     // ... step 1
+   *   });
+   *   await ai.run('step2', async () => {
+   *     // ... step 2
+   *   });
+   *   return result;
+   * })
+   * ```
+   */
+  run<T>(name: string, func: () => Promise<T>): Promise<T>;
+
+  /**
+   * A flow step that executes the provided function. Each run step is recorded separately in the trace.
+   *
+   * ```ts
+   * ai.defineFlow('hello', async() => {
+   *   await ai.run('step1', async () => {
+   *     // ... step 1
+   *   });
+   *   await ai.run('step2', async () => {
+   *     // ... step 2
+   *   });
+   *   return result;
+   * })
+   */
+  run<T>(
+    name: string,
+    input: any,
+    func: (input?: any) => Promise<T>
+  ): Promise<T>;
+
+  run<T>(
+    name: string,
+    funcOrInput: () => Promise<T> | any,
+    maybeFunc?: (input?: any) => Promise<T>
+  ): Promise<T> {
+    if (maybeFunc) {
+      return run(name, funcOrInput, maybeFunc, this.registry);
+    }
+    return run(name, funcOrInput, this.registry);
+  }
+
+  /**
    * Configures the Genkit instance.
    */
   private configure() {
@@ -1117,9 +1137,8 @@ export class Genkit implements HasRegistry {
    * Stops all servers.
    */
   async stopServers() {
-    await Promise.all([this.reflectionServer?.stop(), this.flowServer?.stop()]);
+    await this.reflectionServer?.stop();
     this.reflectionServer = null;
-    this.flowServer = null;
   }
 
   private async resolveModel(
@@ -1144,12 +1163,6 @@ export class Genkit implements HasRegistry {
       )) as ModelAction;
     }
   }
-
-  startFlowServer(options: FlowServerOptions): FlowServer {
-    const flowServer = new FlowServer(this.registry, options);
-    flowServer.start();
-    return flowServer;
-  }
 }
 
 /**
@@ -1164,7 +1177,7 @@ export function genkit(options: GenkitOptions): Genkit {
 
 const shutdown = async () => {
   logger.info('Shutting down all Genkit servers...');
-  await Promise.all([ReflectionServer.stopAll(), FlowServer.stopAll()]);
+  await ReflectionServer.stopAll();
   process.exit(0);
 };
 

--- a/js/genkit/src/index.ts
+++ b/js/genkit/src/index.ts
@@ -111,7 +111,6 @@ export {
   type SessionStore,
 } from '@genkit-ai/ai/session';
 export {
-  FlowServer,
   GENKIT_CLIENT_HEADER,
   GENKIT_VERSION,
   GenkitError,
@@ -124,28 +123,22 @@ export {
   getFlowAuth,
   getStreamingCallback,
   isDevEnv,
-  run,
   runWithStreamingCallback,
   z,
   type Action,
   type ActionMetadata,
-  type CallableFlow,
   type Flow,
-  type FlowAuthPolicy,
   type FlowConfig,
   type FlowFn,
-  type FlowServerOptions,
   type JSONSchema,
   type JSONSchema7,
   type Middleware,
   type ReflectionServerOptions,
   type RunActionResponse,
   type Status,
-  type StreamableFlow,
   type StreamingCallback,
-  type StreamingFlowConfig,
+  type StreamingResponse,
   type TelemetryConfig,
-  type __RequestWithAuth,
 } from '@genkit-ai/core';
 export { loadPromptFile } from '@genkit-ai/dotprompt';
 export {

--- a/js/plugins/express/README.md
+++ b/js/plugins/express/README.md
@@ -3,7 +3,7 @@
 This plugin provides utilities for conveninetly exposing Genkit flows and actions via Express HTTP server as REST APIs.
 
 ```ts
-import { handler } from '@genkit-ai/express';
+import { expressHandler } from '@genkit-ai/express';
 import express from 'express';
 
 const simpleFlow = ai.defineFlow(
@@ -21,7 +21,7 @@ const simpleFlow = ai.defineFlow(
 const app = express();
 app.use(express.json());
 
-app.post('/simpleFlow', handler(simpleFlow));
+app.post('/simpleFlow', expressHandler(simpleFlow));
 
 app.listen(8080);
 ```
@@ -42,7 +42,7 @@ const authMiddleware = async (req, resp, next) => {
 app.post(
   '/simpleFlow',
   authMiddleware,
-  handler(simpleFlow, {
+  expressHandler(simpleFlow, {
     authPolicy: ({ auth }) => {
       if (auth.user !== 'Ali Baba') {
         throw new Error('not authorized');
@@ -52,7 +52,7 @@ app.post(
 );
 ```
 
-Flows and actions exposed using the `handler` function can be accessed using `genkit/client` library:
+Flows and actions exposed using the `expressHandler` function can be accessed using `genkit/client` library:
 
 ```ts
 import { runFlow, streamFlow } from 'genkit/client';

--- a/js/plugins/express/package.json
+++ b/js/plugins/express/package.json
@@ -27,15 +27,20 @@
   },
   "author": "genkit",
   "license": "Apache-2.0",
-  "dependencies": {},
+  "dependencies": {
+    "cors": "^2.8.5",
+    "body-parser": "^1.20.3"
+  },
   "peerDependencies": {
     "genkit": "workspace:*",
     "express": "^4.21.1"
   },
   "devDependencies": {
     "get-port": "^5.1.0",
+    "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.16",
+    "@types/body-parser": "^1.19.5",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
     "tsup": "^8.3.5",

--- a/js/plugins/express/tests/express_test.ts
+++ b/js/plugins/express/tests/express_test.ts
@@ -22,9 +22,15 @@ import getPort from 'get-port';
 import * as http from 'http';
 import assert from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
-import { RequestWithAuth, handler } from '../src/index.js';
+import {
+  FlowServer,
+  RequestWithAuth,
+  expressHandler,
+  startFlowServer,
+  withAuth,
+} from '../src/index.js';
 
-describe('telemetry', async () => {
+describe('expressHandler', async () => {
   let server: http.Server;
   let port;
 
@@ -70,9 +76,9 @@ describe('telemetry', async () => {
       }
     );
 
-    const flowWithContext = ai.defineFlow(
+    const flowWithAuth = ai.defineFlow(
       {
-        name: 'flowWithContext',
+        name: 'flowWithAuth',
         inputSchema: z.object({ question: z.string() }),
       },
       async (input, { context }) => {
@@ -84,10 +90,10 @@ describe('telemetry', async () => {
     app.use(express.json());
     port = await getPort();
 
-    app.post('/voidInput', handler(voidInput));
-    app.post('/stringInput', handler(stringInput));
-    app.post('/objectInput', handler(objectInput));
-    app.post('/streamingFlow', handler(streamingFlow));
+    app.post('/voidInput', expressHandler(voidInput));
+    app.post('/stringInput', expressHandler(stringInput));
+    app.post('/objectInput', expressHandler(objectInput));
+    app.post('/streamingFlow', expressHandler(streamingFlow));
     app.post(
       '/flowWithAuth',
       async (req, resp, next) => {
@@ -99,7 +105,7 @@ describe('telemetry', async () => {
         };
         next();
       },
-      handler(flowWithContext, {
+      expressHandler(flowWithAuth, {
         authPolicy: ({ auth, action, input, request }) => {
           assert.ok(auth, 'auth must be set');
           assert.ok(action, 'flow must be set');
@@ -114,7 +120,7 @@ describe('telemetry', async () => {
     );
 
     // Can also expose any action.
-    app.post('/echoModel', handler(echoModel));
+    app.post('/echoModel', expressHandler(echoModel));
     app.post(
       '/echoModelWithAuth',
       async (req, resp, next) => {
@@ -126,7 +132,7 @@ describe('telemetry', async () => {
         };
         next();
       },
-      handler(echoModel, {
+      expressHandler(echoModel, {
         authPolicy: ({ auth, action, input, request }) => {
           assert.ok(auth, 'auth must be set');
           assert.ok(action, 'flow must be set');
@@ -320,6 +326,193 @@ describe('telemetry', async () => {
         { content: [{ text: '2' }] },
         { content: [{ text: '1' }] },
       ]);
+    });
+  });
+});
+
+describe('startFlowServer', async () => {
+  let server: FlowServer;
+  let port;
+
+  beforeEach(async () => {
+    const ai = genkit({});
+    const echoModel = defineEchoModel(ai);
+
+    const voidInput = ai.defineFlow('voidInput', async () => {
+      return 'banana';
+    });
+
+    const stringInput = ai.defineFlow('stringInput', async (input) => {
+      const { text } = await ai.generate({
+        model: 'echoModel',
+        prompt: input,
+      });
+      return text;
+    });
+
+    const objectInput = ai.defineFlow(
+      { name: 'objectInput', inputSchema: z.object({ question: z.string() }) },
+      async (input) => {
+        const { text } = await ai.generate({
+          model: 'echoModel',
+          prompt: input.question,
+        });
+        return text;
+      }
+    );
+
+    const streamingFlow = ai.defineFlow(
+      {
+        name: 'streamingFlow',
+        inputSchema: z.object({ question: z.string() }),
+      },
+      async (input, sendChunk) => {
+        const { text } = await ai.generate({
+          model: 'echoModel',
+          prompt: input.question,
+          onChunk: sendChunk,
+        });
+        return text;
+      }
+    );
+
+    const flowWithAuth = ai.defineFlow(
+      {
+        name: 'flowWithAuth',
+        inputSchema: z.object({ question: z.string() }),
+      },
+      async (input, { context }) => {
+        return `${input.question} - ${JSON.stringify(context)}`;
+      }
+    );
+
+    port = await getPort();
+
+    server = startFlowServer({
+      flows: [
+        voidInput,
+        stringInput,
+        objectInput,
+        streamingFlow,
+        withAuth(
+          flowWithAuth,
+          async (req, resp, next) => {
+            (req as RequestWithAuth).auth = {
+              user:
+                req.header('authorization') === 'open sesame'
+                  ? 'Ali Baba'
+                  : '40 thieves',
+            };
+            return next();
+          },
+          ({ auth, action, input, request }) => {
+            assert.ok(auth, 'auth must be set');
+            assert.ok(action, 'flow must be set');
+            assert.ok(input, 'input must be set');
+            assert.ok(request, 'request must be set');
+
+            if (auth.user !== 'Ali Baba') {
+              throw new Error('not authorized');
+            }
+          }
+        ),
+      ],
+      port,
+    });
+  });
+
+  afterEach(() => {
+    server.stop();
+  });
+
+  describe('runFlow', () => {
+    it('should call a void input flow', async () => {
+      const result = await runFlow({
+        url: `http://localhost:${port}/voidInput`,
+      });
+      assert.strictEqual(result, 'banana');
+    });
+
+    it('should run a flow with string input', async () => {
+      const result = await runFlow({
+        url: `http://localhost:${port}/stringInput`,
+        input: 'hello',
+      });
+      assert.strictEqual(result, 'Echo: hello');
+    });
+
+    it('should run a flow with object input', async () => {
+      const result = await runFlow({
+        url: `http://localhost:${port}/objectInput`,
+        input: {
+          question: 'olleh',
+        },
+      });
+      assert.strictEqual(result, 'Echo: olleh');
+    });
+
+    it('should fail a bad input', async () => {
+      const result = runFlow({
+        url: `http://localhost:${port}/objectInput`,
+        input: {
+          badField: 'hello',
+        },
+      });
+      await assert.rejects(result, (err: Error) => {
+        return err.message.includes('INVALID_ARGUMENT');
+      });
+    });
+
+    it('should call a flow with auth', async () => {
+      const result = await runFlow<string>({
+        url: `http://localhost:${port}/flowWithAuth`,
+        input: {
+          question: 'hello',
+        },
+        headers: {
+          Authorization: 'open sesame',
+        },
+      });
+      assert.strictEqual(result, 'hello - {"user":"Ali Baba"}');
+    });
+
+    it('should fail a flow with auth', async () => {
+      const result = runFlow({
+        url: `http://localhost:${port}/flowWithAuth`,
+        input: {
+          question: 'hello',
+        },
+        headers: {
+          Authorization: 'thieve #24',
+        },
+      });
+      await assert.rejects(result, (err) => {
+        return (err as Error).message.includes('not authorized');
+      });
+    });
+  });
+
+  describe('streamFlow', () => {
+    it('stream a flow', async () => {
+      const result = streamFlow<string, GenerateResponseChunkData>({
+        url: `http://localhost:${port}/streamingFlow`,
+        input: {
+          question: 'olleh',
+        },
+      });
+
+      const gotChunks: GenerateResponseChunkData[] = [];
+      for await (const chunk of result.stream()) {
+        gotChunks.push(chunk);
+      }
+
+      assert.deepStrictEqual(gotChunks, [
+        { content: [{ text: '3' }] },
+        { content: [{ text: '2' }] },
+        { content: [{ text: '1' }] },
+      ]);
+
+      assert.strictEqual(await result.output(), 'Echo: olleh');
     });
   });
 });

--- a/js/plugins/firebase/package.json
+++ b/js/plugins/firebase/package.json
@@ -32,6 +32,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@genkit-ai/google-cloud": "workspace:*",
+    "@genkit-ai/express": "workspace:*",
     "express": "^4.21.0",
     "google-auth-library": "^9.6.3"
   },
@@ -51,7 +52,10 @@
     "@types/jest": "^29.5.12",
     "@jest/globals": "^29.7.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.2"
+    "ts-jest": "^29.1.2",
+    "express": "^4.21.1",
+    "get-port": "^5.1.0",
+    "firebase": "^11.1.0"
   },
   "types": "./lib/index.d.ts",
   "exports": {

--- a/js/plugins/firebase/src/auth.ts
+++ b/js/plugins/firebase/src/auth.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { RequestWithAuth } from '@genkit-ai/express';
 import { Response } from 'express';
 import { DecodedIdToken, getAuth } from 'firebase-admin/auth';
-import { __RequestWithAuth, z } from 'genkit';
+import { z } from 'genkit';
 import { FunctionFlowAuth } from './functions.js';
 import { initializeAppIfNecessary } from './helpers.js';
 
@@ -71,7 +72,7 @@ export function firebaseAuth<I extends z.ZodTypeAny>(
         return;
       }
 
-      (req as __RequestWithAuth).auth = decoded;
+      (req as RequestWithAuth).auth = decoded;
 
       next();
     },

--- a/js/plugins/firebase/tests/functions_test.ts
+++ b/js/plugins/firebase/tests/functions_test.ts
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import express from 'express';
+import { initializeApp } from 'firebase/app';
+import { getFunctions, httpsCallableFromURL } from 'firebase/functions';
+import { Genkit, genkit } from 'genkit';
+import { runFlow, streamFlow } from 'genkit/client';
+import getPort from 'get-port';
+import * as http from 'http';
+import { RequestWithAuth, noAuth, onFlow } from '../lib/functions.js';
+
+describe('function', () => {
+  let ai: Genkit;
+  let server: http.Server;
+  let port: number;
+
+  beforeEach(async () => {
+    ai = genkit({});
+
+    const authPolicy = {
+      provider: async (req, resp, next) => {
+        (req as RequestWithAuth).auth = {
+          user:
+            req.header('authorization') === 'open sesame'
+              ? 'Ali Baba'
+              : '40 thieves',
+        };
+        next();
+      },
+      policy: (auth, input) => {
+        if (auth.user !== 'Ali Baba') {
+          throw new Error('not authorized');
+        }
+      },
+    };
+
+    const flow = onFlow(
+      ai,
+      {
+        name: 'flow',
+        authPolicy: noAuth(),
+      },
+      async (input) => {
+        return `hi ${input}`;
+      }
+    );
+
+    const streamingFlow = onFlow(
+      ai,
+      {
+        name: 'streamingFlow',
+        authPolicy: noAuth(),
+      },
+      async (input, { sendChunk }) => {
+        sendChunk({ chubk: 1 });
+        sendChunk({ chubk: 2 });
+        sendChunk({ chubk: 3 });
+
+        return `hi ${input}`;
+      }
+    );
+
+    const flowWithAuth = onFlow(
+      ai,
+      {
+        name: 'flowWithAuth',
+        authPolicy: authPolicy,
+      },
+      async (input, { context }) => {
+        return `hi ${input} - ${JSON.stringify(context)}`;
+      }
+    );
+
+    const streamingFlowWithAuth = onFlow(
+      ai,
+      {
+        name: 'streamingFlowWithAuth',
+        authPolicy: authPolicy,
+      },
+      async (input, { context, sendChunk }) => {
+        sendChunk({ chubk: 1 });
+        sendChunk({ chubk: 2 });
+        sendChunk({ chubk: 3 });
+
+        return `hi ${input} - ${JSON.stringify(context)}`;
+      }
+    );
+    const app = express();
+    app.use(express.json());
+    port = await getPort();
+    app.post('/flow', flow);
+    app.post('/flowWithAuth', flowWithAuth);
+    app.post('/streamingFlow', streamingFlow);
+    app.post('/streamingFlowWithAuth', streamingFlowWithAuth);
+    server = app.listen(port, () => {
+      console.log(`Example app listening on port ${port}`);
+    });
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it('should call as an express route using callable functions SDK', async () => {
+    const functions = getFunctions(initializeApp({}));
+
+    const callableFlow = httpsCallableFromURL(
+      functions,
+      `http://localhost:${port}/flow`
+    );
+
+    const callableResponse = await callableFlow('Pavel');
+    expect(callableResponse.data).toBe('hi Pavel');
+  });
+
+  it('should stream as an express route using callable functions SDK', async () => {
+    const functions = getFunctions(initializeApp({}));
+
+    const callableFlow = httpsCallableFromURL(
+      functions,
+      `http://localhost:${port}/streamingFlow`
+    );
+
+    const callableResponse = await callableFlow.stream('Pavel');
+    const chunks: any[] = [];
+    for await (const chunk of callableResponse.stream) {
+      chunks.push(chunk);
+    }
+    expect(await callableResponse.data).toEqual('hi Pavel');
+    expect(chunks).toStrictEqual([{ chubk: 1 }, { chubk: 2 }, { chubk: 3 }]);
+  });
+
+  it('should call as an express route using genkit client SDK', async () => {
+    const result = await runFlow<string>({
+      url: `http://localhost:${port}/flowWithAuth`,
+      input: 'Pavel',
+      headers: {
+        Authorization: 'open sesame',
+      },
+    });
+
+    expect(result).toBe('hi Pavel - {"user":"Ali Baba"}');
+  });
+
+  it('should call as an express route using genkit client SDK', async () => {
+    const result = await streamFlow<string>({
+      url: `http://localhost:${port}/streamingFlowWithAuth`,
+      input: 'Pavel',
+      headers: {
+        Authorization: 'open sesame',
+      },
+    });
+
+    const chunks: any[] = [];
+    for await (const chunk of result.stream()) {
+      chunks.push(chunk);
+    }
+
+    expect(await result.output()).toBe('hi Pavel - {"user":"Ali Baba"}');
+    expect(chunks).toStrictEqual([{ chubk: 1 }, { chubk: 2 }, { chubk: 3 }]);
+  });
+});

--- a/js/plugins/google-cloud/tests/logs_no_io_test.ts
+++ b/js/plugins/google-cloud/tests/logs_no_io_test.ts
@@ -23,7 +23,7 @@ import {
   jest,
 } from '@jest/globals';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { GenerateResponseData, Genkit, genkit, run, z } from 'genkit';
+import { GenerateResponseData, Genkit, genkit, z } from 'genkit';
 import assert from 'node:assert';
 import { Writable } from 'stream';
 import {
@@ -144,8 +144,8 @@ describe('GoogleCloudLogs no I/O', () => {
       };
     });
     const testFlow = createFlowWithInput(ai, 'testFlow', async (input) => {
-      return await run('sub1', async () => {
-        return await run('sub2', async () => {
+      return await ai.run('sub1', async () => {
+        return await ai.run('sub2', async () => {
           return await ai.generate({
             model: testModel,
             prompt: `${input} prompt`,

--- a/js/plugins/google-cloud/tests/logs_test.ts
+++ b/js/plugins/google-cloud/tests/logs_test.ts
@@ -23,7 +23,7 @@ import {
   jest,
 } from '@jest/globals';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { GenerateResponseData, Genkit, genkit, run, z } from 'genkit';
+import { GenerateResponseData, Genkit, genkit, z } from 'genkit';
 import { SPAN_TYPE_ATTR, appendSpan } from 'genkit/tracing';
 import assert from 'node:assert';
 import { Writable } from 'stream';
@@ -147,8 +147,8 @@ describe('GoogleCloudLogs', () => {
       };
     });
     const testFlow = createFlowWithInput(ai, 'testFlow', async (input) => {
-      return await run('sub1', async () => {
-        return await run('sub2', async () => {
+      return await ai.run('sub1', async () => {
+        return await ai.run('sub2', async () => {
           return await ai.generate({
             model: testModel,
             prompt: `${input} prompt`,

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -30,7 +30,7 @@ import {
   SumMetricData,
 } from '@opentelemetry/sdk-metrics';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { GenerateResponseData, Genkit, genkit, run, z } from 'genkit';
+import { GenerateResponseData, Genkit, genkit, z } from 'genkit';
 import { SPAN_TYPE_ATTR, appendSpan } from 'genkit/tracing';
 import assert from 'node:assert';
 import {
@@ -499,12 +499,12 @@ describe('GoogleCloudMetrics', () => {
 
   it('writes path metrics for a successful flow', async () => {
     const flow = createFlow(ai, 'pathTestFlow', async () => {
-      await run('step1', async () => {
-        return await run('substep_a', async () => {
-          return await run('substep_b', async () => 'res1');
+      await ai.run('step1', async () => {
+        return await ai.run('substep_a', async () => {
+          return await ai.run('substep_b', async () => 'res1');
         });
       });
-      await run('step2', async () => 'res2');
+      await ai.run('step2', async () => 'res2');
       return;
     });
 
@@ -544,7 +544,7 @@ describe('GoogleCloudMetrics', () => {
 
   it('writes path metrics for a failing flow with exception in root', async () => {
     const flow = createFlow(ai, 'testFlow', async () => {
-      const subPath = await run('sub-action', async () => {
+      const subPath = await ai.run('sub-action', async () => {
         return 'done';
       });
       return Promise.reject(new Error('failed'));
@@ -582,8 +582,8 @@ describe('GoogleCloudMetrics', () => {
 
   it('writes path metrics for a failing flow with exception in subaction', async () => {
     const flow = createFlow(ai, 'testFlow', async () => {
-      const subPath1 = await run('sub-action-1', async () => {
-        const subPath2 = await run('sub-action-2', async () => {
+      const subPath1 = await ai.run('sub-action-1', async () => {
+        const subPath2 = await ai.run('sub-action-2', async () => {
           return Promise.reject(new Error('failed'));
         });
         return 'done';
@@ -627,8 +627,8 @@ describe('GoogleCloudMetrics', () => {
 
   it('writes path metrics for a flow with exception in action', async () => {
     const flow = createFlow(ai, 'testFlow', async () => {
-      const subPath1 = await run('sub-action-1', async () => {
-        const subPath2 = await run('sub-action-2', async () => {
+      const subPath1 = await ai.run('sub-action-1', async () => {
+        const subPath2 = await ai.run('sub-action-2', async () => {
           return 'done';
         });
         return Promise.reject(new Error('failed'));
@@ -674,10 +674,10 @@ describe('GoogleCloudMetrics', () => {
 
   it('writes path metrics for a flow with an exception in a serial action', async () => {
     const flow = createFlow(ai, 'testFlow', async () => {
-      const subPath1 = await run('sub-action-1', async () => {
+      const subPath1 = await ai.run('sub-action-1', async () => {
         return 'done';
       });
-      const subPath2 = await run('sub-action-2', async () => {
+      const subPath2 = await ai.run('sub-action-2', async () => {
         return Promise.reject(new Error('failed'));
       });
       return 'done';

--- a/js/plugins/google-cloud/tests/traces_test.ts
+++ b/js/plugins/google-cloud/tests/traces_test.ts
@@ -23,7 +23,7 @@ import {
   jest,
 } from '@jest/globals';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { Genkit, genkit, run, z } from 'genkit';
+import { Genkit, genkit, z } from 'genkit';
 import { appendSpan } from 'genkit/tracing';
 import assert from 'node:assert';
 import {
@@ -103,8 +103,8 @@ describe('GoogleCloudTracing', () => {
 
   it('sub actions are contained within flows', async () => {
     const testFlow = createFlow(ai, 'testFlow', async () => {
-      return await run('subAction', async () => {
-        return await run('subAction2', async () => {
+      return await ai.run('subAction', async () => {
+        return await ai.run('subAction2', async () => {
           return 'done';
         });
       });
@@ -137,7 +137,7 @@ describe('GoogleCloudTracing', () => {
 
   it('labels failed spans', async () => {
     const testFlow = createFlow(ai, 'badFlow', async () => {
-      return await run('badStep', async () => {
+      return await ai.run('badStep', async () => {
         throw new Error('oh no!');
       });
     });
@@ -159,7 +159,7 @@ describe('GoogleCloudTracing', () => {
 
   it('labels the root feature', async () => {
     const testFlow = createFlow(ai, 'niceFlow', async () => {
-      return run('niceStep', async () => {});
+      return ai.run('niceStep', async () => {});
     });
     await testFlow();
 
@@ -195,7 +195,7 @@ describe('GoogleCloudTracing', () => {
       }
     );
     const testFlow = createFlow(ai, 'modelFlow', async () => {
-      return run('runFlow', async () => {
+      return ai.run('runFlow', async () => {
         await ai.generate({
           model: echoModel,
           prompt: 'Testing model telemetry',

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
 
   doc-snippets:
     dependencies:
+      '@genkit-ai/express':
+        specifier: workspace:*
+        version: link:../plugins/express
       '@genkit-ai/firebase':
         specifier: workspace:*
         version: link:../plugins/firebase
@@ -401,6 +404,12 @@ importers:
 
   plugins/express:
     dependencies:
+      body-parser:
+        specifier: ^1.20.3
+        version: 1.20.3
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
       express:
         specifier: ^4.21.1
         version: 4.21.1
@@ -408,6 +417,12 @@ importers:
         specifier: workspace:*
         version: link:../../genkit
     devDependencies:
+      '@types/body-parser':
+        specifier: ^1.19.5
+        version: 1.19.5
+      '@types/cors':
+        specifier: ^2.8.17
+        version: 2.8.17
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
@@ -435,6 +450,9 @@ importers:
 
   plugins/firebase:
     dependencies:
+      '@genkit-ai/express':
+        specifier: workspace:*
+        version: link:../express
       '@genkit-ai/google-cloud':
         specifier: workspace:*
         version: link:../google-cloud
@@ -466,6 +484,12 @@ importers:
       '@types/node':
         specifier: ^20.11.16
         version: 20.11.30
+      firebase:
+        specifier: ^11.1.0
+        version: 11.1.0
+      get-port:
+        specifier: ^5.1.0
+        version: 5.1.0
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.11.30)
@@ -947,6 +971,9 @@ importers:
 
   testapps/docs-menu-basic:
     dependencies:
+      '@genkit-ai/express':
+        specifier: workspace:*
+        version: link:../../plugins/express
       '@genkit-ai/firebase':
         specifier: workspace:*
         version: link:../../plugins/firebase
@@ -1344,7 +1371,7 @@ importers:
         version: link:../../plugins/ollama
       genkitx-openai:
         specifier: ^0.10.1
-        version: 0.10.1(@genkit-ai/ai@1.0.0-rc.0)(@genkit-ai/core@1.0.0-rc.0)
+        version: 0.10.1(@genkit-ai/ai@1.0.0-rc.2)(@genkit-ai/core@1.0.0-rc.2)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -2134,38 +2161,248 @@ packages:
   '@fastify/busboy@3.0.0':
     resolution: {integrity: sha512-83rnH2nCvclWaPQQKvkJ2pdOjG4TZyEVuFDnlOF6KP08lDaaceVyw/W63mDuafQT+MKHCvXIPpE5uYWeM0rT4w==}
 
+  '@firebase/analytics-compat@0.2.16':
+    resolution: {integrity: sha512-Q/s+u/TEMSb2EDJFQMGsOzpSosybBl8HuoSEMyGZ99+0Pu7SIR9MPDGUjc8PKiCFQWDJ3QXxgqh1d/rujyAMbA==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/analytics-types@0.8.3':
+    resolution: {integrity: sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==}
+
+  '@firebase/analytics@0.10.10':
+    resolution: {integrity: sha512-Psdo7c9g2SLAYh6u1XRA+RZ7ab2JfBVuAt/kLzXkhKZL/gS2cQUCMsOW5p0RIlDPRKqpdNSmvujd2TeRWLKOkQ==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-check-compat@0.3.17':
+    resolution: {integrity: sha512-a/eadrGsY0MVCBPhrNbKUhoYpms4UKTYLKO7nswwSFVsm3Rw6NslQQCNLfvljcDqP4E7alQDRGJXjkxd/5gJ+Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
   '@firebase/app-check-interop-types@0.3.1':
     resolution: {integrity: sha512-NILZbe6RH3X1pZmJnfOfY2gLIrlKmrkUMMrrK6VSXHcSE0eQv28xFEcw16D198i9JYZpy5Kwq394My62qCMaIw==}
+
+  '@firebase/app-check-interop-types@0.3.3':
+    resolution: {integrity: sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==}
+
+  '@firebase/app-check-types@0.5.3':
+    resolution: {integrity: sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==}
+
+  '@firebase/app-check@0.8.10':
+    resolution: {integrity: sha512-DWFfxxif/t+Ow4MmRUevDX+A3hVxm1rUf6y5ZP4sIomfnVCO1NNahqtsv9rb1/tKGkTeoVT40weiTS/WjQG1mA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-compat@0.2.47':
+    resolution: {integrity: sha512-TdEWGDp6kSwuO1mxiM2Fe39eLWygfyzqTZcoU3aPV0viqqphPCbBBnVjPbFJErZ4+yaS7uCWXEbFEP9m5/COKA==}
+    engines: {node: '>=18.0.0'}
 
   '@firebase/app-types@0.9.1':
     resolution: {integrity: sha512-nFGqTYsnDFn1oXf1tCwPAc+hQPxyvBT/QB7qDjwK+IDYThOn63nGhzdUTXxVD9Ca8gUY/e5PQMngeo0ZW/E3uQ==}
 
+  '@firebase/app-types@0.9.3':
+    resolution: {integrity: sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==}
+
+  '@firebase/app@0.10.17':
+    resolution: {integrity: sha512-53sIYyAnYEPIZdaxuyq5OST7j4KBc2pqmktz+tEb1BIUSbXh8Gp4k/o6qzLelLpm4ngrBz7SRN0PZJqNRAyPog==}
+    engines: {node: '>=18.0.0'}
+
+  '@firebase/auth-compat@0.5.16':
+    resolution: {integrity: sha512-YlYwJMBqAyv0ESy3jDUyshMhZlbUiwAm6B6+uUmigNDHU+uq7j4SFiDJEZlFFIz397yBzKn06SUdqutdQzGnCA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
   '@firebase/auth-interop-types@0.2.2':
     resolution: {integrity: sha512-k3NA28Jfoo0+o391bFjoV9X5QLnUL1WbLhZZRbTQhZdmdGYJfX8ixtNNlHsYQ94bwG0QRbsmvkzDnzuhHrV11w==}
+
+  '@firebase/auth-interop-types@0.2.4':
+    resolution: {integrity: sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==}
+
+  '@firebase/auth-types@0.12.3':
+    resolution: {integrity: sha512-Zq9zI0o5hqXDtKg6yDkSnvMCMuLU6qAVS51PANQx+ZZX5xnzyNLEBO3GZgBUPsV5qIMFhjhqmLDxUqCbnAYy2A==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/auth@1.8.1':
+    resolution: {integrity: sha512-LX9N/Cf5Z35r5yqm2+5M3+2bRRe/+RFaa/+u4HDni7TA27C/Xm4XHLKcWcLg1BzjrS4zngSaBEOSODvp6RFOqQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@react-native-async-storage/async-storage': ^1.18.1
+    peerDependenciesMeta:
+      '@react-native-async-storage/async-storage':
+        optional: true
+
+  '@firebase/component@0.6.11':
+    resolution: {integrity: sha512-eQbeCgPukLgsKD0Kw5wQgsMDX5LeoI1MIrziNDjmc6XDq5ZQnuUymANQgAb2wp1tSF9zDSXyxJmIUXaKgN58Ug==}
+    engines: {node: '>=18.0.0'}
 
   '@firebase/component@0.6.6':
     resolution: {integrity: sha512-pp7sWqHmAAlA3os6ERgoM3k5Cxff510M9RLXZ9Mc8KFKMBc2ct3RkZTWUF7ixJNvMiK/iNgRLPDrLR2gtRJ9iQ==}
 
+  '@firebase/data-connect@0.1.3':
+    resolution: {integrity: sha512-FbAQpWNHownJx1VTCQI4ydbWGOZmSWXoFlirQn3ItHqsLJYSywqxSgDafzvyooifFh3J/2WqaM8y9hInnPcsTw==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
   '@firebase/database-compat@1.0.4':
     resolution: {integrity: sha512-GEEDAvsSMAkqy0BIFSVtFzoOIIcKHFfDM4aXHtWL/JCaNn4OOjH7td73jDfN3ALvpIN4hQki0FcxQ89XjqaTjQ==}
+
+  '@firebase/database-compat@2.0.1':
+    resolution: {integrity: sha512-IsFivOjdE1GrjTeKoBU/ZMenESKDXidFDzZzHBPQ/4P20ptGdrl3oLlWrV/QJqJ9lND4IidE3z4Xr5JyfUW1vg==}
+    engines: {node: '>=18.0.0'}
 
   '@firebase/database-types@1.0.2':
     resolution: {integrity: sha512-JRigr5JNLEHqOkI99tAGHDZF47469/cJz1tRAgGs8Feh+3ZmQy/vVChSqwMp2DuVUGp9PlmGsNSlpINJ/hDuIA==}
 
+  '@firebase/database-types@1.0.7':
+    resolution: {integrity: sha512-I7zcLfJXrM0WM+ksFmFdAMdlq/DFmpeMNa+/GNsLyFo5u/lX5zzkPzGe3srVWqaBQBY5KprylDGxOsP6ETfL0A==}
+
+  '@firebase/database@1.0.10':
+    resolution: {integrity: sha512-sWp2g92u7xT4BojGbTXZ80iaSIaL6GAL0pwvM0CO/hb0nHSnABAqsH7AhnWGsGvXuEvbPr7blZylPaR9J+GSuQ==}
+    engines: {node: '>=18.0.0'}
+
   '@firebase/database@1.0.4':
     resolution: {integrity: sha512-k84cXh+dtpzvY6yOhfyr1B+I1vjvSMtmlqotE0lTNVylc8m5nmOohjzpTLEQDrBWvwACX/VP5fEyajAdmnOKqA==}
+
+  '@firebase/firestore-compat@0.3.40':
+    resolution: {integrity: sha512-18HopMN811KYBc9Ptpr1Rewwio0XF09FF3jc5wtV6rGyAs815SlFFw5vW7ZeLd43zv9tlEc2FzM0H+5Vr9ZRxw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/firestore-types@3.0.3':
+    resolution: {integrity: sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/firestore@4.7.5':
+    resolution: {integrity: sha512-OO3rHvjC07jL2ITN255xH/UzCVSvh6xG8oTzQdFScQvFbcm1fjCL1hgAdpDZcx3vVcKMV+6ktr8wbllkB8r+FQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/functions-compat@0.3.17':
+    resolution: {integrity: sha512-oj2XV8YsJYutyPCRYUfbN6swmfrL6zar0/qtqZsKT7P7btOiYRl+lD6fxtQaT+pKE5YgOBGZW//kLPZfY0jWhw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/functions-types@0.6.3':
+    resolution: {integrity: sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==}
+
+  '@firebase/functions@0.12.0':
+    resolution: {integrity: sha512-plTtzY/nT0jOgHzT0vB9qch4FpHFOhCnR8HhYBqqdArG6GOQMIruKZbiTyLybO8bcaaNgQ6kSm9yohGUwxHcIw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/installations-compat@0.2.11':
+    resolution: {integrity: sha512-SHRgw5LTa6v8LubmJZxcOCwEd1MfWQPUtKdiuCx2VMWnapX54skZd1PkQg0K4l3k+4ujbI2cn7FE6Li9hbChBw==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/installations-types@0.5.3':
+    resolution: {integrity: sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+
+  '@firebase/installations@0.6.11':
+    resolution: {integrity: sha512-w8fY8mw6fxJzsZM2ufmTtomopXl1+bn/syYon+Gpn+0p0nO1cIUEVEFrFazTLaaL9q1CaVhc3HmseRTsI3igAA==}
+    peerDependencies:
+      '@firebase/app': 0.x
 
   '@firebase/logger@0.4.1':
     resolution: {integrity: sha512-tTIixB5UJbG9ZHSGZSZdX7THr3KWOLrejZ9B7jYsm6fpwgRNngKznQKA2wgYVyvBc1ta7dGFh9NtJ8n7qfiYIw==}
 
+  '@firebase/logger@0.4.4':
+    resolution: {integrity: sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==}
+    engines: {node: '>=18.0.0'}
+
+  '@firebase/messaging-compat@0.2.15':
+    resolution: {integrity: sha512-mEKKASRvRWq1aBNHgioGsOYR2c5nBZpO7k90K794zjKe0WkGNf0k7PLs5SlCf8FKnzumEkhTAp/SjYxovuxa8A==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/messaging-interop-types@0.2.3':
+    resolution: {integrity: sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==}
+
+  '@firebase/messaging@0.12.15':
+    resolution: {integrity: sha512-Bz+qvWNEwEWAbYtG4An8hgcNco6NWNoNLuLbGVwPL2fAoCF1zz+dcaBp+iTR2+K199JyRyDT9yDPAXhNHNDaKQ==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/performance-compat@0.2.11':
+    resolution: {integrity: sha512-DqeNBy51W2xzlklyC7Ht9JQ94HhTA08PCcM4MDeyG/ol3fqum/+YgtHWQ2IQuduqH9afETthZqLwCZiSgY7hiA==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/performance-types@0.2.3':
+    resolution: {integrity: sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==}
+
+  '@firebase/performance@0.6.11':
+    resolution: {integrity: sha512-FlkJFeqLlIeh5T4Am3uE38HVzggliDIEFy/fErEc1faINOUFCb6vQBEoNZGaXvRnTR8lh3X/hP7tv37C7BsK9g==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/remote-config-compat@0.2.11':
+    resolution: {integrity: sha512-zfIjpwPrGuIOZDmduukN086qjhZ1LnbJi/iYzgua+2qeTlO0XdlE1v66gJPwygGB3TOhT0yb9EiUZ3nBNttMqg==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/remote-config-types@0.3.3':
+    resolution: {integrity: sha512-YlRI9CHxrk3lpQuFup9N1eohpwdWayKZUNZ/YeQ0PZoncJ66P32UsKUKqVXOaieTjJIOh7yH8JEzRdht5s+d6g==}
+
+  '@firebase/remote-config@0.4.11':
+    resolution: {integrity: sha512-9z0rgKuws2nj+7cdiqF+NY1QR4na6KnuOvP+jQvgilDOhGtKOcCMq5XHiu66i73A9kFhyU6QQ2pHXxcmaq1pBw==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/storage-compat@0.3.14':
+    resolution: {integrity: sha512-Ok5FmXJiapaNAOQ8W8qppnfwgP8540jw2B8M0c4TFZqF4BD+CoKBxW0dRtOuLNGadLhzqqkDZZZtkexxrveQqA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/storage-types@0.8.3':
+    resolution: {integrity: sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/storage@0.13.4':
+    resolution: {integrity: sha512-b1KaTTRiMupFurIhpGIbReaWev0k5O3ouTHkAPcEssT+FvU3q/1JwzvkX4+ZdB60Fc43Mbp8qQ1gWfT0Z2FP9Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/util@1.10.2':
+    resolution: {integrity: sha512-qnSHIoE9FK+HYnNhTI8q14evyqbc/vHRivfB4TgCIUOl4tosmKSQlp7ltymOlMP4xVIJTg5wrkfcZ60X4nUf7Q==}
+    engines: {node: '>=18.0.0'}
+
   '@firebase/util@1.9.5':
     resolution: {integrity: sha512-PP4pAFISDxsf70l3pEy34Mf3GkkUcVQ3MdKp6aSVb7tcpfUQxnsdV7twDd8EkfB6zZylH6wpUAoangQDmCUMqw==}
 
-  '@genkit-ai/ai@1.0.0-rc.0':
-    resolution: {integrity: sha512-755VyQwYXonxT9l6WShYuHPjOvhAvA0nf5hETTQtqrrE93hsG1QWVPC7tQ3lVrKNu/M4xmwGVsNgrRx3LIMYZg==}
+  '@firebase/vertexai@1.0.2':
+    resolution: {integrity: sha512-4dC9m2nD0tkfKJT5v+i27tELrmUePjFXW3CDAxhVHUEv647B2R7kqpGQnyPkNEeaXkCr76THe7GGg35EWn4lDw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-types': 0.x
 
-  '@genkit-ai/core@1.0.0-rc.0':
-    resolution: {integrity: sha512-Sc/Ivlx2djH6716dfFXlBMpX6LCQRW/4rAg/AsG09Ux0Sygx8oj/GwHtRTNdzR+lNf907m21hpwxT8kLxd3a2w==}
+  '@firebase/webchannel-wrapper@1.0.3':
+    resolution: {integrity: sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==}
+
+  '@genkit-ai/ai@1.0.0-rc.2':
+    resolution: {integrity: sha512-pAyjFtfw0pv9bcQHy3b40gcMUx7FL3vbdDIYvfbbizPEq+/k9DGk/HQwYI1B490xm2On/AXIvYtCo7/aTEAIcw==}
+
+  '@genkit-ai/core@1.0.0-rc.2':
+    resolution: {integrity: sha512-wnrK0ZOt+VguN71kTo9/DdPchofIadKvpyG1UOzuHkc/SCMWkHzP8yHneh1clZ/uskPDR5OzrSBaQ2P0i8fwnw==}
 
   '@gerrit0/mini-shiki@1.24.4':
     resolution: {integrity: sha512-YEHW1QeAg6UmxEmswiQbOVEg1CW22b1XUD/lNTliOsu0LD0wqoyleFMnmbTp697QE0pcadQiR5cVtbbAPncvpw==}
@@ -2271,6 +2508,10 @@ packages:
   '@grpc/grpc-js@1.10.4':
     resolution: {integrity: sha512-MqBisuxTkYvPFnEiu+dag3xG/NBUDzSbAFAWlzfkGnQkjVZ6by3h4atbBc+Ikqup1z5BfB4BN18gKWR1YyppNw==}
     engines: {node: '>=12.10.0'}
+
+  '@grpc/grpc-js@1.9.15':
+    resolution: {integrity: sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==}
+    engines: {node: ^8.13.0 || >=10.10.0}
 
   '@grpc/proto-loader@0.7.12':
     resolution: {integrity: sha512-DCVwMxqYzpUCiDMl7hQ384FqP4T3DbNpXU8pt681l3UWCip1WUiD5JrkImUwCB9a7f2cq4CUTmi5r/xIMRPY1Q==}
@@ -4197,6 +4438,9 @@ packages:
     peerDependencies:
       firebase-admin: ^10.0.0 || ^11.0.0 || ^12.0.0
 
+  firebase@11.1.0:
+    resolution: {integrity: sha512-3OoNW3vBXmBLYJvcwbPCwfluptbDVp2zZYjrfHPVFAXfPgmyy/LWjidt+Sw2WNvRelsG0v++WN2Wor6J3OwDRg==}
+
   flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
@@ -4482,6 +4726,9 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  idb@7.1.1:
+    resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -6794,15 +7041,121 @@ snapshots:
 
   '@fastify/busboy@3.0.0': {}
 
+  '@firebase/analytics-compat@0.2.16(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/analytics': 0.10.10(@firebase/app@0.10.17)
+      '@firebase/analytics-types': 0.8.3
+      '@firebase/app-compat': 0.2.47
+      '@firebase/component': 0.6.11
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/analytics-types@0.8.3': {}
+
+  '@firebase/analytics@0.10.10(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/component': 0.6.11
+      '@firebase/installations': 0.6.11(@firebase/app@0.10.17)
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+
+  '@firebase/app-check-compat@0.3.17(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app-check': 0.8.10(@firebase/app@0.10.17)
+      '@firebase/app-check-types': 0.5.3
+      '@firebase/app-compat': 0.2.47
+      '@firebase/component': 0.6.11
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@firebase/app'
+
   '@firebase/app-check-interop-types@0.3.1': {}
+
+  '@firebase/app-check-interop-types@0.3.3': {}
+
+  '@firebase/app-check-types@0.5.3': {}
+
+  '@firebase/app-check@0.8.10(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/component': 0.6.11
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+
+  '@firebase/app-compat@0.2.47':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/component': 0.6.11
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
 
   '@firebase/app-types@0.9.1': {}
 
+  '@firebase/app-types@0.9.3': {}
+
+  '@firebase/app@0.10.17':
+    dependencies:
+      '@firebase/component': 0.6.11
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      idb: 7.1.1
+      tslib: 2.6.2
+
+  '@firebase/auth-compat@0.5.16(@firebase/app-compat@0.2.47)(@firebase/app-types@0.9.3)(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app-compat': 0.2.47
+      '@firebase/auth': 1.8.1(@firebase/app@0.10.17)
+      '@firebase/auth-types': 0.12.3(@firebase/app-types@0.9.3)(@firebase/util@1.10.2)
+      '@firebase/component': 0.6.11
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+      - '@react-native-async-storage/async-storage'
+
   '@firebase/auth-interop-types@0.2.2': {}
+
+  '@firebase/auth-interop-types@0.2.4': {}
+
+  '@firebase/auth-types@0.12.3(@firebase/app-types@0.9.3)(@firebase/util@1.10.2)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.10.2
+
+  '@firebase/auth@1.8.1(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/component': 0.6.11
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+
+  '@firebase/component@0.6.11':
+    dependencies:
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
 
   '@firebase/component@0.6.6':
     dependencies:
       '@firebase/util': 1.9.5
+      tslib: 2.6.2
+
+  '@firebase/data-connect@0.1.3(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/auth-interop-types': 0.2.4
+      '@firebase/component': 0.6.11
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
       tslib: 2.6.2
 
   '@firebase/database-compat@1.0.4':
@@ -6814,10 +7167,34 @@ snapshots:
       '@firebase/util': 1.9.5
       tslib: 2.6.2
 
+  '@firebase/database-compat@2.0.1':
+    dependencies:
+      '@firebase/component': 0.6.11
+      '@firebase/database': 1.0.10
+      '@firebase/database-types': 1.0.7
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+
   '@firebase/database-types@1.0.2':
     dependencies:
       '@firebase/app-types': 0.9.1
       '@firebase/util': 1.9.5
+
+  '@firebase/database-types@1.0.7':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.10.2
+
+  '@firebase/database@1.0.10':
+    dependencies:
+      '@firebase/app-check-interop-types': 0.3.3
+      '@firebase/auth-interop-types': 0.2.4
+      '@firebase/component': 0.6.11
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      faye-websocket: 0.11.4
+      tslib: 2.6.2
 
   '@firebase/database@1.0.4':
     dependencies:
@@ -6829,7 +7206,182 @@ snapshots:
       faye-websocket: 0.11.4
       tslib: 2.6.2
 
+  '@firebase/firestore-compat@0.3.40(@firebase/app-compat@0.2.47)(@firebase/app-types@0.9.3)(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app-compat': 0.2.47
+      '@firebase/component': 0.6.11
+      '@firebase/firestore': 4.7.5(@firebase/app@0.10.17)
+      '@firebase/firestore-types': 3.0.3(@firebase/app-types@0.9.3)(@firebase/util@1.10.2)
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/firestore-types@3.0.3(@firebase/app-types@0.9.3)(@firebase/util@1.10.2)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.10.2
+
+  '@firebase/firestore@4.7.5(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/component': 0.6.11
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      '@firebase/webchannel-wrapper': 1.0.3
+      '@grpc/grpc-js': 1.9.15
+      '@grpc/proto-loader': 0.7.13
+      tslib: 2.6.2
+
+  '@firebase/functions-compat@0.3.17(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app-compat': 0.2.47
+      '@firebase/component': 0.6.11
+      '@firebase/functions': 0.12.0(@firebase/app@0.10.17)
+      '@firebase/functions-types': 0.6.3
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/functions-types@0.6.3': {}
+
+  '@firebase/functions@0.12.0(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/app-check-interop-types': 0.3.3
+      '@firebase/auth-interop-types': 0.2.4
+      '@firebase/component': 0.6.11
+      '@firebase/messaging-interop-types': 0.2.3
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+
+  '@firebase/installations-compat@0.2.11(@firebase/app-compat@0.2.47)(@firebase/app-types@0.9.3)(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app-compat': 0.2.47
+      '@firebase/component': 0.6.11
+      '@firebase/installations': 0.6.11(@firebase/app@0.10.17)
+      '@firebase/installations-types': 0.5.3(@firebase/app-types@0.9.3)
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/installations-types@0.5.3(@firebase/app-types@0.9.3)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+
+  '@firebase/installations@0.6.11(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/component': 0.6.11
+      '@firebase/util': 1.10.2
+      idb: 7.1.1
+      tslib: 2.6.2
+
   '@firebase/logger@0.4.1':
+    dependencies:
+      tslib: 2.6.2
+
+  '@firebase/logger@0.4.4':
+    dependencies:
+      tslib: 2.6.2
+
+  '@firebase/messaging-compat@0.2.15(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app-compat': 0.2.47
+      '@firebase/component': 0.6.11
+      '@firebase/messaging': 0.12.15(@firebase/app@0.10.17)
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/messaging-interop-types@0.2.3': {}
+
+  '@firebase/messaging@0.12.15(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/component': 0.6.11
+      '@firebase/installations': 0.6.11(@firebase/app@0.10.17)
+      '@firebase/messaging-interop-types': 0.2.3
+      '@firebase/util': 1.10.2
+      idb: 7.1.1
+      tslib: 2.6.2
+
+  '@firebase/performance-compat@0.2.11(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app-compat': 0.2.47
+      '@firebase/component': 0.6.11
+      '@firebase/logger': 0.4.4
+      '@firebase/performance': 0.6.11(@firebase/app@0.10.17)
+      '@firebase/performance-types': 0.2.3
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/performance-types@0.2.3': {}
+
+  '@firebase/performance@0.6.11(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/component': 0.6.11
+      '@firebase/installations': 0.6.11(@firebase/app@0.10.17)
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+
+  '@firebase/remote-config-compat@0.2.11(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app-compat': 0.2.47
+      '@firebase/component': 0.6.11
+      '@firebase/logger': 0.4.4
+      '@firebase/remote-config': 0.4.11(@firebase/app@0.10.17)
+      '@firebase/remote-config-types': 0.3.3
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/remote-config-types@0.3.3': {}
+
+  '@firebase/remote-config@0.4.11(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/component': 0.6.11
+      '@firebase/installations': 0.6.11(@firebase/app@0.10.17)
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+
+  '@firebase/storage-compat@0.3.14(@firebase/app-compat@0.2.47)(@firebase/app-types@0.9.3)(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app-compat': 0.2.47
+      '@firebase/component': 0.6.11
+      '@firebase/storage': 0.13.4(@firebase/app@0.10.17)
+      '@firebase/storage-types': 0.8.3(@firebase/app-types@0.9.3)(@firebase/util@1.10.2)
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/storage-types@0.8.3(@firebase/app-types@0.9.3)(@firebase/util@1.10.2)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.10.2
+
+  '@firebase/storage@0.13.4(@firebase/app@0.10.17)':
+    dependencies:
+      '@firebase/app': 0.10.17
+      '@firebase/component': 0.6.11
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+
+  '@firebase/util@1.10.2':
     dependencies:
       tslib: 2.6.2
 
@@ -6837,9 +7389,21 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  '@genkit-ai/ai@1.0.0-rc.0':
+  '@firebase/vertexai@1.0.2(@firebase/app-types@0.9.3)(@firebase/app@0.10.17)':
     dependencies:
-      '@genkit-ai/core': 1.0.0-rc.0
+      '@firebase/app': 0.10.17
+      '@firebase/app-check-interop-types': 0.3.3
+      '@firebase/app-types': 0.9.3
+      '@firebase/component': 0.6.11
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.10.2
+      tslib: 2.6.2
+
+  '@firebase/webchannel-wrapper@1.0.3': {}
+
+  '@genkit-ai/ai@1.0.0-rc.2':
+    dependencies:
+      '@genkit-ai/core': 1.0.0-rc.2
       '@opentelemetry/api': 1.9.0
       '@types/node': 20.16.9
       colorette: 2.0.20
@@ -6850,7 +7414,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@genkit-ai/core@1.0.0-rc.0':
+  '@genkit-ai/core@1.0.0-rc.2':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/context-async-hooks': 1.25.1(@opentelemetry/api@1.9.0)
@@ -7072,6 +7636,11 @@ snapshots:
     dependencies:
       '@grpc/proto-loader': 0.7.12
       '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/grpc-js@1.9.15':
+    dependencies:
+      '@grpc/proto-loader': 0.7.13
+      '@types/node': 20.16.9
 
   '@grpc/proto-loader@0.7.12':
     dependencies:
@@ -9240,6 +9809,39 @@ snapshots:
       - encoding
       - supports-color
 
+  firebase@11.1.0:
+    dependencies:
+      '@firebase/analytics': 0.10.10(@firebase/app@0.10.17)
+      '@firebase/analytics-compat': 0.2.16(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)
+      '@firebase/app': 0.10.17
+      '@firebase/app-check': 0.8.10(@firebase/app@0.10.17)
+      '@firebase/app-check-compat': 0.3.17(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)
+      '@firebase/app-compat': 0.2.47
+      '@firebase/app-types': 0.9.3
+      '@firebase/auth': 1.8.1(@firebase/app@0.10.17)
+      '@firebase/auth-compat': 0.5.16(@firebase/app-compat@0.2.47)(@firebase/app-types@0.9.3)(@firebase/app@0.10.17)
+      '@firebase/data-connect': 0.1.3(@firebase/app@0.10.17)
+      '@firebase/database': 1.0.10
+      '@firebase/database-compat': 2.0.1
+      '@firebase/firestore': 4.7.5(@firebase/app@0.10.17)
+      '@firebase/firestore-compat': 0.3.40(@firebase/app-compat@0.2.47)(@firebase/app-types@0.9.3)(@firebase/app@0.10.17)
+      '@firebase/functions': 0.12.0(@firebase/app@0.10.17)
+      '@firebase/functions-compat': 0.3.17(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)
+      '@firebase/installations': 0.6.11(@firebase/app@0.10.17)
+      '@firebase/installations-compat': 0.2.11(@firebase/app-compat@0.2.47)(@firebase/app-types@0.9.3)(@firebase/app@0.10.17)
+      '@firebase/messaging': 0.12.15(@firebase/app@0.10.17)
+      '@firebase/messaging-compat': 0.2.15(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)
+      '@firebase/performance': 0.6.11(@firebase/app@0.10.17)
+      '@firebase/performance-compat': 0.2.11(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)
+      '@firebase/remote-config': 0.4.11(@firebase/app@0.10.17)
+      '@firebase/remote-config-compat': 0.2.11(@firebase/app-compat@0.2.47)(@firebase/app@0.10.17)
+      '@firebase/storage': 0.13.4(@firebase/app@0.10.17)
+      '@firebase/storage-compat': 0.3.14(@firebase/app-compat@0.2.47)(@firebase/app-types@0.9.3)(@firebase/app@0.10.17)
+      '@firebase/util': 1.10.2
+      '@firebase/vertexai': 1.0.2(@firebase/app-types@0.9.3)(@firebase/app@0.10.17)
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+
   flat@5.0.2: {}
 
   fn.name@1.1.0: {}
@@ -9343,10 +9945,10 @@ snapshots:
       - encoding
       - supports-color
 
-  genkitx-openai@0.10.1(@genkit-ai/ai@1.0.0-rc.0)(@genkit-ai/core@1.0.0-rc.0):
+  genkitx-openai@0.10.1(@genkit-ai/ai@1.0.0-rc.2)(@genkit-ai/core@1.0.0-rc.2):
     dependencies:
-      '@genkit-ai/ai': 1.0.0-rc.0
-      '@genkit-ai/core': 1.0.0-rc.0
+      '@genkit-ai/ai': 1.0.0-rc.2
+      '@genkit-ai/core': 1.0.0-rc.2
       openai: 4.53.0(encoding@0.1.13)
       zod: 3.23.8
     transitivePeerDependencies:
@@ -9664,6 +10266,8 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  idb@7.1.1: {}
 
   ieee754@1.2.1:
     optional: true

--- a/js/testapps/dev-ui-gallery/src/main/flows-firebase-functions.ts
+++ b/js/testapps/dev-ui-gallery/src/main/flows-firebase-functions.ts
@@ -18,36 +18,8 @@ import { firebaseAuth } from '@genkit-ai/firebase/auth';
 import { noAuth, onFlow } from '@genkit-ai/firebase/functions';
 import { gemini15Flash } from '@genkit-ai/googleai';
 import { DecodedIdToken } from 'firebase-admin/auth';
-import { run, z } from 'genkit';
+import { z } from 'genkit';
 import { ai } from '../genkit.js';
-
-export const flowBasicAuth = ai.defineFlow(
-  {
-    name: 'flowBasicAuth',
-    inputSchema: z.object({ language: z.string(), uid: z.string() }),
-    outputSchema: z.string(),
-    authPolicy: (auth, input) => {
-      if (!auth) {
-        throw new Error('Authorization required.');
-      }
-      if (input.uid !== auth.uid) {
-        throw new Error('You may only summarize your own profile data.');
-      }
-    },
-  },
-  async (input) => {
-    const prompt = `Say hello in language ${input.language}`;
-
-    return await run('call-llm', async () => {
-      const llmResponse = await ai.generate({
-        model: gemini15Flash,
-        prompt: prompt,
-      });
-
-      return llmResponse.text;
-    });
-  }
-);
 
 export const flowAuth = onFlow(
   ai,
@@ -67,7 +39,7 @@ export const flowAuth = onFlow(
   async (language) => {
     const prompt = `Say hello in language ${language}`;
 
-    return await run('call-llm', async () => {
+    return await ai.run('call-llm', async () => {
       const llmResponse = await ai.generate({
         model: gemini15Flash,
         prompt: prompt,
@@ -92,7 +64,7 @@ export const flowAuthNone = onFlow(
   async (language) => {
     const prompt = `Say hello in language ${language}`;
 
-    return await run('call-llm', async () => {
+    return await ai.run('call-llm', async () => {
       const llmResponse = await ai.generate({
         model: gemini15Flash,
         prompt: prompt,

--- a/js/testapps/dev-ui-gallery/src/main/flows.ts
+++ b/js/testapps/dev-ui-gallery/src/main/flows.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { run, z } from 'genkit';
+import { z } from 'genkit';
 import { generateString } from '../common/util';
 import { ai } from '../genkit.js';
 
@@ -25,7 +25,7 @@ import { ai } from '../genkit.js';
 const flowSingleStep = ai.defineFlow(
   { name: 'flowSingleStep' },
   async (input) => {
-    return await run('step1', async () => {
+    return await ai.run('step1', async () => {
       return input;
     });
   }
@@ -40,15 +40,15 @@ const flowMultiStep = ai.defineFlow(
   async (input) => {
     let i = 1;
 
-    const result1 = await run('step1', async () => {
+    const result1 = await ai.run('step1', async () => {
       return `${input} ${i++},`;
     });
 
-    const result2 = await run('step2', async () => {
+    const result2 = await ai.run('step2', async () => {
       return `${result1} ${i++},`;
     });
 
-    return await run('step3', async () => {
+    return await ai.run('step3', async () => {
       return `${result2} ${i++}`;
     });
   }
@@ -76,7 +76,7 @@ const flowNested = ai.defineFlow(
 // Flow - streaming
 //
 
-ai.defineStreamingFlow(
+ai.defineFlow(
   {
     name: 'flowStreaming',
     inputSchema: z.number(),
@@ -100,7 +100,7 @@ ai.defineStreamingFlow(
 //
 
 ai.defineFlow({ name: 'flowSingleStepThrows' }, async (input) => {
-  return await run('step1', async () => {
+  return await ai.run('step1', async () => {
     if (input) {
       throw new Error('Got an error!');
     }
@@ -115,18 +115,18 @@ ai.defineFlow({ name: 'flowSingleStepThrows' }, async (input) => {
 ai.defineFlow({ name: 'flowMultiStepThrows' }, async (input) => {
   let i = 1;
 
-  const result1 = await run('step1', async () => {
+  const result1 = await ai.run('step1', async () => {
     return `${input} ${i++},`;
   });
 
-  const result2 = await run('step2', async () => {
+  const result2 = await ai.run('step2', async () => {
     if (result1) {
       throw new Error('Got an error!');
     }
     return `${result1} ${i++},`;
   });
 
-  return await run('step3', async () => {
+  return await ai.run('step3', async () => {
     return `${result2} ${i++}`;
   });
 });
@@ -138,13 +138,13 @@ ai.defineFlow({ name: 'flowMultiStepThrows' }, async (input) => {
 ai.defineFlow({ name: 'flowMultiStepCaughtError' }, async (input) => {
   let i = 1;
 
-  const result1 = await run('step1', async () => {
+  const result1 = await ai.run('step1', async () => {
     return `${input} ${i++},`;
   });
 
   let result2 = '';
   try {
-    result2 = await run('step2', async () => {
+    result2 = await ai.run('step2', async () => {
       if (result1) {
         throw new Error('Got an error!');
       }
@@ -152,7 +152,7 @@ ai.defineFlow({ name: 'flowMultiStepCaughtError' }, async (input) => {
     });
   } catch (e) {}
 
-  return await run('step3', async () => {
+  return await ai.run('step3', async () => {
     return `${result2} ${i++}`;
   });
 });
@@ -161,7 +161,7 @@ ai.defineFlow({ name: 'flowMultiStepCaughtError' }, async (input) => {
 // Flow - streamingThrows
 //
 
-ai.defineStreamingFlow(
+ai.defineFlow(
   {
     name: 'flowStreamingThrows',
     inputSchema: z.number(),
@@ -193,16 +193,16 @@ ai.defineStreamingFlow(
 export const largeSteps = ai.defineFlow(
   { name: 'flowLargeOutput' },
   async () => {
-    await run('step1', async () => {
+    await ai.run('step1', async () => {
       return generateString(100_000);
     });
-    await run('step2', async () => {
+    await ai.run('step2', async () => {
       return generateString(800_000);
     });
-    await run('step3', async () => {
+    await ai.run('step3', async () => {
       return generateString(900_000);
     });
-    await run('step4', async () => {
+    await ai.run('step4', async () => {
       return generateString(999_000);
     });
     return 'something...';

--- a/js/testapps/dev-ui-gallery/src/main/prompts.ts
+++ b/js/testapps/dev-ui-gallery/src/main/prompts.ts
@@ -89,7 +89,7 @@ export const codeDefinedPromptVariant = ai.definePrompt(
   template
 );
 
-ai.defineStreamingFlow(
+ai.defineFlow(
   {
     name: 'flowCodeDefinedPrompt',
     inputSchema: HelloSchema,

--- a/js/testapps/docs-menu-basic/package.json
+++ b/js/testapps/docs-menu-basic/package.json
@@ -18,6 +18,7 @@
     "genkit": "workspace:*",
     "@genkit-ai/firebase": "workspace:*",
     "@genkit-ai/googleai": "workspace:*",
+    "@genkit-ai/express": "workspace:*",
     "express": "^4.21.0"
   },
   "devDependencies": {

--- a/js/testapps/docs-menu-basic/src/index.ts
+++ b/js/testapps/docs-menu-basic/src/index.ts
@@ -16,6 +16,7 @@
 
 // This sample is referenced by the genkit docs. Changes should be made to
 // both.
+import { startFlowServer } from '@genkit-ai/express';
 import { gemini15Flash, googleAI } from '@genkit-ai/googleai';
 import { genkit, z } from 'genkit';
 
@@ -42,6 +43,6 @@ export const menuSuggestionFlow = ai.defineFlow(
   }
 );
 
-ai.startFlowServer({
+startFlowServer({
   flows: [menuSuggestionFlow],
 });

--- a/js/testapps/docs-menu-rag/src/indexer.ts
+++ b/js/testapps/docs-menu-rag/src/indexer.ts
@@ -16,7 +16,7 @@
 
 import { devLocalIndexerRef } from '@genkit-ai/dev-local-vectorstore';
 import { readFile } from 'fs/promises';
-import { run, z } from 'genkit';
+import { z } from 'genkit';
 import { Document } from 'genkit/retriever';
 import { chunk } from 'llm-chunk';
 import path from 'path';
@@ -48,12 +48,12 @@ export const indexMenu = ai.defineFlow(
     filePath = path.resolve(filePath);
 
     // Read the pdf.
-    const pdfTxt = await run('extract-text', () =>
+    const pdfTxt = await ai.run('extract-text', () =>
       extractTextFromPdf(filePath)
     );
 
     // Divide the pdf text into segments.
-    const chunks = await run('chunk-it', async () =>
+    const chunks = await ai.run('chunk-it', async () =>
       chunk(pdfTxt, chunkingConfig)
     );
 

--- a/js/testapps/evals/src/pdf-rag.ts
+++ b/js/testapps/evals/src/pdf-rag.ts
@@ -19,7 +19,7 @@ import {
   devLocalRetrieverRef,
 } from '@genkit-ai/dev-local-vectorstore';
 import { gemini15Flash } from '@genkit-ai/googleai';
-import { run, z } from 'genkit';
+import { z } from 'genkit';
 import { Document } from 'genkit/retriever';
 import { chunk } from 'llm-chunk';
 import path from 'path';
@@ -104,9 +104,9 @@ export const indexPdf = ai.defineFlow(
   },
   async (filePath) => {
     filePath = path.resolve(filePath);
-    const pdfTxt = await run('extract-text', () => extractText(filePath));
+    const pdfTxt = await ai.run('extract-text', () => extractText(filePath));
 
-    const chunks = await run('chunk-it', async () =>
+    const chunks = await ai.run('chunk-it', async () =>
       chunk(pdfTxt, chunkingConfig)
     );
 

--- a/js/testapps/express/src/index.ts
+++ b/js/testapps/express/src/index.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { AuthPolicy, RequestWithAuth, handler } from '@genkit-ai/express';
+import {
+  AuthPolicy,
+  RequestWithAuth,
+  expressHandler,
+} from '@genkit-ai/express';
 import { gemini15Flash, googleAI } from '@genkit-ai/googleai';
 import { vertexAI } from '@genkit-ai/vertexai';
 import express, {
@@ -23,7 +27,7 @@ import express, {
   Request,
   Response,
 } from 'express';
-import { genkit, run, z } from 'genkit';
+import { genkit, z } from 'genkit';
 import { logger } from 'genkit/logging';
 import { ollama } from 'genkitx-ollama';
 
@@ -46,7 +50,7 @@ const ai = genkit({
 export const jokeFlow = ai.defineFlow(
   { name: 'jokeFlow', inputSchema: z.string(), outputSchema: z.string() },
   async (subject, streamingCallback) => {
-    return await run('call-llm', async () => {
+    return await ai.run('call-llm', async () => {
       const llmResponse = await ai.generate({
         prompt: `tell me long joke about ${subject}`,
         model: gemini15Flash,
@@ -86,12 +90,12 @@ ai.flows.forEach((f) => {
   app.post(
     `/${f.name}`,
     auth,
-    handler(f, { authPolicy: authPolicies[f.name] })
+    expressHandler(f, { authPolicy: authPolicies[f.name] })
   );
 });
 
 // curl http://localhost:5000/jokeHandler?stream=true -d '{"data": "banana"}' -H "content-type: application/json"
-app.post('/jokeHandler', handler(jokeFlow));
+app.post('/jokeHandler', expressHandler(jokeFlow));
 
 // curl http://localhost:5000/jokeWithFlow?subject=banana
 app.get('/jokeWithFlow', async (req: Request, res: Response) => {

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -26,7 +26,7 @@ import { GoogleAIFileManager } from '@google/generative-ai/server';
 import { AlwaysOnSampler } from '@opentelemetry/sdk-trace-base';
 import { initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
-import { GenerateResponseData, MessageSchema, genkit, run, z } from 'genkit';
+import { GenerateResponseData, MessageSchema, genkit, z } from 'genkit';
 import { logger } from 'genkit/logging';
 import { ModelMiddleware } from 'genkit/model';
 import { PluginProvider } from 'genkit/plugin';
@@ -94,7 +94,7 @@ export const jokeFlow = ai.defineFlow(
     outputSchema: z.string(),
   },
   async (input) => {
-    return await run('call-llm', async () => {
+    return await ai.run('call-llm', async () => {
       const llmResponse = await ai.generate({
         model: input.modelName,
         config: { version: input.modelVersion },
@@ -112,7 +112,7 @@ export const drawPictureFlow = ai.defineFlow(
     outputSchema: z.string(),
   },
   async (input) => {
-    return await run('call-llm', async () => {
+    return await ai.run('call-llm', async () => {
       const llmResponse = await ai.generate({
         model: input.modelName,
         prompt: `Draw a picture of a ${input.object}.`,
@@ -122,7 +122,7 @@ export const drawPictureFlow = ai.defineFlow(
   }
 );
 
-export const streamFlow = ai.defineStreamingFlow(
+export const streamFlow = ai.defineFlow(
   {
     name: 'streamFlow',
     inputSchema: z.string(),
@@ -160,7 +160,7 @@ const GameCharactersSchema = z.object({
     .describe('Characters'),
 });
 
-export const streamJsonFlow = ai.defineStreamingFlow(
+export const streamJsonFlow = ai.defineFlow(
   {
     name: 'streamJsonFlow',
     inputSchema: z.number(),
@@ -269,7 +269,7 @@ export const vertexStreamer = ai.defineFlow(
     outputSchema: z.string(),
   },
   async (input, streamingCallback) => {
-    return await run('call-llm', async () => {
+    return await ai.run('call-llm', async () => {
       const llmResponse = await ai.generate({
         model: gemini15Flash,
         prompt: `Tell me a very long joke about ${input}.`,
@@ -386,7 +386,7 @@ const jokeSubjectGenerator = ai.defineTool(
   }
 );
 
-export const toolCaller = ai.defineStreamingFlow(
+export const toolCaller = ai.defineFlow(
   {
     name: 'toolCaller',
     outputSchema: z.string(),
@@ -508,7 +508,7 @@ export const toolTester = ai.defineFlow(
   }
 );
 
-export const arrayStreamTester = ai.defineStreamingFlow(
+export const arrayStreamTester = ai.defineFlow(
   {
     name: 'arrayStreamTester',
     inputSchema: z.string().nullish(),

--- a/js/testapps/format-tester/src/index.ts
+++ b/js/testapps/format-tester/src/index.ts
@@ -21,7 +21,7 @@ import {
   claude35SonnetV2,
   vertexAIModelGarden,
 } from '@genkit-ai/vertexai/modelgarden';
-import { CallableFlow, GenerateOptions, genkit, z } from 'genkit';
+import { Flow, GenerateOptions, genkit, z } from 'genkit';
 import { logger } from 'genkit/logging';
 
 logger.setLogLevel('debug');
@@ -142,7 +142,7 @@ const prompts: Record<string, GenerateOptions> = {
   },
 };
 
-const flows: CallableFlow<z.ZodString, z.ZodTypeAny>[] = [];
+const flows: Flow<z.ZodString, z.ZodTypeAny>[] = [];
 for (const format in prompts) {
   flows.push(formatFlow(format, prompts[format]));
 }
@@ -165,7 +165,7 @@ async function main() {
         await flow(model);
       } catch (e: any) {
         console.error('ERROR:', e.stack);
-        fails.push({ model, flow: flow.flow.name, error: e.message });
+        fails.push({ model, flow: flow.__action.name, error: e.message });
       }
     }
   }

--- a/js/testapps/langchain/src/index.ts
+++ b/js/testapps/langchain/src/index.ts
@@ -24,7 +24,7 @@ import {
   RunnablePassthrough,
   RunnableSequence,
 } from '@langchain/core/runnables';
-import { genkit, run, z } from 'genkit';
+import { genkit, z } from 'genkit';
 import { GenkitTracer } from 'genkitx-langchain';
 import { ollama } from 'genkitx-ollama';
 import { PDFLoader } from 'langchain/document_loaders/fs/pdf';
@@ -51,10 +51,10 @@ const model = new GoogleVertexAI();
 export const indexPdf = ai.defineFlow(
   { name: 'indexPdf', inputSchema: z.string(), outputSchema: z.void() },
   async (filePath) => {
-    const docs = await run('load-pdf', async () => {
+    const docs = await ai.run('load-pdf', async () => {
       return await new PDFLoader(filePath).load();
     });
-    await run('index', async () => {
+    await ai.run('index', async () => {
       vectorStore.addDocuments(docs);
     });
   }
@@ -83,7 +83,3 @@ export const pdfQA = ai.defineFlow(
     return await chain.invoke(question, { callbacks: [new GenkitTracer()] });
   }
 );
-
-ai.startFlowServer({
-  flows: [pdfQA],
-});

--- a/js/testapps/prompt-file/src/index.ts
+++ b/js/testapps/prompt-file/src/index.ts
@@ -77,7 +77,7 @@ ai.defineFlow(
 
 // A variation that supports streaming, optionally
 
-ai.defineStreamingFlow(
+ai.defineFlow(
   {
     name: 'tellStory',
     inputSchema: z.object({

--- a/js/testapps/rag/src/pdf-rag-firebase.ts
+++ b/js/testapps/rag/src/pdf-rag-firebase.ts
@@ -21,7 +21,7 @@ import { FieldValue } from '@google-cloud/firestore';
 import { initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { readFile } from 'fs/promises';
-import { run, z } from 'genkit';
+import { z } from 'genkit';
 import { chunk } from 'llm-chunk';
 import path from 'path';
 import pdf from 'pdf-parse';
@@ -119,16 +119,16 @@ export const indexPdfFirebase = ai.defineFlow(
   },
   async (filePath) => {
     filePath = path.resolve(filePath);
-    const pdfTxt = await run('extract-text', () =>
+    const pdfTxt = await ai.run('extract-text', () =>
       extractTextFromPdf(filePath)
     );
 
-    const chunks = await run('chunk-it', async () =>
+    const chunks = await ai.run('chunk-it', async () =>
       chunk(pdfTxt, chunkingConfig)
     );
 
     // Add chunks to the index.
-    await run('index-chunks', async () => indexToFirestore(chunks));
+    await ai.run('index-chunks', async () => indexToFirestore(chunks));
   }
 );
 

--- a/js/testapps/rag/src/pdf-rag.ts
+++ b/js/testapps/rag/src/pdf-rag.ts
@@ -20,7 +20,7 @@ import {
 } from '@genkit-ai/dev-local-vectorstore';
 import { gemini15Flash } from '@genkit-ai/vertexai';
 import fs from 'fs';
-import { Document, run, z } from 'genkit';
+import { Document, z } from 'genkit';
 import { chunk } from 'llm-chunk';
 import path from 'path';
 import pdf from 'pdf-parse';
@@ -74,9 +74,9 @@ export const indexPdf = ai.defineFlow(
   },
   async (filePath) => {
     filePath = path.resolve(filePath);
-    const pdfTxt = await run('extract-text', () => extractText(filePath));
+    const pdfTxt = await ai.run('extract-text', () => extractText(filePath));
 
-    const chunks = await run('chunk-it', async () =>
+    const chunks = await ai.run('chunk-it', async () =>
       chunk(pdfTxt, chunkingConfig)
     );
 
@@ -108,9 +108,9 @@ export const synthesizeQuestions = ai.defineFlow(
   },
   async (filePath) => {
     filePath = path.resolve(filePath);
-    const pdfTxt = await run('extract-text', () => extractText(filePath));
+    const pdfTxt = await ai.run('extract-text', () => extractText(filePath));
 
-    const chunks = await run('chunk-it', async () =>
+    const chunks = await ai.run('chunk-it', async () =>
       chunk(pdfTxt, chunkingConfig)
     );
 
@@ -127,7 +127,3 @@ export const synthesizeQuestions = ai.defineFlow(
     return questions;
   }
 );
-
-ai.startFlowServer({
-  flows: [pdfQA],
-});

--- a/js/testapps/vertexai-reranker/src/index.ts
+++ b/js/testapps/vertexai-reranker/src/index.ts
@@ -87,7 +87,3 @@ export const rerankFlow = ai.defineFlow(
     }));
   }
 );
-
-ai.startFlowServer({
-  flows: [rerankFlow],
-});

--- a/js/testapps/vertexai-vector-search-bigquery/src/index.ts
+++ b/js/testapps/vertexai-vector-search-bigquery/src/index.ts
@@ -164,7 +164,3 @@ export const queryFlow = ai.defineFlow(
     };
   }
 );
-
-ai.startFlowServer({
-  flows: [indexFlow],
-});

--- a/js/testapps/vertexai-vector-search-custom/src/index.ts
+++ b/js/testapps/vertexai-vector-search-custom/src/index.ts
@@ -233,7 +233,3 @@ export const queryFlow = ai.defineFlow(
     };
   }
 );
-
-ai.startFlowServer({
-  flows: [indexFlow, queryFlow],
-});

--- a/js/testapps/vertexai-vector-search-firestore/src/index.ts
+++ b/js/testapps/vertexai-vector-search-firestore/src/index.ts
@@ -167,7 +167,3 @@ export const queryFlow = ai.defineFlow(
     };
   }
 );
-
-ai.startFlowServer({
-  flows: [indexFlow, queryFlow],
-});


### PR DESCRIPTION
Removed all express stuff from flows core. Flows are just simple actions now. Actions have the flow interface (including streaming).

Removed auth policy from flows. The policy is now a plugin feature. `startFlowServer` also moved to the express plugin.

```ts
import { startFlowServer, withAuth } from '@genkit-ai/express';

startFlowServer({
  flows: [
    simpleFlow,
    withAuth(flowThatNeedsAuth, authProvider, ({ auth, action, input, request }) => {
      if (!auth) {
        throw new Error('Authorization required.');
      }
    })
  ],
});
```

`run` is now `ai.run`.


Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
