### PR TITLE
chore(js/testapps/prompt-file): Fix Google AI provider and model configuration in testapps

### DIFF
--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -1861,9 +1861,9 @@ importers:
 
   testapps/prompt-file:
     dependencies:
-      '@genkit-ai/googleai':
+      '@genkit-ai/google-genai':
         specifier: workspace:*
-        version: link:../../plugins/googleai
+        version: link:../../plugins/google-genai
       genkit:
         specifier: workspace:*
         version: link:../../genkit

--- a/js/testapps/prompt-file/package.json
+++ b/js/testapps/prompt-file/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "dependencies": {
     "genkit": "workspace:*",
-    "@genkit-ai/googleai": "workspace:*"
+    "@genkit-ai/google-genai": "workspace:*"
   },
   "main": "lib/index.js",
   "scripts": {

--- a/js/testapps/prompt-file/prompts/recipe.prompt
+++ b/js/testapps/prompt-file/prompts/recipe.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-pro
+model: googleai/gemini-pro-latest
 input:
   schema:
     food: string

--- a/js/testapps/prompt-file/prompts/recipe.robot.prompt
+++ b/js/testapps/prompt-file/prompts/recipe.robot.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-pro
+model: googleai/gemini-pro-latest
 input:
   schema:
     food: string

--- a/js/testapps/prompt-file/prompts/story.prompt
+++ b/js/testapps/prompt-file/prompts/story.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-pro
+model: googleai/gemini-pro-latest
 input:
   schema:
     subject: string

--- a/js/testapps/prompt-file/src/index.ts
+++ b/js/testapps/prompt-file/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { googleAI } from '@genkit-ai/googleai';
+import { googleAI } from '@genkit-ai/google-genai';
 import { genkit, z } from 'genkit';
 
 const ai = genkit({


### PR DESCRIPTION
Description here... Help the reviewer by:
 - Replaced deprecated `@genkit-ai/googleai` with `@genkit-ai/google-genai` in testapps
 (The deprecated `@genkit-ai/googleai` package fails at runtime (models and embedders) under UI-driven execution)
 - Updated model names referenced in dotprompt files to currently supported Gemini models
 (Model identifiers (e.g. `googleai/gemini-pro`) referenced in .prompt / dotprompt files no longer resolve or function, regardless of which Google AI package is used)

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
