### PR TITLE
refactor(py): rename all plugin packages to use the genkit-plugin-* naming convention

### DIFF
--- a/py/plugins/chroma/pyproject.toml
+++ b/py/plugins/chroma/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = ["genkit-ai"]
 description = "Genkit Chroma Plugin"
 license = { text = "Apache-2.0" }
-name = "genkit-chroma-plugin"
+name = "genkit-plugin-chroma"
 readme = "README.md"
 requires-python = ">=3.12"
 version = "0.1.0"

--- a/py/plugins/compat-oai/pyproject.toml
+++ b/py/plugins/compat-oai/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = ["genkit-ai", "openai"]
 description = "Genkit OpenAI API Compatible"
 license = { text = "Apache-2.0" }
-name = "genkit-compat-oai-plugin"
+name = "genkit-plugin-compat-oai"
 readme = "README.md"
 requires-python = ">=3.12"
 version = "0.1.0"

--- a/py/plugins/firebase/pyproject.toml
+++ b/py/plugins/firebase/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = ["genkit-ai"]
 description = "Genkit Firebase Plugin"
 license = { text = "Apache-2.0" }
-name = "genkit-firebase-plugin"
+name = "genkit-plugin-firebase"
 readme = "README.md"
 requires-python = ">=3.12"
 version = "0.1.0"

--- a/py/plugins/google-ai/pyproject.toml
+++ b/py/plugins/google-ai/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = ["genkit-ai", "google-genai==1.0.0"]
 description = "Genkit Google AI Plugin"
 license = { text = "Apache-2.0" }
-name = "genkit-google-ai-plugin"
+name = "genkit-plugin-google-ai"
 readme = "README.md"
 requires-python = ">=3.12"
 version = "0.1.0"

--- a/py/plugins/google-cloud/pyproject.toml
+++ b/py/plugins/google-cloud/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = ["genkit-ai"]
 description = "Genkit Google Cloud Plugin"
 license = { text = "Apache-2.0" }
-name = "genkit-google-cloud-plugin"
+name = "genkit-plugin-google-cloud"
 readme = "README.md"
 requires-python = ">=3.12"
 version = "0.1.0"

--- a/py/plugins/google-genai/pyproject.toml
+++ b/py/plugins/google-genai/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ]
 description = "Genkit Google GenAI Plugin"
 license = { text = "Apache-2.0" }
-name = "genkit-google-genai-plugin"
+name = "genkit-plugin-google-genai"
 readme = "README.md"
 requires-python = ">=3.12"
 version = "0.1.0"

--- a/py/plugins/ollama/pyproject.toml
+++ b/py/plugins/ollama/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = ["genkit-ai", "ollama~=0.4"]
 description = "Genkit Ollama Plugin"
 license = { text = "Apache-2.0" }
-name = "genkit-ollama-plugin"
+name = "genkit-plugin-ollama"
 readme = "README.md"
 requires-python = ">=3.12"
 version = "0.1.0"

--- a/py/plugins/pinecone/pyproject.toml
+++ b/py/plugins/pinecone/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = ["genkit-ai"]
 description = "Genkit Pinecone Plugin"
 license = { text = "Apache-2.0" }
-name = "genkit-pinecone-plugin"
+name = "genkit-plugin-pinecone"
 readme = "README.md"
 requires-python = ">=3.12"
 version = "0.1.0"

--- a/py/plugins/vertex-ai/pyproject.toml
+++ b/py/plugins/vertex-ai/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = ["genkit-ai", "google-cloud-aiplatform>=1.77.0", "pytest-mock"]
 description = "Genkit Google Cloud Vertex AI Plugin"
 license = { text = "Apache-2.0" }
-name = "genkit-vertex-ai-plugin"
+name = "genkit-plugin-vertex-ai"
 readme = "README.md"
 requires-python = ">=3.12"
 version = "0.1.0"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -2,15 +2,15 @@
 dependencies = [
   "dotpromptz",
   "genkit-ai",
-  "genkit-chroma-plugin",
-  "genkit-compat-oai-plugin",
-  "genkit-firebase-plugin",
-  "genkit-google-genai-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-chroma",
+  "genkit-plugin-compat-oai",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-genai",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
 ]
 description = "Workspace for Genkit packages"
 license = { text = "Apache-2.0" }
@@ -69,15 +69,15 @@ context-caching            = { workspace = true }
 dotpromptz                 = { git = "https://github.com/google/dotprompt.git", subdirectory = "python/dotpromptz", rev = "main" }
 flow-sample1               = { workspace = true }
 genkit-ai                  = { workspace = true }
-genkit-chroma-plugin       = { workspace = true }
-genkit-compat-oai-plugin   = { workspace = true }
-genkit-firebase-plugin     = { workspace = true }
-genkit-google-ai-plugin    = { workspace = true }
-genkit-google-cloud-plugin = { workspace = true }
-genkit-google-genai-plugin = { workspace = true }
-genkit-ollama-plugin       = { workspace = true }
-genkit-pinecone-plugin     = { workspace = true }
-genkit-vertex-ai-plugin    = { workspace = true }
+genkit-plugin-chroma       = { workspace = true }
+genkit-plugin-compat-oai   = { workspace = true }
+genkit-plugin-firebase     = { workspace = true }
+genkit-plugin-google-ai    = { workspace = true }
+genkit-plugin-google-cloud = { workspace = true }
+genkit-plugin-google-genai = { workspace = true }
+genkit-plugin-ollama       = { workspace = true }
+genkit-plugin-pinecone     = { workspace = true }
+genkit-plugin-vertex-ai    = { workspace = true }
 hello                      = { workspace = true }
 menu                       = { workspace = true }
 multi_server               = { workspace = true }

--- a/py/samples/basic-gemini/pyproject.toml
+++ b/py/samples/basic-gemini/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "basic-gemini Genkit sample"

--- a/py/samples/coffee-shop/pyproject.toml
+++ b/py/samples/coffee-shop/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "coffee-shop Genkit sample"

--- a/py/samples/context-caching/pyproject.toml
+++ b/py/samples/context-caching/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "context-caching Genkit sample"

--- a/py/samples/flow-sample1/pyproject.toml
+++ b/py/samples/flow-sample1/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "flow-sample1 Genkit sample"

--- a/py/samples/google-ai/pyproject.toml
+++ b/py/samples/google-ai/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "Hello world sample"

--- a/py/samples/google_genai/pyproject.toml
+++ b/py/samples/google_genai/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "Hello world sample"

--- a/py/samples/google_genai_image/pyproject.toml
+++ b/py/samples/google_genai_image/pyproject.toml
@@ -17,12 +17,12 @@ classifiers = [
 dependencies = [
   "genkit-ai",
   "pillow",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "Vision API and Image Generation example"

--- a/py/samples/hello/pyproject.toml
+++ b/py/samples/hello/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "hello Genkit sample"

--- a/py/samples/menu/pyproject.toml
+++ b/py/samples/menu/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "menu Genkit sample"

--- a/py/samples/ollama-hello/pyproject.toml
+++ b/py/samples/ollama-hello/pyproject.toml
@@ -16,10 +16,10 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
   "pydantic>=2.10.5",
 ]
 description = "Ollama sample"

--- a/py/samples/ollama-simple-embed/pyproject.toml
+++ b/py/samples/ollama-simple-embed/pyproject.toml
@@ -16,10 +16,10 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
   "pydantic>=2.10.5",
 ]
 description = "Ollama Simple Embed"

--- a/py/samples/openai/pyproject.toml
+++ b/py/samples/openai/pyproject.toml
@@ -16,13 +16,13 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
-  "genkit-compat-oai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
+  "genkit-plugin-compat-oai",
   "pydantic>=2.10.5",
 ]
 description = "OpenAI sample"

--- a/py/samples/prompt-file/pyproject.toml
+++ b/py/samples/prompt-file/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "prompt-file Genkit sample"

--- a/py/samples/rag/pyproject.toml
+++ b/py/samples/rag/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "rag Genkit sample"

--- a/py/samples/vertex-ai-imagen/pyproject.toml
+++ b/py/samples/vertex-ai-imagen/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "Imagen Genkit sample"

--- a/py/samples/vertex-ai-model-garden/pyproject.toml
+++ b/py/samples/vertex-ai-model-garden/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "vertex-ai-vector-search Genkit sample"

--- a/py/samples/vertex-ai-reranker/pyproject.toml
+++ b/py/samples/vertex-ai-reranker/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "vertex-ai-reranker Genkit sample"

--- a/py/samples/vertex-ai-vector-search/pyproject.toml
+++ b/py/samples/vertex-ai-vector-search/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
   "pydantic>=2.10.5",
 ]
 description = "vertex-ai-model-garden Genkit sample"

--- a/py/tests/smoke/pyproject.toml
+++ b/py/tests/smoke/pyproject.toml
@@ -15,12 +15,12 @@ classifiers = [
 ]
 dependencies = [
   "genkit-ai",
-  "genkit-firebase-plugin",
-  "genkit-google-ai-plugin",
-  "genkit-google-cloud-plugin",
-  "genkit-ollama-plugin",
-  "genkit-pinecone-plugin",
-  "genkit-vertex-ai-plugin",
+  "genkit-plugin-firebase",
+  "genkit-plugin-google-ai",
+  "genkit-plugin-google-cloud",
+  "genkit-plugin-ollama",
+  "genkit-plugin-pinecone",
+  "genkit-plugin-vertex-ai",
 ]
 description = "Packaging smoke test"
 license = { text = "Apache-2.0" }

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -13,15 +13,15 @@ members = [
     "context-caching",
     "flow-sample1",
     "genkit-ai",
-    "genkit-chroma-plugin",
-    "genkit-compat-oai-plugin",
-    "genkit-firebase-plugin",
-    "genkit-google-ai-plugin",
-    "genkit-google-cloud-plugin",
-    "genkit-google-genai-plugin",
-    "genkit-ollama-plugin",
-    "genkit-pinecone-plugin",
-    "genkit-vertex-ai-plugin",
+    "genkit-plugin-chroma",
+    "genkit-plugin-compat-oai",
+    "genkit-plugin-firebase",
+    "genkit-plugin-google-ai",
+    "genkit-plugin-google-cloud",
+    "genkit-plugin-google-genai",
+    "genkit-plugin-ollama",
+    "genkit-plugin-pinecone",
+    "genkit-plugin-vertex-ai",
     "genkit-workspace",
     "hello",
     "hello-genai",
@@ -187,24 +187,24 @@ version = "0.1.0"
 source = { editable = "samples/basic-gemini" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -397,24 +397,24 @@ version = "0.1.0"
 source = { editable = "samples/coffee-shop" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -445,24 +445,24 @@ version = "0.1.0"
 source = { editable = "samples/context-caching" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -701,24 +701,24 @@ version = "0.1.0"
 source = { editable = "samples/flow-sample1" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -771,7 +771,7 @@ requires-dist = [
 ]
 
 [[package]]
-name = "genkit-chroma-plugin"
+name = "genkit-plugin-chroma"
 version = "0.1.0"
 source = { editable = "plugins/chroma" }
 dependencies = [
@@ -782,7 +782,7 @@ dependencies = [
 requires-dist = [{ name = "genkit-ai", editable = "packages/genkit-ai" }]
 
 [[package]]
-name = "genkit-compat-oai-plugin"
+name = "genkit-plugin-compat-oai"
 version = "0.1.0"
 source = { editable = "plugins/compat-oai" }
 dependencies = [
@@ -797,7 +797,7 @@ requires-dist = [
 ]
 
 [[package]]
-name = "genkit-firebase-plugin"
+name = "genkit-plugin-firebase"
 version = "0.1.0"
 source = { editable = "plugins/firebase" }
 dependencies = [
@@ -808,7 +808,7 @@ dependencies = [
 requires-dist = [{ name = "genkit-ai", editable = "packages/genkit-ai" }]
 
 [[package]]
-name = "genkit-google-ai-plugin"
+name = "genkit-plugin-google-ai"
 version = "0.1.0"
 source = { editable = "plugins/google-ai" }
 dependencies = [
@@ -823,7 +823,7 @@ requires-dist = [
 ]
 
 [[package]]
-name = "genkit-google-cloud-plugin"
+name = "genkit-plugin-google-cloud"
 version = "0.1.0"
 source = { editable = "plugins/google-cloud" }
 dependencies = [
@@ -834,7 +834,7 @@ dependencies = [
 requires-dist = [{ name = "genkit-ai", editable = "packages/genkit-ai" }]
 
 [[package]]
-name = "genkit-google-genai-plugin"
+name = "genkit-plugin-google-genai"
 version = "0.1.0"
 source = { editable = "plugins/google-genai" }
 dependencies = [
@@ -851,7 +851,7 @@ requires-dist = [
 ]
 
 [[package]]
-name = "genkit-ollama-plugin"
+name = "genkit-plugin-ollama"
 version = "0.1.0"
 source = { editable = "plugins/ollama" }
 dependencies = [
@@ -866,7 +866,7 @@ requires-dist = [
 ]
 
 [[package]]
-name = "genkit-pinecone-plugin"
+name = "genkit-plugin-pinecone"
 version = "0.1.0"
 source = { editable = "plugins/pinecone" }
 dependencies = [
@@ -877,7 +877,7 @@ dependencies = [
 requires-dist = [{ name = "genkit-ai", editable = "packages/genkit-ai" }]
 
 [[package]]
-name = "genkit-vertex-ai-plugin"
+name = "genkit-plugin-vertex-ai"
 version = "0.1.0"
 source = { editable = "plugins/vertex-ai" }
 dependencies = [
@@ -900,15 +900,15 @@ source = { virtual = "." }
 dependencies = [
     { name = "dotpromptz" },
     { name = "genkit-ai" },
-    { name = "genkit-chroma-plugin" },
-    { name = "genkit-compat-oai-plugin" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-google-genai-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-chroma" },
+    { name = "genkit-plugin-compat-oai" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-google-genai" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
 ]
 
 [package.dev-dependencies]
@@ -932,15 +932,15 @@ lint = [
 requires-dist = [
     { name = "dotpromptz", git = "https://github.com/google/dotprompt.git?subdirectory=python%2Fdotpromptz&rev=main" },
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-chroma-plugin", editable = "plugins/chroma" },
-    { name = "genkit-compat-oai-plugin", editable = "plugins/compat-oai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-google-genai-plugin", editable = "plugins/google-genai" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-chroma", editable = "plugins/chroma" },
+    { name = "genkit-plugin-compat-oai", editable = "plugins/compat-oai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
 ]
 
 [package.metadata.requires-dev]
@@ -1265,24 +1265,24 @@ version = "0.1.0"
 source = { editable = "samples/hello" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -1292,24 +1292,24 @@ version = "0.1.0"
 source = { editable = "samples/google-ai" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -1319,24 +1319,24 @@ version = "0.1.0"
 source = { editable = "samples/google_genai" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -1383,12 +1383,12 @@ version = "0.1.0"
 source = { editable = "samples/google_genai_image" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pillow" },
     { name = "pydantic" },
 ]
@@ -1396,12 +1396,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pillow" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
@@ -1412,24 +1412,24 @@ version = "0.1.0"
 source = { editable = "samples/vertex-ai-imagen" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -2009,24 +2009,24 @@ version = "0.1.0"
 source = { editable = "samples/menu" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -2317,20 +2317,20 @@ version = "0.1.0"
 source = { virtual = "samples/ollama-hello" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -2340,20 +2340,20 @@ version = "0.1.0"
 source = { virtual = "samples/ollama-simple-embed" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -2382,26 +2382,26 @@ version = "0.1.0"
 source = { editable = "samples/openai" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-compat-oai-plugin" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-compat-oai" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-compat-oai-plugin", editable = "plugins/compat-oai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-compat-oai", editable = "plugins/compat-oai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -2595,24 +2595,24 @@ version = "0.1.0"
 source = { editable = "samples/prompt-file" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -2984,24 +2984,24 @@ version = "0.1.0"
 source = { editable = "samples/rag" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -3443,24 +3443,24 @@ version = "0.1.0"
 source = { editable = "samples/vertex-ai-vector-search" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -3470,24 +3470,24 @@ version = "0.1.0"
 source = { editable = "samples/vertex-ai-reranker" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 
@@ -3497,24 +3497,24 @@ version = "0.1.0"
 source = { editable = "samples/vertex-ai-model-garden" }
 dependencies = [
     { name = "genkit-ai" },
-    { name = "genkit-firebase-plugin" },
-    { name = "genkit-google-ai-plugin" },
-    { name = "genkit-google-cloud-plugin" },
-    { name = "genkit-ollama-plugin" },
-    { name = "genkit-pinecone-plugin" },
-    { name = "genkit-vertex-ai-plugin" },
+    { name = "genkit-plugin-firebase" },
+    { name = "genkit-plugin-google-ai" },
+    { name = "genkit-plugin-google-cloud" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-pinecone" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit-ai", editable = "packages/genkit-ai" },
-    { name = "genkit-firebase-plugin", editable = "plugins/firebase" },
-    { name = "genkit-google-ai-plugin", editable = "plugins/google-ai" },
-    { name = "genkit-google-cloud-plugin", editable = "plugins/google-cloud" },
-    { name = "genkit-ollama-plugin", editable = "plugins/ollama" },
-    { name = "genkit-pinecone-plugin", editable = "plugins/pinecone" },
-    { name = "genkit-vertex-ai-plugin", editable = "plugins/vertex-ai" },
+    { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
+    { name = "genkit-plugin-google-ai", editable = "plugins/google-ai" },
+    { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 


### PR DESCRIPTION
refactor(py): rename all plugin packages to use the genkit-plugin-* naming convention

CHANGELOG:
- [ ] Rename all the plugin package names to use the genkit-plugin-*
  naming convention.