### PR TITLE
bug(go):Propagate telemetry labels from Reflection API to tracing

### DIFF
--- a/go/genkit/reflection_test.go
+++ b/go/genkit/reflection_test.go
@@ -152,6 +152,12 @@ func TestServeMux(t *testing.T) {
 				wantResult: "2",
 			},
 			{
+				name:       "check telemetry labels",
+				body:       `{"key": "/custom/test/dec", "input": 3,"telemetryLabels":{"test_k":"test_v"}}`,
+				wantStatus: http.StatusOK,
+				wantResult: "2",
+			},
+			{
 				name:       "invalid action key",
 				body:       `{"key": "/custom/test/invalid", "input": 3}`,
 				wantStatus: http.StatusNotFound,


### PR DESCRIPTION
Handling of telemetryLabels coming from UI in payload to set in span.
Resolving : https://github.com/firebase/genkit/issues/2422

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
