### PR TITLE
refactor(py): add action kind and refactor register_action usage

### DIFF
--- a/py/packages/genkit/src/genkit/core/action_test.py
+++ b/py/packages/genkit/src/genkit/core/action_test.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from genkit.core.action import ActionKind
+
+
+def test_action_enum_behaves_like_str() -> None:
+    """Ensure the ActionType behaves like a string and to ensure we're using the
+    correct variants."""
+    assert ActionKind.CHATLLM == 'chat-llm'
+    assert ActionKind.CUSTOM == 'custom'
+    assert ActionKind.EMBEDDER == 'embedder'
+    assert ActionKind.EVALUATOR == 'evaluator'
+    assert ActionKind.FLOW == 'flow'
+    assert ActionKind.INDEXER == 'indexer'
+    assert ActionKind.MODEL == 'model'
+    assert ActionKind.PROMPT == 'prompt'
+    assert ActionKind.RETRIEVER == 'retriever'
+    assert ActionKind.TEXTLLM == 'text-llm'
+    assert ActionKind.TOOL == 'tool'
+    assert ActionKind.UTIL == 'util'

--- a/py/packages/genkit/src/genkit/core/headers.py
+++ b/py/packages/genkit/src/genkit/core/headers.py
@@ -1,0 +1,12 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contains definitions for custom headers used by the framework and other
+related functionality."""
+
+from enum import Enum
+
+
+class HttpHeader(str, Enum):
+    CONTENT_TYPE = 'Content-Type'
+    X_GENKIT_VERSION = 'X-Genkit-Version'

--- a/py/packages/genkit/src/genkit/core/plugin_abc.py
+++ b/py/packages/genkit/src/genkit/core/plugin_abc.py
@@ -1,6 +1,8 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+"""Abstract base class for Genkit plugins."""
+
 from __future__ import annotations
 
 import abc

--- a/py/packages/genkit/src/genkit/core/reflection.py
+++ b/py/packages/genkit/src/genkit/core/reflection.py
@@ -7,6 +7,7 @@
 import json
 from http.server import BaseHTTPRequestHandler
 
+from genkit.core.headers import HttpHeader
 from genkit.core.registry import Registry
 from pydantic import BaseModel
 
@@ -58,8 +59,7 @@ def make_reflection_server(registry: Registry):
                 content_len = int(self.headers.get('Content-Length') or 0)
                 post_body = self.rfile.read(content_len)
                 payload = json.loads(post_body.decode(encoding=self.ENCODING))
-                print(payload)
-                action = registry.lookup_by_absolute_name(payload['key'])
+                action = registry.lookup_action_by_key(payload['key'])
                 if '/flow/' in payload['key']:
                     input_action = action.input_type.validate_python(
                         payload['input']['start']['input']
@@ -72,8 +72,8 @@ def make_reflection_server(registry: Registry):
                 output = action.fn(input_action)
 
                 self.send_response(200)
-                self.send_header('x-genkit-version', '0.9.1')
-                self.send_header('Content-type', 'application/json')
+                self.send_header(HttpHeader.X_GENKIT_VERSION, '0.9.1')
+                self.send_header(HttpHeader.CONTENT_TYPE, 'application/json')
                 self.end_headers()
 
                 if isinstance(output.response, BaseModel):

--- a/py/packages/genkit/src/genkit/core/registry.py
+++ b/py/packages/genkit/src/genkit/core/registry.py
@@ -1,27 +1,64 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+"""The registry is used to store and lookup resources such as actions and
+flows."""
 
-"""The registry is used to store and lookup resources."""
-
-from genkit.core.action import Action
+from genkit.core.action import Action, ActionKind
 
 
 class Registry:
     """Stores actions, trace stores, flow state stores, plugins, and schemas."""
 
-    actions: dict[str, dict[str, Action]] = {}
+    actions: dict[ActionKind, dict[str, Action]] = {}
 
-    def register_action(self, action_type: str, name: str, action: Action):
-        if action_type not in self.actions:
-            self.actions[action_type] = {}
-        self.actions[action_type][name] = action
+    def register_action(self, action: Action) -> None:
+        """Register an action.
 
-    def lookup_action(self, action_type: str, name: str):
-        if action_type in self.actions and name in self.actions[action_type]:
-            return self.actions[action_type][name]
-        return None
+        Args:
+            action: The action to register.
+        """
+        kind = action.kind
+        if kind not in self.actions:
+            self.actions[kind] = {}
+        self.actions[kind][action.name] = action
 
-    def lookup_by_absolute_name(self, name: str):
-        tkns = name.split('/', 2)
-        return self.lookup_action(tkns[1], tkns[2])
+    def lookup_action(self, kind: ActionKind, name: str) -> Action | None:
+        """Lookup an action by its kind and name.
+
+        Args:
+            kind: The kind of the action.
+            name: The name of the action.
+
+        Returns:
+            The action if found, otherwise None.
+        """
+        if kind in self.actions and name in self.actions[kind]:
+            return self.actions[kind][name]
+
+    def lookup_action_by_key(self, key: str) -> Action | None:
+        """Lookup an action by its key.
+
+        The key is of the form:
+        <kind>/<name>
+
+        Args:
+            key: The key to lookup the action by.
+
+        Returns:
+            The action if found, otherwise None.
+
+        Raises:
+            ValueError: If the key format is invalid.
+        """
+        # TODO: Use pattern matching to validate the key format
+        # and verify whether the key can have only 2 parts.
+        tokens = key.split('/')
+        if len(tokens) != 2:
+            msg = (
+                f'Invalid action key format: `{key}`. '
+                'Expected format: `<kind>/<name>`'
+            )
+            raise ValueError(msg)
+        kind, name = tokens
+        return self.lookup_action(kind, name)

--- a/py/packages/genkit/src/genkit/core/registry_test.py
+++ b/py/packages/genkit/src/genkit/core/registry_test.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from genkit.core.action import Action, ActionKind
+from genkit.core.registry import Registry
+
+
+def test_register_action_with_name_and_kind() -> None:
+    """Ensure we can register an action with a name and kind."""
+    registry = Registry()
+    action = Action(name='test_action', kind=ActionKind.CUSTOM, fn=lambda x: x)
+    registry.register_action(action)
+    got = registry.lookup_action(ActionKind.CUSTOM, 'test_action')
+
+    assert got == action
+    assert got.name == 'test_action'
+    assert got.kind == ActionKind.CUSTOM
+
+
+def test_lookup_action_by_key() -> None:
+    """Ensure we can lookup an action by its key."""
+    registry = Registry()
+    action = Action(name='test_action', kind=ActionKind.CUSTOM, fn=lambda x: x)
+    registry.register_action(action)
+    got = registry.lookup_action_by_key('custom/test_action')
+
+    assert got == action
+    assert got.name == 'test_action'
+    assert got.kind == ActionKind.CUSTOM
+
+
+def test_lookup_action_by_key_invalid_format() -> None:
+    """Ensure lookup_action_by_key handles invalid key format."""
+    registry = Registry()
+    with pytest.raises(ValueError, match='Invalid action key format'):
+        registry.lookup_action_by_key('invalid_key')
+    with pytest.raises(ValueError, match='Invalid action key format'):
+        registry.lookup_action_by_key('too/many/parts')

--- a/py/packages/genkit/src/genkit/core/schemas.py
+++ b/py/packages/genkit/src/genkit/core/schemas.py
@@ -19,15 +19,15 @@ class InstrumentationLibrary(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     name: str
     version: str | None = None
-    schemaUrl: str | None = None
+    schema_url: str | None = Field(None, alias='schemaUrl')
 
 
 class SpanContext(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    traceId: str
-    spanId: str
-    isRemote: bool | None = None
-    traceFlags: float
+    trace_id: str = Field(..., alias='traceId')
+    span_id: str = Field(..., alias='spanId')
+    is_remote: bool | None = Field(None, alias='isRemote')
+    trace_flags: float = Field(..., alias='traceFlags')
 
 
 class SameProcessAsParentSpan(BaseModel):
@@ -46,7 +46,7 @@ class SpanMetadata(BaseModel):
     state: State | None = None
     input: Any | None = None
     output: Any | None = None
-    isRoot: bool | None = None
+    is_root: bool | None = Field(None, alias='isRoot')
     metadata: dict[str, str] | None = None
 
 
@@ -85,8 +85,8 @@ class DataPart(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     text: Any | None = None
     media: Any | None = None
-    toolRequest: Any | None = None
-    toolResponse: Any | None = None
+    tool_request: Any | None = Field(None, alias='toolRequest')
+    tool_response: Any | None = Field(None, alias='toolResponse')
     data: Any | None = None
     metadata: dict[str, Any] | None = None
 
@@ -108,7 +108,7 @@ class Content(BaseModel):
 
 class Media(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    contentType: str | None = None
+    content_type: str | None = Field(None, alias='contentType')
     url: str
 
 
@@ -133,9 +133,9 @@ class ToolChoice(Enum):
 class Output(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     format: str | None = None
-    contentType: str | None = None
+    content_type: str | None = Field(None, alias='contentType')
     instructions: bool | str | None = None
-    jsonSchema: Any | None = None
+    json_schema: Any | None = Field(None, alias='jsonSchema')
     constrained: bool | None = None
 
 
@@ -155,25 +155,25 @@ class GenerationCommonConfig(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     version: str | None = None
     temperature: float | None = None
-    maxOutputTokens: float | None = None
-    topK: float | None = None
-    topP: float | None = None
-    stopSequences: list[str] | None = None
+    max_output_tokens: float | None = Field(None, alias='maxOutputTokens')
+    top_k: float | None = Field(None, alias='topK')
+    top_p: float | None = Field(None, alias='topP')
+    stop_sequences: list[str] | None = Field(None, alias='stopSequences')
 
 
 class GenerationUsage(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    inputTokens: float | None = None
-    outputTokens: float | None = None
-    totalTokens: float | None = None
-    inputCharacters: float | None = None
-    outputCharacters: float | None = None
-    inputImages: float | None = None
-    outputImages: float | None = None
-    inputVideos: float | None = None
-    outputVideos: float | None = None
-    inputAudioFiles: float | None = None
-    outputAudioFiles: float | None = None
+    input_tokens: float | None = Field(None, alias='inputTokens')
+    output_tokens: float | None = Field(None, alias='outputTokens')
+    total_tokens: float | None = Field(None, alias='totalTokens')
+    input_characters: float | None = Field(None, alias='inputCharacters')
+    output_characters: float | None = Field(None, alias='outputCharacters')
+    input_images: float | None = Field(None, alias='inputImages')
+    output_images: float | None = Field(None, alias='outputImages')
+    input_videos: float | None = Field(None, alias='inputVideos')
+    output_videos: float | None = Field(None, alias='outputVideos')
+    input_audio_files: float | None = Field(None, alias='inputAudioFiles')
+    output_audio_files: float | None = Field(None, alias='outputAudioFiles')
     custom: dict[str, float] | None = None
 
 
@@ -188,12 +188,12 @@ class Supports(BaseModel):
     multiturn: bool | None = None
     media: bool | None = None
     tools: bool | None = None
-    systemRole: bool | None = None
+    system_role: bool | None = Field(None, alias='systemRole')
     output: list[str] | None = None
-    contentType: list[str] | None = None
+    content_type: list[str] | None = Field(None, alias='contentType')
     context: bool | None = None
     constrained: Constrained | None = None
-    toolChoice: bool | None = None
+    tool_choice: bool | None = Field(None, alias='toolChoice')
 
 
 class ModelInfo(BaseModel):
@@ -214,11 +214,15 @@ class ToolDefinition(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     name: str
     description: str
-    inputSchema: dict[str, Any] = Field(
-        ..., description='Valid JSON Schema representing the input of the tool.'
+    input_schema: dict[str, Any] = Field(
+        ...,
+        alias='inputSchema',
+        description='Valid JSON Schema representing the input of the tool.',
     )
-    outputSchema: dict[str, Any] | None = Field(
-        None, description='Valid JSON Schema describing the output of the tool.'
+    output_schema: dict[str, Any] | None = Field(
+        None,
+        alias='outputSchema',
+        description='Valid JSON Schema describing the output of the tool.',
     )
     metadata: dict[str, Any] | None = Field(
         None, description='additional metadata for this tool definition'
@@ -267,7 +271,7 @@ class Content2(BaseModel):
 
 class Media2(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    contentType: str | None = None
+    content_type: str | None = Field(None, alias='contentType')
     url: str
 
 
@@ -329,38 +333,44 @@ class Link(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     context: SpanContext | None = None
     attributes: dict[str, Any] | None = None
-    droppedAttributesCount: float | None = None
+    dropped_attributes_count: float | None = Field(
+        None, alias='droppedAttributesCount'
+    )
 
 
 class TimeEvents(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    timeEvent: list[TimeEvent] | None = None
+    time_event: list[TimeEvent] | None = Field(None, alias='timeEvent')
 
 
 class SpanData(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    spanId: str
-    traceId: str
-    parentSpanId: str | None = None
-    startTime: float
-    endTime: float
+    span_id: str = Field(..., alias='spanId')
+    trace_id: str = Field(..., alias='traceId')
+    parent_span_id: str | None = Field(None, alias='parentSpanId')
+    start_time: float = Field(..., alias='startTime')
+    end_time: float = Field(..., alias='endTime')
     attributes: dict[str, Any]
-    displayName: str
+    display_name: str = Field(..., alias='displayName')
     links: list[Link] | None = None
-    instrumentationLibrary: InstrumentationLibrary
-    spanKind: str
-    sameProcessAsParentSpan: SameProcessAsParentSpan | None = None
+    instrumentation_library: InstrumentationLibrary = Field(
+        ..., alias='instrumentationLibrary'
+    )
+    span_kind: str = Field(..., alias='spanKind')
+    same_process_as_parent_span: SameProcessAsParentSpan | None = Field(
+        None, alias='sameProcessAsParentSpan'
+    )
     status: SpanStatus | None = None
-    timeEvents: TimeEvents | None = None
+    time_events: TimeEvents | None = Field(None, alias='timeEvents')
     truncated: bool | None = None
 
 
 class TraceData(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    traceId: str
-    displayName: str | None = None
-    startTime: float | None = None
-    endTime: float | None = None
+    trace_id: str = Field(..., alias='traceId')
+    display_name: str | None = Field(None, alias='displayName')
+    start_time: float | None = Field(None, alias='startTime')
+    end_time: float | None = Field(None, alias='endTime')
     spans: dict[str, SpanData]
 
 
@@ -368,8 +378,8 @@ class MediaPart(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     text: Text | None = None
     media: Media
-    toolRequest: ToolRequest | None = None
-    toolResponse: ToolResponse | None = None
+    tool_request: ToolRequest | None = Field(None, alias='toolRequest')
+    tool_response: ToolResponse | None = Field(None, alias='toolResponse')
     data: Any | None = None
     metadata: Metadata | None = None
 
@@ -378,8 +388,8 @@ class TextPart(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     text: str
     media: MediaModel | None = None
-    toolRequest: ToolRequest | None = None
-    toolResponse: ToolResponse | None = None
+    tool_request: ToolRequest | None = Field(None, alias='toolRequest')
+    tool_response: ToolResponse | None = Field(None, alias='toolResponse')
     data: Data | None = None
     metadata: Metadata | None = None
 
@@ -388,8 +398,8 @@ class ToolRequestPart(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     text: Text | None = None
     media: MediaModel | None = None
-    toolRequest: ToolRequest1
-    toolResponse: ToolResponse | None = None
+    tool_request: ToolRequest1 = Field(..., alias='toolRequest')
+    tool_response: ToolResponse | None = Field(None, alias='toolResponse')
     data: Data | None = None
     metadata: Metadata | None = None
 
@@ -398,8 +408,8 @@ class ToolResponsePart(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     text: Text | None = None
     media: MediaModel | None = None
-    toolRequest: ToolRequest | None = None
-    toolResponse: ToolResponse1
+    tool_request: ToolRequest | None = Field(None, alias='toolRequest')
+    tool_response: ToolResponse1 = Field(..., alias='toolResponse')
     data: Data | None = None
     metadata: Metadata | None = None
 
@@ -456,8 +466,8 @@ class Candidate(BaseModel):
     index: float
     message: Message
     usage: GenerationUsage | None = None
-    finishReason: FinishReason
-    finishMessage: str | None = None
+    finish_reason: FinishReason = Field(..., alias='finishReason')
+    finish_message: str | None = Field(None, alias='finishMessage')
     custom: Any | None = None
 
 
@@ -467,11 +477,11 @@ class GenerateActionOptions(BaseModel):
     docs: list[Doc] | None = None
     messages: list[Message]
     tools: list[str] | None = None
-    toolChoice: ToolChoice | None = None
+    tool_choice: ToolChoice | None = Field(None, alias='toolChoice')
     config: Any | None = None
     output: Output | None = None
-    returnToolRequests: bool | None = None
-    maxTurns: float | None = None
+    return_tool_requests: bool | None = Field(None, alias='returnToolRequests')
+    max_turns: float | None = Field(None, alias='maxTurns')
 
 
 class GenerateRequest(BaseModel):
@@ -479,7 +489,7 @@ class GenerateRequest(BaseModel):
     messages: list[Message]
     config: Any | None = None
     tools: list[ToolDefinition] | None = None
-    toolChoice: ToolChoice | None = None
+    tool_choice: ToolChoice | None = Field(None, alias='toolChoice')
     output: Output1 | None = None
     context: list[Items] | None = None
     candidates: float | None = None
@@ -488,9 +498,9 @@ class GenerateRequest(BaseModel):
 class GenerateResponse(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     message: Message | None = None
-    finishReason: FinishReason | None = None
-    finishMessage: str | None = None
-    latencyMs: float | None = None
+    finish_reason: FinishReason | None = Field(None, alias='finishReason')
+    finish_message: str | None = Field(None, alias='finishMessage')
+    latency_ms: float | None = Field(None, alias='latencyMs')
     usage: GenerationUsage | None = None
     custom: Any | None = None
     request: GenerateRequest | None = None
@@ -502,7 +512,7 @@ class ModelRequest(BaseModel):
     messages: Messages
     config: Config | None = None
     tools: Tools | None = None
-    toolChoice: ToolChoice | None = None
+    tool_choice: ToolChoice | None = Field(None, alias='toolChoice')
     output: OutputModel | None = None
     context: list[Items] | None = None
 
@@ -514,9 +524,9 @@ class Request(RootModel[GenerateRequest]):
 class ModelResponse(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
     message: Message | None = None
-    finishReason: FinishReason
-    finishMessage: FinishMessage | None = None
-    latencyMs: LatencyMs | None = None
+    finish_reason: FinishReason = Field(..., alias='finishReason')
+    finish_message: FinishMessage | None = Field(None, alias='finishMessage')
+    latency_ms: LatencyMs | None = Field(None, alias='latencyMs')
     usage: Usage | None = None
     custom: Custom | None = None
     request: Request | None = None

--- a/py/packages/genkit/src/genkit/veneer/server.py
+++ b/py/packages/genkit/src/genkit/veneer/server.py
@@ -1,0 +1,83 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Functionality used by the Genkit veneer to start multiple servers.
+
+The following servers may be started depending upon the host environment:
+
+- Reflection API server.
+- Flows server.
+
+The reflection API server is started only in dev mode, which is enabled by the
+setting the environment variable `GENKIT_ENV` to `dev`. By default, the
+reflection API server binds and listens on (localhost, 3100).  The flows server
+is the production servers that exposes flows and actions over HTTP.
+"""
+
+import atexit
+import json
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+@dataclass
+class ServerSpec:
+    """ServerSpec encapsulates the scheme, host and port information for a
+    server to bind to and listen on."""
+
+    port: int
+    scheme: str = 'http'
+    host: str = 'localhost'
+
+    @property
+    def url(self) -> str:
+        """URL evaluates to the host base URL given the server specs."""
+        return f'{self.scheme}://{self.host}:{self.port}'
+
+
+def create_runtime(
+    runtime_dir: str,
+    reflection_server_spec: ServerSpec,
+    at_exit_fn: Callable[[Path], None] | None = None,
+) -> Path:
+    """Create a runtime configuration for use with the genkit CLI.
+    The runtime information is stored in the form of a timestamped JSON file.
+    Note that the file will be cleaned up as soon as the program terminates.
+    Args:
+        runtime_dir: The directory to store the runtime file in.
+        reflection_server_spec: The server specification for the reflection
+        server.
+        at_exit_fn: A function to call when the runtime file is deleted.
+    Returns:
+        A path object representing the created runtime metadata file.
+    """
+    if not os.path.exists(runtime_dir):
+        os.makedirs(runtime_dir)
+
+    current_datetime = datetime.now()
+    runtime_file_name = f'{current_datetime.isoformat()}.json'
+    runtime_file_path = Path(os.path.join(runtime_dir, runtime_file_name))
+    metadata = json.dumps(
+        {
+            'id': f'{os.getpid()}',
+            'pid': os.getpid(),
+            'reflectionServerUrl': reflection_server_spec.url,
+            'timestamp': f'{current_datetime.isoformat()}',
+        }
+    )
+    runtime_file_path.write_text(metadata, encoding='utf-8')
+
+    if at_exit_fn:
+        atexit.register(lambda: at_exit_fn(runtime_file_path))
+    return runtime_file_path
+
+
+def is_dev_environment() -> bool:
+    """Returns True if the current environment is a development environment.
+    Returns:
+        True if the current environment is a development environment.
+    """
+    return os.getenv('GENKIT_ENV') == 'dev'

--- a/py/packages/genkit/src/genkit/veneer/server_test.py
+++ b/py/packages/genkit/src/genkit/veneer/server_test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import tempfile
+from unittest import mock
+
+from genkit.veneer import server
+
+
+def test_server_spec() -> None:
+    assert (
+        server.ServerSpec(scheme='http', host='localhost', port=3100).url
+        == 'http://localhost:3100'
+    )
+
+    # Test with different schemes and hosts
+    assert (
+        server.ServerSpec(scheme='https', host='example.com', port=8080).url
+        == 'https://example.com:8080'
+    )
+
+    # Test with default values
+    spec = server.ServerSpec(port=5000)
+    assert spec.scheme == 'http'
+    assert spec.host == 'localhost'
+    assert spec.url == 'http://localhost:5000'
+
+
+def test_create_runtime() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        spec = server.ServerSpec(port=3100)
+
+        # Test runtime file creation
+        runtime_path = server.create_runtime(temp_dir, spec)
+        assert runtime_path.exists()
+
+        # Verify file content
+        content = json.loads(runtime_path.read_text(encoding='utf-8'))
+        assert isinstance(content, dict)
+        assert 'id' in content
+        assert 'pid' in content
+        assert content['reflectionServerUrl'] == 'http://localhost:3100'
+        assert 'timestamp' in content
+
+        # Test directory creation
+        new_dir = os.path.join(temp_dir, 'new_dir')
+        runtime_path = server.create_runtime(new_dir, spec)
+        assert os.path.exists(new_dir)
+        assert runtime_path.exists()
+
+
+def test_is_dev_environment() -> None:
+    # Test when GENKIT_ENV is not set
+    with mock.patch.dict(os.environ, clear=True):
+        assert not server.is_dev_environment()
+
+    # Test when GENKIT_ENV is set to 'dev'
+    with mock.patch.dict(os.environ, {'GENKIT_ENV': 'dev'}):
+        assert server.is_dev_environment()
+
+    # Test when GENKIT_ENV is set to something else
+    with mock.patch.dict(os.environ, {'GENKIT_ENV': 'prod'}):
+        assert not server.is_dev_environment()

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -52,7 +52,7 @@ testpaths = ["packages", "plugins", "samples"]
 addopts = "--cov"
 
 [tool.coverage.report]
-fail_under = 70
+fail_under = 80
 
 # uv based package management.
 [tool.uv]
@@ -131,6 +131,7 @@ select = [
 
 
 [tool.ruff.format]
+docstring-code-format     = true
 indent-style              = "space"
 line-ending               = "lf"
 quote-style               = "single"
@@ -146,17 +147,18 @@ warn_unused_configs      = true
 #collapse-root-models = true # Don't use; produces Any as types.
 #strict-types = ["str", "int", "float", "bool", "bytes"] # Don't use; produces StrictStr, StrictInt, etc.
 #use-subclass-enum        = true
-capitalize-enum-members = true
-disable-timestamp       = true
-enable-version-header   = true
-field-constraints       = true
-input                   = "../genkit-tools/genkit-schema.json"
-input-file-type         = "jsonschema"
-output                  = "packages/genkit/src/genkit/core/schemas.py"
-output-model-type       = "pydantic_v2.BaseModel"
-#snake-case-field = true
+capitalize-enum-members  = true
+disable-timestamp        = true
+enable-version-header    = true
+field-constraints        = true
+input                    = "../genkit-tools/genkit-schema.json"
+input-file-type          = "jsonschema"
+output                   = "packages/genkit/src/genkit/core/schemas.py"
+output-model-type        = "pydantic_v2.BaseModel"
+snake-case-field         = true
 strict-nullable          = true
 target-python-version    = "3.12"
+use-default              = false
 use-schema-description   = true
 use-standard-collections = true
 use-union-operator       = true

--- a/py/samples/hello/hello.py
+++ b/py/samples/hello/hello.py
@@ -1,5 +1,8 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
+
+"""A hello world sample that just calls some flows."""
+
 from typing import Any
 
 from genkit.core.schemas import GenerateRequest, Message, Role, TextPart


### PR DESCRIPTION
refactor(py): add action kind and refactor register_action usage

CHANGELOG:
- [ ] Add unit test coverage for the following modules:
  - [ ] server
  - [ ] action
  - [ ] registry
- [ ] update schemas to use snake_case for field names
- [ ] add a headers.py module to contain HttpHeader enum.
- [ ] Define an ActionKind type to enumerate action variants.
- [ ] Refactor the registry methods to reduce redundancy.
- [ ] Push coverage threshold to 80%.

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
