### PR TITLE
feat(py): refactoring a Plugin abstraction

### DIFF
--- a/py/packages/genkit/src/genkit/core/plugin_abc.py
+++ b/py/packages/genkit/src/genkit/core/plugin_abc.py
@@ -8,72 +8,20 @@ from __future__ import annotations
 import abc
 import typing
 
-from genkit.core.schema_types import GenerateRequest, GenerateResponse
-
 if typing.TYPE_CHECKING:
+    # TODO: Must point to an abstraction, not an actual implementation,
+    #       which should resolve the circular import problem.
     from genkit.veneer import Genkit
 
 
 class Plugin(abc.ABC):
     """
-    Abstract class defining common interface
-    for the Genkit Plugin implementation
-
-    NOTE: Any plugin defined for the Genkit must inherit from this class
+    Abstract base class for plugins.
     """
 
     @abc.abstractmethod
-    def attach_to_veneer(self, veneer: Genkit) -> None:
+    def initialize(self, ai: Genkit) -> None:
         """
-        Entrypoint for attaching the plugin to the requested Genkit Veneer
-
-        Implementation must be provided for any inheriting plugin.
-
-        Args:
-            veneer: requested `genkit.veneer.Genkit` instance
-
-        Returns:
-            None
-        """
-        pass
-
-    def _add_model_to_veneer(
-        self, veneer: Genkit, name: str, metadata: dict | None = None
-    ) -> None:
-        """
-        Defines plugin's model in the Genkit Registry
-
-        Uses self._model_callback as a generic callback wrapper
-
-        Args:
-            veneer: requested `genkit.veneer.Genkit` instance
-            name: name of the model to attach
-            metadata: metadata information associated
-                      with the provided model (optional)
-
-        Returns:
-            None
-        """
-        if not metadata:
-            metadata = {}
-        veneer.define_model(
-            name=name, fn=self._model_callback, metadata=metadata
-        )
-
-    @abc.abstractmethod
-    def _model_callback(self, request: GenerateRequest) -> GenerateResponse:
-        """
-        Wrapper around any plugin's model callback.
-
-        Is considered an entrypoint for any model's request.
-        Implementation must be provided for any inheriting plugin.
-
-        Args:
-            request: incoming request as generic
-                     `genkit.core.schemas.GenerateRequest` instance
-
-        Returns:
-            Model response represented as generic
-            `genkit.core.schemas.GenerateResponse` instance
+        Entrypoint for attaching the plugin to the Genkit Veneer.
         """
         pass

--- a/py/packages/genkit/src/genkit/veneer/veneer.py
+++ b/py/packages/genkit/src/genkit/veneer/veneer.py
@@ -60,7 +60,7 @@ class Genkit:
         else:
             for plugin in plugins:
                 if isinstance(plugin, Plugin):
-                    plugin.attach_to_veneer(veneer=self)
+                    plugin.initialize(self)
                 else:
                     raise ValueError(
                         f'Invalid {plugin=} provided to Genkit: '

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/plugin_api.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/plugin_api.py
@@ -37,23 +37,13 @@ class VertexAI(Plugin):
         self._gemini = Gemini(self.VERTEX_AI_GENERATIVE_MODEL_NAME)
         vertexai.init(project=project_id, location=location)
 
-    def attach_to_veneer(self, veneer: Genkit) -> None:
-        self._add_model_to_veneer(veneer=veneer)
-
-    def _add_model_to_veneer(self, veneer: Genkit, **kwargs) -> None:
-        return super()._add_model_to_veneer(
-            veneer=veneer,
+    def initialize(self, ai: Genkit) -> None:
+        ai.define_model(
             name=vertexai_name(self.VERTEX_AI_GENERATIVE_MODEL_NAME),
-            metadata=self.vertex_ai_model_metadata,
+            fn=self._gemini.handle_request,
+            metadata={
+                'model': {
+                    'supports': {'multiturn': True},
+                }
+            },
         )
-
-    @property
-    def vertex_ai_model_metadata(self) -> dict[str, dict[str, Any]]:
-        return {
-            'model': {
-                'supports': {'multiturn': True},
-            }
-        }
-
-    def _model_callback(self, request: GenerateRequest) -> GenerateResponse:
-        return self._gemini.handle_request(request=request)

--- a/py/samples/hello/src/hello.py
+++ b/py/samples/hello/src/hello.py
@@ -6,12 +6,13 @@
 from typing import Any
 
 from genkit.core.schema_types import GenerateRequest, Message, Role, TextPart
-from genkit.plugins.vertex_ai import VertexAI
+from genkit.plugins.vertex_ai import VertexAI, vertexai_name
 from genkit.veneer.veneer import Genkit
 from pydantic import BaseModel, Field
 
 ai = Genkit(
-    plugins=[VertexAI()], model=VertexAI.VERTEX_AI_GENERATIVE_MODEL_NAME
+    plugins=[VertexAI()],
+    model=vertexai_name(VertexAI.VERTEX_AI_GENERATIVE_MODEL_NAME),
 )
 
 


### PR DESCRIPTION
Description:

- Refactored a Plugin abstraction to make it more versatile in use.
- Updated the `VertexAI` plugin and a code sample

Problem:

1. Current implementation assumes that only one model is defined, whereas we may have multiple models.
2. It is unclear why `_model_callback` needs to be defined in the Plugin. Since each model (or model family) has its own execution logic, it should provide its own callback

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
