### PR TITLE
fix(py): resolve pyproject.toml license deprecation warnings

### DIFF
--- a/py/packages/genkit/pyproject.toml
+++ b/py/packages/genkit/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -52,7 +51,7 @@ dependencies = [
   "anyio>=4.9.0",
 ]
 description = "Genkit AI Framework"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/anthropic/pyproject.toml
+++ b/py/plugins/anthropic/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
 ]
 dependencies = ["genkit", "anthropic>=0.40.0"]
 description = "Genkit Anthropic Plugin"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-anthropic"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/compat-oai/pyproject.toml
+++ b/py/plugins/compat-oai/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
 ]
 dependencies = ["genkit", "openai", "strenum>=0.4.15; python_version < '3.11'"]
 description = "Genkit OpenAI API Compatible"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-compat-oai"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/deepseek/pyproject.toml
+++ b/py/plugins/deepseek/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
 ]
 dependencies = ["genkit", "genkit-plugin-compat-oai", "openai>=1.0.0"]
 description = "Genkit DeepSeek Plugin"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-deepseek"
 requires-python = ">=3.10"
 version = "0.1.0"

--- a/py/plugins/dev-local-vectorstore/pyproject.toml
+++ b/py/plugins/dev-local-vectorstore/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -40,7 +39,7 @@ dependencies = [
   "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "Genkit Local Vector Store Plugin"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-dev-local-vectorstore"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/evaluators/pyproject.toml
+++ b/py/plugins/evaluators/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -38,7 +37,7 @@ dependencies = [
   "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "Genkit Evaluators Plugin for RAGAS"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-evaluators"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/firebase/pyproject.toml
+++ b/py/plugins/firebase/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -39,7 +38,7 @@ dependencies = [
   "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "Genkit Firebase Plugin"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-firebase"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/flask/pyproject.toml
+++ b/py/plugins/flask/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -41,7 +40,7 @@ dependencies = [
   "flask",
 ]
 description = "Genkit Firebase Plugin"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-flask"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/google-cloud/pyproject.toml
+++ b/py/plugins/google-cloud/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -40,7 +39,7 @@ dependencies = [
   "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "Genkit Google Cloud Plugin"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-google-cloud"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/google-genai/pyproject.toml
+++ b/py/plugins/google-genai/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -41,7 +40,7 @@ dependencies = [
   "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "Genkit Google GenAI Plugin"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-google-genai"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/mcp/pyproject.toml
+++ b/py/plugins/mcp/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
 ]
 dependencies = ["genkit", "mcp"]
 description = "Genkit MCP Plugin"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugins-mcp"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/ollama/pyproject.toml
+++ b/py/plugins/ollama/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
 ]
 dependencies = ["genkit", "ollama~=0.4", "structlog>=25.2.0"]
 description = "Genkit Ollama Plugin"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-ollama"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/vertex-ai/pyproject.toml
+++ b/py/plugins/vertex-ai/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -44,7 +43,7 @@ dependencies = [
   "google-cloud-firestore",
 ]
 description = "Genkit Google Cloud Vertex AI Plugin"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-vertex-ai"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/plugins/xai/pyproject.toml
+++ b/py/plugins/xai/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
 ]
 dependencies = ["genkit", "xai-sdk>=0.0.1"]
 description = "Genkit xAI Plugin"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-plugin-xai"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
+authors = [{ name = "Google" }]
 dependencies = [
   "dotpromptz==0.1.4",
   "genkit",
@@ -35,7 +36,7 @@ dependencies = [
   "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "Workspace for Genkit packages"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "genkit-workspace"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/anthropic-hello/pyproject.toml
+++ b/py/samples/anthropic-hello/pyproject.toml
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
+authors = [{ name = "Google" }]
 dependencies = [
   "genkit",
   "genkit-plugin-anthropic",

--- a/py/samples/compat-oai-hello/pyproject.toml
+++ b/py/samples/compat-oai-hello/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -41,7 +40,7 @@ dependencies = [
   "httpx>=0.28.1",
 ]
 description = "OpenAI sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "compat-oai-hello"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/deepseek-hello/pyproject.toml
+++ b/py/samples/deepseek-hello/pyproject.toml
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
+authors = [{ name = "Google" }]
 dependencies = [
   "genkit",
   "genkit-plugin-deepseek",

--- a/py/samples/dev-local-vectorstore-hello/pyproject.toml
+++ b/py/samples/dev-local-vectorstore-hello/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -41,7 +40,7 @@ dependencies = [
   "structlog>=25.2.0",
 ]
 description = "hello Genkit sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "dev-local-vectorstore-hello"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/evaluator-demo/pyproject.toml
+++ b/py/samples/evaluator-demo/pyproject.toml
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
+authors = [{ name = "Google" }]
 dependencies    = ["genkit", "pydantic>=2.0.0", "structlog>=24.0.0", "pypdf"]
 description     = "Genkit Python Evaluation Demo"
 name            = "eval-demo"

--- a/py/samples/firestore-retreiver/pyproject.toml
+++ b/py/samples/firestore-retreiver/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
 ]
 dependencies = ["genkit", "google-cloud-firestore"]
 description = "firestore-retreiver Genkit sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "firestore-retreiver"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/flask-hello/pyproject.toml
+++ b/py/samples/flask-hello/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -40,7 +39,7 @@ dependencies = [
   "flask",
 ]
 description = "hello Genkit sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "flask-hello"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/google-genai-code-execution/pyproject.toml
+++ b/py/samples/google-genai-code-execution/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -40,7 +39,7 @@ dependencies = [
   "structlog>=25.2.0",
 ]
 description = "Code execution sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "google-genai-code-execution"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/google-genai-context-caching/pyproject.toml
+++ b/py/samples/google-genai-context-caching/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -41,7 +40,7 @@ dependencies = [
   "structlog>=25.2.0",
 ]
 description = "context-caching Genkit sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "google-genai-context-caching"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/google-genai-hello/pyproject.toml
+++ b/py/samples/google-genai-hello/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -42,7 +41,7 @@ dependencies = [
   "structlog>=25.2.0",
 ]
 description = "Hello world sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "google-genai-hello"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/google-genai-image/pyproject.toml
+++ b/py/samples/google-genai-image/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -40,7 +39,7 @@ dependencies = [
   "pydantic>=2.10.5",
 ]
 description = "Vision API and Image Generation example"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "google-genai-image"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/google-genai-vertexai-hello/pyproject.toml
+++ b/py/samples/google-genai-vertexai-hello/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -40,7 +39,7 @@ dependencies = [
   "structlog>=25.2.0",
 ]
 description = "Hello world sample on VertexAI API on GenAI"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "google-genai-vertexai-hello"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/google-genai-vertexai-image/pyproject.toml
+++ b/py/samples/google-genai-vertexai-image/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -40,7 +39,7 @@ dependencies = [
   "pydantic>=2.10.5",
 ]
 description = "Image Generation on VertexAI with GenAI library example"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "google-genai-vertexai-image"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/menu/pyproject.toml
+++ b/py/samples/menu/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -44,7 +43,7 @@ dependencies = [
   "pydantic>=2.10.5",
 ]
 description = "menu Genkit sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "menu"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/model-garden/pyproject.toml
+++ b/py/samples/model-garden/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -33,7 +32,7 @@ classifiers = [
 ]
 dependencies = ["genkit", "genkit-plugin-vertex-ai", "pydantic>=2.10.5"]
 description = "Model Garden sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "model-garden-example"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/multi-server/pyproject.toml
+++ b/py/samples/multi-server/pyproject.toml
@@ -15,13 +15,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
+authors = [{ name = "Google" }]
+license = "Apache-2.0"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",

--- a/py/samples/ollama-hello/pyproject.toml
+++ b/py/samples/ollama-hello/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -40,7 +39,7 @@ dependencies = [
   "structlog>=25.2.0",
 ]
 description = "Ollama hello sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "ollama-hello"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/ollama-simple-embed/pyproject.toml
+++ b/py/samples/ollama-simple-embed/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -40,7 +39,7 @@ dependencies = [
   "structlog>=25.2.0",
 ]
 description = "Ollama Simple Embed"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "ollama_simple_embed"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/prompt_demo/pyproject.toml
+++ b/py/samples/prompt_demo/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
 ]
 dependencies = ["genkit", "structlog>=25.2.0", "genkit-plugin-google-genai"]
 description = "Genkit prompt demo"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "prompt-demo"
 requires-python = ">=3.10"
 version = "0.0.1"

--- a/py/samples/short-n-long/pyproject.toml
+++ b/py/samples/short-n-long/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -43,7 +42,7 @@ dependencies = [
   "uvloop>=0.21.0",
 ]
 description = "Short and long sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "short-n-long"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/tool-interrupts/pyproject.toml
+++ b/py/samples/tool-interrupts/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
 ]
 dependencies = ["genkit", "genkit-plugin-google-genai", "pydantic>=2.10.5"]
 description = "Tool interrupts sample"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "tool-interrupts"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/vertex-ai-vector-search-bigquery/pyproject.toml
+++ b/py/samples/vertex-ai-vector-search-bigquery/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -43,7 +42,7 @@ dependencies = [
   "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "An example demonstrating the use Vector Search API with BigQuery retriever for Vertex AI"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "vertex-ai-vector-search-bigquery"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/vertex-ai-vector-search-firestore/pyproject.toml
+++ b/py/samples/vertex-ai-vector-search-firestore/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -43,7 +42,7 @@ dependencies = [
   "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "An example demonstrating the use Vector Search API with Firestore retriever for Vertex AI"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "vertex-ai-vector-search-firestore"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/samples/xai-hello/pyproject.toml
+++ b/py/samples/xai-hello/pyproject.toml
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
+authors = [{ name = "Google" }]
 dependencies = [
   "genkit",
   "genkit-plugin-xai",

--- a/py/tests/smoke/pyproject.toml
+++ b/py/tests/smoke/pyproject.toml
@@ -15,13 +15,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
+authors = [{ name = "Google" }]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -42,7 +42,7 @@ dependencies = [
   "strenum>=0.4.15; python_version < '3.11'",
 ]
 description = "Packaging smoke test"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "smoke"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Updates `pyproject.toml` files across all python subprojects to address `SetuptoolsDeprecationWarning`.

CHANGELOG:
- Replaces the deprecated `license` table (e.g., `license = { text = "Apache-2.0" }`) with a simple SPDX expression string (`license = "Apache-2.0"`).
- Removes the deprecated `License :: OSI Approved :: Apache Software License` classifier, as the SPDX expression is now preferred.
