### PR TITLE
fix: remove idx subbutton and lint fixes

### DIFF
--- a/samples/js-character-generator/README.md
+++ b/samples/js-character-generator/README.md
@@ -1,5 +1,6 @@
 # Character Generator
 
+<!-- markdownlint-disable MD033 -->
 <a href="https://idx.google.com/new?template=https%3A%2F%2Fgithub.com%2Ffirebase%2Fgenkit%2Ftree%2Fmain%2Fsamples%2Fjs-character-generator">
   <picture>
     <source
@@ -14,6 +15,7 @@
       src="https://cdn.idx.dev/btn/open_purple_32.svg">
   </picture>
 </a>
+<!-- markdownlint-enable MD033 -->
 
 This sample is used as the Genkit template in Project IDX, you can check it out in IDX!
 

--- a/samples/js-character-generator/package.json
+++ b/samples/js-character-generator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Character Generator",
+  "name": "character_generator",
   "version": "0.1.0",
   "description": "A simple Firebase Genkit app to generate fantasy characters",
   "main": "index.js",

--- a/samples/js-coffee-shop/README.md
+++ b/samples/js-coffee-shop/README.md
@@ -1,24 +1,7 @@
-## Running the sample
+# Running the sample
 
 ```bash
 export GOOGLE_GENAI_API_KEY=<yourkey>
 npm i
 npm run genkit:dev
 ```
-
-or try it out on Project IDX, our Cloud-based IDE
-
-<a href="https://idx.google.com/template?url=https%3A%2F%2Fgithub.com%2Ffirebase%2Fgenkit%2Ftree%2Fremove-idx-subbutton%2Fsamples%2Fjs-coffee-shop">
-  <picture>
-    <source
-      media="(prefers-color-scheme: dark)"
-      srcset="https://cdn.idx.dev/btn/try_dark_32.svg">
-    <source
-      media="(prefers-color-scheme: light)"
-      srcset="https://cdn.idx.dev/btn/try_light_32.svg">
-    <img
-      height="32"
-      alt="Try in IDX"
-      src="https://cdn.idx.dev/btn/try_purple_32.svg">
-  </picture>
-</a>

--- a/samples/js-coffee-shop/README.md
+++ b/samples/js-coffee-shop/README.md
@@ -8,7 +8,7 @@ npm run genkit:dev
 
 or try it out on Project IDX, our Cloud-based IDE
 
-<a href="https://idx.google.com/import?url=https%3A%2F%2Fgithub.com%2Ffirebase%2Fgenkit%2Ftree%2Fmain%2Fsamples%2Fjs-coffee-shop">
+<a href="https://idx.google.com/template?url=https%3A%2F%2Fgithub.com%2Ffirebase%2Fgenkit%2Ftree%2Fremove-idx-subbutton%2Fsamples%2Fjs-coffee-shop">
   <picture>
     <source
       media="(prefers-color-scheme: dark)"

--- a/samples/js-menu/README.md
+++ b/samples/js-menu/README.md
@@ -1,4 +1,4 @@
-## Menu Understanding Sample Application
+# Menu Understanding Sample Application
 
 This sample demonstrates an application that can understand a restaurant menu and answer relevant questions about the items on the menu.
 
@@ -6,11 +6,11 @@ There are 5 iterations of this sample application, growing in complexity and dem
 
 To test each one out, open the Developer UI and exercise the prompts and flows. Each step contains one or more `example.json` files which you can use as inputs.
 
-### Prerequisites
+## Prerequisites
 
 This example uses Vertex AI for language models and embeddings.
 
-### Prompts and Flows
+## Prompts and Flows
 
 1. This step shows how to define prompts in code that can accept user input to their templates.
 2. This step illustrates how to wrap your llm calls and other application code into flows with strong input and output schemas.


### PR DESCRIPTION
Remove the button on the individual sample in favor or the button on the overall /samples/ directory.  I'll look at adding the sub-button back, but it might need to wait for a FR in IDX to prevent duplication

Checklist (if applicable):
- [ x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ x] Tested (manually, unit tested, etc.)
- [ x] Docs updated (updated docs or a docs bug required)
