### PR TITLE
feat(go): implement load prompt from source

### DIFF
--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -1030,6 +1030,22 @@ func LoadPromptDir(g *Genkit, dir string, namespace string) {
 	ai.LoadPromptDir(g.reg, dir, namespace)
 }
 
+// LoadPromptFromSource loads a single prompt from a string source into the registry,
+// associating it with the given `namespace`, and returns the resulting [ai.prompt].
+//
+// The `source` should be the string content of the prompt.
+// The `name` is the name of the prompt (e.g. "greeting"). If the name contains a dot,
+// the suffix is treated as the variant (e.g. "greeting.formal").
+// The `namespace` acts as a prefix to the prompt name (e.g., namespace "myApp" and
+// name "greeting" results in prompt name "myApp/greeting"). Use an empty
+// string for no namespace.
+//
+// This provides a way to load specific prompt sources programmatically, outside of the
+// automatic loading done by [Init] or [LoadPromptDir].
+func LoadPromptFromSource(g *Genkit, source, name, namespace string) ai.Prompt {
+	return ai.LoadPromptFromSource(g.reg, source, name, namespace)
+}
+
 // LoadPrompt loads a single `.prompt` file specified by `path` into the registry,
 // associating it with the given `namespace`, and returns the resulting [ai.prompt].
 //

--- a/go/genkit/genkit_test.go
+++ b/go/genkit/genkit_test.go
@@ -123,3 +123,21 @@ func TestDefineSchemaWithType_Error(t *testing.T) {
 
 	DefineSchemaFor[Invalid](g)
 }
+
+func TestLoadPromptFromSource(t *testing.T) {
+	g := Init(t.Context())
+
+	source := `---
+model: test/model
+---
+Hello`
+
+	p := LoadPromptFromSource(g, source, "testPrompt", "testNamespace")
+	if p == nil {
+		t.Fatal("LoadPromptFromSource returned nil")
+	}
+
+	if p.Name() != "testNamespace/testPrompt" {
+		t.Errorf("got name %q, want %q", p.Name(), "testNamespace/testPrompt")
+	}
+}


### PR DESCRIPTION
Usage:
```go
	source := `---
description: Test Prompt
model: test/model
input:
  schema:
    username: string
---
Hello {{username}}`

	p := LoadPromptFromSource(g, source, "testPrompt", "testNamespace")
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)