### PR TITLE
fix(py/genkit): resolve Pydantic serialization warnings in resources

### DIFF
--- a/py/packages/genkit/src/genkit/blocks/resource.py
+++ b/py/packages/genkit/src/genkit/blocks/resource.py
@@ -232,8 +232,8 @@ def dynamic_resource(opts: ResourceOptions, fn: ResourceFn) -> Action:
                     p = p.root
 
                 if hasattr(p, 'metadata'):
-                    if p.metadata is None:
-                        p.metadata = {}
+                    if p.metadata is None or isinstance(p.metadata, dict):
+                        p.metadata = Metadata(root=p.metadata or {})
 
                     if isinstance(p.metadata, Metadata):
                         p_metadata = p.metadata.root

--- a/py/packages/genkit/tests/genkit/veneer/resource_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/resource_test.py
@@ -33,7 +33,7 @@ async def test_define_resource_veneer():
     ai = Genkit(plugins=[])
 
     async def my_resource_fn(input, ctx):
-        return {'content': [Part(TextPart(text=f'Content for {input.uri}'))]}
+        return {'content': [Part(root=TextPart(text=f'Content for {input.uri}'))]}
 
     act = ai.define_resource({'uri': 'http://example.com/foo'}, my_resource_fn)
 


### PR DESCRIPTION
This change fixes PydanticSerializationUnexpectedValue warnings that occurred when defining resources.

In genkit/blocks/resource.py , explicitly wrap dictionary metadata in the
Metadata class before assignment. Pydantic V2 is strict about RootModel types
and does not always automatically cast dictionaries when assigning to fields typed as
Metadata (which is a RootModel[dict]).

In resource_test.py , update Part instantiation to use the explicit root argument,
avoiding implicit conversion warnings during test setup.

These changes ensure compatibility with strict Pydantic V2 serialization requirements.
