### PR TITLE
docs(js/plugins/google-cloud): API reference docs

### DIFF
--- a/js/plugins/firebase/src/index.ts
+++ b/js/plugins/firebase/src/index.ts
@@ -26,6 +26,12 @@ import {
 } from '@genkit-ai/google-cloud';
 export { defineFirestoreRetriever } from './firestoreRetriever.js';
 
+/**
+ * Enables telemetry export to Firebase Genkit Monitoring, backed by the
+ * Google Cloud Observability suite.
+ *
+ * @param options configuration options
+ */
 export async function enableFirebaseTelemetry(
   options?: GcpTelemetryConfigOptions
 ) {

--- a/js/plugins/google-cloud/src/index.ts
+++ b/js/plugins/google-cloud/src/index.ts
@@ -23,6 +23,11 @@ import { GcpOpenTelemetry } from './gcpOpenTelemetry.js';
 import { TelemetryConfigs } from './telemetry/defaults.js';
 import { GcpTelemetryConfig, GcpTelemetryConfigOptions } from './types.js';
 
+/**
+ * Enables telemetry export to the Google Cloud Observability suite.
+ *
+ * @param options configuration options
+ */
 export function enableGoogleCloudTelemetry(
   options?: GcpTelemetryConfigOptions
 ) {
@@ -36,7 +41,7 @@ export function enableGoogleCloudTelemetry(
 
 /**
  * Create a configuration object for the plugin.
- * Not normally needed, but exposed for use by the firebase plugin.
+ * Not normally needed, but exposed for use by the Firebase plugin.
  */
 async function configureGcpPlugin(
   options?: GcpTelemetryConfigOptions

--- a/js/plugins/google-cloud/src/types.ts
+++ b/js/plugins/google-cloud/src/types.ts
@@ -21,40 +21,96 @@ import { JWTInput } from 'google-auth-library';
 
 /** Configuration options for the Google Cloud plugin. */
 export interface GcpTelemetryConfigOptions {
-  /** Cloud projectId is required, either passed here, through GCLOUD_PROJECT or application default credentials. */
+  /**
+   * Google Cloud Project ID. If provided, will take precedence over the
+   * projectId inferred from the application credential and/or environment.
+   * Required when providing an external credential (e.g. Workload Identity
+   * Federation.)
+   */
   projectId?: string;
 
-  /** Credentials must be provided to export telemetry, if not available through the environment. */
+  /**
+   * Credentials for authenticating with Google Cloud. Primarily intended for
+   * use in environments outside of GCP. On GCP credentials will typically be
+   * inferred from the environment via Application Default Credentials (ADC).
+   */
   credentials?: JWTInput;
 
-  /** Trace sampler, defaults to always on which exports all traces. */
+  /**
+   * OpenTelemetry sampler; controls the number of traces collected and exported
+   * to Google Cloud. Defaults to AlwaysOnSampler, which will collect and export
+   * all traces.
+   *
+   * There are four built-in samplers to choose from:
+   *
+   * - {@link https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-sdk-trace-base/src/sampler/AlwaysOnSampler.ts | AlwaysOnSampler} - samples all traces
+   * - {@link https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-sdk-trace-base/src/sampler/AlwaysOffSampler.ts | AlwaysOffSampler} - samples no traces
+   * - {@link https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-sdk-trace-base/src/sampler/ParentBasedSampler.ts | ParentBasedSampler} - samples based on parent span
+   * - {@link https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-sdk-trace-base/src/sampler/TraceIdRatioBasedSampler.ts | TraceIdRatioBasedSampler} - samples a configurable percentage of traces
+   */
   sampler?: Sampler;
 
-  /** Include OpenTelemetry autoInstrumentation. Defaults to true. */
+  /**
+   * Enabled by default, OpenTelemetry will automatically collect telemetry for
+   * popular libraries via auto instrumentations without any additional code
+   * or configuration. All available instrumentations will be collected, unless
+   * otherwise specified via {@link autoInstrumentationConfig}.
+   *
+   * @see https://opentelemetry.io/docs/zero-code/js/
+   */
   autoInstrumentation?: boolean;
+
+  /**
+   * Map of auto instrumentations and their configuration options. Available
+   * options will vary by instrumentation.
+   *
+   * @see https://opentelemetry.io/docs/zero-code/js/
+   */
   autoInstrumentationConfig?: InstrumentationConfigMap;
+
+  /**
+   * Additional OpenTelemetry instrumentations to include, beyond those
+   * provided by auto instrumentations.
+   */
   instrumentations?: Instrumentation[];
 
-  /** Metric export intervals, minimum is 5000ms. */
+  /**
+   * Metrics export interval in milliseconds; Google Cloud requires a minimum
+   * value of 5000ms.
+   */
   metricExportIntervalMillis?: number;
+
+  /**
+   * Timeout for the metrics export in milliseconds.
+   */
   metricExportTimeoutMillis?: number;
 
-  /** When true, metrics are not exported. */
+  /**
+   * If set to true, metrics will not be exported to Google Cloud. Traces and
+   * logs may still be exported.
+   */
   disableMetrics?: boolean;
 
-  /** When true, traces are not exported. */
+  /**
+   * If set to true, traces will not be exported to Google Cloud. Metrics and
+   * logs may still be exported.
+   */
   disableTraces?: boolean;
 
-  /** When true, inputs and outputs are not logged to GCP */
+  /**
+   * If set to true, input and output logs will not be collected.
+   */
   disableLoggingInputAndOutput?: boolean;
 
-  /** When true, telemetry data will be exported, even for local runs. Defaults to not exporting development traces. */
+  /**
+   * If set to true, telemetry data will be exported in the Genkit `dev`
+   * environment. Useful for local testing and troubleshooting; default is
+   * false.
+   */
   forceDevExport?: boolean;
 }
 
-/**
- * Internal telemetry configuration.
- */
+/** Internal telemetry configuration. */
 export interface GcpTelemetryConfig {
   projectId?: string;
   credentials?: JWTInput;


### PR DESCRIPTION
Paves the way for Genkit docs to link back to the API reference.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)
