### PR TITLE
feat(py/plugins): add Mistral AI embeddings support (mistral-embed)

### DIFF
--- a/py/plugins/mistral/src/genkit/plugins/mistral/__init__.py
+++ b/py/plugins/mistral/src/genkit/plugins/mistral/__init__.py
@@ -108,6 +108,9 @@ Supported Models:
     - ministral-8b-latest: Compact model for edge deployment
     - ministral-3b-latest: Smallest model for resource-constrained environments
 
+Supported Embedders:
+    - mistral-embed: 1024-dimensional text embeddings for RAG and search
+
 Example:
     ```python
     from genkit import Genkit
@@ -131,6 +134,7 @@ See Also:
     - Genkit documentation: https://genkit.dev/
 """
 
+from .embeddings import SUPPORTED_EMBEDDING_MODELS, MistralEmbedConfig
 from .model_info import SUPPORTED_MISTRAL_MODELS
 from .models import MISTRAL_PLUGIN_NAME, mistral_name
 from .plugin import Mistral
@@ -141,7 +145,9 @@ DEFAULT_MISTRAL_API_URL = 'https://api.mistral.ai'
 __all__ = [
     'DEFAULT_MISTRAL_API_URL',
     'MISTRAL_PLUGIN_NAME',
-    'SUPPORTED_MISTRAL_MODELS',
+    'MistralEmbedConfig',
     'Mistral',
+    'SUPPORTED_EMBEDDING_MODELS',
+    'SUPPORTED_MISTRAL_MODELS',
     'mistral_name',
 ]

--- a/py/plugins/mistral/src/genkit/plugins/mistral/embeddings.py
+++ b/py/plugins/mistral/src/genkit/plugins/mistral/embeddings.py
@@ -1,0 +1,125 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mistral AI embeddings integration for Genkit.
+
+This module provides embedding support using Mistral AI's ``mistral-embed``
+model. Embeddings convert text into dense vector representations for use in
+semantic search, retrieval-augmented generation (RAG), clustering, and
+similarity comparisons.
+
+See: https://docs.mistral.ai/capabilities/embeddings/
+"""
+
+from typing import Any, Literal
+
+from mistralai import Mistral as MistralClient
+from pydantic import BaseModel, Field
+
+from genkit.blocks.embedding import EmbedRequest, EmbedResponse
+from genkit.types import Embedding, TextPart
+
+__all__ = [
+    'SUPPORTED_EMBEDDING_MODELS',
+    'MistralEmbedConfig',
+    'MistralEmbedder',
+]
+
+# Mistral's supported embedding models and their default dimensions.
+# See: https://docs.mistral.ai/capabilities/embeddings/
+SUPPORTED_EMBEDDING_MODELS: dict[str, dict[str, Any]] = {
+    'mistral-embed': {
+        'label': 'Mistral AI - Embed',
+        'dimensions': 1024,
+        'supports': {'input': ['text']},
+    },
+}
+
+
+class MistralEmbedConfig(BaseModel):
+    """Configuration options for Mistral embedding requests.
+
+    Attributes:
+        output_dimension: Optional dimensionality of the output embeddings.
+            If not specified, the model's default dimension (1024) is used.
+            Useful for reducing storage or matching an existing vector index.
+        output_dtype: Optional data type for the returned embeddings. One of
+            ``float``, ``int8``, ``uint8``, ``binary``, or ``ubinary``.
+        encoding_format: Optional format of the returned embeddings. One of
+            ``float`` or ``base64``.
+    """
+
+    output_dimension: int | None = Field(default=None, ge=1)
+    output_dtype: Literal['float', 'int8', 'uint8', 'binary', 'ubinary'] | None = None
+    encoding_format: Literal['float', 'base64'] | None = None
+
+
+class MistralEmbedder:
+    """Handles embedding requests using a Mistral AI embedding model.
+
+    Converts Genkit ``EmbedRequest`` documents into vectors by calling
+    the Mistral ``embeddings.create_async`` API and returning the results
+    as a Genkit ``EmbedResponse``.
+    """
+
+    def __init__(self, model: str, client: MistralClient) -> None:
+        """Initialize the Mistral embedder.
+
+        Args:
+            model: The model identifier (e.g. ``mistral-embed``).
+            client: A configured ``MistralClient`` instance.
+        """
+        self.model = model
+        self.client = client
+
+    async def embed(self, request: EmbedRequest) -> EmbedResponse:
+        """Generate embeddings for the given documents.
+
+        Extracts text from each ``Document`` in the request, sends them to
+        the Mistral embeddings API, and returns the resulting vectors.
+
+        Args:
+            request: The embedding request containing input documents.
+
+        Returns:
+            An ``EmbedResponse`` with one embedding per input document.
+        """
+        # Extract text from each document's content parts.
+        texts: list[str] = []
+        for doc in request.input:
+            doc_text = ''.join(
+                part.root.text for part in doc.content if isinstance(part.root, TextPart) and part.root.text
+            )
+            texts.append(doc_text)
+
+        # Build optional parameters from request options.
+        kwargs: dict[str, Any] = {}
+        if request.options:
+            if dim_val := request.options.get('output_dimension'):
+                kwargs['output_dimension'] = int(dim_val)
+            if dtype_val := request.options.get('output_dtype'):
+                kwargs['output_dtype'] = str(dtype_val)
+            if enc_val := request.options.get('encoding_format'):
+                kwargs['encoding_format'] = str(enc_val)
+
+        response = await self.client.embeddings.create_async(
+            model=self.model,
+            inputs=texts,
+            **kwargs,
+        )
+
+        embeddings = [Embedding(embedding=item.embedding) for item in response.data]
+        return EmbedResponse(embeddings=embeddings)

--- a/py/plugins/mistral/src/genkit/plugins/mistral/plugin.py
+++ b/py/plugins/mistral/src/genkit/plugins/mistral/plugin.py
@@ -14,17 +14,34 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Mistral AI Plugin for Genkit."""
+"""Mistral AI Plugin for Genkit.
+
+Registers both chat/completion models and the ``mistral-embed`` embedder
+with the Genkit framework.
+"""
 
 import os
 from typing import Any
 
+from mistralai import Mistral as MistralClient
+
 from genkit.ai import Plugin
+from genkit.blocks.embedding import (
+    EmbedderOptions,
+    EmbedderSupports,
+    EmbedRequest,
+    EmbedResponse,
+    embedder_action_metadata,
+)
 from genkit.blocks.model import model_action_metadata
 from genkit.core.action import Action, ActionMetadata
 from genkit.core.action.types import ActionKind
 from genkit.core.error import GenkitError
 from genkit.core.schema import to_json_schema
+from genkit.plugins.mistral.embeddings import (
+    SUPPORTED_EMBEDDING_MODELS,
+    MistralEmbedder,
+)
 from genkit.plugins.mistral.model_info import SUPPORTED_MISTRAL_MODELS
 from genkit.plugins.mistral.models import (
     MISTRAL_PLUGIN_NAME,
@@ -33,23 +50,35 @@ from genkit.plugins.mistral.models import (
     mistral_name,
 )
 
+# Models that are embedders, not chat/completion models.
+_EMBEDDING_MODEL_NAMES = frozenset(SUPPORTED_EMBEDDING_MODELS.keys())
+
 
 class Mistral(Plugin):
     """Mistral AI plugin for Genkit.
 
     This plugin provides integration with Mistral AI's official Python SDK,
-    enabling the use of Mistral models within the Genkit framework.
+    enabling the use of Mistral chat models **and** embedders within the
+    Genkit framework.
 
-    Example:
-        >>> from genkit import Genkit
-        >>> from genkit.plugins.mistral import Mistral
-        >>>
-        >>> ai = Genkit(
-        ...     plugins=[Mistral()],
-        ...     model='mistral/mistral-large-latest',
-        ... )
-        >>>
-        >>> response = await ai.generate(prompt='Hello!')
+    Example::
+
+        from genkit import Genkit
+        from genkit.plugins.mistral import Mistral
+
+        ai = Genkit(
+            plugins=[Mistral()],
+            model='mistral/mistral-large-latest',
+        )
+
+        # Chat completion
+        response = await ai.generate(prompt='Hello!')
+
+        # Embeddings
+        embeddings = await ai.embed(
+            embedder='mistral/mistral-embed',
+            content=['Hello world'],
+        )
     """
 
     name = MISTRAL_PLUGIN_NAME
@@ -80,6 +109,15 @@ class Mistral(Plugin):
         self.models = models
         self.mistral_params = mistral_params
 
+        # Shared client for all embedder instances (created lazily).
+        self._client: MistralClient | None = None
+
+    def _get_client(self) -> MistralClient:
+        """Return a shared Mistral client, creating it on first access."""
+        if self._client is None:
+            self._client = MistralClient(api_key=str(self.api_key), **self.mistral_params)
+        return self._client
+
     async def init(self) -> list[Action]:
         """Initialize the plugin.
 
@@ -91,6 +129,10 @@ class Mistral(Plugin):
     async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
         """Resolve an action by creating and returning an Action object.
 
+        Routes to the correct factory based on action type and model name:
+        - Embedding models are resolved only for ``ActionKind.EMBEDDER``.
+        - Chat/completion models are resolved only for ``ActionKind.MODEL``.
+
         Args:
             action_type: The kind of action to resolve.
             name: The namespaced name of the action to resolve.
@@ -98,10 +140,20 @@ class Mistral(Plugin):
         Returns:
             Action object if found, None otherwise.
         """
-        if action_type != ActionKind.MODEL:
-            return None
+        clean_name = name.replace(MISTRAL_PLUGIN_NAME + '/', '') if name.startswith(MISTRAL_PLUGIN_NAME) else name
 
-        return self._create_model_action(name)
+        if action_type == ActionKind.EMBEDDER:
+            if clean_name not in _EMBEDDING_MODEL_NAMES:
+                return None
+            return self._create_embedder_action(name, clean_name)
+
+        if action_type == ActionKind.MODEL:
+            # Embedding models should not be resolved as chat models.
+            if clean_name in _EMBEDDING_MODEL_NAMES:
+                return None
+            return self._create_model_action(name)
+
+        return None
 
     def _create_model_action(self, name: str) -> Action:
         """Create an Action object for a Mistral model.
@@ -137,18 +189,71 @@ class Mistral(Plugin):
             },
         )
 
+    def _create_embedder_action(self, name: str, clean_name: str) -> Action:
+        """Create an Action object for a Mistral embedder.
+
+        Args:
+            name: The namespaced name of the embedder.
+            clean_name: The model name without the plugin prefix.
+
+        Returns:
+            Action object for the embedder.
+        """
+        embedder_info = SUPPORTED_EMBEDDING_MODELS.get(
+            clean_name,
+            {
+                'label': f'Mistral AI Embedding - {clean_name}',
+                'dimensions': 1024,
+                'supports': {'input': ['text']},
+            },
+        )
+        embedder = MistralEmbedder(model=clean_name, client=self._get_client())
+
+        async def embed_fn(request: EmbedRequest) -> EmbedResponse:
+            return await embedder.embed(request)
+
+        return Action(
+            kind=ActionKind.EMBEDDER,
+            name=name,
+            fn=embed_fn,
+            metadata=embedder_action_metadata(
+                name=name,
+                options=EmbedderOptions(
+                    label=embedder_info['label'],
+                    supports=EmbedderSupports(input=embedder_info['supports']['input']),
+                    dimensions=embedder_info.get('dimensions'),
+                ),
+            ).metadata,
+        )
+
     async def list_actions(self) -> list[ActionMetadata]:
-        """Generate a list of available Mistral models.
+        """Generate a list of available Mistral models and embedders.
 
         Returns:
             list[ActionMetadata]: A list of ActionMetadata objects for each
-                supported Mistral model, including name, metadata, and config schema.
+                supported Mistral model and embedder.
         """
-        actions_list = []
+        actions_list: list[ActionMetadata] = []
+
         for model, model_info in SUPPORTED_MISTRAL_MODELS.items():
+            # Skip embedding models from the model list — they're listed separately.
+            if model in _EMBEDDING_MODEL_NAMES:
+                continue
             actions_list.append(
                 model_action_metadata(
                     name=mistral_name(model), info=model_info.model_dump(), config_schema=MistralConfig
+                )
+            )
+
+        for embed_model, embed_info in SUPPORTED_EMBEDDING_MODELS.items():
+            actions_list.append(
+                embedder_action_metadata(
+                    name=mistral_name(embed_model),
+                    options=EmbedderOptions(
+                        label=embed_info['label'],
+                        supports=EmbedderSupports(input=embed_info['supports']['input']),
+                        dimensions=embed_info.get('dimensions'),
+                    ),
                 )
             )
 

--- a/py/plugins/mistral/tests/mistral_embeddings_test.py
+++ b/py/plugins/mistral/tests/mistral_embeddings_test.py
@@ -1,0 +1,215 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Mistral AI embeddings integration."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genkit.blocks.document import Document
+from genkit.blocks.embedding import EmbedRequest
+from genkit.core.action.types import ActionKind
+from genkit.plugins.mistral import Mistral
+from genkit.plugins.mistral.embeddings import (
+    SUPPORTED_EMBEDDING_MODELS,
+    MistralEmbedConfig,
+    MistralEmbedder,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for MistralEmbedder
+# ---------------------------------------------------------------------------
+
+
+def _make_embed_request(texts: list[str]) -> EmbedRequest:
+    """Helper to build an EmbedRequest from a list of strings."""
+    docs = [Document.from_text(t) for t in texts]
+    return EmbedRequest(input=docs)
+
+
+@pytest.mark.asyncio
+async def test_embedder_embed_single_text() -> None:
+    """Test embedding a single text document."""
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_item = MagicMock()
+    mock_item.embedding = [0.1, 0.2, 0.3]
+    mock_response.data = [mock_item]
+    mock_client.embeddings.create_async = AsyncMock(return_value=mock_response)
+
+    embedder = MistralEmbedder(model='mistral-embed', client=mock_client)
+    request = _make_embed_request(['Hello world'])
+    response = await embedder.embed(request)
+
+    mock_client.embeddings.create_async.assert_called_once_with(
+        model='mistral-embed',
+        inputs=['Hello world'],
+    )
+    assert len(response.embeddings) == 1
+    assert response.embeddings[0].embedding == [0.1, 0.2, 0.3]
+
+
+@pytest.mark.asyncio
+async def test_embedder_embed_multiple_texts() -> None:
+    """Test embedding multiple text documents in a single call."""
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_item1 = MagicMock()
+    mock_item1.embedding = [0.1, 0.2]
+    mock_item2 = MagicMock()
+    mock_item2.embedding = [0.3, 0.4]
+    mock_response.data = [mock_item1, mock_item2]
+    mock_client.embeddings.create_async = AsyncMock(return_value=mock_response)
+
+    embedder = MistralEmbedder(model='mistral-embed', client=mock_client)
+    request = _make_embed_request(['Hello', 'World'])
+    response = await embedder.embed(request)
+
+    assert len(response.embeddings) == 2
+    assert response.embeddings[0].embedding == [0.1, 0.2]
+    assert response.embeddings[1].embedding == [0.3, 0.4]
+
+
+@pytest.mark.asyncio
+async def test_embedder_passes_options() -> None:
+    """Test that embedding options are forwarded to the API call."""
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_item = MagicMock()
+    mock_item.embedding = [0.5]
+    mock_response.data = [mock_item]
+    mock_client.embeddings.create_async = AsyncMock(return_value=mock_response)
+
+    embedder = MistralEmbedder(model='mistral-embed', client=mock_client)
+    request = _make_embed_request(['Test'])
+    request.options = {
+        'output_dimension': 512,
+        'output_dtype': 'float',
+        'encoding_format': 'float',
+    }
+    await embedder.embed(request)
+
+    mock_client.embeddings.create_async.assert_called_once_with(
+        model='mistral-embed',
+        inputs=['Test'],
+        output_dimension=512,
+        output_dtype='float',
+        encoding_format='float',
+    )
+
+
+@pytest.mark.asyncio
+async def test_embedder_empty_options() -> None:
+    """Test embedding with no options passes no extra kwargs."""
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.data = []
+    mock_client.embeddings.create_async = AsyncMock(return_value=mock_response)
+
+    embedder = MistralEmbedder(model='mistral-embed', client=mock_client)
+    request = _make_embed_request([])
+    await embedder.embed(request)
+
+    mock_client.embeddings.create_async.assert_called_once_with(
+        model='mistral-embed',
+        inputs=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for MistralEmbedConfig
+# ---------------------------------------------------------------------------
+
+
+def test_embed_config_defaults() -> None:
+    """Test MistralEmbedConfig has sensible defaults."""
+    config = MistralEmbedConfig()
+    assert config.output_dimension is None
+    assert config.output_dtype is None
+    assert config.encoding_format is None
+
+
+def test_embed_config_with_values() -> None:
+    """Test MistralEmbedConfig accepts valid values."""
+    config = MistralEmbedConfig(
+        output_dimension=512,
+        output_dtype='int8',
+        encoding_format='base64',
+    )
+    assert config.output_dimension == 512
+    assert config.output_dtype == 'int8'
+    assert config.encoding_format == 'base64'
+
+
+# ---------------------------------------------------------------------------
+# Plugin integration tests for embedder
+# ---------------------------------------------------------------------------
+
+
+@patch('genkit.plugins.mistral.models.MistralClient')
+@pytest.mark.asyncio
+async def test_plugin_resolve_embedder_action(mock_client: MagicMock) -> None:
+    """Test plugin resolves embedder actions for mistral-embed."""
+    plugin = Mistral(api_key='test-key')
+    action = await plugin.resolve(ActionKind.EMBEDDER, 'mistral/mistral-embed')
+
+    assert action is not None
+    assert action.kind == ActionKind.EMBEDDER
+    assert action.name == 'mistral/mistral-embed'
+
+
+@patch('genkit.plugins.mistral.models.MistralClient')
+@pytest.mark.asyncio
+async def test_plugin_resolve_embedder_rejects_chat_models(mock_client: MagicMock) -> None:
+    """Test plugin does not resolve chat models as embedders."""
+    plugin = Mistral(api_key='test-key')
+    action = await plugin.resolve(ActionKind.EMBEDDER, 'mistral/mistral-large-latest')
+    assert action is None
+
+
+@patch('genkit.plugins.mistral.models.MistralClient')
+@pytest.mark.asyncio
+async def test_plugin_resolve_model_rejects_embedder(mock_client: MagicMock) -> None:
+    """Test plugin does not resolve mistral-embed as a chat model."""
+    plugin = Mistral(api_key='test-key')
+    action = await plugin.resolve(ActionKind.MODEL, 'mistral/mistral-embed')
+    assert action is None
+
+
+@pytest.mark.asyncio
+async def test_plugin_list_actions_includes_embedders() -> None:
+    """Test list_actions includes both models and embedders."""
+    plugin = Mistral(api_key='test-key')
+    actions = await plugin.list_actions()
+
+    action_names = [a.name for a in actions]
+    assert 'mistral/mistral-embed' in action_names
+    assert 'mistral/mistral-large-latest' in action_names
+
+    # Embedder should appear exactly once and not also as a model.
+    embed_actions = [a for a in actions if a.name == 'mistral/mistral-embed']
+    assert len(embed_actions) == 1
+    assert embed_actions[0].kind == ActionKind.EMBEDDER
+
+
+def test_supported_embedding_models_metadata() -> None:
+    """Test SUPPORTED_EMBEDDING_MODELS has required fields."""
+    for name, info in SUPPORTED_EMBEDDING_MODELS.items():
+        assert 'label' in info, f'Embedding model {name} missing label'
+        assert 'dimensions' in info, f'Embedding model {name} missing dimensions'
+        assert 'supports' in info, f'Embedding model {name} missing supports'
+        assert 'input' in info['supports'], f'Embedding model {name} missing supports.input'

--- a/py/plugins/mistral/tests/mistral_plugin_test.py
+++ b/py/plugins/mistral/tests/mistral_plugin_test.py
@@ -30,6 +30,7 @@ from genkit.plugins.mistral import (
     Mistral,
     mistral_name,
 )
+from genkit.plugins.mistral.embeddings import SUPPORTED_EMBEDDING_MODELS
 from genkit.plugins.mistral.model_info import get_default_model_info
 
 
@@ -110,14 +111,17 @@ async def test_plugin_resolve_non_model_returns_none(mock_client: MagicMock) -> 
 
 @pytest.mark.asyncio
 async def test_plugin_list_actions() -> None:
-    """Test plugin lists supported models."""
+    """Test plugin lists supported models and embedders."""
     plugin = Mistral(api_key='test-key')
     actions = await plugin.list_actions()
 
-    assert len(actions) == len(SUPPORTED_MISTRAL_MODELS)
+    # Total = (chat models - embedding models) + embedding models.
+    expected_count = len(SUPPORTED_MISTRAL_MODELS) - len(SUPPORTED_EMBEDDING_MODELS) + len(SUPPORTED_EMBEDDING_MODELS)
+    assert len(actions) == expected_count
     action_names = [action.name for action in actions]
     assert 'mistral/mistral-large-latest' in action_names
     assert 'mistral/mistral-small-latest' in action_names
+    assert 'mistral/mistral-embed' in action_names
 
 
 def test_supported_models_have_required_fields() -> None:

--- a/py/samples/mistral-hello/README.md
+++ b/py/samples/mistral-hello/README.md
@@ -64,7 +64,10 @@ genkit start -- uv run src/main.py
 5. **Test chat**:
    - [ ] `chat_flow` - Multi-turn conversation
 
-6. **Expected behavior**:
+6. **Test embeddings**:
+   - [ ] `embed_flow` - Generate embeddings using mistral-embed
+
+7. **Expected behavior**:
    - mistral-small: Fast, capable responses
    - mistral-large: More detailed, nuanced responses
    - codestral: High-quality code generation
@@ -78,3 +81,4 @@ genkit start -- uv run src/main.py
 | `codestral-latest` | Code generation and explanation |
 | `pixtral-large-latest` | Vision tasks (image understanding) |
 | `ministral-8b-latest` | Edge deployment, resource-constrained |
+| `mistral-embed` | Text embeddings for search and RAG |


### PR DESCRIPTION
## Summary

Adds embedder support to the Mistral AI plugin, enabling text embeddings via the `mistral-embed` model (1024-dimensional vectors).

## Changes

- **New `embeddings.py` module**: `MistralEmbedder` class wraps `embeddings.create_async` API
- **`MistralEmbedConfig`**: Configuration model with `output_dimension`, `output_dtype`, `encoding_format` options
- **Plugin routing**: `resolve()` now routes `ActionKind.EMBEDDER` to the embedder factory
- **Exclusive resolution**: Embedding models excluded from `ActionKind.MODEL` (and vice versa)
- **`list_actions()`**: Returns both model and embedder metadata
- **Shared client**: Lazy-initialized `MistralClient` reused across embedder instances
- **Full test coverage**: Unit tests for embedder, config, and plugin integration (39 tests, all passing)

## Supported Models

| Model | Dimensions | Description |
|-------|-----------|-------------|
| `mistral-embed` | 1024 | Text embeddings for RAG, search, and similarity |

## Usage

```python
from genkit import Genkit
from genkit.plugins.mistral import Mistral

ai = Genkit(plugins=[Mistral()])

# Create embeddings
embeddings = await ai.embed(
    embedder='mistral/mistral-embed',
    content=['Hello world', 'Semantic search'],
)
```

## Priority

P1 from the plugin conformance roadmap.