### PR TITLE
fix(js/plugins/firebase): Ensure Firestore retriever works with no options.

### DIFF
--- a/js/plugins/firebase/src/firestoreRetriever.ts
+++ b/js/plugins/firebase/src/firestoreRetriever.ts
@@ -136,7 +136,8 @@ export function defineFirestoreRetriever(
       },
       configSchema: z.object({
         where: z.record(z.any()).optional(),
-        limit: z.number(),
+        /** Maximum number of results to return. Defaults to 10. */
+        limit: z.number().optional(),
         /* Supply or override the distanceMeasure */
         distanceMeasure: z
           .enum(['COSINE', 'DOT_PRODUCT', 'EUCLIDEAN'])
@@ -150,6 +151,7 @@ export function defineFirestoreRetriever(
       }),
     },
     async (content, options) => {
+      options = options || {};
       if (!options.collection && !collection) {
         throw new Error(
           'Must specify a collection to query in Firestore retriever.'

--- a/js/plugins/firebase/src/firestoreRetriever.ts
+++ b/js/plugins/firebase/src/firestoreRetriever.ts
@@ -136,7 +136,7 @@ export function defineFirestoreRetriever(
       },
       configSchema: z.object({
         where: z.record(z.any()).optional(),
-        /** Maximum number of results to return. Defaults to 10. */
+        /** Max number of results to return. Defaults to 10. */
         limit: z.number().optional(),
         /* Supply or override the distanceMeasure */
         distanceMeasure: z


### PR DESCRIPTION
Fixes bug discussed [in Discord](https://discord.com/channels/1255578482214305893/1347641604004909208).

Right now `ai.retrieve()` with a Firestore retriever won't give you a type error if you don't supply options, but will have a runtime exception. This makes options fully optional.