### PR TITLE
fix(js/plugins/google-genai): use .start on background model action in test

### DIFF
--- a/js/plugins/google-genai/tests/googleai/veo_test.ts
+++ b/js/plugins/google-genai/tests/googleai/veo_test.ts
@@ -235,8 +235,8 @@ describe('Google AI Veo', () => {
         };
         mockFetchResponse(mockOp);
 
-        const { start } = captureModelRunner({ apiKey: defaultApiKey });
-        const result = await start(request);
+        const modelAction = captureModelRunner({ apiKey: defaultApiKey });
+        const result = await modelAction.start(request);
 
         sinon.assert.calledOnce(fetchStub);
         const fetchArgs = fetchStub.lastCall.args;
@@ -275,12 +275,12 @@ describe('Google AI Veo', () => {
         const apiVersion = 'v1test';
         const baseUrl = 'https://test.example.com';
 
-        const { start } = captureModelRunner({
+        const modelAction = captureModelRunner({
           apiKey: defaultApiKey,
           apiVersion,
           baseUrl,
         });
-        await start(request);
+        await modelAction.start(request);
 
         sinon.assert.calledOnce(fetchStub);
         const fetchArgs = fetchStub.lastCall.args;
@@ -297,8 +297,8 @@ describe('Google AI Veo', () => {
         envStub.value({ GOOGLE_API_KEY: envKey });
         mockFetchResponse({ name: 'operations/start789', done: false });
 
-        const { start } = captureModelRunner({ apiKey: undefined });
-        await start(request);
+        const modelAction = captureModelRunner({ apiKey: undefined });
+        await modelAction.start(request);
 
         sinon.assert.calledOnce(fetchStub);
         const fetchArgs = fetchStub.lastCall.args;
@@ -309,9 +309,9 @@ describe('Google AI Veo', () => {
         const errorBody = { error: { message: 'Invalid argument', code: 400 } };
         mockFetchResponse(errorBody, 400);
 
-        const { start } = captureModelRunner({ apiKey: defaultApiKey });
+        const modelAction = captureModelRunner({ apiKey: defaultApiKey });
         await assert.rejects(
-          start(request),
+          modelAction.start(request),
           /Error fetching from .*models\/veo-test-model:predictLongRunning.* Invalid argument/
         );
       });
@@ -333,8 +333,8 @@ describe('Google AI Veo', () => {
         };
         mockFetchResponse(mockResponse);
 
-        const { check } = captureModelRunner({ apiKey: defaultApiKey });
-        const result = await check(pendingOp);
+        const modelAction = captureModelRunner({ apiKey: defaultApiKey });
+        const result = await modelAction.check(pendingOp);
 
         sinon.assert.calledOnce(fetchStub);
         const fetchArgs = fetchStub.lastCall.args;
@@ -364,12 +364,12 @@ describe('Google AI Veo', () => {
         const apiVersion = 'v1test';
         const baseUrl = 'https://test.example.com';
 
-        const { check } = captureModelRunner({
+        const modelAction = captureModelRunner({
           apiKey: defaultApiKey,
           apiVersion,
           baseUrl,
         });
-        await check(pendingOp);
+        await modelAction.check(pendingOp);
 
         sinon.assert.calledOnce(fetchStub);
         const fetchArgs = fetchStub.lastCall.args;
@@ -384,9 +384,9 @@ describe('Google AI Veo', () => {
         const errorBody = { error: { message: 'Not found', code: 404 } };
         mockFetchResponse(errorBody, 404);
 
-        const { check } = captureModelRunner({ apiKey: defaultApiKey });
+        const modelAction = captureModelRunner({ apiKey: defaultApiKey });
         await assert.rejects(
-          check(pendingOp),
+          modelAction.check(pendingOp),
           /Error fetching from .*operations\/check123.* Not found/
         );
       });

--- a/js/plugins/google-genai/tests/vertexai/veo_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/veo_test.ts
@@ -133,8 +133,8 @@ describe('Vertex AI Veo', () => {
         };
         mockFetchResponse(mockOp);
 
-        const { start } = captureModelRunner(defaultRegionalClientOptions);
-        const result = await start(request);
+        const modelAction = captureModelRunner(defaultRegionalClientOptions);
+        const result = await modelAction.start(request);
 
         sinon.assert.calledOnce(fetchStub);
         const fetchArgs = fetchStub.lastCall.args;
@@ -167,9 +167,9 @@ describe('Vertex AI Veo', () => {
         const errorBody = { error: { message: 'Invalid arg', code: 400 } };
         mockFetchResponse(errorBody, 400);
 
-        const { start } = captureModelRunner(defaultRegionalClientOptions);
+        const modelAction = captureModelRunner(defaultRegionalClientOptions);
         await assert.rejects(
-          start(request),
+          modelAction.start(request),
           /Error fetching from .*predictLongRunning.* Invalid arg/
         );
       });
@@ -183,8 +183,8 @@ describe('Vertex AI Veo', () => {
           ...defaultRegionalClientOptions,
           signal: abortSignal,
         };
-        const { start } = captureModelRunner(clientOptionsWithSignal);
-        await start(request);
+        const modelAction = captureModelRunner(clientOptionsWithSignal);
+        await modelAction.start(request);
 
         sinon.assert.calledOnce(fetchStub);
         const fetchOptions = fetchStub.lastCall.args[1];
@@ -219,8 +219,8 @@ describe('Vertex AI Veo', () => {
         };
         mockFetchResponse(mockResponse);
 
-        const { check } = captureModelRunner(defaultRegionalClientOptions);
-        const result = await check(pendingOp);
+        const modelAction = captureModelRunner(defaultRegionalClientOptions);
+        const result = await modelAction.check(pendingOp);
 
         sinon.assert.calledOnce(fetchStub);
         const fetchArgs = fetchStub.lastCall.args;
@@ -251,9 +251,9 @@ describe('Vertex AI Veo', () => {
         const errorBody = { error: { message: 'Not found', code: 404 } };
         mockFetchResponse(errorBody, 404);
 
-        const { check } = captureModelRunner(defaultRegionalClientOptions);
+        const modelAction = captureModelRunner(defaultRegionalClientOptions);
         await assert.rejects(
-          check(pendingOp),
+          modelAction.check(pendingOp),
           /Error fetching from .*fetchPredictOperation.* Not found/
         );
       });


### PR DESCRIPTION
This migration has failing tests. I believe for a background model action you have to call them as methods instead of destructuring.

The captureModelRunner function is returning an instance of `BackgroundActionImpl` at runtime, and if we destructure we lose it's `this` binding as we're creating a new object `start`

https://github.com/firebase/genkit/blob/main/js/core/src/background-action.ts#L107

results in `undefined` type errors in tests:


<img width="628" height="163" alt="Screenshot 2025-09-26 at 16 07 35" src="https://github.com/user-attachments/assets/0653bbb2-01f2-452e-8897-93abc06298f4" />


TODO: on reflection I'm going to give the test changes in the base PR further review