### PR TITLE
fix(js/plugins/google-cloud): pass projectId through to GoogleAuth client

### DIFF
--- a/js/plugins/google-cloud/src/gcpLogger.ts
+++ b/js/plugins/google-cloud/src/gcpLogger.ts
@@ -55,10 +55,10 @@ export class GcpLogger {
     transports.push(
       this.shouldExport(env)
         ? new LoggingWinston({
-            projectId: this.config.projectId,
             labels: { module: 'genkit' },
             prefix: 'genkit',
             logName: 'genkit_log',
+            projectId: this.config.projectId,
             credentials: this.config.credentials,
             autoRetry: true,
             defaultCallback: await this.getErrorHandler(),

--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -123,8 +123,9 @@ export class GcpOpenTelemetry {
     spanExporter = new AdjustingTraceExporter(
       this.shouldExportTraces()
         ? new TraceExporter({
-            // Creds for non-GCP environments; otherwise credentials will be
-            // automatically detected via ADC
+            // provided projectId should take precedence over env vars, etc
+            projectId: this.config.projectId,
+            // creds for non-GCP environments, in lieu of using ADC.
             credentials: this.config.credentials,
           })
         : new InMemorySpanExporter(),
@@ -186,8 +187,9 @@ export class GcpOpenTelemetry {
               product: 'genkit',
               version: GENKIT_VERSION,
             },
-            // Creds for non-GCP environments; otherwise credentials will be
-            // automatically detected via ADC
+            // provided projectId should take precedence over env vars, etc
+            projectId: this.config.projectId,
+            // creds for non-GCP environments, in lieu of using ADC.
             credentials: this.config.credentials,
           },
           getErrorHandler(


### PR DESCRIPTION
Since the various Google telemetry clients will perform their own credential/project lookups, we need to make sure we're always passing the user provided `projectId` into their constructors. Otherwise, `GCLOUD_PROJECT` will take precedence, and we don't want that. :)

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [N/A] Docs updated (updated docs or a docs bug required)
