### PR TITLE
fix(js): Including missing labels in chat spans

### DIFF
--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -406,9 +406,7 @@ class AdjustingTraceExporter implements SpanExporter {
   private markFailedSpan(span: ReadableSpan): ReadableSpan {
     if (
       span.attributes['genkit:state'] === 'error' &&
-      (span.attributes['genkit:type'] === 'action' ||
-        span.attributes['genkit:type'] === 'flowStep' ||
-        span.attributes['genkit:type'] === 'helper')
+      !span.attributes['genkit:isRoot']
     ) {
       if (!!span.attributes['genkit:name']) {
         span.attributes['genkit:failedSpan'] = span.attributes['genkit:name'];


### PR DESCRIPTION
Improves traces that include calls to Chat#send

* Setting helper type
* Adding labels for sessionId and threadName
* Including I/O in send spans
