### PR TITLE
feat(js/ai): added support for dynamically resolvable resources

### DIFF
--- a/js/ai/package.json
+++ b/js/ai/package.json
@@ -35,10 +35,12 @@
     "json5": "^2.2.3",
     "node-fetch": "^3.3.2",
     "partial-json": "^0.1.7",
+    "uri-templates": "^0.2.0",
     "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@types/uuid": "^9.0.6",
+    "@types/uri-templates": "^0.1.34",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
     "tsup": "^8.3.5",

--- a/js/ai/src/document.ts
+++ b/js/ai/src/document.ts
@@ -26,6 +26,7 @@ const EmptyPartSchema = z.object({
   metadata: z.record(z.unknown()).optional(),
   custom: z.record(z.unknown()).optional(),
   reasoning: z.never().optional(),
+  resource: z.never().optional(),
 });
 
 /**
@@ -146,6 +147,18 @@ export const CustomPartSchema = EmptyPartSchema.extend({
  * Custom part.
  */
 export type CustomPart = z.infer<typeof CustomPartSchema>;
+
+/**
+ * Zod schema of a resource part.
+ */
+export const ResourcePartSchema = EmptyPartSchema.extend({
+  resource: z.string(),
+});
+
+/**
+ * Resource part.
+ */
+export type ResourcePart = z.infer<typeof ResourcePartSchema>;
 
 export const PartSchema = z.union([TextPartSchema, MediaPartSchema]);
 export type Part = z.infer<typeof PartSchema>;

--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -42,6 +42,7 @@ import {
   GenerateActionOptionsSchema,
   GenerateResponseChunkSchema,
   GenerateResponseSchema,
+  MessageData,
   resolveModel,
   type GenerateActionOptions,
   type GenerateActionOutputConfig,
@@ -56,6 +57,7 @@ import {
   type Part,
   type Role,
 } from '../model.js';
+import { findMatchingResource } from '../resource.js';
 import { resolveTools, toToolDefinition, type ToolAction } from '../tool.js';
 import {
   assertValidToolNames,
@@ -245,6 +247,7 @@ async function generate(
     rawRequest
   );
   rawRequest = applyFormat(rawRequest, format);
+  rawRequest = await applyResources(registry, rawRequest);
 
   // check to make sure we don't have overlapping tool names *before* generation
   await assertValidToolNames(tools);
@@ -470,4 +473,51 @@ function getRoleFromPart(part: Part): Role {
   if (part.media !== undefined) return 'user';
   if (part.data !== undefined) return 'user';
   throw new Error('No recognized fields in content');
+}
+
+async function applyResources(
+  registry: Registry,
+  rawRequest: GenerateActionOptions
+): Promise<GenerateActionOptions> {
+  // quick check, if no resources bail.
+  if (!rawRequest.messages.find((m) => !!m.content.find((c) => c.resource))) {
+    return rawRequest;
+  }
+
+  const updatedMessages = [] as MessageData[];
+  for (const m of rawRequest.messages) {
+    if (!m.content.find((c) => c.resource)) {
+      updatedMessages.push(m);
+      continue;
+    }
+    const updatedContent = [] as Part[];
+    for (const p of m.content) {
+      if (!p.resource) {
+        updatedContent.push(p);
+        continue;
+      }
+      const resource = await findMatchingResource(registry, p.resource);
+      if (!resource) {
+        throw new GenkitError({
+          status: 'NOT_FOUND',
+          message: `failed to find matching resource for ${p.resource}`,
+        });
+      }
+      const resourceParts = await resource(p.resource);
+      resourceParts.forEach((r) => {
+        r.metadata = { resource: resource.__action.name, uri: p.resource };
+      });
+      updatedContent.push(...resourceParts);
+    }
+
+    updatedMessages.push({
+      ...m,
+      content: updatedContent,
+    });
+  }
+
+  return {
+    ...rawRequest,
+    messages: updatedMessages,
+  };
 }

--- a/js/ai/src/index.ts
+++ b/js/ai/src/index.ts
@@ -111,6 +111,12 @@ export {
   type RerankerReference,
 } from './reranker.js';
 export {
+  defineResource,
+  type ResourceAction,
+  type ResourceFn,
+  type ResourceOptions,
+} from './resource.js';
+export {
   index,
   indexerRef,
   retrieve,

--- a/js/ai/src/model.ts
+++ b/js/ai/src/model.ts
@@ -39,6 +39,7 @@ import {
   DocumentDataSchema,
   MediaPartSchema,
   ReasoningPartSchema,
+  ResourcePartSchema,
   TextPartSchema,
   ToolRequestPartSchema,
   ToolResponsePartSchema,
@@ -88,6 +89,7 @@ export const PartSchema = z.union([
   DataPartSchema,
   CustomPartSchema,
   ReasoningPartSchema,
+  ResourcePartSchema,
 ]);
 
 /**

--- a/js/ai/src/resource.ts
+++ b/js/ai/src/resource.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Action,
+  ActionContext,
+  defineAction,
+  GenkitError,
+  z,
+} from '@genkit-ai/core';
+import { Registry } from '@genkit-ai/core/registry';
+import uriTemplate from 'uri-templates';
+import { Part, PartSchema } from './model.js';
+
+/**
+ * Options for defining a resource.
+ */
+export interface ResourceOptions {
+  /**
+   * The URI of the resource. Can contain template variables.
+   */
+  uri: string;
+
+  /**
+   * A description of the resource.
+   */
+  description?: string;
+}
+
+/**
+ * A function that returns parts for a given resource.
+ */
+export type ResourceFn = (
+  vars: Record<string, string>,
+  ctx: ActionContext
+) => Part[] | Promise<Part[]>;
+
+/**
+ * A resource action.
+ */
+export interface ResourceAction
+  extends Action<
+    z.ZodString,
+    z.ZodArray<typeof PartSchema>,
+    z.ZodArray<typeof PartSchema>
+  > {
+  matches(input: string): boolean;
+}
+
+/**
+ * Defines a resource.
+ *
+ * @param registry The registry to register the resource with.
+ * @param opts The resource options.
+ * @param fn The resource function.
+ * @returns The resource action.
+ */
+export function defineResource(
+  registry: Registry,
+  opts: ResourceOptions,
+  fn: ResourceFn
+): ResourceAction {
+  const template = uriTemplate(opts.uri);
+  const matcher = (input: string) => {
+    return template.fromUri(input);
+  };
+
+  const action = defineAction(
+    registry,
+    {
+      actionType: 'resource',
+      name: opts.uri,
+      description: opts.description,
+      inputSchema: z.string(),
+      outputSchema: z.array(PartSchema),
+      metadata: {
+        template: opts.uri,
+      },
+    },
+    async (input, ctx) => {
+      const templateMatch = matcher(input);
+      if (!templateMatch) {
+        throw new GenkitError({
+          status: 'INVALID_ARGUMENT',
+          message: `input ${input} did not match template ${opts.uri}`,
+        });
+      }
+      return await fn(templateMatch, ctx);
+    }
+  ) as ResourceAction;
+
+  action.matches = (input: string) => matcher(input) !== undefined;
+
+  return action;
+}
+
+/**
+ * Finds a matching resource in the registry. If not found returns undefined.
+ */
+export async function findMatchingResource(
+  registry: Registry,
+  input: string
+): Promise<ResourceAction | undefined> {
+  for (const actKeys of Object.keys(await registry.listResolvableActions())) {
+    if (actKeys.startsWith('/resource/')) {
+      const resource = (await registry.lookupAction(actKeys)) as ResourceAction;
+      if (resource.matches(input)) {
+        return resource;
+      }
+    }
+  }
+  return undefined;
+}

--- a/js/ai/tests/resource/resource_test.ts
+++ b/js/ai/tests/resource/resource_test.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Registry } from '@genkit-ai/core/registry';
+import * as assert from 'assert';
+import { beforeEach, describe, it } from 'node:test';
+import { defineResource, findMatchingResource } from '../../src/resource.js';
+
+describe('resource', () => {
+  let registry: Registry;
+
+  beforeEach(() => {
+    registry = new Registry();
+  });
+
+  it('defines and matches static resource uri', async () => {
+    const testResource = defineResource(
+      registry,
+      {
+        uri: 'foo://bar',
+        description: 'does foo things',
+      },
+      () => {
+        return [{ text: 'foo stuff' }];
+      }
+    );
+
+    assert.ok(testResource);
+    assert.strictEqual(testResource.__action.description, 'does foo things');
+
+    assert.strictEqual(testResource.matches('foo://bar'), true);
+    assert.strictEqual(testResource.matches('foo://baz'), false);
+
+    assert.deepStrictEqual(await testResource('foo://bar'), [
+      { text: 'foo stuff' },
+    ]);
+
+    assert.ok(await registry.lookupAction('/resource/foo://bar'));
+  });
+
+  it('defines and matches templates resource uri', async () => {
+    const testResource = defineResource(
+      registry,
+      {
+        uri: 'foo://bar/{baz}',
+        description: 'does foo things',
+      },
+      ({ baz }) => {
+        return [{ text: `foo stuff ${baz}` }];
+      }
+    );
+
+    assert.ok(testResource);
+    assert.strictEqual(testResource.__action.description, 'does foo things');
+
+    assert.strictEqual(testResource.matches('foo://bar/something'), true);
+    assert.strictEqual(testResource.matches('foo://baz/something'), false);
+
+    assert.deepStrictEqual(await testResource('foo://bar/something'), [
+      { text: 'foo stuff something' },
+    ]);
+
+    assert.ok(await registry.lookupAction('/resource/foo://bar/{baz}'));
+  });
+
+  it('finds matching resource', async () => {
+    defineResource(
+      registry,
+      {
+        uri: 'foo://bar/{baz}',
+        description: 'does foo things',
+      },
+      ({ baz }) => {
+        return [{ text: `foo stuff ${baz}` }];
+      }
+    );
+    defineResource(
+      registry,
+      {
+        uri: 'bar://baz',
+        description: 'does bar things',
+      },
+      ({ baz }) => {
+        return [{ text: `bar` }];
+      }
+    );
+
+    const gotBar = await findMatchingResource(registry, 'bar://baz');
+    assert.ok(gotBar);
+    assert.strictEqual(gotBar.__action.name, 'bar://baz');
+
+    const gotFoo = await findMatchingResource(registry, 'foo://bar/something');
+    assert.ok(gotFoo);
+    assert.strictEqual(gotFoo.__action.name, 'foo://bar/{baz}');
+
+    const gotUnmatched = await findMatchingResource(
+      registry,
+      'unknown://bar/something'
+    );
+    assert.strictEqual(gotUnmatched, undefined);
+  });
+});

--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -52,7 +52,8 @@ export type ActionType =
   | 'reranker'
   | 'retriever'
   | 'tool'
-  | 'util';
+  | 'util'
+  | 'resource';
 
 /**
  * A schema is either a Zod schema or a JSON schema.

--- a/js/genkit/src/genkit-beta.ts
+++ b/js/genkit/src/genkit-beta.ts
@@ -16,11 +16,15 @@
 
 import {
   defineInterrupt,
+  defineResource,
   generateOperation,
   GenerateOptions,
   GenerateResponseData,
   GenerationCommonConfigSchema,
   isExecutablePrompt,
+  ResourceAction,
+  ResourceFn,
+  ResourceOptions,
   type ExecutablePrompt,
   type InterruptConfig,
   type ToolAction,
@@ -265,5 +269,25 @@ export class GenkitBeta extends Genkit {
       | PromiseLike<GenerateOptions<O, CustomOptions>>
   ): Promise<Operation<GenerateResponseData>> {
     return generateOperation(this.registry, opts);
+  }
+
+  /**
+   * Defines a resource. Resources can then be accessed from a genreate call.
+   *
+   * ```ts
+   * ai.defineResource({
+   *   name: 'myResource',
+   *   uri: 'my://resource/{param}',
+   *   description: 'provides my resource',
+   * }, async ({param}) => {
+   *   return [{ text: `resource ${param}` }]
+   * });
+   *
+   * await ai.generate({
+   *   prompt: [{ resource: 'my://resource/value' }]
+   * })
+   */
+  defineResource(opts: ResourceOptions, fn: ResourceFn): ResourceAction {
+    return defineResource(this.registry, opts, fn);
   }
 }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -62,10 +62,16 @@ importers:
       partial-json:
         specifier: ^0.1.7
         version: 0.1.7
+      uri-templates:
+        specifier: ^0.2.0
+        version: 0.2.0
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
     devDependencies:
+      '@types/uri-templates':
+        specifier: ^0.1.34
+        version: 0.1.34
       '@types/uuid':
         specifier: ^9.0.6
         version: 9.0.8
@@ -807,10 +813,10 @@ importers:
         version: 20.19.1
       '@types/react':
         specifier: ^19
-        version: 19.1.8
+        version: 19.0.8
       '@types/react-dom':
         specifier: ^19
-        version: 19.1.6(@types/react@19.1.8)
+        version: 19.1.6(@types/react@19.0.8)
       genkit:
         specifier: workspace:*
         version: link:../../genkit
@@ -1767,7 +1773,7 @@ importers:
         version: link:../../plugins/vertexai
       '@mistralai/mistralai-gcp':
         specifier: ^1.3.4
-        version: 1.5.0(encoding@0.1.13)(zod@3.22.4)
+        version: 1.5.0(zod@3.22.4)
       express:
         specifier: ^4.21.0
         version: 4.21.2
@@ -4102,9 +4108,6 @@ packages:
   '@types/react@19.0.8':
     resolution: {integrity: sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==}
 
-  '@types/react@19.1.8':
-    resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
-
   '@types/request@2.48.12':
     resolution: {integrity: sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==}
 
@@ -4140,6 +4143,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/uri-templates@0.1.34':
+    resolution: {integrity: sha512-13v4r/Op3iEO1y6FvEHQjrUNnrNyO67SigdFC9n80sVfsrM2AWJRNYbE1pBs4/p87I7z1J979JGeLAo3rM1L/Q==}
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
@@ -7399,6 +7405,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  uri-templates@0.2.0:
+    resolution: {integrity: sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==}
+
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
@@ -8980,18 +8989,18 @@ snapshots:
       '@langchain/core': 0.1.63
       js-tiktoken: 1.0.11
 
-  '@mistralai/mistralai-gcp@1.5.0(encoding@0.1.13)(zod@3.22.4)':
-    dependencies:
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      zod: 3.22.4
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   '@mistralai/mistralai-gcp@1.5.0(encoding@0.1.13)(zod@3.25.67)':
     dependencies:
       google-auth-library: 9.15.1(encoding@0.1.13)
       zod: 3.25.67
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@mistralai/mistralai-gcp@1.5.0(zod@3.22.4)':
+    dependencies:
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      zod: 3.22.4
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10023,15 +10032,11 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
-  '@types/react-dom@19.1.6(@types/react@19.1.8)':
+  '@types/react-dom@19.1.6(@types/react@19.0.8)':
     dependencies:
-      '@types/react': 19.1.8
+      '@types/react': 19.0.8
 
   '@types/react@19.0.8':
-    dependencies:
-      csstype: 3.1.3
-
-  '@types/react@19.1.8':
     dependencies:
       csstype: 3.1.3
 
@@ -10074,6 +10079,8 @@ snapshots:
   '@types/triple-beam@1.3.5': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/uri-templates@0.1.34': {}
 
   '@types/uuid@10.0.0': {}
 
@@ -14011,6 +14018,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  uri-templates@0.2.0: {}
 
   url-template@2.0.8: {}
 


### PR DESCRIPTION
```ts
ai.defineResource({
  uri: 'my://resource/{param}',
  description: 'provides my resource',
}, async ({param}) => {
  return [{ text: `resource ${param}` }]
});

await ai.generate({
  prompt: [{ resource: 'my://resource/value' }]
})
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
