### PR TITLE
feat(genkit-tools/mcp): Add README for Genkit MCP Server

### DIFF
--- a/genkit-tools/cli/src/mcp/README.md
+++ b/genkit-tools/cli/src/mcp/README.md
@@ -1,0 +1,30 @@
+## 🚀 Genkit MCP Server: Model Context Protocol Integration
+
+The **Genkit MCP (Model Context Protocol) Server** bridges your Genkit projects with external AI tools and development environments. It exposes Genkit flows and functionalities via the Model Context Protocol, allowing **LLM agents** and **IDEs** to discover, interact with, and monitor your application.
+
+> **Note:** The Genkit MCP server is an experimental feature and may change.
+
+---
+
+### What It Does
+
+The MCP Server enables external tools to:
+
+* **Discover Flows:** List all available Genkit flows, including their input schemas.
+* **Run Flows:** Execute Genkit flows by providing inputs and receiving outputs.
+* **Access Traces:** Retrieve and analyze detailed execution traces for performance insights.
+* **Look up Documentation:** Access Genkit documentation directly.
+
+---
+
+### Available MCP Tools
+
+The following tools allow MCP-aware environments to interact with the Genkit server:
+
+| Tool Name | Description |
+| :--- | :--- |
+| **`get_usage_guide`** | Fetches the Genkit AI framework usage guide (specifiable by language). Intended for AI assistants. |
+| **`lookup_genkit_docs`** | Retrieves Genkit documentation (specifiable by language and files). |
+| **`list_flows`** | Discovers and lists all defined Genkit flows with their input schemas. |
+| **`run_flow`** | Executes a specified Genkit flow, requiring `flowName` and a JSON `input` conforming to the flow's schema. |
+| **`get_trace`** | Retrieves the detailed execution trace for a flow using a `traceId`. |


### PR DESCRIPTION
Added README for the Genkit MCP Server, for use in Jetski store page

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
