### PR TITLE
breaking(js/ai): drop ToolDefinition from ToolArgument (and generate action interface)

### DIFF
--- a/genkit-tools/common/src/types/model.ts
+++ b/genkit-tools/common/src/types/model.ts
@@ -283,7 +283,7 @@ export const GenerateActionOptionsSchema = z.object({
   /** Conversation history for multi-turn prompting when supported by the underlying model. */
   messages: z.array(MessageSchema),
   /** List of registered tool names for this generation if supported by the underlying model. */
-  tools: z.array(z.union([z.string(), ToolDefinitionSchema])).optional(),
+  tools: z.array(z.string()).optional(),
   /** Tool calling mode. `auto` lets the model decide whether to use tools, `required` forces the model to choose a tool, and `none` forces the model not to use any tools. Defaults to `auto`.  */
   toolChoice: z.enum(['auto', 'required', 'none']).optional(),
   /** Configuration for the generation request. */

--- a/genkit-tools/genkit-schema.json
+++ b/genkit-tools/genkit-schema.json
@@ -425,14 +425,7 @@
         "tools": {
           "type": "array",
           "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/$defs/ToolDefinition"
-              }
-            ]
+            "type": "string"
           }
         },
         "toolChoice": {

--- a/js/ai/src/chat.ts
+++ b/js/ai/src/chat.ts
@@ -176,7 +176,7 @@ export class Chat {
           this.requestBase = Promise.resolve({
             ...(await this.requestBase),
             // these things may get changed by tools calling within generate.
-            tools: response?.request?.tools?.map(td => td.name),
+            tools: response?.request?.tools?.map((td) => td.name),
             toolChoice: response?.request?.toolChoice,
             config: response?.request?.config,
           });

--- a/js/ai/src/chat.ts
+++ b/js/ai/src/chat.ts
@@ -176,7 +176,7 @@ export class Chat {
           this.requestBase = Promise.resolve({
             ...(await this.requestBase),
             // these things may get changed by tools calling within generate.
-            tools: response?.request?.tools,
+            tools: response?.request?.tools?.map(td => td.name),
             toolChoice: response?.request?.toolChoice,
             config: response?.request?.config,
           });

--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -697,7 +697,7 @@ export const GenerateActionOptionsSchema = z.object({
   /** Conversation history for multi-turn prompting when supported by the underlying model. */
   messages: z.array(MessageSchema),
   /** List of registered tool names for this generation if supported by the underlying model. */
-  tools: z.array(z.union([z.string(), ToolDefinitionSchema])).optional(),
+  tools: z.array(z.string()).optional(),
   /** Tool calling mode. `auto` lets the model decide whether to use tools, `required` forces the model to choose a tool, and `none` forces the model not to use any tools. Defaults to `auto`.  */
   toolChoice: z.enum(['auto', 'required', 'none']).optional(),
   /** Configuration for the generation request. */

--- a/js/ai/src/tool.ts
+++ b/js/ai/src/tool.ts
@@ -127,11 +127,7 @@ export interface ToolConfig<I extends z.ZodTypeAny, O extends z.ZodTypeAny> {
 export type ToolArgument<
   I extends z.ZodTypeAny = z.ZodTypeAny,
   O extends z.ZodTypeAny = z.ZodTypeAny,
-> =
-  | string
-  | ToolAction<I, O>
-  | Action<I, O>
-  | ExecutablePrompt<any, any, any>;
+> = string | ToolAction<I, O> | Action<I, O> | ExecutablePrompt<any, any, any>;
 
 /**
  * Converts an action to a tool action by setting the appropriate metadata.
@@ -161,7 +157,10 @@ export function asTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
 export async function resolveTools<
   O extends z.ZodTypeAny = z.ZodTypeAny,
   CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
->(registry: Registry, tools?: (ToolArgument | ToolDefinition)[]): Promise<ToolAction[]> {
+>(
+  registry: Registry,
+  tools?: (ToolArgument | ToolDefinition)[]
+): Promise<ToolAction[]> {
   if (!tools || tools.length === 0) {
     return [];
   }

--- a/js/ai/src/tool.ts
+++ b/js/ai/src/tool.ts
@@ -131,7 +131,6 @@ export type ToolArgument<
   | string
   | ToolAction<I, O>
   | Action<I, O>
-  | ToolDefinition
   | ExecutablePrompt<any, any, any>;
 
 /**
@@ -162,7 +161,7 @@ export function asTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
 export async function resolveTools<
   O extends z.ZodTypeAny = z.ZodTypeAny,
   CustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
->(registry: Registry, tools?: ToolArgument[]): Promise<ToolAction[]> {
+>(registry: Registry, tools?: (ToolArgument | ToolDefinition)[]): Promise<ToolAction[]> {
   if (!tools || tools.length === 0) {
     return [];
   }


### PR DESCRIPTION
it wasn't really used or useful

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [n/a] Docs updated (updated docs or a docs bug required)
