### PR TITLE
fix(py/genkit/ai): add missing type annotation

### DIFF
--- a/py/packages/genkit/src/genkit/ai/_aio.py
+++ b/py/packages/genkit/src/genkit/ai/_aio.py
@@ -81,7 +81,7 @@ class Genkit(GenkitBase):
         messages: list[Message] | None = None,
         tools: list[str] | None = None,
         return_tool_requests: bool | None = None,
-        tool_choice: ToolChoice = None,
+        tool_choice: ToolChoice | None = None,
         tool_responses: list[Part] | None = None,
         config: GenerationCommonConfig | dict[str, Any] | None = None,
         max_turns: int | None = None,


### PR DESCRIPTION
py/packages/genkit/src/genkit/ai/_aio.py was missing the "or none" in its type annotation

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
