### PR TITLE
faet(py/core): added stream method to actions and flows

### DIFF
--- a/py/packages/genkit/src/genkit/core/action.py
+++ b/py/packages/genkit/src/genkit/core/action.py
@@ -233,7 +233,7 @@ class Action:
         action_args = input_spec.args.copy()
 
         # special case when using a method as an action, we ignore first "self" arg
-        if len(action_args) == 3 and action_args[0] == 'self':
+        if len(action_args) <= 3 and action_args[0] == 'self':
             del action_args[0]
 
         for arg in action_args:

--- a/py/packages/genkit/src/genkit/core/action.py
+++ b/py/packages/genkit/src/genkit/core/action.py
@@ -233,7 +233,11 @@ class Action:
         action_args = input_spec.args.copy()
 
         # special case when using a method as an action, we ignore first "self" arg
-        if len(action_args) <= 3 and action_args[0] == 'self':
+        if (
+            len(action_args) > 0
+            and len(action_args) <= 3
+            and action_args[0] == 'self'
+        ):
             del action_args[0]
 
         for arg in action_args:

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -96,7 +96,6 @@ async def test_define_sync_action() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip('bug, action ignores args without type annotation')
 async def test_define_sync_action_with_input_without_type_annotation() -> None:
     """Test that a sync action can be defined and run with an input without a type annotation."""
 
@@ -165,6 +164,29 @@ async def test_define_sync_streaming_action() -> None:
             'foo', context={'foo': 'bar'}, on_chunk=on_chunk
         )
     ).response == 3
+    assert chunks == ['1', '2']
+
+
+@pytest.mark.asyncio
+async def test_define_streaming_action_and_stream_it() -> None:
+    """Test that a sync streaming action can be streamed."""
+
+    def syncFoo(input: str, ctx: ActionRunContext):
+        """A sync action that returns 'syncFoo' with streaming output."""
+        ctx.send_chunk('1')
+        ctx.send_chunk('2')
+        return 3
+
+    syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)
+
+    chunks = []
+
+    stream, response = syncFooAction.stream('foo', context={'foo': 'bar'})
+
+    async for chunk in stream:
+        chunks.append(chunk)
+
+    assert (await response) == 3
     assert chunks == ['1', '2']
 
 

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -1255,3 +1255,49 @@ def test_define_retriever_with_schema(setup_test: SetupFixture) -> None:
         },
         'label': 'fooRetriever',
     }
+
+
+@pytest.mark.asyncio
+async def test_define_sync_flow(setup_test: SetupFixture) -> None:
+    ai, _, _, *_ = setup_test
+
+    @ai.flow()
+    def my_flow(input: str, ctx):
+        ctx.send_chunk(1)
+        ctx.send_chunk(2)
+        ctx.send_chunk(3)
+        return input
+
+    assert my_flow('banana') == 'banana'
+
+    stream, response = my_flow.stream('banana2')
+
+    chunks = []
+    async for chunk in stream:
+        chunks.append(chunk)
+
+    assert chunks == [1, 2, 3]
+    assert (await response) == 'banana2'
+
+
+@pytest.mark.asyncio
+async def test_define_async_flow(setup_test: SetupFixture) -> None:
+    ai, _, _, *_ = setup_test
+
+    @ai.flow()
+    async def my_flow(input: str, ctx):
+        ctx.send_chunk(1)
+        ctx.send_chunk(2)
+        ctx.send_chunk(3)
+        return input
+
+    assert (await my_flow('banana')) == 'banana'
+
+    stream, response = my_flow.stream('banana2')
+
+    chunks = []
+    async for chunk in stream:
+        chunks.append(chunk)
+
+    assert chunks == [1, 2, 3]
+    assert (await response) == 'banana2'


### PR DESCRIPTION
```py

    @ai.flow()
    async def my_flow(input: str, ctx):
        ctx.send_chunk(1)
        ctx.send_chunk(2)
        ctx.send_chunk(3)
        return input

    stream, response = my_flow.stream('banana')

    async for chunk in stream:
        print(chunk)

    print(await response)
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
