### PR TITLE
chore(config): set up CODEOWNERS file to automatically mark reviewers #1791

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,18 @@
+# General.
+# TODO: Add groups.
+*                   @pavelgj
+
+# Python-related.
+*.py                @pavelgj @yesudeep
+pyproject.toml      @pavelgj @yesudeep
+py/*                @pavelgj @yesudeep
+
+# Go-related.
+*.go                @apascal07
+go/*                @apascal07
+
+# JavaScript-related.
+*.js                @pavelgj
+*.ts                @pavelgj
+js/*                @pavelgj
+package.json        @pavelgj


### PR DESCRIPTION
ISSUE: https://github.com/firebase/genkit/issues/1791

SEE: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

CHANGELOG:
- [x] Add a `CODEOWNERS` configuration file to automatically assign code reviewers based on changed files.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
