### PR TITLE
feat(py/genkit): refactor embed/embed_many API for JS parity

### DIFF
--- a/py/packages/genkit/src/genkit/ai/_runtime.py
+++ b/py/packages/genkit/src/genkit/ai/_runtime.py
@@ -70,7 +70,7 @@ def _register_atexit_cleanup_handler(path_to_remove: Path | None) -> None:
         logger.warning('Cannot register atexit cleanup: runtime file path not set.')
         return
 
-    def sync_cleanup():
+    def sync_cleanup() -> None:
         # TODO: Neither print nor logger appears to work during atexit.
         _remove_file(path_to_remove)
 
@@ -151,7 +151,7 @@ class RuntimeManager:
         spec: ServerSpec,
         runtime_dir: str | Path | None = None,
         lazy_write: bool = False,
-    ):
+    ) -> None:
         """Initialize the RuntimeManager.
 
         Args:

--- a/py/packages/genkit/src/genkit/aio/_util.py
+++ b/py/packages/genkit/src/genkit/aio/_util.py
@@ -16,7 +16,7 @@
 
 """AIO util module for defining and managing AIO utilities."""
 
-import asyncio
+import inspect
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -30,7 +30,7 @@ def ensure_async(fn: Callable[..., Any] | Callable[..., Awaitable[Any]]) -> Call
     Returns:
         The async function.
     """
-    is_async = asyncio.iscoroutinefunction(fn)
+    is_async = inspect.iscoroutinefunction(fn)
     if is_async:
         return fn
 

--- a/py/packages/genkit/src/genkit/blocks/embedding.py
+++ b/py/packages/genkit/src/genkit/blocks/embedding.py
@@ -14,7 +14,79 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Embedding actions."""
+"""Embedding types and utilities for Genkit.
+
+This module provides types and utilities for working with text embeddings
+in Genkit. Embeddings are numerical vector representations of text that
+capture semantic meaning, enabling similarity search, clustering, and
+other AI applications.
+
+Terminology:
+
+    +-------------------+------------------------------------------------------+
+    | Term              | Description                                          |
+    +===================+======================================================+
+    | Embedding         | A numerical vector (list of floats) representing     |
+    |                   | semantic meaning. Similar texts produce similar      |
+    |                   | vectors. Contains 'embedding' field and metadata.    |
+    +-------------------+------------------------------------------------------+
+    | Embedder          | A model/service that converts text to embeddings.    |
+    |                   | Examples: 'googleai/text-embedding-004'. Registered  |
+    |                   | as actions, invoked via embed() and embed_many().    |
+    +-------------------+------------------------------------------------------+
+    | EmbedderRef       | Reference bundling embedder name with optional       |
+    |                   | config and version. Useful for reusing settings.     |
+    +-------------------+------------------------------------------------------+
+    | Document          | Structured content to embed. Create via              |
+    |                   | Document.from_text(). Can include metadata.          |
+    +-------------------+------------------------------------------------------+
+    | Dimensions        | Size of embedding vector (e.g., 768 or 1536 floats). |
+    |                   | Higher dimensions = more nuance but more storage.    |
+    +-------------------+------------------------------------------------------+
+
+Key Components:
+
+    +-------------------+------------------------------------------------------+
+    | Component         | Description                                          |
+    +===================+======================================================+
+    | EmbedderRef       | Reference to an embedder with optional configuration |
+    +-------------------+------------------------------------------------------+
+    | EmbedderOptions   | Configuration options for defining embedders         |
+    +-------------------+------------------------------------------------------+
+    | EmbedderSupports  | Declares what input types an embedder supports       |
+    +-------------------+------------------------------------------------------+
+    | Embedder          | Runtime wrapper around an embedder action            |
+    +-------------------+------------------------------------------------------+
+    | create_embedder   | Factory function for creating embedder references    |
+    | _ref              |                                                      |
+    +-------------------+------------------------------------------------------+
+
+Usage with Genkit:
+    The primary way to use embeddings is through the Genkit class methods:
+
+    - ai.embed(): Embed a single piece of content
+    - ai.embed_many(): Embed multiple pieces of content in batch
+
+Example - Single embedding:
+    >>> embeddings = await ai.embed(embedder='googleai/text-embedding-004', content='Hello, world!')
+    >>> vector = embeddings[0].embedding
+
+Example - Batch embedding:
+    >>> embeddings = await ai.embed_many(embedder='googleai/text-embedding-004', content=['Doc 1', 'Doc 2', 'Doc 3'])
+
+Example - Using EmbedderRef with configuration:
+    >>> ref = create_embedder_ref('googleai/text-embedding-004', config={'task_type': 'CLUSTERING'}, version='v1')
+    >>> embeddings = await ai.embed(embedder=ref, content='My text')
+
+Note on embed() vs embed_many():
+    - embed() extracts config/version from EmbedderRef and merges with options
+    - embed_many() does NOT extract config from EmbedderRef - pass options directly
+
+See Also:
+    - genkit.ai.Genkit.embed: Single content embedding method
+    - genkit.ai.Genkit.embed_many: Batch embedding method
+    - genkit.core.typing.Embedding: The embedding result type
+"""
 
 from collections.abc import Callable
 from typing import Any, cast

--- a/py/packages/genkit/src/genkit/blocks/formats/array.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/array.py
@@ -55,7 +55,7 @@ class ArrayFormat(FormatDef):
         )
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initializes the ArrayFormat.
 
         Configures the format with:

--- a/py/packages/genkit/src/genkit/blocks/formats/enum.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/enum.py
@@ -50,7 +50,7 @@ class EnumFormat(FormatDef):
         )
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initializes the EnumFormat.
 
         Configures the format with:

--- a/py/packages/genkit/src/genkit/blocks/formats/json.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/json.py
@@ -46,7 +46,7 @@ class JsonFormat(FormatDef):
         )
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initializes a JsonFormat instance.
 
         Sets up the format definition with configurations suitable for JSON,

--- a/py/packages/genkit/src/genkit/blocks/formats/jsonl.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/jsonl.py
@@ -54,7 +54,7 @@ class JsonlFormat(FormatDef):
         )
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initializes the JsonlFormat.
 
         Configures the format with:

--- a/py/packages/genkit/src/genkit/blocks/formats/text.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/text.py
@@ -37,7 +37,7 @@ class TextFormat(FormatDef):
         )
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initializes a TextFormat instance.
 
         Configures the format with:

--- a/py/packages/genkit/src/genkit/blocks/formats/types.py
+++ b/py/packages/genkit/src/genkit/blocks/formats/types.py
@@ -62,7 +62,7 @@ class Formatter(Generic[OutputT, ChunkT]):
         message_parser: MessageParser[OutputT],
         chunk_parser: ChunkParser[ChunkT],
         instructions: str | None,
-    ):
+    ) -> None:
         """Initializes a Formatter.
 
         Args:
@@ -105,7 +105,7 @@ class FormatDef:
     an optional schema.
     """
 
-    def __init__(self, name: str, config: FormatterConfig):
+    def __init__(self, name: str, config: FormatterConfig) -> None:
         """Initializes a FormatDef.
 
         Args:

--- a/py/packages/genkit/src/genkit/blocks/generate.py
+++ b/py/packages/genkit/src/genkit/blocks/generate.py
@@ -62,7 +62,7 @@ DEFAULT_MAX_TURNS = 5
 logger = structlog.get_logger(__name__)
 
 
-def define_generate_action(registry: Registry):
+def define_generate_action(registry: Registry) -> None:
     """Registers generate action in the provided registry."""
 
     async def generate_action_fn(input: GenerateActionOptions, ctx: ActionRunContext) -> GenerateResponse:
@@ -188,7 +188,7 @@ async def generate_action(
         if role is None:
             role = cast(Role, Role.MODEL)
 
-        def wrapper(chunk):
+        def wrapper(chunk) -> None:
             if on_chunk is not None:
                 on_chunk(make_chunk(role, chunk))
 
@@ -568,7 +568,7 @@ async def apply_resources(registry: Registry, raw_request: GenerateActionOptions
     return new_request
 
 
-def assert_valid_tool_names(raw_request: GenerateActionOptions):
+def assert_valid_tool_names(raw_request: GenerateActionOptions) -> None:
     """Assert that tool names in the request are valid.
 
     Args:
@@ -1022,7 +1022,7 @@ class GenerationResponseError(Exception):
         message: str,
         status: str,
         details: dict[str, Any],
-    ):
+    ) -> None:
         """Initialize the GenerationResponseError.
 
         Args:

--- a/py/packages/genkit/src/genkit/blocks/model.py
+++ b/py/packages/genkit/src/genkit/blocks/model.py
@@ -100,7 +100,7 @@ class MessageWrapper(Message):
     def __init__(
         self,
         message: Message,
-    ):
+    ) -> None:
         """Initializes the MessageWrapper.
 
         Args:
@@ -159,7 +159,7 @@ class GenerateResponseWrapper(GenerateResponse):
         response: GenerateResponse,
         request: GenerateRequest,
         message_parser: MessageParser | None = None,
-    ):
+    ) -> None:
         """Initializes a GenerateResponseWrapper instance.
 
         Args:
@@ -189,7 +189,7 @@ class GenerateResponseWrapper(GenerateResponse):
         # Set subclass-specific field after parent initialization
         self.message_parser = message_parser
 
-    def assert_valid(self):
+    def assert_valid(self) -> None:
         """Validates the basic structure of the response.
 
         Note: This method is currently a placeholder (TODO).
@@ -200,7 +200,7 @@ class GenerateResponseWrapper(GenerateResponse):
         # TODO: implement
         pass
 
-    def assert_valid_schema(self):
+    def assert_valid_schema(self) -> None:
         """Validates that the response message conforms to any specified output schema.
 
         Note: This method is currently a placeholder (TODO).
@@ -289,7 +289,7 @@ class GenerateResponseChunkWrapper(GenerateResponseChunk):
         previous_chunks: list[GenerateResponseChunk],
         index: int,
         chunk_parser: ChunkParser | None = None,
-    ):
+    ) -> None:
         """Initializes the GenerateResponseChunkWrapper.
 
         Args:

--- a/py/packages/genkit/src/genkit/blocks/prompt.py
+++ b/py/packages/genkit/src/genkit/blocks/prompt.py
@@ -142,7 +142,7 @@ class ExecutablePrompt:
         _prompt_action: Action | None = None,  # reference to PROMPT action
         # TODO:
         #  docs: list[Document]):
-    ):
+    ) -> None:
         """Initializes an ExecutablePrompt instance.
 
         Args:

--- a/py/packages/genkit/src/genkit/blocks/retriever.py
+++ b/py/packages/genkit/src/genkit/blocks/retriever.py
@@ -46,7 +46,7 @@ class Retriever(Generic[T]):
     def __init__(
         self,
         retriever_fn: RetrieverFn[T],
-    ):
+    ) -> None:
         """Initialize a Retriever.
 
         Args:

--- a/py/packages/genkit/src/genkit/blocks/tools.py
+++ b/py/packages/genkit/src/genkit/blocks/tools.py
@@ -21,7 +21,7 @@ process. This module provides context and error types for tool execution,
 allowing for controlled interruptions and specific response formatting.
 """
 
-from typing import Any, Protocol, cast
+from typing import Any, NoReturn, Protocol, cast
 
 from genkit.core.action import ActionRunContext
 from genkit.core.typing import Metadata, Part, ToolRequestPart, ToolResponse, ToolResponsePart
@@ -44,7 +44,7 @@ class ToolRunContext(ActionRunContext):
     def __init__(
         self,
         ctx: ActionRunContext,
-    ):
+    ) -> None:
         """Initializes the ToolRunContext.
 
         Args:
@@ -55,7 +55,7 @@ class ToolRunContext(ActionRunContext):
             context=ctx.context,
         )
 
-    def interrupt(self, metadata: dict[str, Any] | None = None):
+    def interrupt(self, metadata: dict[str, Any] | None = None) -> NoReturn:
         """Interrupts the current tool execution.
 
         Raises a ToolInterruptError, which can be caught by the generation
@@ -78,7 +78,7 @@ class ToolInterruptError(Exception):
     causing a hard failure.
     """
 
-    def __init__(self, metadata: dict[str, Any] | None = None):
+    def __init__(self, metadata: dict[str, Any] | None = None) -> None:
         """Initializes the ToolInterruptError.
 
         Args:

--- a/py/packages/genkit/src/genkit/core/action/_action.py
+++ b/py/packages/genkit/src/genkit/core/action/_action.py
@@ -126,7 +126,7 @@ class ActionRunContext:
         on_chunk: StreamingCallback | None = None,
         context: dict[str, Any] | None = None,
         on_trace_start: Callable[[str], None] | None = None,
-    ):
+    ) -> None:
         """Initializes an ActionRunContext instance.
 
         Sets up the context with an optional streaming callback and an optional
@@ -433,7 +433,7 @@ class Action:
         action_args: list[str],
         arg_types: list[type],
         input_spec: inspect.FullArgSpec,
-    ):
+    ) -> None:
         """Initializes input/output schemas based on function signature and hints.
 
         Uses Pydantic's TypeAdapter to generate JSON schemas for the first

--- a/py/packages/genkit/src/genkit/core/action/_tracing.py
+++ b/py/packages/genkit/src/genkit/core/action/_tracing.py
@@ -19,7 +19,7 @@
 from genkit.codec import dump_json
 
 
-def record_input_metadata(span, kind, name, span_metadata, input):
+def record_input_metadata(span, kind, name, span_metadata, input) -> None:
     """Records input metadata onto an OpenTelemetry span for a Genkit action.
 
     Sets standard Genkit attributes like action type, subtype (kind), name,

--- a/py/packages/genkit/src/genkit/core/extract.py
+++ b/py/packages/genkit/src/genkit/core/extract.py
@@ -146,7 +146,7 @@ class ExtractItemsResult:
                 processed character.
     """
 
-    def __init__(self, items: list[Any], cursor: int):
+    def __init__(self, items: list[Any], cursor: int) -> None:
         """Initialize an ExtractItemsResult.
 
         Args:

--- a/py/packages/genkit/src/genkit/core/reflection.py
+++ b/py/packages/genkit/src/genkit/core/reflection.py
@@ -340,7 +340,7 @@ def create_reflection_asgi_app(
         # Wrap execution to track the task for cancellation support
         task = asyncio.current_task()
 
-        def on_trace_start(trace_id: str):
+        def on_trace_start(trace_id: str) -> None:
             if task:
                 active_actions[trace_id] = task
 
@@ -382,16 +382,16 @@ def create_reflection_asgi_app(
         # Capture trace_id from the runner task for cleanup
         run_trace_id: str | None = None
 
-        def wrapped_on_trace_start(tid):
+        def wrapped_on_trace_start(tid) -> None:
             nonlocal run_trace_id
             run_trace_id = tid
             on_trace_start(tid)
 
-        async def run_action_task():
+        async def run_action_task() -> None:
             """Run the action and put chunks on the queue."""
             try:
 
-                def send_chunk(chunk):
+                def send_chunk(chunk) -> None:
                     """Callback that puts chunks on the queue."""
                     out = dump_json(chunk)
                     chunk_queue.put_nowait(f'{out}\n')
@@ -477,7 +477,7 @@ def create_reflection_asgi_app(
         """
         run_trace_id: str | None = None
 
-        def wrapped_on_trace_start(tid):
+        def wrapped_on_trace_start(tid) -> None:
             nonlocal run_trace_id
             run_trace_id = tid
             on_trace_start(tid)

--- a/py/packages/genkit/src/genkit/core/registry.py
+++ b/py/packages/genkit/src/genkit/core/registry.py
@@ -78,7 +78,7 @@ class Registry:
 
     default_model: str | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize an empty Registry instance."""
         self._entries: ActionStore = {}
         self._value_by_kind_and_name: dict[str, dict[str, Any]] = {}
@@ -173,7 +173,7 @@ class Registry:
         with self._lock:
             return self._entries.get(kind, {}).copy()
 
-    def register_value(self, kind: str, name: str, value: Any):
+    def register_value(self, kind: str, name: str, value: Any) -> None:
         """Registers a value with a given kind and name.
 
         This method stores a value in a nested dictionary, where the first level

--- a/py/packages/genkit/src/genkit/core/trace/default_exporter.py
+++ b/py/packages/genkit/src/genkit/core/trace/default_exporter.py
@@ -99,7 +99,7 @@ class TelemetryServerSpanExporter(SpanExporter):
         telemetry_server_url: The URL of the telemetry server endpoint.
     """
 
-    def __init__(self, telemetry_server_url: str, telemetry_server_endpoint: str | None = None):
+    def __init__(self, telemetry_server_url: str, telemetry_server_endpoint: str | None = None) -> None:
         """Initializes the TelemetryServerSpanExporter.
 
         Args:

--- a/py/packages/genkit/src/genkit/core/trace/types.py
+++ b/py/packages/genkit/src/genkit/core/trace/types.py
@@ -50,7 +50,7 @@ class GenkitSpan:
     is_root: bool
     _span: trace_api.Span
 
-    def __init__(self, span: trace_api.Span, labels: dict[str, str] | None = None):
+    def __init__(self, span: trace_api.Span, labels: dict[str, str] | None = None) -> None:
         """Create GenkitSpan."""
         self._span = span
         parent = getattr(span, 'parent', None)

--- a/py/packages/genkit/src/genkit/testing.py
+++ b/py/packages/genkit/src/genkit/testing.py
@@ -33,7 +33,7 @@ class ProgrammableModel:
         last_request: The most recent request received.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize a new ProgrammableModel instance."""
         self.request_idx = 0
         self.responses: list[GenerateResponse] = []
@@ -84,7 +84,7 @@ class EchoModel:
         last_request: The most recent request received.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize a new EchoModel instance."""
         self.last_request: GenerateRequest = None
 

--- a/py/packages/genkit/tests/genkit/ai/ai_plugin_test.py
+++ b/py/packages/genkit/tests/genkit/ai/ai_plugin_test.py
@@ -108,7 +108,7 @@ class AsyncInitPlugin(Plugin):
 
 
 @pytest.mark.asyncio
-async def test_async_resolve_is_awaited_via_generate():
+async def test_async_resolve_is_awaited_via_generate() -> None:
     """Test that async resolve is awaited when calling generate."""
     ai = Genkit(plugins=[AsyncResolveOnlyPlugin()])
     resp = await ai.generate('async-resolve-only/lazy-model', prompt='hello')
@@ -116,7 +116,7 @@ async def test_async_resolve_is_awaited_via_generate():
 
 
 @pytest.mark.asyncio
-async def test_async_init_is_awaited_via_generate():
+async def test_async_init_is_awaited_via_generate() -> None:
     """Test that async init is awaited when calling generate."""
     ai = Genkit(plugins=[AsyncInitPlugin()])
     resp = await ai.generate('async-init-plugin/init-model', prompt='hello')

--- a/py/packages/genkit/tests/genkit/ai/ai_registry_test.py
+++ b/py/packages/genkit/tests/genkit/ai/ai_registry_test.py
@@ -32,7 +32,7 @@ class TestGetFuncDescription(unittest.TestCase):
     def test_get_func_description_with_explicit_description(self) -> None:
         """Test that explicit description takes precedence over docstring."""
 
-        def test_func():
+        def test_func() -> None:
             """This docstring should be ignored."""
             pass
 
@@ -42,7 +42,7 @@ class TestGetFuncDescription(unittest.TestCase):
     def test_get_func_description_with_docstring(self) -> None:
         """Test that docstring is used when no explicit description is provided."""
 
-        def test_func():
+        def test_func() -> None:
             """This is the function's docstring."""
             pass
 
@@ -52,7 +52,7 @@ class TestGetFuncDescription(unittest.TestCase):
     def test_get_func_description_without_docstring(self) -> None:
         """Test that empty string is returned when no docstring is present."""
 
-        def test_func():
+        def test_func() -> None:
             pass
 
         description = get_func_description(test_func)
@@ -61,7 +61,7 @@ class TestGetFuncDescription(unittest.TestCase):
     def test_get_func_description_with_none_docstring(self) -> None:
         """Test that empty string is returned when docstring is None."""
 
-        def test_func():
+        def test_func() -> None:
             pass
 
         test_func.__doc__ = None

--- a/py/packages/genkit/tests/genkit/ai/test_resource.py
+++ b/py/packages/genkit/tests/genkit/ai/test_resource.py
@@ -30,7 +30,7 @@ from genkit.core.typing import Metadata, Part, TextPart
 
 
 @pytest.mark.asyncio
-async def test_define_resource():
+async def test_define_resource() -> None:
     """Verifies that a resource can be defined and registered correctly.
 
     Checks:
@@ -56,7 +56,7 @@ async def test_define_resource():
 
 
 @pytest.mark.asyncio
-async def test_resolve_resources():
+async def test_resolve_resources() -> None:
     """Verifies resolving resource references into Action objects.
 
     Checks:
@@ -80,7 +80,7 @@ async def test_resolve_resources():
 
 
 @pytest.mark.asyncio
-async def test_find_matching_resource():
+async def test_find_matching_resource() -> None:
     """Verifies the logic for finding a matching resource given an input URI.
 
     Checks:
@@ -128,7 +128,7 @@ async def test_find_matching_resource():
     assert res is None
 
 
-def test_is_dynamic_resource_action():
+def test_is_dynamic_resource_action() -> None:
     """Verifies identifying dynamic vs registered resource actions.
 
     Checks:
@@ -152,7 +152,7 @@ def test_is_dynamic_resource_action():
 
 
 @pytest.mark.asyncio
-async def test_parent_metadata():
+async def test_parent_metadata() -> None:
     """Verifies that parent metadata is correctly attached to output items.
 
     When a resource is resolved via a template (e.g. `file://{id}`), the output parts
@@ -182,7 +182,7 @@ async def test_parent_metadata():
     assert part['metadata']['resource']['uri'] == 'file://dir/sub1.txt'
 
 
-def test_dynamic_resource_matching():
+def test_dynamic_resource_matching() -> None:
     """Verifies the matching logic for a simple static URI dynamic resource."""
 
     async def my_resource_fn(input, ctx):
@@ -202,7 +202,7 @@ def test_dynamic_resource_matching():
     assert not res.matches(MockInputBad())
 
 
-def test_template_matching():
+def test_template_matching() -> None:
     """Verifies URI template pattern matching.
 
     Checks:
@@ -228,7 +228,7 @@ def test_template_matching():
     assert not res.matches(MockInputBad())
 
 
-def test_reserved_expansion_matching():
+def test_reserved_expansion_matching() -> None:
     """Verifies RFC 6570 reserved expansion {+var} pattern matching.
 
     Checks:

--- a/py/packages/genkit/tests/genkit/ai/test_resource_integration.py
+++ b/py/packages/genkit/tests/genkit/ai/test_resource_integration.py
@@ -26,7 +26,7 @@ from genkit.core.typing import GenerateActionOptions, GenerateResponse, Message,
 
 
 @pytest.mark.asyncio
-async def test_generate_with_resources():
+async def test_generate_with_resources() -> None:
     """Test calling generate with resources."""
     registry = Registry()
 
@@ -63,7 +63,7 @@ async def test_generate_with_resources():
 
 
 @pytest.mark.asyncio
-async def test_dynamic_action_provider_resource():
+async def test_dynamic_action_provider_resource() -> None:
     """Test dynamic action provider with resources."""
     registry = Registry()
 

--- a/py/packages/genkit/tests/genkit/blocks/embedding_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/embedding_test.py
@@ -35,7 +35,7 @@ from genkit.core.schema import to_json_schema
 from genkit.core.typing import Embedding, EmbedRequest, EmbedResponse
 
 
-def test_embedder_action_metadata():
+def test_embedder_action_metadata() -> None:
     """Test for embedder_action_metadata with basic options."""
     options = EmbedderOptions(label='Test Embedder', dimensions=128)
     action_metadata = embedder_action_metadata(
@@ -55,7 +55,7 @@ def test_embedder_action_metadata():
     }
 
 
-def test_embedder_action_metadata_with_supports_and_config_schema():
+def test_embedder_action_metadata_with_supports_and_config_schema() -> None:
     """Test for embedder_action_metadata with supports and config_schema."""
 
     class CustomConfig(BaseModel):
@@ -90,14 +90,14 @@ def test_embedder_action_metadata_with_supports_and_config_schema():
     }
 
 
-def test_embedder_action_metadata_no_options():
+def test_embedder_action_metadata_no_options() -> None:
     """Test embedder_action_metadata when no options are provided."""
     action_metadata = embedder_action_metadata(name='default_model')
     assert isinstance(action_metadata, ActionMetadata)
     assert action_metadata.metadata == {'embedder': {'customOptions': None, 'dimensions': None}}
 
 
-def test_create_embedder_ref_basic():
+def test_create_embedder_ref_basic() -> None:
     """Test basic creation of EmbedderRef."""
     ref = create_embedder_ref('my-embedder')
     assert ref.name == 'my-embedder'
@@ -105,7 +105,7 @@ def test_create_embedder_ref_basic():
     assert ref.version is None
 
 
-def test_create_embedder_ref_with_config():
+def test_create_embedder_ref_with_config() -> None:
     """Test creation of EmbedderRef with configuration."""
     config = {'temperature': 0.5, 'max_tokens': 100}
     ref = create_embedder_ref('configured-embedder', config=config)
@@ -114,7 +114,7 @@ def test_create_embedder_ref_with_config():
     assert ref.version is None
 
 
-def test_create_embedder_ref_with_version():
+def test_create_embedder_ref_with_version() -> None:
     """Test creation of EmbedderRef with a version."""
     ref = create_embedder_ref('versioned-embedder', version='v1.0')
     assert ref.name == 'versioned-embedder'
@@ -122,7 +122,7 @@ def test_create_embedder_ref_with_version():
     assert ref.version == 'v1.0'
 
 
-def test_create_embedder_ref_with_config_and_version():
+def test_create_embedder_ref_with_config_and_version() -> None:
     """Test creation of EmbedderRef with both config and version."""
     config = {'task_type': 'retrieval'}
     ref = create_embedder_ref('full-embedder', config=config, version='beta')
@@ -134,7 +134,7 @@ def test_create_embedder_ref_with_config_and_version():
 class MockGenkitRegistry:
     """A mock registry to simulate action lookup."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the MockGenkitRegistry."""
         self.actions = {}
 
@@ -170,7 +170,7 @@ def mock_genkit_instance():
 
 
 @pytest.mark.asyncio
-async def test_embed_with_embedder_ref(mock_genkit_instance):
+async def test_embed_with_embedder_ref(mock_genkit_instance) -> None:
     """Test the embed method using EmbedderRef."""
     genkit_instance, registry = mock_genkit_instance
 
@@ -192,13 +192,11 @@ async def test_embed_with_embedder_ref(mock_genkit_instance):
     )
     embedder_ref = create_embedder_ref('my-plugin/my-embedder', config={'param': 'value'}, version='v1')
 
-    documents = [Document.from_text('hello world')]
+    content = Document.from_text('hello world')
 
-    response = await genkit_instance.embed(
-        embedder=embedder_ref, documents=documents, options={'additional_option': True}
-    )
+    response = await genkit_instance.embed(embedder=embedder_ref, content=content, options={'additional_option': True})
 
-    assert response.embeddings[0].embedding == [1.0, 2.0, 3.0]
+    assert response[0].embedding == [1.0, 2.0, 3.0]
 
     embed_action = await registry.resolve_action('embedder', 'my-plugin/my-embedder')
     assert embed_action is not None
@@ -206,13 +204,13 @@ async def test_embed_with_embedder_ref(mock_genkit_instance):
 
     called_request = embed_action.arun.call_args[0][0]
     assert isinstance(called_request, EmbedRequest)
-    assert called_request.input == documents
+    assert called_request.input == [content]
     # Check if config from EmbedderRef and options are merged correctly
     assert called_request.options == {'param': 'value', 'additional_option': True, 'version': 'v1'}
 
 
 @pytest.mark.asyncio
-async def test_embed_with_string_name_and_options(mock_genkit_instance):
+async def test_embed_with_string_name_and_options(mock_genkit_instance) -> None:
     """Test the embed method using a string name for embedder and options."""
     genkit_instance, registry = mock_genkit_instance
 
@@ -228,23 +226,83 @@ async def test_embed_with_string_name_and_options(mock_genkit_instance):
         description='Another fake embedder',
     )
 
-    documents = [Document.from_text('test text')]
+    content = 'test text'
 
     response = await genkit_instance.embed(
-        embedder='another-embedder', documents=documents, options={'custom_setting': 'high'}
+        embedder='another-embedder', content=content, options={'custom_setting': 'high'}
     )
 
-    assert response.embeddings[0].embedding == [4.0, 5.0, 6.0]
+    assert response[0].embedding == [4.0, 5.0, 6.0]
     embed_action = await registry.resolve_action('embedder', 'another-embedder')
     called_request = embed_action.arun.call_args[0][0]
     assert called_request.options == {'custom_setting': 'high'}
 
 
 @pytest.mark.asyncio
-async def test_embed_missing_embedder_raises_error(mock_genkit_instance):
+async def test_embed_missing_embedder_raises_error(mock_genkit_instance) -> None:
     """Test that embedding with a missing embedder raises an error."""
     genkit_instance, _ = mock_genkit_instance
-    documents = [Document.from_text('some text')]
+    content = 'some text'
 
     with pytest.raises(ValueError, match='Embedder must be specified as a string name or an EmbedderRef.'):
-        await genkit_instance.embed(documents=documents)
+        await genkit_instance.embed(content=content)
+
+
+@pytest.mark.asyncio
+async def test_embed_many(mock_genkit_instance) -> None:
+    """Test the embed_many method."""
+    genkit_instance, registry = mock_genkit_instance
+
+    async def fake_embedder_fn(request: EmbedRequest) -> EmbedResponse:
+        return EmbedResponse(embeddings=[Embedding(embedding=[1.0, 1.1]), Embedding(embedding=[2.0, 2.1])])
+
+    registry.register_action(
+        name='multi-embedder',
+        kind='embedder',
+        fn=fake_embedder_fn,
+        metadata=embedder_action_metadata('multi-embedder').metadata,
+        description='A multi embedder for testing',
+    )
+
+    content = ['text1', 'text2']
+    response = await genkit_instance.embed_many(embedder='multi-embedder', content=content)
+
+    assert len(response) == 2
+    assert response[0].embedding == [1.0, 1.1]
+    assert response[1].embedding == [2.0, 2.1]
+
+    embed_action = await registry.resolve_action('embedder', 'multi-embedder')
+    called_request = embed_action.arun.call_args[0][0]
+    assert called_request.input == [Document.from_text('text1'), Document.from_text('text2')]
+
+
+# --- Tests for _resolve_embedder_name helper ---
+
+
+def test_resolve_embedder_name_with_string() -> None:
+    """Test _resolve_embedder_name returns name when given a string."""
+    genkit_instance = Genkit()
+    result = genkit_instance._resolve_embedder_name('my-embedder')
+    assert result == 'my-embedder'
+
+
+def test_resolve_embedder_name_with_embedder_ref() -> None:
+    """Test _resolve_embedder_name extracts name from EmbedderRef."""
+    genkit_instance = Genkit()
+    ref = create_embedder_ref('ref-embedder', config={'key': 'value'}, version='v1')
+    result = genkit_instance._resolve_embedder_name(ref)
+    assert result == 'ref-embedder'
+
+
+def test_resolve_embedder_name_with_none_raises_error() -> None:
+    """Test _resolve_embedder_name raises ValueError when given None."""
+    genkit_instance = Genkit()
+    with pytest.raises(ValueError, match='Embedder must be specified as a string name or an EmbedderRef.'):
+        genkit_instance._resolve_embedder_name(None)
+
+
+def test_resolve_embedder_name_with_invalid_type_raises_error() -> None:
+    """Test _resolve_embedder_name raises ValueError for invalid types."""
+    genkit_instance = Genkit()
+    with pytest.raises(ValueError, match='Embedder must be specified as a string name or an EmbedderRef.'):
+        genkit_instance._resolve_embedder_name(123)  # type: ignore[arg-type]

--- a/py/packages/genkit/tests/genkit/blocks/generate_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/generate_test.py
@@ -6,6 +6,7 @@
 """Tests for the action module."""
 
 import pathlib
+from typing import Any
 
 import pytest
 import yaml
@@ -44,7 +45,7 @@ def setup_test():
     pm, _ = define_programmable_model(ai)
 
     @ai.tool(name='testTool')
-    def test_tool():
+    def test_tool() -> Any:
         """description"""  # noqa: D400, D403, D415
         return 'tool called'
 
@@ -270,7 +271,7 @@ async def test_generate_middleware_can_modify_stream(
             )
         )
 
-        def chunk_handler(chunk):
+        def chunk_handler(chunk) -> None:
             ctx.send_chunk(
                 GenerateResponseChunk(
                     role=Role.MODEL,
@@ -289,7 +290,7 @@ async def test_generate_middleware_can_modify_stream(
 
     got_chunks = []
 
-    def collect_chunks(c):
+    def collect_chunks(c) -> None:
         got_chunks.append(text_from_content(c.content))
 
     response = await generate_action(
@@ -340,7 +341,7 @@ async def test_generate_action_spec(spec) -> None:
     pm, _ = define_programmable_model(ai)
 
     @ai.tool(name='testTool')
-    def test_tool():
+    def test_tool() -> Any:
         """description"""  # noqa: D400, D403, D415
         return 'tool called'
 
@@ -363,7 +364,7 @@ async def test_generate_action_spec(spec) -> None:
     if 'stream' in spec and spec['stream']:
         chunks = []
 
-        def on_chunk(chunk):
+        def on_chunk(chunk) -> None:
             chunks.append(chunk)
 
         action_response = await action.arun(
@@ -395,7 +396,7 @@ async def test_generate_action_spec(spec) -> None:
             )
 
 
-def is_equal_lists(a, b):
+def is_equal_lists(a, b) -> bool:
     """Deep compare two lists of actions."""
     if len(a) != len(b):
         return False

--- a/py/packages/genkit/tests/genkit/blocks/model_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/model_test.py
@@ -482,7 +482,7 @@ def test_response_wrapper_interrupts() -> None:
     ]
 
 
-def test_model_action_metadata():
+def test_model_action_metadata() -> None:
     """Test for model_action_metadata."""
     action_metadata = model_action_metadata(
         name='test_model',

--- a/py/packages/genkit/tests/genkit/blocks/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/prompt_test.py
@@ -122,7 +122,7 @@ async def test_prompt_with_kitchensink() -> None:
         value: int | None = Field(default=None, description='value field')
 
     @ai.tool(name='testTool')
-    def test_tool(input: ToolInput):
+    def test_tool(input: ToolInput) -> str:
         """The tool."""
         return 'abc'
 
@@ -159,10 +159,10 @@ async def test_prompt_with_resolvers() -> None:
     """Test that the rendering works with resolvers."""
     ai, *_ = setup_test()
 
-    async def system_resolver(input, context):
+    async def system_resolver(input, context) -> str:
         return f'system {input["name"]}'
 
-    def prompt_resolver(input, context):
+    def prompt_resolver(input, context) -> str:
         return f'prompt {input["name"]}'
 
     async def messages_resolver(input, context):
@@ -626,7 +626,7 @@ async def test_prompt_function_uses_lookup_prompt() -> None:
 
 
 @pytest.mark.asyncio
-async def test_automatic_prompt_loading():
+async def test_automatic_prompt_loading() -> None:
     """Test that Genkit automatically loads prompts from a directory."""
     with tempfile.TemporaryDirectory() as tmp_dir:
         # Create a prompt file
@@ -650,7 +650,7 @@ Hello {{name}}!
 
 
 @pytest.mark.asyncio
-async def test_automatic_prompt_loading_default_none():
+async def test_automatic_prompt_loading_default_none() -> None:
     """Test that Genkit does not load prompts if prompt_dir is None."""
     ai = Genkit(prompt_dir=None)
 
@@ -662,7 +662,7 @@ async def test_automatic_prompt_loading_default_none():
 
 
 @pytest.mark.asyncio
-async def test_automatic_prompt_loading_defaults_mock():
+async def test_automatic_prompt_loading_defaults_mock() -> None:
     """Test that Genkit defaults to ./prompts when prompt_dir is not specified and dir exists."""
     from unittest.mock import ANY, MagicMock, patch
 
@@ -677,7 +677,7 @@ async def test_automatic_prompt_loading_defaults_mock():
 
 
 @pytest.mark.asyncio
-async def test_automatic_prompt_loading_defaults_missing():
+async def test_automatic_prompt_loading_defaults_missing() -> None:
     """Test that Genkit skips loading when ./prompts is missing."""
     from unittest.mock import MagicMock, patch
 

--- a/py/packages/genkit/tests/genkit/blocks/retriever_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/retriever_test.py
@@ -38,7 +38,7 @@ from genkit.core.action import ActionMetadata
 from genkit.core.schema import to_json_schema
 
 
-def test_retriever_action_metadata():
+def test_retriever_action_metadata() -> None:
     """Test for retriever_action_metadata with basic options."""
     options = RetrieverOptions(label='Test Retriever')
     action_metadata = retriever_action_metadata(
@@ -57,7 +57,7 @@ def test_retriever_action_metadata():
     }
 
 
-def test_retriever_action_metadata_with_supports_and_config_schema():
+def test_retriever_action_metadata_with_supports_and_config_schema() -> None:
     """Test for retriever_action_metadata with supports and config_schema."""
 
     class CustomConfig(BaseModel):
@@ -89,14 +89,14 @@ def test_retriever_action_metadata_with_supports_and_config_schema():
     }
 
 
-def test_retriever_action_metadata_no_options():
+def test_retriever_action_metadata_no_options() -> None:
     """Test retriever_action_metadata when no options are provided."""
     action_metadata = retriever_action_metadata(name='default_retriever')
     assert isinstance(action_metadata, ActionMetadata)
     assert action_metadata.metadata == {'retriever': {'customOptions': None}}
 
 
-def test_create_retriever_ref_basic():
+def test_create_retriever_ref_basic() -> None:
     """Test basic creation of RetrieverRef."""
     ref = create_retriever_ref('my-retriever')
     assert ref.name == 'my-retriever'
@@ -104,7 +104,7 @@ def test_create_retriever_ref_basic():
     assert ref.version is None
 
 
-def test_create_retriever_ref_with_config():
+def test_create_retriever_ref_with_config() -> None:
     """Test creation of RetrieverRef with configuration."""
     config = {'k': 5}
     ref = create_retriever_ref('configured-retriever', config=config)
@@ -113,7 +113,7 @@ def test_create_retriever_ref_with_config():
     assert ref.version is None
 
 
-def test_create_retriever_ref_with_version():
+def test_create_retriever_ref_with_version() -> None:
     """Test creation of RetrieverRef with a version."""
     ref = create_retriever_ref('versioned-retriever', version='v1.0')
     assert ref.name == 'versioned-retriever'
@@ -121,7 +121,7 @@ def test_create_retriever_ref_with_version():
     assert ref.version == 'v1.0'
 
 
-def test_create_retriever_ref_with_config_and_version():
+def test_create_retriever_ref_with_config_and_version() -> None:
     """Test creation of RetrieverRef with both config and version."""
     config = {'k': 10}
     ref = create_retriever_ref('full-retriever', config=config, version='beta')
@@ -131,7 +131,7 @@ def test_create_retriever_ref_with_config_and_version():
 
 
 @pytest.mark.asyncio
-async def test_define_retriever():
+async def test_define_retriever() -> None:
     """Test define_retriever registration."""
     registry = MagicMock()
     fn = AsyncMock(return_value=RetrieverResponse(documents=[]))
@@ -145,7 +145,7 @@ async def test_define_retriever():
 
 
 @pytest.mark.asyncio
-async def test_define_indexer():
+async def test_define_indexer() -> None:
     """Test define_indexer registration."""
     registry = MagicMock()
     fn = AsyncMock()
@@ -158,7 +158,7 @@ async def test_define_indexer():
     assert call_args.kwargs['name'] == 'test_indexer'
 
 
-def test_indexer_action_metadata():
+def test_indexer_action_metadata() -> None:
     """Test for indexer_action_metadata with basic options."""
     options = IndexerOptions(label='Test Indexer')
     action_metadata = indexer_action_metadata(
@@ -177,7 +177,7 @@ def test_indexer_action_metadata():
     }
 
 
-def test_create_indexer_ref_basic():
+def test_create_indexer_ref_basic() -> None:
     """Test basic creation of IndexerRef."""
     ref = create_indexer_ref('my-indexer')
     assert ref.name == 'my-indexer'

--- a/py/packages/genkit/tests/genkit/blocks/test_reranker.py
+++ b/py/packages/genkit/tests/genkit/blocks/test_reranker.py
@@ -46,7 +46,7 @@ from genkit.core.typing import (
 class TestRankedDocument:
     """Tests for the RankedDocument class."""
 
-    def test_ranked_document_creation(self):
+    def test_ranked_document_creation(self) -> None:
         """Test creating a RankedDocument with content and score."""
         content = [DocumentPart(root=TextPart(text='Test content'))]
         metadata = {'key': 'value'}
@@ -60,14 +60,14 @@ class TestRankedDocument:
         # Original metadata should not be modified
         assert metadata == {'key': 'value'}
 
-    def test_ranked_document_default_score(self):
+    def test_ranked_document_default_score(self) -> None:
         """Test that RankedDocument has a default score of None."""
         content = [DocumentPart(root=TextPart(text='Test'))]
         doc = RankedDocument(content=content)
 
         assert doc.score is None
 
-    def test_ranked_document_from_data(self):
+    def test_ranked_document_from_data(self) -> None:
         """Test creating RankedDocument from RankedDocumentData."""
         data = RankedDocumentData(
             content=[DocumentPart(root=TextPart(text='Test content'))],
@@ -83,7 +83,7 @@ class TestRankedDocument:
 class TestRerankerRef:
     """Tests for RerankerRef and related helper functions."""
 
-    def test_create_reranker_ref_basic(self):
+    def test_create_reranker_ref_basic(self) -> None:
         """Test creating a basic reranker reference."""
         ref = create_reranker_ref('test-reranker')
 
@@ -92,7 +92,7 @@ class TestRerankerRef:
         assert ref.version is None
         assert ref.info is None
 
-    def test_create_reranker_ref_with_options(self):
+    def test_create_reranker_ref_with_options(self) -> None:
         """Test creating a reranker reference with all options."""
         info = RerankerInfo(label='Test Reranker')
         ref = create_reranker_ref(
@@ -112,7 +112,7 @@ class TestRerankerRef:
 class TestRerankerActionMetadata:
     """Tests for reranker action metadata creation."""
 
-    def test_action_metadata_basic(self):
+    def test_action_metadata_basic(self) -> None:
         """Test creating basic action metadata."""
         metadata = reranker_action_metadata('test-reranker')
 
@@ -121,7 +121,7 @@ class TestRerankerActionMetadata:
         assert metadata.metadata is not None
         assert 'reranker' in metadata.metadata
 
-    def test_action_metadata_with_options(self):
+    def test_action_metadata_with_options(self) -> None:
         """Test creating action metadata with options."""
         options = RerankerOptions(
             label='Custom Label',
@@ -143,7 +143,7 @@ class TestDefineReranker:
         return Registry()
 
     @pytest.mark.asyncio
-    async def test_define_reranker_registers_action(self, registry):
+    async def test_define_reranker_registers_action(self, registry) -> None:
         """Test that define_reranker registers an action in the registry."""
 
         async def simple_reranker(query, documents, options):
@@ -166,7 +166,7 @@ class TestDefineReranker:
         assert action.name == 'test-reranker'
 
     @pytest.mark.asyncio
-    async def test_define_reranker_with_options(self, registry):
+    async def test_define_reranker_with_options(self, registry) -> None:
         """Test define_reranker with custom options."""
 
         async def reranker_fn(query, documents, options):
@@ -196,7 +196,7 @@ class TestRerank:
         ]
 
     @pytest.mark.asyncio
-    async def test_rerank_with_string_query(self, registry, sample_documents):
+    async def test_rerank_with_string_query(self, registry, sample_documents) -> None:
         """Test rerank with a string query."""
 
         async def score_by_length(query, documents, options):
@@ -227,7 +227,7 @@ class TestRerank:
         assert all(isinstance(r, RankedDocument) for r in results)
 
     @pytest.mark.asyncio
-    async def test_rerank_with_reranker_ref(self, registry, sample_documents):
+    async def test_rerank_with_reranker_ref(self, registry, sample_documents) -> None:
         """Test rerank with a RerankerRef."""
 
         async def simple_reranker(query, documents, options):
@@ -257,7 +257,7 @@ class TestRerank:
         assert all(doc.score == 0.5 for doc in results)
 
     @pytest.mark.asyncio
-    async def test_rerank_unknown_reranker_raises(self, registry, sample_documents):
+    async def test_rerank_unknown_reranker_raises(self, registry, sample_documents) -> None:
         """Test that rerank raises ValueError for unknown reranker."""
         with pytest.raises(ValueError, match='Unable to resolve reranker'):
             await rerank(
@@ -297,7 +297,7 @@ class TestCustomRerankers:
         ]
 
     @pytest.mark.asyncio
-    async def test_custom_keyword_overlap_reranker(self, registry, sample_documents):
+    async def test_custom_keyword_overlap_reranker(self, registry, sample_documents) -> None:
         """Test a custom reranker that scores by keyword overlap.
 
         This demonstrates the pattern shown in genkit.dev docs for
@@ -351,7 +351,7 @@ class TestCustomRerankers:
         assert results[0].score > 0
 
     @pytest.mark.asyncio
-    async def test_custom_reranker_with_top_k_option(self, registry, sample_documents):
+    async def test_custom_reranker_with_top_k_option(self, registry, sample_documents) -> None:
         """Test custom reranker with k option to limit results.
 
         Demonstrates using options to configure reranking behavior.
@@ -392,7 +392,7 @@ class TestCustomRerankers:
         assert len(results) == 3
 
     @pytest.mark.asyncio
-    async def test_custom_reranker_preserves_document_content(self, registry):
+    async def test_custom_reranker_preserves_document_content(self, registry) -> None:
         """Test that custom reranker preserves original document content."""
 
         async def identity_reranker(query, documents, options):
@@ -426,7 +426,7 @@ class TestCustomRerankers:
         assert result_texts == original_texts
 
     @pytest.mark.asyncio
-    async def test_custom_reranker_two_stage_retrieval_pattern(self, registry):
+    async def test_custom_reranker_two_stage_retrieval_pattern(self, registry) -> None:
         """Test the two-stage retrieval pattern: retrieve then rerank.
 
         This demonstrates the typical RAG pattern where:

--- a/py/packages/genkit/tests/genkit/codec_test.py
+++ b/py/packages/genkit/tests/genkit/codec_test.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 from genkit.codec import dump_json
 
 
-def test_dump_json_basic():
+def test_dump_json_basic() -> None:
     """Test basic JSON serialization."""
     # Test dictionary
     assert dump_json({'a': 1, 'b': 'test'}) == '{"a": 1, "b": "test"}'
@@ -33,7 +33,7 @@ def test_dump_json_basic():
     assert dump_json({'a': [1, 2], 'b': {'c': 3}}) == '{"a": [1, 2], "b": {"c": 3}}'
 
 
-def test_dump_json_special_types():
+def test_dump_json_special_types() -> None:
     """Test JSON serialization of special Python types."""
     # Test None
     assert dump_json(None) == 'null'
@@ -43,7 +43,7 @@ def test_dump_json_special_types():
     assert dump_json(False) == 'false'
 
 
-def test_dump_json_numbers():
+def test_dump_json_numbers() -> None:
     """Test JSON serialization of different number types."""
     # Test integers
     assert dump_json(42) == '42'
@@ -55,7 +55,7 @@ def test_dump_json_numbers():
     assert dump_json(1e-10) == '1e-10'
 
 
-def test_dump_json_pydantic():
+def test_dump_json_pydantic() -> None:
     """Test JSON serialization of Pydantic models."""
 
     class MyModel(BaseModel):

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -86,7 +86,7 @@ def test_create_action_key() -> None:
 async def test_define_sync_action() -> None:
     """Define and run a sync action."""
 
-    def sync_foo():
+    def sync_foo() -> str:
         """A sync action that returns 'syncFoo'."""
         return 'syncFoo'
 
@@ -100,7 +100,7 @@ async def test_define_sync_action() -> None:
 async def test_define_sync_action_with_input_without_type_annotation() -> None:
     """Define and run a sync action with input without type annotation."""
 
-    def sync_foo(input):
+    def sync_foo(input) -> str:
         """A sync action that returns 'syncFoo' with an input."""
         return f'syncFoo {input}'
 
@@ -114,7 +114,7 @@ async def test_define_sync_action_with_input_without_type_annotation() -> None:
 async def test_define_sync_action_with_input() -> None:
     """Define and run a sync action with input."""
 
-    def sync_foo(input: str):
+    def sync_foo(input: str) -> str:
         """A sync action that returns 'syncFoo' with an input."""
         return f'syncFoo {input}'
 
@@ -128,7 +128,7 @@ async def test_define_sync_action_with_input() -> None:
 async def test_define_sync_action_with_input_and_context() -> None:
     """Define and run a sync action with input and context."""
 
-    def sync_foo(input: str, ctx: ActionRunContext):
+    def sync_foo(input: str, ctx: ActionRunContext) -> str:
         """A sync action that returns 'syncFoo' with an input and context."""
         return f'syncFoo {input} {ctx.context["foo"]}'
 
@@ -142,7 +142,7 @@ async def test_define_sync_action_with_input_and_context() -> None:
 async def test_define_sync_streaming_action() -> None:
     """Define and run a sync streaming action."""
 
-    def sync_foo(input: str, ctx: ActionRunContext):
+    def sync_foo(input: str, ctx: ActionRunContext) -> int:
         """A sync action that returns 'syncFoo' with streaming output."""
         ctx.send_chunk('1')
         ctx.send_chunk('2')
@@ -152,7 +152,7 @@ async def test_define_sync_streaming_action() -> None:
 
     chunks = []
 
-    def on_chunk(c):
+    def on_chunk(c) -> None:
         chunks.append(c)
 
     assert (await action.arun('foo', context={'foo': 'bar'}, on_chunk=on_chunk)).response == 3
@@ -163,7 +163,7 @@ async def test_define_sync_streaming_action() -> None:
 async def test_define_streaming_action_and_stream_it() -> None:
     """Define and stream a streaming action."""
 
-    def sync_foo(input: str, ctx: ActionRunContext):
+    def sync_foo(input: str, ctx: ActionRunContext) -> int:
         """A sync action that returns 'syncFoo' with streaming output."""
         ctx.send_chunk('1')
         ctx.send_chunk('2')
@@ -185,7 +185,7 @@ async def test_define_streaming_action_and_stream_it() -> None:
 async def test_define_async_action() -> None:
     """Define and run an async action."""
 
-    async def async_foo():
+    async def async_foo() -> str:
         """An async action that returns 'asyncFoo'."""
         return 'asyncFoo'
 
@@ -199,7 +199,7 @@ async def test_define_async_action() -> None:
 async def test_define_async_action_with_input() -> None:
     """Define and run an async action with input."""
 
-    async def async_foo(input: str):
+    async def async_foo(input: str) -> str:
         """An async action that returns 'asyncFoo' with an input."""
         return f'asyncFoo {input}'
 
@@ -213,7 +213,7 @@ async def test_define_async_action_with_input() -> None:
 async def test_define_async_action_with_input_and_context() -> None:
     """Define and run async action with input and context."""
 
-    async def async_foo(input: str, ctx: ActionRunContext):
+    async def async_foo(input: str, ctx: ActionRunContext) -> str:
         """An async action that returns 'syncFoo' with an input and context."""
         return f'syncFoo {input} {ctx.context["foo"]}'
 
@@ -227,7 +227,7 @@ async def test_define_async_action_with_input_and_context() -> None:
 async def test_define_async_streaming_action() -> None:
     """Define and run an async streaming action."""
 
-    async def async_foo(input: str, ctx: ActionRunContext):
+    async def async_foo(input: str, ctx: ActionRunContext) -> int:
         """An async action that returns 'syncFoo' with streaming output."""
         ctx.send_chunk('1')
         ctx.send_chunk('2')
@@ -237,14 +237,14 @@ async def test_define_async_streaming_action() -> None:
 
     chunks = []
 
-    def on_chunk(c):
+    def on_chunk(c) -> None:
         chunks.append(c)
 
     assert (await action.arun('foo', context={'foo': 'bar'}, on_chunk=on_chunk)).response == 3
     assert chunks == ['1', '2']
 
 
-def test_parse_plugin_name_from_action_name():
+def test_parse_plugin_name_from_action_name() -> None:
     """Parse plugin name from the action name."""
     assert parse_plugin_name_from_action_name('foo') is None
     assert parse_plugin_name_from_action_name('foo/bar') == 'foo'
@@ -281,7 +281,7 @@ async def test_propagates_context_via_contextvar() -> None:
 async def test_sync_action_raises_errors() -> None:
     """Sync action raises error with necessary metadata."""
 
-    def sync_foo(_: str | None, ctx: ActionRunContext):
+    def sync_foo(_: str | None, ctx: ActionRunContext) -> None:
         raise Exception('oops')
 
     action = Action(name='fooAction', kind=ActionKind.CUSTOM, fn=sync_foo)
@@ -298,7 +298,7 @@ async def test_sync_action_raises_errors() -> None:
 async def test_async_action_raises_errors() -> None:
     """Async action raises error with necessary metadata."""
 
-    async def async_foo(_: str | None, ctx: ActionRunContext):
+    async def async_foo(_: str | None, ctx: ActionRunContext) -> None:
         raise Exception('oops')
 
     action = Action(name='fooAction', kind=ActionKind.CUSTOM, fn=async_foo)

--- a/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
+++ b/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
@@ -72,14 +72,14 @@ async def asgi_client(mock_registry):
 
 
 @pytest.mark.asyncio
-async def test_health_check(asgi_client):
+async def test_health_check(asgi_client) -> None:
     """Test that the health check endpoint returns 200 OK."""
     response = await asgi_client.get('/api/__health')
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_list_actions(asgi_client, mock_registry):
+async def test_list_actions(asgi_client, mock_registry) -> None:
     """Test that the actions list endpoint returns registered actions."""
     from genkit.core.action import ActionMetadata
     from genkit.core.action.types import ActionKind
@@ -103,17 +103,17 @@ async def test_list_actions(asgi_client, mock_registry):
 
 
 @pytest.mark.asyncio
-async def test_notify_endpoint(asgi_client):
+async def test_notify_endpoint(asgi_client) -> None:
     """Test that the notify endpoint returns 200 OK."""
     response = await asgi_client.post('/api/notify')
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_run_action_not_found(asgi_client, mock_registry):
+async def test_run_action_not_found(asgi_client, mock_registry) -> None:
     """Test that requesting a non-existent action returns a 404 error."""
 
-    async def mock_resolve_action_by_key(key):
+    async def mock_resolve_action_by_key(key) -> None:
         return None
 
     mock_registry.resolve_action_by_key = mock_resolve_action_by_key
@@ -126,7 +126,7 @@ async def test_run_action_not_found(asgi_client, mock_registry):
 
 
 @pytest.mark.asyncio
-async def test_run_action_standard(asgi_client, mock_registry):
+async def test_run_action_standard(asgi_client, mock_registry) -> None:
     """Test that a standard (non-streaming) action works correctly."""
     mock_action = AsyncMock()
     mock_output = MagicMock()
@@ -150,7 +150,7 @@ async def test_run_action_standard(asgi_client, mock_registry):
 
 
 @pytest.mark.asyncio
-async def test_run_action_with_context(asgi_client, mock_registry):
+async def test_run_action_with_context(asgi_client, mock_registry) -> None:
     """Test that an action with context works correctly."""
     mock_action = AsyncMock()
     mock_output = MagicMock()
@@ -182,7 +182,7 @@ async def test_run_action_with_context(asgi_client, mock_registry):
 
 @pytest.mark.asyncio
 @patch('genkit.core.reflection.is_streaming_requested')
-async def test_run_action_streaming(mock_is_streaming, asgi_client, mock_registry):
+async def test_run_action_streaming(mock_is_streaming, asgi_client, mock_registry) -> None:
     """Test that streaming actions work correctly."""
     mock_is_streaming.return_value = True
     mock_action = AsyncMock()

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -52,7 +52,7 @@ async def test_resolve_action_by_key_invalid_format() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolve_action_from_plugin():
+async def test_resolve_action_from_plugin() -> None:
     """Resolve action from plugin test."""
     resolver_calls = []
 
@@ -66,7 +66,7 @@ async def test_resolve_action_from_plugin():
             nonlocal resolver_calls
             resolver_calls.append([action_type, name])
 
-            def model_fn():
+            def model_fn() -> None:
                 pass
 
             return Action(name=name, fn=model_fn, kind=action_type)
@@ -91,7 +91,7 @@ async def test_resolve_action_from_plugin():
     assert len(resolver_calls) == 1
 
 
-def test_register_value():
+def test_register_value() -> None:
     """Register a value and lookup test."""
     registry = Registry()
 

--- a/py/packages/genkit/tests/genkit/core/schema_test.py
+++ b/py/packages/genkit/tests/genkit/core/schema_test.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, Field
 from genkit.core.schema import to_json_schema
 
 
-def test_to_json_schema_pydantic_model():
+def test_to_json_schema_pydantic_model() -> None:
     """Test that a Pydantic model can be converted to a JSON schema."""
 
     class TestSchema(BaseModel):
@@ -49,7 +49,7 @@ def test_to_json_schema_pydantic_model():
     }
 
 
-def test_to_json_schema_already_schema():
+def test_to_json_schema_already_schema() -> None:
     """Test that a JSON schema can be converted to a JSON schema."""
     json_schema = {
         'properties': {
@@ -85,7 +85,7 @@ class TestNullType:
     See: https://json-schema.org/understanding-json-schema/reference/null
     """
 
-    def test_none_produces_null_type(self):
+    def test_none_produces_null_type(self) -> None:
         """Python None should produce JSON Schema null type."""
         assert to_json_schema(None) == {'type': 'null'}
 
@@ -96,7 +96,7 @@ class TestStringType:
     See: https://json-schema.org/understanding-json-schema/reference/string
     """
 
-    def test_str_type(self):
+    def test_str_type(self) -> None:
         """Python str type should produce JSON Schema string type."""
         assert to_json_schema(str) == {'type': 'string'}
 
@@ -115,7 +115,7 @@ class TestNumericTypes:
             (float, 'number'),
         ],
     )
-    def test_numeric_types(self, py_type, json_type_name):
+    def test_numeric_types(self, py_type, json_type_name) -> None:
         """Python numeric types should produce correct JSON Schema numeric types."""
         assert to_json_schema(py_type) == {'type': json_type_name}
 
@@ -126,7 +126,7 @@ class TestBooleanType:
     See: https://json-schema.org/understanding-json-schema/reference/boolean
     """
 
-    def test_bool_type(self):
+    def test_bool_type(self) -> None:
         """Python bool type should produce JSON Schema boolean type."""
         assert to_json_schema(bool) == {'type': 'boolean'}
 
@@ -144,7 +144,7 @@ class TestArrayType:
             (list[int], {'type': 'integer'}),
         ],
     )
-    def test_list_types(self, list_type, item_schema):
+    def test_list_types(self, list_type, item_schema) -> None:
         """Python list types should produce array schema with correct item types."""
         result = to_json_schema(list_type)
         assert result['type'] == 'array'
@@ -157,12 +157,12 @@ class TestObjectType:
     See: https://json-schema.org/understanding-json-schema/reference/object
     """
 
-    def test_dict_type(self):
+    def test_dict_type(self) -> None:
         """Python dict should produce object schema."""
         result = to_json_schema(dict)
         assert result['type'] == 'object'
 
-    def test_pydantic_model(self):
+    def test_pydantic_model(self) -> None:
         """Pydantic BaseModel should produce object schema with properties."""
 
         class Person(BaseModel):
@@ -198,6 +198,6 @@ class TestPassthroughBehavior:
         ],
         ids=['simple_schema', 'complex_schema'],
     )
-    def test_passthrough_behavior(self, schema):
+    def test_passthrough_behavior(self, schema) -> None:
         """A dict representing a JSON Schema should be returned as-is."""
         assert to_json_schema(schema) == schema

--- a/py/packages/genkit/tests/genkit/veneer/resource_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/resource_test.py
@@ -28,7 +28,7 @@ from genkit.core.typing import Part, TextPart
 
 
 @pytest.mark.asyncio
-async def test_define_resource_veneer():
+async def test_define_resource_veneer() -> None:
     """Verifies ai.define_resource registers a resource correctly."""
     ai = Genkit(plugins=[])
 

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -382,12 +382,12 @@ async def test_generate_with_iterrupting_tools(
         value: int | None = Field(None, description='value field')
 
     @ai.tool(name='test_tool')
-    def test_tool(input: ToolInput):
+    def test_tool(input: ToolInput) -> int:
         """The tool."""
         return (input.value or 0) + 7
 
     @ai.tool(name='test_interrupt')
-    def test_interrupt(input: ToolInput, ctx: ToolRunContext):
+    def test_interrupt(input: ToolInput, ctx: ToolRunContext) -> None:
         """The interrupt."""
         ctx.interrupt({'banana': 'yes please'})
 
@@ -438,7 +438,7 @@ async def test_generate_with_iterrupting_tools(
                 'title': 'ToolInput',
                 'type': 'object',
             },
-            output_schema={},
+            output_schema={'type': 'integer'},
         ),
         ToolDefinition(
             name='test_interrupt',
@@ -455,7 +455,7 @@ async def test_generate_with_iterrupting_tools(
                 'title': 'ToolInput',
                 'type': 'object',
             },
-            output_schema={},
+            output_schema={'type': 'null'},
         ),
     ]
 
@@ -499,7 +499,7 @@ async def test_generate_with_interrupt_respond(
         return (input.value or 0) + 7
 
     @ai.tool(name='test_interrupt')
-    def test_interrupt(input: ToolInput, ctx: ToolRunContext):
+    def test_interrupt(input: ToolInput, ctx: ToolRunContext) -> None:
         """The interrupt."""
         ctx.interrupt({'banana': 'yes please'})
 
@@ -643,7 +643,7 @@ async def test_generate_with_tools_and_output(setup_test: SetupFixture) -> None:
         value: int | None = Field(None, description='value field')
 
     @ai.tool(name='testTool')
-    def test_tool(input: ToolInput):
+    def test_tool(input: ToolInput) -> str:
         """The tool."""
         return 'abc'
 
@@ -700,7 +700,7 @@ async def test_generate_with_tools_and_output(setup_test: SetupFixture) -> None:
                 'title': 'ToolInput',
                 'type': 'object',
             },
-            output_schema={},
+            output_schema={'type': 'string'},
         )
     ]
 
@@ -714,7 +714,7 @@ async def test_generate_stream_with_tools(setup_test: SetupFixture) -> None:
         value: int | None = Field(None, description='value field')
 
     @ai.tool(name='testTool')
-    def test_tool(input: ToolInput):
+    def test_tool(input: ToolInput) -> str:
         """The tool."""
         return 'abc'
 
@@ -1239,7 +1239,7 @@ async def test_generate_simulates_doc_grounding(
 class MockBananaFormat(FormatDef):
     """Mock format for testing the format."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the format."""
         super().__init__(
             'banana',
@@ -1253,7 +1253,7 @@ class MockBananaFormat(FormatDef):
     def handle(self, schema) -> Formatter:
         """Handle the format."""
 
-        def message_parser(msg: Message):
+        def message_parser(msg: Message) -> str:
             """Parse the message."""
             parts = [p.root.text or '' for p in msg.content if hasattr(p.root, 'text') and p.root.text]
             return f'banana {"".join(parts)}'  # type: ignore[arg-type]
@@ -1624,7 +1624,7 @@ async def test_define_sync_flow(setup_test: SetupFixture) -> None:
 
     assert my_flow('banana') == 'banana'
 
-    stream, response = my_flow.stream('banana2')  # type: ignore[attr-defined]
+    stream, response = my_flow.stream('banana2')
 
     chunks = []
     async for chunk in stream:
@@ -1648,7 +1648,7 @@ async def test_define_async_flow(setup_test: SetupFixture) -> None:
 
     assert (await my_flow('banana')) == 'banana'
 
-    stream, response = my_flow.stream('banana2')  # type: ignore[attr-defined]
+    stream, response = my_flow.stream('banana2')
 
     chunks = []
     async for chunk in stream:

--- a/py/plugins/anthropic/tests/test_models.py
+++ b/py/plugins/anthropic/tests/test_models.py
@@ -59,7 +59,7 @@ def _create_sample_request() -> GenerateRequest:
 
 
 @pytest.mark.asyncio
-async def test_generate_basic():
+async def test_generate_basic() -> None:
     """Test basic generation."""
     sample_request = _create_sample_request()
 
@@ -88,7 +88,7 @@ async def test_generate_basic():
 
 
 @pytest.mark.asyncio
-async def test_generate_with_tools():
+async def test_generate_with_tools() -> None:
     """Test generation with tool calls."""
     sample_request = _create_sample_request()
 
@@ -121,7 +121,7 @@ async def test_generate_with_tools():
 
 
 @pytest.mark.asyncio
-async def test_generate_with_config():
+async def test_generate_with_config() -> None:
     """Test generation with custom config."""
     mock_client = MagicMock()
     mock_response = MagicMock()
@@ -150,7 +150,7 @@ async def test_generate_with_config():
     assert call_args.kwargs['top_p'] == 0.9
 
 
-def test_extract_system():
+def test_extract_system() -> None:
     """Test system prompt extraction."""
     mock_client = MagicMock()
     model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
@@ -164,7 +164,7 @@ def test_extract_system():
     assert system == 'You are helpful.'
 
 
-def test_to_anthropic_messages():
+def test_to_anthropic_messages() -> None:
     """Test message conversion."""
     mock_client = MagicMock()
     model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
@@ -188,7 +188,7 @@ class MockStreamManager:
 
     """Mock stream manager for testing streaming."""
 
-    def __init__(self, chunks, final_content=None):
+    def __init__(self, chunks, final_content=None) -> None:
         """Initialize the MockStreamManager."""
         self.chunks = chunks
         self.final_message = MagicMock()
@@ -220,7 +220,7 @@ class MockStreamManager:
 
 
 @pytest.mark.asyncio
-async def test_streaming_generation():
+async def test_streaming_generation() -> None:
     """Test streaming generation."""
     sample_request = _create_sample_request()
 
@@ -242,7 +242,7 @@ async def test_streaming_generation():
     ctx.is_streaming = True
     collected_chunks = []
 
-    def send_chunk(chunk: GenerateResponseChunk):
+    def send_chunk(chunk: GenerateResponseChunk) -> None:
         collected_chunks.append(chunk)
 
     ctx.send_chunk = send_chunk

--- a/py/plugins/anthropic/tests/test_plugin.py
+++ b/py/plugins/anthropic/tests/test_plugin.py
@@ -37,19 +37,19 @@ from genkit.types import (
 )
 
 
-def test_anthropic_name():
+def test_anthropic_name() -> None:
     """Test anthropic_name helper function."""
     assert anthropic_name('claude-sonnet-4') == 'anthropic/claude-sonnet-4'
 
 
-def test_init_with_api_key():
+def test_init_with_api_key() -> None:
     """Test plugin initialization with API key."""
     plugin = Anthropic(api_key='test-key')
     assert plugin._anthropic_client.api_key == 'test-key'
     assert plugin.models == list(SUPPORTED_MODELS.keys())
 
 
-def test_init_without_api_key_raises():
+def test_init_without_api_key_raises() -> None:
     """Test plugin initialization without API key uses default behavior."""
     with patch.dict('os.environ', {}, clear=True):
         # AsyncAnthropic allows initialization without API key
@@ -58,21 +58,21 @@ def test_init_without_api_key_raises():
         assert plugin._anthropic_client is not None
 
 
-def test_init_with_env_var():
+def test_init_with_env_var() -> None:
     """Test plugin initialization with environment variable."""
     with patch.dict('os.environ', {'ANTHROPIC_API_KEY': 'env-key'}):
         plugin = Anthropic()
         assert plugin._anthropic_client.api_key == 'env-key'
 
 
-def test_custom_models():
+def test_custom_models() -> None:
     """Test plugin initialization with custom models."""
     plugin = Anthropic(api_key='test-key', models=['claude-sonnet-4'])
     assert plugin.models == ['claude-sonnet-4']
 
 
 @pytest.mark.asyncio
-async def test_plugin_init():
+async def test_plugin_init() -> None:
     """Test plugin init method."""
     plugin = Anthropic(api_key='test-key', models=['claude-sonnet-4'])
 
@@ -82,7 +82,7 @@ async def test_plugin_init():
 
 
 @pytest.mark.asyncio
-async def test_resolve_action_model():
+async def test_resolve_action_model() -> None:
     """Test resolve method for model."""
     plugin = Anthropic(api_key='test-key')
 
@@ -94,7 +94,7 @@ async def test_resolve_action_model():
     assert action.kind == ActionKind.MODEL
 
 
-def test_supported_models():
+def test_supported_models() -> None:
     """Test that all supported models have proper metadata."""
     assert len(SUPPORTED_MODELS) == 7
     for _name, info in SUPPORTED_MODELS.items():
@@ -109,7 +109,7 @@ def test_supported_models():
         assert info.supports.system_role is True
 
 
-def test_get_model_info_known():
+def test_get_model_info_known() -> None:
     """Test get_model_info returns correct info for known model."""
     info = get_model_info('claude-sonnet-4')
     assert info.label == 'Anthropic - Claude Sonnet 4'
@@ -118,7 +118,7 @@ def test_get_model_info_known():
     assert info.supports.tools is True
 
 
-def test_get_model_info_unknown():
+def test_get_model_info_unknown() -> None:
     """Test get_model_info returns default info for unknown model."""
     info = get_model_info('unknown-model')
     assert info.label == 'Anthropic - unknown-model'

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/utils.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/utils.py
@@ -34,7 +34,7 @@ from genkit.types import (
 class DictMessageAdapter:
     """Adapter for dictionary-based chat message objects with OpenAI-compatible fields."""
 
-    def __init__(self, data: dict):
+    def __init__(self, data: dict) -> None:
         """Initializes the adapter with a dictionary.
 
         Args:
@@ -73,7 +73,7 @@ class DictMessageAdapter:
 class MessageAdapter:
     """Adapter for object-based chat message objects with OpenAI-compatible fields."""
 
-    def __init__(self, data: object):
+    def __init__(self, data: object) -> None:
         """Initializes the adapter with an object.
 
         Args:

--- a/py/plugins/compat-oai/tests/test_model.py
+++ b/py/plugins/compat-oai/tests/test_model.py
@@ -35,7 +35,7 @@ from genkit.types import (
 )
 
 
-def test_get_messages(sample_request):
+def test_get_messages(sample_request) -> None:
     """Test _get_messages method.
 
     Ensures the method correctly converts GenerateRequest messages into OpenAI-compatible ChatMessage format.
@@ -51,7 +51,7 @@ def test_get_messages(sample_request):
 
 
 @pytest.mark.asyncio
-async def test_get_openai_config(sample_request):
+async def test_get_openai_config(sample_request) -> None:
     """Test _get_openai_request_config method.
 
     Ensures the method correctly constructs the OpenAI API configuration dictionary.
@@ -66,7 +66,7 @@ async def test_get_openai_config(sample_request):
 
 
 @pytest.mark.asyncio
-async def test__generate(sample_request):
+async def test__generate(sample_request) -> None:
     """Test generate method calls OpenAI API and returns GenerateResponse."""
     mock_message = MagicMock()
     mock_message.content = 'Hello, user!'
@@ -89,7 +89,7 @@ async def test__generate(sample_request):
 
 
 @pytest.mark.asyncio
-async def test__generate_stream(sample_request):
+async def test__generate_stream(sample_request) -> None:
     """Test generate_stream method ensures it processes streamed responses correctly."""
     mock_client = MagicMock()
 
@@ -123,7 +123,7 @@ async def test__generate_stream(sample_request):
     model = OpenAIModel(model='gpt-4', client=mock_client)
     collected_chunks = []
 
-    def callback(chunk: GenerateResponseChunk):
+    def callback(chunk: GenerateResponseChunk) -> None:
         collected_chunks.append(chunk.content[0].root.text)
 
     await model._generate_stream(sample_request, callback)
@@ -139,7 +139,7 @@ async def test__generate_stream(sample_request):
     ],
 )
 @pytest.mark.asyncio
-async def test_generate(stream, sample_request):
+async def test_generate(stream, sample_request) -> None:
     """Tests for generate."""
     ctx_mock = MagicMock(spec=ActionRunContext)
     ctx_mock.is_streaming = stream
@@ -174,7 +174,7 @@ async def test_generate(stream, sample_request):
         ),
     ],
 )
-def test_normalize_config(config, expected):
+def test_normalize_config(config, expected) -> None:
     """Tests for _normalize_config."""
     if isinstance(expected, Exception):
         with pytest.raises(ValueError, match=r'Expected request.config to be a dict or OpenAIConfig, got .*'):

--- a/py/plugins/compat-oai/tests/test_plugin.py
+++ b/py/plugins/compat-oai/tests/test_plugin.py
@@ -53,7 +53,7 @@ async def test_openai_plugin_init() -> None:
     [(ActionKind.MODEL, 'gpt-3.5-turbo')],
 )
 @pytest.mark.asyncio
-async def test_openai_plugin_resolve_action(kind, name):
+async def test_openai_plugin_resolve_action(kind, name) -> None:
     """Unit Tests for resolve method."""
     plugin = OpenAI(api_key='test-key')
 
@@ -100,7 +100,7 @@ async def test_openai_plugin_list_actions() -> None:
     [(ActionKind.MODEL, 'model_doesnt_exist')],
 )
 @pytest.mark.asyncio
-async def test_openai_plugin_resolve_action_not_found(kind, name):
+async def test_openai_plugin_resolve_action_not_found(kind, name) -> None:
     """Unit Tests for resolve method with non-existent model."""
     plugin = OpenAI(api_key='test-key')
     action = await plugin.resolve(kind, f'openai/{name}')

--- a/py/plugins/compat-oai/tests/test_tool_calling.py
+++ b/py/plugins/compat-oai/tests/test_tool_calling.py
@@ -82,12 +82,12 @@ async def test_generate_with_tool_calls_executes_tools(sample_request: GenerateR
 
 
 @pytest.mark.asyncio
-async def test_generate_stream_with_tool_calls(sample_request):
+async def test_generate_stream_with_tool_calls(sample_request) -> None:
     """Test generate_stream processes tool calls streamed in chunks correctly."""
     mock_client = MagicMock()
 
     class MockToolCall:
-        def __init__(self, id, index, name, args_chunk):
+        def __init__(self, id, index, name, args_chunk) -> None:
             self.id = id
             self.index = index
             self.function = MagicMock()
@@ -95,7 +95,7 @@ async def test_generate_stream_with_tool_calls(sample_request):
             self.function.arguments = args_chunk
 
     class MockStream:
-        def __init__(self):
+        def __init__(self) -> None:
             self._chunks = [
                 # Initial chunk - empty args
                 self._make_tool_chunk(id='tool123', index=0, name='tool_fn', args_chunk=''),
@@ -132,7 +132,7 @@ async def test_generate_stream_with_tool_calls(sample_request):
     model = OpenAIModel(model='gpt-4', client=mock_client)
     collected_chunks = []
 
-    def callback(chunk: GenerateResponseChunk):
+    def callback(chunk: GenerateResponseChunk) -> None:
         collected_chunks.append(chunk.content[0].root)
 
     await model._generate_stream(sample_request, callback)

--- a/py/plugins/deepseek/tests/test_deepseek_plugin.py
+++ b/py/plugins/deepseek/tests/test_deepseek_plugin.py
@@ -26,27 +26,27 @@ from genkit.core.registry import ActionKind
 from genkit.plugins.deepseek import DeepSeek, deepseek_name
 
 
-def test_deepseek_name():
+def test_deepseek_name() -> None:
     """Test name helper function."""
     assert deepseek_name('deepseek-chat') == 'deepseek/deepseek-chat'
     assert deepseek_name('deepseek-reasoner') == 'deepseek/deepseek-reasoner'
 
 
-def test_plugin_initialization_with_api_key():
+def test_plugin_initialization_with_api_key() -> None:
     """Test plugin initializes with API key."""
     plugin = DeepSeek(api_key='test-key')
     assert plugin.name == 'deepseek'
     assert plugin.api_key == 'test-key'
 
 
-def test_plugin_initialization_from_env():
+def test_plugin_initialization_from_env() -> None:
     """Test plugin reads API key from environment."""
     with patch.dict(os.environ, {'DEEPSEEK_API_KEY': 'env-key'}):
         plugin = DeepSeek()
         assert plugin.api_key == 'env-key'
 
 
-def test_plugin_initialization_without_api_key():
+def test_plugin_initialization_without_api_key() -> None:
     """Test plugin raises error without API key."""
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(GenkitError) as exc_info:
@@ -56,7 +56,7 @@ def test_plugin_initialization_without_api_key():
 
 @patch('genkit.plugins.deepseek.models.DeepSeekClient')
 @pytest.mark.asyncio
-async def test_plugin_initialize(mock_client):
+async def test_plugin_initialize(mock_client) -> None:
     """Test plugin init method."""
     plugin = DeepSeek(api_key='test-key', models=['deepseek-chat'])
 
@@ -68,7 +68,7 @@ async def test_plugin_initialize(mock_client):
 
 @patch('genkit.plugins.deepseek.models.DeepSeekClient')
 @pytest.mark.asyncio
-async def test_plugin_resolve_action(mock_client):
+async def test_plugin_resolve_action(mock_client) -> None:
     """Test plugin resolves models dynamically."""
     plugin = DeepSeek(api_key='test-key', models=[])
 
@@ -80,7 +80,7 @@ async def test_plugin_resolve_action(mock_client):
 
 
 @pytest.mark.asyncio
-async def test_plugin_list_actions():
+async def test_plugin_list_actions() -> None:
     """Test plugin lists available models."""
     plugin = DeepSeek(api_key='test-key')
     actions = await plugin.list_actions()
@@ -92,7 +92,7 @@ async def test_plugin_list_actions():
 
 
 @patch('genkit.plugins.deepseek.models.DeepSeekClient')
-def test_plugin_with_custom_params(mock_client):
+def test_plugin_with_custom_params(mock_client) -> None:
     """Test plugin accepts custom parameters."""
     plugin = DeepSeek(
         api_key='test-key',
@@ -107,7 +107,7 @@ def test_plugin_with_custom_params(mock_client):
 
 @patch('genkit.plugins.deepseek.models.DeepSeekClient')
 @pytest.mark.asyncio
-async def test_plugin_initialize_no_models(mock_client):
+async def test_plugin_initialize_no_models(mock_client) -> None:
     """Test plugin init returns empty list for lazy loading."""
     plugin = DeepSeek(api_key='test-key')
 
@@ -118,7 +118,7 @@ async def test_plugin_initialize_no_models(mock_client):
 
 
 @pytest.mark.asyncio
-async def test_plugin_resolve_action_non_model_kind():
+async def test_plugin_resolve_action_non_model_kind() -> None:
     """Test resolve does nothing for non-MODEL kinds."""
     plugin = DeepSeek(api_key='test-key')
 
@@ -131,7 +131,7 @@ async def test_plugin_resolve_action_non_model_kind():
 
 @patch('genkit.plugins.deepseek.models.DeepSeekClient')
 @pytest.mark.asyncio
-async def test_plugin_resolve_action_without_prefix(mock_client):
+async def test_plugin_resolve_action_without_prefix(mock_client) -> None:
     """Test plugin resolves models without plugin prefix."""
     plugin = DeepSeek(api_key='test-key', models=[])
 
@@ -143,7 +143,7 @@ async def test_plugin_resolve_action_without_prefix(mock_client):
 
 
 @patch('genkit.plugins.deepseek.client.DeepSeekClient.__new__')
-def test_deepseek_client_initialization(mock_new):
+def test_deepseek_client_initialization(mock_new) -> None:
     """Test DeepSeekClient creates OpenAI client with correct params."""
     from genkit.plugins.deepseek.client import DeepSeekClient
 
@@ -158,7 +158,7 @@ def test_deepseek_client_initialization(mock_new):
     mock_new.assert_called_once()
 
 
-def test_deepseek_client_with_custom_base_url():
+def test_deepseek_client_with_custom_base_url() -> None:
     """Test DeepSeekClient accepts custom base_url."""
     from openai import OpenAI
 
@@ -172,7 +172,7 @@ def test_deepseek_client_with_custom_base_url():
         )
 
 
-def test_deepseek_client_default_base_url():
+def test_deepseek_client_default_base_url() -> None:
     """Test DeepSeekClient uses default base_url when not provided."""
     from openai import OpenAI
 

--- a/py/plugins/deepseek/tests/test_model_info.py
+++ b/py/plugins/deepseek/tests/test_model_info.py
@@ -19,20 +19,20 @@
 from genkit.plugins.deepseek.model_info import SUPPORTED_DEEPSEEK_MODELS, get_default_model_info
 
 
-def test_supported_models_exist():
+def test_supported_models_exist() -> None:
     """Test that supported models are defined."""
     assert 'deepseek-reasoner' in SUPPORTED_DEEPSEEK_MODELS
     assert 'deepseek-chat' in SUPPORTED_DEEPSEEK_MODELS
 
 
-def test_model_order():
+def test_model_order() -> None:
     """Test models are in correct order (matching JS)."""
     keys = list(SUPPORTED_DEEPSEEK_MODELS.keys())
     assert keys[0] == 'deepseek-reasoner'
     assert keys[1] == 'deepseek-chat'
 
 
-def test_model_info_structure():
+def test_model_info_structure() -> None:
     """Test model info has required fields."""
     for _model_name, model_info in SUPPORTED_DEEPSEEK_MODELS.items():
         assert model_info.label
@@ -46,7 +46,7 @@ def test_model_info_structure():
         assert 'json' in model_info.supports.output
 
 
-def test_get_default_model_info():
+def test_get_default_model_info() -> None:
     """Test getting default info for unknown models."""
     info = get_default_model_info('deepseek-future-model')
     assert 'deepseek-future-model' in str(info.label)

--- a/py/plugins/dev-local-vectorstore/src/genkit/plugins/dev_local_vectorstore/indexer.py
+++ b/py/plugins/dev-local-vectorstore/src/genkit/plugins/dev_local_vectorstore/indexer.py
@@ -41,7 +41,7 @@ class DevLocalVectorStoreIndexer(LocalVectorStoreAPI):
         index_name: str,
         embedder: str,
         embedder_options: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """Initialize the DevLocalVectorStoreIndexer.
 
         Args:
@@ -60,16 +60,16 @@ class DevLocalVectorStoreIndexer(LocalVectorStoreAPI):
         docs = request.documents
         data = self._load_filestore()
 
-        embed_resp = await self.ai.embed(
+        embed_resp = await self.ai.embed_many(
             embedder=self.embedder,
-            documents=[Document.from_document_data(document_data=doc) for doc in docs],
+            content=docs,
             options=self.embedder_options,
         )
-        if not embed_resp.embeddings:
+        if not embed_resp:
             raise ValueError('Embedder returned no embeddings for documents')
 
         tasks = []
-        for doc_data, emb in zip(docs, embed_resp.embeddings, strict=False):
+        for doc_data, emb in zip(docs, embed_resp, strict=True):
             tasks.append(
                 self.process_document(
                     document=Document.from_document_data(document_data=doc_data),

--- a/py/plugins/dev-local-vectorstore/src/genkit/plugins/dev_local_vectorstore/local_vector_store_api.py
+++ b/py/plugins/dev-local-vectorstore/src/genkit/plugins/dev_local_vectorstore/local_vector_store_api.py
@@ -34,7 +34,7 @@ class LocalVectorStoreAPI:
     def __init__(
         self,
         index_name: str,
-    ):
+    ) -> None:
         """Initialize the LocalVectorStoreAPI."""
         self.index_name = index_name
 

--- a/py/plugins/dev-local-vectorstore/src/genkit/plugins/dev_local_vectorstore/retriever.py
+++ b/py/plugins/dev-local-vectorstore/src/genkit/plugins/dev_local_vectorstore/retriever.py
@@ -49,7 +49,7 @@ class DevLocalVectorStoreRetriever(LocalVectorStoreAPI):
         index_name: str,
         embedder: str,
         embedder_options: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """Initialize the DevLocalVectorStoreRetriever.
 
         Args:
@@ -69,10 +69,10 @@ class DevLocalVectorStoreRetriever(LocalVectorStoreAPI):
 
         embed_resp = await self.ai.embed(
             embedder=self.embedder,
-            documents=[document],
+            content=document,
             options=self.embedder_options,
         )
-        if not embed_resp.embeddings:
+        if not embed_resp:
             raise ValueError('Embedder returned no embeddings for query')
 
         k = 3
@@ -81,7 +81,7 @@ class DevLocalVectorStoreRetriever(LocalVectorStoreAPI):
 
         docs = self._get_closest_documents(
             k=k,
-            query_embeddings=Embedding(embedding=embed_resp.embeddings[0].embedding),
+            query_embeddings=Embedding(embedding=embed_resp[0].embedding),
         )
 
         return RetrieverResponse(documents=[d.document for d in docs])

--- a/py/plugins/evaluators/src/genkit/plugins/evaluators/helpers.py
+++ b/py/plugins/evaluators/src/genkit/plugins/evaluators/helpers.py
@@ -78,7 +78,7 @@ def define_genkit_evaluators(ai: Genkit, params: PluginOptions | list[MetricConf
         _configure_evaluator(ai=ai, param=param)
 
 
-def _configure_evaluator(ai: Genkit, param: MetricConfig):
+def _configure_evaluator(ai: Genkit, param: MetricConfig) -> None:
     """Validates and configures supported evaluators."""
     metric_type = param.metric_type
     match metric_type:

--- a/py/plugins/firebase/src/genkit/plugins/firebase/retriever.py
+++ b/py/plugins/firebase/src/genkit/plugins/firebase/retriever.py
@@ -59,7 +59,7 @@ class FirestoreRetriever:
         content_field: str | Callable[[DocumentSnapshot], list[DocumentPart]],
         distance_measure: DistanceMeasure = DistanceMeasure.COSINE,
         metadata_fields: list[str] | MetadataTransformFn | None = None,
-    ):
+    ) -> None:
         """Initialize the FirestoreRetriever.
 
         Args:
@@ -86,7 +86,7 @@ class FirestoreRetriever:
         self.metadata_fields = metadata_fields
         self._validate_config()
 
-    def _validate_config(self):
+    def _validate_config(self) -> None:
         """Validate the FirestoreRetriever configuration.
 
         Raises:
@@ -169,14 +169,14 @@ class FirestoreRetriever:
         query = Document.from_document_data(document_data=request.query)
         query_embedding_result = await self.ai.embed(
             embedder=self.embedder,
-            documents=[query],
+            content=query,
             options=self.embedder_options,
         )
 
-        if not query_embedding_result.embeddings or len(query_embedding_result.embeddings) == 0:
+        if not query_embedding_result:
             raise GenkitError(message='Embedder returned no embeddings')
 
-        query_embedding = query_embedding_result.embeddings[0].embedding
+        query_embedding = query_embedding_result[0].embedding
         query_vector = Vector(query_embedding)
         collection = self.firestore_client.collection(self.collection)
 

--- a/py/plugins/firebase/src/genkit/plugins/firebase/tests/test_telemetry.py
+++ b/py/plugins/firebase/src/genkit/plugins/firebase/tests/test_telemetry.py
@@ -58,7 +58,7 @@ def _create_model_span(
 
 
 @patch('genkit.plugins.firebase.add_gcp_telemetry')
-def test_firebase_telemetry_delegates_to_gcp(mock_add_gcp_telemetry):
+def test_firebase_telemetry_delegates_to_gcp(mock_add_gcp_telemetry) -> None:
     """Test that Firebase telemetry delegates to GCP telemetry."""
     add_firebase_telemetry()
     mock_add_gcp_telemetry.assert_called_once_with(force_export=False)
@@ -75,7 +75,7 @@ def test_record_generate_metrics_with_model_action(
     mock_latency,
     mock_input_tokens,
     mock_output_tokens,
-):
+) -> None:
     """Test that metrics are recorded for model action spans with usage data."""
     # Setup mocks
     mock_request_counter = MagicMock()

--- a/py/plugins/flask/src/genkit/plugins/flask/handler.py
+++ b/py/plugins/flask/src/genkit/plugins/flask/handler.py
@@ -28,7 +28,8 @@ from genkit.core.error import GenkitError, get_callable_json
 
 
 class _FlaskRequestData(RequestData):
-    def __init__(self):
+    def __init__(self) -> None:
+        super().__init__(request=request)
         self.method = request.method
 
         self.headers = {}
@@ -36,10 +37,7 @@ class _FlaskRequestData(RequestData):
             self.headers[key.lower()] = value
 
         input_data = request.get_json()
-        if 'data' not in input_data:
-            return Response(status=400, response='flow request must be wrapped in {"data": data} object')
-
-        self.input = input_data.get('data')
+        self.input = input_data.get('data') if input_data else None
 
 
 def genkit_flask_handler(ai: Genkit, context_provider: ContextProvider | None = None) -> Callable:
@@ -64,7 +62,7 @@ def genkit_flask_handler(ai: Genkit, context_provider: ContextProvider | None = 
     """
     loop = create_loop()
 
-    def decorator(flow: Callable) -> Callable:
+    def decorator(flow: FlowWrapper) -> Callable:
         if not isinstance(flow, FlowWrapper):
             raise GenkitError(status='INVALID_ARGUMENT', message='must apply @genkit_flask_handler on a @flow')
 

--- a/py/plugins/flask/tests/flask_test.py
+++ b/py/plugins/flask/tests/flask_test.py
@@ -48,7 +48,7 @@ def create_app():
     return app
 
 
-def test_simple_post():
+def test_simple_post() -> None:
     """Test a simple POST request to the chat endpoint."""
     client = create_app().test_client()
     response = client.post(
@@ -62,7 +62,7 @@ def test_simple_post():
     }
 
 
-def test_streaming():
+def test_streaming() -> None:
     """Test a streaming POST request to the chat endpoint."""
     client = create_app().test_client()
     response = client.post(

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
@@ -75,7 +75,7 @@ class Embedder:
         self,
         version: VertexEmbeddingModels | GeminiEmbeddingModels | str,
         client: genai.Client,
-    ):
+    ) -> None:
         """Initialize the embedder.
 
         Args:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -642,7 +642,7 @@ class GeminiModel:
         self,
         version: str | GoogleAIGeminiVersion | VertexAIGeminiVersion,
         client: genai.Client,
-    ):
+    ) -> None:
         """Initialize Gemini model.
 
         Args:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -120,7 +120,7 @@ def vertexai_image_model_info(
 class ImagenModel:
     """Imagen text-to-image model."""
 
-    def __init__(self, version: str | ImagenVersion, client: genai.Client):
+    def __init__(self, version: str | ImagenVersion, client: genai.Client) -> None:
         """Initialize Imagen model.
 
         Args:

--- a/py/plugins/google-genai/test/models/test_googlegenai_embedder.py
+++ b/py/plugins/google-genai/test/models/test_googlegenai_embedder.py
@@ -32,7 +32,7 @@ from genkit.types import (
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('version', [x for x in GeminiEmbeddingModels])
-async def test_embedding(mocker, version):
+async def test_embedding(mocker, version) -> None:
     """Test the embedding method."""
     request_text = 'request text'
     embedding_values = [0.0017063986, -0.044727605, 0.043327782, 0.00044852644]

--- a/py/plugins/google-genai/test/models/test_googlegenai_gemini.py
+++ b/py/plugins/google-genai/test/models/test_googlegenai_gemini.py
@@ -58,7 +58,7 @@ IMAGE_GENERATION_VERSIONS = [GoogleAIGeminiVersion.GEMINI_2_0_FLASH_EXP]
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('version', [x for x in ALL_VERSIONS])
-async def test_generate_text_response(mocker, version):
+async def test_generate_text_response(mocker, version) -> None:
     """Test the generate method for text responses."""
     response_text = 'request answer'
     request_text = 'response question'
@@ -98,7 +98,7 @@ async def test_generate_text_response(mocker, version):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('version', [x for x in ALL_VERSIONS])
-async def test_generate_stream_text_response(mocker, version):
+async def test_generate_stream_text_response(mocker, version) -> None:
     """Test the generate method for text responses."""
     response_text = 'request answer'
     request_text = 'response question'
@@ -139,7 +139,7 @@ async def test_generate_stream_text_response(mocker, version):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('version', [x for x in IMAGE_GENERATION_VERSIONS])
-async def test_generate_media_response(mocker, version):
+async def test_generate_media_response(mocker, version) -> None:
     """Test generate method for media responses."""
     request_text = 'response question'
     response_byte_string = b'\x89PNG\r\n\x1a\n'
@@ -194,7 +194,7 @@ async def test_generate_media_response(mocker, version):
         assert response.read() == response_byte_string
 
 
-def test_convert_schema_property(mocker):
+def test_convert_schema_property(mocker) -> None:
     """Test _convert_schema_property."""
     googleai_client_mock = mocker.AsyncMock()
     gemini = GeminiModel('abc', googleai_client_mock)
@@ -269,7 +269,7 @@ def test_convert_schema_property(mocker):
 
 
 @pytest.mark.asyncio
-async def test_generate_with_system_instructions(mocker):
+async def test_generate_with_system_instructions(mocker) -> None:
     """Test Generate using system instructions."""
     response_text = 'request answer'
     request_text = 'response question'
@@ -339,7 +339,7 @@ async def test_generate_with_system_instructions(mocker):
         ),
     ],
 )
-def test_google_model_info(input, expected):
+def test_google_model_info(input, expected) -> None:
     """Tests for google_model_info."""
     model_info = google_model_info(input)
 
@@ -358,7 +358,7 @@ def gemini_model_instance():
     )
 
 
-def test_gemini_model__init__():
+def test_gemini_model__init__() -> None:
     """Test for init gemini model."""
     version = 'version'
     mock_client = MagicMock(spec=genai.Client)
@@ -377,7 +377,7 @@ def test_gemini_model__init__():
 def test_gemini_model__get_tools(
     mock_create_tool,
     gemini_model_instance,
-):
+) -> None:
     """Unit test for GeminiModel._get_tools."""
     mock_create_tool.return_value = genai_types.Tool()
 
@@ -428,7 +428,7 @@ def test_gemini_model__get_tools(
 
 
 @patch('genkit.plugins.google_genai.models.gemini.GeminiModel._convert_schema_property')
-def test_gemini_model__create_tool(mock_convert_schema_property, gemini_model_instance):
+def test_gemini_model__create_tool(mock_convert_schema_property, gemini_model_instance) -> None:
     """Unit tests for GeminiModel._create_tool."""
     tool_defined = ToolDefinition(
         name='model_tool',
@@ -626,7 +626,7 @@ def test_gemini_model__convert_schema_property(
     defs,
     expected_schema,
     gemini_model_instance,
-):
+) -> None:
     """Unit tests for  GeminiModel._convert_schema_property with various valid schema inputs."""
     result_schema = gemini_model_instance._convert_schema_property(input_schema, defs)
 
@@ -634,7 +634,7 @@ def test_gemini_model__convert_schema_property(
         assert result_schema is None
     else:
 
-        def compare_schemas(s1: genai_types.Schema, s2: genai_types.Schema):
+        def compare_schemas(s1: genai_types.Schema, s2: genai_types.Schema) -> None:
             assert s1.description == s2.description
             assert s1.required == s2.required
             assert s1.type == s2.type
@@ -674,7 +674,7 @@ def test_gemini_model__convert_schema_property(
         ),
     ],
 )
-def test_gemini_model__convert_schema_property_raises_exception(input_schema, defs, gemini_model_instance):
+def test_gemini_model__convert_schema_property_raises_exception(input_schema, defs, gemini_model_instance) -> None:
     """Test GeminiModel._convert_schema_property raises an exception for unresolvable schemas."""
     with pytest.raises(ValueError, match=r'Failed to resolve schema for .*'):
         gemini_model_instance._convert_schema_property(input_schema, defs)
@@ -701,7 +701,7 @@ async def test_gemini_model__retrieve_cached_content(
     mock_validate_context_cache_request,
     cache_key,
     gemini_model_instance,
-):
+) -> None:
     """Unit tests for GeminiModel._retrieve_cached_content."""
     # Mock cache utils
     mock_generate_cache_key.return_value = cache_key

--- a/py/plugins/google-genai/test/models/test_googlegenai_imagen.py
+++ b/py/plugins/google-genai/test/models/test_googlegenai_imagen.py
@@ -37,7 +37,7 @@ from genkit.types import (
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('version', [x for x in ImagenVersion])
-async def test_generate_media_response(mocker, version):
+async def test_generate_media_response(mocker, version) -> None:
     """Test generate method for media responses."""
     request_text = 'response question'
     response_byte_string = b'\x89PNG\r\n\x1a\n'

--- a/py/plugins/google-genai/test/test_google_plugin.py
+++ b/py/plugins/google-genai/test/test_google_plugin.py
@@ -63,7 +63,7 @@ class TestGoogleAIInit(unittest.TestCase):
     """Test cases for __init__ plugin."""
 
     @patch('google.genai.client.Client')
-    def test_init_with_api_key(self, mock_genai_client):
+    def test_init_with_api_key(self, mock_genai_client) -> None:
         """Test using api_key parameter."""
         api_key = 'test_api_key'
         plugin = GoogleAI(api_key=api_key)
@@ -80,7 +80,7 @@ class TestGoogleAIInit(unittest.TestCase):
 
     @patch('google.genai.client.Client')
     @patch.dict(os.environ, {'GEMINI_API_KEY': 'env_api_key'})
-    def test_init_from_env_var(self, mock_genai_client):
+    def test_init_from_env_var(self, mock_genai_client) -> None:
         """Test using env var for api_key."""
         plugin = GoogleAI()
         mock_genai_client.assert_called_once_with(
@@ -95,7 +95,7 @@ class TestGoogleAIInit(unittest.TestCase):
         self.assertIsInstance(plugin._client, MagicMock)
 
     @patch('google.genai.client.Client')
-    def test_init_with_credentials(self, mock_genai_client):
+    def test_init_with_credentials(self, mock_genai_client) -> None:
         """Test using credentials parameter."""
         mock_credentials = MagicMock(spec=Credentials)
         plugin = GoogleAI(credentials=mock_credentials)
@@ -110,7 +110,7 @@ class TestGoogleAIInit(unittest.TestCase):
         self.assertFalse(plugin._vertexai)
         self.assertIsInstance(plugin._client, MagicMock)
 
-    def test_init_raises_value_error_no_api_key(self):
+    def test_init_raises_value_error_no_api_key(self) -> None:
         """Test using credentials parameter."""
         with patch.dict(os.environ, {'GEMINI_API_KEY': ''}, clear=True):
             with self.assertRaisesRegex(
@@ -121,7 +121,7 @@ class TestGoogleAIInit(unittest.TestCase):
 
 
 @pytest.mark.asyncio
-async def test_googleai_initialize():
+async def test_googleai_initialize() -> None:
     """Unit tests for GoogleAI.init method."""
     api_key = 'test_api_key'
     plugin = GoogleAI(api_key=api_key)
@@ -145,7 +145,7 @@ async def test_googleai_initialize():
 
 @patch('genkit.plugins.google_genai.GoogleAI._resolve_model')
 @pytest.mark.asyncio
-async def test_googleai_resolve_action_model(mock_resolve_action, googleai_plugin_instance):
+async def test_googleai_resolve_action_model(mock_resolve_action, googleai_plugin_instance) -> None:
     """Test resolve action for model."""
     plugin = googleai_plugin_instance
 
@@ -155,7 +155,7 @@ async def test_googleai_resolve_action_model(mock_resolve_action, googleai_plugi
 
 @patch('genkit.plugins.google_genai.GoogleAI._resolve_embedder')
 @pytest.mark.asyncio
-async def test_googleai_resolve_action_embedder(mock_resolve_action, googleai_plugin_instance):
+async def test_googleai_resolve_action_embedder(mock_resolve_action, googleai_plugin_instance) -> None:
     """Test resolve action for embedder."""
     plugin = googleai_plugin_instance
 
@@ -185,7 +185,7 @@ def test_googleai__resolve_model(
     expected_model_name,
     key,
     googleai_plugin_instance,
-):
+) -> None:
     """Tests for GoogleAI._resolve_model method."""
     plugin = googleai_plugin_instance
 
@@ -214,7 +214,7 @@ def test_googleai__resolve_embedder(
     expected_model_name,
     clean_name,
     googleai_plugin_instance,
-):
+) -> None:
     """Tests for GoogleAI._resolve_embedder method."""
     plugin = googleai_plugin_instance
 
@@ -226,7 +226,7 @@ def test_googleai__resolve_embedder(
 
 
 @pytest.mark.asyncio
-async def test_googleai_list_actions(googleai_plugin_instance):
+async def test_googleai_list_actions(googleai_plugin_instance) -> None:
     """Unit test for list actions."""
 
     class MockModel(BaseModel):
@@ -380,7 +380,7 @@ async def test_googleai_list_actions(googleai_plugin_instance):
         ),
     ],
 )
-def test_inject_attribution_headers(input_options, expected_headers):
+def test_inject_attribution_headers(input_options, expected_headers) -> None:
     """Tests the _inject_attribution_headers function with various inputs."""
     result = _inject_attribution_headers(input_options)
     assert isinstance(result, HttpOptions)
@@ -392,7 +392,7 @@ class TestVertexAIInit(unittest.TestCase):
 
     @patch('google.genai.client.Client')
     @patch.dict(os.environ, {'GCLOUD_PROJECT': 'project'})
-    def test_init_with_api_key(self, mock_genai_client):
+    def test_init_with_api_key(self, mock_genai_client) -> None:
         """Test using api_key parameter."""
         api_key = 'test_api_key'
         plugin = VertexAI(api_key=api_key)
@@ -411,7 +411,7 @@ class TestVertexAIInit(unittest.TestCase):
 
     @patch('google.genai.client.Client')
     @patch.dict(os.environ, {'GCLOUD_PROJECT': 'project'})
-    def test_init_with_credentials(self, mock_genai_client):
+    def test_init_with_credentials(self, mock_genai_client) -> None:
         """Test using credentials parameter."""
         mock_credentials = MagicMock(spec=Credentials)
         plugin = VertexAI(credentials=mock_credentials)
@@ -429,7 +429,7 @@ class TestVertexAIInit(unittest.TestCase):
         self.assertIsInstance(plugin._client, MagicMock)
 
     @patch('google.genai.client.Client')
-    def test_init_with_all(self, mock_genai_client):
+    def test_init_with_all(self, mock_genai_client) -> None:
         """Test using credentials parameter."""
         mock_credentials = MagicMock(spec=Credentials)
         api_key = 'test_api_key'
@@ -461,7 +461,7 @@ def vertexai_plugin_instance(client):
 
 
 @pytest.mark.asyncio
-async def test_vertexai_initialize(vertexai_plugin_instance):
+async def test_vertexai_initialize(vertexai_plugin_instance) -> None:
     """Unit tests for VertexAI.init method."""
     plugin = vertexai_plugin_instance
 
@@ -484,7 +484,7 @@ async def test_vertexai_initialize(vertexai_plugin_instance):
 
 @patch('genkit.plugins.google_genai.VertexAI._resolve_model')
 @pytest.mark.asyncio
-async def test_vertexai_resolve_action_model(mock_resolve_action, vertexai_plugin_instance):
+async def test_vertexai_resolve_action_model(mock_resolve_action, vertexai_plugin_instance) -> None:
     """Test resolve action for model."""
     plugin = vertexai_plugin_instance
 
@@ -494,7 +494,7 @@ async def test_vertexai_resolve_action_model(mock_resolve_action, vertexai_plugi
 
 @patch('genkit.plugins.google_genai.VertexAI._resolve_embedder')
 @pytest.mark.asyncio
-async def test_vertexai_resolve_action_embedder(mock_resolve_action, vertexai_plugin_instance):
+async def test_vertexai_resolve_action_embedder(mock_resolve_action, vertexai_plugin_instance) -> None:
     """Test resolve action for embedder."""
     plugin = vertexai_plugin_instance
 
@@ -553,7 +553,7 @@ def test_vertexai__resolve_model(
     key,
     image,
     vertexai_plugin_instance,
-):
+) -> None:
     """Tests for VertexAI._resolve_model method."""
     plugin = vertexai_plugin_instance
     MagicMock(spec=Genkit)
@@ -600,7 +600,7 @@ def test_vertexai__resolve_embedder(
     expected_model_name,
     clean_name,
     vertexai_plugin_instance,
-):
+) -> None:
     """Tests for VertexAI._resolve_embedder method."""
     plugin = vertexai_plugin_instance
 
@@ -612,7 +612,7 @@ def test_vertexai__resolve_embedder(
 
 
 @pytest.mark.asyncio
-async def test_vertexai_list_actions(vertexai_plugin_instance):
+async def test_vertexai_list_actions(vertexai_plugin_instance) -> None:
     """Unit test for list actions."""
 
     class MockModel(BaseModel):

--- a/py/plugins/mcp/examples/client/simple_client.py
+++ b/py/plugins/mcp/examples/client/simple_client.py
@@ -29,7 +29,7 @@ except ImportError:
 
 
 # Simple client example connecting to 'everything' server using npx
-async def main():
+async def main() -> None:
     """Run the simple MCP client."""
     # Define the client plugin
     everything_client = create_mcp_client(

--- a/py/plugins/mcp/examples/server/simple_server.py
+++ b/py/plugins/mcp/examples/server/simple_server.py
@@ -34,7 +34,7 @@ class AddInput(BaseModel):
     b: int = Field(..., description='Second number')
 
 
-def main():
+def main() -> None:
     """Run the simple MCP server."""
     # Load prompts from the 'prompts' directory relative to this script
     script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/py/plugins/mcp/src/genkit/plugins/mcp/client/client.py
+++ b/py/plugins/mcp/src/genkit/plugins/mcp/client/client.py
@@ -45,7 +45,7 @@ class McpServerConfig(BaseModel):
 class McpClient(Plugin):
     """Client for connecting to a single MCP server."""
 
-    def __init__(self, name: str, config: McpServerConfig, server_name: str | None = None):
+    def __init__(self, name: str, config: McpServerConfig, server_name: str | None = None) -> None:
         """Initialize the MCP client.
 
         Args:
@@ -99,7 +99,7 @@ class McpClient(Plugin):
         """
         return []
 
-    async def connect(self):
+    async def connect(self) -> None:
         """Connects to the MCP server."""
         if self.config.disabled:
             logger.info(f'MCP server {self.server_name} is disabled.')
@@ -141,7 +141,7 @@ class McpClient(Plugin):
             await self.close()
             raise e
 
-    async def close(self):
+    async def close(self) -> None:
         """Closes the connection."""
         if hasattr(self, '_session_context') and self._session_context:
             try:
@@ -203,7 +203,7 @@ class McpClient(Plugin):
             raise RuntimeError('MCP client is not connected')
         return await self.session.read_resource(AnyUrl(uri))
 
-    async def register_tools(self, ai: Genkit | None = None):
+    async def register_tools(self, ai: Genkit | None = None) -> None:
         """Registers all tools from connected client to Genkit."""
         registry = ai.registry if ai else (self.ai.registry if self.ai else None)
         if not registry:

--- a/py/plugins/mcp/src/genkit/plugins/mcp/client/host.py
+++ b/py/plugins/mcp/src/genkit/plugins/mcp/client/host.py
@@ -24,7 +24,7 @@ from .client import McpClient, McpServerConfig
 class McpHost:
     """Host for managing multiple MCP clients."""
 
-    def __init__(self, clients: dict[str, McpServerConfig]):
+    def __init__(self, clients: dict[str, McpServerConfig]) -> None:
         """Initialize the MCP host.
 
         Args:
@@ -33,31 +33,31 @@ class McpHost:
         self.clients_config = clients
         self.clients: dict[str, McpClient] = {name: McpClient(name, config) for name, config in clients.items()}
 
-    async def start(self):
+    async def start(self) -> None:
         """Starts all enabled MCP clients."""
         for client in self.clients.values():
             if not client.config.disabled:
                 await client.connect()
 
-    async def close(self):
+    async def close(self) -> None:
         """Closes all MCP clients."""
         for client in self.clients.values():
             await client.close()
 
-    async def register_tools(self, ai: Genkit):
+    async def register_tools(self, ai: Genkit) -> None:
         """Registers all tools from connected clients to Genkit."""
         for client in self.clients.values():
             if client.session:
                 await client.register_tools(ai)
 
-    async def enable(self, name: str):
+    async def enable(self, name: str) -> None:
         """Enables and connects an MCP client."""
         if name in self.clients:
             client = self.clients[name]
             client.config.disabled = False
             await client.connect()
 
-    async def disable(self, name: str):
+    async def disable(self, name: str) -> None:
         """Disables and closes an MCP client."""
         if name in self.clients:
             client = self.clients[name]

--- a/py/plugins/mcp/src/genkit/plugins/mcp/server.py
+++ b/py/plugins/mcp/src/genkit/plugins/mcp/server.py
@@ -83,7 +83,7 @@ class McpServer:
     (tools, prompts, resources) available to MCP clients via the Model Context Protocol.
     """
 
-    def __init__(self, ai: Genkit, options: McpServerOptions):
+    def __init__(self, ai: Genkit, options: McpServerOptions) -> None:
         """Initialize the MCP server.
 
         Args:

--- a/py/plugins/mcp/tests/fakes.py
+++ b/py/plugins/mcp/tests/fakes.py
@@ -27,7 +27,7 @@ from genkit.ai import Genkit
 class MockSchema:
     """Mock schema."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         """Initialize mock schema."""
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -52,11 +52,11 @@ def mock_mcp_modules():
     return mock_mcp, None
 
 
-def define_echo_model(ai: Genkit):
+def define_echo_model(ai: Genkit) -> None:
     """Defines a fake echo model for testing."""
 
     @ai.tool(name='echoModel')
-    def echo_model(request: Any):
+    def echo_model(request: Any) -> None:
         # This is a simplified mock of a model action
         # Real model action would handle GenerateRequest and return GenerateResponse
 
@@ -77,7 +77,7 @@ def define_echo_model(ai: Genkit):
 class FakeTransport:
     """Fakes an MCP transport/server for testing."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize fake transport."""
         self.tools = []
         self.prompts = []
@@ -93,11 +93,11 @@ class FakeTransport:
         self.on_close = None
         self.on_error = None
 
-    async def start(self):
+    async def start(self) -> None:
         """Start the transport."""
         pass
 
-    async def send(self, message: dict[str, Any]):
+    async def send(self, message: dict[str, Any]) -> None:
         """Handle incoming JSON-RPC message (simulating server)."""
         # msg_id = request.get("id")
 
@@ -108,10 +108,10 @@ class FakeTransport:
         pass
 
     # Helper methods to populate the fake state
-    def add_tool(self, name: str, description: str = '', schema: dict | None = None):
+    def add_tool(self, name: str, description: str = '', schema: dict | None = None) -> None:
         """Add a tool."""
         self.tools.append({'name': name, 'description': description, 'input_schema': schema or {'type': 'object'}})
 
-    def add_prompt(self, name: str, description: str = '', arguments: list | None = None):
+    def add_prompt(self, name: str, description: str = '', arguments: list | None = None) -> None:
         """Add a prompt."""
         self.prompts.append({'name': name, 'description': description, 'arguments': arguments or []})

--- a/py/plugins/mcp/tests/test_mcp_conversion.py
+++ b/py/plugins/mcp/tests/test_mcp_conversion.py
@@ -32,7 +32,7 @@ to_mcp_resource_contents: Any = None
 to_mcp_tool_result: Any = None
 
 
-def setup_mocks():
+def setup_mocks() -> None:
     """Set up mocks for testing."""
     global to_mcp_prompt_arguments, to_mcp_prompt_message, to_mcp_resource_contents, to_mcp_tool_result
 
@@ -68,11 +68,11 @@ def setup_mocks():
 class TestMessageConversion(unittest.TestCase):
     """Tests for message conversion utilities."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures."""
         setup_mocks()
 
-    def test_convert_user_message(self):
+    def test_convert_user_message(self) -> None:
         """Test converting a user message."""
         message = Message(role='user', content=[Part(root=TextPart(text='Hello, world!'))])
 
@@ -86,7 +86,7 @@ class TestMessageConversion(unittest.TestCase):
         assert isinstance(result.content, TextContent)
         self.assertEqual(result.content.text, 'Hello, world!')
 
-    def test_convert_model_message(self):
+    def test_convert_model_message(self) -> None:
         """Test converting a model message (maps to assistant)."""
         message = Message(role='model', content=[Part(root=TextPart(text='Hi there!'))])
 
@@ -97,7 +97,7 @@ class TestMessageConversion(unittest.TestCase):
         assert isinstance(result.content, TextContent)
         self.assertEqual(result.content.text, 'Hi there!')
 
-    def test_convert_message_with_multiple_text_parts(self):
+    def test_convert_message_with_multiple_text_parts(self) -> None:
         """Test converting a message with multiple text parts."""
         message = Message(
             role='user',
@@ -113,7 +113,7 @@ class TestMessageConversion(unittest.TestCase):
         assert isinstance(result.content, TextContent)
         self.assertEqual(result.content.text, 'Part 1 Part 2 Part 3')
 
-    def test_convert_message_with_invalid_role(self):
+    def test_convert_message_with_invalid_role(self) -> None:
         """Test that converting a message with invalid role raises error."""
         message = Message(role='system', content=[Part(root=TextPart(text='System message'))])
 
@@ -122,7 +122,7 @@ class TestMessageConversion(unittest.TestCase):
 
         self.assertIn('system', str(context.exception).lower())
 
-    def test_convert_message_with_image(self):
+    def test_convert_message_with_image(self) -> None:
         """Test converting a message with image content."""
         message = Message(
             role='user',
@@ -141,7 +141,7 @@ class TestMessageConversion(unittest.TestCase):
         assert isinstance(result.content, ImageContent)
         self.assertEqual(result.content.mimeType, 'image/png')
 
-    def test_convert_message_with_non_data_url_fails(self):
+    def test_convert_message_with_non_data_url_fails(self) -> None:
         """Test that non-data URLs raise an error."""
         message = Message(
             role='user',
@@ -157,11 +157,11 @@ class TestMessageConversion(unittest.TestCase):
 class TestResourceConversion(unittest.TestCase):
     """Tests for resource content conversion."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures."""
         setup_mocks()
 
-    def test_convert_text_resource(self):
+    def test_convert_text_resource(self) -> None:
         """Test converting text resource content."""
         parts = [Part(root=TextPart(text='Resource content'))]
 
@@ -172,7 +172,7 @@ class TestResourceConversion(unittest.TestCase):
         assert isinstance(result[0], TextResourceContents)
         self.assertEqual(result[0].text, 'Resource content')
 
-    def test_convert_multiple_text_parts(self):
+    def test_convert_multiple_text_parts(self) -> None:
         """Test converting multiple text parts."""
         parts = [
             Part(root=TextPart(text='Part 1')),
@@ -187,7 +187,7 @@ class TestResourceConversion(unittest.TestCase):
             assert isinstance(part, TextResourceContents)
             self.assertEqual(part.text, f'Part {i}')
 
-    def test_convert_string_parts(self):
+    def test_convert_string_parts(self) -> None:
         """Test converting string parts - strings are not Part objects, function expects list[Part]."""
         # We need to construct Parts even for strings if the function expects list[Part].
         # If the function handles strings (Union[str, Part]), we should check the function signature.
@@ -203,7 +203,7 @@ class TestResourceConversion(unittest.TestCase):
         assert isinstance(result[1], TextResourceContents)
         self.assertEqual(result[1].text, 'Text 2')
 
-    def test_convert_media_resource(self):
+    def test_convert_media_resource(self) -> None:
         """Test converting media resource content."""
         parts = [Part(root=MediaPart(media=Media(url='data:image/png;base64,abc123', content_type='image/png')))]
 
@@ -215,7 +215,7 @@ class TestResourceConversion(unittest.TestCase):
         assert isinstance(result[0], BlobResourceContents)
         self.assertEqual(result[0].blob, 'abc123')
 
-    def test_convert_mixed_content(self):
+    def test_convert_mixed_content(self) -> None:
         """Test converting mixed text and media content."""
         parts = [
             Part(root=TextPart(text='Description')),
@@ -234,11 +234,11 @@ class TestResourceConversion(unittest.TestCase):
 class TestToolResultConversion(unittest.TestCase):
     """Tests for tool result conversion."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures."""
         setup_mocks()
 
-    def test_convert_string_result(self):
+    def test_convert_string_result(self) -> None:
         """Test converting string result."""
         result = to_mcp_tool_result('Hello, world!')
 
@@ -249,7 +249,7 @@ class TestToolResultConversion(unittest.TestCase):
         assert isinstance(result[0], TextContent)
         self.assertEqual(result[0].text, 'Hello, world!')
 
-    def test_convert_dict_result(self):
+    def test_convert_dict_result(self) -> None:
         """Test converting dict result."""
         result = to_mcp_tool_result({'key': 'value', 'number': 42})
 
@@ -263,7 +263,7 @@ class TestToolResultConversion(unittest.TestCase):
         self.assertEqual(parsed['key'], 'value')
         self.assertEqual(parsed['number'], 42)
 
-    def test_convert_number_result(self):
+    def test_convert_number_result(self) -> None:
         """Test converting number result."""
         result = to_mcp_tool_result(42)
 
@@ -272,7 +272,7 @@ class TestToolResultConversion(unittest.TestCase):
         assert isinstance(result[0], TextContent)
         self.assertEqual(result[0].text, '42')
 
-    def test_convert_boolean_result(self):
+    def test_convert_boolean_result(self) -> None:
         """Test converting boolean result."""
         result = to_mcp_tool_result(True)
 
@@ -285,11 +285,11 @@ class TestToolResultConversion(unittest.TestCase):
 class TestSchemaConversion(unittest.TestCase):
     """Tests for schema conversion utilities."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures."""
         setup_mocks()
 
-    def test_convert_simple_schema(self):
+    def test_convert_simple_schema(self) -> None:
         """Test converting simple string schema."""
         schema = {'type': 'object', 'properties': {'name': {'type': 'string', 'description': 'User name'}}}
 
@@ -300,7 +300,7 @@ class TestSchemaConversion(unittest.TestCase):
         self.assertEqual(result[0]['name'], 'name')
         self.assertEqual(result[0]['description'], 'User name')
 
-    def test_convert_schema_with_required(self):
+    def test_convert_schema_with_required(self) -> None:
         """Test converting schema with required fields."""
         schema = {
             'type': 'object',
@@ -317,7 +317,7 @@ class TestSchemaConversion(unittest.TestCase):
         self.assertTrue(name_arg['required'])
         self.assertFalse(age_arg['required'])
 
-    def test_convert_schema_with_non_string_fails(self):
+    def test_convert_schema_with_non_string_fails(self) -> None:
         """Test that non-string properties raise an error."""
         schema = {'type': 'object', 'properties': {'count': {'type': 'number'}}}
 
@@ -326,7 +326,7 @@ class TestSchemaConversion(unittest.TestCase):
 
         self.assertIn('string', str(context.exception).lower())
 
-    def test_convert_schema_with_union_type(self):
+    def test_convert_schema_with_union_type(self) -> None:
         """Test converting schema with union type including string."""
         schema = {'type': 'object', 'properties': {'value': {'type': ['string', 'null']}}}
 
@@ -336,13 +336,13 @@ class TestSchemaConversion(unittest.TestCase):
         assert result is not None
         self.assertEqual(len(result), 1)
 
-    def test_convert_none_schema(self):
+    def test_convert_none_schema(self) -> None:
         """Test converting None schema."""
         result = to_mcp_prompt_arguments(None)
 
         self.assertIsNone(result)
 
-    def test_convert_schema_without_properties_fails(self):
+    def test_convert_schema_without_properties_fails(self) -> None:
         """Test that schema without properties raises an error."""
         schema = {'type': 'object'}
 

--- a/py/plugins/mcp/tests/test_mcp_host.py
+++ b/py/plugins/mcp/tests/test_mcp_host.py
@@ -31,7 +31,7 @@ McpServerConfig: Any = None
 create_mcp_host: Any = None
 
 
-def setup_mocks():
+def setup_mocks() -> None:
     """Set up mocks for testing."""
     global Genkit, McpServerConfig, create_mcp_host
 
@@ -62,11 +62,11 @@ def setup_mocks():
 class TestMcpHost(unittest.IsolatedAsyncioTestCase):
     """Tests for MCP host."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures."""
         setup_mocks()
 
-    async def test_connect_and_register(self):
+    async def test_connect_and_register(self) -> None:
         """Test connect and register."""
         # Setup configs
         config1 = McpServerConfig(command='echo')

--- a/py/plugins/mcp/tests/test_mcp_integration.py
+++ b/py/plugins/mcp/tests/test_mcp_integration.py
@@ -49,7 +49,7 @@ create_mcp_host: Any = None
 create_mcp_server: Any = None
 
 
-def setup_mocks():
+def setup_mocks() -> None:
     """Set up mocks for testing."""
     global Genkit, McpClient, McpServerConfig, create_mcp_host, create_mcp_server
 
@@ -88,11 +88,11 @@ def setup_mocks():
 class TestClientServerIntegration(unittest.IsolatedAsyncioTestCase):
     """Integration tests for MCP client-server communication."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures."""
         setup_mocks()
 
-    async def test_client_can_list_server_tools(self):
+    async def test_client_can_list_server_tools(self) -> None:
         """Test that a client can list tools from a server."""
         # Create server with tools
         server_ai = Genkit()
@@ -117,7 +117,7 @@ class TestClientServerIntegration(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(tools), 1)
         self.assertEqual(tools[0].name, 'add')
 
-    async def test_client_can_call_server_tool(self):
+    async def test_client_can_call_server_tool(self) -> None:
         """Test that a client can call a tool on a server."""
         # Create client
         client = McpClient(name='test-client', config=McpServerConfig(command='echo'))
@@ -137,7 +137,7 @@ class TestClientServerIntegration(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, '8')
         mock_session.call_tool.assert_called_once_with('add', {'a': 5, 'b': 3})
 
-    async def test_client_can_list_server_resources(self):
+    async def test_client_can_list_server_resources(self) -> None:
         """Test that a client can list resources from a server."""
         # Create client
         client = McpClient(name='test-client', config=McpServerConfig(command='echo'))
@@ -157,7 +157,7 @@ class TestClientServerIntegration(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resources[0].name, 'config')
         self.assertEqual(str(resources[0].uri), 'app://config')
 
-    async def test_client_can_read_server_resource(self):
+    async def test_client_can_read_server_resource(self) -> None:
         """Test that a client can read a resource from a server."""
         # Create client
         client = McpClient(name='test-client', config=McpServerConfig(command='echo'))
@@ -178,7 +178,7 @@ class TestClientServerIntegration(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(result)
         mock_session.read_resource.assert_called_once_with(AnyUrl('app://config'))
 
-    async def test_host_manages_multiple_clients(self):
+    async def test_host_manages_multiple_clients(self) -> None:
         """Test that a host can manage multiple clients."""
         # Create host with multiple servers
         config1 = McpServerConfig(command='server1')
@@ -191,7 +191,7 @@ class TestClientServerIntegration(unittest.IsolatedAsyncioTestCase):
         self.assertIn('server1', host.clients)
         self.assertIn('server2', host.clients)
 
-    async def test_host_can_register_tools_from_multiple_servers(self):
+    async def test_host_can_register_tools_from_multiple_servers(self) -> None:
         """Test that a host can register tools from multiple servers."""
         # Create host
         host = create_mcp_host({'server1': McpServerConfig(command='s1'), 'server2': McpServerConfig(command='s2')})
@@ -214,7 +214,7 @@ class TestClientServerIntegration(unittest.IsolatedAsyncioTestCase):
         # Each client should have registered one tool
         # Tool names should be prefixed with server name
 
-    async def test_client_handles_disabled_server(self):
+    async def test_client_handles_disabled_server(self) -> None:
         """Test that a client handles disabled servers correctly."""
         # Create client with disabled config
         config = McpServerConfig(command='echo', disabled=True)
@@ -226,7 +226,7 @@ class TestClientServerIntegration(unittest.IsolatedAsyncioTestCase):
         # Should not have a session
         self.assertIsNone(client.session)
 
-    async def test_host_can_disable_and_enable_clients(self):
+    async def test_host_can_disable_and_enable_clients(self) -> None:
         """Test that a host can disable and enable clients."""
         host = create_mcp_host({'test': McpServerConfig(command='echo')})
 
@@ -249,11 +249,11 @@ class TestClientServerIntegration(unittest.IsolatedAsyncioTestCase):
 class TestResourceIntegration(unittest.IsolatedAsyncioTestCase):
     """Integration tests specifically for resource handling."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures."""
         setup_mocks()
 
-    async def test_end_to_end_resource_flow(self):
+    async def test_end_to_end_resource_flow(self) -> None:
         """Test complete flow: define resource → expose via server → consume via client."""
         # This is a conceptual test showing the flow
         # In practice, we'd need actual MCP transport for true end-to-end
@@ -283,7 +283,7 @@ class TestResourceIntegration(unittest.IsolatedAsyncioTestCase):
         assert isinstance(read_result.contents[0], TextResourceContents)
         self.assertEqual(read_result.contents[0].text, 'config data')
 
-    async def test_template_resource_matching(self):
+    async def test_template_resource_matching(self) -> None:
         """Test that template resources match correctly."""
         server_ai = Genkit()
 
@@ -320,11 +320,11 @@ class TestResourceIntegration(unittest.IsolatedAsyncioTestCase):
 class TestErrorHandling(unittest.IsolatedAsyncioTestCase):
     """Tests for error handling in client-server communication."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures."""
         setup_mocks()
 
-    async def test_server_handles_missing_tool(self):
+    async def test_server_handles_missing_tool(self) -> None:
         """Test that server properly handles requests for non-existent tools."""
         server_ai = Genkit()
 
@@ -350,7 +350,7 @@ class TestErrorHandling(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn('NOT_FOUND', str(context.exception.status))
 
-    async def test_client_handles_connection_failure(self):
+    async def test_client_handles_connection_failure(self) -> None:
         """Test that client handles connection failures gracefully."""
         client = McpClient(name='test-client', config=McpServerConfig(command='nonexistent_command'))
 

--- a/py/plugins/mcp/tests/test_mcp_server.py
+++ b/py/plugins/mcp/tests/test_mcp_server.py
@@ -55,7 +55,7 @@ from genkit.plugins.mcp import McpServerOptions, create_mcp_server
 class TestMcpServer(unittest.IsolatedAsyncioTestCase):
     """Test MCP server functionality - mirrors JS server_test.ts."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures before each test."""
         self.ai = Genkit()
 
@@ -83,13 +83,13 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
         # Create MCP server
         self.server = create_mcp_server(self.ai, McpServerOptions(name='test-server', version='0.0.1'))
 
-    async def asyncSetUp(self):
+    async def asyncSetUp(self) -> None:
         """Async setup - initialize server."""
         await self.server.setup()
 
     # ===== TOOL TESTS =====
 
-    async def test_list_tools(self):
+    async def test_list_tools(self) -> None:
         """Test listing tools - mirrors JS 'should list tools'."""
         result = await self.server.list_tools(ListToolsRequest(method='tools/list'))
 
@@ -104,7 +104,7 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
         assert tool.inputSchema is not None
         self.assertIsNotNone(tool.inputSchema)
 
-    async def test_call_tool(self):
+    async def test_call_tool(self) -> None:
         """Test calling a tool - mirrors JS 'should call the tool'."""
         # Create mock request
         request = CallToolRequest(
@@ -122,7 +122,7 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
 
     # ===== PROMPT TESTS =====
 
-    async def test_list_prompts(self):
+    async def test_list_prompts(self) -> None:
         """Test listing prompts - mirrors JS 'should list prompts'."""
         result = await self.server.list_prompts(ListPromptsRequest(method='prompts/list'))
 
@@ -130,7 +130,7 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
         prompt_names = [p.name for p in result.prompts]
         self.assertIn('testPrompt', prompt_names)
 
-    async def test_get_prompt(self):
+    async def test_get_prompt(self) -> None:
         """Test rendering a prompt - mirrors JS 'should render prompt'."""
         # Create mock request
         request = GetPromptRequest(
@@ -153,7 +153,7 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
 
     # ===== RESOURCE TESTS =====
 
-    async def test_list_resources(self):
+    async def test_list_resources(self) -> None:
         """Test listing resources - mirrors JS 'should list resources'."""
         result = await self.server.list_resources(ListResourcesRequest(method='resources/list'))
 
@@ -164,7 +164,7 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resource.name, 'testResources')
         self.assertEqual(str(resource.uri), 'my://resource')
 
-    async def test_list_resource_templates(self):
+    async def test_list_resource_templates(self) -> None:
         """Test listing resource templates - mirrors JS 'should list templates'."""
         result = await self.server.list_resource_templates(
             ListResourceTemplatesRequest(method='resources/templates/list')
@@ -177,7 +177,7 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(template.name, 'testTmpl')
         self.assertEqual(template.uriTemplate, 'file://{+path}')
 
-    async def test_read_resource(self):
+    async def test_read_resource(self) -> None:
         """Test reading a resource - mirrors JS 'should read resource'."""
         # Create mock request
         request = ReadResourceRequest(
@@ -194,7 +194,7 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(str(content.uri), 'my://resource')
         self.assertEqual(content.text, 'my resource')
 
-    async def test_read_template_resource(self):
+    async def test_read_template_resource(self) -> None:
         """Test reading a template resource."""
         # Create mock request
         # Create mock request
@@ -214,20 +214,20 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
 
     # ===== ADDITIONAL TESTS =====
 
-    async def test_server_initialization(self):
+    async def test_server_initialization(self) -> None:
         """Test that server initializes correctly."""
         self.assertIsNotNone(self.server)
         self.assertEqual(self.server.options.name, 'test-server')
         self.assertEqual(self.server.options.version, '0.0.1')
         self.assertTrue(self.server.actions_resolved)
 
-    async def test_server_has_all_action_types(self):
+    async def test_server_has_all_action_types(self) -> None:
         """Test that server has tools, prompts, and resources."""
         self.assertGreater(len(self.server.tool_actions), 0)
         self.assertGreater(len(self.server.prompt_actions), 0)
         self.assertGreater(len(self.server.resource_actions), 0)
 
-    async def test_tool_not_found(self):
+    async def test_tool_not_found(self) -> None:
         """Test calling a non-existent tool."""
         from genkit.core.error import GenkitError
 
@@ -241,7 +241,7 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(context.exception.status, 'NOT_FOUND')
 
-    async def test_prompt_not_found(self):
+    async def test_prompt_not_found(self) -> None:
         """Test getting a non-existent prompt."""
         from genkit.core.error import GenkitError
 
@@ -255,7 +255,7 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(context.exception.status, 'NOT_FOUND')
 
-    async def test_resource_not_found(self):
+    async def test_resource_not_found(self) -> None:
         """Test reading a non-existent resource."""
         from genkit.core.error import GenkitError
 
@@ -275,7 +275,7 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
 class TestResourceFunctionality(unittest.IsolatedAsyncioTestCase):
     """Test resource-specific functionality."""
 
-    async def test_resource_registration_with_fixed_uri(self):
+    async def test_resource_registration_with_fixed_uri(self) -> None:
         """Test registering a resource with fixed URI."""
         ai = Genkit()
 
@@ -287,7 +287,7 @@ class TestResourceFunctionality(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(action.kind, ActionKind.RESOURCE)
         self.assertEqual(action.metadata['resource']['uri'], 'test://resource')
 
-    async def test_resource_registration_with_template(self):
+    async def test_resource_registration_with_template(self) -> None:
         """Test registering a resource with URI template."""
         ai = Genkit()
 
@@ -299,7 +299,7 @@ class TestResourceFunctionality(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(action.kind, ActionKind.RESOURCE)
         self.assertEqual(action.metadata['resource']['template'], 'file://{+path}')
 
-    async def test_resource_requires_uri_or_template(self):
+    async def test_resource_requires_uri_or_template(self) -> None:
         """Test that resource requires either uri or template."""
         ai = Genkit()
 
@@ -309,7 +309,7 @@ class TestResourceFunctionality(unittest.IsolatedAsyncioTestCase):
         self.assertIn('uri', str(context.exception).lower())
         self.assertIn('template', str(context.exception).lower())
 
-    async def test_uri_template_matching(self):
+    async def test_uri_template_matching(self) -> None:
         """Test URI template matching."""
         from genkit.blocks.resource import matches_uri_template
 

--- a/py/plugins/mcp/tests/test_mcp_server_resources.py
+++ b/py/plugins/mcp/tests/test_mcp_server_resources.py
@@ -38,7 +38,7 @@ McpServerOptions: Any = None
 create_mcp_server: Any = None
 
 
-def setup_mocks():
+def setup_mocks() -> None:
     """Set up mocks for testing."""
     global Genkit, McpServerOptions, create_mcp_server
 
@@ -77,12 +77,12 @@ def setup_mocks():
 class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
     """Tests for MCP server resource handling."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures."""
         setup_mocks()
         self.ai = Genkit()
 
-    async def test_list_resources_with_fixed_uri(self):
+    async def test_list_resources_with_fixed_uri(self) -> None:
         """Test listing resources with fixed URIs."""
         # Define resources
         self.ai.define_resource(name='config', uri='app://config', fn=lambda req: {'content': [{'text': 'config'}]})
@@ -106,7 +106,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
         config_resource = next(r for r in result.resources if r.name == 'config')
         self.assertEqual(str(config_resource.uri), 'app://config')
 
-    async def test_list_resource_templates(self):
+    async def test_list_resource_templates(self) -> None:
         """Test listing resources with URI templates."""
         # Define template resources
         self.ai.define_resource(
@@ -134,7 +134,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
         file_template = next(t for t in result.resourceTemplates if t.name == 'file')
         self.assertEqual(file_template.uriTemplate, 'file://{+path}')
 
-    async def test_list_resources_excludes_templates(self):
+    async def test_list_resources_excludes_templates(self) -> None:
         """Test that list_resources excludes template resources."""
         # Define mixed resources
         self.ai.define_resource(name='fixed', uri='app://fixed', fn=lambda req: {'content': [{'text': 'fixed'}]})
@@ -153,7 +153,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(result.resources), 1)
         self.assertEqual(result.resources[0].name, 'fixed')
 
-    async def test_list_resource_templates_excludes_fixed(self):
+    async def test_list_resource_templates_excludes_fixed(self) -> None:
         """Test that list_resource_templates excludes fixed URI resources."""
         # Define mixed resources
         self.ai.define_resource(name='fixed', uri='app://fixed', fn=lambda req: {'content': [{'text': 'fixed'}]})
@@ -172,7 +172,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(result.resourceTemplates), 1)
         self.assertEqual(result.resourceTemplates[0].name, 'template')
 
-    async def test_read_resource_with_fixed_uri(self):
+    async def test_read_resource_with_fixed_uri(self) -> None:
         """Test reading a resource with fixed URI."""
 
         def config_resource(req):
@@ -196,7 +196,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
         assert isinstance(result.contents[0], TextResourceContents)
         self.assertEqual(result.contents[0].text, 'Configuration data')
 
-    async def test_read_resource_with_template(self):
+    async def test_read_resource_with_template(self) -> None:
         """Test reading a resource with URI template."""
 
         def file_resource(req):
@@ -222,7 +222,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
         assert isinstance(result.contents[0], TextResourceContents)
         self.assertIn('/home/user/document.txt', result.contents[0].text)
 
-    async def test_read_resource_not_found(self):
+    async def test_read_resource_not_found(self) -> None:
         """Test reading a non-existent resource."""
         self.ai.define_resource(name='existing', uri='app://existing', fn=lambda req: {'content': [{'text': 'data'}]})
 
@@ -241,7 +241,7 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn('NOT_FOUND', str(context.exception.status))
 
-    async def test_read_resource_with_multiple_content_parts(self):
+    async def test_read_resource_with_multiple_content_parts(self) -> None:
         """Test reading a resource that returns multiple content parts."""
 
         def multi_part_resource(req):
@@ -273,12 +273,12 @@ class TestMcpServerResources(unittest.IsolatedAsyncioTestCase):
 class TestMcpServerToolsAndPrompts(unittest.IsolatedAsyncioTestCase):
     """Tests for MCP server tool and prompt handling."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures."""
         setup_mocks()
         self.ai = Genkit()
 
-    async def test_list_tools(self):
+    async def test_list_tools(self) -> None:
         """Test listing tools."""
 
         @self.ai.tool(description='Add two numbers')
@@ -302,7 +302,7 @@ class TestMcpServerToolsAndPrompts(unittest.IsolatedAsyncioTestCase):
         self.assertIn('add', tool_names)
         self.assertIn('multiply', tool_names)
 
-    async def test_call_tool(self):
+    async def test_call_tool(self) -> None:
         """Test calling a tool."""
 
         @self.ai.tool()
@@ -325,7 +325,7 @@ class TestMcpServerToolsAndPrompts(unittest.IsolatedAsyncioTestCase):
         assert isinstance(result.content[0], TextContent)
         self.assertEqual(result.content[0].text, '8')
 
-    async def test_list_prompts(self):
+    async def test_list_prompts(self) -> None:
         """Test listing prompts."""
         self.ai.define_prompt(name='greeting', prompt='Hello {{name}}!')
 
@@ -348,7 +348,7 @@ class TestMcpServerToolsAndPrompts(unittest.IsolatedAsyncioTestCase):
 class TestMcpServerIntegration(unittest.IsolatedAsyncioTestCase):
     """Integration tests for MCP server."""
 
-    async def test_server_exposes_all_action_types(self):
+    async def test_server_exposes_all_action_types(self) -> None:
         """Test that server exposes tools, prompts, and resources."""
         setup_mocks()
         ai = Genkit()
@@ -373,7 +373,7 @@ class TestMcpServerIntegration(unittest.IsolatedAsyncioTestCase):
         self.assertGreater(len(server.prompt_actions), 0)
         self.assertGreater(len(server.resource_actions), 0)
 
-    async def test_server_initialization_idempotent(self):
+    async def test_server_initialization_idempotent(self) -> None:
         """Test that server setup is idempotent."""
         setup_mocks()
         ai = Genkit()

--- a/py/plugins/ollama/tests/models/test_embedders.py
+++ b/py/plugins/ollama/tests/models/test_embedders.py
@@ -35,7 +35,7 @@ from genkit.types import (
 class TestOllamaEmbedderEmbed(unittest.IsolatedAsyncioTestCase):
     """Unit tests for OllamaEmbedder.embed method."""
 
-    async def asyncSetUp(self):
+    async def asyncSetUp(self) -> None:
         """Common setup."""
         self.mock_ollama_client_instance = AsyncMock()
         self.mock_ollama_client_factory = MagicMock(return_value=self.mock_ollama_client_instance)
@@ -45,7 +45,7 @@ class TestOllamaEmbedderEmbed(unittest.IsolatedAsyncioTestCase):
             client=self.mock_ollama_client_factory, embedding_definition=self.mock_embedding_definition
         )
 
-    async def test_embed_single_document_single_content(self):
+    async def test_embed_single_document_single_content(self) -> None:
         """Test embed with a single document containing single text content."""
         request = EmbedRequest(
             input=[
@@ -67,7 +67,7 @@ class TestOllamaEmbedderEmbed(unittest.IsolatedAsyncioTestCase):
         expected_genkit_embeddings = [Embedding(embedding=[0.1, 0.2, 0.3])]
         self.assertEqual(response, EmbedResponse(embeddings=expected_genkit_embeddings))
 
-    async def test_embed_multiple_documents_multiple_content(self):
+    async def test_embed_multiple_documents_multiple_content(self) -> None:
         """Test embed with multiple documents, each with multiple text contents."""
         request = EmbedRequest(
             input=[
@@ -99,7 +99,7 @@ class TestOllamaEmbedderEmbed(unittest.IsolatedAsyncioTestCase):
         ]
         self.assertEqual(response, EmbedResponse(embeddings=expected_genkit_embeddings))
 
-    async def test_embed_empty_input(self):
+    async def test_embed_empty_input(self) -> None:
         """Test embed with an empty input request."""
         request = EmbedRequest(input=[])
         self.mock_ollama_client_instance.embed.return_value = ollama_api.EmbedResponse(embeddings=[])
@@ -113,7 +113,7 @@ class TestOllamaEmbedderEmbed(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(response, EmbedResponse(embeddings=[]))
 
-    async def test_embed_api_raises_exception(self):
+    async def test_embed_api_raises_exception(self) -> None:
         """Test embed method handles exception from client.embed."""
         request = EmbedRequest(input=[Document(content=[DocumentPart(root=TextPart(text='error text'))])])
         self.mock_ollama_client_instance.embed.side_effect = Exception('Ollama Embed API Error')
@@ -123,7 +123,7 @@ class TestOllamaEmbedderEmbed(unittest.IsolatedAsyncioTestCase):
 
         self.mock_ollama_client_instance.embed.assert_awaited_once()
 
-    async def test_embed_response_mismatch_input_count(self):
+    async def test_embed_response_mismatch_input_count(self) -> None:
         """Test embed when client returns fewer embeddings than input texts (edge case)."""
         request = EmbedRequest(
             input=[

--- a/py/plugins/ollama/tests/models/test_models.py
+++ b/py/plugins/ollama/tests/models/test_models.py
@@ -41,7 +41,7 @@ from genkit.types import (
 class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
     """Tests for Generate method of OllamaModel."""
 
-    async def asyncSetUp(self):
+    async def asyncSetUp(self) -> None:
         """Common setup for all async tests."""
         self.mock_client = MagicMock()
         self.request = GenerateRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hello'))])])
@@ -56,7 +56,7 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
             total_tokens=30,
         ),
     )
-    async def test_generate_chat_non_streaming(self, mock_get_basic_usage_stats):
+    async def test_generate_chat_non_streaming(self, mock_get_basic_usage_stats) -> None:
         """Test generate method with CHAT API type in non-streaming mode."""
         model_def = ModelDefinition(
             name='chat-model',
@@ -118,7 +118,7 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
             total_tokens=30,
         ),
     )
-    async def test_generate_generate_non_streaming(self, mock_get_basic_usage_stats):
+    async def test_generate_generate_non_streaming(self, mock_get_basic_usage_stats) -> None:
         """Test generate method with GENERATE API type in non-streaming mode."""
         model_def = ModelDefinition(
             name='generate-model',
@@ -169,7 +169,7 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         'genkit.blocks.model.get_basic_usage_stats',
         return_value=GenerationUsage(),
     )
-    async def test_generate_chat_streaming(self, mock_get_basic_usage_stats):
+    async def test_generate_chat_streaming(self, mock_get_basic_usage_stats) -> None:
         """Test generate method with CHAT API type in streaming mode."""
         model_def = ModelDefinition(name='chat-model', api_type=OllamaAPITypes.CHAT)
         ollama_model = OllamaModel(client=self.mock_client, model_definition=model_def)
@@ -214,7 +214,7 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         'genkit.blocks.model.get_basic_usage_stats',
         return_value=GenerationUsage(),
     )
-    async def test_generate_generate_streaming(self, mock_get_basic_usage_stats):
+    async def test_generate_generate_streaming(self, mock_get_basic_usage_stats) -> None:
         """Test generate method with GENERATE API type in streaming mode."""
         model_def = ModelDefinition(
             name='generate-model',
@@ -256,7 +256,7 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         'genkit.blocks.model.get_basic_usage_stats',
         return_value=GenerationUsage(),
     )
-    async def test_generate_chat_api_response_none(self, mock_get_basic_usage_stats):
+    async def test_generate_chat_api_response_none(self, mock_get_basic_usage_stats) -> None:
         """Test generate method when _chat_with_ollama returns None."""
         model_def = ModelDefinition(name='chat-model', api_type=OllamaAPITypes.CHAT)
         ollama_model = OllamaModel(client=self.mock_client, model_definition=model_def)
@@ -280,7 +280,7 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         'genkit.blocks.model.get_basic_usage_stats',
         return_value=GenerationUsage(),
     )
-    async def test_generate_generate_api_response_none(self, mock_get_basic_usage_stats):
+    async def test_generate_generate_api_response_none(self, mock_get_basic_usage_stats) -> None:
         """Test generate method when _generate_ollama_response returns None."""
         model_def = ModelDefinition(name='generate-model', api_type=OllamaAPITypes.GENERATE)
         ollama_model = OllamaModel(client=self.mock_client, model_definition=model_def)
@@ -302,7 +302,7 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
 class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
     """Unit tests for OllamaModel._chat_with_ollama method."""
 
-    async def asyncSetUp(self):
+    async def asyncSetUp(self) -> None:
         """Common setup."""
         self.mock_ollama_client_instance = AsyncMock()
         self.mock_ollama_client_factory = MagicMock(return_value=self.mock_ollama_client_instance)
@@ -331,14 +331,14 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
 
         self.mock_convert_parameters = MagicMock(return_value={'type': 'string'})
 
-    async def asyncTearDown(self):
+    async def asyncTearDown(self) -> None:
         """Cleanup patches."""
         self.patcher_build_chat_messages.stop()
         self.patcher_is_streaming_request.stop()
         self.patcher_build_request_options.stop()
         self.patcher_build_multimodal_response.stop()
 
-    async def test_non_streaming_chat_success(self):
+    async def test_non_streaming_chat_success(self) -> None:
         """Test _chat_with_ollama in non-streaming mode with successful response."""
         expected_response = ollama_api.ChatResponse(
             message=ollama_api.Message(
@@ -366,7 +366,7 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
 
         self.mock_build_multimodal_response.assert_not_called()
 
-    async def test_streaming_chat_success(self):
+    async def test_streaming_chat_success(self) -> None:
         """Test _chat_with_ollama in streaming mode with multiple chunks."""
         self.mock_is_streaming_request.return_value = True
         self.ctx.is_streaming = True
@@ -406,7 +406,7 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
         cast(MagicMock, self.ctx.send_chunk).assert_any_call(chunk=ANY)
         self.mock_build_multimodal_response.assert_any_call(chat_response=ANY)
 
-    async def test_chat_with_output_format_string(self):
+    async def test_chat_with_output_format_string(self) -> None:
         """Test _chat_with_ollama with request.output.format string."""
         self.request.output = OutputConfig(format='json')
 
@@ -424,7 +424,7 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
         self.assertIn('format', call_kwargs)
         self.assertEqual(call_kwargs['format'], 'json')
 
-    async def test_chat_with_output_format_schema(self):
+    async def test_chat_with_output_format_schema(self) -> None:
         """Test _chat_with_ollama with request.output.schema_ dictionary."""
         schema_dict = {'type': 'object', 'properties': {'name': {'type': 'string'}}}
         self.request.output = OutputConfig(schema=schema_dict)
@@ -443,7 +443,7 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
         self.assertIn('format', call_kwargs)
         self.assertEqual(call_kwargs['format'], schema_dict)
 
-    async def test_chat_with_no_output_format(self):
+    async def test_chat_with_no_output_format(self) -> None:
         """Test _chat_with_ollama with no output format specified."""
         self.request.output = OutputConfig(format=None, schema=None)
 
@@ -461,7 +461,7 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
         self.assertIn('format', call_kwargs)
         self.assertEqual(call_kwargs['format'], '')
 
-    async def test_chat_api_raises_exception(self):
+    async def test_chat_api_raises_exception(self) -> None:
         """Test _chat_with_ollama handles exception from client.chat."""
         self.mock_ollama_client_instance.chat.side_effect = Exception('Ollama API Error')
 
@@ -475,7 +475,7 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
 class TestOllamaModelGenerateOllamaResponse(unittest.IsolatedAsyncioTestCase):
     """Unit tests for OllamaModel._generate_ollama_response."""
 
-    async def asyncSetUp(self):
+    async def asyncSetUp(self) -> None:
         """Common setup."""
         self.mock_ollama_client_instance = AsyncMock()
         self.mock_ollama_client_factory = MagicMock(return_value=self.mock_ollama_client_instance)
@@ -507,13 +507,13 @@ class TestOllamaModelGenerateOllamaResponse(unittest.IsolatedAsyncioTestCase):
         self.mock_is_streaming_request = self.patcher_is_streaming_request.start()
         self.mock_build_request_options = self.patcher_build_request_options.start()
 
-    async def asyncTearDown(self):
+    async def asyncTearDown(self) -> None:
         """Cleanup patches."""
         self.patcher_build_prompt.stop()
         self.patcher_is_streaming_request.stop()
         self.patcher_build_request_options.stop()
 
-    async def test_non_streaming_generate_success(self):
+    async def test_non_streaming_generate_success(self) -> None:
         """Test _generate_ollama_response in non-streaming mode with successful response."""
         expected_response = ollama_api.GenerateResponse(response='Full generated text')
         self.mock_ollama_client_instance.generate.return_value = expected_response
@@ -534,7 +534,7 @@ class TestOllamaModelGenerateOllamaResponse(unittest.IsolatedAsyncioTestCase):
         )
         cast(MagicMock, self.ctx.send_chunk).assert_not_called()
 
-    async def test_streaming_generate_success(self):
+    async def test_streaming_generate_success(self) -> None:
         """Test _generate_ollama_response in streaming mode with multiple chunks."""
         self.mock_is_streaming_request.return_value = True
 
@@ -565,7 +565,7 @@ class TestOllamaModelGenerateOllamaResponse(unittest.IsolatedAsyncioTestCase):
             chunk=GenerateResponseChunk(role=Role.MODEL, index=2, content=[Part(root=TextPart(text='chunk2'))])
         )
 
-    async def test_generate_api_raises_exception(self):
+    async def test_generate_api_raises_exception(self) -> None:
         """Test _generate_ollama_response handles exception from client.generate."""
         self.mock_ollama_client_instance.generate.side_effect = Exception('Ollama generate API Error')
 
@@ -660,7 +660,7 @@ class TestOllamaModelGenerateOllamaResponse(unittest.IsolatedAsyncioTestCase):
         ),
     ],
 )
-def test_convert_parameters(input_schema, expected_output):
+def test_convert_parameters(input_schema, expected_output) -> None:
     """Unit Tests for _convert_parameters function with various input schemas."""
     result = _convert_parameters(input_schema)
     assert result == expected_output

--- a/py/plugins/ollama/tests/test_plugin_api.py
+++ b/py/plugins/ollama/tests/test_plugin_api.py
@@ -31,21 +31,21 @@ from genkit.plugins.ollama.models import ModelDefinition
 class TestOllamaInit(unittest.TestCase):
     """Test cases for Ollama.__init__ plugin."""
 
-    def test_init_with_models(self):
+    def test_init_with_models(self) -> None:
         """Test correct propagation of models param."""
         model_ref = ModelDefinition(name='test_model')
         plugin = Ollama(models=[model_ref])
 
         assert plugin.models[0] == model_ref
 
-    def test_init_with_embedders(self):
+    def test_init_with_embedders(self) -> None:
         """Test correct propagation of embedders param."""
         embedder_ref = EmbeddingDefinition(name='test_embedder')
         plugin = Ollama(embedders=[embedder_ref])
 
         assert plugin.embedders[0] == embedder_ref
 
-    def test_init_with_options(self):
+    def test_init_with_options(self) -> None:
         """Test correct propagation of other options param."""
         model_ref = ModelDefinition(name='test_model')
         embedder_ref = EmbeddingDefinition(name='test_embedder')
@@ -66,7 +66,7 @@ class TestOllamaInit(unittest.TestCase):
 
 
 @pytest.mark.asyncio
-async def test_initialize(ollama_plugin_instance):
+async def test_initialize(ollama_plugin_instance) -> None:
     """Test init method of Ollama plugin."""
     model_ref = ModelDefinition(name='test_model')
     embedder_ref = EmbeddingDefinition(name='test_embedder')
@@ -93,7 +93,7 @@ async def test_initialize(ollama_plugin_instance):
     ],
 )
 @pytest.mark.asyncio
-async def test_resolve_action(kind, name, ollama_plugin_instance):
+async def test_resolve_action(kind, name, ollama_plugin_instance) -> None:
     """Unit Tests for resolve action method."""
     action = await ollama_plugin_instance.resolve(kind, ollama_name(name))
 
@@ -115,7 +115,7 @@ async def test_resolve_action(kind, name, ollama_plugin_instance):
 
 
 @pytest.mark.asyncio
-async def test_list_actions(ollama_plugin_instance):
+async def test_list_actions(ollama_plugin_instance) -> None:
     """Unit tests for list_actions method."""
 
     class MockModelResponse(BaseModel):

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/vector_search.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/vector_search.py
@@ -114,10 +114,10 @@ class DocRetriever(ABC):
         # Get query embedding
         embed_resp = await self.ai.embed(
             embedder=self.embedder,
-            documents=[document],
+            content=document,
             options=self.embedder_options,
         )
-        if not embed_resp.embeddings:
+        if not embed_resp:
             raise ValueError('Embedder returned no embeddings for query')
 
         # Get limit from options
@@ -128,7 +128,7 @@ class DocRetriever(ABC):
         docs = await self._get_closest_documents(
             request=request,
             top_k=limit_neighbors,
-            query_embeddings=Embedding(embedding=embed_resp.embeddings[0].embedding),
+            query_embeddings=Embedding(embedding=embed_resp[0].embedding),
         )
 
         return RetrieverResponse(documents=typing.cast(list[DocumentData], docs))

--- a/py/plugins/vertex-ai/tests/model_garden/test_client.py
+++ b/py/plugins/vertex-ai/tests/model_garden/test_client.py
@@ -24,7 +24,7 @@ from genkit.plugins.vertex_ai.model_garden.client import OpenAIClient
 @patch('google.auth.default')
 @patch('google.auth.transport.requests.Request')
 @patch('openai.OpenAI')
-def test_client_initialization_with_explicit_project_id(mock_openai_cls, mock_request_cls, mock_default_auth):
+def test_client_initialization_with_explicit_project_id(mock_openai_cls, mock_request_cls, mock_default_auth) -> None:
     """Unittests for init client."""
     mock_location = 'location'
     mock_project_id = 'project_id'
@@ -47,7 +47,9 @@ def test_client_initialization_with_explicit_project_id(mock_openai_cls, mock_re
 @patch('google.auth.default')
 @patch('google.auth.transport.requests.Request')
 @patch('openai.OpenAI')
-def test_client_initialization_without_explicit_project_id(mock_openai_cls, mock_request_cls, mock_default_auth):
+def test_client_initialization_without_explicit_project_id(
+    mock_openai_cls, mock_request_cls, mock_default_auth
+) -> None:
     """Unittests for init client."""
     mock_location = 'location'
     mock_token = 'token'

--- a/py/plugins/vertex-ai/tests/model_garden/test_model_garden.py
+++ b/py/plugins/vertex-ai/tests/model_garden/test_model_garden.py
@@ -77,7 +77,7 @@ def model_garden_instance(client):
         ),
     ],
 )
-def test_get_model_info(model_name, expected, model_garden_instance):
+def test_get_model_info(model_name, expected, model_garden_instance) -> None:
     """Unittest for get_model_info."""
     model_garden_instance.name = model_name
 

--- a/py/plugins/vertex-ai/tests/vector_search/test_retrievers.py
+++ b/py/plugins/vertex-ai/tests/vector_search/test_retrievers.py
@@ -33,7 +33,7 @@ from google.cloud.aiplatform_v1 import (
 )
 
 from genkit.blocks.document import Document, DocumentData
-from genkit.core.typing import DocumentPart, Embedding, EmbedResponse
+from genkit.core.typing import DocumentPart, Embedding
 from genkit.plugins.vertex_ai.vector_search import BigQueryRetriever, FirestoreRetriever
 from genkit.types import ActionRunContext, RetrieverRequest, TextPart
 
@@ -41,9 +41,9 @@ from genkit.types import ActionRunContext, RetrieverRequest, TextPart
 class FakeAI:
     """Fake AI instance for testing."""
 
-    async def embed(self, embedder, documents, options=None):
+    async def embed(self, embedder, content=None, metadata=None, options=None):
         """Mock embed method."""
-        return EmbedResponse(embeddings=[Embedding(embedding=[0.1, 0.2, 0.3])])
+        return [Embedding(embedding=[0.1, 0.2, 0.3])]
 
 
 @pytest.fixture
@@ -60,7 +60,7 @@ def bq_retriever_instance():
     )
 
 
-def test_bigquery_retriever__init__(bq_retriever_instance):
+def test_bigquery_retriever__init__(bq_retriever_instance) -> None:
     """Init test."""
     bq_retriever = bq_retriever_instance
 
@@ -89,7 +89,7 @@ async def test_bigquery_retriever_retrieve(
     bq_retriever_instance,
     options,
     top_k,
-):
+) -> None:
     """Test retrieve method bq retriever."""
     # Mock _get_closest_documents
     mock__get_closest_documents_result = [
@@ -132,7 +132,7 @@ async def test_bigquery_retriever_retrieve(
 
 
 @pytest.mark.asyncio
-async def test_bigquery__get_closest_documents(bq_retriever_instance):
+async def test_bigquery__get_closest_documents(bq_retriever_instance) -> None:
     """Test bigquery retriever _get_closest_documents."""
     # Mock find_neighbors method
     mock_vector_search_client = MagicMock(spec=MatchServiceAsyncClient)
@@ -230,7 +230,7 @@ async def test_bigquery__get_closest_documents(bq_retriever_instance):
 async def test_bigquery__get_closest_documents_fail(
     bq_retriever_instance,
     metadata,
-):
+) -> None:
     """Test failures bigquery retriever _get_closest_documents."""
     with pytest.raises(AttributeError):
         await bq_retriever_instance._get_closest_documents(
@@ -253,7 +253,7 @@ async def test_bigquery__get_closest_documents_fail(
 @pytest.mark.asyncio
 async def test_bigquery__retrieve_neighbors_data_from_db(
     bq_retriever_instance,
-):
+) -> None:
     """Test bigquery retriver _retrieve_neighbors_data_from_db."""
     # Mock query job result from bigquery query
     mock_bq_query_job = MagicMock()
@@ -314,7 +314,7 @@ async def test_bigquery__retrieve_neighbors_data_from_db(
 @pytest.mark.asyncio
 async def test_bigquery_retrieve_neighbors_data_from_db_fail(
     bq_retriever_instance,
-):
+) -> None:
     """Test bigquery retriver _retrieve_neighbors_data_from_db when fails."""
     # Mock exception from bigquery query
     bq_retriever_instance.bq_client.query.raises = AttributeError
@@ -353,7 +353,7 @@ def fs_retriever_instance():
     )
 
 
-def test_firestore_retriever__init__(fs_retriever_instance):
+def test_firestore_retriever__init__(fs_retriever_instance) -> None:
     """Init test."""
     assert fs_retriever_instance is not None
 
@@ -361,7 +361,7 @@ def test_firestore_retriever__init__(fs_retriever_instance):
 @pytest.mark.asyncio
 async def test_firesstore__retrieve_neighbors_data_from_db(
     fs_retriever_instance,
-):
+) -> None:
     """Test _retrieve_neighbors_data_from_db for firestore retriever."""
     # Mock storage of firestore
     storage = {

--- a/py/plugins/xai/src/genkit/plugins/xai/models.py
+++ b/py/plugins/xai/src/genkit/plugins/xai/models.py
@@ -88,7 +88,7 @@ class XAIModel:
             assert ctx is not None  # streaming requires ctx
             return await self._generate_streaming(params, request, ctx)
 
-        def _sample():
+        def _sample() -> Any:
             chat = self.client.chat.create(**params)
             return chat.sample()
 
@@ -175,7 +175,7 @@ class XAIModel:
     async def _generate_streaming(
         self, params: dict[str, Any], request: GenerateRequest, ctx: ActionRunContext
     ) -> GenerateResponse:
-        def _sync_stream():
+        def _sync_stream() -> GenerateResponse:
             accumulated_content = []
             final_response = None
 
@@ -287,7 +287,7 @@ class XAIModel:
 
         return result
 
-    def _to_genkit_content(self, response) -> list[Part]:
+    def _to_genkit_content(self, response: Any) -> list[Part]:
         content = []
 
         if response.content:

--- a/py/plugins/xai/tests/test_xai_models.py
+++ b/py/plugins/xai/tests/test_xai_models.py
@@ -59,7 +59,7 @@ def _create_sample_request() -> GenerateRequest:
 
 
 @pytest.mark.asyncio
-async def test_generate_basic():
+async def test_generate_basic() -> None:
     """Test basic generation."""
     sample_request = _create_sample_request()
 
@@ -97,7 +97,7 @@ async def test_generate_basic():
 
 
 @pytest.mark.asyncio
-async def test_generate_with_config():
+async def test_generate_with_config() -> None:
     """Test generation with config."""
     mock_response = MagicMock()
     mock_response.content = 'Response'
@@ -135,7 +135,7 @@ async def test_generate_with_config():
     assert call_args.kwargs['top_p'] == 0.9
 
 
-def test_to_xai_messages():
+def test_to_xai_messages() -> None:
     """Test xAI messages conversion."""
     mock_client = MagicMock()
     model = XAIModel(model_name='grok-3', client=mock_client)
@@ -149,7 +149,7 @@ def test_to_xai_messages():
     assert len(xai_messages) == 2
 
 
-def test_to_genkit_content():
+def test_to_genkit_content() -> None:
     """Test content conversion."""
     mock_client = MagicMock()
     model = XAIModel(model_name='grok-3', client=mock_client)
@@ -167,7 +167,7 @@ def test_to_genkit_content():
 
 
 @pytest.mark.asyncio
-async def test_streaming_generation():
+async def test_streaming_generation() -> None:
     """Test streaming generation."""
     sample_request = _create_sample_request()
 
@@ -209,7 +209,7 @@ async def test_streaming_generation():
     ctx.is_streaming = True
     collected_chunks = []
 
-    def send_chunk(chunk: GenerateResponseChunk):
+    def send_chunk(chunk: GenerateResponseChunk) -> None:
         collected_chunks.append(chunk)
 
     ctx.send_chunk = send_chunk
@@ -234,7 +234,7 @@ async def test_streaming_generation():
 
 
 @pytest.mark.asyncio
-async def test_generate_with_tools():
+async def test_generate_with_tools() -> None:
     """Test generation with tools."""
     sample_request = _create_sample_request()
 
@@ -275,7 +275,7 @@ async def test_generate_with_tools():
 
 
 @pytest.mark.asyncio
-async def test_build_params_basic():
+async def test_build_params_basic() -> None:
     """Test parameters build."""
     mock_client = MagicMock()
     model = XAIModel(model_name='grok-3', client=mock_client)
@@ -293,7 +293,7 @@ async def test_build_params_basic():
 
 
 @pytest.mark.asyncio
-async def test_build_params_with_config():
+async def test_build_params_with_config() -> None:
     """Test parameters build with config."""
     mock_client = MagicMock()
     model = XAIModel(model_name='grok-3', client=mock_client)
@@ -315,7 +315,7 @@ async def test_build_params_with_config():
 
 
 @pytest.mark.asyncio
-async def test_build_params_with_xai_specific_config():
+async def test_build_params_with_xai_specific_config() -> None:
     """Test parameters build with xAI config."""
     mock_client = MagicMock()
     model = XAIModel(model_name='grok-3', client=mock_client)
@@ -341,7 +341,7 @@ async def test_build_params_with_xai_specific_config():
 
 
 @pytest.mark.asyncio
-async def test_to_genkit_content_parses_json_arguments():
+async def test_to_genkit_content_parses_json_arguments() -> None:
     """Test content conversion with JSON arguments."""
     mock_client = MagicMock()
     model = XAIModel(model_name='grok-3', client=mock_client)

--- a/py/plugins/xai/tests/test_xai_plugin.py
+++ b/py/plugins/xai/tests/test_xai_plugin.py
@@ -26,19 +26,19 @@ from genkit.plugins.xai import XAI, xai_name
 from genkit.plugins.xai.model_info import SUPPORTED_XAI_MODELS, get_model_info
 
 
-def test_xai_name():
+def test_xai_name() -> None:
     """Test xAI name helper."""
     assert xai_name('grok-3') == 'xai/grok-3'
 
 
-def test_init_with_api_key():
+def test_init_with_api_key() -> None:
     """Test init with API key."""
     plugin = XAI(api_key='test-key')
     assert plugin._xai_client is not None
     assert plugin.models == list(SUPPORTED_XAI_MODELS.keys())
 
 
-def test_init_without_api_key_raises():
+def test_init_without_api_key_raises() -> None:
     """Test init raises without API key."""
     with patch.dict('os.environ', {}, clear=True):
         try:
@@ -48,21 +48,21 @@ def test_init_without_api_key_raises():
             pass
 
 
-def test_init_with_env_var():
+def test_init_with_env_var() -> None:
     """Test init with env var."""
     with patch.dict('os.environ', {'XAI_API_KEY': 'env-key'}):
         plugin = XAI()
         assert plugin._xai_client is not None
 
 
-def test_custom_models():
+def test_custom_models() -> None:
     """Test custom models."""
     plugin = XAI(api_key='test-key', models=['grok-3', 'grok-3-mini'])
     assert plugin.models == ['grok-3', 'grok-3-mini']
 
 
 @pytest.mark.asyncio
-async def test_plugin_initialize():
+async def test_plugin_initialize() -> None:
     """Test plugin initialization."""
     plugin = XAI(api_key='test-key')
     actions = await plugin.init()
@@ -70,7 +70,7 @@ async def test_plugin_initialize():
 
 
 @pytest.mark.asyncio
-async def test_resolve_action_model():
+async def test_resolve_action_model() -> None:
     """Test resolve action model."""
     plugin = XAI(api_key='test-key')
     action = await plugin.resolve(ActionKind.MODEL, 'xai/grok-3')
@@ -79,7 +79,7 @@ async def test_resolve_action_model():
     assert action.name == 'xai/grok-3'
 
 
-def test_supported_models():
+def test_supported_models() -> None:
     """Test supported models."""
     assert len(SUPPORTED_XAI_MODELS) >= 4
     for _name, info in SUPPORTED_XAI_MODELS.items():
@@ -91,7 +91,7 @@ def test_supported_models():
         assert info.supports.tools
 
 
-def test_get_model_info_known():
+def test_get_model_info_known() -> None:
     """Test get known model info."""
     info = get_model_info('grok-3')
     assert info.versions
@@ -100,7 +100,7 @@ def test_get_model_info_known():
     assert info.supports.multiturn
 
 
-def test_get_model_info_unknown():
+def test_get_model_info_unknown() -> None:
     """Test get unknown model info."""
     info = get_model_info('unknown-model')
     assert info.label

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -169,14 +169,15 @@ unsafe-fixes = true
 [tool.ruff.lint]
 fixable = ["ALL"]
 select = [
-  "E",    # pycodestyle (errors)
-  "W",    # pycodestyle (warnings)
-  "F",    # pyflakes
-  "I",    # isort (import sorting)
-  "UP",   # pyupgrade (Python version upgrades)
-  "B",    # flake8-bugbear (common bugs)
-  "N",    # pep8-naming (naming conventions)
-  "D",    # pydocstyle
+  "E",  # pycodestyle (errors)
+  "W",  # pycodestyle (warnings)
+  "F",  # pyflakes
+  "I",  # isort (import sorting)
+  "UP", # pyupgrade (Python version upgrades)
+  "B",  # flake8-bugbear (common bugs)
+  "N",  # pep8-naming (naming conventions)
+  "D",  # pydocstyle
+  #"ANN",  # flake8-annotations (type hints)
   "F401", # unused imports
   "F403", # wildcard imports
   "F841", # unused variables

--- a/py/samples/anthropic-hello/src/main.py
+++ b/py/samples/anthropic-hello/src/main.py
@@ -32,6 +32,7 @@ Key features demonstrated in this sample:
 """
 
 import os
+from typing import Annotated
 
 import structlog
 from pydantic import BaseModel, Field
@@ -111,7 +112,7 @@ def convert_currency(input: CurrencyInput) -> str:
 
 
 @ai.flow()
-async def say_hi(name: str) -> str:
+async def say_hi(name: Annotated[str, Field(default='Alice')] = 'Alice') -> str:
     """Generate a simple greeting.
 
     Args:
@@ -127,7 +128,10 @@ async def say_hi(name: str) -> str:
 
 
 @ai.flow()
-async def say_hi_stream(topic: str, ctx: ActionRunContext) -> str:
+async def say_hi_stream(
+    topic: Annotated[str, Field(default='space exploration')] = 'space exploration',
+    ctx: ActionRunContext = None,  # type: ignore[assignment]
+) -> str:
     """Generate streaming response.
 
     Args:
@@ -145,7 +149,7 @@ async def say_hi_stream(topic: str, ctx: ActionRunContext) -> str:
 
 
 @ai.flow()
-async def weather_flow(location: str) -> str:
+async def weather_flow(location: Annotated[str, Field(default='San Francisco')] = 'San Francisco') -> str:
     """Get weather using tools.
 
     Args:
@@ -179,7 +183,7 @@ async def currency_exchange(input: CurrencyExchangeInput) -> str:
 
 
 @ai.flow()
-async def say_hi_with_config(name: str) -> str:
+async def say_hi_with_config(name: Annotated[str, Field(default='Alice')] = 'Alice') -> str:
     """Generate greeting with custom configuration.
 
     Args:

--- a/py/samples/compat-oai-hello/src/main.py
+++ b/py/samples/compat-oai-hello/src/main.py
@@ -39,6 +39,7 @@ Key features demonstrated in this sample:
 
 import os
 from decimal import Decimal
+from typing import Annotated
 
 import httpx
 import structlog
@@ -58,8 +59,8 @@ ai = Genkit(plugins=[OpenAI()], model=openai_model('gpt-4o'))
 class MyInput(BaseModel):
     """My input."""
 
-    a: int = Field(description='a field')
-    b: int = Field(description='b field')
+    a: int = Field(default=5, description='a field')
+    b: int = Field(default=3, description='b field')
 
 
 class HelloSchema(BaseModel):
@@ -88,7 +89,7 @@ def sum_two_numbers2(my_input: MyInput) -> int:
 
 
 @ai.flow()
-async def say_hi(name: str) -> str:
+async def say_hi(name: Annotated[str, Field(default='Alice')] = 'Alice') -> str:
     """Say hi to a name.
 
     Args:
@@ -106,7 +107,7 @@ async def say_hi(name: str) -> str:
 
 
 @ai.flow()
-async def say_hi_stream(name: str) -> str:
+async def say_hi_stream(name: Annotated[str, Field(default='Alice')] = 'Alice') -> str:
     """Say hi to a name and stream the response.
 
     Args:
@@ -169,7 +170,7 @@ def get_weather_tool(coordinates: WeatherRequest) -> float:
 
 
 @ai.flow()
-async def get_weather_flow(location: str) -> str:
+async def get_weather_flow(location: Annotated[str, Field(default='New York')] = 'New York') -> str:
     """Get the weather for a location.
 
     Args:
@@ -190,7 +191,7 @@ async def get_weather_flow(location: str) -> str:
 
 
 @ai.flow()
-async def get_weather_flow_stream(location: str) -> str:
+async def get_weather_flow_stream(location: Annotated[str, Field(default='New York')] = 'New York') -> str:
     """Get the weather for a location using a stream.
 
     Args:
@@ -252,7 +253,7 @@ def gablorken_tool(input_: GablorkenInput) -> int:
 
 
 @ai.flow()
-async def calculate_gablorken(value: int):
+async def calculate_gablorken(value: Annotated[int, Field(default=42)] = 42) -> str:
     """Generate a request to calculate gablorken according to gablorken_tool.
 
     Args:
@@ -271,7 +272,7 @@ async def calculate_gablorken(value: int):
 
 
 @ai.flow()
-async def say_hi_constrained(hi_input: str):
+async def say_hi_constrained(hi_input: Annotated[str, Field(default='World')] = 'World') -> HelloSchema:
     """Generate a request to greet a user with response following `HelloSchema` schema.
 
     Args:
@@ -288,7 +289,10 @@ async def say_hi_constrained(hi_input: str):
 
 
 @ai.flow()
-async def generate_character(name: str, ctx: ActionRunContext):
+async def generate_character(
+    name: Annotated[str, Field(default='Bartholomew')] = 'Bartholomew',
+    ctx: ActionRunContext = None,  # type: ignore[assignment]
+) -> RpgCharacter:
     """Generate an RPG character.
 
     Args:

--- a/py/samples/deepseek-hello/src/main.py
+++ b/py/samples/deepseek-hello/src/main.py
@@ -34,6 +34,7 @@ Key features demonstrated in this sample:
 """
 
 import os
+from typing import Annotated
 
 import structlog
 from pydantic import BaseModel, Field
@@ -83,7 +84,7 @@ def get_weather(input: WeatherInput) -> str:
 
 
 @ai.flow()
-async def say_hi(name: str) -> str:
+async def say_hi(name: Annotated[str, Field(default='Alice')] = 'Alice') -> str:
     """Generate a simple greeting.
 
     Args:
@@ -97,7 +98,10 @@ async def say_hi(name: str) -> str:
 
 
 @ai.flow()
-async def streaming_flow(topic: str, ctx: ActionRunContext) -> str:
+async def streaming_flow(
+    topic: Annotated[str, Field(default='pandas')] = 'pandas',
+    ctx: ActionRunContext = None,  # type: ignore[assignment]
+) -> str:
     """Generate with streaming response.
 
     Args:
@@ -115,7 +119,7 @@ async def streaming_flow(topic: str, ctx: ActionRunContext) -> str:
 
 
 @ai.flow()
-async def weather_flow(location: str) -> str:
+async def weather_flow(location: Annotated[str, Field(default='San Francisco, CA')] = 'San Francisco, CA') -> str:
     """Get weather using compat-oai auto tool calling."""
     response = await ai.generate(
         model=deepseek_name('deepseek-chat'),

--- a/py/samples/dev-local-vectorstore-hello/src/main.py
+++ b/py/samples/dev-local-vectorstore-hello/src/main.py
@@ -22,7 +22,7 @@ import os
 from genkit.ai import Genkit
 from genkit.plugins.dev_local_vectorstore import define_dev_local_vector_store
 from genkit.plugins.google_genai import VertexAI
-from genkit.types import Document
+from genkit.types import Document, RetrieverResponse
 
 if 'GCLOUD_PROJECT' not in os.environ:
     os.environ['GCLOUD_PROJECT'] = input('Please enter your GCLOUD_PROJECT: ')
@@ -66,7 +66,7 @@ async def index_documents() -> None:
 
 
 @ai.flow()
-async def retreive_documents():
+async def retreive_documents() -> RetrieverResponse:
     """Retrieve documents from the vector store."""
     return await ai.retrieve(
         query=Document.from_text('sci-fi film'),

--- a/py/samples/evaluator-demo/src/main.py
+++ b/py/samples/evaluator-demo/src/main.py
@@ -67,7 +67,7 @@ ai.define_evaluator(
 )
 
 
-async def main():
+async def main() -> None:
     """Keep alive for Dev UI."""
     print('Genkit server running. Press Ctrl+C to stop.')
     # Keep the process alive for Dev UI

--- a/py/samples/evaluator-demo/src/pdf_rag.py
+++ b/py/samples/evaluator-demo/src/pdf_rag.py
@@ -15,8 +15,10 @@
 """PDF RAG sample flows."""
 
 import os
+from typing import Annotated
 
 from genkit_demo import ai
+from pydantic import Field
 from pypdf import PdfReader
 
 from genkit.blocks.document import Document
@@ -37,7 +39,7 @@ Helpful Answer:"""
 
 # Define a simple RAG flow, we will evaluate this flow
 @ai.flow(name='pdf_qa')
-async def pdf_qa(query: str) -> str:
+async def pdf_qa(query: Annotated[str, Field(default='What is in the PDF?')] = 'What is in the PDF?') -> str:
     """Answer questions about PDF content.
 
     Args:
@@ -75,7 +77,7 @@ async def pdf_qa(query: str) -> str:
 
 # Define a simple structured flow, we will evaluate this flow
 @ai.flow(name='simple_structured')
-async def simple_structured(query: str) -> str:
+async def simple_structured(query: Annotated[str, Field(default='Tell me a joke')] = 'Tell me a joke') -> str:
     """Generate a structured response (simple generation).
 
     Args:
@@ -97,7 +99,7 @@ async def simple_structured(query: str) -> str:
 
 # Define a simple flow
 @ai.flow(name='simple_echo')
-async def simple_echo(i: str) -> str:
+async def simple_echo(i: Annotated[str, Field(default='Hello, echo!')] = 'Hello, echo!') -> str:
     """Echo input using the model.
 
     Args:

--- a/py/samples/evaluator-demo/src/setup.py
+++ b/py/samples/evaluator-demo/src/setup.py
@@ -31,7 +31,7 @@ class SetupInput(BaseModel):
 
 
 @ai.flow(name='setup')
-async def setup(options: SetupInput | None = None):
+async def setup(options: SetupInput | None = None) -> None:
     """Run initial setup (indexing).
 
     Args:

--- a/py/samples/firestore-retreiver/src/main.py
+++ b/py/samples/firestore-retreiver/src/main.py
@@ -26,7 +26,7 @@ from google.cloud.firestore_v1.vector import Vector
 from genkit.ai import Genkit
 from genkit.plugins.firebase import add_firebase_telemetry, define_firestore_vector_store
 from genkit.plugins.google_genai import VertexAI
-from genkit.types import Document
+from genkit.types import Document, RetrieverResponse
 
 if 'GCLOUD_PROJECT' not in os.environ:
     os.environ['GCLOUD_PROJECT'] = input('Please enter your GCLOUD_PROJECT: ')
@@ -73,13 +73,10 @@ films = [
 @ai.flow()
 async def index_documents() -> None:
     """Indexes the film documents in Firestore."""
-    genkit_documents = [Document.from_text(film) for film in films]
-    embed_response = await ai.embed(embedder=EMBEDDING_MODEL, documents=genkit_documents)
-    embeddings = [emb.embedding for emb in embed_response.embeddings]
-
+    embeddings = await ai.embed_many(embedder=EMBEDDING_MODEL, content=films)
     for i, film_text in enumerate(films):
         doc_id = f'doc-{i + 1}'
-        embedding = embeddings[i]
+        embedding = embeddings[i].embedding
 
         doc_ref = firestore_client.collection(collection_name).document(doc_id)
         try:
@@ -97,7 +94,7 @@ async def index_documents() -> None:
 
 
 @ai.flow()
-async def retreive_documents():
+async def retreive_documents() -> RetrieverResponse:
     """Retrieves the film documents from Firestore."""
     return await ai.retrieve(
         query=Document.from_text('sci-fi film'),

--- a/py/samples/flask-hello/src/main.py
+++ b/py/samples/flask-hello/src/main.py
@@ -17,10 +17,15 @@
 """A simple flow served via a flask server."""
 
 import os
+from typing import Annotated
 
 from flask import Flask
+from pydantic import Field
 
 from genkit.ai import Genkit
+from genkit.blocks.model import GenerateResponseWrapper
+from genkit.core.action import ActionRunContext
+from genkit.core.context import RequestData
 from genkit.plugins.flask import genkit_flask_handler
 from genkit.plugins.google_genai import GoogleAI
 from genkit.plugins.google_genai.models.gemini import GoogleAIGeminiVersion
@@ -36,15 +41,18 @@ ai = Genkit(
 app = Flask(__name__)
 
 
-async def my_context_provider(request):
+async def my_context_provider(request: RequestData) -> dict:
     """Provide a context for the flow."""
-    return {'username': request.headers.get('authorization')}
+    return {'username': request.request.headers.get('authorization')}
 
 
 @app.post('/chat')
 @genkit_flask_handler(ai, context_provider=my_context_provider)
 @ai.flow()
-async def say_hi(name: str, ctx):
+async def say_hi(
+    name: Annotated[str, Field(default='Alice')] = 'Alice',
+    ctx: ActionRunContext = None,  # type: ignore[assignment]
+) -> GenerateResponseWrapper:
     """Say hi to the user."""
     return await ai.generate(
         on_chunk=ctx.send_chunk,

--- a/py/samples/google-genai-code-execution/src/main.py
+++ b/py/samples/google-genai-code-execution/src/main.py
@@ -17,8 +17,10 @@
 """Sample demonstrating code execution using the Google Gemini API with GenAI."""
 
 import os
+from typing import Annotated
 
 import structlog
+from pydantic import Field
 
 from genkit.ai import Genkit
 from genkit.blocks.model import MessageWrapper
@@ -37,8 +39,13 @@ ai = Genkit(
 )
 
 
+DEFAULT_CODE_TASK = 'What is the sum of the first 50 prime numbers?'
+
+
 @ai.flow()
-async def execute_code(task: str) -> MessageWrapper:
+async def execute_code(
+    task: Annotated[str, Field(default=DEFAULT_CODE_TASK)] = DEFAULT_CODE_TASK,
+) -> MessageWrapper:
     """Execute code for the given task.
 
     Args:
@@ -59,7 +66,7 @@ async def execute_code(task: str) -> MessageWrapper:
     return response.message
 
 
-def display_code_execution(message: Message):
+def display_code_execution(message: Message) -> None:
     """Display the code execution results from a message."""
     print('\n=== INTERNAL CODE EXECUTION ===')
     for part in message.content:

--- a/py/samples/google-genai-hello/src/main_vertexai.py
+++ b/py/samples/google-genai-hello/src/main_vertexai.py
@@ -43,7 +43,7 @@ class ThinkingLevel(str, Enum):
 
 
 @ai.flow()
-async def thinking_level_pro(level: ThinkingLevel):
+async def thinking_level_pro(level: ThinkingLevel = ThinkingLevel.LOW) -> str:
     """Gemini 3.0 thinkingLevel config (Pro)."""
     response = await ai.generate(
         model='vertexai/gemini-3-pro-preview',
@@ -76,7 +76,7 @@ class ThinkingLevelFlash(str, Enum):
 
 
 @ai.flow()
-async def thinking_level_flash(level: ThinkingLevelFlash):
+async def thinking_level_flash(level: ThinkingLevelFlash = ThinkingLevelFlash.MEDIUM) -> str:
     """Gemini 3.0 thinkingLevel config (Flash)."""
     response = await ai.generate(
         model='vertexai/gemini-3-flash-preview',
@@ -100,7 +100,7 @@ async def thinking_level_flash(level: ThinkingLevelFlash):
 
 
 @ai.flow()
-async def video_understanding_metadata():
+async def video_understanding_metadata() -> str:
     """Video understanding with metadata."""
     response = await ai.generate(
         model='vertexai/gemini-2.5-flash',
@@ -124,7 +124,7 @@ async def video_understanding_metadata():
 
 
 @ai.flow()
-async def maps_grounding():
+async def maps_grounding() -> str:
     """Google maps grounding."""
     response = await ai.generate(
         model='vertexai/gemini-2.5-flash',
@@ -143,7 +143,7 @@ async def maps_grounding():
 
 
 @ai.flow()
-async def search_grounding():
+async def search_grounding() -> str:
     """Search grounding."""
     response = await ai.generate(
         model='vertexai/gemini-2.5-flash',
@@ -154,7 +154,7 @@ async def search_grounding():
 
 
 @ai.flow()
-async def gemini_media_resolution():
+async def gemini_media_resolution() -> str:
     """Media resolution."""
     # Placeholder base64 for sample
     plant_b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
@@ -174,7 +174,7 @@ async def gemini_media_resolution():
 
 
 @ai.flow()
-async def gemini_image_editing():
+async def gemini_image_editing() -> Media | None:
     """Image editing with Gemini."""
     plant_path = pathlib.Path(__file__).parent.parent / 'palm_tree.png'
     room_path = pathlib.Path(__file__).parent.parent / 'my_room.png'
@@ -205,7 +205,7 @@ async def gemini_image_editing():
 
 
 @ai.flow()
-async def nano_banana_pro():
+async def nano_banana_pro() -> Media | None:
     """Nano banana pro config."""
     response = await ai.generate(
         model='vertexai/gemini-3-pro-image-preview',
@@ -225,7 +225,7 @@ async def nano_banana_pro():
 
 
 @ai.flow()
-async def imagen_image_generation():
+async def imagen_image_generation() -> Media | None:
     """A simple example of image generation with Gemini (Imagen)."""
     response = await ai.generate(
         model='vertexai/imagen-3.0-generate-002',
@@ -254,7 +254,7 @@ def celsius_to_fahrenheit(celsius: float) -> float:
 
 
 @ai.flow()
-async def tool_calling(location: str = 'Paris, France'):
+async def tool_calling(location: str = 'Paris, France') -> str:
     """Tool calling with Gemini."""
     response = await ai.generate(
         model='vertexai/gemini-2.5-flash',

--- a/py/samples/google-genai-image/src/main.py
+++ b/py/samples/google-genai-image/src/main.py
@@ -21,10 +21,11 @@ import base64
 import logging
 import os
 import pathlib
-from typing import Any
+from typing import Annotated, Any
 
 from google import genai
 from google.genai import types as genai_types
+from pydantic import Field
 
 from genkit.ai import Genkit
 from genkit.blocks.model import GenerateResponseWrapper
@@ -52,7 +53,9 @@ ai = Genkit(plugins=[GoogleAI()])
 
 
 @ai.flow()
-async def draw_image_with_gemini(prompt: str = '') -> GenerateResponseWrapper:
+async def draw_image_with_gemini(
+    prompt: Annotated[str, Field(default='Draw a cat in a hat.')] = 'Draw a cat in a hat.',
+) -> GenerateResponseWrapper:
     """Draw an image.
 
     Args:
@@ -61,9 +64,6 @@ async def draw_image_with_gemini(prompt: str = '') -> GenerateResponseWrapper:
     Returns:
         The image.
     """
-    if not prompt:
-        prompt = 'Draw a cat in a hat.'
-
     return await ai.generate(
         prompt=prompt,
         config={'response_modalities': ['Text', 'Image']},
@@ -111,7 +111,10 @@ async def describe_image_with_gemini(data: str = '') -> str:
 
 
 @ai.flow()
-async def generate_images(name: str, ctx: ActionRunContext) -> GenerateResponseWrapper:
+async def generate_images(
+    name: Annotated[str, Field(default='Eiffel Tower')] = 'Eiffel Tower',
+    ctx: ActionRunContext = None,  # type: ignore[assignment]
+) -> GenerateResponseWrapper:
     """Generate images for the given name.
 
     Args:
@@ -144,7 +147,7 @@ def screenshot() -> dict:
 
 
 @ai.flow()
-async def multipart_tool_calling():
+async def multipart_tool_calling() -> str:
     """Multipart tool calling."""
     response = await ai.generate(
         model='googleai/gemini-3-pro-preview',
@@ -156,7 +159,7 @@ async def multipart_tool_calling():
 
 
 @ai.flow()
-async def gemini_image_editing():
+async def gemini_image_editing() -> Media | None:
     """Image editing with Gemini."""
     plant_path = pathlib.Path(__file__).parent.parent / 'palm_tree.png'
     room_path = pathlib.Path(__file__).parent.parent / 'my_room.png'
@@ -187,7 +190,7 @@ async def gemini_image_editing():
 
 
 @ai.flow()
-async def nano_banana_pro():
+async def nano_banana_pro() -> Media | None:
     """Nano banana pro config."""
     response = await ai.generate(
         model='googleai/gemini-3-pro-image-preview',
@@ -208,7 +211,7 @@ async def nano_banana_pro():
 
 
 @ai.flow()
-async def photo_move_veo(_: Any, context: ActionRunContext | None = None):
+async def photo_move_veo(_: Any, context: ActionRunContext | None = None) -> Any:
     """An example of using Ver 3 model to make a static photo move."""
     # Find photo.jpg (or my_room.png)
     room_path = pathlib.Path(__file__).parent.parent / 'my_room.png'
@@ -285,7 +288,7 @@ async def photo_move_veo(_: Any, context: ActionRunContext | None = None):
 
 
 @ai.flow()
-async def gemini_media_resolution():
+async def gemini_media_resolution() -> str:
     """Media resolution."""
     # Placeholder base64 for sample
     plant_path = pathlib.Path(__file__).parent.parent / 'palm_tree.png'
@@ -308,7 +311,7 @@ async def gemini_media_resolution():
 
 
 @ai.flow()
-async def multimodal_input():
+async def multimodal_input() -> str:
     """Multimodal input."""
     photo_path = pathlib.Path(__file__).parent.parent / 'photo.jpg'
     with open(photo_path, 'rb') as f:

--- a/py/samples/menu/src/case_02/tools.py
+++ b/py/samples/menu/src/case_02/tools.py
@@ -19,6 +19,7 @@
 
 import json
 import os
+from typing import Any
 
 from ..menu_ai import ai
 from ..menu_schemas import MenuToolOutputSchema
@@ -29,7 +30,7 @@ with open(menu_json_path) as f:
 
 
 @ai.tool(name='todaysMenu')
-def todays_menu(input=None) -> MenuToolOutputSchema:
+def todays_menu(input: Any = None) -> MenuToolOutputSchema:
     """Use this tool to retrieve all the items on today's menu.
 
     Args:

--- a/py/samples/menu/src/case_03/chats.py
+++ b/py/samples/menu/src/case_03/chats.py
@@ -17,7 +17,7 @@
 
 """Chats for case 03."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from genkit.core.typing import Message
 
@@ -25,8 +25,8 @@ from genkit.core.typing import Message
 class ChatSessionInputSchema(BaseModel):
     """Input for starting a chat session."""
 
-    session_id: str
-    question: str
+    session_id: str = Field(default='demo-session-1', description='Unique session identifier')
+    question: str = Field(default='What dishes do you recommend?', description='Question about the menu')
 
 
 class ChatSessionOutputSchema(BaseModel):
@@ -42,12 +42,12 @@ ChatHistory = list[Message]
 class ChatHistoryStore:
     """Store for chat history."""
 
-    def __init__(self, preamble: ChatHistory | None = None):
+    def __init__(self, preamble: ChatHistory | None = None) -> None:
         """Initialize the store."""
         self.preamble = preamble if preamble is not None else []
         self.sessions: dict[str, ChatHistory] = {}
 
-    def write(self, session_id: str, history: ChatHistory):
+    def write(self, session_id: str, history: ChatHistory) -> None:
         """Write history for a session."""
         self.sessions[session_id] = history
 

--- a/py/samples/menu/src/main.py
+++ b/py/samples/menu/src/main.py
@@ -43,7 +43,7 @@ from .menu_ai import ai
 print('All prompts and flows loaded, use the Developer UI to test them out')
 
 
-async def main():
+async def main() -> None:
     """Keep alive for Dev UI."""
     print('Genkit server running. Press Ctrl+C to stop.')
     # Keep the process alive for Dev UI

--- a/py/samples/model-garden/src/main.py
+++ b/py/samples/model-garden/src/main.py
@@ -16,7 +16,10 @@
 
 """Model Garden sample."""
 
+from typing import Annotated
+
 import structlog
+from pydantic import Field
 
 from genkit.ai import Genkit
 from genkit.plugins.vertex_ai.model_garden import ModelGardenPlugin, model_garden_name
@@ -72,7 +75,7 @@ ai = Genkit(
 
 
 @ai.flow()
-async def jokes_flow(subject: str) -> str:
+async def jokes_flow(subject: Annotated[str, Field(default='banana')] = 'banana') -> str:
     """Generate a joke about the given subject.
 
     Args:

--- a/py/samples/ollama-hello/src/main.py
+++ b/py/samples/ollama-hello/src/main.py
@@ -33,6 +33,8 @@ Key features demonstrated in this sample:
 
 """
 
+from typing import Annotated
+
 import structlog
 from pydantic import BaseModel, Field
 
@@ -100,7 +102,7 @@ class GablorkenInput(BaseModel):
 
 
 @ai.tool()
-def gablorken_tool(input: GablorkenInput):
+def gablorken_tool(input: GablorkenInput) -> int:
     """Calculate a gablorken."""
     return input.value * 3 - 5
 
@@ -118,7 +120,7 @@ def get_weather(input: WeatherToolInput) -> str:
 
 
 @ai.flow()
-async def say_hi(hi_input: str):
+async def say_hi(hi_input: Annotated[str, Field(default='World')] = 'World') -> str:
     """Generate a request to greet a user.
 
     Args:
@@ -135,7 +137,7 @@ async def say_hi(hi_input: str):
 
 
 @ai.flow()
-async def weather_flow(location: str):
+async def weather_flow(location: Annotated[str, Field(default='San Francisco')] = 'San Francisco') -> str:
     """Generate a request to calculate gablorken according to gablorken_tool.
 
     Args:
@@ -157,7 +159,7 @@ async def weather_flow(location: str):
 
 
 @ai.flow()
-async def calculate_gablorken(value: int):
+async def calculate_gablorken(value: Annotated[int, Field(default=33)] = 33) -> str:
     """Generate a request to calculate gablorken according to gablorken_tool.
 
     Args:
@@ -179,7 +181,7 @@ async def calculate_gablorken(value: int):
 
 
 @ai.flow()
-async def say_hi_constrained(hi_input: str) -> str:
+async def say_hi_constrained(hi_input: Annotated[str, Field(default='John Doe')] = 'John Doe') -> str:
     """Generate a request to greet a user with response following `HelloSchema` schema.
 
     Args:

--- a/py/samples/ollama-simple-embed/src/main.py
+++ b/py/samples/ollama-simple-embed/src/main.py
@@ -21,12 +21,12 @@ Pokemon using the Ollama plugin.
 """
 
 from math import sqrt
-from typing import cast
+from typing import Annotated, cast
 
 import structlog
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-from genkit.ai import Document, Genkit
+from genkit.ai import Genkit
 from genkit.plugins.ollama import Ollama, ollama_name
 from genkit.plugins.ollama.constants import OllamaAPITypes
 from genkit.plugins.ollama.embedders import EmbeddingDefinition
@@ -98,13 +98,12 @@ pokemon_list = [
 
 async def embed_pokemons() -> None:
     """Embed the Pokemons."""
-    for pokemon in pokemon_list:
-        embedding_response = await ai.embed(
-            embedder=ollama_name(EMBEDDER_MODEL),
-            documents=[Document.from_text(pokemon.description)],
-        )
-        if embedding_response.embeddings:
-            pokemon.embedding = embedding_response.embeddings[0].embedding
+    embeddings = await ai.embed_many(
+        embedder=ollama_name(EMBEDDER_MODEL),
+        content=[pokemon.description for pokemon in pokemon_list],
+    )
+    for pokemon, embedding in zip(pokemon_list, embeddings, strict=True):
+        pokemon.embedding = embedding.embedding
 
 
 def find_nearest_pokemons(input_embedding: list[float], top_n: int = 3) -> list[PokemonInfo]:
@@ -167,9 +166,9 @@ async def generate_response(question: str) -> GenerateResponse:
     """
     input_embedding = await ai.embed(
         embedder=ollama_name(EMBEDDER_MODEL),
-        documents=[Document.from_text(text=question)],
+        content=question,
     )
-    nearest_pokemon = find_nearest_pokemons(input_embedding.embeddings[0].embedding)
+    nearest_pokemon = find_nearest_pokemons(input_embedding[0].embedding)
     pokemons_context = '\n'.join(f'{pokemon.name}: {pokemon.description}' for pokemon in nearest_pokemon)
 
     return await ai.generate(
@@ -181,7 +180,9 @@ async def generate_response(question: str) -> GenerateResponse:
 @ai.flow(
     name='Pokedex',
 )
-async def pokemon_flow(question: str):
+async def pokemon_flow(
+    question: Annotated[str, Field(default='Who is the best water pokemon?')] = 'Who is the best water pokemon?',
+) -> str:
     """Generate a request to greet a user.
 
     Args:

--- a/py/samples/prompt_demo/src/main.py
+++ b/py/samples/prompt_demo/src/main.py
@@ -19,6 +19,7 @@
 import os
 import weakref
 from pathlib import Path
+from typing import Any
 
 import structlog
 from pydantic import BaseModel, Field
@@ -39,7 +40,7 @@ prompts_path = current_dir.parent / 'prompts'
 ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-3-flash-preview', prompt_dir=prompts_path)
 
 
-def list_helper(data, *args, **kwargs):
+def list_helper(data: Any, *args: Any, **kwargs: Any) -> str:
     """Format a list of strings as bullet points.
 
     Args:
@@ -78,7 +79,7 @@ ai.define_schema('Recipe', Recipe)
 _sticky_prompts = {}
 
 
-async def get_sticky_prompt(name: str, variant: str | None = None):
+async def get_sticky_prompt(name: str, variant: str | None = None) -> Any:
     """Helper to get a prompt and keep it alive."""
     key = f'{name}:{variant}' if variant else name
     if key in _sticky_prompts:
@@ -104,7 +105,7 @@ async def get_sticky_prompt(name: str, variant: str | None = None):
 class ChefInput(BaseModel):
     """Input for the chef flow."""
 
-    food: str
+    food: str = Field(default='banana bread', description='The food to create a recipe for')
 
 
 @ai.flow(name='chef_flow')
@@ -155,8 +156,8 @@ async def robot_chef_flow(input: ChefInput) -> Recipe:
 class StoryInput(BaseModel):
     """Input for the story flow."""
 
-    subject: str
-    personality: str | None = None
+    subject: str = Field(default='a brave little toaster', description='The subject of the story')
+    personality: str | None = Field(default='courageous', description='Optional personality trait')
 
 
 @ai.flow(name='tell_story')
@@ -188,7 +189,7 @@ async def tell_story(input: StoryInput, ctx: ActionRunContext) -> str:
     return full_text
 
 
-async def main():
+async def main() -> None:
     """Run the sample flows."""
     prompts = ai.registry.get_actions_by_kind(ActionKind.PROMPT)
     executable_prompts = ai.registry.get_actions_by_kind(ActionKind.EXECUTABLE_PROMPT)
@@ -213,7 +214,7 @@ async def main():
     # Tell Story Flow (Streaming)
     await logger.ainfo('--- Running Tell Story Flow ---')
     # To demonstrate streaming, we'll iterate over the streamer if calling directly like a flow would be consumed.
-    story_stream, _ = tell_story.stream(StoryInput(subject='a brave little toaster', personality='courageous'))  # type: ignore
+    story_stream, _ = tell_story.stream(StoryInput(subject='a brave little toaster', personality='courageous'))
 
     async for chunk in story_stream:
         print(chunk, end='', flush=True)

--- a/py/samples/tool-interrupts/src/main.py
+++ b/py/samples/tool-interrupts/src/main.py
@@ -42,7 +42,7 @@ class TriviaQuestions(BaseModel):
 
 
 @ai.tool()
-def present_questions(questions: TriviaQuestions, ctx: ToolRunContext):
+def present_questions(questions: TriviaQuestions, ctx: ToolRunContext) -> None:
     """Can present questions to the user, responds with the user' selected answer."""
     ctx.interrupt(questions.model_dump())
 

--- a/py/samples/vertex-ai-vector-search-bigquery/src/main.py
+++ b/py/samples/vertex-ai-vector-search-bigquery/src/main.py
@@ -21,7 +21,7 @@ import time
 
 import structlog
 from google.cloud import aiplatform, bigquery
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from genkit.ai import Genkit
 from genkit.blocks.document import Document
@@ -63,8 +63,8 @@ define_vertex_vector_search_big_query(
 class QueryFlowInputSchema(BaseModel):
     """Input schema."""
 
-    query: str
-    k: int
+    query: str = Field(default='document 1', description='Search query text')
+    k: int = Field(default=5, description='Number of results to return')
 
 
 class QueryFlowOutputSchema(BaseModel):

--- a/py/samples/vertex-ai-vector-search-bigquery/src/setup_env.py
+++ b/py/samples/vertex-ai-vector-search-bigquery/src/setup_env.py
@@ -57,7 +57,7 @@ define_vertex_vector_search_big_query(
 
 
 @ai.flow(name='generateEmbeddings')
-async def generate_embeddings():
+async def generate_embeddings() -> None:
     """Generates document embeddings and upserts them to the Vertex AI Vector Search index.
 
     This flow retrieves data from BigQuery, generates embeddings for the documents,
@@ -98,13 +98,13 @@ async def generate_embeddings():
 
     genkit_documents = [Document(content=[DocumentPart(root=TextPart(text=text))]) for text in results_dict.values()]
 
-    embed_response = await ai.embed(
+    embed_response = await ai.embed_many(
         embedder=f'vertexai/{EMBEDDING_MODEL}',
-        documents=genkit_documents,
+        content=genkit_documents,
         options={'task': 'RETRIEVAL_DOCUMENT', 'output_dimensionality': 128},
     )
 
-    embeddings = [emb.embedding for emb in embed_response.embeddings]
+    embeddings = [emb.embedding for emb in embed_response]
 
     ids = list(results_dict.keys())[: len(embeddings)]
     data_embeddings = list(zip(ids, embeddings, strict=True))

--- a/py/samples/vertex-ai-vector-search-firestore/src/main.py
+++ b/py/samples/vertex-ai-vector-search-firestore/src/main.py
@@ -21,7 +21,7 @@ import time
 
 import structlog
 from google.cloud import aiplatform, firestore
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from genkit.ai import Genkit
 from genkit.blocks.document import Document
@@ -62,8 +62,8 @@ define_vertex_vector_search_firestore(
 class QueryFlowInputSchema(BaseModel):
     """Input schema."""
 
-    query: str
-    k: int
+    query: str = Field(default='document 1', description='Search query text')
+    k: int = Field(default=5, description='Number of results to return')
 
 
 class QueryFlowOutputSchema(BaseModel):

--- a/py/samples/xai-hello/src/main.py
+++ b/py/samples/xai-hello/src/main.py
@@ -25,6 +25,7 @@ Demonstrates:
 """
 
 import os
+from typing import Annotated
 
 import structlog
 from pydantic import BaseModel, Field
@@ -122,7 +123,7 @@ def calculate(input: CalculatorInput) -> dict:
 
 
 @ai.flow()
-async def say_hi(name: str) -> str:
+async def say_hi(name: Annotated[str, Field(default='Alice')] = 'Alice') -> str:
     """Generate a simple greeting.
 
     Args:
@@ -140,7 +141,10 @@ async def say_hi(name: str) -> str:
 
 
 @ai.flow()
-async def say_hi_stream(name: str, ctx: ActionRunContext) -> str:
+async def say_hi_stream(
+    name: Annotated[str, Field(default='Bob')] = 'Bob',
+    ctx: ActionRunContext = None,  # type: ignore[assignment]
+) -> str:
     """Generate a streaming story response.
 
     Args:
@@ -162,7 +166,7 @@ async def say_hi_stream(name: str, ctx: ActionRunContext) -> str:
 
 
 @ai.flow()
-async def say_hi_with_config(name: str) -> str:
+async def say_hi_with_config(name: Annotated[str, Field(default='Charlie')] = 'Charlie') -> str:
     """Generate a greeting with custom model configuration.
 
     Args:
@@ -183,7 +187,7 @@ async def say_hi_with_config(name: str) -> str:
 
 
 @ai.flow()
-async def weather_flow(location: str) -> str:
+async def weather_flow(location: Annotated[str, Field(default='New York')] = 'New York') -> str:
     """Get weather info using the weather tool (direct call).
 
     Args:
@@ -203,7 +207,7 @@ async def weather_flow(location: str) -> str:
 
 
 @ai.flow()
-async def calculator_flow(expression: str) -> str:
+async def calculator_flow(expression: Annotated[str, Field(default='add_5_3')] = 'add_5_3') -> str:
     """Parse and calculate a math expression.
 
     Args:
@@ -227,7 +231,7 @@ async def calculator_flow(expression: str) -> str:
     return f'{operation.title()}({a}, {b}) = {result.get("result")}'
 
 
-async def main():
+async def main() -> None:
     """Main entry point - keep alive for Dev UI."""
     import asyncio
 


### PR DESCRIPTION
CHANGELOG:
- [ ] Refactors the embedding veneer API to match the JS canonical
      implementation with proper singular/batch semantics.

      API Changes:

      - embed(): Now takes singular content (string, Document, or
        DocumentData) instead of a list of documents. Extracts config/version
        from EmbedderRef and merges with options. Returns list of Embedding.

      - embed_many(): Batch embedding for multiple content items. Does NOT
        extract config/version from EmbedderRef (matches JS behavior). Returns
        list of Embedding.

      Both methods now unwrap the EmbedResponse to return embeddings directly.
      Add default values to all Python sample flow parameters to enable
      one-click execution from the Genkit DevUI without requiring manual
      input entry.

      Updates:

      - Updated all embedding plugins to use the new API
      - Updated all samples using embedding to use embed_many
      - Refactored batch embedding loops to use single embed_many calls
      - Added test coverage for embed_many

- [ ] Add default values to flow inpurts for one-click DevUI execution

      Uses `Annotated[type, Field(default=...)]` pattern for flow parameters
      and `Field(default=...)` for Pydantic BaseModel fields, following
      established patterns for DevUI-friendly defaults.

      Samples updated:
      - anthropic-hello
      - compat-oai-hello
      - deepseek-hello
      - flask-hello
      - google-genai-code-execution
      - google-genai-hello
      - google-genai-image
      - google-genai-vertexai-hello
      - model-garden
      - ollama-hello
      - short-n-long
      - xai-hello
      - prompt_demo
      - evaluator-demo
      - menu

      Also fixes failing tests in vertex-ai vector_search plugin by updating
      FakeAI.embed() mock to match current Genkit.embed() signature (uses
      'content' parameter instead of 'documents', returns list[Embedding]
      instead of EmbedResponse).
