### PR TITLE
feat(py): return an empty response message when streaming completes

### DIFF
--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/handler.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/handler.py
@@ -72,7 +72,7 @@ class OpenAIModelHandler:
 
     def generate(
         self, request: GenerateRequest, ctx: ActionRunContext
-    ) -> GenerateResponse | None:
+    ) -> GenerateResponse:
         """
         Processes the request using OpenAI's chat completion API.
 
@@ -87,6 +87,6 @@ class OpenAIModelHandler:
             self.validate_version(request.config.model)
 
         if ctx.is_streaming:
-            self._model.generate_stream(request, ctx.send_chunk)
+            return self._model.generate_stream(request, ctx.send_chunk)
         else:
             return self._model.generate(request)

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/model.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/model.py
@@ -92,7 +92,17 @@ class OpenAIModel:
 
     def generate_stream(
         self, request: GenerateRequest, callback: Callable
-    ) -> None:
+    ) -> GenerateResponse:
+        """
+        Generates a streaming response from the OpenAI client and processes it in chunks.
+
+        Args:
+            request (GenerateRequest): The request object containing generation parameters.
+            callback (Callable): A function to handle each chunk of the streamed response.
+
+        Returns:
+            GenerateResponse: An empty response message when streaming is complete.
+        """
         openai_config = self._get_openai_config(request=request)
         openai_config['stream'] = True
 
@@ -110,3 +120,9 @@ class OpenAIModel:
             )
 
             callback(response_chunk)
+
+        # Return an empty response when streaming is complete
+        return GenerateResponse(
+            request=request,
+            message=Message(role=Role.MODEL, content=[TextPart(text='')]),
+        )


### PR DESCRIPTION
Description:

Updated generate stream to return a `GenerateResponse` when streaming completes, ensuring consistency with core system expectations.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
