### PR TITLE
feat(js/plugins): added `experimental_debugTraces` option to googleai and vertexai plugins

### DIFF
--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -866,9 +866,16 @@ export function defineGoogleAIModel({
       return debugTraces
         ? await runInNewSpan(
             ai.registry,
-            { metadata: { name } },
+            {
+              metadata: {
+                name: sendChunk ? 'sendMessageStream' : 'sendMessage',
+              },
+            },
             async (metadata) => {
               metadata.input = {
+                sdk: '@google/generative-ai',
+                cache: cache,
+                model: genModel.model,
                 chatOptions: updatedChatRequest,
                 parts: msg.parts,
                 options,

--- a/js/plugins/googleai/src/index.ts
+++ b/js/plugins/googleai/src/index.ts
@@ -59,7 +59,7 @@ export interface PluginOptions {
     | ModelReference</** @ignore */ typeof GeminiConfigSchema>
     | string
   )[];
-  debugTraces?: boolean;
+  experimental_debugTraces?: boolean;
 }
 
 /**
@@ -85,7 +85,7 @@ export function googleAI(options?: PluginOptions): GenkitPlugin {
           apiKey: options?.apiKey,
           apiVersion: 'v1beta',
           baseUrl: options?.baseUrl,
-          debugTraces: options?.debugTraces,
+          debugTraces: options?.experimental_debugTraces,
         })
       );
     }
@@ -97,7 +97,7 @@ export function googleAI(options?: PluginOptions): GenkitPlugin {
           apiKey: options?.apiKey,
           apiVersion: undefined,
           baseUrl: options?.baseUrl,
-          debugTraces: options?.debugTraces,
+          debugTraces: options?.experimental_debugTraces,
         })
       );
       Object.keys(SUPPORTED_V15_MODELS).forEach((name) =>
@@ -107,7 +107,7 @@ export function googleAI(options?: PluginOptions): GenkitPlugin {
           apiKey: options?.apiKey,
           apiVersion: undefined,
           baseUrl: options?.baseUrl,
-          debugTraces: options?.debugTraces,
+          debugTraces: options?.experimental_debugTraces,
         })
       );
       Object.keys(EMBEDDER_MODELS).forEach((name) =>
@@ -133,7 +133,7 @@ export function googleAI(options?: PluginOptions): GenkitPlugin {
             ...modelRef.info,
             label: `Google AI - ${modelName}`,
           },
-          debugTraces: options?.debugTraces,
+          debugTraces: options?.experimental_debugTraces,
         });
       }
     }

--- a/js/plugins/googleai/src/index.ts
+++ b/js/plugins/googleai/src/index.ts
@@ -59,6 +59,7 @@ export interface PluginOptions {
     | ModelReference</** @ignore */ typeof GeminiConfigSchema>
     | string
   )[];
+  debugTraces?: boolean;
 }
 
 /**
@@ -78,33 +79,36 @@ export function googleAI(options?: PluginOptions): GenkitPlugin {
 
     if (apiVersions.includes('v1beta')) {
       Object.keys(SUPPORTED_V15_MODELS).forEach((name) =>
-        defineGoogleAIModel(
+        defineGoogleAIModel({
           ai,
           name,
-          options?.apiKey,
-          'v1beta',
-          options?.baseUrl
-        )
+          apiKey: options?.apiKey,
+          apiVersion: 'v1beta',
+          baseUrl: options?.baseUrl,
+          debugTraces: options?.debugTraces,
+        })
       );
     }
     if (apiVersions.includes('v1')) {
       Object.keys(SUPPORTED_V1_MODELS).forEach((name) =>
-        defineGoogleAIModel(
+        defineGoogleAIModel({
           ai,
           name,
-          options?.apiKey,
-          undefined,
-          options?.baseUrl
-        )
+          apiKey: options?.apiKey,
+          apiVersion: undefined,
+          baseUrl: options?.baseUrl,
+          debugTraces: options?.debugTraces,
+        })
       );
       Object.keys(SUPPORTED_V15_MODELS).forEach((name) =>
-        defineGoogleAIModel(
+        defineGoogleAIModel({
           ai,
           name,
-          options?.apiKey,
-          undefined,
-          options?.baseUrl
-        )
+          apiKey: options?.apiKey,
+          apiVersion: undefined,
+          baseUrl: options?.baseUrl,
+          debugTraces: options?.debugTraces,
+        })
       );
       Object.keys(EMBEDDER_MODELS).forEach((name) =>
         defineGoogleAIEmbedder(ai, name, { apiKey: options?.apiKey })
@@ -120,17 +124,17 @@ export function googleAI(options?: PluginOptions): GenkitPlugin {
               modelOrRef.name.split('/')[1];
         const modelRef =
           typeof modelOrRef === 'string' ? gemini(modelOrRef) : modelOrRef;
-        defineGoogleAIModel(
+        defineGoogleAIModel({
           ai,
-          modelName,
-          options?.apiKey,
-          undefined,
-          options?.baseUrl,
-          {
+          name: modelName,
+          apiKey: options?.apiKey,
+          baseUrl: options?.baseUrl,
+          info: {
             ...modelRef.info,
             label: `Google AI - ${modelName}`,
-          }
-        );
+          },
+          debugTraces: options?.debugTraces,
+        });
       }
     }
   });

--- a/js/plugins/vertexai/src/common/types.ts
+++ b/js/plugins/vertexai/src/common/types.ts
@@ -26,6 +26,8 @@ export interface CommonPluginOptions {
   location: string;
   /** Provide custom authentication configuration for connecting to Vertex AI. */
   googleAuth?: GoogleAuthOptions;
+  /** Enables additional, detailed debug traces (e.g. raw model API call details). */
+  debugTraces?: boolean;
 }
 
 /** Combined plugin options, extending common options with subplugin-specific options */

--- a/js/plugins/vertexai/src/common/types.ts
+++ b/js/plugins/vertexai/src/common/types.ts
@@ -26,8 +26,8 @@ export interface CommonPluginOptions {
   location: string;
   /** Provide custom authentication configuration for connecting to Vertex AI. */
   googleAuth?: GoogleAuthOptions;
-  /** Enables additional, detailed debug traces (e.g. raw model API call details). */
-  debugTraces?: boolean;
+  /** Enables additional debug traces (e.g. raw model API call details). */
+  experimental_debugTraces?: boolean;
 }
 
 /** Combined plugin options, extending common options with subplugin-specific options */

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -51,6 +51,7 @@ import {
   downloadRequestMedia,
   simulateSystemPrompt,
 } from 'genkit/model/middleware';
+import { runInNewSpan } from 'genkit/tracing';
 import { GoogleAuth } from 'google-auth-library';
 import { PluginOptions } from './common/types.js';
 import { handleCacheIfNeeded } from './context-caching/index.js';
@@ -700,36 +701,47 @@ export function defineGeminiKnownModel(
   vertexClientFactory: (
     request: GenerateRequest<typeof GeminiConfigSchema>
   ) => VertexAI,
-  options: PluginOptions
+  options: PluginOptions,
+  debugTraces?: boolean
 ): ModelAction {
   const modelName = `vertexai/${name}`;
 
   const model: ModelReference<z.ZodTypeAny> = SUPPORTED_GEMINI_MODELS[name];
   if (!model) throw new Error(`Unsupported model: ${name}`);
 
-  return defineGeminiModel(
+  return defineGeminiModel({
     ai,
     modelName,
-    name,
-    model?.info,
+    version: name,
+    modelInfo: model?.info,
     vertexClientFactory,
-    options
-  );
+    options,
+    debugTraces,
+  });
 }
 
 /**
  * Define a Vertex AI Gemini model.
  */
-export function defineGeminiModel(
-  ai: Genkit,
-  modelName: string,
-  version: string,
-  modelInfo: ModelInfo | undefined,
+export function defineGeminiModel({
+  ai,
+  modelName,
+  version,
+  modelInfo,
+  vertexClientFactory,
+  options,
+  debugTraces,
+}: {
+  ai: Genkit;
+  modelName: string;
+  version: string;
+  modelInfo: ModelInfo | undefined;
   vertexClientFactory: (
     request: GenerateRequest<typeof GeminiConfigSchema>
-  ) => VertexAI,
-  options: PluginOptions
-): ModelAction {
+  ) => VertexAI;
+  options: PluginOptions;
+  debugTraces?: boolean;
+}): ModelAction {
   const middlewares: ModelMiddleware[] = [];
   if (SUPPORTED_V1_MODELS[version]) {
     middlewares.push(simulateSystemPrompt());
@@ -884,57 +896,79 @@ export function defineGeminiModel(
         );
       }
 
-      // Handle streaming and non-streaming responses
-      if (streamingCallback) {
-        const result = await genModel
-          .startChat(updatedChatRequest)
-          .sendMessageStream(msg.parts);
+      const callGemini = async () => {
+        // Handle streaming and non-streaming responses
+        if (streamingCallback) {
+          const result = await genModel
+            .startChat(updatedChatRequest)
+            .sendMessageStream(msg.parts);
 
-        for await (const item of result.stream) {
-          (item as GenerateContentResponse).candidates?.forEach((candidate) => {
-            const c = fromGeminiCandidate(candidate, jsonMode);
-            streamingCallback({
-              index: c.index,
-              content: c.message.content,
-            });
-          });
-        }
+          for await (const item of result.stream) {
+            (item as GenerateContentResponse).candidates?.forEach(
+              (candidate) => {
+                const c = fromGeminiCandidate(candidate, jsonMode);
+                streamingCallback({
+                  index: c.index,
+                  content: c.message.content,
+                });
+              }
+            );
+          }
 
-        const response = await result.response;
-        if (!response.candidates?.length) {
-          throw new Error('No valid candidates returned.');
-        }
+          const response = await result.response;
+          if (!response.candidates?.length) {
+            throw new Error('No valid candidates returned.');
+          }
 
-        return {
-          candidates: response.candidates.map((c) =>
+          return {
+            candidates: response.candidates.map((c) =>
+              fromGeminiCandidate(c, jsonMode)
+            ),
+            custom: response,
+          };
+        } else {
+          const result = await genModel
+            .startChat(updatedChatRequest)
+            .sendMessage(msg.parts);
+
+          if (!result?.response.candidates?.length) {
+            throw new Error('No valid candidates returned.');
+          }
+
+          const responseCandidates = result.response.candidates.map((c) =>
             fromGeminiCandidate(c, jsonMode)
-          ),
-          custom: response,
-        };
-      } else {
-        const result = await genModel
-          .startChat(updatedChatRequest)
-          .sendMessage(msg.parts);
+          );
 
-        if (!result?.response.candidates?.length) {
-          throw new Error('No valid candidates returned.');
+          return {
+            candidates: responseCandidates,
+            custom: result.response,
+            usage: {
+              ...getBasicUsageStats(request.messages, responseCandidates),
+              inputTokens: result.response.usageMetadata?.promptTokenCount,
+              outputTokens: result.response.usageMetadata?.candidatesTokenCount,
+              totalTokens: result.response.usageMetadata?.totalTokenCount,
+            },
+          };
         }
-
-        const responseCandidates = result.response.candidates.map((c) =>
-          fromGeminiCandidate(c, jsonMode)
-        );
-
-        return {
-          candidates: responseCandidates,
-          custom: result.response,
-          usage: {
-            ...getBasicUsageStats(request.messages, responseCandidates),
-            inputTokens: result.response.usageMetadata?.promptTokenCount,
-            outputTokens: result.response.usageMetadata?.candidatesTokenCount,
-            totalTokens: result.response.usageMetadata?.totalTokenCount,
-          },
-        };
-      }
+      };
+      // If debugTraces is enable, we wrap the actual model call with a span, add raw
+      // API params as for input.
+      return debugTraces
+        ? await runInNewSpan(
+            ai.registry,
+            { metadata: { name: version } },
+            async (metadata) => {
+              metadata.input = {
+                chatOptions: updatedChatRequest,
+                parts: msg.parts,
+                options,
+              };
+              const response = await callGemini();
+              metadata.output = response.custom;
+              return response;
+            }
+          )
+        : await callGemini();
     }
   );
 }

--- a/js/plugins/vertexai/src/index.ts
+++ b/js/plugins/vertexai/src/index.ts
@@ -95,7 +95,7 @@ export function vertexAI(options?: PluginOptions): GenkitPlugin {
           projectId,
           location,
         },
-        options?.debugTraces
+        options?.experimental_debugTraces
       )
     );
     if (options?.models) {
@@ -117,7 +117,7 @@ export function vertexAI(options?: PluginOptions): GenkitPlugin {
             projectId,
             location,
           },
-          debugTraces: options.debugTraces,
+          debugTraces: options.experimental_debugTraces,
         });
       }
     }

--- a/js/plugins/vertexai/src/index.ts
+++ b/js/plugins/vertexai/src/index.ts
@@ -87,10 +87,16 @@ export function vertexAI(options?: PluginOptions): GenkitPlugin {
       imagenModel(ai, name, authClient, { projectId, location })
     );
     Object.keys(SUPPORTED_GEMINI_MODELS).map((name) =>
-      defineGeminiKnownModel(ai, name, vertexClientFactory, {
-        projectId,
-        location,
-      })
+      defineGeminiKnownModel(
+        ai,
+        name,
+        vertexClientFactory,
+        {
+          projectId,
+          location,
+        },
+        options?.debugTraces
+      )
     );
     if (options?.models) {
       for (const modelOrRef of options?.models) {
@@ -101,17 +107,18 @@ export function vertexAI(options?: PluginOptions): GenkitPlugin {
               modelOrRef.name.split('/')[1];
         const modelRef =
           typeof modelOrRef === 'string' ? gemini(modelOrRef) : modelOrRef;
-        defineGeminiModel(
+        defineGeminiModel({
           ai,
-          modelRef.name,
-          modelName,
-          modelRef.info,
+          modelName: modelRef.name,
+          version: modelName,
+          modelInfo: modelRef.info,
           vertexClientFactory,
-          {
+          options: {
             projectId,
             location,
-          }
-        );
+          },
+          debugTraces: options.debugTraces,
+        });
       }
     }
 

--- a/js/testapps/context-caching/src/index.ts
+++ b/js/testapps/context-caching/src/index.ts
@@ -24,7 +24,10 @@ import { genkit, z } from 'genkit'; // Import Genkit framework and Zod for schem
 import { logger } from 'genkit/logging'; // Import logging utility from Genkit
 
 const ai = genkit({
-  plugins: [vertexAI(), googleAI()], // Initialize Genkit with the Google AI plugin
+  plugins: [
+    vertexAI({ experimental_debugTraces: true, location: 'us-central1' }),
+    googleAI({ experimental_debugTraces: true }),
+  ], // Initialize Genkit with the Google AI plugin
 });
 
 logger.setLogLevel('debug'); // Set the logging level to debug for detailed output
@@ -38,7 +41,7 @@ export const lotrFlowVertex = ai.defineFlow(
     }),
     outputSchema: z.string(), // Define the expected output as a string
   },
-  async ({ query, textFilePath }) => {
+  async ({ query, textFilePath }, { sendChunk }) => {
     const defaultQuery = 'What is the text i provided you with?'; // Default query to use if none is provided
 
     // Read the content from the file if the path is provided
@@ -69,6 +72,7 @@ export const lotrFlowVertex = ai.defineFlow(
       },
       model: gemini15Flash, // Specify the model (gemini15Flash) to use for generation
       prompt: query || defaultQuery, // Use the provided query or fall back to the default query
+      onChunk: sendChunk,
     });
 
     return llmResponse.text; // Return the generated text from the model
@@ -84,7 +88,7 @@ export const lotrFlowGoogleAI = ai.defineFlow(
     }),
     outputSchema: z.string(), // Define the expected output as a string
   },
-  async ({ query, textFilePath }) => {
+  async ({ query, textFilePath }, { sendChunk }) => {
     const defaultQuery = 'What is the text i provided you with?'; // Default query to use if none is provided
 
     // Read the content from the file if the path is provided
@@ -115,6 +119,7 @@ export const lotrFlowGoogleAI = ai.defineFlow(
       },
       model: gemini15FlashGoogleAI, // Specify the model (gemini15Flash) to use for generation
       prompt: query || defaultQuery, // Use the provided query or fall back to the default query
+      onChunk: sendChunk,
     });
 
     return llmResponse.text; // Return the generated text from the model

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -53,8 +53,8 @@ enableGoogleCloudTelemetry({
 
 const ai = genkit({
   plugins: [
-    googleAI({ debugTraces: false }),
-    vertexAI({ location: 'us-central1', debugTraces: false }),
+    googleAI({ experimental_debugTraces: true }),
+    vertexAI({ location: 'us-central1', experimental_debugTraces: true }),
   ],
 });
 


### PR DESCRIPTION
```ts
const ai = genkit({
  plugins: [googleAI({experimental_debugTraces: true})],
});
```

<img width="1290" alt="image" src="https://github.com/user-attachments/assets/85478802-4669-4ec8-ab4e-490994f4c8df" />



Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [n/a] Docs updated (updated docs or a docs bug required)
