### PR TITLE
chore(js/evaluators): remove unnecessary path dependency

### DIFF
--- a/js/plugins/evaluators/package.json
+++ b/js/plugins/evaluators/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "compute-cosine-similarity": "^1.1.0",
     "node-fetch": "^3.3.2",
-    "path": "^0.12.7",
     "dotprompt": "^1.1.1",
     "jsonata": "^2.0.6"
   },

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -459,9 +459,6 @@ importers:
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
-      path:
-        specifier: ^0.12.7
-        version: 0.12.7
     devDependencies:
       '@types/node':
         specifier: ^20.11.16


### PR DESCRIPTION
`path` is a core node module, and adding it as a dependency is pointless, as node (and other compatible runtimes) will always use the core module

Description here... Help the reviewer by:
 - linking to an issue that includes more details
 - if it's a new feature include samples of how to use the new feature
 - (optional if issue link is provided) if you fixed a bug include basic bug details

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.) (manually)
- [ ] _N/A_ ~Docs updated (updated docs or a docs bug required)~
