### PR TITLE
fix(go): add automatic telemetry metrics for background models

### DIFF
--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -131,7 +131,6 @@ func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn Start
 		simulateSystemPrompt(&opts.ModelOptions, nil),
 		augmentWithContext(&opts.ModelOptions, nil),
 		validateSupport(name, &opts.ModelOptions),
-		addAutomaticTelemetry(),
 	}
 	fn := core.ChainMiddleware(mws...)(backgroundModelToModelFn(startFn))
 


### PR DESCRIPTION
Add support for calculating and tracking usage metrics (input/output characters, images, videos, audio) and latency for background model operations. Metrics are now properly calculated when long-running operations complete, not when they start.

Help the reviewer by:

- Modified `background_model.go` to remove `addAutomaticTelemetry()` middleware from the Start operation, since metrics should only be calculated when operations complete
- Added `CalculateInputOutputUsage()` to reuse in background model plugin.
- Updated VEO model implementation to store input request and start time in operation metadata during Start
- Added telemetry calculation in VEO check function that computes both input/output usage metrics and latency when operation completes
- Metadata restoration ensures input metrics and start time are preserved across operation status checks

Checklist (if applicable):

- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually via VEO sample)
- [ ] Docs updated (updated docs or a docs bug required)