### PR TITLE
fix(ruff): use the same command for the ci for python checks

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,7 +31,7 @@ jobs:
         run: uv run --directory py ruff format --check .
 
       - name: Lint with ruff
-        run: uv run --directory py ruff check .
+        run: uv run --directory py ruff check --select I .
 
       - name: Check licenses
         run: ./bin/check_license

--- a/bin/setup
+++ b/bin/setup
@@ -125,7 +125,6 @@ function genkit::install_prerequisites() {
       curl \
       fd-find \
       gh \
-      nodejs \
       python3 \
       ripgrep
   elif [[ -x "$(command -v dnf)" ]]; then
@@ -136,7 +135,6 @@ function genkit::install_prerequisites() {
       fd-find \
       gh \
       go \
-      node \
       python3 \
       ripgrep
   else

--- a/py/bin/generate_schema_types
+++ b/py/bin/generate_schema_types
@@ -21,4 +21,4 @@ python3 "${TOP_DIR}/py/bin/sanitize_schema_types.py" "${SCHEMA_FILE}"
 uv run --directory "${TOP_DIR}/py" \
   ruff format "${TOP_DIR}"
 uv run --directory "${TOP_DIR}/py" \
-  ruff check --fix "${SCHEMA_FILE}"
+  ruff check --select I --fix "${SCHEMA_FILE}"


### PR DESCRIPTION
fix(ruff): use the same command for the ci for python checks

CHANGELOG:
- [ ] Use consistent command for ruff check throughout.
- [ ] Don't install node as prerequisite since nvm installs it.