### PR TITLE
feat(js/plugins/compat-oai): Add reasoning_content support to OpenAI Compatible API plugin

### DIFF
--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -277,19 +277,31 @@ export function fromOpenAIChoice(
   const toolRequestParts = choice.message.tool_calls?.map((toolCall) =>
     fromOpenAIToolCall(toolCall, choice)
   );
+
+  // Build content array based on what's present in the message
+  let content: Part[] = [];
+
+  if (toolRequestParts) {
+    content = toolRequestParts as ToolRequestPart[];
+  } else {
+    // Handle reasoning_content if present
+    if ('reasoning_content' in choice.message && choice.message.reasoning_content) {
+      content.push({ reasoning: choice.message.reasoning_content as string });
+    }
+
+    // Handle regular content
+    content.push(
+      jsonMode
+        ? { data: JSON.parse(choice.message.content!) }
+        : { text: choice.message.content! }
+    );
+  }
+
   return {
     finishReason: finishReasonMap[choice.finish_reason] || 'other',
     message: {
       role: 'model',
-      content: toolRequestParts
-        ? // Note: Not sure why I have to cast here exactly.
-          // Otherwise it thinks toolRequest must be 'undefined' if provided
-          (toolRequestParts as ToolRequestPart[])
-        : [
-            jsonMode
-              ? { data: JSON.parse(choice.message.content!) }
-              : { text: choice.message.content! },
-          ],
+      content,
     },
   };
 }
@@ -308,21 +320,35 @@ export function fromOpenAIChunkChoice(
   const toolRequestParts = choice.delta.tool_calls?.map((toolCall) =>
     fromOpenAIToolCall(toolCall, choice)
   );
+
+  // Build content array based on what's present in the delta
+  let content: Part[] = [];
+
+  if (toolRequestParts) {
+    content = toolRequestParts as ToolRequestPart[];
+  } else {
+    // Handle reasoning_content if present
+    if ('reasoning_content' in choice.delta && choice.delta.reasoning_content) {
+      content.push({ reasoning: choice.delta.reasoning_content as string });
+    }
+
+    // Handle regular content if present
+    if (choice.delta.content) {
+      content.push(
+        jsonMode
+          ? { data: JSON.parse(choice.delta.content) }
+          : { text: choice.delta.content }
+      );
+    }
+  }
+
   return {
     finishReason: choice.finish_reason
       ? finishReasonMap[choice.finish_reason] || 'other'
       : 'unknown',
     message: {
       role: 'model',
-      content: toolRequestParts
-        ? // Note: Not sure why I have to cast here exactly.
-          // Otherwise it thinks toolRequest must be 'undefined' if provided
-          (toolRequestParts as ToolRequestPart[])
-        : [
-            jsonMode
-              ? { data: JSON.parse(choice.delta.content!) }
-              : { text: choice.delta.content! },
-          ],
+      content,
     },
   };
 }

--- a/js/plugins/compat-oai/tests/compat_oai_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_test.ts
@@ -412,6 +412,48 @@ describe('fromOpenAiChoice', () => {
         finishReason: 'stop',
       },
     },
+    {
+      should: 'should work with reasoning_content',
+      choice: {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: null,
+          reasoning_content: 'Let me think about this step by step...',
+          refusal: null,
+        } as any,
+        finish_reason: 'stop',
+        logprobs: null,
+      },
+      expectedOutput: {
+        finishReason: 'stop',
+        message: {
+          role: 'model',
+          content: [{ reasoning: 'Let me think about this step by step...' }],
+        },
+      },
+    },
+    {
+      should: 'should work with both reasoning_content and content',
+      choice: {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: 'Final answer',
+          reasoning_content: 'Let me think...',
+          refusal: null,
+        } as any,
+        finish_reason: 'stop',
+        logprobs: null,
+      },
+      expectedOutput: {
+        finishReason: 'stop',
+        message: {
+          role: 'model',
+          content: [{ reasoning: 'Let me think...' }, { text: 'Final answer' }],
+        },
+      },
+    },
   ];
 
   for (const test of testCases) {
@@ -501,6 +543,43 @@ describe('fromOpenAiChunkChoice', () => {
           ],
         },
         finishReason: 'stop',
+      },
+    },
+    {
+      should: 'should work with reasoning_content',
+      chunkChoice: {
+        index: 0,
+        delta: {
+          role: 'assistant',
+          reasoning_content: 'Let me think about this step by step...',
+        } as any,
+        finish_reason: null,
+      },
+      expectedOutput: {
+        finishReason: 'unknown',
+        message: {
+          role: 'model',
+          content: [{ reasoning: 'Let me think about this step by step...' }],
+        },
+      },
+    },
+    {
+      should: 'should work with both reasoning_content and content',
+      chunkChoice: {
+        index: 0,
+        delta: {
+          role: 'assistant',
+          reasoning_content: 'Let me think...',
+          content: 'Final answer',
+        } as any,
+        finish_reason: 'stop',
+      },
+      expectedOutput: {
+        finishReason: 'stop',
+        message: {
+          role: 'model',
+          content: [{ reasoning: 'Let me think...' }, { text: 'Final answer' }],
+        },
       },
     },
   ];


### PR DESCRIPTION
This commit adds support for handling reasoning_content in both streaming and non-streaming for OpenAI Compatible API Chat Completions responses, allowing models that support reasoning_content to properly return their reasoning traces.

CHANGELOG:
  - [x] Add reasoning_content handling in fromOpenAIChoice
  - [x] Add reasoning_content handling in fromOpenAIChunkChoice
  - [x] Add test cases for reasoning_content in both functions

Description here... Help the reviewer by:
[OpenAI](https://platform.openai.com/docs/api-reference/chat/object) it self not support `reasoning_content` but 
- [xAI](https://docs.x.ai/docs/guides/reasoning)
- [DeepSeek](https://api-docs.deepseek.com/guides/reasoning_model)
- [LiteLLM](https://docs.litellm.ai/docs/reasoning_content)

support `reasoning_content ` when using reasoning model

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
