### PR TITLE
feat(go/plugins/compat_oai): add Ollama Cloud support

### DIFF
--- a/go/plugins/compat_oai/ollamacloud/ollamacloud.go
+++ b/go/plugins/compat_oai/ollamacloud/ollamacloud.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ollamacloud
+
+import (
+	"context"
+	"os"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go/option"
+)
+
+const (
+	provider = "ollamacloud"
+	baseURL  = "https://ollama.com"
+	version  = "/v1"
+)
+
+// supportedModels defines a curated set of Ollama Cloud models.
+// Model IDs are aligned with https://ollama.com/v1/models.
+var supportedModels = map[string]ai.ModelOptions{
+	// Large Language Models (text-only)
+	"gpt-oss:20b": {
+		Label:    "GPT-OSS 20B",
+		Supports: &compat_oai.BasicText,
+		Versions: []string{"gpt-oss:20b"},
+	},
+	"gpt-oss:120b": {
+		Label:    "GPT-OSS 120B",
+		Supports: &compat_oai.BasicText,
+		Versions: []string{"gpt-oss:120b"},
+	},
+	"qwen3-coder:480b": {
+		Label:    "Qwen3 Coder 480B",
+		Supports: &compat_oai.BasicText,
+		Versions: []string{"qwen3-coder:480b"},
+	},
+	"deepseek-v3.1:671b": {
+		Label:    "DeepSeek v3.1 671B",
+		Supports: &compat_oai.BasicText,
+		Versions: []string{"deepseek-v3.1:671b"},
+	},
+	"glm-4.6": {
+		Label:    "GLM-4.6",
+		Supports: &compat_oai.BasicText,
+		Versions: []string{"glm-4.6"},
+	},
+	"minimax-m2": {
+		Label:    "MiniMax M2",
+		Supports: &compat_oai.BasicText,
+		Versions: []string{"minimax-m2"},
+	},
+	"kimi-k2:1t": {
+		Label:    "Kimi K2 1T",
+		Supports: &compat_oai.BasicText,
+		Versions: []string{"kimi-k2:1t"},
+	},
+	"kimi-k2-thinking": {
+		Label:    "Kimi K2 Thinking",
+		Supports: &compat_oai.BasicText,
+		Versions: []string{"kimi-k2-thinking"},
+	},
+
+	// Multimodal Models (Vision + Text)
+	"qwen3-vl:235b-instruct": {
+		Label:    "Qwen3 VL 235B Instruct",
+		Supports: &compat_oai.Multimodal,
+		Versions: []string{"qwen3-vl:235b-instruct"},
+	},
+	"qwen3-vl:235b": {
+		Label:    "Qwen3 VL 235B",
+		Supports: &compat_oai.Multimodal,
+		Versions: []string{"qwen3-vl:235b"},
+	},
+}
+
+// OllamaCloud represents the Ollama Cloud plugin
+type OllamaCloud struct {
+	APIKey string
+	Opts   []option.RequestOption
+
+	openAICompatible *compat_oai.OpenAICompatible
+}
+
+// Name implements genkit.Plugin.
+func (o *OllamaCloud) Name() string {
+	return provider
+}
+
+// Init implements genkit.Plugin.
+func (o *OllamaCloud) Init(ctx context.Context) []api.Action {
+	apiKey := o.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("OLLAMACLOUD_API_KEY")
+	}
+
+	if apiKey == "" {
+		panic("ollamacloud plugin initialization failed: API key is required")
+	}
+
+	if o.openAICompatible == nil {
+		o.openAICompatible = &compat_oai.OpenAICompatible{}
+	}
+
+	// Configure OpenAI-compatible client with Ollama Cloud settings
+	o.openAICompatible.Opts = []option.RequestOption{
+		option.WithAPIKey(apiKey),
+		option.WithBaseURL(baseURL + version),
+	}
+	if len(o.Opts) > 0 {
+		o.openAICompatible.Opts = append(o.openAICompatible.Opts, o.Opts...)
+	}
+
+	o.openAICompatible.Provider = provider
+	compatActions := o.openAICompatible.Init(ctx)
+
+	var actions []api.Action
+	actions = append(actions, compatActions...)
+
+	// Define available models
+	for model, opts := range supportedModels {
+		actions = append(actions, o.DefineModel(model, opts).(api.Action))
+	}
+
+	return actions
+}
+
+// Model returns the ai.Model with the given name.
+func (o *OllamaCloud) Model(g *genkit.Genkit, name string) ai.Model {
+	return o.openAICompatible.Model(g, api.NewName(provider, name))
+}
+
+// DefineModel defines a model with the given ID and options.
+func (o *OllamaCloud) DefineModel(id string, opts ai.ModelOptions) ai.Model {
+	return o.openAICompatible.DefineModel(provider, id, opts)
+}
+
+// ListActions implements genkit.Plugin.
+func (o *OllamaCloud) ListActions(ctx context.Context) []api.ActionDesc {
+	return o.openAICompatible.ListActions(ctx)
+}
+
+// ResolveAction implements genkit.Plugin.
+func (o *OllamaCloud) ResolveAction(atype api.ActionType, name string) api.Action {
+	return o.openAICompatible.ResolveAction(atype, name)
+}

--- a/go/plugins/compat_oai/ollamacloud/ollamacloud.go
+++ b/go/plugins/compat_oai/ollamacloud/ollamacloud.go
@@ -18,6 +18,7 @@ package ollamacloud
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/firebase/genkit/go/ai"
@@ -28,9 +29,9 @@ import (
 )
 
 const (
-	provider = "ollamacloud"
-	baseURL  = "https://ollama.com"
-	version  = "/v1"
+	provider   = "ollamacloud"
+	apiBaseURL = "https://ollama.com"
+	apiVersion = "v1"
 )
 
 // supportedModels defines a curated set of Ollama Cloud models.
@@ -122,7 +123,7 @@ func (o *OllamaCloud) Init(ctx context.Context) []api.Action {
 	// Configure OpenAI-compatible client with Ollama Cloud settings
 	o.openAICompatible.Opts = []option.RequestOption{
 		option.WithAPIKey(apiKey),
-		option.WithBaseURL(baseURL + version),
+		option.WithBaseURL(fmt.Sprintf("%s/%s", apiBaseURL, apiVersion)),
 	}
 	if len(o.Opts) > 0 {
 		o.openAICompatible.Opts = append(o.openAICompatible.Opts, o.Opts...)

--- a/go/plugins/compat_oai/ollamacloud/ollamacloud.go
+++ b/go/plugins/compat_oai/ollamacloud/ollamacloud.go
@@ -36,60 +36,77 @@ const (
 
 // supportedModels defines a curated set of Ollama Cloud models.
 // Model IDs are aligned with https://ollama.com/v1/models.
-var supportedModels = map[string]ai.ModelOptions{
-	// Large Language Models (text-only)
-	"gpt-oss:20b": {
-		Label:    "GPT-OSS 20B",
-		Supports: &compat_oai.BasicText,
-		Versions: []string{"gpt-oss:20b"},
-	},
-	"gpt-oss:120b": {
-		Label:    "GPT-OSS 120B",
-		Supports: &compat_oai.BasicText,
-		Versions: []string{"gpt-oss:120b"},
-	},
-	"qwen3-coder:480b": {
-		Label:    "Qwen3 Coder 480B",
-		Supports: &compat_oai.BasicText,
-		Versions: []string{"qwen3-coder:480b"},
-	},
-	"deepseek-v3.1:671b": {
-		Label:    "DeepSeek v3.1 671B",
-		Supports: &compat_oai.BasicText,
-		Versions: []string{"deepseek-v3.1:671b"},
-	},
-	"glm-4.6": {
-		Label:    "GLM-4.6",
-		Supports: &compat_oai.BasicText,
-		Versions: []string{"glm-4.6"},
-	},
-	"minimax-m2": {
-		Label:    "MiniMax M2",
-		Supports: &compat_oai.BasicText,
-		Versions: []string{"minimax-m2"},
-	},
-	"kimi-k2:1t": {
-		Label:    "Kimi K2 1T",
-		Supports: &compat_oai.BasicText,
-		Versions: []string{"kimi-k2:1t"},
-	},
-	"kimi-k2-thinking": {
-		Label:    "Kimi K2 Thinking",
-		Supports: &compat_oai.BasicText,
-		Versions: []string{"kimi-k2-thinking"},
-	},
+var (
+	textOnly = ai.ModelSupports{
+		Multiturn:  true,
+		Tools:      false,
+		SystemRole: true,
+		Media:      false,
+	}
 
-	// Multimodal Models (Vision + Text)
-	"qwen3-vl:235b-instruct": {
-		Label:    "Qwen3 VL 235B Instruct",
-		Supports: &compat_oai.Multimodal,
-		Versions: []string{"qwen3-vl:235b-instruct"},
-	},
-	"qwen3-vl:235b": {
-		Label:    "Qwen3 VL 235B",
-		Supports: &compat_oai.Multimodal,
-		Versions: []string{"qwen3-vl:235b"},
-	},
+	visionOnly = ai.ModelSupports{
+		Multiturn:  true,
+		Tools:      false,
+		SystemRole: true,
+		Media:      true,
+	}
+)
+
+func modelOptions(label, version string, supports *ai.ModelSupports) ai.ModelOptions {
+	return ai.ModelOptions{
+		Label:    label,
+		Supports: supports,
+		Versions: []string{version},
+	}
+}
+
+var supportedModels = map[string]ai.ModelOptions{
+	// Text models without Ollama tool tags.
+	"cogito-2.1:671b": modelOptions("Cogito 2.1 671B", "cogito-2.1:671b", &textOnly),
+
+	// Text models with Ollama tool tags.
+	"deepseek-v3.1:671b":  modelOptions("DeepSeek V3.1 671B", "deepseek-v3.1:671b", &compat_oai.BasicText),
+	"deepseek-v3.2":       modelOptions("DeepSeek V3.2", "deepseek-v3.2", &compat_oai.BasicText),
+	"deepseek-v4-flash":   modelOptions("DeepSeek V4 Flash", "deepseek-v4-flash", &compat_oai.BasicText),
+	"deepseek-v4-pro":     modelOptions("DeepSeek V4 Pro", "deepseek-v4-pro", &compat_oai.BasicText),
+	"devstral-2:123b":     modelOptions("Devstral 2 123B", "devstral-2:123b", &compat_oai.BasicText),
+	"glm-4.6":             modelOptions("GLM-4.6", "glm-4.6", &compat_oai.BasicText),
+	"glm-4.7":             modelOptions("GLM-4.7", "glm-4.7", &compat_oai.BasicText),
+	"glm-5":               modelOptions("GLM-5", "glm-5", &compat_oai.BasicText),
+	"glm-5.1":             modelOptions("GLM-5.1", "glm-5.1", &compat_oai.BasicText),
+	"gpt-oss:20b":         modelOptions("GPT-OSS 20B", "gpt-oss:20b", &compat_oai.BasicText),
+	"gpt-oss:120b":        modelOptions("GPT-OSS 120B", "gpt-oss:120b", &compat_oai.BasicText),
+	"kimi-k2:1t":          modelOptions("Kimi K2 1T", "kimi-k2:1t", &compat_oai.BasicText),
+	"kimi-k2-thinking":    modelOptions("Kimi K2 Thinking", "kimi-k2-thinking", &compat_oai.BasicText),
+	"minimax-m2":          modelOptions("MiniMax M2", "minimax-m2", &compat_oai.BasicText),
+	"minimax-m2.1":        modelOptions("MiniMax M2.1", "minimax-m2.1", &compat_oai.BasicText),
+	"minimax-m2.5":        modelOptions("MiniMax M2.5", "minimax-m2.5", &compat_oai.BasicText),
+	"minimax-m2.7":        modelOptions("MiniMax M2.7", "minimax-m2.7", &compat_oai.BasicText),
+	"nemotron-3-nano:30b": modelOptions("Nemotron 3 Nano 30B", "nemotron-3-nano:30b", &compat_oai.BasicText),
+	"nemotron-3-super":    modelOptions("Nemotron 3 Super", "nemotron-3-super", &compat_oai.BasicText),
+	"qwen3-coder:480b":    modelOptions("Qwen3 Coder 480B", "qwen3-coder:480b", &compat_oai.BasicText),
+	"qwen3-coder-next":    modelOptions("Qwen3 Coder Next", "qwen3-coder-next", &compat_oai.BasicText),
+	"qwen3-next:80b":      modelOptions("Qwen3 Next 80B", "qwen3-next:80b", &compat_oai.BasicText),
+	"rnj-1:8b":            modelOptions("RNJ-1 8B", "rnj-1:8b", &compat_oai.BasicText),
+
+	// Vision models without Ollama tool tags.
+	"gemma3:4b":  modelOptions("Gemma 3 4B", "gemma3:4b", &visionOnly),
+	"gemma3:12b": modelOptions("Gemma 3 12B", "gemma3:12b", &visionOnly),
+	"gemma3:27b": modelOptions("Gemma 3 27B", "gemma3:27b", &visionOnly),
+
+	// Vision models with Ollama tool tags.
+	"devstral-small-2:24b":   modelOptions("Devstral Small 2 24B", "devstral-small-2:24b", &compat_oai.Multimodal),
+	"gemini-3-flash-preview": modelOptions("Gemini 3 Flash Preview", "gemini-3-flash-preview", &compat_oai.Multimodal),
+	"gemma4:31b":             modelOptions("Gemma 4 31B", "gemma4:31b", &compat_oai.Multimodal),
+	"kimi-k2.5":              modelOptions("Kimi K2.5", "kimi-k2.5", &compat_oai.Multimodal),
+	"kimi-k2.6":              modelOptions("Kimi K2.6", "kimi-k2.6", &compat_oai.Multimodal),
+	"ministral-3:3b":         modelOptions("Ministral 3 3B", "ministral-3:3b", &compat_oai.Multimodal),
+	"ministral-3:8b":         modelOptions("Ministral 3 8B", "ministral-3:8b", &compat_oai.Multimodal),
+	"ministral-3:14b":        modelOptions("Ministral 3 14B", "ministral-3:14b", &compat_oai.Multimodal),
+	"mistral-large-3:675b":   modelOptions("Mistral Large 3 675B", "mistral-large-3:675b", &compat_oai.Multimodal),
+	"qwen3-vl:235b":          modelOptions("Qwen3 VL 235B", "qwen3-vl:235b", &compat_oai.Multimodal),
+	"qwen3-vl:235b-instruct": modelOptions("Qwen3 VL 235B Instruct", "qwen3-vl:235b-instruct", &compat_oai.Multimodal),
+	"qwen3.5:397b":           modelOptions("Qwen3.5 397B", "qwen3.5:397b", &compat_oai.Multimodal),
 }
 
 // OllamaCloud represents the Ollama Cloud plugin
@@ -137,7 +154,7 @@ func (o *OllamaCloud) Init(ctx context.Context) []api.Action {
 
 	// Define available models
 	for model, opts := range supportedModels {
-		actions = append(actions, o.DefineModel(model, opts).(api.Action))
+		actions = append(actions, o.defineModelAction(model, opts))
 	}
 
 	return actions
@@ -151,6 +168,10 @@ func (o *OllamaCloud) Model(g *genkit.Genkit, name string) ai.Model {
 // DefineModel defines a model with the given ID and options.
 func (o *OllamaCloud) DefineModel(id string, opts ai.ModelOptions) ai.Model {
 	return o.openAICompatible.DefineModel(provider, id, opts)
+}
+
+func (o *OllamaCloud) defineModelAction(id string, opts ai.ModelOptions) api.Action {
+	return o.DefineModel(id, opts).(api.Action)
 }
 
 // ListActions implements genkit.Plugin.

--- a/go/plugins/compat_oai/ollamacloud/ollamacloud.go
+++ b/go/plugins/compat_oai/ollamacloud/ollamacloud.go
@@ -19,6 +19,7 @@ package ollamacloud
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"sort"
 	"sync"
@@ -153,7 +154,8 @@ func (o *OllamaCloud) Init(ctx context.Context) []api.Action {
 	}
 
 	if apiKey == "" {
-		panic("ollamacloud plugin initialization failed: API key is required")
+		slog.Error("ollamacloud plugin initialization failed: API key is required", "provider", provider)
+		return nil
 	}
 
 	if o.openAICompatible == nil {

--- a/go/plugins/compat_oai/ollamacloud/ollamacloud.go
+++ b/go/plugins/compat_oai/ollamacloud/ollamacloud.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
@@ -114,6 +115,9 @@ type OllamaCloud struct {
 	APIKey string
 	Opts   []option.RequestOption
 
+	mu      sync.Mutex
+	initted bool
+
 	openAICompatible *compat_oai.OpenAICompatible
 }
 
@@ -124,32 +128,39 @@ func (o *OllamaCloud) Name() string {
 
 // Init implements genkit.Plugin.
 func (o *OllamaCloud) Init(ctx context.Context) []api.Action {
-	apiKey := o.APIKey
-	if apiKey == "" {
-		apiKey = os.Getenv("OLLAMACLOUD_API_KEY")
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	var compatActions []api.Action
+	if !o.initted {
+		apiKey := o.APIKey
+		if apiKey == "" {
+			apiKey = os.Getenv("OLLAMACLOUD_API_KEY")
+		}
+
+		if apiKey == "" {
+			panic("ollamacloud plugin initialization failed: API key is required")
+		}
+
+		if o.openAICompatible == nil {
+			o.openAICompatible = &compat_oai.OpenAICompatible{}
+		}
+
+		// Configure OpenAI-compatible client with Ollama Cloud settings
+		o.openAICompatible.Opts = []option.RequestOption{
+			option.WithAPIKey(apiKey),
+			option.WithBaseURL(fmt.Sprintf("%s/%s", apiBaseURL, apiVersion)),
+		}
+		if len(o.Opts) > 0 {
+			o.openAICompatible.Opts = append(o.openAICompatible.Opts, o.Opts...)
+		}
+
+		o.openAICompatible.Provider = provider
+		compatActions = o.openAICompatible.Init(ctx)
+		o.initted = true
 	}
 
-	if apiKey == "" {
-		panic("ollamacloud plugin initialization failed: API key is required")
-	}
-
-	if o.openAICompatible == nil {
-		o.openAICompatible = &compat_oai.OpenAICompatible{}
-	}
-
-	// Configure OpenAI-compatible client with Ollama Cloud settings
-	o.openAICompatible.Opts = []option.RequestOption{
-		option.WithAPIKey(apiKey),
-		option.WithBaseURL(fmt.Sprintf("%s/%s", apiBaseURL, apiVersion)),
-	}
-	if len(o.Opts) > 0 {
-		o.openAICompatible.Opts = append(o.openAICompatible.Opts, o.Opts...)
-	}
-
-	o.openAICompatible.Provider = provider
-	compatActions := o.openAICompatible.Init(ctx)
-
-	var actions []api.Action
+	actions := make([]api.Action, 0, len(supportedModels)+len(compatActions))
 	actions = append(actions, compatActions...)
 
 	// Define available models

--- a/go/plugins/compat_oai/ollamacloud/ollamacloud.go
+++ b/go/plugins/compat_oai/ollamacloud/ollamacloud.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"sync"
 
 	"github.com/firebase/genkit/go/ai"
@@ -59,6 +60,15 @@ func modelOptions(label, version string, supports *ai.ModelSupports) ai.ModelOpt
 		Supports: supports,
 		Versions: []string{version},
 	}
+}
+
+func sortedSupportedModelIDs() []string {
+	models := make([]string, 0, len(supportedModels))
+	for model := range supportedModels {
+		models = append(models, model)
+	}
+	sort.Strings(models)
+	return models
 }
 
 var supportedModels = map[string]ai.ModelOptions{
@@ -117,6 +127,7 @@ type OllamaCloud struct {
 
 	mu      sync.Mutex
 	initted bool
+	actions []api.Action
 
 	openAICompatible *compat_oai.OpenAICompatible
 }
@@ -131,44 +142,47 @@ func (o *OllamaCloud) Init(ctx context.Context) []api.Action {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	var compatActions []api.Action
-	if !o.initted {
-		apiKey := o.APIKey
-		if apiKey == "" {
-			apiKey = os.Getenv("OLLAMACLOUD_API_KEY")
-		}
-
-		if apiKey == "" {
-			panic("ollamacloud plugin initialization failed: API key is required")
-		}
-
-		if o.openAICompatible == nil {
-			o.openAICompatible = &compat_oai.OpenAICompatible{}
-		}
-
-		// Configure OpenAI-compatible client with Ollama Cloud settings
-		o.openAICompatible.Opts = []option.RequestOption{
-			option.WithAPIKey(apiKey),
-			option.WithBaseURL(fmt.Sprintf("%s/%s", apiBaseURL, apiVersion)),
-		}
-		if len(o.Opts) > 0 {
-			o.openAICompatible.Opts = append(o.openAICompatible.Opts, o.Opts...)
-		}
-
-		o.openAICompatible.Provider = provider
-		compatActions = o.openAICompatible.Init(ctx)
-		o.initted = true
+	if o.initted {
+		return append([]api.Action(nil), o.actions...)
 	}
+
+	var compatActions []api.Action
+	apiKey := o.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("OLLAMACLOUD_API_KEY")
+	}
+
+	if apiKey == "" {
+		panic("ollamacloud plugin initialization failed: API key is required")
+	}
+
+	if o.openAICompatible == nil {
+		o.openAICompatible = &compat_oai.OpenAICompatible{}
+	}
+
+	// Configure OpenAI-compatible client with Ollama Cloud settings
+	o.openAICompatible.Opts = []option.RequestOption{
+		option.WithAPIKey(apiKey),
+		option.WithBaseURL(fmt.Sprintf("%s/%s", apiBaseURL, apiVersion)),
+	}
+	if len(o.Opts) > 0 {
+		o.openAICompatible.Opts = append(o.openAICompatible.Opts, o.Opts...)
+	}
+
+	o.openAICompatible.Provider = provider
+	compatActions = o.openAICompatible.Init(ctx)
 
 	actions := make([]api.Action, 0, len(supportedModels)+len(compatActions))
 	actions = append(actions, compatActions...)
 
 	// Define available models
-	for model, opts := range supportedModels {
-		actions = append(actions, o.defineModelAction(model, opts))
+	for _, model := range sortedSupportedModelIDs() {
+		actions = append(actions, o.defineModelAction(model, supportedModels[model]))
 	}
 
-	return actions
+	o.actions = actions
+	o.initted = true
+	return append([]api.Action(nil), o.actions...)
 }
 
 // Model returns the ai.Model with the given name.
@@ -182,7 +196,11 @@ func (o *OllamaCloud) DefineModel(id string, opts ai.ModelOptions) ai.Model {
 }
 
 func (o *OllamaCloud) defineModelAction(id string, opts ai.ModelOptions) api.Action {
-	return o.DefineModel(id, opts).(api.Action)
+	action, ok := o.DefineModel(id, opts).(api.Action)
+	if !ok {
+		panic(fmt.Sprintf("ollamacloud model %q does not implement api.Action", id))
+	}
+	return action
 }
 
 // ListActions implements genkit.Plugin.

--- a/go/plugins/compat_oai/ollamacloud/ollamacloud_live_test.go
+++ b/go/plugins/compat_oai/ollamacloud/ollamacloud_live_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ollamacloud
+
+import (
+	"context"
+	"math"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/openai/openai-go/option"
+)
+
+func TestPlugin(t *testing.T) {
+	apiKey := os.Getenv("OLLAMACLOUD_API_KEY")
+	if apiKey == "" {
+		t.Skip("Skipping test: OLLAMACLOUD_API_KEY environment variable not set")
+	}
+
+	ctx := context.Background()
+	ollamaCloud := &OllamaCloud{
+		APIKey: apiKey,
+		Opts: []option.RequestOption{
+			option.WithAPIKey(apiKey),
+		},
+	}
+
+	g := genkit.Init(ctx,
+		genkit.WithDefaultModel("ollamacloud/gpt-oss:20b"),
+		genkit.WithPlugins(ollamaCloud))
+
+	gablorkenTool := genkit.DefineTool(g, "gablorken", "use when need to calculate a gablorken",
+		func(ctx *ai.ToolContext, input struct {
+			Value float64
+			Over  float64
+		}) (float64, error) {
+			return math.Pow(input.Value, input.Over), nil
+		})
+
+	t.Log("ollamacloud plugin initialized")
+
+	t.Run("basic completion", func(t *testing.T) {
+		t.Log("generating basic completion response")
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithPrompt("What is the capital of France?"))
+		if err != nil {
+			t.Fatal("error generating basic completion response: ", err)
+		}
+		t.Logf("basic completion response: %+v", resp)
+		out := resp.Message.Content[0].Text
+		if !strings.Contains(strings.ToLower(out), "paris") {
+			t.Errorf("got %q, expecting it to contain 'Paris'", out)
+		}
+		// Verify usage statistics are present
+		if resp.Usage == nil || resp.Usage.TotalTokens == 0 {
+			t.Error("Expected non-zero usage statistics")
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		var streamedOutput string
+		chunks := 0
+		final, err := genkit.Generate(ctx, g,
+			ai.WithPrompt("Write a short paragraph about artificial intelligence."),
+			ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
+				chunks++
+				for _, content := range chunk.Content {
+					streamedOutput += content.Text
+				}
+				return nil
+			}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Verify streaming worked
+		if chunks <= 1 {
+			t.Error("Expected multiple chunks for streaming")
+		}
+		// Verify the final output matches streamed content
+		finalOutput := ""
+		for _, content := range final.Message.Content {
+			finalOutput += content.Text
+		}
+		if streamedOutput != finalOutput {
+			t.Errorf("Streaming output doesn't match final output\nStreamed: %s\nFinal: %s",
+				streamedOutput, finalOutput)
+		}
+		t.Logf("streaming response: %+v", finalOutput)
+	})
+
+	t.Run("media part", func(t *testing.T) {
+		image := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHIAAABUAQMAAABk5vEVAAAABlBMVEX///8AAABVwtN+" +
+			"AAAAI0lEQVR4nGNgGHaA/z8UHIDwOWASDqP8Uf7w56On/1FAQwAAVM0exw1hqwkAAAAASUVORK5CYII="
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModelName("ollamacloud/qwen3-vl:235b-instruct"),
+			ai.WithMessages(
+				ai.NewUserMessage(
+					ai.NewMediaPart("image/png", image),
+					ai.NewTextPart("Is there a rectangle in the picture? Yes or not."),
+				),
+			),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := resp.Message.Content[0].Text
+		if !strings.Contains(strings.ToLower(text), "yes") {
+			t.Errorf("got %q, expecting it to contain 'yes'", text)
+		}
+	})
+
+	t.Run("system message", func(t *testing.T) {
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithPrompt("What are you?"),
+			ai.WithSystem("You are a helpful math tutor who loves numbers."))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := resp.Message.Content[0].Text
+		if !strings.Contains(strings.ToLower(out), "math") {
+			t.Errorf("got %q, expecting response to mention being a math tutor", out)
+		}
+		t.Logf("system message response: %+v", out)
+	})
+
+	t.Run("tool usage with basic completion", func(t *testing.T) {
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModelName("ollamacloud/qwen3-coder:480b"),
+			ai.WithPrompt("Use the gablorken tool to calculate the gablorken of 2 over 3. Set Value=2 and Over=3 as numbers (not strings) and answer with the numeric result."),
+			ai.WithTools(gablorkenTool))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := resp.Message.Content[0].Text
+		const want = "8"
+		if !strings.Contains(out, want) {
+			t.Errorf("got %q, expecting it to contain %q", out, want)
+		}
+		t.Logf("tool usage with basic completion response: %+v", out)
+	})
+
+	t.Run("tool usage with streaming", func(t *testing.T) {
+		var streamedOutput string
+		chunks := 0
+		final, err := genkit.Generate(ctx, g,
+			ai.WithModelName("ollamacloud/qwen3-coder:480b"),
+			ai.WithPrompt("Use the gablorken tool to calculate the gablorken of 2 over 3. Set Value=2 and Over=3 as numbers (not strings) and answer with the numeric result."),
+			ai.WithTools(gablorkenTool),
+			ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
+				chunks++
+				for _, content := range chunk.Content {
+					streamedOutput += content.Text
+				}
+				return nil
+			}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Verify streaming worked
+		if chunks <= 1 {
+			t.Error("Expected multiple chunks for streaming")
+		}
+		// Verify the final output matches streamed content
+		finalOutput := ""
+		for _, content := range final.Message.Content {
+			finalOutput += content.Text
+		}
+		if streamedOutput != finalOutput {
+			t.Errorf("Streaming output doesn't match final output\nStreamed: %s\nFinal: %s",
+				streamedOutput, finalOutput)
+		}
+		const want = "8"
+		if !strings.Contains(finalOutput, want) {
+			t.Errorf("got %q, expecting it to contain %q", finalOutput, want)
+		}
+		t.Logf("tool usage with streaming response: %+v", finalOutput)
+	})
+
+	t.Run("invalid config type", func(t *testing.T) {
+		// Try to use a string as config instead of *openai.ChatCompletionNewParams
+		config := "not a config"
+		_, err := genkit.Generate(ctx, g,
+			ai.WithPrompt("Write a short sentence about artificial intelligence."),
+			ai.WithConfig(config),
+		)
+		if err == nil {
+			t.Fatal("expected error for invalid config type")
+		}
+		if !strings.Contains(err.Error(), "unexpected config type: string") {
+			t.Errorf("got error %q, want error containing 'unexpected config type: string'", err.Error())
+		}
+		t.Logf("invalid config type error: %v", err)
+	})
+}

--- a/go/plugins/compat_oai/ollamacloud/ollamacloud_test.go
+++ b/go/plugins/compat_oai/ollamacloud/ollamacloud_test.go
@@ -18,6 +18,7 @@ package ollamacloud
 
 import (
 	"context"
+	"sort"
 	"testing"
 )
 
@@ -33,5 +34,26 @@ func TestInitCanBeCalledTwice(t *testing.T) {
 	secondActions := plugin.Init(ctx)
 	if got, want := len(secondActions), len(supportedModels); got != want {
 		t.Fatalf("second Init returned %d actions, want %d", got, want)
+	}
+
+	for i := range firstActions {
+		if firstActions[i] != secondActions[i] {
+			t.Fatalf("action %d was not cached between Init calls", i)
+		}
+	}
+}
+
+func TestInitReturnsModelsInSortedOrder(t *testing.T) {
+	ctx := context.Background()
+	plugin := &OllamaCloud{APIKey: "test-api-key"}
+
+	actions := plugin.Init(ctx)
+	names := make([]string, 0, len(actions))
+	for _, action := range actions {
+		names = append(names, action.Name())
+	}
+
+	if !sort.StringsAreSorted(names) {
+		t.Fatalf("Init returned unsorted action names: %v", names)
 	}
 }

--- a/go/plugins/compat_oai/ollamacloud/ollamacloud_test.go
+++ b/go/plugins/compat_oai/ollamacloud/ollamacloud_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ollamacloud
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInitCanBeCalledTwice(t *testing.T) {
+	ctx := context.Background()
+	plugin := &OllamaCloud{APIKey: "test-api-key"}
+
+	firstActions := plugin.Init(ctx)
+	if got, want := len(firstActions), len(supportedModels); got != want {
+		t.Fatalf("first Init returned %d actions, want %d", got, want)
+	}
+
+	secondActions := plugin.Init(ctx)
+	if got, want := len(secondActions), len(supportedModels); got != want {
+		t.Fatalf("second Init returned %d actions, want %d", got, want)
+	}
+}

--- a/go/plugins/compat_oai/ollamacloud/ollamacloud_test.go
+++ b/go/plugins/compat_oai/ollamacloud/ollamacloud_test.go
@@ -57,3 +57,14 @@ func TestInitReturnsModelsInSortedOrder(t *testing.T) {
 		t.Fatalf("Init returned unsorted action names: %v", names)
 	}
 }
+
+func TestInitWithoutAPIKey(t *testing.T) {
+	ctx := context.Background()
+	plugin := &OllamaCloud{}
+
+	actions := plugin.Init(ctx)
+	if actions != nil {
+		t.Fatalf("Init without API key returned actions, want nil")
+	}
+}
+

--- a/go/plugins/compat_oai/ollamacloud/readme.md
+++ b/go/plugins/compat_oai/ollamacloud/readme.md
@@ -1,0 +1,184 @@
+# Ollama Cloud Plugin
+
+This plugin provides a simple interface for using Ollama Cloud services through OpenAI-compatible API.
+
+## Supported Models
+
+The plugin supports the following Ollama Cloud models:
+
+### Large Language Models (Text)
+- **GPT-OSS 20B** - `gpt-oss:20b`
+- **GPT-OSS 120B** - `gpt-oss:120b`
+- **Qwen3 Coder 480B** - `qwen3-coder:480b`
+- **DeepSeek v3.1 671B** - `deepseek-v3.1:671b`
+- **GLM-4.6** - `glm-4.6`
+- **MiniMax M2** - `minimax-m2`
+- **Kimi K2 1T** - `kimi-k2:1t`
+- **Kimi K2 Thinking** - `kimi-k2-thinking`
+
+### Multimodal Models (Vision + Text)
+- **Qwen3 VL 235B Instruct** - `qwen3-vl:235b-instruct` - Vision-language model (images + text, tools)
+- **Qwen3 VL 235B** - `qwen3-vl:235b` - Vision-language model (images + text, tools)
+
+## Prerequisites
+
+- Go installed on your system
+- An Ollama Cloud API key
+
+## Usage
+
+Here's a simple example of how to use the Ollama Cloud plugin:
+
+```go
+import (
+    "context"
+    "os"
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/compat_oai/ollamacloud"
+    "github.com/openai/openai-go/option"
+)
+
+// Initialize the OllamaCloud plugin with your API key
+plugin := &ollamacloud.OllamaCloud{
+    APIKey: "your-ollamacloud-api-key", // 또는 환경변수 OLLAMACLOUD_API_KEY 사용
+    Opts: []option.RequestOption{
+        option.WithAPIKey("your-ollamacloud-api-key"),
+    },
+}
+
+// Initialize Genkit with the OllamaCloud plugin
+g := genkit.Init(ctx,
+    genkit.WithDefaultModel("ollamacloud/gpt-oss:20b"),
+    genkit.WithPlugins(plugin))
+
+// 기본 텍스트 생성
+resp, err := genkit.Generate(ctx, g,
+    ai.WithPromptText("Explain quantum computing in simple terms."))
+
+// 멀티모달 모델 사용 (이미지 + 텍스트)
+resp, err := genkit.Generate(ctx, g,
+    ai.WithModelName("ollamacloud/qwen3-vl:235b-instruct"),
+    ai.WithMessages(
+        ai.NewUserMessage(
+            ai.NewMediaPart("image/png", imageData),
+            ai.NewTextPart("What do you see in this image?"),
+        ),
+    ))
+
+// 도구와 함께 사용
+calculator := genkit.DefineTool(g, "calculator", "simple calculator",
+    func(ctx *ai.ToolContext, input struct {
+        Operation string  `json:"operation"` // "add", "subtract", "multiply", "divide"
+        A         float64 `json:"a"`
+        B         float64 `json:"b"`
+    }) (float64, error) {
+        switch input.Operation {
+        case "add": return input.A + input.B, nil
+        case "subtract": return input.A - input.B, nil
+        case "multiply": return input.A * input.B, nil
+        case "divide": 
+            if input.B == 0 { return 0, fmt.Errorf("division by zero") }
+            return input.A / input.B, nil
+        }
+        return 0, fmt.Errorf("unknown operation")
+    })
+
+resp, err := genkit.Generate(ctx, g,
+    ai.WithPromptText("What is 15 * 23?"),
+    ai.WithTools(calculator))
+
+// 스트리밍 응답
+resp, err := genkit.Generate(ctx, g,
+    ai.WithPromptText("Write a short story about space exploration."),
+    ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
+        for _, content := range chunk.Content {
+            fmt.Print(content.Text)
+        }
+        return nil
+    }))
+```
+
+## Environment Variables
+
+- `OLLAMACLOUD_API_KEY`: Your Ollama Cloud API key (required)
+
+The base URL defaults to `https://ollama.com/v1`. To override it (for example, when using a proxy),
+pass a custom `option.WithBaseURL(...)` value via the plugin's `Opts` field.
+
+## Running Tests
+
+First, set your Ollama Cloud API key as an environment variable:
+
+```bash
+export OLLAMACLOUD_API_KEY=<your-api-key>
+```
+
+### Running All Tests
+
+To run all tests in the directory:
+
+```bash
+go test -v .
+```
+
+### Running Tests from Specific Files
+
+To run tests from a specific file:
+
+```bash
+# Run only the main plugin tests
+go test -run "^TestPlugin"
+```
+
+### Running Individual Tests
+
+To run a specific test case:
+
+```bash
+# Run only the basic completion test
+go test -run "TestPlugin/basic completion"
+
+# Run only the streaming test
+go test -run "TestPlugin/streaming"
+
+# Run only the tool usage test
+go test -run "TestPlugin/tool usage"
+
+# Run only the multimodal test
+go test -run "TestPlugin/media part"
+```
+
+### Test Output Verbosity
+
+Add the `-v` flag for verbose output:
+
+```bash
+go test -v -run "TestPlugin/streaming"
+```
+
+## Features
+
+- ✅ **OpenAI-compatible API**: Uses the standard OpenAI SDK
+- ✅ **Streaming responses**: Real-time streaming for better UX
+- ✅ **Tool calling**: Function calling support for interactive applications
+- ✅ **Multimodal support**: Vision models can process images + text
+- ✅ **Multiple models**: Access to various open-source models
+- ✅ **Genkit integration**: Seamless integration with Genkit framework
+
+## Troubleshooting
+
+### Common Issues
+
+1. **API Key Error**: Make sure `OLLAMA_API_KEY` is set correctly
+2. **Network Issues**: Check your internet connection and firewall settings
+3. **Model Not Found**: Verify the model name is supported by Ollama Cloud
+4. **Rate Limiting**: Check if you've hit API rate limits
+
+### Error Messages
+
+- `"ollamacloud plugin initialization failed: API key is required"`: Set your API key
+- `"unexpected config type: string"`: Use proper OpenAI config types
+- Network errors: Check API endpoint and network connectivity
+
+Note: All live tests require the OLLAMA_API_KEY environment variable to be set. Tests will be skipped if the API key is not provided.

--- a/go/plugins/compat_oai/ollamacloud/readme.md
+++ b/go/plugins/compat_oai/ollamacloud/readme.md
@@ -39,9 +39,9 @@ import (
     "github.com/openai/openai-go/option"
 )
 
-// Initialize the OllamaCloud plugin with your API key
+// Initialize the Ollama Cloud plugin with your API key
 plugin := &ollamacloud.OllamaCloud{
-    APIKey: "your-ollamacloud-api-key", // 또는 환경변수 OLLAMACLOUD_API_KEY 사용
+    APIKey: "your-ollamacloud-api-key", // or use the OLLAMACLOUD_API_KEY environment variable
     Opts: []option.RequestOption{
         option.WithAPIKey("your-ollamacloud-api-key"),
     },
@@ -52,11 +52,11 @@ g := genkit.Init(ctx,
     genkit.WithDefaultModel("ollamacloud/gpt-oss:20b"),
     genkit.WithPlugins(plugin))
 
-// 기본 텍스트 생성
+// Basic text generation
 resp, err := genkit.Generate(ctx, g,
     ai.WithPromptText("Explain quantum computing in simple terms."))
 
-// 멀티모달 모델 사용 (이미지 + 텍스트)
+// Use a multimodal model (image + text)
 resp, err := genkit.Generate(ctx, g,
     ai.WithModelName("ollamacloud/qwen3-vl:235b-instruct"),
     ai.WithMessages(
@@ -66,7 +66,7 @@ resp, err := genkit.Generate(ctx, g,
         ),
     ))
 
-// 도구와 함께 사용
+// Use with tools
 calculator := genkit.DefineTool(g, "calculator", "simple calculator",
     func(ctx *ai.ToolContext, input struct {
         Operation string  `json:"operation"` // "add", "subtract", "multiply", "divide"
@@ -88,7 +88,7 @@ resp, err := genkit.Generate(ctx, g,
     ai.WithPromptText("What is 15 * 23?"),
     ai.WithTools(calculator))
 
-// 스트리밍 응답
+// Streaming responses
 resp, err := genkit.Generate(ctx, g,
     ai.WithPromptText("Write a short story about space exploration."),
     ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {

--- a/go/plugins/compat_oai/ollamacloud/readme.md
+++ b/go/plugins/compat_oai/ollamacloud/readme.md
@@ -1,24 +1,61 @@
 # Ollama Cloud Plugin
 
-This plugin provides a simple interface for using Ollama Cloud services through OpenAI-compatible API.
+This plugin provides a Genkit interface for Ollama Cloud through Ollama's OpenAI-compatible API.
 
 ## Supported Models
 
-The plugin supports the following Ollama Cloud models:
+The plugin registers the direct API model IDs returned by `https://ollama.com/v1/models`. Do not add the local Ollama `-cloud` suffix when using this plugin.
 
-### Large Language Models (Text)
-- **GPT-OSS 20B** - `gpt-oss:20b`
-- **GPT-OSS 120B** - `gpt-oss:120b`
-- **Qwen3 Coder 480B** - `qwen3-coder:480b`
-- **DeepSeek v3.1 671B** - `deepseek-v3.1:671b`
-- **GLM-4.6** - `glm-4.6`
-- **MiniMax M2** - `minimax-m2`
-- **Kimi K2 1T** - `kimi-k2:1t`
-- **Kimi K2 Thinking** - `kimi-k2-thinking`
+### Text Models
 
-### Multimodal Models (Vision + Text)
-- **Qwen3 VL 235B Instruct** - `qwen3-vl:235b-instruct` - Vision-language model (images + text, tools)
-- **Qwen3 VL 235B** - `qwen3-vl:235b` - Vision-language model (images + text, tools)
+| Model | ID | Tools |
+| --- | --- | --- |
+| Cogito 2.1 671B | `cogito-2.1:671b` | No |
+| DeepSeek V3.1 671B | `deepseek-v3.1:671b` | Yes |
+| DeepSeek V3.2 | `deepseek-v3.2` | Yes |
+| DeepSeek V4 Flash | `deepseek-v4-flash` | Yes |
+| DeepSeek V4 Pro | `deepseek-v4-pro` | Yes |
+| Devstral 2 123B | `devstral-2:123b` | Yes |
+| GLM-4.6 | `glm-4.6` | Yes |
+| GLM-4.7 | `glm-4.7` | Yes |
+| GLM-5 | `glm-5` | Yes |
+| GLM-5.1 | `glm-5.1` | Yes |
+| GPT-OSS 20B | `gpt-oss:20b` | Yes |
+| GPT-OSS 120B | `gpt-oss:120b` | Yes |
+| Kimi K2 1T | `kimi-k2:1t` | Yes |
+| Kimi K2 Thinking | `kimi-k2-thinking` | Yes |
+| MiniMax M2 | `minimax-m2` | Yes |
+| MiniMax M2.1 | `minimax-m2.1` | Yes |
+| MiniMax M2.5 | `minimax-m2.5` | Yes |
+| MiniMax M2.7 | `minimax-m2.7` | Yes |
+| Nemotron 3 Nano 30B | `nemotron-3-nano:30b` | Yes |
+| Nemotron 3 Super | `nemotron-3-super` | Yes |
+| Qwen3 Coder 480B | `qwen3-coder:480b` | Yes |
+| Qwen3 Coder Next | `qwen3-coder-next` | Yes |
+| Qwen3 Next 80B | `qwen3-next:80b` | Yes |
+| RNJ-1 8B | `rnj-1:8b` | Yes |
+
+### Vision Models
+
+| Model | ID | Tools |
+| --- | --- | --- |
+| Devstral Small 2 24B | `devstral-small-2:24b` | Yes |
+| Gemini 3 Flash Preview | `gemini-3-flash-preview` | Yes |
+| Gemma 3 4B | `gemma3:4b` | No |
+| Gemma 3 12B | `gemma3:12b` | No |
+| Gemma 3 27B | `gemma3:27b` | No |
+| Gemma 4 31B | `gemma4:31b` | Yes |
+| Kimi K2.5 | `kimi-k2.5` | Yes |
+| Kimi K2.6 | `kimi-k2.6` | Yes |
+| Ministral 3 3B | `ministral-3:3b` | Yes |
+| Ministral 3 8B | `ministral-3:8b` | Yes |
+| Ministral 3 14B | `ministral-3:14b` | Yes |
+| Mistral Large 3 675B | `mistral-large-3:675b` | Yes |
+| Qwen3 VL 235B | `qwen3-vl:235b` | Yes |
+| Qwen3 VL 235B Instruct | `qwen3-vl:235b-instruct` | Yes |
+| Qwen3.5 397B | `qwen3.5:397b` | Yes |
+
+The current compatibility layer maps image media inputs for vision models. It does not advertise audio support in Genkit metadata.
 
 ## Prerequisites
 
@@ -27,84 +64,95 @@ The plugin supports the following Ollama Cloud models:
 
 ## Usage
 
-Here's a simple example of how to use the Ollama Cloud plugin:
+Set `OLLAMACLOUD_API_KEY`, then initialize Genkit with the plugin:
 
 ```go
+package main
+
 import (
-    "context"
-    "os"
-    "github.com/firebase/genkit/go/ai"
-    "github.com/firebase/genkit/go/genkit"
-    "github.com/firebase/genkit/go/plugins/compat_oai/ollamacloud"
-    "github.com/openai/openai-go/option"
+	"context"
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/ollamacloud"
 )
 
-// Initialize the Ollama Cloud plugin with your API key
-plugin := &ollamacloud.OllamaCloud{
-    APIKey: "your-ollamacloud-api-key", // or use the OLLAMACLOUD_API_KEY environment variable
-    Opts: []option.RequestOption{
-        option.WithAPIKey("your-ollamacloud-api-key"),
-    },
+func main() {
+	ctx := context.Background()
+	g := genkit.Init(ctx,
+		genkit.WithDefaultModel("ollamacloud/gpt-oss:20b"),
+		genkit.WithPlugins(&ollamacloud.OllamaCloud{}))
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithPrompt("Explain quantum computing in simple terms."))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(resp.Text())
 }
+```
 
-// Initialize Genkit with the OllamaCloud plugin
-g := genkit.Init(ctx,
-    genkit.WithDefaultModel("ollamacloud/gpt-oss:20b"),
-    genkit.WithPlugins(plugin))
+Use a vision model with image input:
 
-// Basic text generation
+```go
 resp, err := genkit.Generate(ctx, g,
-    ai.WithPromptText("Explain quantum computing in simple terms."))
+	ai.WithModelName("ollamacloud/qwen3-vl:235b-instruct"),
+	ai.WithMessages(
+		ai.NewUserMessage(
+			ai.NewMediaPart("image/png", imageData),
+			ai.NewTextPart("What do you see in this image?"),
+		),
+	))
+```
 
-// Use a multimodal model (image + text)
-resp, err := genkit.Generate(ctx, g,
-    ai.WithModelName("ollamacloud/qwen3-vl:235b-instruct"),
-    ai.WithMessages(
-        ai.NewUserMessage(
-            ai.NewMediaPart("image/png", imageData),
-            ai.NewTextPart("What do you see in this image?"),
-        ),
-    ))
+Use a tool-capable model with tools:
 
-// Use with tools
+```go
 calculator := genkit.DefineTool(g, "calculator", "simple calculator",
-    func(ctx *ai.ToolContext, input struct {
-        Operation string  `json:"operation"` // "add", "subtract", "multiply", "divide"
-        A         float64 `json:"a"`
-        B         float64 `json:"b"`
-    }) (float64, error) {
-        switch input.Operation {
-        case "add": return input.A + input.B, nil
-        case "subtract": return input.A - input.B, nil
-        case "multiply": return input.A * input.B, nil
-        case "divide": 
-            if input.B == 0 { return 0, fmt.Errorf("division by zero") }
-            return input.A / input.B, nil
-        }
-        return 0, fmt.Errorf("unknown operation")
-    })
+	func(ctx *ai.ToolContext, input struct {
+		Operation string  `json:"operation"`
+		A         float64 `json:"a"`
+		B         float64 `json:"b"`
+	}) (float64, error) {
+		switch input.Operation {
+		case "add":
+			return input.A + input.B, nil
+		case "subtract":
+			return input.A - input.B, nil
+		case "multiply":
+			return input.A * input.B, nil
+		case "divide":
+			if input.B == 0 {
+				return 0, fmt.Errorf("division by zero")
+			}
+			return input.A / input.B, nil
+		}
+		return 0, fmt.Errorf("unknown operation")
+	})
 
 resp, err := genkit.Generate(ctx, g,
-    ai.WithPromptText("What is 15 * 23?"),
-    ai.WithTools(calculator))
+	ai.WithModelName("ollamacloud/qwen3-coder:480b"),
+	ai.WithPrompt("What is 15 * 23? Use the calculator tool."),
+	ai.WithTools(calculator))
+```
 
-// Streaming responses
+Stream responses:
+
+```go
 resp, err := genkit.Generate(ctx, g,
-    ai.WithPromptText("Write a short story about space exploration."),
-    ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
-        for _, content := range chunk.Content {
-            fmt.Print(content.Text)
-        }
-        return nil
-    }))
+	ai.WithPrompt("Write a short story about space exploration."),
+	ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
+		fmt.Print(chunk.Text())
+		return nil
+	}))
 ```
 
 ## Environment Variables
 
-- `OLLAMACLOUD_API_KEY`: Your Ollama Cloud API key (required)
+- `OLLAMACLOUD_API_KEY`: Your Ollama Cloud API key. Required unless `APIKey` is set on the plugin.
 
-The base URL defaults to `https://ollama.com/v1`. To override it (for example, when using a proxy),
-pass a custom `option.WithBaseURL(...)` value via the plugin's `Opts` field.
+The base URL defaults to `https://ollama.com/v1`. To override it, for example when using a proxy, pass a custom `option.WithBaseURL(...)` value through the plugin's `Opts` field.
 
 ## Running Tests
 
@@ -114,71 +162,42 @@ First, set your Ollama Cloud API key as an environment variable:
 export OLLAMACLOUD_API_KEY=<your-api-key>
 ```
 
-### Running All Tests
-
-To run all tests in the directory:
+Run all tests in the directory:
 
 ```bash
 go test -v .
 ```
 
-### Running Tests from Specific Files
-
-To run tests from a specific file:
+Run individual live test cases:
 
 ```bash
-# Run only the main plugin tests
-go test -run "^TestPlugin"
-```
-
-### Running Individual Tests
-
-To run a specific test case:
-
-```bash
-# Run only the basic completion test
 go test -run "TestPlugin/basic completion"
-
-# Run only the streaming test
 go test -run "TestPlugin/streaming"
-
-# Run only the tool usage test
 go test -run "TestPlugin/tool usage"
-
-# Run only the multimodal test
 go test -run "TestPlugin/media part"
-```
-
-### Test Output Verbosity
-
-Add the `-v` flag for verbose output:
-
-```bash
-go test -v -run "TestPlugin/streaming"
 ```
 
 ## Features
 
-- ✅ **OpenAI-compatible API**: Uses the standard OpenAI SDK
-- ✅ **Streaming responses**: Real-time streaming for better UX
-- ✅ **Tool calling**: Function calling support for interactive applications
-- ✅ **Multimodal support**: Vision models can process images + text
-- ✅ **Multiple models**: Access to various open-source models
-- ✅ **Genkit integration**: Seamless integration with Genkit framework
+- OpenAI-compatible API through the OpenAI Go SDK
+- Streaming responses
+- Tool calling for models tagged with `tools`
+- Image input for models tagged with `vision`
+- Genkit model registration for the current Ollama Cloud direct API model IDs
 
 ## Troubleshooting
 
 ### Common Issues
 
-1. **API Key Error**: Make sure `OLLAMA_API_KEY` is set correctly
-2. **Network Issues**: Check your internet connection and firewall settings
-3. **Model Not Found**: Verify the model name is supported by Ollama Cloud
-4. **Rate Limiting**: Check if you've hit API rate limits
+1. **API Key Error**: Make sure `OLLAMACLOUD_API_KEY` is set correctly.
+2. **Network Issues**: Check your internet connection and firewall settings.
+3. **Model Not Found**: Verify the model name is listed in `https://ollama.com/v1/models`.
+4. **Rate Limiting**: Check if you have hit API rate limits.
 
 ### Error Messages
 
-- `"ollamacloud plugin initialization failed: API key is required"`: Set your API key
-- `"unexpected config type: string"`: Use proper OpenAI config types
-- Network errors: Check API endpoint and network connectivity
+- `"ollamacloud plugin initialization failed: API key is required"`: Set `OLLAMACLOUD_API_KEY` or the plugin `APIKey` field.
+- `"unexpected config type: string"`: Use proper OpenAI config types.
+- Network errors: Check the API endpoint and network connectivity.
 
-Note: All live tests require the OLLAMA_API_KEY environment variable to be set. Tests will be skipped if the API key is not provided.
+Note: All live tests require the `OLLAMACLOUD_API_KEY` environment variable to be set. Tests will be skipped if the API key is not provided.


### PR DESCRIPTION
## Summary

This PR adds a Go `compat_oai/ollamacloud` plugin that uses Ollama Cloud's OpenAI-compatible API from Genkit.

## Updates

- Registers the current Ollama Cloud direct API model IDs returned by `https://ollama.com/v1/models`, including text, tool-capable, and vision-capable models.
- Categorizes Genkit model support from Ollama model tags: text-only, text with tools, vision-only, and vision with tools.
- Keeps the default text model as `ollamacloud/gpt-oss:20b`, tool live tests on `ollamacloud/qwen3-coder:480b`, and image live tests on `ollamacloud/qwen3-vl:235b-instruct`.
- Updates the README model table, examples, test notes, and troubleshooting guidance for `OLLAMACLOUD_API_KEY`.
- Addresses review feedback by removing the inline model-registration type assertion from `Init` and fixing stale `OLLAMA_API_KEY` references.

## Testing

- `go test -C go ./plugins/compat_oai/ollamacloud`
- `go test -C go ./plugins/compat_oai/...`

Checklist (if applicable):

- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)