### PR TITLE
chore: do not install node with homebrew in the setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -100,7 +100,6 @@ function genkit::install_prerequisites() {
       fd \
       gh \
       go \
-      node \
       python3 \
       ripgrep
   elif [[ -x "$(command -v apt)" ]]; then


### PR DESCRIPTION
node is managed by nvm, installing it with homebrew breaks nvm
