### PR TITLE
fix(ci): make hooks optional (but recommended) and add schema typing generation to ci

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,6 +27,9 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
+      - name: Generate schema typing
+        run: ./py/bin/generate_schema_typing
+
       - name: Format check
         run: uv run --directory py ruff format --check .
 

--- a/bin/setup
+++ b/bin/setup
@@ -140,6 +140,7 @@ function genkit::install_prerequisites() {
       ripgrep
   else
     echo "Unsupported OS. Please install tools manually."
+    exit 1
   fi
 
   genkit::install_rust
@@ -265,7 +266,11 @@ function genkit::configure_commit_template() {
 # Install pre-commit hooks.
 function genkit::install_pre_commit_hooks() {
   genkit::configure_commit_template
-  captainhook install -f -c "${TOP_DIR}/captainhook.json"
+  read -p "Would you like to install git hooks (recommended to catch errors early)? [Y/n] " response
+  response=${response:-Y}
+  if [[ $response =~ ^[Yy]$ ]]; then
+    captainhook install -f -c "${TOP_DIR}/captainhook.json"
+  fi
 }
 
 # Setup genkit.

--- a/py/engdoc/extending/servers.md
+++ b/py/engdoc/extending/servers.md
@@ -13,7 +13,7 @@ the runtime. The initialization process deals with:
 * **Runtime files**: Reflection servers write metadata files to enable tool
   discovery (`<working-directory>/.genkit/runtimes/<timestamp>.json`).
 * **Traces**: Traces metadata (`<working-directory>/.genkit/traces`).
-  
+
 ## Types
 
 | Server Type               | Purpose                                                               | Implementation                            | Notes                                                   |
@@ -26,13 +26,13 @@ the runtime. The initialization process deals with:
 
 ## Networking
 
-| Server                   | Host        | Port                                     | Deployment Environment |
-|--------------------------|-------------|------------------------------------------|------------------------|
-| Flows                    | `localhost` | 3400 (override `PORT`)                   | `'dev'`, `'prod'`      |
-| Dev UI/Tools API         | `localhost` | 4000-4099                                | `'dev'`, `'prod'`      |
-| Reflection API           | `localhost` | 3100 (override `GENKIT_REFLECTION_PORT`) | `'dev'`                |
-| Telemetry                | `localhost` | 4033 (specified programmatically)        | `'dev'`, `'prod'`      |
-| Enginering documentation | `localhost` | 8000                                     | `'dev'`                |
+| Server                    | Host        | Port                                     | Deployment Environment |
+|---------------------------|-------------|------------------------------------------|------------------------|
+| Flows                     | `localhost` | 3400 (override `PORT`)                   | `'dev'`, `'prod'`      |
+| Dev UI/Tools API          | `localhost` | 4000-4099                                | `'dev'`, `'prod'`      |
+| Reflection API            | `localhost` | 3100 (override `GENKIT_REFLECTION_PORT`) | `'dev'`                |
+| Telemetry                 | `localhost` | 4033 (specified programmatically)        | `'dev'`, `'prod'`      |
+| Engineering documentation | `localhost` | 8000                                     | `'dev'`                |
 
 ## Implementations
 


### PR DESCRIPTION
fix(ci): make hooks optional (but recommended) and add schema typing generation to ci
    
CHANGELOG:
- [ ] Add `py/bin/generate_schema_typing` to the Python CI checks
- [ ] Make installing git hooks optional
- [ ] Fix a typo in docs.