### PR TITLE
refactor(js): fix typo in variable name

### DIFF
--- a/js/ai/src/model/middleware.ts
+++ b/js/ai/src/model/middleware.ts
@@ -239,7 +239,7 @@ export interface SimulatedConstrainedGenerationOptions {
   instructionsRenderer?: (schema: Record<string, any>) => string;
 }
 
-const DEFAULT_CONSTRAINED_GENERATION_INSTRUSCTIONS = (
+const DEFAULT_CONSTRAINED_GENERATION_INSTRUCTIONS = (
   schema: Record<string, any>
 ) => `Output should be in JSON format and conform to the following schema:
 
@@ -260,7 +260,7 @@ export function simulateConstrainedGeneration(
     if (req.output?.constrained && req.output?.schema) {
       instructions = (
         options?.instructionsRenderer ??
-        DEFAULT_CONSTRAINED_GENERATION_INSTRUSCTIONS
+        DEFAULT_CONSTRAINED_GENERATION_INSTRUCTIONS
       )(req.output?.schema);
 
       req = {


### PR DESCRIPTION
Fix a simple typo

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.) N/A - CI should be sufficient
- [ ] Docs updated (updated docs or a docs bug required) N/A
