### PR TITLE
feat(py/genkit-ai): add model deprecations metaclass factory

### DIFF
--- a/py/packages/genkit-ai/src/genkit/ai/__init__.py
+++ b/py/packages/genkit-ai/src/genkit/ai/__init__.py
@@ -45,6 +45,7 @@ from genkit.core.typing import (
     RetrieverRequest,
     RetrieverResponse,
     Role,
+    Stage,
     Supports,
     TextPart,
     ToolDefinition,
@@ -88,4 +89,5 @@ __all__ = [
     GenerationUsage.__name__,
     ToolDefinition.__name__,
     tool_response.__name__,
+    Stage.__name__,
 ]

--- a/py/packages/genkit-ai/src/genkit/lang/__init__.py
+++ b/py/packages/genkit-ai/src/genkit/lang/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/py/packages/genkit-ai/src/genkit/lang/deprecations.py
+++ b/py/packages/genkit-ai/src/genkit/lang/deprecations.py
@@ -1,0 +1,111 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for managing deprecations.
+
+This module provides a metaclass for creating deprecated enums. It allows
+developers to mark enum members as deprecated and provides warnings when those
+members are accessed.
+
+The metaclass works by overriding the __getattribute__ method of the enum class.
+When a deprecated member is accessed, a deprecation warning is issued.
+
+## Example
+
+    ```python
+    Deprecations = deprecated_enum_metafactory({
+        'OLD_THING': DeprecationInfo(
+            recommendation='NEW_THING', status=DeprecationStatus.DEPRECATED
+        ),
+    })
+
+
+    class TestEnum(StrEnum, metaclass=Deprecations): ...
+    ```
+"""
+
+import enum
+import warnings
+from dataclasses import dataclass
+
+
+class DeprecationStatus(enum.Enum):
+    """Defines the deprecation status of an enum member."""
+
+    SUPPORTED = 'supported'
+    DEPRECATED = 'deprecated'
+    LEGACY = 'legacy'
+
+
+@dataclass
+class DeprecationInfo:
+    """Holds information about a deprecated enum member."""
+
+    recommendation: str | None
+    status: DeprecationStatus
+
+
+def deprecated_enum_metafactory(
+    deprecated_map: dict[str, DeprecationInfo],
+) -> type[enum.EnumMeta]:
+    """Creates an EnumMeta metaclass to handle deprecated enum members.
+
+    Args:
+        deprecated_map: Dict mapping enum member names to DeprecationInfo.
+
+    Returns:
+        An EnumMeta subclass that warns on deprecated member access.
+    """
+
+    class DeprecatedEnumMeta(enum.EnumMeta):
+        def __getattribute__(cls, name: str) -> object:
+            """Get an attribute of the enum class.
+
+            Args:
+                cls: The enum class.
+                name: The name of the attribute to get.
+
+            Returns:
+                The attribute value.
+            """
+            # This __getattribute__ is called when accessing attributes
+            # directly on the Enum class itself (e.g., MyEnum.MEMBER).
+            if name in deprecated_map:
+                info = deprecated_map[name]
+                if info.status in (
+                    DeprecationStatus.DEPRECATED,
+                    DeprecationStatus.LEGACY,
+                ):
+                    status_str = info.status.value
+                    message = (
+                        (
+                            f'{cls.__name__}.{name} is {status_str}; '
+                            f'use {cls.__name__}.{info.recommendation} instead'
+                        )
+                        if info.recommendation is not None
+                        else f'{cls.__name__}.{name} is {status_str}'
+                    )
+                    # Start with stacklevel=4; adjust if needed based on test
+                    # results (factory adds a frame, metaclass __getattribute__
+                    # adds a frame)
+                    warnings.warn(
+                        message,
+                        DeprecationWarning,
+                        stacklevel=4,
+                    )
+            return super().__getattribute__(name)
+
+    return DeprecatedEnumMeta

--- a/py/packages/genkit-ai/tests/genkit/lang/deprecations_test.py
+++ b/py/packages/genkit-ai/tests/genkit/lang/deprecations_test.py
@@ -1,0 +1,170 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for deprecation helpers."""
+
+import unittest
+import warnings
+from enum import StrEnum
+
+from genkit.lang.deprecations import (
+    DeprecationInfo,
+    DeprecationStatus,
+    deprecated_enum_metafactory,
+)
+
+TEST_DEPRECATED_MODELS = {
+    'GEMINI_1_0_PRO': DeprecationInfo(
+        recommendation='GEMINI_2_0_PRO', status=DeprecationStatus.LEGACY
+    ),
+    'GEMINI_1_5_PRO': DeprecationInfo(
+        recommendation='GEMINI_2_0_PRO', status=DeprecationStatus.DEPRECATED
+    ),
+    'GEMINI_1_5_FLASH': DeprecationInfo(
+        recommendation='GEMINI_2_0_FLASH', status=DeprecationStatus.DEPRECATED
+    ),
+    'GEMINI_1_5_FLASH_8B': DeprecationInfo(
+        recommendation=None, status=DeprecationStatus.DEPRECATED
+    ),
+}
+
+
+class GeminiVersionTest(
+    StrEnum, metaclass=deprecated_enum_metafactory(TEST_DEPRECATED_MODELS)
+):
+    """Test Gemini models enum."""
+
+    GEMINI_1_0_PRO = 'gemini-1.0-pro'
+    GEMINI_1_5_PRO = 'gemini-1.5-pro'
+    GEMINI_1_5_FLASH = 'gemini-1.5-flash'
+    GEMINI_1_5_FLASH_8B = 'gemini-1.5-flash-8b'
+    GEMINI_2_0_FLASH = 'gemini-2.0-flash'
+    GEMINI_2_0_PRO = 'gemini-2.0-pro'  # Added for recommendation
+
+
+class TestDeprecatedEnum(unittest.TestCase):
+    """Test deprecated enum members."""
+
+    def test_legacy_member_warning(self):
+        """Verify warning for legacy member with recommendation."""
+        expected_regex = (
+            r'GeminiVersionTest\.GEMINI_1_0_PRO is legacy; '
+            r'use GeminiVersionTest\.GEMINI_2_0_PRO instead'
+        )
+        warnings.simplefilter('always', DeprecationWarning)
+        try:
+            with self.assertWarnsRegex(DeprecationWarning, expected_regex):
+                member = GeminiVersionTest.GEMINI_1_0_PRO
+            self.assertEqual(member, GeminiVersionTest.GEMINI_1_0_PRO)
+            self.assertEqual(member.value, 'gemini-1.0-pro')
+        finally:
+            warnings.simplefilter('default', DeprecationWarning)
+
+    def test_deprecated_member_with_recommendation_warning(self):
+        """Verify warning for deprecated member with recommendation."""
+        expected_regex = (
+            r'GeminiVersionTest\.GEMINI_1_5_PRO is deprecated; '
+            r'use GeminiVersionTest\.GEMINI_2_0_PRO instead'
+        )
+        warnings.simplefilter('always', DeprecationWarning)
+        try:
+            with self.assertWarnsRegex(DeprecationWarning, expected_regex):
+                member = GeminiVersionTest.GEMINI_1_5_PRO
+            self.assertEqual(member, GeminiVersionTest.GEMINI_1_5_PRO)
+            self.assertEqual(member.value, 'gemini-1.5-pro')
+        finally:
+            warnings.simplefilter('default', DeprecationWarning)
+
+    def test_deprecated_member_without_recommendation_warning(self):
+        """Verify warning for deprecated member without recommendation."""
+        expected_regex = r'GeminiVersionTest\.GEMINI_1_5_FLASH_8B is deprecated'
+        warnings.simplefilter('always', DeprecationWarning)
+        try:
+            with self.assertWarnsRegex(
+                DeprecationWarning, expected_regex
+            ) as cm:
+                member = GeminiVersionTest.GEMINI_1_5_FLASH_8B
+                self.assertTrue(
+                    hasattr(cm, 'warnings') and cm.warnings,
+                    'Warning was not captured by assertWarnsRegex',
+                )
+                self.assertNotIn('instead', str(cm.warnings[0].message))
+            self.assertEqual(member, GeminiVersionTest.GEMINI_1_5_FLASH_8B)
+            self.assertEqual(member.value, 'gemini-1.5-flash-8b')
+        finally:
+            warnings.simplefilter('default', DeprecationWarning)
+
+    def test_supported_member_no_warning(self):
+        """Verify no warning for a supported member."""
+        member_to_test = GeminiVersionTest.GEMINI_2_0_FLASH
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            member = getattr(GeminiVersionTest, member_to_test.name)
+            self.assertEqual(
+                len(w),
+                0,
+                f'Expected no warnings for {member_to_test.name}, but got {len(w)}: {[warn.message for warn in w]}',
+            )
+        self.assertEqual(member, member_to_test)
+        self.assertEqual(member.value, member_to_test.value)
+
+    def test_recommended_member_no_warning(self):
+        """Verify no warning for a member used as a recommendation."""
+        member_to_test = GeminiVersionTest.GEMINI_2_0_PRO
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            member = getattr(GeminiVersionTest, member_to_test.name)
+            self.assertEqual(
+                len(w),
+                0,
+                f'Expected no warnings for {member_to_test.name}, but got {len(w)}: {[warn.message for warn in w]}',
+            )
+        self.assertEqual(member, member_to_test)
+        self.assertEqual(member.value, member_to_test.value)
+
+    def test_access_via_value_no_warning(self):
+        """Verify no warning when accessing members via value lookup."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            member_dep = GeminiVersionTest('gemini-1.5-pro')
+            member_leg = GeminiVersionTest('gemini-1.0-pro')
+            member_sup = GeminiVersionTest('gemini-2.0-flash')
+            self.assertEqual(
+                len(w),
+                0,
+                f'Expected no warnings for value lookup, but got {len(w)}: {[warn.message for warn in w]}',
+            )
+        self.assertEqual(member_dep, GeminiVersionTest.GEMINI_1_5_PRO)
+        self.assertEqual(member_leg, GeminiVersionTest.GEMINI_1_0_PRO)
+        self.assertEqual(member_sup, GeminiVersionTest.GEMINI_2_0_FLASH)
+
+    def test_iteration_no_warning(self):
+        """Verify no warning when iterating over enum members."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            members = list(GeminiVersionTest)
+            self.assertEqual(
+                len(w),
+                0,
+                f'Expected no warnings during iteration, but got {len(w)}: {[warn.message for warn in w]}',
+            )
+        self.assertEqual(len(members), len(GeminiVersionTest.__members__))
+        self.assertIn(GeminiVersionTest.GEMINI_1_5_FLASH_8B, members)
+        self.assertIn(GeminiVersionTest.GEMINI_2_0_FLASH, members)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -139,6 +139,11 @@ from genkit.ai import (
     Supports,
     ToolDefinition,
 )
+from genkit.lang.deprecations import (
+    DeprecationInfo,
+    DeprecationStatus,
+    deprecated_enum_metafactory,
+)
 from genkit.plugins.google_genai.models.utils import PartConverter
 
 
@@ -277,7 +282,23 @@ GEMINI_2_5_PRO_EXP_03_25 = ModelInfo(
 )
 
 
-class GeminiVersion(StrEnum):
+Deprecations = deprecated_enum_metafactory({
+    'GEMINI_1_0_PRO': DeprecationInfo(
+        recommendation='GEMINI_2_0_FLASH', status=DeprecationStatus.DEPRECATED
+    ),
+    'GEMINI_1_5_PRO': DeprecationInfo(
+        recommendation='GEMINI_2_0_FLASH', status=DeprecationStatus.DEPRECATED
+    ),
+    'GEMINI_1_5_FLASH': DeprecationInfo(
+        recommendation='GEMINI_2_0_FLASH', status=DeprecationStatus.DEPRECATED
+    ),
+    'GEMINI_1_5_FLASH_8B': DeprecationInfo(
+        recommendation='GEMINI_2_0_FLASH', status=DeprecationStatus.DEPRECATED
+    ),
+})
+
+
+class GeminiVersion(StrEnum, metaclass=Deprecations):
     """Gemini models.
 
     Model Support:


### PR DESCRIPTION
feat(py/genkit-ai): add model deprecations metaclass factory for later

CHANGELOG:
- [ ] Adds a deprecate models metaclass factory to enable deprecation
      warnings for deprecated models.

[
<img width="1616" alt="deprecation-warnings" src="https://github.com/user-attachments/assets/0d7b2732-73aa-4dda-b82e-a5ddf709e0f5" />
](url)