### PR TITLE
fix(py): fix duplicate keyword argument mime_type

### DIFF
--- a/py/samples/google-genai-image/src/main.py
+++ b/py/samples/google-genai-image/src/main.py
@@ -55,7 +55,10 @@ async def describe_image_with_gemini(data: str) -> str:
         The description of the image.
     """
     if not (data.startswith('data:') and ',' in data):
-        raise ValueError(f'Expected a data URI (e.g., "data:image/jpeg;base64,..."), but got: {data[:50]}...')
+        raise ValueError(
+            f'Expected a data URI (e.g., "data:image/jpeg;base64,..."), '
+            f'but got: {data[:50]}...'
+        )
 
     result = await ai.generate(
         messages=[


### PR DESCRIPTION
Fixed duplicate keyword argument "mime_type" in plugins/google-genai/src/genkit/plugins/google_genai/models/utils.py.
