### PR TITLE
fix(py): add evaluator plugin to requirements

### DIFF
--- a/py/samples/google-genai-hello/pyproject.toml
+++ b/py/samples/google-genai-hello/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "genkit",
   "genkit-plugin-google-genai",
   "genkit-plugin-google-cloud",
+  "genkit-plugin-evaluators",
   "pydantic>=2.10.5",
   "structlog>=25.2.0",
 ]
@@ -39,3 +40,6 @@ packages = ["src/google_genai_hello"]
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.uv.sources]
+genkit-plugin-evaluators = { workspace = true }

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1569,6 +1569,7 @@ version = "0.1.0"
 source = { editable = "samples/google-genai-hello" }
 dependencies = [
     { name = "genkit" },
+    { name = "genkit-plugin-evaluators" },
     { name = "genkit-plugin-google-cloud" },
     { name = "genkit-plugin-google-genai" },
     { name = "pydantic" },
@@ -1578,6 +1579,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-plugin-evaluators", editable = "plugins/evaluators" },
     { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
     { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
     { name = "pydantic", specifier = ">=2.10.5" },


### PR DESCRIPTION
The evaluators plugin was added in code but not in requirements. As long as it is not published, I added it with the flag workspace for the sample to run successfully.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
