### PR TITLE
fix(python): Remove twine validation

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -73,7 +73,6 @@ jobs:
         run: |
           cd py
           uv pip install -e .[dev,test,docs]
-          uv pip install --group dev
 
       - name: Install NPM packages
         run: |

--- a/py/bin/build_dists
+++ b/py/bin/build_dists
@@ -57,14 +57,3 @@ for PROJECT_DIR in "${PROJECT_DIRS[@]}"; do
     build
 done
 
-TWINE_CHECK=$(twine check ${TOP_DIR}/py/dist/*)
-
-echo "$TWINE_CHECK" 
-
-if echo "$TWINE_CHECK" | grep -q "FAIL"; then 
-  echo "Twine check failed"
-  exit 1
-else 
-  echo "Twine passed"
-fi
-


### PR DESCRIPTION
Remove twine validation in order to make build_dist script more portable.

Checklist (if applicable):
- [YES] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [YES] Tested (manually, unit tested, etc.)
- [YES] Docs updated (updated docs or a docs bug required)
