### PR TITLE
refactor(plugins/compat-oai): use ChatCompletionAccumulator for strea…

### DIFF
--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -266,9 +266,7 @@ func (g *ModelGenerator) generateStream(ctx context.Context, handleChunk func(co
 		modelChunk := &ai.ModelResponseChunk{}
 
 		// Handle content delta
-		if _, ok := acc.JustFinishedContent(); ok {
-			// modelChunk.Content = append(modelChunk.Content, ai.NewTextPart(content))
-		} else if chunk.Choices[0].Delta.Content != "" {
+		if chunk.Choices[0].Delta.Content != "" {
 			modelChunk.Content = append(modelChunk.Content, ai.NewTextPart(chunk.Choices[0].Delta.Content))
 		}
 


### PR DESCRIPTION
- Simplified generateStream by using openai-go's ChatCompletionAccumulator
- Removed manual tool call accumulation logic (currentToolCall, toolCallCollects)
- Created convertChatCompletionToModelResponse helper for unified response conversion
- Added support for detailed token usage fields:
  - ThoughtsTokens (reasoning tokens)
  - CachedContentTokens (cached tokens)
  - Audio, prediction tokens in custom field
- Added support for refusal messages and system fingerprint metadata
- Refactored generateComplete to reuse convertChatCompletionToModelResponse
