### PR TITLE
fix(go/plugins/mcp): Retrieve MCP server output schema

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/jba/slog v0.2.0
 	github.com/lib/pq v1.10.9
-	github.com/mark3labs/mcp-go v0.29.0
+	github.com/mark3labs/mcp-go v0.42.0
 	github.com/pgvector/pgvector-go v0.3.0
 	github.com/stretchr/testify v1.10.0
 	github.com/weaviate/weaviate v1.30.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -291,6 +291,8 @@ github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mark3labs/mcp-go v0.29.0 h1:sH1NBcumKskhxqYzhXfGc201D7P76TVXiT0fGVhabeI=
 github.com/mark3labs/mcp-go v0.29.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
+github.com/mark3labs/mcp-go v0.42.0 h1:gk/8nYJh8t3yroCAOBhNbYsM9TCKvkM13I5t5Hfu6Ls=
+github.com/mark3labs/mcp-go v0.42.0/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mbleigh/raymond v0.0.0-20250414171441-6b3a58ab9e0a h1:v2cBA3xWKv2cIOVhnzX/gNgkNXqiHfUgJtA3r61Hf7A=

--- a/go/internal/base/validation.go
+++ b/go/internal/base/validation.go
@@ -21,12 +21,16 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/xeipuuv/gojsonschema"
 )
 
 // ValidateValue will validate any value against the expected schema.
 // It will return an error if it doesn't match the schema, otherwise it will return nil.
 func ValidateValue(data any, schema map[string]any) error {
+	if callToolResult, ok := data.(*mcp.CallToolResult); ok {
+		data = callToolResult.StructuredContent
+	}
 	if schema == nil {
 		return nil
 	}

--- a/go/plugins/mcp/tools_test.go
+++ b/go/plugins/mcp/tools_test.go
@@ -15,10 +15,12 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 )
 
 func asMap(t *testing.T, v any, label string) map[string]any {
@@ -159,5 +161,81 @@ func TestPrepareToolArguments(t *testing.T) {
 	_, err = prepareToolArguments(tool, nil)
 	if err == nil {
 		t.Fatalf("expected error for nil args with required field")
+	}
+}
+
+// TestToolOutputSchema tests that both input and output schemas are correctly retrieved
+// from the MCP server.
+func TestToolOutputSchema(t *testing.T) {
+	// Start a test MCP server with a tool that has an input and output schema.
+	type inputSchema struct {
+		City string
+	}
+	type outputSchema struct {
+		Weather     string
+		Temperature int
+	}
+	mcpServer := server.NewMCPServer("test", "1.0.0",
+		server.WithToolCapabilities(true),
+	)
+	mcpServer.AddTool(
+		mcp.NewTool("getWeather",
+			mcp.WithInputSchema[inputSchema](),
+			mcp.WithOutputSchema[outputSchema](),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultStructured(
+				outputSchema{Weather: "Sunny, 25°C", Temperature: 25},
+				"The weather in Paris is Sunny, 25°C.",
+			), nil
+		},
+	)
+	// Start the stdio server
+	sseServer := server.NewTestServer(mcpServer)
+	defer sseServer.Close()
+	client, err := NewGenkitMCPClient(MCPClientOptions{
+		Name: "test",
+		SSE: &SSEConfig{
+			BaseURL: sseServer.URL + "/sse",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer client.Disconnect()
+	// Retrieve tools from the MCP server
+	tools, err := client.GetActiveTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GetActiveTools error: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	for _, tool := range tools {
+		if tool.Name() != "test_getWeather" {
+			t.Fatalf("unexpected tool: %s", tool.Name())
+		}
+		inputSchema := tool.Definition().InputSchema
+		assertSchemaProperty(t, inputSchema, "City", "string")
+
+		outputSchema := tool.Definition().OutputSchema
+		assertSchemaProperty(t, outputSchema, "Weather", "string")
+		assertSchemaProperty(t, outputSchema, "Temperature", "integer")
+	}
+}
+
+// assertSchemaProperty asserts that a property in a schema is present and of the expected type.
+func assertSchemaProperty(t *testing.T, schema map[string]any, propName string, propType string) {
+	t.Helper()
+	if schema == nil {
+		t.Fatalf("schema is nil")
+	}
+	if props, ok := schema["properties"].(map[string]any); !ok {
+		t.Fatalf("schema properties is nil")
+	} else if propValue, ok := props[propName].(map[string]any); !ok {
+		t.Fatalf("schema properties %s is nil", propName)
+	} else if propValue["type"] != propType {
+		t.Fatalf("schema property %s type is %s, expected %s",
+			propName, propValue["type"], propType)
 	}
 }


### PR DESCRIPTION
Currently,  tool definitions retrieved from an MCP server using `GentkitMCPClient` method `GetActiveTools`  contain only an empty map at `tool.Definition().OutputSchema`, even if the server explicitly declares an output schema for the given tool.

e.g. For the following MCP response:

```
{
  "tools": [
    {
      "name": "embed",
      "description": "Embed a text into a vector",
      "inputSchema": {
        "properties": { "text": { "type": "string" } },
        "required": ["text"],
        "type": "object"
      },
      "outputSchema": {
        "properties": {
          "result": { "items": { "type": "number" }, "type": "array" }
        },
        "required": ["result"],
        "type": "object",
        "x-fastmcp-wrap-result": true
      },
      "_meta": { "_fastmcp": { "tags": [] } }
    }
  ]
}
```
The following data is included in the tool definition:
<img width="720" height="381" alt="Screenshot 2025-10-27 at 2 16 19 PM" src="https://github.com/user-attachments/assets/caea5d8c-c7c5-421a-9329-ad8a457ac39e" />


This is in part because the current version for `github.com/mark3labs/mcp-go` doesn't include the `OutputSchema` attribute in the struct used to deserialize the message:

<img width="675" height="323" alt="Screenshot 2025-10-27 at 2 19 51 PM" src="https://github.com/user-attachments/assets/4fcdd3a6-81df-4100-a532-4e1b555bd61b" />


This PR introduces the following changes:
- Update `github.com/mark3labs/mcp-go` to the latest version, which does include `OutputSchema` in the `Tool` struct.
- Update the genkit MCP functions to actually retrieve the schema and use it during tool retrieval.


Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
