### PR TITLE
fix: update js-chatbot to work in IDX preview

### DIFF
--- a/samples/idx-template.json
+++ b/samples/idx-template.json
@@ -15,6 +15,7 @@
       "default": "js-character-generator",
       "options": {
         "js-character-generator": "Simple Character Generator",
+        "js-chatbot": "A chatbot using Vertex and Llama 3.1 or Gemini Flash",
         "js-coffee-shop": "Coffeeshop w Several types of Prompt",
         "js-schoolAgent": "A Multi-Agent School Assistant",
         "js-prompts": "A sample with various prompt styles",

--- a/samples/js-chatbot/genkit-app/angular.json
+++ b/samples/js-chatbot/genkit-app/angular.json
@@ -67,6 +67,9 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "buildTarget": "genkit-app:build:production"

--- a/samples/js-chatbot/genkit-app/proxy.conf.json
+++ b/samples/js-chatbot/genkit-app/proxy.conf.json
@@ -1,7 +1,7 @@
 {
-    "/chatbotFlow": {
-      "target": "http://localhost:3400/",
-      "secure": false,
-      "logLevel": "debug"
-    }
+  "/chatbotFlow": {
+    "target": "http://localhost:3400/",
+    "secure": false,
+    "logLevel": "debug"
   }
+}

--- a/samples/js-chatbot/genkit-app/proxy.conf.json
+++ b/samples/js-chatbot/genkit-app/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+    "/chatbotFlow": {
+      "target": "http://localhost:3400/",
+      "secure": false,
+      "logLevel": "debug"
+    }
+  }

--- a/samples/js-chatbot/genkit-app/src/app/samples/chatbot/chatbot.component.ts
+++ b/samples/js-chatbot/genkit-app/src/app/samples/chatbot/chatbot.component.ts
@@ -33,7 +33,9 @@ import { MatRadioModule } from '@angular/material/radio';
 import { streamFlow } from 'genkit/beta/client';
 import { MarkdownModule } from 'ngx-markdown';
 
-const url = 'http://127.0.0.1:3400/chatbotFlow';
+// This sample uses an angular proxy to connect to the flow
+// see the config in genkit-app/proxy.conf.json
+const url = '/chatbotFlow';
 
 interface ToolResponse {
   name: string;


### PR DESCRIPTION
Moves to proxy calls to the flowSever through the angular app, this allows it to work as part of the preview pane in IDX

This can be tested here:
<a href="https://idx.google.com/new?template=https%3A%2F%2Fgithub.com%2Ffirebase%2Fgenkit%2Ftree%2Fadd-chatbot-sample-back%2Fsamples">
  <img
    height="32"
    alt="Open in IDX"
    src="https://cdn.idx.dev/btn/open_dark_32.svg">
</a>


Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
