### PR TITLE
fix(js/plugins/google-cloud): Fix feature name parsing to include "dotprompt" type

### DIFF
--- a/js/plugins/google-cloud/src/utils.ts
+++ b/js/plugins/google-cloud/src/utils.ts
@@ -59,7 +59,7 @@ export function extractOuterFeatureNameFromPath(path: string) {
     return '<unknown>';
   }
   const first = path.split('/')[1];
-  const featureName = first?.match('{(.+),t:(flow|action|prompt|helper)');
+  const featureName = first?.match('{(.+),t:(flow|action|prompt|dotprompt|helper)');
   return featureName ? featureName[1] : '<unknown>';
 }
 

--- a/js/plugins/google-cloud/src/utils.ts
+++ b/js/plugins/google-cloud/src/utils.ts
@@ -59,7 +59,9 @@ export function extractOuterFeatureNameFromPath(path: string) {
     return '<unknown>';
   }
   const first = path.split('/')[1];
-  const featureName = first?.match('{(.+),t:(flow|action|prompt|dotprompt|helper)');
+  const featureName = first?.match(
+    '{(.+),t:(flow|action|prompt|dotprompt|helper)'
+  );
   return featureName ? featureName[1] : '<unknown>';
 }
 


### PR DESCRIPTION
Include "dotprompt" as a valid path segment type. When extracting the root "feature name", this prevents paths of this type falling back to the default ("generate").

- [X] Tested (manually)
