### PR TITLE
fix(js/plugins/compat-oai): update model extraction logic to use slice instead of pop for better path handling

### DIFF
--- a/js/plugins/compat-oai/src/audio.ts
+++ b/js/plugins/compat-oai/src/audio.ts
@@ -189,7 +189,7 @@ export function defineCompatOpenAISpeechModel<
 }): ModelAction {
   const { ai, name, client, modelRef, requestBuilder } = params;
 
-  const model = name.split('/').pop();
+  const model = name.split('/').slice(1).join('/');
   return ai.defineModel(
     {
       name,
@@ -351,7 +351,7 @@ export function defineCompatOpenAITranscriptionModel<
       configSchema: modelRef?.configSchema,
     },
     async (request, { abortSignal }) => {
-      const modelName = name.split('/').pop();
+      const modelName = name.split('/').slice(1).join('/');
       const params = toSttRequest(modelName!, request, requestBuilder);
       // Explicitly setting stream to false ensures we use the non-streaming overload
       const result = await client.audio.transcriptions.create(

--- a/js/plugins/compat-oai/src/embedder.ts
+++ b/js/plugins/compat-oai/src/embedder.ts
@@ -40,7 +40,7 @@ export function defineCompatOpenAIEmbedder(params: {
   embedderRef?: EmbedderReference;
 }): EmbedderAction {
   const { ai, name, client, embedderRef } = params;
-  const model = name.split('/').pop();
+  const model = name.split('/').slice(1).join('/');
   return ai.defineEmbedder(
     {
       name,

--- a/js/plugins/compat-oai/src/image.ts
+++ b/js/plugins/compat-oai/src/image.ts
@@ -127,7 +127,7 @@ export function defineCompatOpenAIImageModel<
   requestBuilder?: ImageRequestBuilder;
 }): ModelAction<CustomOptions> {
   const { ai, name, client, modelRef, requestBuilder } = params;
-  const model = name.split('/').pop();
+  const model = name.split('/').slice(1).join('/');
 
   return ai.defineModel(
     {

--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -492,7 +492,7 @@ export function defineCompatOpenAIModel<
   requestBuilder?: ModelRequestBuilder;
 }): ModelAction {
   const { ai, name, client, modelRef, requestBuilder } = params;
-  const modelName = name.split('/').pop();
+  const modelName = name.split('/').slice(1).join('/');
 
   return ai.defineModel(
     {


### PR DESCRIPTION

Description here... Help the reviewer by:
 - linking to an issue that includes more details
 - if it's a new feature include samples of how to use the new feature
 - (optional if issue link is provided) if you fixed a bug include basic bug details

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually)
- [ ] Docs updated (updated docs or a docs bug required)

When I was using OpenRouter as the provider, I discovered this issue: the previous approach using .pop() cannot preserve any of the / separators, which is problematic.
<img width="1624" height="1062" alt="image" src="https://github.com/user-attachments/assets/e0880d7c-a16a-467f-ad98-f06d6ec66241" />

Main Drawback: Cannot Handle Model Names with Multiple '/' Separators
```typescript
const name = 'openrouter/deepseek/deepseek-chat-v3-0324:free';

// Problem with using .pop():
name.split('/').pop() // Only returns the last part: 'deepseek-chat-v3-0324:free'

// You lose all the important middle information:
// - 'deepseek' (model family)
// - Only 'deepseek-chat-v3-0324:free' remains (specific model)
```
Former
<img width="998" height="762" alt="image" src="https://github.com/user-attachments/assets/df066386-1ab0-4a8d-ad63-08928021ac90" />

Now
<img width="990" height="762" alt="image" src="https://github.com/user-attachments/assets/46d5821e-ea0c-4437-ba2c-ffb85837a401" />


```typescript
import {
  compatOaiModelRef,
  defineCompatOpenAIModel,
  openAICompatible,
} from '@genkit-ai/compat-oai';
import { genkit } from 'genkit/beta';

export const deepseekRef = compatOaiModelRef({
  name: 'openrouter/deepseek/deepseek-chat-v3-0324:free',
});

export const ai = genkit({
  plugins: [
    openAICompatible({
      name: 'openrouter',
      apiKey: process.env.OPENROUTER_API_KEY,
      baseURL: 'https://openrouter.ai/api/v1',
      initializer: async (ai, client) => {
        // Register a text model
        defineCompatOpenAIModel({
          ai,
          name: deepseekRef.name,
          client,
          modelRef: deepseekRef,
        });
      },
    }),
  ],
});

const llmResponse = await ai.generate({
  model: deepseekRef,
  prompt: 'Tell me a joke about a llama.',
  config: {
    temperature: 0.9,
  },
});

console.log('llmResponse:', JSON.stringify(llmResponse, null, 2));

console.log('llmResponse (detailed):');
console.dir(llmResponse, { depth: null, colors: true });
```