### PR TITLE
fix: log error with duplicate action key

### DIFF
--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -291,9 +291,8 @@ export class Registry {
     const key = `/${type}/${action.__action.name}`;
     logger.debug(`registering ${key}`);
     if (this.actionsById.hasOwnProperty(key)) {
-      // TODO: Make this an error!
-      logger.warn(
-        `WARNING: ${key} already has an entry in the registry. Overwriting.`
+      logger.error(
+        `ERROR: ${key} already has an entry in the registry. Overwriting.`
       );
     }
     this.actionsById[key] = action;
@@ -318,9 +317,8 @@ export class Registry {
     const key = `/${type}/${name}`;
     logger.debug(`registering ${key} (async)`);
     if (this.actionsById.hasOwnProperty(key)) {
-      // TODO: Make this an error!
-      logger.warn(
-        `WARNING: ${key} already has an entry in the registry. Overwriting.`
+      logger.error(
+        `ERROR: ${key} already has an entry in the registry. Overwriting.`
       );
     }
     this.actionsById[key] = action;


### PR DESCRIPTION
This commit change the behavior with actions with the same name.
Based on the issue description I changed warnings into errors.

Close #26 

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
