### PR TITLE
feat(go/plugins/googlegenai): add gemini-2.5-pro-exp-03-25 model

### DIFF
--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -21,6 +21,8 @@ const (
 	gemini20FlashLitePrev        = "gemini-2.0-flash-lite-preview"
 	gemini20ProExp0205           = "gemini-2.0-pro-exp-02-05"
 	gemini20FlashThinkingExp0121 = "gemini-2.0-flash-thinking-exp-01-21"
+
+	gemini25ProExp0305 = "gemini-2.5-pro-exp-03-25"
 )
 
 var (
@@ -44,6 +46,7 @@ var (
 		gemini20FlashLitePrev,
 		gemini20ProExp0205,
 		gemini20FlashThinkingExp0121,
+		gemini25ProExp0305,
 	}
 
 	supportedGeminiModels = map[string]ai.ModelInfo{
@@ -99,6 +102,11 @@ var (
 		},
 		gemini20FlashThinkingExp0121: {
 			Label:    "Gemini 2.0 Flash Thinking Exp 01-21",
+			Versions: []string{},
+			Supports: &gemini.Multimodal,
+		},
+		gemini25ProExp0305: {
+			Label:    "Gemini 2.5 Pro Exp 03-25",
 			Versions: []string{},
 			Supports: &gemini.Multimodal,
 		},


### PR DESCRIPTION
Added support to `gemini-2.5-pro-exp-03-25` to GoogleAI supported models in googlegenai plugin

Note: Usage stats are empty but responses are being provided

Checklist:
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
