### PR TITLE
fix(py/web): improve ASGI type compatibility with Protocol-based types

### DIFF
--- a/py/GEMINI.md
+++ b/py/GEMINI.md
@@ -315,6 +315,18 @@
     # Print in atexit handler where logger is unavailable
     print(f'Removing file: {path}')  # noqa: T201 - atexit handler, logger unavailable
     ```
+  * **Optional Dependencies**: For optional dependencies used in typing (e.g., `litestar`,
+    `starlette`) that type checkers can't resolve, **do NOT use inline ignore comments**.
+    Instead, add the dependency to the `lint` dependency group in `pyproject.toml`:
+    ```toml
+    # In pyproject.toml [project.optional-dependencies]
+    lint = [
+      # ... other lint deps ...
+      "litestar>=2.0.0",  # For web/typing.py type resolution
+    ]
+    ```
+    This ensures type checkers can resolve the imports during CI while keeping the
+    package optional for runtime.
 * **Import Placement**: All imports must be at the top of the file, outside any
   function definitions. This is a strict Python convention that ensures:
 

--- a/py/packages/genkit/src/genkit/web/typing.py
+++ b/py/packages/genkit/src/genkit/web/typing.py
@@ -14,73 +14,164 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Type annotations to smooth over some rough edges.
+"""ASGI-compatible type definitions for Genkit web framework integration.
 
-Not all ASGI frameworks agree on the type definitions
-and we plan to support as many as we can. Currently,
-we support:
+This module provides Protocol-based type definitions that are compatible with
+any ASGI framework (litestar, starlette, fastapi, Django, etc.) without
+requiring framework-specific type unions.
 
-- asgiref (Django)
-- fastapi
-- litestar
-- starlette
+The ASGI specification defines interfaces using structural typing, so we use
+typing.Protocol to match this approach. Any framework that follows the ASGI
+spec will be compatible with these types.
+
+Supported frameworks:
+    - asgiref (Django)
+    - FastAPI
+    - Litestar
+    - Starlette
+    - Any other ASGI-compliant framework
+
+Example:
+    ```python
+    from genkit.web.typing import Scope, Receive, Send
+
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        # This signature works with any ASGI framework
+        ...
+    ```
+
+See Also:
+    - ASGI Spec: https://asgi.readthedocs.io/
+    - PEP 544 (Protocols): https://peps.python.org/pep-0544/
 """
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, MutableMapping
+from typing import Any, Protocol, runtime_checkable
 
-from asgiref import typing as atyping
+# These Protocol-based types follow the ASGI specification and are compatible
+# with any ASGI framework. Using Protocols instead of Union types allows:
+#
+# 1. Any framework implementing the ASGI interface to work
+# 2. No import-time dependencies on specific frameworks
+# 3. Proper structural subtyping for type checkers
 
-try:
-    import litestar  # type: ignore # pyright: ignore[reportMissingImports]
-    import litestar.types  # type: ignore # pyright: ignore[reportMissingImports]
-except ImportError:
-    litestar = None  # type: ignore
+# ASGI Scope - a dict-like object with connection info
+# Using MutableMapping[str, Any] as the base provides structural compatibility
+Scope = MutableMapping[str, Any]
+"""ASGI scope - connection metadata dict.
 
-try:
-    import starlette.types  # Explicit import for ty type checker
+Contains at minimum:
+    - type: 'http', 'websocket', or 'lifespan'
+    - asgi: dict with 'version' key
 
-    # Import the actual application class
-    from starlette.applications import Starlette as StarletteApp
-except ImportError:
-    starlette = None  # type: ignore[assignment]
-    StarletteApp = None  # type: ignore[assignment,misc]
+For HTTP connections, also includes:
+    - method: HTTP method (GET, POST, etc.)
+    - path: URL path
+    - headers: list of (name, value) byte tuples
+"""
+
+# ASGI Receive Callable
+# Async function that returns the next message from the client
+Receive = Callable[[], Awaitable[MutableMapping[str, Any]]]
+"""ASGI receive callable - async function to get next message from client."""
+
+# ASGI Send Callable
+# Async function that sends a message to the client
+Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
+"""ASGI send callable - async function to send message to client."""
 
 
-# NOTE: Please ask these frameworks to standardize on asgiref.
-if litestar is not None and starlette is not None:
-    Application = atyping.ASGIApplication | litestar.Litestar | StarletteApp  # pyright: ignore[reportOperatorIssue]
-    HTTPScope = atyping.HTTPScope | litestar.types.HTTPScope | starlette.types.Scope
-    LifespanScope = atyping.LifespanScope | litestar.types.LifeSpanScope | starlette.types.Scope
-    Receive = atyping.ASGIReceiveCallable | litestar.types.Receive | starlette.types.Scope
-    Scope = atyping.Scope | litestar.types.Scope | starlette.types.Scope
-    Send = atyping.ASGISendCallable | litestar.types.Send | starlette.types.Send
-elif litestar is not None:
-    Application = atyping.ASGIApplication | litestar.Litestar
-    HTTPScope = atyping.HTTPScope | litestar.types.HTTPScope
-    LifespanScope = atyping.LifespanScope | litestar.types.LifeSpanScope
-    Receive = atyping.ASGIReceiveCallable | litestar.types.Receive
-    Scope = atyping.Scope | litestar.types.Scope
-    Send = atyping.ASGISendCallable | litestar.types.Send
-elif starlette is not None:
-    Application = StarletteApp | atyping.ASGIApplication  # pyright: ignore[reportOptionalOperand]
-    HTTPScope = atyping.HTTPScope | starlette.types.Scope
-    LifespanScope = atyping.LifespanScope | starlette.types.Scope
-    Receive = atyping.ASGIReceiveCallable | starlette.types.Receive
-    Scope = atyping.Scope | starlette.types.Scope
-    Send = atyping.ASGISendCallable | starlette.types.Send
-else:
-    Application = atyping.ASGIApplication
-    HTTPScope = atyping.HTTPScope
-    LifespanScope = atyping.LifespanScope
-    Receive = atyping.ASGIReceiveCallable
-    Scope = atyping.Scope
-    Send = atyping.ASGISendCallable
+@runtime_checkable
+class ASGIApp(Protocol):
+    """Protocol for ASGI applications.
 
-# Type aliases for the web framework.
+    Any async callable with the signature (scope, receive, send) -> None
+    is considered an ASGI application.
+
+    Example:
+        ```python
+        async def my_app(scope: Scope, receive: Receive, send: Send) -> None:
+            await send({
+                'type': 'http.response.start',
+                'status': 200,
+                'headers': [(b'content-type', b'text/plain')],
+            })
+            await send({
+                'type': 'http.response.body',
+                'body': b'Hello, World!',
+            })
+
+
+        # my_app is an ASGIApp
+        assert isinstance(my_app, ASGIApp)
+        ```
+    """
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        """Handle an ASGI connection."""
+        ...
+
+
+# Type alias for ASGI applications
+# Using Any because each framework (Litestar, Starlette, FastAPI) has its own
+# type definitions that aren't structurally compatible with our Protocol.
+# At runtime, they all work correctly - this is purely a type checker limitation.
+Application = Any
+"""Type alias for ASGI application objects.
+
+Note: Uses Any because external frameworks (Litestar, Starlette, etc.) define
+their own ASGI types that aren't structurally compatible with our Protocol.
+At runtime, all ASGI-compliant apps work correctly.
+"""
+
+
+# Specialized Scope Types (for documentation, not enforced at runtime)
+# These are aliases for Scope with documentation about expected keys.
+# Type checkers treat them as Scope, but the docstrings help developers.
+
+HTTPScope = Scope
+"""HTTP connection scope.
+
+Expected keys beyond base Scope:
+    - method: str (GET, POST, etc.)
+    - path: str
+    - query_string: bytes
+    - headers: list[tuple[bytes, bytes]]
+"""
+
+WebSocketScope = Scope
+"""WebSocket connection scope.
+
+Expected keys beyond base Scope:
+    - path: str
+    - query_string: bytes
+    - headers: list[tuple[bytes, bytes]]
+"""
+
+LifespanScope = Scope
+"""Lifespan scope for startup/shutdown.
+
+Expected keys beyond base Scope:
+    - type: 'lifespan'
+"""
+
+
+# Handler Type Aliases
+
 LifespanHandler = Callable[[LifespanScope, Receive, Send], Awaitable[None]]
+"""ASGI lifespan handler - manages app startup and shutdown."""
 
-# Type alias for Starlette/Litestar on_startup/on_shutdown handlers (0-argument async functions)
-# This is distinct from LifespanHandler which is the full ASGI lifespan protocol handler.
 StartupHandler = Callable[[], Awaitable[None]]
+"""Simple startup/shutdown handler (0-argument async function).
+
+Used by Starlette/Litestar for on_startup/on_shutdown callbacks.
+This is distinct from LifespanHandler which is the full ASGI protocol.
+"""

--- a/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
+++ b/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
@@ -67,7 +67,7 @@ async def asgi_client(mock_registry: MagicMock) -> AsyncIterator[AsyncClient]:
         An AsyncClient configured to make requests to the test ASGI app.
     """
     app = create_reflection_asgi_app(mock_registry)
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    transport = ASGITransport(app=app)
     client = AsyncClient(transport=transport, base_url='http://test')
     try:
         yield client

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -75,6 +75,7 @@ dev = [
 lint = [
   "bandit>=1.7.0",
   "deptry>=0.22.0",
+  "litestar>=2.0.0",          # For web/typing.py type resolution
   "mypy>=1.14.0",
   "pip-audit>=2.7.0",
   "pypdf>=6.6.2",
@@ -470,7 +471,7 @@ search-path = [
 ]
 # Ignore missing imports for namespace packages - pyrefly can't resolve PEP 420
 # namespace packages but these imports work at runtime
-ignore-missing-imports = ["genkit.plugins.*", "litestar", "litestar.*"]
+ignore-missing-imports = ["genkit.plugins.*"]
 python_version         = "3.10"
 
 # Treat warnings as errors.

--- a/py/samples/multi-server/src/main.py
+++ b/py/samples/multi-server/src/main.py
@@ -73,12 +73,12 @@ import asyncio
 import time
 from typing import Any, cast
 
-from litestar import Controller, Litestar, get, post  # type: ignore
-from litestar.datastructures import State  # type: ignore
-from litestar.logging.config import LoggingConfig  # type: ignore
-from litestar.middleware.base import AbstractMiddleware  # type: ignore
-from litestar.plugins.structlog import StructlogPlugin  # type: ignore
-from litestar.types import Message  # type: ignore
+from litestar import Controller, Litestar, get, post
+from litestar.datastructures import State
+from litestar.logging.config import LoggingConfig
+from litestar.middleware.base import AbstractMiddleware
+from litestar.plugins.structlog import StructlogPlugin
+from litestar.types import Message, Receive, Scope, Send
 from rich.traceback import install as install_rich_traceback
 from starlette.applications import Starlette
 
@@ -100,7 +100,7 @@ from genkit.web.manager import (
     get_server_info,
 )
 from genkit.web.manager.signals import terminate_all_servers
-from genkit.web.typing import Application, Receive, Scope, Send
+from genkit.web.typing import Application
 
 install_rich_traceback(show_locals=True, width=120, extra_lines=3)
 
@@ -129,11 +129,16 @@ logger = get_logger(__name__)
 class LitestarLoggingMiddleware(AbstractMiddleware):
     """Logging middleware for Litestar that logs requests and responses."""
 
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
         """Process the ASGI request/response cycle with logging."""
         if str(scope['type']) != 'http':
             # pyrefly: ignore[missing-attribute] - app is from AbstractMiddleware
-            await self.app(scope, receive, send)  # type: ignore
+            await self.app(scope, receive, send)
             return
 
         start_time = time.time()
@@ -185,11 +190,11 @@ class LitestarLoggingMiddleware(AbstractMiddleware):
                         'Error logging response',
                         error=str(e),
                     )
-            await send(message)  # type: ignore
+            await send(message)
 
         # Call the next middleware or handler
         # pyrefly: ignore[missing-attribute] - app is from AbstractMiddleware
-        await self.app(scope, receive, wrapped_send)  # type: ignore
+        await self.app(scope, receive, wrapped_send)
 
 
 class BaseControllerMixin:

--- a/py/samples/sample-test/README.md
+++ b/py/samples/sample-test/README.md
@@ -1,0 +1,35 @@
+# Sample Test Utilities
+
+Internal testing utilities for Genkit samples. These scripts help developers
+verify that sample flows are working correctly.
+
+## Scripts
+
+### `review_sample_flows.py`
+
+Reviews and tests all flows in a sample's `main.py`.
+
+```bash
+# Test all flows in a sample
+cd py
+uv run samples/sample-test/review_sample_flows.py samples/google-genai-hello
+
+# Specify custom output file
+uv run samples/sample-test/review_sample_flows.py samples/google-genai-hello --output results.txt
+```
+
+### `run_single_flow.py`
+
+Runs a single flow from a sample. Used internally by `review_sample_flows.py`.
+
+```bash
+cd py
+uv run samples/sample-test/run_single_flow.py samples/google-genai-hello flow_name --input '{"key": "value"}'
+```
+
+## Output
+
+The review script generates a report file with:
+- Summary of successful/failed flows
+- Detailed input/output for each flow
+- Error messages and tracebacks for failures

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -2471,6 +2471,7 @@ dev = [
 lint = [
     { name = "bandit" },
     { name = "deptry" },
+    { name = "litestar" },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pypdf" },
@@ -2536,6 +2537,7 @@ dev = [
 lint = [
     { name = "bandit", specifier = ">=1.7.0" },
     { name = "deptry", specifier = ">=0.22.0" },
+    { name = "litestar", specifier = ">=2.0.0" },
     { name = "mypy", specifier = ">=1.14.0" },
     { name = "pip-audit", specifier = ">=2.7.0" },
     { name = "pypdf", specifier = ">=6.6.2" },


### PR DESCRIPTION
## Summary

Cleans up lint warnings reported by `bin/lint` and improves ASGI type compatibility.

## Changes

### 1. Protocol-Based ASGI Types

Rewrote `py/packages/genkit/src/genkit/web/typing.py` to use Protocol-based types instead of Union types. This makes genkit compatible with any ASGI framework (litestar, starlette, fastapi, Django) without type errors.

**Key types:**
- `Scope = MutableMapping[str, Any]` - ASGI scope dict
- `Receive` / `Send` - Async callables for ASGI message handling
- `ASGIApp` - Protocol for ASGI applications
- `Application = Any` - Uses Any because external frameworks have incompatible type definitions

### 2. Add litestar to Lint Dependencies

Added `litestar>=2.0.0` to the `lint` dependency group so type checkers can resolve imports during CI while keeping the package optional for runtime.

### 3. Remove Unused Type Ignore Comments

Cleaned up unused `# type: ignore` comments flagged by `ty`:
- `py/samples/multi-server/src/main.py` - 6 unused ignores
- `py/packages/genkit/tests/.../reflection_test.py` - 1 unused ignore
- `py/packages/genkit/src/genkit/web/typing.py` - complete rewrite

### 4. Fix multi-server Sample

Updated the multi-server sample to use litestar's native types for the middleware since it extends `AbstractMiddleware` which expects litestar-specific types.

### 5. Add Missing README

Added `py/samples/sample-test/README.md` for the sample-test utility scripts.

### 6. Document Pattern in GEMINI.md

Added guidance about using lint dependencies for optional typing imports instead of inline ignore comments.

## Verification

```
./bin/lint
...
All checks passed!
Exit code: 0
```

## Files Changed

- `py/GEMINI.md` - Documented optional deps pattern
- `py/packages/genkit/src/genkit/web/typing.py` - Protocol-based ASGI types
- `py/packages/genkit/tests/.../reflection_test.py` - Remove unused type ignore
- `py/pyproject.toml` - Add litestar to lint deps, update pyrefly config
- `py/samples/multi-server/src/main.py` - Use litestar native types for middleware
- `py/samples/sample-test/README.md` - Added missing README