### PR TITLE
feat(js/ai/generate): retain all raw data from LLM

### DIFF
--- a/js/ai/src/generate/response.ts
+++ b/js/ai/src/generate/response.ts
@@ -46,6 +46,8 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
   custom: unknown;
   /** The request that generated this response. */
   request?: GenerateRequest;
+  /** The raw response from the LLM. */
+  rawResponse?: unknown;
   /** The parser for output parsing of this response. */
   parser?: MessageParser<O>;
 
@@ -64,6 +66,7 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
         parser: options?.parser,
       });
     }
+    this.rawResponse = response;
     this.finishReason =
       response.finishReason || response.candidates?.[0]?.finishReason!;
     this.finishMessage =


### PR DESCRIPTION
Fixes #2303 

This PR adds a field to the `GenerateResponse` class to retain all information returned by the LLM. The current implementation of `GenerateResponse` selectively retains specific fields from the raw response returned from the LLM.

Case in point: the [`GenerateContentCandidate`](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/nodejs/latest/vertexai/generatecontentcandidate) type in Vertex AI returns a list of citation metadata. My project requires access to this data. Rather than add a new field just for citation metadata, this change is more future proof and flexible.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
