### PR TITLE
fix(js/plugins/express): Check request.body is defined before reading data from it

### DIFF
--- a/js/plugins/express/src/index.ts
+++ b/js/plugins/express/src/index.ts
@@ -57,8 +57,8 @@ export function expressHandler<
     if (!request.body) {
       const errMsg =
         `Error: request.body is undefined. ` +
-        `Are you missing 'content-type: application/json' in your headers? ` +
-        `Or did you forget to use 'express.json()'? `;
+        `Possible reasons: missing 'content-type: application/json' in request ` +
+        `headers or misconfigured JSON middleware ('app.use(express.json()')? `;
       logger.error(errMsg);
       response
         .status(400)

--- a/js/plugins/express/src/index.ts
+++ b/js/plugins/express/src/index.ts
@@ -62,7 +62,7 @@ export function expressHandler<
       logger.error(errMsg);
       response
         .status(400)
-        .json({ message: errMsg, status: 'BAD REQUEST' })
+        .json({ message: errMsg, status: 'INVALID ARGUMENT' })
         .end();
       return;
     }

--- a/js/plugins/express/src/index.ts
+++ b/js/plugins/express/src/index.ts
@@ -54,7 +54,7 @@ export function expressHandler<
     response: express.Response
   ): Promise<void> => {
     const { stream } = request.query;
-    let input = request.body.data as z.infer<I>;
+    let input = request.body?.data as z.infer<I>;
     let context: Record<string, any>;
 
     try {

--- a/js/plugins/express/src/index.ts
+++ b/js/plugins/express/src/index.ts
@@ -54,7 +54,20 @@ export function expressHandler<
     response: express.Response
   ): Promise<void> => {
     const { stream } = request.query;
-    let input = request.body?.data as z.infer<I>;
+    if (!request.body) {
+      const errMsg =
+        `Error: request.body is undefined. ` +
+        `Are you missing 'content-type: application/json' in your headers? ` +
+        `Or did you forget to use 'express.json()'? `;
+      logger.error(errMsg);
+      response
+        .status(400)
+        .json({ message: errMsg, status: 'BAD REQUEST' })
+        .end();
+      return;
+    }
+
+    let input = request.body.data as z.infer<I>;
     let context: Record<string, any>;
 
     try {


### PR DESCRIPTION
If the plugin user misconfigured things, there was a possibility that request.body was undefined.

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
