### PR TITLE
fix: wrong item name actionFn

### DIFF
--- a/samples/js-schoolAgent/src/attendanceAgent.ts
+++ b/samples/js-schoolAgent/src/attendanceAgent.ts
@@ -25,7 +25,7 @@ const toolNames: string[] = tools.map((item) => {
   if (typeof item === 'string') {
     return item;
   } else {
-    return item.name;
+    return item.__action.name;
   }
 });
 

--- a/samples/js-schoolAgent/src/gradesAgent.ts
+++ b/samples/js-schoolAgent/src/gradesAgent.ts
@@ -25,7 +25,7 @@ const toolNames: string[] = tools.map((item) => {
   if (typeof item === 'string') {
     return item;
   } else {
-    return item.name;
+    return item.__action.name;
   }
 });
 


### PR DESCRIPTION
Description
 -  Refer to https://github.com/firebase/genkit/issues/3004#issuecomment-2934472274
    ```
    [ 'actionFn', 'actionFn', 'routingAgent' ]
    [ 'actionFn', 'routingAgent' ]
    ```
- The fix `item.name` → `item.__action.name`
    ```
    [ 'reportAbsence', 'reportTardy', 'routingAgent' ]
    [ 'getRecentGrades', 'routingAgent' ]
    ```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
