### PR TITLE
fix(js/ai): skip response schema validation on tool calls

### DIFF
--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -190,16 +190,14 @@ async function generate(
   );
 
   // Throw an error if the response is not usable.
-  response.assertValid(
-    request,
-    // Skip schema validation if there are tools requests
-    (response.message?.content.filter((part) => !!part.toolRequest).length ??
-      0) > 0
-  );
+  response.assertValid();
   const message = response.message!; // would have thrown if no message
 
   const toolCalls = message.content.filter((part) => !!part.toolRequest);
   if (rawRequest.returnToolRequests || toolCalls.length === 0) {
+    if (toolCalls.length === 0) {
+      response.assertValidSchema(request);
+    }
     return response.toJSON();
   }
   const maxIterations = rawRequest.maxTurns ?? 5;

--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -190,7 +190,12 @@ async function generate(
   );
 
   // Throw an error if the response is not usable.
-  response.assertValid(request);
+  response.assertValid(
+    request,
+    // Skip schema validation if there are tools requests
+    (response.message?.content.filter((part) => !!part.toolRequest).length ??
+      0) > 0
+  );
   const message = response.message!; // would have thrown if no message
 
   const toolCalls = message.content.filter((part) => !!part.toolRequest);

--- a/js/ai/src/generate/response.ts
+++ b/js/ai/src/generate/response.ts
@@ -84,7 +84,7 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
   /**
    * Throws an error if the response does not contain valid output.
    */
-  assertValid(request?: GenerateRequest): void {
+  assertValid(request?: GenerateRequest, skipSchemaValidation?: boolean): void {
     if (this.finishReason === 'blocked') {
       throw new GenerationBlockedError(
         this,
@@ -99,7 +99,10 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
       );
     }
 
-    if (request?.output?.schema || this.request?.output?.schema) {
+    if (
+      !skipSchemaValidation &&
+      (request?.output?.schema || this.request?.output?.schema)
+    ) {
       const o = this.output;
       parseSchema(o, {
         jsonSchema: request?.output?.schema || this.request?.output?.schema,

--- a/js/ai/src/generate/response.ts
+++ b/js/ai/src/generate/response.ts
@@ -84,7 +84,7 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
   /**
    * Throws an error if the response does not contain valid output.
    */
-  assertValid(request?: GenerateRequest, skipSchemaValidation?: boolean): void {
+  assertValid(): void {
     if (this.finishReason === 'blocked') {
       throw new GenerationBlockedError(
         this,
@@ -98,11 +98,13 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
         `Model did not generate a message. Finish reason: '${this.finishReason}': ${this.finishMessage}`
       );
     }
+  }
 
-    if (
-      !skipSchemaValidation &&
-      (request?.output?.schema || this.request?.output?.schema)
-    ) {
+  /**
+   * Throws an error if the response does not conform to expected schema.
+   */
+  assertValidSchema(request?: GenerateRequest): void {
+    if (request?.output?.schema || this.request?.output?.schema) {
       const o = this.output;
       parseSchema(o, {
         jsonSchema: request?.output?.schema || this.request?.output?.schema,
@@ -112,7 +114,8 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
 
   isValid(request?: GenerateRequest): boolean {
     try {
-      this.assertValid(request);
+      this.assertValid();
+      this.assertValidSchema(request);
       return true;
     } catch (e) {
       return false;

--- a/js/ai/tests/generate/response_test.ts
+++ b/js/ai/tests/generate/response_test.ts
@@ -156,7 +156,7 @@ describe('GenerateResponse', () => {
 
       assert.throws(
         () => {
-          response.assertValid(request);
+          response.assertValidSchema(request);
         },
         (err: unknown) => {
           return err instanceof Error && err.message.includes('must be number');
@@ -186,7 +186,7 @@ describe('GenerateResponse', () => {
       };
 
       assert.doesNotThrow(() => {
-        response.assertValid(request);
+        response.assertValidSchema(request);
       });
     });
   });


### PR DESCRIPTION
Fixes https://github.com/firebase/genkit/issues/889