### PR TITLE
refactor(go/plugins/compat_oai): normalize plugin

### DIFF
--- a/go/plugins/compat_oai/anthropic/README.md
+++ b/go/plugins/compat_oai/anthropic/README.md
@@ -14,7 +14,8 @@ First, set your Anthropic API key as an environment variable:
 ```bash
 export ANTHROPIC_API_KEY=<your-api-key>
 ```
-By default, `baseURL` is set to "https://api.anthropic.com/v1". However, if you
+
+By default, `baseURL` is set to "<https://api.anthropic.com/v1>". However, if you
 want to use a custom value, you can set `ANTHROPIC_BASE_URL` environment variable:
 
 ```bash
@@ -22,26 +23,32 @@ export ANTHROPIC_BASE_URL=<your-custom-base-url>
 ```
 
 ### Running All Tests
+
 To run all tests in the directory:
+
 ```bash
 go test -v .
 ```
 
 ### Running Tests from Specific Files
+
 To run tests from a specific file:
+
 ```bash
 # Run only generate_live_test.go tests
 go test -run "^TestGenerator"
 
 # Run only anthropic_live_test.go tests
-go test -run "^TestPlugin"
+go test -run "^TestAnthropicLive"
 ```
 
 ### Running Individual Tests
+
 To run a specific test case:
+
 ```bash
 # Run only the streaming test from anthropic_live_test.go
-go test -run "TestPlugin/streaming"
+go test -run "TestAnthropicLive/streaming"
 
 # Run only the Complete test from generate_live_test.go
 go test -run "TestGenerator_Complete"
@@ -51,9 +58,11 @@ go test -run "TestGenerator_Stream"
 ```
 
 ### Test Output Verbosity
+
 Add the `-v` flag for verbose output:
+
 ```bash
-go test -v -run "TestPlugin/streaming"
+go test -v -run "TestAnthropicLive/streaming"
 ```
 
 Note: All live tests require the ANTHROPIC_API_KEY environment variable to be set. Tests will be skipped if the API key is not provided.

--- a/go/plugins/compat_oai/anthropic/anthropic_live_test.go
+++ b/go/plugins/compat_oai/anthropic/anthropic_live_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/openai/openai-go/option"
 )
 
-func TestPlugin(t *testing.T) {
+func TestAnthropicLive(t *testing.T) {
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
 	if apiKey == "" {
 		t.Skip("Skipping test: ANTHROPIC_API_KEY environment variable not set")

--- a/go/plugins/compat_oai/compat_oai.go
+++ b/go/plugins/compat_oai/compat_oai.go
@@ -119,16 +119,7 @@ func (o *OpenAICompatible) DefineModel(provider, id string, opts ai.ModelOptions
 		input *ai.ModelRequest,
 		cb func(context.Context, *ai.ModelResponseChunk) error,
 	) (*ai.ModelResponse, error) {
-		// Configure the response generator with input
-		generator := NewModelGenerator(o.client, id).WithMessages(input.Messages).WithConfig(input.Config).WithTools(input.Tools)
-
-		// Generate response
-		resp, err := generator.Generate(ctx, input, cb)
-		if err != nil {
-			return nil, err
-		}
-
-		return resp, nil
+		return generate(ctx, o.client, id, input, cb)
 	})
 }
 

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -34,7 +34,6 @@ func mapToStruct(m map[string]any, v any) error {
 	return json.Unmarshal(jsonData, v)
 }
 
-
 // generate executes the generation request using the new functional approach
 func generate(
 	ctx context.Context,

--- a/go/plugins/compat_oai/openai/README.md
+++ b/go/plugins/compat_oai/openai/README.md
@@ -48,26 +48,32 @@ export OPENAI_API_KEY=<your-api-key>
 ```
 
 ### Running All Tests
+
 To run all tests in the directory:
+
 ```bash
 go test -v .
 ```
 
 ### Running Tests from Specific Files
+
 To run tests from a specific file:
+
 ```bash
 # Run only generate_live_test.go tests
 go test -run "^TestGenerator"
 
 # Run only openai_live_test.go tests
-go test -run "^TestPlugin"
+go test -run "^TestOpenAILive"
 ```
 
 ### Running Individual Tests
+
 To run a specific test case:
+
 ```bash
 # Run only the streaming test from openai_live_test.go
-go test -run "TestPlugin/streaming"
+go test -run "TestOpenAILive/streaming"
 
 # Run only the Complete test from generate_live_test.go
 go test -run "TestGenerator_Complete"
@@ -77,9 +83,11 @@ go test -run "TestGenerator_Stream"
 ```
 
 ### Test Output Verbosity
+
 Add the `-v` flag for verbose output:
+
 ```bash
-go test -v -run "TestPlugin/streaming"
+go test -v -run "TestOpenAILive/streaming"
 ```
 
 Note: All live tests require the OPENAI_API_KEY environment variable to be set. Tests will be skipped if the API key is not provided.

--- a/go/plugins/compat_oai/openai/openai_live_test.go
+++ b/go/plugins/compat_oai/openai/openai_live_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/openai/openai-go"
 )
 
-func TestPlugin(t *testing.T) {
+func TestOpenAILive(t *testing.T) {
 	apiKey := os.Getenv("OPENAI_API_KEY")
 	if apiKey == "" {
 		t.Skip("Skipping test: OPENAI_API_KEY environment variable not set")


### PR DESCRIPTION
Normalize the `compat_oai` plugin to match the rest of the plugins architecture.

- Removed `ModelGenerator` and all its attached functions
- Removed `assert` use from live tests
- Removed the _builder_ pattern from the plugin.
- Use translation functions as used in the rest of the plugins

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
