### PR TITLE
bug(go): tool null inputSchema handler to avoid validation error

### DIFF
--- a/go/core/action.go
+++ b/go/core/action.go
@@ -213,24 +213,27 @@ func inputSchemaNullHandler(input []byte) ([]byte, error) {
 	if len(input) == 0 {
 		return []byte{}, nil
 	}
-	var rawInput map[string]interface{}
+	var rawInput any
 	if err := json.Unmarshal(input, &rawInput); err != nil {
-		return nil, NewError(INTERNAL, "failed to unmarshal JSON: %w", err)
+		return nil, NewError(INTERNAL, fmt.Sprintf("failed to unmarshal JSON: %v", err))
 	}
 
-	// Check if the "tools" key exists and if its value is a slice of interfaces.
-	if tools, ok := rawInput["tools"].([]interface{}); ok {
-		for _, t := range tools {
-			if tool, ok := t.(map[string]interface{}); ok {
-				if inputSchema, exists := tool["inputSchema"]; exists && inputSchema == nil {
-					delete(tool, "inputSchema")
+	if rawInputMap, ok := rawInput.(map[string]interface{}); ok {
+		if tools, ok := rawInputMap["tools"].([]interface{}); ok {
+			for _, t := range tools {
+				if tool, ok := t.(map[string]interface{}); ok {
+					if inputSchema, exists := tool["inputSchema"]; exists && inputSchema == nil {
+						delete(tool, "inputSchema")
+					}
 				}
 			}
 		}
 	}
+	// Check if the "tools" key exists and if its value is a slice of interfaces.
+
 	output, err := json.Marshal(rawInput)
 	if err != nil {
-		return nil, NewError(INTERNAL, "failed to marshal JSON: %w", err)
+		return nil, NewError(INTERNAL, fmt.Sprintf("failed to marshal JSON: %v", err))
 	}
 	return output, nil
 }


### PR DESCRIPTION
Addition of a utility to handle the remove the null inputSchema from the tool definition to avoid validation error
Resolving : https://github.com/firebase/genkit/issues/2498

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
