### PR TITLE
chore: set default node version in eng setup to 23 again; add cmake

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -24,7 +24,7 @@ fi
 TOP_DIR=$(git rev-parse --show-toplevel)
 
 PNPM_VERSION="10.2.0"
-NODE_VERSION="22"
+NODE_VERSION="23"
 NVM_VERSION="0.40.1"
 
 AUDIENCE="eng"
@@ -96,6 +96,7 @@ function genkit::install_prerequisites() {
   if [[ ${OS_NAME} == "Darwin" && -x "$(command -v brew)" ]]; then
     # Darwin-based systems.
     brew install \
+      cmake \
       curl \
       fd \
       gh \


### PR DESCRIPTION
CHANGELOG
- [ ] A Python package requires an installation of cmake so add it.
- [ ] Update the default version of node in use to 23 since the test are now fixed.


Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
