### PR TITLE
fix(js): `run()` calls the function with given input

### DIFF
--- a/js/core/src/flow.ts
+++ b/js/core/src/flow.ts
@@ -156,10 +156,12 @@ export function run<T>(
   let func;
   let input;
   let registry: Registry | undefined;
+  let hasInput = false;
   if (typeof funcOrInput === 'function') {
     func = funcOrInput;
   } else {
     input = funcOrInput;
+    hasInput = true;
   }
   if (typeof fnOrRegistry === 'function') {
     func = fnOrRegistry;
@@ -199,7 +201,7 @@ export function run<T>(
     },
     async (meta) => {
       meta.input = input;
-      const output = arguments.length === 3 ? await func(input) : await func();
+      const output = hasInput ? await func(input) : await func();
       meta.output = JSON.stringify(output);
       return output;
     }

--- a/js/core/tests/flow_test.ts
+++ b/js/core/tests/flow_test.ts
@@ -337,6 +337,24 @@ describe('flow', () => {
     });
   });
 
+  describe('run', () => {
+    it('should run the action', async () => {
+      const act = async () => 'bar';
+
+      const result = await run('action', act, registry);
+
+      assert.equal(result, 'bar');
+    });
+
+    it('should run the action with input', async () => {
+      const act = async (input: string) => `${input} bar`;
+
+      const result = await run('action', 'foo', act, registry);
+
+      assert.equal(result, 'foo bar');
+    });
+  });
+
   describe('telemetry', async () => {
     beforeEach(() => {
       spanExporter.exportedSpans = [];


### PR DESCRIPTION
Fix #3376 

- Add tests for `run` function call.
- Avoid to use `arguments.length`

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
