### PR TITLE
fix: uses the provided sessionId from session options if provided

### DIFF
--- a/js/genkit/src/beta.ts
+++ b/js/genkit/src/beta.ts
@@ -107,7 +107,7 @@ export class GenkitBeta extends Genkit {
    * Create a session for this environment.
    */
   createSession<S = any>(options?: SessionOptions<S>): Session<S> {
-    const sessionId = uuidv4();
+    const sessionId = options?.sessionId?.trim() || uuidv4();
     const sessionData: SessionData = {
       id: sessionId,
       state: options?.initialState,


### PR DESCRIPTION
Bugfix (one-line fix)

Fixes issue #1180 

There is an implicit contract when creating a new session that you can set the sessionId by providing this optional parameter on the `createSession()` options-paramter object.

The implementation of `createSession()` ignores this, and always creates a new uuidv4 as the sessionId.

This PR changes that to prioritize the supplied options.sessionId string - if provided.



However, there might be a bigger problem to address, as the `loadSession()` implementation has a potential "footgun" problem: it both accepts an explicit sessionId function parameter (which will take effect), as well as the same kind of `SessionOptions` object – capable of carrying a `sessionId` property too, which will never be used. Mentioning this as there might be a better an more universal refactoring needed to solve both this corners.




**Not sure about the coding-style in my commit. There might be valid opinions to steer clear of this level of optional chaining.**




Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested: Type checking and tests:all suite happy
- [ ] Docs updated (updated docs or a docs bug required)
