### PR TITLE
feat(js/plugins/{googleai,vertexai}): adds YouTube URL support

### DIFF
--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -712,10 +712,22 @@ export function defineGoogleAIModel({
       downloadRequestMedia({
         maxBytes: 1024 * 1024 * 10,
         // don't downlaod files that have been uploaded using the Files API
-        filter: (part) =>
-          !part.media.url.startsWith(
-            'https://generativelanguage.googleapis.com/'
-          ),
+        filter: (part) => {
+          try {
+            const url = new URL(part.media.url);
+            if (
+              // Gemini can handle these URLs
+              [
+                'generativelanguage.googleapis.com',
+                'www.youtube.com',
+                'youtube.com',
+                'youtu.be',
+              ].includes(url.hostname)
+            )
+              return false;
+          } catch {}
+          return true;
+        },
       })
     );
   }

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -808,7 +808,24 @@ export function defineGeminiModel({
   }
   if (modelInfo?.supports?.media) {
     // the gemini api doesn't support downloading media from http(s)
-    middlewares.push(downloadRequestMedia({ maxBytes: 1024 * 1024 * 20 }));
+    middlewares.push(
+      downloadRequestMedia({
+        maxBytes: 1024 * 1024 * 20,
+        filter: (part) => {
+          try {
+            const url = new URL(part.media.url);
+            if (
+              // Gemini can handle these URLs
+              ['www.youtube.com', 'youtube.com', 'youtu.be'].includes(
+                url.hostname
+              )
+            )
+              return false;
+          } catch {}
+          return true;
+        },
+      })
+    );
   }
 
   return ai.defineModel(

--- a/js/testapps/flow-simple-ai/src/index.ts
+++ b/js/testapps/flow-simple-ai/src/index.ts
@@ -816,3 +816,21 @@ ai.defineFlow('simpleDataExtractor', async (input) => {
 ai.defineFlow('echo', async (input) => {
   return input;
 });
+
+ai.defineFlow(
+  {
+    name: 'youtube',
+    inputSchema: z.object({
+      url: z.string(),
+      prompt: z.string(),
+      model: z.string().optional(),
+    }),
+  },
+  async ({ url, prompt, model }) => {
+    const { text } = await ai.generate({
+      model: model || 'googleai/gemini-2.0-flash',
+      prompt: [{ text: prompt }, { media: { url, contentType: 'video/mp4' } }],
+    });
+    return text;
+  }
+);


### PR DESCRIPTION
```ts
const {text} = ai.generate({
  model: 'googleai/gemini-2.0-flash',
  prompt: [
    {text: 'what is this a video of?'},
    {media: {url: "https://www.youtube.com/watch?v=y8Kyi0WNg40", contentType: "video/mp4"}}
  ],
})
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
