### PR TITLE
fix(go/genkit): Update dotprompt version

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.4.0
 	github.com/blues/jsonata-go v1.5.4
 	github.com/goccy/go-yaml v1.17.1
-	github.com/google/dotprompt/go v0.0.0-20250424065700-61c578cf43ac
+	github.com/google/dotprompt/go v0.0.0-20250611200215-bb73406b05ca
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.13.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -161,8 +161,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/google/dotprompt/go v0.0.0-20250424065700-61c578cf43ac h1:ktLPEL36xpnElPk3FZKXtU5qHF+5Ozv5ZcC5kPAwV7k=
-github.com/google/dotprompt/go v0.0.0-20250424065700-61c578cf43ac/go.mod h1:dnIk+MSMnipm9uZyPIgptq7I39aDxyjBiaev/OG0W0Y=
+github.com/google/dotprompt/go v0.0.0-20250611200215-bb73406b05ca h1:LuQ8KS5N04c37jyaq6jelLdNi0GfI6QJb8lpnYaDW9Y=
+github.com/google/dotprompt/go v0.0.0-20250611200215-bb73406b05ca/go.mod h1:dnIk+MSMnipm9uZyPIgptq7I39aDxyjBiaev/OG0W0Y=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=


### PR DESCRIPTION
Description here... Help the reviewer by:
 - https://github.com/firebase/genkit/issues/3019
 - Update the dotprompt version to get changes from the PR : https://github.com/google/dotprompt/pull/312

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
