### PR TITLE
fix(py): use the runtime specified by nox with pytest

### DIFF
--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -32,6 +32,8 @@ def tests(session: nox.Session):
     session.run(
         'uv',
         'run',
+        '--python',
+        f'python{session.python}',
         '--active',
         'pytest',
         # '-v', # Adding verbosity drops coverage for some reason...


### PR DESCRIPTION
CHANGELOG:
- [ ] Use the runtime specified by nox with pytest in `noxfile.py`
