### PR TITLE
fix(py): Support more complex schemas gemini

### DIFF
--- a/go/samples/mcp-server/run-server.sh
+++ b/go/samples/mcp-server/run-server.sh
@@ -1,3 +1,19 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #!/bin/bash
 # Simple wrapper script for Claude Desktop MCP integration
 

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -538,11 +538,23 @@ class GeminiModel:
         Returns:
             Schema or None
         """
-        if input_schema is None or 'type' not in input_schema:
+        if input_schema is None:
             return None
 
         if defs is None:
             defs = input_schema.get('$defs') if '$defs' in input_schema else {}
+
+        if 'type' not in input_schema:
+            if '$ref' in input_schema:
+                ref_tokens = input_schema['$ref'].split('/')
+                if ref_tokens[2] not in defs:
+                    raise ValueError(f'Failed to resolve schema for {ref_tokens[2]}')
+                schema = self._convert_schema_property(defs[ref_tokens[2]], defs)
+                if input_schema.get('description'):
+                    schema.description = input_schema['description']
+                return schema
+            else:
+                return None
 
         schema = genai_types.Schema()
         if input_schema.get('description'):
@@ -565,28 +577,8 @@ class GeminiModel:
                 schema.properties = {}
                 properties = input_schema['properties']
                 for key in properties:
-                    if isinstance(properties[key], dict) and '$ref' in properties[key]:
-                        ref_tokens = properties[key]['$ref'].split('/')
-                        if ref_tokens[2] not in defs:
-                            raise ValueError(f'Failed to resolve schema for {ref_tokens[2]}')
-                        resolved_schema = self._convert_schema_property(defs[ref_tokens[2]], defs)
-                        schema.properties[key] = resolved_schema
-
-                        if 'description' in properties[key]:
-                            schema.properties[key].description = properties[key]['description']
-                    # For lists of structs
-                    elif isinstance(properties[key], dict) and 'items' in properties[key] and '$ref' in properties[key]:
-                        ref_tokens = properties[key]['items']['$ref'].split('/')
-                        if ref_tokens[2] not in defs:
-                            raise ValueError(f'Failed to resolve schema for {ref_tokens[2]}')
-                        resolved_schema = self._convert_schema_property(defs[ref_tokens[2]], defs)
-                        schema.properties[key] = resolved_schema
-
-                        if 'description' in properties[key]:
-                            schema.properties[key].description = properties[key]['description']
-                    else:
-                        nested_schema = self._convert_schema_property(properties[key], defs)
-                        schema.properties[key] = nested_schema
+                    nested_schema = self._convert_schema_property(properties[key], defs)
+                    schema.properties[key] = nested_schema
 
         return schema
 

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -574,6 +574,16 @@ class GeminiModel:
 
                         if 'description' in properties[key]:
                             schema.properties[key].description = properties[key]['description']
+                    # For lists of structs
+                    elif isinstance(properties[key], dict) and 'items' in properties[key] and '$ref' in properties[key]:
+                        ref_tokens = properties[key]['items']['$ref'].split('/')
+                        if ref_tokens[2] not in defs:
+                            raise ValueError(f'Failed to resolve schema for {ref_tokens[2]}')
+                        resolved_schema = self._convert_schema_property(defs[ref_tokens[2]], defs)
+                        schema.properties[key] = resolved_schema
+
+                        if 'description' in properties[key]:
+                            schema.properties[key].description = properties[key]['description']
                     else:
                         nested_schema = self._convert_schema_property(properties[key], defs)
                         schema.properties[key] = nested_schema

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -547,12 +547,12 @@ class GeminiModel:
         if '$ref' in input_schema:
             ref_path = input_schema['$ref']
             ref_tokens = ref_path.split('/')
-            ref_name = ref_tokens[2]
+            ref_name = ref_tokens[-1]
 
             if ref_name not in defs:
-                raise ValueError(f'Failed to resolve schema for {ref_tokens[2]}')
+                raise ValueError(f'Failed to resolve schema for {ref_name}')
 
-            schema = self._convert_schema_property(defs[ref_tokens[2]], defs)
+            schema = self._convert_schema_property(defs[ref_name], defs)
 
             if input_schema.get('description'):
                 schema.description = input_schema['description']

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -547,7 +547,7 @@ class GeminiModel:
         if '$ref' in input_schema:
             ref_path = input_schema['$ref']
             ref_tokens = ref_path.split('/')
-            ref_name = ref_tokens[-1]
+            ref_name = ref_tokens[2]
 
             if ref_name not in defs:
                 raise ValueError(f'Failed to resolve schema for {ref_tokens[2]}')

--- a/py/plugins/google-genai/test/models/test_googlegenai_gemini.py
+++ b/py/plugins/google-genai/test/models/test_googlegenai_gemini.py
@@ -577,6 +577,53 @@ def test_gemini_model__create_tool(mock_convert_schema_property, gemini_model_in
                 },
             ),
         ),
+        # Test Case 11: Object with $ref at list field
+        (
+            {
+                '$defs': {
+                    'Product': {
+                        'properties': {
+                            'product_name': {
+                                'title': 'Product Name',
+                                'type': 'string',
+                            },
+                        },
+                        'required': ['product_name'],
+                        'title': 'Product',
+                        'type': 'object',
+                    },
+                },
+                'properties': {
+                    'products': {
+                        'items': {'$ref': '#/$defs/Product'},
+                        'title': 'Products',
+                        'type': 'array',
+                    },
+                },
+                'required': ['products'],
+                'title': 'Store',
+                'type': 'object',
+            },
+            None,
+            genai_types.Schema(
+                type=genai_types.Type.OBJECT,
+                properties={
+                    'products': genai_types.Schema(
+                        items=genai_types.Schema(
+                            properties={
+                                'product_name': genai_types.Schema(
+                                    type=genai_types.Type.STRING,
+                                ),
+                            },
+                            required=['product_name'],
+                            type=genai_types.Type.OBJECT,
+                        ),
+                        type=genai_types.Type.ARRAY,
+                    ),
+                },
+                required=['products'],
+            ),
+        ),
     ],
 )
 def test_gemini_model__convert_schema_property(


### PR DESCRIPTION
I was doing a recommender system by myself, and I found that gemini do not support this kind of output_schemas:
```
class Product(BaseModel):
    product_name: str = Field(description='name of the product')
    product_description: str = Field(description='description of the product')

class StoreSchema(BaseModel):
    store_name: str = Field(description='name of the store')
    products: list[Product] = Field(description='list of products in the store (5 to 10)')
```
So I decided to generate the bugfix

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
