### PR TITLE
refactor: make registry.register_action construct Action objects internally rather than at call site

### DIFF
--- a/py/packages/genkit/src/genkit/core/action_test.py
+++ b/py/packages/genkit/src/genkit/core/action_test.py
@@ -3,7 +3,8 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-from genkit.core.action import ActionKind
+import pytest
+from genkit.core.action import ActionKind, parse_action_key
 
 
 def test_action_enum_behaves_like_str() -> None:
@@ -21,3 +22,40 @@ def test_action_enum_behaves_like_str() -> None:
     assert ActionKind.TEXTLLM == 'text-llm'
     assert ActionKind.TOOL == 'tool'
     assert ActionKind.UTIL == 'util'
+
+
+def test_parse_action_key_valid() -> None:
+    """Test valid inputs."""
+    test_cases = [
+        ('prompt/my-prompt', (ActionKind.PROMPT, 'my-prompt')),
+        ('model/gpt-4', (ActionKind.MODEL, 'gpt-4')),
+        ('custom/test-action', (ActionKind.CUSTOM, 'test-action')),
+        ('flow/my-flow', (ActionKind.FLOW, 'my-flow')),
+    ]
+
+    for key, expected in test_cases:
+        kind, name = parse_action_key(key)
+        assert kind == expected[0]
+        assert name == expected[1]
+
+
+def test_parse_action_key_invalid_format() -> None:
+    """Test invalid formats."""
+    invalid_keys = [
+        'invalid_key',  # Missing separator
+        'too/many/parts',  # Too many parts
+        '/missing-kind',  # Missing kind
+        'missing-name/',  # Missing name
+        '',  # Empty string
+        '/',  # Just separator
+    ]
+
+    for key in invalid_keys:
+        with pytest.raises(ValueError, match='Invalid action key format'):
+            parse_action_key(key)
+
+
+def test_parse_action_key_invalid_kind() -> None:
+    """Test invalid action kinds."""
+    with pytest.raises(ValueError, match='Invalid action kind'):
+        parse_action_key('invalid-kind/my-action')

--- a/py/packages/genkit/src/genkit/core/registry.py
+++ b/py/packages/genkit/src/genkit/core/registry.py
@@ -4,7 +4,11 @@
 """The registry is used to store and lookup resources such as actions and
 flows."""
 
-from genkit.core.action import Action, ActionKind
+from typing import Any, Callable, Dict
+
+from genkit.core.action import Action, ActionKind, parse_action_key
+
+"""Stores actions, trace stores, flow state stores, plugins, and schemas."""
 
 
 class Registry:
@@ -12,16 +16,40 @@ class Registry:
 
     actions: dict[ActionKind, dict[str, Action]] = {}
 
-    def register_action(self, action: Action) -> None:
+    def register_action(
+        self,
+        kind: ActionKind,
+        name: str,
+        fn: Callable,
+        description: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        span_metadata: dict[str, str] | None = None,
+    ) -> Action:
         """Register an action.
 
         Args:
-            action: The action to register.
+            kind: The kind of the action.
+            name: The name of the action.
+            fn: The function to call when the action is executed.
+            description: The description of the action.
+            metadata: The metadata of the action.
+            span_metadata: The span metadata of the action.
+
+        Returns:
+            The registered action.
         """
-        kind = action.kind
+        action = Action(
+            kind=kind,
+            name=name,
+            fn=fn,
+            description=description,
+            metadata=metadata,
+            span_metadata=span_metadata,
+        )
         if kind not in self.actions:
             self.actions[kind] = {}
-        self.actions[kind][action.name] = action
+        self.actions[kind][name] = action
+        return action
 
     def lookup_action(self, kind: ActionKind, name: str) -> Action | None:
         """Lookup an action by its kind and name.
@@ -51,14 +79,5 @@ class Registry:
         Raises:
             ValueError: If the key format is invalid.
         """
-        # TODO: Use pattern matching to validate the key format
-        # and verify whether the key can have only 2 parts.
-        tokens = key.split('/')
-        if len(tokens) != 2:
-            msg = (
-                f'Invalid action key format: `{key}`. '
-                'Expected format: `<kind>/<name>`'
-            )
-            raise ValueError(msg)
-        kind, name = tokens
+        kind, name = parse_action_key(key)
         return self.lookup_action(kind, name)

--- a/py/packages/genkit/src/genkit/core/registry_test.py
+++ b/py/packages/genkit/src/genkit/core/registry_test.py
@@ -4,15 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from genkit.core.action import Action, ActionKind
+from genkit.core.action import ActionKind
 from genkit.core.registry import Registry
 
 
 def test_register_action_with_name_and_kind() -> None:
     """Ensure we can register an action with a name and kind."""
     registry = Registry()
-    action = Action(name='test_action', kind=ActionKind.CUSTOM, fn=lambda x: x)
-    registry.register_action(action)
+    action = registry.register_action(
+        name='test_action', kind=ActionKind.CUSTOM, fn=lambda x: x
+    )
     got = registry.lookup_action(ActionKind.CUSTOM, 'test_action')
 
     assert got == action
@@ -23,8 +24,9 @@ def test_register_action_with_name_and_kind() -> None:
 def test_lookup_action_by_key() -> None:
     """Ensure we can lookup an action by its key."""
     registry = Registry()
-    action = Action(name='test_action', kind=ActionKind.CUSTOM, fn=lambda x: x)
-    registry.register_action(action)
+    action = registry.register_action(
+        name='test_action', kind=ActionKind.CUSTOM, fn=lambda x: x
+    )
     got = registry.lookup_action_by_key('custom/test_action')
 
     assert got == action

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -52,7 +52,7 @@ testpaths = ["packages", "plugins", "samples"]
 addopts = "--cov"
 
 [tool.coverage.report]
-fail_under = 80
+fail_under = 82
 
 # uv based package management.
 [tool.uv]


### PR DESCRIPTION
refactor: make registry.register_action construct Action objects internally rather than at call site

CHANGELOG:
- [x] Use StrEnum for ActionKind and other string enums.
- [x] Refactor the Registry.register_action to take Action constructor arguments directly and act as a factory.
- [x] Move the parse_action_key function into action.py and add tests.
- [x] Update coverage threshold to 82%.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
