### PR TITLE
chore(js/mcp): Rename "Manager" -> "Host" to align terminology.

### DIFF
--- a/js/plugins/mcp/README.md
+++ b/js/plugins/mcp/README.md
@@ -4,7 +4,7 @@
 > This plugin is experimental, meaning it may not be supported long-term and APIs are subject to more often breaking changes.
 
 This plugin provides integration between Genkit and the [Model Context Protocol](https://modelcontextprotocol.io) (MCP). MCP is an open standard allowing developers to build "servers" which provide tools, resources, and prompts to clients. Genkit MCP allows Genkit developers to:
-- Consume MCP tools, prompts, and resources as a client using `createMcpManager` or `createMcpClient`.
+- Consume MCP tools, prompts, and resources as a client using `createMcpHost` or `createMcpClient`.
 - Provide Genkit tools and prompts as an MCP server using `createMcpServer`.
 
 ## Installation
@@ -15,20 +15,20 @@ To get started, you'll need Genkit and the MCP plugin:
 npm i genkit @genkit-ai/mcp
 ```
 
-## MCP Client Manager
+## MCP Host
 
-To connect to one or more MCP servers, you use the `createMcpManager` function. This function returns a `GenkitMcpManager` instance that manages connections to the configured MCP servers.
+To connect to one or more MCP servers, you use the `createMcpHost` function. This function returns a `GenkitMcpHost` instance that manages connections to the configured MCP servers.
 
 ```ts
 import { genkit } from 'genkit';
-import { createMcpManager } from '@genkit-ai/mcp';
+import { createMcpHost } from '@genkit-ai/mcp';
 
-// Example: Configure a client manager for a local filesystem server
+// Example: Configure a MCP host for a local filesystem server
 // and a hypothetical remote Git server.
 const ALLOWED_DIRS = ['/Users/yourusername/Desktop'];
 
-const mcpManager = createMcpManager({
-  name: 'myMcpClients', // A name for the manager plugin itself
+const McpHost = createMcpHost({
+  name: 'myMcpClients', // A name for the host plugin itself
   mcpServers: {
     // Each key (e.g., 'fs', 'git') becomes a namespace for the server's tools.
     fs: {
@@ -50,7 +50,7 @@ const ai = genkit({
 
 
 // Retrieve tools from all active MCP servers
-const mcpTools = await mcpManager.getActiveTools(genkit);
+const mcpTools = await McpHost.getActiveTools(genkit);
 
 // Provide MCP tools to the model of your choice.
 const response = await ai.generate({
@@ -62,12 +62,12 @@ const response = await ai.generate({
 console.log(response.text);
 ```
 
-The `createMcpManager` function initializes a `GenkitMcpClientManager` instance, which handles the lifecycle and communication with the defined MCP servers.
+The `createMcpHost` function initializes a `GenkitMcpHost` instance, which handles the lifecycle and communication with the defined MCP servers.
 
-### `createMcpManager()` Options
+### `createMcpHost()` Options
 
--   **`name`**: (optional, string) A name for the client manager plugin itself. Defaults to 'genkitx-mcp'.
--   **`version`**: (optional, string) The version of the client manager plugin. Defaults to "1.0.0".
+-   **`name`**: (optional, string) A name for the MCP host plugin itself. Defaults to 'genkitx-mcp'.
+-   **`version`**: (optional, string) The version of the MCP host plugin. Defaults to "1.0.0".
 -   **`mcpServers`**: (required, object) An object where each key is a client-side name (namespace) for an MCP server, and the value is the configuration for that server.
     Each server configuration object can include:
     -   **`rawToolResponses`**: (optional, boolean) If `true`, tool responses from this server are returned in their raw MCP format; otherwise, they are processed for Genkit compatibility. Defaults to `false`.
@@ -125,21 +125,21 @@ runSingleClient();
 The `createMcpClient` function takes an `McpClientOptions` object:
 -   **`name`**: (required, string) A unique name for this client instance. This name will be used as the namespace for its tools and prompts.
 -   **`version`**: (optional, string) Version for this client instance. Defaults to "1.0.0".
--   Plus, all options from `McpServerConfig` (see `disabled`, `rawToolResponses`, and transport configurations under `createMcpManager` options).
+-   Plus, all options from `McpServerConfig` (see `disabled`, `rawToolResponses`, and transport configurations under `createMcpHost` options).
 
 ### Using MCP Actions (Tools, Prompts, Resources)
 
-Both `GenkitMcpManager` (via `getActiveTools()`) and `GenkitMcpClient` (via `getActiveTools()`) discover available tools from their connected and enabled MCP server(s). These tools are standard Genkit `ToolAction` instances and can be provided to Genkit models.
+Both `GenkitMcpHost` (via `getActiveTools()`) and `GenkitMcpClient` (via `getActiveTools()`) discover available tools from their connected and enabled MCP server(s). These tools are standard Genkit `ToolAction` instances and can be provided to Genkit models.
 
 MCP resources are accessed via dynamically generated tools:
 - `[serverName]/list_resources`: Lists available resources.
 - `[serverName]/list_resource_templates`: Lists resource templates.
 - `[serverName]/read_resource`: Reads a specific resource by URI.
 
-MCP prompts can be fetched using `mcpManager.getPrompt(serverName, promptName)` or `mcpClient.getPrompt(promptName)`. These return an `ExecutablePrompt`.
+MCP prompts can be fetched using `McpHost.getPrompt(serverName, promptName)` or `mcpClient.getPrompt(promptName)`. These return an `ExecutablePrompt`.
 
 All MCP actions (tools, prompts, resources) are namespaced.
-- For `createMcpManager`, the namespace is the key you provide for that server in the `mcpServers` configuration (e.g., `localFs/read_file`).
+- For `createMcpHost`, the namespace is the key you provide for that server in the `mcpServers` configuration (e.g., `localFs/read_file`).
 - For `createMcpClient`, the namespace is the `name` you provide in its options (e.g., `myFileSystemClient/list_resources`).
 
 ### Tool Responses

--- a/js/plugins/mcp/README.md
+++ b/js/plugins/mcp/README.md
@@ -27,7 +27,7 @@ import { createMcpHost } from '@genkit-ai/mcp';
 // and a hypothetical remote Git server.
 const ALLOWED_DIRS = ['/Users/yourusername/Desktop'];
 
-const McpHost = createMcpHost({
+const mcpHost = createMcpHost({
   name: 'myMcpClients', // A name for the host plugin itself
   mcpServers: {
     // Each key (e.g., 'fs', 'git') becomes a namespace for the server's tools.

--- a/js/plugins/mcp/src/client/client.ts
+++ b/js/plugins/mcp/src/client/client.ts
@@ -91,7 +91,7 @@ export type McpClientOptions = McpServerConfig & {
  * It handles the lifecycle of the connection (connect, disconnect, disable, re-enable, reconnect)
  * and provides methods to fetch tools from the connected server.
  *
- * An instance of `GenkitMcpClient` is typically managed by a `GenkitMcpClientManager`
+ * An instance of `GenkitMcpClient` is typically managed by a `GenkitMcpHost`
  * when dealing with multiple MCP server connections.
  */
 export class GenkitMcpClient {

--- a/js/plugins/mcp/src/client/host.ts
+++ b/js/plugins/mcp/src/client/host.ts
@@ -284,7 +284,7 @@ export class GenkitMcpHost {
    * to Genkit, for example, when setting up a Genkit plugin.
    *
    * ```ts
-   * const McpHost = createMcpHost({ ... });
+   * const mcpHost = createMcpHost({ ... });
    * // In your Genkit configuration:
    * // const allMcpTools = await McpHost.getActiveTools(ai);
    * // Then, these tools can be used or registered with Genkit.

--- a/js/plugins/mcp/src/client/index.ts
+++ b/js/plugins/mcp/src/client/index.ts
@@ -19,10 +19,10 @@ import { StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { GenkitMcpClient, McpClientOptions } from './client.js';
 import { GenkitMcpHost, McpHostOptions } from './host.js';
-export { GenkitMcpClient, GenkitMcpHost as GenkitMcpHost };
+export { GenkitMcpClient, GenkitMcpHost };
 export type {
   McpClientOptions,
-  McpHostOptions as McpHostOptions,
+  McpHostOptions,
   SSEClientTransportOptions,
   StdioServerParameters,
   Transport,

--- a/js/plugins/mcp/src/client/index.ts
+++ b/js/plugins/mcp/src/client/index.ts
@@ -18,11 +18,11 @@ import { SSEClientTransportOptions } from '@modelcontextprotocol/sdk/client/sse.
 import { StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { GenkitMcpClient, McpClientOptions } from './client.js';
-import { GenkitMcpManager, McpManagerOptions } from './manager.js';
-export { GenkitMcpClient, GenkitMcpManager };
+import { GenkitMcpHost, McpHostOptions } from './host.js';
+export { GenkitMcpClient, GenkitMcpHost as GenkitMcpHost };
 export type {
   McpClientOptions,
-  McpManagerOptions,
+  McpHostOptions as McpHostOptions,
   SSEClientTransportOptions,
   StdioServerParameters,
   Transport,

--- a/js/plugins/mcp/src/index.ts
+++ b/js/plugins/mcp/src/index.ts
@@ -21,11 +21,11 @@ import {
   McpServerConfig,
   McpStdioServerConfig,
 } from './client/client.js';
-import { GenkitMcpManager, McpManagerOptions } from './client/index.js';
+import { GenkitMcpHost, McpHostOptions } from './client/index.js';
 import { GenkitMcpServer } from './server.js';
 export {
   GenkitMcpClient,
-  GenkitMcpManager,
+  GenkitMcpHost,
   type McpClientOptions,
   type McpServerConfig,
   type McpStdioServerConfig,
@@ -40,7 +40,7 @@ export interface McpServerOptions {
 }
 
 /**
- * Creates an MCP Client Manager that connects to one or more MCP servers.
+ * Creates an MCP Client Host that connects to one or more MCP servers.
  * Each server is defined in the `mcpClients` option, where the key is a
  * client-side name for the server and the value is the server's configuration.
  *
@@ -48,8 +48,8 @@ export interface McpServerOptions {
  * their configuration includes `{disabled: true}`.
  *
  * ```ts
- * const clientManager = createMcpManager({
- *   name: "my-mcp-client-manager", // Name for the manager itself
+ * const clientHost = createMcpHost({
+ *   name: "my-mcp-client-host", // Name for the host itself
  *   mcpServers: {
  *     // Each key is a name for this client/server configuration
  *     // Each value is an McpServerConfig object
@@ -59,11 +59,11 @@ export interface McpServerOptions {
  * });
  * ```
  *
- * @param options Configuration for the MCP Client Manager, including the definitions of MCP servers to connect to.
- * @returns A new instance of GenkitMcpClientManager.
+ * @param options Configuration for the MCP Client Host, including the definitions of MCP servers to connect to.
+ * @returns A new instance of GenkitMcpHost.
  */
-export function createMcpManager(options: McpManagerOptions) {
-  return new GenkitMcpManager(options);
+export function createMcpHost(options: McpHostOptions) {
+  return new GenkitMcpHost(options);
 }
 
 /**

--- a/js/plugins/mcp/src/util/resources.ts
+++ b/js/plugins/mcp/src/util/resources.ts
@@ -17,11 +17,11 @@
 import { Resource, ResourceTemplate } from '@modelcontextprotocol/sdk/types.js';
 import { Genkit, GenkitError, ToolAction, z } from 'genkit';
 import { logger } from 'genkit/logging';
-import { GenkitMcpManager } from '../client';
+import { GenkitMcpHost } from '../client';
 
 function listResourcesTool(
   ai: Genkit,
-  manager: GenkitMcpManager,
+  host: GenkitMcpHost,
   params: { asDynamicTool?: boolean }
 ): ToolAction {
   const actionMetadata = {
@@ -43,7 +43,7 @@ function listResourcesTool(
       string,
       { resources: Resource[]; resourceTemplates: ResourceTemplate[] }
     > = {};
-    for (const client of manager.activeClients) {
+    for (const client of host.activeClients) {
       if (
         opts?.servers &&
         opts.servers.length > 0 &&
@@ -83,7 +83,7 @@ function listResourcesTool(
 
 function readResourceTool(
   ai: Genkit,
-  manager: GenkitMcpManager,
+  host: GenkitMcpHost,
   params: { asDynamicTool?: boolean }
 ) {
   const actionMetadata = {
@@ -95,7 +95,7 @@ function readResourceTool(
     }),
   };
   const fn = async ({ server, uri }) => {
-    const client = manager.activeClients.find((c) => c.name === server);
+    const client = host.activeClients.find((c) => c.name === server);
     if (!client) {
       throw new GenkitError({
         status: 'NOT_FOUND',
@@ -121,13 +121,10 @@ function readResourceTool(
  * @param params Configuration parameters, including the client name and server name for namespacing.
  * @returns An array of Genkit `ToolAction` instances for MCP resource operations.
  */
-export function fetchDynamicResourceTools(
-  ai: Genkit,
-  manager: GenkitMcpManager
-) {
+export function fetchDynamicResourceTools(ai: Genkit, host: GenkitMcpHost) {
   const dynamicParams = { asDynamicTool: true };
   return [
-    listResourcesTool(ai, manager, dynamicParams),
-    readResourceTool(ai, manager, dynamicParams),
+    listResourcesTool(ai, host, dynamicParams),
+    readResourceTool(ai, host, dynamicParams),
   ];
 }

--- a/js/testapps/esm/src/index.ts
+++ b/js/testapps/esm/src/index.ts
@@ -24,7 +24,7 @@ import { enableGoogleCloudTelemetry } from '@genkit-ai/google-cloud';
 import { googleAI } from '@genkit-ai/googleai';
 import {
   createMcpClient,
-  createMcpManager,
+  createMcpHost,
   createMcpServer,
 } from '@genkit-ai/mcp';
 import { appRoute } from '@genkit-ai/next';
@@ -53,7 +53,7 @@ devLocalVectorstore;
 genkitEval;
 createMcpClient;
 createMcpServer;
-createMcpManager;
+createMcpHost;
 
 export const ai = genkit({});
 const hello = ai.defineFlow('hello', () => 'hello');

--- a/js/testapps/mcp/src/index.ts
+++ b/js/testapps/mcp/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 import { googleAI } from '@genkit-ai/googleai';
-import { createMcpManager } from '@genkit-ai/mcp';
+import { createMcpHost } from '@genkit-ai/mcp';
 import { genkit, z } from 'genkit';
 import { logger } from 'genkit/logging';
 import path from 'path';
@@ -50,7 +50,7 @@ export const ai = genkit({
 
 logger.setLogLevel('debug'); // Set the logging level to debug for detailed output
 
-export const clientManager = createMcpManager({
+export const clientManager = createMcpHost({
   name: 'test-mcp-manager',
   mcpServers: {
     'git-client': {


### PR DESCRIPTION
The terminology for "thing that managers multiple MCP clients" seems to be converging on "MCP Host" so I'm going with that instead of Manager for the name.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
