### PR TITLE
fix(js/plugins/google-cloud) don't truncate stopSequences

### DIFF
--- a/js/plugins/google-cloud/src/telemetry/generate.ts
+++ b/js/plugins/google-cloud/src/telemetry/generate.ts
@@ -251,7 +251,7 @@ class GenerateTelemetry implements Telemetry {
       topK: input.config?.topK,
       topP: input.config?.topP,
       maxOutputTokens: input.config?.maxOutputTokens,
-      stopSequences: truncate(input.config?.stopSequences, 1024),
+      stopSequences: input.config?.stopSequences, // array
       source: 'ts',
       sourceVersion: GENKIT_VERSION,
     });


### PR DESCRIPTION
It's an array, so pass along object. 

I thought about stringify-ing it and truncating, but these should generally be small, and I think we do want the array as is.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
