### PR TITLE
docs: fix up OpenAI plugin example

### DIFF
--- a/go/plugins/compat_oai/openai/README.md
+++ b/go/plugins/compat_oai/openai/README.md
@@ -14,7 +14,7 @@ Here's a simple example of how to use the OpenAI plugin:
 ```go
 // import "github.com/firebase/genkit/go/plugins/compat_oai/openai"
 // Initialize the OpenAI plugin with your API key
-oai := openai.NewPlugin(apiKey)
+oai := &openai.OpenAI{APIKey: apiKey,}
 
 // Initialize Genkit with the OpenAI plugin
 g, err := genkit.Init(ctx,


### PR DESCRIPTION
Close #3079 

Fix up typo in the docs for OpenAI plugin.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
