### PR TITLE
chore(compat-oai): replace rm with rimraf for cross-platform

### DIFF
--- a/js/plugins/compat-oai/package.json
+++ b/js/plugins/compat-oai/package.json
@@ -33,7 +33,8 @@
     "npm-run-all": "^4.1.5",
     "ts-jest": "^29.1.2",
     "tsup": "^8.0.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "rimraf": "^6.0.1"
   },
   "types": "./lib/index.d.ts",
   "exports": {
@@ -85,7 +86,7 @@
   "scripts": {
     "check": "tsc",
     "compile": "tsup-node",
-    "build:clean": "rm -rf ./lib",
+    "build:clean": "rimraf ./lib",
     "build": "npm-run-all build:clean check compile",
     "build:watch": "tsup-node --watch",
     "test": "jest --coverage"

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -441,6 +441,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
       ts-jest:
         specifier: ^29.1.2
         version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3)


### PR DESCRIPTION
Cross-platform, `rm -rf` doesn't work on Windows

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
