### PR TITLE
fix(go/ai): googleai functions can't have slashes in the name

### DIFF
--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -153,5 +153,5 @@ func runAction(ctx context.Context, action Tool, input any) (any, error) {
 
 // LookupTool looks up the tool in the registry by provided name and returns it.
 func LookupTool(r *registry.Registry, name string) Tool {
-	return &toolAction{action: r.LookupAction(fmt.Sprintf("/tool/local/%s", name))}
+	return &toolAction{action: r.LookupAction(fmt.Sprintf("/tool/%s", name))}
 }


### PR DESCRIPTION
Currently using tools with googleai plugin results in 400 errors due to function names including slashes.

From the docs:
```
name: Use clear, descriptive names without space, period (.), or dash (-) characters. Instead, use underscore (_) characters or camel case.
```

This PR represents a minimal (not necessarily optimal) fix.
