### PR TITLE
fix(go/plugins/googlegenai): `ai.NewMediaPart` support to inline and hosted data

### DIFF
--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -844,6 +844,13 @@ func toGeminiPart(p *ai.Part) (*genai.Part, error) {
 	case p.IsText():
 		return genai.NewPartFromText(p.Text), nil
 	case p.IsMedia():
+		if strings.HasPrefix(p.Text, "data:") {
+			contentType, data, err := uri.Data(p)
+			if err != nil {
+				return nil, err
+			}
+			return genai.NewPartFromBytes(data, contentType), nil
+		}
 		return genai.NewPartFromURI(p.Text, p.ContentType), nil
 	case p.IsData():
 		contentType, data, err := uri.Data(p)

--- a/go/plugins/googlegenai/googleai_live_test.go
+++ b/go/plugins/googlegenai/googleai_live_test.go
@@ -251,7 +251,7 @@ func TestGoogleAILive(t *testing.T) {
 			t.Fatalf("cache name should be a map but got %T", cache)
 		}
 	})
-	t.Run("media content (unstructured data)", func(t *testing.T) {
+	t.Run("media content (inline data)", func(t *testing.T) {
 		i, err := fetchImgAsBase64()
 		if err != nil {
 			t.Fatal(err)
@@ -286,6 +286,27 @@ func TestGoogleAILive(t *testing.T) {
 		}
 		if !strings.Contains(resp.Text(), "Mario Kart") {
 			t.Fatalf("image detection failed, want: Mario Kart, got: %s", resp.Text())
+		}
+	})
+	t.Run("data content (inline data)", func(t *testing.T) {
+		i, err := fetchImgAsBase64()
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithSystem("You are a pirate expert in TV Shows, your response should include the name of the character in the image provided"),
+			ai.WithMessages(
+				ai.NewUserMessage(
+					ai.NewTextPart("do you know who's in the image?"),
+					ai.NewDataPart("data:image/png;base64,"+i),
+				),
+			),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(resp.Text(), "Bluey") {
+			t.Fatalf("image detection failed, want: Bluey, got: %s", resp.Text())
 		}
 	})
 	t.Run("image generation", func(t *testing.T) {

--- a/go/plugins/googlegenai/googleai_live_test.go
+++ b/go/plugins/googlegenai/googleai_live_test.go
@@ -261,7 +261,7 @@ func TestGoogleAILive(t *testing.T) {
 			ai.WithMessages(
 				ai.NewUserMessage(
 					ai.NewTextPart("do you know who's in the image?"),
-					ai.NewDataPart("data:image/png;base64,"+i),
+					ai.NewMediaPart("image/png", "data:image/png;base64,"+i),
 				),
 			),
 		)


### PR DESCRIPTION
`ai.NewMediaPart` was originally supporting only hosted data. This PR includes the support for inline data as in `ai.NewDataPart`

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
