### PR TITLE
feat(py/compat-oai): add multimodal model support (image, TTS, STT)

### DIFF
--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/__init__.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/__init__.py
@@ -17,7 +17,17 @@
 
 """OpenAI Compatible Models for Genkit."""
 
+from .audio import (
+    SUPPORTED_STT_MODELS,
+    SUPPORTED_TTS_MODELS,
+    OpenAISTTModel,
+    OpenAITTSModel,
+)
 from .handler import OpenAIModelHandler
+from .image import (
+    SUPPORTED_IMAGE_MODELS,
+    OpenAIImageModel,
+)
 from .model import OpenAIModel
 from .model_info import (
     SUPPORTED_EMBEDDING_MODELS,
@@ -28,11 +38,17 @@ from .model_info import (
 )
 
 __all__ = [
-    'SUPPORTED_EMBEDDING_MODELS',
-    'SUPPORTED_OPENAI_COMPAT_MODELS',
-    'SUPPORTED_OPENAI_MODELS',
+    'OpenAIImageModel',
     'OpenAIModel',
     'OpenAIModelHandler',
+    'OpenAISTTModel',
+    'OpenAITTSModel',
     'PluginSource',
+    'SUPPORTED_EMBEDDING_MODELS',
+    'SUPPORTED_IMAGE_MODELS',
+    'SUPPORTED_OPENAI_COMPAT_MODELS',
+    'SUPPORTED_OPENAI_MODELS',
+    'SUPPORTED_STT_MODELS',
+    'SUPPORTED_TTS_MODELS',
     'get_default_model_info',
 ]

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/audio.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/audio.py
@@ -1,0 +1,413 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAI-compatible audio models for Genkit (TTS and STT).
+
+Provides text-to-speech (TTS) and speech-to-text (STT / transcription)
+capabilities via the OpenAI Audio API.
+
+Supported TTS models: tts-1, tts-1-hd, gpt-4o-mini-tts
+Supported STT models: gpt-4o-transcribe, gpt-4o-mini-transcribe, whisper-1
+
+Data Flow (TTS)::
+
+    ┌─────────────────────────────────────────────────────────────────────┐
+    │  GenerateRequest (text input)                                       │
+    │         │                                                           │
+    │         ▼                                                           │
+    │  to_tts_params()  ──►  SpeechCreateParams                           │
+    │         │                                                           │
+    │         ▼                                                           │
+    │  client.audio.speech.create()                                       │
+    │         │                                                           │
+    │         ▼                                                           │
+    │  to_tts_response()  ──►  GenerateResponse (audio media part)        │
+    └─────────────────────────────────────────────────────────────────────┘
+
+Data Flow (STT)::
+
+    ┌─────────────────────────────────────────────────────────────────────┐
+    │  GenerateRequest (audio media input)                                │
+    │         │                                                           │
+    │         ▼                                                           │
+    │  to_stt_params()  ──►  TranscriptionCreateParams                    │
+    │         │                                                           │
+    │         ▼                                                           │
+    │  client.audio.transcriptions.create()                               │
+    │         │                                                           │
+    │         ▼                                                           │
+    │  to_stt_response()  ──►  GenerateResponse (text part)               │
+    └─────────────────────────────────────────────────────────────────────┘
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+from openai import AsyncOpenAI
+from openai._legacy_response import HttpxBinaryResponseContent
+from openai.types.audio import Transcription
+
+from genkit.ai import ActionRunContext
+from genkit.core.typing import FinishReason
+from genkit.plugins.compat_oai.models.utils import (
+    _extract_media,
+    _extract_text,
+    _find_text,
+    decode_data_uri_bytes,
+    extract_config_dict,
+)
+from genkit.types import (
+    GenerateRequest,
+    GenerateResponse,
+    Media,
+    MediaPart,
+    Message,
+    ModelInfo,
+    Part,
+    Role,
+    Supports,
+    TextPart,
+)
+
+# Maps audio response formats to their MIME types.
+RESPONSE_FORMAT_MEDIA_TYPES: dict[str, str] = {
+    'mp3': 'audio/mpeg',
+    'opus': 'audio/opus',
+    'aac': 'audio/aac',
+    'flac': 'audio/flac',
+    'wav': 'audio/wav',
+    'pcm': 'audio/L16',
+}
+
+# Maps content types to file extensions for STT input filenames.
+_CONTENT_TYPE_TO_EXTENSION: dict[str, str] = {
+    'audio/mpeg': 'mp3',
+    'audio/mp3': 'mp3',
+    'audio/wav': 'wav',
+    'audio/ogg': 'ogg',
+    'audio/flac': 'flac',
+    'audio/webm': 'webm',
+    'audio/mp4': 'mp4',
+}
+
+# Supported TTS models with their metadata.
+SUPPORTED_TTS_MODELS: dict[str, ModelInfo] = {
+    'tts-1': ModelInfo(
+        label='OpenAI - TTS 1',
+        supports=Supports(
+            media=False,
+            output=['media'],
+            multiturn=False,
+            system_role=False,
+            tools=False,
+        ),
+    ),
+    'tts-1-hd': ModelInfo(
+        label='OpenAI - TTS 1 HD',
+        supports=Supports(
+            media=False,
+            output=['media'],
+            multiturn=False,
+            system_role=False,
+            tools=False,
+        ),
+    ),
+    'gpt-4o-mini-tts': ModelInfo(
+        label='OpenAI - GPT-4o Mini TTS',
+        supports=Supports(
+            media=False,
+            output=['media'],
+            multiturn=False,
+            system_role=False,
+            tools=False,
+        ),
+    ),
+}
+
+# Supported STT / transcription models with their metadata.
+SUPPORTED_STT_MODELS: dict[str, ModelInfo] = {
+    'gpt-4o-transcribe': ModelInfo(
+        label='OpenAI - GPT-4o Transcribe',
+        supports=Supports(
+            media=True,
+            output=['text', 'json'],
+            multiturn=False,
+            system_role=False,
+            tools=False,
+        ),
+    ),
+    'gpt-4o-mini-transcribe': ModelInfo(
+        label='OpenAI - GPT-4o Mini Transcribe',
+        supports=Supports(
+            media=True,
+            output=['text', 'json'],
+            multiturn=False,
+            system_role=False,
+            tools=False,
+        ),
+    ),
+    'whisper-1': ModelInfo(
+        label='OpenAI - Whisper 1',
+        supports=Supports(
+            media=True,
+            output=['text', 'json'],
+            multiturn=False,
+            system_role=False,
+            tools=False,
+        ),
+    ),
+}
+
+
+def _to_tts_params(
+    model_name: str,
+    request: GenerateRequest,
+) -> dict[str, Any]:
+    """Convert a GenerateRequest into OpenAI TTS parameters.
+
+    Args:
+        model_name: The TTS model name (e.g., 'tts-1').
+        request: The Genkit generate request.
+
+    Returns:
+        A dictionary of parameters for client.audio.speech.create().
+    """
+    text = _extract_text(request)
+    config = extract_config_dict(request)
+
+    params: dict[str, Any] = {
+        'model': config.pop('version', None) or model_name,
+        'input': text,
+        'voice': config.pop('voice', 'alloy'),
+    }
+
+    # Optional TTS-specific params.
+    for key in ('speed', 'response_format', 'instructions'):
+        if key in config:
+            params[key] = config.pop(key)
+
+    # Strip standard GenAI config keys.
+    for key in ('temperature', 'maxOutputTokens', 'stopSequences', 'topK', 'topP'):
+        config.pop(key, None)
+
+    return {k: v for k, v in params.items() if v is not None}
+
+
+def _to_tts_response(
+    response: HttpxBinaryResponseContent,
+    response_format: str = 'mp3',
+) -> GenerateResponse:
+    """Convert an OpenAI speech response to a Genkit GenerateResponse.
+
+    The response body is read as bytes and encoded as a base64 data URI.
+
+    Args:
+        response: The raw HTTP response from client.audio.speech.create().
+        response_format: The audio format used (determines MIME type).
+
+    Returns:
+        A GenerateResponse with a media part containing the audio data.
+    """
+    # The response from speech.create() is an HttpxBinaryResponseContent
+    # which supports .read() to get raw bytes.
+    audio_bytes = response.read()
+    media_type = RESPONSE_FORMAT_MEDIA_TYPES.get(response_format, 'audio/mpeg')
+    b64_data = base64.b64encode(audio_bytes).decode('ascii')
+
+    return GenerateResponse(
+        message=Message(
+            role=Role.MODEL,
+            content=[
+                Part(
+                    root=MediaPart(
+                        media=Media(
+                            content_type=media_type,
+                            url=f'data:{media_type};base64,{b64_data}',
+                        )
+                    )
+                )
+            ],
+        ),
+        finish_reason=FinishReason.STOP,
+    )
+
+
+def _to_stt_params(
+    model_name: str,
+    request: GenerateRequest,
+) -> dict[str, Any]:
+    """Convert a GenerateRequest into OpenAI transcription parameters.
+
+    Extracts the audio media from the first message and converts it into
+    a file-like object suitable for the transcriptions API.
+
+    Args:
+        model_name: The STT model name (e.g., 'whisper-1').
+        request: The Genkit generate request.
+
+    Returns:
+        A dictionary of parameters for client.audio.transcriptions.create().
+    """
+    media_url, content_type = _extract_media(request)
+    config = extract_config_dict(request)
+
+    audio_bytes = decode_data_uri_bytes(media_url)
+
+    ext = _CONTENT_TYPE_TO_EXTENSION.get(content_type, 'mp3')
+
+    params: dict[str, Any] = {
+        'model': config.pop('version', None) or model_name,
+        'file': (f'input.{ext}', audio_bytes, content_type or 'audio/mpeg'),
+    }
+
+    prompt_text = _find_text(request)
+    if prompt_text:
+        params['prompt'] = prompt_text
+
+    # Temperature if provided.
+    if temp := config.pop('temperature', None):
+        params['temperature'] = temp
+
+    # Optional STT-specific params.
+    for key in ('language', 'timestamp_granularities'):
+        if key in config:
+            params[key] = config.pop(key)
+
+    # Determine response format: config override > output format > default.
+    response_format = config.pop('response_format', None)
+    if not response_format and request.output and request.output.format in ('json', 'text'):
+        response_format = request.output.format
+    params['response_format'] = response_format or 'text'
+
+    # Strip standard GenAI config keys.
+    for key in ('maxOutputTokens', 'stopSequences', 'topK', 'topP'):
+        config.pop(key, None)
+
+    return {k: v for k, v in params.items() if v is not None}
+
+
+def _to_stt_response(result: Transcription | str) -> GenerateResponse:
+    """Convert an OpenAI transcription result to a Genkit GenerateResponse.
+
+    Handles the full union of types returned by transcriptions.create().
+    All non-str result types (Transcription, TranscriptionVerbose,
+    TranscriptionDiarized) have a .text attribute.
+
+    Args:
+        result: The transcription result (either a Transcription-like
+            object with a .text attribute, or a plain string).
+
+    Returns:
+        A GenerateResponse with a text part containing the transcription.
+    """
+    if isinstance(result, str):
+        text = result
+    elif hasattr(result, 'text'):
+        text = result.text
+    else:
+        text = str(result)
+    return GenerateResponse(
+        message=Message(
+            role=Role.MODEL,
+            content=[Part(root=TextPart(text=text))],
+        ),
+        finish_reason=FinishReason.STOP,
+    )
+
+
+class OpenAITTSModel:
+    """Handles text-to-speech via the OpenAI Audio API.
+
+    Args:
+        model_name: The TTS model to use (e.g., 'tts-1').
+        client: An async OpenAI client instance.
+    """
+
+    def __init__(self, model_name: str, client: AsyncOpenAI) -> None:
+        """Initialize the TTS model.
+
+        Args:
+            model_name: The TTS model to use (e.g., 'tts-1').
+            client: An async OpenAI client instance.
+        """
+        self._model_name = model_name
+        self._client = client
+
+    @property
+    def name(self) -> str:
+        """The name of the TTS model."""
+        return self._model_name
+
+    async def generate(self, request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        """Generate speech audio from the request.
+
+        Args:
+            request: The generate request containing the text input.
+            ctx: The action run context.
+
+        Returns:
+            A GenerateResponse containing audio media parts.
+        """
+        params = _to_tts_params(self._model_name, request)
+        response_format = params.get('response_format', 'mp3')
+        result = await self._client.audio.speech.create(**params)
+        return _to_tts_response(result, response_format)
+
+
+class OpenAISTTModel:
+    """Handles speech-to-text (transcription) via the OpenAI Audio API.
+
+    Args:
+        model_name: The STT model to use (e.g., 'whisper-1').
+        client: An async OpenAI client instance.
+    """
+
+    def __init__(self, model_name: str, client: AsyncOpenAI) -> None:
+        """Initialize the STT model.
+
+        Args:
+            model_name: The STT model to use (e.g., 'whisper-1').
+            client: An async OpenAI client instance.
+        """
+        self._model_name = model_name
+        self._client = client
+
+    @property
+    def name(self) -> str:
+        """The name of the STT model."""
+        return self._model_name
+
+    async def generate(self, request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        """Transcribe audio from the request.
+
+        Args:
+            request: The generate request containing audio media input.
+            ctx: The action run context.
+
+        Returns:
+            A GenerateResponse containing the transcribed text.
+        """
+        params = _to_stt_params(self._model_name, request)
+        result = await self._client.audio.transcriptions.create(
+            **params,
+            stream=False,
+        )
+        # transcriptions.create(stream=False) returns a union of
+        # Transcription | TranscriptionVerbose | TranscriptionDiarized | str.
+        # _to_stt_response handles all of these via isinstance/hasattr checks.
+        return _to_stt_response(result)

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/image.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/image.py
@@ -1,0 +1,194 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAI-compatible image generation model for Genkit.
+
+Provides image generation capabilities via the OpenAI Images API,
+supporting models like DALL-E 3 and GPT-Image-1.
+
+Data Flow::
+
+    ┌─────────────────────────────────────────────────────────────────────┐
+    │  GenerateRequest (text prompt)                                      │
+    │         │                                                           │
+    │         ▼                                                           │
+    │  to_image_generate_params()  ──►  ImageGenerateParams               │
+    │         │                                                           │
+    │         ▼                                                           │
+    │  client.images.generate()                                           │
+    │         │                                                           │
+    │         ▼                                                           │
+    │  to_generate_response()  ──►  GenerateResponse (media parts)        │
+    └─────────────────────────────────────────────────────────────────────┘
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openai import AsyncOpenAI
+from openai.types.images_response import ImagesResponse
+
+from genkit.ai import ActionRunContext
+from genkit.core.typing import FinishReason
+from genkit.plugins.compat_oai.models.utils import _extract_text, extract_config_dict
+from genkit.types import (
+    GenerateRequest,
+    GenerateResponse,
+    Media,
+    MediaPart,
+    Message,
+    ModelInfo,
+    Part,
+    Role,
+    Supports,
+)
+
+# Supported image generation models with their metadata.
+SUPPORTED_IMAGE_MODELS: dict[str, ModelInfo] = {
+    'dall-e-3': ModelInfo(
+        label='OpenAI - DALL-E 3',
+        supports=Supports(
+            media=False,
+            output=['media'],
+            multiturn=False,
+            system_role=False,
+            tools=False,
+        ),
+    ),
+    'gpt-image-1': ModelInfo(
+        label='OpenAI - GPT Image 1',
+        supports=Supports(
+            media=False,
+            output=['media'],
+            multiturn=False,
+            system_role=False,
+            tools=False,
+        ),
+    ),
+}
+
+
+# Re-export _extract_text as _extract_prompt_text for backward compatibility.
+_extract_prompt_text = _extract_text
+
+
+def _to_image_generate_params(
+    model_name: str,
+    request: GenerateRequest,
+) -> dict[str, Any]:
+    """Convert a GenerateRequest into OpenAI image generation parameters.
+
+    Extracts the text prompt and maps Genkit config options to OpenAI's
+    image generation API parameters.
+
+    Args:
+        model_name: The OpenAI model name (e.g., 'dall-e-3').
+        request: The Genkit generate request.
+
+    Returns:
+        A dictionary of parameters for client.images.generate().
+    """
+    prompt = _extract_prompt_text(request)
+    config = extract_config_dict(request)
+
+    # Start with required params.
+    params: dict[str, Any] = {
+        'model': config.pop('version', None) or model_name,
+        'prompt': prompt,
+        'response_format': config.pop('response_format', 'b64_json'),
+    }
+
+    # Strip standard GenAI config keys that don't apply to image generation.
+    for key in ('temperature', 'maxOutputTokens', 'stopSequences', 'topK', 'topP'):
+        config.pop(key, None)
+
+    # Pass remaining config through (size, quality, style, n, etc.).
+    params.update(config)
+
+    # Remove None values.
+    return {k: v for k, v in params.items() if v is not None}
+
+
+def _to_generate_response(result: ImagesResponse) -> GenerateResponse:
+    """Convert an OpenAI ImagesResponse to a Genkit GenerateResponse.
+
+    Each generated image becomes a media part in the response message.
+
+    Args:
+        result: The OpenAI images.generate() response object.
+
+    Returns:
+        A GenerateResponse with media parts for each generated image.
+    """
+    images = result.data
+    if not images:
+        return GenerateResponse(
+            message=Message(role=Role.MODEL, content=[]),
+            finish_reason=FinishReason.STOP,
+        )
+
+    content: list[Part] = []
+    for image in images:
+        url = image.url
+        if not url and image.b64_json:
+            url = f'data:image/png;base64,{image.b64_json}'
+
+        if url:
+            content.append(Part(root=MediaPart(media=Media(content_type='image/png', url=url))))
+
+    return GenerateResponse(
+        message=Message(role=Role.MODEL, content=content),
+        finish_reason=FinishReason.STOP,
+    )
+
+
+class OpenAIImageModel:
+    """Handles image generation via the OpenAI Images API.
+
+    Args:
+        model_name: The image model to use (e.g., 'dall-e-3').
+        client: An async OpenAI client instance.
+    """
+
+    def __init__(self, model_name: str, client: AsyncOpenAI) -> None:
+        """Initialize the image model.
+
+        Args:
+            model_name: The image model to use (e.g., 'dall-e-3').
+            client: An async OpenAI client instance.
+        """
+        self._model_name = model_name
+        self._client = client
+
+    @property
+    def name(self) -> str:
+        """The name of the image model."""
+        return self._model_name
+
+    async def generate(self, request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        """Generate images from the request.
+
+        Args:
+            request: The generate request containing the text prompt.
+            ctx: The action run context.
+
+        Returns:
+            A GenerateResponse containing generated image media parts.
+        """
+        params = _to_image_generate_params(self._model_name, request)
+        result = await self._client.images.generate(**params)
+        return _to_generate_response(result)

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/openai_plugin.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/openai_plugin.py
@@ -17,9 +17,10 @@
 
 """OpenAI OpenAI API Compatible Plugin for Genkit."""
 
-from typing import Any
+import enum
+from typing import Any, TypeAlias
 
-from openai import OpenAI as OpenAIClient
+from openai import AsyncOpenAI, OpenAI as OpenAIClient
 from openai.types import Model
 
 from genkit.ai import Plugin
@@ -31,14 +32,20 @@ from genkit.core.schema import to_json_schema
 from genkit.core.typing import GenerationCommonConfig
 from genkit.plugins.compat_oai.models import (
     SUPPORTED_EMBEDDING_MODELS,
+    SUPPORTED_IMAGE_MODELS,
     SUPPORTED_OPENAI_COMPAT_MODELS,
     SUPPORTED_OPENAI_MODELS,
+    SUPPORTED_STT_MODELS,
+    SUPPORTED_TTS_MODELS,
+    OpenAIImageModel,
     OpenAIModel,
     OpenAIModelHandler,
+    OpenAISTTModel,
+    OpenAITTSModel,
 )
 from genkit.plugins.compat_oai.models.model_info import get_default_openai_model_info
 from genkit.plugins.compat_oai.typing import OpenAIConfig
-from genkit.types import Embedding, EmbedRequest, EmbedResponse, Supports
+from genkit.types import Embedding, EmbedRequest, EmbedResponse, ModelInfo, Supports
 
 
 def open_ai_name(name: str) -> str:
@@ -51,6 +58,127 @@ def open_ai_name(name: str) -> str:
         The fully qualified OpenAI action name.
     """
     return f'openai/{name}'
+
+
+class _ModelType(enum.Enum):
+    """Classification of OpenAI model types based on name patterns."""
+
+    EMBEDDER = 'embedder'
+    IMAGE = 'image'
+    TTS = 'tts'
+    STT = 'stt'
+    CHAT = 'chat'
+
+
+def _classify_model(name: str) -> _ModelType:
+    """Classify a model name into its type based on name patterns.
+
+    Centralizes the name-matching logic used by both resolve() and
+    list_actions() to avoid inconsistencies.
+
+    Args:
+        name: The model name (with or without 'openai/' prefix).
+
+    Returns:
+        The classified model type.
+    """
+    if 'embed' in name:
+        return _ModelType.EMBEDDER
+    if 'gpt-image' in name or 'dall-e' in name:
+        return _ModelType.IMAGE
+    if 'tts' in name:
+        return _ModelType.TTS
+    if 'whisper' in name or 'transcribe' in name:
+        return _ModelType.STT
+    return _ModelType.CHAT
+
+
+# Default Supports for each multimodal model type, used as fallback when
+# a model is not found in the registry.
+_DEFAULT_SUPPORTS: dict[_ModelType, Supports] = {
+    _ModelType.IMAGE: Supports(
+        media=False,
+        output=['media'],
+        multiturn=False,
+        system_role=False,
+        tools=False,
+    ),
+    _ModelType.TTS: Supports(
+        media=False,
+        output=['media'],
+        multiturn=False,
+        system_role=False,
+        tools=False,
+    ),
+    _ModelType.STT: Supports(
+        media=True,
+        output=['text', 'json'],
+        multiturn=False,
+        system_role=False,
+        tools=False,
+    ),
+}
+
+# Type alias for multimodal model classes.
+_MultimodalModel: TypeAlias = OpenAIImageModel | OpenAITTSModel | OpenAISTTModel
+_MultimodalModelConfig: TypeAlias = tuple[type[_MultimodalModel], dict[str, ModelInfo]]
+
+# Maps multimodal model types to their class and registry.
+_MULTIMODAL_CONFIG: dict[_ModelType, _MultimodalModelConfig] = {
+    _ModelType.IMAGE: (OpenAIImageModel, SUPPORTED_IMAGE_MODELS),
+    _ModelType.TTS: (OpenAITTSModel, SUPPORTED_TTS_MODELS),
+    _ModelType.STT: (OpenAISTTModel, SUPPORTED_STT_MODELS),
+}
+
+
+def _get_multimodal_info_dict(
+    name: str,
+    model_type: _ModelType,
+    supported_models: dict[str, ModelInfo],
+) -> dict[str, object]:
+    """Build the info dictionary for a multimodal model.
+
+    Uses registry metadata when available, falls back to default supports.
+
+    Args:
+        name: The raw model name (without the 'openai/' prefix).
+        model_type: The classified model type for default supports fallback.
+        supported_models: Registry of known models and their metadata.
+
+    Returns:
+        A dictionary suitable for Action or ActionMetadata info field.
+    """
+    model_info = supported_models.get(name)
+    if model_info:
+        return model_info.model_dump(by_alias=True, exclude_none=True)
+
+    default_supports = _DEFAULT_SUPPORTS.get(model_type)
+    return {
+        'label': f'OpenAI - {name}',
+        'supports': default_supports.model_dump(by_alias=True, exclude_none=True) if default_supports else {},
+    }
+
+
+def _multimodal_action_metadata(
+    name: str,
+    supported_models: dict[str, ModelInfo],
+    model_type: _ModelType,
+) -> ActionMetadata:
+    """Build ActionMetadata for a multimodal model.
+
+    Args:
+        name: The raw model name (without the 'openai/' prefix).
+        supported_models: Registry of known models and their metadata.
+        model_type: The classified model type for default supports fallback.
+
+    Returns:
+        ActionMetadata for the model.
+    """
+    return model_action_metadata(
+        name=open_ai_name(name),
+        config_schema=GenerationCommonConfig,
+        info=_get_multimodal_info_dict(name, model_type, supported_models),
+    )
 
 
 def default_openai_metadata(name: str) -> dict[str, Any]:
@@ -78,22 +206,35 @@ class OpenAI(Plugin):
         """
         self._openai_params = openai_params
         self._openai_client = OpenAIClient(**openai_params)
+        self._async_client = AsyncOpenAI(**openai_params)
 
     async def init(self) -> list[Action]:
         """Initialize plugin.
 
         Returns:
-            Actions for built-in OpenAI models and embedders.
+            Actions for built-in OpenAI models, embedders, image, TTS, and STT.
         """
         actions = []
 
-        # Add known models
+        # Add known chat models.
         for name in SUPPORTED_OPENAI_MODELS:
             actions.append(self._create_model_action(open_ai_name(name)))
 
-        # Add known embedders
+        # Add known embedders.
         for name in SUPPORTED_EMBEDDING_MODELS:
             actions.append(self._create_embedder_action(open_ai_name(name)))
+
+        # Add multimodal models (Image, TTS, STT).
+        for model_type, (model_class, supported_models) in _MULTIMODAL_CONFIG.items():
+            for name in supported_models:
+                actions.append(
+                    self._create_multimodal_action(
+                        open_ai_name(name),
+                        model_class,
+                        supported_models,
+                        model_type,
+                    )
+                )
 
         return actions
 
@@ -130,6 +271,9 @@ class OpenAI(Plugin):
     async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
         """Resolve an action by creating and returning an Action object.
 
+        Uses name-based pattern matching (mirroring JS implementation) to
+        route to the correct model type: image, TTS, STT, embedder, or chat.
+
         Args:
             action_type: The kind of action to resolve.
             name: The namespaced name of the action to resolve.
@@ -137,10 +281,19 @@ class OpenAI(Plugin):
         Returns:
             Action object if found, None otherwise.
         """
-        if action_type == ActionKind.MODEL:
-            return self._create_model_action(name)
-        elif action_type == ActionKind.EMBEDDER:
+        if action_type == ActionKind.EMBEDDER:
+            if _classify_model(name) != _ModelType.EMBEDDER:
+                return None
             return self._create_embedder_action(name)
+
+        if action_type == ActionKind.MODEL:
+            model_type = _classify_model(name)
+            if model_type == _ModelType.EMBEDDER:
+                return None  # Embedders should not be resolved as models.
+            if model_type in _MULTIMODAL_CONFIG:
+                model_class, supported_models = _MULTIMODAL_CONFIG[model_type]
+                return self._create_multimodal_action(name, model_class, supported_models, model_type)
+            return self._create_model_action(name)
 
         return None
 
@@ -170,6 +323,35 @@ class OpenAI(Plugin):
                     'customOptions': to_json_schema(OpenAIConfig),
                 },
             },
+        )
+
+    def _create_multimodal_action(
+        self,
+        name: str,
+        model_class: type[_MultimodalModel],
+        supported_models: dict[str, ModelInfo],
+        model_type: _ModelType,
+    ) -> Action:
+        """Create an Action for a multimodal model (image, TTS, or STT).
+
+        Args:
+            name: The namespaced name of the model.
+            model_class: The model class to instantiate.
+            supported_models: Registry of known models and their metadata.
+            model_type: The classified model type for default metadata fallback.
+
+        Returns:
+            Action object for the model.
+        """
+        clean_name = name.replace('openai/', '') if name.startswith('openai/') else name
+        model_instance = model_class(clean_name, self._async_client)
+        info_dict = _get_multimodal_info_dict(clean_name, model_type, supported_models)
+
+        return Action(
+            kind=ActionKind.MODEL,
+            name=name,
+            fn=model_instance.generate,
+            metadata={'model': info_dict},
         )
 
     def _create_embedder_action(self, name: str) -> Action:
@@ -242,21 +424,19 @@ class OpenAI(Plugin):
     async def list_actions(self) -> list[ActionMetadata]:
         """Generate a list of available actions or models.
 
+        Uses pattern matching on model names (mirroring the JS implementation)
+        to categorize models as embedders, image generators, TTS, STT, or chat.
+
         Returns:
-            list[ActionMetadata]: A list of ActionMetadata objects, each with the following attributes:
-                - name (str): The name of the action or model.
-                - kind (ActionKind): The type or category of the action.
-                - info (dict): The metadata dictionary describing the model configuration and properties.
-                - config_schema (type): The schema class used for validating the model's configuration.
+            list[ActionMetadata]: A list of ActionMetadata objects.
         """
-        actions = []
-        models_ = self._openai_client.models.list()
+        actions: list[ActionMetadata] = []
+        models_ = await self._async_client.models.list()
         models: list[Model] = models_.data
-        # Print each model
         for model in models:
             name = model.id
-            if 'embed' in name:
-                # Default embedder metadata for OpenAI embedding models
+            model_type = _classify_model(name)
+            if model_type == _ModelType.EMBEDDER:
                 actions.append(
                     embedder_action_metadata(
                         name=open_ai_name(name),
@@ -266,6 +446,9 @@ class OpenAI(Plugin):
                         ),
                     )
                 )
+            elif model_type in _DEFAULT_SUPPORTS:
+                config = _MULTIMODAL_CONFIG[model_type]
+                actions.append(_multimodal_action_metadata(name, config[1], model_type))
             else:
                 actions.append(
                     model_action_metadata(

--- a/py/plugins/compat-oai/tests/audio_model_test.py
+++ b/py/plugins/compat-oai/tests/audio_model_test.py
@@ -1,0 +1,345 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for OpenAI-compatible audio models (TTS and STT)."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genkit.plugins.compat_oai.models.audio import (
+    SUPPORTED_STT_MODELS,
+    SUPPORTED_TTS_MODELS,
+    OpenAISTTModel,
+    OpenAITTSModel,
+    _extract_media,
+    _extract_text,
+    _to_stt_params,
+    _to_stt_response,
+    _to_tts_params,
+    _to_tts_response,
+)
+from genkit.types import (
+    GenerateRequest,
+    Media,
+    MediaPart,
+    Message,
+    Part,
+    Role,
+    TextPart,
+)
+
+
+class TestExtractText:
+    """Tests for extracting text from GenerateRequest."""
+
+    def test_extracts_text(self) -> None:
+        """Verify text extraction from a simple request."""
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='Hello'))]),
+            ],
+        )
+        got = _extract_text(request)
+        assert got == 'Hello'
+
+    def test_raises_on_empty(self) -> None:
+        """Verify ValueError when messages list is empty."""
+        request = GenerateRequest(messages=[])
+        with pytest.raises(ValueError, match='No messages found'):
+            _extract_text(request)
+
+
+class TestExtractMedia:
+    """Tests for extracting media URLs from GenerateRequest."""
+
+    def test_extracts_media_url(self) -> None:
+        """Verify media URL and content type extraction."""
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(
+                            root=MediaPart(
+                                media=Media(
+                                    content_type='audio/mpeg',
+                                    url='data:audio/mpeg;base64,dGVzdA==',
+                                )
+                            )
+                        ),
+                    ],
+                ),
+            ],
+        )
+        url, content_type = _extract_media(request)
+        assert content_type == 'audio/mpeg'
+        assert 'base64' in url
+
+    def test_raises_on_no_media(self) -> None:
+        """Verify ValueError when no media content is found."""
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='no media'))]),
+            ],
+        )
+        with pytest.raises(ValueError, match='No media content found'):
+            _extract_media(request)
+
+
+class TestToTTSParams:
+    """Tests for converting GenerateRequest to TTS params."""
+
+    def test_basic_params(self) -> None:
+        """Verify required TTS params with defaults."""
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='Say hello'))]),
+            ],
+        )
+        got = _to_tts_params('tts-1', request)
+        assert got['model'] == 'tts-1'
+        assert got['input'] == 'Say hello'
+        assert got['voice'] == 'alloy'
+
+    def test_custom_voice(self) -> None:
+        """Verify custom voice config is applied."""
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='test'))]),
+            ],
+            config={'voice': 'nova'},
+        )
+        got = _to_tts_params('tts-1', request)
+        assert got['voice'] == 'nova'
+
+    def test_strips_standard_config(self) -> None:
+        """Verify standard GenAI keys are stripped."""
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='test'))]),
+            ],
+            config={'temperature': 0.5, 'topK': 40},
+        )
+        got = _to_tts_params('tts-1', request)
+        assert 'temperature' not in got
+        assert 'topK' not in got
+
+
+class TestToTTSResponse:
+    """Tests for converting speech response to GenerateResponse."""
+
+    def test_converts_audio_to_media_part(self) -> None:
+        """Verify audio bytes are encoded as base64 data URI."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'fake audio data'
+
+        got = _to_tts_response(mock_response, 'mp3')
+        assert got.message is not None
+        assert len(got.message.content) == 1
+
+        part = got.message.content[0].root
+        assert isinstance(part, MediaPart)
+        assert part.media.content_type == 'audio/mpeg'
+        assert str(part.media.url).startswith('data:audio/mpeg;base64,')
+
+    def test_opus_format(self) -> None:
+        """Verify opus format uses correct MIME type."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'opus data'
+
+        got = _to_tts_response(mock_response, 'opus')
+        assert got.message is not None
+        part = got.message.content[0].root
+        assert isinstance(part, MediaPart)
+        assert part.media.content_type == 'audio/opus'
+
+
+class TestToSTTParams:
+    """Tests for converting GenerateRequest to STT params."""
+
+    def test_basic_params(self) -> None:
+        """Verify required STT params from audio media input."""
+        audio_data = base64.b64encode(b'fake audio').decode('ascii')
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(
+                            root=MediaPart(
+                                media=Media(
+                                    content_type='audio/mpeg',
+                                    url=f'data:audio/mpeg;base64,{audio_data}',
+                                )
+                            )
+                        ),
+                    ],
+                ),
+            ],
+        )
+        got = _to_stt_params('whisper-1', request)
+        assert got['model'] == 'whisper-1'
+        assert 'file' in got
+
+    def test_with_prompt_context(self) -> None:
+        """Verify prompt text is included when present alongside media."""
+        audio_data = base64.b64encode(b'fake audio').decode('ascii')
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(root=TextPart(text='Transcribe this meeting')),
+                        Part(
+                            root=MediaPart(
+                                media=Media(
+                                    content_type='audio/mpeg',
+                                    url=f'data:audio/mpeg;base64,{audio_data}',
+                                )
+                            )
+                        ),
+                    ],
+                ),
+            ],
+        )
+        got = _to_stt_params('whisper-1', request)
+        assert got.get('prompt') == 'Transcribe this meeting'
+
+
+class TestToSTTResponse:
+    """Tests for converting transcription result to GenerateResponse."""
+
+    def test_transcription_object(self) -> None:
+        """Verify Transcription object is converted to text part."""
+        mock_result = MagicMock()
+        mock_result.text = 'Hello world'
+
+        got = _to_stt_response(mock_result)
+        assert got.message is not None
+        part = got.message.content[0].root
+        assert isinstance(part, TextPart)
+        assert part.text == 'Hello world'
+
+    def test_string_result(self) -> None:
+        """Verify plain string result is wrapped as text part."""
+        got = _to_stt_response('Plain text')
+        assert got.message is not None
+        part = got.message.content[0].root
+        assert isinstance(part, TextPart)
+        assert part.text == 'Plain text'
+
+
+class TestModelRegistries:
+    """Tests for model info registries."""
+
+    def test_tts_models(self) -> None:
+        """Verify all expected TTS models are registered."""
+        for name in ('tts-1', 'tts-1-hd', 'gpt-4o-mini-tts'):
+            assert name in SUPPORTED_TTS_MODELS, f'{name!r} not in SUPPORTED_TTS_MODELS'
+
+    def test_stt_models(self) -> None:
+        """Verify all expected STT models are registered."""
+        for name in ('gpt-4o-transcribe', 'gpt-4o-mini-transcribe', 'whisper-1'):
+            assert name in SUPPORTED_STT_MODELS, f'{name!r} not in SUPPORTED_STT_MODELS'
+
+    def test_tts_models_support_media_output(self) -> None:
+        """Verify all TTS models declare media output support."""
+        for name, info in SUPPORTED_TTS_MODELS.items():
+            assert info.supports is not None, f'{name} has no supports'
+            assert 'media' in (info.supports.output or []), f"{name} should support 'media' output"
+
+    def test_stt_models_support_media_input(self) -> None:
+        """Verify all STT models declare media input support."""
+        for name, info in SUPPORTED_STT_MODELS.items():
+            assert info.supports is not None, f'{name} has no supports'
+            assert info.supports.media, f'{name} should support media input'
+
+
+class TestOpenAITTSModel:
+    """Tests for the OpenAITTSModel class."""
+
+    @pytest.mark.asyncio
+    async def test_generate_calls_speech_create(self) -> None:
+        """Verify generate() calls client.audio.speech.create."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'audio bytes'
+
+        mock_client = AsyncMock()
+        mock_client.audio.speech.create = AsyncMock(return_value=mock_response)
+
+        model = OpenAITTSModel('tts-1', mock_client)
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='Say hello'))]),
+            ],
+        )
+
+        ctx = MagicMock()
+        got = await model.generate(request, ctx)
+
+        mock_client.audio.speech.create.assert_called_once()
+        assert got.message is not None
+        assert len(got.message.content) == 1
+
+        part = got.message.content[0].root
+        assert isinstance(part, MediaPart)
+
+
+class TestOpenAISTTModel:
+    """Tests for the OpenAISTTModel class."""
+
+    @pytest.mark.asyncio
+    async def test_generate_calls_transcription_create(self) -> None:
+        """Verify generate() calls client.audio.transcriptions.create."""
+        mock_result = MagicMock()
+        mock_result.text = 'Transcribed text'
+
+        mock_client = AsyncMock()
+        mock_client.audio.transcriptions.create = AsyncMock(return_value=mock_result)
+
+        model = OpenAISTTModel('whisper-1', mock_client)
+        audio_data = base64.b64encode(b'fake audio').decode('ascii')
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(
+                            root=MediaPart(
+                                media=Media(
+                                    content_type='audio/mpeg',
+                                    url=f'data:audio/mpeg;base64,{audio_data}',
+                                )
+                            )
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        ctx = MagicMock()
+        got = await model.generate(request, ctx)
+
+        mock_client.audio.transcriptions.create.assert_called_once()
+        assert got.message is not None
+
+        part = got.message.content[0].root
+        assert isinstance(part, TextPart)
+        assert part.text == 'Transcribed text'

--- a/py/plugins/compat-oai/tests/image_model_test.py
+++ b/py/plugins/compat-oai/tests/image_model_test.py
@@ -1,0 +1,231 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for OpenAI-compatible image generation model."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genkit.plugins.compat_oai.models.image import (
+    SUPPORTED_IMAGE_MODELS,
+    OpenAIImageModel,
+    _extract_prompt_text,
+    _to_generate_response,
+    _to_image_generate_params,
+)
+from genkit.types import (
+    GenerateRequest,
+    MediaPart,
+    Message,
+    Part,
+    Role,
+    TextPart,
+)
+
+
+class TestExtractPromptText:
+    """Tests for extracting text from GenerateRequest messages."""
+
+    def test_extracts_text_from_first_message(self) -> None:
+        """Verify text extraction from a simple single-message request."""
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='a sunset'))]),
+            ],
+        )
+        got = _extract_prompt_text(request)
+        assert got == 'a sunset'
+
+    def test_raises_on_empty_messages(self) -> None:
+        """Verify ValueError when messages list is empty."""
+        request = GenerateRequest(messages=[])
+        with pytest.raises(ValueError, match='No messages found'):
+            _extract_prompt_text(request)
+
+    def test_raises_on_no_text_content(self) -> None:
+        """Verify ValueError when message has no text parts."""
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[]),
+            ],
+        )
+        with pytest.raises(ValueError, match='No text content found'):
+            _extract_prompt_text(request)
+
+
+class TestToImageGenerateParams:
+    """Tests for converting GenerateRequest to OpenAI image params."""
+
+    def test_basic_params(self) -> None:
+        """Verify required params are set with correct defaults."""
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='a cat'))]),
+            ],
+        )
+        got = _to_image_generate_params('dall-e-3', request)
+        assert got['model'] == 'dall-e-3'
+        assert got['prompt'] == 'a cat'
+        assert got['response_format'] == 'b64_json'
+
+    def test_config_passthrough(self) -> None:
+        """Verify image-specific config options pass through."""
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='a dog'))]),
+            ],
+            config={'size': '1024x1024', 'quality': 'hd', 'n': 2},
+        )
+        got = _to_image_generate_params('dall-e-3', request)
+        assert got.get('size') == '1024x1024'
+        assert got.get('quality') == 'hd'
+        assert got.get('n') == 2
+
+    def test_strips_standard_genai_config(self) -> None:
+        """Verify standard GenAI keys are stripped from params."""
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='test'))]),
+            ],
+            config={'temperature': 0.5, 'topK': 40, 'topP': 0.9},
+        )
+        got = _to_image_generate_params('dall-e-3', request)
+        assert 'temperature' not in got
+        assert 'topK' not in got
+        assert 'topP' not in got
+
+    def test_version_override(self) -> None:
+        """Verify model version override via config."""
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='test'))]),
+            ],
+            config={'version': 'dall-e-3-custom'},
+        )
+        got = _to_image_generate_params('dall-e-3', request)
+        assert got['model'] == 'dall-e-3-custom'
+
+
+class TestToGenerateResponse:
+    """Tests for converting OpenAI ImagesResponse to GenerateResponse."""
+
+    def test_empty_data(self) -> None:
+        """Verify empty image data produces empty content."""
+        mock_result = MagicMock()
+        mock_result.data = []
+        got = _to_generate_response(mock_result)
+        assert got.message is not None
+        assert len(got.message.content) == 0
+
+    def test_url_response(self) -> None:
+        """Verify URL-based image response is preserved."""
+        mock_image = MagicMock()
+        mock_image.url = 'https://example.com/image.png'
+        mock_image.b64_json = None
+        mock_result = MagicMock()
+        mock_result.data = [mock_image]
+
+        got = _to_generate_response(mock_result)
+        assert got.message is not None
+        assert len(got.message.content) == 1
+
+        part = got.message.content[0].root
+        assert isinstance(part, MediaPart)
+        assert str(part.media.url) == 'https://example.com/image.png'
+
+    def test_b64_response(self) -> None:
+        """Verify base64-encoded image is wrapped in a data URI."""
+        mock_image = MagicMock()
+        mock_image.url = None
+        mock_image.b64_json = 'aGVsbG8='
+        mock_result = MagicMock()
+        mock_result.data = [mock_image]
+
+        got = _to_generate_response(mock_result)
+        assert got.message is not None
+        part = got.message.content[0].root
+        assert isinstance(part, MediaPart)
+        assert str(part.media.url) == 'data:image/png;base64,aGVsbG8='
+
+    def test_multiple_images(self) -> None:
+        """Verify multiple images produce multiple content parts."""
+        images = []
+        for i in range(3):
+            img = MagicMock()
+            img.url = f'https://example.com/{i}.png'
+            img.b64_json = None
+            images.append(img)
+        mock_result = MagicMock()
+        mock_result.data = images
+
+        got = _to_generate_response(mock_result)
+        assert got.message is not None
+        assert len(got.message.content) == 3
+
+
+class TestSupportedImageModels:
+    """Tests that the model info registry is correct."""
+
+    def test_dall_e_3_in_registry(self) -> None:
+        """Verify DALL-E 3 is registered."""
+        assert 'dall-e-3' in SUPPORTED_IMAGE_MODELS
+
+    def test_gpt_image_1_in_registry(self) -> None:
+        """Verify GPT-Image-1 is registered."""
+        assert 'gpt-image-1' in SUPPORTED_IMAGE_MODELS
+
+    def test_image_models_support_media_output(self) -> None:
+        """Verify all image models declare 'media' output support."""
+        for name, info in SUPPORTED_IMAGE_MODELS.items():
+            assert info.supports is not None, f'{name} has no supports metadata'
+            assert 'media' in (info.supports.output or []), f"{name} should support 'media' output"
+
+
+class TestOpenAIImageModel:
+    """Tests for the OpenAIImageModel class."""
+
+    @pytest.mark.asyncio
+    async def test_generate_calls_client(self) -> None:
+        """Verify generate() calls client.images.generate and returns media."""
+        mock_image = MagicMock()
+        mock_image.url = 'https://example.com/generated.png'
+        mock_image.b64_json = None
+        mock_response = MagicMock()
+        mock_response.data = [mock_image]
+
+        mock_client = AsyncMock()
+        mock_client.images.generate = AsyncMock(return_value=mock_response)
+
+        model = OpenAIImageModel('dall-e-3', mock_client)
+        request = GenerateRequest(
+            messages=[
+                Message(role=Role.USER, content=[Part(root=TextPart(text='a mountain'))]),
+            ],
+        )
+
+        ctx = MagicMock()
+        got = await model.generate(request, ctx)
+
+        mock_client.images.generate.assert_called_once()
+        call_kwargs = mock_client.images.generate.call_args
+        assert call_kwargs.kwargs.get('model') == 'dall-e-3'
+        assert call_kwargs.kwargs.get('prompt') == 'a mountain'
+
+        assert got.message is not None
+        assert len(got.message.content) == 1

--- a/py/plugins/compat-oai/tests/plugin_test.py
+++ b/py/plugins/compat-oai/tests/plugin_test.py
@@ -17,7 +17,7 @@
 
 """Tests for the OpenAI compatible plugin."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from openai.types import Model
@@ -80,9 +80,9 @@ async def test_openai_plugin_list_actions() -> None:
 
     mock_result_ = MagicMock()
     mock_result_.data = entries
-    mock_client.models.list.return_value = mock_result_
+    mock_client.models.list = AsyncMock(return_value=mock_result_)
 
-    plugin._openai_client = mock_client
+    plugin._async_client = mock_client
 
     actions: list[ActionMetadata] = await plugin.list_actions()
     mock_client.models.list.assert_called_once()

--- a/py/plugins/compat-oai/tests/utils_test.py
+++ b/py/plugins/compat-oai/tests/utils_test.py
@@ -1,0 +1,379 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exhaustive tests for models/utils.py utility functions."""
+
+import base64
+
+import pytest
+
+from genkit.plugins.compat_oai.models.utils import (
+    _extract_media,
+    _extract_text,
+    _find_text,
+    decode_data_uri_bytes,
+    extract_config_dict,
+    parse_data_uri_content_type,
+)
+from genkit.types import (
+    GenerateRequest,
+    Media,
+    MediaPart,
+    Message,
+    Part,
+    Role,
+    TextPart,
+)
+
+
+class TestParseDataUriContentType:
+    """Tests for parse_data_uri_content_type."""
+
+    def test_audio_mpeg_with_base64(self) -> None:
+        """Parse content type from a standard audio data URI."""
+        url = 'data:audio/mpeg;base64,AAAA'
+        assert parse_data_uri_content_type(url) == 'audio/mpeg'
+
+    def test_text_plain_without_base64(self) -> None:
+        """Parse content type from a data URI without ;base64 qualifier."""
+        url = 'data:text/plain,hello world'
+        assert parse_data_uri_content_type(url) == 'text/plain'
+
+    def test_image_png_with_base64(self) -> None:
+        """Parse content type from an image data URI."""
+        url = 'data:image/png;base64,iVBOR...'
+        assert parse_data_uri_content_type(url) == 'image/png'
+
+    def test_empty_content_type_with_base64(self) -> None:
+        """Return empty string when content type is missing from data URI."""
+        url = 'data:;base64,AAAA'
+        assert parse_data_uri_content_type(url) == ''
+
+    def test_no_data_prefix(self) -> None:
+        """Return empty string for non-data-URI URLs."""
+        assert parse_data_uri_content_type('https://example.com/file.mp3') == ''
+
+    def test_raw_base64_string(self) -> None:
+        """Return empty string for raw base64 strings."""
+        assert parse_data_uri_content_type('AAAA') == ''
+
+    def test_empty_string(self) -> None:
+        """Return empty string for empty input."""
+        assert parse_data_uri_content_type('') == ''
+
+    def test_data_prefix_no_comma(self) -> None:
+        """Return empty string for malformed data URI without comma."""
+        assert parse_data_uri_content_type('data:audio/mpeg;base64') == ''
+
+    def test_application_json(self) -> None:
+        """Parse content type from a JSON data URI."""
+        url = 'data:application/json;base64,eyJ0ZXN0IjogdHJ1ZX0='
+        assert parse_data_uri_content_type(url) == 'application/json'
+
+    def test_audio_wav_with_extra_params(self) -> None:
+        """Parse content type from a data URI with extra parameters."""
+        url = 'data:audio/wav;rate=44100;base64,AAAA'
+        assert parse_data_uri_content_type(url) == 'audio/wav'
+
+    def test_content_type_with_charset(self) -> None:
+        """Parse content type from a data URI with charset parameter."""
+        url = 'data:text/html;charset=utf-8,<h1>hi</h1>'
+        assert parse_data_uri_content_type(url) == 'text/html'
+
+
+class TestDecodeDataUriBytes:
+    """Tests for decode_data_uri_bytes."""
+
+    def test_valid_data_uri(self) -> None:
+        """Decode bytes from a valid base64 data URI."""
+        payload = b'hello world'
+        b64 = base64.b64encode(payload).decode('ascii')
+        url = f'data:audio/mpeg;base64,{b64}'
+        assert decode_data_uri_bytes(url) == payload
+
+    def test_raw_base64(self) -> None:
+        """Decode bytes from a raw base64 string without data: prefix."""
+        payload = b'test data'
+        b64 = base64.b64encode(payload).decode('ascii')
+        assert decode_data_uri_bytes(b64) == payload
+
+    def test_remote_http_url_raises(self) -> None:
+        """Raise ValueError for http:// URLs."""
+        with pytest.raises(ValueError, match='Remote URLs are not supported'):
+            decode_data_uri_bytes('http://example.com/audio.mp3')
+
+    def test_remote_https_url_raises(self) -> None:
+        """Raise ValueError for https:// URLs."""
+        with pytest.raises(ValueError, match='Remote URLs are not supported'):
+            decode_data_uri_bytes('https://example.com/audio.mp3')
+
+    def test_invalid_data_uri_format_raises(self) -> None:
+        """Raise ValueError for data URI with invalid base64 payload."""
+        with pytest.raises(ValueError, match='Invalid data URI format'):
+            decode_data_uri_bytes('data:audio/mpeg;base64,NOT_VALID_B64!!!')
+
+    def test_invalid_raw_base64_raises(self) -> None:
+        """Raise ValueError for invalid raw base64 strings."""
+        with pytest.raises(ValueError, match='Invalid base64 data'):
+            decode_data_uri_bytes('NOT_VALID_B64!!!')
+
+    def test_empty_payload_data_uri(self) -> None:
+        """Decode empty bytes from a data URI with empty payload."""
+        url = 'data:audio/mpeg;base64,'
+        assert decode_data_uri_bytes(url) == b''
+
+    def test_data_uri_without_base64_qualifier(self) -> None:
+        """Decode bytes from a data URI that omits ;base64 qualifier."""
+        payload = b'test'
+        b64 = base64.b64encode(payload).decode('ascii')
+        url = f'data:text/plain,{b64}'
+        assert decode_data_uri_bytes(url) == payload
+
+    def test_data_uri_with_no_content_type(self) -> None:
+        """Decode bytes from a data URI with empty content type."""
+        payload = b'data'
+        b64 = base64.b64encode(payload).decode('ascii')
+        url = f'data:;base64,{b64}'
+        assert decode_data_uri_bytes(url) == payload
+
+
+class TestExtractConfigDict:
+    """Tests for extract_config_dict."""
+
+    def _make_request(self, config: object = None) -> GenerateRequest:
+        """Create a minimal GenerateRequest with the given config."""
+        return GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='hello'))],
+                )
+            ],
+            config=config,
+        )
+
+    def test_no_config_returns_empty_dict(self) -> None:
+        """Return empty dict when request has no config."""
+        request = self._make_request(config=None)
+        assert extract_config_dict(request) == {}
+
+    def test_dict_config_returns_copy(self) -> None:
+        """Return a copy of the config when it is a dict."""
+        original = {'temperature': 0.5, 'model': 'gpt-4'}
+        request = self._make_request(config=original)
+        result = extract_config_dict(request)
+        assert result == original
+        assert result is not original
+
+    def test_dict_config_mutation_does_not_affect_original(self) -> None:
+        """Verify that mutating the returned dict does not affect the original."""
+        original = {'temperature': 0.5}
+        request = self._make_request(config=original)
+        result = extract_config_dict(request)
+        result['temperature'] = 1.0
+        assert original['temperature'] == 0.5
+
+    def test_empty_dict_config(self) -> None:
+        """Return empty dict when config is an empty dict."""
+        request = self._make_request(config={})
+        assert extract_config_dict(request) == {}
+
+
+class TestFindText:
+    """Tests for _find_text."""
+
+    def test_returns_text_from_first_message(self) -> None:
+        """Find and return text from the first message's text part."""
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='hello'))],
+                )
+            ]
+        )
+        assert _find_text(request) == 'hello'
+
+    def test_returns_none_for_no_messages(self) -> None:
+        """Return None when there are no messages."""
+        request = GenerateRequest(messages=[])
+        assert _find_text(request) is None
+
+    def test_returns_none_for_no_text_parts(self) -> None:
+        """Return None when message has only media parts."""
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=MediaPart(media=Media(url='data:audio/mpeg;base64,AAAA')))],
+                )
+            ]
+        )
+        assert _find_text(request) is None
+
+    def test_returns_first_text_part(self) -> None:
+        """Return the first text part when multiple exist."""
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(root=TextPart(text='first')),
+                        Part(root=TextPart(text='second')),
+                    ],
+                )
+            ]
+        )
+        assert _find_text(request) == 'first'
+
+
+class TestExtractText:
+    """Tests for _extract_text."""
+
+    def test_returns_text_when_present(self) -> None:
+        """Extract and return text when present."""
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='hello'))],
+                )
+            ]
+        )
+        assert _extract_text(request) == 'hello'
+
+    def test_raises_for_no_messages(self) -> None:
+        """Raise ValueError when request has no messages."""
+        request = GenerateRequest(messages=[])
+        with pytest.raises(ValueError, match='No messages found'):
+            _extract_text(request)
+
+    def test_raises_for_no_text_content(self) -> None:
+        """Raise ValueError when no text parts exist."""
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=MediaPart(media=Media(url='data:audio/mpeg;base64,AAAA')))],
+                )
+            ]
+        )
+        with pytest.raises(ValueError, match='No text content found'):
+            _extract_text(request)
+
+
+class TestExtractMedia:
+    """Tests for _extract_media."""
+
+    def test_extracts_media_url_and_content_type(self) -> None:
+        """Extract URL and content type from a media part."""
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(
+                            root=MediaPart(
+                                media=Media(
+                                    url='data:audio/mpeg;base64,AAAA',
+                                    content_type='audio/mpeg',
+                                )
+                            )
+                        )
+                    ],
+                )
+            ]
+        )
+        url, ct = _extract_media(request)
+        assert url == 'data:audio/mpeg;base64,AAAA'
+        assert ct == 'audio/mpeg'
+
+    def test_parses_content_type_from_data_uri_when_missing(self) -> None:
+        """Parse content type from data URI when not explicitly provided."""
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(
+                            root=MediaPart(
+                                media=Media(
+                                    url='data:audio/wav;base64,AAAA',
+                                )
+                            )
+                        )
+                    ],
+                )
+            ]
+        )
+        url, ct = _extract_media(request)
+        assert url == 'data:audio/wav;base64,AAAA'
+        assert ct == 'audio/wav'
+
+    def test_raises_for_no_messages(self) -> None:
+        """Raise ValueError when request has no messages."""
+        request = GenerateRequest(messages=[])
+        with pytest.raises(ValueError, match='No messages found'):
+            _extract_media(request)
+
+    def test_raises_for_no_media_parts(self) -> None:
+        """Raise ValueError when message has no media parts."""
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=TextPart(text='just text'))],
+                )
+            ]
+        )
+        with pytest.raises(ValueError, match='No media content found'):
+            _extract_media(request)
+
+    def test_skips_text_parts_finds_media(self) -> None:
+        """Find media part even when text parts come first."""
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[
+                        Part(root=TextPart(text='instructions')),
+                        Part(
+                            root=MediaPart(
+                                media=Media(
+                                    url='data:image/png;base64,iVBOR',
+                                    content_type='image/png',
+                                )
+                            )
+                        ),
+                    ],
+                )
+            ]
+        )
+        url, ct = _extract_media(request)
+        assert ct == 'image/png'
+
+    def test_content_type_from_data_uri_without_base64_qualifier(self) -> None:
+        """Parse content type from data URI that omits ;base64 qualifier."""
+        request = GenerateRequest(
+            messages=[
+                Message(
+                    role=Role.USER,
+                    content=[Part(root=MediaPart(media=Media(url='data:text/plain,hello')))],
+                )
+            ]
+        )
+        _, ct = _extract_media(request)
+        assert ct == 'text/plain'

--- a/py/samples/compat-oai-hello/README.md
+++ b/py/samples/compat-oai-hello/README.md
@@ -73,8 +73,16 @@ genkit start -- uv run src/main.py
 6. **Test structured output**:
    - [ ] `generate_character` - RPG character generation
 
-7. **Expected behavior**:
+7. **Test multimodal**:
+   - [ ] `generate_image` - DALL-E image generation (returns base64 data URI)
+   - [ ] `text_to_speech` - TTS with voice selection (alloy, echo, nova, etc.)
+   - [ ] `round_trip_tts_stt` - Text → Speech → Text round-trip demo
+
+8. **Expected behavior**:
    - GPT models respond appropriately
    - Streaming shows incremental text
    - Tools are invoked and responses processed
    - Structured output matches Pydantic schema
+   - DALL-E returns a base64 image data URI
+   - TTS returns a base64 audio data URI
+   - Round-trip returns transcribed text matching the original input


### PR DESCRIPTION
## Summary

Add image generation, text-to-speech, and speech-to-text capabilities to the Python `compat-oai` plugin, achieving feature parity with the JavaScript implementation. Update the `compat-oai-hello` sample to demonstrate all multimodal flows.

## Motivation

The JS `compat-oai` plugin supports image generation (DALL-E 3, GPT-Image-1), TTS (tts-1, tts-1-hd, gpt-4o-mini-tts), and STT (whisper-1, gpt-4o-transcribe, gpt-4o-mini-transcribe) models. The Python plugin was missing these capabilities. This change closes that gap.

## Changes

### Plugin — New files
- **`models/image.py`** — `OpenAIImageModel` for image generation via `client.images.generate()`
- **`models/audio.py`** — `OpenAITTSModel` (via `client.audio.speech.create()`) and `OpenAISTTModel` (via `client.audio.transcriptions.create()`)
- **`models/utils.py`** — Shared helpers: `extract_text_from_parts()`, `extract_first_media_url()`, `parse_data_uri()`, and `data_uri_to_bytes()`

### Plugin — Modified files
- **`models/__init__.py`** — Export new model classes and registries (`SUPPORTED_IMAGE_MODELS`, `SUPPORTED_TTS_MODELS`, `SUPPORTED_STT_MODELS`)
- **`openai_plugin.py`** — Register, resolve, and list image/TTS/STT models using name-based pattern matching

### Sample — Updated files
- **`compat-oai-hello/src/main.py`** — Added three new flows:
  - `generate_image` — DALL-E image generation (returns base64 data URI)
  - `text_to_speech` — TTS with voice selection (returns base64 audio data URI)
  - `round_trip_tts_stt` — Self-contained Text → Speech → Text demo (generates audio via TTS, then transcribes it back via Whisper, fully testable from the Dev UI with just text input)
  - Added `_extract_media_url()` helper for extracting `MediaPart` data URIs from responses (since `response.text` returns empty for media-only responses)
- **`compat-oai-hello/README.md`** — Updated testing checklist with multimodal flows

### Tests
- **`image_model_test.py`** — 15 unit tests covering prompt extraction, param conversion, response conversion, model registry, and end-to-end model class
- **`audio_model_test.py`** — 19 unit tests covering text/media extraction, TTS/STT param conversion, response conversion, model registries, and model classes
- **`utils_test.py`** — Unit tests for shared utility functions

## Model Specs

| Type | Models | `supports.media` | `supports.output` | JS Parity |
|------|--------|-------------------|--------------------|-----------| 
| **Image** | dall-e-3, gpt-image-1 | `False` | `["media"]` | ✅ |
| **TTS** | tts-1, tts-1-hd, gpt-4o-mini-tts | `False` | `["media"]` | ✅ |
| **STT** | whisper-1, gpt-4o-transcribe, gpt-4o-mini-transcribe | `True` | `["text", "json"]` | ✅ |

## Design Decisions

- **MediaPart extraction**: `response.text` only extracts `TextPart`s, returning empty string for media-only responses (image, TTS). Flows and the shared `_extract_media_url()` helper iterate through `response.message.content` to find `MediaPart` data URIs.
- **Round-trip STT flow**: Instead of requiring raw base64 audio input (impractical to test in the Dev UI and fails with fake data), the `round_trip_tts_stt` flow generates audio via TTS first, then transcribes it — making it self-contained and testable with just a text input.

## Verification

- [x] `ruff check` — All checks passed
- [x] `pyrefly check` — 0 errors
- [x] `pytest` — All tests passed (34 new + 20 existing)
- [x] All pre-push hooks passed

<img width="1024" height="1024" alt="catto" src="https://github.com/user-attachments/assets/a8d6b43d-a98a-4c45-b304-68affac3ec7d" />
<img width="1024" height="1024" alt="catto2" src="https://github.com/user-attachments/assets/cdcd2310-a751-49da-9278-bebb322ad006" />