### PR TITLE
feat(js/fows): added `schemaMode` option on flows (and other actions) to control schema behavour

### DIFF
--- a/js/core/src/flow.ts
+++ b/js/core/src/flow.ts
@@ -15,7 +15,7 @@
  */
 
 import type { z } from 'zod';
-import { ActionFnArg, action, type Action } from './action.js';
+import { ActionFnArg, ActionParams, action, type Action } from './action.js';
 import { Registry, type HasRegistry } from './registry.js';
 import { SPAN_TYPE_ATTR, runInNewSpan } from './tracing.js';
 
@@ -35,17 +35,8 @@ export interface FlowConfig<
   I extends z.ZodTypeAny = z.ZodTypeAny,
   O extends z.ZodTypeAny = z.ZodTypeAny,
   S extends z.ZodTypeAny = z.ZodTypeAny,
-> {
-  /** Name of the flow. */
+> extends Omit<ActionParams<I, O, S>, 'actionType'> {
   name: string;
-  /** Schema of the input to the flow. */
-  inputSchema?: I;
-  /** Schema of the output from the flow. */
-  outputSchema?: O;
-  /** Schema of the streaming chunks from the flow. */
-  streamSchema?: S;
-  /** Metadata of the flow used by tooling. */
-  metadata?: Record<string, any>;
 }
 
 /**
@@ -115,11 +106,7 @@ function flowAction<
   return action(
     {
       actionType: 'flow',
-      name: config.name,
-      inputSchema: config.inputSchema,
-      outputSchema: config.outputSchema,
-      streamSchema: config.streamSchema,
-      metadata: config.metadata,
+      ...config,
     },
     async (
       input,

--- a/js/core/tests/flow_test.ts
+++ b/js/core/tests/flow_test.ts
@@ -142,6 +142,98 @@ describe('flow', () => {
         }
       );
     });
+
+    it('should parse schema in parse schemaMode', async () => {
+      const testFlow = defineFlow(
+        registry,
+        {
+          name: 'testFlow',
+          inputSchema: z.object({
+            foo: z.string().default('default foo'),
+          }),
+          outputSchema: z.object({
+            input: z
+              .object({
+                foo: z.string().optional(),
+              })
+              .optional(),
+            bar: z.string().transform((val) => `${val}-transformed`),
+          }),
+          schemaMode: 'parse',
+        },
+        async (input) => {
+          return { input, bar: 'bar' };
+        }
+      );
+
+      const result = await testFlow({} as any);
+
+      assert.deepStrictEqual(result, {
+        bar: 'bar-transformed',
+        input: {
+          foo: 'default foo',
+        },
+      });
+    });
+
+    it('should only-validate schema in validate schemaMode', async () => {
+      const testFlow = defineFlow(
+        registry,
+        {
+          name: 'testFlow',
+          inputSchema: z.object({
+            foo: z.string().default('default foo'),
+          }),
+          outputSchema: z.object({
+            input: z
+              .object({
+                foo: z.string().optional(),
+              })
+              .optional(),
+            bar: z.string().transform((val) => `${val}-transformed`),
+          }),
+          schemaMode: 'validate',
+        },
+        async (input) => {
+          return { input, bar: 'bar' };
+        }
+      );
+
+      const result = await testFlow({} as any);
+
+      assert.deepStrictEqual(result, {
+        bar: 'bar',
+        input: {},
+      });
+    });
+
+    it('should ignore schema in none schemaMode', async () => {
+      const testFlow = defineFlow(
+        registry,
+        {
+          name: 'testFlow',
+          inputSchema: z.object({
+            foo: z.string().transform((val) => `${val}-transformed`),
+          }),
+          outputSchema: z.object({
+            bar: z.string().transform((val) => `${val}-transformed`),
+          }),
+          schemaMode: 'none',
+        },
+        async (input) => {
+          return { seriously: 'banana', input } as any;
+        }
+      );
+
+      const result = await testFlow({ banana: 'yeah' } as any);
+
+      assert.deepStrictEqual(result, {
+        input: {
+          banana: 'yeah',
+        },
+        seriously: 'banana',
+      });
+    });
   });
 
   describe('getContext', () => {


### PR DESCRIPTION
Right now we only validate, but if the schema has defaults or transforms those don't get applied. Ex:

```ts
      const testFlow = defineFlow(
        registry,
        {
          name: 'testFlow',
          inputSchema: z.object({
            foo: z.string().default('default foo'),
          }),
          outputSchema: z.object({
            input: z
              .object({
                foo: z.string().optional(),
              })
              .optional(),
            bar: z.string().transform((val) => `${val}-transformed`),
          }),
          schemaMode: 'parse',
        },
        async (input) => {
          return { input, bar: 'bar' };
        }
      );

      const result = await testFlow({} as any);

      assert.deepStrictEqual(result, {
        bar: 'bar-transformed',
        input: {
          foo: 'default foo',
        },
      });
```

also can set `schemaMode: 'none'`, this might be useful in production mode to improve performance in case of large inputs.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
