### PR TITLE
docs(py): add feature parity audit with implementation gap analysis and roadmap

### DIFF
--- a/py/PARITY_AUDIT.md
+++ b/py/PARITY_AUDIT.md
@@ -482,7 +482,7 @@ Full plugin list from the repository README (10 plugins, 33 contributors, 54 rel
 | Gap ID | SDK | Work Item | Reference | Status |
 |--------|-----|-----------|-----------|:------:|
 | G2 → G1 | Python | Add `middleware` storage to `Action`, then add `use=` to `define_model` | §8b.1 | ⬜ |
-| G7 | Python | Wire DAP action discovery into `GET /api/actions` | §8a, §8c.5 | ⬜ |
+| G7 | Python | Wire DAP action discovery into `GET /api/actions` | §8a, §8c.5 | ⏳ Deferred |
 | G6 → G5 | Python | Pass `span_id` in `on_trace_start`, send `X-Genkit-Span-Id` | §8c.3, §8c.4 | ⬜ |
 | G3 | Python | Implement `simulate_constrained_generation` middleware | §8b.3, §8f | ⬜ |
 | G12 | Python | Implement `retry` middleware | §8f | ⬜ |
@@ -499,8 +499,8 @@ Full plugin list from the repository README (10 plugins, 33 contributors, 54 rel
 | G9 | Python | Add Pinecone vector store plugin | §5g | ⬜ |
 | G10 | Python | Add ChromaDB vector store plugin | §5g | ⬜ |
 | G30 | Python | Add Cloud SQL PG vector store parity | §5g | ⬜ |
-| G31 | Python | Add dedicated Python MCP parity sample | §2b/§9 | ⬜ |
-| G8 | Python | Implement `genkit.client` (`run_flow` / `stream_flow`) | §5c/§9 | ⬜ |
+| G31 | Python | Add dedicated Python MCP parity sample | §2b/§9 | ⏳ Deferred |
+| G8 | Python | Implement `genkit.client` (`run_flow` / `stream_flow`) | §5c/§9 | ⏳ Deferred |
 | G17 | Python | Add built-in `api_key()` context provider | §8g | ⬜ |
 | G11 | Python | Add `CHANGELOG.md` to plugins + core | §3c | ⬜ |
 | G33 | Python | Consider LangChain integration parity | §1c/§9 | ⬜ |


### PR DESCRIPTION
## Summary

Adds a comprehensive **feature parity audit** (`py/PARITY_AUDIT.md`) comparing the Python SDK against the canonical JS implementation and the Go SDK. This is a living reference document for tracking implementation gaps, prioritizing work, and coordinating cross-SDK parity efforts.

**Current focus: Python SDK parity.** Go parity work is tracked but deferred to a future effort.

## What's in the audit

### 1. Plugin Parity Matrix (§1)
- **In-tree plugin coverage**: JS (18), Go (16), Python (20) — with per-plugin comparison table
- **External ecosystem**: Full inventory of `genkit-ai` org repos (14) and BloomLabs community plugins (10)
- **Gap table**: Identifies missing Python plugins (Pinecone, ChromaDB, Cloud SQL PG vector stores)

### 2. Sample Parity Matrix (§2)
- Sample counts: JS (32 testapps), Go (37), Python (37 runnable)
- Area-by-area parity assessment (providers, core patterns, MCP, web frameworks, streaming)

### 3. OSS Compliance Audit (§3)
- Per-plugin compliance check: LICENSE, README, pyproject.toml, CHANGELOG, py.typed, tests
- Identifies **21 missing `CHANGELOG.md`** files across all plugins + core package
- Documents recently fixed gaps (py.typed, LICENSE)

### 4. Test Coverage Summary (§4)
- 95 total test files across core + 20 plugins
- Identifies 13 plugins needing test coverage uplift (from "Minimum" 1 file to comprehensive 4+ files)

### 5. Core Framework API Comparison (§5)
- **Define/Registration APIs**: 23 APIs compared across JS/Go/Python
- **Invoke/Runtime APIs**: 14 APIs compared
- **Client helpers**: `runFlow`/`streamFlow` missing in both Go and Python
- **Core infrastructure**: 18 modules compared
- **AI blocks**: 16 building blocks compared
- **Output formats**: Full parity (JSON, JSONL, Array, Enum, Text)
- **Cross-SDK gap table**: 27 specific gaps with priority levels and gap owners

### 6. Community & External Ecosystem (§6)
- Full `genkit-ai` org repository inventory (14 repos)
- BloomLabs plugin coverage analysis (3/6 model providers covered, 0/3 vector stores)

### 7. Action Items (§7)
- **37 tracked gaps** (G1–G37) with priority levels: 13 P1, 16 P2, 8 P3
- Python roadmap (G1–G22, G30–G37) is the active focus
- Go roadmap (G23–G29) is tracked but deferred

### 8. Deep Dive Feature Comparison (§8)
Line-level tracing against JS canonical implementation for:
- **Dynamic Action Providers (DAP)**: Discovery gap — Python's reflection API doesn't query DAPs
- **Model Middleware Architecture**: JS has two-layer dispatch (call-time + model-level); Python has single-layer — 6 of 7 built-in middleware functions missing
- **Reflection Server Wire Protocol**: Mostly aligned, but `X-Genkit-Span-Id` header not sent, `on_trace_start` callback lacks `span_id`
- **Flow Invocation Client**: Missing `run_flow`/`stream_flow` helpers
- **Multipart Tools**: `tool.v2` type not implemented
- **Model API V2**: New streaming interface not implemented
- **Genkit Constructor**: 3 parameters missing (`context`, `clientHeader`, `name`)

### 9. Prioritized Gap Register (§9)
- **37 implementation-ready gap entries** with: primary files to touch, fast validation criteria
- **Dependency matrix**: Which gaps block which
- **6 fast-close bundles** (B1–B6) for coordinated execution

### 10. Implementation Roadmap — Python SDK (§10)
- **Dependency DAG**: Full prerequisite graph with visual ASCII art
- **Topological sort**: 3 dependency levels (L0–L2), critical path: `G2 → G1 → G3`
- **5-phase execution plan** with dependency chains and exit criteria per phase
- **Test coverage uplift plan**: Per-plugin targets with specific test dimensions
- **~31 PRs** broken down by phase with dependency chains

## Key findings

| Metric | Value |
|--------|-------|
| Total tracked gaps | 37 (G1–G37) |
| P1 (release-blocking) | 13 |
| P2 (major parity) | 16 |
| P3 (follow-up) | 8 |
| Critical path length | 3 dependency levels |
| Plugins needing test uplift | 13 of 20 |

## Files changed

| File | Change |
|------|--------|
| `py/PARITY_AUDIT.md` | **New** — 1,537 lines |
