### PR TITLE
feat(py): add embedder reference support matching JS SDK

### DIFF
--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/openai_plugin.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/openai_plugin.py
@@ -25,7 +25,7 @@ from openai.types import Embedding, Model
 
 from genkit.ai._plugin import Plugin
 from genkit.ai._registry import GenkitRegistry
-from genkit.blocks.embedding import embedder_action_metadata
+from genkit.blocks.embedding import EmbedderOptions, EmbedderSupports, embedder_action_metadata
 from genkit.blocks.model import model_action_metadata
 from genkit.core.action import ActionMetadata
 from genkit.core.action.types import ActionKind
@@ -188,17 +188,14 @@ class OpenAI(Plugin):
         for model in models:
             _name = model.id
             if 'embed' in _name:
+                # Default embedder metadata for OpenAI embedding models
                 actions.append(
                     embedder_action_metadata(
                         name=open_ai_name(_name),
-                        config_schema=Embedding,
-                        info={
-                            'label': f'OpenAI Embedding - {_name}',
-                            'dimensions': None,
-                            'supports': {
-                                'input': ['text'],
-                            },
-                        },
+                        options=EmbedderOptions(
+                            label=f'OpenAI Embedding - {_name}',
+                            supports=EmbedderSupports(input=['text']),
+                        ),
                     )
                 )
             else:

--- a/py/plugins/google-genai/test/test_google_plugin.py
+++ b/py/plugins/google-genai/test/test_google_plugin.py
@@ -28,9 +28,10 @@ from google.genai.types import EmbedContentConfig, GenerateImagesConfigOrDict, H
 
 import pytest
 from genkit.ai import Genkit, GENKIT_CLIENT_HEADER
-from genkit.blocks.embedding import embedder_action_metadata
+from genkit.blocks.embedding import embedder_action_metadata, EmbedderOptions, EmbedderSupports
 from genkit.blocks.model import model_action_metadata
 from genkit.core.registry import ActionKind
+from genkit.core.schema import to_json_schema
 from genkit.plugins.google_genai import (
     GoogleAI,
     VertexAI,
@@ -146,7 +147,6 @@ def test_googleai_initialize():
             name=googleai_name(version),
             fn=ANY,
             metadata=ANY,
-            config_schema=GeminiConfigSchema,
         )
 
     for version in GeminiEmbeddingModels:
@@ -154,7 +154,6 @@ def test_googleai_initialize():
             name=googleai_name(version),
             fn=ANY,
             metadata=ANY,
-            config_schema=EmbedContentConfig,
         )
 
 
@@ -219,7 +218,6 @@ def test_googleai__resolve_model(
         name=expected_model_name,
         fn=ANY,
         metadata=ANY,
-        config_schema=GeminiConfigSchema,
     )
     assert key in SUPPORTED_MODELS
 
@@ -247,7 +245,7 @@ def test_googleai__resolve_embedder(
     )
 
     ai_mock.define_embedder.assert_called_once_with(
-        name=expected_model_name, fn=ANY, config_schema=EmbedContentConfig, metadata=default_embedder_info(clean_name)
+        name=expected_model_name, fn=ANY, metadata=default_embedder_info(clean_name)
     )
 
 
@@ -275,22 +273,26 @@ def test_googleai_list_actions(googleai_plugin_instance):
         model_action_metadata(
             name=googleai_name('model1'),
             info=google_model_info('model1').model_dump(),
-            config_schema=GeminiConfigSchema,
         ),
         embedder_action_metadata(
             name=googleai_name('model2'),
-            info=default_embedder_info('model2'),
-            config_schema=EmbedContentConfig,
+            options=EmbedderOptions(
+                label=default_embedder_info('model2').get('label'),
+                supports=EmbedderSupports(input=default_embedder_info('model2').get('supports', {}).get('input')),
+                dimensions=default_embedder_info('model2').get('dimensions'),
+            ),
         ),
         model_action_metadata(
             name=googleai_name('model3'),
             info=google_model_info('model3').model_dump(),
-            config_schema=GeminiConfigSchema,
         ),
         embedder_action_metadata(
             name=googleai_name('model3'),
-            info=default_embedder_info('model3'),
-            config_schema=EmbedContentConfig,
+            options=EmbedderOptions(
+                label=default_embedder_info('model3').get('label'),
+                supports=EmbedderSupports(input=default_embedder_info('model3').get('supports', {}).get('input')),
+                dimensions=default_embedder_info('model3').get('dimensions'),
+            ),
         ),
     ]
 
@@ -496,20 +498,16 @@ def test_vertexai_initialize(vertexai_plugin_instance):
             name=vertexai_name(version),
             fn=ANY,
             metadata=ANY,
-            config_schema=GeminiConfigSchema,
         )
 
     for version in ImagenVersion:
-        ai_mock.define_model.assert_any_call(
-            name=vertexai_name(version), fn=ANY, metadata=ANY, config_schema=GenerateImagesConfigOrDict
-        )
+        ai_mock.define_model.assert_any_call(name=vertexai_name(version), fn=ANY, metadata=ANY)
 
     for version in VertexEmbeddingModels:
         ai_mock.define_embedder.assert_any_call(
             name=vertexai_name(version),
             fn=ANY,
             metadata=ANY,
-            config_schema=EmbedContentConfig,
         )
 
 
@@ -609,7 +607,6 @@ def test_vertexai__resolve_model(
             name=expected_model_name,
             fn=ANY,
             metadata=ANY,
-            config_schema=GenerateImagesConfigOrDict,
         )
         assert key in IMAGE_SUPPORTED_MODELS
     else:
@@ -617,7 +614,6 @@ def test_vertexai__resolve_model(
             name=expected_model_name,
             fn=ANY,
             metadata=ANY,
-            config_schema=GeminiConfigSchema,
         )
         assert key in SUPPORTED_MODELS
 
@@ -653,7 +649,7 @@ def test_vertexai__resolve_embedder(
     )
 
     ai_mock.define_embedder.assert_called_once_with(
-        name=expected_model_name, fn=ANY, config_schema=EmbedContentConfig, metadata=default_embedder_info(clean_name)
+        name=expected_model_name, fn=ANY, metadata=default_embedder_info(clean_name)
     )
 
 
@@ -680,26 +676,33 @@ def test_vertexai_list_actions(vertexai_plugin_instance):
         model_action_metadata(
             name=vertexai_name('model1'),
             info=google_model_info('model1').model_dump(),
-            config_schema=GeminiConfigSchema,
         ),
         embedder_action_metadata(
             name=vertexai_name('model2_embeddings'),
-            info=default_embedder_info('model2_embeddings'),
-            config_schema=EmbedContentConfig,
+            options=EmbedderOptions(
+                label=default_embedder_info('model2_embeddings').get('label'),
+                supports=EmbedderSupports(
+                    input=default_embedder_info('model2_embeddings').get('supports', {}).get('input')
+                ),
+                dimensions=default_embedder_info('model2_embeddings').get('dimensions'),
+            ),
         ),
         model_action_metadata(
             name=vertexai_name('model2_embeddings'),
             info=google_model_info('model2_embeddings').model_dump(),
-            config_schema=GeminiConfigSchema,
         ),
         embedder_action_metadata(
             name=vertexai_name('model3_embedder'),
-            info=default_embedder_info('model3_embedder'),
-            config_schema=EmbedContentConfig,
+            options=EmbedderOptions(
+                label=default_embedder_info('model3_embedder').get('label'),
+                supports=EmbedderSupports(
+                    input=default_embedder_info('model3_embedder').get('supports', {}).get('input')
+                ),
+                dimensions=default_embedder_info('model3_embedder').get('dimensions'),
+            ),
         ),
         model_action_metadata(
             name=vertexai_name('model3_embedder'),
             info=google_model_info('model3_embedder').model_dump(),
-            config_schema=GeminiConfigSchema,
         ),
     ]

--- a/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
@@ -23,9 +23,10 @@ import structlog
 
 import ollama as ollama_api
 from genkit.ai import GenkitRegistry, Plugin
-from genkit.blocks.embedding import embedder_action_metadata
+from genkit.blocks.embedding import EmbedderOptions, EmbedderSupports, embedder_action_metadata
 from genkit.blocks.model import model_action_metadata
 from genkit.core.registry import ActionKind
+from genkit.core.schema import to_json_schema
 from genkit.plugins.ollama.constants import (
     DEFAULT_OLLAMA_SERVER_URL,
     OllamaAPITypes,
@@ -197,7 +198,7 @@ class Ollama(Plugin):
         ai.define_embedder(
             name=ollama_name(embedder_ref.name),
             fn=embedder.embed,
-            config_schema=ollama_api.Options,
+            config_schema=to_json_schema(ollama_api.Options),
             metadata={
                 'label': f'Ollama Embedding - {_clean_name}',
                 'dimensions': embedder_ref.dimensions,
@@ -234,14 +235,11 @@ class Ollama(Plugin):
                 actions.append(
                     embedder_action_metadata(
                         name=ollama_name(_name),
-                        config_schema=ollama_api.Options,
-                        info={
-                            'label': f'Ollama Embedding - {_name}',
-                            'dimensions': None,
-                            'supports': {
-                                'input': ['text'],
-                            },
-                        },
+                        options=EmbedderOptions(
+                            config_schema=to_json_schema(ollama_api.Options),
+                            label=f'Ollama Embedding - {_name}',
+                            supports=EmbedderSupports(input=['text']),
+                        ),
                     )
                 )
             else:

--- a/py/plugins/ollama/tests/test_plugin_api.py
+++ b/py/plugins/ollama/tests/test_plugin_api.py
@@ -24,6 +24,7 @@ import pytest
 from pydantic import BaseModel
 
 from genkit.ai import ActionKind, Genkit
+from genkit.core.schema import to_json_schema
 from genkit.plugins.ollama import Ollama, ollama_name
 from genkit.plugins.ollama.embedders import EmbeddingDefinition
 from genkit.plugins.ollama.models import ModelDefinition
@@ -126,7 +127,7 @@ def test__initialize_embedders(ollama_plugin_instance):
     ai_mock.define_embedder.assert_called_once_with(
         name=ollama_name(name),
         fn=ANY,
-        config_schema=ollama_api.Options,
+        config_schema=to_json_schema(ollama_api.Options),
         metadata={
             'label': f'Ollama Embedding - {name}',
             'dimensions': 1024,
@@ -165,7 +166,7 @@ def test_resolve_action(kind, name, ollama_plugin_instance):
         ai_mock.define_embedder.assert_called_once_with(
             name=ollama_name(name),
             fn=ANY,
-            config_schema=ollama_api.Options,
+            config_schema=to_json_schema(ollama_api.Options),
             metadata={
                 'label': f'Ollama Embedding - {name}',
                 'dimensions': None,
@@ -218,7 +219,7 @@ def test_define_ollama_embedder(name, expected_name, clean_name, ollama_plugin_i
     ai_mock.define_embedder.assert_called_once_with(
         name=expected_name,
         fn=ANY,
-        config_schema=ollama_api.Options,
+        config_schema=to_json_schema(ollama_api.Options),
         metadata={
             'label': f'Ollama Embedding - {clean_name}',
             'dimensions': 1024,


### PR DESCRIPTION
Add EmbedderRef, EmbedderOptions, and EmbedderSupports types to enable referencing embedders with specific configurations, matching the Go SDK functionality.

BREAKING CHANGE: define_embedder() now accepts 'options: EmbedderOptions' parameter instead of separate 'config_schema' parameter.

CHANGELOG:
- Add EmbedderRef, EmbedderOptions, EmbedderSupports types to [embedding.py]
- Add create_embedder_ref() and embedder_action_metadata() to [embedding.py]
- Implement embed() method in Genkit class supporting EmbedderRef
- Update `define_embedder()` to accept EmbedderOptions parameter
- Update all plugins (OpenAI, Google GenAI, Ollama) to use JSON schemas
- Add comprehensive tests for embedder functionality in [embedding_test.py]
- Update test assertions to match new schema conversion behavior

