### PR TITLE
fix(go/ai): enable use of media URIs in prompts

### DIFF
--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -662,9 +662,9 @@ func contentType(ct, uri string) (string, []byte, error) {
 
 		if p, isBase64 := strings.CutSuffix(prefix, ";base64"); isBase64 {
 			if ct == "" {
-				ct = prefix
+				ct = p
 			}
-			return ct, []byte(p), nil
+			return ct, []byte(uri), nil
 		}
 	}
 

--- a/go/samples/prompts/main.go
+++ b/go/samples/prompts/main.go
@@ -39,17 +39,17 @@ func main() {
 		genkit.WithPromptDir("prompts"),
 	)
 
-	//	SimplePrompt(ctx, g)
+	SimplePrompt(ctx, g)
 	PromptWithMultiMessage(ctx, g)
-	// PromptWithInput(ctx, g)
-	// PromptWithOutputType(ctx, g)
-	// PromptWithComplexOutputType(ctx, g)
-	// PromptWithTool(ctx, g)
-	// PromptWithMessageHistory(ctx, g)
-	// PromptWithExecuteOverrides(ctx, g)
-	// PromptWithFunctions(ctx, g)
-	// PromptWithOutputTypeDotprompt(ctx, g)
-	// PromptWithMediaType(ctx, g)
+	PromptWithInput(ctx, g)
+	PromptWithOutputType(ctx, g)
+	PromptWithComplexOutputType(ctx, g)
+	PromptWithTool(ctx, g)
+	PromptWithMessageHistory(ctx, g)
+	PromptWithExecuteOverrides(ctx, g)
+	PromptWithFunctions(ctx, g)
+	PromptWithOutputTypeDotprompt(ctx, g)
+	PromptWithMediaType(ctx, g)
 
 	mux := http.NewServeMux()
 	for _, a := range genkit.ListFlows(g) {
@@ -207,7 +207,7 @@ func PromptWithMultiMessage(ctx context.Context, g *genkit.Genkit) {
 		log.Fatal("empty prompt")
 	}
 	resp, err := prompt.Execute(ctx,
-		ai.WithModelName("googleai/gemini-2.0-flash"),
+		ai.WithModelName("googleai/gemini-2.5-pro"),
 		ai.WithInput(map[string]any{"videoUrl": "https://www.youtube.com/watch?v=K-hY0E6cGfo video/mp4"}),
 	)
 	if err != nil {
@@ -250,6 +250,7 @@ func PromptWithMessageHistory(ctx context.Context, g *genkit.Genkit) {
 	helloPrompt := genkit.DefinePrompt(
 		g, "PromptWithMessageHistory",
 		ai.WithSystem("You are a helpful AI assistant named Walt"),
+		ai.WithModelName("googleai/gemini-2.5-flash-lite"),
 		ai.WithMessages(
 			ai.NewUserTextMessage("Hi, my name is Bob"),
 			ai.NewModelTextMessage("Hi, my name is Walt, what can I help you with?"),
@@ -275,7 +276,7 @@ func PromptWithExecuteOverrides(ctx context.Context, g *genkit.Genkit) {
 
 	// Call the model and add additional messages from the user.
 	resp, err := helloPrompt.Execute(ctx,
-		ai.WithModel(googlegenai.GoogleAIModel(g, "gemini-2.5-pro")),
+		ai.WithModel(googlegenai.GoogleAIModel(g, "gemini-2.5-flash-lite")),
 		ai.WithMessages(ai.NewUserTextMessage("And I like turtles.")),
 	)
 	if err != nil {
@@ -322,8 +323,8 @@ func PromptWithMediaType(ctx context.Context, g *genkit.Genkit) {
 		log.Fatal("empty prompt")
 	}
 	resp, err := prompt.Execute(ctx,
-		ai.WithModelName("googleai/gemini-2.0-flash"),
-		ai.WithInput(map[string]any{"imageUrl": "data:image/jpg;base64," + img}),
+		ai.WithModelName("googleai/gemini-2.5-flash"),
+		ai.WithInput(map[string]any{"imageUrl": "data:image/jpeg;base64," + img}),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/go/samples/prompts/main.go
+++ b/go/samples/prompts/main.go
@@ -39,17 +39,17 @@ func main() {
 		genkit.WithPromptDir("prompts"),
 	)
 
-	SimplePrompt(ctx, g)
+	//	SimplePrompt(ctx, g)
 	PromptWithMultiMessage(ctx, g)
-	PromptWithInput(ctx, g)
-	PromptWithOutputType(ctx, g)
-	PromptWithComplexOutputType(ctx, g)
-	PromptWithTool(ctx, g)
-	PromptWithMessageHistory(ctx, g)
-	PromptWithExecuteOverrides(ctx, g)
-	PromptWithFunctions(ctx, g)
-	PromptWithOutputTypeDotprompt(ctx, g)
-	PromptWithMediaType(ctx, g)
+	// PromptWithInput(ctx, g)
+	// PromptWithOutputType(ctx, g)
+	// PromptWithComplexOutputType(ctx, g)
+	// PromptWithTool(ctx, g)
+	// PromptWithMessageHistory(ctx, g)
+	// PromptWithExecuteOverrides(ctx, g)
+	// PromptWithFunctions(ctx, g)
+	// PromptWithOutputTypeDotprompt(ctx, g)
+	// PromptWithMediaType(ctx, g)
 
 	mux := http.NewServeMux()
 	for _, a := range genkit.ListFlows(g) {
@@ -206,7 +206,10 @@ func PromptWithMultiMessage(ctx context.Context, g *genkit.Genkit) {
 	if prompt == nil {
 		log.Fatal("empty prompt")
 	}
-	resp, err := prompt.Execute(ctx)
+	resp, err := prompt.Execute(ctx,
+		ai.WithModelName("googleai/gemini-2.0-flash"),
+		ai.WithInput(map[string]any{"videoUrl": "https://www.youtube.com/watch?v=K-hY0E6cGfo video/mp4"}),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/samples/prompts/prompts/media.prompt
+++ b/go/samples/prompts/prompts/media.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-2.5-flash-preview-04-17
+model: googleai/gemini-2.5-flash
 config:
   temperature: 0.1
 input:

--- a/go/samples/prompts/prompts/multi-msg.prompt
+++ b/go/samples/prompts/prompts/multi-msg.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     videoUrl: string

--- a/go/samples/prompts/prompts/multi-msg.prompt
+++ b/go/samples/prompts/prompts/multi-msg.prompt
@@ -1,10 +1,16 @@
 ---
 model: googleai/gemini-2.0-flash
+input:
+  schema:
+    videoUrl: string
+output:
+  summary: string
 ---
 {{ role "system" }}
 
-You are a great pirate and an AI assistant.
+You are a great AI assistant that summarizes videos talking as a pirate
 
 {{ role "user" }}
 
-Say hi
+Give me a summary of this video
+{{media url=videoUrl}}


### PR DESCRIPTION
Previously, `.prompt` files were not supporting `gs://` and `http(s):` URIs

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
