### PR TITLE
fix(go): Fixed type assertions on LookupPlugin

### DIFF
--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -767,7 +767,12 @@ func LookupEmbedder(g *Genkit, provider, name string) ai.Embedder {
 // The caller is responsible for type-asserting the returned value to the
 // specific plugin type.
 func LookupPlugin(g *Genkit, name string) Plugin {
-	return g.reg.LookupPlugin(name).(Plugin)
+	switch p := g.reg.LookupPlugin(name).(type) {
+	case Plugin:
+		return p
+	default:
+		return nil
+	}
 }
 
 // DefineEvaluator defines an evaluator that processes test cases one by one,


### PR DESCRIPTION
Description:
 - https://github.com/firebase/genkit/issues/3354
 - Performs a safe type-switch on the returned value of a registry's LookupPlugin. If a plugin does not exist (or is the incorrect type), this will no longer panic.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually) 
- [ ] Docs updated (updated docs or a docs bug required)
