### PR TITLE
fix(py): try tox; also use nox-specified python with pytest in noxfile; fix more 3.10 compatibility issues

### DIFF
--- a/captainhook.json
+++ b/captainhook.json
@@ -40,7 +40,7 @@
           "run": "bin/fmt"
         },
         {
-          "run": "py/bin/run_python_tests_with_nox"
+          "run": "py/bin/run_python_tests_with_tox"
         },
         {
           "run": "echo 'disabled' || uv run --directory py mkdocs build"
@@ -80,7 +80,7 @@
           "run": "bin/fmt"
         },
         {
-          "run": "py/bin/run_python_tests_with_nox"
+          "run": "py/bin/run_python_tests_with_tox"
         },
         {
           "run": "echo 'disabled' || uv run --directory py mkdocs build"

--- a/py/bin/run_python_tests_with_tox
+++ b/py/bin/run_python_tests_with_tox
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Run tests for all supported Python versions using tox
+
+set -euo pipefail
+
+TOP_DIR=$(git rev-parse --show-toplevel)
+PY_DIR="$TOP_DIR/py"
+
+echo "Running Python tests via tox..."
+
+# Use uv run to execute tox, passing the --parallel flag to tox
+# The '-p auto' flag tells tox to use available CPU cores for parallelism.
+# Any arguments passed to this script ($@) are forwarded to tox (and then pytest)
+uv run --directory "$PY_DIR" tox --parallel auto "$@"

--- a/py/plugins/chroma/pyproject.toml
+++ b/py/plugins/chroma/pyproject.toml
@@ -16,7 +16,10 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["genkit"]
+dependencies = [
+  "genkit",
+  "strenum>=0.4.15; python_version < '3.11'",
+]
 description = "Genkit Chroma Plugin"
 license = { text = "Apache-2.0" }
 name = "genkit-plugin-chroma"

--- a/py/plugins/compat-oai/pyproject.toml
+++ b/py/plugins/compat-oai/pyproject.toml
@@ -16,7 +16,11 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["genkit", "openai"]
+dependencies = [
+  "genkit",
+  "openai",
+  "strenum>=0.4.15; python_version < '3.11'",
+]
 description = "Genkit OpenAI API Compatible"
 license = { text = "Apache-2.0" }
 name = "genkit-plugin-compat-oai"

--- a/py/plugins/dev-local-vector-store/pyproject.toml
+++ b/py/plugins/dev-local-vector-store/pyproject.toml
@@ -16,7 +16,12 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["genkit", "pytest-mock", "pytest-asyncio"]
+dependencies = [
+  "genkit",
+  "pytest-mock",
+  "pytest-asyncio",
+  "strenum>=0.4.15; python_version < '3.11'",
+]
 description = "Genkit Local Vector Store Plugin"
 license = { text = "Apache-2.0" }
 name = "genkit-plugin-dev-local-vectorstore"

--- a/py/plugins/firebase/pyproject.toml
+++ b/py/plugins/firebase/pyproject.toml
@@ -16,7 +16,11 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["genkit", "google-cloud-firestore"]
+dependencies = [
+  "genkit",
+  "google-cloud-firestore",
+  "strenum>=0.4.15; python_version < '3.11'",
+]
 description = "Genkit Firebase Plugin"
 license = { text = "Apache-2.0" }
 name = "genkit-plugin-firebase"

--- a/py/plugins/google-ai/pyproject.toml
+++ b/py/plugins/google-ai/pyproject.toml
@@ -16,7 +16,11 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["genkit", "google-genai>=1.7.0"]
+dependencies = [
+  "genkit",
+  "google-genai>=1.7.0",
+  "strenum>=0.4.15; python_version < '3.11'",
+]
 description = "Genkit Google AI Plugin"
 license = { text = "Apache-2.0" }
 name = "genkit-plugin-google-ai"

--- a/py/plugins/google-ai/src/genkit/plugins/google_ai/models/gemini.py
+++ b/py/plugins/google-ai/src/genkit/plugins/google_ai/models/gemini.py
@@ -16,7 +16,13 @@
 
 """Gemini Models for Genkit."""
 
-from enum import StrEnum
+import sys  # noqa
+
+if sys.version_info < (3, 11):  # noqa
+    from strenum import StrEnum  # noqa
+else:  # noqa
+    from enum import StrEnum  # noqa
+
 from functools import cached_property
 
 from google import genai

--- a/py/plugins/google-cloud/pyproject.toml
+++ b/py/plugins/google-cloud/pyproject.toml
@@ -16,7 +16,10 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["genkit"]
+dependencies = [
+  "genkit",
+  "strenum>=0.4.15; python_version < '3.11'",
+]
 description = "Genkit Google Cloud Plugin"
 license = { text = "Apache-2.0" }
 name = "genkit-plugin-google-cloud"

--- a/py/plugins/google-genai/pyproject.toml
+++ b/py/plugins/google-genai/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "google-genai>=1.7.0",
   "google-cloud-aiplatform>=1.77.0",
   "structlog>=25.2.0",
+  "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "Genkit Google GenAI Plugin"
 license = { text = "Apache-2.0" }

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
@@ -17,6 +17,12 @@
 """Google-Genai embedder model."""
 
 import enum
+import sys  # noqa
+
+if sys.version_info < (3, 11):  # noqa
+    from strenum import StrEnum  # noqa
+else:  # noqa
+    from enum import StrEnum  # noqa
 
 from google import genai
 
@@ -24,7 +30,7 @@ from genkit.plugins.google_genai.models.utils import PartConverter
 from genkit.types import Embedding, EmbedRequest, EmbedResponse
 
 
-class VertexEmbeddingModels(enum.StrEnum):
+class VertexEmbeddingModels(StrEnum):
     """Embedding models supported by Google-Genai vertex."""
 
     GECKO_003_ENG = 'textembedding-gecko@003'
@@ -34,7 +40,7 @@ class VertexEmbeddingModels(enum.StrEnum):
     TEXT_EMBEDDING_002_MULTILINGUAL = 'text-multilingual-embedding-002'
 
 
-class GeminiEmbeddingModels(enum.StrEnum):
+class GeminiEmbeddingModels(StrEnum):
     """Embedding models supported by Google-Genai gemini."""
 
     GEMINI_EMBEDDING_EXP_03_07 = 'gemini-embedding-exp-03-07'
@@ -42,7 +48,9 @@ class GeminiEmbeddingModels(enum.StrEnum):
     EMBEDDING_001 = 'embedding-001'
 
 
-class EmbeddingTaskType(enum.StrEnum):
+class EmbeddingTaskType(StrEnum):
+    """Embedding task types supported by Google-Genai."""
+
     RETRIEVAL_QUERY = 'RETRIEVAL_QUERY'
     RETRIEVAL_DOCUMENT = 'RETRIEVAL_DOCUMENT'
     SEMANTIC_SIMILARITY = 'SEMANTIC_SIMILARITY'
@@ -53,11 +61,19 @@ class EmbeddingTaskType(enum.StrEnum):
 
 
 class Embedder:
+    """Embedder for Google-Genai."""
+
     def __init__(
         self,
         version: VertexEmbeddingModels | GeminiEmbeddingModels | str,
         client: genai.Client,
     ):
+        """Initialize the embedder.
+
+        Args:
+            version: Embedding model version.
+            client: Google-Genai client.
+        """
         self._client = client
         self._version = version
 

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -127,7 +127,13 @@ The following models are currently supported by VertexAI API:
 | `gemini-2.0-flash-exp`      | Gemini 2.0 Flash Experimental | Unavailable  |
 """
 
-from enum import StrEnum
+import sys  # noqa
+
+if sys.version_info < (3, 11):  # noqa
+    from strenum import StrEnum  # noqa
+else:  # noqa
+    from enum import StrEnum  # noqa
+
 from functools import cached_property
 from typing import Any
 

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -15,7 +15,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
-from enum import StrEnum
+import sys  # noqa
+
+if sys.version_info < (3, 11):  # noqa
+    from strenum import StrEnum  # noqa
+else:  # noqa
+    from enum import StrEnum  # noqa
+
 from functools import cached_property
 from typing import Any
 

--- a/py/plugins/google-genai/test/models/test_googlegenai_gemini.py
+++ b/py/plugins/google-genai/test/models/test_googlegenai_gemini.py
@@ -15,7 +15,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
-from enum import StrEnum
+import sys  # noqa
+
+if sys.version_info < (3, 11):  # noqa
+    from strenum import StrEnum  # noqa
+else:  # noqa
+    from enum import StrEnum  # noqa
 
 import pytest
 from google import genai

--- a/py/plugins/pinecone/pyproject.toml
+++ b/py/plugins/pinecone/pyproject.toml
@@ -16,7 +16,10 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["genkit"]
+dependencies = [
+  "genkit",
+  "strenum>=0.4.15; python_version < '3.11'",
+]
 description = "Genkit Pinecone Plugin"
 license = { text = "Apache-2.0" }
 name = "genkit-plugin-pinecone"

--- a/py/plugins/vertex-ai/pyproject.toml
+++ b/py/plugins/vertex-ai/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "google-cloud-aiplatform>=1.77.0",
   "pytest-mock",
   "structlog>=25.2.0",
+  "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "Genkit Google Cloud Vertex AI Plugin"
 license = { text = "Apache-2.0" }

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/embedding.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/embedding.py
@@ -16,7 +16,13 @@
 
 """Vertex AI embedding plugin."""
 
-from enum import StrEnum
+import sys  # noqa
+
+if sys.version_info < (3, 11):  # noqa
+    from strenum import StrEnum  # noqa
+else:  # noqa
+    from enum import StrEnum  # noqa
+
 from typing import Any
 
 from vertexai.language_models import TextEmbeddingInput, TextEmbeddingModel

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/gemini.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/gemini.py
@@ -21,7 +21,13 @@ Gemini models through the Vertex AI platform. It includes version
 definitions and a client class for making requests to Gemini models.
 """
 
-from enum import StrEnum
+import sys  # noqa
+
+if sys.version_info < (3, 11):  # noqa
+    from strenum import StrEnum  # noqa
+else:  # noqa
+    from enum import StrEnum  # noqa
+
 from typing import Any
 
 import structlog

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/imagen.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/imagen.py
@@ -14,7 +14,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import StrEnum
+import sys  # noqa
+
+if sys.version_info < (3, 11):  # noqa
+    from strenum import StrEnum  # noqa
+else:  # noqa
+    from enum import StrEnum  # noqa
+
 from typing import Any, Literal
 
 import structlog

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "genkit-plugin-pinecone",
   "genkit-plugin-vertex-ai",
   "liccheck>=0.9.2",
+  "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "Workspace for Genkit packages"
 license = { text = "Apache-2.0" }
@@ -37,6 +38,8 @@ dev = [
   "poethepoet>=0.33.1",
   "pip>=25.0.1",
   "nox>=2024.4.15",
+  "tox>=4.25.0",
+  "tox-uv>=1.25.0",
 ]
 
 lint = ["mypy>=1.15", "ruff>=0.9"]
@@ -51,15 +54,21 @@ py-modules = []
 [tool.pytest]
 
 [tool.pytest.ini_options]
-addopts = ["--cov"]
-asyncio_default_fixture_loop_scope = "session"
-asyncio_mode = "strict"
-python_files = [
-  "packages/**/*_test.py",
-  "plugins/**/*_test.py",
-  "samples/**/*_test.py",
+addopts = [
+    "--cov",
+    #"--cov-report=", # Disable terminal report generation by pytest-cov
+    "-ra",
+    "-vv",
 ]
-testpaths = ["packages", "plugins", "samples"]
+testpaths = [
+    "packages",
+    "plugins",
+    "samples",
+    "tests",
+]
+asyncio_default_fixture_loop_scope = "session"
+#asyncio_mode = "auto"
+asyncio_mode = "strict"
 
 [tool.coverage.report]
 fail_under = 78

--- a/py/tests/smoke/pyproject.toml
+++ b/py/tests/smoke/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "genkit-plugin-ollama",
   "genkit-plugin-pinecone",
   "genkit-plugin-vertex-ai",
+  "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "Packaging smoke test"
 license = { text = "Apache-2.0" }
@@ -30,10 +31,6 @@ name = "smoke"
 readme = "README.md"
 requires-python = ">=3.10"
 version = "0.1.0"
-
-[tool.pytest.ini_options]
-python_files = ["**/*_test.py"]
-testpaths    = ["."]
 
 [tool.hatch.build.targets.wheel]
 packages = ["smoke"]

--- a/py/tox.ini
+++ b/py/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py310, py311, py312, py313
+isolated_build = True
+skipsdist = True # We install editable, so don't build sdist.
+
+[testenv]
+description = Run tests with pytest
+deps =
+    pytest
+    pytest-cov
+    pytest-asyncio
+    pytest-mock
+    PyYAML
+    -e .
+commands =
+    pytest {posargs}

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -401,6 +401,15 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1019,10 +1028,14 @@ version = "0.1.0"
 source = { editable = "plugins/chroma" }
 dependencies = [
     { name = "genkit" },
+    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "genkit", editable = "packages/genkit" }]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
+]
 
 [[package]]
 name = "genkit-plugin-compat-oai"
@@ -1031,12 +1044,14 @@ source = { editable = "plugins/compat-oai" }
 dependencies = [
     { name = "genkit" },
     { name = "openai" },
+    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
     { name = "openai" },
+    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
 ]
 
 [[package]]
@@ -1047,6 +1062,7 @@ dependencies = [
     { name = "genkit" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
+    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
@@ -1054,6 +1070,7 @@ requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
+    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
 ]
 
 [[package]]
@@ -1063,12 +1080,14 @@ source = { editable = "plugins/firebase" }
 dependencies = [
     { name = "genkit" },
     { name = "google-cloud-firestore" },
+    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
     { name = "google-cloud-firestore" },
+    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
 ]
 
 [[package]]
@@ -1098,12 +1117,14 @@ source = { editable = "plugins/google-ai" }
 dependencies = [
     { name = "genkit" },
     { name = "google-genai" },
+    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
     { name = "google-genai", specifier = ">=1.7.0" },
+    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
 ]
 
 [[package]]
@@ -1112,10 +1133,14 @@ version = "0.3.0.dev1"
 source = { editable = "plugins/google-cloud" }
 dependencies = [
     { name = "genkit" },
+    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "genkit", editable = "packages/genkit" }]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
+]
 
 [[package]]
 name = "genkit-plugin-google-genai"
@@ -1125,6 +1150,7 @@ dependencies = [
     { name = "genkit" },
     { name = "google-cloud-aiplatform" },
     { name = "google-genai" },
+    { name = "strenum", marker = "python_full_version < '3.11'" },
     { name = "structlog" },
 ]
 
@@ -1133,6 +1159,7 @@ requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
     { name = "google-cloud-aiplatform", specifier = ">=1.77.0" },
     { name = "google-genai", specifier = ">=1.7.0" },
+    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
     { name = "structlog", specifier = ">=25.2.0" },
 ]
 
@@ -1159,10 +1186,14 @@ version = "0.1.0"
 source = { editable = "plugins/pinecone" }
 dependencies = [
     { name = "genkit" },
+    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "genkit", editable = "packages/genkit" }]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
+]
 
 [[package]]
 name = "genkit-plugin-vertex-ai"
@@ -1172,6 +1203,7 @@ dependencies = [
     { name = "genkit" },
     { name = "google-cloud-aiplatform" },
     { name = "pytest-mock" },
+    { name = "strenum", marker = "python_full_version < '3.11'" },
     { name = "structlog" },
 ]
 
@@ -1180,6 +1212,7 @@ requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
     { name = "google-cloud-aiplatform", specifier = ">=1.77.0" },
     { name = "pytest-mock" },
+    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
     { name = "structlog", specifier = ">=25.2.0" },
 ]
 
@@ -1200,6 +1233,7 @@ dependencies = [
     { name = "genkit-plugin-pinecone" },
     { name = "genkit-plugin-vertex-ai" },
     { name = "liccheck" },
+    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -1217,6 +1251,8 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-watcher" },
+    { name = "tox" },
+    { name = "tox-uv" },
     { name = "twine" },
 ]
 lint = [
@@ -1238,6 +1274,7 @@ requires-dist = [
     { name = "genkit-plugin-pinecone", editable = "plugins/pinecone" },
     { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "liccheck", specifier = ">=0.9.2" },
+    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
 ]
 
 [package.metadata.requires-dev]
@@ -1255,6 +1292,8 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-watcher", specifier = ">=0.4.3" },
+    { name = "tox", specifier = ">=4.25.0" },
+    { name = "tox-uv", specifier = ">=1.25.0" },
     { name = "twine", specifier = ">=6.1.0" },
 ]
 lint = [
@@ -3659,6 +3698,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyproject-api"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/66/fdc17e94486836eda4ba7113c0db9ac7e2f4eea1b968ee09de2fe75e391b/pyproject_api-1.9.0.tar.gz", hash = "sha256:7e8a9854b2dfb49454fae421cb86af43efbb2b2454e5646ffb7623540321ae6e", size = 22714 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/1d/92b7c765df46f454889d9610292b0ccab15362be3119b9a624458455e8d5/pyproject_api-1.9.0-py3-none-any.whl", hash = "sha256:326df9d68dea22d9d98b5243c46e3ca3161b07a1b9b18e213d1e24fd0e605766", size = 13131 },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -4476,6 +4528,42 @@ wheels = [
 ]
 
 [[package]]
+name = "tox"
+version = "4.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "chardet" },
+    { name = "colorama" },
+    { name = "filelock" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "pluggy" },
+    { name = "pyproject-api" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/87/692478f0a194f1cad64803692642bd88c12c5b64eee16bf178e4a32e979c/tox-4.25.0.tar.gz", hash = "sha256:dd67f030317b80722cf52b246ff42aafd3ed27ddf331c415612d084304cf5e52", size = 196255 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/38/33348de6fc4b1afb3d76d8485c8aecbdabcfb3af8da53d40c792332e2b37/tox-4.25.0-py3-none-any.whl", hash = "sha256:4dfdc7ba2cc6fdc6688dde1b21e7b46ff6c41795fb54586c91a3533317b5255c", size = 172420 },
+]
+
+[[package]]
+name = "tox-uv"
+version = "1.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tox" },
+    { name = "uv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/3a/3e445f25978a716ba6674f33f687d9336d0312086a277a778a5e9e9220d7/tox_uv-1.25.0.tar.gz", hash = "sha256:59ee5e694c41fef7bbcf058f22a5f9b6a8509698def2ea60c08554f4e36b9fcc", size = 21114 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/a7/f5c29e0e6faaccefcab607f672b176927144e9412c8183d21301ea2a6f6c/tox_uv-1.25.0-py3-none-any.whl", hash = "sha256:50cfe7795dcd49b2160d7d65b5ece8717f38cfedc242c852a40ec0a71e159bf7", size = 16431 },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4571,6 +4659,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+]
+
+[[package]]
+name = "uv"
+version = "0.6.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/d1/b31059e582f8a92f64a4c98e9684840a83048d3547392d9b14186d98c557/uv-0.6.12.tar.gz", hash = "sha256:b6f67fb3458b2c856152b54b54102f0f3b82cfd18fddbbc38b59ff7fa87e5291", size = 3117528 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/70/38f27bdd68f7e187125c6f5bf2aa653d844c9baacb4be07410470b8b4d18/uv-0.6.12-py3-none-linux_armv6l.whl", hash = "sha256:cddc4ffb7c5337efe7584d3654875db6812175326100fa8a2b5f5af0b90f6482", size = 16011234 },
+    { url = "https://files.pythonhosted.org/packages/3e/f1/0fffa9c63fbf0e54746109fc94c77c09dd805c3f10605715f00a2e6b8fcc/uv-0.6.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c048a48df0fb7cc905a4a9f727179d0c65661d61b850afa3a5d413d81dac3d4", size = 16122250 },
+    { url = "https://files.pythonhosted.org/packages/54/08/b8369dfade56724ce42df1254d7e483d75cdbc535feff60ac9fa2d6672fa/uv-0.6.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:829999121373dd00990abf35b59da3214977d935021027ae338dd55a7f30daa4", size = 14944312 },
+    { url = "https://files.pythonhosted.org/packages/e4/4e/7ff41d3b4b3d6c19276b4f7dd703a7581404fdeabb31756082eb356b72a9/uv-0.6.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:ba1348123de4fdddc9fd75007e42ddc4bf0a213e62fe3d278d7ce98c27da144e", size = 15399035 },
+    { url = "https://files.pythonhosted.org/packages/e7/1e/879f09d579e1610cddab2a3908ab9c4aaccd0026a1f984c7aabbb0ccbe6e/uv-0.6.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72ea6424d54b44a21e63e126d11e86c5102e4840cf93c7af712cc2ff23d66e9b", size = 15673445 },
+    { url = "https://files.pythonhosted.org/packages/4b/56/22c94b9637770c9851f376886c4b062091858719f64b832c3b7427ef3c91/uv-0.6.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32f2123d3a828857d9757d8bb92c8c4b436f8a420d78364cd6b4bb256f27d8d4", size = 16400873 },
+    { url = "https://files.pythonhosted.org/packages/8e/9b/f41b99e547f7d5c2771bb6b28d40d6d97164aaffdf8bda5b132853a81007/uv-0.6.12-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:27bade3c1fbcd8ca97fad1846693d79d0cd2c7c1a5b752929eae53b78acfacb7", size = 17341617 },
+    { url = "https://files.pythonhosted.org/packages/d7/07/2e04fb798f157e536c5a4ab7fe4107e0e82d09d5250c370604793b69cb23/uv-0.6.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9719c163c89c66afa6fd9f82bc965a02ac4d048908f67ebc2a5384de2d8a5205", size = 17098181 },
+    { url = "https://files.pythonhosted.org/packages/c8/f2/91a2e20f55a146bcb4efbdddd5b073137660eb5b22b0b54bbd00fe0256a7/uv-0.6.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5e26dd9aa9b52acf8cec4cca50b0158733f8d94e2a23b6d2910d09162ccfa4d8", size = 21278391 },
+    { url = "https://files.pythonhosted.org/packages/bc/86/710fd8fa0186539fac8962ecd5cb738e6e93452877c1fbfdf5ea5bfc32da/uv-0.6.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6932436148b8c300aa143e1c38b2711ad1ec27ef22bf61036baf6257d8026250", size = 16762542 },
+    { url = "https://files.pythonhosted.org/packages/bb/7f/e11acbbd863ffad2edefdfb57e3cc8e6ab147994f11893ec734eb24aa959/uv-0.6.12-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:15d747d024a93eb5bc9186a601e97c853b9600e522219a7651b4b2041fa6de72", size = 15647309 },
+    { url = "https://files.pythonhosted.org/packages/92/d7/034962db8bac194d97c91a1a761205f8bbfbfe0f4a3bbc05e19394e5a1ac/uv-0.6.12-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:4288d00e346fe82847d90335fb812ba5dd27cae6a4d1fcb7f14c8a9eefd46a1d", size = 15705972 },
+    { url = "https://files.pythonhosted.org/packages/cc/66/55fe8e114460037736a89df83f7d19ac4d6f761c8634f0d362c5a397d571/uv-0.6.12-py3-none-musllinux_1_1_i686.whl", hash = "sha256:98e0dfcd102d1630681eb73f03e1b307e0487a2e714f22adf6bea3d7bd83d40b", size = 16016347 },
+    { url = "https://files.pythonhosted.org/packages/37/7e/f1c95f34de2016d3dba40aad32f15efe21915f128aa7d4f455e0251227e6/uv-0.6.12-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:78f44b83fe4b0e1c747cd5a9d04532e9e4558b63658a7784539a429dbb189160", size = 16902438 },
+    { url = "https://files.pythonhosted.org/packages/aa/4a/a355d564a80d18e43a66b9317ff3348986da9621ec2967dbca279c33de08/uv-0.6.12-py3-none-win32.whl", hash = "sha256:28d207fc832909e19b08cbc6d00b849b3951b358d67926cb1b355467d10dace4", size = 16136117 },
+    { url = "https://files.pythonhosted.org/packages/65/3a/62ac4182edaf27006a4e7d01a058595b871f226f760204fd765f34610415/uv-0.6.12-py3-none-win_amd64.whl", hash = "sha256:2af26986a94a91cad1805d59e76f529c57dcbb69b37f51e329754c254b90ace2", size = 17582809 },
+    { url = "https://files.pythonhosted.org/packages/9f/d5/26b7b5eaa766e7927dca40777aa20c7f685c3ed7aa0bd9fe8f89af46cc8d/uv-0.6.12-py3-none-win_arm64.whl", hash = "sha256:3a016661589c422413acdf2c238cd461570b3cde77a690cbd37205dc21fc1c09", size = 16319209 },
 ]
 
 [[package]]


### PR DESCRIPTION
| Test Runner | Parallel Tests | Isolated Environments | UV support |
|-------------|----------------|-----------------------|------------|
| tox         | [x]            | [x]                   | [x]        |
| nox         | [ ]            | [x]                   | [x]        |

```
zsh❯ py/bin/run_python_tests_with_tox
Running Python tests via tox...
py310: OK ✔ in 7.45 seconds
py311: OK ✔ in 7.63 seconds
py313: OK ✔ in 7.86 seconds
  py310: OK (7.45=setup[0.01]+cmd[0.63,6.82] seconds)
  py311: OK (7.63=setup[0.01]+cmd[0.62,7.00] seconds)
  py312: OK (8.19=setup[0.01]+cmd[0.62,7.55] seconds)
  py313: OK (7.86=setup[0.01]+cmd[0.62,7.22] seconds)
  congratulations :) (8.24 seconds)
```

CHANGELOG:
- [ ] Update `noxfile.py` to ensure the environment and the python
  runtime version matches.
- [ ] Also checking out tox for isolated and parallelized tests.
- [ ] Fix some more 3.10 incompatibilities.
