### PR TITLE
fix(js/core/async): reject channel ready promise on channel error

### DIFF
--- a/js/core/src/async.ts
+++ b/js/core/src/async.ts
@@ -54,9 +54,11 @@ export class Channel<T> implements AsyncIterable<T> {
   }
 
   error(err: unknown): void {
-    // Note: we cannot use this.ready.reject because it will be ignored
-    // if ready.resolved has already been called.
     this.err = err;
+    // Note: we must call this.ready.reject here in case we get an error even before the stream is initiated,
+    // however we cannot rely on this.ready.reject because it will be ignored if ready.resolved has already
+    // been called, so this.err will be checked in the iterator as well.
+    this.ready.reject(err);
   }
 
   [Symbol.asyncIterator](): AsyncIterator<T> {

--- a/js/genkit/tests/generate_test.ts
+++ b/js/genkit/tests/generate_test.ts
@@ -150,7 +150,7 @@ describe('generate', () => {
       ai = genkit({});
     });
 
-    it('rethrows errors', async () => {
+    it('rethrows response errors', async () => {
       ai.defineModel(
         {
           name: 'blockingModel',
@@ -195,7 +195,7 @@ describe('generate', () => {
         }
       );
 
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         const { response, stream } = ai.generateStream({
           prompt: 'hi',
           model: 'blockingModel',
@@ -205,6 +205,22 @@ describe('generate', () => {
         }
         await response;
       });
+    });
+
+    it('rethrows initialization errors', async () => {
+      await assert.rejects(
+        (async () => {
+          const { stream } = ai.generateStream({
+            prompt: 'hi',
+            model: 'modelNotFound',
+          });
+          for await (const chunk of stream) {
+            // nothing
+          }
+        })(), (e: Error) => {
+          return e.message.includes('Model modelNotFound not found');
+        }
+      );
     });
 
     it('passes the streaming callback to the model', async () => {
@@ -449,7 +465,7 @@ describe('generate', () => {
         },
         async (_, { context }) => {
           return {
-            foo: `bar ${context.auth.email}`,
+            foo: `bar ${context.auth?.email}`,
           };
         }
       );

--- a/js/genkit/tests/generate_test.ts
+++ b/js/genkit/tests/generate_test.ts
@@ -217,7 +217,8 @@ describe('generate', () => {
           for await (const chunk of stream) {
             // nothing
           }
-        })(), (e: Error) => {
+        })(),
+        (e: Error) => {
           return e.message.includes('Model modelNotFound not found');
         }
       );

--- a/js/genkit/tests/generate_test.ts
+++ b/js/genkit/tests/generate_test.ts
@@ -209,7 +209,7 @@ describe('generate', () => {
 
     it('rethrows initialization errors', async () => {
       await assert.rejects(
-        (async () => {
+        async () => {
           const { stream } = ai.generateStream({
             prompt: 'hi',
             model: 'modelNotFound',
@@ -217,7 +217,7 @@ describe('generate', () => {
           for await (const chunk of stream) {
             // nothing
           }
-        })(),
+        },
         (e: Error) => {
           return e.message.includes('Model modelNotFound not found');
         }


### PR DESCRIPTION
Fixed this error case:

```ts
  const { stream } = ai.generateStream({
    prompt: 'hi',
    model: 'modelNotFound',
  });
  for await (const chunk of stream) {
    // something
  }
```

which was resulting in a hanging generate call.


Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [n/a] Docs updated (updated docs or a docs bug required)
