### PR TITLE
fix(go/core): List All Plugins to resolve model

### DIFF
--- a/go/core/api/registry.go
+++ b/go/core/api/registry.go
@@ -83,4 +83,7 @@ type Registry interface {
 
 	// Dotprompt returns the dotprompt instance.
 	Dotprompt() *dotprompt.Dotprompt
+
+	// ListAllPlugins return a list of all registered plugins for this and all parent registries
+	ListAllPlugins() []Plugin
 }

--- a/go/internal/registry/registry.go
+++ b/go/internal/registry/registry.go
@@ -186,7 +186,7 @@ func (r *Registry) ResolveAction(key string) api.Action {
 		return nil
 	}
 
-	plugins := r.ListPlugins()
+	plugins := r.ListAllPlugins()
 	for _, plugin := range plugins {
 		if dp, ok := plugin.(api.DynamicPlugin); ok && dp.Name() == provider {
 			resolvedAction := dp.ResolveAction(typ, name)
@@ -220,6 +220,20 @@ func (r *Registry) ListPlugins() []api.Plugin {
 	var plugins []api.Plugin
 	for _, p := range r.plugins {
 		plugins = append(plugins, p)
+	}
+	return plugins
+}
+
+// ListAllPlugins return a list of all registered plugins for this and all parent registries
+func (r *Registry) ListAllPlugins() []api.Plugin {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var plugins []api.Plugin
+	for _, p := range r.plugins {
+		plugins = append(plugins, p)
+	}
+	if r.IsChild() {
+		plugins = append(plugins, r.parent.ListPlugins()...)
 	}
 	return plugins
 }


### PR DESCRIPTION
mcp client sample code is not working, because when registering tools we are creating a child to registry and when resolving model we are trying to fetch plugins from this child registry which doesn't have any registered to it.

Description here... Help the reviewer by:
 - linking to an issue that includes more details
 - if it's a new feature include samples of how to use the new feature
 - (optional if issue link is provided) if you fixed a bug include basic bug details

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
