### PR TITLE
fix(py): update google_genai_hello sample to enable image generation

### DIFF
--- a/py/samples/google-genai-hello/src/google_genai_hello.py
+++ b/py/samples/google-genai-hello/src/google_genai_hello.py
@@ -330,7 +330,7 @@ async def generate_images(name: str, ctx):
     result = await ai.generate(
         model='googleai/gemini-2.5-flash-image',
         prompt=f'tell me about {name} with photos',
-        config={'response_modalities': ['text', 'image']},
+        config=GeminiConfigSchema(response_modalities=['text', 'image']).model_dump(exclude_none=True),
     )
     return result
 


### PR DESCRIPTION
CHANGELOG:
- Use "gemini-2.5-flash-image" instead of "gemini-2.5-flash" to enable image generation.
- Update the prompt in "generate_images" to enable image generation with any customized input.
