### PR TITLE
docs: Point to Genkit template for IDX

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Find excellent examples of community-built plugins for OpenAI, Anthropic, Cohere
 
 Want to skip the local setup? Click below to try out Genkit using [Project IDX](https://idx.dev), Google's AI-assisted workspace for full-stack app development in the cloud.
 
-<a href="https://idx.google.com/import?url=">
+<a href="https://idx.google.com/new/genkit">
   <img
     height="32"
     alt="Try in IDX"


### PR DESCRIPTION
The IDX button was using the generic Github import link. This updates the URL to the Genkit template for IDX.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
