### PR TITLE
[Feat][Js] Make ai.generateStream no longer require a double await

### DIFF
--- a/js/ai/src/formats/index.ts
+++ b/js/ai/src/formats/index.ts
@@ -72,7 +72,7 @@ export function resolveInstructions(
 
 export function injectInstructions(
   messages: MessageData[],
-  instructions: string | boolean | undefined
+  instructions: string | false | undefined
 ): MessageData[] {
   if (!instructions) return messages;
 
@@ -88,7 +88,7 @@ export function injectInstructions(
   }
 
   const newPart: TextPart = {
-    text: instructions as string,
+    text: instructions,
     metadata: { purpose: 'output' },
   };
 

--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -431,23 +431,17 @@ export function generateStream<
   let channel = new Channel<GenerateResponseChunk>();
 
   (async () => {
-    let firstChunkSent = false;
     try {
       const generated = await generate<O, CustomOptions>(registry, {
         ...options,
-        onChunk: (chunk) => {
-          firstChunkSent = true;
-          channel.send(chunk);
-        },
+        onChunk: channel.send,
       });
 
       channel.close();
       fetch.resolve(generated);
     } catch (err) {
-      if (firstChunkSent) {
-        channel.error(err);
-        fetch.reject(err);
-      }
+      channel.error(err);
+      fetch.reject(err);
     }
   })();
 

--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -434,7 +434,7 @@ export function generateStream<
     try {
       const generated = await generate<O, CustomOptions>(registry, {
         ...options,
-        onChunk: channel.send,
+        onChunk: channel.send.bind(channel),
       });
 
       channel.close();

--- a/js/ai/tests/generate/generate_test.ts
+++ b/js/ai/tests/generate/generate_test.ts
@@ -21,6 +21,7 @@ import { beforeEach, describe, it } from 'node:test';
 import {
   GenerateOptions,
   generate,
+  generateStream,
   toGenerateRequest,
 } from '../../src/generate.js';
 import { ModelAction, ModelMiddleware, defineModel } from '../../src/model.js';
@@ -355,6 +356,7 @@ describe('generate', () => {
       })
     );
   });
+
   it('should preserve the request in the returned response, enabling .messages', async () => {
     const response = await generate(registry, {
       model: 'echo',
@@ -364,5 +366,39 @@ describe('generate', () => {
       response.messages.map((m) => m.content[0].text),
       ['Testing messages', 'Testing messages']
     );
+  });
+
+  describe('generateStream', () => {
+    it('should pass a smoke test', async () => {
+      let registry = new Registry();
+
+      defineModel(
+        registry,
+        { name: 'echo-streaming', supports: { tools: true } },
+        async (input, streamingCallback) => {
+          streamingCallback!({ content: [{ text: 'hello, ' }] });
+          streamingCallback!({ content: [{ text: 'world!' }] });
+          return {
+            message: input.messages[0],
+            finishReason: 'stop',
+          };
+        }
+      );
+
+      const { response, stream } = generateStream(registry, {
+        model: 'echo-streaming',
+        prompt: 'Testing streaming',
+      });
+
+      let streamed: string[] = [];
+      for await (const chunk of stream) {
+        streamed.push(chunk.text);
+      }
+      assert.deepEqual(streamed, ['hello, ', 'world!']);
+      assert.deepEqual(
+        (await response).messages.map((m) => m.content[0].text),
+        ['Testing streaming', 'Testing streaming']
+      );
+    });
   });
 });

--- a/js/core/package.json
+++ b/js/core/package.json
@@ -61,6 +61,12 @@
       "import": "./lib/index.mjs",
       "default": "./lib/index.js"
     },
+    "./async": {
+      "types": "./lib/async.ts",
+      "require": "./lib/async.js",
+      "import": "./lib/async.mjs",
+      "default": "./lib/async.js"
+    },
     "./registry": {
       "types": "./lib/registry.d.ts",
       "require": "./lib/registry.js",

--- a/js/core/src/async.ts
+++ b/js/core/src/async.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A handle to a promise and its resolvers.
+ */
+export interface Task<T> {
+  resolve: (result: T) => void;
+  reject: (err: unknown) => void;
+  promise: Promise<T>;
+}
+
+/** Utility for creating Tasks. */
+function createTask<T>(): Task<T> {
+  let resolve: unknown, reject: unknown;
+  let promise = new Promise<T>((res, rej) => ([resolve, reject] = [res, rej]));
+  return {
+    resolve: resolve as Task<T>['resolve'],
+    reject: reject as Task<T>['reject'],
+    promise,
+  };
+}
+
+/**
+ * A class designed to help turn repeated callbacks into async iterators.
+ * Based loosely on a combination of Go channels and Promises.
+ */
+export class Channel<T> implements AsyncIterable<T> {
+  private ready: Task<void> = createTask<void>();
+  private buffer: (T | null)[] = [];
+  private err: unknown = null;
+
+  send(value: T): void {
+    this.buffer.push(value);
+    this.ready.resolve();
+  }
+
+  close(): void {
+    this.buffer.push(null);
+    this.ready.resolve();
+  }
+
+  error(err: unknown): void {
+    // Note: we cannot use this.ready.reject because it will be ignored
+    // if ready.resolved has already been called.
+    this.err = err;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: async (): Promise<IteratorResult<T>> => {
+        if (this.err) {
+          throw this.err;
+        }
+
+        if (!this.buffer.length) {
+          await this.ready.promise;
+        }
+        const value = this.buffer.shift()!;
+        if (!this.buffer.length) {
+          this.ready = createTask<void>();
+        }
+
+        return {
+          value,
+          done: !value,
+        };
+      },
+    };
+  }
+}

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -845,7 +845,7 @@ export class Genkit implements HasRegistry {
    *   model: gemini15Flash, // default model
    * })
    *
-   * const { response, stream } = await ai.generateStream('hi');
+   * const { response, stream } = ai.generateStream('hi');
    * for await (const chunk of stream) {
    *   console.log(chunk.text);
    * }
@@ -854,7 +854,7 @@ export class Genkit implements HasRegistry {
    */
   generateStream<O extends z.ZodTypeAny = z.ZodTypeAny>(
     strPrompt: string
-  ): Promise<GenerateStreamResponse<z.infer<O>>>;
+  ): GenerateStreamResponse<z.infer<O>>;
 
   /**
    * Make a streaming generate call to the default model with a multipart request.
@@ -865,7 +865,7 @@ export class Genkit implements HasRegistry {
    *   model: gemini15Flash, // default model
    * })
    *
-   * const { response, stream } = await ai.generateStream([
+   * const { response, stream } = ai.generateStream([
    *   { media: {url: 'http://....'} },
    *   { text: 'describe this image' }
    * ]);
@@ -877,7 +877,7 @@ export class Genkit implements HasRegistry {
    */
   generateStream<O extends z.ZodTypeAny = z.ZodTypeAny>(
     parts: Part[]
-  ): Promise<GenerateStreamResponse<z.infer<O>>>;
+  ): GenerateStreamResponse<z.infer<O>>;
 
   /**
    * Streaming generate calls a generative model based on the provided prompt and configuration. If
@@ -892,7 +892,7 @@ export class Genkit implements HasRegistry {
    *   plugins: [googleAI()],
    * })
    *
-   * const { response, stream } = await ai.generateStream({
+   * const { response, stream } = ai.generateStream({
    *   system: 'talk like a pirate',
    *   prompt: [
    *     { media: { url: 'http://....' } },
@@ -915,9 +915,9 @@ export class Genkit implements HasRegistry {
     parts:
       | GenerateOptions<O, CustomOptions>
       | PromiseLike<GenerateOptions<O, CustomOptions>>
-  ): Promise<GenerateStreamResponse<z.infer<O>>>;
+  ): GenerateStreamResponse<z.infer<O>>;
 
-  async generateStream<
+  generateStream<
     O extends z.ZodTypeAny = z.ZodTypeAny,
     CustomOptions extends z.ZodTypeAny = typeof GenerationCommonConfigSchema,
   >(
@@ -926,18 +926,11 @@ export class Genkit implements HasRegistry {
       | Part[]
       | GenerateStreamOptions<O, CustomOptions>
       | PromiseLike<GenerateStreamOptions<O, CustomOptions>>
-  ): Promise<GenerateStreamResponse<z.infer<O>>> {
-    let resolvedOptions: GenerateOptions<O, CustomOptions>;
-    if (options instanceof Promise) {
-      resolvedOptions = await options;
-    } else if (typeof options === 'string' || Array.isArray(options)) {
-      resolvedOptions = {
-        prompt: options,
-      };
-    } else {
-      resolvedOptions = options as GenerateOptions<O, CustomOptions>;
+  ): GenerateStreamResponse<z.infer<O>> {
+    if (typeof options === 'string' || Array.isArray(options)) {
+      options = { prompt: options };
     }
-    return generateStream(this.registry, resolvedOptions);
+    return generateStream(this.registry, options);
   }
 
   /**

--- a/js/genkit/tests/generate_test.ts
+++ b/js/genkit/tests/generate_test.ts
@@ -172,7 +172,7 @@ describe('generate', () => {
       );
 
       assert.rejects(async () => {
-        const { response, stream } = await ai.generateStream({
+        const { response, stream } = ai.generateStream({
           prompt: 'hi',
           model: 'blockingModel',
         });

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "setup": "npm-run-all pnpm-install-js pnpm-install-genkit-tools build link-genkit-cli",
-    "format": "(prettier . --write) && (ts-node scripts/copyright.ts)",
-    "format:check": "(prettier . --check) && (ts-node scripts/copyright.ts --check)",
+    "format": "(prettier . --write) && (tsx scripts/copyright.ts)",
+    "format:check": "(prettier . --check) && (tsx scripts/copyright.ts --check)",
     "build": "pnpm build:js && pnpm build:genkit-tools",
     "build:js": "cd js && pnpm i && pnpm build",
     "build:genkit-tools": "cd genkit-tools && pnpm i && pnpm build",


### PR DESCRIPTION
Fixes #1593 

Rewrote generateStream so you longer need to call `await` to get the return value of objects that are themselves async.

As a style change I named the struct for {resolve, reject, promise} as Task because that's how I've commonly seen this design called.

The former method for passing into an async generator was a bit fragile because it depended on the exact order of the callbacks to the run loop (in fact, in my refactoring I broke it). Instead I created a buffering utility class called `Channel<T>`, inspired by Go channels but implements `AsyncIterable` for receiving.

I've had to change the copyright script from `ts-node` to `tsx` in many of my PRs because I get import vs require errors trying to load child-process. Since tsx is more officially supported I decided to change the way the script runs rather than adding module resolution annotations.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (unit tested, including new test)
- [X] Docs updated (updated jsdocs)
