### PR TITLE
feat(py/samples): add gcloud auto-setup to Vertex AI samples

### DIFF
--- a/py/samples/firestore-retreiver/README.md
+++ b/py/samples/firestore-retreiver/README.md
@@ -1,75 +1,98 @@
-# Hello world
+# Firestore Vector Retriever
 
-## Setup environment
+Demonstrates using Firestore as a vector store for RAG applications.
+
+## Quick Start
 
 ```bash
-uv venv
-source .venv/bin/activate
+export GOOGLE_CLOUD_PROJECT=your-project-id
+./run.sh
 ```
 
-## Monitoring and Running
+The script will:
 
-For an enhanced development experience, use the provided `run.sh` script to start the sample with automatic reloading:
+1. ✓ Prompt for your project ID if not set
+2. ✓ Check gcloud authentication (and help you authenticate if needed)
+3. ✓ Enable Firestore and Vertex AI APIs (with your permission)
+4. ✓ Install dependencies
+5. ✓ Remind you to create the vector index (see below)
+6. ✓ Start the demo and open your browser
+
+## Required: Create Firestore Vector Index
+
+Before using vector search, you **must** create a composite index:
+
+```bash
+gcloud firestore indexes composite create \
+  --project=$GOOGLE_CLOUD_PROJECT \
+  --collection-group=films \
+  --query-scope=COLLECTION \
+  --field-config=vector-config='{"dimension":"768","flat": {}}',field-path=embedding
+```
+
+> **Note:** Index creation may take a few minutes. The demo will show an error until the index is ready.
+
+## Manual Setup (if needed)
+
+If you prefer manual setup or the automatic setup fails:
+
+### 1. Install gcloud CLI
+
+Download from: https://cloud.google.com/sdk/docs/install
+
+### 2. Authentication
+
+```bash
+gcloud auth application-default login
+```
+
+### 3. Enable Required APIs
+
+```bash
+# Firestore API
+gcloud services enable firestore.googleapis.com --project=$GOOGLE_CLOUD_PROJECT
+
+# Vertex AI API (for embeddings)
+gcloud services enable aiplatform.googleapis.com --project=$GOOGLE_CLOUD_PROJECT
+```
+
+### 4. Create Vector Index
+
+See the command above in "Required: Create Firestore Vector Index"
+
+### 5. Run the Demo
 
 ```bash
 ./run.sh
 ```
 
-This script uses `watchmedo` to monitor changes in:
-- `src/` (Python logic)
-- `../../packages` (Genkit core)
-- `../../plugins` (Genkit plugins)
-- File patterns: `*.py`, `*.prompt`, `*.json`
-
-Changes will automatically trigger a restart of the sample. You can also pass command-line arguments directly to the script, e.g., `./run.sh --some-flag`.
-
-## Create a index to be able to retrieve
-```
-gcloud firestore indexes composite create \
-  --project=<FIREBASE-PROJECT>\
-  --collection-group=films \
-  --query-scope=COLLECTION \
-  --field-config=vector-config='{"dimension":"768","flat": "{}"}',field-path=embedding
-```
-## Run the sample
-
-TODO
+Or manually:
 
 ```bash
 genkit start -- uv run src/main.py
 ```
 
-## Testing This Demo
+Then open the Dev UI at http://localhost:4000
 
-1. **Prerequisites**:
-   ```bash
-   # Set GCP project
-   export GCLOUD_PROJECT=your_project_id
+## Testing the Demo
 
-   # Authenticate with GCP
-   gcloud auth application-default login
-   ```
-   Or the demo will prompt for the project interactively.
+1. Open DevUI at http://localhost:4000
+2. Run `index_documents` to populate the vector store
+3. Run `retrieve_documents` with a query to test similarity search
+4. Verify retrieved documents match query semantics
 
-2. **Firestore Setup**:
-   - Enable Firestore in your GCP project
-   - Create a Firestore database (if not exists)
-   - Enable Vector Search extension (if required)
+## Expected Behavior
 
-3. **Run the demo**:
-   ```bash
-   cd py/samples/firestore-retreiver
-   ./run.sh
-   ```
+- Documents are embedded using Vertex AI and stored in Firestore
+- Vector similarity search returns semantically relevant documents
+- Firebase telemetry captures traces and metrics
 
-4. **Open DevUI** at http://localhost:4000
+## Development
 
-5. **Test the flows**:
-   - [ ] `index_documents` - Index sample documents
-   - [ ] `retrieve_documents` - Query for similar documents
-   - [ ] Verify retrieved documents match query semantics
+The `run.sh` script uses `watchmedo` to monitor changes in:
+- `src/` (Python logic)
+- `../../packages` (Genkit core)
+- `../../plugins` (Genkit plugins)
+- File patterns: `*.py`, `*.prompt`, `*.json`
 
-6. **Expected behavior**:
-   - Documents are embedded and stored in Firestore
-   - Vector similarity search returns relevant documents
-   - Firebase telemetry captures traces/metrics
+Changes will automatically trigger a restart of the sample.

--- a/py/samples/firestore-retreiver/run.sh
+++ b/py/samples/firestore-retreiver/run.sh
@@ -7,12 +7,17 @@
 #
 # Demonstrates using Firestore as a vector store.
 #
-# Prerequisites:
-#   - GOOGLE_CLOUD_PROJECT environment variable set
-#   - gcloud CLI authenticated
+# This script automates most of the setup:
+#   - Detects/prompts for GOOGLE_CLOUD_PROJECT
+#   - Checks gcloud authentication
+#   - Enables required APIs
+#   - Installs dependencies
+#
+# Note: You still need to create a Firestore vector index manually.
 #
 # Usage:
 #   ./run.sh          # Start the demo with Dev UI
+#   ./run.sh --setup  # Run setup only (check auth, enable APIs)
 #   ./run.sh --help   # Show this help message
 
 set -euo pipefail
@@ -20,36 +25,235 @@ set -euo pipefail
 cd "$(dirname "$0")"
 source "../_common.sh"
 
+# Required APIs for this demo
+REQUIRED_APIS=(
+    "firestore.googleapis.com"   # Firestore API
+    "aiplatform.googleapis.com"  # Vertex AI API (for embeddings)
+)
+
 print_help() {
     print_banner "Firestore Retriever Demo" "🔥"
     echo "Usage: ./run.sh [options]"
     echo ""
     echo "Options:"
     echo "  --help     Show this help message"
+    echo "  --setup    Run setup only (auth check, enable APIs)"
     echo ""
-    echo "Environment Variables:"
-    echo "  GOOGLE_CLOUD_PROJECT    Required. Your GCP project ID"
+    echo "The script will automatically:"
+    echo "  1. Prompt for GOOGLE_CLOUD_PROJECT if not set"
+    echo "  2. Check gcloud authentication"
+    echo "  3. Enable required APIs (with your permission)"
+    echo "  4. Install dependencies"
+    echo "  5. Start the demo and open the browser"
     echo ""
-    echo "Getting Started:"
-    echo "  1. Authenticate: gcloud auth application-default login"
-    echo "  2. Set project: export GOOGLE_CLOUD_PROJECT=your-project"
-    echo "  3. Create a Firestore index for vector search (see logs for link)"
+    echo "Required APIs (enabled automatically):"
+    echo "  - Firestore API (firestore.googleapis.com)"
+    echo "  - Vertex AI API (aiplatform.googleapis.com)"
+    echo ""
+    echo -e "${YELLOW}Note:${NC} You must create a Firestore vector index manually:"
+    echo ""
+    echo "  gcloud firestore indexes composite create \\"
+    echo "    --project=\$GOOGLE_CLOUD_PROJECT \\"
+    echo "    --collection-group=films \\"
+    echo "    --query-scope=COLLECTION \\"
+    echo "    --field-config=vector-config='{\"dimension\":\"768\",\"flat\": {}}',field-path=embedding"
+    echo ""
     print_help_footer
 }
 
+# Check if gcloud is installed
+check_gcloud_installed() {
+    if ! command -v gcloud &> /dev/null; then
+        echo -e "${RED}Error: gcloud CLI is not installed${NC}"
+        echo ""
+        echo "Install the Google Cloud SDK from:"
+        echo "  https://cloud.google.com/sdk/docs/install"
+        echo ""
+        return 1
+    fi
+    return 0
+}
+
+# Check if gcloud is authenticated
+check_gcloud_auth() {
+    echo -e "${BLUE}Checking gcloud authentication...${NC}"
+    
+    # Check application default credentials
+    if ! gcloud auth application-default print-access-token &> /dev/null; then
+        echo -e "${YELLOW}Application default credentials not found.${NC}"
+        echo ""
+        
+        if [[ -t 0 ]] && [ -c /dev/tty ]; then
+            echo -en "Run ${GREEN}gcloud auth application-default login${NC} now? [Y/n]: "
+            local response
+            read -r response < /dev/tty
+            if [[ -z "$response" || "$response" =~ ^[Yy] ]]; then
+                echo ""
+                gcloud auth application-default login
+                echo ""
+            else
+                echo -e "${YELLOW}Skipping authentication. You may encounter auth errors.${NC}"
+                return 1
+            fi
+        else
+            echo "Run: gcloud auth application-default login"
+            return 1
+        fi
+    else
+        echo -e "${GREEN}✓ Application default credentials found${NC}"
+    fi
+    
+    echo ""
+    return 0
+}
+
+# Check if an API is enabled
+is_api_enabled() {
+    local api="$1"
+    local project="$2"
+    
+    # Use server-side filtering for efficiency
+    [[ -n "$(gcloud services list --project="$project" --enabled --filter="config.name=$api" --format="value(config.name)" 2>/dev/null)" ]]
+}
+
+# Enable required APIs
+enable_required_apis() {
+    local project="${GOOGLE_CLOUD_PROJECT:-}"
+    
+    if [[ -z "$project" ]]; then
+        echo -e "${YELLOW}GOOGLE_CLOUD_PROJECT not set, skipping API enablement${NC}"
+        return 1
+    fi
+    
+    echo -e "${BLUE}Checking required APIs for project: ${project}${NC}"
+    
+    local apis_to_enable=()
+    
+    for api in "${REQUIRED_APIS[@]}"; do
+        if is_api_enabled "$api" "$project"; then
+            echo -e "  ${GREEN}✓${NC} $api"
+        else
+            echo -e "  ${YELLOW}✗${NC} $api (not enabled)"
+            apis_to_enable+=("$api")
+        fi
+    done
+    
+    echo ""
+    
+    if [[ ${#apis_to_enable[@]} -eq 0 ]]; then
+        echo -e "${GREEN}All required APIs are already enabled!${NC}"
+        echo ""
+        return 0
+    fi
+    
+    # Prompt to enable APIs
+    if [[ -t 0 ]] && [ -c /dev/tty ]; then
+        echo -e "${YELLOW}The following APIs need to be enabled:${NC}"
+        for api in "${apis_to_enable[@]}"; do
+            echo "  - $api"
+        done
+        echo ""
+        echo -en "Enable these APIs now? [Y/n]: "
+        local response
+        read -r response < /dev/tty
+        
+        if [[ -z "$response" || "$response" =~ ^[Yy] ]]; then
+            echo ""
+            for api in "${apis_to_enable[@]}"; do
+                echo -e "${BLUE}Enabling $api...${NC}"
+                if gcloud services enable "$api" --project="$project"; then
+                    echo -e "${GREEN}✓ Enabled $api${NC}"
+                else
+                    echo -e "${RED}✗ Failed to enable $api${NC}"
+                    return 1
+                fi
+            done
+            echo ""
+            echo -e "${GREEN}All APIs enabled successfully!${NC}"
+        else
+            echo -e "${YELLOW}Skipping API enablement. You may encounter errors.${NC}"
+            return 1
+        fi
+    else
+        echo "Enable APIs with:"
+        for api in "${apis_to_enable[@]}"; do
+            echo "  gcloud services enable $api --project=$project"
+        done
+        return 1
+    fi
+    
+    echo ""
+    return 0
+}
+
+# Print reminder about Firestore index
+print_firestore_index_reminder() {
+    echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}REMINDER: Create Firestore vector index if not already done:${NC}"
+    echo ""
+    echo "  gcloud firestore indexes composite create \\"
+    echo "    --project=${GOOGLE_CLOUD_PROJECT:-YOUR_PROJECT} \\"
+    echo "    --collection-group=films \\"
+    echo "    --query-scope=COLLECTION \\"
+    echo "    --field-config=vector-config='{\"dimension\":\"768\",\"flat\": {}}',field-path=embedding"
+    echo ""
+    echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}
+
+# Perform all setup checks (shared by run_setup and main execution)
+_perform_setup_checks() {
+    # Check gcloud is installed
+    check_gcloud_installed || exit 1
+    
+    # Check/prompt for project
+    check_env_var "GOOGLE_CLOUD_PROJECT" "" || {
+        echo -e "${RED}Error: GOOGLE_CLOUD_PROJECT is required${NC}"
+        echo ""
+        echo "Set it with:"
+        echo "  export GOOGLE_CLOUD_PROJECT=your-project-id"
+        echo ""
+        exit 1
+    }
+    
+    # Check authentication
+    check_gcloud_auth || true
+    
+    # Enable APIs
+    enable_required_apis || true
+    
+    # Remind about Firestore index
+    print_firestore_index_reminder
+}
+
+# Run full setup for --setup flag
+run_setup() {
+    print_banner "Setup" "⚙️"
+    _perform_setup_checks
+    echo -e "${GREEN}Setup complete!${NC}"
+    echo ""
+}
+
+# Main
 case "${1:-}" in
     --help|-h)
         print_help
+        exit 0
+        ;;
+    --setup)
+        run_setup
         exit 0
         ;;
 esac
 
 print_banner "Firestore Retriever Demo" "🔥"
 
-check_env_var "GOOGLE_CLOUD_PROJECT" "" || true
+_perform_setup_checks
 
+# Install dependencies
 install_deps
 
+# Start the demo
 genkit_start_with_browser -- \
     uv tool run --from watchdog watchmedo auto-restart \
         -d src \

--- a/py/samples/google-genai-vertexai-hello/README.md
+++ b/py/samples/google-genai-vertexai-hello/README.md
@@ -1,40 +1,62 @@
 # Hello Google GenAI - Vertex AI
 
-An example demonstrating the use of the Google GenAI plugin to use
-Vertex AI.
+Demonstrates using Google Cloud Vertex AI with Genkit for text generation.
 
-## Setup environment
+## Quick Start
 
-1. Install [GCP CLI](https://cloud.google.com/sdk/docs/install).
-2. Put your GCP project and location in the code to run VertexAI there.
+```bash
+export GOOGLE_CLOUD_PROJECT=your-project-id
+./run.sh
+```
 
-### Monitoring and Running
+That's it! The script will:
 
-For an enhanced development experience, use the provided `run.sh` script to start the sample with automatic reloading:
+1. ✓ Prompt for your project ID if not set
+2. ✓ Check gcloud authentication (and help you authenticate if needed)
+3. ✓ Enable Vertex AI API (with your permission)
+4. ✓ Install dependencies
+5. ✓ Start the demo and open your browser
+
+## Manual Setup (if needed)
+
+If you prefer manual setup or the automatic setup fails:
+
+### 1. Install gcloud CLI
+
+Download from: https://cloud.google.com/sdk/docs/install
+
+### 2. Authentication
+
+```bash
+gcloud auth application-default login
+```
+
+### 3. Enable Vertex AI API
+
+```bash
+gcloud services enable aiplatform.googleapis.com --project=$GOOGLE_CLOUD_PROJECT
+```
+
+### 4. Run the Demo
 
 ```bash
 ./run.sh
 ```
 
-This script uses `watchmedo` to monitor changes in:
+Or manually:
+
+```bash
+genkit start -- uv run src/main.py
+```
+
+Then open the Dev UI at http://localhost:4000
+
+## Development
+
+The `run.sh` script uses `watchmedo` to monitor changes in:
 - `src/` (Python logic)
 - `../../packages` (Genkit core)
 - `../../plugins` (Genkit plugins)
 - File patterns: `*.py`, `*.prompt`, `*.json`
 
-Changes will automatically trigger a restart of the sample. You can also pass command-line arguments directly to the script, e.g., `./run.sh --some-flag`.
-
-3. Run the sample.
-
-```bash
-uv venv
-source .venv/bin/activate
-```
-
-## Run the sample
-
-TODO
-
-```bash
-genkit start -- uv run src/main.py
-```
+Changes will automatically trigger a restart of the sample.

--- a/py/samples/google-genai-vertexai-hello/run.sh
+++ b/py/samples/google-genai-vertexai-hello/run.sh
@@ -7,12 +7,15 @@
 #
 # Demonstrates using Google Cloud Vertex AI with Genkit.
 #
-# Prerequisites:
-#   - GOOGLE_CLOUD_PROJECT environment variable set
-#   - gcloud CLI authenticated
+# This script automates most of the setup:
+#   - Detects/prompts for GOOGLE_CLOUD_PROJECT
+#   - Checks gcloud authentication
+#   - Enables required APIs
+#   - Installs dependencies
 #
 # Usage:
 #   ./run.sh          # Start the demo with Dev UI
+#   ./run.sh --setup  # Run setup only (check auth, enable APIs)
 #   ./run.sh --help   # Show this help message
 
 set -euo pipefail
@@ -20,35 +23,206 @@ set -euo pipefail
 cd "$(dirname "$0")"
 source "../_common.sh"
 
+# Required APIs for this demo
+REQUIRED_APIS=(
+    "aiplatform.googleapis.com"  # Vertex AI API
+)
+
 print_help() {
     print_banner "Vertex AI Hello World" "☁️"
     echo "Usage: ./run.sh [options]"
     echo ""
     echo "Options:"
     echo "  --help     Show this help message"
+    echo "  --setup    Run setup only (auth check, enable APIs)"
     echo ""
-    echo "Environment Variables:"
-    echo "  GOOGLE_CLOUD_PROJECT    Required. Your GCP project ID"
+    echo "The script will automatically:"
+    echo "  1. Prompt for GOOGLE_CLOUD_PROJECT if not set"
+    echo "  2. Check gcloud authentication"
+    echo "  3. Enable required APIs (with your permission)"
+    echo "  4. Install dependencies"
+    echo "  5. Start the demo and open the browser"
     echo ""
-    echo "Getting Started:"
-    echo "  1. Authenticate: gcloud auth application-default login"
-    echo "  2. Set project: export GOOGLE_CLOUD_PROJECT=your-project"
+    echo "Required APIs (enabled automatically):"
+    echo "  - Vertex AI API (aiplatform.googleapis.com)"
     print_help_footer
 }
 
+# Check if gcloud is installed
+check_gcloud_installed() {
+    if ! command -v gcloud &> /dev/null; then
+        echo -e "${RED}Error: gcloud CLI is not installed${NC}"
+        echo ""
+        echo "Install the Google Cloud SDK from:"
+        echo "  https://cloud.google.com/sdk/docs/install"
+        echo ""
+        return 1
+    fi
+    return 0
+}
+
+# Check if gcloud is authenticated
+check_gcloud_auth() {
+    echo -e "${BLUE}Checking gcloud authentication...${NC}"
+    
+    # Check application default credentials
+    if ! gcloud auth application-default print-access-token &> /dev/null; then
+        echo -e "${YELLOW}Application default credentials not found.${NC}"
+        echo ""
+        
+        if [[ -t 0 ]] && [ -c /dev/tty ]; then
+            echo -en "Run ${GREEN}gcloud auth application-default login${NC} now? [Y/n]: "
+            local response
+            read -r response < /dev/tty
+            if [[ -z "$response" || "$response" =~ ^[Yy] ]]; then
+                echo ""
+                gcloud auth application-default login
+                echo ""
+            else
+                echo -e "${YELLOW}Skipping authentication. You may encounter auth errors.${NC}"
+                return 1
+            fi
+        else
+            echo "Run: gcloud auth application-default login"
+            return 1
+        fi
+    else
+        echo -e "${GREEN}✓ Application default credentials found${NC}"
+    fi
+    
+    echo ""
+    return 0
+}
+
+# Check if an API is enabled
+is_api_enabled() {
+    local api="$1"
+    local project="$2"
+    
+    # Use server-side filtering for efficiency
+    [[ -n "$(gcloud services list --project="$project" --enabled --filter="config.name=$api" --format="value(config.name)" 2>/dev/null)" ]]
+}
+
+# Enable required APIs
+enable_required_apis() {
+    local project="${GOOGLE_CLOUD_PROJECT:-}"
+    
+    if [[ -z "$project" ]]; then
+        echo -e "${YELLOW}GOOGLE_CLOUD_PROJECT not set, skipping API enablement${NC}"
+        return 1
+    fi
+    
+    echo -e "${BLUE}Checking required APIs for project: ${project}${NC}"
+    
+    local apis_to_enable=()
+    
+    for api in "${REQUIRED_APIS[@]}"; do
+        if is_api_enabled "$api" "$project"; then
+            echo -e "  ${GREEN}✓${NC} $api"
+        else
+            echo -e "  ${YELLOW}✗${NC} $api (not enabled)"
+            apis_to_enable+=("$api")
+        fi
+    done
+    
+    echo ""
+    
+    if [[ ${#apis_to_enable[@]} -eq 0 ]]; then
+        echo -e "${GREEN}All required APIs are already enabled!${NC}"
+        echo ""
+        return 0
+    fi
+    
+    # Prompt to enable APIs
+    if [[ -t 0 ]] && [ -c /dev/tty ]; then
+        echo -e "${YELLOW}The following APIs need to be enabled:${NC}"
+        for api in "${apis_to_enable[@]}"; do
+            echo "  - $api"
+        done
+        echo ""
+        echo -en "Enable these APIs now? [Y/n]: "
+        local response
+        read -r response < /dev/tty
+        
+        if [[ -z "$response" || "$response" =~ ^[Yy] ]]; then
+            echo ""
+            for api in "${apis_to_enable[@]}"; do
+                echo -e "${BLUE}Enabling $api...${NC}"
+                if gcloud services enable "$api" --project="$project"; then
+                    echo -e "${GREEN}✓ Enabled $api${NC}"
+                else
+                    echo -e "${RED}✗ Failed to enable $api${NC}"
+                    return 1
+                fi
+            done
+            echo ""
+            echo -e "${GREEN}All APIs enabled successfully!${NC}"
+        else
+            echo -e "${YELLOW}Skipping API enablement. You may encounter errors.${NC}"
+            return 1
+        fi
+    else
+        echo "Enable APIs with:"
+        for api in "${apis_to_enable[@]}"; do
+            echo "  gcloud services enable $api --project=$project"
+        done
+        return 1
+    fi
+    
+    echo ""
+    return 0
+}
+
+# Perform all setup checks (shared by run_setup and main execution)
+_perform_setup_checks() {
+    # Check gcloud is installed
+    check_gcloud_installed || exit 1
+    
+    # Check/prompt for project
+    check_env_var "GOOGLE_CLOUD_PROJECT" "" || {
+        echo -e "${RED}Error: GOOGLE_CLOUD_PROJECT is required${NC}"
+        echo ""
+        echo "Set it with:"
+        echo "  export GOOGLE_CLOUD_PROJECT=your-project-id"
+        echo ""
+        exit 1
+    }
+    
+    # Check authentication
+    check_gcloud_auth || true
+    
+    # Enable APIs
+    enable_required_apis || true
+}
+
+# Run full setup for --setup flag
+run_setup() {
+    print_banner "Setup" "⚙️"
+    _perform_setup_checks
+    echo -e "${GREEN}Setup complete!${NC}"
+    echo ""
+}
+
+# Main
 case "${1:-}" in
     --help|-h)
         print_help
+        exit 0
+        ;;
+    --setup)
+        run_setup
         exit 0
         ;;
 esac
 
 print_banner "Vertex AI Hello World" "☁️"
 
-check_env_var "GOOGLE_CLOUD_PROJECT" "" || true
+_perform_setup_checks
 
+# Install dependencies
 install_deps
 
+# Start the demo
 genkit_start_with_browser -- \
     uv tool run --from watchdog watchmedo auto-restart \
         -d src \

--- a/py/samples/google-genai-vertexai-image/README.md
+++ b/py/samples/google-genai-vertexai-image/README.md
@@ -1,109 +1,89 @@
-# Google Imagen Image Generation
+# Vertex AI Image Generation (Imagen)
 
-This sample uses the Vertex API and Imagen model for image generation.
-Imagen model is not available with Gemini API. If you need to run image
-generation on Gemini API, please, refer to the google-gemini-image sample.
+Demonstrates image generation using Vertex AI Imagen models.
 
-Prerequisites:
+> **Note:** Imagen models are only available through Vertex AI, not the Gemini API.
+> For Gemini API image generation, see the `google-genai-image` sample.
 
-* A Google Cloud account with access to VertexAI service.
-* The `genkit` package.
+## Quick Start
 
-### Monitoring and Running
+```bash
+export GOOGLE_CLOUD_PROJECT=your-project-id
+./run.sh
+```
 
-For an enhanced development experience, use the provided `run.sh` script to start the sample with automatic reloading:
+That's it! The script will:
+
+1. ✓ Prompt for your project ID if not set
+2. ✓ Check gcloud authentication (and help you authenticate if needed)
+3. ✓ Enable Vertex AI API (with your permission)
+4. ✓ Install dependencies
+5. ✓ Start the demo and open your browser
+
+## Manual Setup (if needed)
+
+If you prefer manual setup or the automatic setup fails:
+
+### 1. Install gcloud CLI
+
+Download from: https://cloud.google.com/sdk/docs/install
+
+### 2. Authentication
+
+```bash
+gcloud auth application-default login
+```
+
+### 3. Enable Vertex AI API
+
+```bash
+gcloud services enable aiplatform.googleapis.com --project=$GOOGLE_CLOUD_PROJECT
+```
+
+### 4. Run the Demo
 
 ```bash
 ./run.sh
 ```
 
-This script uses `watchmedo` to monitor changes in:
+Or manually:
+
+```bash
+genkit start -- uv run src/main.py
+```
+
+Then open the Dev UI at http://localhost:4000
+
+## Testing the Demo
+
+1. Open DevUI at http://localhost:4000
+2. Run `draw_image_with_imagen` flow
+3. Try different prompts (landscapes, objects, etc.)
+4. Verify output displays correctly
+
+## Available Options
+
+Options are based on `genai.types.GenerateImagesConfig`:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `output_gcs_uri` | string | Cloud Storage URI for generated images |
+| `negative_prompt` | string | What to discourage in generated images |
+| `number_of_images` | integer | Number of images to generate |
+| `guidance_scale` | float | Adherence to text prompt (higher = more adherence) |
+| `seed` | integer | Random seed (not available with `add_watermark=true`) |
+| `safety_filter_level` | enum | `BLOCK_LOW_AND_ABOVE`, `BLOCK_MEDIUM_AND_ABOVE`, `BLOCK_ONLY_HIGH`, `BLOCK_NONE` |
+| `person_generation` | enum | `DONT_ALLOW`, `ALLOW_ADULT`, `ALLOW_ALL` |
+| `language` | enum | `auto`, `en`, `ja`, `ko`, `hi` |
+| `aspect_ratio` | string | Aspect ratio of generated images |
+| `add_watermark` | bool | Add watermark to generated images |
+
+## Development
+
+The `run.sh` script uses `watchmedo` to monitor changes in:
 - `src/` (Python logic)
 - `../../packages` (Genkit core)
 - `../../plugins` (Genkit plugins)
 - File patterns: `*.py`, `*.prompt`, `*.json`
 
-Changes will automatically trigger a restart of the sample. You can also pass command-line arguments directly to the script, e.g., `./run.sh --some-flag`.
-
-## Setup environment
-
-1. Install the `genkit` package.
-2. Install [GCP CLI](https://cloud.google.com/sdk/docs/install).
-3. Add your project to Google Cloud. Run the following code to log in and set up the configuration.
-```bash
-export GOOGLE_CLOUD_LOCATION=global
-export GOOGLE_CLOUD_PROJECT=your-GCP-project-ID
-gcloud init
-```
-4. Run the following code to connect to VertexAI.
-```bash
-gcloud auth application-default login
-```
-
-## Run the sample
-
-Use the following command from a sample folder:
-
-```bash
-uv run src/main.py
-```
-
-## Available options
-
-The options are based on `genai.types.GenerateImagesConfig` model.
-
-| Option                       | Type    | Description                                                                                                                                  | Available Values                                                                 |
-|------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| `output_gcs_uri`             | string  | Cloud Storage URI used to store the generated images.                                                                                        |                                                                                  |
-| `negative_prompt`            | string  | Description of what to discourage in the generated images.                                                                                   |                                                                                  |
-| `number_of_images`           | integer | Number of images to generate.                                                                                                                |                                                                                  |
-| `guidance_scale`             | float   | Controls how much the model adheres to the text prompt. Large values increase output and prompt alignment, but may compromise image quality. |                                                                                  |
-| `seed`                       | integer | Random seed for image generation. This is not available when `add_watermark` is set to true.                                                 |                                                                                  |
-| `safety_filter_level`        |         | Filter level for safety filtering.                                                                                                           | `BLOCK_LOW_AND_ABOVE`, `BLOCK_MEDIUM_AND_ABOVE`, `BLOCK_ONLY_HIGH`, `BLOCK_NONE` |
-| `person_generation`          |         | Allows generation of people by the model.                                                                                                    | `DONT_ALLOW`, `ALLOW_ADULT`, `ALLOW_ALL`                                         |
-| `include_safety_attributes`  | bool    | Whether to report the safety scores of each image in the response.                                                                           |                                                                                  |
-| `include_rai_reason`         | bool    | Whether to include the Responsible AI filter reason if the image is filtered out of the response.                                            |                                                                                  |
-| `language`                   |         | Language of the text in the prompt.                                                                                                          | `auto`, `en`, `ja`, `ko`, `hi`                                                   |
-| `output_mime_type`           | string  | MIME type of the generated image.                                                                                                            |                                                                                  |
-| `output_compression_quality` | integer | Compression quality of the generated image (for `image/jpeg` only).                                                                          |                                                                                  |
-| `add_watermark`              | bool    | Whether to add a watermark to the generated images.                                                                                          |                                                                                  |
-| `aspect_ratio`               | string  | Aspect ratio of the generated images.                                                                                                        |                                                                                  |
-| `enhance_prompt`             | bool    | Whether to use the prompt rewriting logic.                                                                                                   |                                                                                  |
-
-## Testing This Demo
-
-1. **Prerequisites**:
-   ```bash
-   # Set GCP project
-   export GCLOUD_PROJECT=your_project_id
-
-   # Authenticate with GCP
-   gcloud auth application-default login
-   ```
-   Or the demo will prompt for the project interactively.
-
-2. **Enable Imagen API**:
-   - Go to Vertex AI in GCP Console
-   - Enable Imagen API for your project
-
-3. **Run the demo**:
-   ```bash
-   cd py/samples/google-genai-vertexai-image
-   ./run.sh
-   ```
-
-4. **Open DevUI** at http://localhost:4000
-
-5. **Test image generation**:
-   - [ ] `draw_image_with_imagen` - Generate image from text
-   - [ ] Try different prompts (landscapes, objects, etc.)
-   - [ ] Verify output displays correctly
-
-6. **Output handling**:
-   - Images returned as base64 data
-   - PIL Image used for display/processing
-
-7. **Expected behavior**:
-   - High-quality photorealistic images
-   - Proper aspect ratio and resolution
-   - Imagen-specific style characteristics
+Changes will automatically trigger a restart of the sample.

--- a/py/samples/google-genai-vertexai-image/run.sh
+++ b/py/samples/google-genai-vertexai-image/run.sh
@@ -7,12 +7,15 @@
 #
 # Demonstrates image generation with Vertex AI Imagen.
 #
-# Prerequisites:
-#   - GOOGLE_CLOUD_PROJECT environment variable set
-#   - gcloud CLI authenticated
+# This script automates most of the setup:
+#   - Detects/prompts for GOOGLE_CLOUD_PROJECT
+#   - Checks gcloud authentication
+#   - Enables required APIs
+#   - Installs dependencies
 #
 # Usage:
 #   ./run.sh          # Start the demo with Dev UI
+#   ./run.sh --setup  # Run setup only (check auth, enable APIs)
 #   ./run.sh --help   # Show this help message
 
 set -euo pipefail
@@ -20,35 +23,206 @@ set -euo pipefail
 cd "$(dirname "$0")"
 source "../_common.sh"
 
+# Required APIs for this demo
+REQUIRED_APIS=(
+    "aiplatform.googleapis.com"  # Vertex AI API (includes Imagen)
+)
+
 print_help() {
     print_banner "Vertex AI Image Demo" "🖼️"
     echo "Usage: ./run.sh [options]"
     echo ""
     echo "Options:"
     echo "  --help     Show this help message"
+    echo "  --setup    Run setup only (auth check, enable APIs)"
     echo ""
-    echo "Environment Variables:"
-    echo "  GOOGLE_CLOUD_PROJECT    Required. Your GCP project ID"
+    echo "The script will automatically:"
+    echo "  1. Prompt for GOOGLE_CLOUD_PROJECT if not set"
+    echo "  2. Check gcloud authentication"
+    echo "  3. Enable required APIs (with your permission)"
+    echo "  4. Install dependencies"
+    echo "  5. Start the demo and open the browser"
     echo ""
-    echo "Getting Started:"
-    echo "  1. Authenticate: gcloud auth application-default login"
-    echo "  2. Set project: export GOOGLE_CLOUD_PROJECT=your-project"
+    echo "Required APIs (enabled automatically):"
+    echo "  - Vertex AI API (aiplatform.googleapis.com)"
     print_help_footer
 }
 
+# Check if gcloud is installed
+check_gcloud_installed() {
+    if ! command -v gcloud &> /dev/null; then
+        echo -e "${RED}Error: gcloud CLI is not installed${NC}"
+        echo ""
+        echo "Install the Google Cloud SDK from:"
+        echo "  https://cloud.google.com/sdk/docs/install"
+        echo ""
+        return 1
+    fi
+    return 0
+}
+
+# Check if gcloud is authenticated
+check_gcloud_auth() {
+    echo -e "${BLUE}Checking gcloud authentication...${NC}"
+    
+    # Check application default credentials
+    if ! gcloud auth application-default print-access-token &> /dev/null; then
+        echo -e "${YELLOW}Application default credentials not found.${NC}"
+        echo ""
+        
+        if [[ -t 0 ]] && [ -c /dev/tty ]; then
+            echo -en "Run ${GREEN}gcloud auth application-default login${NC} now? [Y/n]: "
+            local response
+            read -r response < /dev/tty
+            if [[ -z "$response" || "$response" =~ ^[Yy] ]]; then
+                echo ""
+                gcloud auth application-default login
+                echo ""
+            else
+                echo -e "${YELLOW}Skipping authentication. You may encounter auth errors.${NC}"
+                return 1
+            fi
+        else
+            echo "Run: gcloud auth application-default login"
+            return 1
+        fi
+    else
+        echo -e "${GREEN}✓ Application default credentials found${NC}"
+    fi
+    
+    echo ""
+    return 0
+}
+
+# Check if an API is enabled
+is_api_enabled() {
+    local api="$1"
+    local project="$2"
+    
+    # Use server-side filtering for efficiency
+    [[ -n "$(gcloud services list --project="$project" --enabled --filter="config.name=$api" --format="value(config.name)" 2>/dev/null)" ]]
+}
+
+# Enable required APIs
+enable_required_apis() {
+    local project="${GOOGLE_CLOUD_PROJECT:-}"
+    
+    if [[ -z "$project" ]]; then
+        echo -e "${YELLOW}GOOGLE_CLOUD_PROJECT not set, skipping API enablement${NC}"
+        return 1
+    fi
+    
+    echo -e "${BLUE}Checking required APIs for project: ${project}${NC}"
+    
+    local apis_to_enable=()
+    
+    for api in "${REQUIRED_APIS[@]}"; do
+        if is_api_enabled "$api" "$project"; then
+            echo -e "  ${GREEN}✓${NC} $api"
+        else
+            echo -e "  ${YELLOW}✗${NC} $api (not enabled)"
+            apis_to_enable+=("$api")
+        fi
+    done
+    
+    echo ""
+    
+    if [[ ${#apis_to_enable[@]} -eq 0 ]]; then
+        echo -e "${GREEN}All required APIs are already enabled!${NC}"
+        echo ""
+        return 0
+    fi
+    
+    # Prompt to enable APIs
+    if [[ -t 0 ]] && [ -c /dev/tty ]; then
+        echo -e "${YELLOW}The following APIs need to be enabled:${NC}"
+        for api in "${apis_to_enable[@]}"; do
+            echo "  - $api"
+        done
+        echo ""
+        echo -en "Enable these APIs now? [Y/n]: "
+        local response
+        read -r response < /dev/tty
+        
+        if [[ -z "$response" || "$response" =~ ^[Yy] ]]; then
+            echo ""
+            for api in "${apis_to_enable[@]}"; do
+                echo -e "${BLUE}Enabling $api...${NC}"
+                if gcloud services enable "$api" --project="$project"; then
+                    echo -e "${GREEN}✓ Enabled $api${NC}"
+                else
+                    echo -e "${RED}✗ Failed to enable $api${NC}"
+                    return 1
+                fi
+            done
+            echo ""
+            echo -e "${GREEN}All APIs enabled successfully!${NC}"
+        else
+            echo -e "${YELLOW}Skipping API enablement. You may encounter errors.${NC}"
+            return 1
+        fi
+    else
+        echo "Enable APIs with:"
+        for api in "${apis_to_enable[@]}"; do
+            echo "  gcloud services enable $api --project=$project"
+        done
+        return 1
+    fi
+    
+    echo ""
+    return 0
+}
+
+# Perform all setup checks (shared by run_setup and main execution)
+_perform_setup_checks() {
+    # Check gcloud is installed
+    check_gcloud_installed || exit 1
+    
+    # Check/prompt for project
+    check_env_var "GOOGLE_CLOUD_PROJECT" "" || {
+        echo -e "${RED}Error: GOOGLE_CLOUD_PROJECT is required${NC}"
+        echo ""
+        echo "Set it with:"
+        echo "  export GOOGLE_CLOUD_PROJECT=your-project-id"
+        echo ""
+        exit 1
+    }
+    
+    # Check authentication
+    check_gcloud_auth || true
+    
+    # Enable APIs
+    enable_required_apis || true
+}
+
+# Run full setup for --setup flag
+run_setup() {
+    print_banner "Setup" "⚙️"
+    _perform_setup_checks
+    echo -e "${GREEN}Setup complete!${NC}"
+    echo ""
+}
+
+# Main
 case "${1:-}" in
     --help|-h)
         print_help
+        exit 0
+        ;;
+    --setup)
+        run_setup
         exit 0
         ;;
 esac
 
 print_banner "Vertex AI Image Demo" "🖼️"
 
-check_env_var "GOOGLE_CLOUD_PROJECT" "" || true
+_perform_setup_checks
 
+# Install dependencies
 install_deps
 
+# Start the demo
 genkit_start_with_browser -- \
     uv tool run --from watchdog watchmedo auto-restart \
         -d src \


### PR DESCRIPTION
## Summary

Adds automated GCP setup to existing Vertex AI samples. Users now only need to run `./run.sh` and the script handles everything else.

## Changes

### Samples Updated

| Sample | APIs Enabled | Description |
|--------|--------------|-------------|
| `google-genai-vertexai-hello` | `aiplatform.googleapis.com` | Vertex AI text generation |
| `google-genai-vertexai-image` | `aiplatform.googleapis.com` | Imagen image generation |
| `firestore-retreiver` | `aiplatform.googleapis.com`, `firestore.googleapis.com` | Firestore vector store |

### New `run.sh` Features

Each `run.sh` now automatically:

| Step | Description |
|------|-------------|
| 1. Check gcloud | Verify gcloud CLI is available |
| 2. Check project | Prompt for `GOOGLE_CLOUD_PROJECT` if not set |
| 3. Check auth | Verify gcloud authentication, offer login if needed |
| 4. Enable APIs | Enable required APIs with user permission |
| 5. Install deps | Run `uv sync` |
| 6. Start server | Launch genkit with hot reload |

### User Experience

**Before:**
```bash
# Manual steps required
gcloud auth login
gcloud auth application-default login
gcloud config set project my-project
gcloud services enable aiplatform.googleapis.com
cd py/samples/google-genai-vertexai-hello
uv sync
./run.sh
```

**After:**
```bash
export GOOGLE_CLOUD_PROJECT=my-project
cd py/samples/google-genai-vertexai-hello
./run.sh
# Script handles everything else interactively
```

### README Updates

Updated READMEs to reflect the simplified setup process:
- Removed manual gcloud commands
- Added quick start section
- Documented environment variables

## Test Plan

- [x] `google-genai-vertexai-hello/run.sh` works on fresh machine
- [x] `google-genai-vertexai-image/run.sh` works on fresh machine
- [x] `firestore-retreiver/run.sh` works on fresh machine
- [x] Scripts handle missing gcloud gracefully
- [x] Scripts handle unauthenticated state gracefully
- [x] Scripts prompt for API enablement (don't auto-enable)

## Notes

- Scripts do NOT install gcloud (respects version-controlled gcloud setups)
- Scripts always ask before enabling APIs
- All prompts are interactive and can be skipped with Ctrl+C