### PR TITLE
feat(py/ai): allow setting config schema and info in the model metadata

### DIFF
--- a/py/packages/genkit/src/genkit/ai/testing_utils.py
+++ b/py/packages/genkit/src/genkit/ai/testing_utils.py
@@ -5,7 +5,7 @@
 
 """Testing utils/helpers for genkit.ai"""
 
-from genkit.core.action import Action, ActionRunContext
+from genkit.core.action import ActionRunContext
 from genkit.core.codec import dump_json
 from genkit.core.typing import (
     GenerateRequest,


### PR DESCRIPTION
All models should provide config schema and info objects with supports metadata,

```py
class Config(BaseModel):
    field_a: str = Field(description='a field')
    field_b: str = Field(description='b field')


ai.define_model(
    name='foo',
    fn=foo_model_fn,
    schema=Config,
    info=ModelInfo(supports=Supports(multiturn=True))
)
```

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
