### PR TITLE
fix(py/bin/build_dists): fix dir path for `py` for portability across nested paths

### DIFF
--- a/py/bin/build_dists
+++ b/py/bin/build_dists
@@ -57,7 +57,7 @@ for PROJECT_DIR in "${PROJECT_DIRS[@]}"; do
     build
 done
 
-TWINE_CHECK=$(uv run --directory py twine check ${TOP_DIR}/py/dist/*)
+TWINE_CHECK=$(uv run --directory ${TOP_DIR}/py twine check ${TOP_DIR}/py/dist/*)
 echo "$TWINE_CHECK"
 if echo "$TWINE_CHECK" | grep -q "FAIL"; then
   echo "Twine check failed."


### PR DESCRIPTION
CHANGELOG:
- [ ] Add the `${TOP_DIR}` prefix for the `py` directory to make it
      portable across nested paths.
