### PR TITLE
docs(samples): Fixed broken link in the samples guide

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -6,7 +6,7 @@ Take a look at some samples of Genkit in use:
   LLM usage
 - [js-menu](js-menu/): Progressively more sophisticated versions of a
   menu understanding app
-- [chatbot](chatbot/): A simple chatbot with a JavaScript frontend
+- [chatbot](js-chatbot/): A simple chatbot with a JavaScript frontend
 - [js-angular](js-angular/): Demo of streaming to an Angular frontend
 - [js-schoolAgent](js-schoolAgent/): A simple school assistant system with a routing agent and specialized agents
 - [js-prompts](js-prompts/): Shows off several prompting techniques

--- a/samples/README.md
+++ b/samples/README.md
@@ -9,7 +9,7 @@ Take a look at some samples of Genkit in use:
 - [chatbot](chatbot/): A simple chatbot with a JavaScript frontend
 - [js-angular](js-angular/): Demo of streaming to an Angular frontend
 - [js-schoolAgent](js-schoolAgent/): A simple school assistant system with a routing agent and specialized agents
-- [prompts](prompts/): Shows off several prompting techniques
+- [js-prompts](js-prompts/): Shows off several prompting techniques
 
 These are also available in IDX, Google's Cloud-Based IDE, for you to try.
 


### PR DESCRIPTION
Updated the link in the /samples folder, prompts to js-prompts, fixing the 404 error
**Update**
Added chatbot.