### PR TITLE
refactor(py/genkit): fix aliasing issue in pydantic models

### DIFF
--- a/py/packages/genkit/src/genkit/ai/_aio.py
+++ b/py/packages/genkit/src/genkit/ai/_aio.py
@@ -526,13 +526,10 @@ class Genkit(GenkitBase):
 
         return (
             await eval_action.arun(
-                # NOTE: Using camelCase alias (evalRunId) because Pydantic models
-                # have populate_by_name=True. The ty type checker only recognizes
-                # aliases, so we use them to pass both ty check and runtime.
                 EvalRequest(
                     dataset=dataset,
                     options=final_options,
-                    evalRunId=eval_run_id,
+                    eval_run_id=eval_run_id,
                 )
             )
         ).response

--- a/py/packages/genkit/src/genkit/ai/_registry.py
+++ b/py/packages/genkit/src/genkit/ai/_registry.py
@@ -425,11 +425,8 @@ class GenkitRegistry:
             self.registry,
             name=name,
             fn=fn,
-            # NOTE: Using camelCase alias (configSchema) because Pydantic models
-            # have populate_by_name=True. The ty type checker only recognizes
-            # aliases, so we use them to pass both ty check and runtime.
             options=RerankerOptions(
-                configSchema=reranker_meta['reranker'].get('customOptions'),
+                config_schema=reranker_meta['reranker'].get('customOptions'),
                 label=reranker_meta['reranker'].get('label'),
             ),
             description=reranker_description,
@@ -550,15 +547,12 @@ class GenkitRegistry:
                                     status=cast(EvalStatusEnum, EvalStatusEnum.FAIL),
                                 )
                                 eval_responses.append(
-                                    # NOTE: Using camelCase aliases (spanId, traceId, testCaseId)
-                                    # because all Pydantic models have populate_by_name=True.
-                                    # This allows both Python attribute names and aliases at runtime.
                                     # The ty type checker only recognizes aliases, so we use them
                                     # to pass both ty check and runtime validation.
                                     EvalFnResponse(
-                                        spanId=span_id,
-                                        traceId=trace_id,
-                                        testCaseId=datapoint.test_case_id,
+                                        span_id=span_id,
+                                        trace_id=trace_id,
+                                        test_case_id=datapoint.test_case_id,
                                         evaluation=evaluation,
                                     )
                                 )
@@ -577,10 +571,8 @@ class GenkitRegistry:
                                 status=cast(EvalStatusEnum, EvalStatusEnum.FAIL),
                             )
                             eval_responses.append(
-                                # NOTE: Using camelCase alias (testCaseId) for ty check.
-                                # See comment above for full explanation.
                                 EvalFnResponse(
-                                    testCaseId=datapoint.test_case_id,
+                                    test_case_id=datapoint.test_case_id,
                                     evaluation=evaluation,
                                 )
                             )

--- a/py/packages/genkit/src/genkit/blocks/document.py
+++ b/py/packages/genkit/src/genkit/blocks/document.py
@@ -107,7 +107,7 @@ class Document(DocumentData):
         return Document(
             # NOTE: DocumentPart is a RootModel requiring root=MediaPart(...) syntax.
             # Using contentType alias for ty type checker compatibility.
-            content=[DocumentPart(root=MediaPart(media=Media(url=url, contentType=content_type)))],
+            content=[DocumentPart(root=MediaPart(media=Media(url=url, content_type=content_type)))],
             metadata=metadata,
         )
 

--- a/py/packages/genkit/src/genkit/blocks/embedding.py
+++ b/py/packages/genkit/src/genkit/blocks/embedding.py
@@ -19,7 +19,8 @@
 from collections.abc import Callable
 from typing import Any, cast
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 from genkit.blocks.document import Document
 from genkit.core.action import Action, ActionMetadata
@@ -40,9 +41,9 @@ class EmbedderSupports(BaseModel):
 class EmbedderOptions(BaseModel):
     """Configuration options for an embedder."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
 
-    config_schema: dict[str, Any] | None = Field(None, alias='configSchema')
+    config_schema: dict[str, Any] | None = None
     label: str | None = None
     supports: EmbedderSupports | None = None
     dimensions: int | None = None

--- a/py/packages/genkit/src/genkit/blocks/evaluator.py
+++ b/py/packages/genkit/src/genkit/blocks/evaluator.py
@@ -24,7 +24,8 @@ model.
 from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 from genkit.core.typing import (
     BaseDataPoint,
@@ -45,10 +46,10 @@ BatchEvaluatorFn = Callable[[EvalRequest, T], Coroutine[Any, Any, list[EvalFnRes
 class EvaluatorRef(BaseModel):
     """Reference to an evaluator."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
 
     name: str
-    config_schema: Any | None = Field(None, alias='configSchema')
+    config_schema: Any | None = None
 
 
 def evaluator_ref(name: str, config_schema: Any | None = None) -> EvaluatorRef:
@@ -61,7 +62,4 @@ def evaluator_ref(name: str, config_schema: Any | None = None) -> EvaluatorRef:
     Returns:
         An EvaluatorRef instance.
     """
-    # NOTE: Using camelCase alias (configSchema) because Pydantic models have
-    # populate_by_name=True. The ty type checker only recognizes aliases, so we
-    # use them to pass both ty check and runtime validation.
-    return EvaluatorRef(name=name, configSchema=config_schema)
+    return EvaluatorRef(name=name, config_schema=config_schema)

--- a/py/packages/genkit/src/genkit/blocks/formats/array.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/array.py
@@ -66,8 +66,7 @@ class ArrayFormat(FormatDef):
         super().__init__(
             'array',
             FormatterConfig(
-                # NOTE: Using camelCase alias for ty type checker compatibility.
-                contentType='application/json',
+                content_type='application/json',
                 constrained=True,
             ),
         )

--- a/py/packages/genkit/src/genkit/blocks/formats/enum.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/enum.py
@@ -61,8 +61,7 @@ class EnumFormat(FormatDef):
         super().__init__(
             'enum',
             FormatterConfig(
-                # NOTE: Using camelCase alias for ty type checker compatibility.
-                contentType='text/enum',
+                content_type='text/enum',
                 constrained=True,
             ),
         )

--- a/py/packages/genkit/src/genkit/blocks/formats/json.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/json.py
@@ -56,8 +56,7 @@ class JsonFormat(FormatDef):
             'json',
             FormatterConfig(
                 format='json',
-                # NOTE: Using camelCase alias for ty type checker compatibility.
-                contentType='application/json',
+                content_type='application/json',
                 constrained=True,
                 default_instructions=False,
             ),

--- a/py/packages/genkit/src/genkit/blocks/formats/jsonl.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/jsonl.py
@@ -64,8 +64,7 @@ class JsonlFormat(FormatDef):
         super().__init__(
             'jsonl',
             FormatterConfig(
-                # NOTE: Using camelCase alias for ty type checker compatibility.
-                contentType='application/jsonl',
+                content_type='application/jsonl',
             ),
         )
 

--- a/py/packages/genkit/src/genkit/blocks/formats/text.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/text.py
@@ -47,8 +47,7 @@ class TextFormat(FormatDef):
         super().__init__(
             'text',
             FormatterConfig(
-                # NOTE: Using camelCase alias for ty type checker compatibility.
-                contentType='text/plain',
+                content_type='text/plain',
             ),
         )
 

--- a/py/packages/genkit/src/genkit/blocks/generate.py
+++ b/py/packages/genkit/src/genkit/blocks/generate.py
@@ -633,17 +633,14 @@ async def action_to_generate_request(
     # TODO: add warning when toolChoice is not supported in ModelInfo
 
     tool_defs = [to_tool_definition(tool) for tool in resolved_tools] if resolved_tools else []
-    # GenerateRequest and OutputConfig use camelCase aliases. Due to extra='forbid', we must
-    # use the alias names for ty type checker compatibility. The models have
-    # populate_by_name=True, so both aliases and Python names work at runtime.
     return GenerateRequest(
         messages=options.messages,
         config=options.config if options.config is not None else {},
         docs=options.docs,
         tools=tool_defs,
-        toolChoice=options.tool_choice,
+        tool_choice=options.tool_choice,
         output=OutputConfig(
-            contentType=options.output.content_type if options.output else None,
+            content_type=options.output.content_type if options.output else None,
             format=options.output.format if options.output else None,
             schema=options.output.json_schema if options.output else None,
             constrained=options.output.constrained if options.output else None,
@@ -668,8 +665,8 @@ def to_tool_definition(tool: Action) -> ToolDefinition:
     tdef = ToolDefinition(
         name=tool.name,
         description=tool.description or '',
-        inputSchema=tool.input_schema,
-        outputSchema=tool.output_schema,
+        input_schema=tool.input_schema,
+        output_schema=tool.output_schema,
     )
     return tdef
 
@@ -751,7 +748,7 @@ def _to_pending_response(request: ToolRequestPart, response: ToolResponsePart) -
     # Part is a RootModel, so we pass content via 'root' parameter
     return Part(
         root=ToolRequestPart(
-            toolRequest=request.tool_request,
+            tool_request=request.tool_request,
             metadata=Metadata(root=metadata),
         )
     )
@@ -782,7 +779,7 @@ async def _resolve_tool_request(tool: Action, tool_request_part: ToolRequestPart
         return (
             Part(
                 root=ToolResponsePart(
-                    toolResponse=ToolResponse(
+                    tool_response=ToolResponse(
                         name=tool_request_part.tool_request.name,
                         ref=tool_request_part.tool_request.ref,
                         output=dump_dict(tool_response),
@@ -799,7 +796,7 @@ async def _resolve_tool_request(tool: Action, tool_request_part: ToolRequestPart
                 None,
                 Part(
                     root=ToolRequestPart(
-                        toolRequest=tool_request_part.tool_request,
+                        tool_request=tool_request_part.tool_request,
                         metadata=Metadata(
                             root={
                                 **(
@@ -951,7 +948,7 @@ def _resolve_resumed_tool_request(raw_request: GenerateActionOptions, tool_reque
             # Part is a RootModel, so we pass content via 'root' parameter
             Part(
                 root=ToolResponsePart(
-                    toolResponse=ToolResponse(
+                    tool_response=ToolResponse(
                         name=tool_req_root.tool_request.name,
                         ref=tool_req_root.tool_request.ref,
                         output=dump_dict(pending_output),
@@ -976,7 +973,7 @@ def _resolve_resumed_tool_request(raw_request: GenerateActionOptions, tool_reque
             # Part is a RootModel, so we pass content via 'root' parameter
             Part(
                 root=ToolRequestPart(
-                    toolRequest=ToolRequest(
+                    tool_request=ToolRequest(
                         name=tool_req_root.tool_request.name,
                         ref=tool_req_root.tool_request.ref,
                         input=tool_req_root.tool_request.input,

--- a/py/packages/genkit/src/genkit/blocks/model.py
+++ b/py/packages/genkit/src/genkit/blocks/model.py
@@ -178,14 +178,11 @@ class GenerateResponseWrapper(GenerateResponse):
                 else response.message
             )
 
-        # GenerateResponse uses camelCase aliases. Due to extra='forbid', we must
-        # use the alias names for ty type checker compatibility. The model has
-        # populate_by_name=True, so both aliases and Python names work at runtime.
         super().__init__(
             message=wrapped_message,
-            finishReason=response.finish_reason,
-            finishMessage=response.finish_message,
-            latencyMs=response.latency_ms,
+            finish_reason=response.finish_reason,
+            finish_message=response.finish_message,
+            latency_ms=response.latency_ms,
             usage=response.usage if response.usage is not None else GenerationUsage(),
             custom=response.custom if response.custom is not None else {},
             request=request,
@@ -431,18 +428,15 @@ def get_basic_usage_stats(input_: list[Message], response: Message | list[Candid
     input_counts = get_part_counts(parts=request_parts)
     output_counts = get_part_counts(parts=response_parts)
 
-    # GenerationUsage uses camelCase aliases. Due to extra='forbid', we must
-    # use the alias names for ty type checker compatibility. The model has
-    # populate_by_name=True, so both aliases and Python names work at runtime.
     return GenerationUsage(
-        inputCharacters=input_counts.characters,
-        inputImages=input_counts.images,
-        inputVideos=input_counts.videos,
-        inputAudioFiles=input_counts.audio,
-        outputCharacters=output_counts.characters,
-        outputImages=output_counts.images,
-        outputVideos=output_counts.videos,
-        outputAudioFiles=output_counts.audio,
+        input_characters=input_counts.characters,
+        input_images=input_counts.images,
+        input_videos=input_counts.videos,
+        input_audio_files=input_counts.audio,
+        output_characters=output_counts.characters,
+        output_images=output_counts.images,
+        output_videos=output_counts.videos,
+        output_audio_files=output_counts.audio,
     )
 
 

--- a/py/packages/genkit/src/genkit/blocks/prompt.py
+++ b/py/packages/genkit/src/genkit/blocks/prompt.py
@@ -350,18 +350,15 @@ class ExecutablePrompt:
             if tool_response_parts:
                 resume = Resume(respond=tool_response_parts)
 
-        # GenerateActionOptions uses camelCase aliases. Due to extra='forbid', we must
-        # use the alias names for ty type checker compatibility. The models have
-        # populate_by_name=True, so both aliases and Python names work at runtime.
         return GenerateActionOptions(
             model=model,
             messages=resolved_msgs,
             config=options.config,
             tools=options.tools,
-            returnToolRequests=options.return_tool_requests,
-            toolChoice=options.tool_choice,
+            return_tool_requests=options.return_tool_requests,
+            tool_choice=options.tool_choice,
             output=output,
-            maxTurns=options.max_turns,
+            max_turns=options.max_turns,
             docs=await render_docs(render_input, options, context),
             resume=resume,
         )
@@ -583,18 +580,15 @@ async def to_generate_action_options(registry: Registry, options: PromptConfig) 
         if tool_response_parts:
             resume = Resume(respond=tool_response_parts)
 
-    # GenerateActionOptions uses camelCase aliases. Due to extra='forbid', we must
-    # use the alias names for ty type checker compatibility. The models have
-    # populate_by_name=True, so both aliases and Python names work at runtime.
     return GenerateActionOptions(
         model=model,
         messages=resolved_msgs,
         config=options.config,
         tools=options.tools,
-        returnToolRequests=options.return_tool_requests,
-        toolChoice=options.tool_choice,
+        return_tool_requests=options.return_tool_requests,
+        tool_choice=options.tool_choice,
         output=output,
-        maxTurns=options.max_turns,
+        max_turns=options.max_turns,
         docs=await render_docs(render_input, options),
         resume=resume,
     )
@@ -637,17 +631,14 @@ async def to_generate_request(registry: Registry, options: GenerateActionOptions
             message='at least one message is required in generate request',
         )
 
-    # GenerateRequest and OutputConfig use camelCase aliases. Due to extra='forbid', we must
-    # use the alias names for ty type checker compatibility. The models have
-    # populate_by_name=True, so both aliases and Python names work at runtime.
     return GenerateRequest(
         messages=options.messages,
         config=options.config if options.config is not None else {},
         docs=options.docs,
         tools=tool_defs,
-        toolChoice=options.tool_choice,
+        tool_choice=options.tool_choice,
         output=OutputConfig(
-            contentType=options.output.content_type if options.output else None,
+            content_type=options.output.content_type if options.output else None,
             format=options.output.format if options.output else None,
             schema=options.output.json_schema if options.output else None,
             constrained=options.output.constrained if options.output else None,
@@ -723,9 +714,6 @@ async def render_system_prompt(
                 input,
                 PromptMetadata(
                     input=PromptInputConfig(
-                        # NOTE: dotpromptz PromptInputConfig uses schema_ with alias='schema'.
-                        # The type checker doesn't recognize 'schema=' as valid, but it works
-                        # at runtime due to Pydantic's populate_by_name=True.
                         schema=to_json_schema(options.input_schema) if options.input_schema else None,  # type: ignore[call-arg]
                     )
                 ),
@@ -828,9 +816,6 @@ async def render_message_prompt(
             ),
             options=PromptMetadata(
                 input=PromptInputConfig(
-                    # NOTE: dotpromptz PromptInputConfig uses schema_ with alias='schema'.
-                    # The type checker doesn't recognize 'schema=' as valid, but it works
-                    # at runtime due to Pydantic's populate_by_name=True.
                     schema=to_json_schema(options.input_schema) if options.input_schema else None,  # type: ignore[call-arg]
                 )
             ),
@@ -886,9 +871,6 @@ async def render_user_prompt(
                 input,
                 PromptMetadata(
                     input=PromptInputConfig(
-                        # NOTE: dotpromptz PromptInputConfig uses schema_ with alias='schema'.
-                        # The type checker doesn't recognize 'schema=' as valid, but it works
-                        # at runtime due to Pydantic's populate_by_name=True.
                         schema=to_json_schema(options.input_schema) if options.input_schema else None,  # type: ignore[call-arg]
                     )
                 ),

--- a/py/packages/genkit/src/genkit/blocks/reranker.py
+++ b/py/packages/genkit/src/genkit/blocks/reranker.py
@@ -125,6 +125,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
 
 from genkit.blocks.document import Document
 from genkit.core.action import Action, ActionMetadata
@@ -218,9 +219,9 @@ class RerankerInfo(BaseModel):
 class RerankerOptions(BaseModel):
     """Configuration options for a reranker."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
 
-    config_schema: dict[str, Any] | None = Field(None, alias='configSchema')
+    config_schema: dict[str, Any] | None = None
     label: str | None = None
     supports: RerankerSupports | None = None
 

--- a/py/packages/genkit/src/genkit/blocks/retriever.py
+++ b/py/packages/genkit/src/genkit/blocks/retriever.py
@@ -26,7 +26,8 @@ import inspect
 from collections.abc import Callable
 from typing import Any, Awaitable, Generic, TypeVar, cast
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 from genkit.blocks.document import Document
 from genkit.core.action import ActionMetadata
@@ -83,9 +84,9 @@ class RetrieverInfo(BaseModel):
 class RetrieverOptions(BaseModel):
     """Configuration options for a retriever."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
 
-    config_schema: dict[str, Any] | None = Field(None, alias='configSchema')
+    config_schema: dict[str, Any] | None = None
     label: str | None = None
     supports: RetrieverSupports | None = None
 
@@ -156,9 +157,9 @@ class IndexerInfo(BaseModel):
 class IndexerOptions(BaseModel):
     """Configuration options for an indexer."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
 
-    config_schema: dict[str, Any] | None = Field(None, alias='configSchema')
+    config_schema: dict[str, Any] | None = None
     label: str | None = None
     supports: RetrieverSupports | None = None
 

--- a/py/packages/genkit/src/genkit/blocks/tools.py
+++ b/py/packages/genkit/src/genkit/blocks/tools.py
@@ -120,7 +120,7 @@ def tool_response(
     tr = cast(ToolRequestLike, tool_request)
     return Part(
         root=ToolResponsePart(
-            toolResponse=ToolResponse(
+            tool_response=ToolResponse(
                 name=tr.name,
                 ref=tr.ref,
                 output=response_data,

--- a/py/packages/genkit/src/genkit/core/action/_action.py
+++ b/py/packages/genkit/src/genkit/core/action/_action.py
@@ -539,7 +539,7 @@ def _make_tracing_wrappers(
                 ) from e
 
             record_output_metadata(span, output=output)
-            return ActionResponse(response=output, traceId=trace_id)
+            return ActionResponse(response=output, trace_id=trace_id)
 
     def sync_tracing_wrapper(input: Any | None, ctx: ActionRunContext) -> ActionResponse:
         """Wrap the function in a sync tracing wrapper.
@@ -580,6 +580,6 @@ def _make_tracing_wrappers(
                 ) from e
 
             record_output_metadata(span, output=output)
-            return ActionResponse(response=output, traceId=trace_id)
+            return ActionResponse(response=output, trace_id=trace_id)
 
     return sync_tracing_wrapper, async_tracing_wrapper

--- a/py/packages/genkit/src/genkit/core/action/types.py
+++ b/py/packages/genkit/src/genkit/core/action/types.py
@@ -25,7 +25,8 @@ if sys.version_info < (3, 11):
 else:
     from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 # Type alias for action name.
 # type ActionName = str
@@ -67,10 +68,10 @@ class ActionResponse(BaseModel):
         trace_id: A unique identifier for tracing the action execution.
     """
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
 
     response: Any
-    trace_id: str = Field(alias='traceId')
+    trace_id: str
 
 
 class ActionMetadataKey(StrEnum):

--- a/py/packages/genkit/src/genkit/core/error.py
+++ b/py/packages/genkit/src/genkit/core/error.py
@@ -19,7 +19,8 @@
 import traceback
 from typing import Any, cast
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 from genkit.core.status_types import StatusCodes, StatusName, http_status_code
 
@@ -27,10 +28,10 @@ from genkit.core.status_types import StatusCodes, StatusName, http_status_code
 class GenkitReflectionApiDetailsWireFormat(BaseModel):
     """Wire format for HTTP error details."""
 
-    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
 
     stack: str | None = None
-    trace_id: str | None = Field(None, alias='traceId')
+    trace_id: str | None = None
 
 
 class GenkitReflectionApiErrorWireFormat(BaseModel):

--- a/py/packages/genkit/src/genkit/core/typing.py
+++ b/py/packages/genkit/src/genkit/core/typing.py
@@ -32,10 +32,10 @@ if sys.version_info < (3, 11):
 else:
     from enum import StrEnum
 
-
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
+from pydantic.alias_generators import to_camel
 
 
 class Model(RootModel[Any]):
@@ -47,7 +47,7 @@ class Model(RootModel[Any]):
 class Embedding(BaseModel):
     """Model for embedding data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     embedding: list[float]
     metadata: dict[str, Any] | None = None
 
@@ -55,21 +55,21 @@ class Embedding(BaseModel):
 class BaseDataPoint(BaseModel):
     """Model for basedatapoint data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     input: Any | None = None
     output: Any | None = None
     context: list[Any] | None = None
     reference: Any | None = None
-    test_case_id: str | None = Field(None, alias='testCaseId')
-    trace_ids: list[str] | None = Field(None, alias='traceIds')
+    test_case_id: str | None = Field(None)
+    trace_ids: list[str] | None = Field(None)
 
 
 class EvalRequest(BaseModel):
     """Model for evalrequest data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     dataset: list[BaseDataPoint]
-    eval_run_id: str = Field(..., alias='evalRunId')
+    eval_run_id: str = Field(...)
     options: Any | None = None
 
 
@@ -84,14 +84,14 @@ class EvalStatusEnum(StrEnum):
 class Details(BaseModel):
     """Model for details data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     reasoning: str | None = None
 
 
 class Score(BaseModel):
     """Model for score data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     id: str | None = Field(None, description='Optional ID to differentiate different scores')
     score: float | str | bool | None = None
     status: EvalStatusEnum | None = None
@@ -102,23 +102,23 @@ class Score(BaseModel):
 class GenkitErrorDetails(BaseModel):
     """Model for genkiterrordetails data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     stack: str | None = None
-    trace_id: str = Field(..., alias='traceId')
+    trace_id: str = Field(...)
 
 
 class Data(BaseModel):
     """Model for data data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    genkit_error_message: str | None = Field(None, alias='genkitErrorMessage')
-    genkit_error_details: GenkitErrorDetails | None = Field(None, alias='genkitErrorDetails')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    genkit_error_message: str | None = Field(None)
+    genkit_error_details: GenkitErrorDetails | None = Field(None)
 
 
 class GenkitError(BaseModel):
     """Model for genkiterror data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     message: str
     stack: str | None = None
     details: Any | None = None
@@ -136,7 +136,7 @@ class Code(StrEnum):
 class CandidateError(BaseModel):
     """Model for candidateerror data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     index: float
     code: Code
     message: str | None = None
@@ -145,11 +145,11 @@ class CandidateError(BaseModel):
 class CustomPart(BaseModel):
     """Model for custompart data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     text: Any | None = None
     media: Any | None = None
-    tool_request: Any | None = Field(None, alias='toolRequest')
-    tool_response: Any | None = Field(None, alias='toolResponse')
+    tool_request: Any | None = Field(None)
+    tool_response: Any | None = Field(None)
     data: Any | None = None
     metadata: dict[str, Any] | None = None
     custom: dict[str, Any]
@@ -179,44 +179,44 @@ class ToolChoice(StrEnum):
 class GenerateActionOutputConfig(BaseModel):
     """Model for generateactionoutputconfig data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     format: str | None = None
-    content_type: str | None = Field(None, alias='contentType')
+    content_type: str | None = Field(None)
     instructions: bool | str | None = None
-    json_schema: Any | None = Field(None, alias='jsonSchema')
+    json_schema: Any | None = Field(None)
     constrained: bool | None = None
 
 
 class GenerationCommonConfig(BaseModel):
     """Model for generationcommonconfig data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     version: str | None = None
     temperature: float | None = None
-    max_output_tokens: float | None = Field(None, alias='maxOutputTokens')
-    top_k: float | None = Field(None, alias='topK')
-    top_p: float | None = Field(None, alias='topP')
-    stop_sequences: list[str] | None = Field(None, alias='stopSequences')
+    max_output_tokens: float | None = Field(None)
+    top_k: float | None = Field(None)
+    top_p: float | None = Field(None)
+    stop_sequences: list[str] | None = Field(None)
 
 
 class GenerationUsage(BaseModel):
     """Model for generationusage data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    input_tokens: float | None = Field(None, alias='inputTokens')
-    output_tokens: float | None = Field(None, alias='outputTokens')
-    total_tokens: float | None = Field(None, alias='totalTokens')
-    input_characters: float | None = Field(None, alias='inputCharacters')
-    output_characters: float | None = Field(None, alias='outputCharacters')
-    input_images: float | None = Field(None, alias='inputImages')
-    output_images: float | None = Field(None, alias='outputImages')
-    input_videos: float | None = Field(None, alias='inputVideos')
-    output_videos: float | None = Field(None, alias='outputVideos')
-    input_audio_files: float | None = Field(None, alias='inputAudioFiles')
-    output_audio_files: float | None = Field(None, alias='outputAudioFiles')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    input_tokens: float | None = Field(None)
+    output_tokens: float | None = Field(None)
+    total_tokens: float | None = Field(None)
+    input_characters: float | None = Field(None)
+    output_characters: float | None = Field(None)
+    input_images: float | None = Field(None)
+    output_images: float | None = Field(None)
+    input_videos: float | None = Field(None)
+    output_videos: float | None = Field(None)
+    input_audio_files: float | None = Field(None)
+    output_audio_files: float | None = Field(None)
     custom: dict[str, float] | None = None
-    thoughts_tokens: float | None = Field(None, alias='thoughtsTokens')
-    cached_content_tokens: float | None = Field(None, alias='cachedContentTokens')
+    thoughts_tokens: float | None = Field(None)
+    cached_content_tokens: float | None = Field(None)
 
 
 class Constrained(StrEnum):
@@ -230,17 +230,17 @@ class Constrained(StrEnum):
 class Supports(BaseModel):
     """Model for supports data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     multiturn: bool | None = None
     media: bool | None = None
     tools: bool | None = None
-    system_role: bool | None = Field(None, alias='systemRole')
+    system_role: bool | None = Field(None)
     output: list[str] | None = None
-    content_type: list[str] | None = Field(None, alias='contentType')
+    content_type: list[str] | None = Field(None)
     context: bool | None = None
     constrained: Constrained | None = None
-    tool_choice: bool | None = Field(None, alias='toolChoice')
-    long_running: bool | None = Field(None, alias='longRunning')
+    tool_choice: bool | None = Field(None)
+    long_running: bool | None = Field(None)
 
 
 class Stage(StrEnum):
@@ -256,10 +256,10 @@ class Stage(StrEnum):
 class ModelInfo(BaseModel):
     """Model for modelinfo data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     versions: list[str] | None = None
     label: str | None = None
-    config_schema: dict[str, Any] | None = Field(None, alias='configSchema')
+    config_schema: dict[str, Any] | None = Field(None)
     supports: Supports | None = None
     stage: Stage | None = None
 
@@ -267,14 +267,14 @@ class ModelInfo(BaseModel):
 class Error(BaseModel):
     """Model for error data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     message: str
 
 
 class Operation(BaseModel):
     """Model for operation data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     action: str | None = None
     id: str
     done: bool | None = None
@@ -286,17 +286,17 @@ class Operation(BaseModel):
 class OutputConfig(BaseModel):
     """Model for outputconfig data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     format: str | None = None
     schema_: dict[str, Any] | None = Field(None, alias='schema')
     constrained: bool | None = None
-    content_type: str | None = Field(None, alias='contentType')
+    content_type: str | None = Field(None)
 
 
 class Resource1(BaseModel):
     """Model for resource1 data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     uri: str
 
 
@@ -312,14 +312,14 @@ class Role(StrEnum):
 class ToolDefinition(BaseModel):
     """Model for tooldefinition data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     name: str
     description: str
     input_schema: dict[str, Any] | None = Field(
-        None, alias='inputSchema', description='Valid JSON Schema representing the input of the tool.'
+        None, description='Valid JSON Schema representing the input of the tool.'
     )
     output_schema: dict[str, Any] | None = Field(
-        None, alias='outputSchema', description='Valid JSON Schema describing the output of the tool.'
+        None, description='Valid JSON Schema describing the output of the tool.'
     )
     metadata: dict[str, Any] | None = Field(None, description='additional metadata for this tool definition')
 
@@ -327,15 +327,15 @@ class ToolDefinition(BaseModel):
 class Media(BaseModel):
     """Model for media data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    content_type: str | None = Field(None, alias='contentType')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    content_type: str | None = Field(None)
     url: str
 
 
 class ToolRequest(BaseModel):
     """Model for toolrequest data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     ref: str | None = None
     name: str
     input: Any | None = None
@@ -345,7 +345,7 @@ class ToolRequest(BaseModel):
 class ToolResponse(BaseModel):
     """Model for toolresponse data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     ref: str | None = None
     name: str
     output: Any | None = None
@@ -355,37 +355,37 @@ class ToolResponse(BaseModel):
 class CommonRerankerOptions(BaseModel):
     """Model for commonrerankeroptions data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     k: float | None = Field(None, description='Number of documents to rerank')
 
 
 class RankedDocumentMetadata(BaseModel):
     """Model for rankeddocumentmetadata data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     score: float
 
 
 class CommonRetrieverOptions(BaseModel):
     """Model for commonretrieveroptions data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     k: float | None = Field(None, description='Number of documents to retrieve')
 
 
 class InstrumentationLibrary(BaseModel):
     """Model for instrumentationlibrary data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     name: str
     version: str | None = None
-    schema_url: str | None = Field(None, alias='schemaUrl')
+    schema_url: str | None = Field(None)
 
 
 class PathMetadata(BaseModel):
     """Model for pathmetadata data."""
 
-    model_config = ConfigDict(extra='forbid', frozen=True, populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', frozen=True, populate_by_name=True)
     path: str
     status: str
     error: str | None = None
@@ -395,17 +395,17 @@ class PathMetadata(BaseModel):
 class SpanContext(BaseModel):
     """Model for spancontext data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    trace_id: str = Field(..., alias='traceId')
-    span_id: str = Field(..., alias='spanId')
-    is_remote: bool | None = Field(None, alias='isRemote')
-    trace_flags: float = Field(..., alias='traceFlags')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    trace_id: str = Field(...)
+    span_id: str = Field(...)
+    is_remote: bool | None = Field(None)
+    trace_flags: float = Field(...)
 
 
 class SameProcessAsParentSpan(BaseModel):
     """Model for sameprocessasparentspan data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     value: bool
 
 
@@ -419,12 +419,12 @@ class State(StrEnum):
 class SpanMetadata(BaseModel):
     """Model for spanmetadata data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     name: str
     state: State | None = None
     input: Any | None = None
     output: Any | None = None
-    is_root: bool | None = Field(None, alias='isRoot')
+    is_root: bool | None = Field(None)
     metadata: dict[str, str] | None = None
     path: str | None = None
 
@@ -432,7 +432,7 @@ class SpanMetadata(BaseModel):
 class SpanStatus(BaseModel):
     """Model for spanstatus data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     code: float
     message: str | None = None
 
@@ -440,7 +440,7 @@ class SpanStatus(BaseModel):
 class Annotation(BaseModel):
     """Model for annotation data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     attributes: dict[str, Any]
     description: str
 
@@ -448,7 +448,7 @@ class Annotation(BaseModel):
 class TimeEvent(BaseModel):
     """Model for timeevent data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     time: float
     annotation: Annotation
 
@@ -456,8 +456,8 @@ class TimeEvent(BaseModel):
 class TraceMetadata(BaseModel):
     """Model for tracemetadata data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    feature_name: str | None = Field(None, alias='featureName')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    feature_name: str | None = Field(None)
     paths: set[PathMetadata] | None = None
     timestamp: float
 
@@ -615,30 +615,30 @@ class TraceId(RootModel[str]):
 class EmbedResponse(BaseModel):
     """Model for embedresponse data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     embeddings: list[Embedding]
 
 
 class BaseEvalDataPoint(BaseModel):
     """Model for baseevaldatapoint data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     input: Input | None = None
     output: Output | None = None
     context: Context | None = None
     reference: Reference | None = None
-    test_case_id: str = Field(..., alias='testCaseId')
-    trace_ids: TraceIds | None = Field(None, alias='traceIds')
+    test_case_id: str = Field(...)
+    trace_ids: TraceIds | None = Field(None)
 
 
 class EvalFnResponse(BaseModel):
     """Model for evalfnresponse data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    sample_index: float | None = Field(None, alias='sampleIndex')
-    test_case_id: str = Field(..., alias='testCaseId')
-    trace_id: str | None = Field(None, alias='traceId')
-    span_id: str | None = Field(None, alias='spanId')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    sample_index: float | None = Field(None)
+    test_case_id: str = Field(...)
+    trace_id: str | None = Field(None)
+    span_id: str | None = Field(None)
     evaluation: Score | list[Score]
 
 
@@ -651,11 +651,11 @@ class EvalResponse(RootModel[list[EvalFnResponse]]):
 class DataPart(BaseModel):
     """Model for datapart data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     text: Text | None = None
     media: MediaModel | None = None
-    tool_request: ToolRequestModel | None = Field(None, alias='toolRequest')
-    tool_response: ToolResponseModel | None = Field(None, alias='toolResponse')
+    tool_request: ToolRequestModel | None = Field(None)
+    tool_response: ToolResponseModel | None = Field(None)
     data: Any | None = None
     metadata: Metadata | None = None
     custom: dict[str, Any] | None = None
@@ -666,11 +666,11 @@ class DataPart(BaseModel):
 class MediaPart(BaseModel):
     """Model for mediapart data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     text: Text | None = None
     media: Media
-    tool_request: ToolRequestModel | None = Field(None, alias='toolRequest')
-    tool_response: ToolResponseModel | None = Field(None, alias='toolResponse')
+    tool_request: ToolRequestModel | None = Field(None)
+    tool_response: ToolResponseModel | None = Field(None)
     data: DataModel | None = None
     metadata: Metadata | None = None
     custom: Custom | None = None
@@ -681,11 +681,11 @@ class MediaPart(BaseModel):
 class ReasoningPart(BaseModel):
     """Model for reasoningpart data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     text: Text | None = None
     media: MediaModel | None = None
-    tool_request: ToolRequestModel | None = Field(None, alias='toolRequest')
-    tool_response: ToolResponseModel | None = Field(None, alias='toolResponse')
+    tool_request: ToolRequestModel | None = Field(None)
+    tool_response: ToolResponseModel | None = Field(None)
     data: DataModel | None = None
     metadata: Metadata | None = None
     custom: Custom | None = None
@@ -696,11 +696,11 @@ class ReasoningPart(BaseModel):
 class ResourcePart(BaseModel):
     """Model for resourcepart data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     text: Text | None = None
     media: MediaModel | None = None
-    tool_request: ToolRequestModel | None = Field(None, alias='toolRequest')
-    tool_response: ToolResponseModel | None = Field(None, alias='toolResponse')
+    tool_request: ToolRequestModel | None = Field(None)
+    tool_response: ToolResponseModel | None = Field(None)
     data: DataModel | None = None
     metadata: Metadata | None = None
     custom: Custom | None = None
@@ -711,11 +711,11 @@ class ResourcePart(BaseModel):
 class TextPart(BaseModel):
     """Model for textpart data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     text: str
     media: MediaModel | None = None
-    tool_request: ToolRequestModel | None = Field(None, alias='toolRequest')
-    tool_response: ToolResponseModel | None = Field(None, alias='toolResponse')
+    tool_request: ToolRequestModel | None = Field(None)
+    tool_response: ToolResponseModel | None = Field(None)
     data: DataModel | None = None
     metadata: Metadata | None = None
     custom: Custom | None = None
@@ -726,11 +726,11 @@ class TextPart(BaseModel):
 class ToolRequestPart(BaseModel):
     """Model for toolrequestpart data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     text: Text | None = None
     media: MediaModel | None = None
-    tool_request: ToolRequest = Field(..., alias='toolRequest')
-    tool_response: ToolResponseModel | None = Field(None, alias='toolResponse')
+    tool_request: ToolRequest = Field(...)
+    tool_response: ToolResponseModel | None = Field(None)
     data: DataModel | None = None
     metadata: Metadata | None = None
     custom: Custom | None = None
@@ -741,11 +741,11 @@ class ToolRequestPart(BaseModel):
 class ToolResponsePart(BaseModel):
     """Model for toolresponsepart data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     text: Text | None = None
     media: MediaModel | None = None
-    tool_request: ToolRequestModel | None = Field(None, alias='toolRequest')
-    tool_response: ToolResponse = Field(..., alias='toolResponse')
+    tool_request: ToolRequestModel | None = Field(None)
+    tool_response: ToolResponse = Field(...)
     data: DataModel | None = None
     metadata: Metadata | None = None
     custom: Custom | None = None
@@ -756,44 +756,44 @@ class ToolResponsePart(BaseModel):
 class Link(BaseModel):
     """Model for link data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     context: SpanContext | None = None
     attributes: dict[str, Any] | None = None
-    dropped_attributes_count: float | None = Field(None, alias='droppedAttributesCount')
+    dropped_attributes_count: float | None = Field(None)
 
 
 class TimeEvents(BaseModel):
     """Model for timeevents data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    time_event: list[TimeEvent] | None = Field(None, alias='timeEvent')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    time_event: list[TimeEvent] | None = Field(None)
 
 
 class SpanData(BaseModel):
     """Model for spandata data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    span_id: str = Field(..., alias='spanId')
-    trace_id: str = Field(..., alias='traceId')
-    parent_span_id: str | None = Field(None, alias='parentSpanId')
-    start_time: float = Field(..., alias='startTime')
-    end_time: float = Field(..., alias='endTime')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    span_id: str = Field(...)
+    trace_id: str = Field(...)
+    parent_span_id: str | None = Field(None)
+    start_time: float = Field(...)
+    end_time: float = Field(...)
     attributes: dict[str, Any]
-    display_name: str = Field(..., alias='displayName')
+    display_name: str = Field(...)
     links: list[Link] | None = None
-    instrumentation_library: InstrumentationLibrary = Field(..., alias='instrumentationLibrary')
-    span_kind: str = Field(..., alias='spanKind')
-    same_process_as_parent_span: SameProcessAsParentSpan | None = Field(None, alias='sameProcessAsParentSpan')
+    instrumentation_library: InstrumentationLibrary = Field(...)
+    span_kind: str = Field(...)
+    same_process_as_parent_span: SameProcessAsParentSpan | None = Field(None)
     status: SpanStatus | None = None
-    time_events: TimeEvents | None = Field(None, alias='timeEvents')
+    time_events: TimeEvents | None = Field(None)
     truncated: bool | None = None
 
 
 class SpanEndEvent(BaseModel):
     """Model for spanendevent data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    trace_id: str = Field(..., alias='traceId')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    trace_id: str = Field(...)
     span: SpanData
     type: Literal['span_end']
 
@@ -801,8 +801,8 @@ class SpanEndEvent(BaseModel):
 class SpanStartEvent(BaseModel):
     """Model for spanstartevent data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    trace_id: TraceId = Field(..., alias='traceId')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    trace_id: TraceId = Field(...)
     span: SpanData
     type: Literal['span_start']
 
@@ -810,21 +810,19 @@ class SpanStartEvent(BaseModel):
 class SpantEventBase(BaseModel):
     """Model for spanteventbase data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    trace_id: TraceId = Field(..., alias='traceId')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    trace_id: TraceId = Field(...)
     span: SpanData
 
 
 class TraceData(BaseModel):
     """Model for tracedata data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
-    trace_id: str = Field(..., alias='traceId')
-    display_name: str | None = Field(None, alias='displayName')
-    start_time: float | None = Field(
-        None, alias='startTime', description='trace start time in milliseconds since the epoch'
-    )
-    end_time: float | None = Field(None, alias='endTime', description='end time in milliseconds since the epoch')
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    trace_id: str = Field(...)
+    display_name: str | None = Field(None)
+    start_time: float | None = Field(None, description='trace start time in milliseconds since the epoch')
+    end_time: float | None = Field(None, description='end time in milliseconds since the epoch')
     spans: dict[str, SpanData]
 
 
@@ -843,7 +841,7 @@ class DocumentPart(RootModel[TextPart | MediaPart]):
 class Resume(BaseModel):
     """Model for resume data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     respond: list[ToolResponsePart] | None = None
     restart: list[ToolRequestPart] | None = None
     metadata: dict[str, Any] | None = None
@@ -864,7 +862,7 @@ class Part(
 class RankedDocumentData(BaseModel):
     """Model for rankeddocumentdata data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     content: list[DocumentPart]
     metadata: RankedDocumentMetadata
 
@@ -872,7 +870,7 @@ class RankedDocumentData(BaseModel):
 class RerankerResponse(BaseModel):
     """Model for rerankerresponse data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     documents: list[RankedDocumentData]
 
 
@@ -885,7 +883,7 @@ class Content(RootModel[list[Part]]):
 class DocumentData(BaseModel):
     """Model for documentdata data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     content: list[DocumentPart]
     metadata: dict[str, Any] | None = None
 
@@ -893,7 +891,7 @@ class DocumentData(BaseModel):
 class EmbedRequest(BaseModel):
     """Model for embedrequest data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     input: list[DocumentData]
     options: Any | None = None
 
@@ -901,7 +899,7 @@ class EmbedRequest(BaseModel):
 class GenerateResponseChunk(BaseModel):
     """Model for generateresponsechunk data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     role: Role | None = None
     index: float | None = None
     content: list[Part]
@@ -912,7 +910,7 @@ class GenerateResponseChunk(BaseModel):
 class Message(BaseModel):
     """Model for message data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     role: Role | str
     content: list[Part]
     metadata: dict[str, Any] | None = None
@@ -921,7 +919,7 @@ class Message(BaseModel):
 class ModelResponseChunk(BaseModel):
     """Model for modelresponsechunk data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     role: Role | None = None
     index: Index | None = None
     content: Content
@@ -932,7 +930,7 @@ class ModelResponseChunk(BaseModel):
 class MultipartToolResponse(BaseModel):
     """Model for multiparttoolresponse data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     output: Any | None = None
     content: list[Part] | None = None
 
@@ -940,7 +938,7 @@ class MultipartToolResponse(BaseModel):
 class RerankerRequest(BaseModel):
     """Model for rerankerrequest data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     query: DocumentData
     documents: list[DocumentData]
     options: Any | None = None
@@ -949,7 +947,7 @@ class RerankerRequest(BaseModel):
 class RetrieverRequest(BaseModel):
     """Model for retrieverrequest data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     query: DocumentData
     options: Any | None = None
 
@@ -957,7 +955,7 @@ class RetrieverRequest(BaseModel):
 class RetrieverResponse(BaseModel):
     """Model for retrieverresponse data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     documents: list[DocumentData]
 
 
@@ -976,41 +974,41 @@ class Messages(RootModel[list[Message]]):
 class Candidate(BaseModel):
     """Model for candidate data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     index: float
     message: Message
     usage: GenerationUsage | None = None
-    finish_reason: FinishReason = Field(..., alias='finishReason')
-    finish_message: str | None = Field(None, alias='finishMessage')
+    finish_reason: FinishReason = Field(...)
+    finish_message: str | None = Field(None)
     custom: Any | None = None
 
 
 class GenerateActionOptions(BaseModel):
     """Model for generateactionoptions data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     model: str | None = None
     docs: list[DocumentData] | None = None
     messages: list[Message]
     tools: list[str] | None = None
     resources: list[str] | None = None
-    tool_choice: ToolChoice | None = Field(None, alias='toolChoice')
+    tool_choice: ToolChoice | None = Field(None)
     config: Any | None = None
     output: GenerateActionOutputConfig | None = None
     resume: Resume | None = None
-    return_tool_requests: bool | None = Field(None, alias='returnToolRequests')
-    max_turns: float | None = Field(None, alias='maxTurns')
-    step_name: str | None = Field(None, alias='stepName')
+    return_tool_requests: bool | None = Field(None)
+    max_turns: float | None = Field(None)
+    step_name: str | None = Field(None)
 
 
 class GenerateRequest(BaseModel):
     """Model for generaterequest data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     messages: list[Message]
     config: Any | None = None
     tools: list[ToolDefinition] | None = None
-    tool_choice: ToolChoice | None = Field(None, alias='toolChoice')
+    tool_choice: ToolChoice | None = Field(None)
     output: OutputConfig | None = None
     docs: list[DocumentData] | None = None
     candidates: float | None = None
@@ -1019,11 +1017,11 @@ class GenerateRequest(BaseModel):
 class GenerateResponse(BaseModel):
     """Model for generateresponse data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     message: Message | None = None
-    finish_reason: FinishReason | None = Field(None, alias='finishReason')
-    finish_message: str | None = Field(None, alias='finishMessage')
-    latency_ms: float | None = Field(None, alias='latencyMs')
+    finish_reason: FinishReason | None = Field(None)
+    finish_message: str | None = Field(None)
+    latency_ms: float | None = Field(None)
     usage: GenerationUsage | None = None
     custom: Any | None = None
     raw: Any | None = None
@@ -1035,11 +1033,11 @@ class GenerateResponse(BaseModel):
 class ModelRequest(BaseModel):
     """Model for modelrequest data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     messages: Messages
     config: Config | None = None
     tools: Tools | None = None
-    tool_choice: ToolChoice | None = Field(None, alias='toolChoice')
+    tool_choice: ToolChoice | None = Field(None)
     output: OutputModel | None = None
     docs: Docs | None = None
 
@@ -1053,11 +1051,11 @@ class Request(RootModel[GenerateRequest]):
 class ModelResponse(BaseModel):
     """Model for modelresponse data."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
     message: Message | None = None
-    finish_reason: FinishReason = Field(..., alias='finishReason')
-    finish_message: FinishMessage | None = Field(None, alias='finishMessage')
-    latency_ms: LatencyMs | None = Field(None, alias='latencyMs')
+    finish_reason: FinishReason = Field(...)
+    finish_message: FinishMessage | None = Field(None)
+    latency_ms: LatencyMs | None = Field(None)
     usage: Usage | None = None
     custom: CustomModel | None = None
     raw: Raw | None = None

--- a/py/packages/genkit/tests/genkit/ai/ai_plugin_test.py
+++ b/py/packages/genkit/tests/genkit/ai/ai_plugin_test.py
@@ -43,7 +43,7 @@ class AsyncResolveOnlyPlugin(Plugin):
         async def _generate(req: GenerateRequest, ctx):
             return GenerateResponse(
                 message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='OK: lazy'))]),
-                finishReason=FinishReason.STOP,
+                finish_reason=FinishReason.STOP,
             )
 
         return Action(
@@ -77,7 +77,7 @@ class AsyncInitPlugin(Plugin):
         async def _generate(req: GenerateRequest, ctx):
             return GenerateResponse(
                 message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='OK: resolve'))]),
-                finishReason=FinishReason.STOP,
+                finish_reason=FinishReason.STOP,
             )
 
         return Action(

--- a/py/packages/genkit/tests/genkit/blocks/document_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/document_test.py
@@ -78,7 +78,7 @@ def test_from_data_media_document() -> None:
     doc = Document.from_data(data, data_type, metadata)
 
     assert doc.media() == [
-        Media(url=data, contentType=data_type),
+        Media(url=data, content_type=data_type),
     ]
     assert doc.metadata == metadata
     assert doc.data_type() == data_type

--- a/py/packages/genkit/tests/genkit/blocks/embedding_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/embedding_test.py
@@ -66,7 +66,7 @@ def test_embedder_action_metadata_with_supports_and_config_schema():
         label='Advanced Embedder',
         dimensions=256,
         supports=EmbedderSupports(input=['text', 'image']),
-        configSchema=to_json_schema(CustomConfig),
+        config_schema=to_json_schema(CustomConfig),
     )
     action_metadata = embedder_action_metadata(
         name='advanced_model',
@@ -146,7 +146,7 @@ class MockGenkitRegistry:
         async def mock_arun_side_effect(request, *args, **kwargs):
             # Call the actual (fake) embedder function directly
             embed_response = await fn(request)
-            return ActionResponse(response=embed_response, traceId='mock_trace_id')
+            return ActionResponse(response=embed_response, trace_id='mock_trace_id')
 
         mock_action.arun = AsyncMock(side_effect=mock_arun_side_effect)
         self.actions[(kind, name)] = mock_action
@@ -178,7 +178,7 @@ async def test_embed_with_embedder_ref(mock_genkit_instance):
         label='Fake Embedder',
         dimensions=3,
         supports=EmbedderSupports(input=['text']),
-        configSchema={'type': 'object', 'properties': {'param': {'type': 'string'}}},
+        config_schema={'type': 'object', 'properties': {'param': {'type': 'string'}}},
     )
     registry.register_action(
         name='my-plugin/my-embedder',

--- a/py/packages/genkit/tests/genkit/blocks/generate_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/generate_test.py
@@ -57,7 +57,7 @@ async def test_simple_text_generate_request(setup_test) -> None:
 
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='bye'))]),
         )
     )
@@ -84,7 +84,7 @@ async def test_simulates_doc_grounding(setup_test) -> None:
 
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='bye'))]),
         )
     )
@@ -140,7 +140,7 @@ async def test_generate_applies_middleware(
         resp: GenerateResponse = await next(req, ctx)
         txt = text_from_message(resp.message)
         return GenerateResponse(
-            finishReason=resp.finish_reason,
+            finish_reason=resp.finish_reason,
             message=Message(role=Role.USER, content=[Part(root=TextPart(text=f'{txt} POST'))]),
         )
 
@@ -173,7 +173,7 @@ async def test_generate_middleware_next_fn_args_optional(
         resp: GenerateResponse = await next()
         txt = text_from_message(resp.message)
         return GenerateResponse(
-            finishReason=resp.finish_reason,
+            finish_reason=resp.finish_reason,
             message=Message(role=Role.USER, content=[Part(root=TextPart(text=f'{txt} POST'))]),
         )
 
@@ -246,7 +246,7 @@ async def test_generate_middleware_can_modify_stream(
 
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='bye'))]),
         )
     )

--- a/py/packages/genkit/tests/genkit/blocks/model_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/model_test.py
@@ -189,11 +189,11 @@ def test_chunk_wrapper_output_uses_parser() -> None:
         [[], PartCounts()],
         [
             [
-                Part(root=MediaPart(media=Media(contentType='image', url=''))),
+                Part(root=MediaPart(media=Media(content_type='image', url=''))),
                 Part(root=MediaPart(media=Media(url='data:image'))),
-                Part(root=MediaPart(media=Media(contentType='audio', url=''))),
+                Part(root=MediaPart(media=Media(content_type='audio', url=''))),
                 Part(root=MediaPart(media=Media(url='data:audio'))),
-                Part(root=MediaPart(media=Media(contentType='video', url=''))),
+                Part(root=MediaPart(media=Media(content_type='video', url=''))),
                 Part(root=MediaPart(media=Media(url='data:video'))),
                 Part(root=TextPart(text='test')),
             ],
@@ -217,14 +217,14 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
             [],
             [],
             GenerationUsage(
-                inputImages=0,
-                inputVideos=0,
-                inputCharacters=0,
-                inputAudioFiles=0,
-                outputAudioFiles=0,
-                outputCharacters=0,
-                outputImages=0,
-                outputVideos=0,
+                input_images=0,
+                input_videos=0,
+                input_characters=0,
+                input_audio_files=0,
+                output_audio_files=0,
+                output_characters=0,
+                output_images=0,
+                output_videos=0,
             ),
         ],
         [
@@ -239,11 +239,11 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 Message(
                     role='user',
                     content=[
-                        Part(root=MediaPart(media=Media(contentType='image', url=''))),
+                        Part(root=MediaPart(media=Media(content_type='image', url=''))),
                         Part(root=MediaPart(media=Media(url='data:image'))),
-                        Part(root=MediaPart(media=Media(contentType='audio', url=''))),
+                        Part(root=MediaPart(media=Media(content_type='audio', url=''))),
                         Part(root=MediaPart(media=Media(url='data:audio'))),
-                        Part(root=MediaPart(media=Media(contentType='video', url=''))),
+                        Part(root=MediaPart(media=Media(content_type='video', url=''))),
                         Part(root=MediaPart(media=Media(url='data:video'))),
                     ],
                 ),
@@ -252,23 +252,23 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 role='user',
                 content=[
                     Part(root=TextPart(text='3')),
-                    Part(root=MediaPart(media=Media(contentType='image', url=''))),
+                    Part(root=MediaPart(media=Media(content_type='image', url=''))),
                     Part(root=MediaPart(media=Media(url='data:image'))),
-                    Part(root=MediaPart(media=Media(contentType='audio', url=''))),
+                    Part(root=MediaPart(media=Media(content_type='audio', url=''))),
                     Part(root=MediaPart(media=Media(url='data:audio'))),
-                    Part(root=MediaPart(media=Media(contentType='video', url=''))),
+                    Part(root=MediaPart(media=Media(content_type='video', url=''))),
                     Part(root=MediaPart(media=Media(url='data:video'))),
                 ],
             ),
             GenerationUsage(
-                inputImages=2,
-                inputVideos=2,
-                inputCharacters=2,
-                inputAudioFiles=2,
-                outputAudioFiles=2,
-                outputCharacters=1,
-                outputImages=2,
-                outputVideos=2,
+                input_images=2,
+                input_videos=2,
+                input_characters=2,
+                input_audio_files=2,
+                output_audio_files=2,
+                output_characters=1,
+                output_images=2,
+                output_videos=2,
             ),
         ],
         [
@@ -284,7 +284,7 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
             [
                 Candidate(
                     index=0,
-                    finishReason='stop',
+                    finish_reason='stop',
                     message=Message(
                         role='user',
                         content=[
@@ -294,17 +294,17 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 ),
                 Candidate(
                     index=1,
-                    finishReason='stop',
+                    finish_reason='stop',
                     message=Message(
                         role='user',
                         content=[
-                            Part(root=MediaPart(media=Media(contentType='image', url=''))),
+                            Part(root=MediaPart(media=Media(content_type='image', url=''))),
                         ],
                     ),
                 ),
                 Candidate(
                     index=2,
-                    finishReason='stop',
+                    finish_reason='stop',
                     message=Message(
                         role='user',
                         content=[
@@ -314,17 +314,17 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 ),
                 Candidate(
                     index=3,
-                    finishReason='stop',
+                    finish_reason='stop',
                     message=Message(
                         role='user',
                         content=[
-                            Part(root=MediaPart(media=Media(contentType='audio', url=''))),
+                            Part(root=MediaPart(media=Media(content_type='audio', url=''))),
                         ],
                     ),
                 ),
                 Candidate(
                     index=4,
-                    finishReason='stop',
+                    finish_reason='stop',
                     message=Message(
                         role='user',
                         content=[
@@ -334,17 +334,17 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 ),
                 Candidate(
                     index=5,
-                    finishReason='stop',
+                    finish_reason='stop',
                     message=Message(
                         role='user',
                         content=[
-                            Part(root=MediaPart(media=Media(contentType='video', url=''))),
+                            Part(root=MediaPart(media=Media(content_type='video', url=''))),
                         ],
                     ),
                 ),
                 Candidate(
                     index=6,
-                    finishReason='stop',
+                    finish_reason='stop',
                     message=Message(
                         role='user',
                         content=[
@@ -354,14 +354,14 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 ),
             ],
             GenerationUsage(
-                inputImages=0,
-                inputVideos=0,
-                inputCharacters=2,
-                inputAudioFiles=0,
-                outputAudioFiles=2,
-                outputCharacters=1,
-                outputImages=2,
-                outputVideos=2,
+                input_images=0,
+                input_videos=0,
+                input_characters=2,
+                input_audio_files=0,
+                output_audio_files=2,
+                output_characters=1,
+                output_images=2,
+                output_videos=2,
             ),
         ],
     ),

--- a/py/packages/genkit/tests/genkit/blocks/retriever_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/retriever_test.py
@@ -63,7 +63,7 @@ def test_retriever_action_metadata_with_supports_and_config_schema():
     options = RetrieverOptions(
         label='Advanced Retriever',
         supports=RetrieverSupports(media=True),
-        configSchema=to_json_schema(CustomConfig),
+        config_schema=to_json_schema(CustomConfig),
     )
     action_metadata = retriever_action_metadata(
         name='advanced_retriever',

--- a/py/packages/genkit/tests/genkit/blocks/test_reranker.py
+++ b/py/packages/genkit/tests/genkit/blocks/test_reranker.py
@@ -123,7 +123,7 @@ class TestRerankerActionMetadata:
         """Test creating action metadata with options."""
         options = RerankerOptions(
             label='Custom Label',
-            configSchema={'type': 'object'},
+            config_schema={'type': 'object'},
         )
         metadata = reranker_action_metadata('test-reranker', options)
 

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -311,7 +311,7 @@ async def test_generate_with_tools(setup_test: SetupFixture) -> None:
         ToolDefinition(
             name='testTool',
             description='The tool.',
-            inputSchema={
+            input_schema={
                 'properties': {
                     'value': {
                         'default': None,
@@ -323,7 +323,7 @@ async def test_generate_with_tools(setup_test: SetupFixture) -> None:
                 'title': 'ToolInput',
                 'type': 'object',
             },
-            outputSchema={},
+            output_schema={},
         )
     ]
 
@@ -375,13 +375,13 @@ async def test_generate_with_iterrupting_tools(
     )
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=tool_request_msg,
         )
     )
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='tool called'))]),
         )
     )
@@ -396,7 +396,7 @@ async def test_generate_with_iterrupting_tools(
         ToolDefinition(
             name='test_tool',
             description='The tool.',
-            inputSchema={
+            input_schema={
                 'properties': {
                     'value': {
                         'default': None,
@@ -408,12 +408,12 @@ async def test_generate_with_iterrupting_tools(
                 'title': 'ToolInput',
                 'type': 'object',
             },
-            outputSchema={},
+            output_schema={},
         ),
         ToolDefinition(
             name='test_interrupt',
             description='The interrupt.',
-            inputSchema={
+            input_schema={
                 'properties': {
                     'value': {
                         'default': None,
@@ -425,7 +425,7 @@ async def test_generate_with_iterrupting_tools(
                 'title': 'ToolInput',
                 'type': 'object',
             },
-            outputSchema={},
+            output_schema={},
         ),
     ]
 
@@ -487,13 +487,13 @@ async def test_generate_with_interrupt_respond(
     )
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=tool_request_msg,
         )
     )
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='tool called'))]),
         )
     )
@@ -627,13 +627,13 @@ async def test_generate_with_tools_and_output(setup_test: SetupFixture) -> None:
     )
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=tool_request_msg,
         )
     )
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='tool called'))]),
         )
     )
@@ -656,7 +656,7 @@ async def test_generate_with_tools_and_output(setup_test: SetupFixture) -> None:
         ToolDefinition(
             name='testTool',
             description='The tool.',
-            inputSchema={
+            input_schema={
                 'properties': {
                     'value': {
                         'default': None,
@@ -668,7 +668,7 @@ async def test_generate_with_tools_and_output(setup_test: SetupFixture) -> None:
                 'title': 'ToolInput',
                 'type': 'object',
             },
-            outputSchema={},
+            output_schema={},
         )
     ]
 
@@ -696,13 +696,13 @@ async def test_generate_stream_with_tools(setup_test: SetupFixture) -> None:
     )
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=tool_request_msg,
         )
     )
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='tool called'))]),
         )
     )
@@ -759,7 +759,7 @@ async def test_generate_stream_no_need_to_await_response(
 
     pm.responses.append(
         GenerateResponse(
-            finishReason=FinishReason.STOP,
+            finish_reason=FinishReason.STOP,
             message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='something else'))]),
         )
     )
@@ -985,7 +985,7 @@ async def test_generate_with_middleware(
         resp: GenerateResponse = await next(req, ctx)
         txt = text_from_message(resp.message)
         return GenerateResponse(
-            finishReason=resp.finish_reason,
+            finish_reason=resp.finish_reason,
             message=Message(role=Role.USER, content=[Part(root=TextPart(text=f'{txt} POST'))]),
         )
 
@@ -1235,7 +1235,7 @@ async def test_define_format(setup_test: SetupFixture) -> None:
     pm.responses = [
         (
             GenerateResponse(
-                finishReason=FinishReason.STOP,
+                finish_reason=FinishReason.STOP,
                 message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='model says'))]),
             )
         )
@@ -1453,7 +1453,7 @@ def test_define_evaluator_simple(setup_test: SetupFixture) -> None:
 
     def my_eval_fn(datapoint: BaseEvalDataPoint, options: Any | None):
         return EvalFnResponse(
-            testCaseId=datapoint.test_case_id,
+            test_case_id=datapoint.test_case_id,
             evaluation=Score(score=True, details=Details(reasoning='I think it is true')),
         )
 
@@ -1481,7 +1481,7 @@ def test_define_evaluator_custom_config(setup_test: SetupFixture) -> None:
 
     def my_eval_fn(datapoint: BaseEvalDataPoint, options: CustomOption | None):
         return EvalFnResponse(
-            testCaseId=datapoint.test_case_id,
+            test_case_id=datapoint.test_case_id,
             evaluation=Score(score=True, details=Details(reasoning=options.foo_bar)),
         )
 
@@ -1523,7 +1523,7 @@ def test_define_batch_evaluator(setup_test: SetupFixture) -> None:
             datapoint = req.dataset[index]
             eval_responses.append(
                 EvalFnResponse(
-                    testCaseId=f'testCase{index}',
+                    test_case_id=f'testCase{index}',
                     evaluation=Score(
                         score=True,
                         details=Details(reasoning=f'I think {datapoint.input} is true'),
@@ -1601,7 +1601,7 @@ async def test_evaluate(setup_test: SetupFixture) -> None:
 
     async def my_eval_fn(datapoint: BaseDataPoint, options: Any | None):
         return EvalFnResponse(
-            testCaseId=datapoint.test_case_id,
+            test_case_id=datapoint.test_case_id,
             evaluation=Score(score=True, details=Details(reasoning='I think it is true')),
         )
 
@@ -1613,8 +1613,8 @@ async def test_evaluate(setup_test: SetupFixture) -> None:
     )
 
     dataset = [
-        BaseDataPoint(input='hi', output='hi', testCaseId='case1'),
-        BaseDataPoint(input='bye', output='bye', testCaseId='case2'),
+        BaseDataPoint(input='hi', output='hi', test_case_id='case1'),
+        BaseDataPoint(input='bye', output='bye', test_case_id='case2'),
     ]
 
     response = await ai.evaluate(evaluator='my_eval', dataset=dataset)

--- a/py/plugins/anthropic/src/genkit/plugins/anthropic/models.py
+++ b/py/plugins/anthropic/src/genkit/plugins/anthropic/models.py
@@ -94,15 +94,15 @@ class AnthropicModel:
         return GenerateResponse(
             message=response_message,
             usage=GenerationUsage(
-                inputTokens=response.usage.input_tokens,
-                outputTokens=response.usage.output_tokens,
-                totalTokens=response.usage.input_tokens + response.usage.output_tokens,
-                inputCharacters=basic_usage.input_characters,
-                outputCharacters=basic_usage.output_characters,
-                inputImages=basic_usage.input_images,
-                outputImages=basic_usage.output_images,
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+                total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+                input_characters=basic_usage.input_characters,
+                output_characters=basic_usage.output_characters,
+                input_images=basic_usage.input_images,
+                output_images=basic_usage.output_images,
             ),
-            finishReason=finish_reason,
+            finish_reason=finish_reason,
         )
 
     def _build_params(self, request: GenerateRequest) -> dict[str, Any]:

--- a/py/plugins/anthropic/tests/test_models.py
+++ b/py/plugins/anthropic/tests/test_models.py
@@ -48,7 +48,7 @@ def _create_sample_request() -> GenerateRequest:
             ToolDefinition(
                 name='get_weather',
                 description='Get weather for a location',
-                inputSchema={
+                input_schema={
                     'type': 'object',
                     'properties': {'location': {'type': 'string', 'description': 'Location name'}},
                     'required': ['location'],
@@ -131,7 +131,7 @@ async def test_generate_with_config():
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Test'))])],
         config=GenerationCommonConfig(
             temperature=0.7,
-            maxOutputTokens=100,
+            max_output_tokens=100,
             topP=0.9,
         ),
     )

--- a/py/plugins/anthropic/tests/test_plugin.py
+++ b/py/plugins/anthropic/tests/test_plugin.py
@@ -137,7 +137,7 @@ def _create_sample_request() -> GenerateRequest:
             ToolDefinition(
                 name='get_weather',
                 description='Get weather for a location',
-                inputSchema={
+                input_schema={
                     'type': 'object',
                     'properties': {'location': {'type': 'string', 'description': 'Location name'}},
                     'required': ['location'],

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/model_info.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/model_info.py
@@ -43,7 +43,7 @@ MULTIMODAL_MODEL_SUPPORTS = Supports(
     multiturn=True,
     media=True,
     tools=True,
-    systemRole=True,
+    system_role=True,
     output=[SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.STRUCTURED_OUTPUTS, SupportedOutputFormat.TEXT],
 )
 
@@ -51,7 +51,7 @@ GPT_4_MODEL_SUPPORTS = Supports(
     multiturn=True,
     media=False,
     tools=True,
-    systemRole=True,
+    system_role=True,
     output=[SupportedOutputFormat.TEXT],
 )
 
@@ -59,7 +59,7 @@ GPT_35_MODEL_SUPPORTS = Supports(
     multiturn=True,
     media=False,
     tools=True,
-    systemRole=True,
+    system_role=True,
     output=[SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.TEXT],
 )
 
@@ -67,7 +67,7 @@ O_SERIES_MODEL_SUPPORTS = Supports(
     multiturn=True,
     media=True,
     tools=True,
-    systemRole=False,
+    system_role=False,
     output=[SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.TEXT],
 )
 
@@ -75,7 +75,7 @@ GPT_5_MODEL_SUPPORTS = Supports(
     multiturn=True,
     media=True,
     tools=True,
-    systemRole=True,
+    system_role=True,
     output=[SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.TEXT],
 )
 
@@ -93,7 +93,7 @@ SUPPORTED_OPENAI_MODELS: dict[str, ModelInfo] = {
             multiturn=True,
             media=False,
             tools=True,
-            systemRole=False,
+            system_role=False,
             output=[SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.TEXT],
         ),
     ),
@@ -119,7 +119,7 @@ SUPPORTED_OPENAI_MODELS: dict[str, ModelInfo] = {
             multiturn=True,
             media=True,
             tools=False,
-            systemRole=True,
+            system_role=True,
             output=[SupportedOutputFormat.TEXT],
         ),
     ),
@@ -151,8 +151,8 @@ SUPPORTED_OPENAI_COMPAT_MODELS: dict[str, ModelInfo] = {
             multiturn=True,
             media=False,
             tools=True,
-            systemRole=True,
-            longRunning=False,
+            system_role=True,
+            long_running=False,
             output=[SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.TEXT],
         ),
     ),
@@ -162,7 +162,7 @@ SUPPORTED_OPENAI_COMPAT_MODELS: dict[str, ModelInfo] = {
             multiturn=True,
             media=True,
             tools=True,
-            systemRole=True,
+            system_role=True,
             output=[SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.TEXT],
         ),
     ),
@@ -173,7 +173,7 @@ DEFAULT_SUPPORTS = Supports(
     multiturn=True,
     media=True,
     tools=True,
-    systemRole=True,
+    system_role=True,
     output=[SupportedOutputFormat.JSON_MODE, SupportedOutputFormat.TEXT],
 )
 

--- a/py/plugins/compat-oai/tests/test_tool_calling.py
+++ b/py/plugins/compat-oai/tests/test_tool_calling.py
@@ -41,7 +41,7 @@ async def test_generate_with_tool_calls_executes_tools(sample_request: GenerateR
     first_message.content = None
 
     first_response = MagicMock()
-    first_response.choices = [MagicMock(finishReason='tool_calls', message=first_message)]
+    first_response.choices = [MagicMock(finish_reason='tool_calls', message=first_message)]
 
     # Second call is the model response
     second_message = MagicMock()
@@ -50,7 +50,7 @@ async def test_generate_with_tool_calls_executes_tools(sample_request: GenerateR
     second_message.content = 'final response'
 
     second_response = MagicMock()
-    second_response.choices = [MagicMock(finishReason='stop', message=second_message)]
+    second_response.choices = [MagicMock(finish_reason='stop', message=second_message)]
 
     mock_client = MagicMock()
     mock_client.chat.completions.create.side_effect = [

--- a/py/plugins/evaluators/src/genkit/plugins/evaluators/helpers.py
+++ b/py/plugins/evaluators/src/genkit/plugins/evaluators/helpers.py
@@ -65,7 +65,7 @@ def fill_scores(
     if status_override_fn is not None:
         status = status_override_fn(score)
     score.status = status
-    return EvalFnResponse(testCaseId=datapoint.test_case_id, evaluation=score)
+    return EvalFnResponse(test_case_id=datapoint.test_case_id, evaluation=score)
 
 
 def define_genkit_evaluators(ai: Genkit, params: PluginOptions | list[MetricConfig]) -> None:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/context_caching/types.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/context_caching/types.py
@@ -16,14 +16,14 @@
 
 from typing import Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 
 class CacheConfigSchema(BaseModel):
-    ttl_seconds: int | None = Field(..., alias='ttlSeconds')
+    model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
 
-    class Config:
-        extra = 'allow'
+    ttl_seconds: int | None = ...
 
 
 CacheConfig = Union[bool, CacheConfigSchema]

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -216,8 +216,8 @@ GEMINI_1_5_PRO = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -234,8 +234,8 @@ GEMINI_1_5_FLASH = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -248,8 +248,8 @@ GEMINI_1_5_FLASH_8B = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -260,8 +260,8 @@ GEMINI_2_0_FLASH = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -272,8 +272,8 @@ GEMINI_2_0_FLASH_LITE = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -284,8 +284,8 @@ GEMINI_2_0_PRO_EXP_02_05 = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -296,8 +296,8 @@ GEMINI_2_0_FLASH_EXP_IMAGEN = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -308,8 +308,8 @@ GEMINI_2_0_FLASH_THINKING_EXP_01_21 = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -320,8 +320,8 @@ GEMINI_2_5_PRO_EXP_03_25 = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -332,8 +332,8 @@ GEMINI_2_5_PRO_PREVIEW_03_25 = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -344,8 +344,8 @@ GEMINI_2_5_PRO_PREVIEW_05_06 = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -356,8 +356,8 @@ GEMINI_2_5_FLASH_PREVIEW_04_17 = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
     ),
 )
@@ -368,8 +368,8 @@ GENERIC_GEMINI_MODEL = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
         output=['text', 'json'],
     ),
@@ -381,8 +381,8 @@ GENERIC_TTS_MODEL = ModelInfo(
         multiturn=False,
         media=False,
         tools=False,
-        toolChoice=False,
-        systemRole=False,
+        tool_choice=False,
+        system_role=False,
         constrained='no-tools',
     ),
 )
@@ -393,8 +393,8 @@ GENERIC_IMAGE_MODEL = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
         output=['text'],
     ),
@@ -406,8 +406,8 @@ GENERIC_GEMMA_MODEL = ModelInfo(
         multiturn=True,
         media=True,
         tools=True,
-        toolChoice=True,
-        systemRole=True,
+        tool_choice=True,
+        system_role=True,
         constrained='no-tools',
         output=['text', 'json'],
     ),
@@ -608,8 +608,8 @@ DEFAULT_SUPPORTS_MODEL = Supports(
     multiturn=True,
     media=True,
     tools=True,
-    toolChoice=True,
-    systemRole=True,
+    tool_choice=True,
+    system_role=True,
     constrained='no-tools',
 )
 
@@ -785,7 +785,7 @@ class GeminiModel:
         if cache:
             updated_expiration_time = datetime.now(timezone.utc) + timedelta(seconds=ttl)
             cache = await self._client.aio.caches.update(
-                name=cache.name, config=genai_types.UpdateCachedContentConfig(expireTime=updated_expiration_time)
+                name=cache.name, config=genai_types.UpdateCachedContentConfig(expire_time=updated_expiration_time)
             )
         else:
             cache = await self._client.aio.caches.create(
@@ -1063,9 +1063,9 @@ class GeminiModel:
             request_config = request.config
             if isinstance(request_config, GenerationCommonConfig):
                 cfg = genai_types.GenerateContentConfig(
-                    maxOutputTokens=request_config.max_output_tokens,
+                    max_output_tokens=request_config.max_output_tokens,
                     top_k=request_config.top_k,
-                    topP=request_config.top_p,
+                    top_p=request_config.top_p,
                     temperature=request_config.temperature,
                     stop_sequences=request_config.stop_sequences,
                 )

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -59,7 +59,7 @@ SUPPORTED_MODELS = {
             media=True,
             multiturn=False,
             tools=False,
-            systemRole=False,
+            system_role=False,
             output=['media'],
         ),
     ),
@@ -69,7 +69,7 @@ SUPPORTED_MODELS = {
             media=False,
             multiturn=False,
             tools=False,
-            systemRole=False,
+            system_role=False,
             output=['media'],
         ),
     ),
@@ -79,7 +79,7 @@ SUPPORTED_MODELS = {
             media=False,
             multiturn=False,
             tools=False,
-            systemRole=False,
+            system_role=False,
             output=['media'],
         ),
     ),
@@ -89,7 +89,7 @@ DEFAULT_IMAGE_SUPPORT = Supports(
     media=True,
     multiturn=False,
     tools=False,
-    systemRole=False,
+    system_role=False,
     output=['media'],
 )
 
@@ -211,7 +211,7 @@ class ImagenModel:
                     Part(
                         media=Media(
                             url=f'data:{image.image.mime_type};base64,{b64_data}',
-                            contentType=image.image.mime_type,
+                            content_type=image.image.mime_type,
                         )
                     )
                 )

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/utils.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/utils.py
@@ -250,7 +250,7 @@ class PartConverter:
             return Part(
                 media=Media(
                     url=f'data:{part.inline_data.mime_type};base64,{b64_data}',
-                    contentType=part.inline_data.mime_type,
+                    content_type=part.inline_data.mime_type,
                 )
             )
         if part.executable_code:

--- a/py/plugins/google-genai/test/models/test_googlegenai_gemini.py
+++ b/py/plugins/google-genai/test/models/test_googlegenai_gemini.py
@@ -384,8 +384,8 @@ def test_gemini_model__get_tools(
         ToolDefinition(
             name='tool_1',
             description='model tool description',
-            inputSchema={},
-            outputSchema={
+            input_schema={},
+            output_schema={
                 'type': 'object',
                 'properties': {
                     'test': {'type': 'string', 'description': 'test field'},
@@ -396,8 +396,8 @@ def test_gemini_model__get_tools(
         ToolDefinition(
             name='tool_2',
             description='model tool description',
-            inputSchema={},
-            outputSchema={
+            input_schema={},
+            output_schema={
                 'type': 'object',
                 'properties': {
                     'test': {'type': 'string', 'description': 'test field'},
@@ -432,11 +432,11 @@ def test_gemini_model__create_tool(mock_convert_schema_property, gemini_model_in
     tool_defined = ToolDefinition(
         name='model_tool',
         description='model tool description',
-        inputSchema={
+        input_schema={
             'type': 'str',
             'description': 'test field',
         },
-        outputSchema={
+        output_schema={
             'type': 'object',
             'properties': {
                 'test': {'type': 'string', 'description': 'test field'},

--- a/py/plugins/mcp/src/genkit/plugins/mcp/server.py
+++ b/py/plugins/mcp/src/genkit/plugins/mcp/server.py
@@ -202,7 +202,7 @@ class McpServer:
                 Tool(
                     name=action.name,
                     description=action.description or '',
-                    inputSchema=input_schema,
+                    input_schema=input_schema,
                     _meta=action.metadata.get('mcp', {}).get('_meta') if action.metadata else None,
                 )
             )

--- a/py/plugins/mcp/tests/fakes.py
+++ b/py/plugins/mcp/tests/fakes.py
@@ -118,7 +118,7 @@ class FakeTransport:
 
     # Helper methods to populate the fake state
     def add_tool(self, name: str, description: str = '', schema: dict | None = None):
-        self.tools.append({'name': name, 'description': description, 'inputSchema': schema or {'type': 'object'}})
+        self.tools.append({'name': name, 'description': description, 'input_schema': schema or {'type': 'object'}})
 
     def add_prompt(self, name: str, description: str = '', arguments: list | None = None):
         self.prompts.append({'name': name, 'description': description, 'arguments': arguments or []})

--- a/py/plugins/mcp/tests/test_mcp_integration.py
+++ b/py/plugins/mcp/tests/test_mcp_integration.py
@@ -54,7 +54,7 @@ class TestClientServerIntegration(unittest.IsolatedAsyncioTestCase):
         mock_tool = MagicMock()
         mock_tool.name = 'add'
         mock_tool.description = 'Add two numbers'
-        mock_tool.inputSchema = {'type': 'object'}
+        mock_tool.input_schema = {'type': 'object'}
 
         mock_session.list_tools.return_value.tools = [mock_tool]
         client.session = mock_session
@@ -157,7 +157,7 @@ class TestClientServerIntegration(unittest.IsolatedAsyncioTestCase):
             mock_tool = MagicMock()
             mock_tool.name = f'{client_name}_tool'
             mock_tool.description = f'Tool from {client_name}'
-            mock_tool.inputSchema = {'type': 'object'}
+            mock_tool.input_schema = {'type': 'object'}
 
             mock_session.list_tools.return_value.tools = [mock_tool]
             client.session = mock_session

--- a/py/plugins/mcp/tests/test_mcp_server.py
+++ b/py/plugins/mcp/tests/test_mcp_server.py
@@ -124,7 +124,7 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(tool.name, 'test_tool')
         self.assertEqual(tool.description, 'test tool')
-        self.assertIsNotNone(tool.inputSchema)
+        self.assertIsNotNone(tool.input_schema)
 
     async def test_call_tool(self):
         """Test calling a tool - mirrors JS 'should call the tool'."""

--- a/py/plugins/ollama/src/genkit/plugins/ollama/models.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/models.py
@@ -254,7 +254,7 @@ class OllamaModel:
                     Part(
                         root=MediaPart(
                             media=Media(
-                                contentType=mimetypes.guess_type(image.value, strict=False)[0],
+                                content_type=mimetypes.guess_type(image.value, strict=False)[0],
                                 url=image.value,
                             )
                         )

--- a/py/plugins/ollama/tests/models/test_models.py
+++ b/py/plugins/ollama/tests/models/test_models.py
@@ -49,9 +49,9 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
     @patch(
         'genkit.blocks.model.get_basic_usage_stats',
         return_value=GenerationUsage(
-            inputTokens=10,
-            outputTokens=20,
-            totalTokens=30,
+            input_tokens=10,
+            output_tokens=20,
+            total_tokens=30,
         ),
     )
     async def test_generate_chat_non_streaming(self, mock_get_basic_usage_stats):
@@ -81,9 +81,9 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         )
         ollama_model.get_usage_info = MagicMock(
             return_value=GenerationUsage(
-                inputTokens=5,
-                outputTokens=10,
-                totalTokens=15,
+                input_tokens=5,
+                output_tokens=10,
+                total_tokens=15,
             ),
         )
         ollama_model.is_streaming_request = MagicMock(return_value=False)
@@ -106,9 +106,9 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
     @patch(
         'genkit.blocks.model.get_basic_usage_stats',
         return_value=GenerationUsage(
-            inputTokens=10,
-            outputTokens=20,
-            totalTokens=30,
+            input_tokens=10,
+            output_tokens=20,
+            total_tokens=30,
         ),
     )
     async def test_generate_generate_non_streaming(self, mock_get_basic_usage_stats):
@@ -133,9 +133,9 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         ollama_model.is_streaming_request = MagicMock(return_value=False)
         ollama_model.get_usage_info = MagicMock(
             return_value=GenerationUsage(
-                inputTokens=7,
-                outputTokens=14,
-                totalTokens=21,
+                input_tokens=7,
+                output_tokens=14,
+                total_tokens=21,
             ),
         )
 
@@ -179,9 +179,9 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         ollama_model.is_streaming_request = MagicMock(return_value=True)
         ollama_model.get_usage_info = MagicMock(
             return_value=GenerationUsage(
-                inputTokens=0,
-                outputTokens=0,
-                totalTokens=0,
+                input_tokens=0,
+                output_tokens=0,
+                total_tokens=0,
             ),
         )
 
@@ -220,9 +220,9 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         ollama_model.is_streaming_request = MagicMock(return_value=True)
         ollama_model.get_usage_info = MagicMock(
             return_value=GenerationUsage(
-                inputTokens=0,
-                outputTokens=0,
-                totalTokens=0,
+                input_tokens=0,
+                output_tokens=0,
+                total_tokens=0,
             ),
         )
 

--- a/py/plugins/xai/src/genkit/plugins/xai/models.py
+++ b/py/plugins/xai/src/genkit/plugins/xai/models.py
@@ -87,15 +87,15 @@ class XAIModel:
         return GenerateResponse(
             message=response_message,
             usage=GenerationUsage(
-                inputTokens=response.usage.prompt_tokens,
-                outputTokens=response.usage.completion_tokens,
-                totalTokens=response.usage.total_tokens,
-                inputCharacters=basic_usage.input_characters,
-                outputCharacters=basic_usage.output_characters,
-                inputImages=basic_usage.input_images,
-                outputImages=basic_usage.output_images,
+                input_tokens=response.usage.prompt_tokens,
+                output_tokens=response.usage.completion_tokens,
+                total_tokens=response.usage.total_tokens,
+                input_characters=basic_usage.input_characters,
+                output_characters=basic_usage.output_characters,
+                input_images=basic_usage.input_images,
+                output_images=basic_usage.output_images,
             ),
-            finishReason=FINISH_REASON_MAP.get(response.finish_reason, 'unknown'),
+            finish_reason=FINISH_REASON_MAP.get(response.finish_reason, 'unknown'),
         )
 
     def _build_params(self, request: GenerateRequest) -> dict[str, Any]:
@@ -211,15 +211,15 @@ class XAIModel:
             return GenerateResponse(
                 message=response_message,
                 usage=GenerationUsage(
-                    inputTokens=final_response.usage.prompt_tokens if final_response else 0,
-                    outputTokens=final_response.usage.completion_tokens if final_response else 0,
-                    totalTokens=final_response.usage.total_tokens if final_response else 0,
-                    inputCharacters=basic_usage.input_characters,
-                    outputCharacters=basic_usage.output_characters,
-                    inputImages=basic_usage.input_images,
-                    outputImages=basic_usage.output_images,
+                    input_tokens=final_response.usage.prompt_tokens if final_response else 0,
+                    output_tokens=final_response.usage.completion_tokens if final_response else 0,
+                    total_tokens=final_response.usage.total_tokens if final_response else 0,
+                    input_characters=basic_usage.input_characters,
+                    output_characters=basic_usage.output_characters,
+                    input_images=basic_usage.input_images,
+                    output_images=basic_usage.output_images,
                 ),
-                finishReason=finish_reason,
+                finish_reason=finish_reason,
             )
 
         return await asyncio.to_thread(_sync_stream)

--- a/py/plugins/xai/tests/test_xai_models.py
+++ b/py/plugins/xai/tests/test_xai_models.py
@@ -48,7 +48,7 @@ def _create_sample_request() -> GenerateRequest:
             ToolDefinition(
                 name='get_weather',
                 description='Get weather for a location',
-                inputSchema={
+                input_schema={
                     'type': 'object',
                     'properties': {'location': {'type': 'string', 'description': 'Location name'}},
                     'required': ['location'],
@@ -69,7 +69,7 @@ async def test_generate_basic():
     mock_response.usage = MagicMock(
         prompt_tokens=10,
         completion_tokens=15,
-        totalTokens=25,
+        total_tokens=25,
     )
     mock_response.tool_calls = None
 
@@ -101,7 +101,7 @@ async def test_generate_with_config():
     mock_response.usage = MagicMock(
         prompt_tokens=5,
         completion_tokens=5,
-        totalTokens=10,
+        total_tokens=10,
     )
     mock_response.tool_calls = None
 
@@ -118,7 +118,7 @@ async def test_generate_with_config():
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Test'))])],
         config=GenerationCommonConfig(
             temperature=0.7,
-            maxOutputTokens=100,
+            max_output_tokens=100,
             topP=0.9,
         ),
     )
@@ -181,7 +181,7 @@ async def test_streaming_generation():
     mock_response.usage = MagicMock(
         prompt_tokens=10,
         completion_tokens=20,
-        totalTokens=30,
+        total_tokens=30,
     )
 
     def mock_stream():
@@ -239,7 +239,7 @@ async def test_generate_with_tools():
     mock_response.usage = MagicMock(
         prompt_tokens=20,
         completion_tokens=10,
-        totalTokens=30,
+        total_tokens=30,
     )
     mock_response.tool_calls = [mock_tool_call]
 


### PR DESCRIPTION
refactor(py/genkit): use alias_generator for Pydantic field aliasing

Replace explicit Field(alias='...') with alias_generator=to_camel in
model_config to improve code consistency and maintainability. This
allows Python code to use idiomatic snake_case attribute names while
maintaining camelCase JSON serialization.

Changes:
- Update sanitize_schema_typing.py to add alias_generator=to_camel and
  remove individual alias= from Field() calls
- Add alias='schema' for schema_ fields (Pydantic reserves 'schema')
- Convert 180+ camelCase parameter usages to snake_case across packages
  and plugins (e.g., systemRole → system_role, toolRequest → tool_request)
- Fix topP → top_p in gemini.py for google.genai API compatibility
- Remove outdated comments referencing camelCase alias workarounds
- Update tests to use snake_case field names consistently

This improves developer experience by allowing natural Python attribute
access while preserving JSON schema compatibility via populate_by_name=True.