### PR TITLE
feat(js/plugins/mcp): added support for MCP resources via dynamicResource

### DIFF
--- a/js/ai/src/index.ts
+++ b/js/ai/src/index.ts
@@ -116,6 +116,7 @@ export {
   defineResource,
   dynamicResource,
   isDynamicResourceAction,
+  type DynamicResourceAction,
   type ResourceAction,
   type ResourceFn,
   type ResourceInput,

--- a/js/genkit/src/common.ts
+++ b/js/genkit/src/common.ts
@@ -45,6 +45,7 @@ export {
   rerankerRef,
   retrieverRef,
   type DocumentData,
+  type DynamicResourceAction,
   type EmbedderAction,
   type EmbedderArgument,
   type EmbedderInfo,

--- a/js/plugins/mcp/src/util/message.ts
+++ b/js/plugins/mcp/src/util/message.ts
@@ -15,7 +15,7 @@
  */
 
 import type { PromptMessage } from '@modelcontextprotocol/sdk/types.js' with { 'resolution-mode': 'import' };
-import { GenkitError, type MessageData, type Part } from 'genkit';
+import { type MessageData, type Part } from 'genkit';
 
 const ROLE_MAP = {
   user: 'user',
@@ -61,12 +61,12 @@ export function fromMcpPart(part: PromptMessage['content']): Part {
         },
       };
     case 'resource':
-      return {};
+      return {
+        resource: {
+          uri: part.uri as string,
+        },
+      };
     default:
       return {};
   }
-  throw new GenkitError({
-    status: 'UNIMPLEMENTED',
-    message: `Part type ${part.type} is not currently supported.`,
-  });
 }

--- a/js/plugins/mcp/src/util/resource.ts
+++ b/js/plugins/mcp/src/util/resource.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import {
+  ReadResourceResult,
+  Resource,
+  ResourceTemplate,
+} from '@modelcontextprotocol/sdk/types.js';
+import {
+  DynamicResourceAction,
+  Genkit,
+  GenkitError,
+  Part,
+  dynamicResource,
+} from 'genkit';
+import { logger } from 'genkit/logging';
+
+function createDynamicResource(
+  client: Client,
+  resource: Resource,
+  params: { serverName: string; name: string }
+): DynamicResourceAction {
+  return dynamicResource(
+    {
+      name: `${params.serverName}/${resource.name}`,
+      description: resource.description || undefined,
+      metadata: { mcp: { _meta: resource._meta || {} } },
+      uri: resource.uri,
+    },
+    async (args, { context }) => {
+      logger.debug(
+        `[MCP] calling resource '${params.serverName}/${resource.name}' in host '${params.name}'`
+      );
+      const result = await client.readResource({
+        uri: args.uri,
+        _meta: context?.mcp?._meta,
+      });
+      return {
+        content: result.contents.map((p) => fromMcpResourcePart(p)),
+      };
+    }
+  );
+}
+
+function createDynamicResourceTemplate(
+  client: Client,
+  template: ResourceTemplate,
+  params: { serverName: string; name: string }
+): DynamicResourceAction {
+  return dynamicResource(
+    {
+      name: `${params.serverName}/${template.name}`,
+      description: template.description || undefined,
+      metadata: { mcp: { _meta: template._meta || {} } },
+      template: template.uriTemplate,
+    },
+    async (args, { context }) => {
+      logger.debug(
+        `[MCP] calling resource template '${params.serverName}/${template.name}' in host '${params.name}'`
+      );
+      const result = await client.readResource({
+        uri: args.uri,
+        _meta: context?.mcp?._meta,
+      });
+      return {
+        content: result.contents.map((p) => fromMcpResourcePart(p)),
+        metadata: result._meta,
+      };
+    }
+  );
+}
+
+type ArrayElement<ArrayType extends readonly unknown[]> =
+  ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+
+function fromMcpResourcePart(
+  part: ArrayElement<ReadResourceResult['contents']>
+): Part {
+  if (part.text) {
+    return { text: part.text as string, metadata: part._meta };
+  }
+  if (part.blob) {
+    return {
+      media: {
+        contentType: part.mimeType,
+        url: `data:${part.mimeType};base64,${part.blob}`,
+      },
+      metadata: part._meta,
+    };
+  }
+  throw new GenkitError({
+    status: 'UNIMPLEMENTED',
+    message: `Part type ${part.type} is not currently supported.`,
+  });
+}
+
+/**
+ * Lookup all resources available in the server and fetches as a Genkit dynamic resource.
+ */
+export async function fetchDynamicResources(
+  ai: Genkit,
+  client: Client,
+  params: { name: string; serverName: string }
+): Promise<DynamicResourceAction[]> {
+  let cursor: string | undefined;
+  let allResources: DynamicResourceAction[] = [];
+  while (true) {
+    const { nextCursor, resources } = await client.listResources({ cursor });
+    allResources.push(
+      ...resources.map((r) => createDynamicResource(client, r, params))
+    );
+    cursor = nextCursor;
+    if (!cursor) break;
+  }
+  while (true) {
+    const { nextCursor, resourceTemplates } =
+      await client.listResourceTemplates({ cursor });
+    allResources.push(
+      ...resourceTemplates.map((r) =>
+        createDynamicResourceTemplate(client, r, params)
+      )
+    );
+    cursor = nextCursor;
+    if (!cursor) break;
+  }
+  return allResources;
+}

--- a/js/plugins/mcp/tests/fakes.ts
+++ b/js/plugins/mcp/tests/fakes.ts
@@ -111,6 +111,7 @@ export class FakeTransport implements Transport {
           capabilities: {
             prompts: {},
             tools: {},
+            resources: {},
           },
           serverInfo: {
             name: 'mock-server',

--- a/js/testapps/mcp/src/index.ts
+++ b/js/testapps/mcp/src/index.ts
@@ -45,7 +45,7 @@ export const PERMISSIVE_SAFETY_SETTINGS: any = {
 
 export const ai = genkit({
   plugins: [googleAI()],
-  model: googleAI.model('gemini-2.5-pro-preview-03-25'),
+  model: googleAI.model('gemini-2.5-flash'),
 });
 
 logger.setLogLevel('debug'); // Set the logging level to debug for detailed output
@@ -85,6 +85,18 @@ ai.defineFlow('get-file', async (q) => {
   const { text } = await ai.generate({
     prompt: `summarize contexts of hello-world.txt (in '${process.cwd()}/test-workspace')`,
     tools: await mcpHost.getActiveTools(ai),
+  });
+
+  return text;
+});
+
+ai.defineFlow('test-resource', async (q) => {
+  const { text } = await ai.generate({
+    prompt: [
+      { text: 'analyze this: ' },
+      { resource: { uri: 'test://static/resource/1' } },
+    ],
+    resources: await mcpHost.getActiveResources(ai),
   });
 
   return text;


### PR DESCRIPTION
```ts
  const { text } = await ai.generate({
    prompt: [
      { text: 'analyze this: ' },
      { resource: { uri: 'test://static/resource/1' } },
    ],
    resources: await mcpHost.getActiveResources(ai),
  });
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
