### PR TITLE
fix(go): replace some instances of archived dependency gopkg.in/yaml.v{2,3} with goccy/go-yaml

### DIFF
--- a/go/ai/action_test.go
+++ b/go/ai/action_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 
 	"github.com/firebase/genkit/go/internal/registry"
+	"github.com/goccy/go-yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"gopkg.in/yaml.v3"
 )
 
 type specSuite struct {

--- a/go/go.mod
+++ b/go/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.22.0
 	github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3
 	github.com/blues/jsonata-go v1.5.4
+	github.com/goccy/go-yaml v1.17.1
 	github.com/google/dotprompt/go v0.0.0-20250415074656-072d95deb01d
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -34,8 +35,6 @@ require (
 	golang.org/x/tools v0.31.0
 	google.golang.org/api v0.197.0
 	google.golang.org/genai v0.7.0
-	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -67,7 +66,6 @@ require (
 	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-openapi/validate v0.21.0 // indirect
-	github.com/goccy/go-yaml v1.17.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
@@ -105,4 +103,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/grpc v1.66.2 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go/tests/api_test.go
+++ b/go/tests/api_test.go
@@ -30,7 +30,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 )
 
 type testFile struct {


### PR DESCRIPTION
fix(go): replace some instances of archived dependency gopkg.in/yaml.v{2,3} with goccy/go-yaml #2755
    
ISSUES: #2755

CHANGELOG:
- [ ] Update a few tests to replace archived lib usage.