### PR TITLE
chore: pin node version using pnpm #1852

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -14,3 +14,7 @@ package-manager-strict-version=true
 # pnpm specified in the `packageManager` field of package.json. This is the same
 # field used by Corepack.
 manage-package-manager-versions=true
+
+# Allow PNPM to manage node versions independently of the operating system
+# installed version of node.
+use-node-version=20.18.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,11 +36,16 @@ information on using pull requests.
 
 ### Environment
 
-1. [Install node v20](https://nodejs.org/en/download)
+1. It is recommended that you [Install node v20](https://nodejs.org/en/download)
 2. Run `corepack enable pnpm` to enable pnpm.
 
 Note: We recommend using Node v20 or greater when compiling and running Genkit.
 Any older versions of Node may not work properly.
+
+In case you're running a system where that is not possible due to access
+restrictions or outdated systems [installing pnpm using their installation
+script](https://pnpm.io/installation#on-posix-systems). PNPM [manages the
+version of node](https://pnpm.io/npmrc#use-node-version) used with genkit.
 
 ### Install dependencies
 


### PR DESCRIPTION
RATIONALE: Some older systems cannot be updated to use the latest version of system software and nodejs owing to access restrictions.

Pinning the version of node used by the project and allowing PNPM to manage the version of node is a suitable workaround.

ISSUE: https://github.com/firebase/genkit/issues/1852

CHANGELOG:
- [x] Update the .npmrc file to set the version of node used by the project.
- [x] Update the CONTRIBUTING.md file to include information about managed node versions.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
