### PR TITLE
fix(py/samples): guard sentry import, fix dual-trace export, improve dev UX

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -101,6 +101,7 @@ lint = [
   "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
   "opentelemetry-instrumentation-asgi>=0.41b0",
   "opentelemetry-instrumentation-fastapi>=0.41b0",
+  "opentelemetry-instrumentation-grpc>=0.41b0",
   "quart>=0.19.0",
   "secure>=1.0.0",
   "sentry-sdk>=2.0.0",

--- a/py/samples/web-endpoints-hello/justfile
+++ b/py/samples/web-endpoints-hello/justfile
@@ -36,12 +36,8 @@ default:
     @just --list
 
 # Start dev server (auto-starts Jaeger for tracing).
-
-# jaeger.sh handles podman/docker install + machine init if needed.
 dev *ARGS:
-    #!/usr/bin/env bash
-    ./scripts/jaeger.sh start || echo "→ Jaeger skipped (continuing without tracing)"
-    ./run.sh --otel-endpoint http://localhost:{{ JAEGER_OTLP_PORT }} {{ ARGS }}
+    ./run.sh {{ ARGS }}
 
 # Start with Litestar and hot reload.
 dev-litestar *ARGS:

--- a/py/samples/web-endpoints-hello/pyproject.toml
+++ b/py/samples/web-endpoints-hello/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
   "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
   "opentelemetry-instrumentation-fastapi>=0.41b0",
   "opentelemetry-instrumentation-asgi>=0.41b0",
+  "opentelemetry-instrumentation-grpc>=0.41b0",
   # OSS security headers — tracks OWASP recommendations automatically.
   "secure>=1.0.0",
 ]

--- a/py/samples/web-endpoints-hello/src/grpc_server.py
+++ b/py/samples/web-endpoints-hello/src/grpc_server.py
@@ -49,6 +49,7 @@ from typing import Any
 import grpc
 import structlog
 from grpc_reflection.v1alpha import reflection
+from opentelemetry.instrumentation.grpc import GrpcAioInstrumentorServer
 
 from .flows import (
     describe_image,
@@ -281,6 +282,11 @@ async def serve_grpc(
             grpcurl).  Must be ``False`` in production — reflection
             exposes the full API schema to unauthenticated clients.
     """
+    # Auto-instrument gRPC with OpenTelemetry semantic conventions.
+    # Adds rpc.system, rpc.service, rpc.method span attributes so gRPC
+    # traces are clearly distinguishable from REST traces in Jaeger.
+    GrpcAioInstrumentorServer().instrument()  # pyrefly: ignore[missing-attribute] — incomplete type stubs
+
     interceptors = [
         GrpcLoggingInterceptor(),
         GrpcRateLimitInterceptor(rate=rate_limit),

--- a/py/samples/web-endpoints-hello/src/schemas.py
+++ b/py/samples/web-endpoints-hello/src/schemas.py
@@ -51,6 +51,16 @@ class TranslateInput(BaseModel):
     """Input for the translation endpoint."""
 
     text: str = Field(
+        default=(
+            "The Northern Lights, or Aurora Borealis, are one of nature's most "
+            "spectacular displays. Charged particles from the Sun collide with "
+            "gases in Earth's atmosphere, creating shimmering curtains of green, "
+            "pink, and violet light that dance across the polar sky. For centuries, "
+            "cultures around the world have woven myths and legends around these "
+            "ethereal lights — the Vikings believed they were reflections of the "
+            "Valkyries' armor, while the Sámi people considered them the energies "
+            "of departed souls."
+        ),
         description="Text to translate",
         min_length=1,
         max_length=10_000,

--- a/py/samples/web-endpoints-hello/src/sentry_init.py
+++ b/py/samples/web-endpoints-hello/src/sentry_init.py
@@ -45,8 +45,12 @@ Usage::
 
 from __future__ import annotations
 
+import typing
+
 import structlog
-from sentry_sdk.integrations import Integration
+
+if typing.TYPE_CHECKING:
+    from sentry_sdk.integrations import Integration
 
 logger = structlog.get_logger(__name__)
 

--- a/py/samples/web-endpoints-hello/tests/schemas_test.py
+++ b/py/samples/web-endpoints-hello/tests/schemas_test.py
@@ -70,8 +70,9 @@ def test_joke_input_accepts_valid_name() -> None:
 
 
 def test_translate_input_defaults() -> None:
-    """TranslateInput requires text and has a default language."""
-    inp = TranslateInput(text="Hello")
+    """TranslateInput has default text and default language."""
+    inp = TranslateInput()
+    assert "Northern Lights" in inp.text
     assert inp.target_language == "French"
 
 

--- a/py/samples/web-endpoints-hello/tests/sentry_init_test.py
+++ b/py/samples/web-endpoints-hello/tests/sentry_init_test.py
@@ -25,10 +25,24 @@ Run with::
     uv run pytest tests/sentry_init_test.py -v
 """
 
+import importlib
 import sys
 from unittest.mock import MagicMock, patch
 
+from src import sentry_init
 from src.sentry_init import _build_integrations, setup_sentry  # noqa: PLC2701 — testing internal helper
+
+
+def test_module_importable_without_sentry_sdk() -> None:
+    """Regression: sentry_init must load when sentry-sdk is absent.
+
+    The TYPE_CHECKING guard on the ``Integration`` import means the
+    module should reload cleanly even when ``sentry_sdk`` is not
+    installed.  This test prevents a future change from accidentally
+    moving that import back to the top level.
+    """
+    with patch.dict(sys.modules, {"sentry_sdk": None, "sentry_sdk.integrations": None}):
+        importlib.reload(sentry_init)
 
 
 def test_setup_sentry_empty_dsn_returns_false() -> None:

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -2558,6 +2558,7 @@ lint = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-instrumentation-asgi" },
     { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-grpc" },
     { name = "pip-audit" },
     { name = "pydantic-settings" },
     { name = "pypdf" },
@@ -2638,6 +2639,7 @@ lint = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20.0" },
     { name = "opentelemetry-instrumentation-asgi", specifier = ">=0.41b0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.41b0" },
+    { name = "opentelemetry-instrumentation-grpc", specifier = ">=0.41b0" },
     { name = "pip-audit", specifier = ">=2.7.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pypdf", specifier = ">=6.6.2" },
@@ -5557,6 +5559,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9c/e7/e7e5e50218cf488377209d85666b182fa2d4928bf52389411ceeee1b2b60/opentelemetry_instrumentation_fastapi-0.60b1.tar.gz", hash = "sha256:de608955f7ff8eecf35d056578346a5365015fd7d8623df9b1f08d1c74769c01", size = 24958, upload-time = "2025-12-11T13:36:59.35Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/cc/6e808328ba54662e50babdcab21138eae4250bc0fddf67d55526a615a2ca/opentelemetry_instrumentation_fastapi-0.60b1-py3-none-any.whl", hash = "sha256:af94b7a239ad1085fc3a820ecf069f67f579d7faf4c085aaa7bd9b64eafc8eaf", size = 13478, upload-time = "2025-12-11T13:36:00.811Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-grpc"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/00/f59a3a99709f340a5564c200b79ce48d3bb9d1ac9596208d3c4cdb00f82f/opentelemetry_instrumentation_grpc-0.60b1.tar.gz", hash = "sha256:049573ddfe4c32af151348d2dbeddaaca788a57c320e70770ec216b7e35ccfd4", size = 31426, upload-time = "2025-12-11T13:37:00.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/e7/75ed12f331f4fdca3a81c4dfd32c21255d981d1fcc883b476b4c14360efd/opentelemetry_instrumentation_grpc-0.60b1-py3-none-any.whl", hash = "sha256:f7a81a87b2a26842fc62cba0743a475f151e77eb21d5b93902fbfd0518a7cca7", size = 27234, upload-time = "2025-12-11T13:36:03.267Z" },
 ]
 
 [[package]]
@@ -8876,6 +8893,7 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-asgi" },
     { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-grpc" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic-settings" },
     { name = "quart" },
@@ -8958,6 +8976,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-asgi", specifier = ">=0.41b0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.41b0" },
     { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'test'", specifier = ">=0.41b0" },
+    { name = "opentelemetry-instrumentation-grpc", specifier = ">=0.41b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'test'", specifier = ">=1.20.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7.0" },


### PR DESCRIPTION
## Summary

<img width="1920" height="736" alt="Screenshot 2026-02-08 at 1 31 28 AM" src="https://github.com/user-attachments/assets/66ccfe43-82e8-4390-a6a1-debe15c24451" />
<img width="1654" height="1135" alt="Screenshot 2026-02-08 at 1 32 04 AM" src="https://github.com/user-attachments/assets/47d5081e-ed49-4638-90ff-e4f1479f2463" />
<img width="1906" height="1098" alt="Screenshot 2026-02-08 at 1 32 46 AM" src="https://github.com/user-attachments/assets/bba64b83-1b07-4145-b812-4cfcacf13351" />

<img width="1916" height="872" alt="Screenshot 2026-02-08 at 1 48 49 AM" src="https://github.com/user-attachments/assets/f2086377-fdc2-42fe-8055-6b5cb032ebf8" />


Fixes and improvements for the `web-endpoints-hello` sample and `_common.sh`.

### 1. Guard sentry_sdk import behind `TYPE_CHECKING`

The top-level `from sentry_sdk.integrations import Integration` causes
`ModuleNotFoundError` when `sentry-sdk` is not installed.

### 2. Fix dual-trace export (DevUI + Jaeger)

Uses `genkit.core.tracing.add_custom_exporter()` to attach the OTLP
exporter to Genkit's existing `TracerProvider`. Both DevUI and Jaeger
receive spans simultaneously. Sets `OTEL_SERVICE_NAME` env var in
`run.sh` so traces show the correct service name.

### 3. Move Jaeger auto-start into `run.sh`

`run.sh` now handles Jaeger start + `--otel-endpoint` (previously only
`just dev` did this). `just dev` simplified to call `./run.sh`.

### 4. gRPC OTel instrumentation

Added `opentelemetry-instrumentation-grpc` for auto-instrumentation of
gRPC spans with OTel semantic conventions (`rpc.system`, `rpc.service`,
`rpc.method`). gRPC and REST traces are distinguishable in Jaeger
by filtering on these attributes.

### 5. Robust CLI installers in `_common.sh`

- **AWS CLI**: checks for `unzip` on Linux and installs it via
  apt-get/dnf/yum if missing.
- **Azure CLI**: detects Linux distro via `/etc/os-release` and uses
  the appropriate installer (Debian/Ubuntu, Fedora/RHEL, or pip fallback).

### 6. Rich default text for `translate_text` flow

`TranslateInput.text` defaults to a paragraph about the Northern Lights.

## Files changed

| File | Change |
|------|--------|
| `src/sentry_init.py` | Guard import behind `TYPE_CHECKING` |
| `src/telemetry.py` | Rewrite to use `add_custom_exporter` |
| `src/grpc_server.py` | Add `GrpcAioInstrumentorServer` instrumentation |
| `src/schemas.py` | Add default text for translate flow |
| `run.sh` | Jaeger auto-start + `OTEL_SERVICE_NAME` |
| `justfile` | Simplify `dev` to call `run.sh` |
| `pyproject.toml` | Add `opentelemetry-instrumentation-grpc` dep |
| `tests/telemetry_otel_test.py` | Update tests for new telemetry API |
| `tests/schemas_test.py` | Update test for new default |
| `py/pyproject.toml` | Add grpc instrumentation to lint deps |
| `py/samples/_common.sh` | Fix unzip dep + Azure distro detection |

## Testing

- All 363 sample tests pass
- `bin/lint` and `just lint` pass with 0 errors