### PR TITLE
Fix JSON Schema parsing when object has no properties

### DIFF
--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -513,7 +513,7 @@ function convertSchemaProperty(property) {
   }
   if (propertyType === 'object') {
     const nestedProperties = {};
-    Object.keys(property.properties).forEach((key) => {
+    Object.keys(property.properties || {}).forEach((key) => {
       nestedProperties[key] = convertSchemaProperty(property.properties[key]);
     });
     return {

--- a/js/plugins/googleai/tests/gemini_test.ts
+++ b/js/plugins/googleai/tests/gemini_test.ts
@@ -550,7 +550,7 @@ describe('plugin', () => {
 });
 
 describe('toGeminiTool', () => {
-  it('', async () => {
+  it('works with a Zod schema', async () => {
     const got = toGeminiTool({
       name: 'foo',
       description: 'tool foo',
@@ -601,6 +601,24 @@ describe('toGeminiTool', () => {
         },
         required: ['simpleString', 'simpleNumber'],
         type: 'object',
+      },
+    };
+    assert.deepStrictEqual(got, want);
+  });
+  it('works with a JSON schema that has no properties', async () => {
+    const got = toGeminiTool({
+      name: 'foo',
+      description: 'tool foo',
+      inputSchema: { type: 'object' },
+    });
+
+    const want = {
+      description: 'tool foo',
+      name: 'foo',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: undefined,
       },
     };
     assert.deepStrictEqual(got, want);


### PR DESCRIPTION
## Description

This fixes an issue in parsing JSON schemas where `googleai` was forcing the schema object to have `properties`. It's legal for a JSON schema to not provide any properties (e.g. `{"type": "object"}` is a legal schema), so it should be robust to that input.

## Tests
 - Added a test for this case.