### PR TITLE
fix(go): Made `WithTools` accept a `ToolRef` interface

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -268,7 +268,7 @@ func Generate(ctx context.Context, r *registry.Registry, opts ...GenerateOption)
 
 	tools := make([]string, len(genOpts.Tools))
 	for i, tool := range genOpts.Tools {
-		tools[i] = tool.Definition().Name
+		tools[i] = tool.Name()
 	}
 
 	messages := []*Message{}

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -25,7 +25,7 @@ type commonOptions struct {
 	Model                   Model                   // Model to use.
 	MessagesFn              messagesFn              // Messages function. If this is set, Messages should be an empty.
 	Config                  *GenerationCommonConfig // Model configuration. If nil will be taken from the prompt config.
-	Tools                   []Tool                  // Tools to use.
+	Tools                   []ToolRef               // References to tools to use.
 	ToolChoice              ToolChoice              // Whether tool calls are required, disabled, or optional.
 	MaxTurns                int                     // Maximum number of tool call iterations.
 	ReturnToolRequests      bool                    // Whether to return tool requests instead of making the tool calls and continuing the generation.
@@ -142,7 +142,7 @@ func WithMessagesFn(fn messagesFn) CommonOption {
 
 // WithTools sets the tools to use for the generate request.
 // Tools cannot be combined with WithToolChoice(ToolChoiceNone).
-func WithTools(tools ...Tool) CommonOption {
+func WithTools(tools ...ToolRef) CommonOption {
 	return &commonOptions{Tools: tools}
 }
 

--- a/go/ai/option_test.go
+++ b/go/ai/option_test.go
@@ -391,7 +391,7 @@ func TestGenerateOptionsComplete(t *testing.T) {
 		commonOptions: commonOptions{
 			Model:                   model,
 			Config:                  &GenerationCommonConfig{Temperature: 0.7},
-			Tools:                   []Tool{tool},
+			Tools:                   []ToolRef{tool},
 			ToolChoice:              ToolChoiceAuto,
 			MaxTurns:                3,
 			ReturnToolRequests:      true,
@@ -477,7 +477,7 @@ func TestPromptOptionsComplete(t *testing.T) {
 		commonOptions: commonOptions{
 			Model:                   model,
 			Config:                  &GenerationCommonConfig{Temperature: 0.7},
-			Tools:                   []Tool{tool},
+			Tools:                   []ToolRef{tool},
 			ToolChoice:              ToolChoiceAuto,
 			MaxTurns:                3,
 			ReturnToolRequests:      true,
@@ -563,7 +563,7 @@ func TestPromptGenerateOptionsComplete(t *testing.T) {
 		commonOptions: commonOptions{
 			Model:                   model,
 			Config:                  &GenerationCommonConfig{Temperature: 0.7},
-			Tools:                   []Tool{tool},
+			Tools:                   []ToolRef{tool},
 			ToolChoice:              ToolChoiceAuto,
 			MaxTurns:                3,
 			ReturnToolRequests:      true,
@@ -611,6 +611,10 @@ func (m *mockModel) Generate(ctx context.Context, req *ModelRequest, cb ModelStr
 
 type mockTool struct {
 	name string
+}
+
+func (t *mockTool) Name() string {
+	return t.name
 }
 
 func (t *mockTool) Definition() *ToolDefinition {

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -268,7 +268,7 @@ func (p *Prompt) buildRequest(ctx context.Context, input any) (*GenerateActionOp
 
 	var tools []string
 	for _, t := range p.Tools {
-		tools = append(tools, t.Definition().Name)
+		tools = append(tools, t.Name())
 	}
 
 	return &GenerateActionOptions{

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -246,7 +246,7 @@ func TestValidPrompt(t *testing.T) {
 		promptFn       promptFn
 		messages       []*Message
 		messagesFn     messagesFn
-		tools          []Tool
+		tools          []ToolRef
 		config         *GenerationCommonConfig
 		inputType      any
 		input          any
@@ -453,7 +453,7 @@ func TestValidPrompt(t *testing.T) {
 			inputType:  HelloPromptInput{},
 			systemText: "say hello",
 			promptText: "my name is foo",
-			tools:      []Tool{testTool(reg, "testTool")},
+			tools:      []ToolRef{testTool(reg, "testTool")},
 			input:      HelloPromptInput{Name: "foo"},
 			executeOptions: []PromptGenerateOption{
 				WithInput(HelloPromptInput{Name: "foo"}),


### PR DESCRIPTION
`ai.WithTools` took in a `Tool` which is a resolved tool action. This works for in-code usages but when loading .prompt files, we only have tool names as strings. We can resolve these but since we load .prompt files at `Genkit` init, tools won't have been initialized yet and during prompt definition, we convert the tools to tool names to adhere to the `GenerateActionOptions` interface. But the user experience is still nicer when defining tools and passing those tool references directly so this is the compromise.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
