### PR TITLE
fix: handle for when no images are generated

### DIFF
--- a/js/plugins/vertexai/src/imagen.ts
+++ b/js/plugins/vertexai/src/imagen.ts
@@ -277,7 +277,7 @@ export function imagenModel(
       const predictClient = predictClientFactory(request);
       const response = await predictClient([instance], toParameters(request));
 
-      const candidates: CandidateData[] = response.predictions.map((p, i) => {
+      const candidates: CandidateData[] = response.predictions?.map((p, i) => {
         const b64data = p.bytesBase64Encoded;
         const mimeType = p.mimeType;
         return {
@@ -295,7 +295,7 @@ export function imagenModel(
             ],
           },
         };
-      });
+      }) || [];
       return {
         candidates,
         usage: {


### PR DESCRIPTION
Sometimes an image not actually returned from Imagen, especially if the image would violate some rule or policy.  This better handles those situations.