### PR TITLE
docs(py): add test file naming convention to GEMINI.md

### DIFF
--- a/py/GEMINI.md
+++ b/py/GEMINI.md
@@ -281,7 +281,7 @@
   | `checks` | `checks_evaluator_test.py` | ✅ Correct |
   
   **Requirements:**
-  * Prefix test files with the plugin/package name (using underscores)
+  * Prefix test files with the plugin/package name, replacing any hyphens (`-`) with underscores (`_`).
   * Use the `foo_test.py` suffix format (not `test_foo.py`)
   * Do **NOT** add `__init__.py` to `tests/` directories (causes module conflicts)
   * Place tests in `plugins/{name}/tests/` or `packages/{name}/tests/`


### PR DESCRIPTION
## Summary

Add documentation for test file naming conventions to prevent pytest module collection conflicts in CI.

## Problem

When multiple plugins have test files with the same name (e.g., `plugin_test.py`, `engine_test.py`), pytest can fail with `ModuleNotFoundError` during test collection because Python treats them as conflicting modules.

## Solution

Document the following requirements in `py/GEMINI.md`:

1. **Unique naming**: Prefix test files with the plugin/package name
2. **Format**: Use `{plugin_name}_{component}_test.py` format
3. **No `__init__.py`**: Tests directories should not have `__init__.py` files

### Examples

| Plugin | Test File | Status |
|--------|-----------|--------|
| `cloud-sql-pg` | `cloud_sql_pg_engine_test.py` | ✅ Correct |
| `cloud-sql-pg` | `engine_test.py` | ❌ Wrong |
| `chroma` | `chroma_retriever_test.py` | ✅ Correct |
| `checks` | `checks_evaluator_test.py` | ✅ Correct |

## Test Plan

- [x] Verify documentation is clear and follows existing GEMINI.md style
- [x] Examples match actual test file naming in the codebase