### PR TITLE
fix(py): use the active virtual environment when running tests with nox

### DIFF
--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -32,6 +32,7 @@ def tests(session: nox.Session):
     session.run(
         'uv',
         'run',
+        '--active',
         'pytest',
         # '-v', # Adding verbosity drops coverage for some reason...
         '.',


### PR DESCRIPTION
CHANGELOG:
- [ ] Fix the warning that nox shows because it was reusuing
  environments.
