### PR TITLE
fix(go): add constructor for postgres struct

### DIFF
--- a/go/plugins/postgresql/genkit.go
+++ b/go/plugins/postgresql/genkit.go
@@ -38,6 +38,12 @@ func (p *Postgres) Name() string {
 	return provider
 }
 
+func NewPostgres(engine *PostgresEngine) *Postgres {
+	return &Postgres{
+		engine: engine,
+	}
+}
+
 // Init initialize the PostgreSQL
 func (p *Postgres) Init(ctx context.Context, g *genkit.Genkit) error {
 	p.mu.Lock()

--- a/go/plugins/postgresql/genkit_test.go
+++ b/go/plugins/postgresql/genkit_test.go
@@ -50,7 +50,7 @@ func TestInit_NoConnectionPool(t *testing.T) {
 	ctx := context.Background()
 	cfg := engineConfig{}
 	engine := &PostgresEngine{Pool: cfg.connPool}
-	gcsp := &Postgres{engine: engine}
+	gcsp := NewPostgres(engine)
 	if err := gcsp.Init(ctx, &genkit.Genkit{}); err == nil {
 		t.Fatal("must fail if connection pool is nil")
 	}
@@ -76,7 +76,7 @@ func TestInit_AlreadyCalled(t *testing.T) {
 
 	g := &genkit.Genkit{}
 
-	gcsp := &Postgres{engine: pEngine}
+	gcsp := NewPostgres(pEngine)
 	g = genkit.Init(ctx, genkit.WithPlugins(gcsp))
 
 	err = gcsp.Init(ctx, g)


### PR DESCRIPTION
**Disclaimer** New to the library and might be missing how to add plugins, but I see the following issue:

### Description

Currently, the Postgres struct doesn't export the engine data member, and at the same time, it has no way of adding it through a constructor or a setter.

In detail, in the file [go/plugins/postgresql/genkit.go](https://github.com/firebase/genkit/blob/main/go/plugins/postgresql/genkit.go#L31)

``` go
// Postgres holds the current plugin state.
type Postgres struct {
	mu      sync.Mutex
	initted bool
	engine  *PostgresEngine
}
```

And in the README.md, it says ([go/plugins/postgresql/README.md](https://github.com/firebase/genkit/blob/main/go/plugins/postgresql/README.md))

```go
	postgres := &Postgres{
		engine: pEngine,
	}
...
```
which is not possible unless you are in the same package, since the engine is not exported. Thus, this blocks the use of any instance of a Postgres struct as a plugin directly with Genkit. For example, the following won't work just because the engine is not exportable

```go
package main

import (
	"context"
	"fmt"

	"github.com/firebase/genkit/go/genkit"
	"github.com/firebase/genkit/go/plugins/postgresql"
	"github.com/jackc/pgx/v5/pgxpool"
)

func main() {
	ctx := context.Background()
	pool, _ := pgxpool.New(ctx, "postgresql://postgres:password@localhost:5432")
	pgEngine, err := postgresql.NewPostgresEngine(ctx,
		postgresql.WithUser("postgres"),
		postgresql.WithPassword("password"),
		postgresql.WithDatabase("example_db"),
		postgresql.WithPool(pool),
	)
	if err != nil {
		fmt.Println(err)
		panic("Error creating pgengine")
	}
	postgres := &postgresql.Postgres{
		engine: pgEngine,
	}
	_ = genkit.Init(ctx, genkit.WithPlugins(postgres))
}
```
If one tries not to add an engine and just pass the Postgres struct instance as a plugin to GenKit, as in:

```go
postgres := &postgresql.Postgres{}
_ = genkit.Init(ctx, genkit.WithPlugins(postgres))
```

will fail with  `panic: genkit.Init: plugin *postgresql.Postgres initialization failed: postgres.Init engine is nil` error, coming from the initialization of the plugin [here](https://github.com/firebase/genkit/blob/main/go/plugins/postgresql/genkit.go#L50)   

### Solution

Add a constructor to the Postgres struct so it can be instantiated with an engine and thus passed to a genkit plugin

```go
func NewPostgres(engine *PostgresEngine) *Postgres {
	return &Postgres{
		engine: engine,
	}
}
```