### PR TITLE
fix(js/ai): properly set prompt meta for variants

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -392,7 +392,7 @@ function definePromptAsync<
 }
 
 function promptMetadata(options: PromptConfig<any, any, any>) {
-  return {
+  const metadata = {
     ...options.metadata,
     prompt: {
       ...options.metadata?.prompt,
@@ -400,11 +400,19 @@ function promptMetadata(options: PromptConfig<any, any, any>) {
       input: {
         schema: options.input ? toJsonSchema(options.input) : undefined,
       },
-      name: `${options.name}${options.variant ? `.${options.variant}` : ''}`,
+      name: options.name.includes('.')
+        ? options.name.split('.')[0]
+        : options.name,
       model: modelName(options.model),
     },
     type: 'prompt',
   };
+
+  if (options.variant) {
+    metadata.prompt.variant = options.variant;
+  }
+
+  return metadata;
 }
 
 function wrapInExecutablePrompt<

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -15,11 +15,11 @@
  */
 
 import { ModelMiddleware, modelRef } from '@genkit-ai/ai/model';
+import { stripUndefinedProps } from '@genkit-ai/core';
 import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
-import { stripUndefinedProps } from '../../core/src';
-import { GenkitBeta, genkit } from '../src/beta';
-import { PromptAction, z } from '../src/index';
+import { GenkitBeta, genkit, z } from '../src/beta';
+import { PromptAction } from '../src/index';
 import {
   ProgrammableModel,
   defineEchoModel,
@@ -1182,15 +1182,15 @@ describe('prompt', () => {
         },
         metadata: {},
         model: undefined,
-        name: 'test.variant',
+        name: 'test',
+        variant: 'variant',
+        template: 'Hello from a variant of the hello prompt',
         raw: {
           config: {
             temperature: 13,
           },
           description: 'a prompt variant in a file',
         },
-        template: 'Hello from a variant of the hello prompt',
-        variant: 'variant',
       },
       type: 'prompt',
     });


### PR DESCRIPTION
Prompt variants weren't loading in the dev ui. Now they are. :)

Name/variant in the metadata is a composite key, so don't set name to the full name (`name.variant`). Note this is not the same as the action name, which remains fully qualified.

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/05bbe032-7230-4c7f-96da-da75f077bf27" />


Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)
