### PR TITLE
fix(ai): propagate abortSignal in recursive generateHelper calls

### DIFF
--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -408,6 +408,7 @@ async function generate(
     currentTurn: currentTurn + 1,
     messageIndex: messageIndex + 1,
     streamingCallback,
+    abortSignal,
   });
 }
 


### PR DESCRIPTION
When generateHelper recursively calls itself during tool iterations, the abortSignal was not being passed to the recursive call. This caused abort signals to be lost after the first tool iteration, preventing proper cancellation of long-running operations with multiple tool calls.

This fix ensures abortSignal is propagated through all recursive calls, maintaining cancellation capability throughout the entire generation lifecycle.

Fixes issue where task cancellation fails when maxTurns > 1

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
