### PR TITLE
fix(py): clean up in-function imports in core framework

### DIFF
--- a/py/packages/genkit/src/genkit/ai/_aio.py
+++ b/py/packages/genkit/src/genkit/ai/_aio.py
@@ -61,6 +61,7 @@ from genkit.blocks.prompt import PromptConfig, load_prompt_folder, to_generate_a
 from genkit.blocks.retriever import IndexerRef, IndexerRequest, RetrieverRef
 from genkit.core.action import Action, ActionRunContext
 from genkit.core.action.types import ActionKind
+from genkit.core.error import GenkitError
 from genkit.core.plugin import Plugin
 from genkit.core.tracing import run_in_new_span
 from genkit.core.typing import (
@@ -1100,8 +1101,6 @@ class Genkit(GenkitBase):
             >>> # Access result
             >>> print(operation.output)
         """
-        from genkit.core.error import GenkitError
-
         # Resolve the model and check for long_running support
         resolved_model = model or self.registry.default_model
         if not resolved_model:

--- a/py/packages/genkit/src/genkit/ai/_registry.py
+++ b/py/packages/genkit/src/genkit/ai/_registry.py
@@ -62,6 +62,7 @@ from genkit.blocks.dap import (
     DynamicActionProvider,
     define_dynamic_action_provider as define_dap_block,
 )
+from genkit.blocks.document import Document
 from genkit.blocks.embedding import EmbedderFn, EmbedderOptions
 from genkit.blocks.evaluator import BatchEvaluatorFn, EvaluatorFn
 from genkit.blocks.formats.types import FormatDef
@@ -82,7 +83,11 @@ from genkit.blocks.reranker import (
     define_reranker as define_reranker_block,
     rerank as rerank_block,
 )
-from genkit.blocks.resource import FlexibleResourceFn, ResourceOptions
+from genkit.blocks.resource import (
+    FlexibleResourceFn,
+    ResourceOptions,
+    define_resource as define_resource_block,
+)
 from genkit.blocks.retriever import IndexerFn, RetrieverFn
 from genkit.blocks.tools import ToolRunContext
 from genkit.codec import dump_dict
@@ -166,8 +171,6 @@ class SimpleRetrieverOptions(BaseModel, Generic[R]):
 
 def _item_to_document(item: R, options: SimpleRetrieverOptions[R]) -> DocumentData:
     """Internal helper to convert a raw item to a Genkit DocumentData."""
-    from genkit.blocks.document import Document
-
     if isinstance(item, (Document, DocumentData)):
         return item
 
@@ -661,8 +664,6 @@ class GenkitRegistry:
         """
         if isinstance(options, str):
             options = SimpleRetrieverOptions(name=options)
-
-        from genkit.blocks.document import Document
 
         async def retriever_fn(query: Document, options_obj: Any) -> RetrieverResponse:  # noqa: ANN401
 
@@ -1508,8 +1509,6 @@ class GenkitRegistry:
         Returns:
             An ExecutablePrompt instance.
         """
-        from genkit.blocks.prompt import ExecutablePrompt
-
         return ExecutablePrompt(
             registry=self.registry,
             _name=name,
@@ -1541,10 +1540,6 @@ class GenkitRegistry:
         Returns:
             The registered Action for the resource.
         """
-        from genkit.blocks.resource import (
-            define_resource as define_resource_block,
-        )
-
         if fn is None:
             raise ValueError('A function `fn` must be provided to define a resource.')
         if opts is None:

--- a/py/packages/genkit/src/genkit/aio/loop.py
+++ b/py/packages/genkit/src/genkit/aio/loop.py
@@ -141,7 +141,8 @@ def run_loop(coro: Coroutine[object, object, T], *, debug: bool | None = None) -
         debug: If True, run in debug mode.
     """
     try:
-        import uvloop
+        # Lazy import: uvloop is optional and only loaded if available
+        import uvloop  # noqa: PLC0415
 
         logger.debug('✅ Using uvloop (recommended)')
         return uvloop.run(coro, debug=debug)

--- a/py/packages/genkit/src/genkit/blocks/background_model.py
+++ b/py/packages/genkit/src/genkit/blocks/background_model.py
@@ -126,6 +126,7 @@ from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
 
+from genkit.codec import dump_dict
 from genkit.core.action import Action, ActionRunContext
 from genkit.core.action.types import ActionKind
 from genkit.core.registry import Registry
@@ -354,8 +355,6 @@ def define_background_model(
     model_options: dict[str, Any] = {}
 
     if info:
-        from genkit.codec import dump_dict
-
         info_dict = dump_dict(info)
         if isinstance(info_dict, dict):
             model_options.update(info_dict)  # type: ignore[arg-type]

--- a/py/packages/genkit/src/genkit/blocks/session/session.py
+++ b/py/packages/genkit/src/genkit/blocks/session/session.py
@@ -238,8 +238,6 @@ class Session:
             chat = session.chat(agent)
             ```
         """
-        from .chat import Chat
-
         # Resolve arguments (matching JS pattern)
         thread_name = MAIN_THREAD
         chat_options: ChatOptions | None = None

--- a/py/packages/genkit/src/genkit/core/_plugins.py
+++ b/py/packages/genkit/src/genkit/core/_plugins.py
@@ -46,7 +46,8 @@ def extend_plugin_namespace() -> None:
     """
     # Import genkit.plugins to initialize the namespace if needed
     if 'genkit.plugins' not in sys.modules:
-        import genkit.plugins  # noqa: F401
+        # Deferred import: initialize the namespace package only if not already loaded
+        import genkit.plugins  # noqa: F401, PLC0415
 
     genkit_plugins = sys.modules.get('genkit.plugins')
     if genkit_plugins is None or not hasattr(genkit_plugins, '__path__'):

--- a/py/packages/genkit/src/genkit/core/plugin.py
+++ b/py/packages/genkit/src/genkit/core/plugin.py
@@ -196,7 +196,8 @@ class Plugin(abc.ABC):
         Returns:
             ModelReference: A reference to the model.
         """
-        from genkit.blocks.model import ModelReference
+        # Deferred import: avoid circular import with genkit.blocks.model
+        from genkit.blocks.model import ModelReference  # noqa: PLC0415
 
         target = name if '/' in name else f'{self.name}/{name}'
         return ModelReference(name=target)
@@ -212,7 +213,8 @@ class Plugin(abc.ABC):
         Returns:
             EmbedderRef: A reference to the embedder.
         """
-        from genkit.blocks.embedding import EmbedderRef
+        # Deferred import: avoid circular import with genkit.blocks.embedding
+        from genkit.blocks.embedding import EmbedderRef  # noqa: PLC0415
 
         target = name if '/' in name else f'{self.name}/{name}'
         return EmbedderRef(name=target)

--- a/py/packages/genkit/src/genkit/core/trace/default_exporter.py
+++ b/py/packages/genkit/src/genkit/core/trace/default_exporter.py
@@ -37,12 +37,17 @@ import httpx
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    SimpleSpanProcessor,
     SpanExporter,
     SpanExportResult,
 )
 
 from genkit.core._compat import override
+from genkit.core.environment import is_dev_environment
 from genkit.core.logging import get_logger
+
+from .realtime_processor import RealtimeSpanProcessor
 
 if TYPE_CHECKING:
     from opentelemetry.sdk.trace import SpanProcessor
@@ -223,12 +228,6 @@ def create_span_processor(exporter: SpanExporter) -> SpanProcessor:
     Returns:
         A SpanProcessor configured for the current environment.
     """
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
-
-    from genkit.core.environment import is_dev_environment
-
-    from .realtime_processor import RealtimeSpanProcessor
-
     # Match JS: RealtimeSpanProcessor requires BOTH dev mode AND env var
     if is_dev_environment() and is_realtime_telemetry_enabled():
         return RealtimeSpanProcessor(exporter)

--- a/py/packages/genkit/src/genkit/web/manager/_adapters.py
+++ b/py/packages/genkit/src/genkit/web/manager/_adapters.py
@@ -174,7 +174,8 @@ class UvicornAdapter(ASGIServerAdapter):
             port: The port to bind to
             log_level: The logging level to use
         """
-        import uvicorn
+        # Lazy import: uvicorn is only imported when this adapter is used
+        import uvicorn  # noqa: PLC0415
 
         # Configure Uvicorn
         config = uvicorn.Config(
@@ -234,7 +235,8 @@ class GranianAdapter(ASGIServerAdapter):
             ImportError: If Granian is not available
             Exception: If the server fails to start or encounters an error
         """
-        import granian  # type: ignore[import-not-found]
+        # Lazy import: granian is optional and only imported when this adapter is used
+        import granian  # type: ignore[import-not-found]  # noqa: PLC0415
 
         # Granian accepts the log level as a string
         # Valid values are: 'trace', 'debug', 'info', 'warn', 'error', or 'off'

--- a/py/packages/genkit/tests/genkit/ai/genkit_api_test.py
+++ b/py/packages/genkit/tests/genkit/ai/genkit_api_test.py
@@ -10,9 +10,13 @@ from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import TracerProvider
 
 from genkit.ai import Genkit
+from genkit.ai._registry import SimpleRetrieverOptions
 from genkit.core.action import Action
+from genkit.core.action._action import _action_context
 from genkit.core.action.types import ActionKind
 from genkit.core.typing import DocumentPart, Operation
 from genkit.types import DocumentData, RetrieverRequest, RetrieverResponse, TextPart
@@ -149,8 +153,6 @@ async def test_define_simple_retriever_mapped() -> None:
             {'id': '2', 'text': 'world', 'extra': 'more'},
         ]
 
-    from genkit.ai._registry import SimpleRetrieverOptions
-
     options = SimpleRetrieverOptions(name='mapped', content='text', metadata=['extra'])
 
     retriever_action = ai.define_simple_retriever(options, db_handler)
@@ -168,8 +170,6 @@ async def test_define_simple_retriever_mapped() -> None:
 @pytest.mark.asyncio
 async def test_current_context() -> None:
     """Test Genkit.current_context method."""
-    from genkit.core.action._action import _action_context
-
     # current_context is a static method
     assert Genkit.current_context() is None
 
@@ -188,9 +188,6 @@ async def test_current_context() -> None:
 @pytest.mark.asyncio
 async def test_flush_tracing() -> None:
     """Test Genkit.flush_tracing method."""
-    from opentelemetry import trace as trace_api
-    from opentelemetry.sdk.trace import TracerProvider
-
     ai = Genkit()
 
     mock_provider = MagicMock(spec=TracerProvider)

--- a/py/packages/genkit/tests/genkit/ai/resource_integration_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resource_integration_test.py
@@ -22,7 +22,7 @@ from typing import cast
 import pytest
 
 from genkit.blocks.generate import generate_action
-from genkit.blocks.resource import ResourceInput, ResourceOutput, define_resource
+from genkit.blocks.resource import ResourceInput, ResourceOutput, define_resource, resource
 from genkit.core.action import ActionRunContext
 from genkit.core.registry import ActionKind, Registry
 from genkit.core.typing import (
@@ -31,6 +31,8 @@ from genkit.core.typing import (
     GenerateResponse,
     Message,
     Part,
+    Resource1,
+    ResourcePart,
     Role,
     TextPart,
 )
@@ -58,9 +60,6 @@ async def test_generate_with_resources() -> None:
 
     registry.register_action(ActionKind.MODEL, 'mock-model', mock_model)
 
-    # 3. Call generate_action with a message containing a resource part
-    from genkit.core.typing import Resource1, ResourcePart
-
     options = GenerateActionOptions(
         model='mock-model',
         messages=[Message(role=Role.USER, content=[Part(root=ResourcePart(resource=Resource1(uri='test://foo')))])],
@@ -80,8 +79,6 @@ async def test_dynamic_action_provider_resource() -> None:
 
     # Register a dynamic provider that handles any "dynamic://*" uri
     def provider_fn(input: dict[str, object], ctx: ActionRunContext) -> object:
-        from genkit.blocks.resource import resource
-
         kind = cast(ActionKind, input['kind'])
         name = cast(str, input['name'])
         if kind == ActionKind.RESOURCE and name.startswith('dynamic://'):
@@ -107,9 +104,6 @@ async def test_dynamic_action_provider_resource() -> None:
         return GenerateResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='Done'))]))
 
     registry.register_action(ActionKind.MODEL, 'mock-model', mock_model)
-
-    # Call generate with dynamic resource in message
-    from genkit.core.typing import Resource1, ResourcePart
 
     options = GenerateActionOptions(
         model='mock-model',

--- a/py/packages/genkit/tests/genkit/ai/resource_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resource_test.py
@@ -28,6 +28,8 @@ import pytest
 from genkit.blocks.resource import (
     ResourceInput,
     define_resource,
+    find_matching_resource,
+    is_dynamic_resource_action,
     resolve_resources,
     resource,
 )
@@ -121,9 +123,6 @@ async def test_find_matching_resource() -> None:
     dynamic_res = resource({'uri': 'baz://qux'}, dynamic_fn)
 
     # Match static from registry
-    from genkit.blocks.resource import find_matching_resource
-
-    # Match static from registry
     res = await find_matching_resource(registry, [], ResourceInput(uri='bar://baz'))
     assert res == static_res
 
@@ -147,7 +146,6 @@ def test_is_dynamic_resource_action() -> None:
     - Unregistered resources created with `resource()` are dynamic.
     - Registered resources created with `define_resource()` are not dynamic.
     """
-    from genkit.blocks.resource import is_dynamic_resource_action
 
     async def fn(input: ResourceInput, ctx: ActionRunContext) -> dict[str, object]:
         return {'content': []}

--- a/py/packages/genkit/tests/genkit/blocks/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/prompt_test.py
@@ -20,6 +20,7 @@
 import tempfile
 from pathlib import Path
 from typing import Any
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel, Field
@@ -796,8 +797,6 @@ async def test_automatic_prompt_loading_default_none() -> None:
 @pytest.mark.asyncio
 async def test_automatic_prompt_loading_defaults_mock() -> None:
     """Test that Genkit defaults to ./prompts when prompt_dir is not specified and dir exists."""
-    from unittest.mock import ANY, MagicMock, patch
-
     with patch('genkit.ai._aio.load_prompt_folder') as mock_load, patch('genkit.ai._aio.Path') as mock_path:
         # Setup mock to simulate ./prompts existing
         mock_path_instance = MagicMock()
@@ -811,8 +810,6 @@ async def test_automatic_prompt_loading_defaults_mock() -> None:
 @pytest.mark.asyncio
 async def test_automatic_prompt_loading_defaults_missing() -> None:
     """Test that Genkit skips loading when ./prompts is missing."""
-    from unittest.mock import MagicMock, patch
-
     with patch('genkit.ai._aio.load_prompt_folder') as mock_load, patch('genkit.ai._aio.Path') as mock_path:
         # Setup mock to simulate ./prompts missing
         mock_path_instance = MagicMock()

--- a/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
+++ b/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
@@ -44,6 +44,8 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+from genkit.core.action import ActionMetadata
+from genkit.core.action.types import ActionKind
 from genkit.core.reflection import create_reflection_asgi_app
 from genkit.core.registry import Registry
 
@@ -83,8 +85,6 @@ async def test_health_check(asgi_client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_list_actions(asgi_client: AsyncClient, mock_registry: MagicMock) -> None:
     """Test that the actions list endpoint returns registered actions."""
-    from genkit.core.action import ActionMetadata
-    from genkit.core.action.types import ActionKind
 
     # Mock the async list_actions method to return a list of ActionMetadata
     async def mock_list_actions_async(allowed_kinds: list[ActionKind] | None = None) -> list[ActionMetadata]:


### PR DESCRIPTION
## Summary

Clean up PLC0415 (import at top-level) violations in the core Genkit framework.

## Changes

| File | Change |
|------|--------|
| `packages/genkit/src/genkit/ai/_aio.py` | Import cleanup |
| `packages/genkit/src/genkit/ai/_registry.py` | Import cleanup |
| `packages/genkit/src/genkit/aio/loop.py` | Added noqa for optional uvloop import with comment |
| `packages/genkit/src/genkit/blocks/background_model.py` | Import cleanup |
| `packages/genkit/src/genkit/blocks/session/session.py` | Import cleanup |
| `packages/genkit/src/genkit/core/_plugins.py` | Fixed import with noqa and comment |
| `packages/genkit/src/genkit/core/plugin.py` | Added noqa with circular import comments |
| `packages/genkit/src/genkit/core/trace/default_exporter.py` | Moved imports to top |
| `packages/genkit/src/genkit/web/manager/_adapters.py` | Added noqa with lazy loading comments |
| `packages/genkit/tests/` | Moved test imports to module level |

## Related

- Related to #4398 (does not close - PR #4399 will enable PLC0415)

## Test Plan

- All Ruff checks pass
- bin/lint passes
- CI will validate tests