### PR TITLE
fix(go/plugins/ollama): add gpt-oss to tool supported models

### DIFF
--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -48,7 +48,7 @@ var (
 		"phi4-mini", "granite3.1-dense", "granite3-dense", "granite3.2", "athene-v2",
 		"nemotron-mini", "nemotron", "llama3-groq-tool-use", "aya-expanse", "granite3-moe",
 		"granite3.2-vision", "granite3.1-moe", "cogito", "command-r7b", "firefunction-v2",
-		"granite3.3", "command-a", "command-r7b-arabic",
+		"granite3.3", "command-a", "command-r7b-arabic", "gpt-oss",
 	}
 	roleMapping = map[ai.Role]string{
 		ai.RoleUser:   "user",


### PR DESCRIPTION
Description:
 - running the `go/samples/ollama-tools` example with the model `gpt-oss` results in the following error:
 
       johnmccabe@dev:~/workspaces/genkit/go/samples/ollama-tools$ go run .
       Generating response with weather tool...
       Error: model "ollama/gpt-oss" does not support tool use, but tools were provided. Request: &{Config:<nil> Docs:[] Messages:[0xc000378e40 0xc000378e70] Output:0xc000378ea0 ToolChoice:auto Tools:[0xc000214600]}

- Updating the `toolSupportedModels` and rerunning with `gpt-oss` results in the `go/samples/ollama-tools` example behaving as expected:

      johnmccabe@dev:~/workspaces/genkit/go/samples/ollama-tools$ go run .
      Generating response with weather tool...
      
      ----- Final Response -----
      Here’s the current weather in Tokyo:
      
      - **Condition:** Cloudy  
      - **Temperature:** 24 °C (≈ 75 °F)  
      
      Let me know if you’d like to check another city or need more details!
      --------------------------

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
