### PR TITLE
fix: be more specific about Vertex project id in auth

### DIFF
--- a/docs/plugins/vertex-ai.md
+++ b/docs/plugins/vertex-ai.md
@@ -51,11 +51,11 @@ The plugin requires you to specify your Google Cloud project ID, the [region](ht
         *   On your local dev environment, do this by running:
 
             ```posix-terminal
-            gcloud auth application-default login
+            gcloud auth application-default login --project YOUR_PROJECT_ID
             ```
-
+            
         *   For other environments, see the [Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc) docs.
-    2. In addition, make sure the account is granted the Vertex AI User IAM role (`roles/aiplatform.user`). See the Vertex AI [access control](https://cloud.google.com/vertex-ai/generative-ai/docs/access-control) docs.
+    1. In addition, make sure the account is granted the Vertex AI User IAM role (`roles/aiplatform.user`). See the Vertex AI [access control](https://cloud.google.com/vertex-ai/generative-ai/docs/access-control) docs.
 
 ## Usage
 


### PR DESCRIPTION
Helps prevent issues where the auth project and the configured project are different

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
