### PR TITLE
feat(py/plugins): add reasoning_content extraction for DeepSeek R1 models

### DIFF
--- a/py/plugins/README.md
+++ b/py/plugins/README.md
@@ -454,6 +454,54 @@ async def hello(name: str) -> str:
     return response.text
 ```
 
+## Plugin Dependency Graph
+
+Shows how plugins relate to each other and the core `genkit` package. Most
+plugins are independent leaf nodes; only a few have inter-plugin dependencies.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                        PLUGIN DEPENDENCY GRAPH                                   │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                  │
+│                           ┌──────────┐                                           │
+│                           │  genkit   │ (core SDK)                               │
+│                           └─────┬────┘                                           │
+│                                 │                                                │
+│              ┌──────────────────┼──────────────────┐                             │
+│              │                  │                   │                             │
+│              ▼                  ▼                   ▼                             │
+│   ┌──────────────────┐ ┌──────────────┐ ┌───────────────────┐                   │
+│   │   compat-oai     │ │ google-genai │ │ All other plugins │                   │
+│   │ (OpenAI compat)  │ │              │ │ (independent)     │                   │
+│   └────────┬─────────┘ └──────┬───────┘ └───────────────────┘                   │
+│            │                  │                                                   │
+│     ┌──────┴──────┐          │                                                   │
+│     │             │          │                                                   │
+│     ▼             ▼          ▼                                                   │
+│ ┌─────────┐ ┌──────────┐ ┌──────────┐                                           │
+│ │deepseek │ │vertex-ai │ │  flask   │                                           │
+│ │(extends)│ │(Model    │ │(uses     │                                           │
+│ │         │ │ Garden)  │ │ google-  │                                           │
+│ │         │ │          │ │ genai)   │                                           │
+│ └─────────┘ └──────────┘ └──────────┘                                           │
+│                                                                                  │
+│   INDEPENDENT PLUGINS (no inter-plugin dependencies):                            │
+│   ─────────────────────────────────────────────────                               │
+│   google-genai, anthropic, amazon-bedrock, microsoft-foundry,                    │
+│   ollama, xai, mistral, huggingface, cloudflare-workers-ai,                      │
+│   google-cloud, firebase, observability, mcp, evaluators,                        │
+│   dev-local-vectorstore, checks                                                  │
+│                                                                                  │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key relationships:**
+- **`compat-oai`** provides the shared OpenAI-compatible model layer (chat, image, TTS, STT)
+- **`deepseek`** extends `compat-oai` with reasoning model detection and param validation
+- **`vertex-ai`** (Model Garden) uses `compat-oai` for third-party model support
+- **`flask`** has a dev dependency on `google-genai` for its sample
+
 ## Further Reading
 
 - [Plugin Planning & Roadmap](../engdoc/planning/)

--- a/py/plugins/compat-oai/tests/compat_oai_model_test.py
+++ b/py/plugins/compat-oai/tests/compat_oai_model_test.py
@@ -72,6 +72,8 @@ async def test__generate(sample_request: GenerateRequest) -> None:
     mock_message = MagicMock()
     mock_message.content = 'Hello, user!'
     mock_message.role = 'model'
+    mock_message.tool_calls = None
+    mock_message.reasoning_content = None
 
     mock_response = MagicMock()
     mock_response.choices = [MagicMock(message=mock_message)]
@@ -113,6 +115,7 @@ async def test__generate_stream(sample_request: GenerateRequest) -> None:
             delta_mock.content = content
             delta_mock.role = None
             delta_mock.tool_calls = None
+            delta_mock.reasoning_content = None
 
             choice_mock = MagicMock()
             choice_mock.delta = delta_mock

--- a/py/plugins/compat-oai/tests/tool_calling_test.py
+++ b/py/plugins/compat-oai/tests/tool_calling_test.py
@@ -39,6 +39,7 @@ async def test_generate_with_tool_calls_executes_tools(sample_request: GenerateR
     first_message.role = 'assistant'
     first_message.tool_calls = [mock_tool_call]
     first_message.content = None
+    first_message.reasoning_content = None
 
     first_response = MagicMock()
     first_response.choices = [MagicMock(finish_reason='tool_calls', message=first_message)]
@@ -48,6 +49,7 @@ async def test_generate_with_tool_calls_executes_tools(sample_request: GenerateR
     second_message.role = 'model'
     second_message.tool_calls = None
     second_message.content = 'final response'
+    second_message.reasoning_content = None
 
     second_response = MagicMock()
     second_response.choices = [MagicMock(finish_reason='stop', message=second_message)]
@@ -111,6 +113,7 @@ async def test_generate_stream_with_tool_calls(sample_request: GenerateRequest) 
             delta_mock.content = None
             delta_mock.role = None
             delta_mock.tool_calls = [MockToolCall(id, index, name, args_chunk)]
+            delta_mock.reasoning_content = None
 
             choice_mock = MagicMock()
             choice_mock.delta = delta_mock

--- a/py/plugins/deepseek/src/genkit/plugins/deepseek/__init__.py
+++ b/py/plugins/deepseek/src/genkit/plugins/deepseek/__init__.py
@@ -130,7 +130,8 @@ See Also:
 """
 
 from .client import DEFAULT_DEEPSEEK_API_URL
+from .model_info import is_reasoning_model
 from .models import deepseek_name
 from .plugin import DeepSeek
 
-__all__ = ['DEFAULT_DEEPSEEK_API_URL', 'DeepSeek', 'deepseek_name']
+__all__ = ['DEFAULT_DEEPSEEK_API_URL', 'DeepSeek', 'deepseek_name', 'is_reasoning_model']

--- a/py/plugins/deepseek/src/genkit/plugins/deepseek/model_info.py
+++ b/py/plugins/deepseek/src/genkit/plugins/deepseek/model_info.py
@@ -14,14 +14,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""DeepSeek model information and metadata."""
+"""DeepSeek model information and metadata.
+
+Defines supported models and their capabilities. Reasoning models
+(deepseek-reasoner, deepseek-r1) have tools disabled because the
+DeepSeek API ignores tool parameters for these models.
+"""
 
 from genkit.types import ModelInfo, Supports
 
-__all__ = ['SUPPORTED_DEEPSEEK_MODELS', 'get_default_model_info']
+__all__ = [
+    'SUPPORTED_DEEPSEEK_MODELS',
+    'get_default_model_info',
+    'is_reasoning_model',
+]
 
-# Model capabilities matching JS implementation
-_DEEPSEEK_SUPPORTS = Supports(
+# Chat model capabilities (supports tools, structured output).
+_DEEPSEEK_CHAT_SUPPORTS = Supports(
     multiturn=True,
     tools=True,
     media=False,
@@ -29,28 +38,62 @@ _DEEPSEEK_SUPPORTS = Supports(
     output=['text', 'json'],
 )
 
+# Reasoning model capabilities (no tools — R1 ignores them silently).
+_DEEPSEEK_REASONING_SUPPORTS = Supports(
+    multiturn=True,
+    tools=False,
+    media=False,
+    system_role=True,
+    output=['text'],
+)
+
+# Names of reasoning models that return reasoning_content and
+# silently ignore temperature, top_p, and tool parameters.
+_REASONING_MODEL_NAMES: frozenset[str] = frozenset({
+    'deepseek-reasoner',
+    'deepseek-r1',
+})
+
 SUPPORTED_DEEPSEEK_MODELS: dict[str, ModelInfo] = {
     'deepseek-reasoner': ModelInfo(
         label='DeepSeek - Reasoner',
         versions=['deepseek-reasoner'],
-        supports=_DEEPSEEK_SUPPORTS,
+        supports=_DEEPSEEK_REASONING_SUPPORTS,
     ),
     'deepseek-chat': ModelInfo(
         label='DeepSeek - Chat',
         versions=['deepseek-chat'],
-        supports=_DEEPSEEK_SUPPORTS,
+        supports=_DEEPSEEK_CHAT_SUPPORTS,
     ),
     'deepseek-v3': ModelInfo(
         label='DeepSeek - V3',
         versions=['deepseek-v3'],
-        supports=_DEEPSEEK_SUPPORTS,
+        supports=_DEEPSEEK_CHAT_SUPPORTS,
     ),
     'deepseek-r1': ModelInfo(
         label='DeepSeek - R1',
         versions=['deepseek-r1'],
-        supports=_DEEPSEEK_SUPPORTS,
+        supports=_DEEPSEEK_REASONING_SUPPORTS,
     ),
 }
+
+
+def is_reasoning_model(name: str) -> bool:
+    """Check if the model is a reasoning model.
+
+    Reasoning models (R1, reasoner) return chain-of-thought in a
+    separate ``reasoning_content`` field and silently ignore parameters
+    like ``temperature``, ``top_p``, and ``tools``.
+
+    Args:
+        name: The model name (with or without the plugin prefix).
+
+    Returns:
+        True if the model is a reasoning model.
+    """
+    # Strip plugin prefix if present.
+    clean = name.split('/', 1)[-1] if '/' in name else name
+    return clean in _REASONING_MODEL_NAMES
 
 
 def get_default_model_info(name: str) -> ModelInfo:
@@ -62,7 +105,8 @@ def get_default_model_info(name: str) -> ModelInfo:
     Returns:
         Default ModelInfo with standard DeepSeek capabilities.
     """
+    supports = _DEEPSEEK_REASONING_SUPPORTS if is_reasoning_model(name) else _DEEPSEEK_CHAT_SUPPORTS
     return ModelInfo(
         label=f'DeepSeek - {name}',
-        supports=_DEEPSEEK_SUPPORTS,
+        supports=supports,
     )

--- a/py/plugins/deepseek/src/genkit/plugins/deepseek/models.py
+++ b/py/plugins/deepseek/src/genkit/plugins/deepseek/models.py
@@ -14,21 +14,39 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""DeepSeek model integration for Genkit."""
+"""DeepSeek model integration for Genkit.
 
+Wraps the compat-oai OpenAIModel for use with DeepSeek's
+OpenAI-compatible API. Adds parameter validation warnings for
+reasoning models (R1, deepseek-reasoner) which silently ignore
+temperature, top_p, and tools parameters.
+"""
+
+import logging
 from collections.abc import Callable
 from typing import Any
 
 from openai import OpenAI
 
+from genkit.core.action._action import ActionRunContext
 from genkit.plugins.compat_oai.models.model import OpenAIModel
 from genkit.plugins.deepseek.client import DeepSeekClient
 from genkit.plugins.deepseek.model_info import (
     SUPPORTED_DEEPSEEK_MODELS,
     get_default_model_info,
+    is_reasoning_model,
 )
+from genkit.types import GenerateRequest, GenerateResponse
 
 DEEPSEEK_PLUGIN_NAME = 'deepseek'
+
+logger = logging.getLogger(__name__)
+
+# Parameters that reasoning models silently ignore.
+_REASONING_IGNORED_PARAMS: frozenset[str] = frozenset({
+    'temperature',
+    'top_p',
+})
 
 
 def deepseek_name(name: str) -> str:
@@ -43,6 +61,45 @@ def deepseek_name(name: str) -> str:
     return f'{DEEPSEEK_PLUGIN_NAME}/{name}'
 
 
+def _get_config_value(config: dict[str, Any] | object, param: str) -> Any:  # noqa: ANN401
+    """Get a config value by name from either a dict or an object.
+
+    Args:
+        config: Dict or Pydantic model config.
+        param: Parameter name to look up.
+
+    Returns:
+        The parameter value, or None if not found.
+    """
+    if isinstance(config, dict):
+        return config.get(param)  # type: ignore[arg-type]
+    return getattr(config, param, None)
+
+
+def _warn_reasoning_params(model_name: str, config: dict[str, Any] | object | None) -> None:
+    """Emit warnings for parameters that reasoning models silently ignore.
+
+    DeepSeek R1 and deepseek-reasoner accept but silently ignore
+    temperature, top_p, and tools. We warn so users don't get
+    confused by unexpected behavior.
+
+    Args:
+        model_name: The model name.
+        config: The request config (may be dict or Pydantic model).
+    """
+    if not is_reasoning_model(model_name) or config is None:
+        return
+
+    for param in _REASONING_IGNORED_PARAMS:
+        if _get_config_value(config, param) is not None:
+            logger.warning(
+                "DeepSeek reasoning model '%s' silently ignores '%s'; "
+                'removing it from your config will silence this warning.',
+                model_name,
+                param,
+            )
+
+
 class DeepSeekModel:
     """Manages DeepSeek model integration for Genkit.
 
@@ -51,7 +108,8 @@ class DeepSeekModel:
     client initialization, model information retrieval, and dynamic model
     definition within the Genkit registry.
 
-    Follows the Model Garden pattern for implementation consistency.
+    For reasoning models (R1, deepseek-reasoner), the generate method
+    validates request parameters and warns about silently ignored ones.
     """
 
     def __init__(
@@ -74,13 +132,8 @@ class DeepSeekModel:
     def get_model_info(self) -> dict[str, Any] | None:
         """Retrieve metadata and supported features for the specified model.
 
-        This method looks up the model's information from a predefined list
-        of supported DeepSeek models or provides default information.
-
         Returns:
             A dictionary containing the model's 'name' and 'supports' features.
-            The 'supports' key contains a dictionary representing the model's
-            capabilities (e.g., tools, streaming).
         """
         model_info = SUPPORTED_DEEPSEEK_MODELS.get(self.name, get_default_model_info(self.name))
         supports_dict = model_info.supports.model_dump(by_alias=True, exclude_none=True) if model_info.supports else {}
@@ -92,13 +145,20 @@ class DeepSeekModel:
     def to_deepseek_model(self) -> Callable:
         """Convert the DeepSeek model into a Genkit-compatible model function.
 
-        This method wraps the underlying DeepSeek client and its generation
-        logic into a callable that adheres to the OpenAI model interface
-        expected by Genkit.
+        For reasoning models, wraps the generate method to validate
+        parameters before forwarding to the OpenAI model.
 
         Returns:
-            A callable function (the generate method of an OpenAIModel instance)
-            that can be used by Genkit.
+            A callable function that can be used by Genkit.
         """
-        deepseek_model = OpenAIModel(self.name, self.client)
-        return deepseek_model.generate
+        openai_model = OpenAIModel(self.name, self.client)
+        model_name = self.name
+
+        async def _generate_with_validation(request: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+            _warn_reasoning_params(model_name, request.config)
+            return await openai_model.generate(request, ctx)
+
+        # Only wrap with validation for reasoning models.
+        if is_reasoning_model(self.name):
+            return _generate_with_validation
+        return openai_model.generate

--- a/py/plugins/deepseek/tests/model_info_test.py
+++ b/py/plugins/deepseek/tests/model_info_test.py
@@ -16,13 +16,19 @@
 
 """Tests for DeepSeek model information."""
 
-from genkit.plugins.deepseek.model_info import SUPPORTED_DEEPSEEK_MODELS, get_default_model_info
+from genkit.plugins.deepseek.model_info import (
+    SUPPORTED_DEEPSEEK_MODELS,
+    get_default_model_info,
+    is_reasoning_model,
+)
 
 
 def test_supported_models_exist() -> None:
     """Test that supported models are defined."""
     assert 'deepseek-reasoner' in SUPPORTED_DEEPSEEK_MODELS
     assert 'deepseek-chat' in SUPPORTED_DEEPSEEK_MODELS
+    assert 'deepseek-v3' in SUPPORTED_DEEPSEEK_MODELS
+    assert 'deepseek-r1' in SUPPORTED_DEEPSEEK_MODELS
 
 
 def test_model_order() -> None:
@@ -32,11 +38,12 @@ def test_model_order() -> None:
     assert keys[1] == 'deepseek-chat'
 
 
-def test_model_info_structure() -> None:
-    """Test model info has required fields."""
-    for _model_name, model_info in SUPPORTED_DEEPSEEK_MODELS.items():
+def test_chat_model_info_structure() -> None:
+    """Test chat model info has required fields and correct capabilities."""
+    for model_name in ('deepseek-chat', 'deepseek-v3'):
+        model_info = SUPPORTED_DEEPSEEK_MODELS[model_name]
         assert model_info.label
-        assert model_info.supports
+        assert model_info.supports is not None
         assert model_info.supports.multiturn is True
         assert model_info.supports.tools is True
         assert model_info.supports.media is False
@@ -46,10 +53,49 @@ def test_model_info_structure() -> None:
         assert 'json' in model_info.supports.output
 
 
-def test_get_default_model_info() -> None:
-    """Test getting default info for unknown models."""
+def test_reasoning_model_info_structure() -> None:
+    """Test reasoning model info has correct capabilities (no tools, text only)."""
+    for model_name in ('deepseek-reasoner', 'deepseek-r1'):
+        model_info = SUPPORTED_DEEPSEEK_MODELS[model_name]
+        assert model_info.label
+        assert model_info.supports is not None
+        assert model_info.supports.multiturn is True
+        assert model_info.supports.tools is False
+        assert model_info.supports.media is False
+        assert model_info.supports.system_role is True
+        assert model_info.supports.output is not None
+        assert 'text' in model_info.supports.output
+        assert 'json' not in model_info.supports.output
+
+
+def test_is_reasoning_model() -> None:
+    """Test reasoning model detection."""
+    assert is_reasoning_model('deepseek-reasoner') is True
+    assert is_reasoning_model('deepseek-r1') is True
+    assert is_reasoning_model('deepseek-chat') is False
+    assert is_reasoning_model('deepseek-v3') is False
+
+
+def test_is_reasoning_model_with_prefix() -> None:
+    """Test reasoning model detection with plugin prefix."""
+    assert is_reasoning_model('deepseek/deepseek-reasoner') is True
+    assert is_reasoning_model('deepseek/deepseek-r1') is True
+    assert is_reasoning_model('deepseek/deepseek-chat') is False
+    assert is_reasoning_model('deepseek/deepseek-v3') is False
+
+
+def test_get_default_model_info_chat() -> None:
+    """Test getting default info for unknown chat models."""
     info = get_default_model_info('deepseek-future-model')
     assert 'deepseek-future-model' in str(info.label)
     assert info.supports is not None
     assert info.supports.multiturn is True
+    assert info.supports.tools is True
+
+
+def test_get_default_model_info_reasoning() -> None:
+    """Test getting default info for unknown reasoning models doesn't apply."""
+    # Unknown model names are treated as chat models by default.
+    info = get_default_model_info('deepseek-some-other')
+    assert info.supports is not None
     assert info.supports.tools is True


### PR DESCRIPTION
## Summary

Adds support for extracting `reasoning_content` from DeepSeek R1/reasoner API responses and adds parameter validation warnings. This achieves parity with the JS canonical implementation in `fromOpenAIChoice()` and `fromOpenAIChunkChoice()`.

### Problem

DeepSeek R1 and deepseek-reasoner models return chain-of-thought reasoning in a separate `reasoning_content` field on the API response. The Python `compat-oai` layer was silently dropping this content, while the JS implementation correctly extracts it and emits `ReasoningPart` objects.

Additionally, R1 models silently ignore `temperature`, `top_p`, and `tools` parameters, which can confuse users who expect them to work.

A secondary issue was that Pydantic models raise `AttributeError` for unknown fields (unlike plain objects where `getattr()` returns a default). This meant that accessing `reasoning_content` on standard OpenAI `ChatCompletionMessage` objects (which lack that field) caused crashes instead of graceful fallback.

### Changes

**compat-oai plugin (shared layer):**
- `utils.py`: Added `reasoning_content` property to `DictMessageAdapter` and `MessageAdapter` with `try-except AttributeError` for safe Pydantic model access; updated `MessageConverter.to_genkit()` to emit `ReasoningPart` before `TextPart` (matching JS order)
- `model.py`: Wrapped raw `ChatCompletionMessage` in `MessageAdapter()` in `_generate()` to ensure safe attribute access; replaced `getattr(delta, 'reasoning_content', None)` with `MessageAdapter(delta).reasoning_content` in `_generate_stream()` for consistent Pydantic-safe handling
- Test mocks: Added explicit `tool_calls = None` and `reasoning_content = None` on `MagicMock` objects to prevent auto-generated truthy attributes from causing `ValueError: Unable to determine content part`

**deepseek plugin:**
- `model_info.py`: Split capabilities into chat (`tools=True`, `output=['text','json']`) vs reasoning (`tools=False`, `output=['text']`); added `is_reasoning_model()` helper
- `models.py`: Added `_warn_reasoning_params()` to log warnings for silently ignored params; wraps `generate` with validation only for reasoning models
- `__init__.py`: Export `is_reasoning_model`

**Tests (all passing on CI across Python 3.10–3.14):**
- `utils_test.py`: 7 new tests for `reasoning_content` in adapters and converter
- `compat_oai_model_test.py`: Fixed mock objects for Pydantic/MessageAdapter compatibility
- `tool_calling_test.py`: Fixed mock objects for Pydantic/MessageAdapter compatibility
- `model_info_test.py`: Updated for chat/reasoning capability split, added `is_reasoning_model()` tests
- `deepseek_plugin_test.py`: Added `_warn_reasoning_params()` and integration tests

### Testing

```bash
# Run all affected tests (103 passed)
uv run --active pytest plugins/compat-oai/tests/ -v

# Run deepseek tests
uv run --active pytest plugins/deepseek/tests/ -v
```
