### PR TITLE
fix(cli): default to current folder when looking for project root

### DIFF
--- a/genkit-tools/common/src/server/server.ts
+++ b/genkit-tools/common/src/server/server.ts
@@ -23,7 +23,7 @@ import os from 'os';
 import path from 'path';
 import { GenkitToolsError } from '../manager';
 import { RuntimeManager } from '../manager/manager';
-import { writeToolsInfoFile } from '../utils';
+import { findProjectRoot, writeToolsInfoFile } from '../utils';
 import { logger } from '../utils/logger';
 import { toolsPackage } from '../utils/package';
 import { downloadAndExtractUiAssets } from '../utils/ui-assets';
@@ -141,8 +141,10 @@ export function startServer(manager: RuntimeManager, port: number) {
 
   server = app.listen(port, async () => {
     const uiUrl = 'http://localhost:' + port;
+    const projectRoot = await findProjectRoot();
+    logger.info(`${clc.green(clc.bold('Project root:'))} ${projectRoot}`);
     logger.info(`${clc.green(clc.bold('Genkit Developer UI:'))} ${uiUrl}`);
-    await writeToolsInfoFile(uiUrl);
+    await writeToolsInfoFile(uiUrl, projectRoot);
   });
 
   return new Promise<void>((resolve) => {

--- a/genkit-tools/common/src/utils/utils.ts
+++ b/genkit-tools/common/src/utils/utils.ts
@@ -74,7 +74,7 @@ export async function findProjectRoot(): Promise<string> {
     }
     currentDir = path.dirname(currentDir);
   }
-  throw new Error('Could not find project root');
+  return process.cwd();
 }
 
 /**


### PR DESCRIPTION
Python projects may not have a any distinctive features -- libraries can be installed globally and project folder may only contain the python file to run.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
