### PR TITLE
fix: log action name in slog

### DIFF
--- a/go/core/action.go
+++ b/go/core/action.go
@@ -184,11 +184,11 @@ func (a *ActionDef[In, Out, Stream]) Run(ctx context.Context, input In, cb Strea
 // Run executes the Action's function in a new trace span.
 func (a *ActionDef[In, Out, Stream]) runWithTelemetry(ctx context.Context, input In, cb StreamCallback[Stream]) (output api.ActionRunResult[Out], err error) {
 	logger.FromContext(ctx).Debug("Action.Run",
-		"name", a.Name,
+		"name", a.Name(),
 		"input", fmt.Sprintf("%#v", input))
 	defer func() {
 		logger.FromContext(ctx).Debug("Action.Run",
-			"name", a.Name,
+			"name", a.Name(),
 			"output", fmt.Sprintf("%#v", output),
 			"err", err)
 	}()


### PR DESCRIPTION
`slog` prints a debug message with the memory address of the function [ActionDef.Name](https://github.com/firebase/genkit/blob/main/go/core/action.go#L173).

`ActionDef.Name` is a function, not a string type.

```go
// Name returns the Action's Name.
func (a *ActionDef[In, Out, Stream]) Name() string { return a.desc.Name }
```

*Current*

```console
2025/09/25 17:56:08 DEBUG Action.Run name=0x102e32910 ...
```

*Expected*

```console
2025/09/25 17:56:08 DEBUG Action.Run name=getWeather ...
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
