### PR TITLE
fix(py/samples/model-garden): fix dependencies

### DIFF
--- a/py/plugins/vertex-ai/pyproject.toml
+++ b/py/plugins/vertex-ai/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "google-cloud-aiplatform>=1.77.0",
   "structlog>=25.2.0",
   "strenum>=0.4.15; python_version < '3.11'",
+  "genkit-plugin-compat-oai",
   "google-cloud-bigquery",
   "google-cloud-firestore",
 ]

--- a/py/samples/model-garden/pyproject.toml
+++ b/py/samples/model-garden/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["genkit", "pydantic>=2.10.5"]
+dependencies = ["genkit", "genkit-plugin-vertex-ai", "pydantic>=2.10.5"]
 description = "Model Garden sample"
 license = { text = "Apache-2.0" }
 name = "model-garden-example"

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1764,6 +1764,7 @@ version = "0.4.0"
 source = { editable = "plugins/vertex-ai" }
 dependencies = [
     { name = "genkit" },
+    { name = "genkit-plugin-compat-oai" },
     { name = "google-cloud-aiplatform" },
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-firestore" },
@@ -1775,6 +1776,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-plugin-compat-oai", editable = "plugins/compat-oai" },
     { name = "google-cloud-aiplatform", specifier = ">=1.77.0" },
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-firestore" },
@@ -3373,12 +3375,14 @@ version = "0.1.0"
 source = { virtual = "samples/model-garden" }
 dependencies = [
     { name = "genkit" },
+    { name = "genkit-plugin-vertex-ai" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]
 


### PR DESCRIPTION
```
zsh❯ py/bin/run_sample
Indexed 0 traces in 0ms in /Users/yesudeep/code/github.com/firebase/genkit/py/samples/model-garden/.genkit/traces_idx
Telemetry API running on http://localhost:4033
Project root: /Users/yesudeep/code/github.com/firebase/genkit/py/samples/model-garden
Genkit Developer UI: http://localhost:4000
Using CPython 3.12.8
Creating virtual environment at: /Users/yesudeep/code/github.com/firebase/genkit/py/.venv
Installed 38 packages in 50ms
2026-01-07 18:25:17 [debug    ] Creating a new global tracer provider for telemetry.
2026-01-07 18:25:17 [debug    ] local_telemetry_server exporter added succesfully.
Traceback (most recent call last):
  File "/Users/yesudeep/code/github.com/firebase/genkit/py/samples/model-garden/src/main.py", line 20, in <module>
    from genkit.plugins.vertex_ai.model_garden import VertexAIModelGarden, model_garden_name
ModuleNotFoundError: No module named 'genkit.plugins.vertex_ai'
/Users/yesudeep/.local/share/pnpm/global/5/.pnpm/@genkit-ai+tools-common@1.27.0_@types+node@22.13.5/node_modules/@genkit-ai/tools-common/lib/cjs/src/manager/process-manager.js:54
                    reject(new Error(`app process exited with code ${code}`));
                           ^

Error: app process exited with code 1
    at ChildProcess.<anonymous> (/Users/yesudeep/.local/share/pnpm/global/5/.pnpm/@genkit-ai+tools-common@1.27.0_@types+node@22.13.5/node_modules/@genkit-ai/tools-common/lib/cjs/src/manager/process-manager.js:54:28)
    at ChildProcess.emit (node:events:507:28)
    at ChildProcess._handle.onexit (node:internal/child_process:294:12)

Node.js v23.11.1
```