### PR TITLE
feat(js/core): allow defining a "list actions" fn for plugins

### DIFF
--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -33,9 +33,9 @@ export { JSONSchema7 };
  * Action metadata.
  */
 export interface ActionMetadata<
-  I extends z.ZodTypeAny,
-  O extends z.ZodTypeAny,
-  S extends z.ZodTypeAny,
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  S extends z.ZodTypeAny = z.ZodTypeAny,
 > {
   actionType?: ActionType;
   name: string;
@@ -283,6 +283,7 @@ export function action<
     outputJsonSchema: config.outputJsonSchema,
     streamSchema: config.streamSchema,
     metadata: config.metadata,
+    actionType: config.actionType,
   } as ActionMetadata<I, O, S>;
   actionFn.run = async (
     input: z.infer<I>,

--- a/js/core/src/plugin.ts
+++ b/js/core/src/plugin.ts
@@ -15,7 +15,7 @@
  */
 
 import { z } from 'zod';
-import { Action } from './action.js';
+import { Action, ActionMetadata } from './action.js';
 import { ActionType } from './registry.js';
 
 export interface Provider<T> {
@@ -30,6 +30,7 @@ export interface PluginProvider {
     | void
     | Promise<InitializedPlugin | void>;
   resolver?: (action: ActionType, target: string) => Promise<void>;
+  listActions?: () => Promise<ActionMetadata[]>
 }
 
 export interface InitializedPlugin {

--- a/js/core/src/plugin.ts
+++ b/js/core/src/plugin.ts
@@ -30,7 +30,7 @@ export interface PluginProvider {
     | void
     | Promise<InitializedPlugin | void>;
   resolver?: (action: ActionType, target: string) => Promise<void>;
-  listActions?: () => Promise<ActionMetadata[]>
+  listActions?: () => Promise<ActionMetadata[]>;
 }
 
 export interface InitializedPlugin {

--- a/js/core/src/reflection.ts
+++ b/js/core/src/reflection.ts
@@ -128,10 +128,10 @@ export class ReflectionServer {
     server.get('/api/actions', async (_, response, next) => {
       logger.debug('Fetching actions.');
       try {
-        const actions = await this.registry.listActions();
+        const actions = await this.registry.listResolvableActions();
         const convertedActions = {};
         Object.keys(actions).forEach((key) => {
-          const action = actions[key].__action;
+          const action = actions[key];
           convertedActions[key] = {
             key,
             name: action.name,

--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -17,7 +17,11 @@
 import { Dotprompt } from 'dotprompt';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import * as z from 'zod';
-import { Action, runOutsideActionRuntimeContext } from './action.js';
+import {
+  Action,
+  ActionMetadata,
+  runOutsideActionRuntimeContext,
+} from './action.js';
 import { GenkitError } from './error.js';
 import { logger } from './logging.js';
 import { PluginProvider } from './plugin.js';
@@ -59,25 +63,42 @@ function parsePluginName(registryKey: string) {
 }
 
 interface ParsedRegistryKey {
-  pluginName: string;
   actionType: ActionType;
+  pluginName?: string;
   actionName: string;
 }
 
-// Parses e.g. /model/googleai/gemini-2.0-flash into parts
-function parseRegistryKey(registryKey: string): ParsedRegistryKey | undefined {
+/**
+ * Parses the registry key into key parts as per the key format convention. Ex:
+ *  - /model/googleai/gemini-2.0-flash
+ *  - /prompt/my-plugin/folder/my-prompt
+ *  - /util/generate
+ */
+export function parseRegistryKey(registryKey: string): ParsedRegistryKey {
   const tokens = registryKey.split('/');
+  if (tokens.length < 3) {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: `invalid action key format: ${registryKey}`,
+    });
+  }
+  // ex: /model/googleai/gemini-2.0-flash or /prompt/my-plugin/folder/my-prompt
   if (tokens.length >= 4) {
     return {
       actionType: tokens[1] as ActionType,
       pluginName: tokens[2],
-      actionName: tokens[3],
+      actionName: tokens.slice(3).join('/'),
     };
   }
-  return undefined;
+  // ex: /util/generate
+  return {
+    actionType: tokens[1] as ActionType,
+    actionName: tokens[2],
+  };
 }
 
-type ActionsRecord = Record<string, Action<z.ZodTypeAny, z.ZodTypeAny>>;
+export type ActionsRecord = Record<string, Action<z.ZodTypeAny, z.ZodTypeAny>>;
+export type ActionMetadataRecord = Record<string, ActionMetadata>;
 
 /**
  * The registry is used to store and lookup actions, trace stores, flow state stores, plugins, and schemas.
@@ -131,7 +152,7 @@ export class Registry {
   >(key: string): Promise<R> {
     // We always try to initialize the plugin first.
     const parsedKey = parseRegistryKey(key);
-    if (parsedKey) {
+    if (parsedKey.pluginName && this.pluginsByName[parsedKey.pluginName]) {
       await this.initializePlugin(parsedKey.pluginName);
 
       // If we don't see the key in the registry, we try to resolve
@@ -159,6 +180,12 @@ export class Registry {
     type: ActionType,
     action: Action<I, O>
   ) {
+    if (type !== action.__action.actionType) {
+      throw new GenkitError({
+        status: 'INVALID_ARGUMENT',
+        message: `action type (${type}) does not match type on action (${action.__action.actionType})`,
+      });
+    }
     const key = `/${type}/${action.__action.name}`;
     logger.debug(`registering ${key}`);
     if (this.actionsById.hasOwnProperty(key)) {
@@ -190,8 +217,8 @@ export class Registry {
   }
 
   /**
-   * Returns all actions in the registry.
-   * @returns All actions in the registry.
+   * Returns all actions that have been registered in the registry.
+   * @returns All actions in the registry as a map of <key, action>.
    */
   async listActions(): Promise<ActionsRecord> {
     await this.initializeAllPlugins();
@@ -204,6 +231,53 @@ export class Registry {
     return {
       ...(await this.parent?.listActions()),
       ...actions,
+    };
+  }
+
+  /**
+   * Returns all actions that are resolvable by plugins as well as those that are already
+   * in the registry.
+   *
+   * NOTE: this method should not be used in latency sensitive code paths.
+   * It may rely on "admin" API calls such as "list models", which may cause increased cold start latency.
+   *
+   * @returns All resolvable action metadata as a map of <key, action metadata>.
+   */
+  async listResolvableActions(): Promise<ActionMetadataRecord> {
+    const resolvableActions = {} as ActionMetadataRecord;
+    // We listActions for all plugins in parallel.
+    await Promise.all(
+      Object.entries(this.pluginsByName).map(async ([pluginName, plugin]) => {
+        if (plugin.listActions) {
+          try {
+            (await plugin.listActions()).forEach((meta) => {
+              if (!meta.name) {
+                throw new GenkitError({
+                  status: 'INVALID_ARGUMENT',
+                  message: `Invalid metadata when listing actions from ${pluginName} - name required`,
+                });
+              }
+              if (!meta.actionType) {
+                throw new GenkitError({
+                  status: 'INVALID_ARGUMENT',
+                  message: `Invalid metadata when listing actions from ${pluginName} - actionType required`,
+                });
+              }
+              resolvableActions[`/${meta.actionType}/${meta.name}`] = meta;
+            });
+          } catch (e) {
+            logger.error(`Error listing actions for ${pluginName}\n`, e);
+          }
+        }
+      })
+    );
+    // Also add actions that are already registered.
+    for (const [key, action] of Object.entries(await this.listActions())) {
+      resolvableActions[key] = action.__action;
+    }
+    return {
+      ...(await this.parent?.listResolvableActions()),
+      ...resolvableActions,
     };
   }
 
@@ -245,6 +319,12 @@ export class Registry {
         if (provider.resolver) {
           await provider.resolver(actionType, target);
         }
+      },
+      listActions: async () => {
+        if (provider.listActions) {
+          return await provider.listActions();
+        }
+        return [];
       },
     };
   }

--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -74,13 +74,13 @@ interface ParsedRegistryKey {
  *  - /prompt/my-plugin/folder/my-prompt
  *  - /util/generate
  */
-export function parseRegistryKey(registryKey: string): ParsedRegistryKey {
+export function parseRegistryKey(
+  registryKey: string
+): ParsedRegistryKey | undefined {
   const tokens = registryKey.split('/');
   if (tokens.length < 3) {
-    throw new GenkitError({
-      status: 'INVALID_ARGUMENT',
-      message: `invalid action key format: ${registryKey}`,
-    });
+    // Invalid key format
+    return undefined;
   }
   // ex: /model/googleai/gemini-2.0-flash or /prompt/my-plugin/folder/my-prompt
   if (tokens.length >= 4) {
@@ -152,7 +152,7 @@ export class Registry {
   >(key: string): Promise<R> {
     // We always try to initialize the plugin first.
     const parsedKey = parseRegistryKey(key);
-    if (parsedKey.pluginName && this.pluginsByName[parsedKey.pluginName]) {
+    if (parsedKey?.pluginName && this.pluginsByName[parsedKey.pluginName]) {
       await this.initializePlugin(parsedKey.pluginName);
 
       // If we don't see the key in the registry, we try to resolve

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -812,6 +812,12 @@ export class Genkit implements HasRegistry {
             await loadedPlugin.resolver(action, target);
           }
         },
+        async listActions() {
+          if (loadedPlugin.listActions) {
+            return await loadedPlugin.listActions();
+          }
+          return []
+        },
       });
     });
   }

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -816,7 +816,7 @@ export class Genkit implements HasRegistry {
           if (loadedPlugin.listActions) {
             return await loadedPlugin.listActions();
           }
-          return []
+          return [];
         },
       });
     });

--- a/js/genkit/src/plugin.ts
+++ b/js/genkit/src/plugin.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ActionMetadata } from '@genkit-ai/core';
 import { Genkit } from './genkit.js';
 import { ActionType } from './registry.js';
 
@@ -21,13 +22,14 @@ export interface PluginProvider {
   name: string;
   initializer: () => void | Promise<void>;
   resolver?: (action: ActionType, target: string) => Promise<void>;
+  listActions?: () => Promise<ActionMetadata[]>;
 }
 
 export type GenkitPlugin = (genkit: Genkit) => PluginProvider;
 
-type PluginInit = (genkit: Genkit) => void | Promise<void>;
+export type PluginInit = (genkit: Genkit) => void | Promise<void>;
 
-type PluginActionResolver = (
+export type PluginActionResolver = (
   genkit: Genkit,
   action: ActionType,
   target: string
@@ -39,7 +41,8 @@ type PluginActionResolver = (
 export function genkitPlugin<T extends PluginInit>(
   pluginName: string,
   initFn: T,
-  resolveFn?: PluginActionResolver
+  resolveFn?: PluginActionResolver,
+  listActionsFn?: () => Promise<ActionMetadata[]>
 ): GenkitPlugin {
   return (genkit: Genkit) => ({
     name: pluginName,
@@ -50,6 +53,12 @@ export function genkitPlugin<T extends PluginInit>(
       if (resolveFn) {
         return await resolveFn(genkit, action, target);
       }
+    },
+    listActions: async (): Promise<ActionMetadata[]> => {
+      if (listActionsFn) {
+        return await listActionsFn();
+      }
+      return [];
     },
   });
 }


### PR DESCRIPTION
Added new `listResolvableActions()` method to the registry that calls `listActions()` for plugins. Switched reflection API `list actions` endpoint to use `listResolvableActions()` .

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
