### PR TITLE
fix(py): make `py/bin/run_python_tests_with_tox` parallel in hooks and serial in term to see logs

### DIFF
--- a/captainhook.json
+++ b/captainhook.json
@@ -40,7 +40,7 @@
           "run": "bin/fmt"
         },
         {
-          "run": "py/bin/run_python_tests_with_tox"
+          "run": "py/bin/run_python_tests_with_tox p"
         },
         {
           "run": "echo 'disabled' || uv run --directory py mkdocs build"
@@ -80,7 +80,7 @@
           "run": "bin/fmt"
         },
         {
-          "run": "py/bin/run_python_tests_with_tox"
+          "run": "py/bin/run_python_tests_with_tox p"
         },
         {
           "run": "echo 'disabled' || uv run --directory py mkdocs build"

--- a/py/bin/run_python_tests_with_tox
+++ b/py/bin/run_python_tests_with_tox
@@ -27,4 +27,4 @@ echo "Running Python tests via tox..."
 # Use uv run to execute tox, passing the --parallel flag to tox
 # The '-p auto' flag tells tox to use available CPU cores for parallelism.
 # Any arguments passed to this script ($@) are forwarded to tox (and then pytest)
-uv run --directory "$PY_DIR" tox --parallel auto "$@"
+uv run --directory "$PY_DIR" tox "$@"


### PR DESCRIPTION
CHANGELOG:
- [ ] `py/bin/run_python_tests_with_tox` is now just a wrapper over tox
  allowing the user to choose the mode of execution.
