### PR TITLE
feat(py/plugins/google-cloud): add GCP telemetry parity with JS/Go implementations

### DIFF
--- a/py/GEMINI.md
+++ b/py/GEMINI.md
@@ -66,6 +66,8 @@
   * When you are not sure about the API or concepts, please refer to the
     JavaScript implementation for the same.
 * Keep examples in documentation and docstrings simple.
+* Add links to relevant documentation on the Web or elsewhere
+  in the relevent places in docstrings.
 
 ### Implementation
 

--- a/py/engdoc/parity-analysis/roadmap.md
+++ b/py/engdoc/parity-analysis/roadmap.md
@@ -4,37 +4,70 @@ This document organizes the identified gaps into executable milestones with depe
 
 ---
 
-## Potential Gaps Not Yet Analyzed
+## Current Status (Updated 2026-01-26)
+
+> [!IMPORTANT]
+> **Overall Parity: ~95% Complete** - Most milestones are done!
+
+### Completed Milestones ✅
+
+| Milestone | Status | Notes |
+|-----------|--------|-------|
+| **M0: Foundation** | ✅ Complete | DevUI config, latency_ms, docs context |
+| **M1: Core APIs** | ✅ Complete | check_operation, run, current_context, dynamic_tool |
+| **M2: Sessions** | ✅ Complete | SessionStore, create/load_session, chat API |
+| **M3: Plugin Parity** | ✅ Complete | Anthropic ThinkingConfig, Google apiVersion/baseUrl |
+| **M4: Telemetry** | ✅ Complete | RealtimeSpanProcessor, flushTracing, AdjustingTraceExporter, GCP parity |
+| **M5: Advanced** | ⚠️ 80% | embed_many ✅, define_simple_retriever ✅, define_background_model ❌ |
+
+### Remaining Work
+
+| Priority | Task | Effort | Status |
+|----------|------|--------|--------|
+| **P0** | Testing Infrastructure (`genkit.testing`) | S | ✅ Complete |
+| **P0** | Context Caching (google-genai) | M | ✅ Complete |
+| **P1** | `define_background_model()` | M | ❌ Not Started |
+| **P1** | Live/Realtime API | L | ❌ Not Started |
+| **P2** | Multi-agent sample | M | ❌ Not Started |
+| **P2** | MCP sample | M | ❌ Not Started |
+
+---
+
+## Remaining Gaps (Prioritized)
 
 > [!NOTE]
-> These areas may require future analysis but are not yet covered in detail.
+> Most original gaps have been addressed. These are the remaining items.
 
-| Gap | Description | Priority |
-|-----|-------------|----------|
-| **Testing Infrastructure** | JS has `echoModel`, `ProgrammableModel`, `TestAction` for unit testing. Python equivalents need verification. | Medium |
-| **CLI/Tooling Parity** | `genkit` CLI commands and their behavior with Python projects (especially DevUI integration) | Medium |
-| **Error Types** | JS has `GenkitError`, `ModelError`, `UserFacingError`. Python error hierarchy needs parity check. | Low |
-| **Context Caching** | Listed as missing plugin feature but no detailed implementation analysis | High |
-| **Auth/Security Patterns** | How auth context flows through actions, middleware patterns for auth | Medium |
-| **Performance Benchmarks** | Streaming latency, memory usage, concurrent request handling | Low |
-| **Migration Guide** | Documentation for teams moving from JS to Python | Low |
-| **Go Parity** | This analysis is JS↔Python only. Go is a third implementation with its own gaps. | Low |
-| **Imagen/Veo Details** | Image/video generation model support specifics | Medium |
-| **Live/Realtime API** | Google GenAI Live API for real-time streaming | High |
+| Gap | Description | Priority | Status |
+|-----|-------------|----------|--------|
+| **Testing Infrastructure** | JS has `echoModel`, `ProgrammableModel`, `TestAction` for unit testing. | **P0** | 🔄 In Progress |
+| **Context Caching** | `ai.cacheContent()`, `cachedContent` option in generate | **P0** | 🔄 In Progress |
+| **define_background_model** | Needed for Veo, Imagen async operations | **P1** | ❌ Not Started |
+| **Live/Realtime API** | Google GenAI Live API for real-time streaming | **P1** | ❌ Not Started |
+| **CLI/Tooling Parity** | `genkit` CLI commands and Python project behavior | Medium | ⚠️ Mostly Working |
+| **Error Types** | Python error hierarchy parity check | Low | ⚠️ Needs Review |
+| **Auth/Security Patterns** | Auth context flow through actions | Medium | ⚠️ Needs Review |
+| **Performance Benchmarks** | Streaming latency, memory usage | Low | ❌ Not Started |
+| **Migration Guide** | Documentation for JS to Python migration | Low | ❌ Not Started |
 
-### Quick Notes on Key Gaps
+### Phase 1 Tasks ✅ COMPLETE (2026-01-26)
 
-**Testing Infrastructure:**
-- JS: `import { echoModel } from '@genkit-ai/ai/testing'`
-- Python: Needs `genkit.testing` module with equivalent utilities
+**1. Testing Infrastructure (`genkit.testing` module)** ✅
+- Location: `py/packages/genkit/src/genkit/testing.py`
+- Implemented:
+  - `EchoModel` / `define_echo_model()` - Returns input as output for testing
+  - `ProgrammableModel` / `define_programmable_model()` - Configurable responses
+  - `StaticResponseModel` / `define_static_response_model()` - Fixed responses
+  - Streaming support with countdown ("3", "2", "1")
+  - Request tracking (`last_request`, `request_count`)
 
-**Context Caching:**
-- JS: `ai.cacheContent()`, `cachedContent` option in generate
-- Python: Missing entirely from google-genai plugin
-
-**Live/Realtime API:**
-- JS: `ai.generate({ model: 'googleai/gemini-live' })` with real-time streaming
-- Python: Not implemented
+**2. Context Caching (google-genai plugin)** ✅
+- Location: `py/plugins/google-genai/src/.../models/context_caching/`
+- Already implemented:
+  - `_retrieve_cached_content()` - Cache lookup/creation
+  - `_build_messages()` - Extracts cache config from message metadata
+  - Model integration with `cached_content` option
+  - Supported models: gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash, etc.
 
 ---
 

--- a/py/packages/genkit/src/genkit/testing.py
+++ b/py/packages/genkit/src/genkit/testing.py
@@ -3,7 +3,45 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Testing utils/helpers for genkit.blocks."""
+"""Testing utilities for Genkit applications.
+
+This module provides mock models and utilities for testing Genkit applications
+without making actual API calls to AI providers.
+
+Key Components:
+    - EchoModel: Echoes input back for verification
+    - ProgrammableModel: Returns configurable responses
+    - StaticResponseModel: Always returns the same response
+
+Example:
+    ```python
+    from genkit.ai import Genkit
+    from genkit.testing import define_echo_model, define_programmable_model
+
+    ai = Genkit()
+
+    # Echo model - useful for verifying request formatting
+    echo, echo_action = define_echo_model(ai)
+    response = await ai.generate(model='echoModel', prompt='Hello')
+    # response contains: "[ECHO] user: "Hello""
+
+    # Programmable model - useful for testing specific scenarios
+    pm, pm_action = define_programmable_model(ai)
+    pm.responses = [GenerateResponse(message=Message(...))]
+    response = await ai.generate(model='programmableModel', prompt='test')
+    assert pm.last_request is not None
+    ```
+
+Cross-Language Parity:
+    - JavaScript: js/genkit/tests/helpers.ts, js/ai/tests/helpers.ts
+    - Go: go/ai/testutil_test.go
+
+See Also:
+    - https://firebase.google.com/docs/genkit for Genkit documentation
+"""
+
+from copy import deepcopy
+from typing import Any
 
 from genkit.ai import Genkit
 from genkit.codec import dump_json
@@ -27,18 +65,48 @@ class ProgrammableModel:
     scenarios.
 
     Attributes:
-        request_idx: Index tracking which request is being processed.
+        request_count: Total number of requests received.
         responses: List of predefined responses to return.
         chunks: Optional list of chunks to stream for each request.
-        last_request: The most recent request received.
+        last_request: The most recent request received (deep copy).
+
+    Example:
+        ```python
+        ai = Genkit()
+        pm, action = define_programmable_model(ai)
+
+        # Set up responses
+        pm.responses = [
+            GenerateResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='Response 1'))])),
+            GenerateResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='Response 2'))])),
+        ]
+
+        # First call returns "Response 1"
+        result1 = await ai.generate(model='programmableModel', prompt='test')
+
+        # Second call returns "Response 2"
+        result2 = await ai.generate(model='programmableModel', prompt='test')
+
+        # Inspect last request
+        assert pm.last_request.messages[0].content[0].root.text == 'test'
+        ```
     """
 
     def __init__(self) -> None:
         """Initialize a new ProgrammableModel instance."""
-        self.request_idx = 0
+        self._request_idx = 0
+        self.request_count = 0
         self.responses: list[GenerateResponse] = []
-        self.chunks: list[list[GenerateResponseChunk]] = None
-        self.last_request: GenerateRequest = None
+        self.chunks: list[list[GenerateResponseChunk]] | None = None
+        self.last_request: GenerateRequest | None = None
+
+    def reset(self) -> None:
+        """Reset the model state for reuse in tests."""
+        self._request_idx = 0
+        self.request_count = 0
+        self.responses = []
+        self.chunks = None
+        self.last_request = None
 
     def model_fn(self, request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
         """Process a generation request and return a programmed response.
@@ -52,18 +120,64 @@ class ProgrammableModel:
 
         Returns:
             The pre-configured response for the current request.
+
+        Raises:
+            IndexError: If more requests are made than responses configured.
         """
-        self.last_request = request
-        response = self.responses[self.request_idx]
-        if self.chunks:
-            for chunk in self.chunks[self.request_idx]:
+        # Store deep copy of request for inspection (matches JS behavior)
+        self.last_request = deepcopy(request)
+        self.request_count += 1
+
+        response = self.responses[self._request_idx]
+        if self.chunks and self._request_idx < len(self.chunks):
+            for chunk in self.chunks[self._request_idx]:
                 ctx.send_chunk(chunk)
-        self.request_idx += 1
+        self._request_idx += 1
         return response
 
 
-def define_programmable_model(ai: Genkit, name: str = 'programmableModel') -> tuple[ProgrammableModel, Action]:
-    """Defines a configurable programmable model."""
+def define_programmable_model(
+    ai: Genkit,
+    name: str = 'programmableModel',
+) -> tuple[ProgrammableModel, Action]:
+    """Define a configurable programmable model for testing.
+
+    Creates a model that returns pre-configured responses, useful for
+    testing specific scenarios like multi-turn conversations, tool calls,
+    or error conditions.
+
+    Args:
+        ai: The Genkit instance to register the model with.
+        name: The name for the model. Defaults to 'programmableModel'.
+
+    Returns:
+        A tuple of (ProgrammableModel instance, registered Action).
+
+    Example:
+        ```python
+        ai = Genkit()
+        pm, action = define_programmable_model(ai)
+
+        # Configure response with tool call
+        pm.responses = [
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[
+                        Part(
+                            root=ToolRequestPart(
+                                tool_request=ToolRequest(
+                                    name='myTool',
+                                    input={'arg': 'value'},
+                                ),
+                            )
+                        )
+                    ],
+                )
+            )
+        ]
+        ```
+    """
     pm = ProgrammableModel()
 
     def model_fn(request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
@@ -75,35 +189,59 @@ def define_programmable_model(ai: Genkit, name: str = 'programmableModel') -> tu
 
 
 class EchoModel:
-    """A simple model implementation that echoes back the input.
+    """A model implementation that echoes back the input with metadata.
 
     This model is useful for testing as it returns a readable representation
-    of the input it received.
+    of the input it received, including config, tools, and output schema.
+
+    The echo format is:
+        [ECHO] role: "content", role: "content" config tool_choice output
 
     Attributes:
         last_request: The most recent request received.
+        stream_countdown: If True, streams "3", "2", "1" chunks before response.
+
+    Example:
+        ```python
+        ai = Genkit()
+        echo, action = define_echo_model(ai, stream_countdown=True)
+
+        response = await ai.generate(model='echoModel', prompt='Hello world', config={'temperature': 0.5})
+        # Response text: '[ECHO] user: "Hello world" {"temperature":0.5}'
+        # With streaming: sends chunks "3", "2", "1" before final response
+        ```
     """
 
-    def __init__(self) -> None:
-        """Initialize a new EchoModel instance."""
-        self.last_request: GenerateRequest = None
+    def __init__(self, stream_countdown: bool = False) -> None:
+        """Initialize a new EchoModel instance.
 
-    def model_fn(self, request: GenerateRequest) -> GenerateResponse:
+        Args:
+            stream_countdown: If True, stream "3", "2", "1" chunks before response.
+        """
+        self.last_request: GenerateRequest | None = None
+        self.stream_countdown = stream_countdown
+
+    def model_fn(self, request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
         """Process a generation request and echo it back in the response.
 
         Args:
             request: The generation request to process.
+            ctx: The action run context for streaming.
 
         Returns:
             A response containing an echo of the input request details.
         """
         self.last_request = request
+
+        # Build echo string from messages
         merged_txt = ''
         for m in request.messages:
             merged_txt += f' {m.role}: ' + ','.join(
                 dump_json(p.root.text) if p.root.text is not None else '""' for p in m.content
             )
         echo_resp = f'[ECHO]{merged_txt}'
+
+        # Add config, tools, and output info
         if request.config:
             echo_resp += f' {dump_json(request.config)}'
         if request.tools:
@@ -112,18 +250,136 @@ class EchoModel:
             echo_resp += f' tool_choice={request.tool_choice}'
         if request.output and dump_json(request.output) != '{}':
             echo_resp += f' output={dump_json(request.output)}'
+
+        # Stream countdown chunks if enabled (matches JS behavior)
+        if self.stream_countdown:
+            for i, countdown in enumerate(['3', '2', '1']):
+                ctx.send_chunk(
+                    chunk=GenerateResponseChunk(role=Role.MODEL, index=i, content=[Part(root=TextPart(text=countdown))])
+                )
+
         # NOTE: Part is a RootModel requiring root=TextPart(...) syntax.
         return GenerateResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text=echo_resp))]))
 
 
-def define_echo_model(ai: Genkit, name: str = 'echoModel') -> tuple[EchoModel, Action]:
-    """Defines a simple echo model that echos requests."""
-    echo = EchoModel()
+def define_echo_model(
+    ai: Genkit,
+    name: str = 'echoModel',
+    stream_countdown: bool = False,
+) -> tuple[EchoModel, Action]:
+    """Define an echo model that returns input back as output.
 
-    # NOTE: model_fn requires ctx parameter to match ModelFn signature.
+    Creates a model that echoes the request back in a readable format,
+    useful for testing request formatting and middleware behavior.
+
+    Args:
+        ai: The Genkit instance to register the model with.
+        name: The name for the model. Defaults to 'echoModel'.
+        stream_countdown: If True, stream "3", "2", "1" before final response.
+
+    Returns:
+        A tuple of (EchoModel instance, registered Action).
+
+    Example:
+        ```python
+        ai = Genkit()
+        echo, action = define_echo_model(ai, stream_countdown=True)
+
+        # Test that middleware properly formats requests
+        response = await ai.generate(model='echoModel', prompt='test')
+        assert '[ECHO]' in response.text
+        ```
+    """
+    echo = EchoModel(stream_countdown=stream_countdown)
+
     def model_fn(request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
-        return echo.model_fn(request)
+        return echo.model_fn(request, ctx)
 
     action = ai.define_model(name=name, fn=model_fn)
 
     return (echo, action)
+
+
+class StaticResponseModel:
+    """A model that always returns the same static response.
+
+    Useful for simple test cases where a fixed response is needed.
+
+    Attributes:
+        response_message: The message to always return.
+        last_request: The most recent request received.
+        request_count: Total number of requests received.
+    """
+
+    def __init__(self, message: dict[str, Any]) -> None:
+        """Initialize with a static message to return.
+
+        Args:
+            message: The message data to always return.
+        """
+        self.response_message = message
+        self.last_request: GenerateRequest | None = None
+        self.request_count = 0
+
+    def model_fn(self, request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        """Return the static response.
+
+        Args:
+            request: The generation request (stored but not used).
+            ctx: The action run context (unused).
+
+        Returns:
+            GenerateResponse with the static message.
+        """
+        self.last_request = request
+        self.request_count += 1
+        return GenerateResponse(message=Message.model_validate(self.response_message))
+
+
+def define_static_response_model(
+    ai: Genkit,
+    message: dict[str, Any],
+    name: str = 'staticModel',
+) -> tuple[StaticResponseModel, Action]:
+    """Define a model that always returns the same response.
+
+    Args:
+        ai: The Genkit instance to register the model with.
+        message: The message data to always return.
+        name: The name for the model. Defaults to 'staticModel'.
+
+    Returns:
+        A tuple of (StaticResponseModel instance, registered Action).
+
+    Example:
+        ```python
+        ai = Genkit()
+        static, action = define_static_response_model(
+            ai,
+            message={'role': 'model', 'content': [{'text': 'Hello!'}]},
+        )
+
+        # Always returns "Hello!"
+        response = await ai.generate(model='staticModel', prompt='anything')
+        assert response.text == 'Hello!'
+        ```
+    """
+    static = StaticResponseModel(message)
+
+    def model_fn(request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        return static.model_fn(request, ctx)
+
+    action = ai.define_model(name=name, fn=model_fn)
+
+    return (static, action)
+
+
+# Export all public symbols
+__all__ = [
+    'EchoModel',
+    'ProgrammableModel',
+    'StaticResponseModel',
+    'define_echo_model',
+    'define_programmable_model',
+    'define_static_response_model',
+]

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/__init__.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/__init__.py
@@ -14,7 +14,60 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Telemetry exports for Google Cloud plugin."""
+"""Google Cloud telemetry integration for Genkit.
+
+This package provides telemetry export to Google Cloud's observability suite,
+enabling monitoring and debugging of Genkit applications through Cloud Trace,
+Cloud Monitoring, and Cloud Logging.
+
+Module Structure:
+    ┌─────────────────────────────────────────────────────────────────────────┐
+    │ Module          │ Purpose                                               │
+    ├─────────────────┼───────────────────────────────────────────────────────┤
+    │ tracing.py      │ Main entry point, exporters, configuration            │
+    │ feature.py      │ Root span metrics (requests, latency)                 │
+    │ path.py         │ Error path tracking and failure metrics               │
+    │ generate.py     │ Model/generate metrics (tokens, latency, media)       │
+    │ action.py       │ Action I/O logging (tools, flows)                     │
+    │ engagement.py   │ User feedback and acceptance metrics                  │
+    │ metrics.py      │ Metric definitions and lazy initialization            │
+    │ utils.py        │ Shared utilities (truncation, path parsing, logging)  │
+    └─────────────────┴───────────────────────────────────────────────────────┘
+
+Quick Start:
+    ```python
+    from genkit.plugins.google_cloud import add_gcp_telemetry
+
+    # Enable telemetry with defaults (PII redaction enabled)
+    add_gcp_telemetry()
+
+    # Or with custom options
+    add_gcp_telemetry(
+        project_id='my-project',
+        log_input_and_output=True,  # Disable PII redaction (caution!)
+    )
+    ```
+
+Cross-Language Parity:
+    This implementation maintains feature parity with:
+    - JavaScript: js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+    - Go: go/plugins/googlecloud/ and go/plugins/firebase/telemetry.go
+
+See Also:
+    - tracing.py module docstring for detailed architecture documentation
+
+GCP Documentation:
+    Cloud Trace:
+        - Overview: https://cloud.google.com/trace/docs
+        - IAM Roles: https://cloud.google.com/trace/docs/iam
+
+    Cloud Monitoring:
+        - Overview: https://cloud.google.com/monitoring/docs
+        - Quotas & Limits: https://cloud.google.com/monitoring/quotas
+
+    OpenTelemetry GCP:
+        - Python Exporters: https://google-cloud-opentelemetry.readthedocs.io/
+"""
 
 from .tracing import add_gcp_telemetry
 

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/action.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/action.py
@@ -1,0 +1,124 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Action telemetry for GCP.
+
+This module logs input/output for tool and generate actions,
+matching the JavaScript implementation.
+
+Logging:
+    When log_input_and_output=True, logs action inputs and outputs to
+    Cloud Logging with structured attributes for correlation.
+
+Cross-Language Parity:
+    - JavaScript: js/plugins/google-cloud/src/telemetry/action.ts
+    - Go: go/plugins/googlecloud/action.go
+
+See Also:
+    - Cloud Logging: https://cloud.google.com/logging/docs
+    - Structured Logging: https://cloud.google.com/logging/docs/structured-logging
+"""
+
+from __future__ import annotations
+
+import structlog
+from opentelemetry.sdk.trace import ReadableSpan
+
+from .utils import (
+    create_common_log_attributes,
+    extract_outer_feature_name_from_path,
+    to_display_path,
+    truncate,
+    truncate_path,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class ActionTelemetry:
+    """Telemetry handler for Genkit actions (tools, generate)."""
+
+    def tick(
+        self,
+        span: ReadableSpan,
+        log_input_and_output: bool,
+        project_id: str | None = None,
+    ) -> None:
+        """Record telemetry for an action span.
+
+        Only logs input/output if log_input_and_output is True.
+
+        Args:
+            span: The span to record telemetry for.
+            log_input_and_output: Whether to log input/output.
+            project_id: Optional GCP project ID.
+        """
+        if not log_input_and_output:
+            return
+
+        attrs = span.attributes or {}
+        action_name = str(attrs.get('genkit:name', '')) or '<unknown>'
+        subtype = str(attrs.get('genkit:metadata:subtype', ''))
+
+        # Only log for tools and generate actions
+        if subtype != 'tool' and action_name != 'generate':
+            return
+
+        path = str(attrs.get('genkit:path', '')) or '<unknown>'
+        input_val = truncate(str(attrs.get('genkit:input', '')))
+        output_val = truncate(str(attrs.get('genkit:output', '')))
+        session_id = str(attrs.get('genkit:sessionId', '')) or None
+        thread_name = str(attrs.get('genkit:threadName', '')) or None
+
+        feature_name = extract_outer_feature_name_from_path(path)
+        if not feature_name or feature_name == '<unknown>':
+            feature_name = action_name
+
+        if input_val:
+            self._write_log(span, 'Input', feature_name, path, input_val, project_id, session_id, thread_name)
+        if output_val:
+            self._write_log(span, 'Output', feature_name, path, output_val, project_id, session_id, thread_name)
+
+    def _write_log(
+        self,
+        span: ReadableSpan,
+        tag: str,
+        feature_name: str,
+        qualified_path: str,
+        content: str,
+        project_id: str | None,
+        session_id: str | None,
+        thread_name: str | None,
+    ) -> None:
+        """Write a structured log entry."""
+        path = truncate_path(to_display_path(qualified_path))
+        metadata = {
+            **create_common_log_attributes(span, project_id),
+            'path': path,
+            'qualifiedPath': qualified_path,
+            'featureName': feature_name,
+            'content': content,
+        }
+        if session_id:
+            metadata['sessionId'] = session_id
+        if thread_name:
+            metadata['threadName'] = thread_name
+
+        logger.info(f'{tag}[{path}, {feature_name}]', **metadata)
+
+
+# Singleton instance
+action_telemetry = ActionTelemetry()

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/engagement.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/engagement.py
@@ -1,0 +1,170 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Engagement telemetry for GCP.
+
+This module tracks user feedback and acceptance metrics,
+matching the JavaScript implementation.
+
+Metrics Recorded:
+    - genkit/engagement/feedback: Counter for user feedback events
+    - genkit/engagement/acceptance: Counter for user acceptance events
+
+Cross-Language Parity:
+    - JavaScript: js/plugins/google-cloud/src/telemetry/engagement.ts
+    - Go: go/plugins/googlecloud/engagement.go
+
+See Also:
+    - Cloud Monitoring Custom Metrics: https://cloud.google.com/monitoring/custom-metrics
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import structlog
+from opentelemetry import metrics
+from opentelemetry.sdk.trace import ReadableSpan
+
+from genkit.core import GENKIT_VERSION
+
+from .utils import create_common_log_attributes, truncate
+
+logger = structlog.get_logger(__name__)
+
+# Lazy-initialized metrics
+_feedback_counter: metrics.Counter | None = None
+_acceptance_counter: metrics.Counter | None = None
+
+
+def _get_feedback_counter() -> metrics.Counter:
+    """Get or create the user feedback counter."""
+    global _feedback_counter
+    if _feedback_counter is None:
+        meter = metrics.get_meter('genkit')
+        _feedback_counter = meter.create_counter(
+            'genkit/engagement/feedback',
+            description='Counts user feedback events.',
+            unit='1',
+        )
+    return _feedback_counter
+
+
+def _get_acceptance_counter() -> metrics.Counter:
+    """Get or create the user acceptance counter."""
+    global _acceptance_counter
+    if _acceptance_counter is None:
+        meter = metrics.get_meter('genkit')
+        _acceptance_counter = meter.create_counter(
+            'genkit/engagement/acceptance',
+            description='Tracks user acceptance events.',
+            unit='1',
+        )
+    return _acceptance_counter
+
+
+class EngagementTelemetry:
+    """Telemetry handler for user engagement (feedback, acceptance)."""
+
+    def tick(
+        self,
+        span: ReadableSpan,
+        log_input_and_output: bool,
+        project_id: str | None = None,
+    ) -> None:
+        """Record telemetry for a user engagement span.
+
+        Args:
+            span: The span to record telemetry for.
+            log_input_and_output: Whether to log input/output (unused here).
+            project_id: Optional GCP project ID.
+        """
+        attrs: dict[str, Any] = dict(span.attributes) if span.attributes else {}
+        subtype = str(attrs.get('genkit:metadata:subtype', ''))
+
+        if subtype == 'userFeedback':
+            self._write_user_feedback(span, attrs, project_id)
+        elif subtype == 'userAcceptance':
+            self._write_user_acceptance(span, attrs, project_id)
+        else:
+            logger.warning('Unknown user engagement subtype', subtype=subtype)
+
+    def _write_user_feedback(
+        self,
+        span: ReadableSpan,
+        attrs: dict[str, Any],
+        project_id: str | None,
+    ) -> None:
+        """Record user feedback metrics and logs."""
+        name = self._extract_trace_name(attrs)
+        feedback_value = attrs.get('genkit:metadata:feedbackValue')
+        text_feedback = attrs.get('genkit:metadata:textFeedback')
+
+        dimensions = {
+            'name': str(name)[:256],
+            'value': str(feedback_value)[:256] if feedback_value else '',
+            'hasText': str(bool(text_feedback)),
+            'source': 'py',
+            'sourceVersion': GENKIT_VERSION,
+        }
+        _get_feedback_counter().add(1, dimensions)
+
+        metadata: dict[str, Any] = {
+            **create_common_log_attributes(span, project_id),
+            'feedbackValue': feedback_value,
+        }
+        if text_feedback:
+            metadata['textFeedback'] = truncate(str(text_feedback))
+
+        logger.info(f'UserFeedback[{name}]', **metadata)
+
+    def _write_user_acceptance(
+        self,
+        span: ReadableSpan,
+        attrs: dict[str, Any],
+        project_id: str | None,
+    ) -> None:
+        """Record user acceptance metrics and logs."""
+        name = self._extract_trace_name(attrs)
+        acceptance_value = attrs.get('genkit:metadata:acceptanceValue')
+
+        dimensions = {
+            'name': str(name)[:256],
+            'value': str(acceptance_value)[:256] if acceptance_value else '',
+            'source': 'py',
+            'sourceVersion': GENKIT_VERSION,
+        }
+        _get_acceptance_counter().add(1, dimensions)
+
+        metadata = {
+            **create_common_log_attributes(span, project_id),
+            'acceptanceValue': acceptance_value,
+        }
+        logger.info(f'UserAcceptance[{name}]', **metadata)
+
+    def _extract_trace_name(self, attrs: dict[str, Any]) -> str:
+        """Extract the trace name from span attributes."""
+        path = str(attrs.get('genkit:path', ''))
+        if not path or path == '<unknown>':
+            return '<unknown>'
+
+        match = re.search(r'/{(.+)}', path)
+        return match.group(1) if match else '<unknown>'
+
+
+# Singleton instance
+engagement_telemetry = EngagementTelemetry()

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/feature.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/feature.py
@@ -1,0 +1,186 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Feature telemetry for GCP.
+
+This module tracks feature-level metrics (requests, latencies) and logs
+input/output for root spans, matching the JavaScript implementation.
+
+Metrics Recorded:
+    - genkit/feature/requests: Counter for root span calls
+    - genkit/feature/latency: Histogram for root span latency (ms)
+
+Cross-Language Parity:
+    - JavaScript: js/plugins/google-cloud/src/telemetry/feature.ts
+    - Go: go/plugins/googlecloud/feature.go
+
+See Also:
+    - Cloud Monitoring Custom Metrics: https://cloud.google.com/monitoring/custom-metrics
+"""
+
+from __future__ import annotations
+
+import structlog
+from opentelemetry import metrics
+from opentelemetry.sdk.trace import ReadableSpan
+
+from genkit.core import GENKIT_VERSION
+
+from .utils import (
+    create_common_log_attributes,
+    extract_error_name,
+    to_display_path,
+    truncate,
+    truncate_path,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Lazy-initialized metrics
+_feature_counter: metrics.Counter | None = None
+_feature_latency: metrics.Histogram | None = None
+
+
+def _get_feature_counter() -> metrics.Counter:
+    """Get or create the feature requests counter."""
+    global _feature_counter
+    if _feature_counter is None:
+        meter = metrics.get_meter('genkit')
+        _feature_counter = meter.create_counter(
+            'genkit/feature/requests',
+            description='Counts calls to genkit features.',
+            unit='1',
+        )
+    return _feature_counter
+
+
+def _get_feature_latency() -> metrics.Histogram:
+    """Get or create the feature latency histogram."""
+    global _feature_latency
+    if _feature_latency is None:
+        meter = metrics.get_meter('genkit')
+        _feature_latency = meter.create_histogram(
+            'genkit/feature/latency',
+            description='Latencies when calling Genkit features.',
+            unit='ms',
+        )
+    return _feature_latency
+
+
+class FeaturesTelemetry:
+    """Telemetry handler for Genkit features (root spans)."""
+
+    def tick(
+        self,
+        span: ReadableSpan,
+        log_input_and_output: bool,
+        project_id: str | None = None,
+    ) -> None:
+        """Record telemetry for a feature span.
+
+        Args:
+            span: The span to record telemetry for.
+            log_input_and_output: Whether to log input/output.
+            project_id: Optional GCP project ID.
+        """
+        attrs = span.attributes or {}
+        name = str(attrs.get('genkit:name', '<unknown>'))
+        path = str(attrs.get('genkit:path', ''))
+        state = str(attrs.get('genkit:state', ''))
+
+        # Calculate latency
+        latency_ms = 0.0
+        if span.end_time and span.start_time:
+            latency_ms = (span.end_time - span.start_time) / 1_000_000
+
+        if state == 'success':
+            self._write_feature_success(name, latency_ms)
+        elif state == 'error':
+            error_name = extract_error_name(list(span.events)) or '<unknown>'
+            self._write_feature_failure(name, latency_ms, error_name)
+        else:
+            logger.warning('Unknown state', state=state)
+            return
+
+        if log_input_and_output:
+            input_val = truncate(str(attrs.get('genkit:input', '')))
+            output_val = truncate(str(attrs.get('genkit:output', '')))
+            session_id = str(attrs.get('genkit:sessionId', '')) or None
+            thread_name = str(attrs.get('genkit:threadName', '')) or None
+
+            if input_val:
+                self._write_log(span, 'Input', name, path, input_val, project_id, session_id, thread_name)
+            if output_val:
+                self._write_log(span, 'Output', name, path, output_val, project_id, session_id, thread_name)
+
+    def _write_feature_success(self, feature_name: str, latency_ms: float) -> None:
+        """Record success metrics for a feature."""
+        dimensions = {
+            'name': feature_name[:256],
+            'status': 'success',
+            'source': 'py',
+            'sourceVersion': GENKIT_VERSION,
+        }
+        _get_feature_counter().add(1, dimensions)
+        _get_feature_latency().record(latency_ms, dimensions)
+
+    def _write_feature_failure(
+        self,
+        feature_name: str,
+        latency_ms: float,
+        error_name: str,
+    ) -> None:
+        """Record failure metrics for a feature."""
+        dimensions = {
+            'name': feature_name[:256],
+            'status': 'failure',
+            'source': 'py',
+            'sourceVersion': GENKIT_VERSION,
+            'error': error_name[:256],
+        }
+        _get_feature_counter().add(1, dimensions)
+        _get_feature_latency().record(latency_ms, dimensions)
+
+    def _write_log(
+        self,
+        span: ReadableSpan,
+        tag: str,
+        feature_name: str,
+        qualified_path: str,
+        content: str,
+        project_id: str | None,
+        session_id: str | None,
+        thread_name: str | None,
+    ) -> None:
+        """Write a structured log entry."""
+        path = truncate_path(to_display_path(qualified_path))
+        metadata = {
+            **create_common_log_attributes(span, project_id),
+            'path': path,
+            'qualifiedPath': qualified_path,
+            'featureName': feature_name,
+            'content': content,
+        }
+        if session_id:
+            metadata['sessionId'] = session_id
+        if thread_name:
+            metadata['threadName'] = thread_name
+
+        logger.info(f'{tag}[{path}, {feature_name}]', **metadata)
+
+
+# Singleton instance
+features_telemetry = FeaturesTelemetry()

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/generate.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/generate.py
@@ -1,0 +1,608 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate action telemetry for GCP.
+
+This module tracks generate action metrics (tokens, latencies) and logs,
+matching the JavaScript implementation in telemetry/generate.ts and Go
+implementation in googlecloud/generate.go.
+
+When It Fires:
+    The generate telemetry handler is called for spans where:
+    - genkit:type = "action"
+    - genkit:metadata:subtype = "model"
+
+Metrics Recorded:
+    ┌─────────────────────────────────────────────────────────────────────────┐
+    │ Metric Name                          │ Type      │ Description          │
+    ├──────────────────────────────────────┼───────────┼──────────────────────┤
+    │ genkit/ai/generate/requests          │ Counter   │ Model call count     │
+    │ genkit/ai/generate/latency           │ Histogram │ Response time (ms)   │
+    │ genkit/ai/generate/input/tokens      │ Counter   │ Input token count    │
+    │ genkit/ai/generate/input/characters  │ Counter   │ Input char count     │
+    │ genkit/ai/generate/input/images      │ Counter   │ Input image count    │
+    │ genkit/ai/generate/input/videos      │ Counter   │ Input video count    │
+    │ genkit/ai/generate/input/audio       │ Counter   │ Input audio count    │
+    │ genkit/ai/generate/output/tokens     │ Counter   │ Output token count   │
+    │ genkit/ai/generate/output/characters │ Counter   │ Output char count    │
+    │ genkit/ai/generate/output/images     │ Counter   │ Output image count   │
+    │ genkit/ai/generate/output/videos     │ Counter   │ Output video count   │
+    │ genkit/ai/generate/output/audio      │ Counter   │ Output audio count   │
+    │ genkit/ai/generate/thinking/tokens   │ Counter   │ Thinking token count │
+    └──────────────────────────────────────┴───────────┴──────────────────────┘
+
+Metric Dimensions:
+    All metrics include these dimensions:
+    - modelName: The model name (e.g., "gemini-2.0-flash")
+    - featureName: The outer flow/feature name
+    - path: The qualified Genkit path
+    - status: "success" or "failure"
+    - error: Error name (only on failure)
+    - source: "py" (language identifier)
+    - sourceVersion: Genkit version
+
+Logs Recorded:
+    1. Config logs (always): Model configuration (maxOutputTokens, stopSequences)
+    2. Input logs (when log_input_and_output=True): Per-message, per-part input
+    3. Output logs (when log_input_and_output=True): Per-part output content
+
+Log Format:
+    - Config[path, model] - Model configuration
+    - Input[path, model] (part X of Y) - Input content with part indices
+    - Output[path, model] (part X of Y) - Output content with part indices
+
+Media Handling:
+    - Data URLs (base64) are hashed with SHA-256 to avoid logging large content
+    - Format: "data:image/png;base64,<sha256(hash)>"
+
+GCP Documentation:
+    Cloud Monitoring Metrics:
+        - Custom Metrics: https://cloud.google.com/monitoring/custom-metrics
+        - Quotas: https://cloud.google.com/monitoring/quotas
+        - Note: Rate limit is 1 point per 5 seconds per time series
+
+    OpenTelemetry:
+        - Python Metrics SDK: https://opentelemetry-python.readthedocs.io/en/stable/sdk/metrics.html
+
+Cross-Language Parity:
+    - JavaScript: js/plugins/google-cloud/src/telemetry/generate.ts
+    - Go: go/plugins/googlecloud/generate.go
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+import structlog
+from opentelemetry import metrics
+from opentelemetry.sdk.trace import ReadableSpan
+
+from genkit.core import GENKIT_VERSION
+
+from .utils import (
+    create_common_log_attributes,
+    extract_error_name,
+    extract_outer_feature_name_from_path,
+    to_display_path,
+    truncate,
+    truncate_path,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Lazy-initialized metrics
+_action_counter: metrics.Counter | None = None
+_latency: metrics.Histogram | None = None
+_input_characters: metrics.Counter | None = None
+_input_tokens: metrics.Counter | None = None
+_input_images: metrics.Counter | None = None
+_input_videos: metrics.Counter | None = None
+_input_audio: metrics.Counter | None = None
+_output_characters: metrics.Counter | None = None
+_output_tokens: metrics.Counter | None = None
+_output_images: metrics.Counter | None = None
+_output_videos: metrics.Counter | None = None
+_output_audio: metrics.Counter | None = None
+_thinking_tokens: metrics.Counter | None = None
+
+
+def _get_meter() -> metrics.Meter:
+    return metrics.get_meter('genkit')
+
+
+def _get_action_counter() -> metrics.Counter:
+    global _action_counter
+    if _action_counter is None:
+        _action_counter = _get_meter().create_counter(
+            'genkit/ai/generate/requests',
+            description='Counts calls to genkit generate actions.',
+            unit='1',
+        )
+    return _action_counter
+
+
+def _get_latency() -> metrics.Histogram:
+    global _latency
+    if _latency is None:
+        _latency = _get_meter().create_histogram(
+            'genkit/ai/generate/latency',
+            description='Latencies when interacting with a Genkit model.',
+            unit='ms',
+        )
+    return _latency
+
+
+def _get_input_characters() -> metrics.Counter:
+    global _input_characters
+    if _input_characters is None:
+        _input_characters = _get_meter().create_counter(
+            'genkit/ai/generate/input/characters',
+            description='Counts input characters to any Genkit model.',
+            unit='1',
+        )
+    return _input_characters
+
+
+def _get_input_tokens() -> metrics.Counter:
+    global _input_tokens
+    if _input_tokens is None:
+        _input_tokens = _get_meter().create_counter(
+            'genkit/ai/generate/input/tokens',
+            description='Counts input tokens to a Genkit model.',
+            unit='1',
+        )
+    return _input_tokens
+
+
+def _get_input_images() -> metrics.Counter:
+    global _input_images
+    if _input_images is None:
+        _input_images = _get_meter().create_counter(
+            'genkit/ai/generate/input/images',
+            description='Counts input images to a Genkit model.',
+            unit='1',
+        )
+    return _input_images
+
+
+def _get_input_videos() -> metrics.Counter:
+    """Get or create the input videos counter (Go parity)."""
+    global _input_videos
+    if _input_videos is None:
+        _input_videos = _get_meter().create_counter(
+            'genkit/ai/generate/input/videos',
+            description='Counts input videos to a Genkit model.',
+            unit='1',
+        )
+    return _input_videos
+
+
+def _get_input_audio() -> metrics.Counter:
+    """Get or create the input audio counter (Go parity)."""
+    global _input_audio
+    if _input_audio is None:
+        _input_audio = _get_meter().create_counter(
+            'genkit/ai/generate/input/audio',
+            description='Counts input audio files to a Genkit model.',
+            unit='1',
+        )
+    return _input_audio
+
+
+def _get_output_characters() -> metrics.Counter:
+    global _output_characters
+    if _output_characters is None:
+        _output_characters = _get_meter().create_counter(
+            'genkit/ai/generate/output/characters',
+            description='Counts output characters from a Genkit model.',
+            unit='1',
+        )
+    return _output_characters
+
+
+def _get_output_tokens() -> metrics.Counter:
+    global _output_tokens
+    if _output_tokens is None:
+        _output_tokens = _get_meter().create_counter(
+            'genkit/ai/generate/output/tokens',
+            description='Counts output tokens from a Genkit model.',
+            unit='1',
+        )
+    return _output_tokens
+
+
+def _get_output_images() -> metrics.Counter:
+    global _output_images
+    if _output_images is None:
+        _output_images = _get_meter().create_counter(
+            'genkit/ai/generate/output/images',
+            description='Count output images from a Genkit model.',
+            unit='1',
+        )
+    return _output_images
+
+
+def _get_output_videos() -> metrics.Counter:
+    """Get or create the output videos counter (Go parity)."""
+    global _output_videos
+    if _output_videos is None:
+        _output_videos = _get_meter().create_counter(
+            'genkit/ai/generate/output/videos',
+            description='Counts output videos from a Genkit model.',
+            unit='1',
+        )
+    return _output_videos
+
+
+def _get_output_audio() -> metrics.Counter:
+    """Get or create the output audio counter (Go parity)."""
+    global _output_audio
+    if _output_audio is None:
+        _output_audio = _get_meter().create_counter(
+            'genkit/ai/generate/output/audio',
+            description='Counts output audio files from a Genkit model.',
+            unit='1',
+        )
+    return _output_audio
+
+
+def _get_thinking_tokens() -> metrics.Counter:
+    global _thinking_tokens
+    if _thinking_tokens is None:
+        _thinking_tokens = _get_meter().create_counter(
+            'genkit/ai/generate/thinking/tokens',
+            description='Counts thinking tokens from a Genkit model.',
+            unit='1',
+        )
+    return _thinking_tokens
+
+
+class GenerateTelemetry:
+    """Telemetry handler for Genkit generate actions (model calls)."""
+
+    def tick(
+        self,
+        span: ReadableSpan,
+        log_input_and_output: bool,
+        project_id: str | None = None,
+    ) -> None:
+        """Record telemetry for a generate action span.
+
+        Args:
+            span: The span to record telemetry for.
+            log_input_and_output: Whether to log input/output.
+            project_id: Optional GCP project ID.
+        """
+        attrs = span.attributes or {}
+        model_name = truncate(str(attrs.get('genkit:name', '<unknown>')), 1024)
+        path = str(attrs.get('genkit:path', ''))
+
+        # Parse input and output from span attributes
+        input_data: dict[str, Any] | None = None
+        output_data: dict[str, Any] | None = None
+
+        input_json = attrs.get('genkit:input')
+        if input_json and isinstance(input_json, str):
+            try:
+                input_data = json.loads(input_json)
+            except json.JSONDecodeError:
+                pass
+
+        output_json = attrs.get('genkit:output')
+        if output_json and isinstance(output_json, str):
+            try:
+                output_data = json.loads(output_json)
+            except json.JSONDecodeError:
+                pass
+
+        err_name = extract_error_name(list(span.events))
+        feature_name = truncate(
+            str(attrs.get('genkit:metadata:flow:name', '')) or extract_outer_feature_name_from_path(path)
+        )
+        if not feature_name or feature_name == '<unknown>':
+            feature_name = 'generate'
+
+        session_id = str(attrs.get('genkit:sessionId', '')) or None
+        thread_name = str(attrs.get('genkit:threadName', '')) or None
+
+        if input_data:
+            self._record_generate_action_metrics(model_name, feature_name, path, output_data, err_name)
+            self._record_generate_action_config_logs(
+                span, model_name, feature_name, path, input_data, project_id, session_id, thread_name
+            )
+
+            if log_input_and_output:
+                self._record_generate_action_input_logs(
+                    span, model_name, feature_name, path, input_data, project_id, session_id, thread_name
+                )
+
+        if output_data and log_input_and_output:
+            self._record_generate_action_output_logs(
+                span, model_name, feature_name, path, output_data, project_id, session_id, thread_name
+            )
+
+    def _record_generate_action_metrics(
+        self,
+        model_name: str,
+        feature_name: str,
+        path: str,
+        response: dict[str, Any] | None,
+        err_name: str | None,
+    ) -> None:
+        """Record metrics for a generate action.
+
+        Records all generate metrics matching JS/Go parity:
+        - requests, latency
+        - input: tokens, characters, images, videos, audio
+        - output: tokens, characters, images, videos, audio
+        - thinking tokens
+        """
+        usage = response.get('usage', {}) if response else {}
+        latency_ms = response.get('latencyMs') if response else None
+
+        # Note: modelName uses 1024 char limit (matching JS/Go), other dimensions use 256
+        shared = {
+            'modelName': model_name[:1024],
+            'featureName': feature_name[:256],
+            'path': path[:256],
+            'source': 'py',
+            'sourceVersion': GENKIT_VERSION,
+            'status': 'failure' if err_name else 'success',
+        }
+
+        error_dims = {'error': err_name[:256]} if err_name else {}
+        _get_action_counter().add(1, {**shared, **error_dims})
+
+        if latency_ms is not None:
+            _get_latency().record(latency_ms, shared)
+
+        # Input metrics
+        if usage.get('inputTokens'):
+            _get_input_tokens().add(int(usage['inputTokens']), shared)
+        if usage.get('inputCharacters'):
+            _get_input_characters().add(int(usage['inputCharacters']), shared)
+        if usage.get('inputImages'):
+            _get_input_images().add(int(usage['inputImages']), shared)
+        if usage.get('inputVideos'):
+            _get_input_videos().add(int(usage['inputVideos']), shared)
+        if usage.get('inputAudio'):
+            _get_input_audio().add(int(usage['inputAudio']), shared)
+
+        # Output metrics
+        if usage.get('outputTokens'):
+            _get_output_tokens().add(int(usage['outputTokens']), shared)
+        if usage.get('outputCharacters'):
+            _get_output_characters().add(int(usage['outputCharacters']), shared)
+        if usage.get('outputImages'):
+            _get_output_images().add(int(usage['outputImages']), shared)
+        if usage.get('outputVideos'):
+            _get_output_videos().add(int(usage['outputVideos']), shared)
+        if usage.get('outputAudio'):
+            _get_output_audio().add(int(usage['outputAudio']), shared)
+
+        # Thinking tokens
+        if usage.get('thoughtsTokens'):
+            _get_thinking_tokens().add(int(usage['thoughtsTokens']), shared)
+
+    def _record_generate_action_config_logs(
+        self,
+        span: ReadableSpan,
+        model: str,
+        feature_name: str,
+        qualified_path: str,
+        input_data: dict[str, Any],
+        project_id: str | None,
+        session_id: str | None,
+        thread_name: str | None,
+    ) -> None:
+        """Log generate action configuration."""
+        path = truncate_path(to_display_path(qualified_path))
+        metadata = {
+            **create_common_log_attributes(span, project_id),
+            'model': model,
+            'path': path,
+            'qualifiedPath': qualified_path,
+            'featureName': feature_name,
+            'source': 'py',
+            'sourceVersion': GENKIT_VERSION,
+        }
+        if session_id:
+            metadata['sessionId'] = session_id
+        if thread_name:
+            metadata['threadName'] = thread_name
+
+        config = input_data.get('config', {})
+        if config.get('maxOutputTokens'):
+            metadata['maxOutputTokens'] = config['maxOutputTokens']
+        if config.get('stopSequences'):
+            metadata['stopSequences'] = config['stopSequences']
+
+        logger.info(f'Config[{path}, {model}]', **metadata)
+
+    def _record_generate_action_input_logs(
+        self,
+        span: ReadableSpan,
+        model: str,
+        feature_name: str,
+        qualified_path: str,
+        input_data: dict[str, Any],
+        project_id: str | None,
+        session_id: str | None,
+        thread_name: str | None,
+    ) -> None:
+        """Log generate action input messages."""
+        path = truncate_path(to_display_path(qualified_path))
+        base_metadata = {
+            **create_common_log_attributes(span, project_id),
+            'model': model,
+            'path': path,
+            'qualifiedPath': qualified_path,
+            'featureName': feature_name,
+        }
+        if session_id:
+            base_metadata['sessionId'] = session_id
+        if thread_name:
+            base_metadata['threadName'] = thread_name
+
+        messages = input_data.get('messages', [])
+        total_messages = len(messages)
+
+        for msg_idx, msg in enumerate(messages):
+            role = msg.get('role', 'user')
+            content = msg.get('content', [])
+            total_parts = len(content)
+
+            for part_idx, part in enumerate(content):
+                part_counts = self._to_part_counts(part_idx, total_parts, msg_idx, total_messages)
+                metadata = {
+                    **base_metadata,
+                    'content': self._to_part_log_content(part),
+                    'role': role,
+                    'partIndex': part_idx,
+                    'totalParts': total_parts,
+                    'messageIndex': msg_idx,
+                    'totalMessages': total_messages,
+                }
+                logger.info(f'Input[{path}, {model}] {part_counts}', **metadata)
+
+    def _record_generate_action_output_logs(
+        self,
+        span: ReadableSpan,
+        model: str,
+        feature_name: str,
+        qualified_path: str,
+        output_data: dict[str, Any],
+        project_id: str | None,
+        session_id: str | None,
+        thread_name: str | None,
+    ) -> None:
+        """Log generate action output."""
+        path = truncate_path(to_display_path(qualified_path))
+        base_metadata = {
+            **create_common_log_attributes(span, project_id),
+            'model': model,
+            'path': path,
+            'qualifiedPath': qualified_path,
+            'featureName': feature_name,
+        }
+        if session_id:
+            base_metadata['sessionId'] = session_id
+        if thread_name:
+            base_metadata['threadName'] = thread_name
+
+        message = output_data.get('message') or (output_data.get('candidates', [{}])[0].get('message'))
+        if not message or not message.get('content'):
+            return
+
+        content = message.get('content', [])
+        total_parts = len(content)
+        finish_reason = output_data.get('finishReason')
+        finish_message = output_data.get('finishMessage')
+
+        for part_idx, part in enumerate(content):
+            part_counts = self._to_part_counts(part_idx, total_parts, 0, 1)
+            metadata = {
+                **base_metadata,
+                'content': self._to_part_log_content(part),
+                'role': message.get('role', 'model'),
+                'partIndex': part_idx,
+                'totalParts': total_parts,
+                'candidateIndex': 0,
+                'totalCandidates': 1,
+                'messageIndex': 0,
+                'finishReason': finish_reason,
+            }
+            if finish_message:
+                metadata['finishMessage'] = truncate(finish_message)
+
+            logger.info(f'Output[{path}, {model}] {part_counts}', **metadata)
+
+    def _to_part_counts(
+        self,
+        part_ordinal: int,
+        parts: int,
+        msg_ordinal: int,
+        messages: int,
+    ) -> str:
+        """Format part counts for log messages."""
+        if parts > 1 and messages > 1:
+            return f'(part {self._x_of_y(part_ordinal, parts)} in message {self._x_of_y(msg_ordinal, messages)})'
+        if parts > 1:
+            return f'(part {self._x_of_y(part_ordinal, parts)})'
+        if messages > 1:
+            return f'(message {self._x_of_y(msg_ordinal, messages)})'
+        return ''
+
+    def _x_of_y(self, x: int, y: int) -> str:
+        """Format 'X of Y' string."""
+        return f'{x + 1} of {y}'
+
+    def _to_part_log_content(self, part: dict[str, Any]) -> str:
+        """Convert a part to log-safe content."""
+        if part.get('text'):
+            return truncate(str(part['text']))
+        if part.get('data'):
+            return truncate(json.dumps(part['data']))
+        if part.get('media'):
+            return self._to_part_log_media(part)
+        if part.get('toolRequest'):
+            return self._to_part_log_tool_request(part)
+        if part.get('toolResponse'):
+            return self._to_part_log_tool_response(part)
+        if part.get('custom'):
+            return truncate(json.dumps(part['custom']))
+        return '<unknown format>'
+
+    def _to_part_log_media(self, part: dict[str, Any]) -> str:
+        """Convert media part to log-safe content."""
+        media = part.get('media', {})
+        url = media.get('url', '')
+
+        if url.startswith('data:'):
+            split_idx = url.find('base64,')
+            if split_idx < 0:
+                return '<unknown media format>'
+            prefix = url[: split_idx + 7]
+            hashed = hashlib.sha256(url[split_idx + 7 :].encode()).hexdigest()
+            return f'{prefix}<sha256({hashed})>'
+
+        return truncate(url)
+
+    def _to_part_log_tool_request(self, part: dict[str, Any]) -> str:
+        """Convert tool request part to log-safe content."""
+        req = part.get('toolRequest', {})
+        name = req.get('name', '')
+        ref = req.get('ref', '')
+        input_val = req.get('input', '')
+        if not isinstance(input_val, str):
+            input_val = json.dumps(input_val)
+        return truncate(f'Tool request: {name}, ref: {ref}, input: {input_val}')
+
+    def _to_part_log_tool_response(self, part: dict[str, Any]) -> str:
+        """Convert tool response part to log-safe content."""
+        resp = part.get('toolResponse', {})
+        name = resp.get('name', '')
+        ref = resp.get('ref', '')
+        output_val = resp.get('output', '')
+        if not isinstance(output_val, str):
+            output_val = json.dumps(output_val)
+        return truncate(f'Tool response: {name}, ref: {ref}, output: {output_val}')
+
+
+# Singleton instance
+generate_telemetry = GenerateTelemetry()

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/metrics.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/metrics.py
@@ -14,7 +14,34 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""AI monitoring metrics for Genkit."""
+"""AI monitoring metrics for Genkit.
+
+This module provides lazy-initialized OpenTelemetry metrics for AI operations.
+Metrics are exported to Google Cloud Monitoring with the workload.googleapis.com
+prefix by default.
+
+Metrics Defined:
+    Input metrics:
+        - genkit/ai/generate/input/tokens
+        - genkit/ai/generate/input/characters
+        - genkit/ai/generate/input/images
+        - genkit/ai/generate/input/videos
+        - genkit/ai/generate/input/audio
+
+    Output metrics:
+        - genkit/ai/generate/output/tokens
+        - genkit/ai/generate/output/characters
+        - genkit/ai/generate/output/images
+        - genkit/ai/generate/output/videos
+        - genkit/ai/generate/output/audio
+
+    Thinking metrics:
+        - genkit/ai/generate/thinking/tokens
+
+See Also:
+    - Cloud Monitoring Custom Metrics: https://cloud.google.com/monitoring/custom-metrics
+    - Workload Metrics: https://cloud.google.com/monitoring/api/metrics_other
+"""
 
 import re
 

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/path.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/path.py
@@ -1,0 +1,157 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Path telemetry for GCP.
+
+This module tracks path-level failure metrics and logs errors,
+matching the JavaScript implementation.
+
+Metrics Recorded:
+    - genkit/feature/path/requests: Counter for unique flow paths
+    - genkit/feature/path/latency: Histogram for path latency (ms)
+
+Cross-Language Parity:
+    - JavaScript: js/plugins/google-cloud/src/telemetry/paths.ts
+    - Go: go/plugins/googlecloud/paths.go
+
+See Also:
+    - Cloud Monitoring Custom Metrics: https://cloud.google.com/monitoring/custom-metrics
+"""
+
+from __future__ import annotations
+
+import structlog
+from opentelemetry import metrics
+from opentelemetry.sdk.trace import ReadableSpan
+
+from genkit.core import GENKIT_VERSION
+
+from .utils import (
+    create_common_log_attributes,
+    extract_error_message,
+    extract_error_name,
+    extract_error_stack,
+    extract_outer_feature_name_from_path,
+    to_display_path,
+    truncate_path,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Lazy-initialized metrics
+_path_counter: metrics.Counter | None = None
+_path_latency: metrics.Histogram | None = None
+
+
+def _get_path_counter() -> metrics.Counter:
+    """Get or create the path requests counter."""
+    global _path_counter
+    if _path_counter is None:
+        meter = metrics.get_meter('genkit')
+        _path_counter = meter.create_counter(
+            'genkit/feature/path/requests',
+            description='Tracks unique flow paths per flow.',
+            unit='1',
+        )
+    return _path_counter
+
+
+def _get_path_latency() -> metrics.Histogram:
+    """Get or create the path latency histogram."""
+    global _path_latency
+    if _path_latency is None:
+        meter = metrics.get_meter('genkit')
+        _path_latency = meter.create_histogram(
+            'genkit/feature/path/latency',
+            description='Latencies per flow path.',
+            unit='ms',
+        )
+    return _path_latency
+
+
+class PathsTelemetry:
+    """Telemetry handler for Genkit paths (error tracking)."""
+
+    def tick(
+        self,
+        span: ReadableSpan,
+        log_input_and_output: bool,
+        project_id: str | None = None,
+    ) -> None:
+        """Record telemetry for a path span.
+
+        Only ticks metrics for failing, leaf spans (isFailureSource).
+
+        Args:
+            span: The span to record telemetry for.
+            log_input_and_output: Whether to log input/output (unused here).
+            project_id: Optional GCP project ID.
+        """
+        attrs = span.attributes or {}
+
+        path = str(attrs.get('genkit:path', ''))
+        is_failure_source = bool(attrs.get('genkit:isFailureSource'))
+        state = str(attrs.get('genkit:state', ''))
+
+        # Only tick metrics for failing, leaf spans
+        if not path or not is_failure_source or state != 'error':
+            return
+
+        session_id = str(attrs.get('genkit:sessionId', '')) or None
+        thread_name = str(attrs.get('genkit:threadName', '')) or None
+
+        events = list(span.events)
+        error_name = extract_error_name(events) or '<unknown>'
+        error_message = extract_error_message(events) or '<unknown>'
+        error_stack = extract_error_stack(events) or ''
+
+        # Calculate latency
+        latency_ms = 0.0
+        if span.end_time and span.start_time:
+            latency_ms = (span.end_time - span.start_time) / 1_000_000
+
+        path_dimensions = {
+            'featureName': extract_outer_feature_name_from_path(path)[:256],
+            'status': 'failure',
+            'error': error_name[:256],
+            'path': path[:256],
+            'source': 'py',
+            'sourceVersion': GENKIT_VERSION,
+        }
+        _get_path_counter().add(1, path_dimensions)
+        _get_path_latency().record(latency_ms, path_dimensions)
+
+        display_path = truncate_path(to_display_path(path))
+        log_attrs = {
+            **create_common_log_attributes(span, project_id),
+            'path': display_path,
+            'qualifiedPath': path,
+            'name': error_name,
+            'message': error_message,
+            'stack': error_stack,
+            'source': 'py',
+            'sourceVersion': GENKIT_VERSION,
+        }
+        if session_id:
+            log_attrs['sessionId'] = session_id
+        if thread_name:
+            log_attrs['threadName'] = thread_name
+
+        logger.error(f'Error[{display_path}, {error_name}]', **log_attrs)
+
+
+# Singleton instance
+paths_telemetry = PathsTelemetry()

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/tracing.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/tracing.py
@@ -15,19 +15,204 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-"""Telemetry and tracing functionality for the Genkit framework.
+"""Telemetry and tracing functionality for the Genkit Google Cloud plugin.
 
 This module provides functionality for collecting and exporting telemetry data
-from Genkit operations. It uses OpenTelemetry for tracing and exports span
-data to a telemetry GCP server for monitoring and debugging purposes.
+from Genkit operations to Google Cloud. It uses OpenTelemetry for tracing and
+exports span data to Google Cloud Trace for monitoring and debugging purposes.
 
-The module includes:
-    - A custom span exporter for sending trace data to a telemetry GCP server
+Architecture Overview:
+    The telemetry system follows a pipeline architecture that processes spans
+    (traces) and metrics before exporting them to Google Cloud:
+
+    ```
+    ┌─────────────────────────────────────────────────────────────────────────┐
+    │                         TELEMETRY DATA FLOW                             │
+    │                                                                         │
+    │  Genkit Actions (flows, models, tools)                                  │
+    │         │                                                               │
+    │         ▼                                                               │
+    │  ┌─────────────────┐                                                    │
+    │  │ OpenTelemetry   │  Creates spans with genkit:* attributes            │
+    │  │ Tracer          │  (type, name, input, output, state, path, etc.)    │
+    │  └────────┬────────┘                                                    │
+    │           │                                                             │
+    │           ▼                                                             │
+    │  ┌─────────────────────────────────────────────────────────────┐        │
+    │  │           GcpAdjustingTraceExporter                         │        │
+    │  │  ┌─────────────────────────────────────────────────────┐    │        │
+    │  │  │ 1. _tick_telemetry()                                │    │        │
+    │  │  │    - pathsTelemetry.tick()    → Error metrics/logs  │    │        │
+    │  │  │    - featuresTelemetry.tick() → Feature metrics     │    │        │
+    │  │  │    - generateTelemetry.tick() → Model metrics       │    │        │
+    │  │  │    - actionTelemetry.tick()   → Action I/O logs     │    │        │
+    │  │  │    - engagementTelemetry.tick() → Feedback metrics  │    │        │
+    │  │  │    - Sets genkit:rootState for root spans           │    │        │
+    │  │  └─────────────────────────────────────────────────────┘    │        │
+    │  │  ┌─────────────────────────────────────────────────────┐    │        │
+    │  │  │ 2. AdjustingTraceExporter._adjust()                 │    │        │
+    │  │  │    - Redact genkit:input/output → "<redacted>"      │    │        │
+    │  │  │    - Mark error spans with /http/status_code: 599   │    │        │
+    │  │  │    - Mark failed spans with genkit:failedSpan       │    │        │
+    │  │  │    - Mark root spans with genkit:feature            │    │        │
+    │  │  │    - Mark model spans with genkit:model             │    │        │
+    │  │  │    - Normalize labels (: → /) for GCP compatibility │    │        │
+    │  │  └─────────────────────────────────────────────────────┘    │        │
+    │  └────────────────────────┬────────────────────────────────────┘        │
+    │                           │                                             │
+    │           ┌───────────────┴───────────────┐                             │
+    │           ▼                               ▼                             │
+    │  ┌─────────────────┐             ┌─────────────────┐                    │
+    │  │ GenkitGCPExporter│             │ Cloud Logging   │                    │
+    │  │ (Cloud Trace)   │             │ (via structlog) │                    │
+    │  └────────┬────────┘             └─────────────────┘                    │
+    │           │                                                             │
+    │           ▼                                                             │
+    │  ┌─────────────────┐                                                    │
+    │  │ Google Cloud    │                                                    │
+    │  │ Trace API       │                                                    │
+    │  └─────────────────┘                                                    │
+    │                                                                         │
+    │  ─────────────────────── METRICS PIPELINE ────────────────────────      │
+    │                                                                         │
+    │  ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐      │
+    │  │ OpenTelemetry   │───▶│ GenkitMetric    │───▶│ Cloud Monitoring│      │
+    │  │ Meter           │    │ Exporter        │    │ API             │      │
+    │  │ (counters,      │    │ (adjusts start  │    │                 │      │
+    │  │  histograms)    │    │  times for      │    │                 │      │
+    │  └─────────────────┘    │  DELTA→CUMUL.)  │    └─────────────────┘      │
+    │                         └─────────────────┘                             │
+    └─────────────────────────────────────────────────────────────────────────┘
+    ```
+
+Key Components:
+    1. **GcpAdjustingTraceExporter**: Extends AdjustingTraceExporter to add
+       GCP-specific telemetry recording before spans are adjusted and exported.
+
+    2. **AdjustingTraceExporter** (from genkit.core.trace): Base class that
+       handles PII redaction, error marking, and label normalization.
+
+    3. **GenkitGCPExporter**: Extends CloudTraceSpanExporter with retry logic
+       for reliable delivery to Google Cloud Trace.
+
+    4. **GenkitMetricExporter**: Wraps CloudMonitoringMetricsExporter and
+       adjusts start times to prevent overlap when GCP converts DELTA to
+       CUMULATIVE aggregation.
+
+    5. **Telemetry Handlers** (in separate modules):
+       - feature.py: Tracks root span requests/latency
+       - path.py: Tracks error paths and failure metrics
+       - generate.py: Tracks model usage (tokens, latency, media)
+       - action.py: Logs tool and action I/O
+       - engagement.py: Tracks user feedback and acceptance
+
+Telemetry Types and When They Fire:
+    ┌─────────────────────────────────────────────────────────────────────────┐
+    │ Telemetry Type │ Condition                    │ What It Records         │
+    ├────────────────┼──────────────────────────────┼─────────────────────────┤
+    │ paths          │ Always (for all spans)       │ Error paths, failures   │
+    │ features       │ genkit:isRoot = true         │ Request count, latency  │
+    │ generate       │ type=action, subtype=model   │ Tokens, latency, media  │
+    │ action         │ type in (action,flow,...)    │ Input/output logs       │
+    │ engagement     │ type=userEngagement          │ Feedback, acceptance    │
+    └────────────────┴──────────────────────────────┴─────────────────────────┘
+
+Span Attributes Used:
+    The system reads these genkit:* attributes from spans:
+    - genkit:type - Span type (action, flow, flowStep, util, userEngagement)
+    - genkit:metadata:subtype - Subtype (model, tool, etc.)
+    - genkit:isRoot - Whether this is the root/entry span
+    - genkit:name - Action/flow name
+    - genkit:path - Hierarchical path like /{flow,t:flow}/{step,t:flowStep}
+    - genkit:input - JSON-encoded input data
+    - genkit:output - JSON-encoded output data
+    - genkit:state - Span state (success, error)
+    - genkit:isFailureSource - Whether this span is the source of a failure
+
+Configuration Options (matching JS/Go parity):
+    ┌─────────────────────────────────────────────────────────────────────────┐
+    │ Option                      │ Type     │ Default    │ Description       │
+    ├─────────────────────────────┼──────────┼────────────┼───────────────────┤
+    │ project_id                  │ str      │ Auto       │ GCP project ID    │
+    │ credentials                 │ dict     │ ADC        │ Service account   │
+    │ log_input_and_output        │ bool     │ False      │ Disable redaction │
+    │ force_dev_export            │ bool     │ True       │ Export in dev     │
+    │ disable_metrics             │ bool     │ False      │ Skip metrics      │
+    │ disable_traces              │ bool     │ False      │ Skip traces       │
+    │ metric_export_interval_ms   │ int      │ 60000      │ Export interval   │
+    │ metric_export_timeout_ms    │ int      │ None       │ Export timeout    │
+    │ sampler                     │ Sampler  │ AlwaysOn   │ Trace sampler     │
+    └─────────────────────────────┴──────────┴────────────┴───────────────────┘
+
+Project ID Resolution Order:
+    1. Explicit project_id parameter
+    2. FIREBASE_PROJECT_ID environment variable
+    3. GOOGLE_CLOUD_PROJECT environment variable
+    4. GCLOUD_PROJECT environment variable
+    5. project_id from credentials dict
+
+Usage:
+    ```python
+    from genkit.plugins.google_cloud import add_gcp_telemetry
+
+    # Enable telemetry with default settings (PII redaction enabled)
+    add_gcp_telemetry()
+
+    # Enable telemetry with input/output logging (disable PII redaction)
+    add_gcp_telemetry(log_input_and_output=True)
+
+    # Force export even in dev environment
+    add_gcp_telemetry(force_dev_export=True)
+
+    # Disable metrics but keep traces
+    add_gcp_telemetry(disable_metrics=True)
+
+    # Custom metric export interval (minimum 5000ms for GCP)
+    add_gcp_telemetry(metric_export_interval_ms=30000)
+    ```
+
+Caveats:
+    - By default, model inputs and outputs are redacted for privacy
+    - Set log_input_and_output=True only in trusted environments
+    - In dev environment, telemetry is skipped unless force_dev_export=True
+    - GCP requires minimum 5000ms metric export interval (see quotas link below)
+
+GCP Documentation References:
+    Cloud Trace:
+        - Overview: https://cloud.google.com/trace/docs
+        - IAM Roles: https://cloud.google.com/trace/docs/iam
+        - Required role: roles/cloudtrace.agent (Cloud Trace Agent)
+
+    Cloud Monitoring:
+        - Overview: https://cloud.google.com/monitoring/docs
+        - Quotas & Limits: https://cloud.google.com/monitoring/quotas
+        - Required role: roles/monitoring.metricWriter (Monitoring Metric Writer)
+          or roles/telemetry.metricsWriter (Cloud Telemetry Metrics Writer)
+
+    OpenTelemetry GCP Exporters:
+        - Documentation: https://google-cloud-opentelemetry.readthedocs.io/
+        - Cloud Trace Exporter: https://google-cloud-opentelemetry.readthedocs.io/en/stable/cloud_trace/cloud_trace.html
+        - Cloud Monitoring Exporter: https://google-cloud-opentelemetry.readthedocs.io/en/stable/cloud_monitoring/cloud_monitoring.html
+
+Cross-Language Parity:
+    This implementation maintains parity with:
+    - JavaScript: js/plugins/google-cloud/src/gcpOpenTelemetry.ts
+    - Go: go/plugins/googlecloud/googlecloud.go
+    - Go: go/plugins/firebase/telemetry.go (FirebaseTelemetryOptions)
+
+    Key parity points:
+    - Same configuration options with equivalent semantics
+    - Same telemetry dispatch logic (when each handler fires)
+    - Same metrics names and dimensions
+    - Same span adjustment pipeline (redaction, marking, normalization)
+    - Same project ID resolution order
 """
 
 import logging
+import os
 import uuid
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from typing import Any
 
 import structlog
 from google.api_core import exceptions as core_exceptions, retry as retries
@@ -39,17 +224,70 @@ from opentelemetry.resourcedetector.gcp_resource_detector import (
     GoogleCloudResourceDetector,
 )
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.metrics.export import (
+    MetricExporter,
+    MetricExportResult,
+    MetricsData,
+    PeriodicExportingMetricReader,
+)
 from opentelemetry.sdk.resources import SERVICE_INSTANCE_ID, SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import ReadableSpan
-from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.sdk.trace.sampling import Sampler
 
 from genkit.core.environment import is_dev_environment
+from genkit.core.trace import AdjustingTraceExporter
 from genkit.core.tracing import add_custom_exporter
 
-from .metrics import record_generate_metrics
+from .action import action_telemetry
+from .engagement import engagement_telemetry
+from .feature import features_telemetry
+from .generate import generate_telemetry
+from .path import paths_telemetry
 
 logger = structlog.get_logger(__name__)
+
+# Constants matching JS/Go implementations
+MIN_METRIC_EXPORT_INTERVAL_MS = 5000
+DEFAULT_METRIC_EXPORT_INTERVAL_MS = 60000
+DEV_METRIC_EXPORT_INTERVAL_MS = 5000
+PROD_METRIC_EXPORT_INTERVAL_MS = 300000
+
+
+def _resolve_project_id(
+    project_id: str | None = None,
+    credentials: dict[str, Any] | None = None,
+) -> str | None:
+    """Resolve the GCP project ID from various sources.
+
+    Resolution order (matching JS/Go):
+    1. Explicit project_id parameter
+    2. FIREBASE_PROJECT_ID environment variable
+    3. GOOGLE_CLOUD_PROJECT environment variable
+    4. GCLOUD_PROJECT environment variable
+    5. Project ID from credentials
+
+    Args:
+        project_id: Explicitly provided project ID.
+        credentials: Optional credentials dict with project_id.
+
+    Returns:
+        The resolved project ID or None.
+    """
+    if project_id:
+        return project_id
+
+    # Check environment variables in order of priority
+    for env_var in ('FIREBASE_PROJECT_ID', 'GOOGLE_CLOUD_PROJECT', 'GCLOUD_PROJECT'):
+        env_value = os.environ.get(env_var)
+        if env_value:
+            return env_value
+
+    # Check credentials for project_id
+    if credentials and 'project_id' in credentials:
+        return credentials['project_id']
+
+    return None
 
 
 class GenkitGCPExporter(CloudTraceSpanExporter):
@@ -78,9 +316,6 @@ class GenkitGCPExporter(CloudTraceSpanExporter):
             server-side success).
         """
         try:
-            for span in spans:
-                record_generate_metrics(span)
-
             self.client.batch_write_spans(
                 request=BatchWriteSpansRequest(
                     name=f'projects/{self.project_id}',
@@ -103,38 +338,462 @@ class GenkitGCPExporter(CloudTraceSpanExporter):
         return SpanExportResult.SUCCESS
 
 
-def add_gcp_telemetry(force_export: bool = True) -> None:
-    """Configure GCP telemetry export for traces and metrics.
+class GenkitMetricExporter(MetricExporter):
+    """Metric exporter wrapper that adjusts start times for GCP compatibility.
+
+    Cloud Monitoring does not support delta metrics for custom metrics and will
+    convert any DELTA aggregations to CUMULATIVE ones on export. There is implicit
+    overlap in the start/end times that the Metric reader sends -- the end_time
+    of the previous export becomes the start_time of the current export.
+
+    This wrapper adds a microsecond to start times to ensure discrete export
+    timeframes and prevent data being overwritten.
+
+    This matches the JavaScript MetricExporterWrapper in gcpOpenTelemetry.ts.
 
     Args:
-        force_export: Export regardless of environment. Defaults to True.
+        exporter: The underlying CloudMonitoringMetricsExporter.
+        error_handler: Optional callback for export errors.
     """
-    should_export = force_export or not is_dev_environment()
-    if not should_export:
-        return
 
-    add_custom_exporter(GenkitGCPExporter(), 'gcp_telemetry_server')
+    def __init__(
+        self,
+        exporter: CloudMonitoringMetricsExporter,
+        error_handler: Callable[[Exception], None] | None = None,
+    ) -> None:
+        """Initialize the metric exporter wrapper.
 
-    try:
-        resource = Resource.create({
-            SERVICE_NAME: 'genkit',
-            SERVICE_INSTANCE_ID: str(uuid.uuid4()),
-        })
+        Args:
+            exporter: The underlying CloudMonitoringMetricsExporter.
+            error_handler: Optional callback for export errors.
+        """
+        self._exporter = exporter
+        self._error_handler = error_handler
 
-        # Suppress detector warnings during GCP resource detection
-        detector_logger = logging.getLogger('opentelemetry.resourcedetector.gcp_resource_detector')
-        original_level = detector_logger.level
-        detector_logger.setLevel(logging.ERROR)
+    def export(
+        self,
+        metrics_data: MetricsData,
+        timeout_millis: float = 10_000,
+        **kwargs: object,
+    ) -> MetricExportResult:
+        """Export metrics after adjusting start times.
+
+        Modifies start times of each data point to ensure no overlap with
+        previous exports when GCP converts DELTA to CUMULATIVE.
+
+        Args:
+            metrics_data: The metrics data to export.
+            timeout_millis: Export timeout in milliseconds.
+            **kwargs: Additional arguments (for base class compatibility).
+
+        Returns:
+            The export result.
+        """
+        self._modify_start_times(metrics_data)
 
         try:
-            resource = resource.merge(GoogleCloudResourceDetector().detect())
-        finally:
-            detector_logger.setLevel(original_level)
+            return self._exporter.export(metrics_data, timeout_millis, **kwargs)
+        except Exception as e:
+            if self._error_handler:
+                self._error_handler(e)
+            raise
 
-        metric_reader = PeriodicExportingMetricReader(
-            exporter=CloudMonitoringMetricsExporter(),
-            export_interval_millis=60000,
+    def _modify_start_times(self, metrics_data: MetricsData) -> None:
+        """Add 1ms to start times to prevent overlap.
+
+        Args:
+            metrics_data: The metrics data to modify.
+        """
+        for resource_metrics in metrics_data.resource_metrics:
+            for scope_metrics in resource_metrics.scope_metrics:
+                for metric in scope_metrics.metrics:
+                    for data_point in metric.data.data_points:
+                        # Add 1 millisecond (1_000_000 nanoseconds) to start time
+                        if hasattr(data_point, 'start_time_unix_nano'):
+                            data_point.start_time_unix_nano += 1_000_000
+
+    def force_flush(self, timeout_millis: float = 10_000) -> bool:
+        """Force flush the underlying exporter.
+
+        Args:
+            timeout_millis: Timeout in milliseconds.
+
+        Returns:
+            True if flush succeeded.
+        """
+        if hasattr(self._exporter, 'force_flush'):
+            return self._exporter.force_flush(timeout_millis)
+        return True
+
+    def shutdown(self, timeout_millis: float = 30_000, **kwargs: object) -> None:
+        """Shut down the underlying exporter.
+
+        Args:
+            timeout_millis: Timeout in milliseconds.
+            **kwargs: Additional arguments (for base class compatibility).
+        """
+        self._exporter.shutdown(timeout_millis, **kwargs)
+
+
+class GcpAdjustingTraceExporter(AdjustingTraceExporter):
+    """GCP-specific span exporter that adds telemetry recording.
+
+    This extends the base AdjustingTraceExporter to add GCP-specific telemetry
+    recording (metrics and logs) for each span, matching the JavaScript
+    implementation in gcpOpenTelemetry.ts.
+
+    The telemetry handlers record:
+    - Feature metrics (requests, latency) for root spans
+    - Path metrics for failure tracking
+    - Generate metrics (tokens, latency) for model actions
+    - Action logs for tools and generate
+    - Engagement metrics for user feedback
+
+    Example:
+        ```python
+        exporter = GcpAdjustingTraceExporter(
+            exporter=GenkitGCPExporter(),
+            log_input_and_output=False,
+            project_id='my-project',
         )
-        metrics.set_meter_provider(MeterProvider(metric_readers=[metric_reader], resource=resource))
-    except Exception as e:
-        logger.error('Failed to configure metrics exporter', error=str(e))
+        ```
+    """
+
+    def __init__(
+        self,
+        exporter: SpanExporter,
+        log_input_and_output: bool = False,
+        project_id: str | None = None,
+        error_handler: Callable[[Exception], None] | None = None,
+    ) -> None:
+        """Initialize the GCP adjusting trace exporter.
+
+        Args:
+            exporter: The underlying SpanExporter to wrap.
+            log_input_and_output: If True, preserve input/output in spans and logs.
+                Defaults to False (redact for privacy).
+            project_id: Optional GCP project ID for log correlation.
+            error_handler: Optional callback invoked when export errors occur.
+        """
+        super().__init__(
+            exporter=exporter,
+            log_input_and_output=log_input_and_output,
+            project_id=project_id,
+            error_handler=error_handler,
+        )
+
+    def _adjust(self, span: ReadableSpan) -> ReadableSpan:
+        """Apply all adjustments to a span including telemetry.
+
+        This overrides the base method to add telemetry recording before
+        the standard adjustments (redaction, marking, normalization).
+
+        Args:
+            span: The span to adjust.
+
+        Returns:
+            The adjusted span.
+        """
+        # Record telemetry before adjustments (uses original attributes)
+        span = self._tick_telemetry(span)
+
+        # Apply standard adjustments from base class
+        return super()._adjust(span)
+
+    def _tick_telemetry(self, span: ReadableSpan) -> ReadableSpan:
+        """Record telemetry for a span and apply root state marking.
+
+        This matches the JavaScript tickTelemetry method in gcpOpenTelemetry.ts.
+        It calls the appropriate telemetry handlers based on span type.
+
+        Args:
+            span: The span to record telemetry for.
+
+        Returns:
+            The span, potentially with genkit:rootState added for root spans.
+        """
+        attrs = span.attributes or {}
+        if 'genkit:type' not in attrs:
+            return span
+
+        span_type = str(attrs.get('genkit:type', ''))
+        subtype = str(attrs.get('genkit:metadata:subtype', ''))
+        is_root = bool(attrs.get('genkit:isRoot'))
+
+        try:
+            # Always record path telemetry for error tracking
+            paths_telemetry.tick(span, self._log_input_and_output, self._project_id)
+
+            if is_root:
+                # Report top level feature request and latency only for root spans
+                features_telemetry.tick(span, self._log_input_and_output, self._project_id)
+
+                # Set root state explicitly
+                # (matches JS: span.attributes['genkit:rootState'] = span.attributes['genkit:state'])
+                state = attrs.get('genkit:state')
+                if state:
+                    # Import here to avoid circular imports
+                    from genkit.core.trace.adjusting_exporter import RedactedSpan
+
+                    new_attrs = dict(attrs)
+                    new_attrs['genkit:rootState'] = state
+                    span = RedactedSpan(span, new_attrs)
+            else:
+                if span_type == 'action' and subtype == 'model':
+                    # Report generate metrics for all model actions
+                    generate_telemetry.tick(span, self._log_input_and_output, self._project_id)
+
+                if span_type == 'action' and subtype == 'tool':
+                    # TODO: Report input and output for tool actions (matching JS comment)
+                    pass
+
+                if span_type in ('action', 'flow', 'flowStep', 'util'):
+                    # Report request and latency metrics for all actions
+                    action_telemetry.tick(span, self._log_input_and_output, self._project_id)
+
+            if span_type == 'userEngagement':
+                # Report user acceptance and feedback metrics
+                engagement_telemetry.tick(span, self._log_input_and_output, self._project_id)
+
+        except Exception as e:
+            logger.warning('Error recording telemetry', error=str(e))
+
+        return span
+
+
+def add_gcp_telemetry(
+    project_id: str | None = None,
+    credentials: dict[str, Any] | None = None,
+    sampler: Sampler | None = None,
+    log_input_and_output: bool = False,
+    force_dev_export: bool = True,
+    disable_metrics: bool = False,
+    disable_traces: bool = False,
+    metric_export_interval_ms: int | None = None,
+    metric_export_timeout_ms: int | None = None,
+    # Legacy parameter name for backwards compatibility
+    force_export: bool | None = None,
+) -> None:
+    """Configure GCP telemetry export for traces and metrics.
+
+    This function sets up OpenTelemetry export to Google Cloud Trace and
+    Cloud Monitoring. By default, model inputs and outputs are redacted
+    for privacy protection.
+
+    Configuration options match the JavaScript (GcpTelemetryConfigOptions) and
+    Go (FirebaseTelemetryOptions/GoogleCloudTelemetryOptions) implementations.
+
+    Args:
+        project_id: Google Cloud project ID. If provided, takes precedence over
+            environment variables and credentials. Required when using external
+            credentials (e.g., Workload Identity Federation).
+        credentials: Service account credentials dict for authenticating with
+            Google Cloud. Primarily for use outside of GCP. On GCP, credentials
+            are typically inferred via Application Default Credentials (ADC).
+        sampler: OpenTelemetry trace sampler. Controls which traces are collected
+            and exported. Defaults to AlwaysOnSampler. Common options:
+            - AlwaysOnSampler: Collect all traces
+            - AlwaysOffSampler: Collect no traces
+            - TraceIdRatioBasedSampler: Sample a percentage of traces
+        log_input_and_output: If True, preserve model input/output in traces
+            and logs. Defaults to False (redact for privacy). Only enable this
+            in trusted environments where PII exposure is acceptable.
+            Maps to JS: !disableLoggingInputAndOutput
+        force_dev_export: If True, export telemetry even in dev environment.
+            Defaults to True. Set to False for production-only telemetry.
+            Maps to JS: forceDevExport
+        disable_metrics: If True, metrics will not be exported. Traces and
+            logs may still be exported. Defaults to False.
+            Maps to JS/Go: disableMetrics
+        disable_traces: If True, traces will not be exported. Metrics and
+            logs may still be exported. Defaults to False.
+            Maps to JS/Go: disableTraces
+        metric_export_interval_ms: Metrics export interval in milliseconds.
+            GCP requires a minimum of 5000ms. Defaults to 60000ms.
+            Dev environment uses 5000ms, production uses 300000ms by default
+            in JS/Go (but we use 60000ms for consistent behavior).
+            Maps to JS/Go: metricExportIntervalMillis
+        metric_export_timeout_ms: Timeout for metrics export in milliseconds.
+            Defaults to the export interval if not specified.
+            Maps to JS/Go: metricExportTimeoutMillis
+        force_export: Deprecated. Use force_dev_export instead.
+
+    Example:
+        ```python
+        # Default: PII redaction enabled
+        add_gcp_telemetry()
+
+        # Enable input/output logging (disable PII redaction)
+        add_gcp_telemetry(log_input_and_output=True)
+
+        # Force export in dev environment with specific project
+        add_gcp_telemetry(force_dev_export=True, project_id='my-project')
+
+        # Disable metrics but keep traces
+        add_gcp_telemetry(disable_metrics=True)
+
+        # Custom metric export interval (minimum 5000ms)
+        add_gcp_telemetry(metric_export_interval_ms=30000)
+
+        # With custom credentials for non-GCP environments
+        add_gcp_telemetry(
+            project_id='my-project',
+            credentials={'type': 'service_account', ...},
+        )
+        ```
+
+    Note:
+        This matches the JavaScript implementation's GcpTelemetryConfigOptions
+        and Go's FirebaseTelemetryOptions/GoogleCloudTelemetryOptions.
+
+    See Also:
+        - JS: js/plugins/google-cloud/src/types.ts (GcpTelemetryConfigOptions)
+        - Go: go/plugins/firebase/telemetry.go (FirebaseTelemetryOptions)
+        - Go: go/plugins/googlecloud/types.go (GoogleCloudTelemetryOptions)
+    """
+    # Handle legacy force_export parameter
+    if force_export is not None:
+        logger.warning('force_export is deprecated, use force_dev_export instead')
+        force_dev_export = force_export
+
+    # Resolve project ID from various sources
+    resolved_project_id = _resolve_project_id(project_id, credentials)
+
+    # Determine if we should export based on environment
+    is_dev = is_dev_environment()
+    should_export = force_dev_export or not is_dev
+
+    if not should_export:
+        logger.debug('Telemetry export disabled in dev environment')
+        return
+
+    # Determine metric export interval
+    if metric_export_interval_ms is None:
+        metric_export_interval_ms = DEV_METRIC_EXPORT_INTERVAL_MS if is_dev else DEFAULT_METRIC_EXPORT_INTERVAL_MS
+
+    # Ensure minimum interval for GCP
+    if metric_export_interval_ms < MIN_METRIC_EXPORT_INTERVAL_MS:
+        logger.warning(
+            f'metric_export_interval_ms ({metric_export_interval_ms}) is below minimum '
+            f'({MIN_METRIC_EXPORT_INTERVAL_MS}), using minimum'
+        )
+        metric_export_interval_ms = MIN_METRIC_EXPORT_INTERVAL_MS
+
+    # Default timeout to interval if not specified
+    if metric_export_timeout_ms is None:
+        metric_export_timeout_ms = metric_export_interval_ms
+
+    # Configure trace export
+    if not disable_traces:
+        # Create the base GCP exporter with optional credentials
+        exporter_kwargs: dict[str, Any] = {}
+        if resolved_project_id:
+            exporter_kwargs['project_id'] = resolved_project_id
+        if credentials:
+            exporter_kwargs['credentials'] = credentials
+
+        base_exporter = GenkitGCPExporter(**exporter_kwargs) if exporter_kwargs else GenkitGCPExporter()
+
+        # Wrap with GcpAdjustingTraceExporter for PII redaction and telemetry
+        # This matches the JS implementation in gcpOpenTelemetry.ts
+        trace_exporter = GcpAdjustingTraceExporter(
+            exporter=base_exporter,
+            log_input_and_output=log_input_and_output,
+            project_id=resolved_project_id,
+            error_handler=lambda e: _handle_tracing_error(e),
+        )
+
+        add_custom_exporter(trace_exporter, 'gcp_telemetry_server')
+
+    # Configure metrics export
+    if not disable_metrics:
+        try:
+            resource = Resource.create({
+                SERVICE_NAME: 'genkit',
+                SERVICE_INSTANCE_ID: str(uuid.uuid4()),
+            })
+
+            # Suppress detector warnings during GCP resource detection
+            detector_logger = logging.getLogger('opentelemetry.resourcedetector.gcp_resource_detector')
+            original_level = detector_logger.level
+            detector_logger.setLevel(logging.ERROR)
+
+            try:
+                resource = resource.merge(GoogleCloudResourceDetector().detect())
+            finally:
+                detector_logger.setLevel(original_level)
+
+            # Create the base metric exporter
+            base_metric_exporter = CloudMonitoringMetricsExporter(
+                project_id=resolved_project_id,
+            )
+
+            # Wrap with our exporter that adjusts start times
+            metric_exporter = GenkitMetricExporter(
+                exporter=base_metric_exporter,
+                error_handler=lambda e: _handle_metrics_error(e),
+            )
+
+            metric_reader = PeriodicExportingMetricReader(
+                exporter=metric_exporter,
+                export_interval_millis=metric_export_interval_ms,
+                export_timeout_millis=metric_export_timeout_ms,
+            )
+            metrics.set_meter_provider(MeterProvider(metric_readers=[metric_reader], resource=resource))
+        except Exception as e:
+            logger.error('Failed to configure metrics exporter', error=str(e))
+
+
+# Error handling helpers (matches JS getErrorHandler pattern)
+_tracing_error_logged = False
+_metrics_error_logged = False
+
+
+def _handle_tracing_error(error: Exception) -> None:
+    """Handle trace export errors with helpful messages.
+
+    Only logs detailed instructions once to avoid spam.
+
+    Args:
+        error: The export error.
+    """
+    global _tracing_error_logged
+    if _tracing_error_logged:
+        return
+
+    error_str = str(error).lower()
+    if 'permission' in error_str or 'denied' in error_str or '403' in error_str:
+        _tracing_error_logged = True
+        logger.error(
+            'Unable to send traces to Google Cloud. '
+            'Ensure the service account has the "Cloud Trace Agent" (roles/cloudtrace.agent) role. '
+            f'Error: {error}'
+        )
+    else:
+        logger.error('Error exporting traces to GCP', error=str(error))
+
+
+def _handle_metrics_error(error: Exception) -> None:
+    """Handle metrics export errors with helpful messages.
+
+    Only logs detailed instructions once to avoid spam.
+
+    Args:
+        error: The export error.
+    """
+    global _metrics_error_logged
+    if _metrics_error_logged:
+        return
+
+    error_str = str(error).lower()
+    if 'permission' in error_str or 'denied' in error_str or '403' in error_str:
+        _metrics_error_logged = True
+        logger.error(
+            'Unable to send metrics to Google Cloud. '
+            'Ensure the service account has the "Monitoring Metric Writer" '
+            '(roles/monitoring.metricWriter) or "Cloud Telemetry Metrics Writer" '
+            '(roles/telemetry.metricsWriter) role. '
+            f'Error: {error}'
+        )
+    else:
+        logger.error('Error exporting metrics to GCP', error=str(error))

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/utils.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/utils.py
@@ -1,0 +1,215 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utility functions for GCP telemetry.
+
+This module provides utility functions used by the telemetry handlers,
+matching the JavaScript implementation in js/plugins/google-cloud/src/utils.ts.
+
+Functions:
+    - truncate(): Limit string length for log content
+    - truncate_path(): Limit Genkit path string length
+    - to_display_path(): Convert internal path to display format
+    - extract_outer_feature_name_from_path(): Get root feature from path
+    - create_common_log_attributes(): Build log attributes dict
+    - extract_error_*(): Error info extraction helpers
+
+See Also:
+    - Cloud Logging Limits: https://cloud.google.com/logging/quotas
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import TraceFlags
+
+# Constants matching JS implementation
+MAX_LOG_CONTENT_CHARS = 128_000
+MAX_PATH_CHARS = 4096
+
+
+def truncate(text: str | None, limit: int = MAX_LOG_CONTENT_CHARS) -> str:
+    """Truncate text to a maximum length.
+
+    Args:
+        text: The text to truncate.
+        limit: Maximum length (default: 128,000 chars).
+
+    Returns:
+        The truncated text or empty string if None.
+    """
+    if not text:
+        return ''
+    return text[:limit]
+
+
+def truncate_path(path: str) -> str:
+    """Truncate a path to the maximum path length.
+
+    Args:
+        path: The path to truncate.
+
+    Returns:
+        The truncated path.
+    """
+    return truncate(path, MAX_PATH_CHARS)
+
+
+def extract_outer_flow_name_from_path(path: str) -> str:
+    """Extract the outer flow name from a Genkit path.
+
+    Args:
+        path: The Genkit path (e.g., '/{myFlow,t:flow}').
+
+    Returns:
+        The flow name or '<unknown>'.
+    """
+    if not path or path == '<unknown>':
+        return '<unknown>'
+
+    match = re.search(r'/{(.+),t:flow}', path)
+    return match.group(1) if match else '<unknown>'
+
+
+def extract_outer_feature_name_from_path(path: str) -> str:
+    """Extract the outer feature name from a Genkit path.
+
+    Extracts the first feature name from paths like:
+    '/{myFlow,t:flow}/{myStep,t:flowStep}/{googleai/gemini-pro,t:action,s:model}'
+    Returns 'myFlow'.
+
+    Args:
+        path: The Genkit path.
+
+    Returns:
+        The feature name or '<unknown>'.
+    """
+    if not path or path == '<unknown>':
+        return '<unknown>'
+
+    parts = path.split('/')
+    if len(parts) < 2:
+        return '<unknown>'
+
+    first = parts[1]
+    match = re.match(r'\{(.+),t:(flow|action|prompt|dotprompt|helper)', first)
+    return match.group(1) if match else '<unknown>'
+
+
+def extract_error_name(events: list[Any]) -> str | None:
+    """Extract the error name from span events.
+
+    Args:
+        events: List of span events.
+
+    Returns:
+        The error type name or None.
+    """
+    for event in events:
+        if event.name == 'exception':
+            attrs = event.attributes or {}
+            error_type = attrs.get('exception.type')
+            if error_type:
+                return truncate(str(error_type), 1024)
+    return None
+
+
+def extract_error_message(events: list[Any]) -> str | None:
+    """Extract the error message from span events.
+
+    Args:
+        events: List of span events.
+
+    Returns:
+        The error message or None.
+    """
+    for event in events:
+        if event.name == 'exception':
+            attrs = event.attributes or {}
+            error_msg = attrs.get('exception.message')
+            if error_msg:
+                return truncate(str(error_msg), 4096)
+    return None
+
+
+def extract_error_stack(events: list[Any]) -> str | None:
+    """Extract the error stack trace from span events.
+
+    Args:
+        events: List of span events.
+
+    Returns:
+        The stack trace or None.
+    """
+    for event in events:
+        if event.name == 'exception':
+            attrs = event.attributes or {}
+            stack = attrs.get('exception.stacktrace')
+            if stack:
+                return truncate(str(stack), 32_768)
+    return None
+
+
+def create_common_log_attributes(span: ReadableSpan, project_id: str | None = None) -> dict[str, Any]:
+    """Create common log attributes for GCP structured logging.
+
+    These attributes link logs to traces in Google Cloud.
+
+    Args:
+        span: The span to extract context from.
+        project_id: Optional GCP project ID.
+
+    Returns:
+        Dictionary with logging.googleapis.com attributes.
+    """
+    span_context = span.context
+    is_sampled = bool(span_context.trace_flags & TraceFlags.SAMPLED)
+
+    return {
+        'logging.googleapis.com/spanId': format(span_context.span_id, '016x'),
+        'logging.googleapis.com/trace': f'projects/{project_id}/traces/{format(span_context.trace_id, "032x")}',
+        'logging.googleapis.com/trace_sampled': '1' if is_sampled else '0',
+    }
+
+
+def to_display_path(qualified_path: str) -> str:
+    """Convert a qualified Genkit path to a display path.
+
+    Simplifies paths like '/{myFlow,t:flow}/{step,t:flowStep}' to 'myFlow/step'.
+
+    Args:
+        qualified_path: The full Genkit path.
+
+    Returns:
+        A simplified display path.
+    """
+    if not qualified_path:
+        return ''
+
+    # Extract names from path segments like '{name,t:type}'
+    parts = []
+    for segment in qualified_path.split('/'):
+        if segment.startswith('{'):
+            match = re.match(r'\{([^,}]+)', segment)
+            if match:
+                parts.append(match.group(1))
+        elif segment:
+            parts.append(segment)
+
+    return '/'.join(parts)

--- a/py/plugins/google-cloud/tests/tracing_test.py
+++ b/py/plugins/google-cloud/tests/tracing_test.py
@@ -1,0 +1,336 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GCP telemetry tracing module.
+
+This module tests the integration of GcpAdjustingTraceExporter with the
+GCP telemetry plugin, ensuring PII redaction and telemetry recording work correctly.
+
+Tests cover JS/Go parity for:
+- Configuration options (project_id, credentials, sampler, etc.)
+- PII redaction (log_input_and_output)
+- Environment-based export control (force_dev_export)
+- Metrics and traces disable flags
+- Metric export interval/timeout
+"""
+
+import os
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+from genkit.core.environment import EnvVar, GenkitEnvironment
+
+
+def test_add_gcp_telemetry_wraps_with_gcp_adjusting_exporter() -> None:
+    """Test that add_gcp_telemetry wraps the exporter with GcpAdjustingTraceExporter."""
+    with (
+        mock.patch.dict(os.environ, {EnvVar.GENKIT_ENV: GenkitEnvironment.PROD}),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitGCPExporter') as mock_gcp_exporter,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GcpAdjustingTraceExporter') as mock_adjusting,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.add_custom_exporter') as mock_add_exporter,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GoogleCloudResourceDetector'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.CloudMonitoringMetricsExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitMetricExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
+    ):
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+
+        # Create mock instances
+        mock_base_exporter = MagicMock()
+        mock_gcp_exporter.return_value = mock_base_exporter
+
+        mock_wrapped_exporter = MagicMock()
+        mock_adjusting.return_value = mock_wrapped_exporter
+
+        # Call the function
+        add_gcp_telemetry()
+
+        # Verify GenkitGCPExporter was created
+        mock_gcp_exporter.assert_called_once()
+
+        # Verify GcpAdjustingTraceExporter was created with correct args
+        mock_adjusting.assert_called_once()
+        call_kwargs = mock_adjusting.call_args.kwargs
+        assert call_kwargs['exporter'] == mock_base_exporter
+        assert call_kwargs['log_input_and_output'] is False  # Default is redaction enabled
+        assert call_kwargs['project_id'] is None
+
+        # Verify the wrapped exporter was added
+        mock_add_exporter.assert_called_once_with(mock_wrapped_exporter, 'gcp_telemetry_server')
+
+
+def test_add_gcp_telemetry_with_log_input_and_output_enabled() -> None:
+    """Test that log_input_and_output=True disables PII redaction (JS parity)."""
+    with (
+        mock.patch.dict(os.environ, {EnvVar.GENKIT_ENV: GenkitEnvironment.PROD}),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitGCPExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GcpAdjustingTraceExporter') as mock_adjusting,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.add_custom_exporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GoogleCloudResourceDetector'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.CloudMonitoringMetricsExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitMetricExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
+    ):
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+
+        # Call with log_input_and_output=True (maps to JS: !disableLoggingInputAndOutput)
+        add_gcp_telemetry(log_input_and_output=True)
+
+        # Verify log_input_and_output was passed correctly
+        call_kwargs = mock_adjusting.call_args.kwargs
+        assert call_kwargs['log_input_and_output'] is True
+
+
+def test_add_gcp_telemetry_with_project_id() -> None:
+    """Test that project_id is passed to GcpAdjustingTraceExporter (JS/Go parity)."""
+    with (
+        mock.patch.dict(os.environ, {EnvVar.GENKIT_ENV: GenkitEnvironment.PROD}),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitGCPExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GcpAdjustingTraceExporter') as mock_adjusting,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.add_custom_exporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GoogleCloudResourceDetector'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.CloudMonitoringMetricsExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitMetricExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
+    ):
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+
+        # Call with project_id
+        add_gcp_telemetry(project_id='my-test-project')
+
+        # Verify project_id was passed correctly
+        call_kwargs = mock_adjusting.call_args.kwargs
+        assert call_kwargs['project_id'] == 'my-test-project'
+
+
+def test_add_gcp_telemetry_skips_in_dev_without_force() -> None:
+    """Test that telemetry is skipped in dev environment without force_dev_export (JS/Go parity)."""
+    with (
+        mock.patch.dict(os.environ, {EnvVar.GENKIT_ENV: GenkitEnvironment.DEV}),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitGCPExporter') as mock_gcp_exporter,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.add_custom_exporter') as mock_add_exporter,
+    ):
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+
+        # Call without force_dev_export (using legacy force_export)
+        add_gcp_telemetry(force_dev_export=False)
+
+        # Verify nothing was called
+        mock_gcp_exporter.assert_not_called()
+        mock_add_exporter.assert_not_called()
+
+
+def test_add_gcp_telemetry_exports_in_dev_with_force() -> None:
+    """Test that telemetry is exported in dev environment with force_dev_export=True (JS/Go parity)."""
+    with (
+        mock.patch.dict(os.environ, {EnvVar.GENKIT_ENV: GenkitEnvironment.DEV}),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitGCPExporter') as mock_gcp_exporter,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GcpAdjustingTraceExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.add_custom_exporter') as mock_add_exporter,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GoogleCloudResourceDetector'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.CloudMonitoringMetricsExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitMetricExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
+    ):
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+
+        # Call with force_dev_export=True (the default)
+        add_gcp_telemetry(force_dev_export=True)
+
+        # Verify exporter was created and added
+        mock_gcp_exporter.assert_called_once()
+        mock_add_exporter.assert_called_once()
+
+
+def test_add_gcp_telemetry_disable_traces() -> None:
+    """Test that disable_traces=True skips trace export (JS/Go parity)."""
+    with (
+        mock.patch.dict(os.environ, {EnvVar.GENKIT_ENV: GenkitEnvironment.PROD}),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitGCPExporter') as mock_gcp_exporter,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.add_custom_exporter') as mock_add_exporter,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GoogleCloudResourceDetector'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.CloudMonitoringMetricsExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitMetricExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
+    ):
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+
+        # Call with disable_traces=True (JS/Go: disableTraces)
+        add_gcp_telemetry(disable_traces=True)
+
+        # Verify trace exporter was NOT created
+        mock_gcp_exporter.assert_not_called()
+        mock_add_exporter.assert_not_called()
+
+
+def test_add_gcp_telemetry_disable_metrics() -> None:
+    """Test that disable_metrics=True skips metrics export (JS/Go parity)."""
+    with (
+        mock.patch.dict(os.environ, {EnvVar.GENKIT_ENV: GenkitEnvironment.PROD}),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitGCPExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GcpAdjustingTraceExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.add_custom_exporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GoogleCloudResourceDetector') as mock_detector,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.CloudMonitoringMetricsExporter') as mock_metric_exp,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitMetricExporter') as mock_genkit_metric,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader') as mock_reader,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
+    ):
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+
+        # Call with disable_metrics=True (JS/Go: disableMetrics)
+        add_gcp_telemetry(disable_metrics=True)
+
+        # Verify metrics exporter was NOT created
+        mock_detector.assert_not_called()
+        mock_metric_exp.assert_not_called()
+        mock_genkit_metric.assert_not_called()
+        mock_reader.assert_not_called()
+
+
+def test_add_gcp_telemetry_custom_metric_interval() -> None:
+    """Test that metric_export_interval_ms is passed correctly (JS/Go parity)."""
+    with (
+        mock.patch.dict(os.environ, {EnvVar.GENKIT_ENV: GenkitEnvironment.PROD}),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitGCPExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GcpAdjustingTraceExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.add_custom_exporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GoogleCloudResourceDetector'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.CloudMonitoringMetricsExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitMetricExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader') as mock_reader,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
+    ):
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+
+        # Call with custom metric_export_interval_ms (JS/Go: metricExportIntervalMillis)
+        add_gcp_telemetry(metric_export_interval_ms=30000)
+
+        # Verify metric reader was created with correct interval
+        mock_reader.assert_called_once()
+        call_kwargs = mock_reader.call_args.kwargs
+        assert call_kwargs['export_interval_millis'] == 30000
+        assert call_kwargs['export_timeout_millis'] == 30000  # Default to interval
+
+
+def test_add_gcp_telemetry_enforces_minimum_interval() -> None:
+    """Test that metric_export_interval_ms enforces minimum 5000ms (GCP requirement)."""
+    with (
+        mock.patch.dict(os.environ, {EnvVar.GENKIT_ENV: GenkitEnvironment.PROD}),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitGCPExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GcpAdjustingTraceExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.add_custom_exporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GoogleCloudResourceDetector'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.CloudMonitoringMetricsExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitMetricExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader') as mock_reader,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
+    ):
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+
+        # Call with interval below minimum
+        add_gcp_telemetry(metric_export_interval_ms=1000)
+
+        # Verify metric reader was created with minimum interval (5000ms)
+        mock_reader.assert_called_once()
+        call_kwargs = mock_reader.call_args.kwargs
+        assert call_kwargs['export_interval_millis'] == 5000
+
+
+def test_resolve_project_id_from_env_vars() -> None:
+    """Test project ID resolution from environment variables (JS/Go parity)."""
+    from genkit.plugins.google_cloud.telemetry.tracing import _resolve_project_id
+
+    # Test FIREBASE_PROJECT_ID has highest priority
+    with mock.patch.dict(
+        os.environ,
+        {
+            'FIREBASE_PROJECT_ID': 'firebase-project',
+            'GOOGLE_CLOUD_PROJECT': 'gcp-project',
+            'GCLOUD_PROJECT': 'gcloud-project',
+        },
+    ):
+        assert _resolve_project_id() == 'firebase-project'
+
+    # Test GOOGLE_CLOUD_PROJECT is second priority
+    with mock.patch.dict(
+        os.environ,
+        {
+            'GOOGLE_CLOUD_PROJECT': 'gcp-project',
+            'GCLOUD_PROJECT': 'gcloud-project',
+        },
+        clear=True,
+    ):
+        assert _resolve_project_id() == 'gcp-project'
+
+    # Test GCLOUD_PROJECT is fallback
+    with mock.patch.dict(os.environ, {'GCLOUD_PROJECT': 'gcloud-project'}, clear=True):
+        assert _resolve_project_id() == 'gcloud-project'
+
+
+def test_resolve_project_id_explicit_takes_precedence() -> None:
+    """Test that explicit project_id parameter takes precedence over env vars."""
+    from genkit.plugins.google_cloud.telemetry.tracing import _resolve_project_id
+
+    with mock.patch.dict(
+        os.environ,
+        {'FIREBASE_PROJECT_ID': 'firebase-project'},
+    ):
+        # Explicit project_id should override env var
+        assert _resolve_project_id(project_id='explicit-project') == 'explicit-project'
+
+
+def test_resolve_project_id_from_credentials() -> None:
+    """Test project ID resolution from credentials dict (Go parity)."""
+    from genkit.plugins.google_cloud.telemetry.tracing import _resolve_project_id
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        # Project ID from credentials
+        credentials = {'project_id': 'creds-project'}
+        assert _resolve_project_id(credentials=credentials) == 'creds-project'
+
+
+def test_legacy_force_export_parameter() -> None:
+    """Test that legacy force_export parameter still works but shows warning."""
+    with (
+        mock.patch.dict(os.environ, {EnvVar.GENKIT_ENV: GenkitEnvironment.DEV}),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitGCPExporter') as mock_gcp_exporter,
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GcpAdjustingTraceExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.add_custom_exporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GoogleCloudResourceDetector'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.CloudMonitoringMetricsExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitMetricExporter'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
+        patch('genkit.plugins.google_cloud.telemetry.tracing.logger') as mock_logger,
+    ):
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+
+        # Call with legacy force_export parameter
+        add_gcp_telemetry(force_export=True)
+
+        # Verify warning was logged about deprecated parameter
+        mock_logger.warning.assert_called_once()
+        assert 'force_export' in str(mock_logger.warning.call_args)
+        assert 'deprecated' in str(mock_logger.warning.call_args)
+
+        # Verify exporter was still created
+        mock_gcp_exporter.assert_called_once()


### PR DESCRIPTION
feat(py/plugins/google-cloud): add GCP telemetry parity with JS/Go implementations
    
This change brings the Python GCP telemetry implementation to feature
parity with the JavaScript and Go implementations, ensuring consistent
observability across all Genkit SDKs.

Rationale:
The Python GCP telemetry plugin was missing several configuration
options and features that exist in the JS/Go implementations. This
makes it difficult for teams using multiple Genkit SDKs to have
consistent telemetry configuration and behavior. This change adds
all missing features to achieve full parity.

Changes:

Configuration Options (JS/Go parity):
- Add `credentials` parameter for service account auth
- Add `sampler` parameter for custom trace sampling
- Add `disable_metrics` to skip metrics export
- Add `disable_traces` to skip trace export
- Add `metric_export_interval_ms` and `metric_export_timeout_ms`
- Rename `force_export` to `force_dev_export` (with deprecation warning)
- Add project ID resolution from env vars (FIREBASE_PROJECT_ID,
  GOOGLE_CLOUD_PROJECT, GCLOUD_PROJECT) matching JS/Go order

New Components:
- Add GenkitMetricExporter wrapper that adjusts start times for
  DELTA→CUMULATIVE conversion (matches JS MetricExporterWrapper)
- Add _resolve_project_id() for multi-source project ID resolution
- Add genkit:rootState marking for root spans (JS parity)

Generate Metrics (Go parity):
- Add input/output videos metrics
- Add input/output audio metrics

Error Handling:
- Add helpful error messages for permission-denied errors with
  guidance on required GCP IAM roles:
  - Cloud Trace Agent (roles/cloudtrace.agent)
  - Monitoring Metric Writer (roles/monitoring.metricWriter) or
    Cloud Telemetry Metrics Writer (roles/telemetry.metricsWriter)

Documentation:
- Add comprehensive architecture documentation with data flow diagrams
- Document the telemetry pipeline and when each handler fires
- Add configuration options table with JS/Go equivalents
- Add GCP quota references (5-second minimum metric interval)

Tests:
- Add 13 tests covering all configuration options
- Test project ID resolution from various sources
- Test disable_metrics/disable_traces flags
- Test metric export interval enforcement (5000ms minimum per GCP)
- Test legacy force_export parameter deprecation

Cross-checked against GCP documentation:
- Cloud Monitoring quotas: https://cloud.google.com/monitoring/quotas
- Cloud Trace IAM: https://cloud.google.com/trace/docs/iam
- OpenTelemetry GCP exporters: https://google-cloud-opentelemetry.readthedocs.io/