### PR TITLE
fix(js/generate): handle when finishReason is length

### DIFF
--- a/js/ai/src/generate/response.ts
+++ b/js/ai/src/generate/response.ts
@@ -93,6 +93,13 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
       );
     }
 
+    if (this.finishReason === 'length') {
+      throw new GenerationResponseError(
+        this,
+        `Model generated a message that is too long. Finish reason: '${this.finishReason}': ${this.finishMessage}`
+      );
+    }
+
     if (!this.message && !this.operation) {
       throw new GenerationResponseError(
         this,


### PR DESCRIPTION
Currently when the model returns finishReason === 'length' the flow fails on schema validation (as output will probably be corrupted), hence hiding the real fail reason.
This fix will raise error properly on that case

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
