### PR TITLE
fix(py): Use file-safe timestamp format for runtime file to prevent OSError on Windows

### DIFF
--- a/py/packages/genkit/src/genkit/ai/_server.py
+++ b/py/packages/genkit/src/genkit/ai/_server.py
@@ -81,7 +81,7 @@ def create_runtime(
         os.makedirs(runtime_dir)
 
     current_datetime = datetime.now()
-    runtime_file_name = f'{current_datetime.isoformat()}.json'
+    runtime_file_name = f'{current_datetime.strftime("%Y-%m-%d_%H-%M-%S.%f")}.json'
     runtime_file_path = Path(os.path.join(runtime_dir, runtime_file_name))
     metadata = json.dumps({
         'reflectionApiSpecVersion': 1,


### PR DESCRIPTION
fix(logging): Use file-safe timestamp format to prevent OSError on Windows

The default string representation of the Python datetime object (e.g., 2025-10-17T15:34:10.127678) includes the colon (:) character in the time component.

The colon is an illegal character for standard filenames on the Windows filesystem, which resulted in an OSError: [Errno 22] Invalid argument whenever genkit attempted to save trace/log files on that platform.

This commit updates the file naming logic to use a cross-platform safe timestamp format (e.g., YYYY-MM-DD_HH-MM-SS-ffffff) that omits the illegal colon character, ensuring successful file persistence across all major operating  @systems
