### PR TITLE
docs: Update evaluation.md with how to download traces

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -244,6 +244,17 @@ provide a comma-separated list of evaluators by name:
 genkit eval:run customLabel_dataset.json --evaluators=genkit/faithfulness,genkit/answer_relevancy
 ```
 
+### Downloading datasets from Genkit monitoring
+
+If you have already deployed your app with [monitoring enabled](./monitoring.md), you can download a set of representative examples directly from the Firebase console.
+
+1. Navigate to the [Genkit Monitoring dashboard](https://console.firebase.google.com/project/_/genai_monitoring) in Firebase
+2. Click on the feature you are interested in
+3. Filter the traces table to the set of traces you are interested in
+4. Click the "Download traces" button
+
+This downlaoded dataset is compatible with Genkit evaluations using any of the methods above or using the Developer UI.
+
 ### Synthesizing test data using an LLM
 
 Here's an example flow that uses a PDF file to generate possible questions users

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -244,7 +244,7 @@ provide a comma-separated list of evaluators by name:
 genkit eval:run customLabel_dataset.json --evaluators=genkit/faithfulness,genkit/answer_relevancy
 ```
 
-### Downloading datasets from Genkit monitoring
+### Downloading datasets from Genkit Monitoring
 
 If you have already deployed your app with [monitoring enabled](./monitoring.md), you can download a set of representative examples directly from the Firebase console.
 


### PR DESCRIPTION
Augment evaluation documentation to include instructions for how to download a dataset from the Genkit Monitoring dashboard.

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
