### PR TITLE
refactor(go/plugins): keep gemini code in `googlegenai`

### DIFF
--- a/go/plugins/googlegenai/cache.go
+++ b/go/plugins/googlegenai/cache.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package gemini
+package googlegenai
 
 import (
 	"context"

--- a/go/plugins/googlegenai/cache_test.go
+++ b/go/plugins/googlegenai/cache_test.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package gemini
+package googlegenai
 
 import (
 	"strings"

--- a/go/plugins/googlegenai/googlegenai.go
+++ b/go/plugins/googlegenai/googlegenai.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
-	"github.com/firebase/genkit/go/plugins/internal/gemini"
 	"google.golang.org/genai"
 )
 
@@ -86,7 +85,7 @@ func (ga *GoogleAI) Init(ctx context.Context, g *genkit.Genkit) (err error) {
 		Backend: genai.BackendGeminiAPI,
 		APIKey:  apiKey,
 		HTTPOptions: genai.HTTPOptions{
-			Headers: gemini.GenkitClientHeader,
+			Headers: GenkitClientHeader,
 		},
 	}
 
@@ -102,7 +101,7 @@ func (ga *GoogleAI) Init(ctx context.Context, g *genkit.Genkit) (err error) {
 		return err
 	}
 	for n, mi := range models {
-		gemini.DefineModel(g, ga.gclient, n, mi)
+		defineModel(g, ga.gclient, n, mi)
 	}
 
 	embedders, err := listEmbedders(gc.Backend)
@@ -110,7 +109,7 @@ func (ga *GoogleAI) Init(ctx context.Context, g *genkit.Genkit) (err error) {
 		return err
 	}
 	for _, e := range embedders {
-		gemini.DefineEmbedder(g, ga.gclient, e)
+		defineEmbedder(g, ga.gclient, e)
 	}
 
 	return nil
@@ -160,7 +159,7 @@ func (v *VertexAI) Init(ctx context.Context, g *genkit.Genkit) (err error) {
 		Project:  v.ProjectID,
 		Location: v.Location,
 		HTTPOptions: genai.HTTPOptions{
-			Headers: gemini.GenkitClientHeader,
+			Headers: GenkitClientHeader,
 		},
 	}
 
@@ -176,7 +175,7 @@ func (v *VertexAI) Init(ctx context.Context, g *genkit.Genkit) (err error) {
 		return err
 	}
 	for n, mi := range models {
-		gemini.DefineModel(g, v.gclient, n, mi)
+		defineModel(g, v.gclient, n, mi)
 	}
 
 	embedders, err := listEmbedders(gc.Backend)
@@ -184,7 +183,7 @@ func (v *VertexAI) Init(ctx context.Context, g *genkit.Genkit) (err error) {
 		return err
 	}
 	for _, e := range embedders {
-		gemini.DefineEmbedder(g, v.gclient, e)
+		defineEmbedder(g, v.gclient, e)
 	}
 
 	return nil
@@ -216,7 +215,7 @@ func (ga *GoogleAI) DefineModel(g *genkit.Genkit, name string, info *ai.ModelInf
 		mi = *info
 	}
 
-	return gemini.DefineModel(g, ga.gclient, name, mi), nil
+	return defineModel(g, ga.gclient, name, mi), nil
 }
 
 // DefineModel defines an unknown model with the given name.
@@ -245,7 +244,7 @@ func (v *VertexAI) DefineModel(g *genkit.Genkit, name string, info *ai.ModelInfo
 		mi = *info
 	}
 
-	return gemini.DefineModel(g, v.gclient, name, mi), nil
+	return defineModel(g, v.gclient, name, mi), nil
 }
 
 // DefineEmbedder defines an embedder with a given name.
@@ -255,7 +254,7 @@ func (ga *GoogleAI) DefineEmbedder(g *genkit.Genkit, name string) (ai.Embedder, 
 	if !ga.initted {
 		return nil, errors.New("GoogleAI plugin not initialized")
 	}
-	return gemini.DefineEmbedder(g, ga.gclient, name), nil
+	return defineEmbedder(g, ga.gclient, name), nil
 }
 
 // DefineEmbedder defines an embedder with a given name.
@@ -265,7 +264,7 @@ func (v *VertexAI) DefineEmbedder(g *genkit.Genkit, name string) (ai.Embedder, e
 	if !v.initted {
 		return nil, errors.New("VertexAI plugin not initialized")
 	}
-	return gemini.DefineEmbedder(g, v.gclient, name), nil
+	return defineEmbedder(g, v.gclient, name), nil
 }
 
 // IsDefinedEmbedder reports whether the named [Embedder] is defined by this plugin.

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/plugins/internal/gemini"
 	"google.golang.org/genai"
 )
 
@@ -57,7 +56,7 @@ var (
 				"gemini-1.5-flash-001",
 				"gemini-1.5-flash-002",
 			},
-			Supports: &gemini.Multimodal,
+			Supports: &Multimodal,
 		},
 		gemini15Pro: {
 			Label: "Gemini 1.5 Pro",
@@ -66,7 +65,7 @@ var (
 				"gemini-1.5-pro-001",
 				"gemini-1.5-pro-002",
 			},
-			Supports: &gemini.Multimodal,
+			Supports: &Multimodal,
 		},
 		gemini15Flash8b: {
 			Label: "Gemini 1.5 Flash 8B",
@@ -74,41 +73,41 @@ var (
 				"gemini-1.5-flash-8b-latest",
 				"gemini-1.5-flash-8b-001",
 			},
-			Supports: &gemini.Multimodal,
+			Supports: &Multimodal,
 		},
 		gemini20Flash: {
 			Label: "Gemini 2.0 Flash",
 			Versions: []string{
 				"gemini-2.0-flash-001",
 			},
-			Supports: &gemini.Multimodal,
+			Supports: &Multimodal,
 		},
 		gemini20FlashLite: {
 			Label: "Gemini 2.0 Flash Lite",
 			Versions: []string{
 				"gemini-2.0-flash-lite-001",
 			},
-			Supports: &gemini.Multimodal,
+			Supports: &Multimodal,
 		},
 		gemini20FlashLitePrev: {
 			Label:    "Gemini 2.0 Flash Lite Preview 02-05",
 			Versions: []string{},
-			Supports: &gemini.Multimodal,
+			Supports: &Multimodal,
 		},
 		gemini20ProExp0205: {
 			Label:    "Gemini 2.0 Pro Exp 02-05",
 			Versions: []string{},
-			Supports: &gemini.Multimodal,
+			Supports: &Multimodal,
 		},
 		gemini20FlashThinkingExp0121: {
 			Label:    "Gemini 2.0 Flash Thinking Exp 01-21",
 			Versions: []string{},
-			Supports: &gemini.Multimodal,
+			Supports: &Multimodal,
 		},
 		gemini25ProExp0305: {
 			Label:    "Gemini 2.5 Pro Exp 03-25",
 			Versions: []string{},
-			Supports: &gemini.Multimodal,
+			Supports: &Multimodal,
 		},
 	}
 


### PR DESCRIPTION
There's no need of having `plugins/internal/gemini`, this PR moves that gemini-specific code to `googlegenai` plugin where it is actually needed.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
