### PR TITLE
fix(js/ai/formats): default to json if jsonSchema present

### DIFF
--- a/js/ai/src/formats/index.ts
+++ b/js/ai/src/formats/index.ts
@@ -50,7 +50,7 @@ export async function resolveFormat(
 ): Promise<Formatter<any, any> | undefined> {
   if (!outputOpts) return undefined;
   // If schema is set but no explicit format is set we default to json.
-  if (outputOpts.schema && !outputOpts.format) {
+  if ((outputOpts.jsonSchema || outputOpts.schema) && !outputOpts.format) {
     return registry.lookupValue<Formatter>('format', 'json');
   }
   if (outputOpts.format) {

--- a/js/ai/tests/formats/format_test.ts
+++ b/js/ai/tests/formats/format_test.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from '@genkit-ai/core';
+import { Registry } from '@genkit-ai/core/registry';
+import assert from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+import { configureFormats, resolveFormat } from '../../src/formats/index.js';
+
+describe('formats', () => {
+  let registry: Registry;
+
+  beforeEach(() => {
+    registry = new Registry();
+    configureFormats(registry);
+  });
+
+  it('defaults to json when there is a schema present', async () => {
+    assert.deepEqual(
+      (await resolveFormat(registry, { schema: z.object({}) }))?.config,
+      {
+        constrained: true,
+        contentType: 'application/json',
+        defaultInstructions: false,
+        format: 'json',
+      }
+    );
+  });
+
+  it('defaults to json when there is a jsonSchema present', async () => {
+    assert.deepEqual(
+      (await resolveFormat(registry, { jsonSchema: {} }))?.config,
+      {
+        constrained: true,
+        contentType: 'application/json',
+        defaultInstructions: false,
+        format: 'json',
+      }
+    );
+  });
+});


### PR DESCRIPTION
The generate action takes a jsonSchema as part of the output configuration. In that case, we should also default to json output conformance.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)
