### PR TITLE
fix: fix up invalid tsconfig shipped on npm

### DIFF
--- a/genkit-tools/cli/.npmignore
+++ b/genkit-tools/cli/.npmignore
@@ -2,3 +2,5 @@ node_modules
 plugins/
 common/
 ui/
+jest.config.ts
+tsconfig.json

--- a/js/genkit/.npmignore
+++ b/js/genkit/.npmignore
@@ -1,0 +1,2 @@
+tsconfig.json
+tsup.config.ts

--- a/js/plugins/firebase/.npmignore
+++ b/js/plugins/firebase/.npmignore
@@ -1,1 +1,4 @@
 node_modules
+jest.config.ts
+tsconfig.json
+tsup.config.ts

--- a/js/plugins/googleai/.npmignore
+++ b/js/plugins/googleai/.npmignore
@@ -1,1 +1,3 @@
 node_modules
+tsconfig.json
+tsup.config.ts


### PR DESCRIPTION
This commit ignore extra files in the npm publication and removes red highlight in VSCode for node_modules.

ISSUE: #2932

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
