### PR TITLE
fix(generate): add output format metadata

### DIFF
--- a/js/ai/src/generate/response.ts
+++ b/js/ai/src/generate/response.ts
@@ -67,6 +67,20 @@ export class GenerateResponse<O = unknown> implements ModelResponseData {
     const generatedMessage =
       response.message || response.candidates?.[0]?.message;
     if (generatedMessage) {
+      if (
+        options?.request?.output?.contentType ||
+        options?.request?.output?.format
+      ) {
+        generatedMessage.metadata = {
+          ...generatedMessage.metadata,
+          generate: {
+            output: {
+              contentType: options?.request?.output?.contentType,
+              format: options?.request?.output?.format,
+            },
+          },
+        };
+      }
       this.message = new Message<O>(generatedMessage, {
         parser: options?.parser,
       });

--- a/js/ai/tests/generate/response_test.ts
+++ b/js/ai/tests/generate/response_test.ts
@@ -244,4 +244,40 @@ describe('GenerateResponse', () => {
       assert.deepStrictEqual(response.toolRequests, [toolCall1, toolCall2]);
     });
   });
+
+  it('returns metadata for output conformance', () => {
+    const request: GenerateRequest = {
+      messages: [],
+      output: {
+        constrained: true,
+        format: 'json',
+        contentType: 'application/json',
+        schema: toJsonSchema({
+          schema: z.object({
+            name: z.string(),
+            age: z.number(),
+          }),
+        }),
+      },
+    };
+
+    const response = new GenerateResponse(
+      {
+        message: {
+          role: 'model',
+          content: [{ text: '{"name": "John", "age": "30"}' }],
+        },
+        finishReason: 'stop',
+      },
+      {
+        request,
+      }
+    );
+
+    assert.deepEqual(response.message?.metadata, {
+      generate: {
+        output: { contentType: 'application/json', format: 'json' },
+      },
+    });
+  });
 });


### PR DESCRIPTION
Will be used by tooling to render in the appropriate expected format. For example, to allow the Dev UI to render json without needing to inspect the input/request object.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [N/A] Docs updated (updated docs or a docs bug required)
