### PR TITLE
refactor(py): renamed `ai.run` to `ai.run_main` to avoid confusion with `ai.run` in JS

### DIFF
--- a/py/docs/get-started.md
+++ b/py/docs/get-started.md
@@ -102,7 +102,7 @@ This guide shows you how to get started with Genkit in a Python app.
     async def main() -> None:
         print(json.dumps(await generate_character('Goblorb'), indent=2))
 
-    ai.run(main())
+    ai.run_main(main())
    ```
 
 6. Run your app. Genkit apps are just regular python application. Run them

--- a/py/docs/index.md
+++ b/py/docs/index.md
@@ -69,7 +69,7 @@ See the following code samples for a concrete idea of how to use these capabilit
         async for chunk in stream:
             print(chunk.text)
 
-    asyncio.run(main())
+    ai.run_main(main())
     ```
 
 === "Structured output"
@@ -100,7 +100,7 @@ See the following code samples for a concrete idea of how to use these capabilit
         )
         print(json.dumps(result.output))
 
-    asyncio.run(main())
+    ai.run_main(main())
     ```
 
 === "Tool calling"
@@ -131,7 +131,7 @@ See the following code samples for a concrete idea of how to use these capabilit
         )
         print(result.text)
 
-    asyncio.run(main())
+    ai.run_main(main())
     ```
 
 ## Development tools

--- a/py/docs/reference/models.md
+++ b/py/docs/reference/models.md
@@ -73,7 +73,7 @@ async def main() -> None:
     )
     print(result.text)
 
-asyncio.run(main())
+ai.run_main(main())
 ```
 
 When you run this brief example it will print out the output of the `generate()`

--- a/py/docs/reference/rag.md
+++ b/py/docs/reference/rag.md
@@ -110,7 +110,7 @@ async def qa_flow(query: str):
 #### Run the retriever flow
 
 ```python
-result = ai.run(qa_flow('Recommend a dessert from the menu while avoiding dairy and nuts'))
+result = await qa_flow('Recommend a dessert from the menu while avoiding dairy and nuts')
 print(result)
 ```
 

--- a/py/packages/genkit/src/genkit/ai/_base.py
+++ b/py/packages/genkit/src/genkit/ai/_base.py
@@ -58,7 +58,7 @@ class GenkitBase(GenkitRegistry):
         self._initialize_server(reflection_server_spec)
         self._initialize_registry(model, plugins)
 
-    def run(self, coro: Coroutine[Any, Any, Any] | None = None) -> Any:
+    def run_main(self, coro: Coroutine[Any, Any, Any] | None = None) -> Any:
         """Runs the provided coroutine on an event loop.
 
         Args:

--- a/py/samples/compat-oai-hello/src/compat_oai_hello.py
+++ b/py/samples/compat-oai-hello/src/compat_oai_hello.py
@@ -173,4 +173,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    ai.run(main())
+    ai.run_main(main())

--- a/py/samples/dev-local-vectorstore-hello/src/hello.py
+++ b/py/samples/dev-local-vectorstore-hello/src/hello.py
@@ -61,4 +61,4 @@ async def retreive_documents():
     )
 
 
-ai.run()
+ai.run_main()

--- a/py/samples/firestore-retreiver/src/main.py
+++ b/py/samples/firestore-retreiver/src/main.py
@@ -110,4 +110,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    ai.run(main())
+    ai.run_main(main())

--- a/py/samples/google-genai-hello/src/google_genai_hello.py
+++ b/py/samples/google-genai-hello/src/google_genai_hello.py
@@ -320,4 +320,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    ai.run(main())
+    ai.run_main(main())

--- a/py/samples/google-genai-image/src/google_genai_image.py
+++ b/py/samples/google-genai-image/src/google_genai_image.py
@@ -90,4 +90,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    ai.run(main())
+    ai.run_main(main())

--- a/py/samples/google-genai-vertexai-hello/src/google_genai_vertexai_hello.py
+++ b/py/samples/google-genai-vertexai-hello/src/google_genai_vertexai_hello.py
@@ -299,4 +299,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    ai.run(main())
+    ai.run_main(main())

--- a/py/samples/ollama-hello/src/ollama_hello.py
+++ b/py/samples/ollama-hello/src/ollama_hello.py
@@ -200,4 +200,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    ai.run(main())
+    ai.run_main(main())


### PR DESCRIPTION
in Genkit JS we also have `ai.run`, but it's for a different purpose: https://js.api.genkit.dev/classes/genkit._.Genkit.html#run

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
