### PR TITLE
chore: update model config parameters

### DIFF
--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -187,6 +187,22 @@ export const ToolDefinitionSchema = z.object({
 export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;
 
 /**
+ * Configuration parameter descriptions.
+ */
+export const GenerationCommonConfigDescriptions = {
+  temperature:
+    'Controls the degree of randomness in token selection. A lower value is ' +
+    'good for a more predictable response. A higher value leads to more ' +
+    'diverse or unexpected results.',
+  maxOutputTokens: 'The maximum number of tokens to include in the response.',
+  topK: 'The maximum number of tokens to consider when sampling.',
+  topP:
+    'Decides how many possible words to consider. A higher value means ' +
+    'that the model looks at more possible words, even the less likely ' +
+    'ones, which makes the generated text more diverse.',
+};
+
+/**
  * Zod schema of a common config object.
  */
 export const GenerationCommonConfigSchema = z.object({
@@ -199,28 +215,14 @@ export const GenerationCommonConfigSchema = z.object({
     .optional(),
   temperature: z
     .number()
-    .describe(
-      'Controls the degree of randomness in token selection. A lower value is ' +
-        'good for a more predictable response. A higher value leads to more ' +
-        'diverse or unexpected results.'
-    )
+    .describe(GenerationCommonConfigDescriptions.temperature)
     .optional(),
   maxOutputTokens: z
     .number()
-    .describe('The maximum number of tokens to include in the response.')
+    .describe(GenerationCommonConfigDescriptions.maxOutputTokens)
     .optional(),
-  topK: z
-    .number()
-    .describe('The maximum number of tokens to consider when sampling.')
-    .optional(),
-  topP: z
-    .number()
-    .describe(
-      'Decides how many possible words to consider. A higher value means ' +
-        'that the model looks at more possible words, even the less likely ' +
-        'ones, which makes the generated text more diverse.'
-    )
-    .optional(),
+  topK: z.number().describe(GenerationCommonConfigDescriptions.topK).optional(),
+  topP: z.number().describe(GenerationCommonConfigDescriptions.topP).optional(),
   stopSequences: z
     .array(z.string())
     .length(5)

--- a/js/genkit/src/model.ts
+++ b/js/genkit/src/model.ts
@@ -22,6 +22,7 @@ export {
   GenerateRequestSchema,
   GenerateResponseChunkSchema,
   GenerateResponseSchema,
+  GenerationCommonConfigDescriptions,
   GenerationCommonConfigSchema,
   GenerationUsageSchema,
   MediaPartSchema,

--- a/js/plugins/ollama/src/index.ts
+++ b/js/plugins/ollama/src/index.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { Genkit, ToolRequest, ToolRequestPart, ToolResponse } from 'genkit';
+import { Genkit, ToolRequest, ToolRequestPart, ToolResponse, z } from 'genkit';
 import { logger } from 'genkit/logging';
 import {
   GenerateRequest,
   GenerateResponseData,
+  GenerationCommonConfigDescriptions,
   GenerationCommonConfigSchema,
   MessageData,
   ToolDefinition,
@@ -59,6 +60,38 @@ export function ollama(params: OllamaPluginParams): GenkitPlugin {
   });
 }
 
+/**
+ * Please refer to: https://github.com/ollama/ollama/blob/main/docs/modelfile.md
+ * for further information.
+ */
+export const OllamaConfigSchema = GenerationCommonConfigSchema.extend({
+  temperature: z
+    .number()
+    .min(0.0)
+    .max(1.0)
+    .describe(
+      GenerationCommonConfigDescriptions.temperature +
+        ' The default value is 0.8.'
+    )
+    .optional(),
+  topK: z
+    .number()
+    .min(1)
+    .max(40)
+    .describe(
+      GenerationCommonConfigDescriptions.topK + ' The default value is 40.'
+    )
+    .optional(),
+  topP: z
+    .number()
+    .min(0)
+    .max(1.0)
+    .describe(
+      GenerationCommonConfigDescriptions.topP + ' The default value is 0.9.'
+    )
+    .optional(),
+});
+
 function ollamaModel(
   ai: Genkit,
   model: ModelDefinition,
@@ -69,7 +102,7 @@ function ollamaModel(
     {
       name: `ollama/${model.name}`,
       label: `Ollama - ${model.name}`,
-      configSchema: GenerationCommonConfigSchema,
+      configSchema: OllamaConfigSchema,
       supports: {
         multiturn: !model.type || model.type === 'chat',
         systemRole: true,

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -42,6 +42,7 @@ import {
 import {
   CandidateData,
   GenerateRequest,
+  GenerationCommonConfigDescriptions,
   GenerationCommonConfigSchema,
   MediaPart,
   MessageData,
@@ -60,6 +61,7 @@ import {
 } from 'genkit/model/middleware';
 import { runInNewSpan } from 'genkit/tracing';
 import { GoogleAuth } from 'google-auth-library';
+
 import { PluginOptions } from './common/types.js';
 import { handleCacheIfNeeded } from './context-caching/index.js';
 import { extractCacheConfig } from './context-caching/utils.js';
@@ -108,8 +110,40 @@ const GoogleSearchRetrievalSchema = z.object({
 
 /**
  * Zod schema of Gemini model options.
+ * Please refer to: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/medlm, for further information.
  */
 export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
+  maxOutputTokens: z
+    .number()
+    .min(1)
+    .max(8192)
+    .describe(GenerationCommonConfigDescriptions.maxOutputTokens)
+    .optional(),
+  temperature: z
+    .number()
+    .min(0.0)
+    .max(1.0)
+    .describe(
+      GenerationCommonConfigDescriptions.temperature +
+        ' The default value is 0.2.'
+    )
+    .optional(),
+  topK: z
+    .number()
+    .min(1)
+    .max(40)
+    .describe(
+      GenerationCommonConfigDescriptions.topK + ' The default value is 40.'
+    )
+    .optional(),
+  topP: z
+    .number()
+    .min(0)
+    .max(1.0)
+    .describe(
+      GenerationCommonConfigDescriptions.topP + ' The default value is 0.8.'
+    )
+    .optional(),
   location: z
     .string()
     .describe('Google Cloud region e.g. us-central1.')

--- a/js/plugins/vertexai/src/modelgarden/mistral.ts
+++ b/js/plugins/vertexai/src/modelgarden/mistral.ts
@@ -42,7 +42,11 @@ import {
   ToolRequestPart,
   z,
 } from 'genkit';
-import { ModelAction, modelRef } from 'genkit/model';
+import {
+  GenerationCommonConfigDescriptions,
+  ModelAction,
+  modelRef,
+} from 'genkit/model';
 
 /**
  * See https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post
@@ -51,12 +55,12 @@ export const MistralConfigSchema = GenerationCommonConfigSchema.extend({
   // TODO: Update this with all the parameters in
   // https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post.
   location: z.string().optional(),
-  maxOutputTokens: z.number().optional(),
-  temperature: z.number().optional(),
-  //   TODO: is this supported?
-  //   topK: z.number().optional(),
-  topP: z.number().optional(),
-  stopSequences: z.array(z.string()).optional(),
+  topP: z
+    .number()
+    .describe(
+      GenerationCommonConfigDescriptions.topP + ' The default value is 1.'
+    )
+    .optional(),
 });
 
 export const mistralLarge = modelRef({


### PR DESCRIPTION
Here's the link to the issue: https://github.com/firebase/genkit/issues/2333. This updates the following plugins: `Ollama`, `vertexai/gemini` and `vertexai/mistral`.

I checked that I am getting the new values on the dev UI by logging out the configuration:

**Ollama:**
![image](https://github.com/user-attachments/assets/4dc5fc75-b397-42f1-abe9-ad50ad06d8d1)

**vertexai/gemini:**
![image](https://github.com/user-attachments/assets/bcbdd556-b3a6-4675-94de-7c67016c129a)

**vertexai/mistral:**
![image](https://github.com/user-attachments/assets/fc1dd363-f9ec-4c19-adb5-accc3d2edc2f)

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
