### PR TITLE
fix(js/plugins/google-cloud): Add missing role field to structured input and output logs from GCP plugin

### DIFF
--- a/js/plugins/google-cloud/src/telemetry/generate.ts
+++ b/js/plugins/google-cloud/src/telemetry/generate.ts
@@ -260,6 +260,7 @@ class GenerateTelemetry implements Telemetry {
         logger.logStructured(`Input[${path}, ${model}] ${partCounts}`, {
           ...sharedMetadata,
           content: this.toPartLogContent(part),
+          role: msg.role,
           partIndex: partIdx,
           totalParts: parts,
           messageIndex: msgIdx,
@@ -302,6 +303,7 @@ class GenerateTelemetry implements Telemetry {
           ...initial,
           ...sharedMetadata,
           content: this.toPartLogContent(part),
+          role: message.role,
           partIndex: partIdx,
           totalParts: parts,
           candidateIndex: 0,

--- a/js/plugins/google-cloud/tests/logs_test.ts
+++ b/js/plugins/google-cloud/tests/logs_test.ts
@@ -296,7 +296,7 @@ describe('GoogleCloudLogs', () => {
     const testModel = createModel(ai, 'testModel', async () => {
       return {
         message: {
-          role: 'user',
+          role: 'model',
           content: [
             {
               text: 'response',
@@ -336,6 +336,7 @@ describe('GoogleCloudLogs', () => {
     await getExportedSpans();
 
     const logs = await getLogs(1, 100, logLines);
+    expect(logs.length).toEqual(8);
     const logObjectMessages = getStructuredLogMessages(logs);
     expect(logObjectMessages).toContain(
       'Config[testFlow > sub1 > sub2 > generate > testModel, testModel]'
@@ -348,6 +349,22 @@ describe('GoogleCloudLogs', () => {
     );
     expect(logObjectMessages).toContain('Input[testFlow, testFlow]');
     expect(logObjectMessages).toContain('Output[testFlow, testFlow]');
+    // Ensure the model input/output has an associated role
+    logs.map((log) => {
+      const structuredLog = JSON.parse(log as string);
+      if (
+        structuredLog.message ===
+        'Input[testFlow > sub1 > sub2 > generate > testModel, testModel] '
+      ) {
+        expect(structuredLog.role).toBe('user');
+      }
+      if (
+        structuredLog.message ===
+        'Output[testFlow > sub1 > sub2 > generate > testModel, testModel]'
+      ) {
+        expect(structuredLog.role).toBe('model');
+      }
+    });
   });
 
   it('writes user feedback log', async () => {


### PR DESCRIPTION
Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
