### PR TITLE
feat(js/mcp): Adds support for MCP _meta via context.

### DIFF
--- a/js/plugins/mcp/src/client/host.ts
+++ b/js/plugins/mcp/src/client/host.ts
@@ -42,6 +42,13 @@ export interface McpHostOptions {
    * The key in the record is used as the identifier for the MCP server.
    */
   mcpServers?: Record<string, McpServerConfig>;
+
+  /**
+   * If true, tool responses from the MCP server will be returned in their raw
+   * MCP format. Otherwise (default), they are processed and potentially
+   * simplified for better compatibility with Genkit's typical data structures.
+   */
+  rawToolResponses?: boolean;
 }
 
 /** Internal representation of client state for logging. */
@@ -69,9 +76,11 @@ export class GenkitMcpHost {
     reject: (err: Error) => void;
   }[] = [];
   private _ready = false;
+  rawToolResponses?: boolean;
 
   constructor(options: McpHostOptions) {
     this.name = options.name || 'genkit-mcp';
+    this.rawToolResponses = options.rawToolResponses;
 
     if (options.mcpServers) {
       this.updateServers(options.mcpServers);
@@ -122,6 +131,7 @@ export class GenkitMcpHost {
         name: this.name,
         serverName: serverName,
         mcpServer: config,
+        rawToolResponses: this.rawToolResponses,
       });
       this._clients[serverName] = client;
     } catch (e) {

--- a/js/plugins/mcp/src/util/prompts.ts
+++ b/js/plugins/mcp/src/util/prompts.ts
@@ -66,7 +66,7 @@ function registerPrompt(
     description: prompt.description || '',
     input: { jsonSchema: toSchema(prompt.arguments) },
     output: { format: 'text' },
-    messages: async (args) => {
+    messages: async (args, { context }) => {
       logger.debug(
         `[MCP] Calling MCP prompt ${params.name}/${prompt.name} with arguments`,
         JSON.stringify(args)
@@ -74,6 +74,7 @@ function registerPrompt(
       const result = await client.getPrompt({
         name: prompt.name,
         arguments: args,
+        _meta: context?.mcp?._meta,
       });
       return result.messages.map(fromMcpPromptMessage);
     },
@@ -119,6 +120,7 @@ function createExecutablePrompt<
     const result = await client.getPrompt({
       name: prompt.name,
       arguments: input as any,
+      _meta: opts?.context?.mcp?._meta,
     });
     const messages = result.messages.map(fromMcpPromptMessage);
     return {

--- a/js/plugins/mcp/src/util/tools.ts
+++ b/js/plugins/mcp/src/util/tools.ts
@@ -111,13 +111,14 @@ function createDynamicTool(
       inputJsonSchema: tool.inputSchema as JSONSchema7,
       outputSchema: z.any(),
     },
-    async (args) => {
+    async (args, { context }) => {
       logger.debug(
         `[MCP] Dynamically calling MCP tool '${params.name}/${tool.name}'`
       );
       const result = await client.callTool({
         name: tool.name,
         arguments: args,
+        _meta: context?.mcp?._meta,
       });
       if (params.rawToolResponses) return result;
       return processResult(result as CallToolResult);

--- a/js/plugins/mcp/tests/fakes.ts
+++ b/js/plugins/mcp/tests/fakes.ts
@@ -129,10 +129,16 @@ export class FakeTransport implements Transport {
         id: request.id,
       });
     } else if (request.method === 'tools/call') {
+      const result = {
+        ...this.callToolResult,
+      };
+      if (request.params?._meta)
+        result.content = [
+          ...(result.content || []),
+          { type: 'text', text: JSON.stringify(request.params._meta) },
+        ];
       this.onmessage?.({
-        result: {
-          ...this.callToolResult,
-        },
+        result,
         jsonrpc: '2.0',
         id: request.id,
       });
@@ -145,10 +151,22 @@ export class FakeTransport implements Transport {
         id: request.id,
       });
     } else if (request.method === 'prompts/get') {
+      const result = {
+        ...this.getPromptResult,
+      };
+      if (request.params?._meta)
+        result.messages = [
+          ...(result.messages || []),
+          {
+            role: 'assistant',
+            content: {
+              type: 'text',
+              text: JSON.stringify(request.params._meta),
+            },
+          },
+        ];
       this.onmessage?.({
-        result: {
-          ...this.getPromptResult,
-        },
+        result,
         jsonrpc: '2.0',
         id: request.id,
       });


### PR DESCRIPTION
This solves the issue raised by #2662 by allowing MCP metadata to be specified as part of context and passed to the server.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
