### PR TITLE
fix(js/plugins/vertexai): correct URL construction for global endpoint

### DIFF
--- a/js/plugins/vertexai/src/evaluation/evaluator_factory.ts
+++ b/js/plugins/vertexai/src/evaluation/evaluator_factory.ts
@@ -82,7 +82,11 @@ export class EvaluatorFactory {
 
         metadata.input = request;
         const client = await this.auth.getClient();
-        const url = `https://${this.location}-aiplatform.googleapis.com/v1beta1/${locationName}:evaluateInstances`;
+        const baseUrl = this.location === 'global'
+          ? 'https://aiplatform.googleapis.com'
+          : `https://${this.location}-aiplatform.googleapis.com`;
+
+        const url = `${baseUrl}/v1beta1/${locationName}:evaluateInstances`;
         const response = await client.request({
           url,
           method: 'POST',

--- a/js/plugins/vertexai/src/list-models.ts
+++ b/js/plugins/vertexai/src/list-models.ts
@@ -38,8 +38,14 @@ export async function listModels(
 ): Promise<Model[]> {
   const fetch = (await import('node-fetch')).default;
   const accessToken = await authClient.getAccessToken();
+  
+  // Global endpoint uses base URL without location prefix
+  const baseUrl = location === 'global'
+    ? 'https://aiplatform.googleapis.com'
+    : `https://${location}-aiplatform.googleapis.com`;
+  
   const response = await fetch(
-    `https://${location}-aiplatform.googleapis.com/v1beta1/publishers/google/models`,
+    `${baseUrl}/v1beta1/publishers/google/models`,
     {
       method: 'GET',
       headers: {

--- a/js/plugins/vertexai/src/modelgarden/v2/llama.ts
+++ b/js/plugins/vertexai/src/modelgarden/v2/llama.ts
@@ -146,10 +146,13 @@ async function resolveOptions(
   clientOptions: ClientOptions,
   requestConfig?: LlamaConfig
 ) {
-  const baseUrlTemplate =
-    clientOptions.baseUrlTemplate ??
-    'https://{location}-aiplatform.googleapis.com/v1/projects/{projectId}/locations/{location}/endpoints/openapi';
   const location = requestConfig?.location || clientOptions.location;
+  const defaultTemplate = location === 'global'
+    ? 'https://aiplatform.googleapis.com/v1/projects/{projectId}/locations/{location}/endpoints/openapi'
+    : 'https://{location}-aiplatform.googleapis.com/v1/projects/{projectId}/locations/{location}/endpoints/openapi';
+
+  const baseUrlTemplate = clientOptions.baseUrlTemplate ?? defaultTemplate;
+
   const baseURL = baseUrlTemplate
     .replace(/{location}/g, location)
     .replace(/{projectId}/g, clientOptions.projectId);

--- a/js/plugins/vertexai/src/predict.ts
+++ b/js/plugins/vertexai/src/predict.ts
@@ -23,8 +23,11 @@ function endpoint(options: {
   location: string;
   model: string;
 }) {
+  const baseUrl = options.location === 'global'
+    ? 'https://aiplatform.googleapis.com'
+    : `https://${options.location}-aiplatform.googleapis.com`;
   return (
-    `https://${options.location}-aiplatform.googleapis.com/v1/` +
+    `${baseUrl}/v1/` +
     `projects/${options.projectId}/locations/${options.location}/` +
     `publishers/google/models/${options.model}:predict`
   );

--- a/js/plugins/vertexai/src/vectorsearch/vector_search/upsert_datapoints.ts
+++ b/js/plugins/vertexai/src/vectorsearch/vector_search/upsert_datapoints.ts
@@ -45,7 +45,11 @@ export async function upsertDatapoints(
 ): Promise<void> {
   const { datapoints, authClient, projectId, location, indexId } = params;
   const accessToken = await authClient.getAccessToken();
-  const url = `https://${location}-aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/indexes/${indexId}:upsertDatapoints`;
+  const baseUrl = location === 'global'
+    ? 'https://aiplatform.googleapis.com'
+    : `https://${location}-aiplatform.googleapis.com`;
+
+  const url = `${baseUrl}/v1/projects/${projectId}/locations/${location}/indexes/${indexId}:upsertDatapoints`;
 
   const requestBody = {
     datapoints: datapoints.map((dp) => {


### PR DESCRIPTION
Fixes #3651

### Problem
When using the **`vertexAi` plugin** provided by **`@genkit-ai/vertexai`**, specifying `location: 'global'` results in an incorrectly constructed URL: `https://global-aiplatform.googleapis.com`. This leads to a 404 error because the correct endpoint for the global location should be `https://aiplatform.googleapis.com`.

### Solution
This PR updates the URL construction logic to handle the `global` location case correctly by removing the location prefix from the domain while keeping it in the path where necessary (e.g. `locations/global`).

The fix applies to:
- [js/plugins/vertexai/src/list-models.ts](cci:7://file:///Users/yeonjaesung/WebstormProjects/genkit/js/plugins/vertexai/src/list-models.ts:0:0-0:0)
- js/plugins/vertexai/src/vectorsearch/vector_search/upsert_datapoints.ts
- [js/plugins/vertexai/src/predict.ts](cci:7://file:///Users/yeonjaesung/WebstormProjects/genkit/js/plugins/vertexai/src/predict.ts:0:0-0:0)
- [js/plugins/vertexai/src/evaluation/evaluator_factory.ts](cci:7://file:///Users/yeonjaesung/WebstormProjects/genkit/js/plugins/vertexai/src/evaluation/evaluator_factory.ts:0:0-0:0)
- [js/plugins/vertexai/src/modelgarden/v2/llama.ts](cci:7://file:///Users/yeonjaesung/WebstormProjects/genkit/js/plugins/vertexai/src/modelgarden/v2/llama.ts:0:0-0:0)

For [llama.ts](cci:7://file:///Users/yeonjaesung/WebstormProjects/genkit/js/plugins/vertexai/src/modelgarden/v2/llama.ts:0:0-0:0), the template logic was updated to use a domain without the location prefix when the location is global, while preserving the path structure.

Implementation follows the pattern used in the official Google Gen AI SDK.

### Checklist
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (Code logic verified against Google Cloud documentation)
- [x] Docs updated (Code comments updated to reflect "Global Endpoint" terminology)