### PR TITLE
Fix(go) prompt.excute merge external incoming messages

### DIFF
--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -176,7 +176,7 @@ func (p *prompt) Execute(ctx context.Context, opts ...PromptExecuteOption) (*Mod
 		if err != nil {
 			return nil, err
 		}
-		actionOpts.Messages = append(actionOpts.Messages, msg...)
+		actionOpts.Messages = msg
 	}
 
 	return GenerateWithRequest(ctx, p.registry, actionOpts, execOpts.Middleware, execOpts.Stream)


### PR DESCRIPTION
Fixes #3544