### PR TITLE
refactor(py/genkit): move port scanning to ports module that has other utilities for this

### DIFF
--- a/py/packages/genkit/src/genkit/web/manager/__init__.py
+++ b/py/packages/genkit/src/genkit/web/manager/__init__.py
@@ -26,14 +26,17 @@ from ._base_server import AbstractBaseServer
 from ._info import get_health_info, get_server_info
 from ._loop import run_loop
 from ._manager import ServerManager
+from ._ports import find_free_port_sync, is_port_available_sync
 from ._server import Server, ServerConfig, ServerLifecycle
 
 __all__ = [
     ASGIServerAdapter.__name__,
     AbstractBaseServer.__name__,
+    find_free_port_sync.__name__,
     get_health_info.__name__,
     get_server_info.__name__,
     GranianAdapter.__name__,
+    is_port_available_sync.__name__,
     run_loop.__name__,
     Server.__name__,
     ServerConfig.__name__,

--- a/py/packages/genkit/src/genkit/web/manager/_ports.py
+++ b/py/packages/genkit/src/genkit/web/manager/_ports.py
@@ -51,3 +51,41 @@ async def is_port_available(port: int, host: str = '127.0.0.1') -> bool:
         # Always close the socket
         with contextlib.suppress(Exception):
             sock.close()
+
+
+def is_port_available_sync(port: int, host: str = '127.0.0.1') -> bool:
+    """Check if a specific port is available for binding.
+
+    Args:
+        port: The port number to check
+        host: The host address to bind to (default: '127.0.0.1')
+
+    Returns:
+        True if the port is available, False otherwise.
+    """
+    try:
+        with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            s.bind(('', port))
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            return True
+    except OSError:
+        return False
+
+
+def find_free_port_sync(lower: int, upper: int) -> int:
+    """Find an unused port in lower-upper range. If not found raises an exception.
+
+    Args:
+        lower: The lower bound of the port range.
+        upper: The upper bound of the port range.
+
+    Returns:
+        An unused port in the range.
+
+    Raises:
+        OSError: If no free port is found in the range.
+    """
+    for port in range(lower, upper + 1):
+        if is_port_available_sync(port):
+            return port
+    raise OSError(f'Failed to find a free port in range {lower}-{upper}')


### PR DESCRIPTION
CHANGELOG:
- [ ] Move port scanning to genkit.web.manager for later.
