### PR TITLE
fix(js/ai/src/prompt): Add variant name in prompt metadata

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -399,7 +399,7 @@ function promptMetadata(options: PromptConfig<any, any, any>) {
       input: {
         schema: options.input ? toJsonSchema(options.input) : undefined,
       },
-      name: options.name,
+      name: `${options.name}${options.variant ? `.${options.variant}` : ''}`,
       model: modelName(options.model),
     },
     type: 'prompt',


### PR DESCRIPTION
Fixes https://github.com/firebase/genkit/issues/2056.

Also checked that go runtime adds variant name at the top level, so it doesn't have the same issue.

With dev-ui-gallery sample:
Before:
![image](https://github.com/user-attachments/assets/23acbe0a-3dd6-48a8-8cdf-b82bb552487c)
![image](https://github.com/user-attachments/assets/c52e9604-3499-4d1b-9839-ef2caeff08e4)

After:
![image](https://github.com/user-attachments/assets/12c998bf-6083-437c-8e2c-66f71cf73873)
![image](https://github.com/user-attachments/assets/cdca3f5d-4ef3-4a9b-b274-e923cd39f0c9)

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually)
- [ ] Docs updated (updated docs or a docs bug required)
