### PR TITLE
refactor: remove the location description of banana

### DIFF
--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -89,7 +89,7 @@ export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
   /**
    * GCP region (e.g. us-central1)
    */
-  location: z.string().describe('banana').optional(),
+  location: z.string().optional(),
 
   /**
    * Safety filter settings. See: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-filters#configurable-filters


### PR DESCRIPTION
Looks like at one point we placed a description of location as banana. This seems to have been left over from a previous edit and wanted to clean it out. Not sure if its an easter egg for folks browsing the code or a load bearing banana.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required) - none needed
