### PR TITLE
feat(py/core/action): added support for async actions (and flows) and streaming

### DIFF
--- a/py/packages/genkit/src/genkit/core/action.py
+++ b/py/packages/genkit/src/genkit/core/action.py
@@ -10,15 +10,13 @@ uninterrupted operations that can operate in streaming or non-streaming mode.
 
 import asyncio
 import inspect
-import json
-import sys
+from collections.abc import Callable
 from enum import StrEnum
-from typing import Any, Callable, Dict
+from typing import Any
 
 from genkit.core.tracing import tracer
+from genkit.core.utils import dump_json
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
-
-from .utils import dump_json
 
 # TODO: add typing, generics
 StreamingCallback = Callable[[Any], None]
@@ -238,8 +236,8 @@ class Action:
         self,
         input: Any = None,
         on_chunk: StreamingCallback = None,
-        context: Dict[str, Any] = None,
-        telemetry_labels: Dict[str, Any] = None,
+        context: dict[str, Any] = None,
+        telemetry_labels: dict[str, Any] = None,
     ) -> ActionResponse:
         # TODO: handle telemetry_labels
         # TODO: propagate context down the callstack via contextvars
@@ -251,8 +249,8 @@ class Action:
         self,
         input: Any = None,
         on_chunk: StreamingCallback = None,
-        context: Dict[str, Any] = None,
-        telemetry_labels: Dict[str, Any] = None,
+        context: dict[str, Any] = None,
+        telemetry_labels: dict[str, Any] = None,
     ) -> ActionResponse:
         # TODO: handle telemetry_labels
         # TODO: propagate context down the callstack via contextvars
@@ -264,8 +262,8 @@ class Action:
         self,
         raw_input: Any,
         on_chunk: StreamingCallback = None,
-        context: Dict[str, Any] = None,
-        telemetry_labels: Dict[str, Any] = None,
+        context: dict[str, Any] = None,
+        telemetry_labels: dict[str, Any] = None,
     ):
         input_action = self.input_type.validate_python(raw_input)
         return await self.arun(

--- a/py/packages/genkit/src/genkit/core/action_test.py
+++ b/py/packages/genkit/src/genkit/core/action_test.py
@@ -6,7 +6,12 @@
 """Tests for the action module."""
 
 import pytest
-from genkit.core.action import ActionKind, Action, ActionRunContext, parse_action_key
+from genkit.core.action import (
+    Action,
+    ActionKind,
+    ActionRunContext,
+    parse_action_key,
+)
 
 
 def test_action_enum_behaves_like_str() -> None:
@@ -62,47 +67,51 @@ def test_parse_action_key_invalid_format() -> None:
 @pytest.mark.asyncio
 async def test_define_sync_action() -> None:
     def syncFoo():
-        return "syncFoo"
+        return 'syncFoo'
 
     syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)
 
-    assert (await syncFooAction.arun()).response == "syncFoo"
-    assert syncFoo() == "syncFoo"
+    assert (await syncFooAction.arun()).response == 'syncFoo'
+    assert syncFoo() == 'syncFoo'
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("bug, action ignores args without type annotation")
+@pytest.mark.skip('bug, action ignores args without type annotation')
 async def test_define_sync_action_with_input_without_type_annotation() -> None:
     def syncFoo(input):
-        return f"syncFoo {input}"
+        return f'syncFoo {input}'
 
     syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)
 
-    assert (await syncFooAction.arun("foo")).response == "syncFoo foo"
-    assert syncFoo("foo") == "syncFoo foo"
+    assert (await syncFooAction.arun('foo')).response == 'syncFoo foo'
+    assert syncFoo('foo') == 'syncFoo foo'
 
 
 @pytest.mark.asyncio
 async def test_define_sync_action_with_input() -> None:
     def syncFoo(input: str):
-        return f"syncFoo {input}"
+        return f'syncFoo {input}'
 
     syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)
 
-    assert (await syncFooAction.arun("foo")).response == "syncFoo foo"
-    assert syncFoo("foo") == "syncFoo foo"
+    assert (await syncFooAction.arun('foo')).response == 'syncFoo foo'
+    assert syncFoo('foo') == 'syncFoo foo'
 
 
 @pytest.mark.asyncio
 async def test_define_sync_action_with_input_and_context() -> None:
     def syncFoo(input: str, ctx: ActionRunContext):
-        return f"syncFoo {input} {ctx.context['foo']}"
+        return f'syncFoo {input} {ctx.context["foo"]}'
 
     syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)
 
-    assert (await syncFooAction.arun("foo", context={"foo": "bar"})).response == "syncFoo foo bar"
-    assert syncFoo("foo", ActionRunContext(
-        context={"foo": "bar"})) == "syncFoo foo bar"
+    assert (
+        await syncFooAction.arun('foo', context={'foo': 'bar'})
+    ).response == 'syncFoo foo bar'
+    assert (
+        syncFoo('foo', ActionRunContext(context={'foo': 'bar'}))
+        == 'syncFoo foo bar'
+    )
 
 
 @pytest.mark.asyncio
@@ -119,45 +128,51 @@ async def test_define_sync_streaming_action() -> None:
     def on_chunk(c):
         chunks.append(c)
 
-    assert (await syncFooAction.arun("foo", context={"foo": "bar"}, on_chunk=on_chunk)).response == 3
+    assert (
+        await syncFooAction.arun(
+            'foo', context={'foo': 'bar'}, on_chunk=on_chunk
+        )
+    ).response == 3
     assert chunks == ['1', '2']
 
 
 @pytest.mark.asyncio
 async def test_define_async_action() -> None:
     async def asyncFoo():
-        return "asyncFoo"
+        return 'asyncFoo'
 
     asyncFooAction = Action(
-        name='asyncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo)
+        name='asyncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo
+    )
 
-    assert (await asyncFooAction.arun()).response == "asyncFoo"
-    assert (await asyncFoo()) == "asyncFoo"
+    assert (await asyncFooAction.arun()).response == 'asyncFoo'
+    assert (await asyncFoo()) == 'asyncFoo'
 
 
 @pytest.mark.asyncio
 async def test_define_async_action_with_input() -> None:
     async def asyncFoo(input: str):
-        return f"syncFoo {input}"
+        return f'syncFoo {input}'
 
-    asyncFooAction = Action(
-        name='syncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo)
+    asyncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo)
 
-    assert (await asyncFooAction.arun("foo")).response == "syncFoo foo"
-    assert (await asyncFoo("foo")) == "syncFoo foo"
+    assert (await asyncFooAction.arun('foo')).response == 'syncFoo foo'
+    assert (await asyncFoo('foo')) == 'syncFoo foo'
 
 
 @pytest.mark.asyncio
 async def test_define_async_action_with_input_and_context() -> None:
     async def asyncFoo(input: str, ctx: ActionRunContext):
-        return f"syncFoo {input} {ctx.context['foo']}"
+        return f'syncFoo {input} {ctx.context["foo"]}'
 
-    asyncFooAction = Action(
-        name='syncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo)
+    asyncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo)
 
-    assert (await asyncFooAction.arun("foo", context={"foo": "bar"})).response == "syncFoo foo bar"
-    assert (await asyncFoo("foo", ActionRunContext(
-        context={"foo": "bar"}))) == "syncFoo foo bar"
+    assert (
+        await asyncFooAction.arun('foo', context={'foo': 'bar'})
+    ).response == 'syncFoo foo bar'
+    assert (
+        await asyncFoo('foo', ActionRunContext(context={'foo': 'bar'}))
+    ) == 'syncFoo foo bar'
 
 
 @pytest.mark.asyncio
@@ -167,13 +182,16 @@ async def test_define_async_streaming_action() -> None:
         ctx.send_chunk('2')
         return 3
 
-    asyncFooAction = Action(
-        name='syncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo)
+    asyncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo)
 
     chunks = []
 
     def on_chunk(c):
         chunks.append(c)
 
-    assert (await asyncFooAction.arun("foo", context={"foo": "bar"}, on_chunk=on_chunk)).response == 3
+    assert (
+        await asyncFooAction.arun(
+            'foo', context={'foo': 'bar'}, on_chunk=on_chunk
+        )
+    ).response == 3
     assert chunks == ['1', '2']

--- a/py/packages/genkit/src/genkit/core/registry.py
+++ b/py/packages/genkit/src/genkit/core/registry.py
@@ -16,9 +16,8 @@ Example:
 
 from collections.abc import Callable
 from typing import Any
-
 from genkit.core.action import Action, ActionKind, parse_action_key
-
+import asyncio
 
 class Registry:
     """Central repository for Genkit resources.
@@ -32,6 +31,9 @@ class Registry:
         actions: A nested dictionary mapping ActionKind to a dictionary of
             action names and their corresponding Action instances.
     """
+
+    actions: dict[ActionKind, dict[str, Action]] = {}
+    loop = asyncio.new_event_loop()
 
     def __init__(self):
         """Initialize an empty Registry instance."""

--- a/py/packages/genkit/src/genkit/core/registry.py
+++ b/py/packages/genkit/src/genkit/core/registry.py
@@ -17,7 +17,7 @@ Example:
 from collections.abc import Callable
 from typing import Any
 from genkit.core.action import Action, ActionKind, parse_action_key
-import asyncio
+
 
 class Registry:
     """Central repository for Genkit resources.
@@ -33,7 +33,6 @@ class Registry:
     """
 
     actions: dict[ActionKind, dict[str, Action]] = {}
-    loop = asyncio.new_event_loop()
 
     def __init__(self):
         """Initialize an empty Registry instance."""

--- a/py/packages/genkit/src/genkit/core/registry.py
+++ b/py/packages/genkit/src/genkit/core/registry.py
@@ -32,8 +32,6 @@ class Registry:
             action names and their corresponding Action instances.
     """
 
-    actions: dict[ActionKind, dict[str, Action]] = {}
-
     def __init__(self):
         """Initialize an empty Registry instance."""
         self.actions: dict[ActionKind, dict[str, Action]] = {}

--- a/py/packages/genkit/src/genkit/core/registry.py
+++ b/py/packages/genkit/src/genkit/core/registry.py
@@ -16,6 +16,7 @@ Example:
 
 from collections.abc import Callable
 from typing import Any
+
 from genkit.core.action import Action, ActionKind, parse_action_key
 
 

--- a/py/packages/genkit/src/genkit/core/registry_test.py
+++ b/py/packages/genkit/src/genkit/core/registry_test.py
@@ -33,7 +33,7 @@ def test_lookup_action_by_key() -> None:
     action = registry.register_action(
         name='test_action', kind=ActionKind.CUSTOM, fn=lambda x: x
     )
-    got = registry.lookup_action_by_key('custom/test_action')
+    got = registry.lookup_action_by_key('/custom/test_action')
 
     assert got == action
     assert got.name == 'test_action'
@@ -45,5 +45,3 @@ def test_lookup_action_by_key_invalid_format() -> None:
     registry = Registry()
     with pytest.raises(ValueError, match='Invalid action key format'):
         registry.lookup_action_by_key('invalid_key')
-    with pytest.raises(ValueError, match='Invalid action key format'):
-        registry.lookup_action_by_key('too/many/parts')

--- a/py/packages/genkit/src/genkit/core/utils.py
+++ b/py/packages/genkit/src/genkit/core/utils.py
@@ -1,9 +1,9 @@
-
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.
 
 import json
 from typing import Any
+
 from pydantic import BaseModel
 
 

--- a/py/packages/genkit/src/genkit/core/utils.py
+++ b/py/packages/genkit/src/genkit/core/utils.py
@@ -1,0 +1,14 @@
+
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.
+
+import json
+from typing import Any
+from pydantic import BaseModel
+
+
+def dump_json(obj: Any):
+    if isinstance(obj, BaseModel):
+        return obj.model_dump_json(by_alias=True)
+    else:
+        return json.dumps(obj)

--- a/py/packages/genkit/src/genkit/veneer/server.py
+++ b/py/packages/genkit/src/genkit/veneer/server.py
@@ -66,6 +66,7 @@ def create_runtime(
     runtime_file_name = f'{current_datetime.isoformat()}.json'
     runtime_file_path = Path(os.path.join(runtime_dir, runtime_file_name))
     metadata = json.dumps({
+        'reflectionApiSpecVersion': 1,
         'id': f'{os.getpid()}',
         'pid': os.getpid(),
         'reflectionServerUrl': reflection_server_spec.url,

--- a/py/packages/genkit/src/genkit/veneer/veneer.py
+++ b/py/packages/genkit/src/genkit/veneer/veneer.py
@@ -3,14 +3,15 @@
 
 """Veneer user-facing API for application developers who use the SDK."""
 
+import asyncio
 import logging
 import os
 import threading
-import asyncio
-from functools import wraps
 from collections.abc import Callable
+from functools import wraps
 from http.server import HTTPServer
 from typing import Any
+
 from genkit.ai.model import ModelFn
 from genkit.ai.prompt import PromptFn
 from genkit.core.action import ActionKind
@@ -123,8 +124,11 @@ class Genkit:
             raise AttributeError('Invalid generate config provided')
 
         model_action = self.registry.lookup_action(ActionKind.MODEL, model)
-        return (await model_action.arun(GenerateRequest(messages=messages,
-                config=config))).response
+        return (
+            await model_action.arun(
+                GenerateRequest(messages=messages, config=config)
+            )
+        ).response
 
     def flow(self, name: str | None = None) -> Callable[[Callable], Callable]:
         """Decorator to register a function as a flow.

--- a/py/packages/genkit/src/genkit/veneer/veneer.py
+++ b/py/packages/genkit/src/genkit/veneer/veneer.py
@@ -3,7 +3,6 @@
 
 """Veneer user-facing API for application developers who use the SDK."""
 
-import asyncio
 import logging
 import os
 import threading
@@ -13,7 +12,6 @@ from http.server import HTTPServer
 from typing import Any
 
 from genkit.ai.model import ModelFn
-from genkit.ai.prompt import PromptFn
 from genkit.core.action import ActionKind
 from genkit.core.environment import is_dev_environment
 from genkit.core.plugin_abc import Plugin

--- a/py/packages/genkit/src/genkit/veneer/veneer.py
+++ b/py/packages/genkit/src/genkit/veneer/veneer.py
@@ -11,7 +11,6 @@ from functools import wraps
 from collections.abc import Callable
 from http.server import HTTPServer
 from typing import Any
-
 from genkit.ai.model import ModelFn
 from genkit.ai.prompt import PromptFn
 from genkit.core.action import ActionKind
@@ -147,17 +146,15 @@ class Genkit:
                 span_metadata={'genkit:metadata:flow:name': flow_name},
             )
 
-            is_async = asyncio.iscoroutinefunction(func)
-
             @wraps(func)
             async def async_wrapper(*args, **kwargs):
                 return (await action.arun(*args, **kwargs)).response
 
             @wraps(func)
             def sync_wrapper(*args, **kwargs):
-                return (self.registry.loop.run_until_complete(action.arun(*args, **kwargs))).response
+                return action.run(*args, **kwargs).response
 
-            return async_wrapper if is_async else sync_wrapper
+            return async_wrapper if action.is_async else sync_wrapper
 
         return wrapper
 

--- a/py/samples/hello/src/hello.py
+++ b/py/samples/hello/src/hello.py
@@ -59,7 +59,7 @@ def say_hi(name: str):
     Returns:
         The generated greeting response.
     """
-    return ai.generate(
+    return await ai.generate(
         messages=[
             Message(
                 role=Role.USER,

--- a/py/samples/hello/src/hello.py
+++ b/py/samples/hello/src/hello.py
@@ -3,8 +3,9 @@
 
 """A hello world sample that just calls some flows."""
 
+import asyncio
 from typing import Any
-
+from genkit.core.action import ActionRunContext
 from genkit.core.typing import GenerateRequest, Message, Role, TextPart
 from genkit.plugins.vertex_ai import VertexAI, vertexai_name
 from genkit.veneer.veneer import Genkit
@@ -50,7 +51,7 @@ def hi_fn(hi_input) -> GenerateRequest:
 
 
 @ai.flow()
-def say_hi(name: str):
+async def say_hi(name: str):
     """Generate a greeting for the given name.
 
     Args:
@@ -82,15 +83,31 @@ def sum_two_numbers2(my_input: MyInput) -> Any:
     return my_input.a + my_input.b
 
 
-def main() -> None:
+@ai.flow()
+def streamingSyncFlow(input: str, ctx: ActionRunContext):
+    ctx.send_chunk(1)
+    ctx.send_chunk({"chunk": "blah"})
+    ctx.send_chunk(3)
+    return "streamingSyncFlow 4"
+
+
+@ai.flow()
+async def streamingAsyncFlow(input: str, ctx: ActionRunContext):
+    ctx.send_chunk(1)
+    ctx.send_chunk({"chunk": "blah"})
+    ctx.send_chunk(3)
+    return "streamingAsyncFlow 4"
+
+
+async def main() -> None:
     """Main entry point for the hello sample.
 
     This function demonstrates the usage of the AI flow by generating
     greetings and performing simple arithmetic operations.
     """
-    print(say_hi('John Doe'))
+    print(await say_hi('John Doe'))
     print(sum_two_numbers2(MyInput(a=1, b=3)))
 
 
 if __name__ == '__main__':
-    main()
+    asyncio.run(main())

--- a/py/samples/hello/src/hello.py
+++ b/py/samples/hello/src/hello.py
@@ -5,6 +5,7 @@
 
 import asyncio
 from typing import Any
+
 from genkit.core.action import ActionRunContext
 from genkit.core.typing import GenerateRequest, Message, Role, TextPart
 from genkit.plugins.vertex_ai import VertexAI, vertexai_name
@@ -86,17 +87,17 @@ def sum_two_numbers2(my_input: MyInput) -> Any:
 @ai.flow()
 def streamingSyncFlow(input: str, ctx: ActionRunContext):
     ctx.send_chunk(1)
-    ctx.send_chunk({"chunk": "blah"})
+    ctx.send_chunk({'chunk': 'blah'})
     ctx.send_chunk(3)
-    return "streamingSyncFlow 4"
+    return 'streamingSyncFlow 4'
 
 
 @ai.flow()
 async def streamingAsyncFlow(input: str, ctx: ActionRunContext):
     ctx.send_chunk(1)
-    ctx.send_chunk({"chunk": "blah"})
+    ctx.send_chunk({'chunk': 'blah'})
     ctx.send_chunk(3)
-    return "streamingAsyncFlow 4"
+    return 'streamingAsyncFlow 4'
 
 
 async def main() -> None:


### PR DESCRIPTION
Actions can be sync or async

```py
def syncFoo(input: str):
    return f"syncFoo {input}"

syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)

# or

async def asyncFoo():
    return "asyncFoo"

asyncFooAction = Action(name='asyncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo)
```

same for flows:
```py
@ai.flow()
def syncFoo(input: str):
    return f"syncFoo {input}"

# or

@ai.flow()
async def asyncFoo():
    return "asyncFoo"
```

all actions can be run asyncronously:

```py
await syncFooAction.arun(input)
```

but only sync actions can be run synchronously (I couldn't find a way around this limitation)

```py
syncFooAction.run(input)
```

any (sync/async) action can stream

```py
async def asyncFoo(input: str, ctx: ActionRunContext):
    ctx.send_chunk('1')
    ctx.send_chunk('2')
    return 3
```

dev facing streaming API design TBD. For now internal API is:

```py
def on_chunk(chunk):
    print(chunk)

await syncFooAction.arun(input, on_chunk=on_chunk)
```

this is now supported via the Dev UI:

![image](https://github.com/user-attachments/assets/31890269-d8ef-401b-b257-fa019ce9da77)

the second argument (`ActionRunContext`) also contains the context. More work needed for proper context propagation.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
