### PR TITLE
fix(cli): fix genkit start in no runtime mode

### DIFF
--- a/genkit-tools/cli/src/commands/start.ts
+++ b/genkit-tools/cli/src/commands/start.ts
@@ -65,7 +65,7 @@ export const start = new Command('start')
 
 async function startRuntime(telemetryServerUrl?: string) {
   if (start.args.length > 0) {
-    const runtimePromise = new Promise((urlResolver, reject) => {
+    return new Promise((urlResolver, reject) => {
       const appProcess = spawn(start.args[0], start.args.slice(1), {
         env: {
           ...process.env,

--- a/genkit-tools/cli/src/commands/start.ts
+++ b/genkit-tools/cli/src/commands/start.ts
@@ -64,9 +64,8 @@ export const start = new Command('start')
   });
 
 async function startRuntime(telemetryServerUrl?: string) {
-  let runtimePromise = Promise.resolve();
   if (start.args.length > 0) {
-    runtimePromise = new Promise((urlResolver, reject) => {
+    const runtimePromise = new Promise((urlResolver, reject) => {
       const appProcess = spawn(start.args[0], start.args.slice(1), {
         env: {
           ...process.env,
@@ -96,5 +95,5 @@ async function startRuntime(telemetryServerUrl?: string) {
       });
     });
   }
-  return runtimePromise;
+  return new Promise(() => {}); // no runtime, return a hanging promise.
 }


### PR DESCRIPTION
right now is just exits

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [n/a] Docs updated (updated docs or a docs bug required)
