### PR TITLE
chore(py/core): add CHANGELOG.md to core genkit package

### DIFF
--- a/py/packages/genkit/CHANGELOG.md
+++ b/py/packages/genkit/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0


### PR DESCRIPTION
## Summary

Adds a `CHANGELOG.md` to the core `genkit` package (`py/packages/genkit/`) following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Links back to the workspace-level `py/CHANGELOG.md` for detailed release history.

Part of gap G11 from the [parity audit](https://github.com/firebase/genkit/pull/4505).

## Files changed

| File | Change |
|------|--------|
| `py/packages/genkit/CHANGELOG.md` | **New** |
