### PR TITLE
fix(js/plugins/google-genai): prevent potential server crash from unhandled stream errors

### DIFF
--- a/js/plugins/google-genai/src/common/utils.ts
+++ b/js/plugins/google-genai/src/common/utils.ts
@@ -33,7 +33,6 @@ import {
   Part,
   isObject,
 } from './types.js';
-
 /**
  * Safely extracts the error message from the error.
  * @param e The error
@@ -402,8 +401,6 @@ async function* generateResponseSequence(
       }
       yield value;
     }
-  } catch (error) {
-    throw error;
   } finally {
     reader.releaseLock();
   }
@@ -424,6 +421,7 @@ async function getResponsePromise(
     }
   } catch (error) {
     if (allResponses.length) {
+      console.error('Stream processing failed. Returning partial response. Error:', error);
       return aggregateResponses(allResponses);
     }
 


### PR DESCRIPTION
## Description

I'd like to report a potential issue with stream error handling in `getResponseStream` that may cause server runtime crashes, and propose a possible fix. I'm not entirely certain about the root cause, so I would appreciate the maintainers' review and feedback on this approach.

### Environment
- **Runtime**: Node.js
- **Node.js version**: v22.17.0
- **Genkit version**: 1.27.0
- **@genkit-ai/google-genai version**: 1.27.0

### Issue Observed

We occasionally encountered **unhandled rejections** that crashed our server runtime. After investigation, I suspect the issue originates from `controller.error()` calls in the `getResponseStream` function, particularly when the **"Failed to parse stream"** error occurs.

**Suspected scenarios:**
1. Stream ends with unparsed text (e.g., `[DONE]` markers, incomplete SSE data like `data: `)
2. `controller.error(new Error('Failed to parse stream'))` is called (line 348)
3. This puts the ReadableStream into an **error state**
4. When stream consumers, call `reader.read()`, it returns a **rejected Promise**
5. Without try-catch blocks, these rejected Promises propagate uncaught through the async call chain.
6. This results in an **unhandled Promise rejection**
7. Node.js terminates the process (default behavior for unhandled rejections)

### Proposed Solution
Add error handling in the stream consumers to catch and properly handle errors from `controller.error()`:

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested manually, unit tested
- [ ] Docs updated (updated docs or a docs bug required)
