### PR TITLE
fix(js/ai): missing types for uuid module (#3000)

### DIFF
--- a/js/ai/package.json
+++ b/js/ai/package.json
@@ -31,13 +31,14 @@
     "@opentelemetry/api": "^1.9.0",
     "@types/node": "^20.11.19",
     "colorette": "^2.0.20",
+    "dotprompt": "^1.1.1",
     "json5": "^2.2.3",
     "node-fetch": "^3.3.2",
     "partial-json": "^0.1.7",
-    "uuid": "^10.0.0",
-    "dotprompt": "^1.1.1"
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
+    "@types/uuid": "^9.0.6",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
     "tsup": "^8.3.5",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0
     devDependencies:
+      '@types/uuid':
+        specifier: ^9.0.6
+        version: 9.0.8
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5


### PR DESCRIPTION
ISSUE: #3000

When building genkit with tsgo, it complains of this error. The
`@types/uuid` dev dependency is missing

**To Reproduce**
1. Setup https://github.com/microsoft/typescript-go
2. Run `pnpm run build`

CHANGELOG:
- [ ] Adds the `@types/uuid` dev dependency.
