### PR TITLE
chore(py): use Imported.__name__ for exports rather than string literals

### DIFF
--- a/py/packages/genkit/src/genkit/ai/__init__.py
+++ b/py/packages/genkit/src/genkit/ai/__init__.py
@@ -39,17 +39,17 @@ from genkit.core.typing import (
 )
 
 __all__ = [
-    Genkit.__name__,
-    GenkitRegistry.__name__,
-    Plugin.__name__,
-    Document.__name__,
     ActionRunContext.__name__,
+    Document.__name__,
     GenerateRequest.__name__,
     GenerateResponse.__name__,
     GenerateResponseChunk.__name__,
+    Genkit.__name__,
+    GenkitRegistry.__name__,
     Media.__name__,
     MediaPart.__name__,
     Message.__name__,
+    Plugin.__name__,
     RetrieverRequest.__name__,
     RetrieverResponse.__name__,
     Role.__name__,

--- a/py/packages/genkit/src/genkit/ai/plugin.py
+++ b/py/packages/genkit/src/genkit/ai/plugin.py
@@ -45,6 +45,8 @@ class Plugin(abc.ABC):
         """
         return self.name
 
+    # TODO: https://github.com/firebase/genkit/issues/2438
+    # @abc.abstractmethod
     def resolve_action(
         self, ai: GenkitRegistry, kind: ActionKind, name: str
     ) -> None:
@@ -60,11 +62,12 @@ class Plugin(abc.ABC):
         """
         pass
 
+    @abc.abstractmethod
     def initialize(self, ai: GenkitRegistry) -> None:
         """Initialize the plugin with the given registry.
 
         Args:
-            registry: Registry to register plugin functionality.
+            ai: Registry to register plugin functionality.
 
         Returns:
             None, initialization is done by side-effect on the registry.

--- a/py/packages/genkit/src/genkit/ai/registry.py
+++ b/py/packages/genkit/src/genkit/ai/registry.py
@@ -136,7 +136,8 @@ class GenkitRegistry:
 
         Args:
             description: Description for the tool to be passed to the model.
-            name: Optional name for the flow. If not provided, uses the function name.
+            name: Optional name for the flow. If not provided, uses the function
+                name.
 
         Returns:
             A decorator function that registers the tool.

--- a/py/packages/genkit/src/genkit/aio/__init__.py
+++ b/py/packages/genkit/src/genkit/aio/__init__.py
@@ -18,4 +18,4 @@
 
 from .channel import Channel
 
-__all__ = ['Channel']
+__all__ = [Channel.__name__]

--- a/py/packages/genkit/src/genkit/blocks/__init__.py
+++ b/py/packages/genkit/src/genkit/blocks/__init__.py
@@ -38,4 +38,4 @@ def package_name() -> str:
     return 'genkit.ai'
 
 
-__all__ = ['package_name']
+__all__ = [package_name.__name__]

--- a/py/packages/genkit/src/genkit/blocks/formats/__init__.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/__init__.py
@@ -30,9 +30,9 @@ built_in_formats = [JsonFormat()]
 
 
 __all__ = [
-    'package_name',
-    Formatter.__name__,
     FormatDef.__name__,
+    Formatter.__name__,
     FormatterConfig.__name__,
     JsonFormat.__name__,
+    package_name.__name__,
 ]

--- a/py/packages/genkit/src/genkit/core/__init__.py
+++ b/py/packages/genkit/src/genkit/core/__init__.py
@@ -37,4 +37,4 @@ def package_name() -> str:
     return 'genkit.core'
 
 
-__all__ = ['package_name']
+__all__ = [package_name.__name__]

--- a/py/packages/genkit/src/genkit/core/endpoints/__init__.py
+++ b/py/packages/genkit/src/genkit/core/endpoints/__init__.py
@@ -19,6 +19,6 @@
 from .reflection import create_reflection_asgi_app, make_reflection_server
 
 __all__ = [
-    'create_reflection_asgi_app',
-    'make_reflection_server',
+    create_reflection_asgi_app.__name__,
+    make_reflection_server.__name__,
 ]

--- a/py/packages/genkit/src/genkit/web/manager/__init__.py
+++ b/py/packages/genkit/src/genkit/web/manager/__init__.py
@@ -29,16 +29,16 @@ from ._manager import ServerManager
 from ._server import Server, ServerConfig, ServerLifecycle
 
 __all__ = [
-    'ASGIServerAdapter',
-    'AbstractBaseServer',
-    'GranianAdapter',
-    'Server',
-    'ServerConfig',
-    'ServerLifecycle',
-    'ServerType',
-    'ServerManager',
-    'UvicornAdapter',
-    'get_health_info',
-    'get_server_info',
-    'run_loop',
+    ASGIServerAdapter.__name__,
+    AbstractBaseServer.__name__,
+    get_health_info.__name__,
+    get_server_info.__name__,
+    GranianAdapter.__name__,
+    run_loop.__name__,
+    Server.__name__,
+    ServerConfig.__name__,
+    ServerLifecycle.__name__,
+    ServerManager.__name__,
+    ServerType.__name__,
+    UvicornAdapter.__name__,
 ]


### PR DESCRIPTION
CHANGELOG:
- [ ] Update all `__init__.py` modules to use `*.__name__` for exports
      rather than string literals.
