### PR TITLE
fix(py/genkit-ai): fix more lint and license header issues

### DIFF
--- a/py/packages/genkit-ai/src/genkit/aio/loop.py
+++ b/py/packages/genkit-ai/src/genkit/aio/loop.py
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""Asyncio loop utilities."""
+
 import asyncio
 import threading
 from collections.abc import AsyncIterable, Callable, Iterable
@@ -30,7 +32,7 @@ def create_loop():
     """
     try:
         return asyncio.get_event_loop()
-    except:
+    except Exception:
         return asyncio.new_event_loop()
 
 

--- a/py/packages/genkit-ai/src/genkit/blocks/document.py
+++ b/py/packages/genkit-ai/src/genkit/blocks/document.py
@@ -30,8 +30,6 @@ from genkit.core.typing import (
     DocumentPart,
     Embedding,
     Media,
-    MediaPart,
-    TextPart,
 )
 
 TEXT_DATA_TYPE: str = 'text'

--- a/py/packages/genkit-ai/src/genkit/blocks/embedding.py
+++ b/py/packages/genkit-ai/src/genkit/blocks/embedding.py
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""Embedding actions."""
+
 from collections.abc import Callable
 
 from genkit.core.typing import EmbedRequest, EmbedResponse

--- a/py/packages/genkit-ai/src/genkit/blocks/middleware.py
+++ b/py/packages/genkit-ai/src/genkit/blocks/middleware.py
@@ -14,11 +14,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Awaitable, Callable
-from functools import cached_property
-from typing import Any
+"""Middleware for the Genkit framework."""
 
-from pydantic import Field
+from collections.abc import Awaitable
 
 from genkit.blocks.model import (
     ModelMiddleware,
@@ -128,8 +126,7 @@ def augment_with_context() -> ModelMiddleware:
 
 
 def last_user_message(messages: list[Message]) -> Message | None:
-    """
-    Finds the last message with the role 'user' in a list of messages.
+    """Finds the last message with the role 'user' in a list of messages.
 
     Args:
         messages: A list of message dictionaries.

--- a/py/packages/genkit-ai/src/genkit/blocks/model.py
+++ b/py/packages/genkit-ai/src/genkit/blocks/model.py
@@ -129,6 +129,7 @@ class GenerateResponseWrapper(GenerateResponse):
         Args:
             response: The original GenerateResponse object.
             request: The GenerateRequest object associated with the response.
+            message_parser: An optional function to parse the output from the message.
         """
         super().__init__(
             message=MessageWrapper(response.message)

--- a/py/packages/genkit-ai/src/genkit/blocks/tools.py
+++ b/py/packages/genkit-ai/src/genkit/blocks/tools.py
@@ -75,7 +75,7 @@ class ToolInterruptError(Exception):
 
 def tool_response(
     interrupt: Part | ToolRequestPart,
-    responseData: Any | None = None,
+    response_data: Any | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> Part:
     """Constructs a ToolResponse Part, typically for an interrupted request.
@@ -86,7 +86,7 @@ def tool_response(
 
     Args:
         interrupt: The original ToolRequest Part or ToolRequestPart that was interrupted.
-        responseData: The data to include in the ToolResponse output. Defaults to None.
+        response_data: The data to include in the ToolResponse output. Defaults to None.
         metadata: Optional metadata to include in the resulting Part, often used
                   to signal that this response corresponds to an interrupt.
                   Defaults to {'interruptResponse': True}.
@@ -100,7 +100,7 @@ def tool_response(
         tool_response=ToolResponse(
             name=tool_request.name,
             ref=tool_request.ref,
-            output=responseData,
+            output=response_data,
         ),
         metadata={
             'interruptResponse': metadata if metadata else True,

--- a/py/packages/genkit-ai/src/genkit/core/flows.py
+++ b/py/packages/genkit-ai/src/genkit/core/flows.py
@@ -1,4 +1,17 @@
 # Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # SPDX-License-Identifier: Apache-2.0
 
 """Flows API module for GenKit.
@@ -62,7 +75,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from genkit.codec import dump_dict
-from genkit.core.action import Action, ActionKind
+from genkit.core.action import Action
 from genkit.core.constants import DEFAULT_GENKIT_VERSION
 from genkit.core.error import get_callable_json
 from genkit.core.registry import Registry

--- a/py/packages/genkit-ai/src/genkit/core/schema.py
+++ b/py/packages/genkit-ai/src/genkit/core/schema.py
@@ -1,6 +1,17 @@
-#!/usr/bin/env python3
-#
 # Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # SPDX-License-Identifier: Apache-2.0
 
 """Functions for working with schema."""
@@ -11,8 +22,7 @@ from pydantic import TypeAdapter
 
 
 def to_json_schema(schema: type | dict[str, Any]) -> dict[str, Any]:
-    """
-    Converts a Python type to a JSON schema.
+    """Converts a Python type to a JSON schema.
 
     If the input `schema` is already a dictionary (assumed json schema), it is
     returned directly. Otherwise, it is assumed to be a Python type, and a

--- a/py/packages/genkit-ai/src/genkit/lang/__init__.py
+++ b/py/packages/genkit-ai/src/genkit/lang/__init__.py
@@ -13,3 +13,5 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+
+"""Language utilities."""


### PR DESCRIPTION
fix(py/genkit-ai): fix more lint and license header issues

CHANGELOG:
- [ ] Fix license header issues.
- [ ] Add missing docstrings.
- [ ] Add missing param descriptions to docstrings.
- [ ] Clean up unused imports.                                                                                                                          
- [ ] Fix param names.