### PR TITLE
fix(py/genkit): logging and coding guidelines should specify python 3.10 as base version

### DIFF
--- a/py/engdoc/contributing/coding_guidelines.md
+++ b/py/engdoc/contributing/coding_guidelines.md
@@ -2,7 +2,7 @@
 
 This is for both bots and humans.
 
-Target: Python >= 3.12
+Target: Python >= 3.10
 
 ### Typing & Style
 

--- a/py/packages/genkit/src/genkit/ai/_base_async.py
+++ b/py/packages/genkit/src/genkit/ai/_base_async.py
@@ -150,10 +150,11 @@ class GenkitBase(GenkitRegistry):
                     async with anyio.create_task_group() as tg:
                         # Start reflection server in the background.
                         tg.start_soon(reflection_server.serve, name='genkit-reflection-server')
-                        logger.info(f'Started Genkit reflection server at {spec.url}')
+                        await logger.ainfo(f'Started Genkit reflection server at {spec.url}')
 
                         # Start the (potentially short-lived) user coroutine wrapper
                         tg.start_soon(run_user_coro_wrapper, name='genkit-user-coroutine')
+                        await logger.ainfo('Started Genkit user coroutine')
 
                         # Block here until the task group is canceled (e.g. Ctrl+C)
                         # or a task raises an unhandled exception. It should not
@@ -168,10 +169,10 @@ class GenkitBase(GenkitRegistry):
 
             # After the TaskGroup finishes (error or cancelation).
             if user_task_finished_event.is_set():
-                logger.debug('User coroutine finished before TaskGroup exit.')
+                await logger.adebug('User coroutine finished before TaskGroup exit.')
                 return user_result
             else:
-                logger.debug('User coroutine did not finish before TaskGroup exit.')
+                await logger.adebug('User coroutine did not finish before TaskGroup exit.')
                 return None
 
         return anyio.run(dev_runner)

--- a/py/packages/genkit/src/genkit/core/tracing.py
+++ b/py/packages/genkit/src/genkit/core/tracing.py
@@ -204,7 +204,9 @@ if is_dev_environment():
         )
         provider.add_span_processor(processor)
     else:
-        logger.warn('GENKIT_TELEMETRY_SERVER is not set. If running with `genkit start`, make sure `genkit-cli` is up to date.')
+        logger.warn(
+            'GENKIT_TELEMETRY_SERVER is not set. If running with `genkit start`, make sure `genkit-cli` is up to date.'
+        )
     # Sets the global default tracer provider
     trace_api.set_tracer_provider(provider)
     tracer = trace_api.get_tracer('genkit-tracer', 'v1', provider)


### PR DESCRIPTION
fix(py/genkit): logging and coding guidelines should specify python 3.10 as base version
    
CHANGELOG:
- [ ] Update coding guidelines to use Python 3.10 as minimum supported
  version.
- [ ] Fix some async logging.
- [ ] Some auto-formatting.