### PR TITLE
fix(go): Added JSON schema hack for `[]any` types.

### DIFF
--- a/go/core/action.go
+++ b/go/core/action.go
@@ -133,12 +133,12 @@ func newAction[In, Out, Stream any](
 	var o Out
 	if inputSchema == nil {
 		if reflect.ValueOf(i).Kind() != reflect.Invalid {
-			inputSchema = base.InferJSONSchema(i)
+			inputSchema = base.InferJSONSchemaNonReferencing(i)
 		}
 	}
 	var outputSchema *jsonschema.Schema
 	if reflect.ValueOf(o).Kind() != reflect.Invalid {
-		outputSchema = base.InferJSONSchema(o)
+		outputSchema = base.InferJSONSchemaNonReferencing(o)
 	}
 	return &ActionDef[In, Out, Stream]{
 		name:   name,

--- a/go/internal/base/json.go
+++ b/go/internal/base/json.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"reflect"
 	"regexp"
 
 	"github.com/invopop/jsonschema"
@@ -71,6 +72,19 @@ func InferJSONSchema(x any) (s *jsonschema.Schema) {
 func InferJSONSchemaNonReferencing(x any) (s *jsonschema.Schema) {
 	r := jsonschema.Reflector{
 		DoNotReference: true,
+		Mapper: func(t reflect.Type) *jsonschema.Schema {
+			// []any generates `{ type: "array", items: true }` which is not valid JSON schema.
+			if t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Interface {
+				return &jsonschema.Schema{
+					Type: "array",
+					Items: &jsonschema.Schema{
+						// This field is not necessary but it's the most benign way for the object to not be empty.
+						AdditionalProperties: jsonschema.TrueSchema,
+					},
+				}
+			}
+			return nil // Return nil to use default schema generation for other types
+		},
 	}
 	s = r.Reflect(x)
 	// TODO: Unwind this change once Monaco Editor supports newer than JSON schema draft-07.


### PR DESCRIPTION
Fixes #2205.

Passing a type to the JSON schema reflector like the following:

```go
type MyStruct struct {
    MyField []any `json:"myField"`
}
```

Results in the following JSON schema:

```json
{
  "properties": {
    "myField": {
      "type": "string",
      "items": true,
    }
  },
  "additionalProperties": false,
  "type": "object"
}
```

Which is not valid. `items` needs to be an object (can be with no fields). The package we're using does not generate that.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
