### PR TITLE
fix(go/internal): discover actions and plugins in parent registry

### DIFF
--- a/go/internal/registry/registry.go
+++ b/go/internal/registry/registry.go
@@ -207,6 +207,21 @@ func (r *Registry) ListActions() []api.Action {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	var actions []api.Action
+	if r.parent != nil {
+		parentValues := r.parent.ListActions()
+		for _, pv := range parentValues {
+			found := false
+			for _, cv := range r.actions {
+				if pv.Name() == cv.Name() {
+					found = true
+					break
+				}
+			}
+			if !found {
+				actions = append(actions, pv)
+			}
+		}
+	}
 	for _, v := range r.actions {
 		actions = append(actions, v)
 	}
@@ -214,10 +229,28 @@ func (r *Registry) ListActions() []api.Action {
 }
 
 // ListPlugins returns a list of all registered plugins.
+// This includes plugins from both the current registry and its parent hierarchy.
+// Child registry plugins take precedence over parent plugins with the same key.
 func (r *Registry) ListPlugins() []api.Plugin {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	var plugins []api.Plugin
+	if r.parent != nil {
+		parentValues := r.parent.ListPlugins()
+		for _, pv := range parentValues {
+			found := false
+			for _, cv := range r.plugins {
+				if pv.Name() == cv.Name() {
+					found = true
+					break
+				}
+			}
+			if !found {
+				plugins = append(plugins, pv)
+			}
+		}
+	}
+
 	for _, p := range r.plugins {
 		plugins = append(plugins, p)
 	}

--- a/go/internal/registry/registry.go
+++ b/go/internal/registry/registry.go
@@ -207,6 +207,8 @@ func (r *Registry) ListActions() []api.Action {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	var actions []api.Action
+
+	// recursively check all the registry parents
 	if r.parent != nil {
 		parentValues := r.parent.ListActions()
 		for _, pv := range parentValues {
@@ -235,6 +237,8 @@ func (r *Registry) ListPlugins() []api.Plugin {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	var plugins []api.Plugin
+
+	// recursively check all the registry parents
 	if r.parent != nil {
 		parentValues := r.parent.ListPlugins()
 		for _, pv := range parentValues {


### PR DESCRIPTION
The child registry was not considering the registered parents' actions and plugins

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
