### PR TITLE
feat(go): support using a custom filesystem to load prompts from #3746

### DIFF
--- a/go/ai/_test_data/prompts/example.prompt
+++ b/go/ai/_test_data/prompts/example.prompt
@@ -1,0 +1,20 @@
+---
+model: test-model
+maxTurns: 5
+description: A test prompt
+toolChoice: required
+returnToolRequests: true
+input:
+  schema:
+    type: object
+    properties:
+      name:
+        type: string
+  default:
+    name: world
+output:
+  format: text
+  schema:
+    type: string
+---
+Hello, {{name}}!

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -16,6 +16,7 @@ package ai
 
 import (
 	"context"
+	"embed"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,6 +29,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
+
+//go:embed _test_data/prompts
+var embededPrompts embed.FS
 
 type InputOutput struct {
 	Text string `json:"text"`
@@ -874,6 +878,15 @@ func assertResponse(t *testing.T, resp *ModelResponse, want string) {
 	got := resp.Message.Content[0].Text
 	if got != want {
 		t.Errorf("fake model replied with %q, want %q", got, want)
+	}
+}
+
+func TestLoadPrompt_FromFS(t *testing.T) {
+	reg := registry.New()
+	LoadPromptFS(reg, embededPrompts, "_test_data/prompts", "test-namespace")
+	prompt := LookupPrompt(reg, "test-namespace/example")
+	if prompt == nil {
+		t.Fatalf("Prompt was not registered")
 	}
 }
 

--- a/go/samples/prompts-dir/main.go
+++ b/go/samples/prompts-dir/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"embed"
 	"errors"
 
 	// Import Genkit and the Google AI plugin
@@ -14,12 +15,17 @@ import (
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 )
 
+//go:embed prompts
+var prompts embed.FS
+
 func main() {
 	ctx := context.Background()
 
 	g := genkit.Init(ctx,
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
 		genkit.WithPromptDir("prompts"),
+		// Without it OS's filesystem will be used
+		genkit.WithPromptFS(prompts),
 	)
 
 	type greetingStyle struct {


### PR DESCRIPTION
Description here... Help the reviewer by:
 - Draft implementation for #3746 
 - Sample `prompts-dir` [was updated](https://github.com/naqerl/genkit/blob/8a73c23cf830b5c1ff89f20410e0e1036236a607/go/samples/prompts-dir/main.go) with the new API
 - Docs will be updated after getting approve on this feature

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
