### PR TITLE
fix(go/py/tooling): More small fixes related to evals

### DIFF
--- a/genkit-tools/common/src/eval/validate.ts
+++ b/genkit-tools/common/src/eval/validate.ts
@@ -29,8 +29,6 @@ import { getModelInput } from '../utils';
 
 // Setup for AJV
 type JSONSchema = JSONSchemaType<any> | any;
-const ajv = new Ajv();
-addFormats(ajv);
 
 /**
  * Validate given data against a target action. Intended to be used via the
@@ -110,6 +108,9 @@ function validate(
   } else {
     input = data;
   }
+
+  const ajv = new Ajv();
+  addFormats(ajv);
   const validator = ajv.compile(jsonSchema);
   const valid = validator(input) as boolean;
   const errors = validator.errors?.map((e) => e);

--- a/py/packages/genkit/src/genkit/ai/_registry.py
+++ b/py/packages/genkit/src/genkit/ai/_registry.py
@@ -322,7 +322,7 @@ class GenkitRegistry:
             for index in range(len(req.dataset)):
                 datapoint = req.dataset[index]
                 if datapoint.test_case_id is None:
-                    datapoint.test_case_id = uuid.uuid4()
+                    datapoint.test_case_id = str(uuid.uuid4())
                 span_metadata = SpanMetadata(
                     name=f'Test Case {datapoint.test_case_id}',
                     metadata={'evaluator:evalRunId': req.eval_run_id},


### PR DESCRIPTION
- `evaluate.ts` -- go returns the new format of responses, updated error collection logic in evals tooling
-  `validate.ts` -- go sets IDs for schemas which are cached in ajv, causing problems for subsequent calls due to the global `ajv` object, made it local instead.
- `_registry.py` -- made uuid string, like it should be.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually)
