### PR TITLE
fix(cli): fix ui:start on Windows (and machines with spaces in path)

### DIFF
--- a/genkit-tools/cli/src/commands/ui-start.ts
+++ b/genkit-tools/cli/src/commands/ui-start.ts
@@ -152,12 +152,15 @@ async function startAndWaitUntilHealthy(
     );
   }
 
+  const command = `"${spawnConfig.command}"`;
+  const args = spawnConfig.args.map((arg) => `"${arg}"`);
+
   logger.debug(
-    `Spawning: ${spawnConfig.command} ${spawnConfig.args.join(' ')}`
+    `Spawning: ${command} ${args.join(' ')}`
   );
   const child = spawn(
-    spawnConfig.command,
-    spawnConfig.args,
+    command,
+    args,
     spawnConfig.options
   );
 


### PR DESCRIPTION
Fixes running `genkit ui:start` on WIndows.
Should also fix running the command on machines that happen to include spaces in paths.

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested on Windows
- [ ] Tested on MacOS