### PR TITLE
fix(js/vertexai): workaround for tool calling issue in Vertex SDK

### DIFF
--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -610,11 +610,9 @@ function fromGeminiFunctionResponsePart(part: GeminiPart): Part {
 
 // Converts vertex part to genkit part
 function fromGeminiPart(part: GeminiPart, jsonMode: boolean): Part {
-  // if (jsonMode && part.text !== undefined) {
-  //   return { data: JSON.parse(part.text) };
-  // }
-  if (part.text !== undefined) return { text: part.text };
+  // functionCall is first to work around https://github.com/googleapis/nodejs-vertexai/issues/494
   if (part.functionCall) return fromGeminiFunctionCallPart(part);
+  if (part.text !== undefined) return { text: part.text };
   if (part.functionResponse) return fromGeminiFunctionResponsePart(part);
   if (part.inlineData) return fromGeminiInlineDataPart(part);
   if (part.fileData) return fromGeminiFileDataPart(part);


### PR DESCRIPTION
See Discord thread: https://discord.com/channels/1255578482214305893/1255583176089276566/1338956279896608800

And related Vertex SDK bug: https://github.com/googleapis/nodejs-vertexai/issues/494

It should never be the case where a single part has multiple types, so we can work around this for now by prioritizing functionCall which will bypass the current behavior of returning `"undefined\n"`.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
