### PR TITLE
feat: Add dev.nix for js-menu

### DIFF
--- a/samples/idx-template.json
+++ b/samples/idx-template.json
@@ -17,7 +17,8 @@
         "js-character-generator": "Simple Character Generator",
         "js-coffee-shop": "Coffeeshop w Several types of Prompt",
         "js-schoolAgent": "A Multi-Agent School Assistant",
-        "js-prompts": "A sample with various prompt styles"
+        "js-prompts": "A sample with various prompt styles",
+        "js-menu": "Menu parsing with increasing levels of complex architectures"
       }
     }
   ]

--- a/samples/js-chatbot/README.md
+++ b/samples/js-chatbot/README.md
@@ -4,7 +4,7 @@ This is a simple chatbot. You can pick which model to use.
 
 Prerequisite
 
-- Google Cloud project with Vertex AI API enabled (https://pantheon.corp.google.com/apis/library/aiplatform.googleapis.com)
+- Google Cloud project with Vertex AI API enabled (https://cloud.google.com/apis/library/aiplatform.googleapis.com)
 - gcloud CLI installed (https://cloud.google.com/sdk/docs/install-sdk)
 - to use Llama 3.1 405b enable it in the Vertex AI [Model Garden](https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama3-405b-instruct-maas)
 

--- a/samples/js-menu/.gitignore
+++ b/samples/js-menu/.gitignore
@@ -1,0 +1,1 @@
+__db_menu-items.json

--- a/samples/js-menu/.idx/dev.nix
+++ b/samples/js-menu/.idx/dev.nix
@@ -1,0 +1,37 @@
+## Default Nix Environment for Typescript + Gemini Examples
+## Requires the sample to be started with npx run genkit:dev
+
+# To learn more about how to use Nix to configure your environment
+# see: https://developers.google.com/idx/guides/customize-idx-env
+{ pkgs, ... }: {
+  # Which nixpkgs channel to use.
+  channel = "stable-24.05"; # or "unstable"
+  # Use https://search.nixos.org/packages to find packages
+  packages = [
+    pkgs.nodejs_20
+    pkgs.util-linux
+  ];
+  # Sets environment variables in the workspace
+  env = {
+    #TODO Get a API key from https://g.co/ai/idxGetGeminiKey 
+    GOOGLE_GENAI_API_KEY = ""; 
+  };
+  idx = {
+    # Search for the extensions you want on https://open-vsx.org/ and use "publisher.id"
+    extensions = [
+    ];
+
+    # Workspace lifecycle hooks
+    workspace = {
+      # Runs when a workspace is first created
+      onCreate = {
+        npm-install = "npm ci --no-audit --prefer-offline --no-progress --timing";
+        default.openFiles = [ "README.md" "src/index.ts" ];
+      };
+      # Runs when the workspace is (re)started
+      onStart = {
+        run-server = "npm run genkit:dev";      
+        };
+    };
+  };
+}

--- a/samples/js-menu/README.md
+++ b/samples/js-menu/README.md
@@ -23,5 +23,5 @@ This example uses Vertex AI for language models and embeddings.
 
 ```bash
 npm i
-genkit start
+npm run genkit:dev
 ```

--- a/samples/js-menu/README.md
+++ b/samples/js-menu/README.md
@@ -8,7 +8,10 @@ To test each one out, open the Developer UI and exercise the prompts and flows. 
 
 ## Prerequisites
 
-This example uses Vertex AI for language models and embeddings.
+Prerequisite
+- Google Cloud project with Vertex AI API enabled (https://console.cloud.google.com/apis/library/aiplatform.googleapis.com)
+- gcloud CLI installed (https://cloud.google.com/sdk/docs/install-sdk)
+- to use Llama 3.1 405b enable it in the Vertex AI [Model Garden](https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama3-405b-instruct-maas)
 
 ## Prompts and Flows
 
@@ -20,6 +23,15 @@ This example uses Vertex AI for language models and embeddings.
 5. This step illustrates how to combine models with different modalities. It uses a vision model to ingest the menu items from a photograph.
 
 ## Running the sample
+
+### Setup authentication (can skip on IDX)
+
+```bash
+gcloud auth login
+gcloud auth application-default login --project YOUR_PROJECT
+```
+
+### Run the sample
 
 ```bash
 npm i

--- a/samples/js-menu/README.md
+++ b/samples/js-menu/README.md
@@ -9,6 +9,7 @@ To test each one out, open the Developer UI and exercise the prompts and flows. 
 ## Prerequisites
 
 Prerequisite
+
 - Google Cloud project with Vertex AI API enabled (https://console.cloud.google.com/apis/library/aiplatform.googleapis.com)
 - gcloud CLI installed (https://cloud.google.com/sdk/docs/install-sdk)
 - to use Llama 3.1 405b enable it in the Vertex AI [Model Garden](https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama3-405b-instruct-maas)

--- a/samples/js-menu/package-lock.json
+++ b/samples/js-menu/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@genkit-ai/dev-local-vectorstore": "^0.9.0-rc || ^0.9",
-        "@genkit-ai/evaluator": "^0.9.0-rc || ^0.9",
-        "@genkit-ai/firebase": "^0.9.0-rc || ^0.9",
-        "@genkit-ai/vertexai": "^0.9.0-rc || ^0.9",
-        "genkit": "^0.9.0-rc || ^0.9"
+        "@genkit-ai/dev-local-vectorstore": "^1.0.0-rc.12",
+        "@genkit-ai/evaluator": "^1.0.0-rc.12",
+        "@genkit-ai/firebase": "^1.0.0-rc.12",
+        "@genkit-ai/vertexai": "^1.0.0-rc.12",
+        "genkit": "^1.0.0-rc.12"
       },
       "devDependencies": {
-        "genkit-cli": "^0.9.0-rc || ^0.9",
+        "genkit-cli": "^1.0.0-rc.12",
         "rimraf": "^6.0.1",
         "typescript": "^5.3.3"
       }
@@ -34,14 +34,6 @@
         "formdata-node": "^4.3.2",
         "node-fetch": "^2.6.7",
         "web-streams-polyfill": "^3.2.1"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.74",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
-      "integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@anthropic-ai/sdk/node_modules/node-fetch": {
@@ -62,11 +54,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/@anthropic-ai/vertex-sdk": {
       "version": "0.4.3",
@@ -588,24 +575,50 @@
       }
     },
     "node_modules/@genkit-ai/ai": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/ai/-/ai-0.9.12.tgz",
-      "integrity": "sha512-xyVVAIGKNpj5zCkoEfWZkzwctl0/hmpX6vKZgdgMH2MiqP5LzTp7rUekBMon8c1rMDVAze97QVSjAmZIoMLSlA==",
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/ai/-/ai-1.0.0-rc.14.tgz",
+      "integrity": "sha512-5CHyRixumiM5uHkzwHl7IWbrYSzWvhDvYAsMoq9mmI8iCJA9g/3u8JOcHSRiseuaap5gv/QGm809IpIlak55ZA==",
       "dependencies": {
-        "@genkit-ai/core": "0.9.12",
+        "@genkit-ai/core": "1.0.0-rc.14",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.11.19",
         "colorette": "^2.0.20",
+        "dotprompt": "^1.0.0-dev.3 || ^1",
         "json5": "^2.2.3",
         "node-fetch": "^3.3.2",
         "partial-json": "^0.1.7",
         "uuid": "^10.0.0"
       }
     },
+    "node_modules/@genkit-ai/ai/node_modules/@types/node": {
+      "version": "20.17.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.17.tgz",
+      "integrity": "sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@genkit-ai/ai/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    },
+    "node_modules/@genkit-ai/ai/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@genkit-ai/core": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-0.9.12.tgz",
-      "integrity": "sha512-QPJZ3TL5Iq2fyeo30MpUjd3ZLcYQf97RsitDZhMbGy3vMwbgig0nhEbJ6v/qaWsOMqSfIxJE/gETY3mMts1vRg==",
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-1.0.0-rc.14.tgz",
+      "integrity": "sha512-8h0Vl3SCP0vYIN60uELaZWEAP6BjLxXTcoWv2MFn7khxblzVkMWq98IxPThHo3s5BGB+Pxnhnsywdb/ItliFUA==",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^1.25.0",
@@ -613,11 +626,13 @@
         "@opentelemetry/sdk-metrics": "^1.25.0",
         "@opentelemetry/sdk-node": "^0.52.0",
         "@opentelemetry/sdk-trace-base": "^1.25.0",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^8.12.0",
         "ajv-formats": "^3.0.1",
         "async-mutex": "^0.5.0",
         "body-parser": "^1.20.3",
         "cors": "^2.8.5",
+        "dotprompt": "^1.0.0-dev.3 || ^1",
         "express": "^4.21.0",
         "get-port": "^5.1.0",
         "json-schema": "^0.4.0",
@@ -626,49 +641,51 @@
       }
     },
     "node_modules/@genkit-ai/dev-local-vectorstore": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/dev-local-vectorstore/-/dev-local-vectorstore-0.9.12.tgz",
-      "integrity": "sha512-wkrLRqTw1N50hZpQlC1Hq8yOWapyz3BiC03auK93j85sL2L6tIFQ1zFHw7qKD+t39fiTmpocl8O6spLEerUKoA==",
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/dev-local-vectorstore/-/dev-local-vectorstore-1.0.0-rc.14.tgz",
+      "integrity": "sha512-oOAtMIg+W5+++qkg1NZbd/oK4vuJzz4D/CnrF/TJGN9I2ytq+7WE0FE8lL09hIFu1LINcogGVtir7mkBCgm4MA==",
       "dependencies": {
         "compute-cosine-similarity": "^1.1.0",
         "ts-md5": "^1.3.1"
       },
       "peerDependencies": {
-        "genkit": "0.9.12"
-      }
-    },
-    "node_modules/@genkit-ai/dotprompt": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/dotprompt/-/dotprompt-0.9.12.tgz",
-      "integrity": "sha512-eEHBRzRVemiPuqCBbXiLgltNWpmCHmC+gVHBhsAnrfOYBlwmPvh2nnAPBXGYnkDH87PuN11jg8YJQmO4kQuoSw==",
-      "dependencies": {
-        "@genkit-ai/ai": "0.9.12",
-        "@genkit-ai/core": "0.9.12",
-        "front-matter": "^4.0.2",
-        "handlebars": "^4.7.8",
-        "node-fetch": "^3.3.2"
+        "genkit": "^1.0.0-rc.14"
       }
     },
     "node_modules/@genkit-ai/evaluator": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/evaluator/-/evaluator-0.9.12.tgz",
-      "integrity": "sha512-JbZfwwqDf6IP84cGt+QZlSB0h+FcdAM7Ur6A/lL5GJdMudIjRdxmhu3FEu/kWKK59EQlJShGBW5/Vyw93ynPqw==",
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/evaluator/-/evaluator-1.0.0-rc.14.tgz",
+      "integrity": "sha512-P/3rfbI15IMuxuvsARbiYh+2tMBQFAtG/uxxt4BqDHw694O/DTctYoahIaw9+hPiAAYOtQ/asSsCIo73U3Uhxw==",
       "dependencies": {
-        "@genkit-ai/dotprompt": "0.9.12",
         "compute-cosine-similarity": "^1.1.0",
+        "dotprompt": "^1.0.0-dev.3 || ^1",
         "node-fetch": "^3.3.2",
         "path": "^0.12.7"
       },
       "peerDependencies": {
-        "genkit": "0.9.12"
+        "genkit": "^1.0.0-rc.14"
+      }
+    },
+    "node_modules/@genkit-ai/express": {
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/express/-/express-1.0.0-rc.14.tgz",
+      "integrity": "sha512-I8VcuV2iyJXs/X3nCQZ/UR+FIO7XwaBo6+KWSDnugJrCweQZQ0LCYHbinSp1obLm/xCML7CWnqpZTX87mnbe3w==",
+      "dependencies": {
+        "body-parser": "^1.20.3",
+        "cors": "^2.8.5"
+      },
+      "peerDependencies": {
+        "express": "^4.21.1",
+        "genkit": "^1.0.0-rc.14"
       }
     },
     "node_modules/@genkit-ai/firebase": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/firebase/-/firebase-0.9.12.tgz",
-      "integrity": "sha512-PbEAPO3GTENaJR5RUqrq88YIVxgkVi2pc82kOCrkJDpw/+PcyRIZcgvbQYSAzB932yVU0sy33zzdUfg9t2thMA==",
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/firebase/-/firebase-1.0.0-rc.14.tgz",
+      "integrity": "sha512-bTbq16E6gUhzn6veClz+zJ6i79QwQg7Sf2c8gN0OHDUDkgbagJP3GcloGVPCh9tDO3KN7hWuUX0xNslmjIbSsA==",
       "dependencies": {
-        "@genkit-ai/google-cloud": "0.9.12",
+        "@genkit-ai/express": "^1.0.0-rc.14",
+        "@genkit-ai/google-cloud": "^1.0.0-rc.14",
         "express": "^4.21.0",
         "google-auth-library": "^9.6.3"
       },
@@ -676,13 +693,13 @@
         "@google-cloud/firestore": "^7.6.0",
         "firebase-admin": ">=12.2",
         "firebase-functions": ">=4.8",
-        "genkit": "0.9.12"
+        "genkit": "^1.0.0-rc.14"
       }
     },
     "node_modules/@genkit-ai/google-cloud": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/google-cloud/-/google-cloud-0.9.12.tgz",
-      "integrity": "sha512-hYDvdQmGdI/JC6hUa6hMs6+Kc04wmi+/54zJIB+EOiNLd6fJ193B+q/pHqI4UxvofJPsf9C6VTK5Q54+yyQm7w==",
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/google-cloud/-/google-cloud-1.0.0-rc.14.tgz",
+      "integrity": "sha512-rPUR//+V9yNJbZJey+aSAKIKfdFfN7jhb5gUkxXjYf+erAAukt2PW9ltDzYKkdESZWvtQvPx/8/keWX28hDZJQ==",
       "dependencies": {
         "@google-cloud/logging-winston": "^6.0.0",
         "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.19.0",
@@ -703,17 +720,17 @@
         "winston": "^3.12.0"
       },
       "peerDependencies": {
-        "genkit": "0.9.12"
+        "genkit": "^1.0.0-rc.14"
       }
     },
     "node_modules/@genkit-ai/telemetry-server": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/telemetry-server/-/telemetry-server-0.9.12.tgz",
-      "integrity": "sha512-8w1O9LOUtMCGc8bx+Vcd5D68L8ctM6H544Vxnfvy8gx4JHV5dj7vQiI9YDgm65pgP15pytQzt1TcRtOtYoimFw==",
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/telemetry-server/-/telemetry-server-1.0.0-rc.14.tgz",
+      "integrity": "sha512-cFxLS8IkXhRds9+wgaru3QirgehQImG9CuhLfjo09MRcIM21Vr9F083YVnlO8WDckWz5NwclkfFKkD25FDpE/w==",
       "dev": true,
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.0.0",
-        "@genkit-ai/tools-common": "0.9.12",
+        "@genkit-ai/tools-common": "1.0.0-rc.14",
         "@google-cloud/firestore": "^7.6.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^1.25.0",
@@ -727,14 +744,16 @@
       }
     },
     "node_modules/@genkit-ai/tools-common": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/tools-common/-/tools-common-0.9.12.tgz",
-      "integrity": "sha512-A9ToM/CY6vxcBSw4o47Q7qrpMaRsk4P6ZuzoDMlCzCVI+RZN5ulTL4LXMrq6nQ/KxY1GT94bSoulROXBMzW/Gw==",
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/tools-common/-/tools-common-1.0.0-rc.14.tgz",
+      "integrity": "sha512-50PE/CIL3u9YC4c3vifz6CVSlC1cmQ3xAHMOsUxsRRvcPzIbL8jOCYMKAnbdgAkp0WGgWG+fLjiKbUPZydEgcg==",
       "dev": true,
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.0.0",
         "@trpc/server": "10.45.0",
         "adm-zip": "^0.5.12",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
         "axios": "^1.7.7",
         "body-parser": "^1.20.2",
         "chokidar": "^3.5.3",
@@ -757,46 +776,15 @@
         "zod-to-json-schema": "^3.22.4"
       }
     },
-    "node_modules/@genkit-ai/tools-common/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/@genkit-ai/tools-common/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@genkit-ai/tools-common/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@genkit-ai/vertexai": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/vertexai/-/vertexai-0.9.12.tgz",
-      "integrity": "sha512-lA6lwh5jgYgFr7RsFCXs+iASUZI2CmrGQEJCR+/qKJTNG0OyI4O7CdoT5SZSc1fK7oXeWH0/4x6mIwcngjy2Gw==",
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/vertexai/-/vertexai-1.0.0-rc.14.tgz",
+      "integrity": "sha512-7j3xV9wdqIhjUjvy6cogIaTATl28z+wjiP9hLfeYb6XOyG7HFve5jZ4xzDHK2pGVOjblrP2XDyahOE2BUK6fyQ==",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.24.3",
         "@anthropic-ai/vertex-sdk": "^0.4.0",
         "@google-cloud/aiplatform": "^3.23.0",
-        "@google-cloud/vertexai": "^1.9.0",
+        "@google-cloud/vertexai": "^1.9.2",
         "@mistralai/mistralai-gcp": "^1.3.5",
         "google-auth-library": "^9.14.2",
         "googleapis": "^140.0.1",
@@ -808,7 +796,7 @@
         "firebase-admin": ">=12.2"
       },
       "peerDependencies": {
-        "genkit": "0.9.12"
+        "genkit": "^1.0.0-rc.14"
       }
     },
     "node_modules/@google-cloud/aiplatform": {
@@ -843,19 +831,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@google-cloud/bigquery/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@google-cloud/common": {
@@ -933,18 +908,6 @@
       },
       "peerDependencies": {
         "winston": ">=3.2.1"
-      }
-    },
-    "node_modules/@google-cloud/logging/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@google-cloud/opentelemetry-cloud-monitoring-exporter": {
@@ -1086,9 +1049,9 @@
       }
     },
     "node_modules/@google-cloud/vertexai": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/vertexai/-/vertexai-1.9.2.tgz",
-      "integrity": "sha512-pJSUG3r5QIvCFNfkz7/y7kEqvEJaVAk0jZbZoKbcPCRUnXaUeAq7p8I0oklqetGyxbUcZ2FOGpt+Y+4uIltVPg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/vertexai/-/vertexai-1.9.3.tgz",
+      "integrity": "sha512-35o5tIEMLW3JeFJOaaMNR2e5sq+6rpnhrF97PuAxeOm0GlqVTESKhkGj7a5B5mmJSSSU3hUfIhcQCRRsw4Ipzg==",
       "dependencies": {
         "google-auth-library": "^9.1.0"
       },
@@ -1321,9 +1284,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
-      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
+      "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
       "engines": {
         "node": ">=14"
       },
@@ -2849,17 +2812,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
-      "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
@@ -3087,6 +3039,11 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+    },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.8.tgz",
@@ -3128,11 +3085,11 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.16.tgz",
-      "integrity": "sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==",
+      "version": "18.19.75",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.75.tgz",
+      "integrity": "sha512-UIksWtThob6ZVSyxcOqCLOUNg/dyO1Qvx4McgeuhrEtHTLFTf7BBhEazaE4K806FGTPtzd/2sE90qn4fVr7cyw==",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -3401,12 +3358,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -3692,9 +3647,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
-      "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA=="
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -4058,6 +4013,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/dotprompt": {
+      "version": "1.0.0-dev.3",
+      "resolved": "https://registry.npmjs.org/dotprompt/-/dotprompt-1.0.0-dev.3.tgz",
+      "integrity": "sha512-gAcIhG+vzZlrZcBN/lO8gEMUtXHKMLbs1+snJuZrPkZnNgnWrzz1hYN4vYotpng/5fHsYSPUEckECy6qUNSrsQ==",
+      "dependencies": {
+        "handlebars": "^4.7.8",
+        "yaml": "^2.5.0"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4219,18 +4183,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/etag": {
@@ -4556,9 +4508,9 @@
       }
     },
     "node_modules/firebase-admin/node_modules/@types/node": {
-      "version": "22.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
-      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
+      "version": "22.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -4581,9 +4533,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.3.0.tgz",
-      "integrity": "sha512-88dRx3dPYvlxIN64H1lJCFV7wGt0cFL0lmXKzVm+rfnkILC0Qt3rMXp3/J/ojf2StclBwJBu2QZ4MRbNYh7B7g==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.3.1.tgz",
+      "integrity": "sha512-LTbmsEkSgaOhzTzGUoF7dv906JJJW89o0/spXgnU8gASyR8JLMrCqwV7FnWLso5hyF0fUqNPaEEw/TzLdZMVXw==",
       "peer": true,
       "dependencies": {
         "@types/cors": "^2.8.5",
@@ -4714,14 +4666,6 @@
       "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
       "dev": true
     },
-    "node_modules/front-matter": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
-      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
-      "dependencies": {
-        "js-yaml": "^3.13.1"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4783,24 +4727,13 @@
         }
       }
     },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/gcp-metadata": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
-      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
       "dependencies": {
-        "gaxios": "^6.0.0",
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
         "json-bigint": "^1.0.0"
       },
       "engines": {
@@ -4808,24 +4741,23 @@
       }
     },
     "node_modules/genkit": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/genkit/-/genkit-0.9.12.tgz",
-      "integrity": "sha512-m1VQE/yhuii0y1aGTnkoSesSXTNE25q1s7vv5YVgJWa/t2gOXuznZOoHTJ847f/3mKC7fgnV7xGI+t/+7wbe0g==",
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/genkit/-/genkit-1.0.0-rc.14.tgz",
+      "integrity": "sha512-JB6fTcJ5CI4UhsP4uNyXpi9/OatyhPwOkBXnbHafE5rdibXuKUXadbb2LC+PWfG3+7WrLXGKlrj7kOIN3Hq2lw==",
       "dependencies": {
-        "@genkit-ai/ai": "0.9.12",
-        "@genkit-ai/core": "0.9.12",
-        "@genkit-ai/dotprompt": "0.9.12",
+        "@genkit-ai/ai": "1.0.0-rc.14",
+        "@genkit-ai/core": "1.0.0-rc.14",
         "uuid": "^10.0.0"
       }
     },
     "node_modules/genkit-cli": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/genkit-cli/-/genkit-cli-0.9.12.tgz",
-      "integrity": "sha512-Qsk7TmVBxghTT+0cRe2j0fYJboUIfWhuUoeVbWshranye6tConGMyDEZdXBIeMWIixSbG7k8a7a2INdRdjcQJw==",
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/genkit-cli/-/genkit-cli-1.0.0-rc.14.tgz",
+      "integrity": "sha512-JR8Vvm2rGGQMsBkq+dWSypUC4ij1Uew5cjFaS74flyv/glV6RMNMuXP5XQBc5C9zIkfXeT+kng8BghHM4Gx/4g==",
       "dev": true,
       "dependencies": {
-        "@genkit-ai/telemetry-server": "0.9.12",
-        "@genkit-ai/tools-common": "0.9.12",
+        "@genkit-ai/telemetry-server": "1.0.0-rc.14",
+        "@genkit-ai/tools-common": "1.0.0-rc.14",
         "axios": "^1.7.7",
         "colorette": "^2.0.20",
         "commander": "^11.1.0",
@@ -4837,6 +4769,18 @@
       },
       "bin": {
         "genkit": "dist/bin/genkit.js"
+      }
+    },
+    "node_modules/genkit/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/get-caller-file": {
@@ -5009,16 +4953,12 @@
         }
       }
     },
-    "node_modules/google-gax/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/googleapis": {
@@ -5047,18 +4987,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/googleapis-common/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gopd": {
@@ -5515,12 +5443,12 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -6099,9 +6027,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.81.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.81.0.tgz",
-      "integrity": "sha512-lXkFkV+He3O6RGnldHncRGef4uWHssDsAVwN5I3bWcgIdDPy/w8vgtIAwvZxAj49m4WiwWVD0+eGTJ9xOv/ISA==",
+      "version": "4.82.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.82.0.tgz",
+      "integrity": "sha512-1bTxOVGZuVGsKKUWbh3BEwX1QxIXUftJv+9COhhGGVDTFwiaOd4gWsMynF2ewj1mg6by3/O+U8+EEHpWRdPaJg==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -6127,14 +6055,6 @@
         }
       }
     },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.74",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
-      "integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "node_modules/openai/node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -6153,11 +6073,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/openapi3-ts": {
       "version": "4.4.0",
@@ -6812,9 +6727,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7021,11 +6936,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -7237,18 +7147,6 @@
         }
       }
     },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/terminate": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/terminate/-/terminate-2.8.0.tgz",
@@ -7408,9 +7306,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unique-string": {
       "version": "2.0.0",
@@ -7464,9 +7362,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7688,7 +7586,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/samples/js-menu/src/index.ts
+++ b/samples/js-menu/src/index.ts
@@ -35,4 +35,6 @@ export {
 } from './05/flows';
 export { s05_readMenuPrompt, s05_textMenuPrompt } from './05/prompts';
 
-console.log("All prompts and flows loaded, use the Developer UI to test them out");
+console.log(
+  'All prompts and flows loaded, use the Developer UI to test them out'
+);

--- a/samples/js-menu/src/index.ts
+++ b/samples/js-menu/src/index.ts
@@ -34,3 +34,5 @@ export {
   s05_visionMenuQuestionFlow,
 } from './05/flows';
 export { s05_readMenuPrompt, s05_textMenuPrompt } from './05/prompts';
+
+console.log("All prompts and flows loaded, use the Developer UI to test them out");


### PR DESCRIPTION
Adds jsmenu to the IDX samples, also fixes a couple links that pointed internally

This sample can be tested here:

<a href="https://idx.google.com/new?template=https%3A%2F%2Fgithub.com%2Ffirebase%2Fgenkit%2Ftree%2Fupdate-jsmenu-to-use-idx%2Fsamples">
  <img
    height="32"
    alt="Try in IDX"
    src="https://cdn.idx.dev/btn/try_light_32.svg">
</a>

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
