### PR TITLE
chore: fix erroneously failing test in formatter_test.go

### DIFF
--- a/go/ai/formatter_test.go
+++ b/go/ai/formatter_test.go
@@ -661,17 +661,14 @@ func TestResolveFormat(t *testing.T) {
 		}
 	})
 
-	t.Run("defaults to text even when schema present but no format", func(t *testing.T) {
+	t.Run("defaults to json when schema present but no format", func(t *testing.T) {
 		schema := map[string]any{"type": "object"}
 		formatter, err := resolveFormat(r, schema, "")
 		if err != nil {
 			t.Fatalf("resolveFormat() error = %v", err)
 		}
-		// Note: The current implementation defaults to text when format is empty,
-		// even if schema is present. The schema/format combination is typically
-		// handled at a higher level (e.g., in Generate options).
-		if formatter.Name() != OutputFormatText {
-			t.Errorf("resolveFormat() = %q, want %q", formatter.Name(), OutputFormatText)
+		if formatter.Name() != OutputFormatJSON {
+			t.Errorf("resolveFormat() = %q, want %q", formatter.Name(), OutputFormatJSON)
 		}
 	})
 


### PR DESCRIPTION
The behavior was changed in #3931

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)

Currently PRs have failing checks:

<img width="886" height="166" alt="image" src="https://github.com/user-attachments/assets/87c84ee9-aa6a-4064-b0eb-ca093d6b75dc" />

