### PR TITLE
fix(js/plugins/googleai,vertexai): support thoughtSignature in fromGeminiPart

### DIFF
--- a/js/plugins/googleai/src/gemini.ts
+++ b/js/plugins/googleai/src/gemini.ts
@@ -1016,7 +1016,7 @@ function fromGeminiPart(
   jsonMode: boolean,
   ref: string
 ): Part {
-  if ('thought' in part) return fromThought(part as any);
+  if ('thought' in part || 'thoughtSignature' in part) return fromThought(part as any);
   if (typeof part.text === 'string') return { text: part.text };
   if (part.inlineData) return fromInlineData(part);
   if (part.functionCall) return fromFunctionCall(part, ref);

--- a/js/plugins/vertexai/src/gemini.ts
+++ b/js/plugins/vertexai/src/gemini.ts
@@ -888,7 +888,7 @@ function fromGeminiPart(
   jsonMode: boolean,
   ref?: string
 ): Part {
-  if ('thought' in part) return fromGeminiThought(part as any);
+  if ('thought' in part || 'thoughtSignature' in part) return fromGeminiThought(part as any);
   if (typeof part.text === 'string') return { text: part.text };
   if (part.inlineData) return fromGeminiInlineDataPart(part);
   if (part.fileData) return fromGeminiFileDataPart(part);


### PR DESCRIPTION
Fixes #3920

**Problem**

When using the Gemini 3 Pro model (e.g., `gemini-3-pro-preview`) which enables thinking by default, the API returns response parts containing a `thoughtSignature` property. The current fromGeminiPart implementation in both `googleai` and `vertexai` plugins throws an `Unsupported GeminiPart type` error because it does not recognize parts that contain `thoughtSignature` without the `thought` property.

**Solution**

This PR updates the fromGeminiPart logic in both plugins to correctly identify and handle `thoughtSignature` parts by checking for both `'thought' in part` and `'thoughtSignature' in part`. This allows these parts to be processed by the existing fromThought / fromGeminiThought functions, which already support the `thoughtSignature` property.

**Checklist:**
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (Manually verified with `gemini-3-pro-preview` - error resolved, responses with `thoughtSignature` now parse correctly)
- [ ] Docs updated (N/A - internal fix, no API changes)