### PR TITLE
fix: Removes package lock from sample

### DIFF
--- a/samples/js-character-generator/idx-template.nix
+++ b/samples/js-character-generator/idx-template.nix
@@ -7,7 +7,6 @@
     mkdir "$out"/.idx
     cp -r ${./.idx}/. "$out/.idx/"
     cp -f ${./package.json} "$out/package.json"
-    cp -f ${./package-lock.json} "$out/package-lock.json"
     cp -f ${./index.ts} "$out/index.ts"
     cp -f ${./.gitignore} "$out/.gitignore"
     cp ${./README_IDX.md} "$out"/README.md


### PR DESCRIPTION
package-lock.json is .gitignored in our samples repo, so remove from nix script
