### PR TITLE
feat(py/genkit): add define_partial for Handlebars partials

### DIFF
--- a/py/packages/genkit/src/genkit/ai/_registry.py
+++ b/py/packages/genkit/src/genkit/ai/_registry.py
@@ -57,6 +57,7 @@ from genkit.blocks.formats.types import FormatDef
 from genkit.blocks.model import ModelFn, ModelMiddleware
 from genkit.blocks.prompt import (
     define_helper,
+    define_partial,
     define_prompt,
     lookup_prompt,
 )
@@ -193,6 +194,18 @@ class GenkitRegistry:
             fn: The helper function to register.
         """
         define_helper(self.registry, name, fn)
+
+    def define_partial(self, name: str, source: str) -> None:
+        """Define a Handlebars partial template in the registry.
+
+        Partials are reusable template fragments that can be included
+        in other prompts using {{>partialName}} syntax.
+
+        Args:
+            name: The name of the partial.
+            source: The template source code for the partial.
+        """
+        define_partial(self.registry, name, source)
 
     def tool(self, name: str | None = None, description: str | None = None) -> Callable[[Callable], Callable]:
         """Decorator to register a function as a tool.

--- a/py/packages/genkit/tests/genkit/blocks/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/prompt_test.py
@@ -372,6 +372,25 @@ async def test_load_and_use_partial() -> None:
 
 
 @pytest.mark.asyncio
+async def test_define_partial_programmatically() -> None:
+    """Test defining partials programmatically using ai.define_partial()."""
+    ai, *_ = setup_test()
+
+    # Define a partial programmatically
+    ai.define_partial('myGreeting', 'Greetings, {{name}}!')
+
+    # Create a prompt that uses the partial
+    my_prompt = ai.define_prompt(
+        messages='{{>myGreeting}} Welcome to Genkit.',
+    )
+
+    response = await my_prompt(input={'name': 'Developer'})
+
+    # The partial should be included in the output
+    assert 'Greetings' in response.text and 'Developer' in response.text
+
+
+@pytest.mark.asyncio
 async def test_prompt_with_messages_list() -> None:
     """Test prompt with explicit messages list."""
     ai, *_ = setup_test()


### PR DESCRIPTION
Expose define_partial in GenkitRegistry class for parity with JS SDK.
Allows programmatic registration of reusable template fragments.
