### PR TITLE
fix(js/plugins/google-cloud): allow user specified otel instrumentations

### DIFF
--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -155,12 +155,17 @@ export class GcpOpenTelemetry {
 
   /** Gets all open telemetry instrumentations as configured by the plugin. */
   private getInstrumentations() {
+    let instrumentations: Instrumentation[] = [];
+
     if (this.config.autoInstrumentation) {
-      return getNodeAutoInstrumentations(
+      instrumentations = getNodeAutoInstrumentations(
         this.config.autoInstrumentationConfig
-      ).concat(this.getDefaultLoggingInstrumentations());
+      );
     }
-    return this.getDefaultLoggingInstrumentations();
+
+    return instrumentations
+      .concat(this.getDefaultLoggingInstrumentations())
+      .concat(this.config.instrumentations ?? []);
   }
 
   private shouldExportTraces(): boolean {


### PR DESCRIPTION
Example using openai instrumentation from elastic:

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/df6b4cbc-049b-4c9f-ae59-6068c97fb637" />

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
