### PR TITLE
chore: cleanup unused /api/sse tooling endpoint

### DIFF
--- a/genkit-tools/common/src/server/server.ts
+++ b/genkit-tools/common/src/server/server.ts
@@ -87,36 +87,6 @@ export function startServer(manager: RuntimeManager, port: number) {
     res.end();
   });
 
-  // General purpose endpoint for Server Side Events to the Developer UI.
-  // Currently only event type "current-time" is supported, which notifies the
-  // subsriber of the currently selected Genkit Runtime (typically most recent).
-  app.get('/api/sse', async (_, res) => {
-    res.writeHead(200, {
-      'Access-Control-Allow-Origin': '*',
-      'Cache-Control': 'no-cache',
-      'Content-Type': 'text/event-stream',
-      Connection: 'keep-alive',
-    });
-
-    // On connection, immediately send the "current" runtime (i.e. most recent)
-    const runtimeInfo = JSON.stringify(manager.getMostRecentRuntime() ?? {});
-    res.write('event: current-runtime\n');
-    res.write(`data: ${runtimeInfo}\n\n`);
-
-    // When runtimes are added or removed, notify the Dev UI which runtime
-    // is considered "current" (i.e. most recent). In the future, we could send
-    // updates and let the developer decide which to use.
-    manager.onRuntimeEvent(() => {
-      const runtimeInfo = JSON.stringify(manager.getMostRecentRuntime() ?? {});
-      res.write('event: current-runtime\n');
-      res.write(`data: ${runtimeInfo}\n\n`);
-    });
-
-    res.on('close', () => {
-      res.end();
-    });
-  });
-
   app.get('/api/__health', (_, res) => {
     res.status(200).send('');
   });


### PR DESCRIPTION
DevUI has switched to using the polling service since IDX does not support SSE.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
