### PR TITLE
fix: instantiate OpenAI client in all relevant async functions

### DIFF
--- a/js/plugins/compat-oai/src/index.ts
+++ b/js/plugins/compat-oai/src/index.ts
@@ -109,23 +109,25 @@ export interface PluginOptions extends Partial<ClientOptions> {
  * ```
  */
 export const openAICompatible = (options: PluginOptions) => {
-  const client = new OpenAI(options);
   let listActionsCache;
   return genkitPlugin(
     options.name,
     async (ai: Genkit) => {
       if (options.initializer) {
+        const client = new OpenAI(options);
         await options.initializer(ai, client);
       }
     },
     async (ai: Genkit, actionType: ActionType, actionName: string) => {
       if (options.resolver) {
+        const client = new OpenAI(options);
         await options.resolver(ai, client, actionType, actionName);
       }
     },
     options.listActions
       ? async () => {
           if (listActionsCache) return listActionsCache;
+          const client = new OpenAI(options);
           listActionsCache = await options.listActions!(client);
           return listActionsCache;
         }


### PR DESCRIPTION
Fixes early open ai library constructor call. When deploying firebase cloud functions the environmental variables are not initiated till functions is deployed therefore process.env.OPENAI_API_KEY is not available even if user has set the secretes.

#3387 
