### PR TITLE
feat(js/plugins/vertexai): added support for restricts and numerical restricts in vector search

### DIFF
--- a/js/plugins/ollama/src/embeddings.ts
+++ b/js/plugins/ollama/src/embeddings.ts
@@ -93,8 +93,9 @@ export function defineOllamaEmbedder(
       });
 
       if (!response.ok) {
+        const errMsg = (await response.json()).error?.message || '';
         throw new Error(
-          `Error fetching embedding from Ollama: ${response.statusText}`
+          `Error fetching embedding from Ollama: ${response.statusText}. ${errMsg}`
         );
       }
 

--- a/js/plugins/ollama/tests/embeddings_test.ts
+++ b/js/plugins/ollama/tests/embeddings_test.ts
@@ -90,7 +90,7 @@ describe('defineOllamaEmbedder', () => {
         assert.ok(error instanceof Error);
         assert.strictEqual(
           error.message,
-          'Error fetching embedding from Ollama: Internal Server Error'
+          'Error fetching embedding from Ollama: Internal Server Error. '
         );
         return true;
       }

--- a/js/plugins/vertexai/src/vectorsearch/index.ts
+++ b/js/plugins/vertexai/src/vectorsearch/index.ts
@@ -35,7 +35,87 @@ export {
   type VectorSearchOptions,
 } from './vector_search/index.js';
 /**
- * Add Google Cloud Vertex AI to Genkit. Includes Gemini and Imagen models and text embedder.
+ * VertexAI vector search plugin
+ *
+ * ```ts
+ * import { vertexAIVectorSearch } from '@genkit-ai/vertexai/vectorsearch';
+ *
+ * const ai = genkit({
+ *   plugins: [
+ *     vertexAI({ ... }),
+ *     vertexAIVectorSearch({
+        projectId: PROJECT_ID,
+        location: LOCATION,
+        vectorSearchOptions: [
+          {
+            publicDomainName: VECTOR_SEARCH_PUBLIC_DOMAIN_NAME,
+            indexEndpointId: VECTOR_SEARCH_INDEX_ENDPOINT_ID,
+            indexId: VECTOR_SEARCH_INDEX_ID,
+            deployedIndexId: VECTOR_SEARCH_DEPLOYED_INDEX_ID,
+            documentRetriever: VECTOR_SEARCH_DOCUMENT_RETRIEVER,
+            documentIndexer: VECTOR_SEARCH_DOCUMENT_INDEXER,
+            embedder: VECTOR_SEARCH_EMBEDDER,
+          },
+        ],
+      }),
+ *   ],
+ * });
+ *
+ * const metadata1 = {
+ *   restricts: [{
+ *     namespace: "colour",
+ *     allowList: ["green", "blue, "purple"],
+ *     denyList:  ["red", "grey"],
+ *   }],
+ *   numericRestricts: [
+ *   {
+ *     namespace: "price",
+ *     valueFloat: 4199.99,
+ *   },
+ *   {
+ *     namespace: "weight",
+ *     valueDouble: 987.6543,
+ *   },
+ *   {
+ *     namespace: "ports",
+ *     valueInt: 3,
+ *   },
+ * ],
+ * }
+ * const productDescription1 = "The 'Synapse Slate' seamlessly integrates neural pathways, allowing users to control applications with thought alone. Its holographic display adapts to any environment, projecting interactive interfaces onto any surface."
+ * const doc1 = Document.fromText(productDescription1, metadata1);
+ *
+ * // Index the document along with its restricts and numericRestricts
+ * const indexResponse = await ai.index({
+ *   indexer: vertexAiIndexerRef({ ... }),
+ *   [doc1],
+ * });
+ *
+ *
+ * // Later, construct a query using restricts and numeric restricts
+ * const queryMetadata = {
+ *   restricts: [{
+ *     namespace: "colour",
+ *     allowList: ["purple"],
+ *     denyList: ["red"],
+ *   }],
+ *   numericRestricts: [{
+ *     namespace: "price",
+ *     valueFloat: 5000.00,
+ *     op: LESS,
+ *   }]
+ * };
+ * const query = "I'm looking for something with a projected display";
+ * const queryDoc = new Document(query, queryMetadata);
+ *
+ * const response = await ai.retrieve({
+ *   retriever: vertexAIRetrieverRef({ ... }),
+ *   query: queryDocument,
+ *   options: { k },
+ * });
+ *
+ * console.log(`response: ${response}`);
+ * ```
  */
 export function vertexAIVectorSearch(options?: PluginOptions): GenkitPlugin {
   return genkitPlugin('vertexAIVectorSearch', async (ai: Genkit) => {

--- a/js/plugins/vertexai/src/vectorsearch/vector_search/firestore.ts
+++ b/js/plugins/vertexai/src/vectorsearch/vector_search/firestore.ts
@@ -41,7 +41,8 @@ export const getFirestoreDocumentRetriever = (
         .doc(neighbor.datapoint?.datapointId!);
       const docSnapshot = await docRef.get();
       if (docSnapshot.exists) {
-        const docData = { ...docSnapshot.data(), metadata: { ...neighbor } };
+        const docData = { ...docSnapshot.data() }; // includes content & metadata
+        docData.metadata = { ...docData.metadata, ...neighbor }; // add neighbor
         const parsedDocData = DocumentDataSchema.safeParse(docData);
         if (parsedDocData.success) {
           docs.push(new Document(parsedDocData.data));

--- a/js/plugins/vertexai/src/vectorsearch/vector_search/retrievers.ts
+++ b/js/plugins/vertexai/src/vectorsearch/vector_search/retrievers.ts
@@ -65,7 +65,7 @@ export function vertexAiRetrievers<EmbedderCustomOptions extends z.ZodTypeAny>(
           );
         }
 
-        const queryEmbeddings = (
+        const queryEmbedding = (
           await ai.embed({
             embedder: embedderReference,
             options: embedderOptions,
@@ -94,7 +94,7 @@ export function vertexAiRetrievers<EmbedderCustomOptions extends z.ZodTypeAny>(
         }
 
         let res = await queryPublicEndpoint({
-          featureVector: queryEmbeddings,
+          featureVector: queryEmbedding,
           neighborCount: options?.k || DEFAULT_K,
           accessToken,
           projectId,
@@ -103,6 +103,8 @@ export function vertexAiRetrievers<EmbedderCustomOptions extends z.ZodTypeAny>(
           projectNumber,
           indexEndpointId: vectorSearchOption.indexEndpointId,
           deployedIndexId: vectorSearchOption.deployedIndexId,
+          restricts: content.metadata?.restricts,
+          numericRestricts: content.metadata?.numericRestricts,
         });
         const nearestNeighbors = res.nearestNeighbors;
 

--- a/js/plugins/vertexai/src/vectorsearch/vector_search/types.ts
+++ b/js/plugins/vertexai/src/vectorsearch/vector_search/types.ts
@@ -61,33 +61,34 @@ export type SparseEmbedding = z.infer<typeof SparseEmbeddingSchema>;
 
 // Define the Zod schema for IRestriction
 export const RestrictionSchema = z.object({
-  namespace: z.string().optional(),
-  allowList: z.array(z.string()).optional(),
-  denyList: z.array(z.string()).optional(),
+  namespace: z.string(),
+  allowList: z.array(z.string()),
+  denyList: z.array(z.string()),
 });
 
 export type Restriction = z.infer<typeof RestrictionSchema>;
+
+export const NumericRestrictionOperatorSchema = z.enum([
+  'OPERATOR_UNSPECIFIED',
+  'LESS',
+  'LESS_EQUAL',
+  'EQUAL',
+  'GREATER_EQUAL',
+  'GREATER',
+  'NOT_EQUAL',
+]);
+
+export type NumericRestrictionOperator = z.infer<
+  typeof NumericRestrictionOperatorSchema
+>;
 
 // Define the Zod schema for INumericRestriction
 export const NumericRestrictionSchema = z.object({
   valueInt: z.union([z.number(), z.string()]).optional(),
   valueFloat: z.number().optional(),
   valueDouble: z.number().optional(),
-  namespace: z.string().optional(),
-  op: z
-    .union([
-      z.enum([
-        'OPERATOR_UNSPECIFIED',
-        'LESS',
-        'LESS_EQUAL',
-        'EQUAL',
-        'GREATER_EQUAL',
-        'GREATER',
-        'NOT_EQUAL',
-      ]),
-      z.null(),
-    ])
-    .optional(),
+  namespace: z.string(),
+  op: z.union([NumericRestrictionOperatorSchema, z.null()]).optional(),
 });
 
 export type NumericRestriction = z.infer<typeof NumericRestrictionSchema>;

--- a/js/plugins/vertexai/tests/vectorsearch/bigquery_test.ts
+++ b/js/plugins/vertexai/tests/vectorsearch/bigquery_test.ts
@@ -45,7 +45,10 @@ class MockBigQuery {
 describe('getBigQueryDocumentRetriever', () => {
   it('returns a function that retrieves documents from BigQuery', async () => {
     const doc1 = Document.fromText('content1');
-    const doc2 = Document.fromText('content2');
+    const doc2Metadata = {
+      restricts: [{ namespace: 'color', allowList: 'red' }],
+    };
+    const doc2 = Document.fromText('content2', doc2Metadata);
 
     const mockRows = [
       {
@@ -56,7 +59,7 @@ describe('getBigQueryDocumentRetriever', () => {
       {
         id: '2',
         content: JSON.stringify(doc2.content),
-        metadata: null,
+        metadata: JSON.stringify(doc2.metadata),
       },
     ];
 

--- a/js/plugins/vertexai/tests/vectorsearch/query_public_endpoint_test.ts
+++ b/js/plugins/vertexai/tests/vectorsearch/query_public_endpoint_test.ts
@@ -20,7 +20,7 @@ import { queryPublicEndpoint } from '../../src/vectorsearch/vector_search/query_
 
 describe('queryPublicEndpoint', () => {
   // FIXME -- t.mock.method is not supported node above 20
-  it.skip('queryPublicEndpoint sends the correct request and retrieves neighbors', async (t) => {
+  it.skip('sends the correct request and retrieves neighbors', async (t) => {
     t.mock.method(global, 'fetch', async (url, options) => {
       return {
         ok: true,
@@ -67,18 +67,21 @@ describe('queryPublicEndpoint', () => {
     );
 
     const body = JSON.parse(options.body);
-    assert.deepStrictEqual(body, {
+    const expectedBody = {
       deployed_index_id: 'deployed-idx123',
       queries: [
         {
           datapoint: {
             datapoint_id: '0',
             feature_vector: [0.1, 0.2, 0.3],
+            restricts: [],
+            numeric_restricts: [],
           },
           neighbor_count: 5,
         },
       ],
-    });
+    };
+    assert.deepStrictEqual(body, expectedBody);
 
     // Verifying the response
     assert.deepStrictEqual(response, expectedResponse);

--- a/js/plugins/vertexai/tests/vectorsearch/upsert_datapoints_test.ts
+++ b/js/plugins/vertexai/tests/vectorsearch/upsert_datapoints_test.ts
@@ -38,7 +38,18 @@ describe('upsertDatapoints', () => {
 
     const params = {
       datapoints: [
-        { datapointId: 'dp1', featureVector: [0.1, 0.2, 0.3] },
+        {
+          datapointId: 'dp1',
+          featureVector: [0.1, 0.2, 0.3],
+          restricts: [
+            {
+              namespace: 'colour',
+              allowList: ['blue'],
+              denyList: ['red', 'purple'],
+            },
+          ],
+          numericRestricts: [{ namespace: 'shipping code', valueInt: 24 }],
+        },
         { datapointId: 'dp2', featureVector: [0.4, 0.5, 0.6] },
       ] as IIndexDatapoint[],
       authClient: mockAuthClient,
@@ -73,7 +84,18 @@ describe('upsertDatapoints', () => {
     const body = JSON.parse(options.body);
     assert.deepStrictEqual(body, {
       datapoints: [
-        { datapoint_id: 'dp1', feature_vector: [0.1, 0.2, 0.3] },
+        {
+          datapoint_id: 'dp1',
+          feature_vector: [0.1, 0.2, 0.3],
+          restricts: [
+            {
+              namespace: 'colour',
+              allow_list: ['blue'],
+              deny_list: ['red', 'purple'],
+            },
+          ],
+          numeric_restricts: [{ namespace: 'shipping code', value_int: 24 }],
+        },
         { datapoint_id: 'dp2', feature_vector: [0.4, 0.5, 0.6] },
       ],
     });

--- a/js/testapps/context-caching2/src/index.ts
+++ b/js/testapps/context-caching2/src/index.ts
@@ -52,7 +52,10 @@ export const warAndPeaceFlow = ai.defineFlow(
         'https://www.gutenberg.org/cache/epub/2600/pg2600.txt'
       );
       if (!response.ok) {
-        throw new Error('Failed to fetch default text content');
+        const errMsg = (await response.json()).error?.message || '';
+        throw new Error(
+          `Failed to fetch default text content: ${response.statusText}. ${errMsg}`
+        );
       }
       textContent = await response.text();
     }

--- a/js/testapps/multimodal/src/pdf.ts
+++ b/js/testapps/multimodal/src/pdf.ts
@@ -116,7 +116,10 @@ const chunkingConfig = {
 export const indexMultimodalPdf = ai.defineFlow(
   {
     name: 'indexMultimodalPdf',
-    inputSchema: z.string().describe('PDF file path'),
+    inputSchema: z
+      .string()
+      .describe('PDF file path')
+      .default('./docs/BirthdayPets.pdf'),
   },
   async (filePath: string) => {
     let documents: Document[] = [];

--- a/js/testapps/multimodal/src/video.ts
+++ b/js/testapps/multimodal/src/video.ts
@@ -60,9 +60,8 @@ export const localIndexVideo = ai.defineFlow(
     name: 'localIndexVideo',
     inputSchema: z
       .string()
-      .describe(
-        `Video URL. e.g. 'gs://cloud-samples-data/generative-ai/video/pixel8.mp4'`
-      ),
+      .describe('A Video URL')
+      .default('gs://cloud-samples-data/generative-ai/video/pixel8.mp4'),
   },
   async (videoUrl: string) => {
     const documents = await ai.run('extract-video', () =>
@@ -82,9 +81,8 @@ export const pineconeIndexVideo = ai.defineFlow(
     name: 'pineconeIndexVideo',
     inputSchema: z
       .string()
-      .describe(
-        `Video URL. e.g. 'gs://cloud-samples-data/generative-ai/video/pixel8.mp4'`
-      ),
+      .describe('A Video URL')
+      .default('gs://cloud-samples-data/generative-ai/video/pixel8.mp4'),
   },
   async (videoUrl: string) => {
     const documents = await ai.run('extract-video', () =>
@@ -104,9 +102,8 @@ export const chromaIndexVideo = ai.defineFlow(
     name: 'chromaIndexVideo',
     inputSchema: z
       .string()
-      .describe(
-        `Video URL. e.g. 'gs://cloud-samples-data/generative-ai/video/pixel8.mp4'`
-      ),
+      .describe('A Video URL')
+      .default('gs://cloud-samples-data/generative-ai/video/pixel8.mp4'),
   },
   async (videoUrl: string) => {
     const documents = await ai.run('extract-video', () =>
@@ -204,7 +201,10 @@ async function extractVideo(filePath: string): Promise<Document[]> {
 export const localVideoQAFlow = ai.defineFlow(
   {
     name: 'localVideoQuestions',
-    inputSchema: z.string(),
+    inputSchema: z
+      .string()
+      .describe('A question about the video')
+      .default('describe the video'),
     outputSchema: z.string(),
   },
   async (query: string, { sendChunk }) => {
@@ -245,7 +245,10 @@ export const localVideoQAFlow = ai.defineFlow(
 export const pineconeVideoQAFlow = ai.defineFlow(
   {
     name: 'pineconeVideoQuestions',
-    inputSchema: z.string(),
+    inputSchema: z
+      .string()
+      .describe('A question about the video')
+      .default('describe the video'),
     outputSchema: z.string(),
   },
   async (query: string, { sendChunk }) => {
@@ -285,7 +288,10 @@ export const pineconeVideoQAFlow = ai.defineFlow(
 export const chromaVideoQAFlow = ai.defineFlow(
   {
     name: 'chromaVideoQuestions',
-    inputSchema: z.string(),
+    inputSchema: z
+      .string()
+      .describe('A question about the video')
+      .default('describe the video'),
     outputSchema: z.string(),
   },
   async (query: string, { sendChunk }) => {


### PR DESCRIPTION
chore: improve multimodal testapp with defaults
fix(js/plugins/vertexai/vectorsearch/firestore): stored doc metadata is  returned with the response.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
