### PR TITLE
feat(js/plugins/google-cloud): Add support to export thinking token usage as a new metric

### DIFF
--- a/js/plugins/google-cloud/src/telemetry/generate.ts
+++ b/js/plugins/google-cloud/src/telemetry/generate.ts
@@ -100,6 +100,14 @@ class GenerateTelemetry implements Telemetry {
     valueType: ValueType.INT,
   });
 
+  private thoughtTokens = new MetricCounter(
+    this._N('generate/thought/tokens'),
+    {
+      description: 'Counts thought tokens from a Genkit model.',
+      valueType: ValueType.INT,
+    }
+  );
+
   private outputImages = new MetricCounter(this._N('generate/output/images'), {
     description: 'Count output images from a Genkit model.',
     valueType: ValueType.INT,
@@ -436,6 +444,9 @@ class GenerateTelemetry implements Telemetry {
     this.outputTokens.add(usage.outputTokens, shared);
     this.outputCharacters.add(usage.outputCharacters, shared);
     this.outputImages.add(usage.outputImages, shared);
+
+    // thoughts
+    this.thoughtTokens.add(usage.thoughtsTokens, shared);
   }
 }
 

--- a/js/plugins/google-cloud/src/telemetry/generate.ts
+++ b/js/plugins/google-cloud/src/telemetry/generate.ts
@@ -100,10 +100,10 @@ class GenerateTelemetry implements Telemetry {
     valueType: ValueType.INT,
   });
 
-  private thoughtTokens = new MetricCounter(
-    this._N('generate/thought/tokens'),
+  private thinkingTokens = new MetricCounter(
+    this._N('generate/thinking/tokens'),
     {
-      description: 'Counts thought tokens from a Genkit model.',
+      description: 'Counts thinking tokens from a Genkit model.',
       valueType: ValueType.INT,
     }
   );
@@ -446,7 +446,7 @@ class GenerateTelemetry implements Telemetry {
     this.outputImages.add(usage.outputImages, shared);
 
     // thoughts
-    this.thoughtTokens.add(usage.thoughtsTokens, shared);
+    this.thinkingTokens.add(usage.thoughtsTokens, shared);
   }
 }
 

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -192,7 +192,7 @@ describe('GoogleCloudMetrics', () => {
       'genkit/ai/generate/output/tokens'
     );
     const thoughtTokenCounter = await getCounterMetric(
-      'genkit/ai/generate/thought/tokens'
+      'genkit/ai/generate/thinking/tokens'
     );
     const inputCharacterCounter = await getCounterMetric(
       'genkit/ai/generate/input/characters'
@@ -300,7 +300,7 @@ describe('GoogleCloudMetrics', () => {
       await getCounterMetric('genkit/ai/generate/requests'),
       await getCounterMetric('genkit/ai/generate/input/tokens'),
       await getCounterMetric('genkit/ai/generate/output/tokens'),
-      await getCounterMetric('genkit/ai/generate/thought/tokens'),
+      await getCounterMetric('genkit/ai/generate/thinking/tokens'),
       await getCounterMetric('genkit/ai/generate/input/characters'),
       await getCounterMetric('genkit/ai/generate/output/characters'),
       await getCounterMetric('genkit/ai/generate/input/images'),

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -191,6 +191,9 @@ describe('GoogleCloudMetrics', () => {
     const outputTokenCounter = await getCounterMetric(
       'genkit/ai/generate/output/tokens'
     );
+    const thoughtTokenCounter = await getCounterMetric(
+      'genkit/ai/generate/thought/tokens'
+    );
     const inputCharacterCounter = await getCounterMetric(
       'genkit/ai/generate/input/characters'
     );
@@ -209,6 +212,7 @@ describe('GoogleCloudMetrics', () => {
     assert.equal(requestCounter.value, 1);
     assert.equal(inputTokenCounter.value, 10);
     assert.equal(outputTokenCounter.value, 14);
+    assert.equal(thoughtTokenCounter.value, 5);
     assert.equal(inputCharacterCounter.value, 8);
     assert.equal(outputCharacterCounter.value, 16);
     assert.equal(inputImageCounter.value, 1);
@@ -218,6 +222,7 @@ describe('GoogleCloudMetrics', () => {
       requestCounter,
       inputTokenCounter,
       outputTokenCounter,
+      thoughtTokenCounter,
       inputCharacterCounter,
       outputCharacterCounter,
       inputImageCounter,
@@ -272,6 +277,7 @@ describe('GoogleCloudMetrics', () => {
         usage: {
           inputTokens: 10,
           outputTokens: 14,
+          thoughtsTokens: 5,
           inputCharacters: 8,
           outputCharacters: 16,
           inputImages: 1,
@@ -294,6 +300,7 @@ describe('GoogleCloudMetrics', () => {
       await getCounterMetric('genkit/ai/generate/requests'),
       await getCounterMetric('genkit/ai/generate/input/tokens'),
       await getCounterMetric('genkit/ai/generate/output/tokens'),
+      await getCounterMetric('genkit/ai/generate/thought/tokens'),
       await getCounterMetric('genkit/ai/generate/input/characters'),
       await getCounterMetric('genkit/ai/generate/output/characters'),
       await getCounterMetric('genkit/ai/generate/input/images'),
@@ -771,6 +778,7 @@ describe('GoogleCloudMetrics', () => {
           outputCharacters: 16,
           inputImages: 1,
           outputImages: 3,
+          thoughtsTokens: 5,
         },
       };
     });


### PR DESCRIPTION
Related to https://github.com/firebase/genkit/issues/3335


Tested exported metrics are visible in Google Cloud and match new thoughtsTokens attributes in the usage block.

The screenshots below were taken before renaming to thinking, however the logic remains the same.

**New Google Cloud metric** 
<img width="1934" height="1030" alt="image" src="https://github.com/user-attachments/assets/3ad2b7f6-c954-4dd5-955b-92a86a7adc3c" />
<img width="596" height="494" alt="image" src="https://github.com/user-attachments/assets/d629e490-6bd0-4ac1-a20e-342275932279" />

**thoughtsToken attribute is visible in Firebase Genkit Monitoring and matches exported metrics**
<img width="2174" height="1216" alt="image" src="https://github.com/user-attachments/assets/c3946f51-a2c2-4cab-ae7a-2eb07a4536d3" />

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
