### PR TITLE
[chore]: Standardize package exports in a way that silences pnpm warnings

### DIFF
--- a/js/ai/package.json
+++ b/js/ai/package.json
@@ -46,80 +46,80 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "require": "./lib/index.js",
       "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     },
     "./retriever": {
       "types": "./lib/retriever.d.ts",
-      "require": "./lib/retriever.js",
       "import": "./lib/retriever.mjs",
+      "require": "./lib/retriever.js",
       "default": "./lib/retriever.js"
     },
     "./embedder": {
       "types": "./lib/embedder.d.ts",
-      "require": "./lib/embedder.js",
       "import": "./lib/embedder.mjs",
+      "require": "./lib/embedder.js",
       "default": "./lib/embedder.js"
     },
     "./evaluator": {
       "types": "./lib/evaluator.d.ts",
-      "require": "./lib/evaluator.js",
       "import": "./lib/evaluator.mjs",
+      "require": "./lib/evaluator.js",
       "default": "./lib/evaluator.js"
     },
     "./model": {
       "types": "./lib/model.d.ts",
-      "require": "./lib/model.js",
       "import": "./lib/model.mjs",
+      "require": "./lib/model.js",
       "default": "./lib/model.js"
     },
     "./model/middleware": {
       "types": "./lib/model/middleware.d.ts",
-      "require": "./lib/model/middleware.js",
       "import": "./lib/model/middleware.mjs",
+      "require": "./lib/model/middleware.js",
       "default": "./lib/model/middleware.js"
     },
     "./extract": {
       "types": "./lib/extract.d.ts",
-      "require": "./lib/extract.js",
       "import": "./lib/extract.mjs",
+      "require": "./lib/extract.js",
       "default": "./lib/extract.js"
     },
     "./tool": {
       "types": "./lib/tool.d.ts",
-      "require": "./lib/tool.js",
       "import": "./lib/tool.mjs",
+      "require": "./lib/tool.js",
       "default": "./lib/tool.js"
     },
     "./testing": {
       "types": "./lib/testing/index.d.ts",
-      "require": "./lib/testing/index.js",
       "import": "./lib/testing/index.mjs",
+      "require": "./lib/testing/index.js",
       "default": "./lib/testing/index.js"
     },
     "./reranker": {
       "types": "./lib/reranker.d.ts",
-      "require": "./lib/reranker.js",
       "import": "./lib/reranker.mjs",
+      "require": "./lib/reranker.js",
       "default": "./lib/reranker.js"
     },
     "./chat": {
       "types": "./lib/chat.d.ts",
-      "require": "./lib/chat.js",
       "import": "./lib/chat.mjs",
+      "require": "./lib/chat.js",
       "default": "./lib/chat.js"
     },
     "./session": {
       "types": "./lib/session.d.ts",
-      "require": "./lib/session.js",
       "import": "./lib/session.mjs",
+      "require": "./lib/session.js",
       "default": "./lib/session.js"
     },
     "./formats": {
       "types": "./lib/formats/index.d.ts",
-      "require": "./lib/formats/index.js",
       "import": "./lib/formats/index.mjs",
+      "require": "./lib/formats/index.js",
       "default": "./lib/formats/index.js"
     }
   },

--- a/js/core/package.json
+++ b/js/core/package.json
@@ -57,32 +57,32 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "require": "./lib/index.js",
       "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     },
     "./registry": {
       "types": "./lib/registry.d.ts",
-      "require": "./lib/registry.js",
       "import": "./lib/registry.mjs",
+      "require": "./lib/registry.js",
       "default": "./lib/registry.js"
     },
     "./tracing": {
       "types": "./lib/tracing.d.ts",
-      "require": "./lib/tracing.js",
       "import": "./lib/tracing.mjs",
+      "require": "./lib/tracing.js",
       "default": "./lib/tracing.js"
     },
     "./logging": {
       "types": "./lib/logging.d.ts",
-      "require": "./lib/logging.js",
       "import": "./lib/logging.mjs",
+      "require": "./lib/logging.js",
       "default": "./lib/logging.js"
     },
     "./schema": {
       "types": "./lib/schema.d.ts",
-      "require": "./lib/schema.js",
       "import": "./lib/schema.mjs",
+      "require": "./lib/schema.js",
       "default": "./lib/schema.js"
     }
   },

--- a/js/genkit/package.json
+++ b/js/genkit/package.json
@@ -52,104 +52,104 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "require": "./lib/index.js",
       "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     },
     "./registry": {
       "types": "./lib/registry.d.ts",
-      "require": "./lib/registry.js",
       "import": "./lib/registry.mjs",
+      "require": "./lib/registry.js",
       "default": "./lib/registry.js"
     },
     "./tracing": {
       "types": "./lib/tracing.d.ts",
-      "require": "./lib/tracing.js",
       "import": "./lib/tracing.mjs",
+      "require": "./lib/tracing.js",
       "default": "./lib/tracing.js"
     },
     "./logging": {
       "types": "./lib/logging.d.ts",
-      "require": "./lib/logging.js",
       "import": "./lib/logging.mjs",
+      "require": "./lib/logging.js",
       "default": "./lib/logging.js"
     },
     "./schema": {
       "types": "./lib/schema.d.ts",
-      "require": "./lib/schema.js",
       "import": "./lib/schema.mjs",
+      "require": "./lib/schema.js",
       "default": "./lib/schema.js"
     },
     "./formats": {
       "types": "./lib/formats.d.ts",
-      "require": "./lib/formats.js",
       "import": "./lib/formats.mjs",
+      "require": "./lib/formats.js",
       "default": "./lib/formats.js"
     },
     "./retriever": {
       "types": "./lib/retriever.d.ts",
-      "require": "./lib/retriever.js",
       "import": "./lib/retriever.mjs",
+      "require": "./lib/retriever.js",
       "default": "./lib/retriever.js"
     },
     "./reranker": {
       "types": "./lib/reranker.d.ts",
-      "require": "./lib/reranker.js",
       "import": "./lib/reranker.mjs",
+      "require": "./lib/reranker.js",
       "default": "./lib/reranker.js"
     },
     "./embedder": {
       "types": "./lib/embedder.d.ts",
-      "require": "./lib/embedder.js",
       "import": "./lib/embedder.mjs",
+      "require": "./lib/embedder.js",
       "default": "./lib/embedder.js"
     },
     "./evaluator": {
       "types": "./lib/evaluator.d.ts",
-      "require": "./lib/evaluator.js",
       "import": "./lib/evaluator.mjs",
+      "require": "./lib/evaluator.js",
       "default": "./lib/evaluator.js"
     },
     "./model": {
       "types": "./lib/model.d.ts",
-      "require": "./lib/model.js",
       "import": "./lib/model.mjs",
+      "require": "./lib/model.js",
       "default": "./lib/model.js"
     },
     "./model/middleware": {
       "types": "./lib/middleware.d.ts",
-      "require": "./lib/middleware.js",
       "import": "./lib/middleware.mjs",
+      "require": "./lib/middleware.js",
       "default": "./lib/middleware.js"
     },
     "./extract": {
       "types": "./lib/extract.d.ts",
-      "require": "./lib/extract.js",
       "import": "./lib/extract.mjs",
+      "require": "./lib/extract.js",
       "default": "./lib/extract.js"
     },
     "./testing": {
       "types": "./lib/testing.d.ts",
-      "require": "./lib/testing.js",
       "import": "./lib/testing.mjs",
+      "require": "./lib/testing.js",
       "default": "./lib/testing.js"
     },
     "./tool": {
       "types": "./lib/tool.d.ts",
-      "require": "./lib/tool.js",
       "import": "./lib/tool.mjs",
+      "require": "./lib/tool.js",
       "default": "./lib/tool.js"
     },
     "./plugin": {
       "types": "./lib/plugin.d.ts",
-      "require": "./lib/plugin.js",
       "import": "./lib/plugin.mjs",
+      "require": "./lib/plugin.js",
       "default": "./lib/plugin.js"
     },
     "./client": {
       "types": "./lib/client/index.d.ts",
-      "require": "./lib/client/index.js",
       "import": "./lib/client/index.mjs",
+      "require": "./lib/client/index.js",
       "default": "./lib/client/index.js"
     }
   },

--- a/js/plugins/checks/package.json
+++ b/js/plugins/checks/package.json
@@ -48,9 +48,9 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     }
   }

--- a/js/plugins/chroma/package.json
+++ b/js/plugins/chroma/package.json
@@ -47,9 +47,9 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     }
   }

--- a/js/plugins/dev-local-vectorstore/package.json
+++ b/js/plugins/dev-local-vectorstore/package.json
@@ -44,9 +44,9 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     }
   }

--- a/js/plugins/dotprompt/package.json
+++ b/js/plugins/dotprompt/package.json
@@ -45,9 +45,9 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     }
   }

--- a/js/plugins/evaluators/package.json
+++ b/js/plugins/evaluators/package.json
@@ -49,9 +49,9 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     }
   }

--- a/js/plugins/express/package.json
+++ b/js/plugins/express/package.json
@@ -45,10 +45,10 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "default": "./lib/index.js",
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts"
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
     }
   }
 }

--- a/js/plugins/firebase/package.json
+++ b/js/plugins/firebase/package.json
@@ -56,27 +56,27 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     },
     "./functions": {
-      "require": "./lib/functions.js",
-      "import": "./lib/functions.mjs",
       "types": "./lib/functions.d.ts",
+      "import": "./lib/functions.mjs",
+      "require": "./lib/functions.js",
       "default": "./lib/functions.js"
     },
     "./auth": {
-      "require": "./lib/auth.js",
-      "import": "./lib/auth.mjs",
       "types": "./lib/auth.d.ts",
+      "import": "./lib/auth.mjs",
+      "require": "./lib/auth.js",
       "default": "./lib/auth.js"
     },
     "./user_engagement": {
-      "require": "./lib/user_engagement.js",
-      "import": "./lib/user_engagement.mjs",
       "types": "./lib/user_engagement.d.ts",
+      "import": "./lib/user_engagement.mjs",
+      "require": "./lib/user_engagement.js",
       "default": "./lib/user_engagement.js"
     }
   },

--- a/js/plugins/google-cloud/package.json
+++ b/js/plugins/google-cloud/package.json
@@ -66,9 +66,9 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     }
   }

--- a/js/plugins/googleai/package.json
+++ b/js/plugins/googleai/package.json
@@ -49,9 +49,9 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     }
   }

--- a/js/plugins/langchain/package.json
+++ b/js/plugins/langchain/package.json
@@ -45,10 +45,10 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "default": "./lib/index.js",
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts"
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
     }
   }
 }

--- a/js/plugins/mcp/package.json
+++ b/js/plugins/mcp/package.json
@@ -15,9 +15,9 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },

--- a/js/plugins/ollama/package.json
+++ b/js/plugins/ollama/package.json
@@ -43,9 +43,9 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "require": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     }
   }

--- a/js/plugins/pinecone/package.json
+++ b/js/plugins/pinecone/package.json
@@ -47,9 +47,9 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     }
   }

--- a/js/plugins/vertexai/package.json
+++ b/js/plugins/vertexai/package.json
@@ -64,33 +64,33 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     },
     "./rerankers": {
-      "require": "./lib/rerankers/index.js",
-      "import": "./lib/rerankers/index.mjs",
       "types": "./lib/rerankers/index.d.ts",
+      "import": "./lib/rerankers/index.mjs",
+      "require": "./lib/rerankers/index.js",
       "default": "./lib/rerankers/index.js"
     },
     "./evaluation": {
-      "require": "./lib/evaluation/index.js",
-      "import": "./lib/evaluation/index.mjs",
       "types": "./lib/evaluation/index.d.ts",
+      "import": "./lib/evaluation/index.mjs",
+      "require": "./lib/evaluation/index.js",
       "default": "./lib/evaluation/index.js"
     },
     "./modelgarden": {
-      "require": "./lib/modelgarden/index.js",
-      "import": "./lib/modelgarden/index.mjs",
       "types": "./lib/modelgarden/index.d.ts",
+      "import": "./lib/modelgarden/index.mjs",
+      "require": "./lib/modelgarden/index.js",
       "default": "./lib/modelgarden/index.js"
     },
     "./vectorsearch": {
-      "require": "./lib/vectorsearch/index.js",
-      "import": "./lib/vectorsearch/index.mjs",
       "types": "./lib/vectorsearch/index.d.ts",
+      "import": "./lib/vectorsearch/index.mjs",
+      "require": "./lib/vectorsearch/index.js",
       "default": "./lib/vectorsearch/index.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "setup": "npm-run-all pnpm-install-js pnpm-install-genkit-tools build link-genkit-cli",
-    "format": "(prettier . --write) && (ts-node scripts/copyright.ts)",
-    "format:check": "(prettier . --check) && (ts-node scripts/copyright.ts --check)",
+    "format": "(prettier . --write) && (tsx scripts/copyright.ts)",
+    "format:check": "(prettier . --check) && (tsx scripts/copyright.ts --check)",
     "build": "pnpm build:js && pnpm build:genkit-tools",
     "build:js": "cd js && pnpm i && pnpm build",
     "build:genkit-tools": "cd genkit-tools && pnpm i && pnpm build",
@@ -36,7 +36,6 @@
     "prettier-plugin-css-order": "2.0.1",
     "prettier-plugin-organize-imports": "^3.2.4",
     "rimraf": "^6.0.1",
-    "ts-node": "^10.9.2",
     "tsx": "^4.19.2"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,18 +35,11 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.12.11)(typescript@5.4.5)
       tsx:
         specifier: ^4.19.2
         version: 4.19.2
 
 packages:
-
-  '@cspotcode/source-map-support@0.8.1':
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
 
   '@esbuild/aix-ppc64@0.23.1':
     resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
@@ -196,40 +189,6 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
-
-  '@jridgewell/sourcemap-codec@1.4.15':
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-
-  '@jridgewell/trace-mapping@0.3.9':
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-
-  '@tsconfig/node10@1.0.11':
-    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
-
-  '@tsconfig/node12@1.0.11':
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-
-  '@tsconfig/node14@1.0.3':
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-
-  '@tsconfig/node16@1.0.4':
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-
-  '@types/node@20.12.11':
-    resolution: {integrity: sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==}
-
-  acorn-walk@8.3.2:
-    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
-    engines: {node: '>=0.4.0'}
-
-  acorn@8.11.3:
-    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -253,9 +212,6 @@ packages:
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
-
-  arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   array-buffer-byte-length@1.0.1:
     resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
@@ -344,9 +300,6 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -379,10 +332,6 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
-
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -638,9 +587,6 @@ packages:
   lru-cache@11.0.1:
     resolution: {integrity: sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==}
     engines: {node: 20 || >=22}
-
-  make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -960,20 +906,6 @@ packages:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
 
-  ts-node@10.9.2:
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
@@ -1013,14 +945,8 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -1060,15 +986,7 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
-
 snapshots:
-
-  '@cspotcode/source-map-support@0.8.1':
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
 
   '@esbuild/aix-ppc64@0.23.1':
     optional: true
@@ -1151,31 +1069,6 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@jridgewell/resolve-uri@3.1.2': {}
-
-  '@jridgewell/sourcemap-codec@1.4.15': {}
-
-  '@jridgewell/trace-mapping@0.3.9':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
-
-  '@tsconfig/node10@1.0.11': {}
-
-  '@tsconfig/node12@1.0.11': {}
-
-  '@tsconfig/node14@1.0.3': {}
-
-  '@tsconfig/node16@1.0.4': {}
-
-  '@types/node@20.12.11':
-    dependencies:
-      undici-types: 5.26.5
-
-  acorn-walk@8.3.2: {}
-
-  acorn@8.11.3: {}
-
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -1193,8 +1086,6 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.1: {}
-
-  arg@4.1.3: {}
 
   array-buffer-byte-length@1.0.1:
     dependencies:
@@ -1296,8 +1187,6 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  create-require@1.1.1: {}
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -1341,8 +1230,6 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-
-  diff@4.0.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -1675,8 +1562,6 @@ snapshots:
       is-unicode-supported: 0.1.0
 
   lru-cache@11.0.1: {}
-
-  make-error@1.3.6: {}
 
   memorystream@0.3.1: {}
 
@@ -2018,24 +1903,6 @@ snapshots:
     dependencies:
       os-tmpdir: 1.0.2
 
-  ts-node@10.9.2(@types/node@20.12.11)(typescript@5.4.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.12.11
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.4.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   tslib@2.6.2: {}
 
   tsx@4.19.2:
@@ -2090,11 +1957,7 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
-  undici-types@5.26.5: {}
-
   util-deprecate@1.0.2: {}
-
-  v8-compile-cache-lib@3.0.1: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -2148,5 +2011,3 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-
-  yn@3.1.1: {}


### PR DESCRIPTION
Fixes #1589 to clean up warnings about our package ordering (which is inconsistent within the repository). Thank you ChatGPT for the suggested ordering, which silences pnpm. I worry but have not verified that the old way might confuse node or typescript on import style.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (builds without warnings)
- [x] Docs updated (N/A)
