### PR TITLE
feat(go): add an interrupt error judgment function

### DIFF
--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -82,13 +82,13 @@ func (e *toolInterruptError) Error() string {
 	return "tool execution interrupted"
 }
 
-// Determine whether the error is an interrupt error returned by the tool。
-func IsToolInterruptError(err error) (map[string]any, bool) {
+// IsToolInterruptError determines whether the error is an interrupt error returned by the tool.
+func IsToolInterruptError(err error) (bool, map[string]any) {
 	var tie *toolInterruptError
 	if errors.As(err, &tie) {
-		return tie.Metadata, true
+		return true, tie.Metadata
 	}
-	return nil, false
+	return false, nil
 }
 
 // InterruptOptions provides configuration for tool interruption.


### PR DESCRIPTION
Add a function for judging tool interruption errors, which is convenient for scenarios where tools are called manually to determine interruption errors.