### PR TITLE
fix(go/plugins/googlegenai): use `boolean` instead of `bool` in JSON schemas

### DIFF
--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -614,7 +614,7 @@ func toGeminiSchema(originalSchema map[string]any, genkitSchema map[string]any) 
 		schema.Type = genai.TypeNumber
 	case "integer":
 		schema.Type = genai.TypeInteger
-	case "bool":
+	case "boolean":
 		schema.Type = genai.TypeBoolean
 	case "object":
 		schema.Type = genai.TypeObject

--- a/go/plugins/googlegenai/gemini_test.go
+++ b/go/plugins/googlegenai/gemini_test.go
@@ -49,7 +49,17 @@ func TestConvertRequest(t *testing.T) {
 		ToolChoice: ai.ToolChoiceAuto,
 		Output: &ai.ModelOutputConfig{
 			Constrained: true,
-			Schema:      map[string]any{"type": string("string")},
+			Schema: map[string]any{
+				"type": string("object"),
+				"properties": map[string]any{
+					"foo": map[string]any{
+						"type": string("string"),
+					},
+					"isFoo": map[string]any{
+						"type": string("boolean"),
+					},
+				},
+			},
 		},
 		Messages: []*ai.Message{
 			{


### PR DESCRIPTION
Google Gen AI plugin was mistakenly using `bool` in JSON schema parsing instead of `boolean`

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
