### PR TITLE
fix(py): add dropped_attributes/events/links to RedactedSpan for OTLP export

### DIFF
--- a/py/packages/genkit/src/genkit/core/trace/adjusting_exporter.py
+++ b/py/packages/genkit/src/genkit/core/trace/adjusting_exporter.py
@@ -182,6 +182,24 @@ class RedactedSpan(ReadableSpan):
         """Return the instrumentation scope."""
         return self._span.instrumentation_scope
 
+    @property
+    @override
+    def dropped_attributes(self) -> int:
+        """Return the number of dropped attributes."""
+        return self._span.dropped_attributes
+
+    @property
+    @override
+    def dropped_events(self) -> int:
+        """Return the number of dropped events."""
+        return self._span.dropped_events
+
+    @property
+    @override
+    def dropped_links(self) -> int:
+        """Return the number of dropped links."""
+        return self._span.dropped_links
+
 
 class AdjustingTraceExporter(SpanExporter):
     """Adjusts spans before exporting for PII redaction and enhancement.


### PR DESCRIPTION
## Description

This PR fixes the `AttributeError: 'TimeAdjustedSpan' object has no attribute '_attributes'` crash that occurs when exporting traces via OTLP to backends like AWS X-Ray.

## Root Cause

`RedactedSpan` wraps a `ReadableSpan` without calling `super().__init__()` (intentionally, to avoid duplicating span state). However, three properties in the base `ReadableSpan` class access private instance variables that are only set by `ReadableSpan.__init__()`:

- `dropped_attributes` → accesses `self._attributes`
- `dropped_events` → accesses `self._events`
- `dropped_links` → accesses `self._links`

When the OTLP encoder tries to serialize span metadata, it crashes because these private fields don't exist.

## Fix

Added property overrides to `RedactedSpan` that delegate to the wrapped span:

```python
@property
@override
def dropped_attributes(self) -> int:
    return self._span.dropped_attributes

@property
@override
def dropped_events(self) -> int:
    return self._span.dropped_events

@property
@override
def dropped_links(self) -> int:
    return self._span.dropped_links
```

## Testing

Added 4 new tests to verify the delegation works correctly:
- `test_redacted_span_exposes_dropped_attributes`
- `test_redacted_span_exposes_dropped_events`
- `test_redacted_span_exposes_dropped_links`
- `test_redacted_span_dropped_properties_default_to_zero`

All 18 tests pass.

## Impact

This enables any telemetry plugin that uses `AdjustingTraceExporter` (AWS Bedrock, Google Cloud, etc.) to properly export traces via OTLP without crashing.

Fixes #4493