### PR TITLE
feat(py): add array, enum, and jsonl output formats for JS parity

### DIFF
--- a/py/packages/genkit/src/genkit/blocks/formats/__init__.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/__init__.py
@@ -15,9 +15,49 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-"""Genkit format package. Provides implementation for various formats like json, jsonl, etc."""
+"""Genkit format package. Provides implementation for various formats like json, jsonl, etc.
 
+Genkit includes built-in formats to handle common output patterns. These formats can be
+specified in `GenerateActionOptions` or `OutputConfig`.
+
+| Format | Description | Constraints |
+| :--- | :--- | :--- |
+| `json` | Parses output as a JSON object. This is the default format when a JSON schema is provided. | Enforced by `constrained: true` if supported by model. |
+| `text` | Returns the raw text output from the model. | No constraints. |
+| `array` | Parses output as a JSON array of items. Useful for generating lists of items. | Enforced by `constrained: true` if supported by model. |
+| `enum` | Parses output as a single enum value. | Enforced by `constrained: true` if supported by model. |
+| `jsonl` | Parses output as newline-delimited JSON objects. Useful for streaming lists of objects. | No constraints (streaming friendly). |
+
+Usage Example:
+
+    # JSON Format (default with schema)
+    ai.generate(
+        output=OutputConfig(
+            schema={'type': 'object', 'properties': {'foo': {'type': 'string'}}}
+        )
+    )
+
+    # Array Format
+    ai.generate(
+        output=OutputConfig(
+            format='array',
+            schema={'type': 'array', 'items': {'type': 'string'}}
+        )
+    )
+
+    # Enum Format
+    ai.generate(
+        output=OutputConfig(
+            format='enum',
+            schema={'type': 'string', 'enum': ['cat', 'dog']}
+        )
+    )
+"""
+
+from genkit.blocks.formats.array import ArrayFormat
+from genkit.blocks.formats.enum import EnumFormat
 from genkit.blocks.formats.json import JsonFormat
+from genkit.blocks.formats.jsonl import JsonlFormat
 from genkit.blocks.formats.text import TextFormat
 from genkit.blocks.formats.types import FormatDef, Formatter, FormatterConfig
 
@@ -27,14 +67,23 @@ def package_name() -> str:
     return 'genkit.blocks.formats'
 
 
-built_in_formats = [JsonFormat(), TextFormat()]
+built_in_formats = [
+    ArrayFormat(),
+    EnumFormat(),
+    JsonFormat(),
+    JsonlFormat(),
+    TextFormat(),
+]
 
 
 __all__ = [
+    ArrayFormat.__name__,
+    EnumFormat.__name__,
     FormatDef.__name__,
     Formatter.__name__,
     FormatterConfig.__name__,
     JsonFormat.__name__,
+    JsonlFormat.__name__,
     TextFormat.__name__,
     package_name.__name__,
 ]

--- a/py/packages/genkit/src/genkit/blocks/formats/array.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/array.py
@@ -1,0 +1,122 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Implementation of Array output format."""
+
+from typing import Any
+
+from genkit.blocks.formats.types import FormatDef, Formatter, FormatterConfig
+from genkit.blocks.model import (
+    GenerateResponseChunkWrapper,
+    MessageWrapper,
+)
+from genkit.codec import dump_json
+from genkit.core.error import GenkitError
+from genkit.core.extract import extract_items
+
+
+class ArrayFormat(FormatDef):
+    """Defines an Array format for use with AI models.
+
+    This format instructs the model to output a JSON array of items matching a specified schema.
+    It is useful for generating lists of structured objects.
+
+    The formatter automatically handles:
+    1.  Validating that the schema is of type `array`.
+    2.  Injecting instructions into the prompt to output a JSON array.
+    3.  Parsing the response (both full messages and streaming chunks) using `extract_items`
+        to recover valid JSON objects from potentially incomplete or noisy output.
+
+    Usage:
+        ai.generate(
+            output=OutputConfig(
+                format='array',
+                schema={
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'properties': {'name': {'type': 'string'}}
+                    }
+                }
+            )
+        )
+    """
+
+    def __init__(self):
+        """Initializes the ArrayFormat.
+
+        Configures the format with:
+        - name: 'array'
+        - content_type: 'application/json'
+        - constrained: True
+        """
+        super().__init__(
+            'array',
+            FormatterConfig(
+                content_type='application/json',
+                constrained=True,
+            ),
+        )
+
+    def handle(self, schema: dict[str, Any] | None) -> Formatter:
+        """Creates a Formatter for handling JSON array data.
+
+        Args:
+            schema: The JSON schema for the array. Must be of type 'array'.
+
+        Returns:
+            A Formatter configured to parse JSON arrays.
+
+        Raises:
+            GenkitError: If the schema is missing or not of type 'array'.
+        """
+        if schema and schema.get('type') != 'array':
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message="Must supply an 'array' schema type when using the 'items' parser format.",
+            )
+
+        def message_parser(msg: MessageWrapper):
+            """Parses a complete message into a list of items."""
+            result = extract_items(msg.text, 0)
+            return result.items
+
+        def chunk_parser(chunk: GenerateResponseChunkWrapper):
+            """Parses a streaming chunk into a list of items."""
+            # Calculate the length of text from previous chunks
+            previous_text_len = len(chunk.accumulated_text) - len(chunk.text)
+
+            # Find cursor position from previous text
+            cursor = 0
+            if previous_text_len > 0:
+                cursor = extract_items(chunk.accumulated_text[:previous_text_len]).cursor
+
+            result = extract_items(chunk.accumulated_text, cursor)
+            return result.items
+
+        instructions = None
+        if schema:
+            instructions = f"""Output should be a JSON array conforming to the following schema:
+
+```
+{dump_json(schema, indent=2)}
+```
+"""
+        return Formatter(
+            chunk_parser=chunk_parser,
+            message_parser=message_parser,
+            instructions=instructions,
+        )

--- a/py/packages/genkit/src/genkit/blocks/formats/enum.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/enum.py
@@ -1,0 +1,104 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Implementation of Enum output format."""
+
+import re
+from typing import Any
+
+from genkit.blocks.formats.types import FormatDef, Formatter, FormatterConfig
+from genkit.blocks.model import (
+    GenerateResponseChunkWrapper,
+    MessageWrapper,
+)
+from genkit.core.error import GenkitError
+
+
+class EnumFormat(FormatDef):
+    """Defines an Enum format for use with AI models.
+
+    This format instructs the model to output a single value from a specified list of enum options.
+    It is useful for classification tasks or choosing from a fixed set of actions.
+
+    The formatter handles:
+    1.  Validating that the schema contains an `enum` property.
+    2.  Injecting instructions to output ONLY one of the enum values.
+    3.  Cleaning the response (removing quotes) to return the raw enum string.
+
+    Usage:
+        ai.generate(
+            output=OutputConfig(
+                format='enum',
+                schema={
+                    'type': 'string',
+                    'enum': ['positive', 'negative', 'neutral']
+                }
+            )
+        )
+    """
+
+    def __init__(self):
+        """Initializes the EnumFormat.
+
+        Configures the format with:
+        - name: 'enum'
+        - content_type: 'text/enum'
+        - constrained: True
+        """
+        super().__init__(
+            'enum',
+            FormatterConfig(
+                content_type='text/enum',
+                constrained=True,
+            ),
+        )
+
+    def handle(self, schema: dict[str, Any] | None) -> Formatter:
+        """Creates a Formatter for handling Enum values.
+
+        Args:
+            schema: The JSON schema. Must be type 'string' with an 'enum' property listing allowed values.
+
+        Returns:
+            A Formatter configured to parse enum values.
+
+        Raises:
+            GenkitError: If the schema type is not 'string' or 'enum'.
+        """
+        if schema and schema.get('type') not in ('string', 'enum'):
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message="Must supply a schema of type 'string' with an 'enum' property when using the enum format.",
+            )
+
+        def message_parser(msg: MessageWrapper):
+            """Parses a complete message, removing quotes."""
+            return re.sub(r'[\'"]', '', msg.text).strip()
+
+        def chunk_parser(chunk: GenerateResponseChunkWrapper):
+            """Parses a chunk, removing quotes from accumulated text."""
+            return re.sub(r'[\'"]', '', chunk.accumulated_text).strip()
+
+        instructions = None
+        if schema and schema.get('enum'):
+            enum_values = '\n'.join([str(v) for v in schema['enum']])
+            instructions = f'Output should be ONLY one of the following enum values. Do not output any additional information or add quotes.\n\n{enum_values}'
+
+        return Formatter(
+            chunk_parser=chunk_parser,
+            message_parser=message_parser,
+            instructions=instructions,
+        )

--- a/py/packages/genkit/src/genkit/blocks/formats/jsonl.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/jsonl.py
@@ -1,0 +1,140 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Implementation of JSONL output format."""
+
+from typing import Any
+
+import json5
+
+from genkit.blocks.formats.types import FormatDef, Formatter, FormatterConfig
+from genkit.blocks.model import (
+    GenerateResponseChunkWrapper,
+    MessageWrapper,
+)
+from genkit.codec import dump_json
+from genkit.core.error import GenkitError
+from genkit.core.extract import extract_json
+
+
+class JsonlFormat(FormatDef):
+    """Defines a JSONL format for use with AI models.
+
+    This format instructs the model to output a sequence of JSON objects, one per line (JSONL).
+    It is particularly useful for streaming lists of objects, as each line can be parsed independently
+    as soon as it is generated, without waiting for the full array to close.
+
+    The formatter handles:
+    1.  Validating that the schema is an array of objects.
+    2.  Injecting instructions to output JSONL.
+    3.  Parsing the response line-by-line to recover objects.
+
+    Usage:
+        ai.generate(
+            output=OutputConfig(
+                format='jsonl',
+                schema={
+                    'type': 'array',
+                    'items': {'type': 'object', 'properties': ...}
+                }
+            )
+        )
+    """
+
+    def __init__(self):
+        """Initializes the JsonlFormat.
+
+        Configures the format with:
+        - name: 'jsonl'
+        - content_type: 'application/jsonl'
+        """
+        super().__init__(
+            'jsonl',
+            FormatterConfig(
+                content_type='application/jsonl',
+            ),
+        )
+
+    def handle(self, schema: dict[str, Any] | None) -> Formatter:
+        """Creates a Formatter for handling JSONL data.
+
+        Args:
+            schema: The JSON schema. Must be type 'array' containing 'object' items.
+
+        Returns:
+            A Formatter configured to parse JSONL.
+
+        Raises:
+            GenkitError: If the schema structure matches expectations for JSONL.
+        """
+        if schema and (schema.get('type') != 'array' or schema.get('items', {}).get('type') != 'object'):
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message="Must supply an 'array' schema type containing 'object' items when using the 'jsonl' parser format.",
+            )
+
+        def message_parser(msg: MessageWrapper):
+            """Parses a complete message into a list of objects."""
+            lines = [line.strip() for line in msg.text.split('\n') if line.strip().startswith('{')]
+            items = []
+            for line in lines:
+                extracted = extract_json(line, throw_on_bad_json=False)
+                if extracted:
+                    items.append(extracted)
+            return items
+
+        def chunk_parser(chunk: GenerateResponseChunkWrapper):
+            """Parses a streaming chunk into a list of objects found in that chunk."""
+            # Calculate the length of text from previous chunks
+            previous_text_len = len(chunk.accumulated_text) - len(chunk.text)
+
+            # Find start index: after the last newline in previous text
+            start_index = 0
+            if previous_text_len > 0:
+                last_newline = chunk.accumulated_text[:previous_text_len].rfind('\n')
+                if last_newline != -1:
+                    start_index = last_newline + 1
+
+            # Process text from the start index onwards
+            text_to_process = chunk.accumulated_text[start_index:]
+
+            results = []
+            lines = text_to_process.split('\n')
+            for line in lines:
+                trimmed = line.strip()
+                if trimmed.startswith('{'):
+                    try:
+                        result = json5.loads(trimmed)
+                        if result:
+                            results.append(result)
+                    except ValueError:
+                        # Incomplete or invalid JSON line, stop processing this chunk
+                        break
+            return results
+
+        instructions = None
+        if schema and schema.get('items'):
+            instructions = f"""Output should be JSONL format, a sequence of JSON objects (one per line) separated by a newline `\\n` character. Each line should be a JSON object conforming to the following schema:
+
+```
+{dump_json(schema['items'], indent=2)}
+```
+"""
+        return Formatter(
+            chunk_parser=chunk_parser,
+            message_parser=message_parser,
+            instructions=instructions,
+        )

--- a/py/packages/genkit/src/genkit/blocks/formats/text.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/text.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from genkit.blocks.formats.types import FormatDef, Formatter, FormatterConfig
 from genkit.blocks.model import (
-    GenerateResponseWrapper,
+    GenerateResponseChunkWrapper,
     MessageWrapper,
 )
 
@@ -28,19 +28,26 @@ from genkit.blocks.model import (
 class TextFormat(FormatDef):
     """Defines a text format for use with AI models.
 
-    This class provides functionality for parsing and formatting text data
-    to interact with AI models.
+    This is the simplest format, returning the raw text content from the model's response.
+    It does not enforce any schema or structural constraints.
+
+    Usage:
+        ai.generate(
+            output=OutputConfig(format='text')
+        )
     """
 
     def __init__(self):
-        """Initializes a TextFormat instance."""
+        """Initializes a TextFormat instance.
+
+        Configures the format with:
+        - name: 'text'
+        - content_type: 'text/plain'
+        """
         super().__init__(
             'text',
             FormatterConfig(
-                format='text',
                 content_type='text/plain',
-                constrained=None,
-                default_instructions=False,
             ),
         )
 
@@ -55,12 +62,26 @@ class TextFormat(FormatDef):
         """
 
         def message_parser(msg: MessageWrapper):
-            """Extracts text from a Message object."""
+            """Extracts text from a Message object.
+
+            Args:
+                msg: The Message object.
+
+            Returns:
+                The raw text content of the message.
+            """
             return msg.text
 
-        def chunk_parser(chunk: GenerateResponseWrapper):
-            """Extracts text from a GenerateResponseWrapper object."""
-            return chunk.accumulated_text
+        def chunk_parser(chunk: GenerateResponseChunkWrapper):
+            """Extracts text from a GenerateResponseChunkWrapper object.
+
+            Args:
+                chunk: The GenerateResponseChunkWrapper object.
+
+            Returns:
+                The text content from the current chunk only.
+            """
+            return chunk.text
 
         return Formatter(
             chunk_parser=chunk_parser,

--- a/py/packages/genkit/src/genkit/blocks/model.py
+++ b/py/packages/genkit/src/genkit/blocks/model.py
@@ -300,13 +300,12 @@ class GenerateResponseChunkWrapper(GenerateResponseChunk):
         Returns:
             str: The combined text content from all chunks seen so far.
         """
-        if not self.previous_chunks:
-            return ''
         atext = ''
-        for chunk in self.previous_chunks:
-            for p in chunk.content:
-                if p.root.text:
-                    atext += p.root.text
+        if self.previous_chunks:
+            for chunk in self.previous_chunks:
+                for p in chunk.content:
+                    if p.root.text:
+                        atext += p.root.text
         return atext + self.text
 
     @cached_property

--- a/py/packages/genkit/tests/genkit/blocks/formats/array_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/formats/array_test.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Array format."""
+
+import pytest
+
+from genkit.blocks.formats.array import ArrayFormat
+from genkit.blocks.model import GenerateResponseChunkWrapper, MessageWrapper
+from genkit.core.error import GenkitError
+from genkit.core.typing import GenerateResponseChunk, Message, TextPart
+
+
+class TestArrayFormatStreaming:
+    """Test streaming chunk parsing."""
+
+    def test_emits_complete_array_items_as_they_arrive(self) -> None:
+        """Test that complete objects are emitted as they arrive in chunks."""
+        array_fmt = ArrayFormat()
+        fmt = array_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        # Chunk 1: [{"id": 1,
+        chunk1 = GenerateResponseChunk(content=[TextPart(text='[{"id": 1,')])
+        result1 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk1, index=0, previous_chunks=[]))
+        assert result1 == []
+
+        # Chunk 2: "name": "first"}
+        chunk2 = GenerateResponseChunk(content=[TextPart(text='"name": "first"}')])
+        result2 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk2, index=0, previous_chunks=[chunk1]))
+        assert result2 == [{'id': 1, 'name': 'first'}]
+
+        # Chunk 3: , {"id": 2, "name": "second"}]
+        chunk3 = GenerateResponseChunk(content=[TextPart(text=', {"id": 2, "name": "second"}]')])
+        result3 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk3, index=0, previous_chunks=[chunk1, chunk2]))
+        assert result3 == [{'id': 2, 'name': 'second'}]
+
+    def test_handles_single_item_arrays(self) -> None:
+        """Test parsing a single item array in one chunk."""
+        array_fmt = ArrayFormat()
+        fmt = array_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        chunk = GenerateResponseChunk(content=[TextPart(text='[{"id": 1, "name": "single"}]')])
+        result = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk, index=0, previous_chunks=[]))
+        assert result == [{'id': 1, 'name': 'single'}]
+
+    def test_handles_preamble_with_code_fence(self) -> None:
+        """Test parsing array with preamble text and code fence."""
+        array_fmt = ArrayFormat()
+        fmt = array_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        # Chunk 1: preamble with code fence start
+        chunk1 = GenerateResponseChunk(content=[TextPart(text='Here is the array you requested:\n\n```json\n[')])
+        result1 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk1, index=0, previous_chunks=[]))
+        assert result1 == []
+
+        # Chunk 2: the actual data
+        chunk2 = GenerateResponseChunk(content=[TextPart(text='{"id": 1, "name": "item"}]\n```')])
+        result2 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk2, index=0, previous_chunks=[chunk1]))
+        assert result2 == [{'id': 1, 'name': 'item'}]
+
+
+class TestArrayFormatMessage:
+    """Test complete message parsing."""
+
+    def test_parses_complete_array_response(self) -> None:
+        """Test parsing a complete array response."""
+        array_fmt = ArrayFormat()
+        fmt = array_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        result = fmt.parse_message(
+            MessageWrapper(Message(role='model', content=[TextPart(text='[{"id": 1, "name": "test"}]')]))
+        )
+        assert result == [{'id': 1, 'name': 'test'}]
+
+    def test_parses_empty_array(self) -> None:
+        """Test parsing an empty array."""
+        array_fmt = ArrayFormat()
+        fmt = array_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        result = fmt.parse_message(MessageWrapper(Message(role='model', content=[TextPart(text='[]')])))
+        assert result == []
+
+    def test_parses_array_with_preamble_and_code_fence(self) -> None:
+        """Test parsing array with preamble and code fence."""
+        array_fmt = ArrayFormat()
+        fmt = array_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        result = fmt.parse_message(
+            MessageWrapper(
+                Message(role='model', content=[TextPart(text='Here is the array:\n\n```json\n[{"id": 1}]\n```')])
+            )
+        )
+        assert result == [{'id': 1}]
+
+
+class TestArrayFormatErrors:
+    """Test error handling."""
+
+    def test_throws_error_for_non_array_schema_type(self) -> None:
+        """Test that non-array schema type raises error."""
+        array_fmt = ArrayFormat()
+
+        with pytest.raises(GenkitError) as exc_info:
+            array_fmt.handle({'type': 'string'})
+        assert "Must supply an 'array' schema type" in str(exc_info.value)
+
+    def test_throws_error_for_object_schema_type(self) -> None:
+        """Test that object schema type raises error."""
+        array_fmt = ArrayFormat()
+
+        with pytest.raises(GenkitError) as exc_info:
+            array_fmt.handle({'type': 'object'})
+        assert "Must supply an 'array' schema type" in str(exc_info.value)
+
+
+class TestArrayFormatInstructions:
+    """Test instruction generation."""
+
+    def test_generates_instructions_with_schema(self) -> None:
+        """Test that instructions are generated when schema is provided."""
+        array_fmt = ArrayFormat()
+        fmt = array_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        assert fmt.instructions is not None
+        assert 'Output should be a JSON array' in fmt.instructions
+
+    def test_no_instructions_without_schema(self) -> None:
+        """Test that no instructions are generated without schema."""
+        array_fmt = ArrayFormat()
+        fmt = array_fmt.handle(None)
+
+        assert fmt.instructions is None

--- a/py/packages/genkit/tests/genkit/blocks/formats/enum_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/formats/enum_test.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Enum format."""
+
+import pytest
+
+from genkit.blocks.formats.enum import EnumFormat
+from genkit.blocks.model import GenerateResponseChunkWrapper, MessageWrapper
+from genkit.core.error import GenkitError
+from genkit.core.typing import GenerateResponseChunk, Message, TextPart
+
+
+class TestEnumFormatMessage:
+    """Test complete message parsing."""
+
+    def test_parses_simple_enum_value(self) -> None:
+        """Test parsing a simple enum value."""
+        enum_fmt = EnumFormat()
+        fmt = enum_fmt.handle({'type': 'string', 'enum': ['VALUE1', 'VALUE2']})
+
+        result = fmt.parse_message(MessageWrapper(Message(role='model', content=[TextPart(text='VALUE1')])))
+        assert result == 'VALUE1'
+
+    def test_trims_whitespace(self) -> None:
+        """Test that whitespace is trimmed from the result."""
+        enum_fmt = EnumFormat()
+        fmt = enum_fmt.handle({'type': 'string', 'enum': ['VALUE1', 'VALUE2']})
+
+        result = fmt.parse_message(MessageWrapper(Message(role='model', content=[TextPart(text='  VALUE2\n')])))
+        assert result == 'VALUE2'
+
+    def test_removes_double_quotes(self) -> None:
+        """Test that double quotes are removed."""
+        enum_fmt = EnumFormat()
+        fmt = enum_fmt.handle({'type': 'string', 'enum': ['foo', 'bar']})
+
+        result = fmt.parse_message(MessageWrapper(Message(role='model', content=[TextPart(text='"foo"')])))
+        assert result == 'foo'
+
+    def test_removes_single_quotes(self) -> None:
+        """Test that single quotes are removed."""
+        enum_fmt = EnumFormat()
+        fmt = enum_fmt.handle({'type': 'string', 'enum': ['foo', 'bar']})
+
+        result = fmt.parse_message(MessageWrapper(Message(role='model', content=[TextPart(text="'bar'")])))
+        assert result == 'bar'
+
+    def test_handles_unquoted_value(self) -> None:
+        """Test that unquoted values are returned as-is."""
+        enum_fmt = EnumFormat()
+        fmt = enum_fmt.handle({'type': 'string', 'enum': ['foo', 'bar']})
+
+        result = fmt.parse_message(MessageWrapper(Message(role='model', content=[TextPart(text='bar')])))
+        assert result == 'bar'
+
+
+class TestEnumFormatStreaming:
+    """Test streaming chunk parsing."""
+
+    def test_parses_accumulated_text_from_chunks(self) -> None:
+        """Test that accumulated text is parsed correctly from chunks."""
+        enum_fmt = EnumFormat()
+        fmt = enum_fmt.handle({'type': 'string', 'enum': ['foo', 'bar']})
+
+        chunk1 = GenerateResponseChunk(content=[TextPart(text='"f')])
+        chunk2 = GenerateResponseChunk(content=[TextPart(text='oo"')])
+
+        result = fmt.parse_chunk(
+            GenerateResponseChunkWrapper(
+                chunk2,
+                index=0,
+                previous_chunks=[chunk1],
+            )
+        )
+        assert result == 'foo'
+
+
+class TestEnumFormatErrors:
+    """Test error handling."""
+
+    def test_throws_error_for_number_schema_type(self) -> None:
+        """Test that number schema type raises error."""
+        enum_fmt = EnumFormat()
+
+        with pytest.raises(GenkitError) as exc_info:
+            enum_fmt.handle({'type': 'number'})
+        assert "Must supply a schema of type 'string' with an 'enum' property" in str(exc_info.value)
+
+    def test_throws_error_for_array_schema_type(self) -> None:
+        """Test that array schema type raises error."""
+        enum_fmt = EnumFormat()
+
+        with pytest.raises(GenkitError) as exc_info:
+            enum_fmt.handle({'type': 'array'})
+        assert "Must supply a schema of type 'string' with an 'enum' property" in str(exc_info.value)
+
+    def test_accepts_enum_schema_type(self) -> None:
+        """Test that 'enum' schema type is accepted."""
+        enum_fmt = EnumFormat()
+        # Should not raise
+        fmt = enum_fmt.handle({'type': 'enum', 'enum': ['a', 'b']})
+        assert fmt is not None
+
+
+class TestEnumFormatInstructions:
+    """Test instruction generation."""
+
+    def test_generates_instructions_with_enum_values(self) -> None:
+        """Test that instructions list enum values."""
+        enum_fmt = EnumFormat()
+        fmt = enum_fmt.handle({'type': 'string', 'enum': ['foo', 'bar']})
+
+        assert fmt.instructions is not None
+        assert 'Output should be ONLY one of the following enum values' in fmt.instructions
+        assert 'foo' in fmt.instructions
+        assert 'bar' in fmt.instructions
+
+    def test_no_instructions_without_enum(self) -> None:
+        """Test that no instructions are generated without enum values."""
+        enum_fmt = EnumFormat()
+        fmt = enum_fmt.handle({'type': 'string'})
+
+        assert fmt.instructions is None
+
+    def test_no_instructions_without_schema(self) -> None:
+        """Test that no instructions are generated without schema."""
+        enum_fmt = EnumFormat()
+        fmt = enum_fmt.handle(None)
+
+        assert fmt.instructions is None

--- a/py/packages/genkit/tests/genkit/blocks/formats/formats_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/formats/formats_test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the formats module initialization and built-in formats."""
+
+from genkit.blocks.formats import (
+    ArrayFormat,
+    EnumFormat,
+    FormatDef,
+    Formatter,
+    FormatterConfig,
+    JsonFormat,
+    JsonlFormat,
+    TextFormat,
+    built_in_formats,
+)
+
+
+class TestBuiltInFormats:
+    """Test built-in format registration."""
+
+    def test_built_in_formats_contains_all_expected_formats(self) -> None:
+        """Test that built_in_formats list contains all expected formats."""
+        format_names = [f.name for f in built_in_formats]
+
+        assert 'array' in format_names
+        assert 'enum' in format_names
+        assert 'json' in format_names
+        assert 'jsonl' in format_names
+        assert 'text' in format_names
+
+    def test_built_in_formats_count(self) -> None:
+        """Test that there are exactly 5 built-in formats."""
+        assert len(built_in_formats) == 5
+
+    def test_built_in_formats_are_format_def_instances(self) -> None:
+        """Test that all built-in formats are FormatDef instances."""
+        for format_def in built_in_formats:
+            assert isinstance(format_def, FormatDef)
+
+
+class TestJsonFormatConfig:
+    """Test JSON format default configuration."""
+
+    def test_json_format_config(self) -> None:
+        """Test that JSON format has correct default config."""
+        json_format = JsonFormat()
+
+        assert json_format.name == 'json'
+        assert json_format.config.content_type == 'application/json'
+        assert json_format.config.constrained is True
+        assert json_format.config.format == 'json'
+        assert json_format.config.default_instructions is False
+
+
+class TestArrayFormatConfig:
+    """Test Array format default configuration."""
+
+    def test_array_format_config(self) -> None:
+        """Test that Array format has correct default config."""
+        array_format = ArrayFormat()
+
+        assert array_format.name == 'array'
+        assert array_format.config.content_type == 'application/json'
+        assert array_format.config.constrained is True
+
+
+class TestEnumFormatConfig:
+    """Test Enum format default configuration."""
+
+    def test_enum_format_config(self) -> None:
+        """Test that Enum format has correct default config."""
+        enum_format = EnumFormat()
+
+        assert enum_format.name == 'enum'
+        assert enum_format.config.content_type == 'text/enum'
+        assert enum_format.config.constrained is True
+
+
+class TestJsonlFormatConfig:
+    """Test JSONL format default configuration."""
+
+    def test_jsonl_format_config(self) -> None:
+        """Test that JSONL format has correct default config."""
+        jsonl_format = JsonlFormat()
+
+        assert jsonl_format.name == 'jsonl'
+        assert jsonl_format.config.content_type == 'application/jsonl'
+
+
+class TestTextFormatConfig:
+    """Test Text format default configuration."""
+
+    def test_text_format_config(self) -> None:
+        """Test that Text format has correct default config."""
+        text_format = TextFormat()
+
+        assert text_format.name == 'text'
+        assert text_format.config.content_type == 'text/plain'
+        assert text_format.config.constrained is None
+
+
+class TestModuleExports:
+    """Test that all required types are exported from the module."""
+
+    def test_format_def_exported(self) -> None:
+        """Test that FormatDef class is exported."""
+        assert FormatDef is not None
+
+    def test_formatter_exported(self) -> None:
+        """Test that Formatter class is exported."""
+        assert Formatter is not None
+
+    def test_formatter_config_exported(self) -> None:
+        """Test that FormatterConfig class is exported."""
+        assert FormatterConfig is not None
+
+    def test_all_format_classes_exported(self) -> None:
+        """Test that all format classes are exported."""
+        assert ArrayFormat is not None
+        assert EnumFormat is not None
+        assert JsonFormat is not None
+        assert JsonlFormat is not None
+        assert TextFormat is not None

--- a/py/packages/genkit/tests/genkit/blocks/formats/json_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/formats/json_test.py
@@ -10,22 +10,149 @@ from genkit.blocks.model import GenerateResponseChunkWrapper, MessageWrapper
 from genkit.core.typing import GenerateResponseChunk, Message, TextPart
 
 
-def test_json_format() -> None:
-    json = JsonFormat()
+class TestJsonFormatStreaming:
+    """Test streaming chunk parsing."""
 
-    json_format = json.handle({
-        'properties': {
-            'value': {
-                'description': 'value field',
-                'type': 'string',
-            }
-        },
-        'type': 'object',
-    })
+    def test_parses_complete_json_object(self) -> None:
+        """Test parsing a complete JSON object in one chunk."""
+        json_fmt = JsonFormat()
+        fmt = json_fmt.handle({'type': 'object'})
 
-    assert (
-        json_format.instructions
-        == """Output should be in JSON format and conform to the following schema:
+        chunk = GenerateResponseChunk(content=[TextPart(text='{"id": 1, "name": "test"}')])
+        result = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk, index=0, previous_chunks=[]))
+        assert result == {'id': 1, 'name': 'test'}
+
+    def test_handles_partial_json(self) -> None:
+        """Test parsing partial JSON across multiple chunks."""
+        json_fmt = JsonFormat()
+        fmt = json_fmt.handle({'type': 'object'})
+
+        # Chunk 1: partial object
+        chunk1 = GenerateResponseChunk(content=[TextPart(text='{"id": 1')])
+        result1 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk1, index=0, previous_chunks=[]))
+        assert result1 == {'id': 1}
+
+        # Chunk 2: complete object
+        chunk2 = GenerateResponseChunk(content=[TextPart(text=', "name": "test"}')])
+        result2 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk2, index=0, previous_chunks=[chunk1]))
+        assert result2 == {'id': 1, 'name': 'test'}
+
+    def test_handles_preamble_with_code_fence(self) -> None:
+        """Test parsing JSON with preamble text and code fence."""
+        json_fmt = JsonFormat()
+        fmt = json_fmt.handle({'type': 'object'})
+
+        # Chunk 1: preamble
+        chunk1 = GenerateResponseChunk(content=[TextPart(text='Here is the JSON:\n\n```json\n')])
+        result1 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk1, index=0, previous_chunks=[]))
+        assert result1 is None
+
+        # Chunk 2: actual data
+        chunk2 = GenerateResponseChunk(content=[TextPart(text='{"id": 1}\n```')])
+        result2 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk2, index=0, previous_chunks=[chunk1]))
+        assert result2 == {'id': 1}
+
+
+class TestJsonFormatMessage:
+    """Test complete message parsing."""
+
+    def test_parses_complete_json_response(self) -> None:
+        """Test parsing a complete JSON response."""
+        json_fmt = JsonFormat()
+        fmt = json_fmt.handle({'type': 'object'})
+
+        result = fmt.parse_message(
+            MessageWrapper(Message(role='model', content=[TextPart(text='{"id": 1, "name": "test"}')]))
+        )
+        assert result == {'id': 1, 'name': 'test'}
+
+    def test_handles_empty_response(self) -> None:
+        """Test parsing an empty response."""
+        json_fmt = JsonFormat()
+        fmt = json_fmt.handle({'type': 'object'})
+
+        result = fmt.parse_message(MessageWrapper(Message(role='model', content=[TextPart(text='')])))
+        assert result is None
+
+    def test_parses_json_with_preamble_and_code_fence(self) -> None:
+        """Test parsing JSON with preamble and code fence."""
+        json_fmt = JsonFormat()
+        fmt = json_fmt.handle({'type': 'object'})
+
+        result = fmt.parse_message(
+            MessageWrapper(
+                Message(role='model', content=[TextPart(text='Here is the JSON:\n\n```json\n{"id": 1}\n```')])
+            )
+        )
+        assert result == {'id': 1}
+
+    def test_parses_partial_json_message(self) -> None:
+        """Test parsing a message with partial/incomplete JSON."""
+        json_fmt = JsonFormat()
+        fmt = json_fmt.handle({'type': 'object'})
+
+        result = fmt.parse_message(MessageWrapper(Message(role='user', content=[TextPart(text='{"foo": "bar"')])))
+        assert result == {'foo': 'bar'}
+
+    def test_parses_complex_nested_json(self) -> None:
+        """Test parsing complex nested JSON across multiple parts."""
+        json_fmt = JsonFormat()
+        fmt = json_fmt.handle({'type': 'object'})
+
+        result = fmt.parse_chunk(
+            GenerateResponseChunkWrapper(
+                GenerateResponseChunk(content=[TextPart(text='", "baz": [1,2')]),
+                index=0,
+                previous_chunks=[
+                    GenerateResponseChunk(content=[TextPart(text='{"bar":'), TextPart(text='"ba')]),
+                    GenerateResponseChunk(content=[TextPart(text='z')]),
+                ],
+            )
+        )
+        assert result == {'bar': 'baz', 'baz': [1, 2]}
+
+
+class TestJsonFormatInstructions:
+    """Test instruction generation."""
+
+    def test_generates_instructions_with_schema(self) -> None:
+        """Test that instructions include the schema."""
+        json_fmt = JsonFormat()
+        fmt = json_fmt.handle({
+            'type': 'object',
+            'properties': {
+                'value': {
+                    'description': 'value field',
+                    'type': 'string',
+                }
+            },
+        })
+
+        assert fmt.instructions is not None
+        assert 'Output should be in JSON format' in fmt.instructions
+        assert 'value' in fmt.instructions
+
+    def test_no_instructions_without_schema(self) -> None:
+        """Test that no instructions are generated without schema."""
+        json_fmt = JsonFormat()
+        fmt = json_fmt.handle(None)
+
+        assert fmt.instructions is None
+
+    def test_instructions_format_matches_expected(self) -> None:
+        """Test that instructions format matches expected structure."""
+        json_fmt = JsonFormat()
+        fmt = json_fmt.handle({
+            'properties': {
+                'value': {
+                    'description': 'value field',
+                    'type': 'string',
+                }
+            },
+            'type': 'object',
+        })
+
+        expected = """Output should be in JSON format and conform to the following schema:
 
 ```
 {
@@ -39,19 +166,4 @@ def test_json_format() -> None:
 }
 ```
 """
-    )
-
-    assert json_format.parse_message(MessageWrapper(Message(role='user', content=[TextPart(text='{"foo": "bar')]))) == {
-        'foo': 'bar'
-    }
-
-    assert json_format.parse_chunk(
-        GenerateResponseChunkWrapper(
-            GenerateResponseChunk(content=[TextPart(text='", "baz": [1,2')]),
-            index=0,
-            previous_chunks=[
-                GenerateResponseChunk(content=[TextPart(text='{"bar":'), TextPart(text='"ba')]),
-                GenerateResponseChunk(content=[TextPart(text='z')]),
-            ],
-        )
-    ) == {'bar': 'baz', 'baz': [1, 2]}
+        assert fmt.instructions == expected

--- a/py/packages/genkit/tests/genkit/blocks/formats/jsonl_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/formats/jsonl_test.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the JSONL format."""
+
+import pytest
+
+from genkit.blocks.formats.jsonl import JsonlFormat
+from genkit.blocks.model import GenerateResponseChunkWrapper, MessageWrapper
+from genkit.core.error import GenkitError
+from genkit.core.typing import GenerateResponseChunk, Message, TextPart
+
+
+class TestJsonlFormatStreaming:
+    """Test streaming chunk parsing."""
+
+    def test_emits_complete_json_objects_as_they_arrive(self) -> None:
+        """Test that complete objects are emitted as they arrive in chunks."""
+        jsonl_fmt = JsonlFormat()
+        fmt = jsonl_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        # Chunk 1: first complete object
+        chunk1 = GenerateResponseChunk(content=[TextPart(text='{"id": 1, "name": "first"}\n')])
+        result1 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk1, index=0, previous_chunks=[]))
+        assert result1 == [{'id': 1, 'name': 'first'}]
+
+        # Chunk 2: second object complete, third starts
+        chunk2 = GenerateResponseChunk(content=[TextPart(text='{"id": 2, "name": "second"}\n{"id": 3')])
+        result2 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk2, index=0, previous_chunks=[chunk1]))
+        assert result2 == [{'id': 2, 'name': 'second'}]
+
+        # Chunk 3: third object completes
+        chunk3 = GenerateResponseChunk(content=[TextPart(text=', "name": "third"}\n')])
+        result3 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk3, index=0, previous_chunks=[chunk1, chunk2]))
+        assert result3 == [{'id': 3, 'name': 'third'}]
+
+    def test_handles_single_object(self) -> None:
+        """Test parsing a single object in one chunk."""
+        jsonl_fmt = JsonlFormat()
+        fmt = jsonl_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        chunk = GenerateResponseChunk(content=[TextPart(text='{"id": 1, "name": "single"}\n')])
+        result = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk, index=0, previous_chunks=[]))
+        assert result == [{'id': 1, 'name': 'single'}]
+
+    def test_handles_preamble_with_code_fence(self) -> None:
+        """Test parsing JSONL with preamble text and code fence."""
+        jsonl_fmt = JsonlFormat()
+        fmt = jsonl_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        # Chunk 1: preamble
+        chunk1 = GenerateResponseChunk(content=[TextPart(text='Here are the objects:\n\n```\n')])
+        result1 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk1, index=0, previous_chunks=[]))
+        assert result1 == []
+
+        # Chunk 2: actual data
+        chunk2 = GenerateResponseChunk(content=[TextPart(text='{"id": 1, "name": "item"}\n```')])
+        result2 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk2, index=0, previous_chunks=[chunk1]))
+        assert result2 == [{'id': 1, 'name': 'item'}]
+
+    def test_ignores_non_object_lines(self) -> None:
+        """Test that non-object lines are ignored."""
+        jsonl_fmt = JsonlFormat()
+        fmt = jsonl_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        chunk = GenerateResponseChunk(content=[TextPart(text='First object:\n{"id": 1}\nSecond object:\n{"id": 2}\n')])
+        result = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk, index=0, previous_chunks=[]))
+        assert result == [{'id': 1}, {'id': 2}]
+
+
+class TestJsonlFormatMessage:
+    """Test complete message parsing."""
+
+    def test_parses_complete_jsonl_response(self) -> None:
+        """Test parsing a complete JSONL response."""
+        jsonl_fmt = JsonlFormat()
+        fmt = jsonl_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        result = fmt.parse_message(
+            MessageWrapper(Message(role='model', content=[TextPart(text='{"id": 1, "name": "test"}\n{"id": 2}\n')]))
+        )
+        assert result == [{'id': 1, 'name': 'test'}, {'id': 2}]
+
+    def test_handles_empty_response(self) -> None:
+        """Test parsing an empty response."""
+        jsonl_fmt = JsonlFormat()
+        fmt = jsonl_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        result = fmt.parse_message(MessageWrapper(Message(role='model', content=[TextPart(text='')])))
+        assert result == []
+
+    def test_parses_jsonl_with_preamble_and_code_fence(self) -> None:
+        """Test parsing JSONL with preamble and code fence."""
+        jsonl_fmt = JsonlFormat()
+        fmt = jsonl_fmt.handle({'type': 'array', 'items': {'type': 'object'}})
+
+        result = fmt.parse_message(
+            MessageWrapper(
+                Message(
+                    role='model', content=[TextPart(text='Here are the objects:\n\n```\n{"id": 1}\n{"id": 2}\n```')]
+                )
+            )
+        )
+        assert result == [{'id': 1}, {'id': 2}]
+
+
+class TestJsonlFormatErrors:
+    """Test error handling."""
+
+    def test_throws_error_for_non_array_schema_type(self) -> None:
+        """Test that non-array schema type raises error."""
+        jsonl_fmt = JsonlFormat()
+
+        with pytest.raises(GenkitError) as exc_info:
+            jsonl_fmt.handle({'type': 'string'})
+        assert "Must supply an 'array' schema type" in str(exc_info.value)
+
+    def test_throws_error_for_array_with_non_object_items(self) -> None:
+        """Test that array with non-object items raises error."""
+        jsonl_fmt = JsonlFormat()
+
+        with pytest.raises(GenkitError) as exc_info:
+            jsonl_fmt.handle({'type': 'array', 'items': {'type': 'string'}})
+        assert "containing 'object' items" in str(exc_info.value)
+
+
+class TestJsonlFormatInstructions:
+    """Test instruction generation."""
+
+    def test_generates_instructions_with_items_schema(self) -> None:
+        """Test that instructions include items schema."""
+        jsonl_fmt = JsonlFormat()
+        fmt = jsonl_fmt.handle({'type': 'array', 'items': {'type': 'object', 'properties': {'id': {'type': 'number'}}}})
+
+        assert fmt.instructions is not None
+        assert 'Output should be JSONL format' in fmt.instructions
+        assert 'newline' in fmt.instructions
+
+    def test_no_instructions_without_items(self) -> None:
+        """Test that no instructions are generated without items schema."""
+        jsonl_fmt = JsonlFormat()
+        fmt = jsonl_fmt.handle(None)
+
+        assert fmt.instructions is None

--- a/py/packages/genkit/tests/genkit/blocks/formats/text_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/formats/text_test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Text format."""
+
+from genkit.blocks.formats.text import TextFormat
+from genkit.blocks.model import GenerateResponseChunkWrapper, MessageWrapper
+from genkit.core.typing import GenerateResponseChunk, Message, TextPart
+
+
+class TestTextFormatStreaming:
+    """Test streaming chunk parsing."""
+
+    def test_emits_text_chunks_as_they_arrive(self) -> None:
+        """Test that text chunks return only the current chunk's text."""
+        text_fmt = TextFormat()
+        fmt = text_fmt.handle(None)
+
+        # Chunk 1: "Hello"
+        chunk1 = GenerateResponseChunk(content=[TextPart(text='Hello')])
+        result1 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk1, index=0, previous_chunks=[]))
+        assert result1 == 'Hello'
+
+        # Chunk 2: " world" - should return only this chunk's text, not accumulated
+        chunk2 = GenerateResponseChunk(content=[TextPart(text=' world')])
+        result2 = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk2, index=0, previous_chunks=[chunk1]))
+        assert result2 == ' world'
+
+    def test_handles_empty_chunks(self) -> None:
+        """Test handling empty text chunks."""
+        text_fmt = TextFormat()
+        fmt = text_fmt.handle(None)
+
+        chunk = GenerateResponseChunk(content=[TextPart(text='')])
+        result = fmt.parse_chunk(GenerateResponseChunkWrapper(chunk, index=0, previous_chunks=[]))
+        assert result == ''
+
+
+class TestTextFormatMessage:
+    """Test complete message parsing."""
+
+    def test_parses_complete_text_response(self) -> None:
+        """Test parsing a complete text response."""
+        text_fmt = TextFormat()
+        fmt = text_fmt.handle(None)
+
+        result = fmt.parse_message(MessageWrapper(Message(role='model', content=[TextPart(text='Hello world')])))
+        assert result == 'Hello world'
+
+    def test_handles_empty_response(self) -> None:
+        """Test parsing an empty response."""
+        text_fmt = TextFormat()
+        fmt = text_fmt.handle(None)
+
+        result = fmt.parse_message(MessageWrapper(Message(role='model', content=[TextPart(text='')])))
+        assert result == ''
+
+    def test_handles_multiline_text(self) -> None:
+        """Test parsing multiline text."""
+        text_fmt = TextFormat()
+        fmt = text_fmt.handle(None)
+
+        result = fmt.parse_message(
+            MessageWrapper(Message(role='model', content=[TextPart(text='Line 1\nLine 2\nLine 3')]))
+        )
+        assert result == 'Line 1\nLine 2\nLine 3'
+
+
+class TestTextFormatConfig:
+    """Test format configuration."""
+
+    def test_has_correct_content_type(self) -> None:
+        """Test that content type is text/plain."""
+        text_fmt = TextFormat()
+        assert text_fmt.config.content_type == 'text/plain'
+
+    def test_has_no_constrained(self) -> None:
+        """Test that constrained is not set."""
+        text_fmt = TextFormat()
+        assert text_fmt.config.constrained is None
+
+
+class TestTextFormatInstructions:
+    """Test instruction generation."""
+
+    def test_no_instructions(self) -> None:
+        """Test that text format has no instructions."""
+        text_fmt = TextFormat()
+        fmt = text_fmt.handle(None)
+
+        assert fmt.instructions is None
+
+    def test_no_instructions_with_schema(self) -> None:
+        """Test that text format ignores schema for instructions."""
+        text_fmt = TextFormat()
+        fmt = text_fmt.handle({'type': 'string'})
+
+        assert fmt.instructions is None

--- a/py/samples/format-demo/README.md
+++ b/py/samples/format-demo/README.md
@@ -1,0 +1,23 @@
+# Format Demo
+
+This sample demonstrates the different output formats supported by Genkit Python.
+
+## Formats Demonstrated
+
+1.  **Text (`text`)**: Raw text output.
+2.  **JSON (`json`)**: Structured JSON object output.
+3.  **Array (`array`)**: JSON array of items.
+4.  **Enum (`enum`)**: Single value from a predefined list.
+5.  **JSONL (`jsonl`)**: Newline-delimited JSON objects (great for streaming).
+
+## Running
+
+1.  Set your `GEMINI_API_KEY` environment variable.
+2.  Run the sample:
+
+```bash
+export GEMINI_API_KEY=your-key
+./run.sh
+```
+
+Then use the Genkit Developer UI to test the flows.

--- a/py/samples/format-demo/pyproject.toml
+++ b/py/samples/format-demo/pyproject.toml
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[project]
+authors         = [{ name = "Google" }]
+dependencies    = ["genkit", "genkit-plugin-google-genai", "pydantic", "structlog"]
+description     = "Sample demonstrating various output formats in Genkit"
+license         = "Apache-2.0"
+name            = "format-demo"
+readme          = "README.md"
+requires-python = ">=3.10"
+version         = "0.1.0"

--- a/py/samples/format-demo/run.sh
+++ b/py/samples/format-demo/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+set -e
+export GEMINI_API_KEY=${GEMINI_API_KEY}
+genkit start -- uv run --package format-demo src/main.py

--- a/py/samples/format-demo/src/main.py
+++ b/py/samples/format-demo/src/main.py
@@ -1,0 +1,249 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Format demo sample.
+
+This sample demonstrates the various output formats available in Genkit:
+
+1. **text** - Raw text output (default)
+2. **json** - Structured JSON object output
+3. **array** - JSON array of items
+4. **enum** - Single value from a predefined set
+5. **jsonl** - Newline-delimited JSON (streaming friendly)
+
+Run with: genkit start -- uv run --package format-demo src/main.py
+Then use the Dev UI to test each flow.
+
+Example inputs for testing in the Dev UI (pre-populated with defaults):
+
+- generate_haiku_text: {"topic": "coding"}
+- get_country_info_json: {"country": "Japan"}
+- recommend_books_array: {"genre": "Fantasy"}
+- classify_sentiment_enum: {"review": "This product is terrible and broke after one day"}
+- create_story_characters_jsonl: {"theme": "Space Opera"}
+"""
+
+import asyncio
+import os
+
+import structlog
+from pydantic import BaseModel, Field
+
+from genkit.ai import Genkit
+from genkit.core.typing import OutputConfig
+from genkit.plugins.google_genai import GoogleAI
+
+logger = structlog.get_logger(__name__)
+
+if 'GEMINI_API_KEY' not in os.environ:
+    os.environ['GEMINI_API_KEY'] = input('Please enter your GEMINI_API_KEY: ')
+
+ai = Genkit(
+    plugins=[GoogleAI()],
+    model='googleai/gemini-2.5-flash',
+)
+
+
+# --- 1. Text Format ---
+class HaikuInput(BaseModel):
+    """Input for generating a haiku."""
+
+    topic: str = Field(default='coding', description='The topic for the haiku')
+
+
+@ai.flow()
+async def generate_haiku_text(input: HaikuInput) -> str:
+    """Generate a haiku about a given topic.
+
+    Uses the 'text' format which returns the model's response as a plain string.
+    This is the simplest format, useful when you just need unstructured text.
+
+    Example output:
+        "Lines of code cascade,
+        Bugs hide in the syntax maze,
+        Debug brings the dawn."
+    """
+    response = await ai.generate(
+        prompt=f'Write a haiku about {input.topic}',
+        output=OutputConfig(format='text'),
+    )
+    return response.text
+
+
+# --- 2. JSON Format ---
+class CountryInfoInput(BaseModel):
+    """Input for getting country information."""
+
+    country: str = Field(default='Japan', description='Name of the country')
+
+
+class CountryInfo(BaseModel):
+    """Information about a country."""
+
+    name: str
+    capital: str
+    population: int
+
+
+@ai.flow()
+async def get_country_info_json(input: CountryInfoInput) -> dict:
+    """Get structured information about a country.
+
+    Uses the 'json' format which parses the model's response as a JSON object.
+    You provide a schema (as a JSON Schema dict) to define the expected structure.
+    Genkit uses constrained decoding when supported by the model.
+
+    Example output:
+        {"name": "Japan", "capital": "Tokyo", "population": 125000000}
+    """
+    response = await ai.generate(
+        prompt=f'Give me information about {input.country}',
+        output=OutputConfig(format='json', schema=CountryInfo.model_json_schema()),
+    )
+    return response.output
+
+
+# --- 3. Array Format ---
+class RecommendBooksInput(BaseModel):
+    """Input for book recommendations."""
+
+    genre: str = Field(default='Fantasy', description='Book genre to recommend')
+
+
+class Book(BaseModel):
+    """A book with title and author."""
+
+    title: str
+    author: str
+
+
+@ai.flow()
+async def recommend_books_array(input: RecommendBooksInput) -> list:
+    """Recommend famous books in a given genre.
+
+    Uses the 'array' format which parses the model's response as a JSON array of objects.
+    This is useful for generating lists of structured items.
+    The schema must be of type 'array' with 'items' defining the object structure.
+
+    Example output:
+        [
+            {"title": "The Lord of the Rings", "author": "J.R.R. Tolkien"},
+            {"title": "A Game of Thrones", "author": "George R.R. Martin"},
+            {"title": "The Name of the Wind", "author": "Patrick Rothfuss"}
+        ]
+    """
+    response = await ai.generate(
+        prompt=f'List 3 famous {input.genre} books',
+        output=OutputConfig(
+            format='array',
+            schema={
+                'type': 'array',
+                'items': Book.model_json_schema(),
+            },
+        ),
+    )
+    return response.output
+
+
+# --- 4. Enum Format ---
+class ClassifySentimentInput(BaseModel):
+    """Input for sentiment classification."""
+
+    review: str = Field(
+        default='This product is terrible and broke after one day',
+        description='Product review text to classify',
+    )
+
+
+@ai.flow()
+async def classify_sentiment_enum(input: ClassifySentimentInput) -> str:
+    """Classify the sentiment of a product review.
+
+    Uses the 'enum' format which constrains the model to output exactly one value
+    from a predefined list. This is perfect for classification tasks.
+    The response is cleaned (quotes stripped) automatically.
+
+    Example inputs and outputs:
+        "This product is terrible!" -> "NEGATIVE"
+        "Works as expected, nothing special" -> "NEUTRAL"
+        "Best purchase ever! Highly recommend!" -> "POSITIVE"
+    """
+    response = await ai.generate(
+        prompt=f'Classify the sentiment of this review: "{input.review}"',
+        output=OutputConfig(
+            format='enum',
+            schema={
+                'type': 'string',
+                'enum': ['POSITIVE', 'NEGATIVE', 'NEUTRAL'],
+            },
+        ),
+    )
+    return response.output
+
+
+# --- 5. JSONL Format ---
+class CreateStoryCharactersInput(BaseModel):
+    """Input for creating story characters."""
+
+    theme: str = Field(default='Space Opera', description='Theme or genre of the story')
+
+
+class Character(BaseModel):
+    """A character in a story."""
+
+    name: str
+    role: str
+
+
+@ai.flow()
+async def create_story_characters_jsonl(input: CreateStoryCharactersInput) -> list:
+    """Create characters for a story with a given theme.
+
+    Uses the 'jsonl' format which outputs newline-delimited JSON objects.
+    This is particularly useful for streaming scenarios where you want
+    to process each object as soon as it's generated, without waiting
+    for the full array to complete.
+
+    Each line is a complete JSON object that can be parsed independently.
+    The schema must be 'array' type with 'object' items.
+
+    Example output (raw):
+        {"name": "Captain Zara", "role": "Ship Commander"}
+        {"name": "Dr. Vex", "role": "Science Officer"}
+        {"name": "K-7", "role": "Android Navigator"}
+        {"name": "Luna", "role": "Engineer"}
+        {"name": "The Broker", "role": "Mysterious Informant"}
+    """
+    response = await ai.generate(
+        prompt=f'Generate 5 characters for a {input.theme} story',
+        output=OutputConfig(
+            format='jsonl',
+            schema={
+                'type': 'array',
+                'items': Character.model_json_schema(),
+            },
+        ),
+    )
+    return response.output
+
+
+async def main() -> None:
+    """Main function."""
+    await logger.ainfo('Genkit server running. Press Ctrl+C to stop.')
+    # Keep the process alive for Dev UI
+    await asyncio.Event().wait()
+
+
+if __name__ == '__main__':
+    ai.run_main(main())

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -17,6 +17,7 @@ members = [
     "eval-demo",
     "firestore-retreiver",
     "flask-hello",
+    "format-demo",
     "genkit",
     "genkit-plugin-anthropic",
     "genkit-plugin-compat-oai",
@@ -1409,6 +1410,25 @@ requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
     { name = "genkit-plugin-flask", editable = "plugins/flask" },
     { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
+]
+
+[[package]]
+name = "format-demo"
+version = "0.1.0"
+source = { virtual = "samples/format-demo" }
+dependencies = [
+    { name = "genkit" },
+    { name = "genkit-plugin-google-genai" },
+    { name = "pydantic" },
+    { name = "structlog" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
+    { name = "pydantic" },
+    { name = "structlog" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add missing output formats to achieve feature parity with the canonical
JavaScript implementation:

- **array**: Parses model output as a JSON array of objects. Uses
  `extract_items` for robust parsing of streaming chunks.
- **enum**: Constrains model to output a single value from a predefined
  list. Useful for classification tasks.
- **jsonl**: Parses newline-delimited JSON objects. Optimized for
  streaming scenarios where each object can be processed independently.

CHANGELOG:
- Add ArrayFormat, EnumFormat, and JsonlFormat implementations
- Update FormatterConfig to match JS canonical behavior:
  - enum: content_type='text/enum', constrained=True
  - array: content_type='application/json', constrained=True
  - jsonl: content_type='application/jsonl' (unconstrained)
  - text: content_type='text/plain' (unconstrained)
- Fix TextFormat.chunk_parser to return chunk.text (current chunk only)
  instead of accumulated_text, matching JS behavior
- Fix GenerateResponseChunkWrapper.accumulated_text to correctly
  accumulate text from previous chunks
- Update _aio.py to safely handle OutputConfig using getattr() since
  typing.py is auto-generated and may not have all fields
- Add comprehensive documentation with format comparison table
- Add unit tests for all new formats
- Add format-demo sample demonstrating all five formats with
  pre-populated inputs:
  - generate_haiku_text (text format)
  - get_country_info_json (json format)
  - recommend_books_array (array format)
  - classify_sentiment_enum (enum format)
  - create_story_characters_jsonl (jsonl format)
