### PR TITLE
fix(engdocs): update d2 dependency diagram for release eng

### DIFF
--- a/py/engdoc/extending/index.md
+++ b/py/engdoc/extending/index.md
@@ -19,22 +19,33 @@ various elements of generative AI. It has SDKs for JavaScript, Go, and Python.
 
 ```d2
 genkit: {
-  veneer: Veneer API
-  ai: AI Components {
-    prompt: Prompt
-    flow: Flow
-    model: Model
+  ai: {
+    style: {fill: "#E0F7FA"}
+    Veneer API
   }
-  core: Core Foundations {
-    actions: Actions
-    registry: Registry
-    reflection_server: Reflection Server
+  blocks: {
+    style: {fill: "#FFF3E0"}
+    AI Components: {
+      prompt: Prompt
+      model: Model
+      embedder: Embedder
+      retriever: Retriever
+    }
   }
-  plugins: Plugins {
+  core: {
+    style: {fill: "#E8F5E9"}
+    Core Foundations: {
+      flow: Flow
+      actions: Actions
+      registry: Registry
+      reflection_server: Reflection Server
+    }
+  }
+  plugins: {
+    style: {fill: "#FCE4EC"}
     chroma
     pinecone
-    vertex_ai
-    google_ai
+    google_genai
     google_cloud
     openai
     firebase
@@ -43,6 +54,7 @@ genkit: {
 }
 
 lib: {
+  style: {fill: "#EDE7F6"}
   handlebars
   dotprompt
   pydantic
@@ -58,16 +70,15 @@ genkit.core -> lib.asgiref
 genkit.core -> lib.opentelemetry
 genkit.core -> lib.pydantic
 genkit.core -> lib.starlette
-genkit.plugins.chroma -> genkit.veneer
-genkit.plugins.firebase -> genkit.veneer
-genkit.plugins.google_ai -> genkit.veneer
-genkit.plugins.google_cloud -> genkit.veneer
-genkit.plugins.ollama -> genkit.veneer
-genkit.plugins.pinecone -> genkit.veneer
-genkit.plugins.vertex_ai -> genkit.veneer
-genkit.veneer -> genkit.ai
-genkit.veneer -> genkit.core
-genkit.veneer -> lib.uvicorn
+genkit.plugins.chroma -> genkit.ai
+genkit.plugins.firebase -> genkit.ai
+genkit.plugins.google_cloud -> genkit.ai
+genkit.plugins.google_genai -> genkit.ai
+genkit.plugins.ollama -> genkit.ai
+genkit.plugins.pinecone -> genkit.ai
+genkit.ai -> genkit.blocks
+genkit.ai -> genkit.core
+genkit.ai -> lib.uvicorn
 lib.dotprompt -> lib.handlebars
 ```
 
@@ -167,8 +178,8 @@ membership, and loaded for execution.
     FlowState contains a history of FlowExecutions.
 
 Most components of Genkit such as tools, agents, prompts, models, retrievers,
-embedders, evaluators, rerankers, and indexers are _framework-defined_ actions.
-A **flow** is a _user-defined action_.
+embedders, evaluators, rerankers, and indexers are *framework-defined* actions.
+A **flow** is a *user-defined action*.
 
 **OpenTelemetry** integration is baked into each action.
 
@@ -191,7 +202,6 @@ A **flow** is a _user-defined action_.
 TODO
 
 ## System Architecture Diagram
-
 
 ```d2
 vars: {

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -872,7 +872,7 @@ dependencies = [
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
     { name = "google-cloud-aiplatform", specifier = ">=1.77.0" },
-    { name = "google-genai", specifier = "==1.0.0" },
+    { name = "google-genai", specifier = ">=1.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
CHANGELOG:
- [ ] Update the d2 dependency diagram in `py/engdoc/extending/index.md`


![dep-diag](https://github.com/user-attachments/assets/a93fa353-b224-4379-b8c8-32cc1835332e)
