### PR TITLE
feat(py/ci): parallelize ci for multiple versions of python to speed it up and drop dependency on setup script

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,12 +14,36 @@ jobs:
       matrix:
         python-version:
           - "3.12"
+          - "3.13"
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Pre-requisites
-        run: bin/setup -a ci
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libffi-dev cmake curl ripgrep
+
+      - name: Set up Go
+        uses: actions/setup-go@main
+        with:
+          go-version: stable
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10.2.0
 
       - name: Install uv and setup Python version
         uses: astral-sh/setup-uv@v5
@@ -27,8 +51,22 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Python dependencies
+        run: |
+          cd py
+          uv pip install -e .[dev,test,docs]
+
+      - name: Install NPM packages
+        run: |
+          npm install -g license-checker
+
+      - name: Install Go tools
+        run: |
+          go install github.com/google/go-licenses@latest
+          go install oss.terrastruct.com/d2@latest
+
       - name: Generate schema typing
-        run: ./py/bin/generate_schema_typing
+        run: ./py/bin/generate_schema_typing --ci
 
       - name: Format check
         run: uv run --directory py ruff format --check .
@@ -39,8 +77,20 @@ jobs:
       - name: Check licenses
         run: ./bin/check_license
 
-      - name: Run tests
-        run: ./py/bin/run_python_tests
+      - name: Run Python tests
+        run: uv run --directory py pytest -xvs --log-level=DEBUG .
+
+      - name: Install mkdocs
+        run: |
+          uv tool install \
+          mkdocs \
+          --with mkdocs-autorefs \
+          --with mkdocs-d2-plugin \
+          --with mkdocs-literate-nav \
+          --with mkdocs-material \
+          --with mkdocs-mermaid2-plugin \
+          --with mkdocs-minify-plugin \
+          --with mkdocstrings[python]
 
       - name: Build documentation
         run: uv run --directory py mkdocs build --strict

--- a/captainhook.json
+++ b/captainhook.json
@@ -34,7 +34,7 @@
           "run": "pnpm i --frozen-lockfile"
         },
         {
-          "run": "py/bin/generate_schema_typing"
+          "run": "py/bin/generate_schema_typing --ci"
         },
         {
           "run": "bin/fmt"
@@ -71,7 +71,7 @@
           "run": "pnpm i --frozen-lockfile"
         },
         {
-          "run": "py/bin/generate_schema_typing"
+          "run": "py/bin/generate_schema_typing --ci"
         },
         {
           "run": "bin/fmt"

--- a/py/bin/generate_schema_typing
+++ b/py/bin/generate_schema_typing
@@ -9,14 +9,33 @@
 
 set -euo pipefail
 
+CI_ENABLED=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ci)
+      CI_ENABLED=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--ci]"
+      exit 1
+      ;;
+  esac
+done
+
 TOP_DIR=$(git rev-parse --show-toplevel)
 TYPING_FILE="${TOP_DIR}/py/packages/genkit/src/genkit/core/typing.py"
 
-# Generate types using configuration from pyproject.toml
-uv run --directory "${TOP_DIR}/py" datamodel-codegen
+# If in CI mode and the file exists, make a backup copy to compare later.
+if [[ "$CI_ENABLED" == "true" ]] && [[ -f "$TYPING_FILE" ]]; then
+  BACKUP_FILE="${TYPING_FILE}.backup"
+  cp "$TYPING_FILE" "$BACKUP_FILE"
+fi
 
-# This isn't causing runtime errors at the moment so letting it be.
-#sed -i '' '/^class Model(RootModel\[Any\]):$/,/^    root: Any$/d' "${TYPING_FILE}"
+# Generate types using configuration from pyproject.toml.
+uv run --directory "${TOP_DIR}/py" datamodel-codegen
 
 # Sanitize the generated schema.
 python3 "${TOP_DIR}/py/bin/sanitize_schema_typing.py" "${TYPING_FILE}"
@@ -28,3 +47,15 @@ uv run --directory "${TOP_DIR}/py" \
   ruff check --fix "${TYPING_FILE}"
 uv run --directory "${TOP_DIR}/py" \
   ruff format "${TOP_DIR}"
+
+# We want to detect and raise an error when this file changes in our hooks or in
+# CI.
+if [[ "$CI_ENABLED" == "true" ]] && [[ -f "$BACKUP_FILE" ]]; then
+  if ! diff -q "$BACKUP_FILE" "$TYPING_FILE" >/dev/null; then
+    echo "Error: Generated schema typing file differs from the existing one."
+    echo "Please run './py/bin/generate_schema_typing' locally and commit the changes."
+    rm "$BACKUP_FILE"
+    exit 1
+  fi
+  rm "$BACKUP_FILE"
+fi

--- a/py/packages/genkit/src/genkit/core/typing.py
+++ b/py/packages/genkit/src/genkit/core/typing.py
@@ -661,7 +661,7 @@ class TimeEvents(BaseModel):
     """Model for timeevents data."""
 
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    time_event: list[TimeEvent] = Field(..., alias='timeEvent')
+    time_event: list[TimeEvent] | None = Field(None, alias='timeEvent')
 
 
 class SpanData(BaseModel):

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -957,6 +957,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "pytest-watcher" },
 ]
 lint = [
@@ -989,6 +990,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-watcher", specifier = ">=0.4.3" },
 ]
 lint = [


### PR DESCRIPTION
CHANGELOG:
- [ ] Parallelize the execution of python tests to make them run ~2x
  faster.
- [ ] Regenerate `typing.py` based on latest changes.
- [ ] Raise an error when the `typing.py` file changes in CI/hooks.
      That means we need to update and fix our code.
