### PR TITLE
fix(js/plugins/anthropic): remove duplicate test:live script

### DIFF
--- a/js/plugins/anthropic/package.json
+++ b/js/plugins/anthropic/package.json
@@ -64,7 +64,6 @@
     "build": "npm-run-all build:clean check compile",
     "build:watch": "tsup-node --watch",
     "test": "tsx --test tests/*_test.ts",
-    "test:live": "tsx --test tests/live_test.ts",
     "test:file": "tsx --test",
     "test:live": "tsx --test tests/live_test.ts",
     "test:coverage": "check-node-version --node '>=22' && tsx --test --experimental-test-coverage --test-coverage-include='src/**/*.ts' ./tests/**/*_test.ts"


### PR DESCRIPTION
Remove duplicate `test:live` npm script entry in `js/plugins/anthropic/package.json`.

The package.json file had two identical `test:live` entries on lines 67 and 69, which could cause confusion and potential issues with script execution.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)