### PR TITLE
fix(py): clean up in-function imports in plugins and tools

### DIFF
--- a/py/GEMINI.md
+++ b/py/GEMINI.md
@@ -688,7 +688,7 @@ BREAKING CHANGE: Plugin initialization now requires explicit configuration.
 * Add a rationale paragraph explaining the **why** and the **what** before
   listing all the changes.
 * For scope, refer to release-please configuration if available.
-* Keep it short and simple.
+* Keep the subject line short and simple.
 
 ## Pull Request Description Guidelines
 
@@ -702,6 +702,16 @@ Every PR description MUST include:
 1. **Summary** - One-paragraph overview of what the PR does and why
 2. **Changes** - Bullet list of specific modifications
 3. **Test Plan** - How the changes were verified
+
+### Prefer Tables for Information
+
+Use markdown tables whenever presenting structured information such as:
+- Configuration options and their defaults
+- API parameter lists
+- Comparison of before/after behavior
+- File changes summary
+
+Tables are easier to scan and review than prose or bullet lists.
 
 ### Architecture Diagrams
 

--- a/py/bin/build_dists
+++ b/py/bin/build_dists
@@ -25,34 +25,25 @@ if ((EUID == 0)); then
 fi
 
 TOP_DIR=$(git rev-parse --show-toplevel)
+PY_DIR="${TOP_DIR}/py"
 
-PROJECT_DIRS=(
-  "packages/genkit"
-  "plugins/compat-oai"
-  "plugins/dev-local-vectorstore"
-  "plugins/firebase"
-  "plugins/flask"
-  "plugins/google-cloud"
-  "plugins/google-genai"
-  "plugins/ollama"
-  "plugins/vertex-ai"
-  "samples/compat-oai-hello"
-  "samples/google-genai-context-caching"
-  "samples/firestore-retreiver"
-  "samples/flask-hello"
-  "samples/google-genai-hello"
-  "samples/google-genai-image"
-  "samples/google-genai-vertexai-hello"
-  "samples/google-genai-vertexai-image"
-  "samples/menu"
-  "samples/multi-server"
-  "samples/ollama-hello"
-  "samples/ollama-simple-embed"
-  "samples/tool-interrupts"
-  "samples/vertex-ai-vector-search-bigquery"
-  "samples/vertex-ai-vector-search-firestore"
-  "tests/smoke"
-)
+# Automatically discover all directories containing pyproject.toml
+# This includes packages, plugins, samples, and tests
+PROJECT_DIRS=()
+while IFS= read -r -d '' pyproject; do
+  # Get the directory containing pyproject.toml, relative to py/
+  project_dir=$(dirname "${pyproject}")
+  project_dir="${project_dir#${PY_DIR}/}"
+  PROJECT_DIRS+=("$project_dir")
+done < <(find "${PY_DIR}/packages" "${PY_DIR}/plugins" "${PY_DIR}/samples" "${PY_DIR}/tests" \
+  -name "pyproject.toml" -type f -print0 2>/dev/null)
+
+echo "Discovered ${#PROJECT_DIRS[@]} projects to build:"
+for dir in "${PROJECT_DIRS[@]}"; do
+  echo "  - $dir"
+done
+echo ""
+
 
 for PROJECT_DIR in "${PROJECT_DIRS[@]}"; do
   uv \

--- a/py/bin/sanitize_schema_typing.py
+++ b/py/bin/sanitize_schema_typing.py
@@ -43,6 +43,7 @@ Transformations applied:
 from __future__ import annotations
 
 import ast
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -425,8 +426,6 @@ def fix_field_defaults(content: str) -> str:
     Pyright doesn't recognize Field(None) as providing a default value,
     but it does recognize Field(default=None).
     """
-    import re
-
     # Replace Field(None) with Field(default=None)
     content = content.replace('Field(None)', 'Field(default=None)')
     # Replace Field(None, other_args) with Field(default=None, other_args)
@@ -441,8 +440,6 @@ def add_schema_field_suppression(content: str) -> str:
     While protected_namespaces=() allows this in Pydantic, pyrefly still
     reports it as a bad-override. We add a suppression comment.
     """
-    import re
-
     # Find lines that define a 'schema' field and add the suppression comment
     # Pattern: "    schema: ... = Field(...)"
     pattern = r'^(    schema: .+= Field\(.+\))$'

--- a/py/plugins/aws-bedrock/src/genkit/plugins/aws_bedrock/plugin.py
+++ b/py/plugins/aws-bedrock/src/genkit/plugins/aws_bedrock/plugin.py
@@ -59,6 +59,7 @@ Trademark Notice:
     Amazon.com, Inc. or its affiliates.
 """
 
+import json
 import os
 from typing import Any
 
@@ -394,8 +395,6 @@ class AWSBedrock(Plugin):
 
         async def embed_fn(request: EmbedRequest) -> EmbedResponse:
             """Generate embeddings using AWS Bedrock."""
-            import json
-
             # Extract text from document content
             texts: list[str] = []
             for doc in request.input:

--- a/py/plugins/aws-bedrock/tests/aws_bedrock_plugin_test.py
+++ b/py/plugins/aws-bedrock/tests/aws_bedrock_plugin_test.py
@@ -24,6 +24,8 @@ This module tests the AWS Bedrock plugin functionality including:
 - Model info registry
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from genkit.plugins.aws_bedrock import (
@@ -46,6 +48,7 @@ from genkit.plugins.aws_bedrock import (
     mistral_large_3,
     nova_pro,
 )
+from genkit.plugins.aws_bedrock.models.model import BedrockModel
 from genkit.plugins.aws_bedrock.models.model_info import (
     SUPPORTED_BEDROCK_MODELS,
     SUPPORTED_EMBEDDING_MODELS,
@@ -492,8 +495,6 @@ class TestAutoInferenceProfileConversion:
     @pytest.fixture
     def mock_client(self) -> object:
         """Create a mock boto3 client."""
-        from unittest.mock import MagicMock
-
         return MagicMock()
 
     @pytest.fixture
@@ -507,8 +508,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test IAM auth (no API key) returns direct model ID unchanged."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         # No AWS_BEARER_TOKEN_BEDROCK set = IAM auth
         model = BedrockModel('anthropic.claude-sonnet-4-5-20250929-v1:0', mock_client)
         assert model._get_effective_model_id() == 'anthropic.claude-sonnet-4-5-20250929-v1:0'
@@ -517,8 +516,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test API key auth with US region adds 'us.' prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'us-east-1')
 
@@ -529,8 +526,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test API key auth with us-west region adds 'us.' prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'us-west-2')
 
@@ -541,8 +536,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test API key auth with EU region adds 'eu.' prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'eu-west-1')
 
@@ -553,8 +546,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test API key auth with eu-central region adds 'eu.' prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'eu-central-1')
 
@@ -565,8 +556,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test API key auth with APAC region adds 'apac.' prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'ap-northeast-1')
 
@@ -577,8 +566,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test API key auth with ap-southeast region adds 'apac.' prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'ap-southeast-1')
 
@@ -589,8 +576,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test API key auth falls back to AWS_DEFAULT_REGION."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_DEFAULT_REGION', 'eu-west-2')
 
@@ -601,8 +586,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test AWS_REGION takes precedence over AWS_DEFAULT_REGION."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'us-east-1')
         monkeypatch.setenv('AWS_DEFAULT_REGION', 'eu-west-1')
@@ -615,8 +598,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test model with existing 'us.' prefix is unchanged."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'eu-west-1')  # Different region
 
@@ -628,8 +609,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test model with existing 'eu.' prefix is unchanged."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'us-east-1')  # Different region
 
@@ -641,8 +620,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test model with existing 'apac.' prefix is unchanged."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'us-east-1')  # Different region
 
@@ -654,8 +631,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test API key auth without region returns direct model ID with warning."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         # No AWS_REGION or AWS_DEFAULT_REGION set
 
@@ -667,8 +642,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test unknown region prefix defaults to 'us.'."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'unknown-region-1')  # Unrecognized
 
@@ -679,8 +652,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test Canada region uses 'us.' prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'ca-central-1')
 
@@ -692,8 +663,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test South America region uses 'us.' prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'sa-east-1')
 
@@ -705,8 +674,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test Middle East region uses 'apac.' prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'me-south-1')
 
@@ -718,8 +685,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test Africa region uses 'apac.' prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'af-south-1')
 
@@ -731,8 +696,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test DeepSeek model auto-converts with API key auth."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'us-west-2')
 
@@ -743,8 +706,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test Nova model auto-converts with API key auth."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'ap-south-1')
 
@@ -755,8 +716,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test Cohere model auto-converts with API key auth."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'eu-north-1')
 
@@ -767,8 +726,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test AI21 models do NOT get inference profile prefix (not supported)."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'us-east-1')
 
@@ -780,8 +737,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test AI21 Jamba Mini model does NOT get inference profile prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'eu-west-1')
 
@@ -793,8 +748,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test Stability AI models do NOT get inference profile prefix (not supported)."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'us-west-2')
 
@@ -806,8 +759,6 @@ class TestAutoInferenceProfileConversion:
         self, mock_client: object, clear_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test unknown/unsupported providers do NOT get inference profile prefix."""
-        from genkit.plugins.aws_bedrock.models.model import BedrockModel
-
         monkeypatch.setenv('AWS_BEARER_TOKEN_BEDROCK', 'test-token')
         monkeypatch.setenv('AWS_REGION', 'us-east-1')
 

--- a/py/plugins/deepseek/tests/deepseek_plugin_test.py
+++ b/py/plugins/deepseek/tests/deepseek_plugin_test.py
@@ -20,10 +20,12 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from openai import OpenAI
 
 from genkit.core.error import GenkitError
 from genkit.core.registry import ActionKind
 from genkit.plugins.deepseek import DeepSeek, deepseek_name
+from genkit.plugins.deepseek.client import DEFAULT_DEEPSEEK_API_URL, DeepSeekClient
 
 
 def test_deepseek_name() -> None:
@@ -147,8 +149,6 @@ async def test_plugin_resolve_action_without_prefix(mock_client: MagicMock) -> N
 @patch('genkit.plugins.deepseek.client.DeepSeekClient.__new__')
 def test_deepseek_client_initialization(mock_new: MagicMock) -> None:
     """Test DeepSeekClient creates OpenAI client with correct params."""
-    from genkit.plugins.deepseek.client import DeepSeekClient
-
     # Set up mock to return a fake client
     mock_client_instance = MagicMock()
     mock_new.return_value = mock_client_instance
@@ -162,10 +162,6 @@ def test_deepseek_client_initialization(mock_new: MagicMock) -> None:
 
 def test_deepseek_client_with_custom_base_url() -> None:
     """Test DeepSeekClient accepts custom base_url."""
-    from openai import OpenAI
-
-    from genkit.plugins.deepseek.client import DeepSeekClient
-
     with patch.object(OpenAI, '__init__', return_value=None) as mock_init:
         DeepSeekClient(api_key='test-key', base_url='https://custom.api.deepseek.com')
         mock_init.assert_called_once_with(
@@ -176,10 +172,6 @@ def test_deepseek_client_with_custom_base_url() -> None:
 
 def test_deepseek_client_default_base_url() -> None:
     """Test DeepSeekClient uses default base_url when not provided."""
-    from openai import OpenAI
-
-    from genkit.plugins.deepseek.client import DEFAULT_DEEPSEEK_API_URL, DeepSeekClient
-
     with patch.object(OpenAI, '__init__', return_value=None) as mock_init:
         DeepSeekClient(api_key='test-key')
         mock_init.assert_called_once_with(

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/tracing.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/tracing.py
@@ -538,7 +538,7 @@ class GcpAdjustingTraceExporter(AdjustingTraceExporter):
                 state = attrs.get('genkit:state')
                 if state:
                     # Import here to avoid circular imports
-                    from genkit.core.trace.adjusting_exporter import RedactedSpan
+                    from genkit.core.trace.adjusting_exporter import RedactedSpan  # noqa: PLC0415
 
                     new_attrs = dict(attrs)
                     new_attrs['genkit:rootState'] = state

--- a/py/plugins/google-cloud/tests/tracing_test.py
+++ b/py/plugins/google-cloud/tests/tracing_test.py
@@ -47,7 +47,7 @@ def test_add_gcp_telemetry_wraps_with_gcp_adjusting_exporter() -> None:
         patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader'),
         patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
     ):
-        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry  # noqa: PLC0415
 
         # Create mock instances
         mock_base_exporter = MagicMock()
@@ -86,7 +86,7 @@ def test_add_gcp_telemetry_with_log_input_and_output_enabled() -> None:
         patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader'),
         patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
     ):
-        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry  # noqa: PLC0415
 
         # Call with log_input_and_output=True (maps to JS: !disableLoggingInputAndOutput)
         add_gcp_telemetry(log_input_and_output=True)
@@ -109,7 +109,7 @@ def test_add_gcp_telemetry_with_project_id() -> None:
         patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader'),
         patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
     ):
-        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry  # noqa: PLC0415
 
         # Call with project_id
         add_gcp_telemetry(project_id='my-test-project')
@@ -126,7 +126,7 @@ def test_add_gcp_telemetry_skips_in_dev_without_force() -> None:
         patch('genkit.plugins.google_cloud.telemetry.tracing.GenkitGCPExporter') as mock_gcp_exporter,
         patch('genkit.plugins.google_cloud.telemetry.tracing.add_custom_exporter') as mock_add_exporter,
     ):
-        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry  # noqa: PLC0415
 
         # Call without force_dev_export (using legacy force_export)
         add_gcp_telemetry(force_dev_export=False)
@@ -149,7 +149,7 @@ def test_add_gcp_telemetry_exports_in_dev_with_force() -> None:
         patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader'),
         patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
     ):
-        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry  # noqa: PLC0415
 
         # Call with force_dev_export=True (the default)
         add_gcp_telemetry(force_dev_export=True)
@@ -171,7 +171,7 @@ def test_add_gcp_telemetry_disable_traces() -> None:
         patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader'),
         patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
     ):
-        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry  # noqa: PLC0415
 
         # Call with disable_traces=True (JS/Go: disableTraces)
         add_gcp_telemetry(disable_traces=True)
@@ -194,7 +194,7 @@ def test_add_gcp_telemetry_disable_metrics() -> None:
         patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader') as mock_reader,
         patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
     ):
-        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry  # noqa: PLC0415
 
         # Call with disable_metrics=True (JS/Go: disableMetrics)
         add_gcp_telemetry(disable_metrics=True)
@@ -219,7 +219,7 @@ def test_add_gcp_telemetry_custom_metric_interval() -> None:
         patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader') as mock_reader,
         patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
     ):
-        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry  # noqa: PLC0415
 
         # Call with custom metric_export_interval_ms (JS/Go: metricExportIntervalMillis)
         add_gcp_telemetry(metric_export_interval_ms=30000)
@@ -244,7 +244,7 @@ def test_add_gcp_telemetry_enforces_minimum_interval() -> None:
         patch('genkit.plugins.google_cloud.telemetry.tracing.PeriodicExportingMetricReader') as mock_reader,
         patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
     ):
-        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry  # noqa: PLC0415
 
         # Call with interval below minimum
         add_gcp_telemetry(metric_export_interval_ms=1000)
@@ -257,7 +257,7 @@ def test_add_gcp_telemetry_enforces_minimum_interval() -> None:
 
 def test_resolve_project_id_from_env_vars() -> None:
     """Test project ID resolution from environment variables (JS/Go parity)."""
-    from genkit.plugins.google_cloud.telemetry.tracing import _resolve_project_id
+    from genkit.plugins.google_cloud.telemetry.tracing import _resolve_project_id  # noqa: PLC0415
 
     # Test FIREBASE_PROJECT_ID has highest priority
     with mock.patch.dict(
@@ -288,7 +288,7 @@ def test_resolve_project_id_from_env_vars() -> None:
 
 def test_resolve_project_id_explicit_takes_precedence() -> None:
     """Test that explicit project_id parameter takes precedence over env vars."""
-    from genkit.plugins.google_cloud.telemetry.tracing import _resolve_project_id
+    from genkit.plugins.google_cloud.telemetry.tracing import _resolve_project_id  # noqa: PLC0415
 
     with mock.patch.dict(
         os.environ,
@@ -300,7 +300,7 @@ def test_resolve_project_id_explicit_takes_precedence() -> None:
 
 def test_resolve_project_id_from_credentials() -> None:
     """Test project ID resolution from credentials dict (Go parity)."""
-    from genkit.plugins.google_cloud.telemetry.tracing import _resolve_project_id
+    from genkit.plugins.google_cloud.telemetry.tracing import _resolve_project_id  # noqa: PLC0415
 
     with mock.patch.dict(os.environ, {}, clear=True):
         # Project ID from credentials
@@ -322,7 +322,7 @@ def test_legacy_force_export_parameter() -> None:
         patch('genkit.plugins.google_cloud.telemetry.tracing.metrics'),
         patch('genkit.plugins.google_cloud.telemetry.tracing.logger') as mock_logger,
     ):
-        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry
+        from genkit.plugins.google_cloud.telemetry.tracing import add_gcp_telemetry  # noqa: PLC0415
 
         # Call with legacy force_export parameter
         add_gcp_telemetry(force_export=True)

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -451,7 +451,7 @@ class GoogleAI(Plugin):
         Returns:
             BackgroundAction for the Veo model.
         """
-        from genkit.blocks.background_model import BackgroundAction
+        from genkit.blocks.background_model import BackgroundAction  # noqa: PLC0415
 
         _clean_name = name.replace(GOOGLEAI_PLUGIN_NAME + '/', '') if name.startswith(GOOGLEAI_PLUGIN_NAME) else name
 

--- a/py/plugins/google-genai/test/google_plugin_test.py
+++ b/py/plugins/google-genai/test/google_plugin_test.py
@@ -35,6 +35,7 @@ from genkit.plugins.google_genai.google import googleai_name, vertexai_name
 from genkit.plugins.google_genai.google import _inject_attribution_headers
 from genkit.plugins.google_genai.models.gemini import (
     DEFAULT_SUPPORTS_MODEL,
+    GeminiModel,
     SUPPORTED_MODELS,
     GeminiConfigSchema,
 )
@@ -50,6 +51,7 @@ from genkit.types import (
     Role,
     TextPart,
 )
+from google import genai
 
 
 @pytest.fixture
@@ -724,10 +726,6 @@ def test_config_schema_extra_fields() -> None:
 
 def test_system_prompt_handling() -> None:
     """Test that system prompts are correctly extracted to config."""
-    from google import genai
-
-    from genkit.plugins.google_genai.models.gemini import GeminiModel
-
     mock_client = MagicMock(spec=genai.Client)
     model = GeminiModel(version='gemini-1.5-flash', client=mock_client)
 

--- a/py/plugins/mcp/src/genkit/plugins/mcp/util/prompts.py
+++ b/py/plugins/mcp/src/genkit/plugins/mcp/util/prompts.py
@@ -79,7 +79,7 @@ def convert_mcp_prompt_messages(prompt_result: GetPromptResult) -> list[dict[str
     Returns:
         List of Genkit-formatted messages
     """
-    from .message import from_mcp_prompt_message
+    from .message import from_mcp_prompt_message  # noqa: PLC0415
 
     if not hasattr(prompt_result, 'messages') or not prompt_result.messages:
         return []

--- a/py/plugins/mcp/src/genkit/plugins/mcp/util/transport.py
+++ b/py/plugins/mcp/src/genkit/plugins/mcp/util/transport.py
@@ -20,6 +20,7 @@ This module contains helper functions for creating and managing
 MCP transport connections (stdio, SSE, custom).
 """
 
+import importlib.util
 from typing import cast
 
 import structlog
@@ -67,8 +68,6 @@ async def transport_from(config: dict[str, object], session_id: str | None = Non
     # Handle SSE/HTTP config
     if 'url' in config and config['url']:
         # Check if SSE client is available
-        import importlib.util
-
         if importlib.util.find_spec('mcp.client.sse') is None:
             logger.warning('SSE client not available')
             return (None, 'http')

--- a/py/plugins/mcp/tests/mcp_conversion_test.py
+++ b/py/plugins/mcp/tests/mcp_conversion_test.py
@@ -16,6 +16,7 @@
 
 """Tests for MCP conversion utilities."""
 
+import json
 import os
 import sys
 import unittest
@@ -46,11 +47,13 @@ def setup_mocks() -> None:
         sys.path.insert(0, src_path)
 
     try:
-        from fakes import mock_mcp_modules
+        # Deferred import: mock_mcp_modules must be called before importing genkit.plugins.mcp
+        from fakes import mock_mcp_modules  # noqa: PLC0415
 
         mock_mcp_modules()
 
-        from genkit.plugins.mcp.util import (
+        # Deferred import: these imports must happen after mock_mcp_modules() is called
+        from genkit.plugins.mcp.util import (  # noqa: PLC0415
             to_mcp_prompt_arguments as _to_mcp_prompt_arguments,
             to_mcp_prompt_message as _to_mcp_prompt_message,
             to_mcp_resource_contents as _to_mcp_resource_contents,
@@ -256,8 +259,6 @@ class TestToolResultConversion(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].type, 'text')
         # Should be JSON serialized
-        import json
-
         assert isinstance(result[0], TextContent)
         parsed = json.loads(result[0].text)
         self.assertEqual(parsed['key'], 'value')

--- a/py/plugins/mcp/tests/mcp_host_test.py
+++ b/py/plugins/mcp/tests/mcp_host_test.py
@@ -45,12 +45,17 @@ def setup_mocks() -> None:
         sys.path.insert(0, src_path)
 
     try:
-        from fakes import mock_mcp_modules
+        # Deferred import: mock_mcp_modules must be called before importing genkit.plugins.mcp
+        from fakes import mock_mcp_modules  # noqa: PLC0415
 
         mock_mcp_modules()
 
-        from genkit.ai import Genkit as _Genkit
-        from genkit.plugins.mcp import McpServerConfig as _McpServerConfig, create_mcp_host as _create_mcp_host
+        # Deferred import: these imports must happen after mock_mcp_modules() is called
+        from genkit.ai import Genkit as _Genkit  # noqa: PLC0415
+        from genkit.plugins.mcp import (  # noqa: PLC0415
+            McpServerConfig as _McpServerConfig,
+            create_mcp_host as _create_mcp_host,
+        )
 
         Genkit = _Genkit
         McpServerConfig = _McpServerConfig

--- a/py/plugins/mcp/tests/mcp_server_test.py
+++ b/py/plugins/mcp/tests/mcp_server_test.py
@@ -48,7 +48,9 @@ from mcp.types import (
 )
 
 from genkit.ai import Genkit
+from genkit.blocks.resource import matches_uri_template
 from genkit.core.action.types import ActionKind
+from genkit.core.error import GenkitError
 from genkit.plugins.mcp import McpServerOptions, create_mcp_server
 
 
@@ -230,8 +232,6 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
 
     async def test_tool_not_found(self) -> None:
         """Test calling a non-existent tool."""
-        from genkit.core.error import GenkitError
-
         request = CallToolRequest(
             method='tools/call',
             params=CallToolRequestParams(name='nonexistent_tool', arguments={}),
@@ -244,8 +244,6 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
 
     async def test_prompt_not_found(self) -> None:
         """Test getting a non-existent prompt."""
-        from genkit.core.error import GenkitError
-
         request = GetPromptRequest(
             method='prompts/get',
             params=GetPromptRequestParams(name='nonexistent_prompt', arguments={}),
@@ -258,8 +256,6 @@ class TestMcpServer(unittest.IsolatedAsyncioTestCase):
 
     async def test_resource_not_found(self) -> None:
         """Test reading a non-existent resource."""
-        from genkit.core.error import GenkitError
-
         request = ReadResourceRequest(
             method='resources/read',
             params=ReadResourceRequestParams(uri=AnyUrl('nonexistent://resource')),
@@ -318,8 +314,6 @@ class TestResourceFunctionality(unittest.IsolatedAsyncioTestCase):
 
     async def test_uri_template_matching(self) -> None:
         """Test URI template matching."""
-        from genkit.blocks.resource import matches_uri_template
-
         # Test exact match
         result = matches_uri_template('file://{+path}', 'file:///home/user/doc.txt')
         assert result is not None

--- a/py/plugins/msfoundry/tests/msfoundry_plugin_test.py
+++ b/py/plugins/msfoundry/tests/msfoundry_plugin_test.py
@@ -41,6 +41,7 @@ from genkit.plugins.msfoundry import (
     msfoundry_model,
 )
 from genkit.plugins.msfoundry.models.model import MSFoundryModel
+from genkit.plugins.msfoundry.models.model_info import get_model_info
 from genkit.types import (
     GenerateRequest,
     Message,
@@ -295,8 +296,6 @@ class TestMSFoundryModelInfo:
 
     def test_get_model_info_known_model(self) -> None:
         """Test getting info for a known model."""
-        from genkit.plugins.msfoundry.models.model_info import get_model_info
-
         info = get_model_info('gpt-4o')
         assert info is not None
         assert info.label is not None
@@ -304,8 +303,6 @@ class TestMSFoundryModelInfo:
 
     def test_get_model_info_unknown_model(self) -> None:
         """Test getting info for an unknown model returns default."""
-        from genkit.plugins.msfoundry.models.model_info import get_model_info
-
         info = get_model_info('unknown-model-xyz')
         assert info is not None
         assert info.label is not None

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/model_garden/modelgarden_plugin.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/model_garden/modelgarden_plugin.py
@@ -115,7 +115,7 @@ class ModelGardenPlugin(Plugin):
         )
 
         if clean_name.startswith('anthropic/'):
-            from .anthropic import AnthropicModelGarden as AnthropicWorker
+            from .anthropic import AnthropicModelGarden as AnthropicWorker  # noqa: PLC0415
 
             location = self.model_locations.get(clean_name, self.location)
             if not self.project_id:

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -203,7 +203,9 @@ select = [
   "F401", # unused imports
   "F403", # wildcard imports
   "F841", # unused variables
-  # TODO(https://github.com/firebase/genkit/issues/XXXX): Add PLC0415 after cleaning up remaining in-function imports
+  # TODO(https://github.com/firebase/genkit/issues/4398): Enable PLC0415 after
+  # completing cleanup of remaining in-function imports in core framework.
+  # "PLC0415",
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -214,6 +216,7 @@ select = [
 "samples/*/*.py"     = ["E402"]
 "samples/*/**/*.py"  = ["E402"]
 "samples/*/src/*.py" = ["E402"]
+
 
 [tool.ruff.lint.isort]
 combine-as-imports = true


### PR DESCRIPTION
## Summary

Clean up PLC0415 (import at top-level) violations in plugins and build tools. This is part of the ongoing Python codebase hygiene improvements.

## Changes

| File | Change |
|------|--------|
| `plugins/aws-bedrock/` | Moved `json` import to top; fixed test imports |
| `plugins/google-cloud/` | Added noqa for circular import in tracing; noqa for test mocks |
| `plugins/google-genai/` | Added noqa for runtime import; fixed test imports |
| `plugins/mcp/` | Moved `importlib.util` to top; noqa for mock-deferred imports |
| `plugins/deepseek/` | Fixed test imports |
| `plugins/msfoundry/` | Fixed test imports |
| `plugins/vertex-ai/` | Added noqa for intentional import |
| `bin/build_dists` | Auto-discover packages via pyproject.toml |
| `bin/sanitize_schema_typing.py` | Moved `re` import to top |
| `GEMINI.md` | Added PR table preference, clarified commit subject line guidance |
| `pyproject.toml` | Updated TODO with issue #4398 for core framework cleanup |

## Related

- #4398 - Tracks remaining core framework import cleanup

## Test Plan

- All Ruff checks pass
- CI will validate tests