### PR TITLE
docs(py): add cross-language parity tables for plugins and samples

### DIFF
--- a/py/plugins/README.md
+++ b/py/plugins/README.md
@@ -502,6 +502,72 @@ plugins are independent leaf nodes; only a few have inter-plugin dependencies.
 - **`vertex-ai`** (Model Garden) uses `compat-oai` for third-party model support
 - **`flask`** has a dev dependency on `google-genai` for its sample
 
+## Cross-Language Plugin Coverage
+
+> **Last audited**: 2026-02-07
+
+The table below compares plugin availability across Python and JavaScript SDKs.
+Python currently has **20 plugins** vs JavaScript's **17 plugins**, with broader
+model provider diversity.
+
+### Model Providers
+
+| Plugin | Python | JavaScript | Notes |
+|--------|:------:|:----------:|-------|
+| Google GenAI (Gemini, Imagen, Veo, Lyria) | ✅ | ✅ | |
+| Vertex AI (Model Garden, Vector Search) | ✅ | ✅ | |
+| Anthropic (Claude) | ✅ | ✅ | |
+| Ollama | ✅ | ✅ | |
+| OpenAI-Compatible (compat-oai) | ✅ | ✅ | |
+| Amazon Bedrock | ✅ | — | Python-only; community 🌐 |
+| Microsoft Foundry (Azure AI) | ✅ | — | Python-only; community 🌐 |
+| DeepSeek | ✅ | — | Python-only |
+| xAI (Grok) | ✅ | — | Python-only |
+| Cloudflare Workers AI | ✅ | — | Python-only; community 🌐 |
+| Mistral | ✅ | — | Python-only |
+| HuggingFace | ✅ | — | Python-only |
+
+### Telemetry & Observability
+
+| Plugin | Python | JavaScript | Notes |
+|--------|:------:|:----------:|-------|
+| Google Cloud (Trace, Logging) | ✅ | ✅ | |
+| Firebase | ✅ | ✅ | |
+| Observability (Sentry, Honeycomb, Datadog, Grafana, Axiom) | ✅ | — | Python-only; community 🌐 |
+
+### Integrations
+
+| Plugin | Python | JavaScript | Notes |
+|--------|:------:|:----------:|-------|
+| MCP (Model Context Protocol) | ✅ | ✅ | |
+| Flask | ✅ | — | Python-only |
+| Express | — | ✅ | JS-only |
+| Next.js | — | ✅ | JS-only |
+
+### Vector Stores
+
+| Plugin | Python | JavaScript | Notes |
+|--------|:------:|:----------:|-------|
+| Dev Local Vectorstore | ✅ | ✅ | |
+| Firebase (Firestore vectors) | ✅ | ✅ | |
+| Vertex AI Vector Search | ✅ | ✅ | |
+| Chroma | — | ✅ | JS-only |
+| Pinecone | — | ✅ | JS-only |
+| Cloud SQL PG | — | ✅ | JS-only |
+
+### Safety & Evaluation
+
+| Plugin | Python | JavaScript | Notes |
+|--------|:------:|:----------:|-------|
+| Evaluators (RAGAS) | ✅ | ✅ | |
+| Checks (Content Safety) | ✅ | ✅ | |
+
+### Other
+
+| Plugin | Python | JavaScript | Notes |
+|--------|:------:|:----------:|-------|
+| LangChain | — | ✅ | JS-only |
+
 ## Further Reading
 
 - [Plugin Planning & Roadmap](../engdoc/planning/)

--- a/py/samples/README.md
+++ b/py/samples/README.md
@@ -274,6 +274,78 @@ export AXIOM_TOKEN="xaat-..."
 
 Each sample's README.md contains specific environment requirements.
 
+## Cross-Language Sample Parity
+
+> **Last audited**: 2026-02-07
+
+The table below compares sample coverage across Python and JavaScript SDKs.
+Python currently has **32 samples/testapps** covering more provider diversity
+than JavaScript's **32 testapps + 9 top-level samples**.
+
+### Parity Status
+
+| JS Testapp / Sample | Python Equivalent | Status |
+|---------------------|-------------------|:------:|
+| `basic-gemini` | `provider-google-genai-hello` | ✅ |
+| `anthropic` | `provider-anthropic-hello` | ✅ |
+| `ollama` | `provider-ollama-hello` | ✅ |
+| `compat-oai` | `provider-compat-oai-hello` | ✅ |
+| `prompt-file` | `framework-prompt-demo` | ✅ |
+| `context-caching` | `provider-google-genai-context-caching` | ✅ |
+| `custom-evaluators`, `evals` | `framework-evaluator-demo` | ✅ |
+| `format-tester` | `framework-format-demo` | ✅ |
+| `express` | `web-flask-hello` | ✅ |
+| `vertexai-vector-search-bigquery` | `provider-vertex-ai-vector-search-bigquery` | ✅ |
+| `vertexai-vector-search-firestore` | `provider-vertex-ai-vector-search-firestore` | ✅ |
+| `vertexai-modelgarden` | `provider-vertex-ai-model-garden` | ✅ |
+| `vertexai-reranker` | `provider-vertex-ai-rerank-eval` | ✅ |
+| `menu`, `docs-menu-rag` | `framework-restaurant-demo` | ✅ |
+| `multimodal` | `provider-google-genai-media-models-demo` | ✅ |
+| `mcp` | — | ❌ |
+| `multiagents-demo` | — | ❌ |
+| `rag` | — | ❌ |
+| `dev-ui-gallery` | — | 🟡 |
+| `durable-streaming` | — | 🟡 |
+| `firebase-functions-sample1` | — | 🟡 |
+| `next`, `esm` | — | 🟡 |
+| `model-armor` | — | 🟡 |
+| `model-tester` | — | 🟡 |
+| `js-chatbot`, `js-coffee-shop`, etc. | — | 🟡 |
+
+**Legend**: ✅ = parity achieved, ❌ = gap (should port), 🟡 = low priority or JS-specific
+
+### Python-Only Samples (No JS Equivalent)
+
+Python has significantly broader provider and framework coverage:
+
+| Python Sample | Category |
+|---------------|----------|
+| `provider-amazon-bedrock-hello` | Model provider |
+| `provider-microsoft-foundry-hello` | Model provider |
+| `provider-deepseek-hello` | Model provider |
+| `provider-xai-hello` | Model provider |
+| `provider-cloudflare-workers-ai-hello` | Model provider |
+| `provider-mistral-hello` | Model provider |
+| `provider-huggingface-hello` | Model provider |
+| `provider-observability-hello` | Telemetry (5 backends) |
+| `provider-firestore-retriever` | Vector store |
+| `provider-google-genai-vertexai-image` | Image generation |
+| `framework-middleware-demo` | Framework |
+| `framework-realtime-tracing-demo` | Framework |
+| `framework-context-demo` | Framework |
+| `framework-dynamic-tools-demo` | Framework |
+| `web-multi-server` | Web (Litestar + Starlette) |
+| `web-short-n-long` | Web (ASGI long-running) |
+| `genkit-chat` (testapp) | Full-stack testapp |
+
+### Gaps to Close (Prioritized)
+
+| Priority | Sample to Create | JS Reference | Why |
+|:--------:|------------------|--------------|-----|
+| 🔴 High | `framework-multiagent-demo` | `multiagents-demo` | Multi-agent orchestration with handoffs is a flagship feature |
+| 🟡 Medium | `framework-mcp-demo` | `mcp` | Python has the MCP plugin but no sample demonstrating it |
+| 🟡 Medium | `framework-rag-demo` | `rag` | End-to-end RAG pipeline (index → embed → retrieve → generate) |
+
 ## Creating New Samples
 
 When creating new samples, follow these guidelines:


### PR DESCRIPTION
## Summary

Adds cross-language parity tables to track Python vs JavaScript SDK coverage.

### Changes

**`py/plugins/README.md`** — Plugin coverage comparison:
- 20 Python plugins vs 17 JS plugins
- Category breakdowns: model providers, telemetry, integrations, vector stores, safety
- Highlights Python-only plugins (Bedrock, Azure, DeepSeek, xAI, Cloudflare, Mistral, HuggingFace, Observability)
- Notes JS-only plugins that could be ported (Chroma, Pinecone, Cloud SQL PG, LangChain)

**`py/samples/README.md`** — Sample parity comparison:
- Maps 15 JS testapps to their Python equivalents (all ✅)
- Lists 17 Python-only samples with no JS equivalent
- Identifies 3 gaps to close (prioritized):
  - 🔴 Multi-agent demo (flagship feature)
  - 🟡 MCP demo (plugin exists, no sample)
  - 🟡 RAG pipeline demo (end-to-end)

### Review feedback addressed

- Fixed plugin counts: 20 Python (was 19), 17 JavaScript (was 18)
- Fixed sample count: 32 samples (was 37) — 15 parity + 17 Python-only

### Why

These tables provide a single source of truth for tracking cross-language coverage, making it easy to identify where to invest next and where Python already leads.