### PR TITLE
fix(py/samples/google-genai-hello): fix dependency on evaluators plugin #3952

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -19,12 +19,13 @@ dependencies = [
   "dotpromptz==0.1.4",
   "genkit",
   "genkit-plugin-anthropic",
-  "genkit-plugin-dev-local-vectorstore",
   "genkit-plugin-compat-oai",
+  "genkit-plugin-dev-local-vectorstore",
+  "genkit-plugin-evaluators",
   "genkit-plugin-firebase",
   "genkit-plugin-flask",
-  "genkit-plugin-google-genai",
   "genkit-plugin-google-cloud",
+  "genkit-plugin-google-genai",
   "genkit-plugin-ollama",
   "genkit-plugin-vertex-ai",
   "liccheck>=0.9.2",
@@ -103,6 +104,7 @@ genkit                              = { workspace = true }
 genkit-plugin-anthropic             = { workspace = true }
 genkit-plugin-compat-oai            = { workspace = true }
 genkit-plugin-dev-local-vectorstore = { workspace = true }
+genkit-plugin-evaluators            = { workspace = true }
 genkit-plugin-firebase              = { workspace = true }
 genkit-plugin-flask                 = { workspace = true }
 genkit-plugin-google-cloud          = { workspace = true }

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1487,6 +1487,7 @@ dependencies = [
     { name = "genkit-plugin-anthropic" },
     { name = "genkit-plugin-compat-oai" },
     { name = "genkit-plugin-dev-local-vectorstore" },
+    { name = "genkit-plugin-evaluators" },
     { name = "genkit-plugin-firebase" },
     { name = "genkit-plugin-flask" },
     { name = "genkit-plugin-google-cloud" },
@@ -1529,6 +1530,7 @@ requires-dist = [
     { name = "genkit-plugin-anthropic", editable = "plugins/anthropic" },
     { name = "genkit-plugin-compat-oai", editable = "plugins/compat-oai" },
     { name = "genkit-plugin-dev-local-vectorstore", editable = "plugins/dev-local-vectorstore" },
+    { name = "genkit-plugin-evaluators", editable = "plugins/evaluators" },
     { name = "genkit-plugin-firebase", editable = "plugins/firebase" },
     { name = "genkit-plugin-flask", editable = "plugins/flask" },
     { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },


### PR DESCRIPTION
Fix for:

```
zsh❯ genkit start -- uv run --python python3.10 samples/google-genai-hello/src/google_genai_hello.py
Indexed 0 traces in 1ms in /Users/yesudeep/code/github.com/firebase/genkit/py/.genkit/traces_idx
Telemetry API running on http://localhost:4033
Project root: /Users/yesudeep/code/github.com/firebase/genkit/py
Genkit Developer UI: http://localhost:4000
Using CPython 3.10.16
Creating virtual environment at: .venv
   Building genkit @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/packages/genkit
   Building genkit-plugin-anthropic @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/anthropic
   Building genkit-plugin-compat-oai @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/compat-oai
   Building genkit-plugin-dev-local-vectorstore @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/dev-local-vectorstore
   Building genkit-plugin-firebase @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/firebase
   Building genkit-plugin-flask @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/flask
   Building genkit-plugin-google-cloud @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/google-cloud
   Building genkit-plugin-google-genai @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/google-genai
   Building genkit-plugin-ollama @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/ollama
   Building genkit-plugin-vertex-ai @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/vertex-ai
      Built genkit-plugin-firebase @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/firebase
      Built genkit @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/packages/genkit
      Built genkit-plugin-ollama @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/ollama
      Built genkit-plugin-vertex-ai @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/vertex-ai
      Built genkit-plugin-dev-local-vectorstore @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/dev-local-vectorstore
      Built genkit-plugin-google-genai @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/google-genai
      Built genkit-plugin-flask @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/flask
      Built genkit-plugin-anthropic @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/anthropic
      Built genkit-plugin-compat-oai @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/compat-oai
      Built genkit-plugin-google-cloud @ file:///Users/yesudeep/code/github.com/firebase/genkit/py/plugins/google-cloud
Installed 237 packages in 921ms
2025-12-16 14:35:36 [debug    ] Creating a new global tracer provider for telemetry.
2025-12-16 14:35:36 [debug    ] local_telemetry_server exporter added succesfully.
Traceback (most recent call last):
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/samples/google-genai-hello/src/google_genai_hello.py", line 51, in <module>
    from genkit.plugins.evaluators import (
ModuleNotFoundError: No module named 'genkit.plugins.evaluators'
/Users/yesudeep/.local/share/pnpm/global/5/.pnpm/@genkit-ai+tools-common@1.26.0_@types+node@22.13.5/node_modules/@genkit-ai/tools-common/lib/cjs/src/manager/process-manager.js:54
                    reject(new Error(`app process exited with code ${code}`));
                           ^

Error: app process exited with code 1
    at ChildProcess.<anonymous> (/Users/yesudeep/.local/share/pnpm/global/5/.pnpm/@genkit-ai+tools-common@1.26.0_@types+node@22.13.5/node_modules/@genkit-ai/tools-common/lib/cjs/src/manager/process-manager.js:54:28)
    at ChildProcess.emit (node:events:507:28)
    at ChildProcess._handle.onexit (node:internal/child_process:294:12)

Node.js v23.11.1
```