### PR TITLE
chore(js): mark runWithStreamingCallback as deprecated

### DIFF
--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -529,6 +529,8 @@ export const sentinelNoopStreamingCallback = () => null;
 /**
  * Executes provided function with streaming callback in async local storage which can be retrieved
  * using {@link getStreamingCallback}.
+ *
+ * @deprecated `getStreamingCallback` is no longer used internally
  */
 export function runWithStreamingCallback<S, O>(
   streamingCallback: StreamingCallback<S> | undefined,


### PR DESCRIPTION
All relevant uses were removed in #3243 . This is a documentation change so that library users can see in typescript that this method is deprecated. Note that this only updates the jsdoc. `util.deprecate` could also be used to wrap the function and provide a runtime deprecation message.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] _N/A_ Tested (manually, unit tested, etc.)
- [ ] _N/A_ Docs updated (updated docs or a docs bug required)
