### PR TITLE
docs: Fix out-of-sequence instructions

### DIFF
--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -6,7 +6,6 @@ as callable functions using the Cloud Functions client libraries.
 
 ## Before you begin
 
-*   Install the [Firebase CLI](/docs/cli).
 *   You should be familiar with Genkit's concept of [flows](flows), and how to
     write them. The instructions on this page assume that you already have some
     flows defined, which you want to deploy.
@@ -23,6 +22,8 @@ up, follow these steps:
 
 1.  Upgrade the project to the Blaze plan, which is required to deploy Cloud
     Functions.
+
+1.  Install the [Firebase CLI](/docs/cli).
 
 1.  Log in with the Firebase CLI:
 


### PR DESCRIPTION
docs: Pre-PR version sends you to install CLI, which tells you to create a project. Then, when you come back, you subsequently get told to create a project again (but with with additional requirements).

This PR improves the UX by fixing this issue.

Description here... Help the reviewer by:
 - linking to an issue that includes more details
 - if it's a new feature include samples of how to use the new feature
 - (optional if issue link is provided) if you fixed a bug include basic bug details

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
