### PR TITLE
fix: set prompt metadata for render action as expected by dev ui

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -395,6 +395,7 @@ function promptMetadata(options: PromptConfig<any, any, any>) {
   return {
     ...options.metadata,
     prompt: {
+      ...options.metadata?.prompt,
       config: options.config,
       input: {
         schema: options.input ? toJsonSchema(options.input) : undefined,
@@ -784,7 +785,7 @@ function loadPrompt(
           type: 'prompt',
           prompt: {
             ...promptMetadata,
-            template: source,
+            template: parsedPrompt.template,
           },
         },
         maxTurns: promptMetadata.raw?.['maxTurns'],

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -1154,7 +1154,7 @@ describe('prompt', () => {
     );
   });
 
-  it('loads a varaint from from the folder', async () => {
+  it('loads a variant from from the folder', async () => {
     const testPrompt = ai.prompt('test', { variant: 'variant' }); // see tests/prompts folder
 
     const { text } = await testPrompt();
@@ -1163,6 +1163,37 @@ describe('prompt', () => {
       text,
       'Echo: Hello from a variant of the hello prompt; config: {"temperature":13}'
     );
+  });
+
+  it('includes metadata expected by the dev ui', async () => {
+    const testPrompt: PromptAction = await ai.registry.lookupAction(
+      '/prompt/test.variant'
+    );
+
+    assert.deepStrictEqual(testPrompt.__action.metadata, {
+      prompt: {
+        config: {
+          temperature: 13,
+        },
+        description: 'a prompt variant in a file',
+        ext: {},
+        input: {
+          schema: null,
+        },
+        metadata: {},
+        model: undefined,
+        name: 'test.variant',
+        raw: {
+          config: {
+            temperature: 13,
+          },
+          description: 'a prompt variant in a file',
+        },
+        template: 'Hello from a variant of the hello prompt',
+        variant: 'variant',
+      },
+      type: 'prompt',
+    });
   });
 
   it('returns a ref to functional prompts', async () => {


### PR DESCRIPTION
<img width="1491" alt="image" src="https://github.com/user-attachments/assets/f87c2790-9391-4e07-8e99-58f89279f167" />

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [N/A] Docs updated (updated docs or a docs bug required)
