### PR TITLE
fix(py): Remove hardcoded name for firestore plugin 

### DIFF
--- a/py/plugins/firebase/src/genkit/plugins/firebase/firestore.py
+++ b/py/plugins/firebase/src/genkit/plugins/firebase/firestore.py
@@ -41,6 +41,7 @@ def firestore_action_name(name: str) -> str:
 
 class FirestoreVectorStore(Plugin):
     """Firestore retriever plugin.
+
     Args:
         name: name if the retriever.
         collection: The name of the Firestore collection to query.
@@ -53,8 +54,6 @@ class FirestoreVectorStore(Plugin):
         metadata_fields: Optional list of metadata fields to include.
     """
 
-    name = 'firebaseFirestore'
-
     def __init__(
         self,
         name: str,
@@ -66,11 +65,19 @@ class FirestoreVectorStore(Plugin):
         embedder_options: dict[str, Any] | None = None,
         distance_measure: DistanceMeasure = DistanceMeasure.COSINE,
         metadata_fields: list[str] | MetadataTransformFn | None = None,
-    ):
+    ) -> None:
         """Initialize the firestore plugin.
 
         Args:
-            params: List of firestore retriever configurations.
+            name: name if the retriever.
+            collection: The name of the Firestore collection to query.
+            vector_field: The name of the field containing the vector embeddings.
+            content_field: The name of the field containing the document content, you wish to return.
+            embedder: The embedder to use with this retriever.
+            embedder_options: Optional configuration to pass to the embedder.
+            distance_measure: The distance measure to use when comparing vectors. Defaults to 'COSINE'.
+            firestore_client: The Firestore database instance from which to query.
+            metadata_fields: Optional list of metadata fields to include.
         """
         self.name = name
         self.firestore_client = firestore_client

--- a/py/samples/firestore-retreiver/README.md
+++ b/py/samples/firestore-retreiver/README.md
@@ -11,9 +11,9 @@ source .venv/bin/activate
 ```
 gcloud firestore indexes composite create \
   --project=<FIREBASE-PROJECT>\
-  --collection-group=<COLLECTION-NAME> \
+  --collection-group=films \
   --query-scope=COLLECTION \
-  --field-config=vector-config='{"dimension":"3","flat": "{}"}',field-path=<VECTOR-FIELD>
+  --field-config=vector-config='{"dimension":"768","flat": "{}"}',field-path=embedding
 ```
 ## Run the sample
 

--- a/py/samples/firestore-retreiver/src/main.py
+++ b/py/samples/firestore-retreiver/src/main.py
@@ -38,7 +38,7 @@ ai = Genkit(
     plugins=[
         VertexAI(),
         FirestoreVectorStore(
-            name='filmsretriever',
+            name='my_firestore_retriever',
             collection='films',
             vector_field='embedding',
             content_field='text',
@@ -96,7 +96,7 @@ async def retreive_documents():
     """Retrieves the film documents from Firestore."""
     return await ai.retrieve(
         query=Document.from_text('sci-fi film'),
-        retriever=firestore_action_name('filmsretriever'),
+        retriever=firestore_action_name('my_firestore_retriever'),
     )
 
 
@@ -106,7 +106,7 @@ async def main() -> None:
     This function demonstrates how to create and use AI flows in the
     Genkit framework.
     """
-    print(await index_documents())
+    await index_documents()
     print(await retreive_documents())
 
 


### PR DESCRIPTION
To solve this issue https://github.com/firebase/genkit/issues/3052 the plugin had a name hardcoded. I deleted the hardcoded name and added some documentation fixes.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
