### PR TITLE
fix(py/genkit): handle None type correctly in to_json_schema per JSON Schema spec

### DIFF
--- a/py/packages/genkit/src/genkit/core/schema.py
+++ b/py/packages/genkit/src/genkit/core/schema.py
@@ -21,7 +21,7 @@ from typing import Any
 from pydantic import TypeAdapter
 
 
-def to_json_schema(schema: type | dict[str, Any] | None) -> dict[str, Any]:
+def to_json_schema(schema: type | dict[str, Any] | str | None) -> dict[str, Any]:
     """Converts a Python type to a JSON schema.
 
     If the input `schema` is already a dictionary (assumed json schema), it is
@@ -60,6 +60,8 @@ def to_json_schema(schema: type | dict[str, Any] | None) -> dict[str, Any]:
         >>> print(result)
         {'type': 'string'}
     """
+    if schema is None:
+        return {'type': 'null'}
     if isinstance(schema, dict):
         return schema
     type_adapter = TypeAdapter(schema)


### PR DESCRIPTION
- Return `{"type": "null"}` for None input per JSON Schema specification
- Add [str](cci:1://file:///Users/yesudeep/code/github.com/firebase/genkit/py/packages/genkit/src/genkit/core/action/_action.py:383:4-425:38) to accepted schema types for string-based schema descriptors
- Add comprehensive tests for all JSON Schema primitive types:
  - null (None)
  - string (str)
  - integer (int)
  - number (float)
  - boolean (bool)
  - array (list[T])
  - object (dict, BaseModel)
- Add tests for dict passthrough behavior

Ref: https://json-schema.org/understanding-json-schema/reference/null
