### PR TITLE
fix: remove legacy prompts from go

### DIFF
--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -76,8 +76,6 @@ func DefinePrompt(r *registry.Registry, name string, opts ...PromptOption) (*Pro
 	}
 	maps.Copy(meta, promptMeta)
 
-	// Legacy prompt type; Go never supported it but it does show up in Dev UI for now.
-	core.DefineActionWithInputSchema(r, provider, name, atype.Prompt, meta, p.InputSchema, p.buildRequest)
 	p.action = *core.DefineActionWithInputSchema(r, provider, name, atype.ExecutablePrompt, meta, p.InputSchema, p.buildRequest)
 
 	return p, nil


### PR DESCRIPTION
This is needed for https://github.com/FirebasePrivate/genkit-ui/pull/1332

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
