### PR TITLE
feat(py/plugins/mistral): add embeddings support and fix streaming

### DIFF
--- a/py/plugins/mistral/src/genkit/plugins/mistral/models.py
+++ b/py/plugins/mistral/src/genkit/plugins/mistral/models.py
@@ -30,6 +30,7 @@ from mistralai.models import (
     ChatCompletionChoice,
     ChatCompletionResponse,
     CompletionChunk,
+    CompletionEvent,
     Function,
     FunctionCall,
     SystemMessage,
@@ -416,9 +417,10 @@ class MistralModel:
         # Track tool calls being streamed (by index)
         tool_calls: dict[int, dict[str, Any]] = {}
 
-        stream: AsyncIterator[CompletionChunk] = await self.client.chat.stream_async(**params)
+        stream: AsyncIterator[CompletionEvent] = await self.client.chat.stream_async(**params)
 
-        async for chunk in stream:
+        async for event in stream:
+            chunk: CompletionChunk = event.data
             if chunk.choices:
                 choice = chunk.choices[0]
 


### PR DESCRIPTION
## Summary

Two related fixes for the Mistral AI plugin:

### 1. Embeddings Support (`mistral-embed`)
Adds support for Mistral's embedding model via the `mistral-embed` endpoint. This enables vector embedding generation for use in RAG, semantic search, and clustering workflows.

### 2. Streaming Fix (`CompletionEvent` unwrap)
Fixes an `AttributeError: 'CompletionEvent' object has no attribute 'choices'` in the streaming path. The `mistralai` SDK (v1.0+) wraps `CompletionChunk` objects inside `CompletionEvent.data`. The plugin was accessing `.choices` directly on the event instead of on `.data`.

**Changes:**
- Import `CompletionEvent` from `mistralai.models.completionevent`
- Access `event.data` to get the `CompletionChunk` before reading `.choices`
- Update type hint for the stream iterator to `AsyncIterator[CompletionEvent]`

## Testing

- `bin/lint` passes with 0 errors
- All type checks pass (ty, pyrefly, pyright)
