### PR TITLE
fix(go): exclude reasoning part when return value from Text() function

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -768,13 +768,16 @@ func (c *ModelResponseChunk) Text() string {
 	}
 	var sb strings.Builder
 	for _, p := range c.Content {
-		sb.WriteString(p.Text)
+		if p.IsText() || p.IsData() {
+			sb.WriteString(p.Text)
+		}
 	}
 	return sb.String()
 }
 
 // Text returns the contents of a [Message] as a string. It
 // returns an empty string if the message has no content.
+// If you want to get reasoning from the message, use Reasoning() instead.
 func (m *Message) Text() string {
 	if m == nil {
 		return ""
@@ -787,7 +790,9 @@ func (m *Message) Text() string {
 	}
 	var sb strings.Builder
 	for _, p := range m.Content {
-		sb.WriteString(p.Text)
+		if p.IsText() || p.IsData() {
+			sb.WriteString(p.Text)
+		}
 	}
 	return sb.String()
 }


### PR DESCRIPTION
I’ve noticed that the `Text()` function is meant to operate on `TextPart` or `DataPart` only. If a developer wants to retrieve the reasoning part as text, they should use `Reasoning()` instead.

However, `Text()` currently returns a merged value that includes the reasoning part, which does not match the intended behavior.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
