### PR TITLE
fix(ci): only run CI checks on pull request not all pushes

### DIFF
--- a/.github/workflows/engdoc.yml
+++ b/.github/workflows/engdoc.yml
@@ -17,10 +17,6 @@
 name: Eng Documentation Checks
 
 on:
-  push:
-    paths:
-      - "py/docs/**"
-      - ".github/workflows/engdoc.yml"
   pull_request:
     paths:
       - "py/docs/**"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,11 +17,6 @@
 name: Go tests and checks
 
 on:
-  push:
-    paths:
-      - "go/**"
-      - "genkit-tools/**"
-      - ".github/workflows/go.yml"
   pull_request:
     paths:
       - "go/**"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,11 +17,6 @@
 name: Python Checks
 
 on:
-  push:
-    paths:
-      - "py/**"
-      - "genkit-tools/**"
-      - ".github/workflows/python.yml"
   pull_request:
     paths:
       - "py/**"

--- a/py/bin/generate_schema_typing
+++ b/py/bin/generate_schema_typing
@@ -48,7 +48,7 @@ if [[ "$CI_ENABLED" == "true" ]] && [[ -f "$TYPING_FILE" ]]; then
 fi
 
 # Generate types using configuration from pyproject.toml.
-uv run --directory "${TOP_DIR}/py" datamodel-codegen --capitalize-enum-members
+uv run --directory "${TOP_DIR}/py" datamodel-codegen
 
 # Sanitize the generated schema.
 python3 "${TOP_DIR}/py/bin/sanitize_schema_typing.py" "${TYPING_FILE}"


### PR DESCRIPTION
fix(ci): only run CI checks on pull request not all pushes

CHANGELOG:
- [ ] Update `python.yml`, `go.yml` and `engdoc.yml` to run CI
      checks only on PR not on all pushes.