### PR TITLE
feat(vertexai): add Claude 4 models support to Model Garden

### DIFF
--- a/js/plugins/vertexai/src/modelgarden/anthropic.ts
+++ b/js/plugins/vertexai/src/modelgarden/anthropic.ts
@@ -131,6 +131,54 @@ export const claude3Opus = modelRef({
   configSchema: AnthropicConfigSchema,
 });
 
+export const claudeSonnet4 = modelRef({
+  name: 'vertexai/claude-sonnet-4',
+  info: {
+    label: 'Vertex AI Model Garden - Claude Sonnet 4',
+    versions: ['claude-sonnet-4@20250514'],
+    supports: {
+      multiturn: true,
+      media: true,
+      tools: true,
+      systemRole: true,
+      output: ['text'],
+    },
+  },
+  configSchema: AnthropicConfigSchema,
+});
+
+export const claudeOpus4 = modelRef({
+  name: 'vertexai/claude-opus-4',
+  info: {
+    label: 'Vertex AI Model Garden - Claude Opus 4',
+    versions: ['claude-opus-4@20250514'],
+    supports: {
+      multiturn: true,
+      media: true,
+      tools: true,
+      systemRole: true,
+      output: ['text'],
+    },
+  },
+  configSchema: AnthropicConfigSchema,
+});
+
+export const claudeOpus41 = modelRef({
+  name: 'vertexai/claude-opus-4-1',
+  info: {
+    label: 'Vertex AI Model Garden - Claude Opus 4.1',
+    versions: ['claude-opus-4-1@20250805'],
+    supports: {
+      multiturn: true,
+      media: true,
+      tools: true,
+      systemRole: true,
+      output: ['text'],
+    },
+  },
+  configSchema: AnthropicConfigSchema,
+});
+
 export const SUPPORTED_ANTHROPIC_MODELS: Record<
   string,
   ModelReference<typeof AnthropicConfigSchema>
@@ -140,6 +188,9 @@ export const SUPPORTED_ANTHROPIC_MODELS: Record<
   'claude-3-sonnet': claude3Sonnet,
   'claude-3-opus': claude3Opus,
   'claude-3-haiku': claude3Haiku,
+  'claude-sonnet-4': claudeSonnet4,
+  'claude-opus-4': claudeOpus4,
+  'claude-opus-4-1': claudeOpus41,
 };
 
 export function toAnthropicRequest(

--- a/js/plugins/vertexai/src/modelgarden/index.ts
+++ b/js/plugins/vertexai/src/modelgarden/index.ts
@@ -72,6 +72,9 @@ export {
   claude3Haiku,
   claude3Opus,
   claude3Sonnet,
+  claudeSonnet4,
+  claudeOpus4,
+  claudeOpus41,
 } from './anthropic.js';
 export { codestral, mistralLarge, mistralNemo } from './mistral.js';
 export { llama3, llama31, llama32 } from './model_garden.js';


### PR DESCRIPTION
## Summary
Adds support for Claude 4 models to the Vertex AI Model Garden plugin:
- Claude Sonnet 4 (`claude-sonnet-4@20250514`)
- Claude Opus 4 (`claude-opus-4@20250514`) 
- Claude Opus 4.1 (`claude-opus-4-1@20250805`)

## Changes
- Added model definitions for all three Claude 4 variants in `anthropic.ts`
- Updated `SUPPORTED_ANTHROPIC_MODELS` to include the new models
- Updated exports in `modelgarden/index.ts` to expose Claude 4 models
- Follows existing patterns used for Claude 3 models

## Testing
- Verified model definitions follow existing conventions
- TypeScript compilation successful with proper type definitions
- All exports properly included for external usage

## Related Issues
Closes #3059

## Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)