### PR TITLE
fix(js/plugins/googleai): Handle Gemini API thought signatures.

### DIFF
--- a/js/plugins/googleai/tests/gemini_test.ts
+++ b/js/plugins/googleai/tests/gemini_test.ts
@@ -136,6 +136,17 @@ describe('toGeminiMessages', () => {
         ],
       },
     },
+    {
+      should: 'should re-populate thoughtSignature from reasoning metadata',
+      inputMessage: {
+        role: 'model',
+        content: [{ reasoning: '', metadata: { thoughtSignature: 'abc123' } }],
+      },
+      expectedOutput: {
+        role: 'model',
+        parts: [{ thought: true, thoughtSignature: 'abc123' }],
+      },
+    },
   ];
   for (const test of testCases) {
     it(test.should, () => {
@@ -328,6 +339,102 @@ describe('fromGeminiCandidate', () => {
                 input: { topic: 'dog' },
                 ref: '0',
               },
+            },
+          ],
+        },
+        finishReason: 'stop',
+        finishMessage: undefined,
+        custom: {
+          citationMetadata: undefined,
+          safetyRatings: [
+            {
+              category: 'HARM_CATEGORY_HATE_SPEECH',
+              probability: 'NEGLIGIBLE',
+              probabilityScore: 0.11858909,
+              severity: 'HARM_SEVERITY_NEGLIGIBLE',
+              severityScore: 0.11456649,
+            },
+            {
+              category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+              probability: 'NEGLIGIBLE',
+              probabilityScore: 0.13857833,
+              severity: 'HARM_SEVERITY_NEGLIGIBLE',
+              severityScore: 0.11417085,
+            },
+            {
+              category: 'HARM_CATEGORY_HARASSMENT',
+              probability: 'NEGLIGIBLE',
+              probabilityScore: 0.28012377,
+              severity: 'HARM_SEVERITY_NEGLIGIBLE',
+              severityScore: 0.112405084,
+            },
+            {
+              category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+              probability: 'NEGLIGIBLE',
+            },
+          ],
+        },
+      },
+    },
+    {
+      should:
+        'should transform gemini candidate to genkit candidate (thought parts) correctly',
+      geminiCandidate: {
+        content: {
+          role: 'model',
+          parts: [
+            {
+              thought: true,
+              thoughtSignature: 'abc123',
+            },
+            {
+              thought: true,
+              text: 'thought with text',
+              thoughtSignature: 'def456',
+            },
+          ],
+        },
+        finishReason: 'STOP',
+        safetyRatings: [
+          {
+            category: 'HARM_CATEGORY_HATE_SPEECH',
+            probability: 'NEGLIGIBLE',
+            probabilityScore: 0.11858909,
+            severity: 'HARM_SEVERITY_NEGLIGIBLE',
+            severityScore: 0.11456649,
+          },
+          {
+            category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+            probability: 'NEGLIGIBLE',
+            probabilityScore: 0.13857833,
+            severity: 'HARM_SEVERITY_NEGLIGIBLE',
+            severityScore: 0.11417085,
+          },
+          {
+            category: 'HARM_CATEGORY_HARASSMENT',
+            probability: 'NEGLIGIBLE',
+            probabilityScore: 0.28012377,
+            severity: 'HARM_SEVERITY_NEGLIGIBLE',
+            severityScore: 0.112405084,
+          },
+          {
+            category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+            probability: 'NEGLIGIBLE',
+          },
+        ],
+      },
+      expectedOutput: {
+        index: 0,
+        message: {
+          role: 'model',
+          content: [
+            {
+              reasoning: '',
+              metadata: { thoughtSignature: 'abc123' },
+            },
+            {
+              reasoning: 'thought with text',
+              metadata: { thoughtSignature: 'def456' },
             },
           ],
         },


### PR DESCRIPTION
The Gemini API has started (? unclear when) returning `{thought: true, thoughtSignature: "abc123"}` which was blowing up our conversion because it doesn't have a `text` part.

This preserves the thought signature so that it is kept for future turns in all cases, and handles the "empty thought" case.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
