### PR TITLE
fix(py/plugins/google-genai): mark as legacy and deprecated v1 Gemini models

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -99,22 +99,22 @@ Date / Snapshot ID (e.g., `02-05`, `03-25`)
 
 The following models are currently supported:
 
-| Model                       | Description               | Deprecated    |
-|-----------------------------|---------------------------|---------------|
-| `gemini-1.0-pro`            | Gemini 1.0 Pro            | Yes           |
-| `gemini-1.5-pro`            | Gemini 1.5 Pro            | Yes           |
-| `gemini-1.5-flash`          | Gemini 1.5 Flash          | Yes           |
-| `gemini-1.5-flash-8b`       | Gemini 1.5 Flash 8B       | Yes           |
-| `gemini-2.0-flash`          | Gemini 2.0 Flash          | No            |
-| `gemini-2.0-flash-lite`     | Gemini 2.0 Flash Lite     | No            |
-| `gemini-2.0-pro-exp-02-05`  | Gemini 2.0 Pro Exp 02-05  | No            |
-| `gemini-2.5-pro-exp-03-25`  | Gemini 2.5 Pro Exp 03-25  | No            |
+| Model                       | Description               | Status     |
+|-----------------------------|---------------------------|------------|
+| `gemini-1.0-pro`            | Gemini 1.0 Pro            | Obsolete   |
+| `gemini-1.5-pro`            | Gemini 1.5 Pro            | Deprecated |
+| `gemini-1.5-flash`          | Gemini 1.5 Flash          | Deprecated |
+| `gemini-1.5-flash-8b`       | Gemini 1.5 Flash 8B       | Deprecated |
+| `gemini-2.0-flash`          | Gemini 2.0 Flash          | Supported  |
+| `gemini-2.0-flash-lite`     | Gemini 2.0 Flash Lite     | Supported  |
+| `gemini-2.0-pro-exp-02-05`  | Gemini 2.0 Pro Exp 02-05  | Supported  |
+| `gemini-2.5-pro-exp-03-25`  | Gemini 2.5 Pro Exp 03-25  | Supported  |
 
 The following models are supported for API only:
 
-| Model                  | Description                   | Deprecated   |
-|------------------------|-------------------------------|--------------|
-| `gemini-2.0-flash-exp` | Gemini 2.0 Flash Experimental | No           |
+| Model                  | Description                   | Status     |
+|------------------------|-------------------------------|------------|
+| `gemini-2.0-flash-exp` | Gemini 2.0 Flash Experimental | Supported  |
 """
 
 from enum import StrEnum
@@ -134,6 +134,7 @@ from genkit.core.typing import (
     Message,
     ModelInfo,
     Role,
+    Stage,
     Supports,
     TextPart,
     ToolDefinition,
@@ -142,6 +143,7 @@ from genkit.plugins.google_genai.models.utils import PartConverter
 
 GEMINI_1_0_PRO = ModelInfo(
     label='Google AI - Gemini Pro',
+    stage=Stage.LEGACY,
     versions=['gemini-pro', 'gemini-1.0-pro-latest', 'gemini-1.0-pro-001'],
     supports=Supports(
         multiturn=True,
@@ -156,6 +158,7 @@ GEMINI_1_0_PRO = ModelInfo(
 
 GEMINI_1_5_PRO = ModelInfo(
     label='Google AI - Gemini 1.5 Pro',
+    stage=Stage.DEPRECATED,
     versions=[
         'gemini-1.5-pro-latest',
         'gemini-1.5-pro-001',
@@ -174,6 +177,7 @@ GEMINI_1_5_PRO = ModelInfo(
 
 GEMINI_1_5_FLASH = ModelInfo(
     label='Google AI - Gemini 1.5 Flash',
+    stage=Stage.DEPRECATED,
     versions=[
         'gemini-1.5-flash-latest',
         'gemini-1.5-flash-001',
@@ -192,6 +196,7 @@ GEMINI_1_5_FLASH = ModelInfo(
 
 GEMINI_1_5_FLASH_8B = ModelInfo(
     label='Google AI - Gemini 1.5 Flash',
+    stage=Stage.DEPRECATED,
     versions=['gemini-1.5-flash-8b-latest', 'gemini-1.5-flash-8b-001'],
     supports=Supports(
         multiturn=True,
@@ -268,7 +273,21 @@ GEMINI_2_5_PRO_EXP_03_25 = ModelInfo(
 
 
 class GeminiVersion(StrEnum):
-    """Gemini models."""
+    """Gemini models.
+
+    Model Support:
+
+    | Model                       | Description               | Status     |
+    |-----------------------------|---------------------------|------------|
+    | `gemini-1.0-pro`            | Gemini 1.0 Pro            | Obsolete   |
+    | `gemini-1.5-pro`            | Gemini 1.5 Pro            | Deprecated |
+    | `gemini-1.5-flash`          | Gemini 1.5 Flash          | Deprecated |
+    | `gemini-1.5-flash-8b`       | Gemini 1.5 Flash 8B       | Deprecated |
+    | `gemini-2.0-flash`          | Gemini 2.0 Flash          | Supported  |
+    | `gemini-2.0-flash-lite`     | Gemini 2.0 Flash Lite     | Supported  |
+    | `gemini-2.0-pro-exp-02-05`  | Gemini 2.0 Pro Exp 02-05  | Supported  |
+    | `gemini-2.5-pro-exp-03-25`  | Gemini 2.5 Pro Exp 03-25  | Supported  |
+    """
 
     GEMINI_1_0_PRO = 'gemini-1.0-pro'
     GEMINI_1_5_PRO = 'gemini-1.5-pro'

--- a/py/samples/hello-google-genai/src/hello.py
+++ b/py/samples/hello-google-genai/src/hello.py
@@ -62,7 +62,7 @@ async def simple_generate_with_tools_flow(value: int) -> str:
         The generated response with a function.
     """
     response = await ai.generate(
-        model=google_genai_name(gemini.GoogleAiVersion.GEMINI_1_5_FLASH),
+        model=google_genai_name(gemini.GoogleAiVersion.GEMINI_2_0_FLASH),
         messages=[
             Message(
                 role=Role.USER,
@@ -82,7 +82,7 @@ def gablorkenTool2(input_: GablorkenInput, ctx: ToolRunContext):
 @ai.flow()
 async def simple_generate_with_interrupts(value: int) -> str:
     response1 = await ai.generate(
-        model=google_genai_name(gemini.GoogleAiVersion.GEMINI_1_5_FLASH),
+        model=google_genai_name(gemini.GoogleAiVersion.GEMINI_2_0_FLASH),
         messages=[
             Message(
                 role=Role.USER,
@@ -97,7 +97,7 @@ async def simple_generate_with_interrupts(value: int) -> str:
 
     tr = tool_response(response1.tool_requests[0], 178)
     response = await ai.generate(
-        model=google_genai_name(gemini.GoogleAiVersion.GEMINI_1_5_FLASH),
+        model=google_genai_name(gemini.GoogleAiVersion.GEMINI_2_0_FLASH),
         messages=response1.messages,
         tool_responses=[tr],
         tools=['gablorkenTool'],
@@ -200,4 +200,5 @@ if __name__ == '__main__':
 
 
 # prevent app from exiting when genkit is running in dev mode
+# TODO: Clean this up.
 ai.join()


### PR DESCRIPTION
fix(py/plugins/google-genai): mark as legacy and deprecated v1 Gemini models
    
MODEL SUPPORT:

| Model                       | Description               | Status     |
|-----------------------------|---------------------------|------------|
| `gemini-1.0-pro`            | Gemini 1.0 Pro            | Obsolete   |
| `gemini-1.5-pro`            | Gemini 1.5 Pro            | Deprecated |
| `gemini-1.5-flash`          | Gemini 1.5 Flash          | Deprecated |
| `gemini-1.5-flash-8b`       | Gemini 1.5 Flash 8B       | Deprecated |
| `gemini-2.0-flash`          | Gemini 2.0 Flash          | Supported  |
| `gemini-2.0-flash-lite`     | Gemini 2.0 Flash Lite     | Supported  |
| `gemini-2.0-pro-exp-02-05`  | Gemini 2.0 Pro Exp 02-05  | Supported  |
| `gemini-2.5-pro-exp-03-25`  | Gemini 2.5 Pro Exp 03-25  | Supported  |

CHANGELOG:
- [ ] Mark v1 models as legacy or deprecated.

```
ClientError("404 NOT_FOUND. {'error': {'code': 404, 'message': 'models/gemini-1.0-pro is not found for API version v1beta, or is not supported for generateContent. Call ListModels to see the list of available models and their supported methods.', 'status': 'NOT_FOUND'}}")
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/packages/genkit-ai/src/genkit/core/action.py", line 300, in async_tracing_wrapper
    output = await afn(input, ctx)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py", line 460, in generate
    return await self._generate(request_contents, request_cfg)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py", line 476, in _generate
    response = await self._client.aio.models.generate_content(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/.venv/lib/python3.12/site-packages/google/genai/models.py", line 5826, in generate_content
    response = await self._generate_content(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/.venv/lib/python3.12/site-packages/google/genai/models.py", line 5010, in _generate_content
    response_dict = await self._api_client.async_request(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/.venv/lib/python3.12/site-packages/google/genai/_api_client.py", line 483, in async_request
    result = await self._async_request(http_request=http_request, stream=False)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/.venv/lib/python3.12/site-packages/google/genai/_api_client.py", line 426, in _async_request
    return await asyncio.to_thread(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yesudeep/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yesudeep/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/.venv/lib/python3.12/site-packages/google/genai/_api_client.py", line 384, in _request
    return self._request_unauthorized(http_request, stream)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/.venv/lib/python3.12/site-packages/google/genai/_api_client.py", line 407, in _request_unauthorized
    errors.APIError.raise_for_response(response)
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/.venv/lib/python3.12/site-packages/google/genai/errors.py", line 100, in raise_for_response
    raise ClientError(status_code, response)
    ```