### PR TITLE
fix(go): fixes to AIM telemetry

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -340,13 +340,7 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 				}
 			}
 
-			toolCount := 0
-			for _, part := range resp.Message.Content {
-				if part.IsToolRequest() {
-					toolCount++
-				}
-			}
-			if toolCount == 0 || opts.ReturnToolRequests {
+			if len(resp.ToolRequests()) > 0 || opts.ReturnToolRequests {
 				return resp, nil
 			}
 

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -316,52 +316,63 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 
 	fn := core.ChainMiddleware(mw...)(m.Generate)
 
-	currentTurn := 0
-	for {
-		resp, err := fn(ctx, req, cb)
-		if err != nil {
-			return nil, err
+	// Inline recursive helper function that captures variables from parent scope.
+	var generate func(context.Context, *ModelRequest, int) (*ModelResponse, error)
+
+	generate = func(ctx context.Context, req *ModelRequest, currentTurn int) (*ModelResponse, error) {
+		spanMetadata := &tracing.SpanMetadata{
+			Name:    "generate",
+			Type:    "util",
+			Subtype: "util",
 		}
 
-		if formatHandler != nil {
-			resp.Message, err = formatHandler.ParseMessage(resp.Message)
+		return tracing.RunInNewSpan(ctx, spanMetadata, req, func(ctx context.Context, req *ModelRequest) (*ModelResponse, error) {
+			resp, err := fn(ctx, req, cb)
 			if err != nil {
-				logger.FromContext(ctx).Debug("model failed to generate output matching expected schema", "error", err.Error())
-				return nil, core.NewError(core.INTERNAL, "model failed to generate output matching expected schema: %v", err)
+				return nil, err
 			}
-		}
 
-		toolCount := 0
-		for _, part := range resp.Message.Content {
-			if part.IsToolRequest() {
-				toolCount++
+			if formatHandler != nil {
+				resp.Message, err = formatHandler.ParseMessage(resp.Message)
+				if err != nil {
+					logger.FromContext(ctx).Debug("model failed to generate output matching expected schema", "error", err.Error())
+					return nil, core.NewError(core.INTERNAL, "model failed to generate output matching expected schema: %v", err)
+				}
 			}
-		}
-		if toolCount == 0 || opts.ReturnToolRequests {
-			return resp, nil
-		}
 
-		if currentTurn+1 > maxTurns {
-			return nil, core.NewError(core.ABORTED, "exceeded maximum tool call iterations (%d)", maxTurns)
-		}
+			toolCount := 0
+			for _, part := range resp.Message.Content {
+				if part.IsToolRequest() {
+					toolCount++
+				}
+			}
+			if toolCount == 0 || opts.ReturnToolRequests {
+				return resp, nil
+			}
 
-		newReq, interruptMsg, err := handleToolRequests(ctx, r, req, resp, cb)
-		if err != nil {
-			return nil, err
-		}
-		if interruptMsg != nil {
-			resp.FinishReason = "interrupted"
-			resp.FinishMessage = "One or more tool calls resulted in interrupts."
-			resp.Message = interruptMsg
-			return resp, nil
-		}
-		if newReq == nil {
-			return resp, nil
-		}
+			if currentTurn+1 > maxTurns {
+				return nil, core.NewError(core.ABORTED, "exceeded maximum tool call iterations (%d)", maxTurns)
+			}
 
-		req = newReq
-		currentTurn++
+			newReq, interruptMsg, err := handleToolRequests(ctx, r, req, resp, cb)
+			if err != nil {
+				return nil, err
+			}
+			if interruptMsg != nil {
+				resp.FinishReason = "interrupted"
+				resp.FinishMessage = "One or more tool calls resulted in interrupts."
+				resp.Message = interruptMsg
+				return resp, nil
+			}
+			if newReq == nil {
+				return resp, nil
+			}
+
+			return generate(ctx, newReq, currentTurn+1)
+		})
 	}
+
+	return generate(ctx, req, 0)
 }
 
 // Generate generates a model response based on the provided options.
@@ -500,15 +511,7 @@ func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*Mod
 	}
 	actionOpts.Messages = processedMessages
 
-	spanMetadata := &tracing.SpanMetadata{
-		Name:    "generate",
-		Type:    "util",
-		Subtype: "util",
-	}
-	return tracing.RunInNewSpan(ctx, spanMetadata, actionOpts,
-		func(ctx context.Context, actionOpts *GenerateActionOptions) (*ModelResponse, error) {
-			return GenerateWithRequest(ctx, r, actionOpts, genOpts.Middleware, genOpts.Stream)
-		})
+	return GenerateWithRequest(ctx, r, actionOpts, genOpts.Middleware, genOpts.Stream)
 }
 
 // GenerateText run generate request for this model. Returns generated text only.

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -340,7 +340,7 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 				}
 			}
 
-			if len(resp.ToolRequests()) > 0 || opts.ReturnToolRequests {
+			if len(resp.ToolRequests()) == 0 || opts.ReturnToolRequests {
 				return resp, nil
 			}
 

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -123,15 +123,7 @@ func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
 					"err", err)
 			}()
 
-			spanMetadata := &tracing.SpanMetadata{
-				Name:    "generate",
-				Type:    "util",
-				Subtype: "util",
-			}
-			return tracing.RunInNewSpan(ctx, spanMetadata, actionOpts,
-				func(ctx context.Context, actionOpts *GenerateActionOptions) (*ModelResponse, error) {
-					return GenerateWithRequest(ctx, r, actionOpts, nil, cb)
-				})
+			return GenerateWithRequest(ctx, r, actionOpts, nil, cb)
 		}))
 }
 
@@ -508,7 +500,15 @@ func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*Mod
 	}
 	actionOpts.Messages = processedMessages
 
-	return GenerateWithRequest(ctx, r, actionOpts, genOpts.Middleware, genOpts.Stream)
+	spanMetadata := &tracing.SpanMetadata{
+		Name:    "generate",
+		Type:    "util",
+		Subtype: "util",
+	}
+	return tracing.RunInNewSpan(ctx, spanMetadata, actionOpts,
+		func(ctx context.Context, actionOpts *GenerateActionOptions) (*ModelResponse, error) {
+			return GenerateWithRequest(ctx, r, actionOpts, genOpts.Middleware, genOpts.Stream)
+		})
 }
 
 // GenerateText run generate request for this model. Returns generated text only.

--- a/go/plugins/googlecloud/action.go
+++ b/go/plugins/googlecloud/action.go
@@ -49,29 +49,31 @@ func (a *ActionTelemetry) Tick(span sdktrace.ReadOnlySpan, logInputOutput bool, 
 
 	subtype := extractStringAttribute(attributes, "genkit:metadata:subtype")
 
-	if subtype == "tool" || actionName == "generate" {
-		path := extractStringAttribute(attributes, "genkit:path")
-		if path == "" {
-			path = "<unknown>"
-		}
+	if subtype != "tool" && actionName != "generate" {
+		return
+	}
 
-		input := truncate(extractStringAttribute(attributes, "genkit:input"))
-		output := truncate(extractStringAttribute(attributes, "genkit:output"))
-		sessionID := extractStringAttribute(attributes, "genkit:sessionId")
-		threadName := extractStringAttribute(attributes, "genkit:threadName")
+	path := extractStringAttribute(attributes, "genkit:path")
+	if path == "" {
+		path = "<unknown>"
+	}
 
-		featureName := extractOuterFeatureNameFromPath(path)
-		if featureName == "" || featureName == "<unknown>" {
-			featureName = actionName
-		}
+	input := truncate(extractStringAttribute(attributes, "genkit:input"))
+	output := truncate(extractStringAttribute(attributes, "genkit:output"))
+	sessionID := extractStringAttribute(attributes, "genkit:sessionId")
+	threadName := extractStringAttribute(attributes, "genkit:threadName")
 
-		if input != "" {
-			a.writeLog(span, "Input", featureName, path, input, projectID, sessionID, threadName)
-		}
+	featureName := extractOuterFeatureNameFromPath(path)
+	if featureName == "" || featureName == "<unknown>" {
+		featureName = actionName
+	}
 
-		if output != "" {
-			a.writeLog(span, "Output", featureName, path, output, projectID, sessionID, threadName)
-		}
+	if input != "" {
+		a.writeLog(span, "Input", featureName, path, input, projectID, sessionID, threadName)
+	}
+
+	if output != "" {
+		a.writeLog(span, "Output", featureName, path, output, projectID, sessionID, threadName)
 	}
 }
 

--- a/go/plugins/googlecloud/engagement_test.go
+++ b/go/plugins/googlecloud/engagement_test.go
@@ -122,7 +122,7 @@ func TestEngagementTelemetry_PipelineIntegration(t *testing.T) {
 	_, span := f.tracer.Start(ctx, "test-span")
 
 	span.SetAttributes(
-		attribute.String("genkit:type", "action"), // Required for telemetry processing
+		attribute.String("genkit:type", "userEngagement"), // Required for telemetry processing
 		attribute.String("genkit:metadata:subtype", "userFeedback"),
 		attribute.String("genkit:path", "/{testFlow,t:flow}/{myAction,t:action}"),
 		attribute.String("genkit:metadata:feedbackValue", "positive"),
@@ -175,7 +175,7 @@ func TestEngagementTelemetry_MetricCapture(t *testing.T) {
 		{
 			name: "user feedback captures metrics correctly",
 			attrs: map[string]string{
-				"genkit:type":                   "action",
+				"genkit:type":                   "userEngagement",
 				"genkit:metadata:subtype":       "userFeedback",
 				"genkit:path":                   "/{chatFlow,t:flow}/{generateResponse,t:action}",
 				"genkit:metadata:feedbackValue": "positive",
@@ -190,7 +190,7 @@ func TestEngagementTelemetry_MetricCapture(t *testing.T) {
 		{
 			name: "user feedback without text",
 			attrs: map[string]string{
-				"genkit:type":                   "action",
+				"genkit:type":                   "userEngagement",
 				"genkit:metadata:subtype":       "userFeedback",
 				"genkit:path":                   "/{testFlow,t:flow}/{myAction,t:action}",
 				"genkit:metadata:feedbackValue": "negative",
@@ -204,7 +204,7 @@ func TestEngagementTelemetry_MetricCapture(t *testing.T) {
 		{
 			name: "user acceptance captures metrics correctly",
 			attrs: map[string]string{
-				"genkit:type":                     "action",
+				"genkit:type":                     "userEngagement",
 				"genkit:metadata:subtype":         "userAcceptance",
 				"genkit:path":                     "/{codeAssistant,t:flow}/{suggestCode,t:action}",
 				"genkit:metadata:acceptanceValue": "accepted",
@@ -217,7 +217,7 @@ func TestEngagementTelemetry_MetricCapture(t *testing.T) {
 		{
 			name: "unknown subtype captures no metrics",
 			attrs: map[string]string{
-				"genkit:type":             "action",
+				"genkit:type":             "userEngagement",
 				"genkit:metadata:subtype": "unknownType",
 				"genkit:path":             "/{testFlow,t:flow}/{myAction,t:action}",
 			},
@@ -366,7 +366,7 @@ func TestEngagementTelemetry_ComprehensiveScenarios(t *testing.T) {
 		{
 			name: "user feedback with text",
 			attrs: map[string]string{
-				"genkit:type":                   "action",
+				"genkit:type":                   "userEngagement",
 				"genkit:metadata:subtype":       "userFeedback",
 				"genkit:path":                   "/{chatFlow,t:flow}/{generateResponse,t:action}",
 				"genkit:metadata:feedbackValue": "positive",
@@ -379,7 +379,7 @@ func TestEngagementTelemetry_ComprehensiveScenarios(t *testing.T) {
 		{
 			name: "user feedback without text",
 			attrs: map[string]string{
-				"genkit:type":                   "action",
+				"genkit:type":                   "userEngagement",
 				"genkit:metadata:subtype":       "userFeedback",
 				"genkit:path":                   "/{testFlow,t:flow}/{myAction,t:action}",
 				"genkit:metadata:feedbackValue": "negative",
@@ -391,7 +391,7 @@ func TestEngagementTelemetry_ComprehensiveScenarios(t *testing.T) {
 		{
 			name: "user acceptance",
 			attrs: map[string]string{
-				"genkit:type":                     "action",
+				"genkit:type":                     "userEngagement",
 				"genkit:metadata:subtype":         "userAcceptance",
 				"genkit:path":                     "/{codeAssistant,t:flow}/{suggestCode,t:action}",
 				"genkit:metadata:acceptanceValue": "accepted",
@@ -403,7 +403,7 @@ func TestEngagementTelemetry_ComprehensiveScenarios(t *testing.T) {
 		{
 			name: "unknown subtype",
 			attrs: map[string]string{
-				"genkit:type":             "action",
+				"genkit:type":             "userEngagement",
 				"genkit:metadata:subtype": "unknownType",
 				"genkit:path":             "/{testFlow,t:flow}/{myAction,t:action}",
 			},
@@ -413,7 +413,7 @@ func TestEngagementTelemetry_ComprehensiveScenarios(t *testing.T) {
 		{
 			name: "no subtype",
 			attrs: map[string]string{
-				"genkit:type": "action",
+				"genkit:type": "userEngagement",
 				"genkit:path": "/{testFlow,t:flow}/{myAction,t:action}",
 			},
 			expectLog:    false,

--- a/go/plugins/googlecloud/generate.go
+++ b/go/plugins/googlecloud/generate.go
@@ -89,11 +89,6 @@ func NewGenerateTelemetry() *GenerateTelemetry {
 func (g *GenerateTelemetry) Tick(span sdktrace.ReadOnlySpan, logInputOutput bool, projectID string) {
 	attributes := span.Attributes()
 
-	subtype := extractStringAttribute(attributes, "genkit:metadata:subtype")
-	if subtype != "model" {
-		return
-	}
-
 	modelName := truncate(extractStringAttribute(attributes, "genkit:name"), 1024)
 	path := extractStringAttribute(attributes, "genkit:path")
 	inputStr := extractStringAttribute(attributes, "genkit:input")

--- a/go/plugins/googlecloud/googlecloud.go
+++ b/go/plugins/googlecloud/googlecloud.go
@@ -45,8 +45,6 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
-const provider = "googlecloud"
-
 // EnableGoogleCloudTelemetry enables comprehensive telemetry export to Google Cloud Observability suite.
 // This directly initializes telemetry without requiring plugin registration.
 //
@@ -74,7 +72,10 @@ func EnableGoogleCloudTelemetry(options *GoogleCloudTelemetryOptions) {
 func initializeTelemetry(opts *GoogleCloudTelemetryOptions) {
 	projectID := opts.ProjectID
 	if projectID == "" {
+		// Check environment variables in priority order: GOOGLE_CLOUD_PROJECT, then GCLOUD_PROJECT
 		if envProjectID := os.Getenv("GOOGLE_CLOUD_PROJECT"); envProjectID != "" {
+			projectID = envProjectID
+		} else if envProjectID := os.Getenv("GCLOUD_PROJECT"); envProjectID != "" {
 			projectID = envProjectID
 		}
 	}

--- a/go/plugins/googlecloud/types.go
+++ b/go/plugins/googlecloud/types.go
@@ -39,8 +39,9 @@ type SharedDimensions struct {
 // Matches the JavaScript Google Cloud plugin options for full compatibility.
 //
 // Environment Variables:
-// - GENKIT_ENV: Set to "dev" to disable export unless ForceExport is true
+// - GENKIT_ENV: Set to "dev" to disable export unless ForceDevExport is true
 // - GOOGLE_CLOUD_PROJECT: Auto-detected project ID if ProjectID is not set
+// - GCLOUD_PROJECT: Auto-detected project ID if ProjectID is not set
 type GoogleCloudTelemetryOptions struct {
 	// ProjectID is the Google Cloud project ID.
 	// If empty, will be auto-detected from environment.

--- a/go/plugins/vertexai/modelgarden/anthropic.go
+++ b/go/plugins/vertexai/modelgarden/anthropic.go
@@ -69,7 +69,10 @@ func (a *Anthropic) Init(ctx context.Context) []api.Action {
 	if projectID == "" {
 		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
 		if projectID == "" {
-			panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_PROJECT in the environment. You can get a project ID at https://console.cloud.google.com/home/dashboard")
+			projectID = os.Getenv("GCLOUD_PROJECT")
+			if projectID == "" {
+				panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_PROJECT or GCLOUD_PROJECT in the environment. You can get a project ID at https://console.cloud.google.com/home/dashboard")
+			}
 		}
 	}
 


### PR DESCRIPTION
Addresses feedback here: https://docs.google.com/spreadsheets/d/1yYuyBLzA6S9blsGv05C-YKJSqyZsfMjh8IX7SW4RbTY/edit?gid=0#gid=0

Mainly:
1) Move the generate span generation to the ai.Generate() method - the Generation Action already gets a span from the action framework so there's no need to add it there, and ai.Generate() DOES need the extra span since it's not an action. This is the cause of most of the weirdness
2) Add support for GCLOUD_PROJECT (same as genkit ts)
3) Make firebase plugin match googlecloud plugin in terms of options (pass thru directly)
4) Handle credential detection automatically
5) Make sure exact same logs as genkit ts are being emitted by ensuring that logic for which telemetry module to call is exactly the same. Also update the user engagement tests to reflect reality; since user engagement spans have type="userEngagement"

Tested manually, some screenshots:
<img width="1978" height="112" alt="unnamed" src="https://github.com/user-attachments/assets/4c544463-3e99-4073-a45e-d95deea5f8c5" />
<img width="1216" height="569" alt="Screenshot 2025-09-11 at 11 25 19 AM" src="https://github.com/user-attachments/assets/94c9903b-c8ec-46da-afcf-cd16e2d67542" />

