### PR TITLE
feat(go/ai): add streaming support for GenerateData with partial JSON parsing

### DIFF
--- a/go/ai/format_array.go
+++ b/go/ai/format_array.go
@@ -103,3 +103,30 @@ func (a arrayHandler) ParseMessage(m *Message) (*Message, error) {
 
 	return m, nil
 }
+
+// ParseChunk parses a streaming chunk and returns parsed array data.
+// Based on JS version: js/ai/src/formats/array.ts parseChunk method
+func (a arrayHandler) ParseChunk(chunk *ModelResponseChunk, accumulatedText string) (interface{}, error) {
+	if chunk == nil || len(chunk.Content) == 0 {
+		return nil, nil
+	}
+
+	// Try to extract array items from accumulated text
+	items := base.ExtractItems(accumulatedText)
+	if len(items) > 0 {
+		return items, nil
+	}
+
+	// If no items found, try partial JSON parsing
+	data, err := base.ParsePartialJSON(accumulatedText)
+	if err != nil {
+		return nil, nil
+	}
+
+	// Check if data is an array
+	if arr, ok := data.([]interface{}); ok {
+		return arr, nil
+	}
+
+	return nil, nil
+}

--- a/go/ai/format_jsonl.go
+++ b/go/ai/format_jsonl.go
@@ -106,3 +106,29 @@ func (j jsonlHandler) ParseMessage(m *Message) (*Message, error) {
 
 	return m, nil
 }
+
+// ParseChunk parses a streaming chunk and returns parsed JSONL data.
+// Based on JS version: js/ai/src/formats/jsonl.ts parseChunk method
+func (j jsonlHandler) ParseChunk(chunk *ModelResponseChunk, accumulatedText string) (interface{}, error) {
+	if chunk == nil || len(chunk.Content) == 0 {
+		return nil, nil
+	}
+
+	// Extract JSON objects from accumulated text (one per line)
+	lines := base.GetJsonObjectLines(accumulatedText)
+	if len(lines) > 0 {
+		// For JSONL, return array of parsed objects
+		var items []interface{}
+		for _, line := range lines {
+			var item interface{}
+			if err := json.Unmarshal([]byte(line), &item); err == nil {
+				items = append(items, item)
+			}
+		}
+		if len(items) > 0 {
+			return items, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/go/ai/format_text.go
+++ b/go/ai/format_text.go
@@ -51,3 +51,8 @@ func (t textHandler) Instructions() string {
 func (t textHandler) ParseMessage(m *Message) (*Message, error) {
 	return m, nil
 }
+
+// ParseChunk for text format simply returns the accumulated text
+func (t textHandler) ParseChunk(chunk *ModelResponseChunk, accumulatedText string) (interface{}, error) {
+	return accumulatedText, nil
+}

--- a/go/ai/formatter.go
+++ b/go/ai/formatter.go
@@ -50,6 +50,9 @@ type Formatter interface {
 type FormatHandler interface {
 	// ParseMessage parses the message and returns a new formatted message.
 	ParseMessage(message *Message) (*Message, error)
+	// ParseChunk parses a streaming chunk and returns parsed data (optional).
+	// Based on JS version: js/ai/src/formats/types.ts parseChunk method
+	ParseChunk(chunk *ModelResponseChunk, accumulatedText string) (interface{}, error)
 	// Instructions returns the formatter instructions to embed in the prompt.
 	Instructions() string
 	// Config returns the output config for the model request.

--- a/go/ai/gen.go
+++ b/go/ai/gen.go
@@ -272,6 +272,10 @@ type ModelResponseChunk struct {
 	Custom     any     `json:"custom,omitempty"`
 	Index      int     `json:"index,omitempty"`
 	Role       Role    `json:"role,omitempty"`
+	
+	// Metadata holds additional information for streaming.
+	// Based on JS version: js/ai/src/generate/chunk.ts
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 // OutputConfig describes the structure that the model's output


### PR DESCRIPTION
## Description
This PR adds streaming support for `GenerateData` in Genkit Go, enabling partial JSON parsing during streaming responses.

### Background
When using `GenerateData` with streaming callbacks, the following error occurs:

`Bad stream: SyntaxError: Unexpected end of JSON input`

This happens because `GenerateData` doesn't support parsing partial JSON during streaming, which is a common use case when generating structured data (like menus, configurations, etc.) with streaming enabled for better user experience.

### Solution
Following the JavaScript implementation approach, this PR implements:

1. Partial JSON parsing capability - Added functions to parse incomplete JSON structures during streaming, based on `js/ai/src/extract.ts`
2. Formatter streaming support - Added `ParseChunk` method to all formatters to handle streaming data
3. Metadata field for chunks - Added to `ModelResponseChunk` to store parsed partial data, matching `js/ai/src/generate/chunk.ts`

### Example
This allows for an implementation as per the document: https://genkit.dev/go/docs/flows/#streaming-flows

```go
type Menu struct {
    Theme  string     `json:"theme"`
    Items  []MenuItem `json:"items"`
}

type MenuItem struct {
    Name        string `json:"name"`
    Description string `json:"description"`
}

menuSuggestionFlow := genkit.DefineStreamingFlow(g, "menuSuggestionFlow",
    func(ctx context.Context, theme string, callback core.StreamCallback[string]) (Menu, error) {
        item, _, err := genkit.GenerateData[MenuItem](ctx, g,
            ai.WithPrompt("Invent a menu item for a %s themed restaurant.", theme),
            ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
                // Here, you could process the chunk in some way before sending it to
                // the output stream using StreamCallback. In this example, we output
                // the text of the chunk, unmodified.
                return callback(ctx, chunk.Text())
            }),
        )
        if err != nil {
            return nil, err
        }

        return Menu{
            Theme: theme,
            Items: []MenuItem{item},
        }, nil
    })
```

This brings feature parity with the JavaScript SDK and resolves the TODO comment in the code.

### Test Results

All tests pass successfully:

```bash
$ go test ./ai/... -v
=== RUN   TestGenerateAction
...
PASS
ok      github.com/firebase/genkit/go/ai        0.357s

$ go test ./internal/base/... -v
=== RUN   TestExtractJSONFromMarkdown
...
=== RUN   TestParsePartialJSON
...
=== RUN   TestExtractJSON
...
PASS
ok      github.com/firebase/genkit/go/internal/base     0.220s

$ go test ./... -short
ok      github.com/firebase/genkit/go/ai        0.304s
ok      github.com/firebase/genkit/go/core      0.644s
ok      github.com/firebase/genkit/go/genkit    0.966s
ok      github.com/firebase/genkit/go/internal/base     1.396s
... (all packages pass)
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
