### PR TITLE
fix(py/genkit): use the function docstring as the description unless you want to override; saves duplication

### DIFF
--- a/py/docs/index.md
+++ b/py/docs/index.md
@@ -119,8 +119,9 @@ See the following code samples for a concrete idea of how to use these capabilit
     class WeatherToolInput(BaseModel):
         location: str = Field(description='weather location')
 
-    @ai.tool('Use it to get weather')
+    @ai.tool()
     def get_weather(input:WeatherToolInput) -> str:
+        """Use it get the weather."""
         return f'Weather in {input.location} is 23°'
 
     async def main():

--- a/py/docs/reference/interrupts.md
+++ b/py/docs/reference/interrupts.md
@@ -63,8 +63,9 @@ class Questions(BaseModel):
     allow_other: bool = Field(description='when true, allow write-ins')
 
 
-@ai.tool('use this to ask the user a clarifying question')
+@ai.tool()
 def ask_question(input: Questions, ctx) -> str:
+    """Use this to ask the user a clarifying question"""
     ctx.interrupt()
 ```
 

--- a/py/docs/reference/tools.md
+++ b/py/docs/reference/tools.md
@@ -108,14 +108,15 @@ class WeatherInput(BaseModel):
     location: str = Field(description='The location to get the current weather for')
 
 
-@ai.tool('Gets the current weather in a given location')
+@ai.tool()
 def get_weather(input: WeatherInput) -> str:
+    """Gets the current weather in a given location"""
     return f'The current weather in ${input.location} is 63°F and sunny.'
 ```
 
-The syntax here looks just like the `flow()` syntax; however `description` 
-parameter is required. When writing a tool definition, take special care 
-with the wording and descriptiveness of these parameters. They are vital 
+The syntax here looks just like the `flow()` syntax; however `description`
+parameter is required. When writing a tool definition, take special care
+with the wording and descriptiveness of these parameters. They are vital
 for the LLM to make effective use of the available tools.
 
 ### Using tools

--- a/py/packages/genkit/tests/genkit/ai/ai_registry_test.py
+++ b/py/packages/genkit/tests/genkit/ai/ai_registry_test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the AI registry module.
+
+This module contains unit tests for the GenkitRegistry class and its associated
+functionality, ensuring proper registration and management of Genkit resources.
+"""
+
+import unittest
+
+from genkit.ai.registry import get_func_description
+
+
+class TestGetFuncDescription(unittest.TestCase):
+    """Test the get_func_description function."""
+
+    def test_get_func_description_with_explicit_description(self) -> None:
+        """Test that explicit description takes precedence over docstring."""
+
+        def test_func():
+            """This docstring should be ignored."""
+            pass
+
+        description = get_func_description(test_func, 'Explicit description')
+        self.assertEqual(description, 'Explicit description')
+
+    def test_get_func_description_with_docstring(self) -> None:
+        """Test that docstring is used when no explicit description is provided."""
+
+        def test_func():
+            """This is the function's docstring."""
+            pass
+
+        description = get_func_description(test_func)
+        self.assertEqual(description, "This is the function's docstring.")
+
+    def test_get_func_description_without_docstring(self) -> None:
+        """Test that empty string is returned when no docstring is present."""
+
+        def test_func():
+            pass
+
+        description = get_func_description(test_func)
+        self.assertEqual(description, '')
+
+    def test_get_func_description_with_none_docstring(self) -> None:
+        """Test that empty string is returned when docstring is None."""
+
+        def test_func():
+            pass
+
+        test_func.__doc__ = None
+
+        description = get_func_description(test_func)
+        self.assertEqual(description, '')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/packages/genkit/tests/genkit/blocks/generate_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/generate_test.py
@@ -36,19 +36,22 @@ from genkit.testing import (
 
 @pytest.fixture
 def setup_test():
+    """Setup the test."""
     ai = Genkit()
 
     pm, _ = define_programmable_model(ai)
 
-    @ai.tool('the tool')
-    def testTool():
-        return 'abc'
+    @ai.tool(name='testTool')
+    def test_tool():
+        """description"""
+        return 'tool called'
 
     return (ai, pm)
 
 
 @pytest.mark.asyncio
 async def test_simple_text_generate_request(setup_test) -> None:
+    """Test that the generate action can generate text."""
     ai, pm = setup_test
 
     pm.responses.append(
@@ -328,8 +331,9 @@ async def test_generate_action_spec(spec) -> None:
 
     pm, _ = define_programmable_model(ai)
 
-    @ai.tool('description')
-    def testTool():
+    @ai.tool(name='testTool')
+    def test_tool():
+        """description"""
         return 'tool called'
 
     if 'modelResponses' in spec:

--- a/py/packages/genkit/tests/genkit/blocks/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/prompt_test.py
@@ -108,8 +108,9 @@ async def test_prompt_with_kitchensink() -> None:
     class ToolInput(BaseModel):
         value: int = Field(None, description='value field')
 
-    @ai.tool('the tool', name='testTool')
+    @ai.tool(name='testTool')
     def test_tool(input: ToolInput):
+        """The tool."""
         return 'abc'
 
     my_prompt = ai.define_prompt(

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -289,8 +289,9 @@ async def test_generate_with_tools(setup_test: SetupFixture) -> None:
     class ToolInput(BaseModel):
         value: int = Field(None, description='value field')
 
-    @ai.tool('the tool', name='testTool')
+    @ai.tool(name='testTool')
     def test_tool(input: ToolInput):
+        """The tool."""
         return input.value
 
     response = await ai.generate(
@@ -305,7 +306,7 @@ async def test_generate_with_tools(setup_test: SetupFixture) -> None:
     want_request = [
         ToolDefinition(
             name='testTool',
-            description='the tool',
+            description='The tool.',
             input_schema={
                 'properties': {
                     'value': {
@@ -346,12 +347,14 @@ async def test_generate_with_iterrupting_tools(
     class ToolInput(BaseModel):
         value: int = Field(None, description='value field')
 
-    @ai.tool('the tool', name='test_tool')
+    @ai.tool(name='test_tool')
     def test_tool(input: ToolInput):
+        """The tool."""
         return input.value + 7
 
-    @ai.tool('the interrupt', name='test_interrupt')
+    @ai.tool(name='test_interrupt')
     def test_interrupt(input: ToolInput, ctx: ToolRunContext):
+        """The interrupt."""
         ctx.interrupt({'banana': 'yes please'})
 
     tool_request_msg = MessageWrapper(
@@ -386,7 +389,7 @@ async def test_generate_with_iterrupting_tools(
     want_request = [
         ToolDefinition(
             name='test_tool',
-            description='the tool',
+            description='The tool.',
             input_schema={
                 'properties': {
                     'value': {
@@ -403,7 +406,7 @@ async def test_generate_with_iterrupting_tools(
         ),
         ToolDefinition(
             name='test_interrupt',
-            description='the interrupt',
+            description='The interrupt.',
             input_schema={
                 'properties': {
                     'value': {
@@ -452,12 +455,14 @@ async def test_generate_with_interrupt_respond(
     class ToolInput(BaseModel):
         value: int = Field(None, description='value field')
 
-    @ai.tool('the tool', name='test_tool')
+    @ai.tool(name='test_tool')
     def test_tool(input: ToolInput):
+        """The tool."""
         return input.value + 7
 
-    @ai.tool('the interrupt', name='test_interrupt')
+    @ai.tool(name='test_interrupt')
     def test_interrupt(input: ToolInput, ctx: ToolRunContext):
+        """The interrupt."""
         ctx.interrupt({'banana': 'yes please'})
 
     tool_request_msg = MessageWrapper(
@@ -587,8 +592,9 @@ async def test_generate_with_tools_and_output(setup_test: SetupFixture) -> None:
     class ToolInput(BaseModel):
         value: int = Field(None, description='value field')
 
-    @ai.tool('the tool', name='testTool')
+    @ai.tool(name='testTool')
     def test_tool(input: ToolInput):
+        """The tool."""
         return 'abc'
 
     tool_request_msg = MessageWrapper(
@@ -627,7 +633,7 @@ async def test_generate_with_tools_and_output(setup_test: SetupFixture) -> None:
     assert pm.last_request.tools == [
         ToolDefinition(
             name='testTool',
-            description='the tool',
+            description='The tool.',
             input_schema={
                 'properties': {
                     'value': {
@@ -653,8 +659,9 @@ async def test_generate_stream_with_tools(setup_test: SetupFixture) -> None:
     class ToolInput(BaseModel):
         value: int = Field(None, description='value field')
 
-    @ai.tool('the tool', name='testTool')
+    @ai.tool(name='testTool')
     def test_tool(input: ToolInput):
+        """The tool."""
         return 'abc'
 
     tool_request_msg = MessageWrapper(

--- a/py/samples/basic-gemini/src/basic_gemini.py
+++ b/py/samples/basic-gemini/src/basic_gemini.py
@@ -74,7 +74,7 @@ class ConversionInput(BaseModel):
     amount: float = Field(description='The currency amount to convert')
 
 
-@ai.tool('Converts currency with latest exchange rate')
+@ai.tool()
 def convert_currency(input: ConversionInput) -> float:
     """Tool to convert the currency with latest exchange rate.
 

--- a/py/samples/hello-google-genai-vertexai/src/hello_google_genai_vertexai.py
+++ b/py/samples/hello-google-genai-vertexai/src/hello_google_genai_vertexai.py
@@ -75,7 +75,7 @@ class GablorkenInput(BaseModel):
     value: int = Field(description='value to calculate gablorken for')
 
 
-@ai.tool('calculates a gablorken', name='gablorkenTool')
+@ai.tool(name='gablorkenTool')
 def gablorken_tool(input_: GablorkenInput) -> int:
     """Calculate a gablorken.
 
@@ -111,7 +111,7 @@ async def simple_generate_with_tools_flow(value: int) -> str:
     return response.text
 
 
-@ai.tool('calculates a gablorken', name='gablorkenTool2')
+@ai.tool(name='gablorkenTool2')
 def gablorken_tool2(input_: GablorkenInput, ctx: ToolRunContext):
     """The user-defined tool function.
 

--- a/py/samples/hello-google-genai/src/hello_google_genai.py
+++ b/py/samples/hello-google-genai/src/hello_google_genai.py
@@ -76,7 +76,7 @@ class GablorkenInput(BaseModel):
     value: int = Field(description='value to calculate gablorken for')
 
 
-@ai.tool('calculates a gablorken', name='gablorkenTool')
+@ai.tool(name='gablorkenTool')
 def gablorken_tool(input_: GablorkenInput) -> int:
     """Calculate a gablorken.
 
@@ -112,7 +112,7 @@ async def simple_generate_with_tools_flow(value: int) -> str:
     return response.text
 
 
-@ai.tool('calculates a gablorken', name='gablorkenTool2')
+@ai.tool(name='gablorkenTool2')
 def gablorken_tool2(input_: GablorkenInput, ctx: ToolRunContext):
     """The user-defined tool function.
 

--- a/py/samples/hello/src/hello.py
+++ b/py/samples/hello/src/hello.py
@@ -115,7 +115,7 @@ class GablorkenInput(BaseModel):
     value: int = Field(description='value to calculate gablorken for')
 
 
-@ai.tool('calculates a gablorken', name='gablorkenTool')
+@ai.tool(name='gablorkenTool')
 def gablorken_tool(input: GablorkenInput):
     """Calculate a gablorken.
 

--- a/py/samples/menu/src/case_02/tools.py
+++ b/py/samples/menu/src/case_02/tools.py
@@ -22,15 +22,13 @@ from menu_ai import ai
 from menu_schemas import MenuToolOutputSchema
 
 menu_json_path = os.path.join(os.path.dirname(__file__), '..', '..', 'data', 'menu.json')
-with open(menu_json_path, 'r') as f:
+with open(menu_json_path) as f:
     menu_data = json.load(f)
 
 
-@ai.tool(
-    description="Use this tool to retrieve all the items on today's menu",
-    name='menu_tool',
-)
+@ai.tool(name='menu_tool')
 def menu_tool(input=None) -> MenuToolOutputSchema:
+    """Use this tool to retrieve all the items on today's menu."""
     return MenuToolOutputSchema(
         menu_data=menu_data,
     )

--- a/py/samples/ollama-hello/src/ollama_hello.py
+++ b/py/samples/ollama-hello/src/ollama_hello.py
@@ -105,7 +105,7 @@ class GablorkenOutputSchema(BaseModel):
     result: int
 
 
-@ai.tool('calculates a gablorken')
+@ai.tool()
 def gablorken_tool(input: int) -> int:
     """Calculate a gablorken.
 

--- a/py/samples/openai/src/openai_example.py
+++ b/py/samples/openai/src/openai_example.py
@@ -98,7 +98,7 @@ async def say_hi_stream(name: str) -> str:
     return result
 
 
-@ai.tool('Get current temperature for provided coordinates in celsius')
+@ai.tool()
 def get_weather_tool(coordinates: WeatherRequest) -> float:
     """Get the current temperature for provided coordinates in celsius.
 

--- a/py/samples/tool-interrupts/src/tool_interrupts.py
+++ b/py/samples/tool-interrupts/src/tool_interrupts.py
@@ -38,8 +38,9 @@ class TriviaQuestions(BaseModel):
     answers: list[str] = Field(description='list of multiple choice answers (typically 4), 1 correct 3 wrong')
 
 
-@ai.tool("can present questions to the user, responds with the user' selected answer")
+@ai.tool()
 def present_questions(questions: TriviaQuestions, ctx: ToolRunContext):
+    """Can present questions to the user, responds with the user' selected answer."""
     ctx.interrupt(questions)
 
 


### PR DESCRIPTION
Python already provides a way to provide function descriptions
as docstrings. Let's use those when available to avoid duplication
for action descriptions. The `description` kwarg can be used to
override.

CHANGELOG:
- [ ] Update docs to reflect this.
- [ ] Update decorators and tests.
