### PR TITLE
refactor(py/web/responses): foo_response -> write_foo_response and some docstrings/formatting fixes

### DIFF
--- a/py/packages/genkit/src/genkit/core/action.py
+++ b/py/packages/genkit/src/genkit/core/action.py
@@ -234,7 +234,8 @@ class Action:
 
         action_args = input_spec.args.copy()
 
-        # special case when using a method as an action, we ignore first "self" arg
+        # Special case when using a method as an action, we ignore first "self"
+        # arg.
         if (
             len(action_args) > 0
             and len(action_args) <= 3
@@ -457,8 +458,8 @@ class Action:
         context: dict[str, Any] | None = None,
         telemetry_labels: dict[str, Any] | None = None,
     ) -> tuple[
-        AsyncIterator,
-        asyncio.Future,
+        AsyncIterator[ActionResponse],
+        asyncio.Future[ActionResponse],
     ]:
         """Run the action and return an async iterator of the results.
 
@@ -482,7 +483,7 @@ class Action:
         )
         stream.set_close_future(resp)
 
-        result_future = asyncio.Future()
+        result_future: asyncio.Future[ActionResponse] = asyncio.Future()
         stream.closed.add_done_callback(
             lambda _: result_future.set_result(stream.closed.result().response)
         )

--- a/py/packages/genkit/src/genkit/core/registry.py
+++ b/py/packages/genkit/src/genkit/core/registry.py
@@ -68,7 +68,7 @@ class Registry:
         self._action_resolvers: dict[str, ActionResolver] = {}
         self._entries: ActionStore = {}
         self._value_by_kind_and_name: dict[str, dict[str, Any]] = {}
-        self._lock = threading.RLock()  # Reentrant lock for thread safety
+        self._lock = threading.RLock()
 
         # TODO: Figure out how to set this.
         self.api_stability: str = 'stable'

--- a/py/packages/genkit/src/genkit/web/handlers.py
+++ b/py/packages/genkit/src/genkit/web/handlers.py
@@ -6,7 +6,7 @@
 
 import structlog
 
-from genkit.web.responses import json_response
+from genkit.web.responses import write_json_response
 from genkit.web.typing import (
     HTTPScope,
     LifespanHandler,
@@ -28,7 +28,7 @@ async def handle_health_check(
         receive: ASGI receive function.
         send: ASGI send function.
     """
-    await json_response(
+    await write_json_response(
         scope,
         receive,
         send,

--- a/py/packages/genkit/src/genkit/web/responses.py
+++ b/py/packages/genkit/src/genkit/web/responses.py
@@ -7,12 +7,11 @@ import json
 from typing import Any
 
 from genkit.codec import dump_json
-from genkit.web.enums import HTTPHeader
 
 from .typing import HTTPScope, Receive, Send
 
 
-async def json_response(
+async def write_json_response(
     scope: HTTPScope,
     receive: Receive,
     send: Send,
@@ -52,7 +51,7 @@ async def json_response(
     })
 
 
-async def not_found_response(
+async def write_not_found_response(
     scope: HTTPScope, receive: Receive, send: Send
 ) -> None:
     """Handle 404 not found responses.
@@ -73,19 +72,25 @@ async def not_found_response(
     })
 
 
-def json_chunk_response(chunk, encoding='utf-8'):
-    """Create a JSON chunk response.
+async def write_json_chunk_response(
+    scope: HTTPScope,
+    receive: Receive,
+    send: Send,
+    chunk: Any,
+    encoding: str = 'utf-8',
+) -> None:
+    """Sends a JSON chunk response.
 
     Args:
+        scope: ASGI HTTP scope.
+        receive: ASGI receive function.
+        send: ASGI send function.
         chunk: The chunk to send.
         encoding: The encoding of the response.
-
-    Returns:
-        A tuple of the response and the body.
     """
     chunk_data = dump_json(chunk).encode(encoding) + b'\n'
-    return {
+    await send({
         'type': 'http.response.body',
         'body': chunk_data,
         'more_body': True,
-    }
+    })

--- a/py/packages/genkit/src/genkit/web/web.py
+++ b/py/packages/genkit/src/genkit/web/web.py
@@ -12,7 +12,7 @@ import structlog
 from .handlers import (
     create_lifespan_handler,
 )
-from .responses import not_found_response
+from .responses import write_not_found_response
 from .typing import (
     Application,
     LifespanHandler,
@@ -104,6 +104,6 @@ def create_asgi_app(
                 await route.handler(scope, receive, send)
                 return
 
-        await not_found_response(scope, receive, send)
+        await write_not_found_response(scope, receive, send)
 
     return app

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -40,7 +40,7 @@ def test_action_enum_behaves_like_str() -> None:
 
 
 def test_parse_action_key_valid() -> None:
-    """Test valid inputs."""
+    """Parse action key valid."""
     test_cases = [
         ('/prompt/my-prompt', (ActionKind.PROMPT, 'my-prompt')),
         ('/model/gpt-4', (ActionKind.MODEL, 'gpt-4')),
@@ -59,7 +59,7 @@ def test_parse_action_key_valid() -> None:
 
 
 def test_parse_action_key_invalid_format() -> None:
-    """Test invalid formats."""
+    """Parse action key invalid format."""
     invalid_keys = [
         'invalid_key',  # Missing separator
         '/missing-kind',  # Missing kind
@@ -74,7 +74,7 @@ def test_parse_action_key_invalid_format() -> None:
 
 
 def test_create_action_key() -> None:
-    """Test that create_action_key returns the correct action key."""
+    """Create action key."""
     assert create_action_key(ActionKind.CUSTOM, 'foo') == '/custom/foo'
     assert create_action_key(ActionKind.MODEL, 'foo') == '/model/foo'
     assert create_action_key(ActionKind.PROMPT, 'foo') == '/prompt/foo'
@@ -85,76 +85,76 @@ def test_create_action_key() -> None:
 
 @pytest.mark.asyncio
 async def test_define_sync_action() -> None:
-    """Test that a sync action can be defined and run."""
+    """Define and run a sync action."""
 
-    def syncFoo():
+    def sync_foo():
         """A sync action that returns 'syncFoo'."""
         return 'syncFoo'
 
-    syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)
+    action = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=sync_foo)
 
-    assert (await syncFooAction.arun()).response == 'syncFoo'
-    assert syncFoo() == 'syncFoo'
+    assert (await action.arun()).response == 'syncFoo'
+    assert sync_foo() == 'syncFoo'
 
 
 @pytest.mark.asyncio
 async def test_define_sync_action_with_input_without_type_annotation() -> None:
-    """Test that a sync action can be defined and run with an input without a type annotation."""
+    """Define and run a sync action with input without type annotation."""
 
-    def syncFoo(input):
+    def sync_foo(input):
         """A sync action that returns 'syncFoo' with an input."""
         return f'syncFoo {input}'
 
-    syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)
+    action = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=sync_foo)
 
-    assert (await syncFooAction.arun('foo')).response == 'syncFoo foo'
-    assert syncFoo('foo') == 'syncFoo foo'
+    assert (await action.arun('foo')).response == 'syncFoo foo'
+    assert sync_foo('foo') == 'syncFoo foo'
 
 
 @pytest.mark.asyncio
 async def test_define_sync_action_with_input() -> None:
-    """Test that a sync action can be defined and run with an input."""
+    """Define and run a sync action with input."""
 
-    def syncFoo(input: str):
+    def sync_foo(input: str):
         """A sync action that returns 'syncFoo' with an input."""
         return f'syncFoo {input}'
 
-    syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)
+    action = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=sync_foo)
 
-    assert (await syncFooAction.arun('foo')).response == 'syncFoo foo'
-    assert syncFoo('foo') == 'syncFoo foo'
+    assert (await action.arun('foo')).response == 'syncFoo foo'
+    assert sync_foo('foo') == 'syncFoo foo'
 
 
 @pytest.mark.asyncio
 async def test_define_sync_action_with_input_and_context() -> None:
-    """Test that a sync action can be defined and run with an input and context."""
+    """Define and run a sync action with input and context."""
 
-    def syncFoo(input: str, ctx: ActionRunContext):
+    def sync_foo(input: str, ctx: ActionRunContext):
         """A sync action that returns 'syncFoo' with an input and context."""
         return f'syncFoo {input} {ctx.context["foo"]}'
 
-    syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)
+    action = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=sync_foo)
 
     assert (
-        await syncFooAction.arun('foo', context={'foo': 'bar'})
+        await action.arun('foo', context={'foo': 'bar'})
     ).response == 'syncFoo foo bar'
     assert (
-        syncFoo('foo', ActionRunContext(context={'foo': 'bar'}))
+        sync_foo('foo', ActionRunContext(context={'foo': 'bar'}))
         == 'syncFoo foo bar'
     )
 
 
 @pytest.mark.asyncio
 async def test_define_sync_streaming_action() -> None:
-    """Test that a sync action can be defined and run with streaming output."""
+    """Define and run a sync streaming action."""
 
-    def syncFoo(input: str, ctx: ActionRunContext):
+    def sync_foo(input: str, ctx: ActionRunContext):
         """A sync action that returns 'syncFoo' with streaming output."""
         ctx.send_chunk('1')
         ctx.send_chunk('2')
         return 3
 
-    syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)
+    action = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=sync_foo)
 
     chunks = []
 
@@ -162,29 +162,26 @@ async def test_define_sync_streaming_action() -> None:
         chunks.append(c)
 
     assert (
-        await syncFooAction.arun(
-            'foo', context={'foo': 'bar'}, on_chunk=on_chunk
-        )
+        await action.arun('foo', context={'foo': 'bar'}, on_chunk=on_chunk)
     ).response == 3
     assert chunks == ['1', '2']
 
 
 @pytest.mark.asyncio
 async def test_define_streaming_action_and_stream_it() -> None:
-    """Test that a sync streaming action can be streamed."""
+    """Define and stream a streaming action."""
 
-    def syncFoo(input: str, ctx: ActionRunContext):
+    def sync_foo(input: str, ctx: ActionRunContext):
         """A sync action that returns 'syncFoo' with streaming output."""
         ctx.send_chunk('1')
         ctx.send_chunk('2')
         return 3
 
-    syncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=syncFoo)
+    action = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=sync_foo)
 
     chunks = []
 
-    stream, response = syncFooAction.stream('foo', context={'foo': 'bar'})
-
+    stream, response = action.stream('foo', context={'foo': 'bar'})
     async for chunk in stream:
         chunks.append(chunk)
 
@@ -194,63 +191,61 @@ async def test_define_streaming_action_and_stream_it() -> None:
 
 @pytest.mark.asyncio
 async def test_define_async_action() -> None:
-    """Test that an async action can be defined and run."""
+    """Define and run an async action."""
 
-    async def asyncFoo():
+    async def async_foo():
         """An async action that returns 'asyncFoo'."""
         return 'asyncFoo'
 
-    asyncFooAction = Action(
-        name='asyncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo
-    )
+    action = Action(name='asyncFoo', kind=ActionKind.CUSTOM, fn=async_foo)
 
-    assert (await asyncFooAction.arun()).response == 'asyncFoo'
-    assert (await asyncFoo()) == 'asyncFoo'
+    assert (await action.arun()).response == 'asyncFoo'
+    assert (await async_foo()) == 'asyncFoo'
 
 
 @pytest.mark.asyncio
 async def test_define_async_action_with_input() -> None:
-    """Test that an async action can be defined and run with an input."""
+    """Define and run an async action with input."""
 
-    async def asyncFoo(input: str):
+    async def async_foo(input: str):
         """An async action that returns 'asyncFoo' with an input."""
-        return f'syncFoo {input}'
+        return f'asyncFoo {input}'
 
-    asyncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo)
+    action = Action(name='asyncFoo', kind=ActionKind.CUSTOM, fn=async_foo)
 
-    assert (await asyncFooAction.arun('foo')).response == 'syncFoo foo'
-    assert (await asyncFoo('foo')) == 'syncFoo foo'
+    assert (await action.arun('foo')).response == 'asyncFoo foo'
+    assert (await async_foo('foo')) == 'asyncFoo foo'
 
 
 @pytest.mark.asyncio
 async def test_define_async_action_with_input_and_context() -> None:
-    """Test that an async action can be defined and run with an input and context."""
+    """Define and run async action with input and context."""
 
-    async def asyncFoo(input: str, ctx: ActionRunContext):
+    async def async_foo(input: str, ctx: ActionRunContext):
         """An async action that returns 'syncFoo' with an input and context."""
         return f'syncFoo {input} {ctx.context["foo"]}'
 
-    asyncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo)
+    action = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=async_foo)
 
     assert (
-        await asyncFooAction.arun('foo', context={'foo': 'bar'})
+        await action.arun('foo', context={'foo': 'bar'})
     ).response == 'syncFoo foo bar'
     assert (
-        await asyncFoo('foo', ActionRunContext(context={'foo': 'bar'}))
+        await async_foo('foo', ActionRunContext(context={'foo': 'bar'}))
     ) == 'syncFoo foo bar'
 
 
 @pytest.mark.asyncio
 async def test_define_async_streaming_action() -> None:
-    """Test that an async action can be defined and run with streaming output."""
+    """Define and run an async streaming action."""
 
-    async def asyncFoo(input: str, ctx: ActionRunContext):
+    async def async_foo(input: str, ctx: ActionRunContext):
         """An async action that returns 'syncFoo' with streaming output."""
         ctx.send_chunk('1')
         ctx.send_chunk('2')
         return 3
 
-    asyncFooAction = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=asyncFoo)
+    action = Action(name='syncFoo', kind=ActionKind.CUSTOM, fn=async_foo)
 
     chunks = []
 
@@ -258,40 +253,39 @@ async def test_define_async_streaming_action() -> None:
         chunks.append(c)
 
     assert (
-        await asyncFooAction.arun(
-            'foo', context={'foo': 'bar'}, on_chunk=on_chunk
-        )
+        await action.arun('foo', context={'foo': 'bar'}, on_chunk=on_chunk)
     ).response == 3
     assert chunks == ['1', '2']
 
 
 def test_parse_plugin_name_from_action_name():
-    assert parse_plugin_name_from_action_name('foo') == None
+    """Parse plugin name from the action name."""
+    assert parse_plugin_name_from_action_name('foo') is None
     assert parse_plugin_name_from_action_name('foo/bar') == 'foo'
     assert parse_plugin_name_from_action_name('foo/bar/baz') == 'foo'
 
 
 @pytest.mark.asyncio
 async def test_propagates_context_via_contextvar() -> None:
-    """Test that context is properly propagated via contextvar."""
+    """Context is properly propagated via contextvar."""
 
     async def foo(_: str | None, ctx: ActionRunContext):
         return dump_json(ctx.context)
 
-    fooAction = Action(name='foo', kind=ActionKind.CUSTOM, fn=foo)
+    foo_action = Action(name='foo', kind=ActionKind.CUSTOM, fn=foo)
 
     async def bar():
-        return (await fooAction.arun()).response
+        return (await foo_action.arun()).response
 
-    barAction = Action(name='bar', kind=ActionKind.CUSTOM, fn=bar)
+    bar_action = Action(name='bar', kind=ActionKind.CUSTOM, fn=bar)
 
     async def baz():
-        return (await barAction.arun()).response
+        return (await bar_action.arun()).response
 
-    bazAction = Action(name='baz', kind=ActionKind.CUSTOM, fn=baz)
+    baz_action = Action(name='baz', kind=ActionKind.CUSTOM, fn=baz)
 
-    first = bazAction.arun(context={'foo': 'bar'})
-    second = bazAction.arun(context={'bar': 'baz'})
+    first = baz_action.arun(context={'foo': 'bar'})
+    second = baz_action.arun(context={'bar': 'baz'})
 
     assert (await second).response == '{"bar": "baz"}'
     assert (await first).response == '{"foo": "bar"}'
@@ -299,17 +293,17 @@ async def test_propagates_context_via_contextvar() -> None:
 
 @pytest.mark.asyncio
 async def test_sync_action_raises_errors() -> None:
-    """Test that sync action raises error with necessary metadata."""
+    """Sync action raises error with necessary metadata."""
 
-    def fooAction():
+    def sync_foo(_: str | None, ctx: ActionRunContext):
         raise Exception('oops')
 
-    fooAction = Action(name='fooAction', kind=ActionKind.CUSTOM, fn=fooAction)
+    action = Action(name='fooAction', kind=ActionKind.CUSTOM, fn=sync_foo)
 
     with pytest.raises(
         GenkitError, match=r'.*Error while running action fooAction.*'
     ) as e:
-        await fooAction.arun()
+        await action.arun()
 
     assert 'stack' in e.value.details
     assert 'trace_id' in e.value.details
@@ -318,17 +312,17 @@ async def test_sync_action_raises_errors() -> None:
 
 @pytest.mark.asyncio
 async def test_async_action_raises_errors() -> None:
-    """Test that async action raises error with necessary metadata."""
+    """Async action raises error with necessary metadata."""
 
-    async def fooAction():
+    async def async_foo(_: str | None, ctx: ActionRunContext):
         raise Exception('oops')
 
-    fooAction = Action(name='fooAction', kind=ActionKind.CUSTOM, fn=fooAction)
+    action = Action(name='fooAction', kind=ActionKind.CUSTOM, fn=async_foo)
 
     with pytest.raises(
         GenkitError, match=r'.*Error while running action fooAction.*'
     ) as e:
-        await fooAction.arun()
+        await action.arun()
 
     assert 'stack' in e.value.details
     assert 'trace_id' in e.value.details

--- a/py/packages/genkit/tests/genkit/core/schema_test.py
+++ b/py/packages/genkit/tests/genkit/core/schema_test.py
@@ -1,13 +1,16 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+"""Tests for the schema module."""
+
+from pydantic import BaseModel, Field
 
 from genkit.core.schema import to_json_schema
 
 
 def test_to_json_schema_pydantic_model():
+    """Test that a Pydantic model can be converted to a JSON schema."""
+
     class TestSchema(BaseModel):
         foo: int = Field(None, description='foo field')
         bar: str = Field(None, description='bar field')
@@ -33,6 +36,7 @@ def test_to_json_schema_pydantic_model():
 
 
 def test_to_json_schema_already_schema():
+    """Test that a JSON schema can be converted to a JSON schema."""
     json_schema = {
         'properties': {
             'bar': {

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -143,6 +143,8 @@ select = [
   "N",    # pep8-naming (naming conventions)
   "D",    # pydocstyle
   "F401", # unused imports
+  "F403", # wildcard imports
+  "F841", # unused variables
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
refactor(py/web/responses): foo_response -> write_foo_response and some docstrings/formatting fixes
    
CHANGELOG:
- [ ] Rename `responses.foo_response` -> `responses.write_foo_response`
- [ ] Fix some docstrings
- [ ] Fix some var names
- [ ] Fix some types.
- [ ] Fix some formatting.