### PR TITLE
fix(py/genkit): use ai.run instead of ai.run_async

### DIFF
--- a/py/packages/genkit/src/genkit/ai/_aio.py
+++ b/py/packages/genkit/src/genkit/ai/_aio.py
@@ -49,7 +49,7 @@ from genkit.types import (
     ToolChoice,
 )
 
-from ._base_sync import GenkitBase
+from ._base import GenkitBase
 from ._plugin import Plugin
 from ._server import ServerSpec
 

--- a/py/packages/genkit/src/genkit/ai/_base.py
+++ b/py/packages/genkit/src/genkit/ai/_base.py
@@ -58,22 +58,6 @@ class GenkitBase(GenkitRegistry):
         self._initialize_server(reflection_server_spec)
         self._initialize_registry(model, plugins)
 
-    # NOTE: Since we decided that Genkit classes should be bifurcated into sync
-    # and async variants, we will remove this method. For now, keeping it here
-    # so that documentation is not broken.
-    def run_async(self, coro: Coroutine[Any, Any, Any]) -> Any:
-        """Runs the provided coroutine on an event loop.
-
-        Deprecated: Use `run(coro)` instead.
-
-        Args:
-            coro: The coroutine to run.
-
-        Returns:
-            The result of the coroutine.
-        """
-        return self.run(coro)
-
     def run(self, coro: Coroutine[Any, Any, Any]) -> Any:
         """Runs the provided coroutine on an event loop.
 


### PR DESCRIPTION
Public APIs are forever. This is the best time to fix this.

Since we decided that Genkit classes should be bifurcated into sync
and async variants, removing this wrapper `ai.run_async`. 
The equivalent functionality is in `ai.run`. The method on the sync
instance should be called the same.