### PR TITLE
fix(py/core): make reflection server pick unused address and telemetry exporter export to the correct telemetry server

### DIFF
--- a/py/packages/genkit-ai/src/genkit/ai/aio.py
+++ b/py/packages/genkit-ai/src/genkit/ai/aio.py
@@ -51,7 +51,7 @@ from genkit.core.typing import (
     ToolChoice,
 )
 
-from .base import DEFAULT_REFLECTION_SERVER_SPEC, GenkitBase
+from .base import GenkitBase
 
 
 class Genkit(GenkitBase):
@@ -61,7 +61,7 @@ class Genkit(GenkitBase):
         self,
         plugins: list[Plugin] | None = None,
         model: str | None = None,
-        reflection_server_spec: server.ServerSpec = DEFAULT_REFLECTION_SERVER_SPEC,
+        reflection_server_spec: server.ServerSpec | None = None,
     ) -> None:
         """Initialize a new Genkit instance.
 

--- a/py/packages/genkit-ai/src/genkit/ai/server.py
+++ b/py/packages/genkit-ai/src/genkit/ai/server.py
@@ -23,8 +23,9 @@ The following servers may be started depending upon the host environment:
 
 The reflection API server is started only in dev mode, which is enabled by the
 setting the environment variable `GENKIT_ENV` to `dev`. By default, the
-reflection API server binds and listens on (localhost, 3100).  The flows server
-is the production servers that exposes flows and actions over HTTP.
+reflection API server binds and listens on (localhost, 3100 or the next available
+port).  The flows server is the production servers that exposes flows and actions
+over HTTP.
 """
 
 import atexit


### PR DESCRIPTION
Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
