### PR TITLE
fix(js/testapps/docs-menu-rag): resolve circular dependency by moving ai to genkit.ts

### DIFF
--- a/js/testapps/docs-menu-rag/src/genkit.ts
+++ b/js/testapps/docs-menu-rag/src/genkit.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { devLocalVectorstore } from '@genkit-ai/dev-local-vectorstore';
+import { textEmbedding004, vertexAI } from '@genkit-ai/vertexai';
+import { genkit } from 'genkit';
+
+export const ai = genkit({
+  plugins: [
+    vertexAI(),
+    devLocalVectorstore([
+      {
+        indexName: 'menuQA',
+        embedder: textEmbedding004,
+      },
+    ]),
+  ],
+});

--- a/js/testapps/docs-menu-rag/src/index.ts
+++ b/js/testapps/docs-menu-rag/src/index.ts
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-import { devLocalVectorstore } from '@genkit-ai/dev-local-vectorstore';
-import { textEmbedding004, vertexAI } from '@genkit-ai/vertexai';
-import { genkit, z } from 'genkit';
+import { z } from 'genkit';
+import { ai } from './genkit.js';
 import { indexMenu } from './indexer';
-
-export const ai = genkit({
-  plugins: [
-    vertexAI(),
-    devLocalVectorstore([
-      {
-        indexName: 'menuQA',
-        embedder: textEmbedding004,
-      },
-    ]),
-  ],
-});
 
 const menus = ['./docs/GenkitGrubPub.pdf'];
 

--- a/js/testapps/docs-menu-rag/src/indexer.ts
+++ b/js/testapps/docs-menu-rag/src/indexer.ts
@@ -21,7 +21,7 @@ import { Document } from 'genkit/retriever';
 import { chunk } from 'llm-chunk';
 import path from 'path';
 import pdf from 'pdf-parse';
-import { ai } from './index.js';
+import { ai } from './genkit.js';
 
 // Create a reference to the configured local indexer.
 export const menuPdfIndexer = devLocalIndexerRef('menuQA');

--- a/js/testapps/docs-menu-rag/src/menuQA.ts
+++ b/js/testapps/docs-menu-rag/src/menuQA.ts
@@ -17,7 +17,7 @@
 import { devLocalRetrieverRef } from '@genkit-ai/dev-local-vectorstore';
 import { gemini15Flash } from '@genkit-ai/vertexai';
 import { z } from 'genkit';
-import { ai } from './index.js';
+import { ai } from './genkit.js';
 
 // Define the retriever reference
 export const menuRetriever = devLocalRetrieverRef('menuQA');


### PR DESCRIPTION
This PR resolves the problem where the sample code could not be executed by addressing the dependency issue.

When attempting to run the sample code for `js/testapps/docs-menu-rag` using `pnpm run build-and-run`, an error occurred stating that `defineFlow` was not defined. 

<details>

<summary>logs</summary>

```bash
$ genkit start -- pnpm run build-and-run                                                                                                                                                    (base) 
[Telemetry Server] initialized local file trace store at root: [REDACTED]/genkit/js/testapps/docs-menu-rag/.genkit/traces
Telemetry API running on http://localhost:4034
Genkit Developer UI: http://localhost:4001

> rag@1.0.0 build-and-run [REDACTED]/genkit/js/testapps/docs-menu-rag
> pnpm build && node lib/index.js


> rag@1.0.0 build [REDACTED]/genkit/js/testapps/docs-menu-rag
> pnpm build:clean && pnpm compile


> rag@1.0.0 build:clean [REDACTED]/genkit/js/testapps/docs-menu-rag
> rimraf ./lib


> rag@1.0.0 compile [REDACTED]/genkit/js/testapps/docs-menu-rag
> tsc

[REDACTED]/genkit/js/testapps/docs-menu-rag/lib/indexer.js:43
exports.indexMenu = index_js_1.ai.defineFlow({
                                  ^

TypeError: Cannot read properties of undefined (reading 'defineFlow')
```

</details>

The root cause of this issue was a circular dependency between `index.ts` and `indexer.ts`. In `index.ts`, `genkit` is instantiated as `ai` and exported, but before this, `indexer.js` was imported, leading to the use of `defineFlow` with the `ai` instance prematurely.


Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
