### PR TITLE
docs: fix a line break that turned into a bullet point

### DIFF
--- a/docs/plugins/firebase.md
+++ b/docs/plugins/firebase.md
@@ -68,7 +68,7 @@ To provide Firebase credentials, you also need to set up Google Cloud
 Application Default Credentials. To specify your credentials:
 
 - If you're running your flow from a Google Cloud environment (Cloud Functions,
-- Cloud Run, and so on), this is set automatically.
+  Cloud Run, and so on), this is set automatically.
 
 - For other environments:
 


### PR DESCRIPTION
It seems like when breaking a line to 80 columns, a bullet point was introduced. This PR fixes that.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
