### PR TITLE
fix(go): removed provider and provider input in LookUpTool

### DIFF
--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -28,7 +28,7 @@ import (
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
-const provider = "local"
+const provider = ""
 
 // ToolRef is a reference to a tool.
 type ToolRef interface {
@@ -181,7 +181,7 @@ func runAction(ctx context.Context, def *ToolDefinition, action core.Action, inp
 
 // LookupTool looks up the tool in the registry by provided name and returns it.
 func LookupTool(r *registry.Registry, name string) Tool {
-	action := r.LookupAction(fmt.Sprintf("/%s/%s/%s", atype.Tool, provider, name))
+	action := r.LookupAction(fmt.Sprintf("/%s/%s", atype.Tool, name))
 	if action == nil {
 		return nil
 	}


### PR DESCRIPTION
Issue:

[Go] Tool name (OpenAPI format) local/toolName is not valid #2587
https://github.com/firebase/genkit/issues/2587

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
