### PR TITLE
fix: Update metric attribute length truncation to match Trace attribute max length.

### DIFF
--- a/js/plugins/google-cloud/src/metrics.ts
+++ b/js/plugins/google-cloud/src/metrics.ts
@@ -25,7 +25,6 @@ import type { PathMetadata } from 'genkit/tracing';
 
 export const METER_NAME = 'genkit';
 export const METRIC_NAME_PREFIX = 'genkit';
-const METRIC_DIMENSION_MAX_CHARS = 32;
 
 export function internalMetricNamespaceWrap(...namespaces) {
   return [METRIC_NAME_PREFIX, ...namespaces].join('/');
@@ -76,7 +75,6 @@ export class MetricCounter extends Metric<Counter> {
 
   add(val?: number, opts?: any) {
     if (val) {
-      truncateDimensions(opts);
       this.get().add(val, opts);
     }
   }
@@ -96,25 +94,8 @@ export class MetricHistogram extends Metric<Histogram> {
 
   record(val?: number, opts?: any) {
     if (val) {
-      truncateDimensions(opts);
       this.get().record(val, opts);
     }
-  }
-}
-
-/**
- * Truncates all of the metric dimensions to avoid long, high-cardinality
- * dimensions being added to metrics.
- */
-function truncateDimensions(opts?: any) {
-  if (opts) {
-    Object.keys(opts).forEach((k) => {
-      // We don't want to truncate paths. They are known to be long but with
-      // relatively low cardinality, and are useful for downstream monitoring.
-      if (!k.startsWith('path') && typeof opts[k] == 'string') {
-        opts[k] = opts[k].substring(0, METRIC_DIMENSION_MAX_CHARS);
-      }
-    });
   }
 }
 

--- a/js/plugins/google-cloud/src/metrics.ts
+++ b/js/plugins/google-cloud/src/metrics.ts
@@ -111,7 +111,7 @@ export class MetricHistogram extends Metric<Histogram> {
 function truncateDimensions(opts?: any) {
   if (opts) {
     Object.keys(opts).forEach((k) => {
-      if (typeof opts[k] == 'string') {
+      if (typeof opts[k] === 'string') {
         opts[k] = opts[k].substring(0, METRIC_DIMENSION_MAX_CHARS);
       }
     });

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -259,25 +259,6 @@ describe('GoogleCloudMetrics', () => {
     assert.ok(latencyHistogram.attributes.sourceVersion);
   });
 
-  it('truncates metric dimensions', async () => {
-    const testFlow = createFlow(ai, 'anExtremelyLongFlowNameThatIsTooBig');
-
-    await testFlow();
-
-    await getExportedSpans();
-
-    const requestCounter = await getCounterMetric('genkit/feature/requests');
-    const latencyHistogram = await getHistogramMetric('genkit/feature/latency');
-    assert.equal(
-      requestCounter.attributes.name,
-      'anExtremelyLongFlowNameThatIsToo'
-    );
-    assert.equal(
-      latencyHistogram.attributes.name,
-      'anExtremelyLongFlowNameThatIsToo'
-    );
-  });
-
   it('writes action failure metrics', async () => {
     const testAction = ai.defineTool(
       { name: 'testActionWithFailure', description: 'Just a test' },


### PR DESCRIPTION
Attribute truncation should be consistent between metric data written and trace data written so that data can be correlated between aggregate metric data and specific traces.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
