### PR TITLE
fix(py): clean up in-function imports to follow PEP 8 conventions

### DIFF
--- a/py/plugins/aws-bedrock/src/genkit/plugins/aws_bedrock/plugin.py
+++ b/py/plugins/aws-bedrock/src/genkit/plugins/aws_bedrock/plugin.py
@@ -557,8 +557,6 @@ def get_inference_profile_prefix(region: str | None = None) -> str:
         >>> get_inference_profile_prefix('ap-northeast-1')
         'apac'
     """
-    import os
-
     if region is None:
         region = os.environ.get('AWS_REGION') or os.environ.get('AWS_DEFAULT_REGION')
 

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/metrics.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/metrics.py
@@ -43,6 +43,7 @@ See Also:
     - Workload Metrics: https://cloud.google.com/monitoring/api/metrics_other
 """
 
+import json
 import re
 
 import structlog
@@ -164,8 +165,6 @@ def record_generate_metrics(span: ReadableSpan) -> None:
     Args:
         span: OpenTelemetry span containing model execution data
     """
-    import json
-
     attrs = span.attributes
     if not attrs:
         return

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -120,9 +120,13 @@ source = ["packages", "plugins"]
 default-groups = ["dev", "lint"]
 
 [tool.uv.sources]
+aws-bedrock-hello                   = { workspace = true }
+aws-hello                           = { workspace = true }
 evaluator-demo                      = { workspace = true }
 genkit                              = { workspace = true }
 genkit-plugin-anthropic             = { workspace = true }
+genkit-plugin-aws                   = { workspace = true }
+genkit-plugin-aws-bedrock           = { workspace = true }
 genkit-plugin-compat-oai            = { workspace = true }
 genkit-plugin-deepseek              = { workspace = true }
 genkit-plugin-dev-local-vectorstore = { workspace = true }
@@ -133,16 +137,12 @@ genkit-plugin-google-cloud          = { workspace = true }
 genkit-plugin-google-genai          = { workspace = true }
 genkit-plugin-mcp                   = { workspace = true }
 genkit-plugin-msfoundry             = { workspace = true }
-genkit-plugin-aws-bedrock           = { workspace = true }
-genkit-plugin-aws                   = { workspace = true }
 genkit-plugin-ollama                = { workspace = true }
 genkit-plugin-vertex-ai             = { workspace = true }
 genkit-plugin-xai                   = { workspace = true }
 google-genai-hello                  = { workspace = true }
 google-genai-image                  = { workspace = true }
 msfoundry-hello                     = { workspace = true }
-aws-bedrock-hello                   = { workspace = true }
-aws-hello                           = { workspace = true }
 prompt-demo                         = { workspace = true }
 
 [tool.uv.workspace]
@@ -285,7 +285,7 @@ authorized_licenses = [
   "bsd-2-clause",
   "apache license 2.0",
   "apache-2.0 and mit",
-  "mpl-2.0 and mit",  # tqdm uses this dual license
+  "mpl-2.0 and mit",                    # tqdm uses this dual license
 ]
 dependencies = true
 unauthorized_licenses = [

--- a/py/samples/anthropic-hello/src/main.py
+++ b/py/samples/anthropic-hello/src/main.py
@@ -65,7 +65,9 @@ Key Features
 | Multimodal (Image Input)                | `describe_image`                    |
 """
 
+import asyncio
 import os
+import random
 
 from pydantic import BaseModel, Field
 from rich.traceback import install as install_rich_traceback
@@ -74,7 +76,7 @@ from genkit.ai import Genkit, Output
 from genkit.core.action import ActionRunContext
 from genkit.core.logging import get_logger
 from genkit.plugins.anthropic import Anthropic, anthropic_name
-from genkit.types import GenerationCommonConfig
+from genkit.types import GenerationCommonConfig, Media, MediaPart, Part, TextPart
 
 install_rich_traceback(show_locals=True, width=120, extra_lines=3)
 
@@ -213,8 +215,6 @@ async def currency_exchange(input: CurrencyExchangeInput) -> str:
 @ai.flow()
 async def describe_image(input: ImageDescribeInput) -> str:
     """Describe an image using Anthropic."""
-    from genkit.types import Media, MediaPart, Part, TextPart
-
     response = await ai.generate(
         prompt=[
             Part(root=TextPart(text='Describe this image')),
@@ -251,8 +251,6 @@ def get_weather(input: WeatherInput) -> str:
     Returns:
         Weather information with temperature in degree Celsius.
     """
-    import random
-
     weather_options = [
         '32° C sunny',
         '17° C cloudy',
@@ -355,8 +353,6 @@ async def weather_flow(input: WeatherFlowInput) -> str:
 
 async def main() -> None:
     """Main entry point for the Anthropic sample - keep alive for Dev UI."""
-    import asyncio
-
     await logger.ainfo('Genkit server running. Press Ctrl+C to stop.')
     # Keep the process alive for Dev UI
     await asyncio.Event().wait()

--- a/py/samples/aws-bedrock-hello/src/main.py
+++ b/py/samples/aws-bedrock-hello/src/main.py
@@ -68,7 +68,9 @@ Supported Models
 - And many more...
 """
 
+import asyncio
 import os
+import random
 
 from pydantic import BaseModel, Field
 from rich.traceback import install as install_rich_traceback
@@ -86,7 +88,7 @@ from genkit.plugins.aws_bedrock import (
     inference_profile,
     nova_pro,
 )
-from genkit.types import GenerationCommonConfig
+from genkit.types import GenerationCommonConfig, Media, MediaPart, Part, TextPart
 
 install_rich_traceback(show_locals=True, width=120, extra_lines=3)
 
@@ -231,8 +233,6 @@ def get_weather(input: WeatherInput) -> str:
     Returns:
         Weather information with temperature in degree Celsius.
     """
-    import random
-
     weather_options = [
         '32° C sunny',
         '17° C cloudy',
@@ -389,8 +389,6 @@ async def describe_image(input: ImageDescribeInput) -> str:
     Returns:
         Image description.
     """
-    from genkit.types import Media, MediaPart, Part, TextPart
-
     response = await ai.generate(
         prompt=[
             Part(root=TextPart(text='Describe this image in detail')),
@@ -413,8 +411,6 @@ async def describe_image_nova(input: ImageDescribeInput) -> str:
     Returns:
         Image description.
     """
-    from genkit.types import Media, MediaPart, Part, TextPart
-
     response = await ai.generate(
         model=_nova_model,
         prompt=[
@@ -476,8 +472,6 @@ async def reasoning_demo(input: ReasoningInput) -> str:
 
 async def main() -> None:
     """Main entry point for the AWS Bedrock sample - keep alive for Dev UI."""
-    import asyncio
-
     await logger.ainfo('Genkit server running. Press Ctrl+C to stop.')
     # Keep the process alive for Dev UI
     await asyncio.Event().wait()

--- a/py/samples/compat-oai-hello/src/main.py
+++ b/py/samples/compat-oai-hello/src/main.py
@@ -58,6 +58,7 @@ Key Features
 See README.md for testing instructions.
 """
 
+import asyncio
 import os
 from decimal import Decimal
 
@@ -443,8 +444,6 @@ async def sum_two_numbers2(my_input: MyInput) -> int:
 
 async def main() -> None:
     """Main entry point for the OpenAI sample - keep alive for Dev UI."""
-    import asyncio
-
     await logger.ainfo('Genkit server running. Press Ctrl+C to stop.')
     # Keep the process alive for Dev UI
     _ = await asyncio.Event().wait()

--- a/py/samples/deepseek-hello/src/main.py
+++ b/py/samples/deepseek-hello/src/main.py
@@ -59,7 +59,9 @@ Key Features
 | Multi-turn Chat                         | `chat_flow`                             |
 """
 
+import asyncio
 import os
+import random
 
 from pydantic import BaseModel, Field
 from rich.traceback import install as install_rich_traceback
@@ -171,8 +173,6 @@ def get_weather(input: WeatherInput) -> str:
     Returns:
         Weather information with temperature in degrees Celsius.
     """
-    import random
-
     weather_options = [
         '32° C sunny',
         '17° C cloudy',
@@ -425,8 +425,6 @@ async def weather_flow(input: WeatherFlowInput) -> str:
 
 async def main() -> None:
     """Main entry point for the DeepSeek sample - keep alive for Dev UI."""
-    import asyncio
-
     await logger.ainfo('Genkit server running. Press Ctrl+C to stop.')
     # Keep the process alive for Dev UI
     await asyncio.Event().wait()

--- a/py/samples/dev-local-vectorstore-hello/src/main.py
+++ b/py/samples/dev-local-vectorstore-hello/src/main.py
@@ -93,6 +93,7 @@ Key Features
 See README.md for testing instructions.
 """
 
+import asyncio
 import os
 
 from rich.traceback import install as install_rich_traceback
@@ -157,8 +158,6 @@ async def retreive_documents() -> RetrieverResponse:
 
 async def main() -> None:
     """Main entry point for the sample - keep alive for Dev UI."""
-    import asyncio
-
     print('Genkit server running. Press Ctrl+C to stop.')
     # Keep the process alive for Dev UI
     await asyncio.Event().wait()

--- a/py/samples/google-genai-context-caching/src/main.py
+++ b/py/samples/google-genai-context-caching/src/main.py
@@ -91,6 +91,7 @@ How Context Caching Works
 See README.md for testing instructions.
 """
 
+import asyncio
 import os
 
 import httpx
@@ -223,8 +224,6 @@ async def main() -> None:
     This function demonstrates how to use context caching in Genkit for
     improved performance.
     """
-    import asyncio
-
     await logger.ainfo('Genkit server running. Press Ctrl+C to stop.')
     # Keep the process alive for Dev UI
     await asyncio.Event().wait()

--- a/py/samples/google-genai-hello/src/main.py
+++ b/py/samples/google-genai-hello/src/main.py
@@ -86,6 +86,7 @@ import asyncio
 import base64
 import os
 import sys
+import tempfile
 
 from google import genai as google_genai_sdk
 from rich.traceback import install as install_rich_traceback
@@ -622,9 +623,6 @@ async def upload_blob_to_file_search_store(client: google_genai_sdk.Client, file
         'it was the spark of her imagination that had transformed her ordinary world into a realm of endless '
         'adventures. She smiled, knowing her journey was just beginning'
     )
-
-    # Create a temporary file to upload
-    import tempfile
 
     with tempfile.NamedTemporaryFile(mode='w+', delete=False, suffix='.txt') as tmp:
         tmp.write(text_content)

--- a/py/samples/msfoundry-hello/src/main.py
+++ b/py/samples/msfoundry-hello/src/main.py
@@ -135,6 +135,7 @@ Note:
     "Microsoft", "Azure", and "Microsoft Foundry" are trademarks of Microsoft Corporation.
 """
 
+import asyncio
 import os
 import random
 
@@ -145,6 +146,7 @@ from genkit.ai import Genkit
 from genkit.core.action import ActionRunContext
 from genkit.core.logging import get_logger
 from genkit.plugins.msfoundry import MSFoundry, gpt4o
+from genkit.types import Media, MediaPart, Part, TextPart
 
 install_rich_traceback(show_locals=True, width=120, extra_lines=3)
 
@@ -290,8 +292,6 @@ async def describe_image(input: ImageDescribeInput) -> str:
     This demonstrates multimodal capabilities with vision models.
     Note: Requires a vision-capable model like gpt-4o.
     """
-    from genkit.types import Media, MediaPart, Part, TextPart
-
     response = await ai.generate(
         prompt=[
             Part(root=TextPart(text='Describe this image in detail')),
@@ -321,8 +321,6 @@ async def say_hi_with_config(input: SayHiInput) -> str:
 
 async def main() -> None:
     """Main entry point for the sample."""
-    import asyncio
-
     await logger.ainfo('Genkit server running. Press Ctrl+C to stop.')
     await logger.ainfo('Open the Genkit Dev UI to test the flows.')
     # Keep the process alive for Dev UI

--- a/py/samples/realtime-tracing-demo/src/main.py
+++ b/py/samples/realtime-tracing-demo/src/main.py
@@ -371,8 +371,6 @@ async def slow_operation(description: str, delay: float = 1.0) -> str:
 
 async def main() -> None:
     """Main entry point - keeps the server running for DevUI."""
-    import asyncio
-
     enabled = is_realtime_telemetry_enabled()
     if enabled:
         await logger.ainfo('Realtime tracing ENABLED. Spans appear in DevUI immediately.')

--- a/py/samples/xai-hello/src/main.py
+++ b/py/samples/xai-hello/src/main.py
@@ -55,6 +55,7 @@ Key Features
 | Tool Calling                            | `weather_flow`                      |
 """
 
+import asyncio
 import os
 
 from pydantic import BaseModel, Field
@@ -217,8 +218,6 @@ async def weather_flow(input_data: WeatherInput) -> str:
 
 async def main() -> None:
     """Main entry point - keep alive for Dev UI."""
-    import asyncio
-
     logger.info('Genkit server running. Press Ctrl+C to stop.')
     # Keep the process alive for Dev UI
     await asyncio.Event().wait()


### PR DESCRIPTION
## Summary
Moves in-function imports to the top of files to follow PEP 8 conventions and improve code quality.

## Rationale
Python's PEP 8 style guide recommends placing all imports at the top of the module. Having imports inside functions can:
- Make dependencies harder to discover
- Cause subtle performance issues from repeated import lookups
- Reduce code readability and tooling support (type checkers, linters)

## Changes
### Plugins
- **aws-bedrock**: Removed redundant import removal in `plugin.py`
- **google-cloud**: Cleaned up `telemetry/metrics.py` imports

### Samples
Moved all in-function imports to the top of the file:
- **anthropic-hello**: `random`, `genkit.types` imports
- **aws-bedrock-hello**: `asyncio`, `random`, `genkit.types` imports  
- **compat-oai-hello**: `asyncio` import
- **deepseek-hello**: `asyncio`, `random` imports
- **dev-local-vectorstore-hello**: `asyncio` import
- **google-genai-context-caching**: `asyncio` import
- **google-genai-hello**: `tempfile` import
- **msfoundry-hello**: `asyncio`, `genkit.types` imports
- **realtime-tracing-demo**: `asyncio` import
- **xai-hello**: `asyncio` import

## Testing
- [x] Changes are syntactically correct
- [x] No functional behavior changes (import reorganization only)