### PR TITLE
docs(js/plugins/anthropic): fix CONTRIBUTING.md link path

### DIFF
--- a/js/plugins/anthropic/README.md
+++ b/js/plugins/anthropic/README.md
@@ -173,7 +173,7 @@ This plugin builds on the community work published as [`genkitx-anthropic`](http
 
 ## Contributing
 
-Want to contribute to the project? That's awesome! Head over to our [Contribution Guidelines](../../../CONTRIBUTING.md).
+Want to contribute to the project? That's awesome! Head over to our [Contribution Guidelines](/CONTRIBUTING.md).
 
 ## Need support?
 

--- a/js/plugins/anthropic/README.md
+++ b/js/plugins/anthropic/README.md
@@ -173,7 +173,7 @@ This plugin builds on the community work published as [`genkitx-anthropic`](http
 
 ## Contributing
 
-Want to contribute to the project? That's awesome! Head over to our [Contribution Guidelines](CONTRIBUTING.md).
+Want to contribute to the project? That's awesome! Head over to our [Contribution Guidelines](../../../CONTRIBUTING.md).
 
 ## Need support?
 


### PR DESCRIPTION
Update relative path to CONTRIBUTING.md from the plugin README to correctly point to the repository root (`../../../CONTRIBUTING.md`).

The previous link `CONTRIBUTING.md` was broken as there is no CONTRIBUTING.md file in the plugin directory.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)