### PR TITLE
chore(js/plugins): Deprecate the googleAI and vertexAI plugins...

### DIFF
--- a/js/plugins/googleai/src/common.ts
+++ b/js/plugins/googleai/src/common.ts
@@ -17,6 +17,9 @@
 import { getClientHeader as defaultGetClientHeader } from 'genkit';
 import process from 'process';
 
+/**
+ * @deprecated
+ */
 export function getApiKeyFromEnvVar(): string | undefined {
   return (
     process.env.GEMINI_API_KEY ||
@@ -25,6 +28,9 @@ export function getApiKeyFromEnvVar(): string | undefined {
   );
 }
 
+/**
+ * @deprecated
+ */
 export function getGenkitClientHeader() {
   if (process.env.MONOSPACE_ENV == 'true') {
     return defaultGetClientHeader() + ' firebase-studio-vm';

--- a/js/plugins/googleai/src/embedder.ts
+++ b/js/plugins/googleai/src/embedder.ts
@@ -29,6 +29,9 @@ import { embedderRef } from 'genkit/embedder';
 import { getApiKeyFromEnvVar } from './common.js';
 import type { PluginOptions } from './index.js';
 
+/**
+ * @deprecated
+ */
 export const TaskTypeSchema = z.enum([
   'RETRIEVAL_DOCUMENT',
   'RETRIEVAL_QUERY',
@@ -36,8 +39,14 @@ export const TaskTypeSchema = z.enum([
   'CLASSIFICATION',
   'CLUSTERING',
 ]);
+/**
+ * @deprecated
+ */
 export type TaskType = z.infer<typeof TaskTypeSchema>;
 
+/**
+ * @deprecated
+ */
 export const GeminiEmbeddingConfigSchema = z.object({
   /** Override the API key provided at plugin initialization. */
   apiKey: z.string().optional(),
@@ -58,8 +67,14 @@ export const GeminiEmbeddingConfigSchema = z.object({
   outputDimensionality: z.number().min(1).max(768).optional(),
 });
 
+/**
+ * @deprecated
+ */
 export type GeminiEmbeddingConfig = z.infer<typeof GeminiEmbeddingConfigSchema>;
 
+/**
+ * @deprecated
+ */
 export const textEmbeddingGecko001 = embedderRef({
   name: 'googleai/embedding-001',
   configSchema: GeminiEmbeddingConfigSchema,
@@ -72,6 +87,9 @@ export const textEmbeddingGecko001 = embedderRef({
   },
 });
 
+/**
+ * @deprecated
+ */
 export const textEmbedding004 = embedderRef({
   name: 'googleai/text-embedding-004',
   configSchema: GeminiEmbeddingConfigSchema,
@@ -84,6 +102,9 @@ export const textEmbedding004 = embedderRef({
   },
 });
 
+/**
+ * @deprecated
+ */
 export const geminiEmbedding001 = embedderRef({
   name: 'googleai/gemini-embedding-001',
   configSchema: GeminiEmbeddingConfigSchema,
@@ -96,12 +117,18 @@ export const geminiEmbedding001 = embedderRef({
   },
 });
 
+/**
+ * @deprecated
+ */
 export const SUPPORTED_MODELS = {
   'embedding-001': textEmbeddingGecko001,
   'text-embedding-004': textEmbedding004,
   'gemini-embedding-001': geminiEmbedding001,
 };
 
+/**
+ * @deprecated
+ */
 export function defineGoogleAIEmbedder(
   ai: Genkit,
   name: string,

--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -142,6 +142,9 @@ const VoiceConfigSchema = z
   .describe('Configuration for the voice to use')
   .passthrough();
 
+/**
+ * @deprecated
+ */
 export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
   temperature: z
     .number()
@@ -235,6 +238,9 @@ export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
 }).passthrough();
 export type GeminiConfig = z.infer<typeof GeminiConfigSchema>;
 
+/**
+ * @deprecated
+ */
 export const GeminiGemmaConfigSchema = GeminiConfigSchema.extend({
   temperature: z
     .number()
@@ -247,6 +253,9 @@ export const GeminiGemmaConfigSchema = GeminiConfigSchema.extend({
     .optional(),
 }).passthrough();
 
+/**
+ * @deprecated
+ */
 export const GeminiTtsConfigSchema = GeminiConfigSchema.extend({
   speechConfig: z
     .object({
@@ -276,6 +285,9 @@ export const GeminiTtsConfigSchema = GeminiConfigSchema.extend({
     .optional(),
 }).passthrough();
 
+/**
+ * @deprecated
+ */
 export const gemini10Pro = modelRef({
   name: 'googleai/gemini-1.0-pro',
   info: {
@@ -293,6 +305,9 @@ export const gemini10Pro = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini15Pro = modelRef({
   name: 'googleai/gemini-1.5-pro',
   info: {
@@ -314,6 +329,9 @@ export const gemini15Pro = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini15Flash = modelRef({
   name: 'googleai/gemini-1.5-flash',
   info: {
@@ -337,6 +355,9 @@ export const gemini15Flash = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini15Flash8b = modelRef({
   name: 'googleai/gemini-1.5-flash-8b',
   info: {
@@ -354,6 +375,9 @@ export const gemini15Flash8b = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini20Flash = modelRef({
   name: 'googleai/gemini-2.0-flash',
   info: {
@@ -371,6 +395,9 @@ export const gemini20Flash = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini20FlashExp = modelRef({
   name: 'googleai/gemini-2.0-flash-exp',
   info: {
@@ -388,6 +415,9 @@ export const gemini20FlashExp = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini20FlashLite = modelRef({
   name: 'googleai/gemini-2.0-flash-lite',
   info: {
@@ -405,6 +435,9 @@ export const gemini20FlashLite = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini20ProExp0205 = modelRef({
   name: 'googleai/gemini-2.0-pro-exp-02-05',
   info: {
@@ -422,6 +455,9 @@ export const gemini20ProExp0205 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini25FlashPreview0417 = modelRef({
   name: 'googleai/gemini-2.5-flash-preview-04-17',
   info: {
@@ -439,6 +475,9 @@ export const gemini25FlashPreview0417 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini25FlashPreviewTts = modelRef({
   name: 'googleai/gemini-2.5-flash-preview-tts',
   info: {
@@ -456,6 +495,9 @@ export const gemini25FlashPreviewTts = modelRef({
   configSchema: GeminiTtsConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini25ProExp0325 = modelRef({
   name: 'googleai/gemini-2.5-pro-exp-03-25',
   info: {
@@ -473,6 +515,9 @@ export const gemini25ProExp0325 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini25ProPreview0325 = modelRef({
   name: 'googleai/gemini-2.5-pro-preview-03-25',
   info: {
@@ -490,6 +535,9 @@ export const gemini25ProPreview0325 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini25ProPreviewTts = modelRef({
   name: 'googleai/gemini-2.5-pro-preview-tts',
   info: {
@@ -507,6 +555,9 @@ export const gemini25ProPreviewTts = modelRef({
   configSchema: GeminiTtsConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini25Pro = modelRef({
   name: 'googleai/gemini-2.5-pro',
   info: {
@@ -524,6 +575,9 @@ export const gemini25Pro = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini25Flash = modelRef({
   name: 'googleai/gemini-2.5-flash',
   info: {
@@ -541,6 +595,9 @@ export const gemini25Flash = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini25FlashLite = modelRef({
   name: 'googleai/gemini-2.5-flash-lite',
   info: {
@@ -558,6 +615,9 @@ export const gemini25FlashLite = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemma312bit = modelRef({
   name: 'googleai/gemma-3-12b-it',
   info: {
@@ -575,6 +635,9 @@ export const gemma312bit = modelRef({
   configSchema: GeminiGemmaConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemma31bit = modelRef({
   name: 'googleai/gemma-3-1b-it',
   info: {
@@ -592,6 +655,9 @@ export const gemma31bit = modelRef({
   configSchema: GeminiGemmaConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemma327bit = modelRef({
   name: 'googleai/gemma-3-27b-it',
   info: {
@@ -609,6 +675,9 @@ export const gemma327bit = modelRef({
   configSchema: GeminiGemmaConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemma34bit = modelRef({
   name: 'googleai/gemma-3-4b-it',
   info: {
@@ -626,6 +695,9 @@ export const gemma34bit = modelRef({
   configSchema: GeminiGemmaConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemma3ne4bit = modelRef({
   name: 'googleai/gemma-3n-e4b-it',
   info: {
@@ -643,6 +715,9 @@ export const gemma3ne4bit = modelRef({
   configSchema: GeminiGemmaConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const SUPPORTED_GEMINI_MODELS = {
   'gemini-1.5-pro': gemini15Pro,
   'gemini-1.5-flash': gemini15Flash,
@@ -666,6 +741,9 @@ export const SUPPORTED_GEMINI_MODELS = {
   'gemma-3n-e4b-it': gemma3ne4bit,
 };
 
+/**
+ * @deprecated
+ */
 export const GENERIC_GEMINI_MODEL = modelRef({
   name: 'googleai/gemini',
   configSchema: GeminiConfigSchema,
@@ -694,6 +772,7 @@ function longestMatchingPrefix(version: string, potentialMatches: string[]) {
 
 /**
  * Known model names, to allow code completion for convenience. Allows other model names.
+ * @deprecated
  */
 export type GeminiVersionString =
   | keyof typeof SUPPORTED_GEMINI_MODELS
@@ -708,6 +787,7 @@ export type GeminiVersionString =
  *   model: gemini('gemini-1.5-flash')
  * });
  * ```
+ * @deprecated
  */
 export function gemini(
   version: GeminiVersionString,
@@ -832,7 +912,10 @@ function convertSchemaProperty(property) {
   }
 }
 
-/** @hidden */
+/**
+ * @hidden
+ * @deprecated
+ */
 export function toGeminiTool(
   tool: z.infer<typeof ToolDefinitionSchema>
 ): FunctionDeclaration {
@@ -1026,6 +1109,9 @@ function fromGeminiPart(
   throw new Error('Unsupported GeminiPart type: ' + JSON.stringify(part));
 }
 
+/**
+ * @deprecated
+ */
 export function toGeminiMessage(
   message: MessageData,
   model?: ModelReference<z.ZodTypeAny>
@@ -1047,6 +1133,9 @@ export function toGeminiMessage(
   };
 }
 
+/**
+ * @deprecated
+ */
 export function toGeminiSystemInstruction(message: MessageData): GeminiMessage {
   return {
     role: 'user',
@@ -1054,6 +1143,9 @@ export function toGeminiSystemInstruction(message: MessageData): GeminiMessage {
   };
 }
 
+/**
+ * @deprecated
+ */
 function fromGeminiFinishReason(
   reason: GeminiCandidate['finishReason']
 ): CandidateData['finishReason'] {
@@ -1071,6 +1163,9 @@ function fromGeminiFinishReason(
   }
 }
 
+/**
+ * @deprecated
+ */
 export function fromGeminiCandidate(
   candidate: GeminiCandidate,
   jsonMode = false
@@ -1094,6 +1189,10 @@ export function fromGeminiCandidate(
 
   return genkitCandidate;
 }
+
+/**
+ * @deprecated
+ */
 export function cleanSchema(schema: JSONSchema): JSONSchema {
   const out = structuredClone(schema);
   for (const key in out) {
@@ -1116,6 +1215,7 @@ export function cleanSchema(schema: JSONSchema): JSONSchema {
 
 /**
  * Defines a new GoogleAI model.
+ * @deprecated
  */
 export function defineGoogleAIModel({
   ai,
@@ -1507,6 +1607,7 @@ function toGeminiFunctionModeEnum(
  *
  * This code is copy-pasted from https://github.com/google-gemini/deprecated-generative-ai-js/blob/8b14949a5e8f1f3dfc35c394ebf5b19e68f92a22/src/requests/stream-reader.ts#L153
  * with a small (but critical) bug fix.
+ * @deprecated
  */
 export function aggregateResponses(
   responses: GenerateContentResponse[]

--- a/js/plugins/googleai/src/imagen.ts
+++ b/js/plugins/googleai/src/imagen.ts
@@ -26,10 +26,14 @@ import {
 import { getApiKeyFromEnvVar } from './common.js';
 import { predictModel } from './predict.js';
 
+/**
+ * @deprecated
+ */
 export type KNOWN_IMAGEN_MODELS = 'imagen-3.0-generate-002';
 
 /**
  * See https://ai.google.dev/gemini-api/docs/image-generation#imagen-model
+ * @deprecated
  */
 export const ImagenConfigSchema = z
   .object({
@@ -97,6 +101,9 @@ interface ImagenInstance {
   mask?: { image?: { bytesBase64Encoded: string } };
 }
 
+/**
+ * @deprecated
+ */
 export const GENERIC_IMAGEN_INFO = {
   label: `Google AI - Generic Imagen`,
   supports: {
@@ -108,6 +115,9 @@ export const GENERIC_IMAGEN_INFO = {
   },
 } as ModelInfo;
 
+/**
+ * @deprecated
+ */
 export function defineImagenModel(
   ai: Genkit,
   name: string,

--- a/js/plugins/googleai/src/index.ts
+++ b/js/plugins/googleai/src/index.ts
@@ -92,6 +92,9 @@ export {
   type GeminiVersionString,
 };
 
+/**
+ * @deprecated
+ */
 export interface PluginOptions {
   /**
    * Provide the API key to use to authenticate with the Gemini API. By
@@ -327,6 +330,7 @@ async function listActions(options?: PluginOptions): Promise<ActionMetadata[]> {
 
 /**
  * Google Gemini Developer API plugin.
+ * @deprecated
  */
 export function googleAIPlugin(options?: PluginOptions): GenkitPlugin {
   let listActionsCache;
@@ -343,6 +347,9 @@ export function googleAIPlugin(options?: PluginOptions): GenkitPlugin {
   );
 }
 
+/**
+ * @deprecated
+ */
 export type GoogleAIPlugin = {
   (params?: PluginOptions): GenkitPlugin;
   model(
@@ -366,6 +373,7 @@ export type GoogleAIPlugin = {
 
 /**
  * Google Gemini Developer API plugin.
+ * @deprecated Please use `import { googleAI } from '@genkit-ai/google-genai';` instead. Replace model constants with e.g. googleAI.model('gemini-2.5-pro')
  */
 export const googleAI = googleAIPlugin as GoogleAIPlugin;
 // provide generic implementation for the model function overloads.

--- a/js/plugins/googleai/src/list-models.ts
+++ b/js/plugins/googleai/src/list-models.ts
@@ -15,6 +15,9 @@
  */
 
 // Gemini  model definition
+/**
+ * @deprecated
+ */
 export interface Model {
   name: string;
   baseModelId: string;
@@ -40,6 +43,7 @@ interface ListModelsResponse {
  * List Gemini models by making an RPC call to the API.
  *
  * https://ai.google.dev/api/models#method:-models.list
+ * @deprecated
  */
 export async function listModels(
   baseUrl: string,

--- a/js/plugins/googleai/src/predict.ts
+++ b/js/plugins/googleai/src/predict.ts
@@ -16,8 +16,14 @@
 
 import { getGenkitClientHeader } from './common';
 
+/**
+ * @deprecated
+ */
 export type PredictMethod = 'predict' | 'predictLongRunning';
 
+/**
+ * @deprecated
+ */
 export interface Operation {
   name: string;
   done?: boolean;
@@ -48,11 +54,17 @@ function opCheckEndpoint(options: {
   return `https://generativelanguage.googleapis.com/${options.apiVersion}/${options.operation}?key=${options.apiKey}`;
 }
 
+/**
+ * @deprecated
+ */
 export type PredictClient<I = unknown, R = unknown, P = unknown> = (
   instances: I[],
   parameters: P
 ) => Promise<R>;
 
+/**
+ * @deprecated
+ */
 export function predictModel<I = unknown, R = unknown, P = unknown>(
   model: string,
   apiKey: string,
@@ -95,6 +107,9 @@ export function predictModel<I = unknown, R = unknown, P = unknown>(
   };
 }
 
+/**
+ * @deprecated
+ */
 export async function checkOp(
   operation: string,
   apiKey: string

--- a/js/plugins/googleai/src/veo.ts
+++ b/js/plugins/googleai/src/veo.ts
@@ -31,10 +31,14 @@ import {
 import { getApiKeyFromEnvVar } from './common.js';
 import { Operation as ApiOperation, checkOp, predictModel } from './predict.js';
 
+/**
+ * @deprecated
+ */
 export type KNOWN_VEO_MODELS = 'veo-2.0-generate-001';
 
 /**
  * See https://ai.google.dev/gemini-api/docs/video
+ * @deprecated
  */
 export const VeoConfigSchema = z
   .object({
@@ -114,6 +118,9 @@ interface VeoInstance {
   image?: VeoImage;
 }
 
+/**
+ * @deprecated
+ */
 export const GENERIC_VEO_INFO = {
   label: `Google AI - Generic Veo`,
   supports: {
@@ -126,6 +133,9 @@ export const GENERIC_VEO_INFO = {
   },
 } as ModelInfo;
 
+/**
+ * @deprecated
+ */
 export function defineVeoModel(
   ai: Genkit,
   name: string,

--- a/js/plugins/vertexai/src/embedder.ts
+++ b/js/plugins/vertexai/src/embedder.ts
@@ -24,6 +24,7 @@ import type { GoogleAuth } from 'google-auth-library';
 import type { PluginOptions } from './common/types.js';
 import { predictModel, type PredictClient } from './predict.js';
 
+/** @deprecated */
 export const TaskTypeSchema = z.enum([
   'RETRIEVAL_DOCUMENT',
   'RETRIEVAL_QUERY',
@@ -32,8 +33,10 @@ export const TaskTypeSchema = z.enum([
   'CLUSTERING',
 ]);
 
+/** @deprecated */
 export type TaskType = z.infer<typeof TaskTypeSchema>;
 
+/** @deprecated */
 export const VertexEmbeddingConfigSchema = z.object({
   /**
    * The `task_type` parameter is defined as the intended downstream application
@@ -53,6 +56,7 @@ export const VertexEmbeddingConfigSchema = z.object({
   outputDimensionality: z.number().min(1).max(768).optional(),
 });
 
+/** @deprecated */
 export type VertexEmbeddingConfig = z.infer<typeof VertexEmbeddingConfigSchema>;
 
 type InputType = 'text' | 'image' | 'video';
@@ -74,20 +78,33 @@ function commonRef(
   });
 }
 
+/** @deprecated */
 export const textEmbeddingGecko003 = commonRef('textembedding-gecko@003');
+
+/** @deprecated */
 export const textEmbedding004 = commonRef('text-embedding-004');
+
+/** @deprecated */
 export const textEmbedding005 = commonRef('text-embedding-005');
+
+/** @deprecated */
 export const textEmbeddingGeckoMultilingual001 = commonRef(
   'textembedding-gecko-multilingual@001'
 );
+
+/** @deprecated */
 export const textMultilingualEmbedding002 = commonRef(
   'text-multilingual-embedding-002'
 );
+
+/** @deprecated */
 export const multimodalEmbedding001 = commonRef('multimodalembedding@001', [
   'text',
   'image',
   'video',
 ]);
+
+/** @deprecated */
 export const geminiEmbedding001 = embedderRef({
   name: 'vertexai/gemini-embedding-001',
   configSchema: VertexEmbeddingConfigSchema,
@@ -100,6 +117,7 @@ export const geminiEmbedding001 = embedderRef({
   },
 });
 
+/** @deprecated */
 export const SUPPORTED_EMBEDDER_MODELS: Record<string, EmbedderReference> = {
   'textembedding-gecko@003': textEmbeddingGecko003,
   'text-embedding-004': textEmbedding004,
@@ -253,6 +271,7 @@ type EmbeddingResult = {
   metadata?: Record<string, unknown>;
 };
 
+/** @deprecated */
 export function defineVertexAIEmbedder(
   ai: Genkit,
   name: string,

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -70,6 +70,9 @@ type ExtendedUsageMetadata = UsageMetadata & {
   thoughtsTokenCount?: number;
 };
 
+/**
+ * @deprecated
+ */
 export const SafetySettingsSchema = z.object({
   category: z.enum([
     /** The harm category is unspecified. */
@@ -131,6 +134,7 @@ const GoogleSearchRetrievalSchema = z.object({
 /**
  * Zod schema of Gemini model options.
  * Please refer to: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig, for further information.
+ * @deprecated
  */
 export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
   temperature: z
@@ -283,6 +287,7 @@ export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
 
 /**
  * Known model names, to allow code completion for convenience. Allows other model names.
+ * @deprecated
  */
 export type GeminiVersionString =
   | keyof typeof SUPPORTED_GEMINI_MODELS
@@ -297,6 +302,7 @@ export type GeminiVersionString =
  *   model: gemini('gemini-1.5-flash')
  * });
  * ```
+ * @deprecated
  */
 export function gemini(
   version: GeminiVersionString,
@@ -375,9 +381,13 @@ function longestMatchingPrefix(version: string, potentialMatches: string[]) {
  *     }
  *   }
  * ```
+ * @deprecated
  */
 export type GeminiConfig = z.infer<typeof GeminiConfigSchema>;
 
+/**
+ * @deprecated
+ */
 export const gemini10Pro = modelRef({
   name: 'vertexai/gemini-1.0-pro',
   info: {
@@ -395,6 +405,9 @@ export const gemini10Pro = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini15Pro = modelRef({
   name: 'vertexai/gemini-1.5-pro',
   info: {
@@ -412,6 +425,9 @@ export const gemini15Pro = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini15Flash = modelRef({
   name: 'vertexai/gemini-1.5-flash',
   info: {
@@ -429,6 +445,9 @@ export const gemini15Flash = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini20Flash001 = modelRef({
   name: 'vertexai/gemini-2.0-flash-001',
   info: {
@@ -446,6 +465,9 @@ export const gemini20Flash001 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini20Flash = modelRef({
   name: 'vertexai/gemini-2.0-flash',
   info: {
@@ -463,6 +485,9 @@ export const gemini20Flash = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini20FlashLite = modelRef({
   name: 'vertexai/gemini-2.0-flash-lite',
   info: {
@@ -480,6 +505,9 @@ export const gemini20FlashLite = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini20FlashLitePreview0205 = modelRef({
   name: 'vertexai/gemini-2.0-flash-lite-preview-02-05',
   info: {
@@ -497,6 +525,9 @@ export const gemini20FlashLitePreview0205 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini20ProExp0205 = modelRef({
   name: 'vertexai/gemini-2.0-pro-exp-02-05',
   info: {
@@ -514,6 +545,9 @@ export const gemini20ProExp0205 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini25FlashPreview0417 = modelRef({
   name: 'vertexai/gemini-2.5-flash-preview-04-17',
   info: {
@@ -531,6 +565,9 @@ export const gemini25FlashPreview0417 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini25ProExp0325 = modelRef({
   name: 'vertexai/gemini-2.5-pro-exp-03-25',
   info: {
@@ -548,6 +585,9 @@ export const gemini25ProExp0325 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated
+ */
 export const gemini25ProPreview0325 = modelRef({
   name: 'vertexai/gemini-2.5-pro-preview-03-25',
   info: {
@@ -565,6 +605,9 @@ export const gemini25ProPreview0325 = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated After importing from the new plugin, use vertexAI.model('gemini-2.5-pro')
+ */
 export const gemini25Pro = modelRef({
   name: 'vertexai/gemini-2.5-pro',
   info: {
@@ -581,6 +624,9 @@ export const gemini25Pro = modelRef({
   },
   configSchema: GeminiConfigSchema,
 });
+/**
+ * @deprecated After importing from the new plugin, use vertexAI.model('gemini-2.5-flash')
+ */
 export const gemini25Flash = modelRef({
   name: 'vertexai/gemini-2.5-flash',
   info: {
@@ -598,6 +644,9 @@ export const gemini25Flash = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/**
+ * @deprecated After importing from the new plugin, use vertexAI.model('gemini-2.5-flash-lite')
+ */
 export const gemini25FlashLite = modelRef({
   name: 'vertexai/gemini-2.5-flash-lite',
   info: {
@@ -615,6 +664,7 @@ export const gemini25FlashLite = modelRef({
   configSchema: GeminiConfigSchema,
 });
 
+/** @deprecated */
 export const GENERIC_GEMINI_MODEL = modelRef({
   name: 'vertexai/gemini',
   configSchema: GeminiConfigSchema,
@@ -634,6 +684,7 @@ const SUPPORTED_V1_MODELS = {
   'gemini-1.0-pro': gemini10Pro,
 };
 
+/** @deprecated */
 export const SUPPORTED_V15_MODELS = {
   'gemini-1.5-pro': gemini15Pro,
   'gemini-1.5-flash': gemini15Flash,
@@ -650,6 +701,7 @@ export const SUPPORTED_V15_MODELS = {
   'gemini-2.5-flash-lite': gemini25FlashLite,
 };
 
+/** @deprecated */
 export const SUPPORTED_GEMINI_MODELS = {
   ...SUPPORTED_V15_MODELS,
 } as const;
@@ -680,7 +732,10 @@ function toGeminiRole(
   }
 }
 
-/** @hidden */
+/**
+ * @hidden
+ * @deprecated
+ */
 export const toGeminiTool = (
   tool: z.infer<typeof ToolDefinitionSchema>
 ): FunctionDeclaration => {
@@ -750,6 +805,7 @@ const toGeminiToolResponsePart = (part: Part): GeminiPart => {
   };
 };
 
+/** @deprecated */
 export function toGeminiSystemInstruction(message: MessageData): Content {
   return {
     role: 'user',
@@ -757,6 +813,7 @@ export function toGeminiSystemInstruction(message: MessageData): Content {
   };
 }
 
+/** @deprecated */
 export function toGeminiMessage(
   message: MessageData,
   modelInfo?: ModelInfo
@@ -899,6 +956,8 @@ function fromGeminiPart(
     'Part type is unsupported/corrupted. Either data is missing or type cannot be inferred from type.'
   );
 }
+
+/** @deprecated */
 export function fromGeminiCandidate(
   candidate: GenerateContentCandidate,
   jsonMode: boolean
@@ -997,6 +1056,7 @@ function convertSchemaProperty(property) {
   }
 }
 
+/** @deprecated */
 export function cleanSchema(schema: JSONSchema): JSONSchema {
   const out = structuredClone(schema);
   for (const key in out) {
@@ -1019,6 +1079,7 @@ export function cleanSchema(schema: JSONSchema): JSONSchema {
 
 /**
  * Define a Vertex AI Gemini model.
+ * @deprecated
  */
 export function defineGeminiKnownModel(
   ai: Genkit,
@@ -1047,6 +1108,7 @@ export function defineGeminiKnownModel(
 
 /**
  * Define a Vertex AI Gemini model.
+ * @deprecated
  */
 export function defineGeminiModel({
   ai,

--- a/js/plugins/vertexai/src/imagen.ts
+++ b/js/plugins/vertexai/src/imagen.ts
@@ -31,6 +31,7 @@ import { predictModel, type PredictClient } from './predict.js';
 
 /**
  * See https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api.
+ * @deprecated
  */
 export const ImagenConfigSchema = GenerationCommonConfigSchema.extend({
   // TODO: Remove common config schema extension since Imagen models don't support
@@ -162,6 +163,7 @@ export const ImagenConfigSchema = GenerationCommonConfigSchema.extend({
     .optional(),
 }).passthrough();
 
+/** @deprecated */
 export const imagen2 = modelRef({
   name: 'vertexai/imagen2',
   info: {
@@ -179,6 +181,7 @@ export const imagen2 = modelRef({
   configSchema: ImagenConfigSchema,
 });
 
+/** @deprecated */
 export const imagen3 = modelRef({
   name: 'vertexai/imagen3',
   info: {
@@ -196,6 +199,7 @@ export const imagen3 = modelRef({
   configSchema: ImagenConfigSchema,
 });
 
+/** @deprecated */
 export const imagen3Fast = modelRef({
   name: 'vertexai/imagen3-fast',
   info: {
@@ -213,6 +217,7 @@ export const imagen3Fast = modelRef({
   configSchema: ImagenConfigSchema,
 });
 
+/** @deprecated */
 export const ACTUAL_IMAGEN_MODELS = {
   'imagen-3.0-generate-001': modelRef({
     name: 'vertexai/imagen-3.0-generate-001',
@@ -244,6 +249,7 @@ export const ACTUAL_IMAGEN_MODELS = {
   }),
 } as const;
 
+/** @deprecated */
 export const SUPPORTED_IMAGEN_MODELS = {
   ...ACTUAL_IMAGEN_MODELS,
   // These are old, inconsistent model naming. Only here for backwards compatibility.
@@ -313,6 +319,7 @@ interface ImagenInstance {
   mask?: { image?: { bytesBase64Encoded: string } };
 }
 
+/** @deprecated */
 export const GENERIC_IMAGEN_INFO = {
   label: `Vertex AI - Generic`,
   supports: {
@@ -324,6 +331,7 @@ export const GENERIC_IMAGEN_INFO = {
   },
 } as ModelInfo;
 
+/** @deprecated */
 export function defineImagenModel(
   ai: Genkit,
   name: string,

--- a/js/plugins/vertexai/src/index.ts
+++ b/js/plugins/vertexai/src/index.ts
@@ -283,6 +283,9 @@ function vertexAIPlugin(options?: PluginOptions): GenkitPlugin {
   );
 }
 
+/**
+ * @deprecated
+ */
 export type VertexAIPlugin = {
   (params?: PluginOptions): GenkitPlugin;
   model(
@@ -303,6 +306,7 @@ export type VertexAIPlugin = {
 /**
  * Google Cloud Vertex AI plugin for Genkit.
  * Includes Gemini and Imagen models and text embedder.
+ * @deprecated Please use `import { vertexAI } from '@genkit-ai/google-genai';` instead. Replace model constants with e.g. vertexAI.model('gemini-2.5-pro')
  */
 export const vertexAI = vertexAIPlugin as VertexAIPlugin;
 // provide generic implementation for the model function overloads.


### PR DESCRIPTION
from @genkit-ai/googleai and @genkit-ai/vertexai packages respectively in favour of googleAI and vertexAI plugins from the new @genkit-ai/google-genai package.


Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
