### PR TITLE
fix: Fix for AbortSignal value of "this" issue

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -314,7 +314,6 @@ function definePromptAsync<
           docs = resolvedOptions.docs;
         }
 
-
         const opts: GenerateOptions = stripUndefinedProps({
           model: resolvedOptions.model,
           maxTurns: resolvedOptions.maxTurns,

--- a/js/ai/tests/prompt/prompt_test.ts
+++ b/js/ai/tests/prompt/prompt_test.ts
@@ -46,7 +46,7 @@ describe('prompt', () => {
       },
       async () => 'a'
     );
-    
+
     // Define a special model to test AbortSignal preservation
     defineModel(
       registry,
@@ -858,8 +858,15 @@ describe('prompt', () => {
 
     // Verify the AbortSignal is preserved in the rendered options
     assert.ok(rendered.abortSignal, 'AbortSignal should be preserved');
-    assert.strictEqual(rendered.abortSignal, timeoutSignal, 'Should be the exact same AbortSignal instance');
-    assert.ok(rendered.abortSignal instanceof AbortSignal, 'Should be an AbortSignal instance');
+    assert.strictEqual(
+      rendered.abortSignal,
+      timeoutSignal,
+      'Should be the exact same AbortSignal instance'
+    );
+    assert.ok(
+      rendered.abortSignal instanceof AbortSignal,
+      'Should be an AbortSignal instance'
+    );
 
     // Test manual AbortController
     const controller = new AbortController();
@@ -868,8 +875,15 @@ describe('prompt', () => {
     });
 
     assert.ok(rendered2.abortSignal, 'Manual AbortSignal should be preserved');
-    assert.strictEqual(rendered2.abortSignal, controller.signal, 'Should be the exact same manual AbortSignal instance');
-    assert.ok(rendered2.abortSignal instanceof AbortSignal, 'Manual AbortSignal should be an AbortSignal instance');
+    assert.strictEqual(
+      rendered2.abortSignal,
+      controller.signal,
+      'Should be the exact same manual AbortSignal instance'
+    );
+    assert.ok(
+      rendered2.abortSignal instanceof AbortSignal,
+      'Manual AbortSignal should be an AbortSignal instance'
+    );
   });
 });
 


### PR DESCRIPTION
stripUndefined will remove all undefined parameters from an object however that breaks the prototype chain. 
AbortSignal being a native node.js object shouldn't be processed like that. It has properties that are valid if undefined.
Skipping the strip for AbortSignal fixes the issue.

- Fixes #3348 

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
