### PR TITLE
feat(py/core/reflection): add async implementation of reflection server #1705

### DIFF
--- a/py/packages/genkit/pyproject.toml
+++ b/py/packages/genkit/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "json5>=0.10.0",
   "structlog>=25.2.0",
   "asgiref>=3.8.1",
+  "httpx>=0.28.1",
 ]
 description = "Genkit AI Framework"
 license = { text = "Apache-2.0" }

--- a/py/packages/genkit/src/genkit/core/reflection.py
+++ b/py/packages/genkit/src/genkit/core/reflection.py
@@ -15,10 +15,12 @@ import asyncio
 import json
 import urllib.parse
 from http.server import BaseHTTPRequestHandler
+from typing import Any
 
 import structlog
 
 from genkit.codec import dump_dict, dump_json
+from genkit.core.action import Action
 from genkit.core.constants import DEFAULT_GENKIT_VERSION
 from genkit.core.error import get_callable_json
 from genkit.core.registry import Registry
@@ -28,6 +30,19 @@ from genkit.web import (
     is_query_flag_enabled,
 )
 from genkit.web.enums import ContentType, HTTPHeader
+from genkit.web.handlers import handle_health_check
+from genkit.web.requests import read_json_body
+from genkit.web.responses import json_chunk_response
+from genkit.web.typing import (
+    Application,
+    HTTPScope,
+    LifespanHandler,
+    QueryParams,
+    Receive,
+    Route,
+    Routes,
+    Send,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -214,3 +229,262 @@ def make_reflection_server(registry: Registry, encoding='utf-8'):
                         )
 
     return ReflectionServer
+
+
+def create_reflection_asgi_app(
+    registry: Registry,
+    on_app_startup: LifespanHandler | None = None,
+    on_app_shutdown: LifespanHandler | None = None,
+    version=DEFAULT_GENKIT_VERSION,
+    encoding='utf-8',
+) -> Application:
+    """Create and return an ASGI application for the Genkit reflection API.
+
+    Key endpoints:
+
+        | Method | Path           | Handler               |
+        |--------|----------------|-----------------------|
+        | GET    | /api/runAction | handle_run_action     |
+        | POST   | /api/actions   | handle_list_actions   |
+        | GET    | /api/__health  | handle_health_check   |
+        | POST   | /api/notify    | handle_notify         |
+
+    Args:
+        registry: The registry to use for the reflection server.
+        on_app_startup: Optional callback to execute when the app's
+            lifespan starts. Must be an async function.
+        on_app_shutdown: Optional callback to execute when the app's
+            lifespan ends. Must be an async function.
+        version: The version string to use when setting the value of
+            the X-GENKIT-VERSION HTTP header.
+        encoding: The text encoding to use; default 'utf-8'.
+
+    Returns:
+        An ASGI application configured with the given registry.
+    """
+    # TODO: Add middleware support and implement a logging middleware.
+    # NOTE: We don't take on a dependency on third-party libraries such as
+    # starlette, fastapi, or litestar for this server, to keep the dependencies
+    # minimal for the end-user.
+
+    async def handle_list_actions(
+        scope: HTTPScope, receive: Receive, send: Send
+    ) -> None:
+        """Handle the GET request for listing available actions.
+
+        Args:
+            scope: ASGI HTTP scope.
+            receive: ASGI receive function.
+            send: ASGI send function.
+            query_params: Parsed query parameters.
+        """
+        await send({
+            'type': 'http.response.start',
+            'status': 200,
+            'headers': [
+                (b'content-type', b'application/json'),
+            ],
+        })
+
+        actions = registry.list_serializable_actions()
+        body = json.dumps(actions).encode(encoding)
+        await send({
+            'type': 'http.response.body',
+            'body': body,
+        })
+
+    async def handle_notify(
+        scope: HTTPScope, receive: Receive, send: Send
+    ) -> None:
+        """Handle the POST notification endpoint.
+
+        Args:
+            scope: ASGI HTTP scope.
+            receive: ASGI receive function.
+            send: ASGI send function.
+        """
+        await send({
+            'type': 'http.response.start',
+            'status': 200,
+            'headers': [],
+        })
+        await send({
+            'type': 'http.response.body',
+            'body': b'',
+        })
+
+    async def handle_run_action(
+        scope: HTTPScope, receive: Receive, send: Send
+    ) -> None:
+        """Handle the runAction endpoint for executing registered actions.
+
+        Flow:
+
+        1. Reads and validates the request payload
+        2. Looks up the requested action
+        3. Executes the action with the provided input
+        4. Returns the action result as JSON with trace ID
+
+        The response format varies based on whether the action returns a
+        Pydantic model or a plain value.
+
+        Args:
+            scope: ASGI HTTP scope.
+            receive: ASGI receive function.
+            send: ASGI send function.
+        """
+        payload = await read_json_body(receive, encoding)
+        action = registry.lookup_action_by_key(payload['key'])
+
+        if action is None:
+            await send({
+                'type': 'http.response.start',
+                'status': 404,
+                'headers': [
+                    (
+                        HTTPHeader.CONTENT_TYPE,
+                        ContentType.APPLICATION_JSON,
+                    ),
+                ],
+            })
+            error_message = {'error': f'Action not found: {payload["key"]}'}
+            await send({
+                'type': 'http.response.body',
+                'body': json.dumps(error_message).encode(encoding),
+            })
+            return
+
+        context = payload.get('context', {})
+        headers = [
+            (b'content-type', b'application/json'),
+            (HTTPHeader.X_GENKIT_VERSION.encode(), version.encode()),
+        ]
+        await send({
+            'type': 'http.response.start',
+            'status': 200,
+            'headers': headers,
+        })
+
+        if is_streaming_requested(extract_query_params(scope, encoding)):
+            await handle_streaming_action(
+                scope, receive, send, action, payload, context
+            )
+        else:
+            await handle_standard_action(
+                scope, receive, send, action, payload, context
+            )
+
+    async def handle_streaming_action(
+        scope: HTTPScope,
+        receive: Receive,
+        send: Send,
+        action: Action,
+        payload: dict[str, Any],
+        context: dict[str, Any],
+    ) -> None:
+        """Handle streaming action execution.
+
+        Args:
+            scope: ASGI HTTP scope.
+            receive: ASGI receive function.
+            send: ASGI send function.
+            action: The action to execute.
+            payload: Request payload with input data.
+            context: Execution context.
+
+        Raises:
+            Exception: Any exception raised by the action execution is caught,
+                logged, and an error response is sent to the client. The error
+                response is a JSON object with an 'error' field containing
+                details about the exception.  The response is sent in the body
+                and no more body is sent after that.
+        """
+
+        async def send_chunk(chunk):
+            await send(json_chunk_response(chunk, encoding))
+
+        try:
+            output = await action.arun_raw(
+                raw_input=payload['input'],
+                on_chunk=send_chunk,
+                context=context,
+            )
+            final_response = {
+                'result': dump_dict(output.response),
+                'telemetry': {'traceId': output.trace_id},
+            }
+            await send({
+                'type': 'http.response.body',
+                'body': json.dumps(final_response).encode(encoding),
+                'more_body': False,
+            })
+        except Exception as e:
+            error_response = get_callable_json(e).model_dump(by_alias=True)
+            await logger.aerror('Error streaming action', error=error_response)
+            await send({
+                'type': 'http.response.body',
+                'body': json.dumps({'error': error_response}).encode(encoding),
+                'more_body': False,
+            })
+
+    async def handle_standard_action(
+        scope: HTTPScope,
+        receive: Receive,
+        send: Send,
+        action: Action,
+        payload: dict[str, Any],
+        context: dict[str, Any],
+    ) -> None:
+        """Handle standard (non-streaming) action execution.
+
+        Args:
+            scope: ASGI HTTP scope.
+            receive: ASGI receive function.
+            send: ASGI send function.
+            action: The action to execute.
+            payload: Request payload with input data.
+            context: Execution context.
+
+        Raises:
+            Exception: Any exception raised by the action execution is caught,
+                logged, and a 500 Internal Server Error response is sent to the
+                client. The error response is a JSON object containing details
+                about the exception, and is sent in the response body.
+        """
+        try:
+            output = await action.arun_raw(
+                raw_input=payload['input'], context=context
+            )
+            response = {
+                'result': dump_dict(output.response),
+                'telemetry': {'traceId': output.trace_id},
+            }
+            await send({
+                'type': 'http.response.body',
+                'body': json.dumps(response).encode(encoding),
+                'more_body': False,
+            })
+        except Exception as e:
+            error_response = get_callable_json(e).model_dump(by_alias=True)
+            await logger.aerror('Error executing action', error=error_response)
+            await send({
+                'type': 'http.response.start',
+                'status': 500,
+                'headers': [
+                    (b'content-type', b'application/json'),
+                    (HTTPHeader.X_GENKIT_VERSION.encode(), version.encode()),
+                ],
+            })
+            await send({
+                'type': 'http.response.body',
+                'body': json.dumps(error_response).encode(encoding),
+            })
+
+    routes: Routes = [
+        Route('GET', '/api/__health', handle_health_check),
+        Route('GET', '/api/actions', handle_list_actions),
+        Route('POST', '/api/runAction', handle_run_action),
+        Route('POST', '/api/notify', handle_notify),
+    ]
+
+    return create_asgi_app(routes, on_app_startup, on_app_shutdown)

--- a/py/packages/genkit/src/genkit/web/requests.py
+++ b/py/packages/genkit/src/genkit/web/requests.py
@@ -22,7 +22,8 @@ async def read_json_body(receive: Receive, encoding='utf-8') -> dict:
     more_body = True
     while more_body:
         message = await receive()
-        body += message.get('body', b'').decode(encoding)
-        more_body = message.get('more_body', False)
+        if message['type'] == 'http.request':
+            body += message.get('body', b'')
+            more_body = message.get('more_body', False)
 
-    return json.loads(body) if body else {}
+    return json.loads(body.decode(encoding)) if body else {}

--- a/py/packages/genkit/tests/genkit/core/reflection_test.py
+++ b/py/packages/genkit/tests/genkit/core/reflection_test.py
@@ -1,0 +1,176 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the reflection API server.
+
+This module contains unit tests for the ASGI-based reflection API server
+which provides endpoints for inspecting and interacting with Genkit during
+development.
+
+Test coverage includes:
+- Health check endpoint (/api/__health)
+- Listing registered actions (/api/actions)
+- Notification endpoint (/api/notify)
+- Action execution with various scenarios (/api/runAction):
+  - Standard action execution
+  - Streaming action execution
+  - Error handling when action not found
+  - Context passing to actions
+
+The tests use an ASGI client with mocked Registry to isolate and verify
+each endpoint's behavior.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest  # type: ignore
+import pytest_asyncio  # type: ignore
+from httpx import ASGITransport, AsyncClient  # type: ignore
+
+from genkit.core.reflection import create_reflection_asgi_app  # type: ignore
+from genkit.core.registry import Registry  # type: ignore
+
+
+@pytest.fixture
+def mock_registry():
+    """Create a mock Registry for testing."""
+    return MagicMock(spec=Registry)
+
+
+@pytest_asyncio.fixture
+async def asgi_client(mock_registry):
+    """Create an ASGI test client with a mock registry.
+
+    Args:
+        mock_registry: A mock Registry object.
+
+    Returns:
+        An AsyncClient configured to make requests to the test ASGI app.
+    """
+    app = create_reflection_asgi_app(mock_registry)
+    transport = ASGITransport(app=app)
+    client = AsyncClient(transport=transport, base_url='http://test')
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_health_check(asgi_client):
+    """Test that the health check endpoint returns 200 OK."""
+    response = await asgi_client.get('/api/__health')
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_list_actions(asgi_client, mock_registry):
+    """Test that the actions list endpoint returns registered actions."""
+    mock_registry.list_serializable_actions.return_value = {
+        'action1': {'name': 'Action 1'}
+    }
+    response = await asgi_client.get('/api/actions')
+    assert response.status_code == 200
+    assert response.json() == {'action1': {'name': 'Action 1'}}
+
+
+@pytest.mark.asyncio
+async def test_notify_endpoint(asgi_client):
+    """Test that the notify endpoint returns 200 OK."""
+    response = await asgi_client.post('/api/notify')
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_run_action_not_found(asgi_client, mock_registry):
+    """Test that requesting a non-existent action returns a 404 error."""
+    mock_registry.lookup_action_by_key.return_value = None
+    response = await asgi_client.post(
+        '/api/runAction',
+        json={'key': 'non_existent_action', 'input': {'data': 'test'}},
+    )
+    assert response.status_code == 404
+    assert 'error' in response.json()
+
+
+@pytest.mark.asyncio
+async def test_run_action_standard(asgi_client, mock_registry):
+    """Test that a standard (non-streaming) action works correctly."""
+    mock_action = AsyncMock()
+    mock_output = MagicMock()
+    mock_output.response = {'result': 'success'}
+    mock_output.trace_id = 'test_trace_id'
+    mock_action.arun_raw.return_value = mock_output
+
+    mock_registry.lookup_action_by_key.return_value = mock_action
+
+    response = await asgi_client.post(
+        '/api/runAction', json={'key': 'test_action', 'input': {'data': 'test'}}
+    )
+
+    assert response.status_code == 200
+    response_data = response.json()
+    assert 'result' in response_data
+    assert 'telemetry' in response_data
+    assert response_data['telemetry']['traceId'] == 'test_trace_id'
+    mock_action.arun_raw.assert_called_once_with(
+        raw_input={'data': 'test'}, context={}
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_action_with_context(asgi_client, mock_registry):
+    """Test that an action with context works correctly."""
+    mock_action = AsyncMock()
+    mock_output = MagicMock()
+    mock_output.response = {'result': 'success'}
+    mock_output.trace_id = 'test_trace_id'
+    mock_action.arun_raw.return_value = mock_output
+
+    mock_registry.lookup_action_by_key.return_value = mock_action
+
+    response = await asgi_client.post(
+        '/api/runAction',
+        json={
+            'key': 'test_action',
+            'input': {'data': 'test'},
+            'context': {'user': 'test_user'},
+        },
+    )
+
+    assert response.status_code == 200
+    mock_action.arun_raw.assert_called_once_with(
+        raw_input={'data': 'test'}, context={'user': 'test_user'}
+    )
+
+
+@pytest.mark.asyncio
+@patch('genkit.core.reflection.is_streaming_requested')
+async def test_run_action_streaming(
+    mock_is_streaming, asgi_client, mock_registry
+):
+    """Test that streaming actions work correctly."""
+    mock_is_streaming.return_value = True
+    mock_action = AsyncMock()
+
+    async def mock_streaming(raw_input, on_chunk=None, context=None):
+        if on_chunk:
+            await on_chunk({'chunk': 1})
+            await on_chunk({'chunk': 2})
+        mock_output = MagicMock()
+        mock_output.response = {'final': 'result'}
+        mock_output.trace_id = 'stream_trace_id'
+        return mock_output
+
+    mock_action.arun_raw.side_effect = mock_streaming
+    mock_registry.lookup_action_by_key.return_value = mock_action
+
+    response = await asgi_client.post(
+        '/api/runAction?stream=true',
+        json={'key': 'test_action', 'input': {'data': 'test'}},
+    )
+
+    assert response.status_code == 200
+    assert mock_is_streaming.called

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -788,6 +788,7 @@ source = { editable = "packages/genkit" }
 dependencies = [
     { name = "asgiref" },
     { name = "dotprompt" },
+    { name = "httpx" },
     { name = "json5" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
@@ -801,6 +802,7 @@ dependencies = [
 requires-dist = [
     { name = "asgiref", specifier = ">=3.8.1" },
     { name = "dotprompt" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "json5", specifier = ">=0.10.0" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.29.0" },


### PR DESCRIPTION
ISSUE: https://github.com/firebase/genkit/issues/1705

CHANGELOG:
- [ ] Add asynchronous implementation of the reflection API endpoints
  app
- [ ] Update the `aioia_multi_server.py` testbed sample to use the API.
