### PR TITLE
Named generates

### DIFF
--- a/js/ai/src/generate.ts
+++ b/js/ai/src/generate.ts
@@ -170,6 +170,8 @@ export interface GenerateOptions<
   context?: ActionContext;
   /** Abort signal for the generate request. */
   abortSignal?: AbortSignal;
+  /** Custom step name for this generate call to display in trace views. Defaults to "generate". */
+  stepName?: string;
   /**
    * Additional metadata describing the GenerateOptions, used by tooling. If
    * this is an instance of a rendered dotprompt, will contain any prompt
@@ -500,6 +502,7 @@ export async function toGenerateActionOptions<
     },
     returnToolRequests: options.returnToolRequests,
     maxTurns: options.maxTurns,
+    stepName: options.stepName,
   };
   // if config is empty and it was not explicitly passed in, we delete it, don't want {}
   if (Object.keys(params.config).length === 0 && !options.config) {

--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -123,14 +123,14 @@ export async function generateHelper(
     registry,
     {
       metadata: {
-        name: 'generate',
+        name: options.rawRequest.stepName || 'generate',
       },
       labels: {
         [SPAN_TYPE_ATTR]: 'util',
       },
     },
     async (metadata) => {
-      metadata.name = 'generate';
+      metadata.name = options.rawRequest.stepName || 'generate';
       metadata.input = options.rawRequest;
       const output = await generate(registry, {
         rawRequest: options.rawRequest,

--- a/js/ai/src/model-types.ts
+++ b/js/ai/src/model-types.ts
@@ -406,5 +406,7 @@ export const GenerateActionOptionsSchema = z.object({
   returnToolRequests: z.boolean().optional(),
   /** Maximum number of tool call iterations that can be performed in a single generate call (default 5). */
   maxTurns: z.number().optional(),
+  /** Custom step name for this generate call to display in trace views. Defaults to "generate". */
+  stepName: z.string().optional(),
 });
 export type GenerateActionOptions = z.infer<typeof GenerateActionOptionsSchema>;

--- a/js/ai/tests/generate/generate_test.ts
+++ b/js/ai/tests/generate/generate_test.ts
@@ -571,4 +571,27 @@ describe('generate', () => {
       );
     });
   });
+
+  it('should use custom stepName parameter in tracing', async () => {
+    const response = await generate(registry, {
+      model: 'echo',
+      prompt: 'Testing custom step name',
+      stepName: 'test-generate-custom',
+    });
+    assert.deepEqual(
+      response.messages.map((m) => m.content[0].text),
+      ['Testing custom step name', 'Testing custom step name']
+    );
+  });
+
+  it('should default to "generate" name when no stepName is provided', async () => {
+    const response = await generate(registry, {
+      model: 'echo',
+      prompt: 'Testing default step name',
+    });
+    assert.deepEqual(
+      response.messages.map((m) => m.content[0].text),
+      ['Testing default step name', 'Testing default step name']
+    );
+  });
 });

--- a/js/testapps/basic-gemini/src/index.ts
+++ b/js/testapps/basic-gemini/src/index.ts
@@ -40,6 +40,7 @@ export const jokeFlow = ai.defineFlow(
   },
   async () => {
     const llmResponse = await ai.generate({
+      name: 'joke-creator',
       model: gemini15Flash,
       config: {
         temperature: 2,


### PR DESCRIPTION
Implements #3378 custom span names for generate steps. New optional parameter called `stepName` can be set to define the step name displayed in traces.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
