### PR TITLE
fix(py/samples/hello): fix hello sample; dont use a* or _async suffix for public functions

### DIFF
--- a/py/docs/get-started.md
+++ b/py/docs/get-started.md
@@ -102,7 +102,7 @@ This guide shows you how to get started with Genkit in a Python app.
     async def main() -> None:
         print(json.dumps(await generate_character('Goblorb'), indent=2))
 
-    ai.run_async(main())
+    ai.run(main())
    ```
 
 6. Run your app. Genkit apps are just regular python application. Run them

--- a/py/packages/genkit/src/genkit/ai/aio.py
+++ b/py/packages/genkit/src/genkit/ai/aio.py
@@ -51,7 +51,7 @@ from genkit.types import (
     ToolChoice,
 )
 
-from .base import GenkitBase
+from ._base_sync import GenkitBase
 
 
 class Genkit(GenkitBase):

--- a/py/packages/genkit/src/genkit/aio/loop.py
+++ b/py/packages/genkit/src/genkit/aio/loop.py
@@ -41,7 +41,7 @@ def create_loop():
         return asyncio.new_event_loop()
 
 
-def run_async(loop: asyncio.AbstractEventLoop, fn: Callable):
+def run_async(loop: asyncio.AbstractEventLoop, fn: Callable) -> Any:
     """Runs an async callable on the given event loop and blocks until completion.
 
     If the loop is already running (e.g., called from within an async context),
@@ -61,8 +61,8 @@ def run_async(loop: asyncio.AbstractEventLoop, fn: Callable):
         Any exception raised by the callable `fn`.
     """
     if loop.is_running():
-        output = None
-        error = None
+        output: Any = None
+        error: Exception | None = None
         lock = threading.Lock()
         lock.acquire()
 

--- a/py/samples/firestore-retreiver/src/main.py
+++ b/py/samples/firestore-retreiver/src/main.py
@@ -120,4 +120,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    ai.run_async(main())
+    ai.run(main())

--- a/py/samples/google-genai-hello/src/google_genai_hello.py
+++ b/py/samples/google-genai-hello/src/google_genai_hello.py
@@ -320,9 +320,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    asyncio.run(main())
-
-
-# prevent app from exiting when genkit is running in dev mode
-# TODO: Clean this up.
-ai.join()
+    ai.run(main())

--- a/py/samples/google-genai-image/src/google_genai_image.py
+++ b/py/samples/google-genai-image/src/google_genai_image.py
@@ -90,6 +90,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    asyncio.run(main())
-
-ai.join()
+    ai.run(main())

--- a/py/samples/google-genai-vertexai-hello/src/google_genai_vertexai_hello.py
+++ b/py/samples/google-genai-vertexai-hello/src/google_genai_vertexai_hello.py
@@ -299,9 +299,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    asyncio.run(main())
-
-
-# prevent app from exiting when genkit is running in dev mode
-# TODO: Clean this up.
-ai.join()
+    ai.run(main())

--- a/py/samples/hello/src/hello.py
+++ b/py/samples/hello/src/hello.py
@@ -99,7 +99,7 @@ async def embed_docs(docs: list[str]):
     """
     options = {'task': EmbeddingsTaskType.CLUSTERING}
     return await ai.embed(
-        model=vertexai_name(EmbeddingModels.TEXT_EMBEDDING_004_ENG),
+        embedder=vertexai_name(EmbeddingModels.TEXT_EMBEDDING_004_ENG),
         documents=[Document.from_text(doc) for doc in docs],
         options=options,
     )
@@ -180,17 +180,6 @@ async def streaming_async_flow(inp: str, ctx: ActionRunContext):
     ctx.send_chunk({'chunk': 'blah'})
     ctx.send_chunk(3)
     return 'streamingAsyncFlow 4'
-
-
-async def main() -> None:
-    """Main entry point for the hello sample.
-
-    This function demonstrates the usage of the AI flow by generating
-    greetings and performing simple arithmetic operations.
-    """
-    await logger.ainfo(await say_hi('John Doe'))
-    await logger.ainfo(sum_two_numbers2(MyInput(a=1, b=3)))
-    await logger.ainfo(await embed_docs(['banana muffins? ', 'banana bread? banana muffins?']))
 
 
 def my_model(request: GenerateRequest, ctx: ActionRunContext):
@@ -389,5 +378,16 @@ async def async_streamy_throwy(inp: str, ctx: ActionRunContext):
     ctx.send_chunk(3)
 
 
-# prevent app from exiting when genkit is running in dev mode
-ai.join()
+async def main() -> None:
+    """Main entry point for the hello sample.
+
+    This function demonstrates the usage of the AI flow by generating
+    greetings and performing simple arithmetic operations.
+    """
+    await logger.ainfo(await say_hi('John Doe'))
+    await logger.ainfo(sum_two_numbers2(MyInput(a=1, b=3)))
+    await logger.ainfo(await embed_docs(['banana muffins? ', 'banana bread? banana muffins?']))
+
+
+if __name__ == '__main__':
+    ai.run(main())

--- a/py/samples/ollama-hello/src/ollama_hello.py
+++ b/py/samples/ollama-hello/src/ollama_hello.py
@@ -200,4 +200,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    ai.run_async(main())
+    ai.run(main())


### PR DESCRIPTION
CHANGELOG:
- [ ] update ai.run_async -> ai.run. ai.run_async is still available so
  docs will not break, but deprecated.
- [ ] Move base.py to _base_sync.py for later.
- [ ] Fix types and return types for the `run` method.
- [ ] Fix hello sample to use `embedder` arg rather than `model`.
- [ ] Update all samples that use `run_async`.
