### PR TITLE
chore(py): Add vertexai and google cloud plugins as opt deps

### DIFF
--- a/py/packages/genkit/pyproject.toml
+++ b/py/packages/genkit/pyproject.toml
@@ -46,6 +46,8 @@ flask                 = ["genkit-plugin-flask"]
 google-genai          = ["genkit-plugin-google-genai"]
 ollama                = ["genkit-plugin-ollama"]
 openai                = ["genkit-plugin-compat-oai"]
+google-cloud          = ["genkit-plugin-google-cloud"]
+vertex-ai             = ["genkit-plugin-vertex-ai"]
 
 [build-system]
 build-backend = "hatchling.build"


### PR DESCRIPTION
I only expanded the optional deps list in pyproject.toml to download plugins as optional deps.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
