### PR TITLE
refactor(py/core/reflection): use json_response to handle json responses in asgi reflection api server

### DIFF
--- a/py/packages/genkit/src/genkit/web/responses.py
+++ b/py/packages/genkit/src/genkit/web/responses.py
@@ -9,8 +9,50 @@ from typing import Any
 from genkit.codec import dump_json
 from genkit.web.enums import HTTPHeader
 
+from .typing import HTTPScope, Receive, Send
+
 
 async def json_response(
+    scope: HTTPScope,
+    receive: Receive,
+    send: Send,
+    data: Any,
+    status_code: int = 200,
+    headers: list[tuple[bytes, bytes]] = None,
+    encoding: str = 'utf-8',
+    more_body: bool = False,
+) -> None:
+    """Sends a JSON response.
+
+    Args:
+        scope: ASGI HTTP scope.
+        receive: ASGI receive function.
+        send: ASGI send function.
+        data: The data to serialize as JSON.
+        status_code: HTTP status code for the response.
+        headers: The headers of the response.
+        encoding: The encoding of the response.
+        more_body: Whether to send more body.
+    """
+    if headers is None:
+        headers = []
+    await send({
+        'type': 'http.response.start',
+        'status': status_code,
+        'headers': [
+            (b'content-type', b'application/json'),
+        ]
+        + headers,
+    })
+    body = json.dumps(data).encode(encoding)
+    await send({
+        'type': 'http.response.body',
+        'body': body,
+        'more_body': more_body,
+    })
+
+
+async def json_response2(
     body: Any, status: int = 200, headers: dict[str, str] | None = None
 ) -> tuple[dict, dict]:
     """Create a JSON response.


### PR DESCRIPTION
refactor(py/core/reflection): use json_response to handle json responses in asgi reflection api server #1705
    
ISSUE: #1705

CHANGELOG:
- [ ] Update the ASGI implementation of the reflection API server to use
      json_response to make it more readable.