### PR TITLE
fix(py/samples/hello-google-genai-vertexai): fix stray use of aembed -> embed

### DIFF
--- a/py/samples/hello-google-genai-vertexai/src/hello_google_genai_vertexai.py
+++ b/py/samples/hello-google-genai-vertexai/src/hello_google_genai_vertexai.py
@@ -186,7 +186,7 @@ async def embed_docs(docs: list[str]):
         The generated embedding.
     """
     options = {'task_type': EmbeddingTaskType.CLUSTERING}
-    return await ai.aembed(
+    return await ai.embed(
         model=vertexai_name(VertexEmbeddingModels.TEXT_EMBEDDING_004_ENG),
         documents=[Document.from_text(doc) for doc in docs],
         options=options,


### PR DESCRIPTION
fix(py/samples/google-genai-vertex-ai): fix stray use of aembed -> embed

CHANGELOG:
- [ ] Fix stray reference to `aembed`