### PR TITLE
chore: return `raw` in response generated by `generate`

### DIFF
--- a/js/ai/src/generate/response.ts
+++ b/js/ai/src/generate/response.ts
@@ -210,6 +210,7 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
       custom: (this.custom as { toJSON?: () => any }).toJSON?.() || this.custom,
       request: this.request,
       operation: this.operation,
+      raw: this.raw,
     };
     if (!out.finishMessage) delete out.finishMessage;
     if (!out.request) delete out.request;


### PR DESCRIPTION
- to make it possible to extract segments and words from verbose responses in transcription flows as describe in https://github.com/firebase/genkit/issues/3366
