### PR TITLE
feat(py/plugins/google-genai, py/plugins/vertex-ai): add gemini-2.5-flash-preview-04-17 model

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -112,6 +112,7 @@ The following models are currently supported by GoogleAI API:
 | `gemini-2.0-flash-exp`               | Gemini 2.0 Flash Experimental        | Supported  |
 | `gemini-2.0-flash-thinking-exp-01-21`| Gemini 2.0 Flash Thinking Exp 01-21  | Supported  |
 | `gemini-2.5-pro-preview-03-25`       | Gemini 2.5 Pro Preview 03-25         | Supported  |
+| `gemini-2.5-flash-preview-04-17`     | Gemini 2.5 Flash Preview 04-17       | Supported  |
 
 
 The following models are currently supported by VertexAI API:
@@ -129,6 +130,7 @@ The following models are currently supported by VertexAI API:
 | `gemini-2.0-flash-exp`               | Gemini 2.0 Flash Experimental        | Unavailable  |
 | `gemini-2.0-flash-thinking-exp-01-21`| Gemini 2.0 Flash Thinking Exp 01-21  | Supported    |
 | `gemini-2.5-pro-preview-03-25`       | Gemini 2.5 Pro Preview 03-25         | Supported    |
+| `gemini-2.5-flash-preview-04-17`     | Gemini 2.5 Flash Preview 04-17       | Supported    |
 """
 
 import sys  # noqa
@@ -335,6 +337,18 @@ GEMINI_2_5_PRO_PREVIEW_03_25 = ModelInfo(
     ),
 )
 
+GEMINI_2_5_FLASH_PREVIEW_04_17 = ModelInfo(
+    label='Google AI - Gemini 2.5 Flash Preview 04-17',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained='no-tools',
+    ),
+)
+
 
 Deprecations = deprecated_enum_metafactory({
     'GEMINI_1_0_PRO': DeprecationInfo(recommendation='GEMINI_2_0_FLASH', status=DeprecationStatus.DEPRECATED),
@@ -361,6 +375,7 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):
     | `gemini-2.0-pro-exp-02-05`           | Gemini 2.0 Pro Exp 02-05             | Supported    |
     | `gemini-2.5-pro-exp-03-25`           | Gemini 2.5 Pro Exp 03-25             | Supported    |
     | `gemini-2.5-pro-preview-03-25`       | Gemini 2.5 Pro Preview 03-25         | Supported    |
+    | `gemini-2.5-flash-preview-04-17`     | Gemini 2.5 Flash Preview 04-17       | Supported    |
     """
 
     GEMINI_1_5_FLASH = 'gemini-1.5-flash'
@@ -373,6 +388,7 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):
     GEMINI_2_0_PRO_EXP_02_05 = 'gemini-2.0-pro-exp-02-05'
     GEMINI_2_5_PRO_EXP_03_25 = 'gemini-2.5-pro-exp-03-25'
     GEMINI_2_5_PRO_PREVIEW_03_25 = 'gemini-2.5-pro-preview-03-25'
+    GEMINI_2_5_FLASH_PREVIEW_04_17 = 'gemini-2.5-flash-preview-04-17'
 
 
 class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):
@@ -392,6 +408,7 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):
     | `gemini-2.0-pro-exp-02-05`           | Gemini 2.0 Pro Exp 02-05             | Supported  |
     | `gemini-2.5-pro-exp-03-25`           | Gemini 2.5 Pro Exp 03-25             | Supported  |
     | `gemini-2.5-pro-preview-03-25`       | Gemini 2.5 Pro Preview 03-25         | Supported  |
+    | `gemini-2.5-flash-preview-04-17`     | Gemini 2.5 Flash Preview 04-17       | Supported  |
     """
 
     GEMINI_1_5_FLASH = 'gemini-1.5-flash'
@@ -404,6 +421,7 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):
     GEMINI_2_0_PRO_EXP_02_05 = 'gemini-2.0-pro-exp-02-05'
     GEMINI_2_5_PRO_EXP_03_25 = 'gemini-2.5-pro-exp-03-25'
     GEMINI_2_5_PRO_PREVIEW_03_25 = 'gemini-2.5-pro-preview-03-25'
+    GEMINI_2_5_FLASH_PREVIEW_04_17 = 'gemini-2.5-flash-preview-04-17'
 
 
 SUPPORTED_MODELS = {
@@ -417,6 +435,7 @@ SUPPORTED_MODELS = {
     GoogleAIGeminiVersion.GEMINI_2_0_PRO_EXP_02_05: GEMINI_2_0_PRO_EXP_02_05,
     GoogleAIGeminiVersion.GEMINI_2_5_PRO_EXP_03_25: GEMINI_2_5_PRO_EXP_03_25,
     GoogleAIGeminiVersion.GEMINI_2_5_PRO_PREVIEW_03_25: GEMINI_2_5_PRO_PREVIEW_03_25,
+    GoogleAIGeminiVersion.GEMINI_2_5_FLASH_PREVIEW_04_17: GEMINI_2_5_FLASH_PREVIEW_04_17,
     VertexAIGeminiVersion.GEMINI_1_5_FLASH: GEMINI_1_5_FLASH,
     VertexAIGeminiVersion.GEMINI_1_5_FLASH_8B: GEMINI_1_5_FLASH_8B,
     VertexAIGeminiVersion.GEMINI_1_5_PRO: GEMINI_1_5_PRO,
@@ -427,6 +446,7 @@ SUPPORTED_MODELS = {
     VertexAIGeminiVersion.GEMINI_2_0_PRO_EXP_02_05: GEMINI_2_0_PRO_EXP_02_05,
     VertexAIGeminiVersion.GEMINI_2_5_PRO_EXP_03_25: GEMINI_2_5_PRO_EXP_03_25,
     VertexAIGeminiVersion.GEMINI_2_5_PRO_PREVIEW_03_25: GEMINI_2_5_PRO_PREVIEW_03_25,
+    VertexAIGeminiVersion.GEMINI_2_5_FLASH_PREVIEW_04_17: GEMINI_2_5_FLASH_PREVIEW_04_17,
 }
 
 

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/gemini.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/gemini.py
@@ -64,6 +64,7 @@ class GeminiVersion(StrEnum):
     GEMINI_2_0_FLASH_001 = 'gemini-2.0-flash-001'
     GEMINI_2_0_FLASH_LITE_PREVIEW = 'gemini-2.0-flash-lite-preview-02-05'
     GEMINI_2_0_PRO_EXP = 'gemini-2.0-pro-exp-02-05'
+    GEMINI_2_5_FLASH_PREVIEW = 'gemini-2.5-flash-preview-04-17'
 
 
 SUPPORTED_MODELS: dict[GeminiVersion | str, ModelInfo] = {
@@ -90,6 +91,11 @@ SUPPORTED_MODELS: dict[GeminiVersion | str, ModelInfo] = {
     GeminiVersion.GEMINI_2_0_PRO_EXP: ModelInfo(
         versions=[],
         label='Vertex AI - Gemini 2.0 Flash Pro Experimental 02-05',
+        supports=Supports(multiturn=True, media=True, tools=True, systemRole=True),
+    ),
+    GeminiVersion.GEMINI_2_5_FLASH_PREVIEW: ModelInfo(
+        versions=[],
+        label='Vertex AI - Gemini 2.5 Flash Preview 04-17',
         supports=Supports(multiturn=True, media=True, tools=True, systemRole=True),
     ),
 }


### PR DESCRIPTION
This PR adds support for the gemini-2.5-flash-preview-04-17 model to the Genkit Python plugins (google-genai and vertex-ai).
Note: Support for this model in the Go and JavaScript plugins has already been added in separate pull requests

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
