### PR TITLE
fix(js/plugins/google-cloud): Write input and output logs for generate step

### DIFF
--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -426,7 +426,12 @@ class AdjustingTraceExporter implements SpanExporter {
     if (type === 'action' && subtype === 'tool') {
       // TODO: Report input and output for tool actions
     }
-    if (type === 'action' || type === 'flow' || type == 'flowStep') {
+    if (
+      type === 'action' ||
+      type === 'flow' ||
+      type == 'flowStep' ||
+      type == 'util'
+    ) {
       // Report request and latency metrics for all actions
       actionTelemetry.tick(
         span,

--- a/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+++ b/js/plugins/google-cloud/src/gcpOpenTelemetry.ts
@@ -413,32 +413,33 @@ class AdjustingTraceExporter implements SpanExporter {
       pathsTelemetry.tick(span, paths, this.logInputAndOutput, this.projectId);
       // Set root status explicitly
       span.attributes['genkit:rootState'] = span.attributes['genkit:state'];
-    }
-    if (type === 'action' && subtype === 'model') {
-      // Report generate metrics () for all model actions
-      generateTelemetry.tick(
-        span,
-        unused,
-        this.logInputAndOutput,
-        this.projectId
-      );
-    }
-    if (type === 'action' && subtype === 'tool') {
-      // TODO: Report input and output for tool actions
-    }
-    if (
-      type === 'action' ||
-      type === 'flow' ||
-      type == 'flowStep' ||
-      type == 'util'
-    ) {
-      // Report request and latency metrics for all actions
-      actionTelemetry.tick(
-        span,
-        unused,
-        this.logInputAndOutput,
-        this.projectId
-      );
+    } else {
+      if (type === 'action' && subtype === 'model') {
+        // Report generate metrics () for all model actions
+        generateTelemetry.tick(
+          span,
+          unused,
+          this.logInputAndOutput,
+          this.projectId
+        );
+      }
+      if (type === 'action' && subtype === 'tool') {
+        // TODO: Report input and output for tool actions
+      }
+      if (
+        type === 'action' ||
+        type === 'flow' ||
+        type == 'flowStep' ||
+        type == 'util'
+      ) {
+        // Report request and latency metrics for all actions
+        actionTelemetry.tick(
+          span,
+          unused,
+          this.logInputAndOutput,
+          this.projectId
+        );
+      }
     }
     if (type === 'userEngagement') {
       // Report user acceptance and feedback metrics

--- a/js/plugins/google-cloud/src/telemetry/action.ts
+++ b/js/plugins/google-cloud/src/telemetry/action.ts
@@ -32,24 +32,23 @@ class ActionTelemetry implements Telemetry {
     logInputAndOutput: boolean,
     projectId?: string
   ): void {
+    if (!logInputAndOutput) {
+      return;
+    }
     const attributes = span.attributes;
-
     const actionName = (attributes['genkit:name'] as string) || '<unknown>';
     const subtype = attributes['genkit:metadata:subtype'] as string;
-    const path = (attributes['genkit:path'] as string) || '<unknown>';
-    let featureName = extractOuterFeatureNameFromPath(path);
-    if (!featureName || featureName === '<unknown>') {
-      featureName = actionName;
-    }
 
-    if (
-      (subtype === 'tool' || actionName === 'generate') &&
-      logInputAndOutput
-    ) {
+    if (subtype === 'tool' || actionName === 'generate') {
+      const path = (attributes['genkit:path'] as string) || '<unknown>';
       const input = truncate(attributes['genkit:input'] as string);
       const output = truncate(attributes['genkit:output'] as string);
       const sessionId = attributes['genkit:sessionId'] as string;
       const threadName = attributes['genkit:threadName'] as string;
+      let featureName = extractOuterFeatureNameFromPath(path);
+      if (!featureName || featureName === '<unknown>') {
+        featureName = actionName;
+      }
 
       if (input) {
         this.writeLog(

--- a/js/plugins/google-cloud/src/telemetry/action.ts
+++ b/js/plugins/google-cloud/src/telemetry/action.ts
@@ -42,7 +42,10 @@ class ActionTelemetry implements Telemetry {
       featureName = actionName;
     }
 
-    if (subtype === 'tool' && logInputAndOutput) {
+    if (
+      (subtype === 'tool' || actionName === 'generate') &&
+      logInputAndOutput
+    ) {
       const input = truncate(attributes['genkit:input'] as string);
       const output = truncate(attributes['genkit:output'] as string);
       const sessionId = attributes['genkit:sessionId'] as string;


### PR DESCRIPTION
Previously the 'generate' helpers wrote their full input/output logs only when it is a root node (outside a flow). This change ensures that those logs always get written. They provide useful information in the Firebase console.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
