### PR TITLE
fix: handle stream errors in runAction to prevent circular JSON crash

### DIFF
--- a/genkit-tools/common/src/manager/manager.ts
+++ b/genkit-tools/common/src/manager/manager.ts
@@ -229,7 +229,10 @@ export class RuntimeManager {
           }
         )
         .catch((err) =>
-          this.handleStreamError(err, `Error running action key='${input.key}'.`)
+          this.handleStreamError(
+            err,
+            `Error running action key='${input.key}'.`
+          )
         );
       let genkitVersion: string;
       if (response.headers['x-genkit-version']) {
@@ -304,7 +307,10 @@ export class RuntimeManager {
           responseType: 'stream', // Use stream to get early headers
         })
         .catch((err) =>
-          this.handleStreamError(err, `Error running action key='${input.key}'.`)
+          this.handleStreamError(
+            err,
+            `Error running action key='${input.key}'.`
+          )
         );
 
       const traceId = response.headers['x-genkit-trace-id'];


### PR DESCRIPTION
If the runtime returns an error stream, that was causing tools server to crash with "Converting circular structure to JSON" crash error. This makes sense because you can't call JSON.parse on a stream, it's not serializable due to circular references. This PR ensures that the error passed to httpErrorHandler is serializable.