### PR TITLE
fix(go/plugins/compat_oai): check `ANTHROPIC_API_KEY` during plugin init

### DIFF
--- a/go/plugins/compat_oai/anthropic/anthropic.go
+++ b/go/plugins/compat_oai/anthropic/anthropic.go
@@ -101,6 +101,11 @@ func (a *Anthropic) Init(ctx context.Context) []api.Action {
 	}
 	a.Opts = append([]option.RequestOption{option.WithBaseURL(url)}, a.Opts...)
 
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey != "" {
+		a.Opts = append(a.Opts, option.WithAPIKey(apiKey))
+	}
+
 	// initialize OpenAICompatible
 	a.openAICompatible.Opts = a.Opts
 	compatActions := a.openAICompatible.Init(ctx)

--- a/go/plugins/compat_oai/anthropic/anthropic.go
+++ b/go/plugins/compat_oai/anthropic/anthropic.go
@@ -103,7 +103,7 @@ func (a *Anthropic) Init(ctx context.Context) []api.Action {
 
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
 	if apiKey != "" {
-		a.Opts = append(a.Opts, option.WithAPIKey(apiKey))
+		a.Opts = append([]option.RequestOption{option.WithAPIKey(apiKey)}, a.Opts...)
 	}
 
 	// initialize OpenAICompatible


### PR DESCRIPTION
Anthropic provider for `compat_oai` plugin checks the `ANTHROPIC_API_KEY` value during its initialization.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
