### PR TITLE
fix(go): Remove raw bytes from the debug messages

### DIFF
--- a/go/core/action.go
+++ b/go/core/action.go
@@ -183,15 +183,10 @@ func (a *ActionDef[In, Out, Stream]) Run(ctx context.Context, input In, cb Strea
 
 // Run executes the Action's function in a new trace span.
 func (a *ActionDef[In, Out, Stream]) runWithTelemetry(ctx context.Context, input In, cb StreamCallback[Stream]) (output api.ActionRunResult[Out], err error) {
-	inputBytes, _ := json.Marshal(input)
-	logger.FromContext(ctx).Debug("Action.Run",
-		"name", a.Name(),
-		"input_bytes_count", len(inputBytes))
+	logger.FromContext(ctx).Debug("Action.Run", "name", a.Name())
 	defer func() {
-		outputBytes, _ := json.Marshal(output)
 		logger.FromContext(ctx).Debug("Action.Run",
 			"name", a.Name(),
-			"output_bytes_count", len(outputBytes),
 			"err", err)
 	}()
 


### PR DESCRIPTION
The fix adjust debug messages in `ActionDef.runWithTelemetry` function: it removes JSON bytes from the debug messages and accompanying JSON marshaling code. Debug messages with raw bytes produce unreadable noisy logs and introduce the risk of unintended data exposure through the logs. 

