### PR TITLE
refactor(py/genkit): move python 3.10 compatibility asyncio.wait_for implementation into _compat.py

### DIFF
--- a/py/packages/genkit/src/genkit/aio/_compat.py
+++ b/py/packages/genkit/src/genkit/aio/_compat.py
@@ -1,0 +1,62 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility layer for asyncio.
+
+This module provides a compatibility layer for asyncio.
+
+The asyncio.wait_for function was changed in Python 3.11 to raise a TimeoutError
+instead of an asyncio.TimeoutError. This module provides a compatibility layer
+for this change among others.
+
+See: https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for
+"""
+
+import asyncio
+import sys
+from typing import TypeVar
+
+T = TypeVar('T')
+
+
+async def wait_for_310(fut: asyncio.Future[T], timeout: float | None = None) -> T:
+    """Wait for a future to complete.
+
+    This is a compatibility layer for asyncio.wait_for that raises a TimeoutError
+    instead of an asyncio.TimeoutError.
+
+    This is necessary because the behavior of asyncio.wait_for changed in Python
+    3.11.
+
+    See: https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for
+
+    Args:
+        fut: The future to wait for.
+        timeout: The timeout in seconds.
+
+    Returns:
+        The result of the future.
+    """
+    try:
+        return await asyncio.wait_for(fut, timeout)
+    except asyncio.TimeoutError as e:
+        raise TimeoutError() from e
+
+
+if sys.version_info < (3, 11):
+    wait_for = wait_for_310
+else:
+    wait_for = asyncio.wait_for

--- a/py/packages/genkit/src/genkit/aio/channel.py
+++ b/py/packages/genkit/src/genkit/aio/channel.py
@@ -22,6 +22,8 @@ import asyncio
 from collections.abc import AsyncIterator
 from typing import Generic, TypeVar
 
+from ._compat import wait_for
+
 T = TypeVar('T')
 
 
@@ -111,10 +113,7 @@ class Channel(Generic[T]):
             # Wait for the pop task with a timeout, raise TimeoutError if a
             # timeout is specified and is exceeded and automatically cancel the
             # pending task.
-            try:
-                return await asyncio.wait_for(pop_task, timeout=self._timeout)
-            except asyncio.TimeoutError as e:
-                raise TimeoutError() from e
+            return await wait_for(pop_task, timeout=self._timeout)
 
         try:
             # Wait for either the pop task or the close future to complete.  A
@@ -148,10 +147,7 @@ class Channel(Generic[T]):
         # Wait for the pop task with a timeout, raise TimeoutError if a timeout
         # is specified and is exceeded and automatically cancel the pending
         # task.
-        try:
-            return await asyncio.wait_for(pop_task, timeout=self._timeout)
-        except asyncio.TimeoutError as e:
-            raise TimeoutError() from e
+        return await wait_for(pop_task, timeout=self._timeout)
 
     def send(self, value: T) -> None:
         """Sends a value into the channel.


### PR DESCRIPTION
refactor(py/genkit): move python 3.10 compatibility asyncio.wait_for implementation into _compat.py
    
CHANGELOG:
- [ ] Prevent duplication for the exception handling at callsite.