### PR TITLE
fix(py): optimize CI with parallel jobs and reduced overhead

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -53,32 +53,31 @@ jobs:
         run: uv lock --check --directory py
 
       - name: Format check
-        run: uv run --directory py ruff format --check .
+        run: uv run --directory py ruff format --check --preview .
 
       - name: Lint with ruff
-        run: uv run --directory py ruff check .
+        run: uv run --directory py ruff check --preview .
 
-      - name: Check test file naming convention
-        run: |
-          if find py -name "test_*.py" -not -path "*/.*" | grep -q .; then
-              echo "Error: Found Python test files starting with 'test_'. Please use the '*_test.py' format instead:"
-              find py -name "test_*.py" -not -path "*/.*"
-              exit 1
-          fi
+      - name: Run consistency checks
+        run: ./py/bin/check_consistency
 
   # =============================================================================
-  # Type checking (runs in parallel with lint)
+  # Type checking (runs in parallel - each checker is a separate job)
   # =============================================================================
   type-check:
-    name: Type Check
+    name: Type Check (${{ matrix.checker }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        checker: [ty, pyrefly, pyright]
     steps:
       - uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libffi-dev cmake libjpeg-dev zlib1g-dev
+          sudo apt-get install -y --no-install-recommends build-essential libffi-dev cmake libjpeg-dev zlib1g-dev
 
       - name: Install uv and setup Python
         uses: astral-sh/setup-uv@v5
@@ -95,12 +94,15 @@ jobs:
         run: ./py/bin/generate_schema_typing --ci
 
       - name: Type check with Ty
+        if: matrix.checker == 'ty'
         run: uv run --directory py ty check .
 
       - name: Type check with Pyrefly
+        if: matrix.checker == 'pyrefly'
         run: uv run --directory py pyrefly check .
 
       - name: Type check with Pyright
+        if: matrix.checker == 'pyright'
         run: uv run --directory py pyright packages/
 
   # =============================================================================
@@ -164,35 +166,17 @@ jobs:
           echo "No hardcoded secrets detected"
 
   # =============================================================================
-  # Consistency checks (package metadata, workspace, naming)
+  # Consistency checks (merged into lint-and-format job above for efficiency)
   # =============================================================================
-  consistency-check:
-    name: Consistency Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install uv and setup Python
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: |
-          cd py
-          uv sync --group lint
-
-      - name: Run consistency checks
-        run: ./py/bin/check_consistency
+  # NOTE: consistency-check was merged into lint-and-format to reduce setup overhead
 
   # =============================================================================
-  # Unit tests across multiple Python versions
+  # Unit tests across multiple Python versions (runs in parallel with other jobs)
   # =============================================================================
   tests:
     name: Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    needs: [lint-and-format]  # Don't waste CI time if lint fails
+    # No 'needs' - runs in parallel. If lint fails, concurrency will cancel this.
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -225,53 +209,12 @@ jobs:
             pytest -xvs --log-level=DEBUG .
 
   # =============================================================================
-  # Verify tox/nox work for local development (smoke test)
-  # =============================================================================
-  test-runners:
-    name: Test Runners (tox/nox)
-    runs-on: ubuntu-latest
-    needs: [lint-and-format]  # Don't waste CI time if lint fails
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential libffi-dev cmake libjpeg-dev zlib1g-dev
-
-      - name: Install uv and setup Python
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: |
-          cd py
-          uv sync
-
-      - name: Generate schema typing
-        run: ./py/bin/generate_schema_typing --ci
-
-      # Smoke test tox - run with single Python version to verify it works
-      - name: Verify tox works (smoke test)
-        run: |
-          cd py
-          uv run tox -e py312 -- -x --tb=no -q packages/genkit/tests/genkit/core/
-
-      # Smoke test nox - run with single Python version to verify it works
-      - name: Verify nox works (smoke test)
-        run: |
-          cd py
-          uv run nox -s "tests-3.12" -- -x --tb=no -q packages/genkit/tests/genkit/core/
-
-  # =============================================================================
   # Build verification (runs after tests pass)
   # =============================================================================
   build:
     name: Build Distributions
     runs-on: ubuntu-latest
-    needs: [lint-and-format, type-check, security-and-compliance, consistency-check, tests, test-runners]
+    needs: [lint-and-format, type-check, security-and-compliance, tests]
     steps:
       - uses: actions/checkout@v5
 

--- a/bin/lint
+++ b/bin/lint
@@ -25,12 +25,10 @@ JS_DIR="${TOP_DIR}/js"
 
 uv run --directory "${PY_DIR}" ruff check --fix --preview --unsafe-fixes .
 uv run --directory "${PY_DIR}" ruff format --preview .
-# Ensure Python test files follow the *_test.py naming convention.
-if find "${PY_DIR}" -name "test_*.py" -not -path "*/.*" | grep -q .; then
-  echo "Error: Found Python test files starting with 'test_'. Please use the '*_test.py' format instead:"
-  find "${PY_DIR}" -name "test_*.py" -not -path "*/.*"
-  exit 1
-fi
+
+# Check lockfile is up to date
+echo "--- 🔒 Checking lockfile is up to date ---"
+uv lock --check --directory "${PY_DIR}"
 
 # Fast type checkers first (blocking)
 # Note: ty reads its config (environment.root) from py/pyproject.toml
@@ -50,6 +48,10 @@ uv run --directory "${PY_DIR}" pyright packages/
 # License checks
 echo "--- 📜 Running License Check ---"
 "${TOP_DIR}/bin/check_license"
+
+# Dependency license check
+echo "--- 📜 Running Dependency License Check ---"
+uv run --directory "${PY_DIR}" liccheck -s pyproject.toml
 
 # Consistency checks (Python versions, plugin versions, naming, workspace completeness)
 echo "--- 🔍 Running Consistency Checks ---"


### PR DESCRIPTION
## Summary

Optimize CI workflow with parallel execution and reduced job overhead.

## Changes

### Parallelization
| Before | After |
|--------|-------|
| Type checkers run sequentially (~3-5 min) | 3 parallel jobs via matrix (~1-2 min each) |
| Tests wait for lint to complete | Tests start immediately (cancelled if lint fails) |

### Job Consolidation
| Removed | Merged Into |
|---------|-------------|
| `consistency-check` | `lint-and-format` (saves ~30s setup overhead) |
| `test-runners` | Removed (redundant with `tests` job) |

### Local/CI Alignment
- Add `--preview` flag to ruff commands in CI (matches local)
- Add `uv lock --check` to `bin/lint` (matches CI)
- Add `liccheck` to `bin/lint` (matches CI)

## Job Execution Diagram

```
Before (sequential dependencies):
lint-and-format ──┬──> tests (5 versions) ──┐
                  └──> test-runners ────────┤
type-check (sequential: ty→pyrefly→pyright) ┤
security-and-compliance ────────────────────┼──> build
consistency-check ──────────────────────────┘

After (parallel execution):
lint-and-format (+ consistency) ────────────┐
type-check (ty)     ┐                       │
type-check (pyrefly)├── parallel ───────────┼──> build
type-check (pyright)┘                       │
security-and-compliance ────────────────────┤
tests (3.10) ┐                              │
tests (3.11) │                              │
tests (3.12) ├── parallel (no wait) ────────┘
tests (3.13) │
tests (3.14) ┘
```

## Expected Time Savings

- **Type checking**: ~3-5 min → ~1-2 min (3x faster)
- **Tests**: Start ~1-2 min earlier (no lint wait)
- **Setup overhead**: -2 jobs × ~30s = ~1 min saved

## Related

- Fixes formatting inconsistency observed in PR #4432