### PR TITLE
feat(go): Fix missing input schema from dynamic tools

### DIFF
--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -148,6 +148,14 @@ func NewTool[In, Out any](name, description string, fn ToolFunc[In, Out]) Tool {
 	return &tool{Action: toolAction}
 }
 
+// NewToolWithInputSchema creates a new [Tool] with a custom input schema. It can be passed directly to [Generate].
+func NewToolWithInputSchema[Out any](name, description string, inputSchema map[string]any, fn ToolFunc[any, Out]) Tool {
+	metadata, wrappedFn := implementTool(name, description, fn)
+	metadata["dynamic"] = true
+	toolAction := core.NewAction(name, api.ActionTypeTool, metadata, inputSchema, wrappedFn)
+	return &tool{Action: toolAction}
+}
+
 // implementTool creates the metadata and wrapped function common to both DefineTool and NewTool.
 func implementTool[In, Out any](name, description string, fn ToolFunc[In, Out]) (map[string]any, func(context.Context, In) (Out, error)) {
 	metadata := map[string]any{

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -570,34 +570,34 @@ func castToStringArray(i []any) []string {
 
 // parseInt64FromStringOrNumber parses either a string (decimal) or float64 into int64.
 func parseInt64FromStringOrNumber(v any) (int64, error) {
-    switch vv := v.(type) {
-    case string:
-        i, err := strconv.ParseInt(vv, 10, 64)
-        if err != nil {
-            return 0, err
-        }
-        return i, nil
-    case float64:
-        return int64(vv), nil
-    default:
-        return 0, fmt.Errorf("unsupported type %T for int value", v)
-    }
+	switch vv := v.(type) {
+	case string:
+		i, err := strconv.ParseInt(vv, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return i, nil
+	case float64:
+		return int64(vv), nil
+	default:
+		return 0, fmt.Errorf("unsupported type %T for int value", v)
+	}
 }
 
 // parseFloat64FromStringOrNumber parses either a string or float64 into float64.
 func parseFloat64FromStringOrNumber(v any) (float64, error) {
-    switch vv := v.(type) {
-    case string:
-        f, err := strconv.ParseFloat(vv, 64)
-        if err != nil {
-            return 0, err
-        }
-        return f, nil
-    case float64:
-        return vv, nil
-    default:
-        return 0, fmt.Errorf("unsupported type %T for float value", v)
-    }
+	switch vv := v.(type) {
+	case string:
+		f, err := strconv.ParseFloat(vv, 64)
+		if err != nil {
+			return 0, err
+		}
+		return f, nil
+	case float64:
+		return vv, nil
+	default:
+		return 0, fmt.Errorf("unsupported type %T for float value", v)
+	}
 }
 
 func toGeminiToolChoice(toolChoice ai.ToolChoice, tools []*ai.ToolDefinition) (*genai.ToolConfig, error) {

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -498,32 +498,32 @@ func toGeminiSchema(originalSchema map[string]any, genkitSchema map[string]any) 
 		schema.Title = v.(string)
 	}
 	if v, ok := genkitSchema["minItems"]; ok {
-		i, err := parseInt64FromStringOrNumber(v)
+		i, err := strconv.ParseInt(v.(string), 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid minItems: %w", err)
+			return nil, err
 		}
 		schema.MinItems = genai.Ptr(i)
 	}
 	if v, ok := genkitSchema["maxItems"]; ok {
-		i, err := parseInt64FromStringOrNumber(v)
+		i, err := strconv.ParseInt(v.(string), 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid maxItems: %w", err)
+			return nil, err
 		}
 		schema.MaxItems = genai.Ptr(i)
 	}
 	if v, ok := genkitSchema["maximum"]; ok {
-		f, err := parseFloat64FromStringOrNumber(v)
+		i, err := strconv.ParseFloat(v.(string), 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid maximum: %w", err)
+			return nil, err
 		}
-		schema.Maximum = genai.Ptr(f)
+		schema.Maximum = genai.Ptr(i)
 	}
 	if v, ok := genkitSchema["minimum"]; ok {
-		f, err := parseFloat64FromStringOrNumber(v)
+		i, err := strconv.ParseFloat(v.(string), 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid minimum: %w", err)
+			return nil, err
 		}
-		schema.Minimum = genai.Ptr(f)
+		schema.Minimum = genai.Ptr(i)
 	}
 	if v, ok := genkitSchema["enum"]; ok {
 		schema.Enum = castToStringArray(v.([]any))
@@ -566,38 +566,6 @@ func castToStringArray(i []any) []string {
 		r = append(r, v.(string))
 	}
 	return r
-}
-
-// parseInt64FromStringOrNumber parses either a string (decimal) or float64 into int64.
-func parseInt64FromStringOrNumber(v any) (int64, error) {
-	switch vv := v.(type) {
-	case string:
-		i, err := strconv.ParseInt(vv, 10, 64)
-		if err != nil {
-			return 0, err
-		}
-		return i, nil
-	case float64:
-		return int64(vv), nil
-	default:
-		return 0, fmt.Errorf("unsupported type %T for int value", v)
-	}
-}
-
-// parseFloat64FromStringOrNumber parses either a string or float64 into float64.
-func parseFloat64FromStringOrNumber(v any) (float64, error) {
-	switch vv := v.(type) {
-	case string:
-		f, err := strconv.ParseFloat(vv, 64)
-		if err != nil {
-			return 0, err
-		}
-		return f, nil
-	case float64:
-		return vv, nil
-	default:
-		return 0, fmt.Errorf("unsupported type %T for float value", v)
-	}
 }
 
 func toGeminiToolChoice(toolChoice ai.ToolChoice, tools []*ai.ToolDefinition) (*genai.ToolConfig, error) {

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -498,32 +498,32 @@ func toGeminiSchema(originalSchema map[string]any, genkitSchema map[string]any) 
 		schema.Title = v.(string)
 	}
 	if v, ok := genkitSchema["minItems"]; ok {
-		i, err := strconv.ParseInt(v.(string), 10, 64)
+		i, err := parseInt64FromStringOrNumber(v)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid minItems: %w", err)
 		}
 		schema.MinItems = genai.Ptr(i)
 	}
 	if v, ok := genkitSchema["maxItems"]; ok {
-		i, err := strconv.ParseInt(v.(string), 10, 64)
+		i, err := parseInt64FromStringOrNumber(v)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid maxItems: %w", err)
 		}
 		schema.MaxItems = genai.Ptr(i)
 	}
 	if v, ok := genkitSchema["maximum"]; ok {
-		i, err := strconv.ParseFloat(v.(string), 64)
+		f, err := parseFloat64FromStringOrNumber(v)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid maximum: %w", err)
 		}
-		schema.Maximum = genai.Ptr(i)
+		schema.Maximum = genai.Ptr(f)
 	}
 	if v, ok := genkitSchema["minimum"]; ok {
-		i, err := strconv.ParseFloat(v.(string), 64)
+		f, err := parseFloat64FromStringOrNumber(v)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid minimum: %w", err)
 		}
-		schema.Minimum = genai.Ptr(i)
+		schema.Minimum = genai.Ptr(f)
 	}
 	if v, ok := genkitSchema["enum"]; ok {
 		schema.Enum = castToStringArray(v.([]any))
@@ -566,6 +566,38 @@ func castToStringArray(i []any) []string {
 		r = append(r, v.(string))
 	}
 	return r
+}
+
+// parseInt64FromStringOrNumber parses either a string (decimal) or float64 into int64.
+func parseInt64FromStringOrNumber(v any) (int64, error) {
+    switch vv := v.(type) {
+    case string:
+        i, err := strconv.ParseInt(vv, 10, 64)
+        if err != nil {
+            return 0, err
+        }
+        return i, nil
+    case float64:
+        return int64(vv), nil
+    default:
+        return 0, fmt.Errorf("unsupported type %T for int value", v)
+    }
+}
+
+// parseFloat64FromStringOrNumber parses either a string or float64 into float64.
+func parseFloat64FromStringOrNumber(v any) (float64, error) {
+    switch vv := v.(type) {
+    case string:
+        f, err := strconv.ParseFloat(vv, 64)
+        if err != nil {
+            return 0, err
+        }
+        return f, nil
+    case float64:
+        return vv, nil
+    default:
+        return 0, fmt.Errorf("unsupported type %T for float value", v)
+    }
 }
 
 func toGeminiToolChoice(toolChoice ai.ToolChoice, tools []*ai.ToolDefinition) (*genai.ToolConfig, error) {

--- a/go/plugins/mcp/tools.go
+++ b/go/plugins/mcp/tools.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/internal/base"
 	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/internal/base"
 	"github.com/invopop/jsonschema"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"

--- a/go/plugins/mcp/tools_test.go
+++ b/go/plugins/mcp/tools_test.go
@@ -15,152 +15,151 @@
 package mcp
 
 import (
-	"testing"
+    "encoding/json"
+    "testing"
 
-	"github.com/mark3labs/mcp-go/mcp"
+    "github.com/mark3labs/mcp-go/mcp"
 )
 
 func asMap(t *testing.T, v any, label string) map[string]any {
-	t.Helper()
-	m, ok := v.(map[string]any)
-	if !ok {
-		t.Fatalf("%s: want map[string]any, got %T", label, v)
-	}
-	return m
+    t.Helper()
+    m, ok := v.(map[string]any)
+    if !ok {
+        t.Fatalf("%s: want map[string]any, got %T", label, v)
+    }
+    return m
 }
 
 func eqStr(t *testing.T, got any, want string, label string) {
-	t.Helper()
-	s, ok := got.(string)
-	if !ok || s != want {
-		t.Fatalf("%s: got %v", label, got)
-	}
+    t.Helper()
+    s, ok := got.(string)
+    if !ok || s != want {
+        t.Fatalf("%s: got %v", label, got)
+    }
 }
 
 func eqNum(t *testing.T, got any, want int, label string) {
-	t.Helper()
-	f, ok := got.(float64)
-	if !ok || int(f) != want {
-		t.Fatalf("%s: got %v", label, got)
-	}
+    t.Helper()
+    f, ok := got.(float64)
+    if !ok || int(f) != want {
+        t.Fatalf("%s: got %v", label, got)
+    }
 }
 
 func reqContains(t *testing.T, v any, want string) {
-	t.Helper()
-	switch arr := v.(type) {
-	case []any:
-		for _, x := range arr {
-			if s, ok := x.(string); ok && s == want {
-				return
-			}
-		}
-	case []string:
-		for _, s := range arr {
-			if s == want {
-				return
-			}
-		}
-	default:
-		t.Fatalf("required: unexpected type %T", v)
-	}
-	t.Fatalf("required does not contain %q: %v", want, v)
+    t.Helper()
+    switch arr := v.(type) {
+    case []any:
+        for _, x := range arr {
+            if s, ok := x.(string); ok && s == want {
+                return
+            }
+        }
+    case []string:
+        for _, s := range arr {
+            if s == want {
+                return
+            }
+        }
+    default:
+        t.Fatalf("required: unexpected type %T", v)
+    }
+    t.Fatalf("required does not contain %q: %v", want, v)
 }
 
 // TestCreateTool tests the createTool function.
 func TestCreateTool(t *testing.T) {
-	client := &GenkitMCPClient{options: MCPClientOptions{Name: "srv"}}
+    client := &GenkitMCPClient{options: MCPClientOptions{Name: "srv"}}
+    client.server = &ServerRef{} // avoid nil deref in createToolFunction
 
-	m := mcp.Tool{
-		Name:        "echo",
-		Description: "Echo",
-		InputSchema: mcp.JSONSchema{
-			Type:        "object",
-			Required:    []string{"q"},
-			Description: "Echo input",
-			Properties: map[string]mcp.JSONSchema{
-				"q": {
-					Type:        "string",
-					Description: "query",
-				},
-				"n": {
-					Type:    "number",
-					Minimum: 1,
-					Maximum: 10,
-				},
-				"arr": {
-					Type:     "array",
-					MinItems: 2,
-					MaxItems: 4,
-				},
-			},
-		},
-	}
+    var m mcp.Tool
+    toolJSON := `{
+        "name": "echo",
+        "description": "Echo",
+        "inputSchema": {
+            "type": "object",
+            "description": "Echo input",
+            "required": ["q"],
+            "properties": {
+                "q": {"type": "string", "description": "query"},
+                "n": {"type": "number", "minimum": 1, "maximum": 10},
+                "arr": {"type": "array", "minItems": 2, "maxItems": 4}
+            }
+        }
+    }`
+    if err := json.Unmarshal([]byte(toolJSON), &m); err != nil {
+        t.Fatalf("failed to unmarshal tool JSON: %v", err)
+    }
 
-	tool, err := client.createTool(m)
-	if err != nil {
-		t.Fatalf("createTool error: %v", err)
-	}
+    tool, err := client.createTool(m)
+    if err != nil {
+        t.Fatalf("createTool error: %v", err)
+    }
 
 	// Validate that the tool is namespaced
-	def := tool.Definition()
-	if def.Name != "srv_echo" {
-		t.Fatalf("namespacing failed: got %q", def.Name)
-	}
-	if def.Description != "Echo" {
-		t.Fatalf("description mismatch: %q", def.Description)
-	}
-	if def.InputSchema == nil {
-		t.Fatalf("input schema missing")
-	}
+    def := tool.Definition()
+    if def.Name != "srv_echo" {
+        t.Fatalf("namespacing failed: got %q", def.Name)
+    }
+    if def.Description != "Echo" {
+        t.Fatalf("description mismatch: %q", def.Description)
+    }
+    if def.InputSchema == nil {
+        t.Fatalf("input schema missing")
+    }
 
 	// Validate that the schema is propagated correctly.
-	eqStr(t, def.InputSchema["type"], "object", "schema.type")
-	eqStr(t, def.InputSchema["description"], "Echo input", "schema.description")
-	props := asMap(t, def.InputSchema["properties"], "schema.properties")
+    eqStr(t, def.InputSchema["type"], "object", "schema.type")
+    props := asMap(t, def.InputSchema["properties"], "schema.properties")
 
-	q := asMap(t, props["q"], "properties.q")
-	eqStr(t, q["type"], "string", "q.type")
-	eqStr(t, q["description"], "query", "q.description")
+    q := asMap(t, props["q"], "properties.q")
+    eqStr(t, q["type"], "string", "q.type")
+    eqStr(t, q["description"], "query", "q.description")
 
-	n := asMap(t, props["n"], "properties.n")
-	eqStr(t, n["type"], "number", "n.type")
-	eqNum(t, n["minimum"], 1, "n.minimum")
-	eqNum(t, n["maximum"], 10, "n.maximum")
+    n := asMap(t, props["n"], "properties.n")
+    eqStr(t, n["type"], "number", "n.type")
+    eqNum(t, n["minimum"], 1, "n.minimum")
+    eqNum(t, n["maximum"], 10, "n.maximum")
 
-	arr := asMap(t, props["arr"], "properties.arr")
-	eqStr(t, arr["type"], "array", "arr.type")
-	eqNum(t, arr["minItems"], 2, "arr.minItems")
-	eqNum(t, arr["maxItems"], 4, "arr.maxItems")
+    arr := asMap(t, props["arr"], "properties.arr")
+    eqStr(t, arr["type"], "array", "arr.type")
+    eqNum(t, arr["minItems"], 2, "arr.minItems")
+    eqNum(t, arr["maxItems"], 4, "arr.maxItems")
 
-	reqContains(t, def.InputSchema["required"], "q")
+    reqContains(t, def.InputSchema["required"], "q")
 }
+
 
 // TestPrepareToolArguments tests the prepareToolArguments function.
 // Ensures that required fields are validated.
 func TestPrepareToolArguments(t *testing.T) {
-	tool := mcp.Tool{
-		Name: "echo",
-		InputSchema: mcp.JSONSchema{
-			Type:     "object",
-			Required: []string{"q"},
-		},
-	}
+    var tool mcp.Tool
+    toolJSON := `{
+        "name": "echo",
+        "inputSchema": {
+            "type": "object",
+            "required": ["q"]
+        }
+    }`
+    if err := json.Unmarshal([]byte(toolJSON), &tool); err != nil {
+        t.Fatalf("failed to unmarshal tool JSON: %v", err)
+    }
 
-	okArgs := map[string]any{"q": "hi"}
-	got, err := prepareToolArguments(tool, okArgs)
-	if err != nil {
-		t.Fatalf("unexpected error for valid args: %v", err)
-	}
-	if got["q"] != "hi" {
-		t.Fatalf("args not preserved: %v", got)
-	}
+    okArgs := map[string]any{"q": "hi"}
+    got, err := prepareToolArguments(tool, okArgs)
+    if err != nil {
+        t.Fatalf("unexpected error for valid args: %v", err)
+    }
+    if got["q"] != "hi" {
+        t.Fatalf("args not preserved: %v", got)
+    }
 
-	_, err = prepareToolArguments(tool, map[string]any{})
-	if err == nil {
-		t.Fatalf("expected error for missing required field")
-	}
-	_, err = prepareToolArguments(tool, nil)
-	if err == nil {
-		t.Fatalf("expected error for nil args with required field")
-	}
+    _, err = prepareToolArguments(tool, map[string]any{})
+    if err == nil {
+        t.Fatalf("expected error for missing required field")
+    }
+    _, err = prepareToolArguments(tool, nil)
+    if err == nil {
+        t.Fatalf("expected error for nil args with required field")
+    }
 }

--- a/go/plugins/mcp/tools_test.go
+++ b/go/plugins/mcp/tools_test.go
@@ -15,65 +15,65 @@
 package mcp
 
 import (
-    "encoding/json"
-    "testing"
+	"encoding/json"
+	"testing"
 
-    "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 func asMap(t *testing.T, v any, label string) map[string]any {
-    t.Helper()
-    m, ok := v.(map[string]any)
-    if !ok {
-        t.Fatalf("%s: want map[string]any, got %T", label, v)
-    }
-    return m
+	t.Helper()
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("%s: want map[string]any, got %T", label, v)
+	}
+	return m
 }
 
 func eqStr(t *testing.T, got any, want string, label string) {
-    t.Helper()
-    s, ok := got.(string)
-    if !ok || s != want {
-        t.Fatalf("%s: got %v", label, got)
-    }
+	t.Helper()
+	s, ok := got.(string)
+	if !ok || s != want {
+		t.Fatalf("%s: got %v", label, got)
+	}
 }
 
 func eqNum(t *testing.T, got any, want int, label string) {
-    t.Helper()
-    f, ok := got.(float64)
-    if !ok || int(f) != want {
-        t.Fatalf("%s: got %v", label, got)
-    }
+	t.Helper()
+	f, ok := got.(float64)
+	if !ok || int(f) != want {
+		t.Fatalf("%s: got %v", label, got)
+	}
 }
 
 func reqContains(t *testing.T, v any, want string) {
-    t.Helper()
-    switch arr := v.(type) {
-    case []any:
-        for _, x := range arr {
-            if s, ok := x.(string); ok && s == want {
-                return
-            }
-        }
-    case []string:
-        for _, s := range arr {
-            if s == want {
-                return
-            }
-        }
-    default:
-        t.Fatalf("required: unexpected type %T", v)
-    }
-    t.Fatalf("required does not contain %q: %v", want, v)
+	t.Helper()
+	switch arr := v.(type) {
+	case []any:
+		for _, x := range arr {
+			if s, ok := x.(string); ok && s == want {
+				return
+			}
+		}
+	case []string:
+		for _, s := range arr {
+			if s == want {
+				return
+			}
+		}
+	default:
+		t.Fatalf("required: unexpected type %T", v)
+	}
+	t.Fatalf("required does not contain %q: %v", want, v)
 }
 
 // TestCreateTool tests the createTool function.
 func TestCreateTool(t *testing.T) {
-    client := &GenkitMCPClient{options: MCPClientOptions{Name: "srv"}}
-    client.server = &ServerRef{} // avoid nil deref in createToolFunction
+	client := &GenkitMCPClient{options: MCPClientOptions{Name: "srv"}}
+	client.server = &ServerRef{} // avoid nil deref in createToolFunction
 
-    var m mcp.Tool
-    toolJSON := `{
+	var m mcp.Tool
+	toolJSON := `{
         "name": "echo",
         "description": "Echo",
         "inputSchema": {
@@ -87,79 +87,78 @@ func TestCreateTool(t *testing.T) {
             }
         }
     }`
-    if err := json.Unmarshal([]byte(toolJSON), &m); err != nil {
-        t.Fatalf("failed to unmarshal tool JSON: %v", err)
-    }
+	if err := json.Unmarshal([]byte(toolJSON), &m); err != nil {
+		t.Fatalf("failed to unmarshal tool JSON: %v", err)
+	}
 
-    tool, err := client.createTool(m)
-    if err != nil {
-        t.Fatalf("createTool error: %v", err)
-    }
+	tool, err := client.createTool(m)
+	if err != nil {
+		t.Fatalf("createTool error: %v", err)
+	}
 
 	// Validate that the tool is namespaced
-    def := tool.Definition()
-    if def.Name != "srv_echo" {
-        t.Fatalf("namespacing failed: got %q", def.Name)
-    }
-    if def.Description != "Echo" {
-        t.Fatalf("description mismatch: %q", def.Description)
-    }
-    if def.InputSchema == nil {
-        t.Fatalf("input schema missing")
-    }
+	def := tool.Definition()
+	if def.Name != "srv_echo" {
+		t.Fatalf("namespacing failed: got %q", def.Name)
+	}
+	if def.Description != "Echo" {
+		t.Fatalf("description mismatch: %q", def.Description)
+	}
+	if def.InputSchema == nil {
+		t.Fatalf("input schema missing")
+	}
 
 	// Validate that the schema is propagated correctly.
-    eqStr(t, def.InputSchema["type"], "object", "schema.type")
-    props := asMap(t, def.InputSchema["properties"], "schema.properties")
+	eqStr(t, def.InputSchema["type"], "object", "schema.type")
+	props := asMap(t, def.InputSchema["properties"], "schema.properties")
 
-    q := asMap(t, props["q"], "properties.q")
-    eqStr(t, q["type"], "string", "q.type")
-    eqStr(t, q["description"], "query", "q.description")
+	q := asMap(t, props["q"], "properties.q")
+	eqStr(t, q["type"], "string", "q.type")
+	eqStr(t, q["description"], "query", "q.description")
 
-    n := asMap(t, props["n"], "properties.n")
-    eqStr(t, n["type"], "number", "n.type")
-    eqNum(t, n["minimum"], 1, "n.minimum")
-    eqNum(t, n["maximum"], 10, "n.maximum")
+	n := asMap(t, props["n"], "properties.n")
+	eqStr(t, n["type"], "number", "n.type")
+	eqNum(t, n["minimum"], 1, "n.minimum")
+	eqNum(t, n["maximum"], 10, "n.maximum")
 
-    arr := asMap(t, props["arr"], "properties.arr")
-    eqStr(t, arr["type"], "array", "arr.type")
-    eqNum(t, arr["minItems"], 2, "arr.minItems")
-    eqNum(t, arr["maxItems"], 4, "arr.maxItems")
+	arr := asMap(t, props["arr"], "properties.arr")
+	eqStr(t, arr["type"], "array", "arr.type")
+	eqNum(t, arr["minItems"], 2, "arr.minItems")
+	eqNum(t, arr["maxItems"], 4, "arr.maxItems")
 
-    reqContains(t, def.InputSchema["required"], "q")
+	reqContains(t, def.InputSchema["required"], "q")
 }
-
 
 // TestPrepareToolArguments tests the prepareToolArguments function.
 // Ensures that required fields are validated.
 func TestPrepareToolArguments(t *testing.T) {
-    var tool mcp.Tool
-    toolJSON := `{
+	var tool mcp.Tool
+	toolJSON := `{
         "name": "echo",
         "inputSchema": {
             "type": "object",
             "required": ["q"]
         }
     }`
-    if err := json.Unmarshal([]byte(toolJSON), &tool); err != nil {
-        t.Fatalf("failed to unmarshal tool JSON: %v", err)
-    }
+	if err := json.Unmarshal([]byte(toolJSON), &tool); err != nil {
+		t.Fatalf("failed to unmarshal tool JSON: %v", err)
+	}
 
-    okArgs := map[string]any{"q": "hi"}
-    got, err := prepareToolArguments(tool, okArgs)
-    if err != nil {
-        t.Fatalf("unexpected error for valid args: %v", err)
-    }
-    if got["q"] != "hi" {
-        t.Fatalf("args not preserved: %v", got)
-    }
+	okArgs := map[string]any{"q": "hi"}
+	got, err := prepareToolArguments(tool, okArgs)
+	if err != nil {
+		t.Fatalf("unexpected error for valid args: %v", err)
+	}
+	if got["q"] != "hi" {
+		t.Fatalf("args not preserved: %v", got)
+	}
 
-    _, err = prepareToolArguments(tool, map[string]any{})
-    if err == nil {
-        t.Fatalf("expected error for missing required field")
-    }
-    _, err = prepareToolArguments(tool, nil)
-    if err == nil {
-        t.Fatalf("expected error for nil args with required field")
-    }
+	_, err = prepareToolArguments(tool, map[string]any{})
+	if err == nil {
+		t.Fatalf("expected error for missing required field")
+	}
+	_, err = prepareToolArguments(tool, nil)
+	if err == nil {
+		t.Fatalf("expected error for nil args with required field")
+	}
 }

--- a/go/plugins/mcp/tools_test.go
+++ b/go/plugins/mcp/tools_test.go
@@ -15,155 +15,152 @@
 package mcp
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 func asMap(t *testing.T, v any, label string) map[string]any {
-    t.Helper()
-    m, ok := v.(map[string]any)
-    if !ok {
-        t.Fatalf("%s: want map[string]any, got %T", label, v)
-    }
-    return m
+	t.Helper()
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("%s: want map[string]any, got %T", label, v)
+	}
+	return m
 }
 
 func eqStr(t *testing.T, got any, want string, label string) {
-    t.Helper()
-    s, ok := got.(string)
-    if !ok || s != want {
-        t.Fatalf("%s: got %v", label, got)
-    }
+	t.Helper()
+	s, ok := got.(string)
+	if !ok || s != want {
+		t.Fatalf("%s: got %v", label, got)
+	}
 }
 
 func eqNum(t *testing.T, got any, want int, label string) {
-    t.Helper()
-    f, ok := got.(float64)
-    if !ok || int(f) != want {
-        t.Fatalf("%s: got %v", label, got)
-    }
+	t.Helper()
+	f, ok := got.(float64)
+	if !ok || int(f) != want {
+		t.Fatalf("%s: got %v", label, got)
+	}
 }
 
 func reqContains(t *testing.T, v any, want string) {
-    t.Helper()
-    switch arr := v.(type) {
-    case []any:
-        for _, x := range arr {
-            if s, ok := x.(string); ok && s == want {
-                return
-            }
-        }
-    case []string:
-        for _, s := range arr {
-            if s == want {
-                return
-            }
-        }
-    default:
-        t.Fatalf("required: unexpected type %T", v)
-    }
-    t.Fatalf("required does not contain %q: %v", want, v)
+	t.Helper()
+	switch arr := v.(type) {
+	case []any:
+		for _, x := range arr {
+			if s, ok := x.(string); ok && s == want {
+				return
+			}
+		}
+	case []string:
+		for _, s := range arr {
+			if s == want {
+				return
+			}
+		}
+	default:
+		t.Fatalf("required: unexpected type %T", v)
+	}
+	t.Fatalf("required does not contain %q: %v", want, v)
 }
 
 // TestCreateTool tests the createTool function.
 func TestCreateTool(t *testing.T) {
-    client := &GenkitMCPClient{options: MCPClientOptions{Name: "srv"}}
+	client := &GenkitMCPClient{options: MCPClientOptions{Name: "srv"}}
 
-    m := mcp.Tool{
-        Name:        "echo",
-        Description: "Echo",
-        InputSchema: mcp.JSONSchema{
-            Type:        "object",
-            Required:    []string{"q"},
-            Description: "Echo input",
-            Properties: map[string]mcp.JSONSchema{
-                "q": {
-                    Type:        "string",
-                    Description: "query",
-                },
-                "n": {
-                    Type:     "number",
-                    Minimum:  1,
-                    Maximum:  10,
-                },
-                "arr": {
-                    Type:     "array",
-                    MinItems: 2,
-                    MaxItems: 4,
-                },
-            },
-        },
-    }
+	m := mcp.Tool{
+		Name:        "echo",
+		Description: "Echo",
+		InputSchema: mcp.JSONSchema{
+			Type:        "object",
+			Required:    []string{"q"},
+			Description: "Echo input",
+			Properties: map[string]mcp.JSONSchema{
+				"q": {
+					Type:        "string",
+					Description: "query",
+				},
+				"n": {
+					Type:    "number",
+					Minimum: 1,
+					Maximum: 10,
+				},
+				"arr": {
+					Type:     "array",
+					MinItems: 2,
+					MaxItems: 4,
+				},
+			},
+		},
+	}
 
-    tool, err := client.createTool(m)
-    if err != nil {
-        t.Fatalf("createTool error: %v", err)
-    }
+	tool, err := client.createTool(m)
+	if err != nil {
+		t.Fatalf("createTool error: %v", err)
+	}
 
 	// Validate that the tool is namespaced
-    def := tool.Definition()
-    if def.Name != "srv_echo" {
-        t.Fatalf("namespacing failed: got %q", def.Name)
-    }
-    if def.Description != "Echo" {
-        t.Fatalf("description mismatch: %q", def.Description)
-    }
-    if def.InputSchema == nil {
-        t.Fatalf("input schema missing")
-    }
+	def := tool.Definition()
+	if def.Name != "srv_echo" {
+		t.Fatalf("namespacing failed: got %q", def.Name)
+	}
+	if def.Description != "Echo" {
+		t.Fatalf("description mismatch: %q", def.Description)
+	}
+	if def.InputSchema == nil {
+		t.Fatalf("input schema missing")
+	}
 
 	// Validate that the schema is propagated correctly.
-    eqStr(t, def.InputSchema["type"], "object", "schema.type")
-    eqStr(t, def.InputSchema["description"], "Echo input", "schema.description")
-    props := asMap(t, def.InputSchema["properties"], "schema.properties")
+	eqStr(t, def.InputSchema["type"], "object", "schema.type")
+	eqStr(t, def.InputSchema["description"], "Echo input", "schema.description")
+	props := asMap(t, def.InputSchema["properties"], "schema.properties")
 
-    q := asMap(t, props["q"], "properties.q")
-    eqStr(t, q["type"], "string", "q.type")
-    eqStr(t, q["description"], "query", "q.description")
+	q := asMap(t, props["q"], "properties.q")
+	eqStr(t, q["type"], "string", "q.type")
+	eqStr(t, q["description"], "query", "q.description")
 
-    n := asMap(t, props["n"], "properties.n")
-    eqStr(t, n["type"], "number", "n.type")
-    eqNum(t, n["minimum"], 1, "n.minimum")
-    eqNum(t, n["maximum"], 10, "n.maximum")
+	n := asMap(t, props["n"], "properties.n")
+	eqStr(t, n["type"], "number", "n.type")
+	eqNum(t, n["minimum"], 1, "n.minimum")
+	eqNum(t, n["maximum"], 10, "n.maximum")
 
-    arr := asMap(t, props["arr"], "properties.arr")
-    eqStr(t, arr["type"], "array", "arr.type")
-    eqNum(t, arr["minItems"], 2, "arr.minItems")
-    eqNum(t, arr["maxItems"], 4, "arr.maxItems")
+	arr := asMap(t, props["arr"], "properties.arr")
+	eqStr(t, arr["type"], "array", "arr.type")
+	eqNum(t, arr["minItems"], 2, "arr.minItems")
+	eqNum(t, arr["maxItems"], 4, "arr.maxItems")
 
-    reqContains(t, def.InputSchema["required"], "q")
+	reqContains(t, def.InputSchema["required"], "q")
 }
-
 
 // TestPrepareToolArguments tests the prepareToolArguments function.
 // Ensures that required fields are validated.
 func TestPrepareToolArguments(t *testing.T) {
-    tool := mcp.Tool{
-        Name: "echo",
-        InputSchema: mcp.JSONSchema{
-            Type:     "object",
-            Required: []string{"q"},
-        },
-    }
+	tool := mcp.Tool{
+		Name: "echo",
+		InputSchema: mcp.JSONSchema{
+			Type:     "object",
+			Required: []string{"q"},
+		},
+	}
 
-    okArgs := map[string]any{"q": "hi"}
-    got, err := prepareToolArguments(tool, okArgs)
-    if err != nil {
-        t.Fatalf("unexpected error for valid args: %v", err)
-    }
-    if got["q"] != "hi" {
-        t.Fatalf("args not preserved: %v", got)
-    }
+	okArgs := map[string]any{"q": "hi"}
+	got, err := prepareToolArguments(tool, okArgs)
+	if err != nil {
+		t.Fatalf("unexpected error for valid args: %v", err)
+	}
+	if got["q"] != "hi" {
+		t.Fatalf("args not preserved: %v", got)
+	}
 
-    _, err = prepareToolArguments(tool, map[string]any{})
-    if err == nil {
-        t.Fatalf("expected error for missing required field")
-    }
-    _, err = prepareToolArguments(tool, nil)
-    if err == nil {
-        t.Fatalf("expected error for nil args with required field")
-    }
+	_, err = prepareToolArguments(tool, map[string]any{})
+	if err == nil {
+		t.Fatalf("expected error for missing required field")
+	}
+	_, err = prepareToolArguments(tool, nil)
+	if err == nil {
+		t.Fatalf("expected error for nil args with required field")
+	}
 }
-
-

--- a/go/plugins/mcp/tools_test.go
+++ b/go/plugins/mcp/tools_test.go
@@ -78,7 +78,6 @@ func TestCreateTool(t *testing.T) {
         "description": "Echo",
         "inputSchema": {
             "type": "object",
-            "description": "Echo input",
             "required": ["q"],
             "properties": {
                 "q": {"type": "string", "description": "query"},

--- a/go/plugins/mcp/tools_test.go
+++ b/go/plugins/mcp/tools_test.go
@@ -1,0 +1,169 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+    "testing"
+
+    "github.com/mark3labs/mcp-go/mcp"
+)
+
+func asMap(t *testing.T, v any, label string) map[string]any {
+    t.Helper()
+    m, ok := v.(map[string]any)
+    if !ok {
+        t.Fatalf("%s: want map[string]any, got %T", label, v)
+    }
+    return m
+}
+
+func eqStr(t *testing.T, got any, want string, label string) {
+    t.Helper()
+    s, ok := got.(string)
+    if !ok || s != want {
+        t.Fatalf("%s: got %v", label, got)
+    }
+}
+
+func eqNum(t *testing.T, got any, want int, label string) {
+    t.Helper()
+    f, ok := got.(float64)
+    if !ok || int(f) != want {
+        t.Fatalf("%s: got %v", label, got)
+    }
+}
+
+func reqContains(t *testing.T, v any, want string) {
+    t.Helper()
+    switch arr := v.(type) {
+    case []any:
+        for _, x := range arr {
+            if s, ok := x.(string); ok && s == want {
+                return
+            }
+        }
+    case []string:
+        for _, s := range arr {
+            if s == want {
+                return
+            }
+        }
+    default:
+        t.Fatalf("required: unexpected type %T", v)
+    }
+    t.Fatalf("required does not contain %q: %v", want, v)
+}
+
+// TestCreateTool tests the createTool function.
+func TestCreateTool(t *testing.T) {
+    client := &GenkitMCPClient{options: MCPClientOptions{Name: "srv"}}
+
+    m := mcp.Tool{
+        Name:        "echo",
+        Description: "Echo",
+        InputSchema: mcp.JSONSchema{
+            Type:        "object",
+            Required:    []string{"q"},
+            Description: "Echo input",
+            Properties: map[string]mcp.JSONSchema{
+                "q": {
+                    Type:        "string",
+                    Description: "query",
+                },
+                "n": {
+                    Type:     "number",
+                    Minimum:  1,
+                    Maximum:  10,
+                },
+                "arr": {
+                    Type:     "array",
+                    MinItems: 2,
+                    MaxItems: 4,
+                },
+            },
+        },
+    }
+
+    tool, err := client.createTool(m)
+    if err != nil {
+        t.Fatalf("createTool error: %v", err)
+    }
+
+	// Validate that the tool is namespaced
+    def := tool.Definition()
+    if def.Name != "srv_echo" {
+        t.Fatalf("namespacing failed: got %q", def.Name)
+    }
+    if def.Description != "Echo" {
+        t.Fatalf("description mismatch: %q", def.Description)
+    }
+    if def.InputSchema == nil {
+        t.Fatalf("input schema missing")
+    }
+
+	// Validate that the schema is propagated correctly.
+    eqStr(t, def.InputSchema["type"], "object", "schema.type")
+    eqStr(t, def.InputSchema["description"], "Echo input", "schema.description")
+    props := asMap(t, def.InputSchema["properties"], "schema.properties")
+
+    q := asMap(t, props["q"], "properties.q")
+    eqStr(t, q["type"], "string", "q.type")
+    eqStr(t, q["description"], "query", "q.description")
+
+    n := asMap(t, props["n"], "properties.n")
+    eqStr(t, n["type"], "number", "n.type")
+    eqNum(t, n["minimum"], 1, "n.minimum")
+    eqNum(t, n["maximum"], 10, "n.maximum")
+
+    arr := asMap(t, props["arr"], "properties.arr")
+    eqStr(t, arr["type"], "array", "arr.type")
+    eqNum(t, arr["minItems"], 2, "arr.minItems")
+    eqNum(t, arr["maxItems"], 4, "arr.maxItems")
+
+    reqContains(t, def.InputSchema["required"], "q")
+}
+
+
+// TestPrepareToolArguments tests the prepareToolArguments function.
+// Ensures that required fields are validated.
+func TestPrepareToolArguments(t *testing.T) {
+    tool := mcp.Tool{
+        Name: "echo",
+        InputSchema: mcp.JSONSchema{
+            Type:     "object",
+            Required: []string{"q"},
+        },
+    }
+
+    okArgs := map[string]any{"q": "hi"}
+    got, err := prepareToolArguments(tool, okArgs)
+    if err != nil {
+        t.Fatalf("unexpected error for valid args: %v", err)
+    }
+    if got["q"] != "hi" {
+        t.Fatalf("args not preserved: %v", got)
+    }
+
+    _, err = prepareToolArguments(tool, map[string]any{})
+    if err == nil {
+        t.Fatalf("expected error for missing required field")
+    }
+    _, err = prepareToolArguments(tool, nil)
+    if err == nil {
+        t.Fatalf("expected error for nil args with required field")
+    }
+}
+
+

--- a/go/samples/mcp-client/main.go
+++ b/go/samples/mcp-client/main.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/logger"
@@ -26,139 +25,6 @@ import (
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 	"github.com/firebase/genkit/go/plugins/mcp"
 )
-
-// MCP Host Example - connects to time server and demonstrates both tools and resources
-func managerExample() {
-	ctx := context.Background()
-
-	// Initialize Genkit with Google AI
-	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
-
-	// Create and connect to MCP time server
-	host, _ := mcp.NewMCPHost(g, mcp.MCPHostOptions{
-		Name: "time-example",
-		MCPServers: []mcp.MCPServerConfig{
-			{
-				Name: "time",
-				Config: mcp.MCPClientOptions{
-					Name:    "mcp-time",
-					Version: "1.0.0",
-					Stdio: &mcp.StdioConfig{
-						Command: "uvx",
-						Args:    []string{"mcp-server-time", "--local-timezone=America/New_York"},
-					},
-				},
-			},
-		},
-	})
-
-	// Get tools and resources from MCP servers
-	tools, _ := host.GetActiveTools(ctx, g)
-	logger.FromContext(ctx).Info("Found MCP tools", "count", len(tools), "example", "time")
-
-	// Get detached resources from MCP servers (not auto-registered)
-	allResources, err := host.GetActiveResources(ctx)
-	if err != nil {
-		logger.FromContext(ctx).Warn("Failed to get MCP resources", "error", err)
-	} else {
-		logger.FromContext(ctx).Info("Successfully got detached MCP resources", "count", len(allResources))
-		// Resources can be used via ai.WithResources() in generate calls
-		logger.FromContext(ctx).Info("Resources can be used in prompts via ai.WithResources()")
-	}
-
-	var toolRefs []ai.ToolRef
-	for _, tool := range tools {
-		toolRefs = append(toolRefs, tool)
-	}
-
-	response, err := genkit.Generate(ctx, g,
-		ai.WithModelName("googleai/gemini-2.5-pro-preview-05-06"),
-		ai.WithPrompt("What time is it in New York and Tokyo?"),
-		ai.WithTools(toolRefs...),
-		ai.WithToolChoice(ai.ToolChoiceAuto),
-	)
-	if err != nil {
-		logger.FromContext(ctx).Error("Generation failed", "error", err)
-	} else {
-		logger.FromContext(ctx).Info("Generation completed", "response", response.Text())
-	}
-
-	// Disconnect from server
-	host.Disconnect(ctx, "time")
-	logger.FromContext(ctx).Info("Disconnected from MCP server", "server", "time")
-}
-
-// MCP Host Multi-Server Example - connects to both time and fetch servers, demonstrates tools and resources
-func multiServerManagerExample() {
-	ctx := context.Background()
-
-	// Initialize Genkit with Google AI
-	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
-
-	// Create MCP host for multiple servers
-	host, _ := mcp.NewMCPHost(g, mcp.MCPHostOptions{
-		Name: "multi-server-example",
-		MCPServers: []mcp.MCPServerConfig{
-			{
-				Name: "time",
-				Config: mcp.MCPClientOptions{
-					Name:    "mcp-time",
-					Version: "1.0.0",
-					Stdio: &mcp.StdioConfig{
-						Command: "uvx",
-						Args:    []string{"mcp-server-time", "--local-timezone=America/New_York"},
-					},
-				},
-			},
-			{
-				Name: "fetch",
-				Config: mcp.MCPClientOptions{
-					Name:    "mcp-fetch",
-					Version: "1.0.0",
-					Stdio: &mcp.StdioConfig{
-						Command: "uvx",
-						Args:    []string{"mcp-server-fetch"},
-					},
-				},
-			},
-		},
-	})
-
-	// Get tools and resources from all connected servers
-	tools, _ := host.GetActiveTools(ctx, g)
-	logger.FromContext(ctx).Info("Found MCP tools from all servers", "count", len(tools), "servers", []string{"time", "fetch"})
-
-	// Get detached resources from all MCP servers
-	allResources2, err := host.GetActiveResources(ctx)
-	if err != nil {
-		logger.FromContext(ctx).Warn("Failed to get MCP resources from servers", "error", err)
-	} else {
-		logger.FromContext(ctx).Info("Successfully got detached MCP resources from all servers", "count", len(allResources2), "servers", []string{"time", "fetch"})
-	}
-
-	var toolRefs []ai.ToolRef
-	for _, tool := range tools {
-		toolRefs = append(toolRefs, tool)
-	}
-
-	// Generate response using tools from multiple servers
-	response, err := genkit.Generate(ctx, g,
-		ai.WithModelName("googleai/gemini-2.5-pro-preview-05-06"),
-		ai.WithPrompt("What time is it in New York? Also, fetch the latest news from https://httpbin.org/json and tell me what you find."),
-		ai.WithTools(toolRefs...),
-		ai.WithToolChoice(ai.ToolChoiceAuto),
-	)
-	if err != nil {
-		logger.FromContext(ctx).Error("Generation failed", "error", err)
-	} else {
-		logger.FromContext(ctx).Info("Generation completed", "response", response.Text())
-	}
-
-	// Disconnect from all servers
-	host.Disconnect(ctx, "time")
-	host.Disconnect(ctx, "fetch")
-	logger.FromContext(ctx).Info("Disconnected from all MCP servers", "servers", []string{"time", "fetch"})
-}
 
 // MCP Client Example - connects to time server
 func clientExample() {
@@ -208,92 +74,43 @@ func clientExample() {
 	logger.FromContext(ctx).Info("Disconnected from MCP server", "client", "mcp-time")
 }
 
-// MCP Client GetPrompt Example - connects to a server and uses prompts
-func clientGetPromptExample() {
+// MCP Host Example - connects to time server and demonstrates both tools and resources
+func managerExample() {
 	ctx := context.Background()
 
 	// Initialize Genkit with Google AI
 	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
 
-	logger.FromContext(ctx).Info("Creating MCP client", "server", "everything")
-	// Create and connect to MCP server (using everything server as example)
-	client, err := mcp.NewGenkitMCPClient(mcp.MCPClientOptions{
-		Name:    "mcp-everything",
-		Version: "1.0.0",
-		Stdio: &mcp.StdioConfig{
-			Command: "npx",
-			Args:    []string{"@modelcontextprotocol/server-everything", "stdio"},
-		},
-	})
-	if err != nil {
-		logger.FromContext(ctx).Error("Failed to create MCP client", "error", err)
-		return
-	}
-	logger.FromContext(ctx).Info("MCP client created successfully", "client", "mcp-everything")
-
-	// Get a specific prompt from the server
-	logger.FromContext(ctx).Info("Getting prompt from MCP server", "prompt", "simple_prompt")
-	prompt, err := client.GetPrompt(ctx, g, "simple_prompt", map[string]string{})
-	if err != nil {
-		logger.FromContext(ctx).Error("Failed to get prompt", "prompt", "simple_prompt", "error", err)
-	} else {
-		logger.FromContext(ctx).Info("Retrieved prompt successfully", "promptName", prompt.Name())
-
-		// Execute the prompt directly
-		logger.FromContext(ctx).Info("Executing prompt", "prompt", prompt.Name())
-		response, err := prompt.Execute(ctx,
-			ai.WithInput(map[string]interface{}{}),
-			ai.WithModelName("googleai/gemini-2.5-pro-preview-05-06"),
-		)
-		if err != nil {
-			logger.FromContext(ctx).Error("Prompt execution failed", "prompt", prompt.Name(), "error", err)
-		} else {
-			logger.FromContext(ctx).Info("Prompt execution completed", "prompt", prompt.Name(), "response", response.Text())
-		}
-	}
-}
-
-// MCP Client Streamable HTTP Example - connects to a server via Streamable HTTP transport
-func clientStreamableHTTPExample() {
-	ctx := context.Background()
-
-	// Initialize Genkit with Google AI
-	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
-
-	logger.FromContext(ctx).Info("Creating MCP client with Streamable HTTP transport", "server", "everything")
-	// Create and connect to MCP server using Streamable HTTP transport
-	// Note: Start the server with: npx @modelcontextprotocol/server-everything streamableHttp --port 3001
-	// This will start the server on http://localhost:3001
-	client, err := mcp.NewGenkitMCPClient(mcp.MCPClientOptions{
-		Name:    "mcp-everything-http",
-		Version: "1.0.0",
-		StreamableHTTP: &mcp.StreamableHTTPConfig{
-			BaseURL: "http://localhost:3001",
-			Headers: map[string]string{
-				"User-Agent": "genkit-mcp-client/1.0.0",
+	// Create and connect to MCP time server
+	host, _ := mcp.NewMCPHost(g, mcp.MCPHostOptions{
+		Name: "time-example",
+		MCPServers: []mcp.MCPServerConfig{
+			{
+				Name: "time",
+				Config: mcp.MCPClientOptions{
+					Name:    "mcp-time",
+					Version: "1.0.0",
+					Stdio: &mcp.StdioConfig{
+						Command: "uvx",
+						Args:    []string{"mcp-server-time", "--local-timezone=America/New_York"},
+					},
+				},
 			},
-			Timeout: 30 * time.Second, // Optional timeout
 		},
 	})
-	if err != nil {
-		logger.FromContext(ctx).Error("Failed to create MCP client with Streamable HTTP", "error", err)
-		return
-	}
-	logger.FromContext(ctx).Info("MCP client with Streamable HTTP created successfully", "client", "mcp-everything-http")
 
-	// Get tools and generate response
-	tools, _ := client.GetActiveTools(ctx, g)
-	logger.FromContext(ctx).Info("Found MCP tools via Streamable HTTP", "count", len(tools), "client", "mcp-everything-http")
+	// Get tools and resources from MCP servers
+	tools, _ := host.GetActiveTools(ctx, g)
+	logger.FromContext(ctx).Info("Found MCP tools", "count", len(tools)
 
 	var toolRefs []ai.ToolRef
 	for _, tool := range tools {
 		toolRefs = append(toolRefs, tool)
 	}
 
-	// Generate response using tools from the HTTP server
 	response, err := genkit.Generate(ctx, g,
-		ai.WithModelName("googleai/gemini-2.0-flash-exp"),
-		ai.WithPrompt("Use the echo tool to repeat the message 'Hello from Streamable HTTP!' and then use the add tool to calculate 15 + 27."),
+		ai.WithModelName("googleai/gemini-2.5-pro-preview-05-06"),
+		ai.WithPrompt("What time is it in New York and Tokyo?"),
 		ai.WithTools(toolRefs...),
 		ai.WithToolChoice(ai.ToolChoiceAuto),
 	)
@@ -304,157 +121,30 @@ func clientStreamableHTTPExample() {
 	}
 
 	// Disconnect from server
-	logger.FromContext(ctx).Info("Disconnecting from MCP server", "client", "mcp-everything-http")
-	client.Disconnect()
-	logger.FromContext(ctx).Info("Disconnected from MCP server", "client", "mcp-everything-http")
-}
-
-// MCP Resources Example - demonstrates how to connect to servers and actually use their resources
-func resourcesExample() {
-	ctx := context.Background()
-
-	// Initialize Genkit with Google AI plugin and default model
-	g := genkit.Init(ctx,
-		genkit.WithPlugins(&googlegenai.GoogleAI{}),
-		genkit.WithDefaultModel("googleai/gemini-2.0-flash"),
-	)
-
-	logger.FromContext(ctx).Info("Starting MCP Resources demonstration")
-
-	// === Example 1: Connect to a server that actually provides resources ===
-	logger.FromContext(ctx).Info("Creating MCP client for everything server (has sample resources)")
-	// This server actually provides sample resources we can read
-	everythingClient, err := mcp.NewGenkitMCPClient(mcp.MCPClientOptions{
-		Name:    "mcp-everything",
-		Version: "1.0.0",
-		Stdio: &mcp.StdioConfig{
-			Command: "npx",
-			Args:    []string{"@modelcontextprotocol/server-everything", "stdio"},
-		},
-	})
-	if err != nil {
-		logger.FromContext(ctx).Warn("Failed to create everything MCP client (install: npm install -g @modelcontextprotocol/server-everything)", "error", err)
-	} else {
-		logger.FromContext(ctx).Info("Everything MCP client created successfully")
-
-		// Get detached resources from the everything server (without auto-registering)
-		resources, err := everythingClient.GetActiveResources(ctx)
-		if err != nil {
-			logger.FromContext(ctx).Warn("Failed to get everything server resources", "error", err)
-		} else {
-			logger.FromContext(ctx).Info("Got detached resources from everything server", "count", len(resources))
-
-			// Demonstrate the streamlined UX: use resources directly in generate calls
-			if len(resources) > 0 {
-				logger.FromContext(ctx).Info("Demonstrating streamlined resource usage...")
-
-				// Limit resources to avoid overwhelming the model (just use first 3 for demo)
-				limitedResources := resources
-				if len(resources) > 3 {
-					limitedResources = resources[:3]
-					logger.FromContext(ctx).Info("Limiting to first 3 resources for demo", "total", len(resources), "using", len(limitedResources))
-				}
-
-				// Example: Use MCP resources in an AI generation call
-				response, err := genkit.Generate(ctx, g,
-					ai.WithMessages(ai.NewUserMessage(
-						ai.NewTextPart("List the available resources and describe what each one contains."),
-						// Resource references will be resolved automatically from the detached resources
-					)),
-					ai.WithResources(limitedResources...),
-				)
-				if err != nil {
-					logger.FromContext(ctx).Warn("Failed to generate with MCP resources", "error", err)
-				} else {
-					logger.FromContext(ctx).Info("Generated response using MCP resources", "response", response.Text())
-				}
-
-				// Show available resource names for reference
-				logger.FromContext(ctx).Info("Available resources:")
-				for i, resource := range resources {
-					logger.FromContext(ctx).Info("Resource available",
-						"index", i,
-						"name", resource.Name())
-					// Only show first few for demo
-					if i >= 2 {
-						logger.FromContext(ctx).Info("... and more resources available")
-						break
-					}
-				}
-			} else {
-				logger.FromContext(ctx).Info("No resources available from everything server")
-			}
-		}
-
-		// Disconnect from everything server
-		everythingClient.Disconnect()
-		logger.FromContext(ctx).Info("Disconnected from everything server")
-	}
-
-	// === Example 2: Simple resource workflow ===
-	// Create a detached resource from your own code that you can use in AI generation
-	configResource := genkit.NewResource("app-config", &ai.ResourceOptions{
-		URI: "config://app.json",
-	}, func(ctx context.Context, input *ai.ResourceInput) (*ai.ResourceOutput, error) {
-		config := `{"app": "MyApp", "version": "1.0", "features": ["auth", "chat"]}`
-		return &ai.ResourceOutput{
-			Content: []*ai.Part{ai.NewTextPart(config)},
-		}, nil
-	})
-
-	response, err := genkit.Generate(ctx, g,
-		ai.WithMessages(
-			ai.NewUserMessage(
-				ai.NewTextPart("Here's my config, what features does it have?"),
-				ai.NewResourcePart("config://app.json"),
-			),
-		),
-		ai.WithResources(configResource), // Pass detached resource
-	)
-
-	if err == nil {
-		logger.FromContext(ctx).Info("Resource workflow complete", "response", response.Text())
-	}
-
-	logger.FromContext(ctx).Info("MCP Resources demonstration completed")
+	host.Disconnect(ctx, "time")
+	logger.FromContext(ctx).Info("Disconnected from MCP server", "server", "time")
 }
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Println("Usage: go run main.go [manager|multi|client|getprompt|streamablehttp|resources]")
+		fmt.Println("Usage: go run main.go [manager|client]")
 		fmt.Println("  manager        - MCP Host example with time server (tools & resources)")
-		fmt.Println("  multi          - MCP Host example with multiple servers (tools & resources)")
 		fmt.Println("  client         - MCP Client example with time server")
-		fmt.Println("  getprompt      - MCP Client GetPrompt example")
-		fmt.Println("  streamablehttp - MCP Client Streamable HTTP example")
-		fmt.Println("  resources      - MCP Resources example (filesystem & demo server)")
 		os.Exit(1)
 	}
 
 	ctx := context.Background()
 
 	switch os.Args[1] {
-	case "manager":
-		logger.FromContext(ctx).Info("Running MCP Host example")
-		managerExample()
-	case "multi":
-		logger.FromContext(ctx).Info("Running MCP Host multi-server example")
-		multiServerManagerExample()
 	case "client":
 		logger.FromContext(ctx).Info("Running MCP Client example")
 		clientExample()
-	case "getprompt":
-		logger.FromContext(ctx).Info("Running MCP Client GetPrompt example")
-		clientGetPromptExample()
-	case "streamablehttp":
-		logger.FromContext(ctx).Info("Running MCP Client Streamable HTTP example")
-		clientStreamableHTTPExample()
-	case "resources":
-		logger.FromContext(ctx).Info("Running MCP Resources example")
-		resourcesExample()
+	case "manager":
+		logger.FromContext(ctx).Info("Running MCP Host example")
+		managerExample()
 	default:
 		fmt.Printf("Unknown example: %s\n", os.Args[1])
-		fmt.Println("Use 'manager', 'multi', 'client', 'getprompt', 'streamablehttp', or 'resources'")
+		fmt.Println("Use 'client' or 'manager'")
 		os.Exit(1)
 	}
 }

--- a/go/samples/mcp-client/main.go
+++ b/go/samples/mcp-client/main.go
@@ -101,7 +101,7 @@ func managerExample() {
 
 	// Get tools and resources from MCP servers
 	tools, _ := host.GetActiveTools(ctx, g)
-	logger.FromContext(ctx).Info("Found MCP tools", "count", len(tools)
+	logger.FromContext(ctx).Info("Found MCP tools", "count", len(tools))
 
 	var toolRefs []ai.ToolRef
 	for _, tool := range tools {


### PR DESCRIPTION
When we added support for dynamic tools we didn't have a way to define a dynamic tool with an input schema, so the tools weren't propagating the required arguments correctly. This PR fixes that problem.

I also noticed that for JSON schema properties that are numbers (minItems, maxItems, minimum, maximum), our googlegenai gemini plugin expects these fields to be strings and casts to float. However the JSON schemas from MCP tools get unmarshalled into jsonschema.Schema which types them as floats/ints. I think it's most flexible to support both types in the gemini plugin, so I updated that here.