### PR TITLE
feat(js/ai): Adds GenerateOptions#resume, ToolAction#reply, Message#interrupts

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -42,6 +42,7 @@ import {
   ModelArgument,
   ModelMiddleware,
   Part,
+  ToolResponsePart,
   resolveModel,
 } from './model.js';
 import { ExecutablePrompt } from './prompt.js';
@@ -57,6 +58,22 @@ export interface OutputOptions<O extends z.ZodTypeAny = z.ZodTypeAny> {
   instructions?: boolean | string;
   schema?: O;
   jsonSchema?: any;
+}
+
+/** ResumeOptions configure how to resume generation after an interrupt. */
+export interface ResumeOptions {
+  /**
+   * reply should contain a single or list of `toolResponse` parts corresponding
+   * to interrupt `toolRequest` parts from the most recent model message. Each
+   * entry must have a matching `name` and `ref` (if supplied) for its `toolRequest`
+   * counterpart.
+   *
+   * Tools have a `.reply` helper method to construct a reply ToolResponse and validate
+   * the data against its schema. Call `myTool.reply(interruptToolRequest, yourReplyData)`.
+   */
+  reply: ToolResponsePart | ToolResponsePart[];
+  /** Additional metadata to annotate the created tool message with in the "resume" key. */
+  metadata?: Record<string, any>;
 }
 
 export interface GenerateOptions<
@@ -81,6 +98,27 @@ export interface GenerateOptions<
   config?: z.infer<CustomOptions>;
   /** Configuration for the desired output of the request. Defaults to the model's default output if unspecified. */
   output?: OutputOptions<O>;
+  /**
+   * resume provides convenient capabilities for continuing generation
+   * after an interrupt is triggered. Example:
+   *
+   * ```ts
+   * const myInterrupt = ai.defineInterrupt({...});
+   *
+   * const response = await ai.generate({
+   *   tools: [myInterrupt],
+   *   prompt: "Call myInterrupt",
+   * });
+   *
+   * const interrupt = response.interrupts[0];
+   *
+   * const resumedResponse = await ai.generate({
+   *  messages: response.messages,
+   *  resume: myInterrupt.reply(interrupt, {note: "this is the reply data"}),
+   * });
+   * ```
+   */
+  resume?: ResumeOptions;
   /** When true, return tool calls for manual processing instead of automatically resolving them. */
   returnToolRequests?: boolean;
   /** Maximum number of tool call iterations that can be performed in a single generate call (default 5). */
@@ -97,6 +135,43 @@ export interface GenerateOptions<
   use?: ModelMiddleware[];
 }
 
+function applyResumeOption(
+  options: GenerateOptions,
+  messages: MessageData[]
+): MessageData[] {
+  if (!options.resume) return [];
+  const lastModelMessage =
+    messages[messages.map((m) => m.role).lastIndexOf('model')];
+  if (
+    !lastModelMessage ||
+    !lastModelMessage.content.find((p) => !!p.toolRequest)
+  )
+    throw new GenkitError({
+      status: 'FAILED_PRECONDITION',
+      message: `Cannot 'resume' generation when there is no prior model message with toolRequests.`,
+    });
+  const toolRequests = lastModelMessage.content.filter((p) => !!p.toolRequest);
+  const pendingResponses: ToolResponsePart[] = toolRequests
+    .filter((t) => !!t.metadata?.pendingToolResponse)
+    .map((t) => ({
+      toolResponse: t.metadata!.pendingToolResponse,
+    })) as ToolResponsePart[];
+
+  console.log('PENDING:', pendingResponses);
+
+  const reply = Array.isArray(options.resume.reply)
+    ? options.resume.reply
+    : [options.resume.reply];
+  const message: MessageData = {
+    role: 'tool',
+    content: [...pendingResponses, ...reply],
+    metadata: {
+      resume: options.resume.metadata || true,
+    },
+  };
+  return [message];
+}
+
 export async function toGenerateRequest(
   registry: Registry,
   options: GenerateOptions
@@ -111,6 +186,8 @@ export async function toGenerateRequest(
   if (options.messages) {
     messages.push(...options.messages.map((m) => Message.parseData(m)));
   }
+  // resuming from interrupts occurs after message history but before user prompt
+  messages.push(...applyResumeOption(options, messages));
   if (options.prompt) {
     messages.push({
       role: 'user',

--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -157,8 +157,6 @@ function applyResumeOption(
       toolResponse: t.metadata!.pendingToolResponse,
     })) as ToolResponsePart[];
 
-  console.log('PENDING:', pendingResponses);
-
   const reply = Array.isArray(options.resume.reply)
     ? options.resume.reply
     : [options.resume.reply];

--- a/js/ai/src/generate/response.ts
+++ b/js/ai/src/generate/response.ts
@@ -115,11 +115,10 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
   }
 
   /**
-   * If the selected candidate's message contains a `data` part, it is returned. Otherwise,
+   * If the generated message contains a `data` part, it is returned. Otherwise,
    * the `output()` method extracts the first valid JSON object or array from the text
    * contained in the selected candidate's message and returns it.
    *
-   * @param index The candidate index from which to extract output. If not provided, finds first candidate that conforms to output schema.
    * @returns The structured output contained in the selected candidate.
    */
   get output(): O | null {
@@ -127,8 +126,7 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
   }
 
   /**
-   * Concatenates all `text` parts present in the candidate's message with no delimiter.
-   * @param index The candidate index from which to extract text, defaults to first candidate.
+   * Concatenates all `text` parts present in the generated message with no delimiter.
    * @returns A string of all concatenated text parts.
    */
   get text(): string {
@@ -136,9 +134,8 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
   }
 
   /**
-   * Returns the first detected media part in the selected candidate's message. Useful for
+   * Returns the first detected media part in the generated message. Useful for
    * extracting (for example) an image from a generation expected to create one.
-   * @param index The candidate index from which to extract media, defaults to first candidate.
    * @returns The first detected `media` part in the candidate.
    */
   get media(): { url: string; contentType?: string } | null {
@@ -146,8 +143,7 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
   }
 
   /**
-   * Returns the first detected `data` part of the selected candidate's message.
-   * @param index The candidate index from which to extract data, defaults to first candidate.
+   * Returns the first detected `data` part of the generated message.
    * @returns The first `data` part detected in the candidate (if any).
    */
   get data(): O | null {
@@ -155,12 +151,19 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
   }
 
   /**
-   * Returns all tool request found in the candidate.
-   * @param index The candidate index from which to extract tool requests, defaults to first candidate.
+   * Returns all tool request found in the generated message.
    * @returns Array of all tool request found in the candidate.
    */
   get toolRequests(): ToolRequestPart[] {
     return this.message?.toolRequests || [];
+  }
+
+  /**
+   * Returns all tool requests annotated as interrupts found in the generated message.
+   * @returns A list of ToolRequestParts.
+   */
+  get interrupts(): ToolRequestPart[] {
+    return this.message?.interrupts || [];
   }
 
   /**

--- a/js/ai/src/index.ts
+++ b/js/ai/src/index.ts
@@ -47,6 +47,7 @@ export {
   type GenerateOptions,
   type GenerateStreamOptions,
   type GenerateStreamResponse,
+  type ResumeOptions,
 } from './generate.js';
 export { Message } from './message.js';
 export {

--- a/js/ai/src/message.ts
+++ b/js/ai/src/message.ts
@@ -123,6 +123,14 @@ export class Message<T = unknown> implements MessageData {
   }
 
   /**
+   * Returns all tool requests annotated with interrupt metadata.
+   * @returns Array of all interrupt tool requests.
+   */
+  get interrupts(): ToolRequestPart[] {
+    return this.toolRequests.filter((t) => !!t.metadata?.interrupt);
+  }
+
+  /**
    * Converts the Message to a plain JS object.
    * @returns Plain JS object representing the data contained in the message.
    */

--- a/js/ai/tests/generate/generate_test.ts
+++ b/js/ai/tests/generate/generate_test.ts
@@ -254,13 +254,148 @@ describe('toGenerateRequest', () => {
         output: {},
       },
     },
+    {
+      should:
+        'throw a PRECONDITION_FAILED error if trying to resume without a model message',
+      prompt: {
+        messages: [{ role: 'system', content: [{ text: 'sys' }] }],
+        resume: {
+          reply: { toolResponse: { name: 'test', output: { foo: 'bar' } } },
+        },
+      },
+      throws: 'FAILED_PRECONDITION',
+    },
+    {
+      should:
+        'throw a PRECONDITION_FAILED error if trying to resume a model message without toolRequests',
+      prompt: {
+        messages: [
+          { role: 'user', content: [{ text: 'hi' }] },
+          { role: 'model', content: [{ text: 'there' }] },
+        ],
+        resume: {
+          reply: { toolResponse: { name: 'test', output: { foo: 'bar' } } },
+        },
+      },
+      throws: 'FAILED_PRECONDITION',
+    },
+    {
+      should: 'add pending responses and interrupt replies to a tool message',
+      prompt: {
+        messages: [
+          { role: 'user', content: [{ text: 'hey' }] },
+          {
+            role: 'model',
+            content: [
+              {
+                toolRequest: { name: 'p1', ref: '1', input: { one: '1' } },
+                metadata: {
+                  pendingToolResponse: { name: 'p1', ref: '1', output: 'done' },
+                },
+              },
+              {
+                toolRequest: { name: 'p2', ref: '2', input: { one: '1' } },
+                metadata: {
+                  pendingToolResponse: {
+                    name: 'p2',
+                    ref: '2',
+                    output: 'done2',
+                  },
+                },
+              },
+              {
+                toolRequest: { name: 'i1', ref: '3', input: { one: '1' } },
+                metadata: {
+                  interrupt: true,
+                },
+              },
+              {
+                toolRequest: { name: 'i2', ref: '4', input: { one: '1' } },
+                metadata: {
+                  interrupt: { sky: 'blue' },
+                },
+              },
+            ],
+          },
+        ],
+        resume: {
+          reply: [
+            { toolResponse: { name: 'i1', ref: '3', output: 'done3' } },
+            { toolResponse: { name: 'i2', ref: '4', output: 'done4' } },
+          ],
+        },
+      },
+      expectedOutput: {
+        config: undefined,
+        docs: undefined,
+        output: {},
+        tools: [],
+        messages: [
+          { role: 'user', content: [{ text: 'hey' }] },
+          {
+            role: 'model',
+            content: [
+              {
+                toolRequest: { name: 'p1', ref: '1', input: { one: '1' } },
+                metadata: {
+                  pendingToolResponse: { name: 'p1', ref: '1', output: 'done' },
+                },
+              },
+              {
+                toolRequest: { name: 'p2', ref: '2', input: { one: '1' } },
+                metadata: {
+                  pendingToolResponse: {
+                    name: 'p2',
+                    ref: '2',
+                    output: 'done2',
+                  },
+                },
+              },
+              {
+                toolRequest: { name: 'i1', ref: '3', input: { one: '1' } },
+                metadata: {
+                  interrupt: true,
+                },
+              },
+              {
+                toolRequest: { name: 'i2', ref: '4', input: { one: '1' } },
+                metadata: {
+                  interrupt: { sky: 'blue' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            metadata: {
+              resume: true,
+            },
+            content: [
+              { toolResponse: { name: 'p1', ref: '1', output: 'done' } },
+              { toolResponse: { name: 'p2', ref: '2', output: 'done2' } },
+              { toolResponse: { name: 'i1', ref: '3', output: 'done3' } },
+              { toolResponse: { name: 'i2', ref: '4', output: 'done4' } },
+            ],
+          },
+        ],
+      },
+    },
   ];
   for (const test of testCases) {
     it(test.should, async () => {
-      assert.deepStrictEqual(
-        await toGenerateRequest(registry, test.prompt as GenerateOptions),
-        test.expectedOutput
-      );
+      if (test.throws) {
+        await assert.rejects(
+          async () => {
+            await toGenerateRequest(registry, test.prompt as GenerateOptions);
+          },
+          { name: 'GenkitError', status: test.throws }
+        );
+      } else {
+        assert.deepStrictEqual(
+          await toGenerateRequest(registry, test.prompt as GenerateOptions),
+          test.expectedOutput
+        );
+      }
     });
   }
 });

--- a/js/core/src/error.ts
+++ b/js/core/src/error.ts
@@ -38,6 +38,7 @@ export class GenkitError extends Error {
     super(`${source ? `${source}: ` : ''}${status}: ${message}`);
     this.status = status;
     this.detail = detail;
+    this.name = 'GenkitError';
   }
 }
 

--- a/js/core/tests/flow_test.ts
+++ b/js/core/tests/flow_test.ts
@@ -106,7 +106,7 @@ describe('flow', () => {
         async () => await testFlow({ foo: 'foo', bar: 'bar' } as any),
         (err: Error) => {
           return (
-            err.name === 'Error' &&
+            err.name === 'GenkitError' &&
             err.message.includes('Schema validation failed')
           );
         }

--- a/js/genkit/src/index.ts
+++ b/js/genkit/src/index.ts
@@ -90,6 +90,7 @@ export {
   type RerankerInfo,
   type RerankerParams,
   type RerankerReference,
+  type ResumeOptions,
   type RetrieverAction,
   type RetrieverArgument,
   type RetrieverInfo,


### PR DESCRIPTION
```ts
const myInterrupt = ai.defineInterrupt(...);
const response = await ai.generate({tools: [myInterrupt], prompt: "Call myInterrupt"});

const resumedResponse = await ai.generate({
  messages: response.messages,
  resume: {reply: myInterrupt.reply(response.interrupts[0], "the interrupt response");
});
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs bug filed: #1657 
