### PR TITLE
feat(go/genkit): Use `dotprompt` package for rendering prompt templates

### DIFF
--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -351,24 +351,23 @@ func renderMessages(ctx context.Context, opts promptOptions, messages []*Message
 	}
 
 	for _, msg := range msgs {
+		msgParts := []*Part{}
 		for _, part := range msg.Content {
 			if part.IsText() {
 				parts, err := renderPrompt(ctx, opts, part.Text, input, dp)
 				if err != nil {
 					return nil, err
 				}
-				var rendered string
-				if len(parts) != 0 {
-					rendered = parts[0].Text
-				}
-				msg.Content[0].Text = rendered
+				msgParts = append(msgParts, parts...)
 			}
 		}
+		msg.Content = msgParts
 	}
 
 	return append(messages, msgs...), nil
 }
 
+// renderPrompt renders a prompt template using dotprompt functionalities
 func renderPrompt(ctx context.Context, opts promptOptions, templateText string, input map[string]any, dp *dotprompt.Dotprompt) ([]*Part, error) {
 	renderedFunc, err := dp.Compile(templateText, &dotprompt.PromptMetadata{})
 	if err != nil {
@@ -382,6 +381,7 @@ func renderPrompt(ctx context.Context, opts promptOptions, templateText string, 
 	})
 }
 
+// renderDotpromptToParts executes a dotprompt prompt function and converts the result to a slice of parts
 func renderDotpromptToParts(ctx context.Context, promptFn dotprompt.PromptFunction, input map[string]any, additionalMetadata *dotprompt.PromptMetadata) ([]*Part, error) {
 	// Prepare the context for rendering
 	context := map[string]any{}

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -479,7 +479,7 @@ func loadPromptDir(r *registry.Registry, dir string, namespace string) error {
 					slog.Error("Failed to read partial file", "error", err)
 					continue
 				}
-				addPartial(r, partialName, string(source))
+				DefinePartial(r, partialName, string(source))
 				slog.Debug("Registered Dotprompt partial", "name", partialName, "file", path)
 			} else {
 				if _, err := LoadPrompt(r, dir, filename, namespace); err != nil {
@@ -491,15 +491,24 @@ func loadPromptDir(r *registry.Registry, dir string, namespace string) error {
 	return nil
 }
 
-// addPartial adds the partial to the list of partials to the dotprompt instance
-func addPartial(r *registry.Registry, name string, source string) {
-	// TODO: Add this functionality
+// DefinePartial adds the partial to the list of partials to the dotprompt instance
+func DefinePartial(r *registry.Registry, name string, source string) {
 	if r.Dotprompt == nil {
 		r.Dotprompt = dotprompt.NewDotprompt(&dotprompt.DotpromptOptions{
 			Partials: map[string]string{},
 		})
 	}
 	r.Dotprompt.Partials[name] = source
+}
+
+// DefineHelper adds a helper function to the dotprompt instance
+func DefineHelper(r *registry.Registry, name string, fn any) {
+	if r.Dotprompt == nil {
+		r.Dotprompt = dotprompt.NewDotprompt(&dotprompt.DotpromptOptions{
+			Partials: map[string]string{},
+		})
+	}
+	r.Dotprompt.Helpers[name] = fn
 }
 
 // LoadPrompt loads a single prompt into the registry.

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -479,7 +479,9 @@ func loadPromptDir(r *registry.Registry, dir string, namespace string) error {
 					slog.Error("Failed to read partial file", "error", err)
 					continue
 				}
-				DefinePartial(r, partialName, string(source))
+				if err = r.DefinePartial(partialName, string(source)); err != nil {
+					return err
+				}
 				slog.Debug("Registered Dotprompt partial", "name", partialName, "file", path)
 			} else {
 				if _, err := LoadPrompt(r, dir, filename, namespace); err != nil {
@@ -489,26 +491,6 @@ func loadPromptDir(r *registry.Registry, dir string, namespace string) error {
 		}
 	}
 	return nil
-}
-
-// DefinePartial adds the partial to the list of partials to the dotprompt instance
-func DefinePartial(r *registry.Registry, name string, source string) {
-	if r.Dotprompt == nil {
-		r.Dotprompt = dotprompt.NewDotprompt(&dotprompt.DotpromptOptions{
-			Partials: map[string]string{},
-		})
-	}
-	r.Dotprompt.Partials[name] = source
-}
-
-// DefineHelper adds a helper function to the dotprompt instance
-func DefineHelper(r *registry.Registry, name string, fn any) {
-	if r.Dotprompt == nil {
-		r.Dotprompt = dotprompt.NewDotprompt(&dotprompt.DotpromptOptions{
-			Partials: map[string]string{},
-		})
-	}
-	r.Dotprompt.Helpers[name] = fn
 }
 
 // LoadPrompt loads a single prompt into the registry.

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -372,7 +372,7 @@ func renderMessages(ctx context.Context, opts promptOptions, messages []*Message
 func renderPrompt(ctx context.Context, opts promptOptions, templateText string, input map[string]any, dp *dotprompt.Dotprompt) ([]*Part, error) {
 	renderedFunc, err := dp.Compile(templateText, &dotprompt.PromptMetadata{})
 	if err != nil {
-		return []*Part{}, err
+		return nil, err
 	}
 
 	return renderDotpromptToParts(ctx, renderedFunc, input, &dotprompt.PromptMetadata{
@@ -385,11 +385,9 @@ func renderPrompt(ctx context.Context, opts promptOptions, templateText string, 
 func renderDotpromptToParts(ctx context.Context, promptFn dotprompt.PromptFunction, input map[string]any, additionalMetadata *dotprompt.PromptMetadata) ([]*Part, error) {
 	// Prepare the context for rendering
 	context := map[string]any{}
-	if ctx != nil {
-		actionCtx := core.FromContext(ctx)
-		for k, v := range actionCtx {
-			context[k] = v
-		}
+	actionCtx := core.FromContext(ctx)
+	for k, v := range actionCtx {
+		context[k] = v
 	}
 
 	// Call the prompt function with the input and context

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -1020,7 +1020,7 @@ func TestLoadPromptFolder_DirectoryNotFound(t *testing.T) {
 
 // TestDefinePartialAndHelperJourney demonstrates a complete user journey for defining
 // and using both partials and helpers.
-func TestDefinePartialAndHelperJourney(t *testing.T) {
+func TestDefinePartialAndHelper(t *testing.T) {
 	// Initialize a mock registry
 	reg, err := registry.New()
 	if err != nil {
@@ -1029,10 +1029,24 @@ func TestDefinePartialAndHelperJourney(t *testing.T) {
 
 	model := definePromptModel(reg)
 
-	DefinePartial(reg, "header", "Welcome {{name}}!")
-	DefineHelper(reg, "uppercase", func(s string) string {
+	if err = reg.DefinePartial("header", "Welcome {{name}}!"); err != nil {
+		t.Fatalf("Failed to define partial: %v", err)
+	}
+	if err = reg.DefineHelper("uppercase", func(s string) string {
 		return strings.ToUpper(s)
-	})
+	}); err != nil {
+		t.Fatalf("Failed to define helper: %v", err)
+	}
+
+	// Duplicate partial and helper definitions should return an error
+	if err = reg.DefinePartial("header", "Welcome {{name}}!"); err == nil {
+		t.Fatalf("Expected error defining partial with duplicate name")
+	}
+	if err = reg.DefineHelper("uppercase", func(s string) string {
+		return ""
+	}); err == nil {
+		t.Fatalf("Expected error defining helper with duplicate name")
+	}
 
 	p, err := DefinePrompt(reg, "test", WithPromptText(`{{> header}} {{uppercase greeting}}`), WithModel(model))
 

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -596,3 +596,31 @@ func LoadPrompt(g *Genkit, path string, namespace string) (*ai.Prompt, error) {
 func RegisterSpanProcessor(g *Genkit, sp sdktrace.SpanProcessor) {
 	g.reg.RegisterSpanProcessor(sp)
 }
+
+// DefinePartial wraps DefinePartial to register a partial template with the given name and source.
+// Partials can be referenced in templates with the syntax {{>partialName}}.
+func DefinePartial(g *Genkit, name string, source string) {
+	if g == nil || g.reg == nil {
+		return
+	}
+	ai.DefinePartial(g.reg, name, source)
+}
+
+// DefineHelper wraps DefineHelper to register a helper function with the given name.
+// This allows for extending the templating capabilities with custom logic.
+//
+// Example usage:
+//
+//	genkit.DefineHelper(g, "uppercase", func(s string) string {
+//		return strings.ToUpper(s)
+//	})
+//
+// In a template, you would use it as:
+//
+//	{{uppercase "hello"}} => "HELLO"
+func DefineHelper(g *Genkit, name string, fn any) {
+	if g == nil || g.reg == nil {
+		return
+	}
+	ai.DefineHelper(g.reg, name, fn)
+}

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -599,11 +599,8 @@ func RegisterSpanProcessor(g *Genkit, sp sdktrace.SpanProcessor) {
 
 // DefinePartial wraps DefinePartial to register a partial template with the given name and source.
 // Partials can be referenced in templates with the syntax {{>partialName}}.
-func DefinePartial(g *Genkit, name string, source string) {
-	if g == nil || g.reg == nil {
-		return
-	}
-	ai.DefinePartial(g.reg, name, source)
+func DefinePartial(g *Genkit, name string, source string) error {
+	return g.reg.DefinePartial(name, source)
 }
 
 // DefineHelper wraps DefineHelper to register a helper function with the given name.
@@ -618,9 +615,6 @@ func DefinePartial(g *Genkit, name string, source string) {
 // In a template, you would use it as:
 //
 //	{{uppercase "hello"}} => "HELLO"
-func DefineHelper(g *Genkit, name string, fn any) {
-	if g == nil || g.reg == nil {
-		return
-	}
-	ai.DefineHelper(g.reg, name, fn)
+func DefineHelper(g *Genkit, name string, fn any) error {
+	return g.reg.DefineHelper(name, fn)
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -13,8 +13,8 @@ require (
 	firebase.google.com/go/v4 v4.14.1
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.46.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.22.0
-	github.com/aymerick/raymond v2.0.2+incompatible
-	github.com/google/dotprompt/go v0.0.0-20250320235217-796c6442a3c1
+	github.com/blues/jsonata-go v1.5.4
+	github.com/google/dotprompt/go v0.0.0-20250328143753-e5e8fba19c9a
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.13.0
@@ -52,8 +52,8 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/aymerick/raymond v2.0.2+incompatible // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/blues/jsonata-go v1.5.4 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -67,6 +67,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-openapi/validate v0.21.0 // indirect
+	github.com/goccy/go-yaml v1.16.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/go/go.mod
+++ b/go/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.46.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.22.0
 	github.com/blues/jsonata-go v1.5.4
-	github.com/google/dotprompt/go v0.0.0-20250328143753-e5e8fba19c9a
+	github.com/google/dotprompt/go v0.0.0-20250402175444-30d6a6673f44
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.13.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -149,8 +149,8 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/google/dotprompt/go v0.0.0-20250328143753-e5e8fba19c9a h1:/SjdO42z8uJ8+nYRtcmv1RrQckaQ3K9BD/LcSZeamgA=
-github.com/google/dotprompt/go v0.0.0-20250328143753-e5e8fba19c9a/go.mod h1:4FtFETRicAKVoRUFbHvZWxMB4ptiFCBXR3rqZqqVWZA=
+github.com/google/dotprompt/go v0.0.0-20250402175444-30d6a6673f44 h1:IYZ/fLNoGfCkyfRLmxD2b5eyEgDVbjb3NAAQXiqrBMg=
+github.com/google/dotprompt/go v0.0.0-20250402175444-30d6a6673f44/go.mod h1:wVZXOPYuasZIfPu6UQvYxODdVUR2nIligI4SWs47GVs=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/go/go.sum
+++ b/go/go.sum
@@ -126,6 +126,8 @@ github.com/gobuffalo/packd v0.1.0/go.mod h1:M2Juc+hhDXf/PnmBANFCqx4DM3wRbgDvnVWe
 github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGtJQZ0Odn4pQ=
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
+github.com/goccy/go-yaml v1.16.0 h1:d7m1G7A0t+logajVtklHfDYJs2Et9g3gHwdBNNFou0w=
+github.com/goccy/go-yaml v1.16.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
@@ -147,8 +149,8 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/google/dotprompt/go v0.0.0-20250320235217-796c6442a3c1 h1:iF+srBJCoui58Z8RA7aoC3I+HZW9kyXo5jj6gZAmTxE=
-github.com/google/dotprompt/go v0.0.0-20250320235217-796c6442a3c1/go.mod h1:z/AwzHgCa9E07JcBxa3DoFjXr+DPHR8RTOnchLokjj0=
+github.com/google/dotprompt/go v0.0.0-20250328143753-e5e8fba19c9a h1:/SjdO42z8uJ8+nYRtcmv1RrQckaQ3K9BD/LcSZeamgA=
+github.com/google/dotprompt/go v0.0.0-20250328143753-e5e8fba19c9a/go.mod h1:4FtFETRicAKVoRUFbHvZWxMB4ptiFCBXR3rqZqqVWZA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/go/internal/registry/registry.go
+++ b/go/internal/registry/registry.go
@@ -181,3 +181,39 @@ func CurrentEnvironment() Environment {
 	}
 	return EnvironmentProd
 }
+
+// DefinePartial adds the partial to the list of partials to the dotprompt instance
+func (r *Registry) DefinePartial(name string, source string) error {
+	if r.Dotprompt == nil {
+		r.Dotprompt = dotprompt.NewDotprompt(&dotprompt.DotpromptOptions{
+			Partials: map[string]string{},
+		})
+	}
+	if r.Dotprompt.Partials == nil {
+		r.Dotprompt.Partials = make(map[string]string)
+	}
+
+	if r.Dotprompt.Partials[name] != "" {
+		return fmt.Errorf("partial %q is already defined", name)
+	}
+	r.Dotprompt.Partials[name] = source
+	return nil
+}
+
+// DefineHelper adds a helper function to the dotprompt instance
+func (r *Registry) DefineHelper(name string, fn any) error {
+	if r.Dotprompt == nil {
+		r.Dotprompt = dotprompt.NewDotprompt(&dotprompt.DotpromptOptions{
+			Helpers: map[string]any{},
+		})
+	}
+	if r.Dotprompt.Helpers == nil {
+		r.Dotprompt.Helpers = make(map[string]any)
+	}
+
+	if r.Dotprompt.Helpers[name] != nil {
+		return fmt.Errorf("helper %q is already defined", name)
+	}
+	r.Dotprompt.Helpers[name] = fn
+	return nil
+}

--- a/go/internal/registry/registry.go
+++ b/go/internal/registry/registry.go
@@ -58,7 +58,10 @@ func New() (*Registry, error) {
 	if os.Getenv("GENKIT_TELEMETRY_SERVER") != "" {
 		r.tstate.WriteTelemetryImmediate(tracing.NewHTTPTelemetryClient(os.Getenv("GENKIT_TELEMETRY_SERVER")))
 	}
-	r.Dotprompt = dotprompt.NewDotprompt(nil)
+	r.Dotprompt = dotprompt.NewDotprompt(&dotprompt.DotpromptOptions{
+		Helpers:  make(map[string]any),
+		Partials: make(map[string]string),
+	})
 	return r, nil
 }
 

--- a/go/samples/partials-and-helpers/main.go
+++ b/go/samples/partials-and-helpers/main.go
@@ -37,10 +37,14 @@ func main() {
 		log.Fatal(err)
 	}
 
-	genkit.DefinePartial(g, "header", "Welcome {{name}}!")
-	genkit.DefineHelper(g, "uppercase", func(s string) string {
+	if err = genkit.DefinePartial(g, "header", "Welcome {{name}}!"); err != nil {
+		log.Fatal(err)
+	}
+	if err = genkit.DefineHelper(g, "uppercase", func(s string) string {
 		return strings.ToUpper(s)
-	})
+	}); err != nil {
+		log.Fatal(err)
+	}
 
 	p, err := genkit.DefinePrompt(g, "test", ai.WithPromptText(`{{> header}} {{uppercase greeting}}`))
 

--- a/go/samples/partials-and-helpers/main.go
+++ b/go/samples/partials-and-helpers/main.go
@@ -31,9 +31,7 @@ func main() {
 
 	g, err := genkit.Init(ctx,
 		genkit.WithDefaultModel("googleai/gemini-2.0-flash"),
-		genkit.WithPlugins(&googlegenai.GoogleAI{
-			APIKey: "AIzaSyCjmoM7JvagdMjy-y39foXSWvJKgISTqMI",
-		}),
+		genkit.WithPlugins(&googlegenai.GoogleAI{}),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/go/samples/partials-and-helpers/main.go
+++ b/go/samples/partials-and-helpers/main.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	// Import Genkit and the Google AI plugin
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+)
+
+func main() {
+	ctx := context.Background()
+
+	g, err := genkit.Init(ctx,
+		genkit.WithDefaultModel("googleai/gemini-2.0-flash"),
+		genkit.WithPlugins(&googlegenai.GoogleAI{
+			APIKey: "AIzaSyCjmoM7JvagdMjy-y39foXSWvJKgISTqMI",
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	genkit.DefinePartial(g, "header", "Welcome {{name}}!")
+	genkit.DefineHelper(g, "uppercase", func(s string) string {
+		return strings.ToUpper(s)
+	})
+
+	p, err := genkit.DefinePrompt(g, "test", ai.WithPromptText(`{{> header}} {{uppercase greeting}}`))
+
+	result, err := p.Execute(context.Background(), ai.WithInput(map[string]any{
+		"name":     "User",
+		"greeting": "hello",
+	}))
+	if err != nil {
+		log.Fatal(err)
+	}
+	text := result.Text()
+	log.Printf("Response: %s", text)
+
+}


### PR DESCRIPTION
Description here... Help the reviewer by:
 - #2365 
 - Add dotprompt functions for rendering prompts
 - Modify metadata to pass template data as well 
 - Add input from ActionCtx as input for rendering the templates
 - Removed predefined helpers from prompt.go since they are already declared in the dotprompt function : https://github.com/google/dotprompt/blob/main/go/dotprompt/helper.go#L26

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
