### PR TITLE
refactor(py/plugins): use the a* prefix for all async methods to distinguish from any sync api in plugins

### DIFF
--- a/py/plugins/google-ai/src/genkit/plugins/google_ai/models/gemini.py
+++ b/py/plugins/google-ai/src/genkit/plugins/google_ai/models/gemini.py
@@ -250,7 +250,7 @@ class GeminiModel:
         self._name = name
 
     def _genkit_to_googleai_cfg(self, genkit_cfg: GenerationCommonConfig) -> genai.types.GenerateContentConfig:
-        """Translate GenerationCommonConfig to Google Ai GenerateContentConfig
+        """Translate GenerationCommonConfig to Google Ai GenerateContentConfig.
 
         Args:
             genkit_cfg: Genkit request config
@@ -258,7 +258,6 @@ class GeminiModel:
         Returns:
             Google Ai request config
         """
-
         return genai.types.GenerateContentConfig(
             max_output_tokens=genkit_cfg.max_output_tokens,
             top_k=genkit_cfg.top_k,
@@ -277,7 +276,6 @@ class GeminiModel:
         Returns:
             The model's response to the generation request.
         """
-
         reqest_contents: list[genai.types.Content] = []
         for msg in request.messages:
             content_parts: list[genai.types.Part] = []

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -104,7 +104,7 @@ class GoogleGenai(Plugin):
             for version in ImagenVersion:
                 imagen_model = ImagenModel(version, self._client)
                 ai.define_model(
-                    name=google_genai_name(version), fn=imagen_model.generate, metadata=imagen_model.metadata
+                    name=google_genai_name(version), fn=imagen_model.agenerate, metadata=imagen_model.metadata
                 )
         else:
             supported_gemini_models.extend(list(GeminiApiOnlyVersion))
@@ -113,7 +113,7 @@ class GoogleGenai(Plugin):
             gemini_model = GeminiModel(version, self._client, ai)
             ai.define_model(
                 name=google_genai_name(version),
-                fn=gemini_model.generate,
+                fn=gemini_model.agenerate,
                 metadata=gemini_model.metadata,
                 config_schema=GeminiConfigSchema,
             )
@@ -121,7 +121,7 @@ class GoogleGenai(Plugin):
         embeding_models = VertexEmbeddingModels if self._client.vertexai else GeminiEmbeddingModels
         for version in embeding_models:
             embedder = Embedder(version=version, client=self._client)
-            ai.define_embedder(name=google_genai_name(version), fn=embedder.generate)
+            ai.define_embedder(name=google_genai_name(version), fn=embedder.agenerate)
 
 
 def _inject_attribution_headers(http_options):

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
@@ -61,7 +61,15 @@ class Embedder:
         self._client = client
         self._version = version
 
-    async def generate(self, request: EmbedRequest) -> EmbedResponse:
+    async def agenerate(self, request: EmbedRequest) -> EmbedResponse:
+        """Generate embeddings for a given request
+
+        Args:
+            request: Genkit embed request.
+
+        Returns:
+            EmbedResponse
+        """
         contents = self._build_contents(request)
         config = self._genkit_to_googleai_cfg(request)
         response = await self._client.aio.models.embed_content(model=self._version, contents=contents, config=config)
@@ -70,13 +78,13 @@ class Embedder:
         return EmbedResponse(embeddings=embeddings)
 
     def _build_contents(self, request: EmbedRequest) -> list[genai.types.Content]:
-        """Build google-genai request contents from Genkit request
+        """Build google-genai request contents from Genkit request.
 
         Args:
-            request: Genkit request
+            request: Genkit request.
 
         Returns:
-            list of google-genai contents
+            list of google-genai contents.
         """
 
         request_contents: list[genai.types.Content] = []
@@ -89,13 +97,13 @@ class Embedder:
         return request_contents
 
     def _genkit_to_googleai_cfg(self, request: EmbedRequest) -> genai.types.EmbedContentConfig | None:
-        """Translate EmbedRequest options to Google Ai GenerateContentConfig
+        """Translate EmbedRequest options to Google Ai GenerateContentConfig.
 
         Args:
-            request: Genkit embed request
+            request: Genkit embed request.
 
         Returns:
-            Google Ai embed config or None
+            Google Ai embed config or None.
         """
 
         cfg = None

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -486,7 +486,7 @@ class GeminiModel:
             ]
         )
 
-    async def generate(self, request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+    async def agenerate(self, request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
         """Handle a generation request.
 
         Args:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -108,7 +108,7 @@ class ImagenModel:
                     raise ValueError('Non-text messages are not supported')
         return ' '.join(prompt)
 
-    async def generate(self, request: GenerateRequest, _: ActionRunContext) -> GenerateResponse:
+    async def agenerate(self, request: GenerateRequest, _: ActionRunContext) -> GenerateResponse:
         """Handle a generation request.
 
         Args:
@@ -118,7 +118,6 @@ class ImagenModel:
         Returns:
             The model's response to the generation request.
         """
-
         prompt = self._build_prompt(request)
         config = self._get_config(request.config) if request.config else None
 

--- a/py/plugins/google-genai/test/models/test_googlegenai_embedder.py
+++ b/py/plugins/google-genai/test/models/test_googlegenai_embedder.py
@@ -44,7 +44,7 @@ async def test_embedding(mocker, version):
 
     embedder = Embedder(version, googleai_client_mock)
 
-    response = await embedder.generate(request)
+    response = await embedder.agenerate(request)
 
     googleai_client_mock.assert_has_calls([
         mocker.call.aio.models.embed_content(

--- a/py/plugins/google-genai/test/models/test_googlegenai_gemini.py
+++ b/py/plugins/google-genai/test/models/test_googlegenai_gemini.py
@@ -66,7 +66,7 @@ async def test_generate_text_response(mocker, version):
     gemini = GeminiModel(version, googleai_client_mock, mocker.MagicMock())
 
     ctx = ActionRunContext()
-    response = await gemini.generate(request, ctx)
+    response = await gemini.agenerate(request, ctx)
 
     googleai_client_mock.assert_has_calls([
         mocker.call.aio.models.generate_content(
@@ -106,7 +106,7 @@ async def test_generate_stream_text_response(mocker, version):
     gemini = GeminiModel(version, googleai_client_mock, mocker.MagicMock())
 
     ctx = ActionRunContext(on_chunk=on_chunk_mock)
-    response = await gemini.generate(request, ctx)
+    response = await gemini.agenerate(request, ctx)
 
     googleai_client_mock.assert_has_calls([
         mocker.call.aio.models.generate_content_stream(
@@ -155,7 +155,7 @@ async def test_generate_media_response(mocker, version):
     gemini = GeminiModel(version, googleai_client_mock, mocker.MagicMock())
 
     ctx = ActionRunContext()
-    response = await gemini.generate(request, ctx)
+    response = await gemini.agenerate(request, ctx)
 
     googleai_client_mock.assert_has_calls([
         mocker.call.aio.models.generate_content(
@@ -287,7 +287,7 @@ async def test_generate_with_system_instructions(mocker):
     gemini = GeminiModel(version, googleai_client_mock, mocker.MagicMock())
     ctx = ActionRunContext()
 
-    response = await gemini.generate(request, ctx)
+    response = await gemini.agenerate(request, ctx)
 
     googleai_client_mock.assert_has_calls([
         mocker.call.aio.models.generate_content(

--- a/py/plugins/google-genai/test/models/test_googlegenai_imagen.py
+++ b/py/plugins/google-genai/test/models/test_googlegenai_imagen.py
@@ -65,7 +65,7 @@ async def test_generate_media_response(mocker, version):
     imagen = ImagenModel(version, googleai_client_mock)
 
     ctx = ActionRunContext()
-    response = await imagen.generate(request, ctx)
+    response = await imagen.agenerate(request, ctx)
 
     googleai_client_mock.assert_has_calls([
         mocker.call.aio.models.generate_images(model=version, prompt=request_text, config=None)

--- a/py/plugins/ollama/src/genkit/plugins/ollama/models.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/models.py
@@ -68,7 +68,7 @@ class OllamaModel:
         self.client = client
         self.model_definition = model_definition
 
-    async def generate(self, request: GenerateRequest, ctx: ActionRunContext | None = None) -> GenerateResponse:
+    async def agenerate(self, request: GenerateRequest, ctx: ActionRunContext | None = None) -> GenerateResponse:
         content = [TextPart(text='Failed to get response from Ollama API')]
 
         if self.model_definition.api_type == OllamaAPITypes.CHAT:

--- a/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
@@ -56,7 +56,7 @@ class Ollama(Plugin):
             )
             ai.define_model(
                 name=ollama_name(model_definition.name),
-                fn=model.generate,
+                fn=model.agenerate,
                 metadata={
                     'multiturn': model_definition.api_type == OllamaAPITypes.CHAT,
                     'system_role': True,

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/gemini.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/gemini.py
@@ -60,7 +60,7 @@ class GeminiVersion(StrEnum):
     GEMINI_2_0_PRO_EXP = 'gemini-2.0-pro-exp-02-05'
 
 
-SUPPORTED_MODELS = {
+SUPPORTED_MODELS: dict[GeminiVersion | str, ModelInfo] = {
     GeminiVersion.GEMINI_1_5_PRO: ModelInfo(
         versions=[],
         label='Vertex AI - Gemini 1.5 Pro',
@@ -102,21 +102,27 @@ class Gemini:
         Args:
             version: The version of the Gemini model to use, should be
                 one of the values from GeminiVersion.
+            registry: The registry to use for the Gemini client.
         """
         self._version = version
         self._registry = registry
 
     def is_multimode(self):
+        """Check if the model supports multimode input.
+
+        Returns:
+            True if the model supports multimode input, False otherwise.
+        """
         return SUPPORTED_MODELS[self._version].supports.media
 
     def build_messages(self, request: GenerateRequest) -> list[genai.Content]:
         """Builds a list of VertexAI content from a request.
 
         Args:
-            - request: a packed request for the model
+            request: a packed request for the model.
 
         Returns:
-            - a list of VertexAI GenAI Content for the request
+            A list of VertexAI GenAI Content for the request.
         """
         messages: list[genai.Content] = []
         for message in request.messages:
@@ -160,8 +166,8 @@ class Gemini:
         Args:
             request: The generation request.
 
-         Returns:
-             list of Gemini tools
+        Returns:
+            List of Gemini tools.
         """
         tools = []
         for tool in request.tools:
@@ -208,7 +214,6 @@ class Gemini:
         Returns:
             The model's response to the generation request.
         """
-
         messages = self.build_messages(request)
         tools = self._get_gemini_tools(request) if request.tools else None
         if request.tools:
@@ -223,7 +228,7 @@ class Gemini:
         text_response = ''
         if ctx.is_streaming:
             for chunk in response:
-                # TODO: Support other types of output
+                # TODO: Support other types of output.
                 ctx.send_chunk(
                     GenerateResponseChunk(
                         role=Role.MODEL,
@@ -243,6 +248,11 @@ class Gemini:
 
     @property
     def model_metadata(self) -> dict[str, dict[str, Any]]:
+        """Get the model metadata.
+
+        Returns:
+            A dictionary containing the model metadata.
+        """
         supports = SUPPORTED_MODELS[self._version].supports.model_dump()
         return {
             'model': {


### PR DESCRIPTION
refactor(py/plugins): use the a* prefix for all async methods to distinguish from any sync api in plugins

RATIONALE:
Python libraries (e.g. structlog) use the `a*` prefix to distinguish
async method/function names from sync ones when exposed _at the same
level_.

We're also doing that already with `arun` for `Action`.  Making this
change before people become accustomed to naming issues and we're stuck
with an incorrect convention.

If we decide to add sync and async Genkit implementations, we might
follow `httpx`'s convention of calling both methods the same name since
in that case both would be defined on different classes entirely.
`httpx` calls its `get` method the same regardless of whether it is
async or sync, but only because they're exposed on _different_ classes.

In our case, we're exposing async and sync methods at the veneer API
level, so we use the `a*` prefix to ensure we can support both sync and
async method names.

EXAMPLE:

```python
logger = structlog.get_logger(__name__)

await logger.ainfo('async')

logger.info('sync')
```

CHANGELOG:
- [ ] Use the `a*` prefix for async-API methods to distinguish from any
  sync methods that may be introduced in the future.