### PR TITLE
fix(js/core): add port to runtime id for uniqueness

### DIFF
--- a/js/core/src/reflection.ts
+++ b/js/core/src/reflection.ts
@@ -329,13 +329,16 @@ export class ReflectionServer {
       const date = new Date();
       const time = date.getTime();
       const timestamp = date.toISOString();
+      const runtimeId = `${process.pid}${
+        this.port !== null ? `-${this.port}` : ''
+      }`;
       this.runtimeFilePath = path.join(
         runtimesDir,
-        `${process.pid}-${this.port}-${time}.json`
+        `${runtimeId}-${time}.json`
       );
       const fileContent = JSON.stringify(
         {
-          id: process.env.GENKIT_RUNTIME_ID || process.pid.toString(),
+          id: process.env.GENKIT_RUNTIME_ID || runtimeId,
           pid: process.pid,
           reflectionServerUrl: `http://localhost:${this.port}`,
           timestamp,


### PR DESCRIPTION
Similar to the file, we can also have collisions in the map. Changes to be consistent with the filename (pid-port).

We should probably either deprecate `GENKIT_RUNTIME_ID` and/or introduce the ability to pass an id in as part of the genkit instance.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)
