### PR TITLE
fix: render prompt metadata along with generateoptions

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -170,6 +170,12 @@ export interface GenerateOptions<
   context?: ActionContext;
   /** Abort signal for the generate request. */
   abortSignal?: AbortSignal;
+  /**
+   * Additional metadata describing the GenerateOptions, used by tooling. If
+   * this is an instance of a rendered dotprompt, will contain any prompt
+   * metadata contained in the original frontmatter.
+   **/
+  metadata?: Record<string, any>;
 }
 
 export async function toGenerateRequest(

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -330,6 +330,11 @@ function definePromptAsync<
             ...resolvedOptions?.config,
             ...renderOptions?.config,
           },
+          metadata: resolvedOptions.metadata?.metadata
+            ? {
+                prompt: resolvedOptions.metadata?.metadata,
+              }
+            : undefined,
         });
         // if config is empty and it was not explicitly passed in, we delete it, don't want {}
         if (Object.keys(opts.config).length === 0 && !renderOptions?.config) {
@@ -822,6 +827,18 @@ function loadPrompt(
         delete promptMetadata.input.schema.description;
       }
 
+      const metadata = {
+        ...promptMetadata.metadata,
+        type: 'prompt',
+        prompt: {
+          ...promptMetadata,
+          template: parsedPrompt.template,
+        },
+      };
+      if (promptMetadata.raw?.['metadata']) {
+        metadata['metadata'] = { ...promptMetadata.raw?.['metadata'] };
+      }
+
       return {
         name: registryDefinitionKey(name, variant ?? undefined, ns),
         model: promptMetadata.model,
@@ -835,14 +852,7 @@ function loadPrompt(
         input: {
           jsonSchema: promptMetadata.input?.schema,
         },
-        metadata: {
-          ...promptMetadata.metadata,
-          type: 'prompt',
-          prompt: {
-            ...promptMetadata,
-            template: parsedPrompt.template,
-          },
-        },
+        metadata,
         maxTurns: promptMetadata.raw?.['maxTurns'],
         toolChoice: promptMetadata.raw?.['toolChoice'],
         returnToolRequests: promptMetadata.raw?.['returnToolRequests'],

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -1145,6 +1145,11 @@ describe('prompt', () => {
       returnToolRequests: true,
       toolChoice: 'required',
       tools: ['toolA', 'toolB'],
+      metadata: {
+        prompt: {
+          foo: 'bar',
+        },
+      },
     });
   });
 


### PR DESCRIPTION
It got a little "meta" with all the layers of metadata. Let me know if this looks crazy or not. :)

**dotprompt:**
```yaml
---
model: googleai/gemini-1.5-flash
config:
  maxOutputTokens: 2048
  temperature: 0.6
  topK: 16
  topP: 0.95
  stopSequences:
    - STAWP!
  safetySettings:
    - category: HARM_CATEGORY_HATE_SPEECH
      threshold: BLOCK_ONLY_HIGH
    - category: HARM_CATEGORY_DANGEROUS_CONTENT
      threshold: BLOCK_ONLY_HIGH
    - category: HARM_CATEGORY_HARASSMENT
      threshold: BLOCK_ONLY_HIGH
    - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
      threshold: BLOCK_ONLY_HIGH
metadata:
  foo: bar
input:
  schema:
    name: string
    persona?: string
  default:
    persona: Space Pirate
---

Say hello to {{name}} in the voice of a {{persona}}.
```

**"rendered" as:**
```json
{
  "model": "googleai/gemini-1.5-flash",
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "text": "Say hello to  in the voice of a ."
        }
      ]
    }
  ],
  "output": {},
  "config": {
    "maxOutputTokens": 2048,
    "temperature": 0.6,
    "topK": 16,
    "topP": 0.95,
    "stopSequences": [
      "STAWP!"
    ],
    "safetySettings": [
      {
        "category": "HARM_CATEGORY_HATE_SPEECH",
        "threshold": "BLOCK_ONLY_HIGH"
      },
      {
        "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
        "threshold": "BLOCK_ONLY_HIGH"
      },
      {
        "category": "HARM_CATEGORY_HARASSMENT",
        "threshold": "BLOCK_ONLY_HIGH"
      },
      {
        "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
        "threshold": "BLOCK_ONLY_HIGH"
      }
    ]
  },
  "metadata": {
    "prompt": {
      "foo": "bar"
    }
  }
}
```