### PR TITLE
fix(go): use stable versions of go: 1.23+

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.22.x', '1.23.x', '1.24.x']
+        go-version: ['1.23.x', '1.24.x']
     steps:
       - name: Checkout Repo
         uses: actions/checkout@main

--- a/bin/run_go_tests
+++ b/bin/run_go_tests
@@ -22,9 +22,8 @@ TOP_DIR=$(git rev-parse --show-toplevel)
 # We're concerned about only the release versions of Go, not "tip", but it has
 # been included as an example in case it is needed in the future.
 GO_VERSIONS=(
-  "1.22.12"
-  "1.23.6"
-  "1.24.0"
+  "1.23.7"
+  "1.24.1"
   #"tip" # Fetches and builds the latest version of go from source and is slow.
 )
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/firebase/genkit/go
 
-go 1.24.0
+go 1.24.1
 
 retract (
 	v0.1.4 // Retraction only.


### PR DESCRIPTION
fix(go): use stable versions of go: 1.23+

CHANGELOG:
- [ ] Use stable versions of Go 1.23 and 1.24.