### PR TITLE
fix(js/ai/prompt): delete null descriptions returned by dotprompt

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -739,7 +739,7 @@ function loadPrompt(
 
       // dotprompt can set null description on the schema, which can confuse downstream schema consumers
       if (promptMetadata.output?.schema?.description === null) {
-        delete promptMetadata.output?.schema?.description
+        delete promptMetadata.output?.schema?.description;
       }
 
       return {

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -736,6 +736,12 @@ function loadPrompt(
       if (variant) {
         promptMetadata.variant = variant;
       }
+
+      // dotprompt can set null description on the schema, which can confuse downstream schema consumers
+      if (promptMetadata.output?.schema?.description === null) {
+        delete promptMetadata.output?.schema?.description
+      }
+
       return {
         name: registryDefinitionKey(name, variant ?? undefined, ns),
         model: promptMetadata.model,

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -20,6 +20,7 @@ import { describe, it } from 'node:test';
 import {
   ValidationError,
   parseSchema,
+  toJsonSchema,
   validateSchema,
   z,
 } from '../src/schema.js';
@@ -135,6 +136,29 @@ describe('parse()', () => {
         }
       ),
       { foo: true }
+    );
+  });
+});
+
+describe('toJsonSchema', () => {
+  it('converts zod to JSON schema', async () => {
+    assert.deepStrictEqual(
+      toJsonSchema({
+        schema: z.object({
+          output: z.string(),
+        }),
+      }),
+      {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        additionalProperties: true,
+        properties: {
+          output: {
+            type: 'string',
+          },
+        },
+        required: ['output'],
+        type: 'object',
+      }
     );
   });
 });

--- a/js/genkit/tests/prompts/schemaRef.prompt
+++ b/js/genkit/tests/prompts/schemaRef.prompt
@@ -1,0 +1,9 @@
+---
+model: googleai/gemini-1.5-flash
+input:
+  schema: myInputSchema
+output:
+  schema: myOutputSchema
+---
+
+Write a poem about {{foo}}.

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -900,6 +900,8 @@ describe.only('prompt', () => {
     });
     defineEchoModel(ai);
     pm = defineProgrammableModel(ai);
+    ai.defineSchema('myInputSchema', z.object({ foo: z.string() }));
+    ai.defineSchema('myOutputSchema', z.object({ output: z.string() }));
   });
 
   it('loads from from the folder', async () => {
@@ -1011,6 +1013,23 @@ describe.only('prompt', () => {
       toolChoice: 'required',
       subject: 'banana',
       tools: ['toolA', 'toolB'],
+    });
+  });
+
+  it('resolved schema refs', async () => {
+    const prompt = ai.prompt('schemaRef');
+
+    const rendered = await prompt.render({ foo: 'bar' });
+    assert.deepStrictEqual(rendered.output?.jsonSchema, {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      additionalProperties: true,
+      properties: {
+        output: {
+          type: 'string',
+        },
+      },
+      required: ['output'],
+      type: 'object',
     });
   });
 


### PR DESCRIPTION
it causes description getting sent to the model as:
```
  "output": {
    "format": "json",
    "contentType": "application/json",
    "constrained": true,
    "schema": {
      "type": "object",
      "properties": {
        "output": {
          "type": "string"
        }
      },
      "required": [
        "output"
      ],
      "additionalProperties": true,
      "$schema": "http://json-schema.org/draft-07/schema#",
      "description": {} // <---------
    }
  }
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [n/a] Docs updated (updated docs or a docs bug required)
