### PR TITLE
fix(ollama): fix duplicate tool response

### DIFF
--- a/js/plugins/ollama/src/index.ts
+++ b/js/plugins/ollama/src/index.ts
@@ -430,21 +430,28 @@ function toOllamaRequest(
           toolResponses.push(c.toolResponse);
         }
       });
-      // Add tool responses, if any.
-      toolResponses.forEach((t) => {
-        messages.push({
-          role,
-          content:
-            typeof t.output === 'string' ? t.output : JSON.stringify(t.output),
+      if (toolResponses.length > 0) {
+        toolResponses.forEach((t) => {
+          messages.push({
+            role,
+            content:
+              typeof t.output === 'string'
+                ? t.output
+                : JSON.stringify(t.output),
+            tool_name: t.name,
+          });
         });
-      });
-      messages.push({
-        role: role,
-        content: toolRequests.length > 0 ? '' : messageText,
-        images: images.length > 0 ? images : undefined,
-        tool_calls:
-          toolRequests.length > 0 ? toOllamaToolCall(toolRequests) : undefined,
-      });
+      } else {
+        messages.push({
+          role: role,
+          content: toolRequests.length > 0 ? '' : messageText,
+          images: images.length > 0 ? images : undefined,
+          tool_calls:
+            toolRequests.length > 0
+              ? toOllamaToolCall(toolRequests)
+              : undefined,
+        });
+      }
     });
     request.messages = messages;
   } else {

--- a/js/plugins/ollama/src/types.ts
+++ b/js/plugins/ollama/src/types.ts
@@ -152,8 +152,10 @@ export interface OllamaToolCall {
 export interface Message {
   role: string;
   content: string;
+  thinking?: string;
   images?: string[];
   tool_calls?: any[];
+  tool_name?: string;
 }
 
 // Ollama local model definition


### PR DESCRIPTION
I'm not sure if it was actually having any real-world impact, but I noticed while debugging another issue that we were sending 2 tool responses to back to the model, the second one being mostly empty.

```
{
  model: 'granite4:latest',
  options: {},
  stream: false,
  tools: [ { type: 'function', function: [Object] } ],
  messages: [
    {
      role: 'user',
      content: "what's the weather in cambridge, ma?",
      images: undefined,
      tool_calls: undefined
    },
    {
      role: 'assistant',
      content: '',
      images: undefined,
      tool_calls: [Array]
    },
    {
      role: 'tool',
      content: '{"temperatureF":103,"conditions":"Sunny"}'
    },
    {
      role: 'tool',
      content: '',
      images: undefined,
      tool_calls: undefined
    }
  ]
} ollama request (chat)
```

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)
