### PR TITLE
fix(go): Display clear error message when logger fails

### DIFF
--- a/go/plugins/googlecloud/utils.go
+++ b/go/plugins/googlecloud/utils.go
@@ -121,7 +121,9 @@ gcloud projects add-iam-policy-binding %s \
     --member=serviceAccount:${SERVICE_ACCOUNT_EMAIL} \
     --role=%s
 
-For more information, see: https://cloud.google.com/docs/authentication/getting-started`, role, projectID, role)
+For more information, see: https://cloud.google.com/docs/authentication/getting-started
+
+`, role, projectID, role)
 }
 
 // loggingDeniedHelpText provides specific help for logging permission errors


### PR DESCRIPTION
Mimics TS behavior. When logger fails, we:
- clearly switch to a new logger that writes to stderr
- show a helpful logging denied helptext (first time only)
- reinitialize the logger in case there was an intermittent issue

Example:

```
time=2025-09-12T19:49:08.192-05:00 level=WARN msg="Switched to stderr logging due to Google Cloud logging failure" error="rpc error: code = PermissionDenied desc = Permission 'logging.logEntries.create' denied on resource (or it may not exist).\nerror details: name = ErrorInfo reason = IAM_PERMISSION_DENIED domain = iam.googleapis.com metadata = map[permission:logging.logEntries.create]\nerror details: name = Unknown  desc = log_entry_errors:{key:0  value:{code:7  message:\"Permission 'logging.logEntries.create' denied on resource (or it may not exist).\"}}  log_entry_errors:{key:1  value:{code:7  message:\"Permission 'logging.logEntries.create' denied on resource (or it may not exist).\"}}  log_entry_errors:{key:2  value:{code:7  message:\"Permission 'logging.logEntries.create' denied on resource (or it may not exist).\"}}"                            
time=2025-09-12T19:49:08.192-05:00 level=ERROR msg="Unable to send logs to Google Cloud" error="rpc error: code = PermissionDenied desc = Permission 'logging.logEntries.create' denied on resource (or it may not exist).\nerror details: name = ErrorInfo reason = IAM_PERMISSION_DENIED domain = iam.googleapis.com metadata = map[permission:logging.logEntries.create]\nerror details: name = Unknown  desc = log_entry_errors:{key:0  value:{code:7  message:\"Permission 'logging.logEntries.create' denied on resource (or it may not exist).\"}}  log_entry_errors:{key:1  value:{code:7  message:\"Permission 'logging.logEntries.create' denied on resource (or it may not exist).\"}}  log_entry_errors:{key:2  value:{code:7  message:\"Permission 'logging.logEntries.create' denied on resource (or it may not exist).\"}}"                                                      
Add the role 'roles/logging.logWriter' to your Service Account in the IAM & Admin page on the Google Cloud console, or use the following command:                                                                       
 
gcloud projects add-iam-policy-binding jeff-glm-testing \
    --member=serviceAccount:${SERVICE_ACCOUNT_EMAIL} \
    --role=roles/logging.logWriter
 
For more information, see: https://cloud.google.com/docs/authentication/getting-startedtime=2025-09-12T19:49:09.221-05:00 level=WARN msg="Switched to stderr logging due to Google Cloud logging failure" error="rpc error: code = PermissionDenied desc = Permission 'logging.logEntries.create' denied on resource (or it may not exist).\nerror details: name = ErrorInfo reason = IAM_PERMISSION_DENIED domain = iam.googleapis.com metadata = map[permission:logging.logEntries.create]"                                                               
time=2025-09-12T19:49:09.221-05:00 level=ERROR msg="Unable to send logs to Google Cloud" error="rpc error: code = PermissionDenied desc = Permission 'logging.logEntries.create' denied on resource (or it may not exist).\nerror details: name = ErrorInfo reason = IAM_PERMISSION_DENIED domain = iam.googleapis.com metadata = map[permission:logging.logEntries.create]" 
```