### PR TITLE
fix(go/genkit): remove colons from runtime filename

### DIFF
--- a/genkit-tools/common/src/manager/manager.ts
+++ b/genkit-tools/common/src/manager/manager.ts
@@ -547,12 +547,19 @@ export class RuntimeManager {
  * Checks if the runtime file is valid.
  */
 function isValidRuntimeInfo(data: any): data is RuntimeInfo {
+  let timestamp = '';
+  // runtime filename might come with underscores due OS filename restrictions
+  // revert the underscores so the timestamp gets parsed correctly
+  if (typeof data.timestamp === 'string') {
+    timestamp = data.timestamp.replaceAll('_', ':');
+  }
+
   return (
     typeof data === 'object' &&
     typeof data.id === 'string' &&
     typeof data.pid === 'number' &&
     typeof data.reflectionServerUrl === 'string' &&
     typeof data.timestamp === 'string' &&
-    !isNaN(Date.parse(data.timestamp))
+    !isNaN(Date.parse(timestamp))
   );
 }

--- a/go/genkit/reflection.go
+++ b/go/genkit/reflection.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
@@ -148,6 +149,9 @@ func (s *reflectionServer) writeRuntimeFile(url string) error {
 	}
 
 	timestamp := time.Now().UTC().Format(time.RFC3339)
+	// remove colons to avoid problems with different OS file name restrictions
+	timestamp = strings.ReplaceAll(timestamp, ":", "_")
+
 	s.RuntimeFilePath = filepath.Join(runtimesDir, fmt.Sprintf("%d-%s.json", os.Getpid(), timestamp))
 
 	data := runtimeFileData{


### PR DESCRIPTION
Having colons in the runtime causes Genkit to fail during startup in non-POSIX systems.


Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
