### PR TITLE
chore(py/plugins): add CHANGELOG.md to all 19 plugins

### DIFF
--- a/py/PARITY_AUDIT.md
+++ b/py/PARITY_AUDIT.md
@@ -502,7 +502,7 @@ Full plugin list from the repository README (10 plugins, 33 contributors, 54 rel
 | G31 | Python | Add dedicated Python MCP parity sample | §2b/§9 | ⏳ Deferred |
 | G8 | Python | Implement `genkit.client` (`run_flow` / `stream_flow`) | §5c/§9 | ⏳ Deferred |
 | G17 | Python | Add built-in `api_key()` context provider | §8g | ⬜ |
-| G11 | Python | Add `CHANGELOG.md` to plugins + core | §3c | ⬜ |
+| G11 | Python | Add `CHANGELOG.md` to plugins + core | §3c | ✅ Done |
 | G33 | Python | Consider LangChain integration parity | §1c/§9 | ⬜ |
 | G34 | Python | Track BloomLabs vector stores (Convex, HNSW, Milvus) | §6b/§9 | ⬜ |
 | G35 | Python | Add Groq provider (or document compat-oai usage) | §1d/§6b | ⬜ |

--- a/py/plugins/amazon-bedrock/CHANGELOG.md
+++ b/py/plugins/amazon-bedrock/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-amazon-bedrock` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/anthropic/CHANGELOG.md
+++ b/py/plugins/anthropic/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-anthropic` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/cloudflare-workers-ai/CHANGELOG.md
+++ b/py/plugins/cloudflare-workers-ai/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-cloudflare-workers-ai` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/compat-oai/CHANGELOG.md
+++ b/py/plugins/compat-oai/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-compat-oai` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/deepseek/CHANGELOG.md
+++ b/py/plugins/deepseek/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-deepseek` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/dev-local-vectorstore/CHANGELOG.md
+++ b/py/plugins/dev-local-vectorstore/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-dev-local-vectorstore` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/evaluators/CHANGELOG.md
+++ b/py/plugins/evaluators/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-evaluators` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/firebase/CHANGELOG.md
+++ b/py/plugins/firebase/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-firebase` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/flask/CHANGELOG.md
+++ b/py/plugins/flask/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-flask` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/google-cloud/CHANGELOG.md
+++ b/py/plugins/google-cloud/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-google-cloud` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/google-genai/CHANGELOG.md
+++ b/py/plugins/google-genai/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-google-genai` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/huggingface/CHANGELOG.md
+++ b/py/plugins/huggingface/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-huggingface` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/mcp/CHANGELOG.md
+++ b/py/plugins/mcp/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-mcp` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/microsoft-foundry/CHANGELOG.md
+++ b/py/plugins/microsoft-foundry/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-microsoft-foundry` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/mistral/CHANGELOG.md
+++ b/py/plugins/mistral/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-mistral` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/observability/CHANGELOG.md
+++ b/py/plugins/observability/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-observability` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/ollama/CHANGELOG.md
+++ b/py/plugins/ollama/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-ollama` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/vertex-ai/CHANGELOG.md
+++ b/py/plugins/vertex-ai/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-vertex-ai` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0

--- a/py/plugins/xai/CHANGELOG.md
+++ b/py/plugins/xai/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to `genkit-plugin-xai` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0]
+
+- See the [workspace CHANGELOG](../../CHANGELOG.md) for a comprehensive list of changes.
+
+[Unreleased]: https://github.com/firebase/genkit/compare/genkit-python@0.5.0...HEAD
+[0.5.0]: https://github.com/firebase/genkit/releases/tag/genkit-python@0.5.0


### PR DESCRIPTION
## Summary

Adds per-plugin `CHANGELOG.md` files to all 19 plugins following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Each links back to the workspace-level `py/CHANGELOG.md` for detailed release history.

Part of gap G11 from the [parity audit](https://github.com/firebase/genkit/pull/4505).

## Files changed (19 new files)

| Plugin | File |
|--------|------|
| `genkit-plugin-amazon-bedrock` | `py/plugins/amazon-bedrock/CHANGELOG.md` |
| `genkit-plugin-anthropic` | `py/plugins/anthropic/CHANGELOG.md` |
| `genkit-plugin-cloudflare-workers-ai` | `py/plugins/cloudflare-workers-ai/CHANGELOG.md` |
| `genkit-plugin-compat-oai` | `py/plugins/compat-oai/CHANGELOG.md` |
| `genkit-plugin-deepseek` | `py/plugins/deepseek/CHANGELOG.md` |
| `genkit-plugin-dev-local-vectorstore` | `py/plugins/dev-local-vectorstore/CHANGELOG.md` |
| `genkit-plugin-evaluators` | `py/plugins/evaluators/CHANGELOG.md` |
| `genkit-plugin-firebase` | `py/plugins/firebase/CHANGELOG.md` |
| `genkit-plugin-flask` | `py/plugins/flask/CHANGELOG.md` |
| `genkit-plugin-google-cloud` | `py/plugins/google-cloud/CHANGELOG.md` |
| `genkit-plugin-google-genai` | `py/plugins/google-genai/CHANGELOG.md` |
| `genkit-plugin-huggingface` | `py/plugins/huggingface/CHANGELOG.md` |
| `genkit-plugin-mcp` | `py/plugins/mcp/CHANGELOG.md` |
| `genkit-plugin-microsoft-foundry` | `py/plugins/microsoft-foundry/CHANGELOG.md` |
| `genkit-plugin-mistral` | `py/plugins/mistral/CHANGELOG.md` |
| `genkit-plugin-observability` | `py/plugins/observability/CHANGELOG.md` |
| `genkit-plugin-ollama` | `py/plugins/ollama/CHANGELOG.md` |
| `genkit-plugin-vertex-ai` | `py/plugins/vertex-ai/CHANGELOG.md` |
| `genkit-plugin-xai` | `py/plugins/xai/CHANGELOG.md` |

**Note**: The `checks` plugin is excluded — it does not have a `pyproject.toml` yet (tracked in a separate PR).
