### PR TITLE
feat: add a genkit cli convenience wrapper script to run the repo-local version of genkit cli #1850

### DIFF
--- a/bin/genkit
+++ b/bin/genkit
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Conveniency wrapper script for repo-local genkit cli.
+
+set -euo pipefail
+
+TOP_DIR="$(git rev-parse --show-toplevel)"
+GENKIT_SCRIPT="${TOP_DIR}/genkit-tools/cli/dist/bin/genkit.js"
+
+if [[ ! -f "${GENKIT_SCRIPT}" ]]; then
+    echo "Building genkit..."
+    pushd "${TOP_DIR}"
+
+    # We skip linking here on purpose since this script is a convenience
+    # wrapper.
+    pnpm -C js install
+    pnpm -C genkit-tools install
+    pnpm run build
+
+    popd
+fi
+
+node "${GENKIT_SCRIPT}" "$@"

--- a/tests/specs/generate.yaml
+++ b/tests/specs/generate.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # This file describes the responses of /util/generate action
 
 tests:


### PR DESCRIPTION
 RATIONALE:

On some systems, the `npm link` step in `pnpm run setup` fails to
execute owing to a lack of permissions and elevated privileges
are not available. Therefore, this wrapper script is a convenience
feature to allow using the repo-local version of the genkit cli
without having to symlink it into system directories.
  
ISSUE: https://github.com/firebase/genkit/issues/1850

CHANGELOG:
- [x] Add a convenience wrapper script that does not require `npm link`ing the genkit CLI thereby avoiding permission problems faced on certain operating systems.
- [x] Pre-commits automatically added license header to YAML file.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
