### PR TITLE
fix(genkit-tools/evals): Switch to JSON index in EvalStore

### DIFF
--- a/genkit-tools/common/src/eval/evaluate.ts
+++ b/genkit-tools/common/src/eval/evaluate.ts
@@ -207,7 +207,7 @@ export async function runEvaluation(params: {
   };
 
   logger.info('Finished evaluation, writing key...');
-  const evalStore = getEvalStore();
+  const evalStore = await getEvalStore();
   await evalStore.save(evalRun);
   return evalRun;
 }

--- a/genkit-tools/common/src/eval/index.ts
+++ b/genkit-tools/common/src/eval/index.ts
@@ -23,9 +23,8 @@ export * from './exporter';
 export * from './parser';
 export * from './validate';
 
-export function getEvalStore(): EvalStore {
-  // TODO: This should provide EvalStore, based on tools config.
-  return LocalFileEvalStore.getEvalStore();
+export async function getEvalStore(): Promise<EvalStore> {
+  return await LocalFileEvalStore.getEvalStore();
 }
 
 export function getDatasetStore(): DatasetStore {

--- a/genkit-tools/common/src/eval/localFileEvalStore.ts
+++ b/genkit-tools/common/src/eval/localFileEvalStore.ts
@@ -98,7 +98,6 @@ export class LocalFileEvalStore implements EvalStore {
   ): Promise<ListEvalKeysResponse> {
     logger.debug(`Listing keys for filter: ${JSON.stringify(query)}`);
     let keys = await this.getEvalsIndex().then((index) => Object.values(index));
-    console.log();
 
     if (query?.filter?.actionRef) {
       keys = keys.filter((key) => key.actionRef === query?.filter?.actionRef);

--- a/genkit-tools/common/src/eval/localFileEvalStore.ts
+++ b/genkit-tools/common/src/eval/localFileEvalStore.ts
@@ -15,9 +15,9 @@
  */
 
 import fs from 'fs';
-import { appendFile, readFile, unlink, writeFile } from 'fs/promises';
+import { readFile, unlink, writeFile } from 'fs/promises';
 import path from 'path';
-import * as readline from 'readline';
+import { createInterface } from 'readline';
 import type { ListEvalKeysRequest, ListEvalKeysResponse } from '../types/apis';
 import {
   EvalRunKeySchema,
@@ -32,26 +32,26 @@ import { logger } from '../utils/logger';
  * A local, file-based EvalStore implementation.
  */
 export class LocalFileEvalStore implements EvalStore {
-  private readonly storeRoot;
-  private readonly indexFile;
-  private readonly INDEX_DELIMITER = '\n';
+  private storeRoot: string = '';
+  private indexFile: string = '';
   private static cachedEvalStore: LocalFileEvalStore | null = null;
 
-  private constructor() {
+  private async init() {
     this.storeRoot = this.generateRootPath();
-    this.indexFile = this.getIndexFilePath();
+    this.indexFile = await this.resolveIndexFile();
     fs.mkdirSync(this.storeRoot, { recursive: true });
     if (!fs.existsSync(this.indexFile)) {
-      fs.writeFileSync(path.resolve(this.indexFile), '');
+      fs.writeFileSync(path.resolve(this.indexFile), JSON.stringify({}));
     }
     logger.debug(
       `Initialized local file eval store at root: ${this.storeRoot}`
     );
   }
 
-  static getEvalStore() {
+  static async getEvalStore() {
     if (!this.cachedEvalStore) {
       this.cachedEvalStore = new LocalFileEvalStore();
+      await this.cachedEvalStore.init();
     }
     return this.cachedEvalStore;
   }
@@ -61,7 +61,7 @@ export class LocalFileEvalStore implements EvalStore {
   }
 
   async save(evalRun: EvalRun): Promise<void> {
-    const fileName = this.generateFileName(evalRun.key.evalRunId);
+    const fileName = this.resolveEvalFilename(evalRun.key.evalRunId);
 
     logger.debug(
       `Saving EvalRun ${evalRun.key.evalRunId} to ` +
@@ -72,20 +72,18 @@ export class LocalFileEvalStore implements EvalStore {
       JSON.stringify(evalRun)
     );
 
-    logger.debug(
-      `Save EvalRunKey ${JSON.stringify(evalRun.key)} to ` +
-        path.resolve(this.indexFile)
-    );
-    await appendFile(
+    const index = await this.getEvalsIndex();
+    index[evalRun.key.evalRunId] = evalRun.key;
+    await writeFile(
       path.resolve(this.indexFile),
-      JSON.stringify(evalRun.key) + this.INDEX_DELIMITER
+      JSON.stringify(index, null, 2)
     );
   }
 
   async load(evalRunId: string): Promise<EvalRun | undefined> {
     const filePath = path.resolve(
       this.storeRoot,
-      this.generateFileName(evalRunId)
+      this.resolveEvalFilename(evalRunId)
     );
     if (!fs.existsSync(filePath)) {
       return undefined;
@@ -98,22 +96,12 @@ export class LocalFileEvalStore implements EvalStore {
   async list(
     query?: ListEvalKeysRequest | undefined
   ): Promise<ListEvalKeysResponse> {
-    let keys = await readFile(this.indexFile, 'utf8').then((data) => {
-      if (!data) {
-        return [];
-      }
-      // strip the final carriage return before parsing all lines
-      return data
-        .slice(0, -1)
-        .split(this.INDEX_DELIMITER)
-        .map(this.parseLineToKey);
-    });
-
-    logger.debug(`Found keys: ${JSON.stringify(keys)}`);
+    logger.debug(`Listing keys for filter: ${JSON.stringify(query)}`);
+    let keys = await this.getEvalsIndex().then((index) => Object.values(index));
+    console.log();
 
     if (query?.filter?.actionRef) {
       keys = keys.filter((key) => key.actionRef === query?.filter?.actionRef);
-      logger.debug(`Filtered keys: ${JSON.stringify(keys)}`);
     }
 
     return {
@@ -124,50 +112,66 @@ export class LocalFileEvalStore implements EvalStore {
   async delete(evalRunId: string): Promise<void> {
     const filePath = path.resolve(
       this.storeRoot,
-      this.generateFileName(evalRunId)
+      this.resolveEvalFilename(evalRunId)
     );
-    if (!fs.existsSync(filePath)) {
-      throw new Error(`Cannot find evalRun with id '${evalRunId}'`);
+    if (fs.existsSync(filePath)) {
+      await unlink(filePath);
+
+      const index = await this.getEvalsIndex();
+      delete index[evalRunId];
+      await writeFile(
+        path.resolve(this.indexFile),
+        JSON.stringify(index, null, 2)
+      );
     }
-    return await unlink(filePath).then(() =>
-      this.deleteEvalRunFromIndex(evalRunId)
-    );
   }
 
-  private generateFileName(evalRunId: string): string {
+  private resolveEvalFilename(evalRunId: string): string {
     return `${evalRunId}.json`;
   }
 
-  private getIndexFilePath(): string {
-    return path.resolve(this.storeRoot, 'index.txt');
+  private async resolveIndexFile(): Promise<string> {
+    const txtPath = path.resolve(this.storeRoot, 'index.txt');
+    const jsonPath = path.resolve(this.storeRoot, 'index.json');
+    if (fs.existsSync(txtPath)) {
+      // Copy over index, delete txt file
+      const keys = await this.processLineByLine(txtPath);
+      await writeFile(path.resolve(jsonPath), JSON.stringify(keys, null, 2));
+      await unlink(txtPath);
+    }
+    return jsonPath;
   }
 
-  private parseLineToKey(key: string): EvalRunKey {
-    return EvalRunKeySchema.parse(JSON.parse(key));
+  private async processLineByLine(filePath: string) {
+    const fileStream = fs.createReadStream(filePath);
+    const keys: Record<string, EvalRunKey> = {};
+
+    const rl = createInterface({
+      input: fileStream,
+      crlfDelay: Infinity,
+    });
+    for await (const line of rl) {
+      try {
+        const entry = JSON.parse(line);
+        const runKey = EvalRunKeySchema.parse(entry);
+        keys[runKey.evalRunId] = runKey;
+      } catch (e) {
+        logger.debug(`Error parsing ${line}:\n`, JSON.stringify(e));
+      }
+    }
+    return keys;
   }
 
   private generateRootPath(): string {
-    return path.resolve(process.cwd(), `.genkit/evals`);
+    return path.resolve(process.cwd(), '.genkit', 'evals');
   }
 
-  private async deleteEvalRunFromIndex(evalRunId: string): Promise<void> {
-    const entries = [];
-    const fileStream = fs.createReadStream(this.getIndexFilePath());
-    const rl = readline.createInterface({
-      input: fileStream,
-    });
-
-    for await (const line of rl) {
-      const entry = EvalRunKeySchema.parse(JSON.parse(line));
-      if (entry.evalRunId !== evalRunId) {
-        entries.push(line);
-      }
+  private async getEvalsIndex(): Promise<Record<string, EvalRunKey>> {
+    if (!fs.existsSync(this.indexFile)) {
+      return Promise.resolve({} as any);
     }
-
-    await writeFile(
-      this.getIndexFilePath(),
-      // end with delimiter to parse correctly
-      entries.join(this.INDEX_DELIMITER) + this.INDEX_DELIMITER
+    return await readFile(path.resolve(this.indexFile), 'utf8').then((data) =>
+      JSON.parse(data)
     );
   }
 }

--- a/genkit-tools/common/src/server/router.ts
+++ b/genkit-tools/common/src/server/router.ts
@@ -169,7 +169,8 @@ export const TOOLS_SERVER_ROUTER = (manager: RuntimeManager) =>
       .input(apis.ListEvalKeysRequestSchema)
       .output(apis.ListEvalKeysResponseSchema)
       .query(async ({ input }) => {
-        const response = await getEvalStore().list(input);
+        const store = await getEvalStore();
+        const response = await store.list(input);
         return {
           evalRunKeys: response.evalRunKeys,
         };
@@ -182,7 +183,8 @@ export const TOOLS_SERVER_ROUTER = (manager: RuntimeManager) =>
       .query(async ({ input }) => {
         const parts = input.name.split('/');
         const evalRunId = parts[1];
-        const evalRun = await getEvalStore().load(evalRunId);
+        const store = await getEvalStore();
+        const evalRun = await store.load(evalRunId);
         if (!evalRun) {
           throw new TRPCError({
             code: 'NOT_FOUND',
@@ -198,7 +200,8 @@ export const TOOLS_SERVER_ROUTER = (manager: RuntimeManager) =>
       .mutation(async ({ input }) => {
         const parts = input.name.split('/');
         const evalRunId = parts[1];
-        await getEvalStore().delete(evalRunId);
+        const store = await getEvalStore();
+        await store.delete(evalRunId);
       }),
 
     /** Retrieves all eval datasets */

--- a/genkit-tools/common/tests/eval/localFileEvalStore_test.ts
+++ b/genkit-tools/common/tests/eval/localFileEvalStore_test.ts
@@ -28,54 +28,41 @@ import { LocalFileEvalStore } from '../../src/eval/localFileEvalStore';
 import {
   EvalRunSchema,
   type EvalResult,
+  type EvalRun,
+  type EvalRunKey,
   type EvalStore,
 } from '../../src/types/eval';
 
+// Mock modules
 jest.mock('readline');
+jest.mock('process', () => ({
+  cwd: jest.fn(() => 'store-root'),
+}));
 
+// Test Data
 const EVAL_RESULTS: EvalResult[] = [
   {
     testCaseId: 'alakjdshfalsdkjh',
     input: { subject: 'Kermit the Frog', style: 'Jerry Seinfeld' },
-    output: `So, here's the thing about Kermit the Frog, right? He's got this whole \"it's not easy being green\"
-        routine.  Which, I mean, relatable, right? We've all got our things...But, the guy's a frog! He
-        lives in a swamp! You chose this, Kermit! You could be any color...you picked the one that blends
-        in perfectly with your natural habitat.`,
-    context: [
-      'Kermit has a song called "It\'s not easy being green"',
-      'Kermit is in a complicated relationship with Miss Piggy',
-    ],
-    metrics: [
-      {
-        evaluator: 'faithfulness',
-        score: 0.5,
-        rationale: 'One out of two claims can be inferred from the context',
-      },
-    ],
+    output: '...Kermit output...',
+    context: ['...Kermit context...'],
+    metrics: [{ evaluator: 'faithfulness', score: 0.5, rationale: '...' }],
     traceIds: [],
   },
   {
     testCaseId: 'lkjhasdfkljahsdf',
     input: { subject: "Doctor's office", style: 'Wanda Sykes' },
-    output: `Okay, check this out. You ever been to one of those doctor's offices where it takes you a year to get an appointment, 
-      then they stick you in a waiting room with magazines from like, 1997? It's like, are they expecting me to catch up on all the
-      Kardashian drama from the Bush administration?`,
+    output: '...Doctor output...',
     context: [],
-    metrics: [
-      {
-        evaluator: 'faithfulness',
-        score: 0,
-        rationale: 'No context was provided',
-      },
-    ],
+    metrics: [{ evaluator: 'faithfulness', score: 0, rationale: '...' }],
     traceIds: [],
   },
 ];
 
 const METRICS_METADATA = {
   faithfulness: {
-    displayName: 'Faithfullness',
-    definition: 'Faitfulness definition',
+    displayName: 'Faithfulness',
+    definition: 'Faithfulness definition',
   },
 };
 
@@ -98,257 +85,193 @@ const EVAL_RUN_WITHOUT_ACTION = EvalRunSchema.parse({
   metricMetadata: METRICS_METADATA,
 });
 
-jest.mock('process', () => {
-  return {
-    cwd: jest.fn(() => 'store-root'),
-  };
-});
+const ALL_EVAL_RUN_KEYS = {
+  [EVAL_RUN_WITH_ACTION.key.evalRunId]: EVAL_RUN_WITH_ACTION.key,
+  [EVAL_RUN_WITHOUT_ACTION.key.evalRunId]: EVAL_RUN_WITHOUT_ACTION.key,
+};
 
-describe.only('localFileEvalStore', () => {
+// Mock Helpers
+const mockFsExists = (exists: (path: fs.PathLike) => boolean) => {
+  fs.existsSync = jest
+    .fn<(path: fs.PathLike) => boolean>()
+    .mockImplementation(exists);
+};
+
+const mockReadlineForMigration = (keys: EvalRunKey[]) => {
+  (readline.createInterface as jest.Mock).mockReturnValue({
+    [Symbol.asyncIterator]: async function* () {
+      for (const key of keys) {
+        yield JSON.stringify(key);
+      }
+    },
+  } as any);
+};
+
+const mockIndexFile = (keys: Record<string, EvalRunKey>) => {
+  fs.promises.readFile = jest.fn<any>().mockResolvedValue(JSON.stringify(keys));
+};
+
+const mockEvalRunFile = (evalRun: EvalRun) => {
+  fs.promises.readFile = jest
+    .fn<any>()
+    .mockImplementation(async () => JSON.stringify(evalRun));
+};
+
+describe('localFileEvalStore', () => {
   let evalStore: EvalStore;
+
+  beforeEach(async () => {
+    LocalFileEvalStore.reset();
+    jest.clearAllMocks();
+
+    // Setup default mocks for a clean state before each test
+    mockFsExists(() => false);
+    fs.promises.writeFile = jest.fn<any>().mockResolvedValue(undefined);
+    fs.promises.unlink = jest.fn<any>().mockResolvedValue(undefined);
+    fs.writeFileSync = jest.fn<any>().mockImplementation(() => {});
+
+    evalStore = await LocalFileEvalStore.getEvalStore();
+  });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
   describe('initialization', () => {
-    it('uses json file by default', async () => {
-      LocalFileEvalStore.reset();
-      jest.spyOn(fs, 'writeFileSync');
-      // txt index does not exists, json index does not exist
-      fs.existsSync = jest.fn(() => false);
-      evalStore = (await LocalFileEvalStore.getEvalStore()) as EvalStore;
-
+    it('uses json file by default when no index exists', async () => {
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         expect.stringContaining('evals/index.json'),
-        expect.anything()
+        JSON.stringify({})
       );
     });
 
-    it('migrates to json file if txt is found', async () => {
+    it('migrates to json file if txt index is found', async () => {
       LocalFileEvalStore.reset();
-      jest.spyOn(fs, 'writeFileSync');
-      fs.promises.writeFile = jest.fn(async () => Promise.resolve(undefined));
-      // txt index does exists, json index does not exist
-      fs.existsSync = jest
-        .fn<(path: fs.PathLike) => boolean>()
-        .mockImplementationOnce(() => true)
-        .mockImplementationOnce(() => false);
-      jest.spyOn(fs, 'createReadStream').mockReturnValue({} as any);
-      (readline.createInterface as jest.Mock).mockImplementationOnce(() => {
-        return [JSON.stringify(EVAL_RUN_WITH_ACTION.key)] as any;
-      });
-      fs.promises.unlink = jest.fn(async () => Promise.resolve(undefined));
+      mockFsExists((path) => path.toString().endsWith('index.txt'));
+      fs.createReadStream = jest.fn<any>().mockReturnValue({} as any);
+      mockReadlineForMigration([EVAL_RUN_WITH_ACTION.key]);
 
-      evalStore = (await LocalFileEvalStore.getEvalStore()) as EvalStore;
+      await LocalFileEvalStore.getEvalStore();
 
       expect(fs.promises.unlink).toHaveBeenCalledWith(
         expect.stringContaining('index.txt')
       );
+      const expectedIndex = {
+        [EVAL_RUN_WITH_ACTION.key.evalRunId]: EVAL_RUN_WITH_ACTION.key,
+      };
       expect(fs.promises.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('evals/index.json'),
-        JSON.stringify(
-          { [EVAL_RUN_WITH_ACTION.key.evalRunId]: EVAL_RUN_WITH_ACTION.key },
-          null,
-          2
-        )
+        JSON.stringify(expectedIndex, null, 2)
       );
     });
   });
 
   describe('save', () => {
-    beforeEach(async () => {
-      LocalFileEvalStore.reset();
-      fs.existsSync = jest.fn(() => false);
-      evalStore = (await LocalFileEvalStore.getEvalStore()) as EvalStore;
-
-      fs.writeFileSync = jest.fn();
-      fs.promises.writeFile = jest.fn(async () => Promise.resolve(undefined));
-      fs.promises.appendFile = jest.fn(async () => Promise.resolve(undefined));
-      // For index file reads
-      jest
-        .spyOn(fs.promises, 'readFile')
-        .mockResolvedValue(JSON.stringify({}) as any);
-    });
-
-    it('writes and updates index for eval run with actionId', async () => {
-      await evalStore.save(EVAL_RUN_WITH_ACTION);
+    const testSave = async (evalRun: EvalRun) => {
+      await evalStore.save(evalRun);
 
       expect(fs.promises.writeFile).toHaveBeenCalledWith(
-        expect.stringContaining(`evals/abc1234.json`),
-        JSON.stringify(EVAL_RUN_WITH_ACTION)
+        expect.stringContaining(`evals/${evalRun.key.evalRunId}.json`),
+        JSON.stringify(evalRun)
       );
-      const index = {
-        [EVAL_RUN_WITH_ACTION.key.evalRunId]: EVAL_RUN_WITH_ACTION.key,
-      };
+
+      const expectedIndex = { [evalRun.key.evalRunId]: evalRun.key };
       expect(fs.promises.writeFile).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining('evals/index.json'),
-        JSON.stringify(index, null, 2)
+        JSON.stringify(expectedIndex, null, 2)
       );
+    };
+
+    it('writes and updates index for eval run with actionId', async () => {
+      await testSave(EVAL_RUN_WITH_ACTION);
     });
 
     it('persists a new evalRun file without an actionId', async () => {
-      await evalStore.save(EVAL_RUN_WITHOUT_ACTION);
-
-      expect(fs.promises.writeFile).toHaveBeenCalledWith(
-        expect.stringContaining(`evals/def456.json`),
-        JSON.stringify(EVAL_RUN_WITHOUT_ACTION)
-      );
-      const index = {
-        [EVAL_RUN_WITHOUT_ACTION.key.evalRunId]: EVAL_RUN_WITHOUT_ACTION.key,
-      };
-      expect(fs.promises.writeFile).toHaveBeenNthCalledWith(
-        2,
-        expect.stringContaining('evals/index.json'),
-        JSON.stringify(index, null, 2)
-      );
+      await testSave(EVAL_RUN_WITHOUT_ACTION);
     });
   });
 
   describe('load', () => {
-    beforeEach(async () => {
-      LocalFileEvalStore.reset();
-      fs.existsSync = jest.fn(() => false);
-      evalStore = (await LocalFileEvalStore.getEvalStore()) as EvalStore;
+    it('fetches an evalRun file by id', async () => {
+      mockFsExists(() => true);
+      mockEvalRunFile(EVAL_RUN_WITH_ACTION);
 
-      fs.writeFileSync = jest.fn();
-      fs.promises.writeFile = jest.fn(async () => Promise.resolve(undefined));
-      fs.promises.appendFile = jest.fn(async () => Promise.resolve(undefined));
-      // For index file reads
-      fs.promises.readFile = jest.fn(async () =>
-        Promise.resolve(JSON.stringify({}) as any)
-      );
-    });
-
-    it('fetches an evalRun file by id with actionId', async () => {
-      fs.existsSync = jest
-        .fn<(path: fs.PathLike) => boolean>()
-        .mockReturnValue(true);
-      jest
-        .spyOn(fs.promises, 'readFile')
-        .mockResolvedValue(JSON.stringify(EVAL_RUN_WITH_ACTION) as any);
       const fetchedEvalRun = await evalStore.load(
         EVAL_RUN_WITH_ACTION.key.evalRunId
       );
-      expect(fetchedEvalRun).toMatchObject(EVAL_RUN_WITH_ACTION);
-    });
 
-    it('fetches an evalRun file by id with no actionId', async () => {
-      fs.existsSync = jest
-        .fn<(path: fs.PathLike) => boolean>()
-        .mockReturnValueOnce(true);
-      jest
-        .spyOn(fs.promises, 'readFile')
-        .mockResolvedValue(JSON.stringify(EVAL_RUN_WITHOUT_ACTION) as any);
-      const fetchedEvalRun = await evalStore.load(
-        EVAL_RUN_WITHOUT_ACTION.key.evalRunId
-      );
-      expect(fetchedEvalRun).toMatchObject(EVAL_RUN_WITHOUT_ACTION);
+      expect(fetchedEvalRun).toEqual(EVAL_RUN_WITH_ACTION);
     });
 
     it('returns undefined if file does not exist', async () => {
-      fs.existsSync = jest.fn(() => false);
+      mockFsExists(() => false);
 
-      const fetchedEvalRun = await evalStore.load(
-        EVAL_RUN_WITH_ACTION.key.evalRunId
-      );
+      const fetchedEvalRun = await evalStore.load('non-existent-id');
+
       expect(fetchedEvalRun).toBeUndefined();
     });
   });
 
   describe('delete', () => {
-    beforeEach(async () => {
-      LocalFileEvalStore.reset();
-      fs.existsSync = jest.fn(() => false);
-      evalStore = (await LocalFileEvalStore.getEvalStore()) as EvalStore;
-    });
-
-    it('deletes an evalRun file by id', async () => {
-      fs.existsSync = jest.fn(() => true);
-      fs.promises.writeFile = jest.fn(async () => Promise.resolve(undefined));
-      fs.promises.unlink = jest.fn(async () => Promise.resolve(undefined));
-      jest.spyOn(fs.promises, 'readFile').mockResolvedValue(
-        JSON.stringify({
-          [EVAL_RUN_WITH_ACTION.key.evalRunId]: EVAL_RUN_WITH_ACTION.key,
-          [EVAL_RUN_WITHOUT_ACTION.key.evalRunId]: EVAL_RUN_WITHOUT_ACTION.key,
-        }) as any
-      );
+    it('deletes an evalRun file and updates the index', async () => {
+      mockFsExists(() => true);
+      mockIndexFile(ALL_EVAL_RUN_KEYS);
 
       await evalStore.delete(EVAL_RUN_WITH_ACTION.key.evalRunId);
 
       expect(fs.promises.unlink).toHaveBeenCalledWith(
         expect.stringContaining(EVAL_RUN_WITH_ACTION.key.evalRunId)
       );
-      const index = {
+
+      const expectedIndex = {
         [EVAL_RUN_WITHOUT_ACTION.key.evalRunId]: EVAL_RUN_WITHOUT_ACTION.key,
       };
       expect(fs.promises.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('evals/index.json'),
-        JSON.stringify(index, null, 2)
+        JSON.stringify(expectedIndex, null, 2)
       );
     });
 
-    it('does not throw if file does not exist', async () => {
-      fs.existsSync = jest.fn(() => false);
-      fs.promises.unlink = jest.fn(async () => Promise.resolve(undefined));
+    it('does not throw or unlink if file does not exist', async () => {
+      mockFsExists(() => false);
 
       await evalStore.delete(EVAL_RUN_WITH_ACTION.key.evalRunId);
+
       expect(fs.promises.unlink).not.toHaveBeenCalled();
     });
   });
 
   describe('list', () => {
-    beforeEach(async () => {
-      LocalFileEvalStore.reset();
-      fs.existsSync = jest.fn(() => false);
-      evalStore = (await LocalFileEvalStore.getEvalStore()) as EvalStore;
+    it('lists all evalRun keys from the index', async () => {
+      mockFsExists(() => true);
+      mockIndexFile(ALL_EVAL_RUN_KEYS);
+
+      const { evalRunKeys } = await evalStore.list();
+
+      expect(evalRunKeys).toHaveLength(2);
+      expect(evalRunKeys).toContainEqual(EVAL_RUN_WITH_ACTION.key);
+      expect(evalRunKeys).toContainEqual(EVAL_RUN_WITHOUT_ACTION.key);
     });
 
-    it('lists all evalRun keys from file', async () => {
-      fs.existsSync = jest.fn(() => true);
-      jest.spyOn(fs.promises, 'readFile').mockResolvedValue(
-        JSON.stringify({
-          [EVAL_RUN_WITH_ACTION.key.evalRunId]: EVAL_RUN_WITH_ACTION.key,
-          [EVAL_RUN_WITHOUT_ACTION.key.evalRunId]: EVAL_RUN_WITHOUT_ACTION.key,
-        }) as any
-      );
-      const fetchedEvalKeys = await evalStore.list();
+    it('filters evalRun keys by actionRef', async () => {
+      mockFsExists(() => true);
+      mockIndexFile(ALL_EVAL_RUN_KEYS);
 
-      const expectedKeys = {
-        evalRunKeys: [EVAL_RUN_WITH_ACTION.key, EVAL_RUN_WITHOUT_ACTION.key],
-      };
-      expect(fetchedEvalKeys).toMatchObject(expectedKeys);
-    });
-
-    it('lists all evalRun keys for a flow', async () => {
-      fs.existsSync = jest.fn(() => true);
-      jest.spyOn(fs.promises, 'readFile').mockResolvedValue(
-        JSON.stringify({
-          [EVAL_RUN_WITH_ACTION.key.evalRunId]: EVAL_RUN_WITH_ACTION.key,
-          [EVAL_RUN_WITHOUT_ACTION.key.evalRunId]: EVAL_RUN_WITHOUT_ACTION.key,
-        }) as any
-      );
-
-      const fetchedEvalKeys = await evalStore.list({
-        filter: { actionRef: EVAL_RUN_WITH_ACTION.key.actionRef },
+      const { evalRunKeys } = await evalStore.list({
+        filter: { actionRef: 'flow/tellMeAJoke' },
       });
 
-      const expectedKeys = { evalRunKeys: [EVAL_RUN_WITH_ACTION.key] };
-      expect(fetchedEvalKeys).toMatchObject(expectedKeys);
+      expect(evalRunKeys).toHaveLength(1);
+      expect(evalRunKeys[0]).toEqual(EVAL_RUN_WITH_ACTION.key);
     });
 
-    it('lists all evalRun keys from empty file', async () => {
-      fs.existsSync = jest.fn(() => true);
-      jest
-        .spyOn(fs.promises, 'readFile')
-        .mockResolvedValue(JSON.stringify({}) as any);
-      const fetchedEvalKeys = await evalStore.list();
+    it('returns an empty array if the index is empty', async () => {
+      mockIndexFile({});
 
-      const expectedKeys = {
-        evalRunKeys: [],
-      };
-      expect(fetchedEvalKeys).toMatchObject(expectedKeys);
+      const { evalRunKeys } = await evalStore.list();
+
+      expect(evalRunKeys).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
Switch over (safely) to JSON index in local file store. This should fix the bug where the index is left corrupted by deleting evals.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested)
