### PR TITLE
fix(install_cli):  `sudo: command not found` on certain machines

### DIFF
--- a/.github/workflows/repro-install-cli.yml
+++ b/.github/workflows/repro-install-cli.yml
@@ -1,0 +1,32 @@
+name: Repro install_cli without sudo
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  repro:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:22.04
+    steps:
+      - name: Print environment info
+        run: |
+          id
+          uname -a
+          echo "PATH=$PATH"
+      - name: Install curl
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y curl ca-certificates
+      - name: Reproduce failure (no sudo, non-root)
+        run: |
+          useradd -m runner
+          su - runner -c 'set -x; curl -sL cli.genkit.dev | bash' || true
+      - name: Workaround (user-local install)
+        run: |
+          su - runner -c 'set -x; mkdir -p ~/.local/bin && curl -sL cli.genkit.dev | GENKIT_BINARY=$HOME/.local/bin/genkit bash && ~/.local/bin/genkit --version'
+      - name: Show where genkit installed
+        run: |
+          su - runner -c 'command -v genkit || true; ls -l ~/.local/bin/genkit || true'
+
+

--- a/.github/workflows/repro-install-cli.yml
+++ b/.github/workflows/repro-install-cli.yml
@@ -9,6 +9,8 @@ jobs:
     container:
       image: ubuntu:22.04
     steps:
+      - name: Checkout repository (to use local installer script)
+        uses: actions/checkout@v4
       - name: Print environment info
         run: |
           id
@@ -22,9 +24,10 @@ jobs:
         run: |
           useradd -m runner
           su - runner -c 'set -x; curl -sL cli.genkit.dev | bash' || true
-      - name: Workaround (user-local install)
+      - name: Workaround (user-local install using local script)
         run: |
-          su - runner -c 'set -x; mkdir -p ~/.local/bin && curl -sL cli.genkit.dev | GENKIT_BINARY=$HOME/.local/bin/genkit bash && ~/.local/bin/genkit --version'
+          echo "Using workspace: $GITHUB_WORKSPACE"
+          su - runner -c "set -x; mkdir -p ~/.local/bin && GENKIT_BINARY=\$HOME/.local/bin/genkit upgrade=true bash $GITHUB_WORKSPACE/bin/install_cli && ~/.local/bin/genkit --version"
       - name: Show where genkit installed
         run: |
           su - runner -c 'command -v genkit || true; ls -l ~/.local/bin/genkit || true'

--- a/bin/install_cli
+++ b/bin/install_cli
@@ -134,18 +134,21 @@ send_analytics_event()
 # will crash before we get to that point, so we manually count invocations here.
 send_analytics_event start
 
+# Capture any user-provided desired install target, but keep detection separate.
+DESIRED_BINARY="$GENKIT_BINARY"
+
 # We try to detect any existing binaries on $PATH or two common locations.
-GENKIT_BINARY=${GENKIT_BINARY:-$(which genkit)}
+EXISTING_BINARY="$(command -v genkit 2>/dev/null)"
 LOCAL_BINARY="$HOME/.local/bin/genkit"
 # For info about why we place the binary at this location, see
 # https://unix.stackexchange.com/a/8658
 GLOBAL_BINARY="/usr/local/bin/genkit"
-if [[ -z "$GENKIT_BINARY" ]]; then
-    if [ -e "$LOCAL_BINARY" ]; then
-        GENKIT_BINARY="$LOCAL_BINARY"
-    elif [ -e "$GLOBAL_BINARY" ]; then
-        GENKIT_BINARY="$GLOBAL_BINARY"
-    fi
+if [[ -z "$EXISTING_BINARY" ]]; then
+	if [ -e "$LOCAL_BINARY" ]; then
+		EXISTING_BINARY="$LOCAL_BINARY"
+	elif [ -e "$GLOBAL_BINARY" ]; then
+		EXISTING_BINARY="$GLOBAL_BINARY"
+	fi
 fi
 
 # If the user asked for us to uninstall genkit, then do so.
@@ -156,7 +159,17 @@ if [ "$uninstall" = "true" ]; then
     else
         # Assuming binary install, skip npm check
         echo "-- Removing binary file..."
-        sudo rm -- "$GENKIT_BINARY"
+        uninstall_sudo=""
+        effective_uid=${EUID-}
+        if [ -z "$effective_uid" ]; then
+            effective_uid=$(id -u)
+        fi
+        if [ "$effective_uid" -ne 0 ] && [ ! -w "$(dirname -- \"$GENKIT_BINARY\")" ]; then
+            if command -v sudo >/dev/null 2>&1; then
+                uninstall_sudo="sudo"
+            fi
+        fi
+        $uninstall_sudo rm -- "$GENKIT_BINARY"
     fi
     echo "-- Removing genkit cache..."
     rm -rf ~/.cache/genkit
@@ -173,8 +186,13 @@ fi
 # has "genkit" installed and if so, we exit out.
 echo "-- Checking for existing genkit installation..."
 
-if [[ ! -z "$GENKIT_BINARY" ]]; then
-    INSTALLED_GENKIT_VERSION=$("$GENKIT_BINARY" --version)
+if [[ ! -z "$EXISTING_BINARY" ]]; then
+	# Only treat as installed if the detected binary actually exists and is executable
+	if [ -x "$EXISTING_BINARY" ]; then
+		INSTALLED_GENKIT_VERSION=$("$EXISTING_BINARY" --version)
+	else
+		INSTALLED_GENKIT_VERSION=""
+	fi
 
     # In the case of a corrupt genkit install, we wont be able to
     # retrieve a version number, so to keep the logs correct, we refer to
@@ -254,7 +272,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-GENKIT_BINARY=${GENKIT_BINARY:-$GLOBAL_BINARY}
+# Determine install target: prefer user-provided location, otherwise global default.
+GENKIT_BINARY=${DESIRED_BINARY:-$GLOBAL_BINARY}
 INSTALL_DIR=$(dirname -- "$GENKIT_BINARY")
 
 # We need to ensure that the INSTALL_DIR exists.
@@ -262,10 +281,25 @@ INSTALL_DIR=$(dirname -- "$GENKIT_BINARY")
 # We created it using a non-destructive mkdir command.
 mkdir -p -- "$INSTALL_DIR" 2> /dev/null
 
-# If the directory does not exist or is not writable, we resort to sudo.
+# If the directory does not exist or is not writable, we resort to sudo when available.
 sudo=""
 if [ ! -w "$INSTALL_DIR" ]; then
-    sudo="sudo"
+    # Determine effective UID (works in shells where $EUID is not set)
+    effective_uid=${EUID-}
+    if [ -z "$effective_uid" ]; then
+        effective_uid=$(id -u)
+    fi
+    if [ "$effective_uid" -eq 0 ]; then
+        sudo=""  # already root
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo="sudo"
+    else
+        echo "-- '$INSTALL_DIR' is not writable and 'sudo' is not available; falling back to a user-local install."
+        GENKIT_BINARY="$LOCAL_BINARY"
+        INSTALL_DIR=$(dirname -- "$GENKIT_BINARY")
+        mkdir -p -- "$INSTALL_DIR" 2> /dev/null
+        sudo=""
+    fi
 fi
 
 $sudo mkdir -p -- "$INSTALL_DIR"


### PR DESCRIPTION
Firebase Studio integration was reportedly getting the following:

<img width="635" height="89" alt="Screenshot 2025-08-13 at 11 00 11" src="https://github.com/user-attachments/assets/c854f8f4-84c5-4953-bf0e-759c673dad8e" />

This PR:

- euid/sudo aware installs: if not root and install dir isn’t writable, use sudo when available; otherwise fall back to ~/.local/bin. Uninstall path uses the same logic.
- Correct install detection: separated desired target from existing binary; only treat as installed if an executable exists, preventing false “corrupted/installed” when GENKIT_BINARY is set.
- Repro + validation: added .github/workflows/repro-install-cli.yml to reproduce the sudo-less failure and confirm the fixed script installs locally; verified locally with `act`.