### PR TITLE
feat(js/ai): added a way to define resources dynamically

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -58,7 +58,7 @@ import {
   type ToolResponsePart,
 } from './model.js';
 import { isExecutablePrompt } from './prompt.js';
-import { DynamicResourceAction, isDynamicResource } from './resource.js';
+import { DynamicResourceAction, isDynamicResourceAction } from './resource.js';
 import {
   isDynamicTool,
   resolveTools,
@@ -437,7 +437,7 @@ function maybeRegisterDynamicResources<
 >(registry: Registry, options: GenerateOptions<O, CustomOptions>): Registry {
   let hasDynamicResources = false;
   options?.resources?.forEach((r) => {
-    if (isDynamicResource(r)) {
+    if (isDynamicResourceAction(r)) {
       const attached = r.attach(registry);
       if (!hasDynamicResources) {
         hasDynamicResources = true;

--- a/js/ai/src/index.ts
+++ b/js/ai/src/index.ts
@@ -115,7 +115,7 @@ export {
   ResourceOutputSchema,
   defineResource,
   dynamicResource,
-  isDynamicResource,
+  isDynamicResourceAction,
   type ResourceAction,
   type ResourceFn,
   type ResourceInput,

--- a/js/ai/src/index.ts
+++ b/js/ai/src/index.ts
@@ -114,6 +114,8 @@ export {
   ResourceInputSchema,
   ResourceOutputSchema,
   defineResource,
+  dynamicResource,
+  isDynamicResource,
   type ResourceAction,
   type ResourceFn,
   type ResourceInput,

--- a/js/ai/src/resource.ts
+++ b/js/ai/src/resource.ts
@@ -141,11 +141,13 @@ export async function findMatchingResource(
 }
 
 /** Checks whether provided object is a dynamic resource. */
-export function isDynamicResource(t: unknown): t is DynamicResourceAction {
+export function isDynamicResourceAction(
+  t: unknown
+): t is DynamicResourceAction {
   return (
     (isDetachedAction(t) || isAction(t)) &&
     t.__action.metadata?.type === 'resource' &&
-    t.__action.metadata?.dynamic
+    !!t.__action.metadata?.dynamic
   );
 }
 

--- a/js/ai/tests/resource/resource_test.ts
+++ b/js/ai/tests/resource/resource_test.ts
@@ -17,7 +17,13 @@
 import { Registry } from '@genkit-ai/core/registry';
 import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
-import { defineResource, findMatchingResource } from '../../src/resource.js';
+import {
+  defineResource,
+  dynamicResource,
+  findMatchingResource,
+  isDynamicResourceAction,
+} from '../../src/resource.js';
+import { defineEchoModel } from '../helpers.js';
 
 describe('resource', () => {
   let registry: Registry;
@@ -218,5 +224,40 @@ describe('resource', () => {
       uri: 'unknown://bar/something',
     });
     assert.strictEqual(gotUnmatched, undefined);
+  });
+});
+
+describe('isDynamicResourceAction', () => {
+  let registry: Registry;
+
+  beforeEach(() => {
+    registry = new Registry();
+  });
+
+  it('should recognize dynamic resource actions', () => {
+    assert.strictEqual(
+      isDynamicResourceAction(
+        defineResource(registry, { uri: 'bar://baz' }, () => ({
+          content: [{ text: `bar` }],
+        }))
+      ),
+      false
+    );
+
+    assert.strictEqual(
+      isDynamicResourceAction(defineEchoModel(registry)),
+      false
+    );
+
+    assert.strictEqual(isDynamicResourceAction('banana'), false);
+
+    assert.strictEqual(
+      isDynamicResourceAction(
+        dynamicResource({ uri: 'bar://baz' }, () => ({
+          content: [{ text: `bar` }],
+        }))
+      ),
+      true
+    );
   });
 });

--- a/js/ai/tests/resource/resource_test.ts
+++ b/js/ai/tests/resource/resource_test.ts
@@ -48,6 +48,7 @@ describe('resource', () => {
         template: undefined,
         uri: 'foo://bar',
       },
+      type: 'resource',
     });
 
     assert.strictEqual(testResource.matches({ uri: 'foo://bar' }), true);
@@ -210,6 +211,7 @@ describe('resource', () => {
         template: 'foo://bar/{baz}',
         uri: undefined,
       },
+      type: 'resource',
     });
 
     const gotUnmatched = await findMatchingResource(registry, {

--- a/js/genkit/src/common.ts
+++ b/js/genkit/src/common.ts
@@ -33,6 +33,7 @@ export {
   ToolCallSchema,
   ToolInterruptError,
   ToolSchema,
+  dynamicResource,
   embedderActionMetadata,
   embedderRef,
   evaluatorRef,
@@ -113,7 +114,6 @@ export {
   type SessionStore,
 } from '@genkit-ai/ai/session';
 export { dynamicTool } from '@genkit-ai/ai/tool';
-export { dynamicResource } from '@genkit-ai/ai';
 export {
   GENKIT_CLIENT_HEADER,
   GENKIT_VERSION,

--- a/js/genkit/src/common.ts
+++ b/js/genkit/src/common.ts
@@ -113,6 +113,7 @@ export {
   type SessionStore,
 } from '@genkit-ai/ai/session';
 export { dynamicTool } from '@genkit-ai/ai/tool';
+export { dynamicResource } from '@genkit-ai/ai';
 export {
   GENKIT_CLIENT_HEADER,
   GENKIT_VERSION,


### PR DESCRIPTION
Similar to `dynamicTool`

```ts
const myResource = dynamicResource(
  {
    uri: 'foo://foo',
    description: 'description',
  },
  async () => ({ content: [...] })
);

const { text } = await ai.generate({
  prompt: [
    { text: 'analyze this: ' },
    { resource: { uri: 'foo://foo' } },
  ],
  resources: [myResource],
});

```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
