### PR TITLE
chore: update samples readme to use purple IDX button

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -17,5 +17,5 @@ These are also available in IDX, Google's Cloud-Based IDE, for you to try.
   <img
     height="32"
     alt="Try in IDX"
-    src="https://cdn.idx.dev/btn/try_light_32.svg">
+    src="https://cdn.idx.dev/btn/try_purple_32.svg">
 </a>


### PR DESCRIPTION
Consistent with main README, lets the button pop more so it's less easy to miss.

<img width="814" alt="image" src="https://github.com/user-attachments/assets/5c15aa1c-99b3-459c-b228-34a0bb1a834a" />

