### PR TITLE
chore[js]: Remove esModuleInterop from tsconfig

### DIFF
--- a/genkit-tools/telemetry-server/tests/firestoreTraceStore_test.ts
+++ b/genkit-tools/telemetry-server/tests/firestoreTraceStore_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { rebatchSpans } from '../src/firestoreTraceStore';
 

--- a/js/ai/src/testing/model-tester.ts
+++ b/js/ai/src/testing/model-tester.ts
@@ -17,7 +17,7 @@
 import { z } from '@genkit-ai/core';
 import { Registry } from '@genkit-ai/core/registry';
 import { runInNewSpan } from '@genkit-ai/core/tracing';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { generate } from '../generate';
 import { ModelAction } from '../model';
 import { defineTool } from '../tool';

--- a/js/ai/tests/extract_test.ts
+++ b/js/ai/tests/extract_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { extractItems, extractJson, parsePartialJson } from '../src/extract';
 

--- a/js/ai/tests/formats/array_test.ts
+++ b/js/ai/tests/formats/array_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { arrayFormatter } from '../../src/formats/array.js';
 import { GenerateResponseChunk } from '../../src/generate.js';

--- a/js/ai/tests/formats/enum_test.ts
+++ b/js/ai/tests/formats/enum_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { enumFormatter } from '../../src/formats/enum.js';
 import { Message } from '../../src/message.js';

--- a/js/ai/tests/formats/json_test.ts
+++ b/js/ai/tests/formats/json_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { jsonFormatter } from '../../src/formats/json.js';
 import { GenerateResponseChunk } from '../../src/generate.js';

--- a/js/ai/tests/formats/jsonl_test.ts
+++ b/js/ai/tests/formats/jsonl_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { jsonlFormatter } from '../../src/formats/jsonl.js';
 import { GenerateResponseChunk } from '../../src/generate.js';

--- a/js/ai/tests/formats/text_test.ts
+++ b/js/ai/tests/formats/text_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { textFormatter } from '../../src/formats/text.js';
 import { GenerateResponseChunk } from '../../src/generate.js';

--- a/js/ai/tests/generate/chunk_test.ts
+++ b/js/ai/tests/generate/chunk_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { GenerateResponseChunk } from '../../src/generate.js';
 

--- a/js/ai/tests/generate/generate_test.ts
+++ b/js/ai/tests/generate/generate_test.ts
@@ -16,7 +16,7 @@
 
 import { PluginProvider, z } from '@genkit-ai/core';
 import { Registry } from '@genkit-ai/core/registry';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import {
   GenerateOptions,

--- a/js/ai/tests/generate/response_test.ts
+++ b/js/ai/tests/generate/response_test.ts
@@ -16,7 +16,7 @@
 
 import { z } from '@genkit-ai/core';
 import { toJsonSchema } from '@genkit-ai/core/schema';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import {
   GenerateResponse,

--- a/js/ai/tests/message/message_test.ts
+++ b/js/ai/tests/message/message_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { Message } from '../../src/message';
 

--- a/js/ai/tests/model/document_test.ts
+++ b/js/ai/tests/model/document_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { Document } from '../../src/document.js';
 

--- a/js/ai/tests/model/middleware_test.ts
+++ b/js/ai/tests/model/middleware_test.ts
@@ -15,7 +15,7 @@
  */
 
 import { Registry } from '@genkit-ai/core/registry';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { DocumentData } from '../../src/document.js';
 import { configureFormats } from '../../src/formats/index.js';
@@ -90,7 +90,7 @@ describe('validateSupport', () => {
     for (const example of Object.values(examples)) {
       runner(example, noopNext);
     }
-    assert(nextCalled, "next() wasn't called");
+    assert.ok(nextCalled, "next() wasn't called");
   });
 
   it('throws when media is supplied but not supported', async () => {

--- a/js/ai/tests/prompt/prompt_test.ts
+++ b/js/ai/tests/prompt/prompt_test.ts
@@ -16,7 +16,7 @@
 
 import { z } from '@genkit-ai/core';
 import { Registry } from '@genkit-ai/core/registry';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { definePrompt, renderPrompt } from '../../src/prompt.ts';
 

--- a/js/ai/tests/reranker/reranker_test.ts
+++ b/js/ai/tests/reranker/reranker_test.ts
@@ -16,7 +16,7 @@
 
 import { GenkitError, z } from '@genkit-ai/core';
 import { Registry } from '@genkit-ai/core/registry';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { defineReranker, rerank } from '../../src/reranker';
 import { Document } from '../../src/retriever';
@@ -70,8 +70,8 @@ describe('reranker', () => {
       });
       // Validate the reranked results
       assert.equal(rerankedDocuments.length, 2);
-      assert(rerankedDocuments[0].text.includes('a bit longer'));
-      assert(rerankedDocuments[1].text.includes('short'));
+      assert.ok(rerankedDocuments[0].text.includes('a bit longer'));
+      assert.ok(rerankedDocuments[1].text.includes('short'));
     });
 
     it('handles missing options gracefully', async () => {
@@ -109,7 +109,7 @@ describe('reranker', () => {
         options: { k: 2 },
       });
       assert.equal(rerankedDocuments.length, 2);
-      assert(typeof rerankedDocuments[0].metadata.score === 'number');
+      assert.ok(typeof rerankedDocuments[0].metadata.score === 'number');
     });
 
     it('validates config schema and throws error on invalid input', async () => {
@@ -147,7 +147,7 @@ describe('reranker', () => {
         });
         assert.fail('Expected validation error');
       } catch (err) {
-        assert(err instanceof GenkitError);
+        assert.ok(err instanceof GenkitError);
         assert.equal(err.status, 'INVALID_ARGUMENT');
       }
     });
@@ -211,7 +211,7 @@ describe('reranker', () => {
         });
         assert.fail('Expected an error to be thrown');
       } catch (err) {
-        assert(err instanceof GenkitError);
+        assert.ok(err instanceof GenkitError);
         assert.equal(err.status, 'INTERNAL');
         assert.equal(
           err.message,

--- a/js/core/src/reflection.ts
+++ b/js/core/src/reflection.ts
@@ -19,7 +19,7 @@ import fs from 'fs/promises';
 import getPort, { makeRange } from 'get-port';
 import { Server } from 'http';
 import path from 'path';
-import z from 'zod';
+import * as z from 'zod';
 import { Status, StatusCodes, runWithStreamingCallback } from './action.js';
 import { GENKIT_REFLECTION_API_SPEC_VERSION, GENKIT_VERSION } from './index.js';
 import { logger } from './logging.js';

--- a/js/core/tests/action_test.ts
+++ b/js/core/tests/action_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { z } from 'zod';
 import { action, defineAction } from '../src/action.js';

--- a/js/core/tests/flow_test.ts
+++ b/js/core/tests/flow_test.ts
@@ -15,7 +15,7 @@
  */
 
 import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { defineFlow, run } from '../src/flow.js';
 import { defineAction, getFlowAuth, z } from '../src/index.js';

--- a/js/core/tests/registry_test.ts
+++ b/js/core/tests/registry_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { action } from '../src/action.js';
 import { Registry } from '../src/registry.js';

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 
 import {

--- a/js/genkit/tests/chat_test.ts
+++ b/js/genkit/tests/chat_test.ts
@@ -16,7 +16,7 @@
 
 import { MessageData } from '@genkit-ai/ai';
 import { z } from '@genkit-ai/core';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { Genkit, genkit } from '../src/genkit';
 import {

--- a/js/genkit/tests/embed_test.ts
+++ b/js/genkit/tests/embed_test.ts
@@ -15,7 +15,7 @@
  */
 
 import { Document, EmbedderAction, embedderRef } from '@genkit-ai/ai';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { Genkit, genkit } from '../src/genkit';
 

--- a/js/genkit/tests/evaluate_test.ts
+++ b/js/genkit/tests/evaluate_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { Genkit, genkit } from '../src/genkit';
 import { bonknessEvaluator } from './helpers';

--- a/js/genkit/tests/flow_test.ts
+++ b/js/genkit/tests/flow_test.ts
@@ -15,7 +15,7 @@
  */
 
 import { z } from '@genkit-ai/core';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { Genkit, genkit } from '../src/genkit';
 

--- a/js/genkit/tests/formats_test.ts
+++ b/js/genkit/tests/formats_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { Genkit, genkit } from '../src/genkit';
 import { defineEchoModel } from './helpers';

--- a/js/genkit/tests/generate_test.ts
+++ b/js/genkit/tests/generate_test.ts
@@ -15,7 +15,7 @@
  */
 
 import { z } from '@genkit-ai/core';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { modelRef } from '../../ai/src/model';
 import { Genkit, genkit } from '../src/genkit';

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -15,7 +15,7 @@
  */
 
 import { ModelMiddleware, modelRef } from '@genkit-ai/ai/model';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { Genkit, genkit } from '../src/genkit';
 import { PromptAction, z } from '../src/index';

--- a/js/genkit/tests/session_test.ts
+++ b/js/genkit/tests/session_test.ts
@@ -16,7 +16,7 @@
 
 import { Message } from '@genkit-ai/ai';
 import { SessionStore } from '@genkit-ai/ai/session';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { Genkit, genkit } from '../src/genkit';
 import { TestMemorySessionStore, defineEchoModel } from './helpers';

--- a/js/plugins/dotprompt/src/template.ts
+++ b/js/plugins/dotprompt/src/template.ts
@@ -16,7 +16,7 @@
 
 import { MediaPart, MessageData, Part, Role } from '@genkit-ai/ai/model';
 import { DocumentData } from '@genkit-ai/ai/retriever';
-import Handlebars from 'handlebars';
+import * as Handlebars from 'handlebars';
 import { PromptMetadata } from './metadata.js';
 
 const Promptbars: typeof Handlebars =

--- a/js/plugins/dotprompt/tests/picoschema_test.ts
+++ b/js/plugins/dotprompt/tests/picoschema_test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import * as assert from 'assert';
 import { readFileSync } from 'fs';
-import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import { parse } from 'yaml';
 import { picoschema } from '../src/picoschema';

--- a/js/plugins/dotprompt/tests/prompt_test.ts
+++ b/js/plugins/dotprompt/tests/prompt_test.ts
@@ -23,7 +23,7 @@ import {
   toJsonSchema,
   ValidationError,
 } from '@genkit-ai/core/schema';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
 import { defineDotprompt, Dotprompt, prompt, promptRef } from '../src/index.js';
 import { PromptMetadata } from '../src/metadata.js';

--- a/js/plugins/dotprompt/tests/template_test.ts
+++ b/js/plugins/dotprompt/tests/template_test.ts
@@ -16,7 +16,7 @@
 
 import { MessageData } from '@genkit-ai/ai/model';
 import { DocumentData } from '@genkit-ai/ai/retriever';
-import assert from 'node:assert';
+import * as assert from 'assert';
 import { describe, it } from 'node:test';
 import { compile } from '../src/template';
 

--- a/js/plugins/express/tests/express_test.ts
+++ b/js/plugins/express/tests/express_test.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+import * as assert from 'assert';
 import express from 'express';
 import { GenerateResponseData, Genkit, genkit, z } from 'genkit';
 import { runFlow, streamFlow } from 'genkit/client';
 import { GenerateResponseChunkData, ModelAction } from 'genkit/model';
 import getPort from 'get-port';
 import * as http from 'http';
-import assert from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
   FlowServer,

--- a/js/plugins/firebase/tests/functions_test.ts
+++ b/js/plugins/firebase/tests/functions_test.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
-import express from 'express';
+import * as express from 'express';
 import { initializeApp } from 'firebase/app';
 import { getFunctions, httpsCallableFromURL } from 'firebase/functions';
 import { Genkit, genkit } from 'genkit';
 import { runFlow, streamFlow } from 'genkit/client';
-import getPort from 'get-port';
+import * as getPort from 'get-port';
 import * as http from 'http';
 import { RequestWithAuth, noAuth, onFlow } from '../lib/functions.js';
 

--- a/js/plugins/google-cloud/package.json
+++ b/js/plugins/google-cloud/package.json
@@ -21,7 +21,7 @@
     "build:clean": "rimraf ./lib",
     "build": "npm-run-all build:clean check compile",
     "build:watch": "tsup-node --watch",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest --runInBand --verbose"
+    "test": "node node_modules/jest/bin/jest --runInBand --verbose"
   },
   "repository": {
     "type": "git",

--- a/js/plugins/google-cloud/tests/logs_no_io_test.ts
+++ b/js/plugins/google-cloud/tests/logs_no_io_test.ts
@@ -23,8 +23,8 @@ import {
   jest,
 } from '@jest/globals';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import * as assert from 'assert';
 import { GenerateResponseData, Genkit, genkit, z } from 'genkit';
-import assert from 'node:assert';
 import { Writable } from 'stream';
 import {
   __addTransportStreamForTesting,

--- a/js/plugins/google-cloud/tests/logs_session_test.ts
+++ b/js/plugins/google-cloud/tests/logs_session_test.ts
@@ -24,9 +24,9 @@ import {
   jest,
 } from '@jest/globals';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import * as assert from 'assert';
 import { GenerateResponseData, Genkit, genkit, z } from 'genkit';
 import { ModelAction } from 'genkit/model';
-import assert from 'node:assert';
 import { Writable } from 'stream';
 import {
   __addTransportStreamForTesting,

--- a/js/plugins/google-cloud/tests/logs_test.ts
+++ b/js/plugins/google-cloud/tests/logs_test.ts
@@ -23,9 +23,9 @@ import {
   jest,
 } from '@jest/globals';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import * as assert from 'assert';
 import { GenerateResponseData, Genkit, genkit, z } from 'genkit';
 import { SPAN_TYPE_ATTR, appendSpan } from 'genkit/tracing';
-import assert from 'node:assert';
 import { Writable } from 'stream';
 import {
   __addTransportStreamForTesting,

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -30,9 +30,9 @@ import {
   SumMetricData,
 } from '@opentelemetry/sdk-metrics';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import * as assert from 'assert';
 import { GenerateResponseData, Genkit, genkit, z } from 'genkit';
 import { SPAN_TYPE_ATTR, appendSpan } from 'genkit/tracing';
-import assert from 'node:assert';
 import {
   GcpOpenTelemetry,
   __forceFlushSpansForTesting,

--- a/js/plugins/google-cloud/tests/traces_test.ts
+++ b/js/plugins/google-cloud/tests/traces_test.ts
@@ -24,9 +24,9 @@ import {
   jest,
 } from '@jest/globals';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import * as assert from 'assert';
 import { Genkit, genkit, z } from 'genkit';
 import { appendSpan } from 'genkit/tracing';
-import assert from 'node:assert';
 import {
   __forceFlushSpansForTesting,
   __getSpanExporterForTesting,

--- a/js/plugins/googleai/tests/gemini_test.ts
+++ b/js/plugins/googleai/tests/gemini_test.ts
@@ -15,9 +15,9 @@
  */
 
 import { GenerateContentCandidate } from '@google/generative-ai';
+import * as assert from 'assert';
 import { genkit } from 'genkit';
 import { MessageData, ModelInfo } from 'genkit/model';
-import assert from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
   GENERIC_GEMINI_MODEL,

--- a/js/plugins/ollama/tests/embedding_live_test.ts
+++ b/js/plugins/ollama/tests/embedding_live_test.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as assert from 'assert';
 import { genkit } from 'genkit';
-import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import { defineOllamaEmbedder } from '../src/embeddings.js'; // Adjust the import path as necessary
 import { ollama } from '../src/index.js';

--- a/js/plugins/ollama/tests/embeddings_test.ts
+++ b/js/plugins/ollama/tests/embeddings_test.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as assert from 'assert';
 import { Genkit, genkit } from 'genkit';
-import assert from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
 import { defineOllamaEmbedder } from '../src/embeddings.js';
 import { ollama } from '../src/index.js';
@@ -87,7 +87,7 @@ describe('defineOllamaEmbedder', () => {
         });
       },
       (error) => {
-        assert(error instanceof Error);
+        assert.ok(error instanceof Error);
         assert.strictEqual(
           error.message,
           'Error fetching embedding from Ollama: Internal Server Error'

--- a/js/plugins/vertexai/tests/gemini_test.ts
+++ b/js/plugins/vertexai/tests/gemini_test.ts
@@ -15,8 +15,8 @@
  */
 
 import { GenerateContentCandidate } from '@google-cloud/vertexai';
+import * as assert from 'assert';
 import { MessageData } from 'genkit';
-import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import {
   cleanSchema,

--- a/js/plugins/vertexai/tests/modelgarden/anthropic_test.ts
+++ b/js/plugins/vertexai/tests/modelgarden/anthropic_test.ts
@@ -18,8 +18,8 @@ import {
   Message,
   MessageCreateParamsBase,
 } from '@anthropic-ai/sdk/resources/messages.mjs';
+import * as assert from 'assert';
 import { GenerateRequest, GenerateResponseData } from 'genkit';
-import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import {
   AnthropicConfigSchema,

--- a/js/plugins/vertexai/tests/modelgarden/mistral_test.ts
+++ b/js/plugins/vertexai/tests/modelgarden/mistral_test.ts
@@ -19,8 +19,8 @@ import {
   ChatCompletionResponse,
   CompletionChunk,
 } from '@mistralai/mistralai-gcp/models/components';
+import * as assert from 'assert';
 import { GenerateRequest, GenerateResponseData } from 'genkit';
-import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import {
   MistralConfigSchema,

--- a/js/plugins/vertexai/tests/vectorsearch/bigquery_test.ts
+++ b/js/plugins/vertexai/tests/vectorsearch/bigquery_test.ts
@@ -15,8 +15,8 @@
  */
 
 import { BigQuery } from '@google-cloud/bigquery';
+import * as assert from 'assert';
 import { Document } from 'genkit/retriever';
-import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import { getBigQueryDocumentRetriever } from '../../src/vectorsearch';
 

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    // Please do not turn on helper settings like esModuleInterop because
+    // customers either need to use the same helper settings or turn on
+    // skipLibCheck.
     "declaration": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
@@ -9,7 +12,7 @@
     "noImplicitAny": false,
     "resolveJsonModule": true,
     "sourceMap": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "strict": true,
     "target": "es2022",
     "lib": ["es2022", "DOM"],


### PR DESCRIPTION
Still working on the firebase-functions changes to add `onCallGenkit` without requiring tsconfig changes. `esModuleInterop` is a cascading requirement when `skipLibCheck` is false, requiring all customers to use it. Since this is largely just candy, we can turn it off and be usable by more users.

Note... this is _still_ not enough to get `firebase-functions` compiling without changes. I'm still getting a curious error that `genkit` cannot find `@genkit-ai/ai/formats`. I'll play with module resolution in both libraries to see what needs to be done.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (unit tested)
- [X] Docs updated (N/A)
