### PR TITLE
docs: Point samples to new locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ Want to skip the local setup? Click below to try out Genkit using [Project IDX](
 
 Take a look at some samples of Genkit in use:
 
-- ["AI barista"](samples/js-coffee-shop/) -- demonstrates simple LLM usage
-- [A simple chatbot with a JavaScript frontend](samples/chatbot/) -- add history to LLM sessions
-- [Restaurant menu Q&A app](samples/js-menu/) -- this sample shows progressively
+- ["AI barista"](https://github.com/firebase/quickstart-nodejs/tree/master/genkit/js-coffee-shop) -- demonstrates simple LLM usage
+- [A simple chatbot with a JavaScript frontend](https://github.com/firebase/quickstart-nodejs/tree/master/genkit/chatbot) -- add history to LLM sessions
+- [Restaurant menu Q&A app](https://github.com/firebase/quickstart-nodejs/tree/master/genkit/js-menu) -- this sample shows progressively
   more sophisticated versions of a menu understanding app.
-- [Streaming to an Angular frontend](samples/js-angular/)
+- [Streaming to an Angular frontend](https://github.com/firebase/quickstart-nodejs/tree/master/genkit/js-angular)
 
 ## Connect with us
 


### PR DESCRIPTION
The samples in the readme were pointing to non-existent locations since the location was migrated to the quickstart-nodejs repo. Migrated the sample links to point to the right location.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
