### PR TITLE
refactor(go): moved common types to own package to make registry strongly typed

### DIFF
--- a/go/ai/action_test.go
+++ b/go/ai/action_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/registry"
 	"github.com/goccy/go-yaml"
 	"github.com/google/go-cmp/cmp"
@@ -40,7 +41,7 @@ type testCase struct {
 }
 
 type programmableModel struct {
-	r           *registry.Registry
+	r           api.Registry
 	handleResp  func(ctx context.Context, req *ModelRequest, cb func(context.Context, *ModelResponseChunk) error) (*ModelResponse, error)
 	lastRequest *ModelRequest
 }
@@ -49,7 +50,7 @@ func (pm *programmableModel) Name() string {
 	return "programmableModel"
 }
 
-func (pm *programmableModel) Generate(ctx context.Context, r *registry.Registry, req *ModelRequest, toolCfg *ToolConfig, cb func(context.Context, *ModelResponseChunk) error) (*ModelResponse, error) {
+func (pm *programmableModel) Generate(ctx context.Context, r api.Registry, req *ModelRequest, toolCfg *ToolConfig, cb func(context.Context, *ModelResponseChunk) error) (*ModelResponse, error) {
 	// Make a copy of the request to modify for testing purposes
 	if req != nil && req.Tools != nil {
 		for _, tool := range req.Tools {
@@ -64,7 +65,7 @@ func (pm *programmableModel) Generate(ctx context.Context, r *registry.Registry,
 	return pm.handleResp(ctx, req, cb)
 }
 
-func defineProgrammableModel(r *registry.Registry) *programmableModel {
+func defineProgrammableModel(r api.Registry) *programmableModel {
 	pm := &programmableModel{r: r}
 	supports := &ModelSupports{
 		Tools:     true,

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/firebase/genkit/go/core"
-	"github.com/firebase/genkit/go/internal/registry"
+	"github.com/firebase/genkit/go/core/api"
 )
 
 // EmbedderFunc is the function type for embedding documents.
@@ -33,6 +33,8 @@ type Embedder interface {
 	Name() string
 	// Embed embeds to content as part of the [EmbedRequest].
 	Embed(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error)
+	// Register registers the embedder with the given registry.
+	Register(r api.Registry)
 }
 
 // EmbedderArg is the interface for embedder arguments. It can either be the embedder action itself or a reference to be looked up.
@@ -102,7 +104,7 @@ func NewEmbedder(name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
 	}
 
 	metadata := map[string]any{
-		"type": core.ActionTypeEmbedder,
+		"type": api.ActionTypeEmbedder,
 		// TODO: This should be under "embedder" but JS has it as "info".
 		"info": map[string]any{
 			"label":      opts.Label,
@@ -125,23 +127,23 @@ func NewEmbedder(name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
 	}
 
 	return &embedder{
-		ActionDef: *core.NewAction(name, core.ActionTypeEmbedder, metadata, nil, fn),
+		ActionDef: *core.NewAction(name, api.ActionTypeEmbedder, metadata, nil, fn),
 	}
 }
 
 // DefineEmbedder registers the given embed function as an action, and returns an
 // [Embedder] that runs it.
-func DefineEmbedder(r *registry.Registry, name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
+func DefineEmbedder(r api.Registry, name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
 	e := NewEmbedder(name, opts, fn)
-	e.(*embedder).Register(r)
+	e.Register(r)
 	return e
 }
 
 // LookupEmbedder looks up an [Embedder] registered by [DefineEmbedder].
 // It will try to resolve the embedder dynamically if the embedder is not found.
 // It returns nil if the embedder was not resolved.
-func LookupEmbedder(r *registry.Registry, name string) Embedder {
-	action := core.ResolveActionFor[*EmbedRequest, *EmbedResponse, struct{}](r, core.ActionTypeEmbedder, name)
+func LookupEmbedder(r api.Registry, name string) Embedder {
+	action := core.ResolveActionFor[*EmbedRequest, *EmbedResponse, struct{}](r, api.ActionTypeEmbedder, name)
 	if action == nil {
 		return nil
 	}
@@ -156,7 +158,7 @@ func (e *embedder) Embed(ctx context.Context, req *EmbedRequest) (*EmbedResponse
 }
 
 // Embed invokes the embedder with provided options.
-func Embed(ctx context.Context, r *registry.Registry, opts ...EmbedderOption) (*EmbedResponse, error) {
+func Embed(ctx context.Context, r api.Registry, opts ...EmbedderOption) (*EmbedResponse, error) {
 	embedOpts := &embedderOptions{}
 	for _, opt := range opts {
 		if err := opt.applyEmbedder(embedOpts); err != nil {

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -154,6 +154,10 @@ func LookupEmbedder(r api.Registry, name string) Embedder {
 
 // Embed runs the given [Embedder].
 func (e *embedder) Embed(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+	if e == nil {
+		return nil, core.NewError(core.INVALID_ARGUMENT, "Embedder.Embed: embedder called on a nil embedder; check that all embedders are defined")
+	}
+
 	return e.Run(ctx, req, nil)
 }
 

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -296,7 +296,11 @@ func LookupEvaluator(r api.Registry, name string) Evaluator {
 }
 
 // Evaluate runs the given [Evaluator].
-func (e evaluator) Evaluate(ctx context.Context, req *EvaluatorRequest) (*EvaluatorResponse, error) {
+func (e *evaluator) Evaluate(ctx context.Context, req *EvaluatorRequest) (*EvaluatorResponse, error) {
+	if e == nil {
+		return nil, core.NewError(core.INVALID_ARGUMENT, "Evaluator.Evaluate: evaluator called on a nil evaluator; check that all evaluators are defined")
+	}
+
 	return e.Run(ctx, req, nil)
 }
 

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/tracing"
-	"github.com/firebase/genkit/go/internal/registry"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -40,6 +40,8 @@ type Evaluator interface {
 	Name() string
 	// Evaluates a dataset.
 	Evaluate(ctx context.Context, req *EvaluatorRequest) (*EvaluatorResponse, error)
+	// Register registers the evaluator with the given registry.
+	Register(r api.Registry)
 }
 
 // EvaluatorArg is the interface for evaluator arguments. It can either be the evaluator action itself or a reference to be looked up.
@@ -172,7 +174,7 @@ func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluat
 
 	// TODO(ssbushi): Set this on `evaluator` key on action metadata
 	metadata := map[string]any{
-		"type": core.ActionTypeEvaluator,
+		"type": api.ActionTypeEvaluator,
 		"evaluator": map[string]any{
 			"evaluatorIsBilled":    opts.IsBilled,
 			"evaluatorDisplayName": opts.DisplayName,
@@ -188,7 +190,7 @@ func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluat
 	}
 
 	return &evaluator{
-		ActionDef: *core.NewAction(name, core.ActionTypeEvaluator, metadata, inputSchema, func(ctx context.Context, req *EvaluatorRequest) (output *EvaluatorResponse, err error) {
+		ActionDef: *core.NewAction(name, api.ActionTypeEvaluator, metadata, inputSchema, func(ctx context.Context, req *EvaluatorRequest) (output *EvaluatorResponse, err error) {
 			var results []EvaluationResult
 			for _, datapoint := range req.Dataset {
 				if datapoint.TestCaseId == "" {
@@ -240,9 +242,9 @@ func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluat
 
 // DefineEvaluator creates a new [Evaluator] and registers it.
 // This method processes the input dataset one-by-one.
-func DefineEvaluator(r *registry.Registry, name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluator {
+func DefineEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluator {
 	e := NewEvaluator(name, opts, fn)
-	e.(*evaluator).Register(r)
+	e.Register(r)
 	return e
 }
 
@@ -259,7 +261,7 @@ func NewBatchEvaluator(name string, opts *EvaluatorOptions, fn BatchEvaluatorFun
 	}
 
 	metadata := map[string]any{
-		"type": core.ActionTypeEvaluator,
+		"type": api.ActionTypeEvaluator,
 		"evaluator": map[string]any{
 			"evaluatorIsBilled":    opts.IsBilled,
 			"evaluatorDisplayName": opts.DisplayName,
@@ -268,14 +270,14 @@ func NewBatchEvaluator(name string, opts *EvaluatorOptions, fn BatchEvaluatorFun
 	}
 
 	return &evaluator{
-		ActionDef: *core.NewAction(name, core.ActionTypeEvaluator, metadata, nil, fn),
+		ActionDef: *core.NewAction(name, api.ActionTypeEvaluator, metadata, nil, fn),
 	}
 }
 
 // DefineBatchEvaluator creates a new [Evaluator] and registers it.
 // This method provides the full [EvaluatorRequest] to the callback function,
 // giving more flexibility to the user for processing the data, such as batching or parallelization.
-func DefineBatchEvaluator(r *registry.Registry, name string, opts *EvaluatorOptions, fn BatchEvaluatorFunc) Evaluator {
+func DefineBatchEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn BatchEvaluatorFunc) Evaluator {
 	e := NewBatchEvaluator(name, opts, fn)
 	e.(*evaluator).Register(r)
 	return e
@@ -283,8 +285,8 @@ func DefineBatchEvaluator(r *registry.Registry, name string, opts *EvaluatorOpti
 
 // LookupEvaluator looks up an [Evaluator] registered by [DefineEvaluator].
 // It returns nil if the evaluator was not defined.
-func LookupEvaluator(r *registry.Registry, name string) Evaluator {
-	action := core.LookupActionFor[*EvaluatorRequest, *EvaluatorResponse, struct{}](r, core.ActionTypeEvaluator, name)
+func LookupEvaluator(r api.Registry, name string) Evaluator {
+	action := core.LookupActionFor[*EvaluatorRequest, *EvaluatorResponse, struct{}](r, api.ActionTypeEvaluator, name)
 	if action == nil {
 		return nil
 	}
@@ -299,7 +301,7 @@ func (e evaluator) Evaluate(ctx context.Context, req *EvaluatorRequest) (*Evalua
 }
 
 // Evaluate calls the retrivers with provided options.
-func Evaluate(ctx context.Context, r *registry.Registry, opts ...EvaluatorOption) (*EvaluatorResponse, error) {
+func Evaluate(ctx context.Context, r api.Registry, opts ...EvaluatorOption) (*EvaluatorResponse, error) {
 	evalOpts := &evaluatorOptions{}
 	for _, opt := range opts {
 		if err := opt.applyEvaluator(evalOpts); err != nil {

--- a/go/ai/formatter.go
+++ b/go/ai/formatter.go
@@ -17,7 +17,7 @@ package ai
 import (
 	"fmt"
 
-	"github.com/firebase/genkit/go/internal/registry"
+	"github.com/firebase/genkit/go/core/api"
 )
 
 const (
@@ -57,19 +57,19 @@ type FormatHandler interface {
 }
 
 // ConfigureFormats registers default formats in the registry
-func ConfigureFormats(reg *registry.Registry) {
+func ConfigureFormats(reg api.Registry) {
 	for _, format := range DEFAULT_FORMATS {
 		DefineFormat(reg, "/format/"+format.Name(), format)
 	}
 }
 
 // DefineFormat defines and registers a new [Formatter].
-func DefineFormat(r *registry.Registry, name string, formatter Formatter) {
+func DefineFormat(r api.Registry, name string, formatter Formatter) {
 	r.RegisterValue(name, formatter)
 }
 
 // resolveFormat returns a [Formatter], either a default one or one from the registry.
-func resolveFormat(reg *registry.Registry, schema map[string]any, format string) (Formatter, error) {
+func resolveFormat(reg api.Registry, schema map[string]any, format string) (Formatter, error) {
 	var formatter any
 
 	// If schema is set but no explicit format is set we default to json.

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -286,7 +286,7 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 		// Native constrained output is enabled only when the user has
 		// requested it, the model supports it, and there's a JSON schema.
 		outputCfg.Constrained = opts.Output.JsonSchema != nil &&
-			opts.Output.Constrained && m.(*model).SupportsConstrained(len(toolDefs) > 0)
+			opts.Output.Constrained && m.(*model).supportsConstrained(len(toolDefs) > 0)
 
 		// Add schema instructions to prompt when not using native constraints.
 		// This is a no-op for unstructured output requests.
@@ -542,8 +542,8 @@ func (m *model) Generate(ctx context.Context, req *ModelRequest, cb ModelStreamC
 	return m.ActionDef.Run(ctx, req, cb)
 }
 
-// SupportsConstrained returns whether the model supports constrained output.
-func (m *model) SupportsConstrained(hasTools bool) bool {
+// supportsConstrained returns whether the model supports constrained output.
+func (m *model) supportsConstrained(hasTools bool) bool {
 	if m == nil {
 		return false
 	}

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -25,10 +25,10 @@ import (
 	"strings"
 
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/base"
-	"github.com/firebase/genkit/go/internal/registry"
 )
 
 // Model represents a model that can generate content based on a request.
@@ -37,6 +37,8 @@ type Model interface {
 	Name() string
 	// Generate applies the [Model] to provided request, handling tool requests and handles streaming.
 	Generate(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error)
+	// Register registers the model with the given registry.
+	Register(r api.Registry)
 }
 
 // ModelArg is the interface for model arguments. It can either be the retriever action itself or a reference to be looked up.
@@ -109,8 +111,8 @@ type ModelOptions struct {
 }
 
 // DefineGenerateAction defines a utility generate action.
-func DefineGenerateAction(ctx context.Context, r *registry.Registry) *generateAction {
-	return (*generateAction)(core.DefineStreamingAction(r, "generate", core.ActionTypeUtil, nil, nil,
+func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
+	return (*generateAction)(core.DefineStreamingAction(r, "generate", api.ActionTypeUtil, nil, nil,
 		func(ctx context.Context, actionOpts *GenerateActionOptions, cb ModelStreamCallback) (resp *ModelResponse, err error) {
 			logger.FromContext(ctx).Debug("GenerateAction",
 				"input", fmt.Sprintf("%#v", actionOpts))
@@ -143,7 +145,7 @@ func NewModel(name string, opts *ModelOptions, fn ModelFunc) Model {
 	}
 
 	metadata := map[string]any{
-		"type": core.ActionTypeModel,
+		"type": api.ActionTypeModel,
 		"model": map[string]any{
 			"label": opts.Label,
 			"supports": map[string]any{
@@ -178,22 +180,22 @@ func NewModel(name string, opts *ModelOptions, fn ModelFunc) Model {
 	fn = core.ChainMiddleware(mws...)(fn)
 
 	return &model{
-		ActionDef: *core.NewStreamingAction(name, core.ActionTypeModel, metadata, inputSchema, fn),
+		ActionDef: *core.NewStreamingAction(name, api.ActionTypeModel, metadata, inputSchema, fn),
 	}
 }
 
 // DefineModel creates a new [Model] and registers it.
-func DefineModel(r *registry.Registry, name string, opts *ModelOptions, fn ModelFunc) Model {
+func DefineModel(r api.Registry, name string, opts *ModelOptions, fn ModelFunc) Model {
 	m := NewModel(name, opts, fn)
-	m.(*model).Register(r)
+	m.Register(r)
 	return m
 }
 
 // LookupModel looks up a [Model] registered by [DefineModel].
 // It will try to resolve the model dynamically if the model is not found.
 // It returns nil if the model was not resolved.
-func LookupModel(r *registry.Registry, name string) Model {
-	action := core.ResolveActionFor[*ModelRequest, *ModelResponse, *ModelResponseChunk](r, core.ActionTypeModel, name)
+func LookupModel(r api.Registry, name string) Model {
+	action := core.ResolveActionFor[*ModelRequest, *ModelResponse, *ModelResponseChunk](r, api.ActionTypeModel, name)
 	if action == nil {
 		return nil
 	}
@@ -203,9 +205,9 @@ func LookupModel(r *registry.Registry, name string) Model {
 }
 
 // GenerateWithRequest is the central generation implementation for ai.Generate(), prompt.Execute(), and the GenerateAction direct call.
-func GenerateWithRequest(ctx context.Context, r *registry.Registry, opts *GenerateActionOptions, mw []ModelMiddleware, cb ModelStreamCallback) (*ModelResponse, error) {
+func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActionOptions, mw []ModelMiddleware, cb ModelStreamCallback) (*ModelResponse, error) {
 	if opts.Model == "" {
-		if defaultModel, ok := r.LookupValue(registry.DefaultModelKey).(string); ok && defaultModel != "" {
+		if defaultModel, ok := r.LookupValue(api.DefaultModelKey).(string); ok && defaultModel != "" {
 			opts.Model = defaultModel
 		}
 		if opts.Model == "" {
@@ -364,7 +366,7 @@ func GenerateWithRequest(ctx context.Context, r *registry.Registry, opts *Genera
 }
 
 // Generate generates a model response based on the provided options.
-func Generate(ctx context.Context, r *registry.Registry, opts ...GenerateOption) (*ModelResponse, error) {
+func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*ModelResponse, error) {
 	genOpts := &generateOptions{}
 	for _, opt := range opts {
 		if err := opt.applyGenerate(genOpts); err != nil {
@@ -401,7 +403,7 @@ func Generate(ctx context.Context, r *registry.Registry, opts ...GenerateOption)
 			r = r.NewChild()
 		}
 		for _, t := range dynamicTools {
-			t.(*tool).Register(r)
+			t.Register(r)
 		}
 	}
 
@@ -503,7 +505,7 @@ func Generate(ctx context.Context, r *registry.Registry, opts ...GenerateOption)
 }
 
 // GenerateText run generate request for this model. Returns generated text only.
-func GenerateText(ctx context.Context, r *registry.Registry, opts ...GenerateOption) (string, error) {
+func GenerateText(ctx context.Context, r api.Registry, opts ...GenerateOption) (string, error) {
 	res, err := Generate(ctx, r, opts...)
 	if err != nil {
 		return "", err
@@ -514,7 +516,7 @@ func GenerateText(ctx context.Context, r *registry.Registry, opts ...GenerateOpt
 
 // Generate run generate request for this model. Returns ModelResponse struct.
 // TODO: Stream GenerateData with partial JSON
-func GenerateData[Out any](ctx context.Context, r *registry.Registry, opts ...GenerateOption) (*Out, *ModelResponse, error) {
+func GenerateData[Out any](ctx context.Context, r api.Registry, opts ...GenerateOption) (*Out, *ModelResponse, error) {
 	var value Out
 	opts = append(opts, WithOutputType(value))
 
@@ -597,7 +599,7 @@ func clone[T any](obj *T) *T {
 // handleToolRequests processes any tool requests in the response, returning
 // either a new request to continue the conversation or nil if no tool requests
 // need handling.
-func handleToolRequests(ctx context.Context, r *registry.Registry, req *ModelRequest, resp *ModelResponse, cb ModelStreamCallback) (*ModelRequest, *Message, error) {
+func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, resp *ModelResponse, cb ModelStreamCallback) (*ModelRequest, *Message, error) {
 	toolCount := 0
 	if resp.Message != nil {
 		for _, part := range resp.Message.Content {
@@ -827,7 +829,7 @@ func (m ModelRef) Config() any {
 // handleResumedToolRequest resolves a tool request from a previous, interrupted model turn,
 // when generation is being resumed. It determines the outcome of the tool request based on
 // pending output, or explicit 'respond' or 'restart' directives in the resume options.
-func handleResumedToolRequest(ctx context.Context, r *registry.Registry, genOpts *GenerateActionOptions, p *Part) (*resumedToolRequestOutput, error) {
+func handleResumedToolRequest(ctx context.Context, r api.Registry, genOpts *GenerateActionOptions, p *Part) (*resumedToolRequestOutput, error) {
 	if p == nil || !p.IsToolRequest() {
 		return nil, core.NewError(core.INVALID_ARGUMENT, "handleResumedToolRequest: part is not a tool request")
 	}
@@ -964,7 +966,7 @@ func handleResumedToolRequest(ctx context.Context, r *registry.Registry, genOpts
 
 // handleResumeOption amends message history to handle `resume` arguments.
 // It returns the amended history.
-func handleResumeOption(ctx context.Context, r *registry.Registry, genOpts *GenerateActionOptions) (*resumeOptionOutput, error) {
+func handleResumeOption(ctx context.Context, r api.Registry, genOpts *GenerateActionOptions) (*resumeOptionOutput, error) {
 	if genOpts.Resume == nil || (len(genOpts.Resume.Respond) == 0 && len(genOpts.Resume.Restart) == 0) {
 		return &resumeOptionOutput{revisedRequest: genOpts}, nil
 	}
@@ -1072,7 +1074,7 @@ func handleResumeOption(ctx context.Context, r *registry.Registry, genOpts *Gene
 }
 
 // processResources processes messages to replace resource parts with actual content.
-func processResources(ctx context.Context, r *registry.Registry, messages []*Message) ([]*Message, error) {
+func processResources(ctx context.Context, r api.Registry, messages []*Message) ([]*Message, error) {
 	processedMessages := make([]*Message, len(messages))
 	for i, msg := range messages {
 		processedContent := []*Part{}
@@ -1103,7 +1105,7 @@ func processResources(ctx context.Context, r *registry.Registry, messages []*Mes
 }
 
 // executeResourcePart finds and executes a resource, returning the content parts.
-func executeResourcePart(ctx context.Context, r *registry.Registry, resourceURI string) ([]*Part, error) {
+func executeResourcePart(ctx context.Context, r api.Registry, resourceURI string) ([]*Part, error) {
 	resource, input, err := FindMatchingResource(r, resourceURI)
 	if err != nil {
 		return nil, err

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -330,7 +330,7 @@ func WithMetadata(metadata map[string]any) PromptOption {
 
 // WithInputType uses the type provided to derive the input schema.
 // The inputted value will serve as the default input if no input is given at generation time.
-// Only supports structs and map[string]any types.
+// Only supports structs and map[string]any api.
 func WithInputType(input any) PromptOption {
 	var defaultInput map[string]any
 
@@ -910,7 +910,7 @@ func (o *promptExecutionOptions) applyPromptExecute(pgOpts *promptExecutionOptio
 }
 
 // WithInput sets the input for the prompt request. Input must conform to the
-// prompt's input schema and can either be a map[string]any or a struct of the same type.
+// prompt's input schema and can either be a map[string]any or a struct of the same api.
 func WithInput(input any) PromptExecuteOption {
 	return &promptExecutionOptions{Input: input}
 }

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -26,9 +26,9 @@ import (
 	"strings"
 
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/internal/base"
-	"github.com/firebase/genkit/go/internal/registry"
 	"github.com/google/dotprompt/go/dotprompt"
 	"github.com/invopop/jsonschema"
 )
@@ -47,11 +47,11 @@ type Prompt interface {
 type prompt struct {
 	core.ActionDef[any, *GenerateActionOptions, struct{}]
 	promptOptions
-	registry *registry.Registry
+	registry api.Registry
 }
 
 // DefinePrompt creates a new [Prompt] and registers it.
-func DefinePrompt(r *registry.Registry, name string, opts ...PromptOption) Prompt {
+func DefinePrompt(r api.Registry, name string, opts ...PromptOption) Prompt {
 	if name == "" {
 		panic("ai.DefinePrompt: name is required")
 	}
@@ -88,7 +88,7 @@ func DefinePrompt(r *registry.Registry, name string, opts ...PromptOption) Promp
 	}
 
 	promptMeta := map[string]any{
-		"type": core.ActionTypeExecutablePrompt,
+		"type": api.ActionTypeExecutablePrompt,
 		"prompt": map[string]any{
 			"name":         name,
 			"description":  p.Description,
@@ -102,15 +102,15 @@ func DefinePrompt(r *registry.Registry, name string, opts ...PromptOption) Promp
 	}
 	maps.Copy(meta, promptMeta)
 
-	p.ActionDef = *core.DefineAction(r, name, core.ActionTypeExecutablePrompt, meta, p.InputSchema, p.buildRequest)
+	p.ActionDef = *core.DefineAction(r, name, api.ActionTypeExecutablePrompt, meta, p.InputSchema, p.buildRequest)
 
 	return p
 }
 
 // LookupPrompt looks up a [Prompt] registered by [DefinePrompt].
 // It returns nil if the prompt was not defined.
-func LookupPrompt(r *registry.Registry, name string) Prompt {
-	action := core.LookupActionFor[any, *GenerateActionOptions, struct{}](r, core.ActionTypeExecutablePrompt, name)
+func LookupPrompt(r api.Registry, name string) Prompt {
+	action := core.LookupActionFor[any, *GenerateActionOptions, struct{}](r, api.ActionTypeExecutablePrompt, name)
 	if action == nil {
 		return nil
 	}
@@ -276,15 +276,15 @@ func (p *prompt) buildRequest(ctx context.Context, input any) (*GenerateActionOp
 	}
 
 	messages := []*Message{}
-	messages, err = renderSystemPrompt(ctx, p.promptOptions, messages, m, input, p.registry.Dotprompt)
+	messages, err = renderSystemPrompt(ctx, p.promptOptions, messages, m, input, p.registry.Dotprompt())
 	if err != nil {
 		return nil, err
 	}
-	messages, err = renderMessages(ctx, p.promptOptions, messages, m, input, p.registry.Dotprompt)
+	messages, err = renderMessages(ctx, p.promptOptions, messages, m, input, p.registry.Dotprompt())
 	if err != nil {
 		return nil, err
 	}
-	messages, err = renderUserPrompt(ctx, p.promptOptions, messages, m, input, p.registry.Dotprompt)
+	messages, err = renderUserPrompt(ctx, p.promptOptions, messages, m, input, p.registry.Dotprompt())
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +458,7 @@ func convertToPartPointers(parts []dotprompt.Part) ([]*Part, error) {
 }
 
 // LoadPromptDir loads prompts and partials from the input directory for the given namespace.
-func LoadPromptDir(r *registry.Registry, dir string, namespace string) {
+func LoadPromptDir(r api.Registry, dir string, namespace string) {
 	useDefaultDir := false
 	if dir == "" {
 		dir = "./prompts"
@@ -486,7 +486,7 @@ func LoadPromptDir(r *registry.Registry, dir string, namespace string) {
 }
 
 // loadPromptDir recursively loads prompts and partials from the directory.
-func loadPromptDir(r *registry.Registry, dir string, namespace string) {
+func loadPromptDir(r api.Registry, dir string, namespace string) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		panic(fmt.Errorf("failed to read prompt directory structure: %w", err))
@@ -515,7 +515,7 @@ func loadPromptDir(r *registry.Registry, dir string, namespace string) {
 }
 
 // LoadPrompt loads a single prompt into the registry.
-func LoadPrompt(r *registry.Registry, dir, filename, namespace string) Prompt {
+func LoadPrompt(r api.Registry, dir, filename, namespace string) Prompt {
 	name := strings.TrimSuffix(filename, ".prompt")
 	name, variant, _ := strings.Cut(name, ".")
 
@@ -526,13 +526,13 @@ func LoadPrompt(r *registry.Registry, dir, filename, namespace string) Prompt {
 		return nil
 	}
 
-	parsedPrompt, err := r.Dotprompt.Parse(string(source))
+	parsedPrompt, err := r.Dotprompt().Parse(string(source))
 	if err != nil {
 		slog.Error("Failed to parse file as dotprompt", "file", sourceFile, "error", err)
 		return nil
 	}
 
-	metadata, err := r.Dotprompt.RenderMetadata(string(source), &parsedPrompt.PromptMetadata)
+	metadata, err := r.Dotprompt().RenderMetadata(string(source), &parsedPrompt.PromptMetadata)
 	if err != nil {
 		slog.Error("Failed to render dotprompt metadata", "file", sourceFile, "error", err)
 		return nil

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/base"
 	"github.com/firebase/genkit/go/internal/registry"
 	"github.com/google/go-cmp/cmp"
@@ -33,7 +33,7 @@ type InputOutput struct {
 	Text string `json:"text"`
 }
 
-func testTool(reg *registry.Registry, name string) Tool {
+func testTool(reg api.Registry, name string) Tool {
 	return DefineTool(reg, name, "use when need to execute a test",
 		func(ctx *ToolContext, input struct {
 			Test string
@@ -147,7 +147,7 @@ type HelloPromptInput struct {
 	Name string
 }
 
-func definePromptModel(reg *registry.Registry) Model {
+func definePromptModel(reg api.Registry) Model {
 	return DefineModel(reg, "test/chat",
 		&ModelOptions{Supports: &ModelSupports{
 			Tools:      true,
@@ -829,20 +829,20 @@ Hello, {{name}}!
 		t.Fatalf("Prompt was not registered")
 	}
 
-	if prompt.(core.Action).Desc().InputSchema == nil {
+	if prompt.(api.Action).Desc().InputSchema == nil {
 		t.Fatal("Input schema is nil")
 	}
 
-	if prompt.(core.Action).Desc().InputSchema["type"] != "object" {
-		t.Errorf("Expected input schema type 'object', got '%s'", prompt.(core.Action).Desc().InputSchema["type"])
+	if prompt.(api.Action).Desc().InputSchema["type"] != "object" {
+		t.Errorf("Expected input schema type 'object', got '%s'", prompt.(api.Action).Desc().InputSchema["type"])
 	}
 
-	promptMetadata, ok := prompt.(core.Action).Desc().Metadata["prompt"].(map[string]any)
+	promptMetadata, ok := prompt.(api.Action).Desc().Metadata["prompt"].(map[string]any)
 	if !ok {
-		t.Fatalf("Expected Metadata['prompt'] to be a map, but got %T", prompt.(core.Action).Desc().Metadata["prompt"])
+		t.Fatalf("Expected Metadata['prompt'] to be a map, but got %T", prompt.(api.Action).Desc().Metadata["prompt"])
 	}
 	if promptMetadata["model"] != "test-model" {
-		t.Errorf("Expected model name 'test-model', got '%s'", prompt.(core.Action).Desc().Metadata["model"])
+		t.Errorf("Expected model name 'test-model', got '%s'", prompt.(api.Action).Desc().Metadata["model"])
 	}
 }
 

--- a/go/ai/resource.go
+++ b/go/ai/resource.go
@@ -22,8 +22,8 @@ import (
 	"maps"
 
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	coreresource "github.com/firebase/genkit/go/core/resource"
-	"github.com/firebase/genkit/go/internal/registry"
 )
 
 // ResourceInput represents the input to a resource function.
@@ -50,7 +50,7 @@ type ResourceFunc = func(context.Context, *ResourceInput) (*ResourceOutput, erro
 
 // resource is the internal implementation of the Resource interface.
 // It holds the underlying core action and allows looking up resources
-// by name without knowing their specific input/output types.
+// by name without knowing their specific input/output api.
 type resource struct {
 	core.ActionDef[*ResourceInput, *ResourceOutput, struct{}]
 }
@@ -65,12 +65,14 @@ type Resource interface {
 	ExtractVariables(uri string) (map[string]string, error)
 	// Execute runs the resource with the given input.
 	Execute(ctx context.Context, input *ResourceInput) (*ResourceOutput, error)
+	// Register registers the resource with the given registry.
+	Register(r api.Registry)
 }
 
 // DefineResource creates a resource and registers it with the given Registry.
-func DefineResource(r *registry.Registry, name string, opts *ResourceOptions, fn ResourceFunc) Resource {
+func DefineResource(r api.Registry, name string, opts *ResourceOptions, fn ResourceFunc) Resource {
 	metadata := resourceMetadata(name, opts)
-	return &resource{ActionDef: *core.DefineAction(r, name, core.ActionTypeResource, metadata, nil, fn)}
+	return &resource{ActionDef: *core.DefineAction(r, name, api.ActionTypeResource, metadata, nil, fn)}
 }
 
 // NewResource creates a resource but does not register it in the registry.
@@ -78,7 +80,7 @@ func DefineResource(r *registry.Registry, name string, opts *ResourceOptions, fn
 func NewResource(name string, opts *ResourceOptions, fn ResourceFunc) Resource {
 	metadata := resourceMetadata(name, opts)
 	metadata["dynamic"] = true
-	return &resource{ActionDef: *core.NewAction(name, core.ActionTypeResource, metadata, nil, fn)}
+	return &resource{ActionDef: *core.NewAction(name, api.ActionTypeResource, metadata, nil, fn)}
 }
 
 // resourceMetadata creates the metadata common to both DefineResource and NewResource.
@@ -96,7 +98,7 @@ func resourceMetadata(name string, opts *ResourceOptions) map[string]any {
 
 	// Create metadata with resource-specific information
 	metadata := map[string]any{
-		"type":        core.ActionTypeResource,
+		"type":        api.ActionTypeResource,
 		"name":        name,
 		"description": opts.Description,
 		"resource": map[string]any{
@@ -170,7 +172,7 @@ func (r *resource) Execute(ctx context.Context, input *ResourceInput) (*Resource
 }
 
 // FindMatchingResource finds a resource that matches the given URI.
-func FindMatchingResource(r *registry.Registry, uri string) (Resource, *ResourceInput, error) {
+func FindMatchingResource(r api.Registry, uri string) (Resource, *ResourceInput, error) {
 	for _, a := range r.ListActions() {
 		if action, ok := a.(*core.ActionDef[*ResourceInput, *ResourceOutput, struct{}]); ok {
 			res := &resource{ActionDef: *action}
@@ -188,8 +190,8 @@ func FindMatchingResource(r *registry.Registry, uri string) (Resource, *Resource
 }
 
 // LookupResource looks up the resource in the registry by provided name and returns it.
-func LookupResource(r *registry.Registry, name string) Resource {
-	action := core.LookupActionFor[*ResourceInput, *ResourceOutput, struct{}](r, core.ActionTypeResource, name)
+func LookupResource(r api.Registry, name string) Resource {
+	action := core.LookupActionFor[*ResourceInput, *ResourceOutput, struct{}](r, api.ActionTypeResource, name)
 	if action == nil {
 		return nil
 	}

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -146,7 +146,11 @@ func LookupRetriever(r api.Registry, name string) Retriever {
 }
 
 // Retrieve runs the given [Retriever].
-func (r retriever) Retrieve(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+func (r *retriever) Retrieve(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+	if r == nil {
+		return nil, core.NewError(core.INVALID_ARGUMENT, "Retriever.Retrieve: retriever called on a nil retriever; check that all retrievers are defined")
+	}
+
 	return r.Run(ctx, req, nil)
 }
 

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	"github.com/firebase/genkit/go/core"
-	"github.com/firebase/genkit/go/internal/registry"
+	"github.com/firebase/genkit/go/core/api"
 )
 
 // RetrieverFunc is the function type for retriever implementations.
@@ -34,6 +34,8 @@ type Retriever interface {
 	Name() string
 	// Retrieve retrieves the documents.
 	Retrieve(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error)
+	// Register registers the retriever with the given registry.
+	Register(r api.Registry)
 }
 
 // retriever is an action with functions specific to document retrieval such as Retrieve().
@@ -99,7 +101,7 @@ func NewRetriever(name string, opts *RetrieverOptions, fn RetrieverFunc) Retriev
 	}
 
 	metadata := map[string]any{
-		"type": core.ActionTypeRetriever,
+		"type": api.ActionTypeRetriever,
 		"info": map[string]any{
 			"label": opts.Label,
 			"supports": map[string]any{
@@ -119,22 +121,22 @@ func NewRetriever(name string, opts *RetrieverOptions, fn RetrieverFunc) Retriev
 	}
 
 	return &retriever{
-		ActionDef: *core.NewAction(name, core.ActionTypeRetriever, metadata, inputSchema, fn),
+		ActionDef: *core.NewAction(name, api.ActionTypeRetriever, metadata, inputSchema, fn),
 	}
 }
 
 // DefineRetriever creates a new [Retriever] and registers it.
-func DefineRetriever(r *registry.Registry, name string, opts *RetrieverOptions, fn RetrieverFunc) Retriever {
+func DefineRetriever(r api.Registry, name string, opts *RetrieverOptions, fn RetrieverFunc) Retriever {
 	ret := NewRetriever(name, opts, fn)
-	ret.(*retriever).Register(r)
+	ret.Register(r)
 	return ret
 }
 
 // LookupRetriever looks up a [Retriever] registered by [DefineRetriever].
 // It will try to resolve the retriever dynamically if the retriever is not found.
 // It returns nil if the retriever was not resolved.
-func LookupRetriever(r *registry.Registry, name string) Retriever {
-	action := core.LookupActionFor[*RetrieverRequest, *RetrieverResponse, struct{}](r, core.ActionTypeRetriever, name)
+func LookupRetriever(r api.Registry, name string) Retriever {
+	action := core.LookupActionFor[*RetrieverRequest, *RetrieverResponse, struct{}](r, api.ActionTypeRetriever, name)
 	if action == nil {
 		return nil
 	}
@@ -149,7 +151,7 @@ func (r retriever) Retrieve(ctx context.Context, req *RetrieverRequest) (*Retrie
 }
 
 // Retrieve calls the retriever with the provided options.
-func Retrieve(ctx context.Context, r *registry.Registry, opts ...RetrieverOption) (*RetrieverResponse, error) {
+func Retrieve(ctx context.Context, r api.Registry, opts ...RetrieverOption) (*RetrieverResponse, error) {
 	retOpts := &retrieverOptions{}
 	for _, opt := range opts {
 		if err := opt.applyRetriever(retOpts); err != nil {

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -191,24 +191,23 @@ func (t *tool) Definition() *ToolDefinition {
 // RunRaw runs this tool using the provided raw map format data (JSON parsed
 // as map[string]any).
 func (t *tool) RunRaw(ctx context.Context, input any) (any, error) {
-	return runAction(ctx, t.Definition(), t.Action, input)
-}
+	if t == nil {
+		return nil, core.NewError(core.INVALID_ARGUMENT, "Tool.RunRaw: tool called on a nil tool; check that all tools are defined")
+	}
 
-// runAction runs the given action with the provided raw input and returns the output in raw format.
-func runAction(ctx context.Context, def *ToolDefinition, action api.Action, input any) (any, error) {
 	mi, err := json.Marshal(input)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling tool input for %v: %v", def.Name, err)
+		return nil, fmt.Errorf("error marshalling tool input for %v: %v", t.Name(), err)
 	}
-	output, err := action.RunJSON(ctx, mi, nil)
+	output, err := t.RunJSON(ctx, mi, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error calling tool %v: %w", def.Name, err)
+		return nil, fmt.Errorf("error calling tool %v: %w", t.Name(), err)
 	}
 
 	var uo any
 	err = json.Unmarshal(output, &uo)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing tool output for %v: %v", def.Name, err)
+		return nil, fmt.Errorf("error parsing tool output for %v: %v", t.Name(), err)
 	}
 	return uo, nil
 }

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -21,14 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/base"
 	"github.com/firebase/genkit/go/internal/metrics"
-	"github.com/firebase/genkit/go/internal/registry"
 )
 
 // Func is an alias for non-streaming functions with input of type In and output of type Out.
@@ -40,35 +39,6 @@ type StreamingFunc[In, Out, Stream any] = func(context.Context, In, StreamCallba
 // StreamCallback is a function that is called during streaming to return the next chunk of the stream.
 type StreamCallback[Stream any] = func(context.Context, Stream) error
 
-// Action is the interface that all Genkit primitives (e.g. flows, models, tools) have in common.
-type Action interface {
-	// Name returns the name of the action.
-	Name() string
-	// RunJSON runs the action with the given JSON input and streaming callback and returns the output as JSON.
-	RunJSON(ctx context.Context, input json.RawMessage, cb func(context.Context, json.RawMessage) error) (json.RawMessage, error)
-	// Desc returns a descriptor of the action.
-	Desc() ActionDesc
-	// Register registers the action with the given registry.
-	Register(r *registry.Registry)
-}
-
-// An ActionType is the kind of an action.
-type ActionType string
-
-const (
-	ActionTypeRetriever        ActionType = "retriever"
-	ActionTypeIndexer          ActionType = "indexer"
-	ActionTypeEmbedder         ActionType = "embedder"
-	ActionTypeEvaluator        ActionType = "evaluator"
-	ActionTypeFlow             ActionType = "flow"
-	ActionTypeModel            ActionType = "model"
-	ActionTypeExecutablePrompt ActionType = "executable-prompt"
-	ActionTypeResource         ActionType = "resource"
-	ActionTypeTool             ActionType = "tool"
-	ActionTypeUtil             ActionType = "util"
-	ActionTypeCustom           ActionType = "custom"
-)
-
 // An ActionDef is a named, observable operation that underlies all Genkit primitives.
 // It consists of a function that takes an input of type I and returns an output
 // of type O, optionally streaming values of type S incrementally by invoking a callback.
@@ -78,27 +48,16 @@ const (
 // Each time an ActionDef is run, it results in a new trace span.
 type ActionDef[In, Out, Stream any] struct {
 	fn   StreamingFunc[In, Out, Stream] // Function that is called during runtime. May not actually support streaming.
-	desc *ActionDesc                    // Descriptor of the action.
-}
-
-// ActionDesc is a descriptor of an action.
-type ActionDesc struct {
-	Type         ActionType     `json:"type"`         // Type of the action.
-	Key          string         `json:"key"`          // Key of the action.
-	Name         string         `json:"name"`         // Name of the action.
-	Description  string         `json:"description"`  // Description of the action.
-	InputSchema  map[string]any `json:"inputSchema"`  // JSON schema to validate against the action's input.
-	OutputSchema map[string]any `json:"outputSchema"` // JSON schema to validate against the action's output.
-	Metadata     map[string]any `json:"metadata"`     // Metadata for the action.
+	desc *api.ActionDesc                // Descriptor of the action.
 }
 
 type noStream = func(context.Context, struct{}) error
 
 // NewAction creates a new non-streaming [Action] without registering it.
-// If inputSchema is nil, it is inferred from the function's input type.
+// If inputSchema is nil, it is inferred from the function's input api.
 func NewAction[In, Out any](
 	name string,
-	atype ActionType,
+	atype api.ActionType,
 	metadata map[string]any,
 	inputSchema map[string]any,
 	fn Func[In, Out],
@@ -110,10 +69,10 @@ func NewAction[In, Out any](
 }
 
 // NewStreamingAction creates a new streaming [Action] without registering it.
-// If inputSchema is nil, it is inferred from the function's input type.
+// If inputSchema is nil, it is inferred from the function's input api.
 func NewStreamingAction[In, Out, Stream any](
 	name string,
-	atype ActionType,
+	atype api.ActionType,
 	metadata map[string]any,
 	inputSchema map[string]any,
 	fn StreamingFunc[In, Out, Stream],
@@ -122,11 +81,11 @@ func NewStreamingAction[In, Out, Stream any](
 }
 
 // DefineAction creates a new non-streaming Action and registers it.
-// If inputSchema is nil, it is inferred from the function's input type.
+// If inputSchema is nil, it is inferred from the function's input api.
 func DefineAction[In, Out any](
-	r *registry.Registry,
+	r api.Registry,
 	name string,
-	atype ActionType,
+	atype api.ActionType,
 	metadata map[string]any,
 	inputSchema map[string]any,
 	fn Func[In, Out],
@@ -138,11 +97,11 @@ func DefineAction[In, Out any](
 }
 
 // DefineStreamingAction creates a new streaming action and registers it.
-// If inputSchema is nil, it is inferred from the function's input type.
+// If inputSchema is nil, it is inferred from the function's input api.
 func DefineStreamingAction[In, Out, Stream any](
-	r *registry.Registry,
+	r api.Registry,
 	name string,
-	atype ActionType,
+	atype api.ActionType,
 	metadata map[string]any,
 	inputSchema map[string]any,
 	fn StreamingFunc[In, Out, Stream],
@@ -152,16 +111,16 @@ func DefineStreamingAction[In, Out, Stream any](
 
 // defineAction creates an action and registers it with the given Registry.
 func defineAction[In, Out, Stream any](
-	r *registry.Registry,
+	r api.Registry,
 	name string,
-	atype ActionType,
+	atype api.ActionType,
 	metadata map[string]any,
 	inputSchema map[string]any,
 	fn StreamingFunc[In, Out, Stream],
 ) *ActionDef[In, Out, Stream] {
 	a := newAction(name, atype, metadata, inputSchema, fn)
-	provider, id := ParseName(name)
-	key := NewKey(atype, provider, id)
+	provider, id := api.ParseName(name)
+	key := api.NewKey(atype, provider, id)
 	r.RegisterAction(key, a)
 	return a
 }
@@ -171,7 +130,7 @@ func defineAction[In, Out, Stream any](
 // If inputSchema is nil, it is inferred from In.
 func newAction[In, Out, Stream any](
 	name string,
-	atype ActionType,
+	atype api.ActionType,
 	metadata map[string]any,
 	inputSchema map[string]any,
 	fn StreamingFunc[In, Out, Stream],
@@ -199,7 +158,7 @@ func newAction[In, Out, Stream any](
 			tracing.SetCustomMetadataAttr(ctx, "subtype", string(atype))
 			return fn(ctx, input, cb)
 		},
-		desc: &ActionDesc{
+		desc: &api.ActionDesc{
 			Type:         atype,
 			Key:          fmt.Sprintf("/%s/%s", atype, name),
 			Name:         name,
@@ -287,21 +246,21 @@ func (a *ActionDef[In, Out, Stream]) RunJSON(ctx context.Context, input json.Raw
 }
 
 // Desc returns a descriptor of the action.
-func (a *ActionDef[In, Out, Stream]) Desc() ActionDesc {
+func (a *ActionDef[In, Out, Stream]) Desc() api.ActionDesc {
 	return *a.desc
 }
 
 // Register registers the action with the given registry.
-func (a *ActionDef[In, Out, Stream]) Register(r *registry.Registry) {
+func (a *ActionDef[In, Out, Stream]) Register(r api.Registry) {
 	r.RegisterAction(a.desc.Key, a)
 }
 
 // ResolveActionFor returns the action for the given key in the global registry,
 // or nil if there is none.
-// It panics if the action is of the wrong type.
-func ResolveActionFor[In, Out, Stream any](r *registry.Registry, atype ActionType, name string) *ActionDef[In, Out, Stream] {
-	provider, id := ParseName(name)
-	key := NewKey(atype, provider, id)
+// It panics if the action is of the wrong api.
+func ResolveActionFor[In, Out, Stream any](r api.Registry, atype api.ActionType, name string) *ActionDef[In, Out, Stream] {
+	provider, id := api.ParseName(name)
+	key := api.NewKey(atype, provider, id)
 	a := r.ResolveAction(key)
 	if a == nil {
 		return nil
@@ -311,50 +270,13 @@ func ResolveActionFor[In, Out, Stream any](r *registry.Registry, atype ActionTyp
 
 // LookupActionFor returns the action for the given key in the global registry,
 // or nil if there is none.
-// It panics if the action is of the wrong type.
-func LookupActionFor[In, Out, Stream any](r *registry.Registry, atype ActionType, name string) *ActionDef[In, Out, Stream] {
-	provider, id := ParseName(name)
-	key := NewKey(atype, provider, id)
+// It panics if the action is of the wrong api.
+func LookupActionFor[In, Out, Stream any](r api.Registry, atype api.ActionType, name string) *ActionDef[In, Out, Stream] {
+	provider, id := api.ParseName(name)
+	key := api.NewKey(atype, provider, id)
 	a := r.LookupAction(key)
 	if a == nil {
 		return nil
 	}
 	return a.(*ActionDef[In, Out, Stream])
-}
-
-// NewKey creates a new action key for the given type, provider, and name.
-func NewKey(typ ActionType, provider, id string) string {
-	if provider != "" {
-		return fmt.Sprintf("/%s/%s/%s", typ, provider, id)
-	}
-	return fmt.Sprintf("/%s/%s", typ, id)
-}
-
-// ParseKey parses an action key into a type, provider, and name.
-func ParseKey(key string) (ActionType, string, string) {
-	parts := strings.Split(key, "/")
-	if len(parts) < 4 || parts[0] != "" {
-		// Return empty values if the key doesn't have the expected format
-		return "", "", ""
-	}
-	name := strings.Join(parts[3:], "/")
-	return ActionType(parts[1]), parts[2], name
-}
-
-// NewName creates a new action name for the given provider and id.
-func NewName(provider, id string) string {
-	if provider != "" {
-		return fmt.Sprintf("%s/%s", provider, id)
-	}
-	return id
-}
-
-// ParseName parses an action name into a provider and id.
-func ParseName(name string) (string, string) {
-	parts := strings.Split(name, "/")
-	if len(parts) < 2 {
-		return "", name
-	}
-	id := strings.Join(parts[1:], "/")
-	return parts[0], id
 }

--- a/go/core/action_test.go
+++ b/go/core/action_test.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/registry"
 )
@@ -32,7 +33,7 @@ func inc(_ context.Context, x int, _ noStream) (int, error) {
 
 func TestActionRun(t *testing.T) {
 	r := registry.New()
-	a := defineAction(r, "test/inc", ActionTypeCustom, nil, nil, inc)
+	a := defineAction(r, "test/inc", api.ActionTypeCustom, nil, nil, inc)
 	got, err := a.Run(context.Background(), 3, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +45,7 @@ func TestActionRun(t *testing.T) {
 
 func TestActionRunJSON(t *testing.T) {
 	r := registry.New()
-	a := defineAction(r, "test/inc", ActionTypeCustom, nil, nil, inc)
+	a := defineAction(r, "test/inc", api.ActionTypeCustom, nil, nil, inc)
 	input := []byte("3")
 	want := []byte("4")
 	got, err := a.RunJSON(context.Background(), input, nil)
@@ -71,7 +72,7 @@ func count(ctx context.Context, n int, cb func(context.Context, int) error) (int
 func TestActionStreaming(t *testing.T) {
 	ctx := context.Background()
 	r := registry.New()
-	a := defineAction(r, "test/count", ActionTypeCustom, nil, nil, count)
+	a := defineAction(r, "test/count", api.ActionTypeCustom, nil, nil, count)
 	const n = 3
 
 	// Non-streaming.
@@ -105,8 +106,8 @@ func TestActionTracing(t *testing.T) {
 	r := registry.New()
 	tc := tracing.NewTestOnlyTelemetryClient()
 	tracing.WriteTelemetryImmediate(tc)
-	name := NewName("test", "TestTracing-inc")
-	a := defineAction(r, name, ActionTypeCustom, nil, nil, inc)
+	name := api.NewName("test", "TestTracing-inc")
+	a := defineAction(r, name, api.ActionTypeCustom, nil, nil, inc)
 	if _, err := a.Run(context.Background(), 3, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/go/core/api/action.go
+++ b/go/core/api/action.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Action is the interface that all Genkit primitives (e.g. flows, models, tools) have in common.
+type Action interface {
+	Registerable
+	// Name returns the name of the action.
+	Name() string
+	// RunJSON runs the action with the given JSON input and streaming callback and returns the output as JSON.
+	RunJSON(ctx context.Context, input json.RawMessage, cb func(context.Context, json.RawMessage) error) (json.RawMessage, error)
+	// Desc returns a descriptor of the action.
+	Desc() ActionDesc
+}
+
+// Registerable allows a primitive to be registered with a registry.
+type Registerable interface {
+	Register(r Registry)
+}
+
+// An ActionType is the kind of an action.
+type ActionType string
+
+const (
+	ActionTypeRetriever        ActionType = "retriever"
+	ActionTypeIndexer          ActionType = "indexer"
+	ActionTypeEmbedder         ActionType = "embedder"
+	ActionTypeEvaluator        ActionType = "evaluator"
+	ActionTypeFlow             ActionType = "flow"
+	ActionTypeModel            ActionType = "model"
+	ActionTypeExecutablePrompt ActionType = "executable-prompt"
+	ActionTypeResource         ActionType = "resource"
+	ActionTypeTool             ActionType = "tool"
+	ActionTypeUtil             ActionType = "util"
+	ActionTypeCustom           ActionType = "custom"
+)
+
+// ActionDesc is a descriptor of an action.
+type ActionDesc struct {
+	Type         ActionType     `json:"type"`         // Type of the action.
+	Key          string         `json:"key"`          // Key of the action.
+	Name         string         `json:"name"`         // Name of the action.
+	Description  string         `json:"description"`  // Description of the action.
+	InputSchema  map[string]any `json:"inputSchema"`  // JSON schema to validate against the action's input.
+	OutputSchema map[string]any `json:"outputSchema"` // JSON schema to validate against the action's output.
+	Metadata     map[string]any `json:"metadata"`     // Metadata for the action.
+}

--- a/go/core/api/environment.go
+++ b/go/core/api/environment.go
@@ -1,0 +1,41 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import "os"
+
+// An Environment is the execution context in which the program is running.
+type Environment string
+
+const (
+	EnvironmentDev  Environment = "dev"  // development: testing, debugging, etc.
+	EnvironmentProd Environment = "prod" // production: user data, SLOs, etc.
+)
+
+// CurrentEnvironment returns the currently active environment.
+func CurrentEnvironment() Environment {
+	if v := os.Getenv("GENKIT_ENV"); v != "" {
+		return Environment(v)
+	}
+	return EnvironmentProd
+}
+
+// Registry constants
+const (
+	DefaultModelKey = "genkit/defaultModel"
+	PromptDirKey    = "genkit/promptDir"
+)

--- a/go/core/api/plugin.go
+++ b/go/core/api/plugin.go
@@ -14,12 +14,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package genkit
+package api
 
 import (
 	"context"
-
-	"github.com/firebase/genkit/go/core"
 )
 
 // Plugin is the interface implemented by types that extend Genkit's functionality.
@@ -31,14 +29,14 @@ type Plugin interface {
 	// This name is used for registration and lookup.
 	Name() string
 	// Init initializes the plugin. It is called once during [Init].
-	Init(ctx context.Context) []core.Action
+	Init(ctx context.Context) []Action
 }
 
 // DynamicPlugin is a [Plugin] that can dynamically resolve actions.
 type DynamicPlugin interface {
 	Plugin
-	// ListActions returns a list of action descriptors that the plugin is capable of resolving to [core.Action]s.
-	ListActions(ctx context.Context) []core.ActionDesc
-	// ResolveAction resolves an action type and name to a [core.Action].
-	ResolveAction(atype core.ActionType, name string) core.Action
+	// ListActions returns a list of action descriptors that the plugin is capable of resolving to [Action]s.
+	ListActions(ctx context.Context) []ActionDesc
+	// ResolveAction resolves an action type and name to a [Action].
+	ResolveAction(atype ActionType, name string) Action
 }

--- a/go/core/api/registry.go
+++ b/go/core/api/registry.go
@@ -1,0 +1,86 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"github.com/google/dotprompt/go/dotprompt"
+)
+
+// Registry holds all registered actions and associated types,
+// and provides methods to register, query, and look up actions.
+type Registry interface {
+	// NewChild creates a new child registry that inherits from this registry.
+	// Child registries are cheap to create and will fall back to the parent
+	// for lookups if a value is not found in the child.
+	NewChild() Registry
+
+	// IsChild returns true if the registry is a child of another registry.
+	IsChild() bool
+
+	// RegisterPlugin records the plugin in the registry.
+	// It panics if a plugin with the same name is already registered.
+	RegisterPlugin(name string, p Plugin)
+
+	// RegisterAction records the action in the registry.
+	// It panics if an action with the same type, provider and name is already
+	// registered.
+	RegisterAction(key string, action Action)
+
+	// RegisterValue records an arbitrary value in the registry.
+	// It panics if a value with the same name is already registered.
+	RegisterValue(name string, value any)
+
+	// LookupPlugin returns the plugin for the given name.
+	// It first checks the current registry, then falls back to the parent if not found.
+	// Returns nil if the plugin is not found in the registry hierarchy.
+	LookupPlugin(name string) Plugin
+
+	// LookupAction returns the action for the given key.
+	// It first checks the current registry, then falls back to the parent if not found.
+	LookupAction(key string) Action
+
+	// LookupValue returns the value for the given name.
+	// It first checks the current registry, then falls back to the parent if not found.
+	// Returns nil if the value is not found in the registry hierarchy.
+	LookupValue(name string) any
+
+	// ResolveAction looks up an action by key. If the action is not found, it attempts dynamic resolution.
+	// Returns the action if found, or nil if not found.
+	ResolveAction(key string) Action
+
+	// ListActions returns a list of all registered actions.
+	// This includes actions from both the current registry and its parent hierarchy.
+	// Child registry actions take precedence over parent actions with the same key.
+	ListActions() []Action
+
+	// ListPlugins returns a list of all registered plugins.
+	ListPlugins() []Plugin
+
+	// ListValues returns a list of values of all registered values.
+	// This includes values from both the current registry and its parent hierarchy.
+	// Child registry values take precedence over parent values with the same key.
+	ListValues() map[string]any
+
+	// RegisterPartial adds the partial to the list of partials to the dotprompt instance
+	RegisterPartial(name string, source string)
+
+	// RegisterHelper adds a helper function to the dotprompt instance
+	RegisterHelper(name string, fn any)
+
+	// Dotprompt returns the dotprompt instance.
+	Dotprompt() *dotprompt.Dotprompt
+}

--- a/go/core/api/utils.go
+++ b/go/core/api/utils.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NewKey creates a new action key for the given type, provider, and name.
+func NewKey(typ ActionType, provider, id string) string {
+	if provider != "" {
+		return fmt.Sprintf("/%s/%s/%s", typ, provider, id)
+	}
+	return fmt.Sprintf("/%s/%s", typ, id)
+}
+
+// ParseKey parses an action key into a type, provider, and name.
+func ParseKey(key string) (ActionType, string, string) {
+	parts := strings.Split(key, "/")
+	if len(parts) < 4 || parts[0] != "" {
+		// Return empty values if the key doesn't have the expected format
+		return "", "", ""
+	}
+	name := strings.Join(parts[3:], "/")
+	return ActionType(parts[1]), parts[2], name
+}
+
+// NewName creates a new action name for the given provider and id.
+func NewName(provider, id string) string {
+	if provider != "" {
+		return fmt.Sprintf("%s/%s", provider, id)
+	}
+	return id
+}
+
+// ParseName parses an action name into a provider and id.
+func ParseName(name string) (string, string) {
+	parts := strings.Split(name, "/")
+	if len(parts) < 2 {
+		return "", name
+	}
+	id := strings.Join(parts[1:], "/")
+	return parts[0], id
+}

--- a/go/core/flow.go
+++ b/go/core/flow.go
@@ -22,9 +22,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/base"
-	"github.com/firebase/genkit/go/internal/registry"
 )
 
 // A Flow is a user-defined Action. A Flow[In, Out, Stream] represents a function from In to Out. The Stream parameter is for flows that support streaming: providing their results incrementally.
@@ -44,8 +44,8 @@ var flowContextKey = base.NewContextKey[*flowContext]()
 type flowContext struct{}
 
 // DefineFlow creates a Flow that runs fn, and registers it as an action. fn takes an input of type In and returns an output of type Out.
-func DefineFlow[In, Out any](r *registry.Registry, name string, fn Func[In, Out]) *Flow[In, Out, struct{}] {
-	return (*Flow[In, Out, struct{}])(DefineAction(r, name, ActionTypeFlow, nil, nil, func(ctx context.Context, input In) (Out, error) {
+func DefineFlow[In, Out any](r api.Registry, name string, fn Func[In, Out]) *Flow[In, Out, struct{}] {
+	return (*Flow[In, Out, struct{}])(DefineAction(r, name, api.ActionTypeFlow, nil, nil, func(ctx context.Context, input In) (Out, error) {
 		fc := &flowContext{}
 		ctx = flowContextKey.NewContext(ctx, fc)
 		return fn(ctx, input)
@@ -61,8 +61,8 @@ func DefineFlow[In, Out any](r *registry.Registry, name string, fn Func[In, Out]
 // stream the results by invoking the callback periodically, ultimately returning
 // with a final return value that includes all the streamed data.
 // Otherwise, it should ignore the callback and just return a result.
-func DefineStreamingFlow[In, Out, Stream any](r *registry.Registry, name string, fn StreamingFunc[In, Out, Stream]) *Flow[In, Out, Stream] {
-	return (*Flow[In, Out, Stream])(DefineStreamingAction(r, name, ActionTypeFlow, nil, nil, func(ctx context.Context, input In, cb func(context.Context, Stream) error) (Out, error) {
+func DefineStreamingFlow[In, Out, Stream any](r api.Registry, name string, fn StreamingFunc[In, Out, Stream]) *Flow[In, Out, Stream] {
+	return (*Flow[In, Out, Stream])(DefineStreamingAction(r, name, api.ActionTypeFlow, nil, nil, func(ctx context.Context, input In, cb func(context.Context, Stream) error) (Out, error) {
 		fc := &flowContext{}
 		ctx = flowContextKey.NewContext(ctx, fc)
 		return fn(ctx, input, cb)
@@ -104,7 +104,7 @@ func (f *Flow[In, Out, Stream]) RunJSON(ctx context.Context, input json.RawMessa
 }
 
 // Desc returns the descriptor of the flow.
-func (f *Flow[In, Out, Stream]) Desc() ActionDesc {
+func (f *Flow[In, Out, Stream]) Desc() api.ActionDesc {
 	return (*ActionDef[In, Out, Stream])(f).Desc()
 }
 
@@ -146,7 +146,7 @@ func (f *Flow[In, Out, Stream]) Stream(ctx context.Context, input In) func(func(
 }
 
 // Register registers the flow with the given registry.
-func (f *Flow[In, Out, Stream]) Register(r *registry.Registry) {
+func (f *Flow[In, Out, Stream]) Register(r api.Registry) {
 	(*ActionDef[In, Out, Stream])(f).Register(r)
 }
 

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -25,11 +25,11 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
@@ -44,9 +44,9 @@ type Genkit struct {
 
 // genkitOptions are options for configuring the Genkit instance.
 type genkitOptions struct {
-	DefaultModel string   // Default model to use if no other model is specified.
-	PromptDir    string   // Directory where dotprompts are stored. Will be loaded automatically on initialization.
-	Plugins      []Plugin // Plugin to initialize automatically.
+	DefaultModel string       // Default model to use if no other model is specified.
+	PromptDir    string       // Directory where dotprompts are stored. Will be loaded automatically on initialization.
+	Plugins      []api.Plugin // Plugin to initialize automatically.
 }
 
 type GenkitOption interface {
@@ -82,7 +82,7 @@ func (o *genkitOptions) apply(gOpts *genkitOptions) error {
 // WithPlugins provides a list of plugins to initialize when creating the Genkit instance.
 // Each plugin's [Plugin.Init] method will be called sequentially during [Init].
 // This option can only be applied once.
-func WithPlugins(plugins ...Plugin) GenkitOption {
+func WithPlugins(plugins ...api.Plugin) GenkitOption {
 	return &genkitOptions{Plugins: plugins}
 }
 
@@ -189,26 +189,14 @@ func Init(ctx context.Context, opts ...GenkitOption) *Genkit {
 		r.RegisterPlugin(plugin.Name(), plugin)
 	}
 
-	r.ActionResolver = func(actionType, provider, id string) {
-		plugins := r.ListPlugins()
-		for _, plugin := range plugins {
-			if dp, ok := plugin.(DynamicPlugin); ok && dp.Name() == provider {
-				action := dp.ResolveAction(core.ActionType(actionType), id)
-				if action != nil {
-					action.Register(r)
-				}
-			}
-		}
-	}
-
 	ai.ConfigureFormats(r)
 	ai.DefineGenerateAction(ctx, r)
 	ai.LoadPromptDir(r, gOpts.PromptDir, "")
 
-	r.RegisterValue("genkit/defaultModel", gOpts.DefaultModel)
-	r.RegisterValue("genkit/promptDir", gOpts.PromptDir)
+	r.RegisterValue(api.DefaultModelKey, gOpts.DefaultModel)
+	r.RegisterValue(api.PromptDirKey, gOpts.PromptDir)
 
-	if registry.CurrentEnvironment() == registry.EnvironmentDev {
+	if api.CurrentEnvironment() == api.EnvironmentDev {
 		errCh := make(chan error, 1)
 		serverStartCh := make(chan struct{})
 
@@ -234,14 +222,14 @@ func Init(ctx context.Context, opts ...GenkitOption) *Genkit {
 	return g
 }
 
-// RegisterAction registers a [core.Action] that was previously created by calling
+// RegisterAction registers a [api.Action] that was previously created by calling
 // NewX instead of DefineX.
 //
 // Example:
 //
 //	model := ai.NewModel(...)
-//	genkit.RegisterAction(g, model.(core.Action))
-func RegisterAction(g *Genkit, action core.Action) {
+//	genkit.RegisterAction(g, model)
+func RegisterAction(g *Genkit, action api.Registerable) {
 	action.Register(g.reg)
 }
 
@@ -357,17 +345,16 @@ func Run[Out any](ctx context.Context, name string, fn func() (Out, error)) (Out
 	return core.Run(ctx, name, fn)
 }
 
-// ListFlows returns a slice of all [core.Action] instances that represent
+// ListFlows returns a slice of all [api.Action] instances that represent
 // flows registered with the Genkit instance `g`.
 // This is useful for introspection or for dynamically exposing flow endpoints,
 // for example, in an HTTP server.
-func ListFlows(g *Genkit) []core.Action {
+func ListFlows(g *Genkit) []api.Action {
 	acts := listActions(g)
-	flows := []core.Action{}
+	flows := []api.Action{}
 	for _, act := range acts {
-		if act.Type == core.ActionTypeFlow {
-			key := fmt.Sprintf("/%s/%s", act.Type, act.Name)
-			flows = append(flows, g.reg.LookupAction(key).(core.Action))
+		if act.Type == api.ActionTypeFlow {
+			flows = append(flows, g.reg.LookupAction(act.Key))
 		}
 	}
 	return flows
@@ -379,20 +366,10 @@ func ListFlows(g *Genkit) []core.Action {
 func ListTools(g *Genkit) []ai.Tool {
 	acts := g.reg.ListActions()
 	tools := []ai.Tool{}
-	for _, act := range acts {
-		action, ok := act.(core.Action)
-		if !ok {
-			continue
-		}
-		actionDesc := action.Desc()
-		if strings.HasPrefix(actionDesc.Key, "/"+string(core.ActionTypeTool)+"/") {
-			// Extract tool name from key
-			toolName := strings.TrimPrefix(actionDesc.Key, "/"+string(core.ActionTypeTool)+"/")
-			// Lookup the actual tool
-			tool := LookupTool(g, toolName)
-			if tool != nil {
-				tools = append(tools, tool)
-			}
+	for _, action := range acts {
+		tool := LookupTool(g, action.Desc().Name)
+		if tool != nil {
+			tools = append(tools, tool)
 		}
 	}
 	return tools
@@ -815,14 +792,9 @@ func LookupEmbedder(g *Genkit, name string) ai.Embedder {
 // Plugins are registered during initialization via [WithPlugins].
 // It returns the plugin instance as `Plugin` if found, or `nil` otherwise.
 // The caller is responsible for type-asserting the returned value to the
-// specific plugin type.
-func LookupPlugin(g *Genkit, name string) Plugin {
-	switch p := g.reg.LookupPlugin(name).(type) {
-	case Plugin:
-		return p
-	default:
-		return nil
-	}
+// specific plugin api.
+func LookupPlugin(g *Genkit, name string) api.Plugin {
+	return g.reg.LookupPlugin(name)
 }
 
 // DefineEvaluator defines an evaluator that processes test cases one by one,
@@ -1061,12 +1033,9 @@ func ListResources(g *Genkit) []ai.Resource {
 	acts := g.reg.ListActions()
 	resources := []ai.Resource{}
 	for _, act := range acts {
-		action, ok := act.(core.Action)
-		if !ok {
-			continue
-		}
+		action := act
 		actionDesc := action.Desc()
-		if actionDesc.Type == core.ActionTypeResource {
+		if actionDesc.Type == api.ActionTypeResource {
 			// Look up the resource wrapper
 			if resourceValue := g.reg.LookupValue(fmt.Sprintf("resource/%s", actionDesc.Name)); resourceValue != nil {
 				if resource, ok := resourceValue.(ai.Resource); ok {

--- a/go/genkit/reflection_test.go
+++ b/go/genkit/reflection_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/tracing"
 )
 
@@ -86,8 +87,8 @@ func TestServeMux(t *testing.T) {
 	tc := tracing.NewTestOnlyTelemetryClient()
 	tracing.WriteTelemetryImmediate(tc)
 
-	core.DefineAction(g.reg, "test/inc", core.ActionTypeCustom, nil, nil, inc)
-	core.DefineAction(g.reg, "test/dec", core.ActionTypeCustom, nil, nil, dec)
+	core.DefineAction(g.reg, "test/inc", api.ActionTypeCustom, nil, nil, inc)
+	core.DefineAction(g.reg, "test/dec", api.ActionTypeCustom, nil, nil, dec)
 
 	ts := httptest.NewServer(serveMux(g))
 	defer ts.Close()
@@ -112,7 +113,7 @@ func TestServeMux(t *testing.T) {
 		}
 		defer res.Body.Close()
 
-		var actions map[string]core.ActionDesc
+		var actions map[string]api.ActionDesc
 		if err := json.NewDecoder(res.Body).Decode(&actions); err != nil {
 			t.Fatal(err)
 		}
@@ -201,7 +202,7 @@ func TestServeMux(t *testing.T) {
 			}
 			return x, nil
 		}
-		core.DefineStreamingAction(g.reg, "test/streaming", core.ActionTypeCustom, nil, nil, streamingInc)
+		core.DefineStreamingAction(g.reg, "test/streaming", api.ActionTypeCustom, nil, nil, streamingInc)
 
 		body := `{"key": "/custom/test/streaming", "input": 3}`
 		req, err := http.NewRequest("POST", ts.URL+"/api/runAction?stream=true", strings.NewReader(body))

--- a/go/genkit/servers.go
+++ b/go/genkit/servers.go
@@ -29,6 +29,7 @@ import (
 	"sync/atomic"
 
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/logger"
 )
 
@@ -62,10 +63,10 @@ func WithContextProviders(ctxProviders ...core.ContextProvider) HandlerOption {
 //
 // Example:
 //
-//	genkit.Handler(g, genkit.WithContextProviders(func(ctx context.Context, req core.RequestData) (core.ActionContext, error) {
-//		return core.ActionContext{"myKey": "myValue"}, nil
+//	genkit.Handler(g, genkit.WithContextProviders(func(ctx context.Context, req core.RequestData) (api.ActionContext, error) {
+//		return api.ActionContext{"myKey": "myValue"}, nil
 //	}))
-func Handler(a core.Action, opts ...HandlerOption) http.HandlerFunc {
+func Handler(a api.Action, opts ...HandlerOption) http.HandlerFunc {
 	params := &handlerParams{}
 	for _, opt := range opts {
 		opt.apply(params)
@@ -101,7 +102,7 @@ func wrapHandler(h func(http.ResponseWriter, *http.Request) error) http.HandlerF
 }
 
 // handler returns an HTTP handler function that serves the action with the provided params. Responses are written in server-sent events (SSE) format.
-func handler(a core.Action, params *handlerParams) func(http.ResponseWriter, *http.Request) error {
+func handler(a api.Action, params *handlerParams) func(http.ResponseWriter, *http.Request) error {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		if a == nil {
 			return errors.New("action is nil; cannot serve")

--- a/go/internal/cmd/jsonschemagen/jsonschemagen.go
+++ b/go/internal/cmd/jsonschemagen/jsonschemagen.go
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // A simple, self-contained code generator for JSON Schema.
-// It converts a JSON Schema to equivalent Go types.
+// It converts a JSON Schema to equivalent Go api.
 package main
 
 import (
@@ -95,13 +95,13 @@ func run(infile, defaultPkgPath, configFile, outRoot string) error {
 	}
 
 	// The defs field of the top-level schema is the only interesting part.
-	// It is a map from type name to JSON schema for that type.
+	// It is a map from type name to JSON schema for that api.
 	schemas := schema.Defs
 
 	// Many of the types are anonymous, used directly as the type of fields.
 	// We would end up generating something like
 	//     someField struct { x int; y bool}
-	// While that is legal Go, it is hard to construct values of those types.
+	// While that is legal Go, it is hard to construct values of those api.
 	// Hoist all anonymous types to top level and name them.
 	// We do this as a transformation on the map of schemas.
 	nameAnonymousTypes(schemas)
@@ -521,7 +521,7 @@ func (g *generator) typeExpr(s *Schema) (string, error) {
 	case "number":
 		return "float64", nil
 	case "":
-		// Assume the empty schema, which means any type.
+		// Assume the empty schema, which means any api.
 		return "any", nil
 	default:
 		return "", fmt.Errorf("typeExpr can't handle type %q", typ)
@@ -586,7 +586,7 @@ type itemConfig struct {
 // The config file is line-oriented. Empty lines and lines beginning
 // with '#' are ignored.
 // Other lines start with a word which names either a package, a type or the
-// field of a type (as TYPE.FIELD).
+// field of a type (as api.FIELD).
 // Except for packages, the names are always the original JSONSchema names, not Go names.
 // The rest of the line is a directive; one of
 //

--- a/go/internal/cmd/weave/weave.go
+++ b/go/internal/cmd/weave/weave.go
@@ -19,7 +19,7 @@
 //
 // Example usage:
 //
-//	$ go run internal/cmd/weave go-types.md > README.md
+//	$ go run internal/cmd/weave go-api.md > README.md
 //
 // The weave command copies lines of the input file to standard output, with two
 // exceptions:

--- a/go/plugins/alloydb/distance_strategy.go
+++ b/go/plugins/alloydb/distance_strategy.go
@@ -118,7 +118,7 @@ func (i IVFFlatOptions) Options() string {
 	return fmt.Sprintf("(lists = %d)", i.Lists)
 }
 
-// indexOptions returns the specific options for the index based on the index type.
+// indexOptions returns the specific options for the index based on the index api.
 func (index *BaseIndex) indexOptions() string {
 	return index.options.Options()
 }

--- a/go/plugins/alloydb/genkit.go
+++ b/go/plugins/alloydb/genkit.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 )
 
@@ -39,7 +39,7 @@ func (p *Postgres) Name() string {
 }
 
 // Init initialize the PostgreSQL
-func (p *Postgres) Init(ctx context.Context) []core.Action {
+func (p *Postgres) Init(ctx context.Context) []api.Action {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.initted {
@@ -54,7 +54,7 @@ func (p *Postgres) Init(ctx context.Context) []core.Action {
 		panic("postgres.Init engine has no pool")
 	}
 	p.initted = true
-	return []core.Action{}
+	return []api.Action{}
 }
 
 // Config provides configuration options for [DefineRetriever].

--- a/go/plugins/alloydb/mocks_test.go
+++ b/go/plugins/alloydb/mocks_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
 )
 
 type mockEmbedderFail struct{}
@@ -27,3 +28,4 @@ func (m mockEmbedderFail) Name() string { return "mock" }
 func (m mockEmbedderFail) Embed(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
 	return nil, errors.New("mock fail")
 }
+func (m mockEmbedderFail) Register(r api.Registry) {}

--- a/go/plugins/compat_oai/anthropic/anthropic.go
+++ b/go/plugins/compat_oai/anthropic/anthropic.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai"
 	"github.com/openai/openai-go/option"
@@ -93,7 +93,7 @@ func (a *Anthropic) Name() string {
 	return provider
 }
 
-func (a *Anthropic) Init(ctx context.Context) []core.Action {
+func (a *Anthropic) Init(ctx context.Context) []api.Action {
 	// Set the base URL
 	a.Opts = append(a.Opts, option.WithBaseURL(baseURL))
 
@@ -101,19 +101,19 @@ func (a *Anthropic) Init(ctx context.Context) []core.Action {
 	a.openAICompatible.Opts = a.Opts
 	compatActions := a.openAICompatible.Init(ctx)
 
-	var actions []core.Action
+	var actions []api.Action
 	actions = append(actions, compatActions...)
 
 	// define default models
 	for model, opts := range supportedModels {
-		actions = append(actions, a.DefineModel(model, opts).(core.Action))
+		actions = append(actions, a.DefineModel(model, opts).(api.Action))
 	}
 
 	return actions
 }
 
 func (a *Anthropic) Model(g *genkit.Genkit, id string) ai.Model {
-	return a.openAICompatible.Model(g, core.NewName(provider, id))
+	return a.openAICompatible.Model(g, api.NewName(provider, id))
 }
 
 func (a *Anthropic) DefineModel(id string, opts ai.ModelOptions) ai.Model {

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -24,7 +24,7 @@ import (
 	"github.com/openai/openai-go/shared"
 )
 
-// mapToStruct unmarshals a map[string]any to the expected config type.
+// mapToStruct unmarshals a map[string]any to the expected config api.
 func mapToStruct(m map[string]any, v any) error {
 	jsonData, err := json.Marshal(m)
 	if err != nil {

--- a/go/plugins/compat_oai/openai/openai.go
+++ b/go/plugins/compat_oai/openai/openai.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/compat_oai"
 	openaiGo "github.com/openai/openai-go"
@@ -175,7 +176,7 @@ func (o *OpenAI) Name() string {
 }
 
 // Init implements genkit.Plugin.
-func (o *OpenAI) Init(ctx context.Context) []core.Action {
+func (o *OpenAI) Init(ctx context.Context) []api.Action {
 	apiKey := o.APIKey
 
 	// if api key is not set, get it from environment variable
@@ -202,12 +203,12 @@ func (o *OpenAI) Init(ctx context.Context) []core.Action {
 	o.openAICompatible.Provider = provider
 	compatActions := o.openAICompatible.Init(ctx)
 
-	var actions []core.Action
+	var actions []api.Action
 	actions = append(actions, compatActions...)
 
 	// define default models
 	for model, opts := range supportedModels {
-		actions = append(actions, o.DefineModel(model, opts).(core.Action))
+		actions = append(actions, o.DefineModel(model, opts).(api.Action))
 	}
 
 	// define default embedders
@@ -218,14 +219,14 @@ func (o *OpenAI) Init(ctx context.Context) []core.Action {
 			Supports:     embedder.Supports,
 			Dimensions:   embedder.Dimensions,
 		}
-		actions = append(actions, o.DefineEmbedder(embedder.Name, opts).(core.Action))
+		actions = append(actions, o.DefineEmbedder(embedder.Name, opts).(api.Action))
 	}
 
 	return actions
 }
 
 func (o *OpenAI) Model(g *genkit.Genkit, name string) ai.Model {
-	return o.openAICompatible.Model(g, core.NewName(provider, name))
+	return o.openAICompatible.Model(g, api.NewName(provider, name))
 }
 
 func (o *OpenAI) DefineModel(id string, opts ai.ModelOptions) ai.Model {
@@ -237,13 +238,13 @@ func (o *OpenAI) DefineEmbedder(id string, opts *ai.EmbedderOptions) ai.Embedder
 }
 
 func (o *OpenAI) Embedder(g *genkit.Genkit, name string) ai.Embedder {
-	return o.openAICompatible.Embedder(g, core.NewName(provider, name))
+	return o.openAICompatible.Embedder(g, api.NewName(provider, name))
 }
 
-func (o *OpenAI) ListActions(ctx context.Context) []core.ActionDesc {
+func (o *OpenAI) ListActions(ctx context.Context) []api.ActionDesc {
 	return o.openAICompatible.ListActions(ctx)
 }
 
-func (o *OpenAI) ResolveAction(atype core.ActionType, name string) core.Action {
+func (o *OpenAI) ResolveAction(atype api.ActionType, name string) api.Action {
 	return o.openAICompatible.ResolveAction(atype, name)
 }

--- a/go/plugins/evaluators/evaluators.go
+++ b/go/plugins/evaluators/evaluators.go
@@ -14,7 +14,7 @@ import (
 
 	jsonata "github.com/blues/jsonata-go"
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/logger"
 )
 
@@ -58,7 +58,7 @@ func (ge *GenkitEval) Name() string {
 }
 
 // Init initializes the plugin.
-func (ge *GenkitEval) Init(ctx context.Context) []core.Action {
+func (ge *GenkitEval) Init(ctx context.Context) []api.Action {
 	if ge == nil {
 		ge = &GenkitEval{}
 	}
@@ -72,9 +72,9 @@ func (ge *GenkitEval) Init(ctx context.Context) []core.Action {
 	}
 	ge.initted = true
 
-	var actions []core.Action
+	var actions []api.Action
 	for _, metric := range ge.Metrics {
-		actions = append(actions, ConfigureMetric(metric).(core.Action))
+		actions = append(actions, ConfigureMetric(metric).(api.Action))
 	}
 	return actions
 }
@@ -98,7 +98,7 @@ func configureRegexEvaluator() ai.Evaluator {
 		Definition:  "Tests output against the regexp provided as reference",
 		IsBilled:    false,
 	}
-	return ai.NewEvaluator(core.NewName(provider, "regex"), &evalOptions, func(ctx context.Context, req *ai.EvaluatorCallbackRequest) (*ai.EvaluatorCallbackResponse, error) {
+	return ai.NewEvaluator(api.NewName(provider, "regex"), &evalOptions, func(ctx context.Context, req *ai.EvaluatorCallbackRequest) (*ai.EvaluatorCallbackResponse, error) {
 		dataPoint := req.Input
 		var score ai.Score
 		if dataPoint.Output == nil {
@@ -126,7 +126,7 @@ func configureRegexEvaluator() ai.Evaluator {
 		} else {
 			// Mark as failed if output is not string type
 			logger.FromContext(ctx).Debug("genkitEval",
-				"regex", fmt.Sprintf("Failed regex evaluation, as output is not string type. TestCaseId: %s", dataPoint.TestCaseId))
+				"regex", fmt.Sprintf("Failed regex evaluation, as output is not string api. TestCaseId: %s", dataPoint.TestCaseId))
 			score = ai.Score{
 				Score:  false,
 				Status: ai.ScoreStatusFail.String(),
@@ -146,7 +146,7 @@ func configureDeepEqualEvaluator() ai.Evaluator {
 		Definition:  "Tests equality of output against the provided reference",
 		IsBilled:    false,
 	}
-	return ai.NewEvaluator(core.NewName(provider, "deep_equal"), &evalOptions, func(ctx context.Context, req *ai.EvaluatorCallbackRequest) (*ai.EvaluatorCallbackResponse, error) {
+	return ai.NewEvaluator(api.NewName(provider, "deep_equal"), &evalOptions, func(ctx context.Context, req *ai.EvaluatorCallbackRequest) (*ai.EvaluatorCallbackResponse, error) {
 		dataPoint := req.Input
 		var score ai.Score
 		if dataPoint.Output == nil {
@@ -181,7 +181,7 @@ func configureJsonataEvaluator() ai.Evaluator {
 		Definition:  "Tests JSONata expression (provided in reference) against output",
 		IsBilled:    false,
 	}
-	return ai.NewEvaluator(core.NewName(provider, "jsonata"), &evalOptions, func(ctx context.Context, req *ai.EvaluatorCallbackRequest) (*ai.EvaluatorCallbackResponse, error) {
+	return ai.NewEvaluator(api.NewName(provider, "jsonata"), &evalOptions, func(ctx context.Context, req *ai.EvaluatorCallbackRequest) (*ai.EvaluatorCallbackResponse, error) {
 		dataPoint := req.Input
 		var score ai.Score
 		if dataPoint.Output == nil {

--- a/go/plugins/firebase/firebase.go
+++ b/go/plugins/firebase/firebase.go
@@ -26,7 +26,7 @@ import (
 
 	firebasev4 "firebase.google.com/go/v4"
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 )
 
@@ -49,7 +49,7 @@ func (f *Firebase) Name() string {
 }
 
 // Init initializes the Firebase plugin.
-func (f *Firebase) Init(ctx context.Context) []core.Action {
+func (f *Firebase) Init(ctx context.Context) []api.Action {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -76,7 +76,7 @@ func (f *Firebase) Init(ctx context.Context) []core.Action {
 	}
 
 	f.initted = true
-	return []core.Action{}
+	return []api.Action{}
 }
 
 // DefineRetriever defines a Retriever with the given configuration.

--- a/go/plugins/firebase/retriever.go
+++ b/go/plugins/firebase/retriever.go
@@ -22,6 +22,7 @@ import (
 	"cloud.google.com/go/firestore"
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 )
 
@@ -137,7 +138,7 @@ func defineFirestoreRetriever(g *genkit.Genkit, cfg RetrieverOptions, client *fi
 		},
 	}
 
-	return genkit.DefineRetriever(g, core.NewName(provider, cfg.Name), retOpts, retrieve), nil
+	return genkit.DefineRetriever(g, api.NewName(provider, cfg.Name), retOpts, retrieve), nil
 }
 
 // resolveFirestoreCollection resolves the Firestore collection name from the environment if necessary

--- a/go/plugins/firebase/retriever_test.go
+++ b/go/plugins/firebase/retriever_test.go
@@ -22,6 +22,7 @@ import (
 	"cloud.google.com/go/firestore"
 	firebasev4 "firebase.google.com/go/v4"
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"google.golang.org/api/iterator"
 )
@@ -121,6 +122,8 @@ func (e *MockEmbedder) Embed(ctx context.Context, req *ai.EmbedRequest) (*ai.Emb
 	}
 	return &ai.EmbedResponse{Embeddings: embeddings}, nil
 }
+
+func (e *MockEmbedder) Register(r api.Registry) {}
 
 // To run this test you must have a Firestore database initialized in a GCP project, with a vector indexed collection (of dimension 3).
 // Warning: This test will delete all documents in the collection in cleanup.

--- a/go/plugins/googlecloud/googlecloud.go
+++ b/go/plugins/googlecloud/googlecloud.go
@@ -30,7 +30,7 @@ import (
 	"cloud.google.com/go/logging"
 	mexporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
 	texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/tracing"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -56,13 +56,13 @@ func (gc *GoogleCloud) Name() string {
 
 // Init initializes all telemetry in this package.
 // In the dev environment, this does nothing unless [Options.ForceExport] is true.
-func (gc *GoogleCloud) Init(ctx context.Context) []core.Action {
+func (gc *GoogleCloud) Init(ctx context.Context) []api.Action {
 	if gc.ProjectID == "" {
 		panic("config missing ProjectID")
 	}
 	shouldExport := gc.ForceExport || os.Getenv("GENKIT_ENV") != "dev"
 	if !shouldExport {
-		return []core.Action{}
+		return []api.Action{}
 	}
 	// Add a SpanProcessor for tracing.
 	texp, err := texporter.New(texporter.WithProjectID(gc.ProjectID))
@@ -77,7 +77,7 @@ func (gc *GoogleCloud) Init(ctx context.Context) []core.Action {
 	if err := setLogHandler(gc.ProjectID, gc.LogLevel); err != nil {
 		panic(fmt.Errorf("googlecloud.Init: %w", err))
 	}
-	return []core.Action{}
+	return []api.Action{}
 }
 
 func setMeterProvider(projectID string, interval time.Duration) error {

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal"
 	"github.com/firebase/genkit/go/internal/base"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
@@ -99,7 +100,7 @@ func configToMap(config any) map[string]any {
 	return result
 }
 
-// mapToStruct unmarshals a map[string]any to the expected config type.
+// mapToStruct unmarshals a map[string]any to the expected config api.
 func mapToStruct(m map[string]any, v any) error {
 	jsonData, err := json.Marshal(m)
 	if err != nil {
@@ -184,7 +185,7 @@ func newModel(client *genai.Client, name string, opts ai.ModelOptions) ai.Model 
 			},
 		}))(fn)
 	}
-	return ai.NewModel(core.NewName(provider, name), meta, fn)
+	return ai.NewModel(api.NewName(provider, name), meta, fn)
 }
 
 // newEmbedder creates an embedder without registering it
@@ -198,7 +199,7 @@ func newEmbedder(client *genai.Client, name string, embedOpts *ai.EmbedderOption
 		embedOpts.ConfigSchema = core.InferSchemaMap(genai.EmbedContentConfig{})
 	}
 
-	return ai.NewEmbedder(core.NewName(provider, name), embedOpts, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+	return ai.NewEmbedder(api.NewName(provider, name), embedOpts, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
 		var content []*genai.Content
 		var embedConfig *genai.EmbedContentConfig
 

--- a/go/plugins/googlegenai/googlegenai.go
+++ b/go/plugins/googlegenai/googlegenai.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 
 	"google.golang.org/genai"
@@ -58,7 +58,7 @@ func (v *VertexAI) Name() string {
 // Init initializes the Google AI plugin and all known models and embedders.
 // After calling Init, you may call [DefineModel] and [DefineEmbedder] to create
 // and register any additional generative models and embedders
-func (ga *GoogleAI) Init(ctx context.Context) []core.Action {
+func (ga *GoogleAI) Init(ctx context.Context) []api.Action {
 	if ga == nil {
 		ga = &GoogleAI{}
 	}
@@ -94,7 +94,7 @@ func (ga *GoogleAI) Init(ctx context.Context) []core.Action {
 	ga.gclient = client
 	ga.initted = true
 
-	var actions []core.Action
+	var actions []api.Action
 
 	models, err := listModels(googleAIProvider)
 	if err != nil {
@@ -102,7 +102,7 @@ func (ga *GoogleAI) Init(ctx context.Context) []core.Action {
 	}
 	for n, mi := range models {
 		model := newModel(ga.gclient, n, mi)
-		actions = append(actions, model.(core.Action))
+		actions = append(actions, model.(api.Action))
 	}
 
 	embedders, err := listEmbedders(gc.Backend)
@@ -111,7 +111,7 @@ func (ga *GoogleAI) Init(ctx context.Context) []core.Action {
 	}
 	for e, eOpts := range embedders {
 		embedder := newEmbedder(ga.gclient, e, &eOpts)
-		actions = append(actions, embedder.(core.Action))
+		actions = append(actions, embedder.(api.Action))
 	}
 
 	return actions
@@ -120,7 +120,7 @@ func (ga *GoogleAI) Init(ctx context.Context) []core.Action {
 // Init initializes the VertexAI plugin and all known models and embedders.
 // After calling Init, you may call [DefineModel] and [DefineEmbedder] to create
 // and register any additional generative models and embedders
-func (v *VertexAI) Init(ctx context.Context) []core.Action {
+func (v *VertexAI) Init(ctx context.Context) []api.Action {
 	if v == nil {
 		v = &VertexAI{}
 	}
@@ -167,7 +167,7 @@ func (v *VertexAI) Init(ctx context.Context) []core.Action {
 	v.gclient = client
 	v.initted = true
 
-	var actions []core.Action
+	var actions []api.Action
 
 	models, err := listModels(vertexAIProvider)
 	if err != nil {
@@ -175,7 +175,7 @@ func (v *VertexAI) Init(ctx context.Context) []core.Action {
 	}
 	for n, mi := range models {
 		model := newModel(v.gclient, n, mi)
-		actions = append(actions, model.(core.Action))
+		actions = append(actions, model.(api.Action))
 	}
 
 	embedders, err := listEmbedders(gc.Backend)
@@ -184,7 +184,7 @@ func (v *VertexAI) Init(ctx context.Context) []core.Action {
 	}
 	for e, eOpts := range embedders {
 		embedder := newEmbedder(v.gclient, e, &eOpts)
-		actions = append(actions, embedder.(core.Action))
+		actions = append(actions, embedder.(api.Action))
 	}
 
 	return actions
@@ -266,12 +266,12 @@ func (v *VertexAI) DefineEmbedder(g *genkit.Genkit, name string, embedOpts *ai.E
 
 // IsDefinedEmbedder reports whether the named [Embedder] is defined by this plugin.
 func (ga *GoogleAI) IsDefinedEmbedder(g *genkit.Genkit, name string) bool {
-	return genkit.LookupEmbedder(g, core.NewName(googleAIProvider, name)) != nil
+	return genkit.LookupEmbedder(g, api.NewName(googleAIProvider, name)) != nil
 }
 
 // IsDefinedEmbedder reports whether the named [Embedder] is defined by this plugin.
 func (v *VertexAI) IsDefinedEmbedder(g *genkit.Genkit, name string) bool {
-	return genkit.LookupEmbedder(g, core.NewName(vertexAIProvider, name)) != nil
+	return genkit.LookupEmbedder(g, api.NewName(vertexAIProvider, name)) != nil
 }
 
 // GoogleAIModelRef creates a new ModelRef for a Google AI model with the given name and configuration.
@@ -287,29 +287,29 @@ func VertexAIModelRef(name string, config *genai.GenerateContentConfig) ai.Model
 // GoogleAIModel returns the [ai.Model] with the given name.
 // It returns nil if the model was not defined.
 func GoogleAIModel(g *genkit.Genkit, name string) ai.Model {
-	return genkit.LookupModel(g, core.NewName(googleAIProvider, name))
+	return genkit.LookupModel(g, api.NewName(googleAIProvider, name))
 }
 
 // VertexAIModel returns the [ai.Model] with the given name.
 // It returns nil if the model was not defined.
 func VertexAIModel(g *genkit.Genkit, name string) ai.Model {
-	return genkit.LookupModel(g, core.NewName(vertexAIProvider, name))
+	return genkit.LookupModel(g, api.NewName(vertexAIProvider, name))
 }
 
 // GoogleAIEmbedder returns the [ai.Embedder] with the given name.
 // It returns nil if the embedder was not defined.
 func GoogleAIEmbedder(g *genkit.Genkit, name string) ai.Embedder {
-	return genkit.LookupEmbedder(g, core.NewName(googleAIProvider, name))
+	return genkit.LookupEmbedder(g, api.NewName(googleAIProvider, name))
 }
 
 // VertexAIEmbedder returns the [ai.Embedder] with the given name.
 // It returns nil if the embedder was not defined.
 func VertexAIEmbedder(g *genkit.Genkit, name string) ai.Embedder {
-	return genkit.LookupEmbedder(g, core.NewName(vertexAIProvider, name))
+	return genkit.LookupEmbedder(g, api.NewName(vertexAIProvider, name))
 }
 
-func (ga *GoogleAI) ListActions(ctx context.Context) []core.ActionDesc {
-	actions := []core.ActionDesc{}
+func (ga *GoogleAI) ListActions(ctx context.Context) []api.ActionDesc {
+	actions := []api.ActionDesc{}
 	models, err := listGenaiModels(ctx, ga.gclient)
 	if err != nil {
 		return nil
@@ -332,30 +332,30 @@ func (ga *GoogleAI) ListActions(ctx context.Context) []core.ActionDesc {
 		}
 		metadata["label"] = fmt.Sprintf("%s - %s", googleAILabelPrefix, name)
 
-		actions = append(actions, core.ActionDesc{
-			Type:     core.ActionTypeModel,
+		actions = append(actions, api.ActionDesc{
+			Type:     api.ActionTypeModel,
 			Name:     fmt.Sprintf("%s/%s", googleAIProvider, name),
-			Key:      fmt.Sprintf("/%s/%s/%s", core.ActionTypeModel, googleAIProvider, name),
+			Key:      fmt.Sprintf("/%s/%s/%s", api.ActionTypeModel, googleAIProvider, name),
 			Metadata: metadata,
 		})
 	}
 
 	for _, e := range models.embedders {
-		actions = append(actions, core.ActionDesc{
-			Type: core.ActionTypeEmbedder,
+		actions = append(actions, api.ActionDesc{
+			Type: api.ActionTypeEmbedder,
 			Name: fmt.Sprintf("%s/%s", googleAIProvider, e),
-			Key:  fmt.Sprintf("/%s/%s/%s", core.ActionTypeEmbedder, googleAIProvider, e),
+			Key:  fmt.Sprintf("/%s/%s/%s", api.ActionTypeEmbedder, googleAIProvider, e),
 		})
 	}
 
 	return actions
 }
 
-func (ga *GoogleAI) ResolveAction(atype core.ActionType, name string) core.Action {
+func (ga *GoogleAI) ResolveAction(atype api.ActionType, name string) api.Action {
 	switch atype {
-	case core.ActionTypeEmbedder:
-		return newEmbedder(ga.gclient, name, &ai.EmbedderOptions{}).(core.Action)
-	case core.ActionTypeModel:
+	case api.ActionTypeEmbedder:
+		return newEmbedder(ga.gclient, name, &ai.EmbedderOptions{}).(api.Action)
+	case api.ActionTypeModel:
 		var supports *ai.ModelSupports
 		if strings.Contains(name, "gemini") || strings.Contains(name, "gemma") {
 			supports = &Multimodal
@@ -366,14 +366,14 @@ func (ga *GoogleAI) ResolveAction(atype core.ActionType, name string) core.Actio
 			Stage:    ai.ModelStageStable,
 			Versions: []string{},
 			Supports: supports,
-		}).(core.Action)
+		}).(api.Action)
 	}
 
 	return nil
 }
 
-func (v *VertexAI) ListActions(ctx context.Context) []core.ActionDesc {
-	actions := []core.ActionDesc{}
+func (v *VertexAI) ListActions(ctx context.Context) []api.ActionDesc {
+	actions := []api.ActionDesc{}
 	models, err := listGenaiModels(ctx, v.gclient)
 	if err != nil {
 		return nil
@@ -395,30 +395,30 @@ func (v *VertexAI) ListActions(ctx context.Context) []core.ActionDesc {
 			},
 		}
 		metadata["label"] = fmt.Sprintf("%s - %s", vertexAILabelPrefix, name)
-		actions = append(actions, core.ActionDesc{
-			Type:     core.ActionTypeModel,
+		actions = append(actions, api.ActionDesc{
+			Type:     api.ActionTypeModel,
 			Name:     fmt.Sprintf("%s/%s", vertexAIProvider, name),
-			Key:      fmt.Sprintf("/%s/%s/%s", core.ActionTypeModel, vertexAIProvider, name),
+			Key:      fmt.Sprintf("/%s/%s/%s", api.ActionTypeModel, vertexAIProvider, name),
 			Metadata: metadata,
 		})
 	}
 
 	for _, e := range models.embedders {
-		actions = append(actions, core.ActionDesc{
-			Type: core.ActionTypeEmbedder,
+		actions = append(actions, api.ActionDesc{
+			Type: api.ActionTypeEmbedder,
 			Name: fmt.Sprintf("%s/%s", vertexAIProvider, e),
-			Key:  fmt.Sprintf("/%s/%s/%s", core.ActionTypeEmbedder, vertexAIProvider, e),
+			Key:  fmt.Sprintf("/%s/%s/%s", api.ActionTypeEmbedder, vertexAIProvider, e),
 		})
 	}
 
 	return actions
 }
 
-func (v *VertexAI) ResolveAction(atype core.ActionType, name string) core.Action {
+func (v *VertexAI) ResolveAction(atype api.ActionType, name string) api.Action {
 	switch atype {
-	case core.ActionTypeEmbedder:
-		return newEmbedder(v.gclient, name, &ai.EmbedderOptions{}).(core.Action)
-	case core.ActionTypeModel:
+	case api.ActionTypeEmbedder:
+		return newEmbedder(v.gclient, name, &ai.EmbedderOptions{}).(api.Action)
+	case api.ActionTypeModel:
 		var supports *ai.ModelSupports
 		if strings.Contains(name, "gemini") {
 			supports = &Multimodal
@@ -429,7 +429,7 @@ func (v *VertexAI) ResolveAction(atype core.ActionType, name string) core.Action
 			Stage:    ai.ModelStageStable,
 			Versions: []string{},
 			Supports: supports,
-		}).(core.Action)
+		}).(api.Action)
 	}
 	return nil
 }

--- a/go/plugins/localvec/localvec.go
+++ b/go/plugins/localvec/localvec.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/genkit"
 )
@@ -62,18 +63,18 @@ func DefineRetriever(g *genkit.Genkit, name string, cfg Config, opts *ai.Retriev
 		opts.ConfigSchema = core.InferSchemaMap(RetrieverOptions{})
 	}
 
-	return ds, genkit.DefineRetriever(g, core.NewName(provider, name), opts, ds.retrieve), nil
+	return ds, genkit.DefineRetriever(g, api.NewName(provider, name), opts, ds.retrieve), nil
 }
 
 // IsDefinedRetriever reports whether the named [Retriever] is defined by this plugin.
 func IsDefinedRetriever(g *genkit.Genkit, name string) bool {
-	return genkit.LookupRetriever(g, core.NewName(provider, name)) != nil
+	return genkit.LookupRetriever(g, api.NewName(provider, name)) != nil
 }
 
 // Retriever returns the retriever with the given name.
 // The name must match the [Config.Name] value passed to [Init].
 func Retriever(g *genkit.Genkit, name string) ai.Retriever {
-	return genkit.LookupRetriever(g, core.NewName(provider, name))
+	return genkit.LookupRetriever(g, api.NewName(provider, name))
 }
 
 // DocStore implements a local vector database.

--- a/go/plugins/ollama/embed.go
+++ b/go/plugins/ollama/embed.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 )
 
@@ -135,7 +135,7 @@ func (o *Ollama) DefineEmbedder(g *genkit.Genkit, serverAddress string, model st
 	if !o.initted {
 		panic("ollama.Init not called")
 	}
-	return genkit.DefineEmbedder(g, core.NewName(provider, serverAddress), embedOpts, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+	return genkit.DefineEmbedder(g, api.NewName(provider, serverAddress), embedOpts, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
 		if req.Options == nil {
 			req.Options = &EmbedOptions{Model: model}
 		}
@@ -148,11 +148,11 @@ func (o *Ollama) DefineEmbedder(g *genkit.Genkit, serverAddress string, model st
 
 // IsDefinedEmbedder reports whether the embedder with the given server address is defined by this plugin.
 func IsDefinedEmbedder(g *genkit.Genkit, serverAddress string) bool {
-	return genkit.LookupEmbedder(g, core.NewName(provider, serverAddress)) != nil
+	return genkit.LookupEmbedder(g, api.NewName(provider, serverAddress)) != nil
 }
 
 // Embedder returns the [ai.Embedder] with the given server address.
 // It returns nil if the embedder was not defined.
 func Embedder(g *genkit.Genkit, serverAddress string) ai.Embedder {
-	return genkit.LookupEmbedder(g, core.NewName(provider, serverAddress))
+	return genkit.LookupEmbedder(g, api.NewName(provider, serverAddress))
 }

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -32,7 +32,7 @@ import (
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
 )
@@ -88,21 +88,21 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 		Versions: []string{},
 	}
 	gen := &generator{model: model, serverAddress: o.ServerAddress}
-	return genkit.DefineModel(g, core.NewName(provider, model.Name), meta, gen.generate)
+	return genkit.DefineModel(g, api.NewName(provider, model.Name), meta, gen.generate)
 }
 
 // IsDefinedModel reports whether a model is defined.
 func IsDefinedModel(g *genkit.Genkit, name string) bool {
-	return genkit.LookupModel(g, core.NewName(provider, name)) != nil
+	return genkit.LookupModel(g, api.NewName(provider, name)) != nil
 }
 
 // Model returns the [ai.Model] with the given name.
 // It returns nil if the model was not configured.
 func Model(g *genkit.Genkit, name string) ai.Model {
-	return genkit.LookupModel(g, core.NewName(provider, name))
+	return genkit.LookupModel(g, api.NewName(provider, name))
 }
 
-// ModelDefinition represents a model with its name and type.
+// ModelDefinition represents a model with its name and api.
 type ModelDefinition struct {
 	Name string
 	Type string
@@ -208,7 +208,7 @@ func (o *Ollama) Name() string {
 // Init initializes the plugin.
 // Since Ollama models are locally hosted, the plugin doesn't initialize any default models.
 // After downloading a model, call [DefineModel] to use it.
-func (o *Ollama) Init(ctx context.Context) []core.Action {
+func (o *Ollama) Init(ctx context.Context) []api.Action {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if o.initted {
@@ -218,7 +218,7 @@ func (o *Ollama) Init(ctx context.Context) []core.Action {
 		panic("ollama: need ServerAddress")
 	}
 	o.initted = true
-	return []core.Action{}
+	return []api.Action{}
 }
 
 // Generate makes a request to the Ollama API and processes the response.

--- a/go/plugins/ollama/ollama_test.go
+++ b/go/plugins/ollama/ollama_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/core/api"
 )
 
-var _ genkit.Plugin = (*Ollama)(nil)
+var _ api.Plugin = (*Ollama)(nil)
 
 func TestConcatMessages(t *testing.T) {
 	tests := []struct {

--- a/go/plugins/pinecone/genkit.go
+++ b/go/plugins/pinecone/genkit.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 )
 
@@ -59,7 +59,7 @@ func (p *Pinecone) Name() string {
 // Init initializes the Pinecone plugin.
 // If apiKey is the empty string, it is read from the PINECONE_API_KEY
 // environment variable.
-func (p *Pinecone) Init(ctx context.Context) []core.Action {
+func (p *Pinecone) Init(ctx context.Context) []api.Action {
 	// Init initializes the Pinecone plugin.
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -73,7 +73,7 @@ func (p *Pinecone) Init(ctx context.Context) []core.Action {
 	}
 	p.client = client
 	p.initted = true
-	return []core.Action{}
+	return []api.Action{}
 }
 
 // Config provides configuration options for [DefineRetriever].
@@ -107,12 +107,12 @@ func DefineRetriever(ctx context.Context, g *genkit.Genkit, cfg Config, opts *ai
 	if err != nil {
 		return nil, nil, err
 	}
-	return ds, genkit.DefineRetriever(g, core.NewName(provider, cfg.IndexID), opts, ds.Retrieve), nil
+	return ds, genkit.DefineRetriever(g, api.NewName(provider, cfg.IndexID), opts, ds.Retrieve), nil
 }
 
 // IsDefinedRetriever reports whether the named [Retriever] is defined by this plugin.
 func IsDefinedRetriever(g *genkit.Genkit, name string) bool {
-	return genkit.LookupRetriever(g, core.NewName(provider, name)) != nil
+	return genkit.LookupRetriever(g, api.NewName(provider, name)) != nil
 }
 
 func (p *Pinecone) newDocstore(ctx context.Context, cfg Config) (*Docstore, error) {
@@ -149,7 +149,7 @@ func (p *Pinecone) newDocstore(ctx context.Context, cfg Config) (*Docstore, erro
 
 // Retriever returns the retriever with the given index name.
 func Retriever(g *genkit.Genkit, name string) ai.Retriever {
-	return genkit.LookupRetriever(g, core.NewName(provider, name))
+	return genkit.LookupRetriever(g, api.NewName(provider, name))
 }
 
 // Docstore implements the genkit [ai.DocumentStore] interface.

--- a/go/plugins/postgresql/distance_strategy.go
+++ b/go/plugins/postgresql/distance_strategy.go
@@ -118,7 +118,7 @@ func (i IVFFlatOptions) Options() string {
 	return fmt.Sprintf("(lists = %d)", i.Lists)
 }
 
-// indexOptions returns the specific options for the index based on the index type.
+// indexOptions returns the specific options for the index based on the index api.
 func (index *BaseIndex) indexOptions() string {
 	return index.options.Options()
 }

--- a/go/plugins/postgresql/genkit.go
+++ b/go/plugins/postgresql/genkit.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 )
 
@@ -39,7 +39,7 @@ func (p *Postgres) Name() string {
 }
 
 // Init initialize the PostgreSQL
-func (p *Postgres) Init(ctx context.Context) []core.Action {
+func (p *Postgres) Init(ctx context.Context) []api.Action {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.initted {
@@ -55,7 +55,7 @@ func (p *Postgres) Init(ctx context.Context) []core.Action {
 	}
 
 	p.initted = true
-	return []core.Action{}
+	return []api.Action{}
 }
 
 // Config provides configuration options for [DefineRetriever].
@@ -89,12 +89,12 @@ func DefineRetriever(ctx context.Context, g *genkit.Genkit, p *Postgres, cfg *Co
 		return nil, nil, err
 	}
 
-	return ds, genkit.DefineRetriever(g, core.NewName(provider, ds.config.TableName), &ai.RetrieverOptions{}, ds.Retrieve), nil
+	return ds, genkit.DefineRetriever(g, api.NewName(provider, ds.config.TableName), &ai.RetrieverOptions{}, ds.Retrieve), nil
 }
 
-// Retriever returns the retriever with the given index name.
-func Retriever(g *genkit.Genkit, name string) ai.Retriever {
-	return genkit.LookupRetriever(g, core.NewName(provider, name))
+// Retriever returns the retriever with the given index id.
+func Retriever(g *genkit.Genkit, id string) ai.Retriever {
+	return genkit.LookupRetriever(g, api.NewName(provider, id))
 }
 
 /* +++++++++++++++++++++++

--- a/go/plugins/postgresql/mocks_test.go
+++ b/go/plugins/postgresql/mocks_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
 )
 
 type mockEmbedderFail struct{}
@@ -27,3 +28,4 @@ func (m mockEmbedderFail) Name() string { return "mock" }
 func (m mockEmbedderFail) Embed(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
 	return nil, errors.New("mock fail")
 }
+func (m mockEmbedderFail) Register(r api.Registry) {}

--- a/go/plugins/vertexai/modelgarden/anthropic.go
+++ b/go/plugins/vertexai/modelgarden/anthropic.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
 	"github.com/invopop/jsonschema"
@@ -54,7 +54,7 @@ func (a *Anthropic) Name() string {
 	return provider
 }
 
-func (a *Anthropic) Init(ctx context.Context) []core.Action {
+func (a *Anthropic) Init(ctx context.Context) []api.Action {
 	if a == nil {
 		a = &Anthropic{}
 	}
@@ -91,19 +91,19 @@ func (a *Anthropic) Init(ctx context.Context) []core.Action {
 	a.initted = true
 	a.client = c
 
-	var actions []core.Action
+	var actions []api.Action
 	for name, mi := range anthropicModels {
 		model := defineAnthropicModel(a.client, name, mi)
-		actions = append(actions, model.(core.Action))
+		actions = append(actions, model.(api.Action))
 	}
 
 	return actions
 }
 
-// AnthropicModel returns the [ai.Model] with the given name.
+// AnthropicModel returns the [ai.Model] with the given id.
 // It returns nil if the model was not defined
-func AnthropicModel(g *genkit.Genkit, name string) ai.Model {
-	return genkit.LookupModel(g, core.NewName(provider, name))
+func AnthropicModel(g *genkit.Genkit, id string) ai.Model {
+	return genkit.LookupModel(g, api.NewName(provider, id))
 }
 
 // DefineModel adds the model to the registry
@@ -127,7 +127,7 @@ func defineAnthropicModel(client anthropic.Client, name string, opts ai.ModelOpt
 		ConfigSchema: opts.ConfigSchema,
 		Stage:        opts.Stage,
 	}
-	return ai.NewModel(core.NewName(provider, name), meta, func(
+	return ai.NewModel(api.NewName(provider, name), meta, func(
 		ctx context.Context,
 		input *ai.ModelRequest,
 		cb func(context.Context, *ai.ModelResponseChunk) error,

--- a/go/plugins/weaviate/weaviate.go
+++ b/go/plugins/weaviate/weaviate.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/auth"
@@ -66,7 +66,7 @@ func (w *Weaviate) Name() string {
 }
 
 // Init initializes the Weaviate plugin.
-func (w *Weaviate) Init(ctx context.Context) []core.Action {
+func (w *Weaviate) Init(ctx context.Context) []api.Action {
 	if w == nil {
 		w = &Weaviate{}
 	}
@@ -124,7 +124,7 @@ func (w *Weaviate) Init(ctx context.Context) []core.Action {
 	w.client = client
 	w.initted = true
 
-	return []core.Action{}
+	return []api.Action{}
 }
 
 // ClassConfig holds configuration options for a retriever.
@@ -160,7 +160,7 @@ func DefineRetriever(ctx context.Context, g *genkit.Genkit, cfg ClassConfig, opt
 	if err != nil {
 		return nil, nil, err
 	}
-	retriever := genkit.DefineRetriever(g, core.NewName(provider, cfg.Class), opts, ds.Retrieve)
+	retriever := genkit.DefineRetriever(g, api.NewName(provider, cfg.Class), opts, ds.Retrieve)
 	return ds, retriever, nil
 }
 
@@ -206,7 +206,7 @@ func (w *Weaviate) newDocstore(ctx context.Context, cfg *ClassConfig) (*Docstore
 
 // Retriever returns the retriever for the given class.
 func Retriever(g *genkit.Genkit, class string) ai.Retriever {
-	return genkit.LookupRetriever(g, core.NewName(provider, class))
+	return genkit.LookupRetriever(g, api.NewName(provider, class))
 }
 
 // RetrieverOptions may be passed in the Options field

--- a/go/samples/basic-gemini/main.go
+++ b/go/samples/basic-gemini/main.go
@@ -39,7 +39,7 @@ func main() {
 			ai.WithConfig(&genai.GenerateContentConfig{
 				Temperature: genai.Ptr[float32](1.0),
 				ThinkingConfig: &genai.ThinkingConfig{
-					ThinkingBudget: genai.Ptr[int32](0), // disable thinking in the generate call
+					ThinkingBudget: genai.Ptr[int32](0),
 				},
 			}),
 			ai.WithPrompt(`Tell short jokes about %s`, input))
@@ -47,8 +47,7 @@ func main() {
 			return "", err
 		}
 
-		text := resp.Text()
-		return text, nil
+		return resp.Text(), nil
 	})
 
 	<-ctx.Done()

--- a/go/samples/pgvector/main.go
+++ b/go/samples/pgvector/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 	_ "github.com/lib/pq"
@@ -165,7 +165,7 @@ func defineRetriever(g *genkit.Genkit, db *sql.DB, embedder ai.Embedder, retOpts
 		}
 		return res, nil
 	}
-	return genkit.DefineRetriever(g, core.NewName(provider, "shows"), retOpts, f)
+	return genkit.DefineRetriever(g, api.NewName(provider, "shows"), retOpts, f)
 }
 
 // [END retr]

--- a/go/samples/prompts/main.go
+++ b/go/samples/prompts/main.go
@@ -103,7 +103,7 @@ func PromptWithOutputType(ctx context.Context, g *genkit.Genkit) {
 		Countries []string
 	}
 
-	// Define prompt with output type.
+	// Define prompt with output api.
 	helloPrompt := genkit.DefinePrompt(
 		g, "PromptWithOutputType",
 		ai.WithOutputType(CountryList{}),
@@ -173,7 +173,7 @@ func PromptWithComplexOutputType(ctx context.Context, g *genkit.Genkit) {
 		Countries []countryData `json:"countries"`
 	}
 
-	// Define prompt with output type.
+	// Define prompt with output api.
 	prompt := genkit.DefinePrompt(
 		g, "PromptWithComplexOutputType",
 		ai.WithOutputType(countries{}),

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/evaluators"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
@@ -118,7 +119,7 @@ func main() {
 		IsBilled:    false,
 	}
 
-	genkit.DefineEvaluator(g, core.NewName("custom", "simpleEvaluator"), &evalOptions, func(ctx context.Context, req *ai.EvaluatorCallbackRequest) (*ai.EvaluatorCallbackResponse, error) {
+	genkit.DefineEvaluator(g, api.NewName("custom", "simpleEvaluator"), &evalOptions, func(ctx context.Context, req *ai.EvaluatorCallbackRequest) (*ai.EvaluatorCallbackResponse, error) {
 		m := make(map[string]any)
 		m["reasoning"] = "No good reason"
 		score := ai.Score{
@@ -134,7 +135,7 @@ func main() {
 		return &callbackResponse, nil
 	})
 
-	genkit.DefineBatchEvaluator(g, core.NewName("custom", "simpleBatchEvaluator"), &evalOptions, func(ctx context.Context, req *ai.EvaluatorRequest) (*ai.EvaluatorResponse, error) {
+	genkit.DefineBatchEvaluator(g, api.NewName("custom", "simpleBatchEvaluator"), &evalOptions, func(ctx context.Context, req *ai.EvaluatorRequest) (*ai.EvaluatorResponse, error) {
 		var evalResponses []ai.EvaluationResult
 		for _, datapoint := range req.Dataset {
 			m := make(map[string]any)


### PR DESCRIPTION
Common interfaces like `Action`, `Plugin`, `DynamicPlugin` are now in a `api` package that is used by `core`, `ai`, and `registry` so that the registry remains an internal implementation detail but can have strongly typed registration functions, primitives have a `Register(api.Registry)` function in their individual interfaces so they can be easily registered after creating, and the interface is public is that custom primitive implementations can be mocked out by third parties.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
