### PR TITLE
fix(py): fix test failures and enforce type checking in CI (zero lint except samples)

### DIFF
--- a/py/packages/genkit/src/genkit/ai/_registry.py
+++ b/py/packages/genkit/src/genkit/ai/_registry.py
@@ -46,7 +46,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
-    from genkit.blocks.resource import ResourceFn, ResourceOptions
+    from genkit.blocks.resource import FlexibleResourceFn, ResourceFn, ResourceOptions
 
 import structlog
 from pydantic import BaseModel
@@ -832,7 +832,7 @@ class GenkitRegistry:
     def define_resource(
         self,
         opts: 'ResourceOptions | None' = None,
-        fn: 'ResourceFn | None' = None,
+        fn: 'FlexibleResourceFn | None' = None,
         *,
         name: str | None = None,
         uri: str | None = None,
@@ -855,6 +855,9 @@ class GenkitRegistry:
             The registered Action for the resource.
         """
         from genkit.blocks.resource import (
+            FlexibleResourceFn,
+            ResourceFn,
+            ResourceOptions,
             define_resource as define_resource_block,
         )
 

--- a/py/packages/genkit/src/genkit/core/action/_action.py
+++ b/py/packages/genkit/src/genkit/core/action/_action.py
@@ -224,6 +224,8 @@ class Action:
         self._metadata = metadata if metadata else {}
         self._description = description
         self._is_async = inspect.iscoroutinefunction(fn)
+        # Optional matcher function for resource actions
+        self.matches: Callable[[Any], bool] | None = None
 
         input_spec = inspect.getfullargspec(metadata_fn if metadata_fn else fn)
         action_args, arg_types = extract_action_args_and_types(input_spec)

--- a/py/packages/genkit/tests/genkit/ai/test_resource_integration.py
+++ b/py/packages/genkit/tests/genkit/ai/test_resource_integration.py
@@ -54,6 +54,7 @@ async def test_generate_with_resources():
 
     response = await generate_action(registry, options)
     # Part also uses RootModel, access via root
+    assert response.message is not None
     assert response.message.content[0].root.text == 'Done'
 
 
@@ -100,4 +101,5 @@ async def test_dynamic_action_provider_resource():
     )
 
     response = await generate_action(registry, options)
+    assert response.message is not None
     assert response.message.content[0].root.text == 'Done'

--- a/py/packages/genkit/tests/genkit/blocks/embedding_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/embedding_test.py
@@ -73,6 +73,7 @@ def test_embedder_action_metadata_with_supports_and_config_schema():
         options=options,
     )
     assert isinstance(action_metadata, ActionMetadata)
+    assert action_metadata.metadata is not None
     assert action_metadata.metadata['embedder']['label'] == 'Advanced Embedder'
     assert action_metadata.metadata['embedder']['dimensions'] == options.dimensions
     assert action_metadata.metadata['embedder']['supports'] == {
@@ -162,7 +163,7 @@ def mock_genkit_instance():
     """Fixture for a Genkit instance with a mock registry."""
     registry = MockGenkitRegistry()
     genkit_instance = Genkit()
-    genkit_instance.registry = registry
+    genkit_instance.registry = registry  # type: ignore[assignment]
     return genkit_instance, registry
 
 

--- a/py/packages/genkit/tests/genkit/blocks/middleware_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/middleware_test.py
@@ -25,6 +25,7 @@ from genkit.blocks.middleware import augment_with_context
 from genkit.core.action import ActionRunContext
 from genkit.core.typing import (
     DocumentData,
+    DocumentPart,
     GenerateRequest,
     GenerateResponse,
     Message,
@@ -70,8 +71,8 @@ async def test_augment_with_context_adds_docs_as_context() -> None:
             Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))]),
         ],
         docs=[
-            DocumentData(content=[TextPart(text='doc content 1')]),
-            DocumentData(content=[TextPart(text='doc content 2')]),
+            DocumentData(content=[DocumentPart(root=TextPart(text='doc content 1'))]),
+            DocumentData(content=[DocumentPart(root=TextPart(text='doc content 2'))]),
         ],
     )
 
@@ -96,8 +97,8 @@ async def test_augment_with_context_adds_docs_as_context() -> None:
             )
         ],
         docs=[
-            DocumentData(content=[TextPart(text='doc content 1')]),
-            DocumentData(content=[TextPart(text='doc content 2')]),
+            DocumentData(content=[DocumentPart(root=TextPart(text='doc content 1'))]),
+            DocumentData(content=[DocumentPart(root=TextPart(text='doc content 2'))]),
         ],
     )
 
@@ -113,7 +114,7 @@ async def test_augment_with_context_should_not_modify_non_pending_part() -> None
                     Part(
                         root=TextPart(
                             text='this is already context',
-                            metadata={'purpose': 'context'},
+                            metadata=Metadata(root={'purpose': 'context'}),
                         )
                     ),
                     Part(root=TextPart(text='hi')),
@@ -121,7 +122,7 @@ async def test_augment_with_context_should_not_modify_non_pending_part() -> None
             ),
         ],
         docs=[
-            DocumentData(content=[TextPart(text='doc content 1')]),
+            DocumentData(content=[DocumentPart(root=TextPart(text='doc content 1'))]),
         ],
     )
 
@@ -141,7 +142,7 @@ async def test_augment_with_context_with_purpose_part() -> None:
                     Part(
                         root=TextPart(
                             text='insert context here',
-                            metadata={'purpose': 'context', 'pending': True},
+                            metadata=Metadata(root={'purpose': 'context', 'pending': True}),
                         )
                     ),
                     Part(root=TextPart(text='hi')),
@@ -149,7 +150,7 @@ async def test_augment_with_context_with_purpose_part() -> None:
             ),
         ],
         docs=[
-            DocumentData(content=[TextPart(text='doc content 1')]),
+            DocumentData(content=[DocumentPart(root=TextPart(text='doc content 1'))]),
         ],
     )
 
@@ -173,6 +174,6 @@ async def test_augment_with_context_with_purpose_part() -> None:
             )
         ],
         docs=[
-            DocumentData(content=[TextPart(text='doc content 1')]),
+            DocumentData(content=[DocumentPart(root=TextPart(text='doc content 1'))]),
         ],
     )

--- a/py/packages/genkit/tests/genkit/blocks/model_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/model_test.py
@@ -21,6 +21,7 @@ from genkit.core.action import ActionMetadata
 from genkit.core.typing import (
     Candidate,
     DocumentPart,
+    FinishReason,
     GenerateRequest,
     GenerateResponse,
     GenerateResponseChunk,
@@ -28,6 +29,7 @@ from genkit.core.typing import (
     Media,
     MediaPart,
     Message,
+    Metadata,
     Part,
     TextPart,
     ToolRequest,
@@ -284,7 +286,7 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
             [
                 Candidate(
                     index=0,
-                    finish_reason='stop',
+                    finish_reason=FinishReason.STOP,
                     message=Message(
                         role='user',
                         content=[
@@ -294,7 +296,7 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 ),
                 Candidate(
                     index=1,
-                    finish_reason='stop',
+                    finish_reason=FinishReason.STOP,
                     message=Message(
                         role='user',
                         content=[
@@ -304,7 +306,7 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 ),
                 Candidate(
                     index=2,
-                    finish_reason='stop',
+                    finish_reason=FinishReason.STOP,
                     message=Message(
                         role='user',
                         content=[
@@ -314,7 +316,7 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 ),
                 Candidate(
                     index=3,
-                    finish_reason='stop',
+                    finish_reason=FinishReason.STOP,
                     message=Message(
                         role='user',
                         content=[
@@ -324,7 +326,7 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 ),
                 Candidate(
                     index=4,
-                    finish_reason='stop',
+                    finish_reason=FinishReason.STOP,
                     message=Message(
                         role='user',
                         content=[
@@ -334,7 +336,7 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 ),
                 Candidate(
                     index=5,
-                    finish_reason='stop',
+                    finish_reason=FinishReason.STOP,
                     message=Message(
                         role='user',
                         content=[
@@ -344,7 +346,7 @@ def test_get_part_counts(test_parts, expected_part_counts) -> None:
                 ),
                 Candidate(
                     index=6,
-                    finish_reason='stop',
+                    finish_reason=FinishReason.STOP,
                     message=Message(
                         role='user',
                         content=[
@@ -442,7 +444,7 @@ def test_response_wrapper_interrupts() -> None:
                     Part(
                         root=ToolRequestPart(
                             tool_request=ToolRequest(name='tool2', input={'bcd': 4}),
-                            metadata={'interrupt': {'banana': 'yes'}},
+                            metadata=Metadata(root={'interrupt': {'banana': 'yes'}}),
                         )
                     ),
                     Part(root=TextPart(text='bar')),
@@ -461,7 +463,8 @@ def test_response_wrapper_interrupts() -> None:
 
     assert wrapper.interrupts == [
         ToolRequestPart(
-            tool_request=ToolRequest(name='tool2', input={'bcd': 4}), metadata={'interrupt': {'banana': 'yes'}}
+            tool_request=ToolRequest(name='tool2', input={'bcd': 4}),
+            metadata=Metadata(root={'interrupt': {'banana': 'yes'}}),
         )
     ]
 

--- a/py/packages/genkit/tests/genkit/blocks/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/prompt_test.py
@@ -29,6 +29,7 @@ from genkit.blocks.prompt import load_prompt_folder, lookup_prompt, prompt
 from genkit.core.action.types import ActionKind
 from genkit.core.typing import (
     DocumentData,
+    DocumentPart,
     GenerateActionOptions,
     GenerateRequest,
     GenerateResponse,
@@ -115,10 +116,10 @@ async def test_prompt_with_kitchensink() -> None:
     ai, *_ = setup_test()
 
     class PromptInput(BaseModel):
-        name: str = Field(None, description='the name')
+        name: str | None = Field(default=None, description='the name')
 
     class ToolInput(BaseModel):
-        value: int = Field(None, description='value field')
+        value: int | None = Field(default=None, description='value field')
 
     @ai.tool(name='testTool')
     def test_tool(input: ToolInput):
@@ -184,7 +185,7 @@ async def test_prompt_with_docs_resolver() -> None:
     pm.responses = [GenerateResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='ok'))]))]
 
     async def docs_resolver(input, context):
-        return [DocumentData(content=[TextPart(text=f'doc {input["name"]}')])]
+        return [DocumentData(content=[DocumentPart(root=TextPart(text=f'doc {input["name"]}'))])]
 
     my_prompt = ai.define_prompt(
         model='programmableModel',

--- a/py/packages/genkit/tests/genkit/blocks/retriever_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/retriever_test.py
@@ -70,6 +70,8 @@ def test_retriever_action_metadata_with_supports_and_config_schema():
         options=options,
     )
     assert isinstance(action_metadata, ActionMetadata)
+    assert action_metadata.metadata is not None
+    assert action_metadata.metadata.get('retriever') is not None
     assert action_metadata.metadata['retriever']['label'] == 'Advanced Retriever'
     assert action_metadata.metadata['retriever']['supports'] == {
         'media': True,

--- a/py/packages/genkit/tests/genkit/blocks/test_reranker.py
+++ b/py/packages/genkit/tests/genkit/blocks/test_reranker.py
@@ -105,6 +105,7 @@ class TestRerankerRef:
         assert ref.name == 'test-reranker'
         assert ref.config == {'k': 10}
         assert ref.version == '1.0.0'
+        assert ref.info is not None
         assert ref.info.label == 'Test Reranker'
 
 
@@ -117,6 +118,7 @@ class TestRerankerActionMetadata:
 
         assert metadata.kind == ActionKind.RERANKER
         assert metadata.name == 'test-reranker'
+        assert metadata.metadata is not None
         assert 'reranker' in metadata.metadata
 
     def test_action_metadata_with_options(self):
@@ -127,6 +129,7 @@ class TestRerankerActionMetadata:
         )
         metadata = reranker_action_metadata('test-reranker', options)
 
+        assert metadata.metadata is not None
         assert metadata.metadata['reranker']['label'] == 'Custom Label'
         assert metadata.metadata['reranker']['customOptions'] == {'type': 'object'}
 
@@ -344,6 +347,7 @@ class TestCustomRerankers:
         assert len(results) == 7
         # 'quantum mechanics' should have the highest score (overlaps 2 words)
         assert results[0].text() == 'quantum mechanics'
+        assert results[0].score is not None
         assert results[0].score > 0
 
     @pytest.mark.asyncio
@@ -478,5 +482,8 @@ class TestCustomRerankers:
         ai_scores = [doc.score for doc in reranked if 'AI' in doc.text() or 'learning' in doc.text()]
         non_ai_scores = [doc.score for doc in reranked if 'Pizza' in doc.text() or 'Cats' in doc.text()]
 
-        # AI-related documents should have higher scores on average
-        assert max(ai_scores) > max(non_ai_scores)
+        # Filter out None values and validate lists are not empty before comparing
+        ai_scores_valid = [s for s in ai_scores if s is not None]
+        non_ai_scores_valid = [s for s in non_ai_scores if s is not None]
+        assert ai_scores_valid and non_ai_scores_valid, 'Cannot compare scores if one of the lists is empty or contains only None'
+        assert max(ai_scores_valid) > max(non_ai_scores_valid)

--- a/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
+++ b/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
@@ -63,7 +63,7 @@ async def asgi_client(mock_registry):
         An AsyncClient configured to make requests to the test ASGI app.
     """
     app = create_reflection_asgi_app(mock_registry)
-    transport = ASGITransport(app=app)
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
     client = AsyncClient(transport=transport, base_url='http://test')
     try:
         yield client

--- a/py/packages/genkit/tests/genkit/core/error_test.py
+++ b/py/packages/genkit/tests/genkit/core/error_test.py
@@ -57,6 +57,7 @@ def test_genkit_error_to_json() -> None:
     assert isinstance(serializable, GenkitReflectionApiErrorWireFormat)
     assert serializable.code == 5
     assert serializable.message == 'Resource not found'
+    assert serializable.details is not None
     assert serializable.details.model_dump()['id'] == 123
 
 

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -25,6 +25,7 @@ async def test_register_action_with_name_and_kind() -> None:
     got = await registry.resolve_action(ActionKind.CUSTOM, 'test_action')
 
     assert got == action
+    assert got is not None
     assert got.name == 'test_action'
     assert got.kind == ActionKind.CUSTOM
 
@@ -37,6 +38,7 @@ async def test_resolve_action_by_key() -> None:
     got = await registry.resolve_action_by_key('/custom/test_action')
 
     assert got == action
+    assert got is not None
     assert got.name == 'test_action'
     assert got.kind == ActionKind.CUSTOM
 

--- a/py/packages/genkit/tests/genkit/core/schema_test.py
+++ b/py/packages/genkit/tests/genkit/core/schema_test.py
@@ -26,22 +26,22 @@ def test_to_json_schema_pydantic_model():
     """Test that a Pydantic model can be converted to a JSON schema."""
 
     class TestSchema(BaseModel):
-        foo: int = Field(None, description='foo field')
-        bar: str = Field(None, description='bar field')
+        foo: int | None = Field(default=None, description='foo field')
+        bar: str | None = Field(default=None, description='bar field')
 
     assert to_json_schema(TestSchema) == {
         'properties': {
             'bar': {
+                'anyOf': [{'type': 'string'}, {'type': 'null'}],
                 'default': None,
                 'description': 'bar field',
                 'title': 'Bar',
-                'type': 'string',
             },
             'foo': {
+                'anyOf': [{'type': 'integer'}, {'type': 'null'}],
                 'default': None,
                 'description': 'foo field',
                 'title': 'Foo',
-                'type': 'integer',
             },
         },
         'title': 'TestSchema',

--- a/py/packages/genkit/tests/genkit/core/status_types_test.py
+++ b/py/packages/genkit/tests/genkit/core/status_types_test.py
@@ -58,19 +58,19 @@ def test_status_validation() -> None:
     """Tests that Status validates inputs correctly."""
     # Test invalid status name
     with pytest.raises(ValidationError):
-        Status(name='INVALID_STATUS')
+        Status(name='INVALID_STATUS')  # type: ignore[arg-type]
 
     # Test with invalid type for name
     with pytest.raises(ValidationError):
-        Status(name=123)
+        Status(name=123)  # type: ignore[arg-type]
 
     # Test with invalid type for message
     with pytest.raises(ValidationError):
-        Status(name='OK', message=123)
+        Status(name='OK', message=123)  # type: ignore[arg-type]
 
     # Test with extra fields
     with pytest.raises(ValidationError):
-        Status(name='OK', extra_field='value')
+        Status(name='OK', extra_field='value')  # type: ignore[call-arg]
 
 
 def test_http_status_code_mapping() -> None:
@@ -97,7 +97,7 @@ def test_http_status_code_mapping() -> None:
 def test_http_status_code_invalid_input() -> None:
     """Tests http_status_code function with invalid input."""
     with pytest.raises(KeyError):
-        http_status_code('INVALID_STATUS')
+        http_status_code('INVALID_STATUS')  # type: ignore[arg-type]
 
 
 def test_status_json_serialization() -> None:

--- a/py/packages/genkit/tests/genkit/veneer/resource_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/resource_test.py
@@ -22,6 +22,7 @@ JS SDK's `ai.defineResource`.
 import pytest
 
 from genkit.ai import Genkit
+from genkit.core.action.types import ActionKind
 from genkit.core.typing import Part, TextPart
 
 
@@ -39,7 +40,7 @@ async def test_define_resource_veneer():
     assert act.metadata['resource']['uri'] == 'http://example.com/foo'
 
     # Verify lookup via global registry (contained in ai.registry)
-    looked_up = await ai.registry.resolve_action('resource', 'http://example.com/foo')
+    looked_up = await ai.registry.resolve_action(ActionKind.RESOURCE, 'http://example.com/foo')
     assert looked_up == act
 
     # Verify execution

--- a/py/packages/genkit/tests/genkit/web/manager/signals_test.py
+++ b/py/packages/genkit/tests/genkit/web/manager/signals_test.py
@@ -159,13 +159,13 @@ class AsyncSignalHandlerTest(IsolatedAsyncioTestCase):
         """Test the async wrapper for signal handling."""
         signal_handler = SignalHandler()
         # Mock the handle_signal method
-        signal_handler.handle_signal = mock.Mock()
+        signal_handler.handle_signal = mock.Mock()  # type: ignore[method-assign]
 
         # Call the async signal handler
         await signal_handler.handle_signal_async(signal.SIGINT)
 
         # Verify handle_signal was called with the signal
-        signal_handler.handle_signal.assert_called_once_with(signal.SIGINT)
+        signal_handler.handle_signal.assert_called_once_with(signal.SIGINT)  # type: ignore[union-attr]
 
     async def test_integration(self) -> None:
         """Test the full signal handling flow."""

--- a/py/plugins/anthropic/src/genkit/plugins/anthropic/plugin.py
+++ b/py/plugins/anthropic/src/genkit/plugins/anthropic/plugin.py
@@ -16,6 +16,8 @@
 
 """Anthropic plugin for Genkit."""
 
+from typing import Any
+
 from anthropic import AsyncAnthropic
 from genkit.ai import Plugin
 from genkit.blocks.model import model_action_metadata
@@ -52,7 +54,7 @@ class Anthropic(Plugin):
     def __init__(
         self,
         models: list[str] | None = None,
-        **anthropic_params: str,
+        **anthropic_params: Any,
     ) -> None:
         """Initializes Anthropic plugin with given configuration.
 
@@ -110,7 +112,7 @@ class Anthropic(Plugin):
             fn=model.generate,
             metadata={
                 'model': {
-                    'supports': model_info.supports.model_dump(),
+                    'supports': model_info.supports.model_dump() if model_info.supports else {},
                     'customOptions': to_json_schema(GenerationCommonConfig),
                 },
             },
@@ -127,7 +129,7 @@ class Anthropic(Plugin):
             actions.append(
                 model_action_metadata(
                     name=anthropic_name(model_name),
-                    info={'supports': model_info.supports.model_dump()},
+                    info={'supports': model_info.supports.model_dump() if model_info.supports else {}},
                     config_schema=GenerationCommonConfig,
                 )
             )

--- a/py/plugins/anthropic/tests/test_models.py
+++ b/py/plugins/anthropic/tests/test_models.py
@@ -74,11 +74,14 @@ async def test_generate_basic():
     model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
     response = await model.generate(sample_request)
 
+    assert response.message is not None
+    assert response.message.content is not None
     assert len(response.message.content) == 1
     part = response.message.content[0]
     actual_part = part.root if isinstance(part, Part) else part
     assert isinstance(actual_part, TextPart)
     assert actual_part.text == "Hello! I'm doing well."
+    assert response.usage is not None
     assert response.usage.input_tokens == 10
     assert response.usage.output_tokens == 15
     assert response.finish_reason == 'stop'
@@ -105,10 +108,13 @@ async def test_generate_with_tools():
     model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
     response = await model.generate(sample_request)
 
+    assert response.message is not None
+    assert response.message.content is not None
     assert len(response.message.content) == 1
     part = response.message.content[0]
     actual_part = part.root if isinstance(part, Part) else part
     assert isinstance(actual_part, ToolRequestPart)
+    assert actual_part.tool_request is not None
     assert actual_part.tool_request.name == 'get_weather'
     assert actual_part.tool_request.ref == 'tool_123'
     assert actual_part.tool_request.input == {'location': 'Paris'}
@@ -132,7 +138,7 @@ async def test_generate_with_config():
         config=GenerationCommonConfig(
             temperature=0.7,
             max_output_tokens=100,
-            topP=0.9,
+            top_p=0.9,
         ),
     )
 
@@ -248,10 +254,12 @@ async def test_streaming_generation():
     chunk2_actual = chunk2_part.root if isinstance(chunk2_part, Part) else chunk2_part
     assert chunk2_actual.text == '!'
 
+    assert response.usage is not None
     assert response.usage.input_tokens == 10
     assert response.usage.output_tokens == 20
 
     # Verify final response content is populated
+    assert response.message is not None
     assert len(response.message.content) == 1
     final_part = response.message.content[0]
     assert isinstance(final_part, Part)

--- a/py/plugins/anthropic/tests/test_plugin.py
+++ b/py/plugins/anthropic/tests/test_plugin.py
@@ -98,9 +98,11 @@ def test_supported_models():
     """Test that all supported models have proper metadata."""
     assert len(SUPPORTED_MODELS) == 7
     for _name, info in SUPPORTED_MODELS.items():
+        assert info.label is not None
         assert info.label.startswith('Anthropic - ')
         assert info.versions is not None
         assert len(info.versions) > 0
+        assert info.supports is not None
         assert info.supports.multiturn is True
         assert info.supports.tools is True
         assert info.supports.media is True
@@ -111,6 +113,7 @@ def test_get_model_info_known():
     """Test get_model_info returns correct info for known model."""
     info = get_model_info('claude-sonnet-4')
     assert info.label == 'Anthropic - Claude Sonnet 4'
+    assert info.supports is not None
     assert info.supports.multiturn is True
     assert info.supports.tools is True
 
@@ -119,6 +122,7 @@ def test_get_model_info_unknown():
     """Test get_model_info returns default info for unknown model."""
     info = get_model_info('unknown-model')
     assert info.label == 'Anthropic - unknown-model'
+    assert info.supports is not None
     assert info.supports.multiturn is True
     assert info.supports.tools is True
 

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/handler.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/handler.py
@@ -16,7 +16,7 @@
 
 """OpenAI Compatible Model handlers for Genkit."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from openai import OpenAI
@@ -65,7 +65,7 @@ class OpenAIModelHandler:
     @classmethod
     def get_model_handler(
         cls, model: str, client: OpenAI, source: PluginSource = PluginSource.OPENAI
-    ) -> Callable[[GenerateRequest, ActionRunContext], GenerateResponse]:
+    ) -> Callable[[GenerateRequest, ActionRunContext], Awaitable[GenerateResponse]]:
         """Factory method to initialize the model handler for the specified OpenAI model.
 
         OpenAI models in this context are not instantiated as traditional
@@ -123,7 +123,7 @@ class OpenAIModelHandler:
         """
         request.config = self._model.normalize_config(request.config)
 
-        if request.config.model:
+        if request.config and hasattr(request.config, 'model') and request.config.model:
             self._validate_version(request.config.model)
 
         return await self._model.generate(request, ctx)

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/model.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/model.py
@@ -41,7 +41,7 @@ from genkit.types import (
 class OpenAIModel:
     """Handles OpenAI API interactions for the Genkit plugin."""
 
-    def __init__(self, model: str, client: OpenAI):
+    def __init__(self, model: str, client: Any) -> None:
         """Initializes the OpenAIModel instance with the specified model and OpenAI client parameters.
 
         Args:
@@ -127,7 +127,7 @@ class OpenAIModel:
                 }
 
             model = SUPPORTED_OPENAI_MODELS[self._model]
-            if model.supports.output and SupportedOutputFormat.JSON_MODE in model.supports.output:
+            if model.supports and model.supports.output and SupportedOutputFormat.JSON_MODE in model.supports.output:
                 return {'type': 'json_object'}
 
         return {'type': 'text'}

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/model_info.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/model_info.py
@@ -188,4 +188,4 @@ def get_default_model_info(name: str) -> ModelInfo:
 
 def get_default_openai_model_info(name: str) -> ModelInfo:
     """Gets the default model info given a name."""
-    return ModelInfo(label=f'OpenAI - {name}', supports={'multiturn': True})
+    return ModelInfo(label=f'OpenAI - {name}', supports=Supports(multiturn=True))

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/utils.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/utils.py
@@ -130,7 +130,7 @@ class MessageConverter:
         tool_messages = []
 
         for part in message.content:
-            root: Part = part.root
+            root = part.root
 
             if isinstance(root, TextPart):
                 text_parts.append(root.text)
@@ -203,7 +203,7 @@ class MessageConverter:
         Returns:
             A `Part` instance containing the text.
         """
-        return Part(text=content)
+        return Part(root=TextPart(text=content))
 
     @classmethod
     def tool_call_to_genkit(
@@ -219,13 +219,28 @@ class MessageConverter:
         Returns:
             A `Part` instance containing a `ToolRequest`.
         """
-        args_segment = args_segment if args_segment is not None else tool_call.function.arguments
+        # Get function info from tool_call (could be dict or object)
+        if hasattr(tool_call, 'function') and hasattr(tool_call, 'id'):
+            func = tool_call.function
+            tool_id = tool_call.id
+            func_name = func.name if hasattr(func, 'name') else ''
+            func_args = func.arguments if hasattr(func, 'arguments') else ''
+        else:
+            # Assume dict-like access
+            func = tool_call.get('function', {})  # type: ignore[attr-defined]
+            tool_id = tool_call.get('id', '')  # type: ignore[attr-defined]
+            func_name = func.get('name', '')
+            func_args = func.get('arguments', '')
+
+        args_segment = args_segment if args_segment is not None else func_args  # type: ignore[assignment]
         args_segment = args_parser(args_segment) if args_parser else args_segment
 
         return Part(
-            tool_request=ToolRequest(
-                ref=tool_call.id,
-                name=tool_call.function.name,
-                input=args_segment,
+            root=ToolRequestPart(
+                tool_request=ToolRequest(
+                    ref=str(tool_id) if tool_id else None,
+                    name=str(func_name) if func_name else '',
+                    input=args_segment,
+                )
             )
         )

--- a/py/plugins/compat-oai/tests/test_model.py
+++ b/py/plugins/compat-oai/tests/test_model.py
@@ -80,6 +80,7 @@ async def test__generate(sample_request):
 
     mock_client.chat.completions.create.assert_called_once()
     assert isinstance(response, GenerateResponse)
+    assert response.message is not None
     assert response.message.role == Role.MODEL
     assert response.message.content[0].root.text == 'Hello, user!'
 
@@ -143,16 +144,16 @@ async def test_generate(stream, sample_request):
     mock_response = GenerateResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='mocked'))]))
 
     model = OpenAIModel(model='gpt-4', client=MagicMock())
-    model._generate_stream = AsyncMock(return_value=mock_response)
-    model._generate = AsyncMock(return_value=mock_response)
-    model.normalize_config = MagicMock(return_value={})
+    model._generate_stream = AsyncMock(return_value=mock_response)  # type: ignore[method-assign]
+    model._generate = AsyncMock(return_value=mock_response)  # type: ignore[method-assign]
+    model.normalize_config = MagicMock(return_value={})  # type: ignore[method-assign]
     response = await model.generate(sample_request, ctx_mock)
 
     assert response == mock_response
     if stream:
-        model._generate_stream.assert_called_once()
+        model._generate_stream.assert_called_once()  # type: ignore[union-attr]
     else:
-        model._generate.assert_called_once()
+        model._generate.assert_called_once()  # type: ignore[union-attr]
 
 
 @pytest.mark.parametrize(

--- a/py/plugins/compat-oai/tests/test_tool_calling.py
+++ b/py/plugins/compat-oai/tests/test_tool_calling.py
@@ -62,6 +62,7 @@ async def test_generate_with_tool_calls_executes_tools(sample_request: GenerateR
 
     response = await model._generate(sample_request)
 
+    assert response.message is not None
     part = response.message.content[0].root
 
     assert isinstance(part, ToolRequestPart)
@@ -69,9 +70,9 @@ async def test_generate_with_tool_calls_executes_tools(sample_request: GenerateR
     assert part.tool_request.name == 'tool_fn'
     assert part.tool_request.ref == 'tool123'
 
-    # Assume the sample request was processed by Genkit, but a mock side effect was applied
     response = await model._generate(sample_request)
 
+    assert response.message is not None
     part = response.message.content[0].root
 
     assert isinstance(part, TextPart)

--- a/py/plugins/deepseek/src/genkit/plugins/deepseek/models.py
+++ b/py/plugins/deepseek/src/genkit/plugins/deepseek/models.py
@@ -57,7 +57,7 @@ class DeepSeekModel:
         self,
         model: str,
         api_key: str,
-        **deepseek_params,
+        **deepseek_params: Any,
     ) -> None:
         """Initialize the DeepSeek instance.
 
@@ -82,9 +82,10 @@ class DeepSeekModel:
             capabilities (e.g., tools, streaming).
         """
         model_info = SUPPORTED_DEEPSEEK_MODELS.get(self.name, get_default_model_info(self.name))
+        supports_dict = model_info.supports.model_dump() if model_info.supports else {}
         return {
             'name': model_info.label,
-            'supports': model_info.supports.model_dump(),
+            'supports': supports_dict,
         }
 
     def to_deepseek_model(self) -> Callable:

--- a/py/plugins/deepseek/src/genkit/plugins/deepseek/plugin.py
+++ b/py/plugins/deepseek/src/genkit/plugins/deepseek/plugin.py
@@ -102,7 +102,7 @@ class DeepSeek(Plugin):
         # Create the DeepSeek model instance
         deepseek_model = DeepSeekModel(
             model=clean_name,
-            api_key=self.api_key,
+            api_key=str(self.api_key),
             **self.deepseek_params,
         )
 

--- a/py/plugins/deepseek/tests/test_model_info.py
+++ b/py/plugins/deepseek/tests/test_model_info.py
@@ -41,6 +41,7 @@ def test_model_info_structure():
         assert model_info.supports.tools is True
         assert model_info.supports.media is False
         assert model_info.supports.system_role is True
+        assert model_info.supports.output is not None
         assert 'text' in model_info.supports.output
         assert 'json' in model_info.supports.output
 
@@ -48,6 +49,7 @@ def test_model_info_structure():
 def test_get_default_model_info():
     """Test getting default info for unknown models."""
     info = get_default_model_info('deepseek-future-model')
-    assert 'deepseek-future-model' in info.label
+    assert 'deepseek-future-model' in str(info.label)
+    assert info.supports is not None
     assert info.supports.multiturn is True
     assert info.supports.tools is True

--- a/py/plugins/evaluators/src/genkit/plugins/metrics/helper.py
+++ b/py/plugins/evaluators/src/genkit/plugins/metrics/helper.py
@@ -39,6 +39,6 @@ async def render_text(prompt: PromptFunction, input_: dict[str, Any]) -> str:
     )
     result = []
     for message in rendered.messages:
-        result.append(''.join(e.text for e in message.content))
+        result.append(''.join(e.text for e in message.content if hasattr(e, 'text') and e.text))  # type: ignore[arg-type]
 
     return ''.join(result)

--- a/py/plugins/firebase/src/genkit/plugins/firebase/firestore.py
+++ b/py/plugins/firebase/src/genkit/plugins/firebase/firestore.py
@@ -23,6 +23,7 @@ from google.cloud.firestore_v1.base_vector_query import DistanceMeasure
 from genkit.ai import Genkit
 from genkit.blocks.retriever import RetrieverOptions, retriever_action_metadata
 from genkit.core.action.types import ActionKind
+from genkit.core.typing import DocumentPart
 from genkit.plugins.firebase.retriever import FirestoreRetriever
 
 from .constant import MetadataTransformFn
@@ -49,7 +50,7 @@ def define_firestore_vector_store(
     embedder_options: dict[str, Any] | None = None,
     collection: str,
     vector_field: str,
-    content_field: str | Callable[[DocumentSnapshot], list[dict[str, str]]],
+    content_field: str | Callable[[DocumentSnapshot], list['DocumentPart']],
     firestore_client: Any,
     distance_measure: DistanceMeasure = DistanceMeasure.COSINE,
     metadata_fields: list[str] | MetadataTransformFn | None = None,

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/metrics.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/metrics.py
@@ -41,8 +41,9 @@ def _metric(name: str, desc: str, unit: str = '1') -> tuple[str, str, str]:
     return f'genkit/ai/{name}', desc, unit
 
 
-# Metric cache for lazy initialization
-_metrics_cache: dict[str, metrics.Counter | metrics.Histogram] = {}
+# Metric caches for lazy initialization
+_counter_cache: dict[str, metrics.Counter] = {}
+_histogram_cache: dict[str, metrics.Histogram] = {}
 
 
 def _get_counter(name: str, desc: str, unit: str = '1') -> metrics.Counter:
@@ -56,9 +57,9 @@ def _get_counter(name: str, desc: str, unit: str = '1') -> metrics.Counter:
     Returns:
         OpenTelemetry Counter metric
     """
-    if name not in _metrics_cache:
-        _metrics_cache[name] = meter.create_counter(name, description=desc, unit=unit)
-    return _metrics_cache[name]
+    if name not in _counter_cache:
+        _counter_cache[name] = meter.create_counter(name, description=desc, unit=unit)
+    return _counter_cache[name]
 
 
 def _get_histogram(name: str, desc: str, unit: str = '1') -> metrics.Histogram:
@@ -72,9 +73,9 @@ def _get_histogram(name: str, desc: str, unit: str = '1') -> metrics.Histogram:
     Returns:
         OpenTelemetry Histogram metric
     """
-    if name not in _metrics_cache:
-        _metrics_cache[name] = meter.create_histogram(name, description=desc, unit=unit)
-    return _metrics_cache[name]
+    if name not in _histogram_cache:
+        _histogram_cache[name] = meter.create_histogram(name, description=desc, unit=unit)
+    return _histogram_cache[name]
 
 
 # Metric definitions

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -250,8 +250,11 @@ class GoogleAI(Plugin):
         """
         actions_list = list()
         for m in self._client.models.list():
-            name = m.name.replace('models/', '')
-            if 'generateContent' in m.supported_actions:
+            model_name = m.name
+            if not model_name:
+                continue
+            name = model_name.replace('models/', '')
+            if m.supported_actions and 'generateContent' in m.supported_actions:
                 actions_list.append(
                     model_action_metadata(
                         name=googleai_name(name),
@@ -259,7 +262,7 @@ class GoogleAI(Plugin):
                     ),
                 )
 
-            if 'embedContent' in m.supported_actions:
+            if m.supported_actions and 'embedContent' in m.supported_actions:
                 embed_info = default_embedder_info(name)
                 actions_list.append(
                     embedder_action_metadata(
@@ -459,7 +462,10 @@ class VertexAI(Plugin):
         """
         actions_list = list()
         for m in self._client.models.list():
-            name = m.name.replace('publishers/google/models/', '')
+            model_name = m.name
+            if not model_name:
+                continue
+            name = model_name.replace('publishers/google/models/', '')
             if 'embed' in name.lower():
                 embed_info = default_embedder_info(name)
                 actions_list.append(
@@ -484,25 +490,29 @@ class VertexAI(Plugin):
         return actions_list
 
 
-def _inject_attribution_headers(http_options: HttpOptions | dict | None = None) -> HttpOptions:
+def _inject_attribution_headers(http_options: HttpOptions | HttpOptionsDict | None = None) -> HttpOptions:
     """Adds genkit client info to the appropriate http headers."""
-    if not http_options:
-        http_options = HttpOptions()
+    # Normalize to HttpOptions instance
+    opts: HttpOptions
+    if http_options is None:
+        opts = HttpOptions()
+    elif isinstance(http_options, HttpOptions):
+        opts = http_options
     else:
-        if isinstance(http_options, dict):
-            http_options = HttpOptions(**http_options)
+        # HttpOptionsDict or other dict-like - use model_validate for proper type conversion
+        opts = HttpOptions.model_validate(http_options)
 
-    if not http_options.headers:
-        http_options.headers = {}
+    if not opts.headers:
+        opts.headers = {}
 
-    if 'x-goog-api-client' not in http_options.headers:
-        http_options.headers['x-goog-api-client'] = GENKIT_CLIENT_HEADER
+    if 'x-goog-api-client' not in opts.headers:
+        opts.headers['x-goog-api-client'] = GENKIT_CLIENT_HEADER
     else:
-        http_options.headers['x-goog-api-client'] += f' {GENKIT_CLIENT_HEADER}'
+        opts.headers['x-goog-api-client'] += f' {GENKIT_CLIENT_HEADER}'
 
-    if 'user-agent' not in http_options.headers:
-        http_options.headers['user-agent'] = GENKIT_CLIENT_HEADER
+    if 'user-agent' not in opts.headers:
+        opts.headers['user-agent'] = GENKIT_CLIENT_HEADER
     else:
-        http_options.headers['user-agent'] += f' {GENKIT_CLIENT_HEADER}'
+        opts.headers['user-agent'] += f' {GENKIT_CLIENT_HEADER}'
 
-    return http_options
+    return opts

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/context_caching/types.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/context_caching/types.py
@@ -23,7 +23,7 @@ from pydantic.alias_generators import to_camel
 class CacheConfigSchema(BaseModel):
     model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
 
-    ttl_seconds: int | None = ...
+    ttl_seconds: int | None = None
 
 
 CacheConfig = Union[bool, CacheConfigSchema]

--- a/py/plugins/google-genai/test/models/test_googlegenai_imagen.py
+++ b/py/plugins/google-genai/test/models/test_googlegenai_imagen.py
@@ -71,7 +71,7 @@ async def test_generate_media_response(mocker, version):
         mocker.call.aio.models.generate_images(model=version, prompt=request_text, config=None)
     ])
     assert isinstance(response, GenerateResponse)
-
+    assert response.message is not None
     content = response.message.content[0]
     assert isinstance(content.root, MediaPart)
 

--- a/py/plugins/mcp/examples/client/simple_client.py
+++ b/py/plugins/mcp/examples/client/simple_client.py
@@ -22,7 +22,7 @@ from genkit.plugins.mcp import McpServerConfig, create_mcp_client
 try:
     from genkit.plugins.google_genai import GoogleAI
 except ImportError:
-    GoogleAI = None
+    GoogleAI = None  # type: ignore
 
 
 # Simple client example connecting to 'everything' server using npx

--- a/py/plugins/mcp/pyproject.toml
+++ b/py/plugins/mcp/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 dependencies = ["genkit", "mcp"]
 description = "Genkit MCP Plugin"
 license = "Apache-2.0"
-name = "genkit-plugins-mcp"
+name = "genkit-plugin-mcp"
 readme = "README.md"
 requires-python = ">=3.10"
 version = "0.1.0"
@@ -45,4 +45,4 @@ build-backend = "hatchling.build"
 requires      = ["hatchling"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src"]
+packages = ["src/genkit", "src/genkit/plugins"]

--- a/py/plugins/mcp/src/genkit/plugins/mcp/util/message.py
+++ b/py/plugins/mcp/src/genkit/plugins/mcp/util/message.py
@@ -20,12 +20,12 @@ This module contains helper functions for converting between MCP message
 formats and Genkit message formats.
 """
 
-from typing import Any
+from typing import Any, Literal, cast
 
 import structlog
 
 from genkit.core.typing import Message
-from mcp.types import ImageContent, PromptMessage, TextContent
+from mcp.types import ImageContent, PromptMessage, Role, TextContent
 
 logger = structlog.get_logger(__name__)
 
@@ -36,7 +36,7 @@ ROLE_MAP = {
 }
 
 
-def from_mcp_prompt_message(message: dict[str, Any]) -> dict[str, Any]:
+def from_mcp_prompt_message(message: dict[str, Any] | PromptMessage) -> dict[str, Any]:
     """Convert MCP PromptMessage to Genkit MessageData format.
 
     This involves mapping MCP roles (user, assistant) to Genkit roles (user, model)
@@ -48,9 +48,18 @@ def from_mcp_prompt_message(message: dict[str, Any]) -> dict[str, Any]:
     Returns:
         Genkit MessageData object with 'role' and 'content' fields
     """
+    if isinstance(message, PromptMessage):
+        role = message.role
+        content = message.content
+        part_dict = content.model_dump() if hasattr(content, 'model_dump') else content
+    else:
+        role = message.get('role', 'user')
+        content = message.get('content', {})
+        part_dict = content
+
     return {
-        'role': ROLE_MAP.get(message.get('role', 'user'), 'user'),
-        'content': [from_mcp_part(message.get('content', {}))],
+        'role': ROLE_MAP.get(role, 'user'),
+        'content': [from_mcp_part(part_dict)],
     }
 
 
@@ -146,7 +155,7 @@ def to_mcp_prompt_message(message: Message) -> PromptMessage:
             f"MCP prompt messages do not support role '{message.role}'. Only 'user' and 'model' messages are supported."
         )
 
-    mcp_role = role_map[message.role]
+    mcp_role = cast(Role, role_map[message.role])
 
     # First, look for any media content as MCP content is currently single-part
     if message.content:

--- a/py/plugins/mcp/src/genkit/plugins/mcp/util/resource.py
+++ b/py/plugins/mcp/src/genkit/plugins/mcp/util/resource.py
@@ -24,13 +24,13 @@ from typing import Any
 
 import structlog
 
-from genkit.core.typing import Part
-from mcp.types import BlobResourceContents, ReadResourceResult, Resource, TextResourceContents
+from genkit.core.typing import MediaPart, Part, TextPart
+from mcp.types import AnyUrl, BlobResourceContents, ReadResourceResult, Resource, TextResourceContents
 
 logger = structlog.get_logger(__name__)
 
 
-def from_mcp_resource_part(content: dict[str, Any]) -> dict[str, Any]:
+def from_mcp_resource_part(content: dict[str, Any] | TextResourceContents | BlobResourceContents) -> dict[str, Any]:
     """Convert MCP resource content to Genkit Part format.
 
     Handles different content types:
@@ -43,6 +43,17 @@ def from_mcp_resource_part(content: dict[str, Any]) -> dict[str, Any]:
     Returns:
         Genkit Part representation
     """
+    if isinstance(content, TextResourceContents):
+        return {'text': content.text}
+    elif isinstance(content, BlobResourceContents):
+        return {
+            'media': {
+                'contentType': content.mimeType,
+                'url': f'data:{content.mimeType};base64,{content.blob}',
+            }
+        }
+
+    # Handle legacy dict
     content_type = content.get('type', '')
 
     if content_type == 'text':
@@ -95,7 +106,7 @@ def convert_resource_to_genkit_part(resource: Resource) -> dict[str, Any]:
     }
 
 
-def to_mcp_resource_contents(uri: str, parts: list[Part]) -> list[TextResourceContents | BlobResourceContents]:
+def to_mcp_resource_contents(uri: str | AnyUrl, parts: list[Part]) -> list[TextResourceContents | BlobResourceContents]:
     """Convert Genkit Parts to MCP resource contents.
 
     Args:
@@ -110,10 +121,32 @@ def to_mcp_resource_contents(uri: str, parts: list[Part]) -> list[TextResourceCo
         ValueError: If part type is not supported.
     """
     contents: list[TextResourceContents | BlobResourceContents] = []
+    uri_str = str(uri)
 
     for part in parts:
-        if isinstance(part, dict):
-            # Handle media/image content
+        if isinstance(part, Part):
+            # Handle Genkit Part object
+            if isinstance(part.root, TextPart) and part.root.text is not None:
+                contents.append(TextResourceContents(uri=AnyUrl(uri_str), text=part.root.text))
+            elif isinstance(part.root, MediaPart):
+                media = part.root.media
+                url = media.url
+                content_type = media.content_type
+
+                if not url.startswith('data:'):
+                    raise ValueError('MCP resource messages only support base64 data images.')
+
+                try:
+                    mime_type = content_type or url[url.index(':') + 1 : url.index(';')]
+                    blob_data = url[url.index(',') + 1 :]
+                    contents.append(BlobResourceContents(uri=AnyUrl(uri), mimeType=mime_type, blob=blob_data))
+                except ValueError as e:
+                    raise ValueError(f'Invalid data URL format: {url}') from e
+            elif isinstance(part.root, TextPart):
+                contents.append(TextResourceContents(uri=AnyUrl(uri_str), text=part.root.text))
+
+        elif isinstance(part, dict):
+            # Legacy/Dict definition support
             if 'media' in part:
                 media = part['media']
                 url = media.get('url', '')
@@ -122,24 +155,22 @@ def to_mcp_resource_contents(uri: str, parts: list[Part]) -> list[TextResourceCo
                 if not url.startswith('data:'):
                     raise ValueError('MCP resource messages only support base64 data images.')
 
-                # Extract MIME type and base64 data
                 try:
                     mime_type = content_type or url[url.index(':') + 1 : url.index(';')]
                     blob_data = url[url.index(',') + 1 :]
                 except ValueError as e:
                     raise ValueError(f'Invalid data URL format: {url}') from e
 
-                contents.append(BlobResourceContents(uri=uri, mimeType=mime_type, blob=blob_data))
+                contents.append(BlobResourceContents(uri=AnyUrl(uri_str), mimeType=mime_type, blob=blob_data))
 
-            # Handle text content
             elif 'text' in part:
-                contents.append(TextResourceContents(uri=uri, text=part['text']))
+                contents.append(TextResourceContents(uri=AnyUrl(uri_str), text=part['text']))
             else:
                 raise ValueError(
                     f'MCP resource messages only support media and text parts. '
                     f'Unsupported part type: {list(part.keys())}'
                 )
         elif isinstance(part, str):
-            contents.append(TextResourceContents(uri=uri, text=part))
+            contents.append(TextResourceContents(uri=AnyUrl(uri_str), text=part))
 
     return contents

--- a/py/plugins/mcp/tests/fakes.py
+++ b/py/plugins/mcp/tests/fakes.py
@@ -29,28 +29,11 @@ class MockSchema:
 
 def mock_mcp_modules():
     """Sets up comprehensive MCP mocks in sys.modules."""
+    # We only mock the runtime components that do I/O or logic we want to control
+    # types are imported from the real library now
     mock_mcp = MagicMock()
-    sys.modules['mcp'] = mock_mcp
-    sys.modules['mcp'].__path__ = []
-
-    types_mock = MagicMock()
-    sys.modules['mcp.types'] = types_mock
-    types_mock.ListToolsResult = MockSchema
-    types_mock.CallToolResult = MockSchema
-    types_mock.ListPromptsResult = MockSchema
-    types_mock.GetPromptResult = MockSchema
-    types_mock.ListResourcesResult = MockSchema
-    types_mock.ListResourceTemplatesResult = MockSchema
-    types_mock.ReadResourceResult = MockSchema
-    types_mock.Tool = MockSchema
-    types_mock.Prompt = MockSchema
-    types_mock.Resource = MockSchema
-    types_mock.ResourceTemplate = MockSchema
-    types_mock.TextContent = MockSchema
-    types_mock.PromptMessage = MockSchema
-    types_mock.TextResourceContents = MockSchema
-    types_mock.BlobResourceContents = MockSchema
-    types_mock.ImageContent = MockSchema
+    # sys.modules['mcp'] = mock_mcp  <-- removed
+    # sys.modules['mcp.types'] = ... <-- removed
 
     sys.modules['mcp.server'] = MagicMock()
     sys.modules['mcp.server.stdio'] = MagicMock()
@@ -60,7 +43,7 @@ def mock_mcp_modules():
     sys.modules['mcp.client.sse'] = MagicMock()
     sys.modules['mcp.server.sse'] = MagicMock()
 
-    return mock_mcp, types_mock
+    return mock_mcp, None
 
 
 def define_echo_model(ai: Genkit):

--- a/py/plugins/mcp/tests/test_mcp_host.py
+++ b/py/plugins/mcp/tests/test_mcp_host.py
@@ -27,6 +27,8 @@ mock_mcp_modules()
 import unittest
 from unittest.mock import patch
 
+from mcp.types import Tool
+
 from genkit.ai import Genkit
 
 # Now import plugin
@@ -48,9 +50,9 @@ class TestMcpHost(unittest.IsolatedAsyncioTestCase):
 
         # Mock session for registration
         host.clients['server1'].session = AsyncMock()
-        mock_tool = MagicMock()
-        mock_tool.name = 'tool1'
-        host.clients['server1'].session.list_tools.return_value.tools = [mock_tool]
+        host.clients['server1'].session = AsyncMock()
+        tool1 = Tool(name='tool1', description='tool desc', inputSchema={'type': 'object'})
+        host.clients['server1'].session.list_tools.return_value.tools = [tool1]
 
         ai = MagicMock(spec=Genkit)
         ai.registry = MagicMock()

--- a/py/plugins/mcp/tests/test_mcp_server_resources.py
+++ b/py/plugins/mcp/tests/test_mcp_server_resources.py
@@ -28,6 +28,16 @@ from fakes import mock_mcp_modules
 mock_mcp_modules()
 
 import pytest
+from mcp.types import (
+    ListPromptsRequest,
+    ListResourcesRequest,
+    ListResourceTemplatesRequest,
+    ListToolsRequest,
+    ReadResourceRequest,
+    ReadResourceRequestParams,
+    TextContent,
+    TextResourceContents,
+)
 
 from genkit.ai import Genkit
 from genkit.plugins.mcp import McpServerOptions, create_mcp_server
@@ -53,7 +63,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
         await server.setup()
 
         # List resources
-        result = await server.list_resources({})
+        result = await server.list_resources(ListResourcesRequest(method='resources/list'))
 
         # Verify
         self.assertEqual(len(result.resources), 2)
@@ -63,7 +73,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
 
         # Verify URIs
         config_resource = next(r for r in result.resources if r.name == 'config')
-        self.assertEqual(config_resource.uri, 'app://config')
+        self.assertEqual(str(config_resource.uri), 'app://config')
 
     async def test_list_resource_templates(self):
         """Test listing resources with URI templates."""
@@ -81,7 +91,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
         await server.setup()
 
         # List resource templates
-        result = await server.list_resource_templates({})
+        result = await server.list_resource_templates(ListResourceTemplatesRequest(method='resources/templates/list'))
 
         # Verify
         self.assertEqual(len(result.resourceTemplates), 2)
@@ -107,7 +117,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
         await server.setup()
 
         # List resources (should only include fixed URI)
-        result = await server.list_resources({})
+        result = await server.list_resources(ListResourcesRequest(method='resources/list'))
 
         self.assertEqual(len(result.resources), 1)
         self.assertEqual(result.resources[0].name, 'fixed')
@@ -126,7 +136,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
         await server.setup()
 
         # List templates (should only include template)
-        result = await server.list_resource_templates({})
+        result = await server.list_resource_templates(ListResourceTemplatesRequest(method='resources/templates/list'))
 
         self.assertEqual(len(result.resourceTemplates), 1)
         self.assertEqual(result.resourceTemplates[0].name, 'template')
@@ -152,6 +162,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
 
         # Verify
         self.assertEqual(len(result.contents), 1)
+        assert isinstance(result.contents[0], TextResourceContents)
         self.assertEqual(result.contents[0].text, 'Configuration data')
 
     async def test_read_resource_with_template(self):
@@ -177,6 +188,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
 
         # Verify
         self.assertEqual(len(result.contents), 1)
+        assert isinstance(result.contents[0], TextResourceContents)
         self.assertIn('/home/user/document.txt', result.contents[0].text)
 
     async def test_read_resource_not_found(self):
@@ -218,8 +230,11 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
 
         # Verify
         self.assertEqual(len(result.contents), 3)
+        assert isinstance(result.contents[0], TextResourceContents)
         self.assertEqual(result.contents[0].text, 'Part 1')
+        assert isinstance(result.contents[1], TextResourceContents)
         self.assertEqual(result.contents[1].text, 'Part 2')
+        assert isinstance(result.contents[2], TextResourceContents)
         self.assertEqual(result.contents[2].text, 'Part 3')
 
 
@@ -247,7 +262,7 @@ class TestMcpServerToolsAndPrompts(unittest.IsolatedAsyncioTestCase):
         await server.setup()
 
         # List tools
-        result = await server.list_tools({})
+        result = await server.list_tools(ListToolsRequest(method='tools/list'))
 
         # Verify
         self.assertEqual(len(result.tools), 2)
@@ -275,6 +290,7 @@ class TestMcpServerToolsAndPrompts(unittest.IsolatedAsyncioTestCase):
 
         # Verify
         self.assertEqual(len(result.content), 1)
+        assert isinstance(result.content[0], TextContent)
         self.assertEqual(result.content[0].text, '8')
 
     async def test_list_prompts(self):
@@ -288,7 +304,7 @@ class TestMcpServerToolsAndPrompts(unittest.IsolatedAsyncioTestCase):
         await server.setup()
 
         # List prompts
-        result = await server.list_prompts({})
+        result = await server.list_prompts(ListPromptsRequest(method='prompts/list'))
 
         # Verify
         self.assertGreaterEqual(len(result.prompts), 2)

--- a/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
@@ -222,6 +222,8 @@ class Ollama(Plugin):
         actions = []
         for model in response.models:
             _name = model.model
+            if not _name:
+                continue
             if 'embed' in _name:
                 actions.append(
                     embedder_action_metadata(

--- a/py/plugins/ollama/tests/models/test_embedders.py
+++ b/py/plugins/ollama/tests/models/test_embedders.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import ollama as ollama_api
 
+from genkit.core.typing import DocumentPart
 from genkit.plugins.ollama.embedders import EmbeddingDefinition, OllamaEmbedder
 from genkit.types import (
     Document,
@@ -71,8 +72,13 @@ class TestOllamaEmbedderEmbed(unittest.IsolatedAsyncioTestCase):
         """Test embed with multiple documents, each with multiple text contents."""
         request = EmbedRequest(
             input=[
-                Document(content=[TextPart(text='doc1_part1'), TextPart(text='doc1_part2')]),
-                Document(content=[TextPart(text='doc2_part1')]),
+                Document(
+                    content=[
+                        DocumentPart(root=TextPart(text='doc1_part1')),
+                        DocumentPart(root=TextPart(text='doc1_part2')),
+                    ]
+                ),
+                Document(content=[DocumentPart(root=TextPart(text='doc2_part1'))]),
             ]
         )
         expected_ollama_embeddings = [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
@@ -110,7 +116,7 @@ class TestOllamaEmbedderEmbed(unittest.IsolatedAsyncioTestCase):
 
     async def test_embed_api_raises_exception(self):
         """Test embed method handles exception from client.embed."""
-        request = EmbedRequest(input=[Document(content=[TextPart(text='error text')])])
+        request = EmbedRequest(input=[Document(content=[DocumentPart(root=TextPart(text='error text'))])])
         self.mock_ollama_client_instance.embed.side_effect = Exception('Ollama Embed API Error')
 
         with self.assertRaisesRegex(Exception, 'Ollama Embed API Error'):
@@ -122,8 +128,8 @@ class TestOllamaEmbedderEmbed(unittest.IsolatedAsyncioTestCase):
         """Test embed when client returns fewer embeddings than input texts (edge case)."""
         request = EmbedRequest(
             input=[
-                Document(content=[TextPart(text='text1')]),
-                Document(content=[TextPart(text='text2')]),
+                Document(content=[DocumentPart(root=TextPart(text='text1'))]),
+                Document(content=[DocumentPart(root=TextPart(text='text2'))]),
             ]
         )
         # Simulate Ollama returning only one embedding for two inputs

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/model_garden/anthropic.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/model_garden/anthropic.py
@@ -15,11 +15,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
+from typing import cast
 
-from anthropic import AsyncAnthropicVertex
+from anthropic import AsyncAnthropic, AsyncAnthropicVertex
 
 from genkit.ai import ActionRunContext
+from genkit.core.typing import Supports
 from genkit.plugins.anthropic.models import AnthropicModel
 from genkit.types import GenerateRequest, GenerateResponse, GenerationCommonConfig, ModelInfo
 
@@ -49,9 +51,9 @@ class AnthropicModelGarden:
         self.client = AsyncAnthropicVertex(region=location, project_id=project_id)
         # Strip 'anthropic/' prefix for the model passed to Anthropic SDK
         clean_model_name = model.removeprefix('anthropic/')
-        self._anthropic_model = AnthropicModel(model_name=clean_model_name, client=self.client)
+        self._anthropic_model = AnthropicModel(model_name=clean_model_name, client=cast(AsyncAnthropic, self.client))
 
-    def get_handler(self) -> Callable[[GenerateRequest, ActionRunContext], GenerateResponse]:
+    def get_handler(self) -> Callable[[GenerateRequest, ActionRunContext], Awaitable[GenerateResponse]]:
         """Returns the generate handler function for this model.
 
         Returns:
@@ -67,13 +69,13 @@ class AnthropicModelGarden:
         """
         return ModelInfo(
             label=f'ModelGarden - {self.name}',
-            supports={
-                'multiturn': True,
-                'media': True,
-                'tools': True,
-                'systemRole': True,
-                'output': ['text', 'json'],
-            },
+            supports=Supports(
+                multiturn=True,
+                media=True,
+                tools=True,
+                system_role=True,
+                output=['text', 'json'],
+            ),
         )
 
     @staticmethod

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/model_garden/client.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/model_garden/client.py
@@ -14,6 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import google.auth.transport.requests
 from google import auth
 from openai import OpenAI as _OpenAI
 

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/model_garden/model_garden.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/model_garden/model_garden.py
@@ -14,7 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import typing
 from collections.abc import Callable
+from typing import Any, cast
+
+if typing.TYPE_CHECKING:
+    from openai import OpenAI
 
 from genkit.plugins.compat_oai.models import (
     SUPPORTED_OPENAI_COMPAT_MODELS,
@@ -68,7 +73,7 @@ class ModelGarden:
         openai_params = {'location': location, 'project_id': project_id}
         self.client = OpenAIClient(**openai_params)
 
-    def get_model_info(self) -> dict[str, str] | None:
+    def get_model_info(self) -> dict[str, Any] | None:
         """Retrieves metadata and supported features for the specified model.
 
         This method looks up the model's information from a predefined list
@@ -81,9 +86,10 @@ class ModelGarden:
             the model's capabilities (e.g., tools, streaming).
         """
         model_info = SUPPORTED_OPENAI_COMPAT_MODELS.get(self.name, get_default_model_info(self.name))
+        supports = model_info.supports
         return {
             'name': model_info.label,
-            'supports': model_info.supports.model_dump(),
+            'supports': supports.model_dump() if supports and hasattr(supports, 'model_dump') else {},
         }
 
     def to_openai_compatible_model(self) -> Callable:
@@ -97,5 +103,5 @@ class ModelGarden:
             A callable function (specifically, the `generate` method of an
             `OpenAIModel` instance) that can be used by Genkit.
         """
-        openai_model = OpenAIModel(self.name, self.client)
+        openai_model = OpenAIModel(self.name, cast('OpenAI', self.client))
         return openai_model.generate

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/model_garden/modelgarden_plugin.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/model_garden/modelgarden_plugin.py
@@ -17,6 +17,8 @@
 """ModelGarden API Compatible Plugin for Genkit."""
 
 import os
+import typing
+from typing import Any, cast
 
 from genkit.ai import Plugin
 from genkit.blocks.model import model_action_metadata
@@ -117,6 +119,8 @@ class ModelGardenPlugin(Plugin):
             from .anthropic import AnthropicModelGarden as AnthropicWorker
 
             location = self.model_locations.get(clean_name, self.location)
+            if not self.project_id:
+                raise ValueError('project_id must be provided')
             model_proxy = AnthropicWorker(
                 model=clean_name,
                 location=location,
@@ -139,6 +143,8 @@ class ModelGardenPlugin(Plugin):
             )
 
         location = self.model_locations.get(clean_name, self.location)
+        if not self.project_id:
+            raise ValueError('project_id must be provided')
         model_proxy = ModelGarden(
             model=clean_name,
             location=location,
@@ -155,7 +161,11 @@ class ModelGardenPlugin(Plugin):
             fn=handler,
             metadata={
                 'model': {
-                    **(model_info.model_dump() if hasattr(model_info, 'model_dump') else model_info),
+                    **(
+                        cast(Any, model_info).model_dump()
+                        if hasattr(model_info, 'model_dump')
+                        else cast(dict[str, Any], model_info)
+                    ),
                     'customOptions': to_json_schema(OpenAIConfig),
                 },
             },

--- a/py/plugins/vertex-ai/tests/vector_search/test_retrievers.py
+++ b/py/plugins/vertex-ai/tests/vector_search/test_retrievers.py
@@ -33,7 +33,7 @@ from google.cloud.aiplatform_v1 import (
 )
 
 from genkit.blocks.document import Document, DocumentData
-from genkit.core.typing import Embedding, EmbedResponse
+from genkit.core.typing import DocumentPart, Embedding, EmbedResponse
 from genkit.plugins.vertex_ai.vector_search import BigQueryRetriever, FirestoreRetriever
 from genkit.types import ActionRunContext, Part, RetrieverRequest, TextPart
 
@@ -108,7 +108,7 @@ async def test_bigquery_retriever_retrieve(
     request = RetrieverRequest(
         query=DocumentData(
             content=[
-                TextPart(text='test-1'),
+                DocumentPart(root=TextPart(text='test-1')),
             ],
         ),
         options=options,
@@ -163,7 +163,7 @@ async def test_bigquery__get_closest_documents(bq_retriever_instance):
     await bq_retriever_instance._get_closest_documents(
         request=RetrieverRequest(
             query=DocumentData(
-                content=[TextPart(text='test-1')],
+                content=[DocumentPart(root=TextPart(text='test-1'))],
                 metadata={
                     'index_endpoint_path': 'index_endpoint_path',
                     'api_endpoint': 'api_endpoint',
@@ -233,7 +233,7 @@ async def test_bigquery__get_closest_documents_fail(
         await bq_retriever_instance._get_closest_documents(
             request=RetrieverRequest(
                 query=DocumentData(
-                    content=[TextPart(text='test-1')],
+                    content=[DocumentPart(root=TextPart(text='test-1'))],
                     metadata=metadata,
                 ),
                 options={
@@ -375,7 +375,7 @@ async def test_firesstore__retrieve_neighbors_data_from_db(
             doc_ref = MagicMock()
             doc_snapshot = MagicMock()
 
-            doc_ref.get.return_value = doc_snapshot
+            doc_ref.get = AsyncMock(return_value=doc_snapshot)
             if storage.get(document_id) is not None:
                 doc_snapshot.exists = True
                 doc_snapshot.to_dict.return_value = storage.get(document_id)

--- a/py/plugins/xai/src/genkit/plugins/xai/plugin.py
+++ b/py/plugins/xai/src/genkit/plugins/xai/plugin.py
@@ -17,6 +17,7 @@
 """xAI plugin for Genkit."""
 
 import os
+from typing import Any
 
 from xai_sdk import Client as XAIClient
 
@@ -48,7 +49,7 @@ class XAI(Plugin):
         self,
         api_key: str | None = None,
         models: list[str] | None = None,
-        **xai_params: str,
+        **xai_params: Any,
     ) -> None:
         api_key = api_key or os.getenv('XAI_API_KEY')
 
@@ -111,7 +112,7 @@ class XAI(Plugin):
             fn=model.generate,
             metadata={
                 'model': {
-                    'supports': model_info.supports.model_dump(),
+                    'supports': model_info.supports.model_dump() if model_info.supports else {},
                     'customOptions': to_json_schema(GenerationCommonConfig),
                 },
             },
@@ -128,7 +129,7 @@ class XAI(Plugin):
             actions.append(
                 model_action_metadata(
                     name=xai_name(model_name),
-                    info={'supports': model_info.supports.model_dump()},
+                    info={'supports': model_info.supports.model_dump() if model_info.supports else {}},
                     config_schema=GenerationCommonConfig,
                 )
             )

--- a/py/plugins/xai/tests/test_xai_models.py
+++ b/py/plugins/xai/tests/test_xai_models.py
@@ -83,11 +83,14 @@ async def test_generate_basic():
     model = XAIModel(model_name='grok-3', client=mock_client)
     response = await model.generate(sample_request)
 
+    assert response.message
+    assert response.message.content
     assert len(response.message.content) == 1
     part = response.message.content[0]
     actual_part = part.root if isinstance(part, Part) else part
     assert isinstance(actual_part, TextPart)
     assert actual_part.text == "Hello! I'm doing well."
+    assert response.usage
     assert response.usage.input_tokens == 10
     assert response.usage.output_tokens == 15
     assert response.finish_reason == 'stop'
@@ -119,7 +122,7 @@ async def test_generate_with_config():
         config=GenerationCommonConfig(
             temperature=0.7,
             max_output_tokens=100,
-            topP=0.9,
+            top_p=0.9,
         ),
     )
 
@@ -210,11 +213,14 @@ async def test_streaming_generation():
     response = await model.generate(sample_request, ctx)
 
     assert len(collected_chunks) == 3
+    assert response.usage
     assert response.usage.input_tokens == 10
     assert response.usage.output_tokens == 20
     assert response.finish_reason == 'stop'
 
     accumulated_text = ''
+    assert response.message
+    assert response.message.content
     for part in response.message.content:
         actual_part = part.root if isinstance(part, Part) else part
         if isinstance(actual_part, TextPart):
@@ -253,6 +259,8 @@ async def test_generate_with_tools():
     model = XAIModel(model_name='grok-3', client=mock_client)
     response = await model.generate(sample_request)
 
+    assert response.message
+    assert response.message.content
     assert len(response.message.content) == 1
     part = response.message.content[0]
     actual_part = part.root if isinstance(part, Part) else part

--- a/py/plugins/xai/tests/test_xai_plugin.py
+++ b/py/plugins/xai/tests/test_xai_plugin.py
@@ -75,17 +75,23 @@ async def test_resolve_action_model():
 def test_supported_models():
     assert len(SUPPORTED_XAI_MODELS) >= 4
     for _name, info in SUPPORTED_XAI_MODELS.items():
+        assert info.label
         assert info.label.startswith('xAI - ')
+        assert info.versions
         assert len(info.versions) > 0
+        assert info.supports
         assert info.supports.tools
 
 
 def test_get_model_info_known():
     info = get_model_info('grok-3')
+    assert info.versions
     assert 'grok-3' in info.versions[0]
+    assert info.supports
     assert info.supports.multiturn
 
 
 def test_get_model_info_unknown():
     info = get_model_info('unknown-model')
+    assert info.label
     assert 'unknown-model' in info.label

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "genkit-plugin-ollama",
   "genkit-plugin-vertex-ai",
   "genkit-plugin-xai",
+  "genkit-plugin-mcp",
   "liccheck>=0.9.2",
   "mcp>=1.25.0",
   "strenum>=0.4.15; python_version < '3.11'",
@@ -66,7 +67,7 @@ dev = [
 lint = ["strenum>=0.4.15", "ty>=0.0.1", "ruff>=0.9"]
 
 [tool.hatch.build.targets.wheel]
-packages = []
+
 
 [tool.setuptools]
 py-modules = []
@@ -116,6 +117,7 @@ genkit-plugin-firebase              = { workspace = true }
 genkit-plugin-flask                 = { workspace = true }
 genkit-plugin-google-cloud          = { workspace = true }
 genkit-plugin-google-genai          = { workspace = true }
+genkit-plugin-mcp                   = { workspace = true }
 genkit-plugin-ollama                = { workspace = true }
 genkit-plugin-vertex-ai             = { workspace = true }
 genkit-plugin-xai                   = { workspace = true }

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -28,10 +28,10 @@ members = [
     "genkit-plugin-flask",
     "genkit-plugin-google-cloud",
     "genkit-plugin-google-genai",
+    "genkit-plugin-mcp",
     "genkit-plugin-ollama",
     "genkit-plugin-vertex-ai",
     "genkit-plugin-xai",
-    "genkit-plugins-mcp",
     "genkit-workspace",
     "google-genai-code-execution",
     "google-genai-context-caching",
@@ -1999,6 +1999,21 @@ requires-dist = [
 ]
 
 [[package]]
+name = "genkit-plugin-mcp"
+version = "0.1.0"
+source = { editable = "plugins/mcp" }
+dependencies = [
+    { name = "genkit" },
+    { name = "mcp" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "mcp" },
+]
+
+[[package]]
 name = "genkit-plugin-ollama"
 version = "0.4.0"
 source = { editable = "plugins/ollama" }
@@ -2060,21 +2075,6 @@ requires-dist = [
 ]
 
 [[package]]
-name = "genkit-plugins-mcp"
-version = "0.1.0"
-source = { editable = "plugins/mcp" }
-dependencies = [
-    { name = "genkit" },
-    { name = "mcp" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "genkit", editable = "packages/genkit" },
-    { name = "mcp" },
-]
-
-[[package]]
 name = "genkit-workspace"
 version = "0.1.0"
 source = { virtual = "." }
@@ -2090,6 +2090,7 @@ dependencies = [
     { name = "genkit-plugin-flask" },
     { name = "genkit-plugin-google-cloud" },
     { name = "genkit-plugin-google-genai" },
+    { name = "genkit-plugin-mcp" },
     { name = "genkit-plugin-ollama" },
     { name = "genkit-plugin-vertex-ai" },
     { name = "genkit-plugin-xai" },
@@ -2137,6 +2138,7 @@ requires-dist = [
     { name = "genkit-plugin-flask", editable = "plugins/flask" },
     { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
     { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
+    { name = "genkit-plugin-mcp", editable = "plugins/mcp" },
     { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
     { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "genkit-plugin-xai", editable = "plugins/xai" },


### PR DESCRIPTION
fix(py): fix test failures and enforce type checking in CI

This commit addresses test failures caused by type annotation fixes and
enables strict type checking in CI.

CI Enforcement:
- Remove --exit-zero from uv ty check in python.yml to fail CI on
  type errors

Bug Fixes:
- Fix MCP server read_resource to convert AnyUrl to str before passing
  to resource actions (server.py)
- Add callable() check for action.matches in find_matching_resource
  to prevent NoneType errors with dynamic action providers (resource.py)

Test Expectation Updates:
- Update schema expectations for nullable types to use anyOf format
  instead of simple type field (Pydantic v2 behavior for int | None)
  - veneer_test.py: 10 test expectations
  - schema_test.py: 1 test expectation

Type Annotation Fixes:
- Fix incorrect nullable type annotations across plugins:
  - value: int = None -> value: int | None = None
  - Updates to Ollama, Vertex-AI, Google-GenAI, Anthropic, MCP,
    compat-oai, DeepSeek, xAI plugins and core genkit packages

Context:
Pydantic v2 generates {"anyOf": [{"type": "integer"}, {"type": "null"}]}
for int | None fields, while the old incorrect annotations int = None
produced {"type": "integer"}. This commit updates all test expectations
to match the correct schema output.