### PR TITLE
feat(js/ai): improving definePrompt backwards compatibility, to ease the transition

### DIFF
--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -393,7 +393,7 @@ export class Genkit implements HasRegistry {
     CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
   >(
     options: PromptConfig<I, O, CustomOptions>,
-    /** @deprecated */
+    /** @deprecated use `options.messages` with a template string instead. */
     templateOrFn?: string | PromptFn<I>
   ): ExecutablePrompt<z.infer<I>, O, CustomOptions> {
     // For backwards compatibility...

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -402,7 +402,7 @@ export class Genkit implements HasRegistry {
         throw new GenkitError({
           status: 'INVALID_ARGUMENT',
           message:
-            'Cannot specify template/function argument and options.message at the same time',
+            'Cannot specify template/function argument and `options.messages` at the same time',
         });
       }
       if (typeof templateOrFn === 'string') {

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -664,33 +664,60 @@ describe('definePrompt', () => {
     });
 
     it('calls legacy prompt with default model', async () => {
-      const hi = ai.definePrompt({
-        name: 'hi',
-        input: {
-          schema: z.object({
-            name: z.string(),
-          }),
+      const hi = ai.definePrompt(
+        {
+          name: 'hi',
+          input: {
+            schema: z.object({
+              name: z.string(),
+            }),
+          },
         },
-      }, async (input) => {
-        return {messages: [{ role: 'user', content: [{ text: `hi ${input.name}` }] }]};
-      });
+        async (input) => {
+          return {
+            messages: [
+              { role: 'user', content: [{ text: `hi ${input.name}` }] },
+            ],
+          };
+        }
+      );
 
       const response = await hi({ name: 'Genkit' });
       assert.strictEqual(response.text, 'Echo: hi Genkit; config: {}');
     });
 
     it('calls legacy prompt with default model', async () => {
-      const hi = ai.definePrompt({
-        name: 'hi',
-        input: {
-          schema: z.object({
-            name: z.string(),
-          }),
+      const hi = ai.definePrompt(
+        {
+          name: 'hi',
+          input: {
+            schema: z.object({
+              name: z.string(),
+            }),
+          },
         },
-      }, 'hi {{ name }}');
+        'hi {{ name }}'
+      );
 
       const response = await hi({ name: 'Genkit' });
       assert.strictEqual(response.text, 'Echo: hi Genkit; config: {}');
+    });
+
+    it('thrown on prompt with both legacy template and messages', async () => {
+      assert.throws(() =>
+        ai.definePrompt(
+          {
+            name: 'hi',
+            input: {
+              schema: z.object({
+                name: z.string(),
+              }),
+            },
+            messages: 'something',
+          },
+          'hi {{ name }}'
+        )
+      );
     });
 
     it('calls prompt with default model with config', async () => {

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -663,6 +663,36 @@ describe('definePrompt', () => {
       assert.strictEqual(response.text, 'Echo: hi Genkit; config: {}');
     });
 
+    it('calls legacy prompt with default model', async () => {
+      const hi = ai.definePrompt({
+        name: 'hi',
+        input: {
+          schema: z.object({
+            name: z.string(),
+          }),
+        },
+      }, async (input) => {
+        return {messages: [{ role: 'user', content: [{ text: `hi ${input.name}` }] }]};
+      });
+
+      const response = await hi({ name: 'Genkit' });
+      assert.strictEqual(response.text, 'Echo: hi Genkit; config: {}');
+    });
+
+    it('calls legacy prompt with default model', async () => {
+      const hi = ai.definePrompt({
+        name: 'hi',
+        input: {
+          schema: z.object({
+            name: z.string(),
+          }),
+        },
+      }, 'hi {{ name }}');
+
+      const response = await hi({ name: 'Genkit' });
+      assert.strictEqual(response.text, 'Echo: hi Genkit; config: {}');
+    });
+
     it('calls prompt with default model with config', async () => {
       const hi = ai.definePrompt({
         name: 'hi',


### PR DESCRIPTION
will still work....

```ts
      const hi = ai.definePrompt({
        name: 'hi',
        input: {
          schema: z.object({
            name: z.string(),
          }),
        },
      }, 'hi {{ name }}');
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
