### PR TITLE
feat(py): add DAP, test_models, generate_operation, and tests

### DIFF
--- a/py/packages/genkit/src/genkit/blocks/dap.py
+++ b/py/packages/genkit/src/genkit/blocks/dap.py
@@ -1,0 +1,519 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dynamic Action Provider (DAP) support for Genkit.
+
+Dynamic Action Providers allow external systems to supply actions at runtime,
+enabling integration with dynamic tooling systems like MCP (Model Context
+Protocol) servers, plugin marketplaces, or other dynamic action sources.
+
+Overview
+========
+
+A Dynamic Action Provider is a registered action that acts as a factory for
+other actions. When Genkit needs to resolve an action that isn't statically
+registered, it queries relevant DAPs to see if they can provide it.
+
+    ┌─────────────────────────────────────────────────────────────────────────┐
+    │                    Dynamic Action Provider Flow                          │
+    ├─────────────────────────────────────────────────────────────────────────┤
+    │                                                                          │
+    │   ┌──────────────┐      ┌──────────────┐      ┌──────────────┐          │
+    │   │   Request    │      │     DAP      │      │   External   │          │
+    │   │   Action     │ ───► │    Cache     │ ───► │   System     │          │
+    │   │  Resolution  │      │   (TTL)      │      │  (e.g. MCP)  │          │
+    │   └──────────────┘      └──────────────┘      └──────────────┘          │
+    │          │                    │                      │                   │
+    │          │                    ▼                      ▼                   │
+    │          │              ┌──────────────┐      ┌──────────────┐          │
+    │          └───────────── │   Return     │ ◄─── │   Actions    │          │
+    │                         │   Action     │      │   Created    │          │
+    │                         └──────────────┘      └──────────────┘          │
+    │                                                                          │
+    └─────────────────────────────────────────────────────────────────────────┘
+
+Key Concepts
+============
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Concept              │ Description                                          │
+├──────────────────────┼──────────────────────────────────────────────────────┤
+│ DAP                  │ Dynamic Action Provider - a factory for actions      │
+│ DapFn                │ Async function that returns actions by type          │
+│ DapConfig            │ Configuration including name, description, caching   │
+│ DapValue             │ Dictionary mapping action types to action lists      │
+│ Cache TTL            │ Time-to-live for cached actions (default: 3000ms)    │
+└─────────────────────┴──────────────────────────────────────────────────────┘
+
+Use Cases
+=========
+
+1. **MCP Integration**: Connect to MCP servers that provide tools/resources
+2. **Plugin Marketplaces**: Load tools from external plugin systems
+3. **Multi-tenant Systems**: Provide tenant-specific actions dynamically
+4. **Feature Flags**: Enable/disable actions based on runtime configuration
+
+Example:
+    ```python
+    from genkit.ai import Genkit
+    from genkit.blocks.dap import define_dynamic_action_provider
+
+    ai = Genkit()
+
+
+    # Define a DAP that provides tools from an external source
+    async def get_mcp_tools():
+        # Connect to MCP server and get available tools
+        tools = await mcp_client.list_tools()
+        return {
+            'tool': [
+                ai.dynamic_tool(
+                    name=t.name,
+                    description=t.description,
+                    fn=lambda input: mcp_client.call_tool(t.name, input),
+                )
+                for t in tools
+            ]
+        }
+
+
+    dap = define_dynamic_action_provider(
+        ai.registry,
+        config={'name': 'mcp-tools', 'cache_config': {'ttl_millis': 5000}},
+        fn=get_mcp_tools,
+    )
+    ```
+
+Caveats:
+    - DAPs are queried during action resolution, so they should be fast
+    - Cache TTL balances freshness with performance - choose wisely
+    - Actions from DAPs have the DAP name prefixed for identification
+
+See Also:
+    - MCP Plugin: genkit.plugins.mcp for Model Context Protocol integration
+    - JS Implementation: js/core/src/dynamic-action-provider.ts
+"""
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from genkit.core.action import Action
+from genkit.core.action.types import ActionKind
+from genkit.core.registry import Registry
+
+ActionMetadataLike = Mapping[str, object]
+"""Type alias for action metadata - any string-keyed mapping.
+
+This type represents objects that behave like action metadata dictionaries,
+providing key-based access to action properties like 'name', 'description',
+'type', etc.
+
+Examples of compatible types:
+    - dict[str, object]
+    - dict[str, Any]
+    - ActionMetadata (from genkit.core.action)
+    - Any other Mapping[str, object]
+"""
+
+DapValue = dict[str, list[Action[Any, Any]]]
+"""Dictionary mapping action type names to lists of actions."""
+
+DapFn = Callable[[], Awaitable[DapValue]]
+"""Async function that returns actions organized by type."""
+
+DapMetadata = dict[str, list[ActionMetadataLike]]
+"""Dictionary mapping action type names to lists of action metadata."""
+
+
+@dataclass
+class DapCacheConfig:
+    """Configuration for DAP caching behavior.
+
+    Attributes:
+        ttl_millis: Time-to-live for cache in milliseconds.
+            - Negative: No caching (always fetch fresh)
+            - Zero/None: Default (3000 milliseconds)
+            - Positive: Cache validity duration in milliseconds
+    """
+
+    ttl_millis: int | None = None
+
+
+@dataclass
+class DapConfig:
+    """Configuration for a Dynamic Action Provider.
+
+    Attributes:
+        name: Unique name for this DAP (used as prefix for actions).
+        description: Human-readable description of what this DAP provides.
+        cache_config: Optional caching configuration.
+        metadata: Additional metadata to attach to the DAP action.
+    """
+
+    name: str
+    description: str | None = None
+    cache_config: DapCacheConfig | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class SimpleCache:
+    """Thread-safe cache for DAP values with TTL expiration.
+
+    This cache ensures that concurrent requests for the same data share
+    a single fetch operation, preventing thundering herd problems.
+    """
+
+    def __init__(
+        self,
+        dap: 'DynamicActionProvider',
+        config: DapConfig,
+        dap_fn: DapFn,
+    ) -> None:
+        """Initialize the cache.
+
+        Args:
+            dap: The parent DAP action.
+            config: DAP configuration including TTL.
+            dap_fn: Function to fetch actions from the external source.
+        """
+        self._dap = dap
+        self._dap_fn = dap_fn
+        self._value: DapValue | None = None
+        self._expires_at: float | None = None
+        self._fetch_task: asyncio.Task[DapValue] | None = None
+
+        # Determine TTL (default 3000ms)
+        ttl = config.cache_config.ttl_millis if config.cache_config else None
+        self._ttl_millis = 3000 if ttl is None or ttl == 0 else ttl
+
+    async def get_or_fetch(self, skip_trace: bool = False) -> DapValue:
+        """Get cached value or fetch fresh data if stale.
+
+        This method handles concurrent requests by sharing a single
+        fetch operation across all waiters.
+
+        Args:
+            skip_trace: If True, don't run the DAP action (used by DevUI
+                to avoid excessive trace entries).
+
+        Returns:
+            The DAP value containing actions by type.
+        """
+        # Check if cache is still valid
+        is_stale = (
+            self._value is None
+            or self._expires_at is None
+            or self._ttl_millis < 0
+            or time.time() * 1000 > self._expires_at
+        )
+
+        if not is_stale and self._value is not None:
+            return self._value
+
+        # If there's already a fetch in progress, wait for it
+        if self._fetch_task is not None:
+            return await self._fetch_task
+
+        # Start a new fetch
+        self._fetch_task = asyncio.create_task(self._do_fetch(skip_trace))
+        try:
+            return await self._fetch_task
+        finally:
+            self._fetch_task = None
+
+    async def _do_fetch(self, skip_trace: bool) -> DapValue:
+        """Perform the actual fetch operation.
+
+        Args:
+            skip_trace: If True, skip running the DAP action.
+
+        Returns:
+            Fresh DAP value.
+        """
+        try:
+            self._value = await self._dap_fn()
+            self._expires_at = time.time() * 1000 + self._ttl_millis
+
+            # Run the DAP action for tracing (unless skipped)
+            if not skip_trace:
+                metadata = transform_dap_value(self._value)
+                await self._dap.action.arun(metadata)
+
+            return self._value
+        except Exception:
+            self.invalidate()
+            raise
+
+    def invalidate(self) -> None:
+        """Invalidate the cache, forcing a fresh fetch on next access."""
+        self._value = None
+        self._expires_at = None
+
+
+def transform_dap_value(value: DapValue) -> DapMetadata:
+    """Transform DAP value to metadata format for logging.
+
+    Args:
+        value: DAP value with actions.
+
+    Returns:
+        DAP metadata with action metadata.
+    """
+    metadata: DapMetadata = {}
+    for action_type, actions in value.items():
+        action_metadata_list: list[ActionMetadataLike] = []
+        for action in actions:
+            # Action.metadata is dict[str, object] which satisfies ActionMetadataLike
+            meta: ActionMetadataLike = action.metadata if action.metadata else {}
+            action_metadata_list.append(meta)
+        metadata[action_type] = action_metadata_list
+    return metadata
+
+
+class DynamicActionProvider:
+    """A Dynamic Action Provider that lazily resolves actions.
+
+    This class wraps a DAP function and provides methods to query
+    for actions by type and name, with caching for performance.
+    """
+
+    def __init__(
+        self,
+        action: Action[Any, Any],
+        config: DapConfig,
+        dap_fn: DapFn,
+    ) -> None:
+        """Initialize the DAP.
+
+        Args:
+            action: The underlying DAP action.
+            config: DAP configuration.
+            dap_fn: Function to fetch actions.
+        """
+        self.action = action
+        self.config = config
+        self._cache = SimpleCache(self, config, dap_fn)
+
+    def invalidate_cache(self) -> None:
+        """Invalidate the cache, forcing a fresh fetch on next access."""
+        self._cache.invalidate()
+
+    async def get_action(
+        self,
+        action_type: str,
+        action_name: str,
+    ) -> Action[Any, Any] | None:
+        """Get a specific action by type and name.
+
+        Args:
+            action_type: The type of action (e.g., 'tool', 'model').
+            action_name: The name of the action.
+
+        Returns:
+            The action if found, None otherwise.
+        """
+        result = await self._cache.get_or_fetch()
+        actions = result.get(action_type, [])
+        for action in actions:
+            if action.name == action_name:
+                return action
+        return None
+
+    async def list_action_metadata(
+        self,
+        action_type: str,
+        action_name: str,
+    ) -> list[ActionMetadataLike]:
+        """List metadata for actions matching type and name pattern.
+
+        Args:
+            action_type: The type of action.
+            action_name: Name or pattern to match:
+                - '*': Match all actions of this type
+                - 'prefix*': Match actions starting with prefix
+                - 'exact': Match only this exact name
+
+        Returns:
+            List of matching action metadata.
+        """
+        result = await self._cache.get_or_fetch()
+        actions = result.get(action_type, [])
+        if not actions:
+            return []
+
+        metadata_list: list[ActionMetadataLike] = []
+        for action in actions:
+            meta: ActionMetadataLike = action.metadata if action.metadata else {}
+            metadata_list.append(meta)
+
+        # Match all
+        if action_name == '*':
+            return metadata_list
+
+        # Prefix match
+        if action_name.endswith('*'):
+            prefix = action_name[:-1]
+            return [m for m in metadata_list if str(m.get('name', '')).startswith(prefix)]
+
+        # Exact match
+        return [m for m in metadata_list if m.get('name') == action_name]
+
+    async def get_action_metadata_record(
+        self,
+        dap_prefix: str,
+    ) -> dict[str, ActionMetadataLike]:
+        """Get all actions as a metadata record for reflection API.
+
+        This is used by the DevUI to list available actions.
+
+        Args:
+            dap_prefix: Prefix to add to action keys.
+
+        Returns:
+            Dictionary mapping action keys to metadata.
+        """
+        dap_actions: dict[str, ActionMetadataLike] = {}
+
+        # Skip trace to avoid excessive DevUI trace entries
+        result = await self._cache.get_or_fetch(skip_trace=True)
+
+        for action_type, actions in result.items():
+            for action in actions:
+                if not action.name:
+                    raise ValueError(f'Invalid metadata when listing dynamic actions from {dap_prefix} - name required')
+                key = f'{dap_prefix}:{action_type}/{action.name}'
+                dap_actions[key] = action.metadata if action.metadata else {}
+
+        return dap_actions
+
+
+def is_dynamic_action_provider(obj: object) -> bool:
+    """Check if an object is a Dynamic Action Provider.
+
+    Args:
+        obj: Object to check.
+
+    Returns:
+        True if the object is a DAP.
+    """
+    if isinstance(obj, DynamicActionProvider):
+        return True
+    if hasattr(obj, 'metadata'):
+        metadata = getattr(obj, 'metadata', None)
+        if isinstance(metadata, dict):
+            return metadata.get('type') == 'dynamic-action-provider'
+    return False
+
+
+def define_dynamic_action_provider(
+    registry: Registry,
+    config: DapConfig | str,
+    fn: DapFn,
+) -> DynamicActionProvider:
+    """Define and register a Dynamic Action Provider.
+
+    A DAP is a factory that can dynamically provide actions at runtime.
+    This is useful for integrating with external systems like MCP servers
+    or plugin marketplaces.
+
+    Args:
+        registry: The registry to register the DAP with.
+        config: DAP configuration or just a name string.
+        fn: Async function that returns actions organized by type.
+
+    Returns:
+        The registered DynamicActionProvider.
+
+    Example:
+        ```python
+        # Simple DAP that provides tools
+        async def get_tools():
+            return {
+                'tool': [
+                    ai.dynamic_tool(name='tool1', fn=...),
+                    ai.dynamic_tool(name='tool2', fn=...),
+                ]
+            }
+
+
+        dap = define_dynamic_action_provider(
+            registry,
+            config='my-tools',
+            fn=get_tools,
+        )
+
+        # DAP with custom caching
+        dap = define_dynamic_action_provider(
+            registry,
+            config=DapConfig(
+                name='mcp-tools',
+                description='Tools from MCP server',
+                cache_config=DapCacheConfig(ttl_millis=10000),
+            ),
+            fn=get_tools,
+        )
+        ```
+
+    See Also:
+        - JS implementation: js/core/src/dynamic-action-provider.ts
+    """
+    # Normalize config
+    if isinstance(config, str):
+        cfg = DapConfig(name=config)
+    else:
+        cfg = config
+
+    # Create metadata with DAP type marker
+    action_metadata = {
+        **cfg.metadata,
+        'type': 'dynamic-action-provider',
+    }
+
+    # Define the underlying action
+    # The action itself just returns its input (for logging purposes)
+    async def dap_action(input: DapMetadata) -> DapMetadata:
+        return input
+
+    action = registry.register_action(
+        name=cfg.name,
+        kind=ActionKind.DYNAMIC_ACTION_PROVIDER,
+        description=cfg.description,
+        fn=dap_action,
+        metadata=action_metadata,
+    )
+
+    # Wrap in DynamicActionProvider
+    dap = DynamicActionProvider(action, cfg, fn)
+
+    return dap
+
+
+__all__ = [
+    'ActionMetadataLike',
+    'DapCacheConfig',
+    'DapConfig',
+    'DapFn',
+    'DapMetadata',
+    'DapValue',
+    'DynamicActionProvider',
+    'SimpleCache',
+    'define_dynamic_action_provider',
+    'is_dynamic_action_provider',
+    'transform_dap_value',
+]

--- a/py/packages/genkit/src/genkit/blocks/model.py
+++ b/py/packages/genkit/src/genkit/blocks/model.py
@@ -184,6 +184,7 @@ class GenerateResponseWrapper(GenerateResponse, Generic[OutputT]):
             custom=response.custom if response.custom is not None else {},
             request=request,
             candidates=response.candidates,
+            operation=response.operation,
         )
         # Set subclass-specific field after parent initialization
         self._message_parser = message_parser

--- a/py/packages/genkit/src/genkit/testing.py
+++ b/py/packages/genkit/src/genkit/testing.py
@@ -5,18 +5,31 @@
 
 """Testing utilities for Genkit applications.
 
-This module provides mock models and utilities for testing Genkit applications
-without making actual API calls to AI providers.
+This module provides mock models, test utilities, and a model test suite for
+testing Genkit applications without making actual API calls to AI providers.
 
-Key Components:
-    - EchoModel: Echoes input back for verification
-    - ProgrammableModel: Returns configurable responses
-    - StaticResponseModel: Always returns the same response
+Key Components
+==============
+
+┌───────────────────────────────────────────────────────────────────────────┐
+│                         Testing Components                                 │
+├───────────────────────┬───────────────────────────────────────────────────┤
+│ Component             │ Purpose                                           │
+├───────────────────────┼───────────────────────────────────────────────────┤
+│ EchoModel             │ Echoes input back - verify request formatting     │
+│ ProgrammableModel     │ Returns configurable responses - test scenarios   │
+│ StaticResponseModel   │ Always returns same response - simple tests       │
+│ test_models()         │ Run standard test suite against models            │
+└───────────────────────┴───────────────────────────────────────────────────┘
 
 Example:
     ```python
     from genkit.ai import Genkit
-    from genkit.testing import define_echo_model, define_programmable_model
+    from genkit.testing import (
+        define_echo_model,
+        define_programmable_model,
+        test_models,
+    )
 
     ai = Genkit()
 
@@ -30,10 +43,15 @@ Example:
     pm.responses = [GenerateResponse(message=Message(...))]
     response = await ai.generate(model='programmableModel', prompt='test')
     assert pm.last_request is not None
+
+    # Test suite - validate model implementations
+    report = await test_models(ai, ['googleai/gemini-2.0-flash'])
+    for test in report:
+        print(f'{test["description"]}: {test["models"]}')
     ```
 
 Cross-Language Parity:
-    - JavaScript: js/genkit/tests/helpers.ts, js/ai/tests/helpers.ts
+    - JavaScript: js/ai/src/testing/model-tester.ts
     - Go: go/ai/testutil_test.go
 
 See Also:
@@ -41,18 +59,26 @@ See Also:
 """
 
 from copy import deepcopy
-from typing import Any
+from typing import Any, TypedDict
 
-from genkit.ai import Genkit
+from pydantic import BaseModel, Field
+
+from genkit.ai import Genkit, Output
 from genkit.codec import dump_json
 from genkit.core.action import Action, ActionRunContext
+from genkit.core.action.types import ActionKind
+from genkit.core.tracing import run_in_new_span
 from genkit.core.typing import (
     GenerateRequest,
     GenerateResponse,
     GenerateResponseChunk,
+    Media,
+    MediaPart,
     Message,
+    ModelInfo,
     Part,
     Role,
+    SpanMetadata,
     TextPart,
 )
 
@@ -374,12 +400,325 @@ def define_static_response_model(
     return (static, action)
 
 
+class SkipTestError(Exception):
+    """Exception raised to skip a test case.
+
+    This is used internally by the test suite to indicate that a test
+    should be skipped (e.g., because the model doesn't support the
+    feature being tested).
+    """
+
+
+def skip() -> None:
+    """Skip the current test case.
+
+    Raises:
+        SkipTestError: Always raised to skip the test.
+    """
+    raise SkipTestError()
+
+
+class ModelTestError(TypedDict, total=False):
+    """Error information from a failed test."""
+
+    message: str
+    stack: str | None
+
+
+class ModelTestResult(TypedDict, total=False):
+    """Result of testing a single model on a single test case."""
+
+    name: str
+    passed: bool
+    skipped: bool
+    error: ModelTestError
+
+
+class TestCaseReport(TypedDict):
+    """Report for a single test case across all models."""
+
+    description: str
+    models: list[ModelTestResult]
+
+
+TestReport = list[TestCaseReport]
+"""Complete test report for all test cases and models."""
+
+
+class GablorkenInput(BaseModel):
+    """Input for the gablorken tool used in tool calling tests."""
+
+    value: float = Field(..., description='The value to calculate gablorken for')
+
+
+async def test_models(ai: Genkit, models: list[str]) -> TestReport:
+    r"""Run a standard test suite against one or more models.
+
+    This function runs a series of tests to validate model implementations,
+    checking for basic functionality, multimodal support, conversation history,
+    system prompts, structured output, and tool calling.
+
+    Test Suite Overview
+    ===================
+
+    ┌─────────────────────────────────────────────────────────────────────────┐
+    │                          Model Test Suite                                │
+    ├─────────────────────────────────────────────────────────────────────────┤
+    │                                                                          │
+    │  Test Case              │ Description                    │ Auto-Skip    │
+    │  ───────────────────────┼────────────────────────────────┼─────────────│
+    │  basic hi               │ Simple text generation         │ Never        │
+    │  multimodal             │ Image input processing         │ No media     │
+    │  history                │ Multi-turn conversation        │ No multiturn │
+    │  system prompt          │ System message handling        │ Never        │
+    │  structured output      │ JSON schema output             │ Never        │
+    │  tool calling           │ Function calling               │ No tools     │
+    │                                                                          │
+    └─────────────────────────────────────────────────────────────────────────┘
+
+    Args:
+        ai: The Genkit instance with models to test.
+        models: List of model names to test (e.g., ['googleai/gemini-2.0-flash']).
+
+    Returns:
+        A TestReport containing results for each test case and model.
+
+    Example:
+        ```python
+        from genkit.ai import Genkit
+        from genkit.plugins.google_genai import GoogleAI
+        from genkit.testing import test_models
+
+        ai = Genkit(plugins=[GoogleAI()])
+
+        # Test multiple models
+        report = await test_models(
+            ai,
+            [
+                'googleai/gemini-2.0-flash',
+                'googleai/gemini-1.5-pro',
+            ],
+        )
+
+        # Print results
+        for test in report:
+            print(f'\\n{test["description"]}:')
+            for model in test['models']:
+                status = '✓' if model['passed'] else ('⊘' if model.get('skipped') else '✗')
+                print(f'  {status} {model["name"]}')
+                if 'error' in model:
+                    print(f'      Error: {model["error"]["message"]}')
+        ```
+
+    Note:
+        - Tests are automatically skipped if the model doesn't support
+          the required capability (e.g., tools, media, multiturn).
+        - A 'gablorkenTool' is automatically registered for tool calling tests.
+        - The test uses a small base64-encoded test image for multimodal tests.
+
+    See Also:
+        - JS implementation: js/ai/src/testing/model-tester.ts
+    """
+
+    # Register the gablorken tool for tool calling tests
+    # NOTE: Tool name is camelCase to match JS implementation for parity
+    @ai.tool(name='gablorkenTool')
+    def gablorken_tool(input: GablorkenInput) -> float:
+        """Calculate the gablorken of a value. Use when need to calculate a gablorken."""
+        return (input.value**3) + 1.407
+
+    async def get_model_info(model_name: str) -> ModelInfo | None:
+        """Get ModelInfo for a model, or None if not available.
+
+        Args:
+            model_name: The name of the model to look up.
+
+        Returns:
+            ModelInfo if available, None otherwise.
+        """
+        model_action = await ai.registry.resolve_action(ActionKind.MODEL, model_name)
+        if model_action and model_action.metadata:
+            info_obj = model_action.metadata.get('model')
+            if isinstance(info_obj, ModelInfo):
+                return info_obj
+        return None
+
+    # Define test cases
+    async def test_basic_hi(model: str) -> None:
+        """Test basic text generation."""
+        response = await ai.generate(model=model, prompt='just say "Hi", literally')
+        got = response.text.strip()
+        assert 'hi' in got.lower(), f'Expected "Hi" in response, got: {got}'
+
+    async def test_multimodal(model: str) -> None:
+        """Test multimodal (image) input."""
+        info = await get_model_info(model)
+        if not (info and info.supports and info.supports.media):
+            skip()
+
+        # Small test image (plus sign)
+        test_image = (
+            'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2'
+            'AAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9TpSoVETOIOGSoulgQFXHU'
+            'KhShQqgVWnUwufRDaNKQtLg4Cq4FBz8Wqw4uzro6uAqC4AeIs4OToouU+L+k0CLG'
+            'g+N+vLv3uHsHCLUi0+22MUA3ylYyHpPSmRUp9IpOhCCiFyMKs81ZWU7Ad3zdI8DX'
+            'uyjP8j/35+jWsjYDAhLxDDOtMvE68dRm2eS8TyyygqIRnxOPWnRB4keuqx6/cc67'
+            'LPBM0Uol54hFYinfwmoLs4KlE08SRzTdoHwh7bHGeYuzXqywxj35C8NZY3mJ6zQH'
+            'EccCFiFDgooKNlBEGVFaDVJsJGk/5uMfcP0yuVRybYCRYx4l6FBcP/gf/O7Wzk2M'
+            'e0nhGND+4jgfQ0BoF6hXHef72HHqJ0DwGbgymv5SDZj+JL3a1CJHQM82cHHd1NQ9'
+            '4HIH6H8yFUtxpSBNIZcD3s/omzJA3y3Qter11tjH6QOQoq4SN8DBITCcp+w1n3d3'
+            'tPb275lGfz9aC3Kd0jYiSQAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAAd0SU1FB+gJ'
+            'BxQRO1/5qB8AAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAA'
+            'sUlEQVQoz61SMQqEMBDcO5SYToUE/IBPyRMCftAH+INUviApUwYjNkKCVcTiQK7I'
+            'HSw45czODrMswCOQUkopEQZjzDiOWemdZfu+b5oGYYgx1nWNMPwB2vACAK01Y4wQ'
+            '8qGqqirL8jzPlNI9t64r55wQUgBA27be+xDCfaJhGJxzSqnv3UKIn7ne+2VZEB2s'
+            'tZRSRLN93+d5RiRs28Y5RySEEI7jyEpFlp2mqeu6Zx75ApQwPdsIcq0ZAAAAAElF'
+            'TkSuQmCC'
+        )
+
+        response = await ai.generate(
+            model=model,
+            prompt=[
+                Part(root=MediaPart(media=Media(url=test_image))),
+                Part(root=TextPart(text='what math operation is this? plus, minus, multiply or divide?')),
+            ],
+        )
+        got = response.text.strip().lower()
+        assert 'plus' in got, f'Expected "plus" in response, got: {got}'
+
+    async def test_history(model: str) -> None:
+        """Test conversation history (multi-turn)."""
+        info = await get_model_info(model)
+        if not (info and info.supports and info.supports.multiturn):
+            skip()
+
+        response1 = await ai.generate(model=model, prompt='My name is Glorb')
+        response2 = await ai.generate(
+            model=model,
+            prompt="What's my name?",
+            messages=response1.messages,
+        )
+        got = response2.text.strip()
+        assert 'Glorb' in got, f'Expected "Glorb" in response, got: {got}'
+
+    async def test_system_prompt(model: str) -> None:
+        """Test system prompt handling."""
+        response = await ai.generate(
+            model=model,
+            prompt='Hi',
+            messages=[
+                Message.model_validate({
+                    'role': 'system',
+                    'content': [{'text': 'If the user says "Hi", just say "Bye"'}],
+                }),
+            ],
+        )
+        got = response.text.strip()
+        assert 'Bye' in got, f'Expected "Bye" in response, got: {got}'
+
+    async def test_structured_output(model: str) -> None:
+        """Test structured JSON output."""
+
+        class PersonInfo(BaseModel):
+            name: str
+            occupation: str
+
+        response = await ai.generate(
+            model=model,
+            prompt='extract data as json from: Jack was a Lumberjack',
+            output=Output(schema=PersonInfo),
+        )
+        got = response.output
+        assert got is not None, 'Expected structured output'
+        # Output can be dict or model instance depending on parsing
+        if isinstance(got, BaseModel):
+            got = got.model_dump()
+
+        assert isinstance(got, dict), f'Expected output to be a dict or BaseModel, got {type(got)}'
+        assert got.get('name') == 'Jack', f"Expected name='Jack', got: {got.get('name')}"
+        assert got.get('occupation') == 'Lumberjack', f"Expected occupation='Lumberjack', got: {got.get('occupation')}"
+
+    async def test_tool_calling(model: str) -> None:
+        """Test tool/function calling."""
+        info = await get_model_info(model)
+        if not (info and info.supports and info.supports.tools):
+            skip()
+
+        response = await ai.generate(
+            model=model,
+            prompt='what is a gablorken of 2? use provided tool',
+            tools=['gablorkenTool'],
+        )
+        got = response.text.strip()
+        # 2^3 + 1.407 = 9.407
+        assert '9.407' in got, f'Expected "9.407" in response, got: {got}'
+
+    # Map of test cases
+    tests: dict[str, Any] = {
+        'basic hi': test_basic_hi,
+        'multimodal': test_multimodal,
+        'history': test_history,
+        'system prompt': test_system_prompt,
+        'structured output': test_structured_output,
+        'tool calling': test_tool_calling,
+    }
+
+    # Run tests with tracing
+    report: TestReport = []
+
+    with run_in_new_span(SpanMetadata(name='testModels'), labels={'genkit:type': 'testSuite'}):
+        for test_name, test_fn in tests.items():
+            with run_in_new_span(SpanMetadata(name=test_name), labels={'genkit:type': 'testCase'}):
+                case_report: TestCaseReport = {
+                    'description': test_name,
+                    'models': [],
+                }
+
+                for model in models:
+                    model_result: ModelTestResult = {
+                        'name': model,
+                        'passed': True,  # Optimistic
+                    }
+
+                    try:
+                        await test_fn(model)
+                    except SkipTestError:
+                        model_result['passed'] = False
+                        model_result['skipped'] = True
+                    except AssertionError as e:
+                        model_result['passed'] = False
+                        model_result['error'] = {
+                            'message': str(e),
+                            'stack': None,
+                        }
+                    except Exception as e:
+                        model_result['passed'] = False
+                        model_result['error'] = {
+                            'message': str(e),
+                            'stack': None,
+                        }
+
+                    case_report['models'].append(model_result)
+
+                report.append(case_report)
+
+    return report
+
+
 # Export all public symbols
 __all__ = [
     'EchoModel',
+    'GablorkenInput',
+    'ModelTestError',
+    'ModelTestResult',
     'ProgrammableModel',
+    'SkipTestError',
     'StaticResponseModel',
+    'TestCaseReport',
+    'TestReport',
     'define_echo_model',
     'define_programmable_model',
     'define_static_response_model',
+    'skip',
+    'test_models',
 ]

--- a/py/packages/genkit/tests/genkit/ai/ai_registry_test.py
+++ b/py/packages/genkit/tests/genkit/ai/ai_registry_test.py
@@ -19,11 +19,41 @@
 
 This module contains unit tests for the GenkitRegistry class and its associated
 functionality, ensuring proper registration and management of Genkit resources.
+
+Test Coverage
+=============
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Test Case                           │ Description                           │
+├─────────────────────────────────────┼───────────────────────────────────────┤
+│ get_func_description Tests                                                  │
+├─────────────────────────────────────┼───────────────────────────────────────┤
+│ test_with_explicit_description      │ Explicit desc takes precedence        │
+│ test_with_docstring                 │ Docstring used when no explicit desc  │
+│ test_without_docstring              │ Empty string when no docstring        │
+│ test_with_none_docstring            │ Empty string when docstring is None   │
+├─────────────────────────────────────┼───────────────────────────────────────┤
+│ define_json_schema Tests                                                    │
+├─────────────────────────────────────┼───────────────────────────────────────┤
+│ test_define_json_schema_basic       │ Register a basic JSON schema          │
+│ test_define_json_schema_complex     │ Register complex nested schema        │
+│ test_define_json_schema_returns     │ Method returns the schema             │
+├─────────────────────────────────────┼───────────────────────────────────────┤
+│ define_dynamic_action_provider Tests                                        │
+├─────────────────────────────────────┼───────────────────────────────────────┤
+│ test_define_dap_with_string         │ DAP with string config                │
+│ test_define_dap_with_config         │ DAP with DapConfig object             │
+│ test_define_dap_returns_provider    │ Method returns DynamicActionProvider  │
+└─────────────────────────────────────┴───────────────────────────────────────┘
 """
 
 import unittest
 
+import pytest
+
+from genkit.ai import Genkit
 from genkit.ai._registry import get_func_description
+from genkit.blocks.dap import DapCacheConfig, DapConfig, DapValue, DynamicActionProvider
 
 
 class TestGetFuncDescription(unittest.TestCase):
@@ -68,6 +98,138 @@ class TestGetFuncDescription(unittest.TestCase):
 
         description = get_func_description(test_func)
         self.assertEqual(description, '')
+
+
+class TestDefineJsonSchema:
+    """Tests for the define_json_schema method."""
+
+    def test_define_json_schema_basic(self) -> None:
+        """Test registering a basic JSON schema."""
+        ai = Genkit()
+
+        schema = ai.define_json_schema(
+            'SimpleObject',
+            {
+                'type': 'object',
+                'properties': {
+                    'name': {'type': 'string'},
+                    'age': {'type': 'integer'},
+                },
+                'required': ['name'],
+            },
+        )
+
+        assert schema is not None
+        assert schema['type'] == 'object'
+        assert 'properties' in schema
+
+    def test_define_json_schema_complex(self) -> None:
+        """Test registering a complex nested JSON schema."""
+        ai = Genkit()
+
+        schema = ai.define_json_schema(
+            'Recipe',
+            {
+                'type': 'object',
+                'properties': {
+                    'title': {'type': 'string'},
+                    'ingredients': {
+                        'type': 'array',
+                        'items': {'type': 'string'},
+                    },
+                    'instructions': {'type': 'string'},
+                    'nutrition': {
+                        'type': 'object',
+                        'properties': {
+                            'calories': {'type': 'number'},
+                            'protein': {'type': 'number'},
+                        },
+                    },
+                },
+                'required': ['title', 'ingredients', 'instructions'],
+            },
+        )
+
+        assert schema is not None
+        assert schema['type'] == 'object'
+        # Type checker doesn't narrow dict[str, object] properly after isinstance
+        properties: dict[str, object] = schema['properties']  # type: ignore[assignment]
+        assert isinstance(properties, dict)
+        assert 'ingredients' in properties
+        ingredients: dict[str, object] = properties['ingredients']  # type: ignore[assignment]
+        assert isinstance(ingredients, dict)
+        assert ingredients['type'] == 'array'
+
+    def test_define_json_schema_returns_same_schema(self) -> None:
+        """Test that define_json_schema returns the schema for convenience."""
+        ai = Genkit()
+
+        input_schema: dict[str, object] = {
+            'type': 'string',
+            'minLength': 1,
+        }
+
+        returned_schema = ai.define_json_schema('StringSchema', input_schema)
+
+        # Should return the same schema object
+        assert returned_schema is input_schema
+
+
+class TestDefineDynamicActionProvider:
+    """Tests for the define_dynamic_action_provider method via Genkit."""
+
+    @pytest.mark.asyncio
+    async def test_define_dap_with_string_config(self) -> None:
+        """Test defining a DAP with a string name."""
+        ai = Genkit()
+
+        async def dap_fn() -> DapValue:
+            return {}
+
+        dap = ai.define_dynamic_action_provider('my-dap', dap_fn)
+
+        assert isinstance(dap, DynamicActionProvider)
+        assert dap.config.name == 'my-dap'
+
+    @pytest.mark.asyncio
+    async def test_define_dap_with_config_object(self) -> None:
+        """Test defining a DAP with a DapConfig object."""
+        ai = Genkit()
+
+        async def dap_fn() -> DapValue:
+            return {}
+
+        config = DapConfig(
+            name='configured-dap',
+            description='A configured DAP',
+            cache_config=DapCacheConfig(ttl_millis=5000),
+            metadata={'custom': 'value'},
+        )
+
+        dap = ai.define_dynamic_action_provider(config, dap_fn)
+
+        assert isinstance(dap, DynamicActionProvider)
+        assert dap.config.name == 'configured-dap'
+        assert dap.config.description == 'A configured DAP'
+        assert dap.config.cache_config is not None
+        assert dap.config.cache_config.ttl_millis == 5000
+
+    @pytest.mark.asyncio
+    async def test_define_dap_returns_provider(self) -> None:
+        """Test that define_dynamic_action_provider returns a DynamicActionProvider."""
+        ai = Genkit()
+
+        async def dap_fn() -> DapValue:
+            return {}
+
+        result = ai.define_dynamic_action_provider('test-dap', dap_fn)
+
+        assert isinstance(result, DynamicActionProvider)
+        # Should have required methods
+        assert hasattr(result, 'get_action')
+        assert hasattr(result, 'list_action_metadata')
+        assert hasattr(result, 'invalidate_cache')
+        assert hasattr(result, 'get_action_metadata_record')
 
 
 if __name__ == '__main__':

--- a/py/packages/genkit/tests/genkit/ai/generate_operation_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_operation_test.py
@@ -1,0 +1,298 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the generate_operation method.
+
+This module tests the generate_operation method which is used for long-running
+model operations (like video generation with Veo). The method:
+
+- Only works with models that support long-running operations
+- Returns an Operation that can be polled with check_operation()
+- Throws errors if the model doesn't support long-running ops
+
+Test Coverage
+=============
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Test Case                              │ Description                        │
+├────────────────────────────────────────┼────────────────────────────────────┤
+│ test_no_model_specified                │ Error when no model provided       │
+│ test_model_not_found                   │ Error when model doesn't exist     │
+│ test_model_no_long_running_support     │ Error when model lacks LRO support │
+│ test_model_no_operation_returned       │ Error when no operation returned   │
+│ test_long_running_model_success        │ Success path for LRO models        │
+└────────────────────────────────────────┴────────────────────────────────────┘
+
+Cross-Language Parity:
+    - JavaScript: js/ai/src/generate.ts (generateOperation function)
+
+Note:
+    This is a beta feature matching the JS implementation. Only models that
+    explicitly support long-running operations (model.supports.longRunning=True)
+    can be used with generate_operation().
+"""
+
+import pytest
+
+from genkit.ai import Genkit
+from genkit.core.action import ActionRunContext
+from genkit.core.error import GenkitError
+from genkit.core.typing import (
+    GenerateRequest,
+    GenerateResponse,
+    Message,
+    ModelInfo,
+    Operation,
+    Part,
+    Role,
+    Supports,
+    TextPart,
+)
+
+
+@pytest.fixture
+def ai() -> Genkit:
+    """Create a fresh Genkit instance for each test."""
+    return Genkit()
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_no_model_specified(ai: Genkit) -> None:
+    """Test that generate_operation raises error when no model specified."""
+    with pytest.raises(GenkitError) as exc_info:
+        await ai.generate_operation(prompt='Hi')
+
+    assert 'No model specified' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_model_not_found(ai: Genkit) -> None:
+    """Test that generate_operation raises error when model not found."""
+    with pytest.raises(GenkitError) as exc_info:
+        await ai.generate_operation(model='nonexistent/model', prompt='Hi')
+
+    assert 'not found' in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_model_no_long_running_support(ai: Genkit) -> None:
+    """Test that generate_operation raises error when model doesn't support long-running.
+
+    This matches the JS behavior where models must have supports.longRunning=True.
+    """
+
+    # Define a standard model without long_running support
+    def model_fn(request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        return GenerateResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='Hello'))],
+            ),
+        )
+
+    ai.define_model(
+        name='standard-model',
+        fn=model_fn,
+        info=ModelInfo(
+            supports=Supports(
+                multiturn=True,
+                tools=True,
+                media=False,
+                long_running=False,  # Not a long-running model
+            ),
+        ),
+    )
+
+    with pytest.raises(GenkitError) as exc_info:
+        await ai.generate_operation(model='standard-model', prompt='Hi')
+
+    assert 'does not support long running operations' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_model_no_supports_info(ai: Genkit) -> None:
+    """Test that models without supports info are rejected."""
+
+    # Define a model without any ModelInfo
+    def model_fn(request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        return GenerateResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='Hello'))],
+            ),
+        )
+
+    ai.define_model(name='no-info-model', fn=model_fn)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await ai.generate_operation(model='no-info-model', prompt='Hi')
+
+    assert 'does not support long running operations' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_no_operation_returned(ai: Genkit) -> None:
+    """Test error when model supports LRO but doesn't return an operation.
+
+    This matches the JS FAILED_PRECONDITION error case.
+    """
+
+    # Define a model that claims to support long_running but doesn't return an operation
+    def model_fn(request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        # Return a normal response without an operation
+        return GenerateResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='Hello'))],
+            ),
+        )
+
+    ai.define_model(
+        name='fake-lro-model',
+        fn=model_fn,
+        info=ModelInfo(
+            supports=Supports(
+                long_running=True,  # Claims to support LRO
+            ),
+        ),
+    )
+
+    with pytest.raises(GenkitError) as exc_info:
+        await ai.generate_operation(model='fake-lro-model', prompt='Hi')
+
+    assert 'did not return an operation' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_success_with_lro_model(ai: Genkit) -> None:
+    """Test successful generate_operation with a proper long-running model."""
+    expected_operation = Operation(
+        id='test-operation-123',
+        done=False,
+        action='/background-model/lro-model',
+    )
+
+    # Define a model that supports long_running and returns an operation
+    def model_fn(request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        return GenerateResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='Started'))],
+            ),
+            operation=expected_operation,
+        )
+
+    ai.define_model(
+        name='lro-model',
+        fn=model_fn,
+        info=ModelInfo(
+            supports=Supports(
+                long_running=True,
+            ),
+        ),
+    )
+
+    operation = await ai.generate_operation(model='lro-model', prompt='Generate video')
+
+    assert isinstance(operation, Operation)
+    assert operation.id == 'test-operation-123'
+    assert operation.done is False
+    assert operation.action == '/background-model/lro-model'
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_with_default_model(ai: Genkit) -> None:
+    """Test generate_operation uses default model when set."""
+    expected_operation = Operation(
+        id='default-op-456',
+        done=False,
+    )
+
+    def model_fn(request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        return GenerateResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='Started'))],
+            ),
+            operation=expected_operation,
+        )
+
+    ai.define_model(
+        name='default-lro-model',
+        fn=model_fn,
+        info=ModelInfo(
+            supports=Supports(
+                long_running=True,
+            ),
+        ),
+    )
+
+    # Create a new Genkit instance with the default model set
+    ai_with_default = Genkit(model='default-lro-model')
+    # Re-register the model on the new instance
+    ai_with_default.define_model(
+        name='default-lro-model',
+        fn=model_fn,
+        info=ModelInfo(
+            supports=Supports(
+                long_running=True,
+            ),
+        ),
+    )
+
+    operation = await ai_with_default.generate_operation(prompt='Generate video')
+
+    assert isinstance(operation, Operation)
+    assert operation.id == 'default-op-456'
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_passes_all_options(ai: Genkit) -> None:
+    """Test that generate_operation passes all options to generate()."""
+    captured_request: GenerateRequest | None = None
+    expected_operation = Operation(id='opt-test-789', done=False)
+
+    def model_fn(request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        nonlocal captured_request
+        captured_request = request
+        return GenerateResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='Started'))],
+            ),
+            operation=expected_operation,
+        )
+
+    ai.define_model(
+        name='options-test-model',
+        fn=model_fn,
+        info=ModelInfo(
+            supports=Supports(
+                long_running=True,
+            ),
+        ),
+    )
+
+    await ai.generate_operation(
+        model='options-test-model',
+        prompt='Test prompt',
+        system='You are a test assistant',
+        config={'temperature': 0.7},
+    )
+
+    assert captured_request is not None
+    # Verify config was passed
+    assert captured_request.config is not None

--- a/py/packages/genkit/tests/genkit/blocks/dap_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/dap_test.py
@@ -1,0 +1,533 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Dynamic Action Provider (DAP) module.
+
+This module contains comprehensive tests for the DAP functionality,
+ensuring parity with the JavaScript implementation in:
+    js/core/tests/dynamic-action-provider_test.ts
+
+Test Coverage
+=============
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Test Case                     │ Description                                  │
+├───────────────────────────────┼──────────────────────────────────────────────┤
+│ test_gets_specific_action     │ Get a specific action by type and name       │
+│ test_lists_action_metadata    │ List metadata with wildcard pattern          │
+│ test_caches_actions           │ Verify caching prevents redundant fetches    │
+│ test_invalidates_cache        │ Cache invalidation forces fresh fetch        │
+│ test_respects_cache_ttl       │ TTL expiration triggers refresh              │
+│ test_lists_actions_with_prefix│ Prefix matching for action names             │
+│ test_lists_actions_exact_match│ Exact name matching                          │
+│ test_gets_action_metadata_rec │ Reflection API metadata record format        │
+│ test_handles_concurrent_reqs  │ Concurrent requests share single fetch       │
+│ test_handles_fetch_errors     │ Error recovery and cache invalidation        │
+│ test_identifies_dap           │ Type identification helper                   │
+│ test_transform_dap_value      │ Value to metadata transformation             │
+└───────────────────────────────┴──────────────────────────────────────────────┘
+"""
+
+import asyncio
+
+import pytest
+
+from genkit.blocks.dap import (
+    DapCacheConfig,
+    DapConfig,
+    DapValue,
+    DynamicActionProvider,
+    define_dynamic_action_provider,
+    is_dynamic_action_provider,
+    transform_dap_value,
+)
+from genkit.core.action import Action
+from genkit.core.action.types import ActionKind
+from genkit.core.registry import Registry
+
+
+@pytest.fixture
+def registry() -> Registry:
+    """Create a fresh registry for each test."""
+    return Registry()
+
+
+@pytest.fixture
+def tool1(registry: Registry) -> Action:
+    """Create tool1 action for testing."""
+
+    async def tool1_fn(input: str) -> str:
+        return 'tool1'
+
+    return registry.register_action(
+        name='tool1',
+        kind=ActionKind.TOOL,
+        fn=tool1_fn,
+        metadata={'name': 'tool1'},
+    )
+
+
+@pytest.fixture
+def tool2(registry: Registry) -> Action:
+    """Create tool2 action for testing."""
+
+    async def tool2_fn(input: str) -> str:
+        return 'tool2'
+
+    return registry.register_action(
+        name='tool2',
+        kind=ActionKind.TOOL,
+        fn=tool2_fn,
+        metadata={'name': 'tool2'},
+    )
+
+
+@pytest.fixture
+def other_tool(registry: Registry) -> Action:
+    """Create other-tool action for testing prefix matching."""
+
+    async def other_tool_fn(input: str) -> str:
+        return 'other'
+
+    return registry.register_action(
+        name='other-tool',
+        kind=ActionKind.TOOL,
+        fn=other_tool_fn,
+        metadata={'name': 'other-tool'},
+    )
+
+
+@pytest.mark.asyncio
+async def test_gets_specific_action(registry: Registry, tool1: Action, tool2: Action) -> None:
+    """Test getting a specific action by type and name.
+
+    Corresponds to JS test: 'gets a specific action'
+    """
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        return {'tool': [tool1, tool2]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    action = await dap.get_action('tool', 'tool1')
+    assert action is tool1
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_lists_action_metadata(registry: Registry, tool1: Action, tool2: Action) -> None:
+    """Test listing action metadata with wildcard.
+
+    Corresponds to JS test: 'lists action metadata'
+    """
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        return {'tool': [tool1, tool2]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    metadata = await dap.list_action_metadata('tool', '*')
+    assert len(metadata) == 2
+    assert metadata[0] == tool1.metadata
+    assert metadata[1] == tool2.metadata
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_caches_actions(registry: Registry, tool1: Action, tool2: Action) -> None:
+    """Test that actions are cached across multiple calls.
+
+    Corresponds to JS test: 'caches the actions'
+    """
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        return {'tool': [tool1, tool2]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    action = await dap.get_action('tool', 'tool1')
+    assert action is tool1
+    assert call_count == 1
+
+    # This should be cached
+    action = await dap.get_action('tool', 'tool2')
+    assert action is tool2
+    assert call_count == 1
+
+    metadata = await dap.list_action_metadata('tool', '*')
+    assert len(metadata) == 2
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_invalidates_cache(registry: Registry, tool1: Action, tool2: Action) -> None:
+    """Test that cache invalidation forces a fresh fetch.
+
+    Corresponds to JS test: 'invalidates the cache'
+    """
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        return {'tool': [tool1, tool2]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    await dap.get_action('tool', 'tool1')
+    assert call_count == 1
+
+    dap.invalidate_cache()
+
+    await dap.get_action('tool', 'tool2')
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_respects_cache_ttl(registry: Registry, tool1: Action, tool2: Action) -> None:
+    """Test that cache respects TTL configuration.
+
+    Corresponds to JS test: 'respects cache ttl'
+    """
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        return {'tool': [tool1, tool2]}
+
+    config = DapConfig(name='my-dap', cache_config=DapCacheConfig(ttl_millis=10))
+    dap = define_dynamic_action_provider(registry, config, dap_fn)
+
+    await dap.get_action('tool', 'tool1')
+    assert call_count == 1
+
+    # Wait for TTL to expire
+    await asyncio.sleep(0.025)  # 25ms > 10ms TTL
+
+    await dap.get_action('tool', 'tool2')
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_lists_actions_with_prefix(registry: Registry, tool1: Action, tool2: Action, other_tool: Action) -> None:
+    """Test listing actions with prefix pattern matching.
+
+    Corresponds to JS test: 'lists actions with prefix'
+    """
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        return {'tool': [tool1, tool2, other_tool]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    metadata = await dap.list_action_metadata('tool', 'tool*')
+    assert len(metadata) == 2
+    assert metadata[0] == tool1.metadata
+    assert metadata[1] == tool2.metadata
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_lists_actions_exact_match(registry: Registry, tool1: Action, tool2: Action) -> None:
+    """Test listing actions with exact name matching.
+
+    Corresponds to JS test: 'lists actions with exact match'
+    """
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        return {'tool': [tool1, tool2]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    metadata = await dap.list_action_metadata('tool', 'tool1')
+    assert len(metadata) == 1
+    assert metadata[0] == tool1.metadata
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_gets_action_metadata_record(registry: Registry, tool1: Action, tool2: Action) -> None:
+    """Test getting action metadata record for reflection API.
+
+    Corresponds to JS test: 'gets action metadata record'
+    """
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        return {
+            'tool': [tool1, tool2],
+            'flow': [tool1],
+        }
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    record = await dap.get_action_metadata_record('dap/my-dap')
+    assert 'dap/my-dap:tool/tool1' in record
+    assert 'dap/my-dap:tool/tool2' in record
+    assert 'dap/my-dap:flow/tool1' in record
+    assert record['dap/my-dap:tool/tool1'] == tool1.metadata
+    assert record['dap/my-dap:tool/tool2'] == tool2.metadata
+    assert record['dap/my-dap:flow/tool1'] == tool1.metadata
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_handles_concurrent_requests(registry: Registry, tool1: Action, tool2: Action) -> None:
+    """Test that concurrent requests share a single fetch operation.
+
+    Corresponds to JS test: 'handles concurrent requests'
+    """
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.01)  # Simulate async work
+        return {'tool': [tool1, tool2]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    # Run two requests concurrently
+    results = await asyncio.gather(
+        dap.list_action_metadata('tool', '*'),
+        dap.list_action_metadata('tool', '*'),
+    )
+
+    metadata1, metadata2 = results
+    assert len(metadata1) == 2
+    assert len(metadata2) == 2
+    assert metadata1[0] == tool1.metadata
+    assert metadata2[0] == tool1.metadata
+    # Only one fetch should have occurred
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_handles_fetch_errors(registry: Registry, tool1: Action, tool2: Action) -> None:
+    """Test error handling and cache invalidation on fetch failure.
+
+    Corresponds to JS test: 'handles fetch errors'
+    """
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError('Fetch failed')
+        return {'tool': [tool1, tool2]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    # First call should raise
+    with pytest.raises(RuntimeError, match='Fetch failed'):
+        await dap.list_action_metadata('tool', '*')
+    assert call_count == 1
+
+    # Second call should succeed (cache was invalidated)
+    metadata = await dap.list_action_metadata('tool', '*')
+    assert len(metadata) == 2
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_identifies_dap(registry: Registry, tool1: Action) -> None:
+    """Test the is_dynamic_action_provider helper function.
+
+    Corresponds to JS test: 'identifies dynamic action providers'
+    """
+
+    async def dap_fn() -> DapValue:
+        return {}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+    assert is_dynamic_action_provider(dap) is True
+
+    # Regular action should not be identified as DAP
+    assert is_dynamic_action_provider(tool1) is False
+
+
+def test_transform_dap_value(tool1: Action, tool2: Action) -> None:
+    """Test the transform_dap_value utility function."""
+    value: DapValue = {'tool': [tool1, tool2]}
+
+    metadata = transform_dap_value(value)
+
+    assert 'tool' in metadata
+    assert len(metadata['tool']) == 2
+    assert metadata['tool'][0] == tool1.metadata
+    assert metadata['tool'][1] == tool2.metadata
+
+
+def test_dap_config_string_normalization(registry: Registry) -> None:
+    """Test that string config is normalized to DapConfig.
+
+    The define_dynamic_action_provider should accept either a string
+    or a DapConfig object.
+    """
+
+    async def dap_fn() -> DapValue:
+        return {}
+
+    # String config
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+    assert isinstance(dap, DynamicActionProvider)
+    assert dap.config.name == 'my-dap'
+
+
+def test_dap_config_with_full_options(registry: Registry) -> None:
+    """Test DapConfig with all options specified."""
+
+    async def dap_fn() -> DapValue:
+        return {}
+
+    config = DapConfig(
+        name='full-config-dap',
+        description='A DAP with all options',
+        cache_config=DapCacheConfig(ttl_millis=5000),
+        metadata={'custom': 'value'},
+    )
+
+    dap = define_dynamic_action_provider(registry, config, dap_fn)
+    assert dap.config.name == 'full-config-dap'
+    assert dap.config.description == 'A DAP with all options'
+    assert dap.config.cache_config is not None
+    assert dap.config.cache_config.ttl_millis == 5000
+    assert dap.config.metadata == {'custom': 'value'}
+
+
+@pytest.mark.asyncio
+async def test_get_action_returns_none_for_unknown_type(registry: Registry, tool1: Action) -> None:
+    """Test that get_action returns None for unknown action types."""
+
+    async def dap_fn() -> DapValue:
+        return {'tool': [tool1]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    action = await dap.get_action('unknown-type', 'tool1')
+    assert action is None
+
+
+@pytest.mark.asyncio
+async def test_get_action_returns_none_for_unknown_name(registry: Registry, tool1: Action) -> None:
+    """Test that get_action returns None for unknown action names."""
+
+    async def dap_fn() -> DapValue:
+        return {'tool': [tool1]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    action = await dap.get_action('tool', 'unknown-name')
+    assert action is None
+
+
+@pytest.mark.asyncio
+async def test_list_action_metadata_returns_empty_for_unknown_type(registry: Registry, tool1: Action) -> None:
+    """Test that list_action_metadata returns empty list for unknown types."""
+
+    async def dap_fn() -> DapValue:
+        return {'tool': [tool1]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    metadata = await dap.list_action_metadata('unknown-type', '*')
+    assert metadata == []
+
+
+@pytest.mark.asyncio
+async def test_negative_ttl_disables_caching(registry: Registry, tool1: Action, tool2: Action) -> None:
+    """Test that negative TTL disables caching (always fetch fresh)."""
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        return {'tool': [tool1, tool2]}
+
+    config = DapConfig(name='my-dap', cache_config=DapCacheConfig(ttl_millis=-1))
+    dap = define_dynamic_action_provider(registry, config, dap_fn)
+
+    await dap.get_action('tool', 'tool1')
+    assert call_count == 1
+
+    # With negative TTL, this should trigger another fetch
+    await dap.get_action('tool', 'tool2')
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_zero_ttl_uses_default(registry: Registry, tool1: Action, tool2: Action) -> None:
+    """Test that zero TTL uses the default (3000ms)."""
+    call_count = 0
+
+    async def dap_fn() -> DapValue:
+        nonlocal call_count
+        call_count += 1
+        return {'tool': [tool1, tool2]}
+
+    config = DapConfig(name='my-dap', cache_config=DapCacheConfig(ttl_millis=0))
+    dap = define_dynamic_action_provider(registry, config, dap_fn)
+
+    await dap.get_action('tool', 'tool1')
+    assert call_count == 1
+
+    # With default TTL (3s), this should still be cached
+    await dap.get_action('tool', 'tool2')
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_action_metadata_record_raises_on_missing_name(registry: Registry) -> None:
+    """Test that get_action_metadata_record raises error when action has no name."""
+
+    async def nameless_fn(input: str) -> str:
+        return 'nameless'
+
+    nameless_action = registry.register_action(
+        name='nameless',
+        kind=ActionKind.TOOL,
+        fn=nameless_fn,
+        metadata={},  # No 'name' in metadata
+    )
+    # Clear the name attribute to simulate a nameless action
+    nameless_action._name = ''
+
+    async def dap_fn() -> DapValue:
+        return {'tool': [nameless_action]}
+
+    dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    with pytest.raises(ValueError, match='name required'):
+        await dap.get_action_metadata_record('dap/my-dap')

--- a/py/packages/genkit/tests/genkit/testing_test.py
+++ b/py/packages/genkit/tests/genkit/testing_test.py
@@ -1,0 +1,652 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the testing utilities module.
+
+This module contains comprehensive tests for the testing utilities,
+ensuring parity with the JavaScript implementation in:
+    js/ai/src/testing/model-tester.ts
+
+Test Coverage
+=============
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Test Case                        │ Description                              │
+├──────────────────────────────────┼──────────────────────────────────────────┤
+│ EchoModel Tests                                                             │
+├──────────────────────────────────┼──────────────────────────────────────────┤
+│ test_echo_model_basic            │ Basic echo functionality                 │
+│ test_echo_model_with_config      │ Echo includes config in response         │
+│ test_echo_model_stream_countdown │ Stream countdown chunks                  │
+│ test_echo_model_stores_request   │ Stores last request for inspection       │
+├──────────────────────────────────┼──────────────────────────────────────────┤
+│ ProgrammableModel Tests                                                     │
+├──────────────────────────────────┼──────────────────────────────────────────┤
+│ test_programmable_model_basic    │ Returns programmed responses             │
+│ test_programmable_model_multiple │ Multiple sequential responses            │
+│ test_programmable_model_chunks   │ Streams programmed chunks                │
+│ test_programmable_model_reset    │ Reset clears state                       │
+│ test_programmable_model_request  │ Stores deep copy of last request         │
+├──────────────────────────────────┼──────────────────────────────────────────┤
+│ StaticResponseModel Tests                                                   │
+├──────────────────────────────────┼──────────────────────────────────────────┤
+│ test_static_model_basic          │ Returns same response always             │
+│ test_static_model_request_count  │ Counts requests                          │
+├──────────────────────────────────┼──────────────────────────────────────────┤
+│ test_models() Tests                                                         │
+├──────────────────────────────────┼──────────────────────────────────────────┤
+│ test_test_models_basic           │ Basic test suite execution               │
+│ test_test_models_report_format   │ Report structure matches JS              │
+│ test_skip_test_error             │ SkipTestError handling                   │
+│ test_gablorken_tool              │ Tool calculation test                    │
+└──────────────────────────────────┴──────────────────────────────────────────┘
+"""
+
+import pytest
+
+from genkit.ai import Genkit
+from genkit.core.typing import (
+    GenerateRequest,
+    GenerateResponse,
+    GenerateResponseChunk,
+    Message,
+    Part,
+    Role,
+    TextPart,
+)
+from genkit.testing import (
+    EchoModel,
+    GablorkenInput,
+    ProgrammableModel,
+    SkipTestError,
+    StaticResponseModel,
+    define_echo_model,
+    define_programmable_model,
+    define_static_response_model,
+    skip,
+    test_models as run_model_tests,
+)
+
+
+class MockActionRunContext:
+    """Mock context for testing model functions directly."""
+
+    def __init__(self) -> None:
+        """Initialize with empty chunks list."""
+        self.chunks: list[GenerateResponseChunk] = []
+
+    def send_chunk(self, chunk: GenerateResponseChunk) -> None:
+        """Append a chunk to the chunks list."""
+        self.chunks.append(chunk)
+
+
+@pytest.fixture
+def ai() -> Genkit:
+    """Create a fresh Genkit instance for each test."""
+    return Genkit()
+
+
+class TestEchoModel:
+    """Tests for EchoModel functionality."""
+
+    def test_echo_model_basic(self) -> None:
+        """Test basic echo functionality."""
+        echo = EchoModel()
+        ctx = MockActionRunContext()
+
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='Hello world'))],
+                ),
+            ],
+        )
+
+        # pyright: ignore[reportArgumentType] - MockActionRunContext is compatible
+        response = echo.model_fn(request, ctx)  # type: ignore[arg-type]
+
+        assert response.message is not None
+        text = response.message.content[0].root.text
+        assert isinstance(text, str)
+        assert '[ECHO]' in text
+        assert 'user:' in text
+        assert 'Hello world' in text
+
+    def test_echo_model_with_config(self) -> None:
+        """Test that echo includes config in response."""
+        echo = EchoModel()
+        ctx = MockActionRunContext()
+
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='test'))],
+                ),
+            ],
+            config={'temperature': 0.5},
+        )
+
+        response = echo.model_fn(request, ctx)  # type: ignore[arg-type]
+
+        assert response.message is not None
+        text = response.message.content[0].root.text
+        assert isinstance(text, str)
+        assert 'temperature' in text
+
+    def test_echo_model_stream_countdown(self) -> None:
+        """Test stream countdown functionality."""
+        echo = EchoModel(stream_countdown=True)
+        ctx = MockActionRunContext()
+
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='test'))],
+                ),
+            ],
+        )
+
+        echo.model_fn(request, ctx)  # type: ignore[arg-type]
+
+        # Should have streamed 3, 2, 1
+        assert len(ctx.chunks) == 3
+        assert ctx.chunks[0].content[0].root.text == '3'
+        assert ctx.chunks[1].content[0].root.text == '2'
+        assert ctx.chunks[2].content[0].root.text == '1'
+
+    def test_echo_model_stores_request(self) -> None:
+        """Test that echo stores the last request."""
+        echo = EchoModel()
+        ctx = MockActionRunContext()
+
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='test'))],
+                ),
+            ],
+        )
+
+        echo.model_fn(request, ctx)  # type: ignore[arg-type]
+
+        assert echo.last_request is not None
+        assert echo.last_request.messages[0].content[0].root.text == 'test'
+
+    @pytest.mark.asyncio
+    async def test_define_echo_model(self, ai: Genkit) -> None:
+        """Test define_echo_model helper function."""
+        echo, action = define_echo_model(ai, name='testEcho')
+
+        response = await ai.generate(model='testEcho', prompt='Hello')
+
+        assert '[ECHO]' in response.text
+        assert echo.last_request is not None
+
+
+class TestProgrammableModel:
+    """Tests for ProgrammableModel functionality."""
+
+    def test_programmable_model_basic(self) -> None:
+        """Test basic programmable model functionality."""
+        pm = ProgrammableModel()
+        pm.responses = [
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Response 1'))],
+                ),
+            ),
+        ]
+        ctx = MockActionRunContext()
+
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='test'))],
+                ),
+            ],
+        )
+
+        response = pm.model_fn(request, ctx)  # type: ignore[arg-type]
+
+        assert response.message is not None
+        assert response.message.content[0].root.text == 'Response 1'
+        assert pm.request_count == 1
+
+    def test_programmable_model_multiple_responses(self) -> None:
+        """Test multiple sequential responses."""
+        pm = ProgrammableModel()
+        pm.responses = [
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Response 1'))],
+                ),
+            ),
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Response 2'))],
+                ),
+            ),
+        ]
+        ctx = MockActionRunContext()
+
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='test'))],
+                ),
+            ],
+        )
+
+        response1 = pm.model_fn(request, ctx)  # type: ignore[arg-type]
+        response2 = pm.model_fn(request, ctx)  # type: ignore[arg-type]
+
+        assert response1.message is not None
+        assert response2.message is not None
+        assert response1.message.content[0].root.text == 'Response 1'
+        assert response2.message.content[0].root.text == 'Response 2'
+        assert pm.request_count == 2
+
+    def test_programmable_model_chunks(self) -> None:
+        """Test streaming programmed chunks."""
+        pm = ProgrammableModel()
+        pm.responses = [
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Final'))],
+                ),
+            ),
+        ]
+        pm.chunks = [
+            [
+                GenerateResponseChunk(content=[Part(root=TextPart(text='Chunk 1'))]),
+                GenerateResponseChunk(content=[Part(root=TextPart(text='Chunk 2'))]),
+            ],
+        ]
+        ctx = MockActionRunContext()
+
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='test'))],
+                ),
+            ],
+        )
+
+        pm.model_fn(request, ctx)  # type: ignore[arg-type]
+
+        assert len(ctx.chunks) == 2
+        assert ctx.chunks[0].content[0].root.text == 'Chunk 1'
+        assert ctx.chunks[1].content[0].root.text == 'Chunk 2'
+
+    def test_programmable_model_reset(self) -> None:
+        """Test reset clears state."""
+        pm = ProgrammableModel()
+        pm.responses = [
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Response'))],
+                ),
+            ),
+        ]
+        ctx = MockActionRunContext()
+
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='test'))],
+                ),
+            ],
+        )
+
+        pm.model_fn(request, ctx)  # type: ignore[arg-type]
+        assert pm.request_count == 1
+        assert pm.last_request is not None
+
+        pm.reset()
+
+        assert pm.request_count == 0
+        assert pm.last_request is None
+        assert pm.responses == []
+        assert pm.chunks is None
+
+    def test_programmable_model_stores_deep_copy(self) -> None:
+        """Test that last_request is a deep copy."""
+        pm = ProgrammableModel()
+        pm.responses = [
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Response'))],
+                ),
+            ),
+        ]
+        ctx = MockActionRunContext()
+
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='original'))],
+                ),
+            ],
+        )
+
+        pm.model_fn(request, ctx)  # type: ignore[arg-type]
+
+        # Modify original request
+        original_part = request.messages[0].content[0].root
+        assert isinstance(original_part, TextPart)
+        original_part.text = 'modified'
+
+        # last_request should still have original value (deep copy)
+        assert pm.last_request is not None
+        stored_part = pm.last_request.messages[0].content[0].root
+        assert isinstance(stored_part, TextPart)
+        assert stored_part.text == 'original'
+
+    @pytest.mark.asyncio
+    async def test_define_programmable_model(self, ai: Genkit) -> None:
+        """Test define_programmable_model helper function."""
+        pm, action = define_programmable_model(ai, name='testPM')
+        pm.responses = [
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Programmed response'))],
+                ),
+            ),
+        ]
+
+        response = await ai.generate(model='testPM', prompt='Hello')
+
+        assert response.text == 'Programmed response'
+        assert pm.last_request is not None
+
+
+class TestStaticResponseModel:
+    """Tests for StaticResponseModel functionality."""
+
+    def test_static_model_basic(self) -> None:
+        """Test basic static response model functionality."""
+        static = StaticResponseModel(
+            message={
+                'role': 'model',
+                'content': [{'text': 'Static response'}],
+            }
+        )
+        ctx = MockActionRunContext()
+
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='test'))],
+                ),
+            ],
+        )
+
+        response = static.model_fn(request, ctx)  # type: ignore[arg-type]
+
+        assert response.message is not None
+        assert response.message.content[0].root.text == 'Static response'
+
+    def test_static_model_request_count(self) -> None:
+        """Test request counting."""
+        static = StaticResponseModel(
+            message={
+                'role': 'model',
+                'content': [{'text': 'Static'}],
+            }
+        )
+        ctx = MockActionRunContext()
+
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='test'))],
+                ),
+            ],
+        )
+
+        static.model_fn(request, ctx)  # type: ignore[arg-type]
+        static.model_fn(request, ctx)  # type: ignore[arg-type]
+        static.model_fn(request, ctx)  # type: ignore[arg-type]
+
+        assert static.request_count == 3
+
+    @pytest.mark.asyncio
+    async def test_define_static_response_model(self, ai: Genkit) -> None:
+        """Test define_static_response_model helper function."""
+        static, action = define_static_response_model(
+            ai,
+            message={
+                'role': 'model',
+                'content': [{'text': 'Always this'}],
+            },
+            name='testStatic',
+        )
+
+        response1 = await ai.generate(model='testStatic', prompt='First')
+        response2 = await ai.generate(model='testStatic', prompt='Second')
+
+        assert response1.text == 'Always this'
+        assert response2.text == 'Always this'
+        assert static.request_count == 2
+
+
+class TestSkipTestError:
+    """Tests for SkipTestError and skip() function."""
+
+    def test_skip_raises_error(self) -> None:
+        """Test that skip() raises SkipTestError."""
+        with pytest.raises(SkipTestError):
+            skip()
+
+    def test_skip_test_error_is_exception(self) -> None:
+        """Test that SkipTestError is an Exception subclass."""
+        assert issubclass(SkipTestError, Exception)
+
+
+class TestGablorkenInput:
+    """Tests for GablorkenInput model."""
+
+    def test_gablorken_input_validation(self) -> None:
+        """Test GablorkenInput validates correctly."""
+        input = GablorkenInput(value=2.0)
+        assert input.value == 2.0
+
+    def test_gablorken_calculation(self) -> None:
+        """Test the gablorken calculation: value^3 + 1.407."""
+        # 2^3 + 1.407 = 9.407
+        value = 2.0
+        expected = (value**3) + 1.407
+        assert expected == 9.407
+
+
+class TestTestModels:
+    """Tests for the test_models() function."""
+
+    @pytest.mark.asyncio
+    async def test_test_models_with_echo_model(self, ai: Genkit) -> None:
+        """Test test_models with an echo model."""
+        # Define an echo model that will pass the basic hi test
+        pm, _ = define_programmable_model(ai, name='testModel')
+        pm.responses = [
+            # For basic hi test
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Hi'))],
+                ),
+            ),
+            # For multimodal test (will skip since no media support)
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='plus'))],
+                ),
+            ),
+            # For history test
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Nice to meet you'))],
+                ),
+            ),
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Your name is Glorb'))],
+                ),
+            ),
+            # For system prompt test
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Bye'))],
+                ),
+            ),
+            # For structured output test
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='{"name": "Jack", "occupation": "Lumberjack"}'))],
+                ),
+            ),
+            # For tool calling test (will skip since no tools support)
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='9.407'))],
+                ),
+            ),
+        ]
+
+        report = await run_model_tests(ai, ['testModel'])
+
+        # Verify report structure
+        assert isinstance(report, list)
+        assert len(report) == 6  # 6 test cases
+
+        # Check test case names match JS implementation
+        test_names = [r['description'] for r in report]
+        assert 'basic hi' in test_names
+        assert 'multimodal' in test_names
+        assert 'history' in test_names
+        assert 'system prompt' in test_names
+        assert 'structured output' in test_names
+        assert 'tool calling' in test_names
+
+    @pytest.mark.asyncio
+    async def test_test_models_report_format(self, ai: Genkit) -> None:
+        """Test that report format matches JS implementation."""
+        pm, _ = define_programmable_model(ai, name='formatTestModel')
+        pm.responses = [
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Hi'))],
+                ),
+            ),
+        ] * 10  # Enough responses for all tests
+
+        report = await run_model_tests(ai, ['formatTestModel'])
+
+        # Verify report structure matches JS TestReport type
+        for case_report in report:
+            assert 'description' in case_report
+            assert 'models' in case_report
+            assert isinstance(case_report['models'], list)
+
+            for model_result in case_report['models']:
+                assert 'name' in model_result
+                assert 'passed' in model_result
+                # Optional fields: skipped, error
+                if not model_result['passed'] and 'error' in model_result:
+                    assert 'message' in model_result['error']
+
+    @pytest.mark.asyncio
+    async def test_test_models_multiple_models(self, ai: Genkit) -> None:
+        """Test test_models with multiple models."""
+        pm1, _ = define_programmable_model(ai, name='model1')
+        pm1.responses = [
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Hi'))],
+                ),
+            ),
+        ] * 10
+
+        pm2, _ = define_programmable_model(ai, name='model2')
+        pm2.responses = [
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Hello'))],
+                ),
+            ),
+        ] * 10
+
+        report = await run_model_tests(ai, ['model1', 'model2'])
+
+        # Each test case should have results for both models
+        for case_report in report:
+            assert len(case_report['models']) == 2
+            model_names = [m.get('name') for m in case_report['models']]
+            assert 'model1' in model_names
+            assert 'model2' in model_names
+
+    @pytest.mark.asyncio
+    async def test_test_models_handles_failures(self, ai: Genkit) -> None:
+        """Test that test_models properly reports failures."""
+        pm, _ = define_programmable_model(ai, name='failingModel')
+        pm.responses = [
+            # Return something that doesn't match expected pattern
+            GenerateResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(root=TextPart(text='Goodbye'))],  # Should be "Hi"
+                ),
+            ),
+        ] * 10
+
+        report = await run_model_tests(ai, ['failingModel'])
+
+        # Find the basic hi test
+        basic_hi_report = next(r for r in report if r['description'] == 'basic hi')
+        model_result = basic_hi_report['models'][0]
+
+        # Should have failed
+        assert model_result.get('passed') is False
+        assert 'error' in model_result
+        error = model_result.get('error')
+        assert error is not None
+        assert 'message' in error


### PR DESCRIPTION
## Summary

- Add Dynamic Action Provider (DAP) module for dynamic action resolution matching JS implementation
- Add `test_models()` function for standardized model testing matching JS `testModels`
- Add `generate_operation()` for long-running model operations (like video generation with Veo)
- Add `define_json_schema()` for registering raw JSON schemas
- Fix `GenerateResponseWrapper` to preserve `operation` field from response

## Test plan

- [x] Add comprehensive tests for DAP module (20 test cases)
- [x] Add tests for testing utilities (EchoModel, ProgrammableModel, StaticResponseModel)
- [x] Add tests for `test_models()` function
- [x] Add tests for `generate_operation()` method (8 test cases)
- [x] Add tests for `define_json_schema()` and `define_dynamic_action_provider()`
- [x] All 60 new tests pass
- [x] Ruff linting passes

## Cross-language parity

| Python | JavaScript |
|--------|-----------|
| `genkit.blocks.dap` | `js/core/src/dynamic-action-provider.ts` |
| `genkit.testing.test_models()` | `js/ai/src/testing/model-tester.ts` |
| `ai.generate_operation()` | `js/ai/src/generate.ts` |