### PR TITLE
refactor(py/genkit-ai): use the `a*` prefix for all async methods to distinguish from any sync api at same level

### DIFF
--- a/py/docs/cloud-run.md
+++ b/py/docs/cloud-run.md
@@ -36,7 +36,7 @@ app = Flask(__name__)
 @genkit_flask_handler(ai)
 @ai.flow()
 async def joke(name: str, ctx):
-    return await ai.generate(
+    return await ai.agenerate(
         on_chunk=ctx.send_chunk,
         prompt=f'tell a medium sized joke about {name}',
     )

--- a/py/docs/flask.md
+++ b/py/docs/flask.md
@@ -39,7 +39,7 @@ Prerequisites: make sure you have everything installed from [Get Started](./get-
     @genkit_flask_handler(ai)
     @ai.flow()
     async def joke(name: str, ctx):
-        return await ai.generate(
+        return await ai.agenerate(
             on_chunk=ctx.send_chunk,
             prompt=f'tell a medium sized joke about {name}',
         )

--- a/py/docs/get-started.md
+++ b/py/docs/get-started.md
@@ -89,7 +89,7 @@ This guide shows you how to get started with Genkit in a Python app.
 
     @ai.flow()
     async def generate_character(name: str):
-        result = await ai.generate(
+        result = await ai.agenerate(
             prompt=f'generate an RPG character named {name}',
             output_schema=RpgCharacter,
         )

--- a/py/docs/index.md
+++ b/py/docs/index.md
@@ -64,10 +64,10 @@ See the following code samples for a concrete idea of how to use these capabilit
     )
 
     async def main():
-        result = await ai.generate(prompt=f'Why is AI awesome?')
+        result = await ai.agenerate(prompt=f'Why is AI awesome?')
         print(result.text)
 
-        stream, _ = await ai.generate_stream(prompt=f'Tell me a story')
+        stream, _ = ai.generate_stream(prompt=f'Tell me a story')
         async for chunk in stream:
             print(chunk.text)
 
@@ -96,7 +96,7 @@ See the following code samples for a concrete idea of how to use these capabilit
         abilities: list[str] = Field(description='list of abilities (3-4)')
 
     async def main():
-        result = await ai.generate(
+        result = await ai.agenerate(
             prompt=f'generate an RPG character named Glorb',
             output_schema=RpgCharacter,
         )

--- a/py/docs/reference/flows.md
+++ b/py/docs/reference/flows.md
@@ -45,7 +45,7 @@ a function that calls `generate()`:
 ```py
 @ai.flow()
 async def menu_suggestion_flow(theme: str):
-    response = await ai.generate(
+    response = await ai.agenerate(
       prompt=f'Invent a menu item for a {theme} themed restaurant.',
     )
     return response.text
@@ -74,7 +74,7 @@ class MenuItemSchema(BaseModel):
 
 @ai.flow()
 async def menu_suggestion_flow(theme: str) -> MenuItemSchema:
-    response = await ai.generate(
+    response = await ai.agenerate(
       prompt=f'Invent a menu item for a {theme} themed restaurant.',
       output_schema=MenuItemSchema,
     )
@@ -90,7 +90,7 @@ string, which the flow returns.
 ```py
 @ai.flow()
 async def menu_suggestion_flow(theme: str) => MenuItemSchema:
-    response = await ai.generate(
+    response = await ai.agenerate(
       prompt=f'Invent a menu item for a {theme} themed restaurant.',
       output_schema=MenuItemSchema,
     )

--- a/py/docs/reference/interrupts.md
+++ b/py/docs/reference/interrupts.md
@@ -79,7 +79,7 @@ other types of tools. You can pass both normal tools and interrupts to the
 same `generate` call:
 
 ```py
-interrupted_response = await ai.generate(
+interrupted_response = await ai.agenerate(
     prompt='Ask me a movie trivia question.',
     tools=['ask_question'],
 )
@@ -107,7 +107,7 @@ Once resumed, the model re-enters the generation loop, including tool
 execution, until either it completes or another interrupt is triggered:
 
 ```py
-response = await ai.generate(
+response = await ai.agenerate(
     messages=interrupted_response.messages,
     tool_responses=[tool_response(interrupted_response.tool_requests[0], 'b')],
     tools=['ask_question'],

--- a/py/docs/reference/models.md
+++ b/py/docs/reference/models.md
@@ -49,12 +49,12 @@ you've already done this. Otherwise, see the [Getting Started](../get-started.md
 guide or the individual plugin's documentation and follow the steps there before
 continuing.
 
-### The generate() method
+### The agenerate() method
 
 In Genkit, the primary interface through which you interact with generative AI
-models is the `generate()` method.
+models is the `agenerate()` method.
 
-The simplest `generate()` call specifies the model you want to use and a text
+The simplest `agenerate()` call specifies the model you want to use and a text
 prompt:
 
 ```py
@@ -68,7 +68,7 @@ ai = Genkit(
 )
 
 async def main() -> None:
-    result = await ai.generate(
+    result = await ai.agenerate(
         prompt='Invent a menu item for a pirate themed restaurant.',
     )
     print(result.text)
@@ -76,7 +76,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-When you run this brief example it will print out the output of the `generate()` 
+When you run this brief example it will print out the output of the `agenerate()`
 all, which will usually be Markdown text as in the following example:
 
 ```md
@@ -99,10 +99,10 @@ Run the script again and you'll get a different output.
 The preceding code sample sent the generation request to the default model,
 which you specified when you configured the Genkit instance.
 
-You can also specify a model for a single `generate()` call:
+You can also specify a model for a single `agenerate()` call:
 
 ```py
-result = await ai.generate(
+result = await ai.agenerate(
     prompt='Invent a menu item for a pirate themed restaurant.',
     model='google_genai/gemini-2.0-pro',
 )
@@ -114,14 +114,14 @@ plugin-specific string identifier for a specific version of a model.
 
 
 These examples also illustrate an important point: when you use
-`generate()` to make generative AI model calls, changing the model you want to
+`agenerate()` to make generative AI model calls, changing the model you want to
 use is simply a matter of passing a different value to the model parameter. By
-using `generate()` instead of the native model SDKs, you give yourself the
+using `agenerate()` instead of the native model SDKs, you give yourself the
 flexibility to more easily use several different models in your app and change
 models in the future.
 
-So far you have only seen examples of the simplest `generate()` calls. However,
-`generate()` also provides an interface for more advanced interactions with
+So far you have only seen examples of the simplest `agenerate()` calls. However,
+`agenerate()` also provides an interface for more advanced interactions with
 generative models, which you will see in the sections that follow.
 
 ### System prompts
@@ -135,7 +135,7 @@ If the model you're using supports system prompts, you can provide one with the
 `system` parameter:
 
 ```py
-result = await ai.generate(
+result = await ai.agenerate(
     system='You are a food industry marketing consultant.',
     prompt='Invent a menu item for a pirate themed restaurant.',
 )
@@ -143,11 +143,11 @@ result = await ai.generate(
 
 ### Model parameters
 
-The `generate()` function takes a `config` parameter, through which you can
+The `agenerate()` function takes a `config` parameter, through which you can
 specify optional settings that control how the model generates content:
 
 ```py
-result = await ai.generate(
+result = await ai.agenerate(
     prompt='Invent a menu item for a pirate themed restaurant.',
     config={
       'max_output_tokens': 400,
@@ -174,7 +174,7 @@ applications of generative AI, such as programmatic use of the model's output,
 or feeding the output of one model into another, structured output is a must.
 
 In Genkit, you can request structured output from a model by specifying a schema
-when you call `generate()`:
+when you call `agenerate()`:
 
 ```py
 from pydantic import BaseModel
@@ -185,7 +185,7 @@ class MenuItemSchema(BaseModel):
     calories: int
     allergens: list[str]
 
-result = await ai.generate(
+result = await ai.agenerate(
     prompt='Invent a menu item for a pirate themed restaurant.',
     output_schema=MenuItemSchema,
 )
@@ -197,7 +197,7 @@ unpredictable output of generative AI models. Pydantic lets you write code that 
 rely on the fact that a successful generate call will always return output that
 conforms to your Python types.
 
-When you specify a schema in `generate()`, Genkit does several things behind the
+When you specify a schema in `agenerate()`, Genkit does several things behind the
 scenes:
 
 - Augments the prompt with additional guidance about the desired output format.
@@ -224,7 +224,7 @@ improves the perceived responsiveness of the application and enhances the
 illusion of chatting with an intelligent counterpart.
 
 In Genkit, you can stream output using the `generateStream()` method. Its
-syntax is similar to the `generate()` method:
+syntax is similar to the `agenerate()` method:
 
 ```py
 stream, response = ai.generate_stream(
@@ -261,7 +261,7 @@ class MenuSchema(BaseModel):
     mains: list[MenuItemSchema]
     desserts: list[MenuItemSchema]
 
-stream, response = await ai.generate_stream(
+stream, response = ai.generate_stream(
     prompt='Invent a menu item for a pirate themed restaurant.',
     output_schema=MenuSchema,
 )
@@ -330,7 +330,7 @@ simple text prompt to `generate`, pass an array consisting of a media part and a
 text part:
 
 ```py
-result = await ai.generate(
+result = await ai.agenerate(
     prompt=[
       Part(media={'url': 'https://example.com/photo.jpg'}),
       Part(text='Compose a poem about this image.'),
@@ -344,7 +344,7 @@ example:
 
 ```ts
 base64_encoded_image = base64.b64encode(read_file('image.jpg'))
-result = await ai.generate(
+result = await ai.agenerate(
     prompt=[
       Part(media={'url': f'data:image/jpeg;base64,{base64_encoded_image}'}),
       Part(text='Compose a poem about this image.'),
@@ -360,7 +360,7 @@ plugin also lets you use Cloud Storage (`gs://`) URLs.
 
 So far, most of the examples on this page have dealt with generating text using
 LLMs. However, Genkit can also be used with image generation models. Using
-`generate()` with an image generation model is similar to using an LLM. For
+`agenerate()` with an image generation model is similar to using an LLM. For
 example, to generate an image using the Imagen model:
 
 ```py

--- a/py/docs/reference/tools.md
+++ b/py/docs/reference/tools.md
@@ -123,7 +123,7 @@ for the LLM to make effective use of the available tools.
 Include defined tools in your prompts to generate content.
 
 ```py
-result = await ai.generate(
+result = await ai.agenerate(
     prompt='What is the weather in Baltimore?',
     tools=['get_weather'],
 )
@@ -153,7 +153,7 @@ apply more complicated logic, set the `return_tool_requests` parameter to `True`
 Now it's your responsibility to ensure all of the tool requests are fulfilled:
 
 ```py
-result = await ai.generate(
+result = await ai.agenerate(
     prompt='What is the weather in Baltimore?',
     tools=['get_weather'],
     return_tool_requests=True,

--- a/py/engdoc/index.md
+++ b/py/engdoc/index.md
@@ -96,10 +96,10 @@ capabilities in code:
           model: gemini15Flash,
         })
 
-        response = await ai.generate('Why is AI awesome?')
+        response = await ai.agenerate('Why is AI awesome?')
         await logger.adebug(response.text)
 
-        stream = await ai.generate_stream("Tell me a story")
+        stream, _ = ai.generate_stream("Tell me a story")
         async for chunk in stream:
             await logger.adebug("Received chunk", text=chunk.text)
         await logger.adebug("Finished generating text stream")
@@ -179,7 +179,7 @@ capabilities in code:
         })
 
         await logger.adebug("Generating structured output", prompt="Create a brief profile for a character in a fantasy video game.")
-        response = await ai.generate(
+        response = await ai.agenerate(
             prompt="Create a brief profile for a character in a fantasy video game.",
             output={
                 "format": "json",
@@ -268,7 +268,7 @@ capabilities in code:
         )
 
         await logger.adebug("Generating text with tool", prompt="What is the weather like in New York?")
-        response = await ai.generate(
+        response = await ai.agenerate(
             prompt="What is the weather like in New York?",
             tools=[get_weather_tool],
         )
@@ -477,7 +477,7 @@ capabilities in code:
         docs = await ai.retrieve(retriever=retriever, query=query)
 
         await logger.adebug("Generating answer", query=query)
-        response = await ai.generate(
+        response = await ai.agenerate(
             prompt=f"Use the provided context from the BobFacts database to answer this query: {query}",
             docs=docs,
         )
@@ -517,7 +517,7 @@ capabilities in code:
       query: 'How old is bob?',
     );
 
-    const result = await ai.generate({
+    const result = await ai.agenerate({
         prompt: `Use the provided context from the Genkit documentation to answer this query: ${query}`,
         docs // Pass retrieved documents to the model
     });

--- a/py/packages/genkit-ai/README.md
+++ b/py/packages/genkit-ai/README.md
@@ -8,7 +8,6 @@ You can deploy and run Genkit libraries anywhere Python is supported. It's desig
 many AI model providers and vector databases. While we offer integrations for Firebase and Google Cloud,
 you can use Genkit independently of any Google services.
 
-
 ## Setup Instructions
 
 ```bash
@@ -37,7 +36,7 @@ class RpgCharacter(BaseModel):
 
 @ai.flow()
 async def generate_character(name: str):
-    result = await ai.generate(
+    result = await ai.agenerate(
         prompt=f'generate an RPG character named {name}',
         output_schema=RpgCharacter,
     )

--- a/py/packages/genkit-ai/src/genkit/ai/veneer.py
+++ b/py/packages/genkit-ai/src/genkit/ai/veneer.py
@@ -64,7 +64,7 @@ content, define flows, define formats, etc.
 
 | Category         | Method                                                                       | Description                          |
 |------------------|------------------------------------------------------------------------------|--------------------------------------|
-| **AI**           | [`generate()`][genkit.ai.veneer.Genkit.generate]                         | Generates content.                   |
+| **AI**           | [`agenerate()`][genkit.ai.veneer.Genkit.generate]                        | Generates content.                   |
 |                  | [`generate_stream()`][genkit.ai.veneer.Genkit.generate_stream]           | Generates a stream of content.       |
 |                  | [`embed()`][genkit.ai.veneer.Genkit.embed]                               | Calculates embeddings for documents. |
 | **Registration** | [`define_embedder()`][genkit.ai.registry.GenkitRegistry.define_embedder] | Defines and registers an embedder.   |
@@ -211,7 +211,7 @@ class Genkit(GenkitRegistry):
         )
         httpd.serve_forever()
 
-    async def generate(
+    async def agenerate(
         self,
         model: str | None = None,
         prompt: str | Part | list[Part] | None = None,
@@ -403,7 +403,7 @@ class Genkit(GenkitRegistry):
         """
         stream = Channel()
 
-        resp = self.generate(
+        resp = self.agenerate(
             model=model,
             prompt=prompt,
             system=system,
@@ -427,7 +427,7 @@ class Genkit(GenkitRegistry):
 
         return (stream, stream.closed)
 
-    async def embed(
+    async def aembed(
         self,
         model: str | None = None,
         documents: list[Document] | None = None,

--- a/py/packages/genkit-ai/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit-ai/tests/genkit/veneer/veneer_test.py
@@ -65,7 +65,7 @@ async def test_generate_uses_default_model(setup_test: SetupFixture) -> None:
 
     want_txt = '[ECHO] user: "hi" {"temperature": 11}'
 
-    response = await ai.generate(prompt='hi', config={'temperature': 11})
+    response = await ai.agenerate(prompt='hi', config={'temperature': 11})
 
     assert response.text == want_txt
 
@@ -79,7 +79,7 @@ async def test_generate_with_explicit_model(setup_test: SetupFixture) -> None:
     """Test that the generate function uses the explicit model."""
     ai, *_ = setup_test
 
-    response = await ai.generate(model='echoModel', prompt='hi', config={'temperature': 11})
+    response = await ai.agenerate(model='echoModel', prompt='hi', config={'temperature': 11})
 
     assert response.text == '[ECHO] user: "hi" {"temperature": 11}'
 
@@ -93,7 +93,7 @@ async def test_generate_with_str_prompt(setup_test: SetupFixture) -> None:
     """Test that the generate function with a string prompt works."""
     ai, *_ = setup_test
 
-    response = await ai.generate(prompt='hi', config={'temperature': 11})
+    response = await ai.agenerate(prompt='hi', config={'temperature': 11})
 
     assert response.text == '[ECHO] user: "hi" {"temperature": 11}'
 
@@ -105,7 +105,7 @@ async def test_generate_with_part_prompt(setup_test: SetupFixture) -> None:
 
     want_txt = '[ECHO] user: "hi" {"temperature": 11}'
 
-    response = await ai.generate(prompt=Part(text='hi'), config={'temperature': 11})
+    response = await ai.agenerate(prompt=Part(text='hi'), config={'temperature': 11})
 
     assert response.text == want_txt
 
@@ -121,7 +121,7 @@ async def test_generate_with_part_list_prompt(setup_test: SetupFixture) -> None:
 
     want_txt = '[ECHO] user: "hello","world" {"temperature": 11}'
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         prompt=[Part(text='hello'), Part(text='world')],
         config={'temperature': 11},
     )
@@ -143,7 +143,7 @@ async def test_generate_with_str_system(setup_test: SetupFixture) -> None:
 
     want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature": 11}'
 
-    response = await ai.generate(system='talk like pirate', prompt='hi', config={'temperature': 11})
+    response = await ai.agenerate(system='talk like pirate', prompt='hi', config={'temperature': 11})
 
     assert response.text == want_txt
 
@@ -159,7 +159,7 @@ async def test_generate_with_part_system(setup_test: SetupFixture) -> None:
 
     want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature": 11}'
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         system=Part(text='talk like pirate'),
         prompt='hi',
         config={'temperature': 11},
@@ -183,7 +183,7 @@ async def test_generate_with_part_list_system(setup_test: SetupFixture) -> None:
 
     want_txt = '[ECHO] system: "talk","like pirate" user: "hi" {"temperature": 11}'
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         system=[Part(text='talk'), Part(text='like pirate')],
         prompt='hi',
         config={'temperature': 11},
@@ -205,7 +205,7 @@ async def test_generate_with_messages(setup_test: SetupFixture) -> None:
     """Test that the generate function with a list of messages works."""
     ai, *_ = setup_test
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         messages=[
             Message(
                 role=Role.USER,
@@ -239,7 +239,7 @@ async def test_generate_with_system_prompt_messages(
 
     want_txt = '[ECHO] system: "talk like pirate" user: "hi" model: "bye" user: "hi again"'
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         system='talk like pirate',
         prompt='hi again',
         messages=[
@@ -286,7 +286,7 @@ async def test_generate_with_tools(setup_test: SetupFixture) -> None:
     def test_tool(input: ToolInput):
         return input.value
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         model='echoModel',
         prompt='hi',
         tool_choice=ToolChoice.REQUIRED,
@@ -370,7 +370,7 @@ async def test_generate_with_iterrupting_tools(
         )
     )
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         model='programmableModel',
         prompt='hi',
         tools=['test_tool', 'test_interrupt'],
@@ -476,7 +476,7 @@ async def test_generate_with_interrupt_respond(
         )
     )
 
-    interrupted_response = await ai.generate(
+    interrupted_response = await ai.agenerate(
         model='programmableModel',
         prompt='hi',
         tools=['test_tool', 'test_interrupt'],
@@ -521,7 +521,7 @@ async def test_generate_with_interrupt_respond(
         ),
     ]
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         model='programmableModel',
         messages=interrupted_response.messages,
         tool_responses=[tool_response(interrupted_response.tool_requests[0], {'bar': 2})],
@@ -603,7 +603,7 @@ async def test_generate_with_tools_and_output(setup_test: SetupFixture) -> None:
         )
     )
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         model='programmableModel',
         prompt='hi',
         tool_choice=ToolChoice.REQUIRED,
@@ -779,7 +779,7 @@ async def test_generate_with_output(setup_test: SetupFixture) -> None:
         ),
     )
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         model='echoModel',
         prompt='hi',
         output_constrained=True,
@@ -847,7 +847,7 @@ async def test_generate_defaults_to_json_format(
         ),
     )
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         model='echoModel',
         prompt='hi',
         output_schema=TestSchema,
@@ -906,7 +906,7 @@ async def test_generate_json_format_unconstrained(
         ),
     )
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         model='echoModel',
         prompt='hi',
         output_schema=TestSchema,
@@ -953,7 +953,7 @@ async def test_generate_with_middleware(
 
     want = '[ECHO] user: "PRE hi" POST'
 
-    response = await ai.generate(model='echoModel', prompt='hi', use=[pre_middle, post_middle])
+    response = await ai.agenerate(model='echoModel', prompt='hi', use=[pre_middle, post_middle])
 
     assert response.text == want
 
@@ -984,7 +984,7 @@ async def test_generate_passes_through_current_action_context(
         )
 
     async def action_fn():
-        return await ai.generate(model='echoModel', prompt='hi', use=[inject_context])
+        return await ai.agenerate(model='echoModel', prompt='hi', use=[inject_context])
 
     action = ai.registry.register_action(name='test_action', kind='custom', fn=action_fn)
     action_response = await action.arun(context={'foo': 'bar'})
@@ -1014,7 +1014,7 @@ async def test_generate_uses_explicitly_passed_in_context(
         )
 
     async def action_fn():
-        return await ai.generate(
+        return await ai.agenerate(
             model='echoModel',
             prompt='hi',
             use=[inject_context],
@@ -1078,7 +1078,7 @@ async def test_generate_json_format_unconstrained_with_instructions(
         ),
     )
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         model='echoModel',
         prompt='hi',
         output_schema=TestSchema,
@@ -1117,7 +1117,7 @@ async def test_generate_simulates_doc_grounding(
         ],
     )
 
-    response = await ai.generate(
+    response = await ai.agenerate(
         messages=[
             Message(
                 role=Role.USER,

--- a/py/plugins/flask/src/genkit/plugins/flask/handler.py
+++ b/py/plugins/flask/src/genkit/plugins/flask/handler.py
@@ -39,7 +39,7 @@ def genkit_flask_handler(ai: Genkit) -> Callable:
     @genkit_flask_handler(ai)
     @ai.flow()
     async def say_hi(name: str, ctx):
-        return await ai.generate(
+        return await ai.agenerate(
             on_chunk=ctx.send_chunk,
             prompt=f'tell a medium sized joke about {name}',
         )

--- a/py/plugins/ollama/tests/test_plugin_api.py
+++ b/py/plugins/ollama/tests/test_plugin_api.py
@@ -58,7 +58,7 @@ async def test_async_get_chat_model_response_from_llama_api_flow(
     mock_ollama_api_async_client.return_value.chat.side_effect = fake_chat_response
 
     async def _test_fun():
-        return await genkit_veneer_chat_model.generate(
+        return await genkit_veneer_chat_model.agenerate(
             messages=[
                 Message(
                     role=Role.USER,
@@ -91,7 +91,7 @@ async def test_async_get_generate_model_response_from_llama_api_flow(
     mock_ollama_api_async_client.return_value.generate.side_effect = fake_generate_response
 
     async def _test_fun():
-        return await genkit_veneer_generate_model.generate(
+        return await genkit_veneer_generate_model.agenerate(
             messages=[
                 Message(
                     role=Role.USER,

--- a/py/samples/basic-gemini/src/basic_gemini.py
+++ b/py/samples/basic-gemini/src/basic_gemini.py
@@ -57,7 +57,7 @@ async def generate_joke(subject: str) -> str:
     Returns:
         str: The generated joke.
     """
-    return await ai.generate(
+    return await ai.agenerate(
         config=GenerationCommonConfig(temperature=0.1, version='gemini-2.0-flash-001'),
         messages=[
             Message(
@@ -116,7 +116,7 @@ async def convert_with_tools(amount: float) -> str:
 
 @ai.flow()
 async def draw_image(description: str):
-    return await ai.generate(
+    return await ai.agenerate(
         model=vertexai_name(ImagenVersion.IMAGEN3_FAST),
         messages=[
             Message(
@@ -144,7 +144,7 @@ async def generate_structured_content(food: str):
     Returns:
         List of recipes that follows schema config.
     """
-    response = await ai.generate(
+    response = await ai.agenerate(
         model=vertexai_name(GeminiVersion.GEMINI_2_0_FLASH),
         messages=[
             Message(

--- a/py/samples/google-ai/src/google_ai_sample.py
+++ b/py/samples/google-ai/src/google_ai_sample.py
@@ -47,7 +47,7 @@ async def say_hi(data: str):
     Returns:
         The generated greeting.
     """
-    return await ai.generate(messages=[Message(role=Role.USER, content=[TextPart(text=f'hi {data}')])])
+    return await ai.agenerate(messages=[Message(role=Role.USER, content=[TextPart(text=f'hi {data}')])])
 
 
 async def say_hi_with_configured_temperature(data: str):
@@ -59,7 +59,7 @@ async def say_hi_with_configured_temperature(data: str):
     Returns:
         The generated greeting.
     """
-    return await ai.generate(
+    return await ai.agenerate(
         messages=[Message(role=Role.USER, content=[TextPart(text=f'hi {data}')])],
         config=GenerationCommonConfig(temperature=0.1),
     )

--- a/py/samples/google-genai-image/src/google_genai_image.py
+++ b/py/samples/google-genai-image/src/google_genai_image.py
@@ -40,7 +40,7 @@ async def draw_image_with_gemini() -> str:
     Returns:
         The image.
     """
-    return await ai.generate(
+    return await ai.agenerate(
         messages=[Message(role=Role.USER, content=[TextPart(text='Draw a cat in a hat.')])],
         config={'response_modalities': ['Text', 'Image']},
         model=google_genai_name('gemini-2.0-flash-exp'),
@@ -57,7 +57,7 @@ async def describe_image_with_gemini(data: str) -> str:
     Returns:
         The description of the image.
     """
-    result = await ai.generate(
+    result = await ai.agenerate(
         messages=[
             Message(
                 role=Role.USER,

--- a/py/samples/google-genai-imagen/src/google_genai_imagen.py
+++ b/py/samples/google-genai-imagen/src/google_genai_imagen.py
@@ -36,7 +36,7 @@ async def draw_image_with_imagen() -> str:
         The image.
     """
     config = {'number_of_images': 1, 'language': 'en'}
-    return await ai.generate(
+    return await ai.agenerate(
         prompt='Draw a cat in a hat',
         model=google_genai_name('imagegeneration@006'),
         # optional config; check README for available fields

--- a/py/samples/hello-flask/src/hello_flask.py
+++ b/py/samples/hello-flask/src/hello_flask.py
@@ -37,7 +37,7 @@ app = Flask(__name__)
 @genkit_flask_handler(ai)
 @ai.flow()
 async def say_hi(name: str, ctx):
-    return await ai.generate(
+    return await ai.agenerate(
         on_chunk=ctx.send_chunk,
         prompt=f'tell a medium sized joke about {name}',
     )

--- a/py/samples/hello-google-genai/src/hello_google_genai.py
+++ b/py/samples/hello-google-genai/src/hello_google_genai.py
@@ -99,7 +99,7 @@ async def simple_generate_with_tools_flow(value: int) -> str:
     Returns:
         The generated response with a function.
     """
-    response = await ai.generate(
+    response = await ai.agenerate(
         model=google_genai_name(gemini.GoogleAiVersion.GEMINI_2_0_FLASH),
         messages=[
             Message(
@@ -136,7 +136,7 @@ async def simple_generate_with_interrupts(value: int) -> str:
     Returns:
         The generated response with a function.
     """
-    response1 = await ai.generate(
+    response1 = await ai.agenerate(
         model=google_genai_name(gemini.GoogleAiVersion.GEMINI_2_0_FLASH),
         messages=[
             Message(
@@ -151,7 +151,7 @@ async def simple_generate_with_interrupts(value: int) -> str:
         return response1.text
 
     tr = tool_response(response1.tool_requests[0], 178)
-    response = await ai.generate(
+    response = await ai.agenerate(
         model=google_genai_name(gemini.GoogleAiVersion.GEMINI_2_0_FLASH),
         messages=response1.messages,
         tool_responses=[tr],
@@ -170,7 +170,7 @@ async def say_hi(name: str):
     Returns:
         The generated response with a function.
     """
-    resp = await ai.generate(
+    resp = await ai.agenerate(
         prompt=f'hi {name}',
     )
     return resp.text
@@ -187,7 +187,7 @@ async def embed_docs(docs: list[str]):
         The generated embedding.
     """
     options = {'task_type': EmbeddingTaskType.CLUSTERING}
-    return await ai.embed(
+    return await ai.aembed(
         model=google_genai_name(GeminiEmbeddingModels.TEXT_EMBEDDING_004),
         documents=[Document.from_text(doc) for doc in docs],
         options=options,
@@ -204,7 +204,7 @@ async def say_hi_with_configured_temperature(data: str):
     Returns:
         The generated response with a function.
     """
-    return await ai.generate(
+    return await ai.agenerate(
         messages=[Message(role=Role.USER, content=[TextPart(text=f'hi {data}')])],
         config=GenerationCommonConfig(temperature=0.1),
     )
@@ -267,7 +267,7 @@ async def generate_character(name: str, ctx):
 
         return (await result).output
     else:
-        result = await ai.generate(
+        result = await ai.agenerate(
             prompt=f'generate an RPG character named {name}',
             output_schema=RpgCharacter,
         )
@@ -285,7 +285,7 @@ async def generate_character_unconstrained(name: str, ctx):
     Returns:
         The generated RPG character.
     """
-    result = await ai.generate(
+    result = await ai.agenerate(
         prompt=f'generate an RPG character named {name}',
         output_schema=RpgCharacter,
         output_constrained=False,
@@ -305,7 +305,7 @@ async def generate_images(name: str, ctx):
     Returns:
         The generated response with a function.
     """
-    result = await ai.generate(
+    result = await ai.agenerate(
         prompt='tell me a about the Eifel Tower with photos',
         config=GeminiConfigSchema(response_modalities=['text', 'image']),
     )

--- a/py/samples/hello/src/hello.py
+++ b/py/samples/hello/src/hello.py
@@ -72,7 +72,7 @@ async def say_hi(name: str):
     Returns:
         The generated greeting response.
     """
-    return await ai.generate(
+    return await ai.agenerate(
         messages=[
             Message(
                 role=Role.USER,
@@ -93,7 +93,7 @@ async def embed_docs(docs: list[str]):
         The generated embedding.
     """
     options = {'task': EmbeddingsTaskType.CLUSTERING}
-    return await ai.embed(
+    return await ai.aembed(
         model=vertexai_name(EmbeddingModels.TEXT_EMBEDDING_004_ENG),
         documents=[Document.from_text(doc) for doc in docs],
         options=options,
@@ -133,7 +133,7 @@ async def simple_generate_action_with_tools_flow(value: int) -> Any:
     Returns:
         The generated greeting response.
     """
-    response = await ai.generate(
+    response = await ai.agenerate(
         model='vertexai/gemini-1.5-flash',
         messages=[
             Message(
@@ -262,7 +262,7 @@ async def describe_picture(url: str):
     Returns:
         The description of the picture.
     """
-    return await ai.generate(
+    return await ai.agenerate(
         messages=[
             Message(
                 role=Role.USER,

--- a/py/samples/menu/src/case_03/flows.py
+++ b/py/samples/menu/src/case_03/flows.py
@@ -66,7 +66,7 @@ async def s03_multiTurnChatFlow(
 ) -> ChatSessionOutputSchema:
     history = chat_history_store.read(my_input.session_id)
 
-    llm_response = await ai.generate(
+    llm_response = await ai.agenerate(
         model=google_genai_name(GeminiVersion.GEMINI_1_5_FLASH),
         messages=history,
         prompt=[TextPart(text=my_input.question)],

--- a/py/samples/ollama-hello/src/ollama_hello.py
+++ b/py/samples/ollama-hello/src/ollama_hello.py
@@ -128,7 +128,7 @@ async def say_hi(hi_input: str):
     Returns:
         A GenerateRequest object with the greeting message.
     """
-    return await ai.generate(
+    return await ai.agenerate(
         model=ollama_name(GEMMA_MODEL),
         messages=[
             Message(
@@ -151,7 +151,7 @@ async def calculate_gablorken(value: int):
     Returns:
         A GenerateRequest object with the evaluation output
     """
-    response = await ai.generate(
+    response = await ai.agenerate(
         messages=[
             Message(
                 role=Role.USER,
@@ -178,7 +178,7 @@ async def say_hi_constrained(hi_input: str):
     Returns:
         A `HelloSchema` object with the greeting message.
     """
-    response = await ai.generate(
+    response = await ai.agenerate(
         messages=[
             Message(
                 role=Role.USER,

--- a/py/samples/ollama-simple-embed/src/pokemon_glossary.py
+++ b/py/samples/ollama-simple-embed/src/pokemon_glossary.py
@@ -106,7 +106,7 @@ pokemon_list = [
 async def embed_pokemons() -> None:
     """Embed the Pokemons."""
     for pokemon in pokemon_list:
-        embedding_response = await ai.embed(
+        embedding_response = await ai.aembed(
             model=ollama_name(EMBEDDER_MODEL),
             documents=[Document.from_text(pokemon.description)],
         )
@@ -172,14 +172,14 @@ async def generate_response(question: str) -> GenerateResponse:
     Returns:
         A GenerateResponse object with the answer.
     """
-    input_embedding = await ai.embed(
+    input_embedding = await ai.aembed(
         model=ollama_name(EMBEDDER_MODEL),
         documents=[question],
     )
     nearest_pokemon = find_nearest_pokemons(input_embedding.embeddings[0])
     pokemons_context = '\n'.join(f'{pokemon["name"]}: {pokemon["description"]}' for pokemon in nearest_pokemon)
 
-    return await ai.generate(
+    return await ai.agenerate(
         model=ollama_name(GENERATE_MODEL),
         prompt=f'Given the following context on Pokemon:\n${pokemons_context}\n\nQuestion: ${question}\n\nAnswer:',
     )

--- a/py/samples/openai/src/openai_example.py
+++ b/py/samples/openai/src/openai_example.py
@@ -68,7 +68,7 @@ async def say_hi(name: str) -> str:
     Returns:
         The response from the OpenAI API.
     """
-    response = await ai.generate(
+    response = await ai.agenerate(
         model=openai_model('gpt-4'),
         config={'model': 'gpt-4-0613', 'temperature': 1},
         prompt=f'hi {name}',
@@ -129,7 +129,7 @@ async def get_weather_flow(location: str) -> str:
     Returns:
         The weather for the location.
     """
-    response = await ai.generate(
+    response = await ai.agenerate(
         model=openai_model('gpt-4'),
         system='You are an assistant that provides current weather information.',
         config={'model': 'gpt-4-0613', 'temperature': 1},

--- a/py/samples/tool-interrupts/src/tool_interrupts.py
+++ b/py/samples/tool-interrupts/src/tool_interrupts.py
@@ -44,7 +44,7 @@ def present_questions(questions: TriviaQuestions, ctx: ToolRunContext):
 
 
 async def main() -> None:
-    response = await ai.generate(
+    response = await ai.agenerate(
         prompt='You a trivia game host. Cheerfully greet the user when they '
         + 'first join and ank them to for the theme of the trivia game, suggest '
         + "a few theme options, they don't have to use your suggestion, feel free "
@@ -57,7 +57,7 @@ async def main() -> None:
     print(response.text)
     messages = response.messages
     while True:
-        response = await ai.generate(
+        response = await ai.agenerate(
             messages=messages,
             prompt=input('Say: '),
             tools=['present_questions'],
@@ -72,7 +72,7 @@ async def main() -> None:
                 i += 1
 
             tr = tool_response(request, input('Your answer (number): '))
-            response = await ai.generate(
+            response = await ai.agenerate(
                 messages=messages,
                 tool_responses=[tr],
                 tools=['present_questions'],

--- a/py/samples/vertex-ai-imagen/src/vertex_ai_imagen_sample.py
+++ b/py/samples/vertex-ai-imagen/src/vertex_ai_imagen_sample.py
@@ -35,7 +35,7 @@ ai = Genkit(plugins=[VertexAI()], model=vertexai_name(ImagenVersion.IMAGEN3_FAST
 async def draw_image(prompt: str):
     # config is optional
     config = ImagenOptions(number_of_images=3)
-    return await ai.generate(
+    return await ai.agenerate(
         messages=[
             Message(
                 role=Role.USER,


### PR DESCRIPTION
refactor(py/genkit-ai): use the `a*` prefix for all async methods to distinguish from any sync api

RATIONALE:
Python libraries (e.g. structlog) use the `a*` prefix to distinguish
async method/function names from sync ones when exposed _at the same
level_.

We're also doing that already with `arun` for `Action`.  Making this
change before people become accustomed to naming issues and we're stuck
with an incorrect convention.

If we decide to add sync and async Genkit implementations, we might
follow `httpx`'s convention of calling both methods the same name since
in that case both would be defined on different classes entirely.
`httpx` calls its `get` method the same regardless of whether it is
async or sync, but only because they're exposed on _different_ classes.

In our case, we're exposing async and sync methods at the veneer API
level, so we use the `a*` prefix to ensure we can support both sync and
async method names.

EXAMPLE:

```python
logger = structlog.get_logger(__name__)

await logger.ainfo('async')

logger.info('sync')
```

CHANGELOG:
- [ ] Use the `a*` prefix for async-API methods to distinguish from any
  sync methods that may be introduced in the future.