### PR TITLE
fix(py/core/aio): cancel pop task when closing cannel to avoid warnings

### DIFF
--- a/py/packages/genkit/src/genkit/core/aio.py
+++ b/py/packages/genkit/src/genkit/core/aio.py
@@ -60,6 +60,8 @@ class Channel[T]:
         if pop in finished:
             return pop.result()
         if self.__close_future in finished:
+            # cancel pop task if we're done, avoid warnings
+            pop.cancel()
             raise StopAsyncIteration()
         return await pop
 


### PR DESCRIPTION
this fixes pytest warnings related to aio

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
