### PR TITLE
fix(go/genkit): use controlled flushing on JSON responses

### DIFF
--- a/go/genkit/reflection.go
+++ b/go/genkit/reflection.go
@@ -438,6 +438,12 @@ func runAction(ctx context.Context, reg *registry.Registry, key string, input js
 // writeJSON writes a JSON-marshaled value to the response writer.
 func writeJSON(ctx context.Context, w http.ResponseWriter, value any) error {
 	w.Header().Set("Content-Type", "application/json")
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
 	if err := json.NewEncoder(w).Encode(value); err != nil {
 		logger.FromContext(ctx).Error("writing output", "err", err)
 	}

--- a/go/genkit/reflection.go
+++ b/go/genkit/reflection.go
@@ -444,7 +444,7 @@ func writeJSON(ctx context.Context, w http.ResponseWriter, value any) error {
 		return err
 	}
 	_, err = w.Write(data)
-	if err := json.NewEncoder(w).Encode(value); err != nil {
+	if err != nil {
 		logger.FromContext(ctx).Error("writing output", "err", err)
 	}
 	if f, ok := w.(http.Flusher); ok {


### PR DESCRIPTION
`json.NewEncoder()` and `encoder.Encode()` were causing unexpected flushes to the response writer when streaming responses back to the reflection server causing invalid JSONS to be received during the stream execution.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
