### PR TITLE
feat(ci): add promotion scripts

### DIFF
--- a/bin/install_cli
+++ b/bin/install_cli
@@ -23,7 +23,7 @@
 ## <style>body {color: #272822; background-color: #272822; font-size: 0.8em;} </style>
 
 # Configuration variables
-DOMAIN="genkit.tools"
+DOMAIN="cli.genkit.dev"
 TRACKING_ID="UA-XXXXXXXXX-X"  # Not used when analytics is commented out
 
 : ==========================================

--- a/scripts/cli-releases/README.md
+++ b/scripts/cli-releases/README.md
@@ -1,0 +1,163 @@
+# CLI Release Scripts
+
+This directory contains scripts for managing Genkit CLI releases, including promotion from GitHub artifacts to Google Cloud Storage (GCS).
+
+## Overview
+
+The release management process consists of two scripts:
+1. `promote_cli_gcs.sh` - Downloads binaries from GitHub and uploads to GCS
+2. `update_cli_metadata.sh` - Updates metadata JSON files with version information
+
+## Prerequisites
+
+- Google Cloud SDK (`gcloud` and `gsutil`) installed and authenticated
+- GitHub CLI (`gh`) installed and authenticated (for artifact downloads)
+- Appropriate permissions on the GCS bucket
+
+## Usage
+
+### Promoting from a GitHub Actions Run
+
+```bash
+# Promote binaries from a specific GitHub Actions run
+./scripts/cli-releases/promote_cli_gcs.sh \
+  --github-run-id=123456789 \
+  --channel=next \
+  --version=1.15.5
+
+# Update metadata
+./scripts/cli-releases/update_cli_metadata.sh \
+  --channel=next \
+  --version=1.15.5
+```
+
+### Promoting from a GitHub Release
+
+```bash
+# Promote binaries from a GitHub release tag
+./scripts/cli-releases/promote_cli_gcs.sh \
+  --github-tag=v1.15.5 \
+  --channel=prod \
+  --version=1.15.5
+
+# Update metadata
+./scripts/cli-releases/update_cli_metadata.sh \
+  --channel=prod \
+  --version=1.15.5
+```
+
+### Dry Run Mode
+
+Both scripts support a `--dry-run` flag to see what would be done without actually doing it:
+
+```bash
+./scripts/cli-releases/promote_cli_gcs.sh \
+  --github-run-id=123456789 \
+  --channel=next \
+  --version=1.15.5 \
+  --dry-run
+```
+
+## Script Options
+
+### promote_cli_gcs.sh
+
+| Option | Description | Required |
+|--------|-------------|----------|
+| `--github-run-id=ID` | GitHub Actions run ID to download artifacts from | One of github-run-id or github-tag |
+| `--github-tag=TAG` | GitHub release tag to download artifacts from | One of github-run-id or github-tag |
+| `--channel=CHANNEL` | Target channel (prod/next) | No (default: next) |
+| `--version=VERSION` | Version string for GCS paths | Yes |
+| `--bucket=BUCKET` | GCS bucket name | No (default: genkit-cli-binaries) |
+| `--dry-run` | Show what would be done without doing it | No |
+
+### update_cli_metadata.sh
+
+| Option | Description | Required |
+|--------|-------------|----------|
+| `--channel=CHANNEL` | Target channel (prod/next) | No (default: next) |
+| `--version=VERSION` | Version to mark as latest | Yes |
+| `--bucket=BUCKET` | GCS bucket name | No (default: genkit-cli-binaries) |
+| `--dry-run` | Show what would be done without doing it | No |
+
+## GCS Bucket Structure
+
+The scripts create the following structure in GCS:
+
+```
+gs://genkit-cli-binaries/
+├── prod/
+│   └── bin/
+│       ├── linux-x64/
+│       │   ├── latest
+│       │   └── v1.15.5/
+│       │       └── genkit
+│       ├── linux-arm64/
+│       │   ├── latest
+│       │   └── v1.15.5/
+│       │       └── genkit
+│       ├── darwin-x64/
+│       │   ├── latest
+│       │   └── v1.15.5/
+│       │       └── genkit
+│       ├── darwin-arm64/
+│       │   ├── latest
+│       │   └── v1.15.5/
+│       │       └── genkit
+│       └── win32-x64/
+│           ├── latest.exe
+│           └── v1.15.5/
+│               └── genkit.exe
+├── next/
+│   └── bin/
+│       └── [same structure as prod]
+├── metadata-prod.json
+└── metadata-next.json
+```
+
+## Metadata Format
+
+The metadata JSON files contain information about the latest version:
+
+```json
+{
+  "channel": "prod",
+  "latestVersion": "1.15.5",
+  "lastUpdated": "2025-01-15T10:00:00Z",
+  "platforms": {
+    "linux-x64": {
+      "url": "https://cli.genkit.dev/bin/linux-x64/latest",
+      "version": "1.15.5",
+      "versionedUrl": "https://cli.genkit.dev/bin/linux-x64/v1.15.5/genkit"
+    },
+    ...
+  }
+}
+```
+
+## Integration with Cloud Build
+
+These scripts are designed to be called from Cloud Build or other CI/CD systems. Example Cloud Build step:
+
+```yaml
+steps:
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        ./scripts/cli-releases/promote_cli_gcs.sh \
+          --github-run-id=${_GITHUB_RUN_ID} \
+          --channel=${_CHANNEL} \
+          --version=${_VERSION}
+        
+        ./scripts/cli-releases/update_cli_metadata.sh \
+          --channel=${_CHANNEL} \
+          --version=${_VERSION}
+```
+
+## Notes
+
+- Binary naming conventions match those from `build-cli-binaries.yml`
+- The domain `cli.genkit.dev` should be configured to serve from the GCS bucket
+- Cache headers are set appropriately (1 hour for versioned files, 5 minutes for latest)

--- a/scripts/cli-releases/promote_cli_gcs.sh
+++ b/scripts/cli-releases/promote_cli_gcs.sh
@@ -130,7 +130,7 @@ if [[ -n "$GITHUB_RUN_ID" ]]; then
     echo "Downloading artifact: genkit-$platform"
     if [[ "$DRY_RUN" == "false" ]]; then
       # Use gh CLI to download the artifact
-      if gh run download "$GITHUB_RUN_ID" -n "genkit-$platform" -R firebase/genkit 2>/dev/null; then
+      if gh run download "$GITHUB_RUN_ID" -n "genkit-$platform" -R firebase/genkit; then
         # The artifact is downloaded as a directory, move the binary to the current directory
         if [[ -f "genkit-$platform" ]]; then
           mv "genkit-$platform" .

--- a/scripts/cli-releases/promote_cli_gcs.sh
+++ b/scripts/cli-releases/promote_cli_gcs.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+# Script to promote CLI binaries from GitHub artifacts to GCS
+# Usage: promote_cli_gcs.sh [options]
+#
+# Options:
+#   --github-run-id=ID    GitHub Actions run ID to download artifacts from
+#   --github-tag=TAG      GitHub release tag to download artifacts from  
+#   --channel=CHANNEL     Target channel (prod/next)
+#   --version=VERSION     Version string for GCS paths
+#   --bucket=BUCKET       GCS bucket name (default: genkit-cli-binaries)
+#   --dry-run            Show what would be done without doing it
+
+# Default values
+GITHUB_RUN_ID=""
+GITHUB_TAG=""
+CHANNEL="next"
+VERSION=""
+BUCKET="genkit-cli-binaries"
+DRY_RUN=false
+
+# Parse command line arguments
+for arg in "$@"; do
+  case $arg in
+    --github-run-id=*)
+      GITHUB_RUN_ID="${arg#*=}"
+      shift
+      ;;
+    --github-tag=*)
+      GITHUB_TAG="${arg#*=}"
+      shift
+      ;;
+    --channel=*)
+      CHANNEL="${arg#*=}"
+      shift
+      ;;
+    --version=*)
+      VERSION="${arg#*=}"
+      shift
+      ;;
+    --bucket=*)
+      BUCKET="${arg#*=}"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate inputs
+if [[ -z "$GITHUB_RUN_ID" && -z "$GITHUB_TAG" ]]; then
+  echo "Error: Either --github-run-id or --github-tag must be specified"
+  exit 1
+fi
+
+if [[ -z "$VERSION" ]]; then
+  echo "Error: --version must be specified"
+  exit 1
+fi
+
+if [[ "$CHANNEL" != "prod" && "$CHANNEL" != "next" ]]; then
+  echo "Error: --channel must be either 'prod' or 'next'"
+  exit 1
+fi
+
+# Platform list matching build-cli-binaries.yml
+PLATFORMS=(
+  "linux-x64"
+  "linux-arm64"
+  "darwin-x64"
+  "darwin-arm64"
+  "win32-x64"
+)
+
+echo "=== CLI Binary Promotion to GCS ==="
+echo "Channel: $CHANNEL"
+echo "Version: $VERSION"
+echo "Bucket: $BUCKET"
+echo "Dry run: $DRY_RUN"
+echo ""
+
+# Create temporary directory for downloads
+TMP_DIR=$(mktemp -d)
+trap "rm -rf $TMP_DIR" EXIT
+
+# Validate that TMP_DIR exists and is writable
+if [[ -z "$TMP_DIR" || ! -d "$TMP_DIR" || ! -w "$TMP_DIR" ]]; then
+  echo "Error: Failed to create a writable temporary directory."
+  exit 1
+fi
+
+cd "$TMP_DIR"
+
+# Download artifacts from GitHub
+if [[ -n "$GITHUB_RUN_ID" ]]; then
+  echo "Downloading artifacts from GitHub run ID: $GITHUB_RUN_ID"
+  
+  # Check if gh CLI is available
+  if ! command -v gh &> /dev/null; then
+    echo "Error: GitHub CLI (gh) is not installed"
+    echo "Please install it from: https://cli.github.com/"
+    exit 1
+  fi
+  
+  # Download all artifacts for the run
+  for platform in "${PLATFORMS[@]}"; do
+    echo "Downloading artifact: genkit-$platform"
+    if [[ "$DRY_RUN" == "false" ]]; then
+      # Use gh CLI to download the artifact
+      if gh run download "$GITHUB_RUN_ID" -n "genkit-$platform" -R firebase/genkit 2>/dev/null; then
+        # The artifact is downloaded as a directory, move the binary to the current directory
+        if [[ -f "genkit-$platform" ]]; then
+          mv "genkit-$platform" .
+        elif [[ -f "genkit-$platform.exe" ]]; then
+          mv "genkit-$platform.exe" .
+        fi
+      else
+        echo "Warning: Failed to download genkit-$platform"
+      fi
+    else
+      echo "[DRY RUN] Would download: genkit-$platform"
+    fi
+  done
+elif [[ -n "$GITHUB_TAG" ]]; then
+  echo "Downloading artifacts from GitHub release tag: $GITHUB_TAG"
+  
+  # Download release assets
+  for platform in "${PLATFORMS[@]}"; do
+    # Determine file extension
+    if [[ "$platform" == "win32-x64" ]]; then
+      ext=".exe"
+    else
+      ext=""
+    fi
+    
+    echo "Downloading release asset: genkit-$platform$ext"
+    if [[ "$DRY_RUN" == "false" ]]; then
+      gh release download "$GITHUB_TAG" -p "genkit-$platform$ext" -R firebase/genkit || {
+        echo "Warning: Failed to download genkit-$platform$ext"
+      }
+    else
+      echo "[DRY RUN] Would download: genkit-$platform$ext"
+    fi
+  done
+fi
+
+# Upload to GCS
+echo ""
+echo "Uploading binaries to GCS..."
+
+for platform in "${PLATFORMS[@]}"; do
+  # Determine file extension and names
+  if [[ "$platform" == "win32-x64" ]]; then
+    ext=".exe"
+    binary_name="genkit.exe"
+    latest_name="latest.exe"
+  else
+    ext=""
+    binary_name="genkit"
+    latest_name="latest"
+  fi
+  
+  source_file="genkit-$platform$ext"
+  
+  # Check if file exists
+  if [[ ! -f "$source_file" ]]; then
+    echo "Warning: $source_file not found, skipping..."
+    continue
+  fi
+  
+  # Upload versioned binary
+  versioned_path="gs://$BUCKET/$CHANNEL/bin/$platform/v$VERSION/$binary_name"
+  echo "Uploading $source_file to $versioned_path"
+  if [[ "$DRY_RUN" == "false" ]]; then
+    gsutil -h "Cache-Control:public, max-age=3600" cp "$source_file" "$versioned_path"
+  else
+    echo "[DRY RUN] Would upload to: $versioned_path"
+  fi
+  
+  # Upload/copy as latest
+  latest_path="gs://$BUCKET/$CHANNEL/bin/$platform/$latest_name"
+  echo "Copying to $latest_path"
+  if [[ "$DRY_RUN" == "false" ]]; then
+    gsutil -h "Cache-Control:public, max-age=300" cp "$source_file" "$latest_path"
+  else
+    echo "[DRY RUN] Would copy to: $latest_path"
+  fi
+  
+  echo ""
+done
+
+echo "=== Promotion complete ==="
+echo ""
+echo "Binaries are now available at:"
+echo "  Latest: https://cli.genkit.dev/bin/{platform}/latest"
+echo "  Versioned: https://cli.genkit.dev/bin/{platform}/v$VERSION/genkit"
+echo ""
+echo "Run update_cli_metadata.sh to update the metadata files."

--- a/scripts/cli-releases/update_cli_metadata.sh
+++ b/scripts/cli-releases/update_cli_metadata.sh
@@ -134,18 +134,20 @@ for platform in "${PLATFORMS[@]}"; do
     echo "," >> "$METADATA_FILE"
   fi
   
-  # Determine binary name
+  # Determine binary names
   if [[ "$platform" == "win32-x64" ]]; then
     binary_name="latest.exe"
+    versioned_binary_name="genkit.exe"
   else
     binary_name="latest"
+    versioned_binary_name="genkit"
   fi
   
   cat >> "$METADATA_FILE" << EOF
     "$platform": {
-      "url": "https://cli.genkit.dev/bin/$platform/$binary_name",
+      "url": "https://cli.genkit.dev/$CHANNEL/bin/$platform/$binary_name",
       "version": "$VERSION",
-      "versionedUrl": "https://cli.genkit.dev/bin/$platform/v$VERSION/genkit"
+      "versionedUrl": "https://cli.genkit.dev/$CHANNEL/bin/$platform/v$VERSION/$versioned_binary_name"
     }
 EOF
 done

--- a/scripts/cli-releases/update_cli_metadata.sh
+++ b/scripts/cli-releases/update_cli_metadata.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+# Script to update CLI metadata in GCS
+# Usage: update_cli_metadata.sh [options]
+#
+# Options:
+#   --channel=CHANNEL     Target channel (prod/next)
+#   --version=VERSION     Version to mark as latest
+#   --bucket=BUCKET       GCS bucket name (default: genkit-cli-binaries)
+#   --dry-run            Show what would be done without doing it
+
+# Default values
+CHANNEL="next"
+VERSION=""
+BUCKET="genkit-cli-binaries"
+DRY_RUN=false
+
+# Parse command line arguments
+for arg in "$@"; do
+  case $arg in
+    --channel=*)
+      CHANNEL="${arg#*=}"
+      shift
+      ;;
+    --version=*)
+      VERSION="${arg#*=}"
+      shift
+      ;;
+    --bucket=*)
+      BUCKET="${arg#*=}"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate inputs
+if [[ -z "$VERSION" ]]; then
+  echo "Error: --version must be specified"
+  exit 1
+fi
+
+if [[ "$CHANNEL" != "prod" && "$CHANNEL" != "next" ]]; then
+  echo "Error: --channel must be either 'prod' or 'next'"
+  exit 1
+fi
+
+# Platform list
+PLATFORMS=(
+  "linux-x64"
+  "linux-arm64"
+  "darwin-x64"
+  "darwin-arm64"
+  "win32-x64"
+)
+
+echo "=== CLI Metadata Update ==="
+echo "Channel: $CHANNEL"
+echo "Version: $VERSION"
+echo "Bucket: $BUCKET"
+echo "Dry run: $DRY_RUN"
+echo ""
+
+# Create temporary directory
+TMP_DIR=$(mktemp -d)
+trap "rm -rf $TMP_DIR" EXIT
+
+# Validate that TMP_DIR exists and is writable
+if [[ -z "$TMP_DIR" || ! -d "$TMP_DIR" || ! -w "$TMP_DIR" ]]; then
+  echo "Error: Failed to create a writable temporary directory."
+  exit 1
+fi
+
+cd "$TMP_DIR"
+
+# Get current timestamp
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Create metadata JSON
+METADATA_FILE="metadata-$CHANNEL.json"
+echo "Generating metadata file: $METADATA_FILE"
+
+# Try to download existing metadata to preserve release history
+EXISTING_METADATA=""
+if [[ "$DRY_RUN" == "false" ]]; then
+  echo "Checking for existing metadata..."
+  if gsutil cp "gs://$BUCKET/$METADATA_FILE" "$METADATA_FILE.existing" 2>/dev/null; then
+    echo "Found existing metadata, will preserve release history"
+    EXISTING_METADATA=$(cat "$METADATA_FILE.existing")
+  else
+    echo "No existing metadata found, creating new file"
+  fi
+fi
+
+# Start building the JSON
+cat > "$METADATA_FILE" << EOF
+{
+  "channel": "$CHANNEL",
+  "latestVersion": "$VERSION",
+  "lastUpdated": "$TIMESTAMP",
+  "platforms": {
+EOF
+
+# Add platform entries
+first=true
+for platform in "${PLATFORMS[@]}"; do
+  if [[ "$first" == "true" ]]; then
+    first=false
+  else
+    echo "," >> "$METADATA_FILE"
+  fi
+  
+  # Determine binary name
+  if [[ "$platform" == "win32-x64" ]]; then
+    binary_name="latest.exe"
+  else
+    binary_name="latest"
+  fi
+  
+  cat >> "$METADATA_FILE" << EOF
+    "$platform": {
+      "url": "https://cli.genkit.dev/bin/$platform/$binary_name",
+      "version": "$VERSION",
+      "versionedUrl": "https://cli.genkit.dev/bin/$platform/v$VERSION/genkit"
+    }
+EOF
+done
+
+# Close the JSON
+cat >> "$METADATA_FILE" << EOF
+
+  }
+}
+EOF
+
+# Pretty print the JSON
+if command -v jq &> /dev/null; then
+  jq . "$METADATA_FILE" > "$METADATA_FILE.tmp" && mv "$METADATA_FILE.tmp" "$METADATA_FILE"
+fi
+
+# Show the metadata
+echo ""
+echo "Generated metadata:"
+cat "$METADATA_FILE"
+echo ""
+
+# Upload to GCS
+METADATA_PATH="gs://$BUCKET/$METADATA_FILE"
+echo "Uploading metadata to: $METADATA_PATH"
+
+if [[ "$DRY_RUN" == "false" ]]; then
+  # Upload with appropriate cache headers
+  gsutil -h "Cache-Control:public, max-age=60" \
+         -h "Content-Type:application/json" \
+         cp "$METADATA_FILE" "$METADATA_PATH"
+  
+  # Make the file publicly readable
+  gsutil acl ch -u AllUsers:R "$METADATA_PATH"
+  
+  echo ""
+  echo "Metadata uploaded successfully!"
+else
+  echo "[DRY RUN] Would upload to: $METADATA_PATH"
+fi
+
+echo ""
+echo "=== Metadata update complete ==="
+echo ""
+echo "Metadata is now available at:"
+echo "  https://cli.genkit.dev/$METADATA_FILE"


### PR DESCRIPTION

This PR adds scripts to promote Genkit CLI binaries from GitHub artifacts to Google Cloud Storage (GCS), along with metadata management for version tracking.

## What's Added

### Scripts
- **`scripts/promote_cli_gcs.sh`** - Downloads binaries from GitHub and uploads to GCS
- **`scripts/update_cli_metadata.sh`** - Updates metadata JSON files with version information

### Documentation
- **`scripts/cli-promotion/README.md`**

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
