### PR TITLE
fix(go): Remove 'openai/' prefix from embedding model names

### DIFF
--- a/go/plugins/compat_oai/openai/openai.go
+++ b/go/plugins/compat_oai/openai/openai.go
@@ -130,7 +130,7 @@ var (
 
 	supportedEmbeddingModels = map[string]EmbedderRef{
 		openaiGo.EmbeddingModelTextEmbeddingAda002: {
-			Name:         "openai/text-embedding-ada-002",
+			Name:         "text-embedding-ada-002",
 			ConfigSchema: TextEmbeddingConfig{},
 			Dimensions:   1536,
 			Label:        "Open AI - Text Embedding ADA 002",
@@ -139,7 +139,7 @@ var (
 			},
 		},
 		openaiGo.EmbeddingModelTextEmbedding3Large: {
-			Name:         "openai/text-embedding-3-large",
+			Name:         "text-embedding-3-large",
 			ConfigSchema: TextEmbeddingConfig{},
 			Dimensions:   3072,
 			Label:        "Open AI - Text Embedding 3 Large",
@@ -148,7 +148,7 @@ var (
 			},
 		},
 		openaiGo.EmbeddingModelTextEmbedding3Small: {
-			Name:         "openai/text-embedding-3-small",
+			Name:         "text-embedding-3-small",
 			ConfigSchema: TextEmbeddingConfig{}, // Represents the configurable options
 			Dimensions:   1536,
 			Label:        "Open AI - Text Embedding 3 Small",


### PR DESCRIPTION
### Description
This PR fixes a critical issue where embedding model calls were failing with `"invalid model ID"` errors by removing the incorrect prefix from embedding model names. The OpenAI API expects model names without the provider prefix, but our plugin was sending prefixed names like `openai/text-embedding-3-small` instead of the correct . `openai/``text-embedding-3-small`

### Files Changed
- Updated embedding model name mappings `go/plugins/compat_oai/openai/openai.go`

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
