### PR TITLE
Expose newest Image 3 model

### DIFF
--- a/js/plugins/vertexai/src/imagen.ts
+++ b/js/plugins/vertexai/src/imagen.ts
@@ -182,7 +182,7 @@ export const imagen3 = modelRef({
   name: 'vertexai/imagen3',
   info: {
     label: 'Vertex AI - Imagen3',
-    versions: ['imagen-3.0-generate-001'],
+    versions: ['imagen-3.0-generate-002, imagen-3.0-generate-001'],
     supports: {
       media: true,
       multiturn: false,
@@ -191,7 +191,7 @@ export const imagen3 = modelRef({
       output: ['media'],
     },
   },
-  version: 'imagen-3.0-generate-001',
+  version: 'imagen-3.0-generate-002',
   configSchema: ImagenConfigSchema,
 });
 


### PR DESCRIPTION
Expose the newest Imagen 3 model version: imagen-3.0-generate-002

https://cloud.google.com/vertex-ai/generative-ai/docs/image/model-versioning
