### PR TITLE
refactor(plugins/googleai): migrate to v2

### DIFF
--- a/js/plugins/googleai/src/embedder.ts
+++ b/js/plugins/googleai/src/embedder.ts
@@ -25,9 +25,9 @@ import {
   type EmbedderReference,
 } from 'genkit';
 import { embedderRef as createEmbedderRef } from 'genkit/embedder';
+import { embedder } from 'genkit/plugin';
 import { getApiKeyFromEnvVar } from './common.js';
 import type { PluginOptions } from './index.js';
-import { embedder } from 'genkit/plugin';
 
 export const TaskTypeSchema = z.enum([
   'RETRIEVAL_DOCUMENT',

--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -42,8 +42,8 @@ import { GenkitError, z, type JSONSchema } from 'genkit';
 import {
   GenerationCommonConfigDescriptions,
   GenerationCommonConfigSchema,
-  getBasicUsageStats,
   modelRef as createModelRef,
+  getBasicUsageStats,
   type CandidateData,
   type MediaPart,
   type MessageData,
@@ -57,11 +57,11 @@ import {
   type ToolResponsePart,
 } from 'genkit/model';
 import { downloadRequestMedia } from 'genkit/model/middleware';
+import { model } from 'genkit/plugin';
 import { runInNewSpan } from 'genkit/tracing';
 import { getApiKeyFromEnvVar, getGenkitClientHeader } from './common';
 import { handleCacheIfNeeded } from './context-caching';
 import { extractCacheConfig } from './context-caching/utils';
-import { model } from 'genkit/plugin';
 
 // Extra type guard to keep the compiler happy and avoid a cast to any. The
 // legacy Gemini SDK is no longer maintained, and doesn't have updated types.
@@ -1205,7 +1205,10 @@ export function defineGoogleAIModel({
       configSchema: GeminiConfigSchema,
       use: middleware,
     },
-    async (request, { streamingRequested, sendChunk, abortSignal, registry }) => {
+    async (
+      request,
+      { streamingRequested, sendChunk, abortSignal, registry }
+    ) => {
       const options: RequestOptions = { apiClient: getGenkitClientHeader() };
       if (apiVersion) {
         options.apiVersion = apiVersion;
@@ -1254,12 +1257,11 @@ export function defineGoogleAIModel({
 
       if (codeExecutionFromConfig) {
         tools.push({
-          codeExecution:
-            requestConfig.codeExecution ?
-              requestConfig.codeExecution === true
-                ? {}
-                : requestConfig.codeExecution
-              : {},
+          codeExecution: requestConfig.codeExecution
+            ? requestConfig.codeExecution === true
+              ? {}
+              : requestConfig.codeExecution
+            : {},
         });
       }
 

--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -38,12 +38,12 @@ import {
   type ToolConfig,
   type UsageMetadata,
 } from '@google/generative-ai';
-import { GenkitError, z, type Genkit, type JSONSchema } from 'genkit';
+import { GenkitError, z, type JSONSchema } from 'genkit';
 import {
   GenerationCommonConfigDescriptions,
   GenerationCommonConfigSchema,
   getBasicUsageStats,
-  modelRef,
+  modelRef as createModelRef,
   type CandidateData,
   type MediaPart,
   type MessageData,
@@ -61,6 +61,7 @@ import { runInNewSpan } from 'genkit/tracing';
 import { getApiKeyFromEnvVar, getGenkitClientHeader } from './common';
 import { handleCacheIfNeeded } from './context-caching';
 import { extractCacheConfig } from './context-caching/utils';
+import { model } from 'genkit/plugin';
 
 // Extra type guard to keep the compiler happy and avoid a cast to any. The
 // legacy Gemini SDK is no longer maintained, and doesn't have updated types.
@@ -276,7 +277,7 @@ export const GeminiTtsConfigSchema = GeminiConfigSchema.extend({
     .optional(),
 }).passthrough();
 
-export const gemini10Pro = modelRef({
+export const gemini10Pro = createModelRef({
   name: 'googleai/gemini-1.0-pro',
   info: {
     label: 'Google AI - Gemini Pro',
@@ -293,7 +294,7 @@ export const gemini10Pro = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini15Pro = modelRef({
+export const gemini15Pro = createModelRef({
   name: 'googleai/gemini-1.5-pro',
   info: {
     label: 'Google AI - Gemini 1.5 Pro',
@@ -314,7 +315,7 @@ export const gemini15Pro = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini15Flash = modelRef({
+export const gemini15Flash = createModelRef({
   name: 'googleai/gemini-1.5-flash',
   info: {
     label: 'Google AI - Gemini 1.5 Flash',
@@ -337,7 +338,7 @@ export const gemini15Flash = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini15Flash8b = modelRef({
+export const gemini15Flash8b = createModelRef({
   name: 'googleai/gemini-1.5-flash-8b',
   info: {
     label: 'Google AI - Gemini 1.5 Flash',
@@ -354,7 +355,7 @@ export const gemini15Flash8b = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini20Flash = modelRef({
+export const gemini20Flash = createModelRef({
   name: 'googleai/gemini-2.0-flash',
   info: {
     label: 'Google AI - Gemini 2.0 Flash',
@@ -371,7 +372,7 @@ export const gemini20Flash = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini20FlashExp = modelRef({
+export const gemini20FlashExp = createModelRef({
   name: 'googleai/gemini-2.0-flash-exp',
   info: {
     label: 'Google AI - Gemini 2.0 Flash (Experimental)',
@@ -388,7 +389,7 @@ export const gemini20FlashExp = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini20FlashLite = modelRef({
+export const gemini20FlashLite = createModelRef({
   name: 'googleai/gemini-2.0-flash-lite',
   info: {
     label: 'Google AI - Gemini 2.0 Flash Lite',
@@ -405,7 +406,7 @@ export const gemini20FlashLite = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini20ProExp0205 = modelRef({
+export const gemini20ProExp0205 = createModelRef({
   name: 'googleai/gemini-2.0-pro-exp-02-05',
   info: {
     label: 'Google AI - Gemini 2.0 Pro Exp 02-05',
@@ -422,7 +423,7 @@ export const gemini20ProExp0205 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini25FlashPreview0417 = modelRef({
+export const gemini25FlashPreview0417 = createModelRef({
   name: 'googleai/gemini-2.5-flash-preview-04-17',
   info: {
     label: 'Google AI - Gemini 2.5 Flash Preview 04-17',
@@ -439,7 +440,7 @@ export const gemini25FlashPreview0417 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini25FlashPreviewTts = modelRef({
+export const gemini25FlashPreviewTts = createModelRef({
   name: 'googleai/gemini-2.5-flash-preview-tts',
   info: {
     label: 'Google AI - Gemini 2.5 Flash Preview TTS',
@@ -456,7 +457,7 @@ export const gemini25FlashPreviewTts = modelRef({
   configSchema: GeminiTtsConfigSchema,
 });
 
-export const gemini25ProExp0325 = modelRef({
+export const gemini25ProExp0325 = createModelRef({
   name: 'googleai/gemini-2.5-pro-exp-03-25',
   info: {
     label: 'Google AI - Gemini 2.5 Pro Exp 03-25',
@@ -473,7 +474,7 @@ export const gemini25ProExp0325 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini25ProPreview0325 = modelRef({
+export const gemini25ProPreview0325 = createModelRef({
   name: 'googleai/gemini-2.5-pro-preview-03-25',
   info: {
     label: 'Google AI - Gemini 2.5 Pro Preview 03-25',
@@ -490,7 +491,7 @@ export const gemini25ProPreview0325 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini25ProPreviewTts = modelRef({
+export const gemini25ProPreviewTts = createModelRef({
   name: 'googleai/gemini-2.5-pro-preview-tts',
   info: {
     label: 'Google AI - Gemini 2.5 Pro Preview TTS',
@@ -507,7 +508,7 @@ export const gemini25ProPreviewTts = modelRef({
   configSchema: GeminiTtsConfigSchema,
 });
 
-export const gemini25Pro = modelRef({
+export const gemini25Pro = createModelRef({
   name: 'googleai/gemini-2.5-pro',
   info: {
     label: 'Google AI - Gemini 2.5 Pro',
@@ -524,7 +525,7 @@ export const gemini25Pro = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini25Flash = modelRef({
+export const gemini25Flash = createModelRef({
   name: 'googleai/gemini-2.5-flash',
   info: {
     label: 'Google AI - Gemini 2.5 Flash',
@@ -541,7 +542,7 @@ export const gemini25Flash = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemini25FlashLite = modelRef({
+export const gemini25FlashLite = createModelRef({
   name: 'googleai/gemini-2.5-flash-lite',
   info: {
     label: 'Google AI - Gemini 2.5 Flash Lite',
@@ -558,7 +559,7 @@ export const gemini25FlashLite = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
-export const gemma312bit = modelRef({
+export const gemma312bit = createModelRef({
   name: 'googleai/gemma-3-12b-it',
   info: {
     label: 'Google AI - Gemma 3 12B',
@@ -575,7 +576,7 @@ export const gemma312bit = modelRef({
   configSchema: GeminiGemmaConfigSchema,
 });
 
-export const gemma31bit = modelRef({
+export const gemma31bit = createModelRef({
   name: 'googleai/gemma-3-1b-it',
   info: {
     label: 'Google AI - Gemma 3 1B',
@@ -592,7 +593,7 @@ export const gemma31bit = modelRef({
   configSchema: GeminiGemmaConfigSchema,
 });
 
-export const gemma327bit = modelRef({
+export const gemma327bit = createModelRef({
   name: 'googleai/gemma-3-27b-it',
   info: {
     label: 'Google AI - Gemma 3 27B',
@@ -609,7 +610,7 @@ export const gemma327bit = modelRef({
   configSchema: GeminiGemmaConfigSchema,
 });
 
-export const gemma34bit = modelRef({
+export const gemma34bit = createModelRef({
   name: 'googleai/gemma-3-4b-it',
   info: {
     label: 'Google AI - Gemma 3 4B',
@@ -626,7 +627,7 @@ export const gemma34bit = modelRef({
   configSchema: GeminiGemmaConfigSchema,
 });
 
-export const gemma3ne4bit = modelRef({
+export const gemma3ne4bit = createModelRef({
   name: 'googleai/gemma-3n-e4b-it',
   info: {
     label: 'Google AI - Gemma 3n E4B',
@@ -666,7 +667,7 @@ export const SUPPORTED_GEMINI_MODELS = {
   'gemma-3n-e4b-it': gemma3ne4bit,
 };
 
-export const GENERIC_GEMINI_MODEL = modelRef({
+export const GENERIC_GEMINI_MODEL = createModelRef({
   name: 'googleai/gemini',
   configSchema: GeminiConfigSchema,
   info: {
@@ -714,7 +715,7 @@ export function gemini(
   options: GeminiConfig = {}
 ): ModelReference<typeof GeminiConfigSchema> {
   const nearestModel = nearestGeminiModelRef(version);
-  return modelRef({
+  return createModelRef({
     name: `googleai/${version}`,
     config: options,
     configSchema: GeminiConfigSchema,
@@ -1118,7 +1119,6 @@ export function cleanSchema(schema: JSONSchema): JSONSchema {
  * Defines a new GoogleAI model.
  */
 export function defineGoogleAIModel({
-  ai,
   name,
   apiKey: apiKeyOption,
   apiVersion,
@@ -1127,7 +1127,6 @@ export function defineGoogleAIModel({
   defaultConfig,
   debugTraces,
 }: {
-  ai: Genkit;
   name: string;
   apiKey?: string | false;
   apiVersion?: string;
@@ -1154,9 +1153,9 @@ export function defineGoogleAIModel({
     ? name.substring('googleai/'.length)
     : name;
 
-  const model: ModelReference<z.ZodTypeAny> =
+  const modelRef: ModelReference<z.ZodTypeAny> =
     SUPPORTED_GEMINI_MODELS[apiModelName] ??
-    modelRef({
+    createModelRef({
       name: `googleai/${apiModelName}`,
       info: {
         label: `Google AI - ${apiModelName}`,
@@ -1173,7 +1172,7 @@ export function defineGoogleAIModel({
     });
 
   const middleware: ModelMiddleware[] = [];
-  if (model.info?.supports?.media) {
+  if (modelRef.info?.supports?.media) {
     // the gemini api doesn't support downloading media from http(s)
     middleware.push(
       downloadRequestMedia({
@@ -1199,15 +1198,14 @@ export function defineGoogleAIModel({
     );
   }
 
-  return ai.defineModel(
+  return model(
     {
-      apiVersion: 'v2',
-      name: model.name,
-      ...model.info,
-      configSchema: model.configSchema,
+      name: modelRef.name,
+      ...modelRef.info,
+      configSchema: GeminiConfigSchema,
       use: middleware,
     },
-    async (request, { streamingRequested, sendChunk, abortSignal }) => {
+    async (request, { streamingRequested, sendChunk, abortSignal, registry }) => {
       const options: RequestOptions = { apiClient: getGenkitClientHeader() };
       if (apiVersion) {
         options.apiVersion = apiVersion;
@@ -1228,7 +1226,7 @@ export function defineGoogleAIModel({
       // systemInstructions to be provided as a separate input. The first
       // message detected with role=system will be used for systemInstructions.
       let systemInstruction: GeminiMessage | undefined = undefined;
-      if (model.info?.supports?.systemRole) {
+      if (modelRef.info?.supports?.systemRole) {
         const systemMessage = messages.find((m) => m.role === 'system');
         if (systemMessage) {
           messages.splice(messages.indexOf(systemMessage), 1);
@@ -1257,9 +1255,11 @@ export function defineGoogleAIModel({
       if (codeExecutionFromConfig) {
         tools.push({
           codeExecution:
-            request.config.codeExecution === true
-              ? {}
-              : request.config.codeExecution,
+            requestConfig.codeExecution ?
+              requestConfig.codeExecution === true
+                ? {}
+                : requestConfig.codeExecution
+              : {},
         });
       }
 
@@ -1306,7 +1306,7 @@ export function defineGoogleAIModel({
         generationConfig.responseSchema = cleanSchema(request.output.schema);
       }
 
-      const msg = toGeminiMessage(messages[messages.length - 1], model);
+      const msg = toGeminiMessage(messages[messages.length - 1], modelRef);
 
       const fromJSONModeScopedGeminiCandidate = (
         candidate: GeminiCandidate
@@ -1321,11 +1321,11 @@ export function defineGoogleAIModel({
         toolConfig,
         history: messages
           .slice(0, -1)
-          .map((message) => toGeminiMessage(message, model)),
+          .map((message) => toGeminiMessage(message, modelRef)),
         safetySettings: safetySettingsFromConfig,
       } as StartChatParams;
       const modelVersion = (versionFromConfig ||
-        model.version ||
+        modelRef.version ||
         apiModelName) as string;
       const cacheConfigDetails = extractCacheConfig(request);
 
@@ -1428,9 +1428,9 @@ export function defineGoogleAIModel({
 
       // If debugTraces is enable, we wrap the actual model call with a span, add raw
       // API params as for input.
-      return debugTraces
+      return debugTraces && registry
         ? await runInNewSpan(
-            ai.registry,
+            registry,
             {
               metadata: {
                 name: streamingRequested ? 'sendMessageStream' : 'sendMessage',

--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -1205,10 +1205,7 @@ export function defineGoogleAIModel({
       configSchema: GeminiConfigSchema,
       use: middleware,
     },
-    async (
-      request,
-      { streamingRequested, sendChunk, abortSignal, registry }
-    ) => {
+    async (request, { streamingRequested, sendChunk, abortSignal }) => {
       const options: RequestOptions = { apiClient: getGenkitClientHeader() };
       if (apiVersion) {
         options.apiVersion = apiVersion;
@@ -1430,9 +1427,8 @@ export function defineGoogleAIModel({
 
       // If debugTraces is enable, we wrap the actual model call with a span, add raw
       // API params as for input.
-      return debugTraces && registry
+      return debugTraces
         ? await runInNewSpan(
-            registry,
             {
               metadata: {
                 name: streamingRequested ? 'sendMessageStream' : 'sendMessage',

--- a/js/plugins/googleai/src/imagen.ts
+++ b/js/plugins/googleai/src/imagen.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { GenkitError, MessageData, z, type Genkit } from 'genkit';
+import { GenkitError, MessageData, z } from 'genkit';
 import {
   getBasicUsageStats,
-  modelRef,
+  modelRef as createModelRef,
   type GenerateRequest,
   type ModelAction,
   type ModelInfo,
@@ -25,6 +25,7 @@ import {
 } from 'genkit/model';
 import { getApiKeyFromEnvVar } from './common.js';
 import { predictModel } from './predict.js';
+import { model } from 'genkit/plugin';
 
 export type KNOWN_IMAGEN_MODELS = 'imagen-3.0-generate-002';
 
@@ -109,7 +110,6 @@ export const GENERIC_IMAGEN_INFO = {
 } as ModelInfo;
 
 export function defineImagenModel(
-  ai: Genkit,
   name: string,
   apiKey?: string | false
 ): ModelAction {
@@ -125,7 +125,7 @@ export function defineImagenModel(
     }
   }
   const modelName = `googleai/${name}`;
-  const model: ModelReference<z.ZodTypeAny> = modelRef({
+  const modelRef: ModelReference<z.ZodTypeAny> = createModelRef({
     name: modelName,
     info: {
       ...GENERIC_IMAGEN_INFO,
@@ -134,10 +134,10 @@ export function defineImagenModel(
     configSchema: ImagenConfigSchema,
   });
 
-  return ai.defineModel(
+  return model(
     {
       name: modelName,
-      ...model.info,
+      ...modelRef.info,
       configSchema: ImagenConfigSchema,
     },
     async (request) => {
@@ -153,7 +153,7 @@ export function defineImagenModel(
         ImagenInstance,
         ImagenPrediction,
         ImagenParameters
-      >(model.version || name, apiKey as string, 'predict');
+      >(modelRef.version || name, apiKey as string, 'predict');
       const response = await predictClient([instance], toParameters(request));
 
       if (!response.predictions || response.predictions.length == 0) {

--- a/js/plugins/googleai/src/imagen.ts
+++ b/js/plugins/googleai/src/imagen.ts
@@ -16,16 +16,16 @@
 
 import { GenkitError, MessageData, z } from 'genkit';
 import {
-  getBasicUsageStats,
   modelRef as createModelRef,
+  getBasicUsageStats,
   type GenerateRequest,
   type ModelAction,
   type ModelInfo,
   type ModelReference,
 } from 'genkit/model';
+import { model } from 'genkit/plugin';
 import { getApiKeyFromEnvVar } from './common.js';
 import { predictModel } from './predict.js';
-import { model } from 'genkit/plugin';
 
 export type KNOWN_IMAGEN_MODELS = 'imagen-3.0-generate-002';
 

--- a/js/plugins/googleai/src/index.ts
+++ b/js/plugins/googleai/src/index.ts
@@ -25,7 +25,11 @@ import {
 } from 'genkit';
 import { logger } from 'genkit/logging';
 import { modelRef } from 'genkit/model';
-import { genkitPluginV2, ResolvableAction, type GenkitPluginV2 } from 'genkit/plugin';
+import {
+  ResolvableAction,
+  genkitPluginV2,
+  type GenkitPluginV2,
+} from 'genkit/plugin';
 import type { ActionType } from 'genkit/registry';
 import { getApiKeyFromEnvVar } from './common.js';
 import {
@@ -111,7 +115,9 @@ export interface PluginOptions {
   experimental_debugTraces?: boolean;
 }
 
-async function initializer(options?: PluginOptions): Promise<ResolvableAction[]> {
+async function initializer(
+  options?: PluginOptions
+): Promise<ResolvableAction[]> {
   let apiVersions = ['v1'];
   const actions: ResolvableAction[] = [];
 
@@ -125,24 +131,28 @@ async function initializer(options?: PluginOptions): Promise<ResolvableAction[]>
 
   if (apiVersions.includes('v1beta')) {
     Object.keys(SUPPORTED_GEMINI_MODELS).forEach((name) =>
-      actions.push(defineGoogleAIModel({
-        name,
-        apiKey: options?.apiKey,
-        apiVersion: 'v1beta',
-        baseUrl: options?.baseUrl,
-        debugTraces: options?.experimental_debugTraces,
-      }))
+      actions.push(
+        defineGoogleAIModel({
+          name,
+          apiKey: options?.apiKey,
+          apiVersion: 'v1beta',
+          baseUrl: options?.baseUrl,
+          debugTraces: options?.experimental_debugTraces,
+        })
+      )
     );
   }
   if (apiVersions.includes('v1')) {
     Object.keys(SUPPORTED_GEMINI_MODELS).forEach((name) =>
-      actions.push(defineGoogleAIModel({
-        name,
-        apiKey: options?.apiKey,
-        apiVersion: undefined,
-        baseUrl: options?.baseUrl,
-        debugTraces: options?.experimental_debugTraces,
-      }))
+      actions.push(
+        defineGoogleAIModel({
+          name,
+          apiKey: options?.apiKey,
+          apiVersion: undefined,
+          baseUrl: options?.baseUrl,
+          debugTraces: options?.experimental_debugTraces,
+        })
+      )
     );
     Object.keys(EMBEDDER_MODELS).forEach((name) =>
       actions.push(defineGoogleAIEmbedder(name, { apiKey: options?.apiKey }))
@@ -158,16 +168,18 @@ async function initializer(options?: PluginOptions): Promise<ResolvableAction[]>
             modelOrRef.name.split('/')[1];
       const modelRef =
         typeof modelOrRef === 'string' ? gemini(modelOrRef) : modelOrRef;
-      actions.push(defineGoogleAIModel({
-        name: modelName,
-        apiKey: options?.apiKey,
-        baseUrl: options?.baseUrl,
-        info: {
-          ...modelRef.info,
-          label: `Google AI - ${modelName}`,
-        },
-        debugTraces: options?.experimental_debugTraces,
-      }));
+      actions.push(
+        defineGoogleAIModel({
+          name: modelName,
+          apiKey: options?.apiKey,
+          baseUrl: options?.baseUrl,
+          info: {
+            ...modelRef.info,
+            label: `Google AI - ${modelName}`,
+          },
+          debugTraces: options?.experimental_debugTraces,
+        })
+      );
     }
   }
 
@@ -195,7 +207,10 @@ async function resolver(
   return undefined;
 }
 
-function resolveModel(actionName: string, options?: PluginOptions): ResolvableAction | undefined {
+function resolveModel(
+  actionName: string,
+  options?: PluginOptions
+): ResolvableAction | undefined {
   if (actionName.startsWith('imagen')) {
     return defineImagenModel(actionName, options?.apiKey);
   }
@@ -336,7 +351,7 @@ export function googleAIPlugin(options?: PluginOptions): GenkitPluginV2 {
       if (listActionsCache) return listActionsCache;
       listActionsCache = await listActions(options);
       return listActionsCache;
-    }
+    },
   });
 }
 

--- a/js/plugins/googleai/src/index.ts
+++ b/js/plugins/googleai/src/index.ts
@@ -20,13 +20,12 @@ import {
   modelActionMetadata,
   type ActionMetadata,
   type EmbedderReference,
-  type Genkit,
   type ModelReference,
   type z,
 } from 'genkit';
 import { logger } from 'genkit/logging';
 import { modelRef } from 'genkit/model';
-import { genkitPlugin, type GenkitPlugin } from 'genkit/plugin';
+import { genkitPluginV2, ResolvableAction, type GenkitPluginV2 } from 'genkit/plugin';
 import type { ActionType } from 'genkit/registry';
 import { getApiKeyFromEnvVar } from './common.js';
 import {
@@ -112,8 +111,9 @@ export interface PluginOptions {
   experimental_debugTraces?: boolean;
 }
 
-async function initializer(ai: Genkit, options?: PluginOptions) {
+async function initializer(options?: PluginOptions): Promise<ResolvableAction[]> {
   let apiVersions = ['v1'];
+  const actions: ResolvableAction[] = [];
 
   if (options?.apiVersion) {
     if (Array.isArray(options?.apiVersion)) {
@@ -125,29 +125,27 @@ async function initializer(ai: Genkit, options?: PluginOptions) {
 
   if (apiVersions.includes('v1beta')) {
     Object.keys(SUPPORTED_GEMINI_MODELS).forEach((name) =>
-      defineGoogleAIModel({
-        ai,
+      actions.push(defineGoogleAIModel({
         name,
         apiKey: options?.apiKey,
         apiVersion: 'v1beta',
         baseUrl: options?.baseUrl,
         debugTraces: options?.experimental_debugTraces,
-      })
+      }))
     );
   }
   if (apiVersions.includes('v1')) {
     Object.keys(SUPPORTED_GEMINI_MODELS).forEach((name) =>
-      defineGoogleAIModel({
-        ai,
+      actions.push(defineGoogleAIModel({
         name,
         apiKey: options?.apiKey,
         apiVersion: undefined,
         baseUrl: options?.baseUrl,
         debugTraces: options?.experimental_debugTraces,
-      })
+      }))
     );
     Object.keys(EMBEDDER_MODELS).forEach((name) =>
-      defineGoogleAIEmbedder(ai, name, { apiKey: options?.apiKey })
+      actions.push(defineGoogleAIEmbedder(name, { apiKey: options?.apiKey }))
     );
   }
 
@@ -160,8 +158,7 @@ async function initializer(ai: Genkit, options?: PluginOptions) {
             modelOrRef.name.split('/')[1];
       const modelRef =
         typeof modelOrRef === 'string' ? gemini(modelOrRef) : modelOrRef;
-      defineGoogleAIModel({
-        ai,
+      actions.push(defineGoogleAIModel({
         name: modelName,
         apiKey: options?.apiKey,
         baseUrl: options?.baseUrl,
@@ -170,40 +167,41 @@ async function initializer(ai: Genkit, options?: PluginOptions) {
           label: `Google AI - ${modelName}`,
         },
         debugTraces: options?.experimental_debugTraces,
-      });
+      }));
     }
   }
+
+  return actions;
 }
 
 async function resolver(
-  ai: Genkit,
   actionType: ActionType,
   actionName: string,
   options?: PluginOptions
-) {
+): Promise<ResolvableAction | undefined> {
   if (actionType === 'embedder') {
-    resolveEmbedder(ai, actionName, options);
+    return resolveEmbedder(actionName, options);
   } else if (actionName.startsWith('veo')) {
     // we do it this way because the request may come in for
     // action type 'model' and action name 'veo-...'. That case should
     // be a noop. It's just the order or model lookup.
     if (actionType === 'background-model') {
-      defineVeoModel(ai, actionName, options?.apiKey);
+      return defineVeoModel(actionName, options?.apiKey);
     }
   } else if (actionType === 'model') {
-    resolveModel(ai, actionName, options);
+    return resolveModel(actionName, options);
   }
+
+  return undefined;
 }
 
-function resolveModel(ai: Genkit, actionName: string, options?: PluginOptions) {
+function resolveModel(actionName: string, options?: PluginOptions): ResolvableAction | undefined {
   if (actionName.startsWith('imagen')) {
-    defineImagenModel(ai, actionName, options?.apiKey);
-    return;
+    return defineImagenModel(actionName, options?.apiKey);
   }
 
   const modelRef = gemini(actionName);
-  defineGoogleAIModel({
-    ai,
+  return defineGoogleAIModel({
     name: modelRef.name,
     apiKey: options?.apiKey,
     baseUrl: options?.baseUrl,
@@ -216,11 +214,10 @@ function resolveModel(ai: Genkit, actionName: string, options?: PluginOptions) {
 }
 
 function resolveEmbedder(
-  ai: Genkit,
   actionName: string,
   options?: PluginOptions
-) {
-  defineGoogleAIEmbedder(ai, `googleai/${actionName}`, {
+): ResolvableAction | undefined {
+  return defineGoogleAIEmbedder(`googleai/${actionName}`, {
     apiKey: options?.apiKey,
   });
 }
@@ -328,23 +325,23 @@ async function listActions(options?: PluginOptions): Promise<ActionMetadata[]> {
 /**
  * Google Gemini Developer API plugin.
  */
-export function googleAIPlugin(options?: PluginOptions): GenkitPlugin {
+export function googleAIPlugin(options?: PluginOptions): GenkitPluginV2 {
   let listActionsCache;
-  return genkitPlugin(
-    'googleai',
-    async (ai: Genkit) => await initializer(ai, options),
-    async (ai: Genkit, actionType: ActionType, actionName: string) =>
-      await resolver(ai, actionType, actionName, options),
-    async () => {
+  return genkitPluginV2({
+    name: 'googleai',
+    init: async () => await initializer(options),
+    resolve: async (actionType: ActionType, actionName: string) =>
+      await resolver(actionType, actionName, options),
+    list: async () => {
       if (listActionsCache) return listActionsCache;
       listActionsCache = await listActions(options);
       return listActionsCache;
     }
-  );
+  });
 }
 
 export type GoogleAIPlugin = {
-  (params?: PluginOptions): GenkitPlugin;
+  (params?: PluginOptions): GenkitPluginV2;
   model(
     name: keyof typeof SUPPORTED_GEMINI_MODELS | (`gemini-${string}` & {}),
     config?: z.infer<typeof GeminiConfigSchema>

--- a/js/plugins/googleai/src/index.ts
+++ b/js/plugins/googleai/src/index.ts
@@ -130,8 +130,8 @@ async function initializer(
   }
 
   if (apiVersions.includes('v1beta')) {
-    Object.keys(SUPPORTED_GEMINI_MODELS).forEach((name) =>
-      actions.push(
+    actions.push(
+      ...Object.keys(SUPPORTED_GEMINI_MODELS).map((name) =>
         defineGoogleAIModel({
           name,
           apiKey: options?.apiKey,
@@ -143,8 +143,8 @@ async function initializer(
     );
   }
   if (apiVersions.includes('v1')) {
-    Object.keys(SUPPORTED_GEMINI_MODELS).forEach((name) =>
-      actions.push(
+    actions.push(
+      ...Object.keys(SUPPORTED_GEMINI_MODELS).map((name) =>
         defineGoogleAIModel({
           name,
           apiKey: options?.apiKey,
@@ -154,8 +154,10 @@ async function initializer(
         })
       )
     );
-    Object.keys(EMBEDDER_MODELS).forEach((name) =>
-      actions.push(defineGoogleAIEmbedder(name, { apiKey: options?.apiKey }))
+    actions.push(
+      ...Object.keys(EMBEDDER_MODELS).map((name) =>
+        defineGoogleAIEmbedder(name, { apiKey: options?.apiKey })
+      )
     );
   }
 

--- a/js/plugins/googleai/src/veo.ts
+++ b/js/plugins/googleai/src/veo.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  GenerateResponseData,
-  GenkitError,
-  Operation,
-  z,
-} from 'genkit';
+import { GenerateResponseData, GenkitError, Operation, z } from 'genkit';
 import {
   BackgroundModelAction,
   modelRef as createModelRef,
@@ -27,9 +22,9 @@ import {
   type ModelInfo,
   type ModelReference,
 } from 'genkit/model';
+import { backgroundModel } from 'genkit/plugin';
 import { getApiKeyFromEnvVar } from './common.js';
 import { Operation as ApiOperation, checkOp, predictModel } from './predict.js';
-import { backgroundModel } from 'genkit/plugin';
 
 export type KNOWN_VEO_MODELS = 'veo-2.0-generate-001';
 

--- a/js/plugins/googleai/src/veo.ts
+++ b/js/plugins/googleai/src/veo.ts
@@ -19,17 +19,17 @@ import {
   GenkitError,
   Operation,
   z,
-  type Genkit,
 } from 'genkit';
 import {
   BackgroundModelAction,
-  modelRef,
+  modelRef as createModelRef,
   type GenerateRequest,
   type ModelInfo,
   type ModelReference,
 } from 'genkit/model';
 import { getApiKeyFromEnvVar } from './common.js';
 import { Operation as ApiOperation, checkOp, predictModel } from './predict.js';
+import { backgroundModel } from 'genkit/plugin';
 
 export type KNOWN_VEO_MODELS = 'veo-2.0-generate-001';
 
@@ -127,7 +127,6 @@ export const GENERIC_VEO_INFO = {
 } as ModelInfo;
 
 export function defineVeoModel(
-  ai: Genkit,
   name: string,
   apiKey?: string | false
 ): BackgroundModelAction<typeof VeoConfigSchema> {
@@ -143,7 +142,7 @@ export function defineVeoModel(
     }
   }
   const modelName = `googleai/${name}`;
-  const model: ModelReference<z.ZodTypeAny> = modelRef({
+  const modelRef: ModelReference<z.ZodTypeAny> = createModelRef({
     name: modelName,
     info: {
       ...GENERIC_VEO_INFO,
@@ -152,9 +151,9 @@ export function defineVeoModel(
     configSchema: VeoConfigSchema,
   });
 
-  return ai.defineBackgroundModel({
+  return backgroundModel({
     name: modelName,
-    ...model.info,
+    ...modelRef.info,
     configSchema: VeoConfigSchema,
     async start(request) {
       const instance: VeoInstance = {
@@ -169,7 +168,7 @@ export function defineVeoModel(
         VeoInstance,
         ApiOperation,
         VeoParameters
-      >(model.version || name, apiKey as string, 'predictLongRunning');
+      >(modelRef.version || name, apiKey as string, 'predictLongRunning');
       const response = await predictClient([instance], toParameters(request));
 
       return toGenkitOp(response);


### PR DESCRIPTION
Resolves https://github.com/firebase/genkit/issues/3443

[Plugin migration guide](https://docs.google.com/document/d/1s1YKwhqdrGN44IG7lSAwltxM3Bqh9p6jTcri8SNaBWk/edit?usp=sharing)

**Notable Changes**
- Migrates from v1 to v2 API.
 
**Testing**
  - [x] Checked that the same number of modes and embedders load.

<img width="289" height="703" alt="image" src="https://github.com/user-attachments/assets/6c8ffeae-ccc0-4505-811a-7b7b7ffc0a61" />

  - [x] Checked that the models load with the same names/prefixes on the UI.

<img width="361" height="647" alt="image" src="https://github.com/user-attachments/assets/f0e53f5a-0775-4af2-8909-1bc1f69f97d7" />

  - [x] Checked that the embedders load with the same names/prefixes on the UI.

<img width="1765" height="1025" alt="image" src="https://github.com/user-attachments/assets/6f404877-be4b-49a2-ac2f-c5aa77c50aff" />

  - [x] Checked that at least one Gemini model works consistent with pre-migration on the UI.

<img width="2159" height="719" alt="image" src="https://github.com/user-attachments/assets/7ba05e08-5882-4a95-91e4-775658f9cdc8" />

  - [x] Checked that at least one Imagen model works consistent with pre-migration on the UI.

<img width="2153" height="653" alt="image" src="https://github.com/user-attachments/assets/5f62a1df-d1af-4960-a98f-ee21a4cd4cb2" />

  - [ ] Checked that at least one Veo model works consistent with pre-migration on the UI.
[**Can't see any load in, even before migration.**](https://gyazo.com/b5b51427e6a471a970e0eae96436d81a)

  - [x] Checked that at least one Gemma model works consistent with pre-migration on the UI.

<img width="2151" height="807" alt="image" src="https://github.com/user-attachments/assets/237c5842-525a-450d-9bdb-244d7107ae1f" />

  - [x] Checked that at least one embedder works consistent with pre-migration on the UI.

<img width="2141" height="2341" alt="image" src="https://github.com/user-attachments/assets/44b78c8c-f0ac-439b-9f2f-0f0f0c5451a3" />

  - [x] Using a model object, checked using a flow works consistent with pre-migration.

<img width="2181" height="1697" alt="image" src="https://github.com/user-attachments/assets/e0d33d8d-dbe8-437e-b098-e2027094fc7a" />

  - [x] Using an embedder object, checked using a flow works consistent with pre-migration.

<img width="2179" height="1913" alt="image" src="https://github.com/user-attachments/assets/9e8c7ff4-1204-4133-aad9-770ecad3a219" />

  - [x] Using a model string (`'pluginName/modelName'`), checked using a flow works consistent with pre-migration.

<img width="2177" height="1699" alt="image" src="https://github.com/user-attachments/assets/6f47d1da-95f1-4a2c-97cd-6a3f5d95a2c7" />

  - [x] Using an embedder string (`'pluginName/embedderName'`), checked using a flow works consistent with pre-migration.

<img width="2177" height="1919" alt="image" src="https://github.com/user-attachments/assets/03948b46-5426-4eca-abdd-1f7922d481ee" />

  - [x] Using a resolved model object, checked using a flow works.

<img width="2181" height="889" alt="image" src="https://github.com/user-attachments/assets/81baa9d7-749c-4d3a-91b4-24955b4e9b6d" />

  - [x] Using a resolved embedder object, checked using a flow works.

<img width="2173" height="1015" alt="image" src="https://github.com/user-attachments/assets/ed5f24c2-642d-4ad4-8e11-cfdc22d5c4f1" />

- [x] Using a model string, checked using a streaming flow works consistent with pre-migration.

<img width="2181" height="1891" alt="image" src="https://github.com/user-attachments/assets/db533043-f95a-4903-8218-7624bf5627ac" />

- [x] Using a model object, checked using a streaming flow works consistent with pre-migration.

<img width="2175" height="1823" alt="image" src="https://github.com/user-attachments/assets/1192291a-93b5-4071-8740-0ee0c17fc058" />

- [x] Using a resolved model object, checked using a streaming flow works.

<img width="2179" height="1023" alt="image" src="https://github.com/user-attachments/assets/4a897463-c63e-40f8-9ef9-d1f30ab08beb" />

  - [x] Tested error response from model.
<img width="1753" height="829" alt="image" src="https://github.com/user-attachments/assets/a0627e54-24b9-481f-9783-99cea847e684" />

  - [x] Tested error response from embedder.

<img width="1741" height="839" alt="image" src="https://github.com/user-attachments/assets/182f620b-9f41-4cf5-bd85-89def760ad91" />

  - [x] Tested model media input.

<img width="2149" height="899" alt="image" src="https://github.com/user-attachments/assets/04d5c2d5-4b13-4789-8a17-5f3a1d79b59b" />

  - [x] Tested model tool calling.

<img width="2147" height="1717" alt="image" src="https://github.com/user-attachments/assets/ab2f2c6f-6f99-43c5-88a2-5fb3e9bd6629" />

  - [x] Tested `.list`

<img width="2181" height="1043" alt="image" src="https://github.com/user-attachments/assets/4bb556ea-8b1e-467a-8613-3e24fcbb46aa" />