### PR TITLE
feat(py/samples): add code_flow to all hello samples

### DIFF
--- a/py/samples/amazon-bedrock-hello/src/main.py
+++ b/py/samples/amazon-bedrock-hello/src/main.py
@@ -60,6 +60,7 @@ Key Features
 | Generation with Tools                   | `weather_flow`, `currency_exchange` |
 | Generation Configuration (temperature)  | `say_hi_with_config`                |
 | Multimodal (Image Input)                | `describe_image`                    |
+| Code Generation                         | `code_flow`                         |
 | Embeddings                              | `embed_text`                        |
 
 Supported Models
@@ -233,6 +234,15 @@ class ReasoningInput(BaseModel):
     question: str = Field(
         default='What is 15% of 240? Show your work step by step.',
         description='Question requiring reasoning',
+    )
+
+
+class CodeInput(BaseModel):
+    """Input for code generation flow."""
+
+    task: str = Field(
+        default='Write a Python function to calculate fibonacci numbers',
+        description='Coding task description',
     )
 
 
@@ -479,6 +489,23 @@ async def reasoning_demo(input: ReasoningInput) -> str:
             'max_tokens': 4096,
             'temperature': 0.5,
         },
+    )
+    return response.text
+
+
+@ai.flow()
+async def code_flow(input: CodeInput) -> str:
+    """Generate code using AWS Bedrock models.
+
+    Args:
+        input: Input with coding task description.
+
+    Returns:
+        Generated code.
+    """
+    response = await ai.generate(
+        prompt=input.task,
+        system='You are an expert programmer. Provide clean, well-documented code with explanations.',
     )
     return response.text
 

--- a/py/samples/anthropic-hello/src/main.py
+++ b/py/samples/anthropic-hello/src/main.py
@@ -62,6 +62,7 @@ Key Features
 | Generation with Tools                   | `weather_flow`, `currency_exchange` |
 | Generation Configuration (temperature)  | `say_hi_with_config`                |
 | Thinking (CoT)                          | `thinking_demo`                     |
+| Code Generation                         | `code_flow`                         |
 | Multimodal (Image Input)                | `describe_image`                    |
 | Prompt Caching                          | `cached_generation`                 |
 | PDF Document Input                      | `analyze_pdf`                       |
@@ -171,6 +172,15 @@ class WeatherFlowInput(BaseModel):
     """Input for weather flow."""
 
     location: str = Field(default='San Francisco', description='Location to get weather for')
+
+
+class CodeInput(BaseModel):
+    """Input for code generation flow."""
+
+    task: str = Field(
+        default='Write a Python function to calculate fibonacci numbers',
+        description='Coding task description',
+    )
 
 
 @ai.tool()
@@ -332,6 +342,23 @@ async def thinking_demo(input: ThinkingInput) -> str:
             'thinking': {'type': 'enabled', 'budget_tokens': 1024},
             'max_output_tokens': 4096,  # Required when thinking is enabled
         },
+    )
+    return response.text
+
+
+@ai.flow()
+async def code_flow(input: CodeInput) -> str:
+    """Generate code using Claude.
+
+    Args:
+        input: Input with coding task description.
+
+    Returns:
+        Generated code.
+    """
+    response = await ai.generate(
+        prompt=input.task,
+        system='You are an expert programmer. Provide clean, well-documented code with explanations.',
     )
     return response.text
 

--- a/py/samples/cloudflare-workers-ai-hello/src/main.py
+++ b/py/samples/cloudflare-workers-ai-hello/src/main.py
@@ -390,6 +390,15 @@ class ConfigDemoInput(BaseModel):
     )
 
 
+class CodeInput(BaseModel):
+    """Input for code generation flow."""
+
+    task: str = Field(
+        default='Write a Python function to calculate fibonacci numbers',
+        description='Coding task description',
+    )
+
+
 @ai.flow()
 async def say_hi_with_config(input: ConfigDemoInput) -> str:
     """Generate text with custom configuration.
@@ -411,6 +420,23 @@ async def say_hi_with_config(input: ConfigDemoInput) -> str:
             repetition_penalty=1.2,  # Discourage repetition
             max_output_tokens=256,
         ),
+    )
+    return response.text
+
+
+@ai.flow()
+async def code_flow(input: CodeInput) -> str:
+    """Generate code using Cloudflare Workers AI models.
+
+    Args:
+        input: Input with coding task description.
+
+    Returns:
+        Generated code.
+    """
+    response = await ai.generate(
+        prompt=input.task,
+        system='You are an expert programmer. Provide clean, well-documented code with explanations.',
     )
     return response.text
 

--- a/py/samples/compat-oai-hello/src/main.py
+++ b/py/samples/compat-oai-hello/src/main.py
@@ -61,6 +61,7 @@ Key Features
 | Tool Response Handling with context                      | `generate_character`                   |
 | Image Generation (DALL-E)                                | `generate_image`                       |
 | Text-to-Speech (TTS)                                     | `text_to_speech`                       |
+| Code Generation                                          | `code_flow`                            |
 | TTS → STT Round-Trip                                     | `round_trip_tts_stt`                   |
 
 See README.md for testing instructions.
@@ -203,6 +204,15 @@ class WeatherFlowInput(BaseModel):
     """Input for weather flow."""
 
     location: str = Field(default='New York', description='Location to get weather for')
+
+
+class CodeInput(BaseModel):
+    """Input for code generation flow."""
+
+    task: str = Field(
+        default='Write a Python function to calculate fibonacci numbers',
+        description='Coding task description',
+    )
 
 
 @ai.tool(description='calculates a gablorken', name='gablorkenTool')
@@ -591,6 +601,23 @@ async def round_trip_tts_stt(input: RoundTripInput) -> str:
         ],
     )
     return stt_response.text
+
+
+@ai.flow()
+async def code_flow(input: CodeInput) -> str:
+    """Generate code using OpenAI models.
+
+    Args:
+        input: Input with coding task description.
+
+    Returns:
+        Generated code.
+    """
+    response = await ai.generate(
+        prompt=input.task,
+        system='You are an expert programmer. Provide clean, well-documented code with explanations.',
+    )
+    return response.text
 
 
 async def main() -> None:

--- a/py/samples/deepseek-hello/src/main.py
+++ b/py/samples/deepseek-hello/src/main.py
@@ -56,6 +56,7 @@ Key Features
 | Generation with Tools                   | `weather_flow`                          |
 | Reasoning Model (deepseek-reasoner)     | `reasoning_flow`                        |
 | Generation with Config                  | `custom_config_flow`                    |
+| Code Generation                         | `code_flow`                             |
 | Multi-turn Chat                         | `chat_flow`                             |
 """
 
@@ -163,6 +164,15 @@ class CustomConfigInput(BaseModel):
     task: str = Field(default='creative', description='Task type: creative, precise, or detailed')
 
 
+class CodeInput(BaseModel):
+    """Input for code generation flow."""
+
+    task: str = Field(
+        default='Write a Python function to calculate fibonacci numbers',
+        description='Coding task description',
+    )
+
+
 @ai.tool()
 def get_weather(input: WeatherInput) -> str:
     """Return a random realistic weather string for a location.
@@ -195,6 +205,25 @@ async def reasoning_flow(input: ReasoningInput) -> str:
     response = await ai.generate(
         model=deepseek_name('deepseek-reasoner'),
         prompt=input.prompt,
+    )
+    return response.text
+
+
+@ai.flow()
+async def code_flow(input: CodeInput) -> str:
+    """Generate code using DeepSeek.
+
+    DeepSeek excels at code generation tasks.
+
+    Args:
+        input: Input with coding task description.
+
+    Returns:
+        Generated code.
+    """
+    response = await ai.generate(
+        prompt=input.task,
+        system='You are an expert programmer. Provide clean, well-documented code with explanations.',
     )
     return response.text
 

--- a/py/samples/google-genai-hello/src/main.py
+++ b/py/samples/google-genai-hello/src/main.py
@@ -76,6 +76,7 @@ Key Features
 | Multi-modal Output Configuration                         | `generate_images`                      |
 | GCP Telemetry (Traces and Metrics)                       | `add_gcp_telemetry()`                  |
 | Thinking Mode (CoT)                                      | `thinking_level_pro`, `thinking_level_flash` |
+| Code Generation                                          | `code_flow`                            |
 | Search Grounding                                         | `search_grounding`                     |
 | URL Context                                              | `url_context`                          |
 | Multimodal Generation (Video input)                      | `youtube_videos`                       |
@@ -228,6 +229,15 @@ class ToolCallingInput(BaseModel):
     """Input for tool calling flow."""
 
     location: str = Field(default='Paris, France', description='Location to get weather for')
+
+
+class CodeInput(BaseModel):
+    """Input for code generation flow."""
+
+    task: str = Field(
+        default='Write a Python function to calculate fibonacci numbers',
+        description='Coding task description',
+    )
 
 
 @ai.tool()
@@ -760,6 +770,23 @@ async def tool_calling(input: ToolCallingInput) -> str:
         tools=['getWeather', 'celsiusToFahrenheit'],
         prompt=f"What's the weather in {input.location}? Convert the temperature to Fahrenheit.",
         config=GenerationCommonConfig(temperature=1),
+    )
+    return response.text
+
+
+@ai.flow()
+async def code_flow(input: CodeInput) -> str:
+    """Generate code using Gemini.
+
+    Args:
+        input: Input with coding task description.
+
+    Returns:
+        Generated code.
+    """
+    response = await ai.generate(
+        prompt=input.task,
+        system='You are an expert programmer. Provide clean, well-documented code with explanations.',
     )
     return response.text
 

--- a/py/samples/google-genai-vertexai-hello/src/main.py
+++ b/py/samples/google-genai-vertexai-hello/src/main.py
@@ -61,6 +61,7 @@ Key Features
 | Structured Output (Schema)                               | `generate_character`                   |
 | Pydantic for Structured Output Schema                    | `RpgCharacter`                         |
 | Unconstrained Structured Output                          | `generate_character_unconstrained`     |
+| Code Generation                                          | `code_flow`                            |
 
 Testing This Demo
 =================
@@ -209,6 +210,15 @@ class ToolsFlowInput(BaseModel):
     """Input for tools flow."""
 
     value: int = Field(default=42, description='Value for gablorken calculation')
+
+
+class CodeInput(BaseModel):
+    """Input for code generation flow."""
+
+    task: str = Field(
+        default='Write a Python function to calculate fibonacci numbers',
+        description='Coding task description',
+    )
 
 
 @ai.tool()
@@ -449,6 +459,23 @@ async def simple_generate_with_tools_flow(input: ToolsFlowInput) -> str:
     response = await ai.generate(
         prompt=f'what is a gablorken of {input.value}',
         tools=['gablorkenTool'],
+    )
+    return response.text
+
+
+@ai.flow()
+async def code_flow(input: CodeInput) -> str:
+    """Generate code using Vertex AI Gemini.
+
+    Args:
+        input: Input with coding task description.
+
+    Returns:
+        Generated code.
+    """
+    response = await ai.generate(
+        prompt=input.task,
+        system='You are an expert programmer. Provide clean, well-documented code with explanations.',
     )
     return response.text
 

--- a/py/samples/huggingface-hello/src/main.py
+++ b/py/samples/huggingface-hello/src/main.py
@@ -60,6 +60,7 @@ Key Features
 | Streaming Response                      | `streaming_flow`                        |
 | Different Models                        | `llama_flow`, `qwen_flow`               |
 | Generation with Config                  | `custom_config_flow`                    |
+| Code Generation                         | `code_flow`                             |
 | Multi-turn Chat                         | `chat_flow`                             |
 | Tool Calling                            | `weather_flow`                          |
 | Structured Output (JSON)                | `generate_character`                    |
@@ -132,6 +133,15 @@ class CharacterInput(BaseModel):
     """Input for character generation."""
 
     name: str = Field(default='Luna', description='Character name')
+
+
+class CodeInput(BaseModel):
+    """Input for code generation flow."""
+
+    task: str = Field(
+        default='Write a Python function to calculate fibonacci numbers',
+        description='Coding task description',
+    )
 
 
 class Skills(BaseModel):
@@ -409,6 +419,23 @@ async def generate_character(input: CharacterInput) -> RpgCharacter:
         output=Output(schema=RpgCharacter),
     )
     return result.output
+
+
+@ai.flow()
+async def code_flow(input: CodeInput) -> str:
+    """Generate code using Hugging Face models.
+
+    Args:
+        input: Input with coding task description.
+
+    Returns:
+        Generated code.
+    """
+    response = await ai.generate(
+        prompt=input.task,
+        system='You are an expert programmer. Provide clean, well-documented code with explanations.',
+    )
+    return response.text
 
 
 async def main() -> None:

--- a/py/samples/microsoft-foundry-hello/src/main.py
+++ b/py/samples/microsoft-foundry-hello/src/main.py
@@ -58,6 +58,7 @@ Key Features
 | Streaming Generation             | `say_hi_stream`                   |
 | Generation with Tools            | `weather_flow`                    |
 | Generation Configuration         | `say_hi_with_config`              |
+| Code Generation                  | `code_flow`                       |
 | Multimodal (Image Input)         | `describe_image`                  |
 
 Endpoint Types
@@ -215,6 +216,15 @@ class ImageDescribeInput(BaseModel):
     )
 
 
+class CodeInput(BaseModel):
+    """Input for code generation flow."""
+
+    task: str = Field(
+        default='Write a Python function to calculate fibonacci numbers',
+        description='Coding task description',
+    )
+
+
 @ai.flow()
 async def say_hi(input: SayHiInput) -> str:
     """Generate a simple greeting.
@@ -307,6 +317,23 @@ async def say_hi_with_config(input: SayHiInput) -> str:
             'max_tokens': 50,
             'frequency_penalty': 0.5,
         },
+    )
+    return response.text
+
+
+@ai.flow()
+async def code_flow(input: CodeInput) -> str:
+    """Generate code using Microsoft Foundry models.
+
+    Args:
+        input: Input with coding task description.
+
+    Returns:
+        Generated code.
+    """
+    response = await ai.generate(
+        prompt=input.task,
+        system='You are an expert programmer. Provide clean, well-documented code with explanations.',
     )
     return response.text
 

--- a/py/samples/ollama-hello/src/main.py
+++ b/py/samples/ollama-hello/src/main.py
@@ -59,6 +59,7 @@ Key Features
 | Generation with Messages (`Message`, `Role`, `TextPart`) | `say_hi_constrained`                   |
 | Generation with Tools                                    | `calculate_gablorken`                  |
 | Tool Response Handling                                   | `say_hi_constrained`                   |
+| Code Generation                                         | `code_flow`                            |
 """
 
 from typing import Any, cast
@@ -206,6 +207,15 @@ class WeatherFlowInput(BaseModel):
     """Input for weather flow."""
 
     location: str = Field(default='San Francisco', description='Location for weather')
+
+
+class CodeInput(BaseModel):
+    """Input for code generation flow."""
+
+    task: str = Field(
+        default='Write a Python function to calculate fibonacci numbers',
+        description='Coding task description',
+    )
 
 
 @ai.flow()
@@ -395,6 +405,23 @@ async def weather_flow(input: WeatherFlowInput) -> str:
         prompt=f'Use the get_weather tool to tell me the weather in {input.location}',
         model=ollama_name(MISTRAL_MODEL),
         tools=['get_weather'],
+    )
+    return response.text
+
+
+@ai.flow()
+async def code_flow(input: CodeInput) -> str:
+    """Generate code using local Ollama models.
+
+    Args:
+        input: Input with coding task description.
+
+    Returns:
+        Generated code.
+    """
+    response = await ai.generate(
+        prompt=input.task,
+        system='You are an expert programmer. Provide clean, well-documented code with explanations.',
     )
     return response.text
 

--- a/py/samples/xai-hello/src/main.py
+++ b/py/samples/xai-hello/src/main.py
@@ -52,6 +52,7 @@ Key Features
 | Streaming Generation                    | `say_hi_stream`                     |
 | Tool Usage (Decorated)                  | `get_weather`, `calculate`          |
 | Generation Configuration                | `say_hi_with_config`                |
+| Code Generation                         | `code_flow`                         |
 | Tool Calling                            | `weather_flow`                      |
 """
 
@@ -124,6 +125,15 @@ class ConfigInput(BaseModel):
     """Input for config flow."""
 
     name: str = Field(default='Ginger', description='User name for greeting')
+
+
+class CodeInput(BaseModel):
+    """Input for code generation flow."""
+
+    task: str = Field(
+        default='Write a Python function to calculate fibonacci numbers',
+        description='Coding task description',
+    )
 
 
 # Decorated tools
@@ -221,6 +231,23 @@ async def weather_flow(input_data: WeatherInput) -> str:
     Exposes weather logic as a traceable Genkit flow.
     """
     return await weather_logic(ai, input_data)
+
+
+@ai.flow()
+async def code_flow(input: CodeInput) -> str:
+    """Generate code using Grok.
+
+    Args:
+        input: Input with coding task description.
+
+    Returns:
+        Generated code.
+    """
+    response = await ai.generate(
+        prompt=input.task,
+        system='You are an expert programmer. Provide clean, well-documented code with explanations.',
+    )
+    return response.text
 
 
 async def main() -> None:


### PR DESCRIPTION
## Summary

Add a standardized `code_flow` to all hello sample applications to demonstrate code generation capabilities across all supported providers.

## Changes

Each `code_flow` uses the sample's default model with an expert programmer system prompt. A `CodeInput` Pydantic model with a default fibonacci task is added to each sample, following the pattern established in `mistral-hello`.

### Samples Updated (11 total)

| Sample | Provider |
|--------|----------|
| `amazon-bedrock-hello` | AWS Bedrock (Claude) |
| `anthropic-hello` | Anthropic (Claude) |
| `cloudflare-workers-ai-hello` | Cloudflare Workers AI (Llama) |
| `compat-oai-hello` | OpenAI (GPT-4o) |
| `deepseek-hello` | DeepSeek |
| `google-genai-hello` | Google AI (Gemini) |
| `google-genai-vertexai-hello` | Vertex AI (Gemini) |
| `huggingface-hello` | Hugging Face (Mistral) |
| `microsoft-foundry-hello` | Microsoft Foundry (GPT-4o) |
| `ollama-hello` | Ollama (Gemma) |
| `xai-hello` | xAI (Grok) |

## Testing

- `bin/lint` passes with 0 errors
- All ruff checks pass
- All type checks pass (ty, pyrefly, pyright)
