### PR TITLE
fix(py/typing): respect additionalProperties from JSON schema

### DIFF
--- a/py/packages/genkit/src/genkit/core/typing.py
+++ b/py/packages/genkit/src/genkit/core/typing.py
@@ -79,7 +79,7 @@ class EvalStatusEnum(StrEnum):
 class Details(BaseModel):
     """Model for details data."""
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='allow', populate_by_name=True)
     reasoning: str | None = None
 
 
@@ -264,7 +264,7 @@ class ModelInfo(BaseModel):
 class Error(BaseModel):
     """Model for error data."""
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='allow', populate_by_name=True)
     message: str
 
 
@@ -363,7 +363,7 @@ class CommonRerankerOptions(BaseModel):
 class RankedDocumentMetadata(BaseModel):
     """Model for rankeddocumentmetadata data."""
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='allow', populate_by_name=True)
     score: float
 
 


### PR DESCRIPTION
## Summary

Fixes the Python schema generator to respect `additionalProperties: true` from the canonical JSON schema, matching JavaScript behavior for models using `.passthrough()` in Zod.

## Problem

The Python schema sanitizer (`py/bin/sanitize_schema_typing.py`) was always setting `extra='forbid'` for all Pydantic models, regardless of the `additionalProperties` setting in the JSON schema. This caused a parity issue with the JavaScript implementation where models use `.passthrough()` to allow extra properties.

**Impact**: 
- Reranker metadata was being discarded
- Evaluation score details beyond `reasoning` were rejected
- Operation error details beyond `message` were rejected

## Solution

Updated the schema sanitizer to:
1. Read `genkit-tools/genkit-schema.json` at generation time
2. Identify models with `additionalProperties: true`:
   - Top-level `$defs` (e.g., `RankedDocumentMetadata`)
   - Inline nested objects (e.g., `Score.details` → `Details` class, `Operation.error` → `Error` class)
3. Use `extra='allow'` for those models (equivalent to `.passthrough()` in Zod)
4. Use `extra='forbid'` for all other models (default behavior)

## Changes

| File | Description |
|------|-------------|
| `py/bin/sanitize_schema_typing.py` | Added `load_models_allowing_extra()` function to read JSON schema and identify passthrough models (both top-level and inline). Updated `ClassTransformer` to use `extra='allow'` for those models. |
| `py/packages/genkit/src/genkit/core/typing.py` | Regenerated - three classes now use `extra='allow'` instead of `extra='forbid'` |

## Affected Models

| Model | Source | Purpose |
|-------|--------|---------|
| `RankedDocumentMetadata` | Top-level `$defs` | Preserves arbitrary metadata during reranking |
| `Details` | Inline in `Score.details` | Allows extra evaluation score details |
| `Error` | Inline in `Operation.error` | Allows extra error details |

## Before/After

**Before:**
```python
class RankedDocumentMetadata(BaseModel):
    model_config = ConfigDict(..., extra='forbid', ...)  # Rejects extra fields

class Details(BaseModel):
    model_config = ConfigDict(..., extra='forbid', ...)  # Rejects extra fields

class Error(BaseModel):
    model_config = ConfigDict(..., extra='forbid', ...)  # Rejects extra fields
```

**After:**
```python
class RankedDocumentMetadata(BaseModel):
    model_config = ConfigDict(..., extra='allow', ...)  # Matches JS .passthrough()

class Details(BaseModel):
    model_config = ConfigDict(..., extra='allow', ...)  # Matches JS .passthrough()

class Error(BaseModel):
    model_config = ConfigDict(..., extra='allow', ...)  # Matches JS .passthrough()
```

## Testing

- All 500 tests pass
- Verified all three models now correctly have `extra='allow'`
- Verified the detection works for both top-level and inline schemas

## Related

- Fixes JS/Python parity for type validation
- Related to #4428 (Vertex AI Rerankers and Evaluators)
