### PR TITLE
feat(js/plugins/googleai): Adds support for variable apiKey in Google AI.

### DIFF
--- a/js/plugins/googleai/src/index.ts
+++ b/js/plugins/googleai/src/index.ts
@@ -52,7 +52,16 @@ export {
 };
 
 export interface PluginOptions {
-  apiKey?: string;
+  /**
+   * Provide the API key to use to authenticate with the Gemini API. By
+   * default, an API key must be provided explicitly here or through the
+   * `GEMINI_API_KEY` or `GOOGLE_API_KEY` environment variables.
+   *
+   * If `false` is explicitly passed, the plugin will be configured to
+   * expect an `apiKey` option to be provided to the model config at
+   * call time.
+   **/
+  apiKey?: string | false;
   apiVersion?: string | string[];
   baseUrl?: string;
   models?: (

--- a/js/plugins/googleai/tests/gemini_test.ts
+++ b/js/plugins/googleai/tests/gemini_test.ts
@@ -417,6 +417,18 @@ describe('plugin', () => {
     assert.ok(ai);
   });
 
+  describe('plugin - no env', () => {
+    it('should throw when registering models with no apiKey and no env', async () => {
+      const ai = genkit({ plugins: [googleAI()] });
+      assert.rejects(ai.registry.initializeAllPlugins());
+    });
+
+    it('should not throw when registering models with {apiKey: false} and no env', () => {
+      const ai = genkit({ plugins: [googleAI({ apiKey: false })] });
+      assert.doesNotReject(ai.registry.initializeAllPlugins());
+    });
+  });
+
   describe('plugin', () => {
     beforeEach(() => {
       process.env.GOOGLE_GENAI_API_KEY = 'testApiKey';


### PR DESCRIPTION
```ts
const ai = genkit({
  plugins: [googleAI({apiKey: false})], // specify "false" to explicitly opt-out of loading key from env var
});

await ai.generate({
  model: "googleai/gemini-2.0-flash",
  prompt: "Tell me a pirate joke.",
  config: {apiKey: endUserApiKey}
})

await ai.embed({
  model: textEmbeddingGecko001,
  content: "Some content.",
  options: {apiKey: endUserApiKey}
})
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
