### PR TITLE
fix(go/plugins/googlecloud): use local trace export in dev mode

### DIFF
--- a/go/plugins/googlecloud/googlecloud.go
+++ b/go/plugins/googlecloud/googlecloud.go
@@ -126,7 +126,12 @@ func initializeTelemetry(opts *GoogleCloudTelemetryOptions) {
 	var spanProcessors []sdktrace.SpanProcessor
 
 	shouldExport := opts.ForceDevExport || os.Getenv("GENKIT_ENV") != "dev"
-	if shouldExport && !opts.DisableTraces {
+	if !shouldExport {
+		slog.Info("Google Cloud telemetry export disabled in dev environment", "project_id", projectID)
+		return
+	}
+
+	if !opts.DisableTraces {
 		var traceOpts []texporter.Option
 		traceOpts = append(traceOpts, texporter.WithProjectID(projectID))
 


### PR DESCRIPTION
Fixes an issue where even when ForceDevExport is false (the default) if Firebase/Cloud telemetry plugin(s) are loaded, no traces are sent in development environment.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)
