### PR TITLE
chore(js): remove extraneous console.log statements

### DIFF
--- a/js/ai/src/generate/resolve-tool-requests.ts
+++ b/js/ai/src/generate/resolve-tool-requests.ts
@@ -337,7 +337,6 @@ export async function resolveResumeOption(
   interruptedResponse?: GenerateResponseData;
 }> {
   if (!rawRequest.resume) return { revisedRequest: rawRequest }; // no-op if no resume option
-  console.log('RESOLVE RESUME OPTION:', rawRequest.resume);
   const toolMap = toToolMap(await resolveTools(registry, rawRequest.tools));
 
   const messages = rawRequest.messages;
@@ -346,11 +345,11 @@ export async function resolveResumeOption(
   if (
     !lastMessage ||
     lastMessage.role !== 'model' ||
-    !lastMessage.content.find((p) => p.toolRequest && p.metadata?.interrupt)
+    !lastMessage.content.find((p) => p.toolRequest)
   ) {
     throw new GenkitError({
       status: 'FAILED_PRECONDITION',
-      message: `Cannot 'resume' generation unless the previous message is a model message with at least one interrupt.`,
+      message: `Cannot 'resume' generation unless the previous message is a model message with at least one tool request.`,
     });
   }
 
@@ -365,7 +364,6 @@ export async function resolveResumeOption(
         part,
         toolMap
       );
-      console.log('RESOLVED TOOL', part.toolRequest.name, 'TO', resolved);
       if (resolved.interrupt) {
         interrupted = true;
         return resolved.interrupt;
@@ -407,7 +405,6 @@ export async function resolveResumeOption(
     },
   };
 
-  console.log('CONSTRUCTED A TOOL MESSAGE:', toolMessage.content);
   return stripUndefinedProps({
     revisedRequest: {
       ...rawRequest,

--- a/js/core/src/tracing/processor.ts
+++ b/js/core/src/tracing/processor.ts
@@ -72,10 +72,6 @@ class FilteringReadableSpanProxy implements ReadableSpan {
     return this.span.status;
   }
   get attributes() {
-    console.log(
-      'FilteringReadableSpanProxy get attributes',
-      this.span.attributes
-    );
     const out = {} as Record<string, any>;
     for (const [key, value] of Object.entries(this.span.attributes)) {
       if (!key.startsWith(ATTR_PREFIX + ':')) {

--- a/js/plugins/langchain/src/tracing.ts
+++ b/js/plugins/langchain/src/tracing.ts
@@ -62,13 +62,7 @@ export class GenkitTracer extends BaseTracer {
       ctx = trace.setSpan(context.active(), parentCtx);
     }
     const span = this.tracer.startSpan(run.name, undefined, ctx);
-    console.log('run', JSON.stringify(run, undefined, '  '));
     if (run.inputs) {
-      console.log('setting inputs', run.inputs);
-      console.log(
-        'setting inputs flattened',
-        this.maybeFlattenInput(run.inputs)
-      );
       span.setAttribute(
         'genkit:input',
         JSON.stringify(this.maybeFlattenInput(run.inputs))

--- a/js/plugins/mcp/src/server.ts
+++ b/js/plugins/mcp/src/server.ts
@@ -99,7 +99,6 @@ export class GenkitMcpServer {
     const toolList: ToolAction[] = [];
     const promptList: PromptAction[] = [];
     for (const k in allActions) {
-      console.log('action:', k);
       if (k.startsWith('/tool/')) {
         toolList.push(allActions[k] as ToolAction);
       } else if (k.startsWith('/prompt/')) {


### PR DESCRIPTION
Also relaxes requirement on interrupt resuming to only require tool requests, not necessarily interrupts (metadata sometimes gets lost, see #1816)