### PR TITLE
fix(go): Return error message if go code is not re-generated from updated schema

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,8 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - name: Checkout Repo
+        uses: actions/checkout@main
       
       - name: Set up Node
         uses: actions/setup-node@main
@@ -43,8 +44,8 @@ jobs:
         with:
           go-version: '1.22.x'
           
-      - name: Generate Go code from schema
-        run: cd go/core && go run ../internal/cmd/jsonschemagen -outdir .. -config schemas.config ../../genkit-tools/genkit-schema.json ai
+      - name: Check if generated code is up to date
+        run: bash .github/workflows/scripts/check-generated-go.sh
       
       - name: Run tests
         run: go test -C go -v ./...

--- a/.github/workflows/scripts/check-generated-go.sh
+++ b/.github/workflows/scripts/check-generated-go.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Check if generated Go code is up to date
+cd go/core
+go run ../internal/cmd/jsonschemagen -outdir .. -config schemas.config ../../genkit-tools/genkit-schema.json ai
+
+# Check if git detects changes to the generated file
+if git diff --quiet ../ai/gen.go; then
+    exit 0
+else
+    echo "::error::Generated Go code is out of date. Please run:"
+    echo "::error::cd go/core && go run ../internal/cmd/jsonschemagen -outdir .. -config schemas.config ../../genkit-tools/genkit-schema.json ai"
+    exit 1
+fi 

--- a/.github/workflows/scripts/check-generated-go.sh
+++ b/.github/workflows/scripts/check-generated-go.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Check if generated Go code is up to date
 cd go/core


### PR DESCRIPTION
Manually tested, Screenshot: 
<img width="1278" alt="Screenshot 2025-03-21 at 5 07 55 PM" src="https://github.com/user-attachments/assets/1390a9a8-3912-426c-9e1d-d3f0a6d5dc1a" />
