### PR TITLE
fix(go): When converting the openai tool message, the parameter passi…

### DIFF
--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -107,8 +107,8 @@ func (g *ModelGenerator) WithMessages(messages []*ai.Message) *ModelGenerator {
 				}
 
 				tm := openai.ToolMessage(
-					toolCallID,
 					anyToJSONString(p.ToolResponse.Output),
+					toolCallID,
 				)
 				oaiMessages = append(oaiMessages, tm)
 			}


### PR DESCRIPTION
The ToolMessage signature is as follows. Passing parameters in reverse causes an error
<img width="950" height="368" alt="image" src="https://github.com/user-attachments/assets/e83e198c-c78a-40da-ae1c-3abe016df89e" />
