### PR TITLE
fix(editorconfig): misconfiguration that would cause editors to format incorrectly #1786

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,9 +3,21 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = space
+end_of_line = lf
 indent_size = 2
+indent_style = space
 insert_final_newline = true
-trim_trailing_whitespace = true
 max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.{js,jsx,ts,tsx}]
 quote_type = single
+
+[*.py]
+indent_size = 4
+indent_style = space
+quote_type = single
+
+[{Makefile,go.mod,go.sum,*.go,.gitmodules}]
+indent_size = 4
+indent_style = tab


### PR DESCRIPTION
Issue: https://github.com/firebase/genkit/issues/1786

Before

<img width="957" alt="emacs" src="https://github.com/user-attachments/assets/3947cc34-88e4-48d3-9341-4b023f8988a8" />

After:

<img width="1072" alt="emacs-after" src="https://github.com/user-attachments/assets/bfeade38-a036-432b-8ea2-a496fbe69477" />


CHANGELOG:
- [x] Makefiles, go files, and other related files use tabs for indentation. Set indent width for these to 4 to indentify this clearly.
- [x] Configure editor for Python to use 4 spaces for indentation.
- [x] Use linefeed `\n` character to end lines for all files so that tools work properly.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
