### PR TITLE
fix(py): lookup fix for plugin actions

### DIFF
--- a/py/packages/genkit/src/genkit/core/action.py
+++ b/py/packages/genkit/src/genkit/core/action.py
@@ -99,7 +99,7 @@ def parse_action_key(key: str) -> tuple[ActionKind, str]:
         raise ValueError(msg)
 
     kind_str = tokens[1]
-    name = tokens[2]
+    name = '/'.join(tokens[2:])
     try:
         kind = ActionKind(kind_str)
     except ValueError as e:

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -42,6 +42,10 @@ def test_parse_action_key_valid() -> None:
     test_cases = [
         ('/prompt/my-prompt', (ActionKind.PROMPT, 'my-prompt')),
         ('/model/gpt-4', (ActionKind.MODEL, 'gpt-4')),
+        (
+            '/model/vertexai/gemini-1.0',
+            (ActionKind.MODEL, 'vertexai/gemini-1.0'),
+        ),
         ('/custom/test-action', (ActionKind.CUSTOM, 'test-action')),
         ('/flow/my-flow', (ActionKind.FLOW, 'my-flow')),
     ]


### PR DESCRIPTION
This fix is needed because for plugin action (eg `/model/vertexai/gemini`) we should preserve `vertexai/gemini` as the name.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
