### PR TITLE
RFC: Reflection API V2 (WebSocket)

### DIFF
--- a/docs/rfc-reflection-api-v2.md
+++ b/docs/rfc-reflection-api-v2.md
@@ -58,7 +58,13 @@ sequenceDiagram
 
 **1. Connection & Discovery**
    - **Runtime** connects via WebSocket.
-   - **Runtime** sends `register`.
+   - **Runtime** sends `register` with:
+     - `id`: Unique runtime identifier (e.g., UUID).
+     - `pid`: Process ID.
+     - `name`: Application name.
+     - `genkitVersion`: SDK version.
+     - `labels`: array of labels, usually set by the CLI itself via an env var or other means.
+     - `reflectionApiSpecVersion`: Protocol version.
    - **Manager** sends `configure`.
    - **Manager** sends `listActions` to populate the UI.
 


### PR DESCRIPTION
Introduces a new Reflection API (V2) based on WebSockets and JSON-RPC 2.0. This architecture reverses the connection direction of V1: the Genkit CLI (Runtime Manager) acts as the WebSocket server, and Genkit Runtimes connect to it as clients.

Related RFCs:
 - https://github.com/firebase/genkit/pull/4210
