### PR TITLE
fix(vertexai): use correct API URL for global location

### DIFF
--- a/js/plugins/vertexai/src/evaluation/evaluator_factory.ts
+++ b/js/plugins/vertexai/src/evaluation/evaluator_factory.ts
@@ -82,7 +82,10 @@ export class EvaluatorFactory {
 
         metadata.input = request;
         const client = await this.auth.getClient();
-        const url = `https://${this.location}-aiplatform.googleapis.com/v1beta1/${locationName}:evaluateInstances`;
+        const baseUrl = this.location === 'global'
+          ? 'https://aiplatform.googleapis.com'
+          : `https://${this.location}-aiplatform.googleapis.com`;
+        const url = `${baseUrl}/v1beta1/${locationName}:evaluateInstances`;
         const response = await client.request({
           url,
           method: 'POST',

--- a/js/plugins/vertexai/src/list-models.ts
+++ b/js/plugins/vertexai/src/list-models.ts
@@ -38,8 +38,11 @@ export async function listModels(
 ): Promise<Model[]> {
   const fetch = (await import('node-fetch')).default;
   const accessToken = await authClient.getAccessToken();
+  const baseUrl = location === 'global'
+    ? 'https://aiplatform.googleapis.com'
+    : `https://${location}-aiplatform.googleapis.com`;
   const response = await fetch(
-    `https://${location}-aiplatform.googleapis.com/v1beta1/publishers/google/models`,
+    `${baseUrl}/v1beta1/publishers/google/models`,
     {
       method: 'GET',
       headers: {

--- a/js/plugins/vertexai/src/modelgarden/legacy/model_garden.ts
+++ b/js/plugins/vertexai/src/modelgarden/legacy/model_garden.ts
@@ -115,10 +115,16 @@ export function modelGardenOpenaiCompatibleModel(
     request: GenerateRequest<typeof ModelGardenModelConfigSchema>
   ): Promise<OpenAI> => {
     const requestLocation = request.config?.location || location;
+    const baseUrl = requestLocation === 'global'
+      ? baseUrlTemplate!
+          .replace(/{location}-aiplatform\.googleapis\.com/g, 'aiplatform.googleapis.com')
+          .replace(/{location}/g, requestLocation)
+          .replace(/{projectId}/g, projectId)
+      : baseUrlTemplate!
+          .replace(/{location}/g, requestLocation)
+          .replace(/{projectId}/g, projectId);
     return new OpenAI({
-      baseURL: baseUrlTemplate!
-        .replace(/{location}/g, requestLocation)
-        .replace(/{projectId}/g, projectId),
+      baseURL: baseUrl,
       apiKey: (await googleAuth.getAccessToken())!,
       defaultHeaders: {
         'X-Goog-Api-Client': getGenkitClientHeader(),

--- a/js/plugins/vertexai/src/modelgarden/v2/llama.ts
+++ b/js/plugins/vertexai/src/modelgarden/v2/llama.ts
@@ -150,9 +150,14 @@ async function resolveOptions(
     clientOptions.baseUrlTemplate ??
     'https://{location}-aiplatform.googleapis.com/v1/projects/{projectId}/locations/{location}/endpoints/openapi';
   const location = requestConfig?.location || clientOptions.location;
-  const baseURL = baseUrlTemplate
-    .replace(/{location}/g, location)
-    .replace(/{projectId}/g, clientOptions.projectId);
+  const baseURL = location === 'global'
+    ? baseUrlTemplate
+        .replace(/{location}-aiplatform\.googleapis\.com/g, 'aiplatform.googleapis.com')
+        .replace(/{location}/g, location)
+        .replace(/{projectId}/g, clientOptions.projectId)
+    : baseUrlTemplate
+        .replace(/{location}/g, location)
+        .replace(/{projectId}/g, clientOptions.projectId);
   const apiKey = await clientOptions.authClient.getAccessToken();
   if (!apiKey) {
     throw new GenkitError({

--- a/js/plugins/vertexai/src/predict.ts
+++ b/js/plugins/vertexai/src/predict.ts
@@ -23,8 +23,11 @@ function endpoint(options: {
   location: string;
   model: string;
 }) {
+  const baseUrl = options.location === 'global'
+    ? 'https://aiplatform.googleapis.com'
+    : `https://${options.location}-aiplatform.googleapis.com`;
   return (
-    `https://${options.location}-aiplatform.googleapis.com/v1/` +
+    `${baseUrl}/v1/` +
     `projects/${options.projectId}/locations/${options.location}/` +
     `publishers/google/models/${options.model}:predict`
   );

--- a/js/plugins/vertexai/src/vectorsearch/vector_search/upsert_datapoints.ts
+++ b/js/plugins/vertexai/src/vectorsearch/vector_search/upsert_datapoints.ts
@@ -45,7 +45,10 @@ export async function upsertDatapoints(
 ): Promise<void> {
   const { datapoints, authClient, projectId, location, indexId } = params;
   const accessToken = await authClient.getAccessToken();
-  const url = `https://${location}-aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/indexes/${indexId}:upsertDatapoints`;
+  const baseUrl = location === 'global'
+    ? 'https://aiplatform.googleapis.com'
+    : `https://${location}-aiplatform.googleapis.com`;
+  const url = `${baseUrl}/v1/projects/${projectId}/locations/${location}/indexes/${indexId}:upsertDatapoints`;
 
   const requestBody = {
     datapoints: datapoints.map((dp) => {


### PR DESCRIPTION
Fixes the Vertex AI plugin to use https://aiplatform.googleapis.com instead of https://global-aiplatform.googleapis.com when location: 'global' is specified.

Fixes #3651

Changes:
- list-models.ts - Model listing endpoint
- predict.ts - Predict endpoint
- upsert_datapoints.ts - Vector search upsert endpoint
- evaluator_factory.ts - Evaluation endpoint
- model_garden.ts (legacy) - Model garden template URL
- llama.ts (v2) - Llama model template URL