### PR TITLE
fix(js): Fix deep export of @genkit-ai/ai/formats

### DIFF
--- a/js/ai/package.json
+++ b/js/ai/package.json
@@ -154,6 +154,9 @@
       ],
       "session": [
         "lib/session"
+      ],
+      "formats": [
+        "lib/formats"
       ]
     }
   }


### PR DESCRIPTION
While trying to write `onCallGenkit` with a hard dependency I came up with the weeeeeirdest compiler error. Genkit couldn't find a deep export from @genkit-ai/ai!

```bash
node_modules/genkit/lib/index-BbHVu_0v.d.ts:10:27 - error TS2307: Cannot find module '@genkit-ai/ai/formats' or its corresponding type declarations.

10 import { Formatter } from '@genkit-ai/ai/formats';
                             ~~~~~~~~~~~~~~~~~~~~~~~
```

Turns out it's because the directory is missing from package.json's typesVersions dictionary.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (unit tests)
- [X] Docs updated (N/A)
