### PR TITLE
fix(go/ai): properly render dotprompt multi-message prompts

### DIFF
--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -1432,70 +1432,32 @@ Hello!
 
 	prompt := LoadPromptFromFS(reg, os.DirFS(tempDir), ".", "example.prompt", "multi-namespace")
 
-	_, err = prompt.Execute(context.Background())
+	result, err := prompt.Execute(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to execute prompt: %v", err)
-	}
-}
-
-func TestMultiMessagesRenderPrompt(t *testing.T) {
-	tempDir := t.TempDir()
-
-	mockPromptFile := filepath.Join(tempDir, "example.prompt")
-	mockPromptContent := `---
-model: test/chat
-description: A test prompt
----
-<<<dotprompt:role:system>>>
-You are a pirate!
-
-<<<dotprompt:role:user>>>
-Hello!
-`
-
-	if err := os.WriteFile(mockPromptFile, []byte(mockPromptContent), 0o644); err != nil {
-		t.Fatalf("Failed to create mock prompt file: %v", err)
-	}
-
-	prompt := LoadPromptFromFS(registry.New(), os.DirFS(tempDir), ".", "example.prompt", "multi-namespace-roles")
-
-	actionOpts, err := prompt.Render(context.Background(), map[string]any{})
-	if err != nil {
-		t.Fatalf("Failed to execute prompt: %v", err)
-	}
-
-	// Check that actionOpts is not nil
-	if actionOpts == nil {
-		t.Fatal("Expected actionOpts to be non-nil")
 	}
 
 	// Check that we have exactly 2 messages (system and user)
-	if len(actionOpts.Messages) != 2 {
-		t.Fatalf("Expected 2 messages, got %d", len(actionOpts.Messages))
+	if len(result.Request.Messages) != 2 {
+		t.Fatalf("Expected 2 messages, got %d", len(result.Request.Messages))
 	}
 
 	// Check first message (system role)
-	systemMsg := actionOpts.Messages[0]
+	systemMsg := result.Request.Messages[0]
 	if systemMsg.Role != RoleSystem {
 		t.Errorf("Expected first message role to be 'system', got '%s'", systemMsg.Role)
 	}
-	if len(systemMsg.Content) == 0 {
-		t.Fatal("Expected system message to have content")
-	}
-	if strings.TrimSpace(systemMsg.Content[0].Text) != "You are a pirate!" {
-		t.Errorf("Expected system message text to be 'You are a pirate!', got '%s'", systemMsg.Content[0].Text)
+	if strings.TrimSpace(systemMsg.Text()) != "You are a pirate!" {
+		t.Errorf("Expected system message text to be 'You are a pirate!', got '%s'", systemMsg.Text())
 	}
 
 	// Check second message (user role)
-	userMsg := actionOpts.Messages[1]
+	userMsg := result.Request.Messages[1]
 	if userMsg.Role != RoleUser {
 		t.Errorf("Expected second message role to be 'user', got '%s'", userMsg.Role)
 	}
-	if len(userMsg.Content) == 0 {
-		t.Fatal("Expected user message to have content")
-	}
-	if strings.TrimSpace(userMsg.Content[0].Text) != "Hello!" {
-		t.Errorf("Expected user message text to be 'Hello!', got '%s'", userMsg.Content[0].Text)
+	if strings.TrimSpace(userMsg.Text()) != "Hello!" {
+		t.Errorf("Expected user message text to be 'Hello!', got '%s'", userMsg.Text())
 	}
 }
 

--- a/go/samples/prompts/main.go
+++ b/go/samples/prompts/main.go
@@ -209,7 +209,10 @@ func PromptWithMultiMessage(ctx context.Context, g *genkit.Genkit) {
 	}
 	resp, err := prompt.Execute(ctx,
 		ai.WithModelName("googleai/gemini-2.5-pro"),
-		ai.WithInput(map[string]any{"videoUrl": "https://www.youtube.com/watch?v=K-hY0E6cGfo video/mp4"}),
+		ai.WithInput(map[string]any{
+			"videoUrl":    "https://www.youtube.com/watch?v=K-hY0E6cGfo",
+			"contentType": "video/mp4",
+		}),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/go/samples/prompts/prompts/multi-msg.prompt
+++ b/go/samples/prompts/prompts/multi-msg.prompt
@@ -3,6 +3,7 @@ model: googleai/gemini-2.5-flash
 input:
   schema:
     videoUrl: string
+    contentType: string
 output:
   summary: string
 ---
@@ -13,4 +14,4 @@ You are a great AI assistant that summarizes videos talking as a pirate
 {{ role "user" }}
 
 Give me a summary of this video
-{{media url=videoUrl}}
+{{media url=videoUrl contentType=contentType}}


### PR DESCRIPTION
This PR will properly handle rendering dotprompt(s) with multiple "messages" within, e.g. system prompts, message history, etc.

The primary fix is to move rendering from load time (incorrect) to execution time (correct).

However, I think there are some additional key changes (not implemented) that I believe we should make that I want opinions on, specifically with regards to bringing Go into parity with the TS implementation. I'll file an issue for these, as it will be a "breaking" change for sure.

In general, Go tries to merge all of the various options together. It tries to move system messages to the top, interleave history from various sources (Messages, PromptFn, etc), and then end with the User prompt.

In contrast, in Typescript, dotprompt has complete control over where messages (history) are rendered (via `{{history}}`) helper. And if you provide a `MessageFn`, again that also gets `messages` (history) as an argument and is responsible for injecting in the right place. I think without doing this, Go _can interleave things in unexpected ways._ Separately, any static list of messages (WithMessages), or a message function (WithMessageFn) _should not_ try to render as templates as they do today. You want to accept these "as is", because they represent history in the former, and in the latter the Fn should have the control.

### Background

Currently, there is a lot of confusion here, which has led to some PR and issue churn. See below.

**Issues:**
- https://github.com/firebase/genkit/issues/3710 - erroneously reports that examples should use "internal" markup instead of the `role` "helper (probably based on trying to investigate the following report, below)
- https://github.com/firebase/genkit/issues/3711 - reports that `role` is not respected in Go dotprompt (issue still persists)

**PRs:**
- #3780 
  - Incorrectly pre-renders system and history messages at prompt definition time, instead of waiting until `Execute` time.
- #3998 
  - Erroneously changes dotprompt example(s) to use "internal" markup instead of the `role` "helper"
  
**Checklist (if applicable):**
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)

**Dev UI (after changes):**
<img width="350" alt="image" src="https://github.com/user-attachments/assets/cbfef149-9b79-4bfa-bba5-4ac559eff7ad" /> <img width="350" alt="image" src="https://github.com/user-attachments/assets/1242b6a0-1a19-4116-83fa-a8fcc12c59b8" />


Fixes #3711
