### PR TITLE
refactor(plugins/vertexai): migrate to v2 API

### DIFF
--- a/js/plugins/vertexai/src/embedder.ts
+++ b/js/plugins/vertexai/src/embedder.ts
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-import { z, type Document, type Genkit } from 'genkit';
+import { z, type Document } from 'genkit';
 import {
-  embedderRef,
+  embedderRef as createEmbedderRef,
   type EmbedderAction,
   type EmbedderReference,
 } from 'genkit/embedder';
 import type { GoogleAuth } from 'google-auth-library';
 import type { PluginOptions } from './common/types.js';
 import { predictModel, type PredictClient } from './predict.js';
+import { embedder } from 'genkit/plugin';
 
 export const TaskTypeSchema = z.enum([
   'RETRIEVAL_DOCUMENT',
@@ -61,7 +62,7 @@ function commonRef(
   name: string,
   input?: InputType[]
 ): EmbedderReference<typeof VertexEmbeddingConfigSchema> {
-  return embedderRef({
+  return createEmbedderRef({
     name: `vertexai/${name}`,
     configSchema: VertexEmbeddingConfigSchema,
     info: {
@@ -88,7 +89,7 @@ export const multimodalEmbedding001 = commonRef('multimodalembedding@001', [
   'image',
   'video',
 ]);
-export const geminiEmbedding001 = embedderRef({
+export const geminiEmbedding001 = createEmbedderRef({
   name: 'vertexai/gemini-embedding-001',
   configSchema: VertexEmbeddingConfigSchema,
   info: {
@@ -254,14 +255,13 @@ type EmbeddingResult = {
 };
 
 export function defineVertexAIEmbedder(
-  ai: Genkit,
   name: string,
   client: GoogleAuth,
   options: PluginOptions
 ): EmbedderAction<any> {
-  const embedder =
+  const embedderRef =
     SUPPORTED_EMBEDDER_MODELS[name] ??
-    embedderRef({
+    createEmbedderRef({
       name: `vertexai/${name}`,
       configSchema: VertexEmbeddingConfigSchema,
       info: {
@@ -298,18 +298,18 @@ export function defineVertexAIEmbedder(
     return predictClients[requestLocation];
   };
 
-  return ai.defineEmbedder(
+  return embedder(
     {
-      name: embedder.name,
-      configSchema: embedder.configSchema,
-      info: embedder.info!,
+      name: embedderRef.name,
+      configSchema: embedderRef.configSchema,
+      info: embedderRef.info!,
     },
     async (input, options) => {
-      const predictClient = predictClientFactory(options);
+      const predictClient = predictClientFactory(embedderRef.config);
       const response = await predictClient(
-        input.map((doc: Document) => {
+        input.input.map((doc: Document) => {
           let instance: EmbeddingInstance;
-          if (isMultiModal(embedder) && checkValidDocument(embedder, doc)) {
+          if (isMultiModal(embedderRef) && checkValidDocument(embedderRef, doc)) {
             instance = {};
             if (doc.text) {
               instance.text = doc.text;
@@ -370,13 +370,13 @@ export function defineVertexAIEmbedder(
             // Text only embedder
             instance = {
               content: doc.text,
-              task_type: options?.taskType,
-              title: options?.title,
+              task_type: embedderRef.config?.taskType,
+              title: embedderRef.config?.title,
             };
           }
           return instance;
         }),
-        { outputDimensionality: options?.outputDimensionality }
+        { outputDimensionality: embedderRef.config?.outputDimensionality }
       );
       return {
         embeddings: response.predictions

--- a/js/plugins/vertexai/src/evaluation/evaluation.ts
+++ b/js/plugins/vertexai/src/evaluation/evaluation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z, type Action, type Genkit } from 'genkit';
+import { z, type Action } from 'genkit';
 import type { GoogleAuth } from 'google-auth-library';
 import { EvaluatorFactory } from './evaluator_factory.js';
 
@@ -54,7 +54,6 @@ function stringify(input: unknown) {
 }
 
 export function vertexEvaluators(
-  ai: Genkit,
   auth: GoogleAuth,
   metrics: VertexAIEvaluationMetric[],
   projectId: string,
@@ -67,28 +66,28 @@ export function vertexEvaluators(
 
     switch (metricType) {
       case VertexAIEvaluationMetricType.BLEU: {
-        return createBleuEvaluator(ai, factory, metricSpec);
+        return createBleuEvaluator(factory, metricSpec);
       }
       case VertexAIEvaluationMetricType.ROUGE: {
-        return createRougeEvaluator(ai, factory, metricSpec);
+        return createRougeEvaluator(factory, metricSpec);
       }
       case VertexAIEvaluationMetricType.FLUENCY: {
-        return createFluencyEvaluator(ai, factory, metricSpec);
+        return createFluencyEvaluator(factory, metricSpec);
       }
       case VertexAIEvaluationMetricType.SAFETY: {
-        return createSafetyEvaluator(ai, factory, metricSpec);
+        return createSafetyEvaluator(factory, metricSpec);
       }
       case VertexAIEvaluationMetricType.GROUNDEDNESS: {
-        return createGroundednessEvaluator(ai, factory, metricSpec);
+        return createGroundednessEvaluator(factory, metricSpec);
       }
       case VertexAIEvaluationMetricType.SUMMARIZATION_QUALITY: {
-        return createSummarizationQualityEvaluator(ai, factory, metricSpec);
+        return createSummarizationQualityEvaluator(factory, metricSpec);
       }
       case VertexAIEvaluationMetricType.SUMMARIZATION_HELPFULNESS: {
-        return createSummarizationHelpfulnessEvaluator(ai, factory, metricSpec);
+        return createSummarizationHelpfulnessEvaluator(factory, metricSpec);
       }
       case VertexAIEvaluationMetricType.SUMMARIZATION_VERBOSITY: {
-        return createSummarizationVerbosityEvaluator(ai, factory, metricSpec);
+        return createSummarizationVerbosityEvaluator(factory, metricSpec);
       }
     }
   });
@@ -108,12 +107,10 @@ const BleuResponseSchema = z.object({
 
 // TODO: Add support for batch inputs
 function createBleuEvaluator(
-  ai: Genkit,
   factory: EvaluatorFactory,
   metricSpec: any
 ): Action {
   return factory.create(
-    ai,
     {
       metric: VertexAIEvaluationMetricType.BLEU,
       displayName: 'BLEU',
@@ -150,12 +147,10 @@ const RougeResponseSchema = z.object({
 
 // TODO: Add support for batch inputs
 function createRougeEvaluator(
-  ai: Genkit,
   factory: EvaluatorFactory,
   metricSpec: any
 ): Action {
   return factory.create(
-    ai,
     {
       metric: VertexAIEvaluationMetricType.ROUGE,
       displayName: 'ROUGE',
@@ -191,12 +186,10 @@ const FluencyResponseSchema = z.object({
 });
 
 function createFluencyEvaluator(
-  ai: Genkit,
   factory: EvaluatorFactory,
   metricSpec: any
 ): Action {
   return factory.create(
-    ai,
     {
       metric: VertexAIEvaluationMetricType.FLUENCY,
       displayName: 'Fluency',
@@ -233,12 +226,10 @@ const SafetyResponseSchema = z.object({
 });
 
 function createSafetyEvaluator(
-  ai: Genkit,
   factory: EvaluatorFactory,
   metricSpec: any
 ): Action {
   return factory.create(
-    ai,
     {
       metric: VertexAIEvaluationMetricType.SAFETY,
       displayName: 'Safety',
@@ -275,12 +266,10 @@ const GroundednessResponseSchema = z.object({
 });
 
 function createGroundednessEvaluator(
-  ai: Genkit,
   factory: EvaluatorFactory,
   metricSpec: any
 ): Action {
   return factory.create(
-    ai,
     {
       metric: VertexAIEvaluationMetricType.GROUNDEDNESS,
       displayName: 'Groundedness',
@@ -319,12 +308,10 @@ const SummarizationQualityResponseSchema = z.object({
 });
 
 function createSummarizationQualityEvaluator(
-  ai: Genkit,
   factory: EvaluatorFactory,
   metricSpec: any
 ): Action {
   return factory.create(
-    ai,
     {
       metric: VertexAIEvaluationMetricType.SUMMARIZATION_QUALITY,
       displayName: 'Summarization quality',
@@ -363,12 +350,10 @@ const SummarizationHelpfulnessResponseSchema = z.object({
 });
 
 function createSummarizationHelpfulnessEvaluator(
-  ai: Genkit,
   factory: EvaluatorFactory,
   metricSpec: any
 ): Action {
   return factory.create(
-    ai,
     {
       metric: VertexAIEvaluationMetricType.SUMMARIZATION_HELPFULNESS,
       displayName: 'Summarization helpfulness',
@@ -408,12 +393,10 @@ const SummarizationVerbositySchema = z.object({
 });
 
 function createSummarizationVerbosityEvaluator(
-  ai: Genkit,
   factory: EvaluatorFactory,
   metricSpec: any
 ): Action {
   return factory.create(
-    ai,
     {
       metric: VertexAIEvaluationMetricType.SUMMARIZATION_VERBOSITY,
       displayName: 'Summarization verbosity',

--- a/js/plugins/vertexai/src/evaluation/evaluator_factory.ts
+++ b/js/plugins/vertexai/src/evaluation/evaluator_factory.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { type Action, type Genkit, type z } from 'genkit';
+import { type Action, type z } from 'genkit';
 import type { BaseEvalDataPoint, Score } from 'genkit/evaluator';
 import { runInNewSpan } from 'genkit/tracing';
 import type { GoogleAuth } from 'google-auth-library';
 import { getGenkitClientHeader } from '../common/index.js';
 import type { VertexAIEvaluationMetricType } from './evaluation.js';
+import { evaluator } from 'genkit/plugin';
 
 export class EvaluatorFactory {
   constructor(
@@ -29,7 +30,6 @@ export class EvaluatorFactory {
   ) {}
 
   create<ResponseType extends z.ZodTypeAny>(
-    ai: Genkit,
     config: {
       metric: VertexAIEvaluationMetricType;
       displayName: string;
@@ -39,7 +39,7 @@ export class EvaluatorFactory {
     toRequest: (datapoint: BaseEvalDataPoint) => any,
     responseHandler: (response: z.infer<ResponseType>) => Score
   ): Action {
-    return ai.defineEvaluator(
+    return evaluator(
       {
         name: `vertexai/${config.metric.toLocaleLowerCase()}`,
         displayName: config.displayName,
@@ -48,7 +48,6 @@ export class EvaluatorFactory {
       async (datapoint: BaseEvalDataPoint) => {
         const responseSchema = config.responseSchema;
         const response = await this.evaluateInstances(
-          ai,
           toRequest(datapoint),
           responseSchema
         );
@@ -62,13 +61,11 @@ export class EvaluatorFactory {
   }
 
   async evaluateInstances<ResponseType extends z.ZodTypeAny>(
-    ai: Genkit,
     partialRequest: any,
     responseSchema: ResponseType
   ): Promise<z.infer<ResponseType>> {
     const locationName = `projects/${this.projectId}/locations/${this.location}`;
     return await runInNewSpan(
-      ai,
       {
         metadata: {
           name: 'EvaluationService#evaluateInstances',

--- a/js/plugins/vertexai/src/evaluation/index.ts
+++ b/js/plugins/vertexai/src/evaluation/index.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import type { Genkit } from 'genkit';
-import { genkitPlugin, type GenkitPlugin } from 'genkit/plugin';
+import { genkitPluginV2, type GenkitPluginV2 } from 'genkit/plugin';
 import { getDerivedParams } from '../common/index.js';
 import { vertexEvaluators } from './evaluation.js';
 import type { PluginOptions } from './types.js';
@@ -25,10 +24,13 @@ export type { PluginOptions };
 /**
  * Add Google Cloud Vertex AI Rerankers API to Genkit.
  */
-export function vertexAIEvaluation(options: PluginOptions): GenkitPlugin {
-  return genkitPlugin('vertexAIEvaluation', async (ai: Genkit) => {
-    const { projectId, location, authClient } = await getDerivedParams(options);
+export function vertexAIEvaluation(options: PluginOptions): GenkitPluginV2 {
+  return genkitPluginV2({
+    name: 'vertexAIEvaluation',
+    init: async () => {
+      const { projectId, location, authClient } = await getDerivedParams(options);
 
-    vertexEvaluators(ai, authClient, options.metrics, projectId, location);
+      return vertexEvaluators(authClient, options.metrics, projectId, location);
+    },
   });
 }

--- a/js/plugins/vertexai/src/imagen.ts
+++ b/js/plugins/vertexai/src/imagen.ts
@@ -18,7 +18,7 @@ import { z, type Genkit } from 'genkit';
 import {
   GenerationCommonConfigSchema,
   getBasicUsageStats,
-  modelRef,
+  modelRef as createModelRef,
   type CandidateData,
   type GenerateRequest,
   type ModelAction,
@@ -28,6 +28,7 @@ import {
 import type { GoogleAuth } from 'google-auth-library';
 import type { PluginOptions } from './common/types.js';
 import { predictModel, type PredictClient } from './predict.js';
+import { model } from 'genkit/plugin';
 
 /**
  * See https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api.
@@ -162,7 +163,7 @@ export const ImagenConfigSchema = GenerationCommonConfigSchema.extend({
     .optional(),
 }).passthrough();
 
-export const imagen2 = modelRef({
+export const imagen2 = createModelRef({
   name: 'vertexai/imagen2',
   info: {
     label: 'Vertex AI - Imagen2',
@@ -179,7 +180,7 @@ export const imagen2 = modelRef({
   configSchema: ImagenConfigSchema,
 });
 
-export const imagen3 = modelRef({
+export const imagen3 = createModelRef({
   name: 'vertexai/imagen3',
   info: {
     label: 'Vertex AI - Imagen3',
@@ -196,7 +197,7 @@ export const imagen3 = modelRef({
   configSchema: ImagenConfigSchema,
 });
 
-export const imagen3Fast = modelRef({
+export const imagen3Fast = createModelRef({
   name: 'vertexai/imagen3-fast',
   info: {
     label: 'Vertex AI - Imagen3 Fast',
@@ -214,7 +215,7 @@ export const imagen3Fast = modelRef({
 });
 
 export const ACTUAL_IMAGEN_MODELS = {
-  'imagen-3.0-generate-001': modelRef({
+  'imagen-3.0-generate-001': createModelRef({
     name: 'vertexai/imagen-3.0-generate-001',
     info: {
       label: 'Vertex AI - imagen-3.0-generate-001',
@@ -228,7 +229,7 @@ export const ACTUAL_IMAGEN_MODELS = {
     },
     configSchema: ImagenConfigSchema,
   }),
-  'imagen-3.0-fast-generate-001': modelRef({
+  'imagen-3.0-fast-generate-001': createModelRef({
     name: 'vertexai/imagen-3.0-fast-generate-001',
     info: {
       label: 'Vertex AI - imagen-3.0-fast-generate-001',
@@ -325,15 +326,14 @@ export const GENERIC_IMAGEN_INFO = {
 } as ModelInfo;
 
 export function defineImagenModel(
-  ai: Genkit,
   name: string,
   client: GoogleAuth,
   options: PluginOptions
 ): ModelAction {
   const modelName = `vertexai/${name}`;
-  const model: ModelReference<z.ZodTypeAny> =
+  const modelRef: ModelReference<z.ZodTypeAny> =
     SUPPORTED_IMAGEN_MODELS[name] ||
-    modelRef({
+    createModelRef({
       name: modelName,
       info: {
         ...GENERIC_IMAGEN_INFO,
@@ -361,16 +361,16 @@ export function defineImagenModel(
           ...options,
           location: requestLocation,
         },
-        request.config?.version || model.version || name
+        request.config?.version || modelRef.version || name
       );
     }
     return predictClients[requestLocation];
   };
 
-  return ai.defineModel(
+  return model(
     {
       name: modelName,
-      ...model.info,
+      ...modelRef.info,
       configSchema: ImagenConfigSchema,
     },
     async (request) => {

--- a/js/plugins/vertexai/src/modelgarden/anthropic.ts
+++ b/js/plugins/vertexai/src/modelgarden/anthropic.ts
@@ -32,7 +32,6 @@ import { AnthropicVertex } from '@anthropic-ai/vertex-sdk';
 import {
   z,
   type GenerateRequest,
-  type Genkit,
   type Part as GenkitPart,
   type MessageData,
   type ModelReference,
@@ -46,6 +45,7 @@ import {
   type ModelAction,
 } from 'genkit/model';
 import { getGenkitClientHeader } from '../common/index.js';
+import { model } from 'genkit/plugin';
 
 export const AnthropicConfigSchema = GenerationCommonConfigSchema.extend({
   location: z.string().optional(),
@@ -429,7 +429,6 @@ function toAnthropicToolResponse(part: Part): ToolResultBlockParam {
 }
 
 export function anthropicModel(
-  ai: Genkit,
   modelName: string,
   projectId: string,
   region: string
@@ -447,22 +446,22 @@ export function anthropicModel(
     }
     return clients[region];
   };
-  const model = SUPPORTED_ANTHROPIC_MODELS[modelName];
-  if (!model) {
+  const modelRef = SUPPORTED_ANTHROPIC_MODELS[modelName];
+  if (!modelRef) {
     throw new Error(`unsupported Anthropic model name ${modelName}`);
   }
 
-  return ai.defineModel(
+  return model(
     {
-      name: model.name,
-      label: model.info?.label,
+      name: modelRef.name,
+      label: modelRef.info?.label,
       configSchema: AnthropicConfigSchema,
-      supports: model.info?.supports,
-      versions: model.info?.versions,
+      supports: modelRef.info?.supports,
+      versions: modelRef.info?.versions,
     },
-    async (input, sendChunk) => {
+    async (input, options) => {
       const client = clientFactory(input.config?.location || region);
-      if (!sendChunk) {
+      if (!options) {
         const response = await client.messages.create({
           ...toAnthropicRequest(input.config?.version ?? modelName, input),
           stream: false,
@@ -474,7 +473,7 @@ export function anthropicModel(
         );
         for await (const event of stream) {
           if (event.type === 'content_block_delta') {
-            sendChunk({
+            options.sendChunk({
               index: 0,
               content: [
                 {

--- a/js/plugins/vertexai/src/modelgarden/index.ts
+++ b/js/plugins/vertexai/src/modelgarden/index.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { Genkit } from 'genkit';
-import { genkitPlugin, type GenkitPlugin } from 'genkit/plugin';
+import type { Action, Genkit } from 'genkit';
+import { genkitPluginV2, type GenkitPluginV2 } from 'genkit/plugin';
 import { getDerivedParams } from '../common/index.js';
 import { SUPPORTED_ANTHROPIC_MODELS, anthropicModel } from './anthropic.js';
 import { SUPPORTED_MISTRAL_MODELS, mistralModel } from './mistral.js';
@@ -28,41 +28,47 @@ import type { PluginOptions } from './types.js';
 /**
  * Add Google Cloud Vertex AI Rerankers API to Genkit.
  */
-export function vertexAIModelGarden(options: PluginOptions): GenkitPlugin {
-  return genkitPlugin('vertexAIModelGarden', async (ai: Genkit) => {
-    const { projectId, location, authClient } = await getDerivedParams(options);
+export function vertexAIModelGarden(options: PluginOptions): GenkitPluginV2 {
+  return genkitPluginV2({
+    name: 'vertexAIModelGarden',
+    init: async () => {
+      const { projectId, location, authClient } = await getDerivedParams(options);
 
-    options.models.forEach((m) => {
-      const anthropicEntry = Object.entries(SUPPORTED_ANTHROPIC_MODELS).find(
-        ([_, value]) => value.name === m.name
-      );
-      if (anthropicEntry) {
-        anthropicModel(ai, anthropicEntry[0], projectId, location);
-        return;
-      }
-      const mistralEntry = Object.entries(SUPPORTED_MISTRAL_MODELS).find(
-        ([_, value]) => value.name === m.name
-      );
-      if (mistralEntry) {
-        mistralModel(ai, mistralEntry[0], projectId, location);
-        return;
-      }
-      const openaiModel = Object.entries(SUPPORTED_OPENAI_FORMAT_MODELS).find(
-        ([_, value]) => value.name === m.name
-      );
-      if (openaiModel) {
-        modelGardenOpenaiCompatibleModel(
-          ai,
-          openaiModel[0],
-          projectId,
-          location,
-          authClient,
-          options.openAiBaseUrlTemplate
+      const actions: Action[] = [];
+
+      options.models.forEach((m) => {
+        const anthropicEntry = Object.entries(SUPPORTED_ANTHROPIC_MODELS).find(
+          ([_, value]) => value.name === m.name
         );
-        return;
-      }
-      throw new Error(`Unsupported model garden model: ${m.name}`);
-    });
+        if (anthropicEntry) {
+          actions.push(anthropicModel(anthropicEntry[0], projectId, location));
+          return;
+        }
+        const mistralEntry = Object.entries(SUPPORTED_MISTRAL_MODELS).find(
+          ([_, value]) => value.name === m.name
+        );
+        if (mistralEntry) {
+          actions.push(mistralModel(mistralEntry[0], projectId, location));
+          return;
+        }
+        const openaiModel = Object.entries(SUPPORTED_OPENAI_FORMAT_MODELS).find(
+          ([_, value]) => value.name === m.name
+        );
+        if (openaiModel) {
+          actions.push(modelGardenOpenaiCompatibleModel(
+            openaiModel[0],
+            projectId,
+            location,
+            authClient,
+            options.openAiBaseUrlTemplate
+          ));
+          return;
+        }
+        throw new Error(`Unsupported model garden model: ${m.name}`);
+      });
+
+      return actions;
+    },
   });
 }
 

--- a/js/plugins/vertexai/src/modelgarden/mistral.ts
+++ b/js/plugins/vertexai/src/modelgarden/mistral.ts
@@ -33,7 +33,6 @@ import {
   GenerationCommonConfigSchema,
   z,
   type GenerateRequest,
-  type Genkit,
   type MessageData,
   type ModelReference,
   type ModelResponseData,
@@ -47,6 +46,7 @@ import {
   type ModelAction,
 } from 'genkit/model';
 import { getGenkitClientHeader } from '../common/index.js';
+import { model } from 'genkit/plugin';
 
 /**
  * See https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post
@@ -330,33 +330,32 @@ export function fromMistralResponse(
 }
 
 export function mistralModel(
-  ai: Genkit,
   modelName: string,
   projectId: string,
   region: string
 ): ModelAction {
   const getClient = createClientFactory(projectId);
 
-  const model = SUPPORTED_MISTRAL_MODELS[modelName];
-  if (!model) {
+  const modelRef = SUPPORTED_MISTRAL_MODELS[modelName];
+  if (!modelRef) {
     throw new Error(`Unsupported Mistral model name ${modelName}`);
   }
 
-  return ai.defineModel(
+  return model(
     {
-      name: model.name,
-      label: model.info?.label,
+      name: modelRef.name,
+      label: modelRef.info?.label,
       configSchema: MistralConfigSchema,
-      supports: model.info?.supports,
-      versions: model.info?.versions,
+      supports: modelRef.info?.supports,
+      versions: modelRef.info?.versions,
     },
-    async (input, sendChunk) => {
+    async (input, options) => {
       const client = getClient(input.config?.location || region);
 
       const versionedModel =
-        input.config?.version ?? model.info?.versions?.[0] ?? model.name;
+        input.config?.version ?? modelRef.info?.versions?.[0] ?? modelRef.name;
 
-      if (!sendChunk) {
+      if (!options) {
         const mistralRequest = toMistralRequest(versionedModel, input);
 
         const response = await client.chat.complete(mistralRequest, {
@@ -381,7 +380,7 @@ export function mistralModel(
         for await (const event of stream) {
           const parts = fromMistralCompletionChunk(event.data);
           if (parts.length > 0) {
-            sendChunk({
+            options.sendChunk({
               content: parts,
             });
           }

--- a/js/plugins/vertexai/src/modelgarden/model_garden.ts
+++ b/js/plugins/vertexai/src/modelgarden/model_garden.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z, type Genkit, type ModelReference } from 'genkit';
+import { z, type ModelReference } from 'genkit';
 import { modelRef, type GenerateRequest, type ModelAction } from 'genkit/model';
 import type { GoogleAuth } from 'google-auth-library';
 import OpenAI from 'openai';
@@ -92,15 +92,14 @@ export const SUPPORTED_OPENAI_FORMAT_MODELS = {
 };
 
 export function modelGardenOpenaiCompatibleModel(
-  ai: Genkit,
   name: string,
   projectId: string,
   location: string,
   googleAuth: GoogleAuth,
   baseUrlTemplate: string | undefined
 ): ModelAction<typeof ModelGardenModelConfigSchema> {
-  const model = SUPPORTED_OPENAI_FORMAT_MODELS[name];
-  if (!model) throw new Error(`Unsupported model: ${name}`);
+  const modelRef = SUPPORTED_OPENAI_FORMAT_MODELS[name];
+  if (!modelRef) throw new Error(`Unsupported model: ${name}`);
   if (!baseUrlTemplate) {
     baseUrlTemplate =
       'https://{location}-aiplatform.googleapis.com/v1beta1/projects/{projectId}/locations/{location}/endpoints/openapi';
@@ -120,5 +119,5 @@ export function modelGardenOpenaiCompatibleModel(
       },
     });
   };
-  return openaiCompatibleModel(ai, model, clientFactory);
+  return openaiCompatibleModel(modelRef, clientFactory);
 }

--- a/js/plugins/vertexai/src/rerankers/index.ts
+++ b/js/plugins/vertexai/src/rerankers/index.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Genkit } from 'genkit';
-import { genkitPlugin, type GenkitPlugin } from 'genkit/plugin';
+import { genkitPluginV2, type GenkitPluginV2 } from 'genkit/plugin';
 import type { CommonPluginOptions } from '../common/types.js';
 import type { RerankerOptions } from './types.js';
 
@@ -28,17 +28,20 @@ export interface PluginOptions extends CommonPluginOptions, RerankerOptions {}
 /**
  * Add Google Cloud Vertex AI Rerankers API to Genkit.
  */
-export function vertexAIRerankers(options: PluginOptions): GenkitPlugin {
-  return genkitPlugin('vertexAIRerankers', async (ai: Genkit) => {
-    const { projectId, location, authClient } = await getDerivedParams(options);
+export function vertexAIRerankers(options: PluginOptions): GenkitPluginV2 {
+  return genkitPluginV2({
+    name: 'vertexAIRerankers',
+    init: async () => {
+      const { projectId, location, authClient } = await getDerivedParams(options);
 
-    await vertexAiRerankers(ai, {
-      projectId,
-      location,
-      authClient,
-      rerankOptions: options.rerankers.map((o) =>
-        typeof o === 'string' ? { model: o } : o
-      ),
-    });
+      return vertexAiRerankers({
+        projectId,
+        location,
+        authClient,
+        rerankOptions: options.rerankers.map((o) =>
+          typeof o === 'string' ? { model: o } : o
+        ),
+      });
+    },
   });
 }

--- a/js/plugins/vertexai/src/rerankers/reranker.ts
+++ b/js/plugins/vertexai/src/rerankers/reranker.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import type { Genkit } from 'genkit';
 import { RankedDocument, rerankerRef } from 'genkit/reranker';
 import { DEFAULT_MODEL, getRerankEndpoint } from './constants.js';
 import {
   VertexAIRerankerOptionsSchema,
   type VertexRerankOptions,
 } from './types.js';
+import { reranker, ResolvableAction } from 'genkit/plugin';
 
 /**
  * Creates Vertex AI rerankers.
@@ -31,9 +31,8 @@ import {
  * @returns {Promise<void>}
  */
 export async function vertexAiRerankers(
-  ai: Genkit,
   options: VertexRerankOptions
-): Promise<void> {
+): Promise<ResolvableAction[]> {
   const rerankOptions = options.rerankOptions;
 
   if (rerankOptions.length === 0) {
@@ -44,11 +43,12 @@ export async function vertexAiRerankers(
   const client = await auth.getClient();
   const projectId = options.projectId;
 
+  const rerankerActions: ResolvableAction[] = [];
   for (const rerankOption of rerankOptions) {
     if (!rerankOption.name && !rerankOption.model) {
       throw new Error('At least one of name or model must be provided.');
     }
-    ai.defineReranker(
+    const rerankerAction = reranker(
       {
         name: `vertexai/${rerankOption.name || rerankOption.model}`,
         configSchema: VertexAIRerankerOptionsSchema.optional(),
@@ -83,7 +83,11 @@ export async function vertexAiRerankers(
         return { documents: rankedDocuments };
       }
     );
+
+    rerankerActions.push(rerankerAction);
   }
+
+  return rerankerActions;
 }
 
 /**

--- a/js/plugins/vertexai/src/vectorsearch/index.ts
+++ b/js/plugins/vertexai/src/vectorsearch/index.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import type { Genkit } from 'genkit';
-import { genkitPlugin, type GenkitPlugin } from 'genkit/plugin';
+import { genkitPluginV2, ResolvableAction, type GenkitPluginV2 } from 'genkit/plugin';
 import { getDerivedParams } from '../common/index.js';
 import type { PluginOptions } from './types.js';
 import { vertexAiIndexers, vertexAiRetrievers } from './vector_search/index.js';
@@ -117,25 +116,31 @@ export {
  * console.log(`response: ${response}`);
  * ```
  */
-export function vertexAIVectorSearch(options?: PluginOptions): GenkitPlugin {
-  return genkitPlugin('vertexAIVectorSearch', async (ai: Genkit) => {
+export function vertexAIVectorSearch(options?: PluginOptions): GenkitPluginV2 {
+  return genkitPluginV2({
+    name: 'vertexAIVectorSearch',
+    init: async () => {
     const { authClient } = await getDerivedParams(options);
+
+    const actions: ResolvableAction[] = [];
 
     if (
       options?.vectorSearchOptions &&
       options.vectorSearchOptions.length > 0
     ) {
-      vertexAiIndexers(ai, {
+      actions.push(...vertexAiIndexers({
         pluginOptions: options,
         authClient,
         defaultEmbedder: options.embedder,
-      });
+      }));
 
-      vertexAiRetrievers(ai, {
+      actions.push(...vertexAiRetrievers({
         pluginOptions: options,
         authClient,
         defaultEmbedder: options.embedder,
-      });
+      }));
     }
-  });
+
+    return actions;
+  }});
 }

--- a/js/plugins/vertexai/src/vectorsearch/vector_search/indexers.ts
+++ b/js/plugins/vertexai/src/vectorsearch/vector_search/indexers.ts
@@ -22,6 +22,7 @@ import {
   type VertexVectorSearchOptions,
 } from './types';
 import { upsertDatapoints } from './upsert_datapoints';
+import { indexer } from 'genkit/plugin';
 
 /**
  * Creates a reference to a Vertex AI indexer.
@@ -54,14 +55,13 @@ export const vertexAiIndexerRef = (params: {
  * @returns {IndexerAction<z.ZodTypeAny>[]} - An array of indexer actions.
  */
 export function vertexAiIndexers<EmbedderCustomOptions extends z.ZodTypeAny>(
-  ai: Genkit,
   params: VertexVectorSearchOptions<EmbedderCustomOptions>
 ): IndexerAction<z.ZodTypeAny>[] {
   const vectorSearchOptions = params.pluginOptions.vectorSearchOptions;
-  const indexers: IndexerAction<z.ZodTypeAny>[] = [];
+  const indexerActions: IndexerAction<z.ZodTypeAny>[] = [];
 
   if (!vectorSearchOptions || vectorSearchOptions.length === 0) {
-    return indexers;
+    return indexerActions;
   }
 
   for (const vectorSearchOption of vectorSearchOptions) {
@@ -76,7 +76,7 @@ export function vertexAiIndexers<EmbedderCustomOptions extends z.ZodTypeAny>(
     }
     const embedderOptions = vectorSearchOption.embedderOptions;
 
-    const indexer = ai.defineIndexer(
+    const indexerAction = indexer(
       {
         name: `vertexai/${indexId}`,
         configSchema: VertexAIVectorIndexerOptionsSchema.optional(),
@@ -128,7 +128,7 @@ export function vertexAiIndexers<EmbedderCustomOptions extends z.ZodTypeAny>(
       }
     );
 
-    indexers.push(indexer);
+    indexerActions.push(indexerAction);
   }
-  return indexers;
+  return indexerActions;
 }

--- a/js/plugins/vertexai/src/vectorsearch/vector_search/retrievers.ts
+++ b/js/plugins/vertexai/src/vectorsearch/vector_search/retrievers.ts
@@ -16,7 +16,6 @@
 
 import {
   retrieverRef,
-  type Genkit,
   type RetrieverAction,
   type z,
 } from 'genkit';
@@ -26,6 +25,7 @@ import {
   type VertexVectorSearchOptions,
 } from './types';
 import { getProjectNumber } from './utils';
+import { retriever } from 'genkit/plugin';
 
 const DEFAULT_K = 10;
 
@@ -39,23 +39,22 @@ const DEFAULT_K = 10;
  * @returns {RetrieverAction<z.ZodTypeAny>[]} - An array of retriever actions.
  */
 export function vertexAiRetrievers<EmbedderCustomOptions extends z.ZodTypeAny>(
-  ai: Genkit,
   params: VertexVectorSearchOptions<EmbedderCustomOptions>
 ): RetrieverAction<z.ZodTypeAny>[] {
   const vectorSearchOptions = params.pluginOptions.vectorSearchOptions;
   const defaultEmbedder = params.defaultEmbedder;
 
-  const retrievers: RetrieverAction<z.ZodTypeAny>[] = [];
+  const retrieverActions: RetrieverAction<z.ZodTypeAny>[] = [];
 
   if (!vectorSearchOptions || vectorSearchOptions.length === 0) {
-    return retrievers;
+    return retrieverActions;
   }
 
   for (const vectorSearchOption of vectorSearchOptions) {
     const { documentRetriever, indexId, publicDomainName } = vectorSearchOption;
     const embedderOptions = vectorSearchOption.embedderOptions;
 
-    const retriever = ai.defineRetriever(
+    const retrieverAction = retriever(
       {
         name: `vertexai/${indexId}`,
         configSchema: VertexAIVectorRetrieverOptionsSchema.optional(),
@@ -125,10 +124,10 @@ export function vertexAiRetrievers<EmbedderCustomOptions extends z.ZodTypeAny>(
       }
     );
 
-    retrievers.push(retriever);
+    retrieverActions.push(retrieverAction);
   }
 
-  return retrievers;
+  return retrieverActions;
 }
 
 /**


### PR DESCRIPTION
Couple of issues still:
- Unsure of `ai.embed` alternative in `vector_search/indexers.ts`
- Unsure of `ai.embedMany` alternative in `vector_search/retrievers.ts`

Todo:
- [ ] Test