### PR TITLE
feat(js): Log sessionId to I/O logs when span attribute is present

### DIFF
--- a/js/ai/src/chat.ts
+++ b/js/ai/src/chat.ts
@@ -15,7 +15,11 @@
  */
 
 import { StreamingCallback, z } from '@genkit-ai/core';
-import { SPAN_TYPE_ATTR, runInNewSpan } from '@genkit-ai/core/tracing';
+import {
+  ATTR_PREFIX,
+  SPAN_TYPE_ATTR,
+  runInNewSpan,
+} from '@genkit-ai/core/tracing';
 import {
   GenerateOptions,
   GenerateResponse,
@@ -36,6 +40,8 @@ import {
 } from './session.js';
 
 export const MAIN_THREAD = 'main';
+export const SESSION_ID_ATTR = `${ATTR_PREFIX}:sessionId`;
+export const THREAD_NAME_ATTR = `${ATTR_PREFIX}:threadName`;
 
 export type ChatGenerateOptions<
   O extends z.ZodTypeAny = z.ZodTypeAny,
@@ -143,8 +149,8 @@ export class Chat {
           },
           labels: {
             [SPAN_TYPE_ATTR]: 'helper',
-            sessionId: this.session.id,
-            threadName: this.threadName,
+            [SESSION_ID_ATTR]: this.session.id,
+            [THREAD_NAME_ATTR]: this.threadName,
           },
         },
         async (metadata) => {
@@ -205,8 +211,8 @@ export class Chat {
           metadata: { name: 'send' },
           labels: {
             [SPAN_TYPE_ATTR]: 'helper',
-            sessionId: this.session.id,
-            threadName: this.threadName,
+            [SESSION_ID_ATTR]: this.session.id,
+            [THREAD_NAME_ATTR]: this.threadName,
           },
         },
         async (metadata) => {

--- a/js/plugins/google-cloud/src/gcpLogger.ts
+++ b/js/plugins/google-cloud/src/gcpLogger.ts
@@ -25,6 +25,7 @@ import { loggingDenied, loggingDeniedHelpText } from './utils.js';
  * Additional streams for writing log data to. Useful for unit testing.
  */
 let additionalStream: Writable;
+let useJsonFormatOverride: boolean = false;
 
 /**
  * Provides a logger for exporting Genkit debug logs to GCP Cloud
@@ -40,13 +41,15 @@ export class GcpLogger {
     // an internal OT warning and will result in logs not being
     // associated with correct spans/traces.
     const winston = await import('winston');
-    const format = this.shouldExport(env)
-      ? { format: winston.format.json() }
-      : {
-          format: winston.format.printf((info): string => {
-            return `[${info.level}] ${info.message}`;
-          }),
-        };
+
+    const format =
+      useJsonFormatOverride || this.shouldExport(env)
+        ? { format: winston.format.json() }
+        : {
+            format: winston.format.printf((info): string => {
+              return `[${info.level}] ${info.message}`;
+            }),
+          };
 
     let transports: any[] = [];
     transports.push(
@@ -113,4 +116,9 @@ export class GcpLogger {
 /** @hidden */
 export function __addTransportStreamForTesting(stream: Writable) {
   additionalStream = stream;
+}
+
+/** @hidden */
+export function __useJsonFormatForTesting() {
+  useJsonFormatOverride = true;
 }

--- a/js/plugins/google-cloud/src/telemetry/action.ts
+++ b/js/plugins/google-cloud/src/telemetry/action.ts
@@ -81,11 +81,32 @@ class ActionTelemetry implements Telemetry {
     if (subtype === 'tool' && logIO) {
       const input = attributes['genkit:input'] as string;
       const output = attributes['genkit:output'] as string;
+      const sessionId = attributes['genkit:sessionId'] as string;
+      const threadName = attributes['genkit:threadName'] as string;
+
       if (input) {
-        this.recordIO(span, 'Input', featureName, path, input, projectId);
+        this.recordIO(
+          span,
+          'Input',
+          featureName,
+          path,
+          input,
+          projectId,
+          sessionId,
+          threadName
+        );
       }
       if (output) {
-        this.recordIO(span, 'Output', featureName, path, output, projectId);
+        this.recordIO(
+          span,
+          'Output',
+          featureName,
+          path,
+          output,
+          projectId,
+          sessionId,
+          threadName
+        );
       }
     }
   }
@@ -134,7 +155,9 @@ class ActionTelemetry implements Telemetry {
     featureName: string,
     qualifiedPath: string,
     input: string,
-    projectId?: string
+    projectId?: string,
+    sessionId?: string,
+    threadName?: string
   ) {
     const path = toDisplayPath(qualifiedPath);
     const sharedMetadata = {
@@ -142,6 +165,8 @@ class ActionTelemetry implements Telemetry {
       path,
       qualifiedPath,
       featureName,
+      sessionId,
+      threadName,
     };
     logger.logStructured(`${tag}[${path}, ${featureName}]`, {
       ...sharedMetadata,

--- a/js/plugins/google-cloud/src/telemetry/feature.ts
+++ b/js/plugins/google-cloud/src/telemetry/feature.ts
@@ -79,11 +79,32 @@ class FeaturesTelemetry implements Telemetry {
     if (logIO) {
       const input = attributes['genkit:input'] as string;
       const output = attributes['genkit:output'] as string;
+      const sessionId = attributes['genkit:sessionId'] as string;
+      const threadName = attributes['genkit:threadName'] as string;
+
       if (input) {
-        this.recordIO(span, 'Input', name, path, input, projectId);
+        this.recordIO(
+          span,
+          'Input',
+          name,
+          path,
+          input,
+          projectId,
+          sessionId,
+          threadName
+        );
       }
       if (output) {
-        this.recordIO(span, 'Output', name, path, output, projectId);
+        this.recordIO(
+          span,
+          'Output',
+          name,
+          path,
+          output,
+          projectId,
+          sessionId,
+          threadName
+        );
       }
     }
   }
@@ -121,7 +142,9 @@ class FeaturesTelemetry implements Telemetry {
     featureName: string,
     qualifiedPath: string,
     input: string,
-    projectId?: string
+    projectId?: string,
+    sessionId?: string,
+    threadName?: string
   ) {
     const path = toDisplayPath(qualifiedPath);
     const sharedMetadata = {
@@ -129,6 +152,8 @@ class FeaturesTelemetry implements Telemetry {
       path,
       qualifiedPath,
       featureName,
+      sessionId,
+      threadName,
     };
     logger.logStructured(`${tag}[${path}, ${featureName}]`, {
       ...sharedMetadata,

--- a/js/plugins/google-cloud/src/telemetry/generate.ts
+++ b/js/plugins/google-cloud/src/telemetry/generate.ts
@@ -158,6 +158,9 @@ class GenerateTelemetry implements Telemetry {
       featureName = 'generate';
     }
 
+    const sessionId = attributes['genkit:sessionId'] as string;
+    const threadName = attributes['genkit:threadName'] as string;
+
     if (input) {
       this.recordGenerateActionMetrics(modelName, featureName, path, input, {
         response: output,
@@ -169,7 +172,9 @@ class GenerateTelemetry implements Telemetry {
         featureName,
         path,
         input,
-        projectId
+        projectId,
+        sessionId,
+        threadName
       );
 
       if (logIO) {
@@ -179,7 +184,9 @@ class GenerateTelemetry implements Telemetry {
           featureName,
           path,
           input,
-          projectId
+          projectId,
+          sessionId,
+          threadName
         );
       }
     }
@@ -191,7 +198,9 @@ class GenerateTelemetry implements Telemetry {
         featureName,
         path,
         output,
-        projectId
+        projectId,
+        sessionId,
+        threadName
       );
     }
   }
@@ -222,7 +231,9 @@ class GenerateTelemetry implements Telemetry {
     featureName: string,
     qualifiedPath: string,
     input: GenerateRequestData,
-    projectId?: string
+    projectId?: string,
+    sessionId?: string,
+    threadName?: string
   ) {
     const path = toDisplayPath(qualifiedPath);
     const sharedMetadata = {
@@ -231,6 +242,8 @@ class GenerateTelemetry implements Telemetry {
       path,
       qualifiedPath,
       featureName,
+      sessionId,
+      threadName,
     };
     logger.logStructured(`Config[${path}, ${model}]`, {
       ...sharedMetadata,
@@ -250,7 +263,9 @@ class GenerateTelemetry implements Telemetry {
     featureName: string,
     qualifiedPath: string,
     input: GenerateRequestData,
-    projectId?: string
+    projectId?: string,
+    sessionId?: string,
+    threadName?: string
   ) {
     const path = toDisplayPath(qualifiedPath);
     const sharedMetadata = {
@@ -259,6 +274,8 @@ class GenerateTelemetry implements Telemetry {
       path,
       qualifiedPath,
       featureName,
+      sessionId,
+      threadName,
     };
 
     const messages = input.messages.length;
@@ -284,7 +301,9 @@ class GenerateTelemetry implements Telemetry {
     featureName: string,
     qualifiedPath: string,
     output: GenerateResponseData,
-    projectId?: string
+    projectId?: string,
+    sessionId?: string,
+    threadName?: string
   ) {
     const path = toDisplayPath(qualifiedPath);
     const sharedMetadata = {
@@ -293,6 +312,8 @@ class GenerateTelemetry implements Telemetry {
       path,
       qualifiedPath,
       featureName,
+      sessionId,
+      threadName,
     };
     const message = output.message || output.candidates?.[0]?.message!;
 

--- a/js/plugins/google-cloud/tests/logs_session_test.ts
+++ b/js/plugins/google-cloud/tests/logs_session_test.ts
@@ -1,0 +1,220 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { GenerateResponseData, Genkit, genkit, z } from 'genkit';
+import { ModelAction } from 'genkit/model';
+import assert from 'node:assert';
+import { Writable } from 'stream';
+import {
+  __addTransportStreamForTesting,
+  __forceFlushSpansForTesting,
+  __getSpanExporterForTesting,
+  __useJsonFormatForTesting,
+  enableGoogleCloudTelemetry,
+} from '../src/index.js';
+
+jest.mock('../src/auth.js', () => {
+  const original = jest.requireActual('../src/auth.js');
+  return {
+    ...(original || {}),
+    resolveCurrentPrincipal: jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        projectId: 'test',
+        serviceAccountEmail: 'test@test.com',
+      });
+    }),
+    credentialsFromEnvironment: jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        projectId: 'test',
+        credentials: {
+          client_email: 'test@genkit.com',
+          private_key: '-----BEGIN PRIVATE KEY-----',
+        },
+      });
+    }),
+  };
+});
+
+describe('GoogleCloudLogs for sessions', () => {
+  let logLines = '';
+  const logStream = new Writable();
+  logStream._write = (chunk, encoding, next) => {
+    logLines = logLines += chunk.toString();
+    next();
+  };
+
+  let ai: Genkit;
+  let testModel: ModelAction;
+
+  beforeAll(async () => {
+    process.env.GCLOUD_PROJECT = 'test';
+    process.env.GENKIT_ENV = 'dev';
+    __useJsonFormatForTesting();
+    __addTransportStreamForTesting(logStream);
+
+    await enableGoogleCloudTelemetry({
+      projectId: 'test',
+      forceDevExport: false,
+      metricExportIntervalMillis: 100,
+      metricExportTimeoutMillis: 100,
+    });
+
+    ai = genkit({
+      // Force GCP Plugin to use in-memory metrics exporter
+      plugins: [],
+    });
+
+    testModel = createModel(ai, 'testModel', async () => {
+      return {
+        message: {
+          role: 'user',
+          content: [
+            {
+              text: 'response',
+            },
+          ],
+        },
+        finishReason: 'stop',
+        usage: {
+          inputTokens: 10,
+          outputTokens: 14,
+          inputCharacters: 8,
+          outputCharacters: 16,
+          inputImages: 1,
+          outputImages: 3,
+        },
+      };
+    });
+
+    await waitForLogsInit(ai, logLines);
+  });
+
+  beforeEach(async () => {
+    logLines = '';
+    __getSpanExporterForTesting().reset();
+  });
+  afterAll(async () => {
+    await ai.stopServers();
+  });
+
+  it('writes logs with sessionId', async () => {
+    const chat = ai.chat();
+
+    await chat.send({ model: testModel, prompt: 'Test message' });
+
+    await getExportedSpans();
+
+    const logMessages = await getLogs(1, 100, logLines);
+    const logObjects = logMessages.map((l) => JSON.parse(l as string));
+
+    // Right now sessionId is applied only at the top level send.
+    // We intend to eventually make the session id available on all relevant spans.
+    logObjects.forEach((logBlob) => {
+      if (
+        logBlob.message === 'Input[send, send]' ||
+        logBlob.message === 'Output[send, send]' ||
+        logBlob.message === 'Paths[send]'
+      ) {
+        expect(logBlob.sessionId).not.toBeUndefined();
+        expect(logBlob.threadName).not.toBeUndefined();
+        return;
+      }
+
+      expect(logBlob.sessionId).toBeUndefined();
+      expect(logBlob.threadName).toBeUndefined();
+    });
+  });
+});
+
+/** Helper to create a flow with no inputs or outputs */
+function createFlow(
+  ai: Genkit,
+  name: string,
+  fn: () => Promise<any> = async () => {}
+) {
+  return ai.defineFlow(
+    {
+      name,
+      inputSchema: z.void(),
+      outputSchema: z.void(),
+    },
+    fn
+  );
+}
+
+/**
+ * Helper to create a model that returns the value produced by the given
+ * response function.
+ */
+function createModel(
+  genkit: Genkit,
+  name: string,
+  respFn: () => Promise<GenerateResponseData>
+) {
+  return genkit.defineModel({ name }, (req) => respFn());
+}
+
+async function waitForLogsInit(genkit: Genkit, logLines: any) {
+  await import('winston');
+  const testFlow = createFlow(genkit, 'testFlow');
+  await testFlow();
+  await getLogs(1, 100, logLines);
+}
+
+async function getLogs(
+  logCount: number,
+  maxAttempts: number,
+  logLines: string
+): Promise<String[]> {
+  var attempts = 0;
+  while (attempts++ < maxAttempts) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const found = logLines
+      .trim()
+      .split('\n')
+      .map((l) => l.trim());
+    if (found.length >= logCount) {
+      return found.filter((l) => l !== undefined && l !== '');
+    }
+  }
+  assert.fail(`Waiting for logs, but none have been written.`);
+}
+
+/** Polls the in memory metric exporter until the genkit scope is found. */
+async function getExportedSpans(
+  maxAttempts: number = 200
+): Promise<ReadableSpan[]> {
+  __forceFlushSpansForTesting();
+  var attempts = 0;
+  while (attempts++ < maxAttempts) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const found = __getSpanExporterForTesting().getFinishedSpans();
+    if (found.length > 0) {
+      return found;
+    }
+  }
+  assert.fail(`Timed out while waiting for spans to be exported.`);
+}

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -12279,6 +12279,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.25.7)
+      esbuild: 0.24.0
 
   ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@20.16.9)(ts-node@10.9.2(@types/node@20.16.9)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:


### PR DESCRIPTION
To better support observability for chat/sessions in Firebase, add the sessionId and threadName attributes to log entries when present. 

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
