### PR TITLE
fix(go/ai/options): update commonGenOptions apply opts

### DIFF
--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -138,7 +138,6 @@ func (o *commonGenOptions) applyCommonGen(opts *commonGenOptions) error {
 			return errors.New("cannot set model more than once (either WithModel or WithModelName)")
 		}
 		opts.Model = o.Model
-		return nil
 	}
 
 	if o.Tools != nil {


### PR DESCRIPTION
Return too early. This leads to the loss of the tools defined in the prompt file after loading it.
Fixes #3499