### PR TITLE
fix(go/plugins/googleai): convertTools err propagate and schema type integer

### DIFF
--- a/go/plugins/googleai/googleai.go
+++ b/go/plugins/googleai/googleai.go
@@ -382,7 +382,7 @@ func convertTools(inTools []*ai.ToolDefinition) ([]*genai.Tool, error) {
 	var outTools []*genai.Tool
 	for _, t := range inTools {
 		inputSchema, err := convertSchema(t.InputSchema, t.InputSchema)
-		if err != err {
+		if err != nil {
 			return nil, err
 		}
 		fd := &genai.FunctionDeclaration{
@@ -414,7 +414,7 @@ func convertSchema(originalSchema map[string]any, genkitSchema map[string]any) (
 		schema.Type = genai.TypeNumber
 	case "number":
 		schema.Type = genai.TypeNumber
-	case "int":
+	case "integer":
 		schema.Type = genai.TypeInteger
 	case "bool":
 		schema.Type = genai.TypeBoolean

--- a/go/plugins/googleai/googleai_test.go
+++ b/go/plugins/googleai/googleai_test.go
@@ -1,7 +1,6 @@
 // Copyright 2024 Google LLC
 // SPDX-License-Identifier: Apache-2.0
 
-
 package googleai_test
 
 import (
@@ -56,10 +55,10 @@ func TestLive(t *testing.T) {
 	}
 	gablorkenTool := genkit.DefineTool(g, "gablorken", "use when need to calculate a gablorken",
 		func(ctx *ai.ToolContext, input struct {
-			Value float64
+			Value int
 			Over  float64
 		}) (float64, error) {
-			return math.Pow(input.Value, input.Over), nil
+			return math.Pow(float64(input.Value), input.Over), nil
 		},
 	)
 	t.Run("embedder", func(t *testing.T) {
@@ -140,7 +139,7 @@ func TestLive(t *testing.T) {
 		}
 
 		out := resp.Message.Content[0].Text
-		const want = "12.25"
+		const want = "11.31"
 		if !strings.Contains(out, want) {
 			t.Errorf("got %q, expecting it to contain %q", out, want)
 		}


### PR DESCRIPTION
* In this CL a bug is fixed that prevented errors from being propagated from convertSchema() through convertTools().
* The above bug hid an issue where the genkit schema type switch was trying to match "int" instead of "integer".  This issue is also corrected.
* Tests updated and corrected