### PR TITLE
feat(go/plugins/compat_oai): add support for Claude 4.1 and 4.5 models

### DIFF
--- a/go/plugins/compat_oai/anthropic/anthropic.go
+++ b/go/plugins/compat_oai/anthropic/anthropic.go
@@ -32,6 +32,36 @@ const (
 
 // Supported models: https://docs.anthropic.com/en/docs/about-claude/models/all-models
 var supportedModels = map[string]ai.ModelOptions{
+	"claude-opus-4-1-20250805": {
+		Label: "Claude 4.1 Opus",
+		Supports: &ai.ModelSupports{
+			Multiturn:  true,
+			Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
+			SystemRole: true,
+			Media:      true,
+		},
+		Versions: []string{"claude-opus-4-1-latest", "claude-opus-4-1-20250805"},
+	},
+	"claude-sonnet-4-5-20250929": {
+		Label: "Claude 4.5 Sonnet",
+		Supports: &ai.ModelSupports{
+			Multiturn:  true,
+			Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
+			SystemRole: true,
+			Media:      true,
+		},
+		Versions: []string{"claude-sonnet-4-5-latest", "claude-sonnet-4-5-20250929"},
+	},
+	"claude-haiku-4-5-20251001": {
+		Label: "Claude 4.5 Haiku",
+		Supports: &ai.ModelSupports{
+			Multiturn:  true,
+			Tools:      false, // NOTE: Anthropic supports tool use, but it's not compatible with the OpenAI API
+			SystemRole: true,
+			Media:      true,
+		},
+		Versions: []string{"claude-haiku-4-5-latest", "claude-haiku-4-5-20251001"},
+	},
 	"claude-3-7-sonnet-20250219": {
 		Label: "Claude 3.7 Sonnet",
 		Supports: &ai.ModelSupports{

--- a/go/plugins/compat_oai/anthropic/anthropic_live_test.go
+++ b/go/plugins/compat_oai/anthropic/anthropic_live_test.go
@@ -34,10 +34,10 @@ func TestPlugin(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Initialize genkit with claude-3-7-sonnet as default model
+	// Initialize genkit with claude-4-5-sonnet as default model
 	g := genkit.Init(
 		ctx,
-		genkit.WithDefaultModel("anthropic/claude-3-7-sonnet-20250219"),
+		genkit.WithDefaultModel("anthropic/claude-sonnet-4-5-20250929"),
 		genkit.WithPlugins(&anthropic.Anthropic{
 			Opts: []option.RequestOption{
 				option.WithAPIKey(apiKey),


### PR DESCRIPTION
This PR adds support for the latest Anthropic models, based on the official documentation:
- `claude-opus-4-1-20250805`
- `claude-sonnet-4-5-20250929`
- `claude-haiku-4-5-20251001`

Reference: https://docs.anthropic.com/en/docs/about-claude/models/all-models

Additionally, this PR updates the `anthropic` example to use the new `claude-sonnet-4-5-20250929` as the default model.

---

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (Manually tested by running the updated example in `examples/anthropic/main.go` and confirming a successful API response.)
- [x] Docs updated (The model list within the plugin and the example code are both updated.)