### PR TITLE
test: update pytest runner to also output coverage report and set min threshold to 70% #1714

### DIFF
--- a/py/bin/run_tests
+++ b/py/bin/run_tests
@@ -6,11 +6,11 @@ set -euo pipefail
 
 TOP_DIR=$(git rev-parse --show-toplevel)
 PYTHON_VERSIONS=(
-    "3.12"
-    "3.13"
+  "3.12"
+  "3.13"
 )
 
 for VERSION in "${PYTHON_VERSIONS[@]}"; do
-    echo "Running tests with Python ${VERSION}..."
-    uv run --python "python${VERSION}" --directory "${TOP_DIR}/py" pytest .
+  echo "Running tests with Python ${VERSION}..."
+  uv run --python "python${VERSION}" --directory "${TOP_DIR}/py" pytest .
 done

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -46,6 +46,12 @@ python_files = [
 ]
 testpaths = ["packages", "plugins", "samples"]
 
+[tool.pytest.ini_options]
+addopts = "--cov"
+
+[tool.coverage.report]
+fail_under = 70
+
 # uv based package management.
 [tool.uv]
 default-groups = ["dev", "lint"]


### PR DESCRIPTION
ISSUE: https://github.com/firebase/genkit/issues/1714

CHANGELOG:
- [x] Update the `pyproject.toml` configuration for pytest-cov to:
  - [x] Accept no lower than 70% as coverage threshold.
  - [x] Run tests with coverage reports generated in the console.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
