### PR TITLE
[SUPERSEDED] feat(py): add model middleware parity with JS SDK

### DIFF
--- a/py/GEMINI.md
+++ b/py/GEMINI.md
@@ -1329,9 +1329,28 @@ Some code may be excluded from coverage requirements:
 
 ### Logging
 
-* **Library**: Use `structlog` for structured logging.
-* **Async**: Use `await logger.ainfo(...)` within coroutines.
-* **Format**: Avoid f-strings for async logging; use structured key-values.
+* **Library**: Use `structlog` via the typed `genkit.core.logging.get_logger` wrapper.
+  **Do NOT use the standard library `logging` module directly.** The typed wrapper
+  provides IDE support, async variants, and structured key-value logging.
+* **Import pattern**:
+
+  ```python
+  from genkit.core.logging import get_logger
+
+  logger = get_logger(__name__)
+  ```
+
+* **Sync vs Async**: Use `logger.info(...)` in synchronous code and
+  `await logger.ainfo(...)` within coroutines.
+* **Structured key-values**: Pass context as keyword arguments, not f-strings:
+
+  ```python
+  # Correct
+  logger.info("Request processed", model=model_name, latency_ms=elapsed)
+
+  # Wrong — unstructured f-string
+  logger.info(f"Request processed for {model_name} in {elapsed}ms")
+  ```
 
 ### Licensing
 

--- a/py/packages/genkit/src/genkit/blocks/middleware.py
+++ b/py/packages/genkit/src/genkit/blocks/middleware.py
@@ -14,25 +14,146 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Middleware for the Genkit framework."""
+"""Model middleware for the Genkit framework.
 
+Provides reusable middleware functions that can be composed into model
+generation pipelines via ``ai.generate(use=[...])``. Each middleware
+intercepts the ``GenerateRequest`` before it reaches the model and/or
+the ``GenerateResponse`` after it returns.
+
+Middleware catalogue:
+
+    ┌──────────────────────────────────────┬──────────────────────────────────────┐
+    │ Middleware                           │ Purpose                              │
+    ├──────────────────────────────────────┼──────────────────────────────────────┤
+    │ ``augment_with_context()``           │ Inject RAG context into prompt       │
+    │ ``download_request_media()``         │ Inline HTTP media as data URIs       │
+    │ ``validate_support()``               │ Check model capability support       │
+    │ ``simulate_system_prompt()``         │ Fold system prompt into user msgs    │
+    │ ``simulate_constrained_generation()``│ Inject JSON schema instructions      │
+    │ ``retry()``                          │ Retry with exponential backoff       │
+    │ ``fallback()``                       │ Cascade to fallback models           │
+    └──────────────────────────────────────┴──────────────────────────────────────┘
+
+See Also:
+    - JS reference: ``js/ai/src/model/middleware.ts``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import random
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, cast
+
+from genkit.blocks.messages import inject_instructions
 from genkit.blocks.model import (
     ModelMiddleware,
     ModelMiddlewareNext,
     text_from_content,
 )
 from genkit.core.action import ActionRunContext
+from genkit.core.error import GenkitError
+from genkit.core.http_client import get_cached_client
+from genkit.core.logging import get_logger
+from genkit.core.status_types import StatusName
 from genkit.core.typing import (
     DocumentData,
     GenerateRequest,
     GenerateResponse,
+    Media,
+    MediaPart,
     Message,
     Metadata,
+    OutputConfig,
     Part,
+    Supports,
     TextPart,
 )
 
+if TYPE_CHECKING:
+    from genkit.core.registry import Registry
+
+logger = get_logger(__name__)
+
 CONTEXT_PREFACE = '\n\nUse the following information to complete your task:\n\n'
+
+DEFAULT_RETRY_STATUSES: list[StatusName] = [
+    'UNAVAILABLE',
+    'DEADLINE_EXCEEDED',
+    'RESOURCE_EXHAUSTED',
+    'ABORTED',
+    'INTERNAL',
+]
+
+DEFAULT_FALLBACK_STATUSES: list[StatusName] = [
+    'UNAVAILABLE',
+    'DEADLINE_EXCEEDED',
+    'RESOURCE_EXHAUSTED',
+    'ABORTED',
+    'INTERNAL',
+    'NOT_FOUND',
+    'UNIMPLEMENTED',
+]
+
+
+def last_user_message(messages: list[Message]) -> Message | None:
+    """Finds the last message with the role 'user' in a list of messages.
+
+    Args:
+        messages: A list of Message objects.
+
+    Returns:
+        The last message with the role 'user', or None if no such message exists.
+    """
+    for i in range(len(messages) - 1, -1, -1):
+        if messages[i].role == 'user':
+            return messages[i]
+    return None
+
+
+def part_has_media(part: Part) -> bool:
+    """Check whether a Part contains a media attachment.
+
+    This is a safe accessor that works regardless of the concrete Part
+    variant (TextPart, MediaPart, ToolRequestPart, etc.).
+
+    Args:
+        part: The Part to inspect.
+
+    Returns:
+        True if the part is a MediaPart with a non-None media field.
+    """
+    return hasattr(part.root, 'media') and part.root.media is not None
+
+
+def has_media_in_messages(messages: list[Message]) -> bool:
+    """Check whether any message in a list contains a media part.
+
+    Args:
+        messages: The messages to scan.
+
+    Returns:
+        True if at least one Part in any message contains media.
+    """
+    return any(part_has_media(part) for msg in messages for part in msg.content)
+
+
+def find_system_message_index(messages: list[Message]) -> int:
+    """Find the index of the first system message.
+
+    Args:
+        messages: The messages to scan.
+
+    Returns:
+        The index of the first system message, or -1 if none found.
+    """
+    for i, msg in enumerate(messages):
+        if msg.role == 'system':
+            return i
+    return -1
 
 
 def context_item_template(d: DocumentData, index: int) -> str:
@@ -56,10 +177,15 @@ def context_item_template(d: DocumentData, index: int) -> str:
     return out
 
 
+def _default_constrained_generation_instructions(schema: dict[str, Any]) -> str:
+    """Default instructions renderer for simulated constrained generation."""
+    return f'Output should be in JSON format and conform to the following schema:\n\n```\n{json.dumps(schema)}\n```\n'
+
+
 def augment_with_context() -> ModelMiddleware:
     """Returns a ModelMiddleware that augments the prompt with document context.
 
-    This middleware checks if the `GenerateRequest` includes documents (`req.docs`).
+    This middleware checks if the ``GenerateRequest`` includes documents (``req.docs``).
     If documents are present, it finds the last user message and injects the
     rendered content of the documents into it as a special context Part.
 
@@ -72,12 +198,7 @@ def augment_with_context() -> ModelMiddleware:
         ctx: ActionRunContext,
         next_middleware: ModelMiddlewareNext,
     ) -> GenerateResponse:
-        """The actual middleware logic to inject context.
-
-        Checks for documents in the request. If found, locates the last user message.
-        It then either replaces an existing pending context Part or appends a new
-        context Part (rendered from the documents) to the user message before
-        passing the request to the next middleware or the model.
+        """Inject context documents into the last user message.
 
         Args:
             req: The incoming GenerateRequest.
@@ -96,7 +217,6 @@ def augment_with_context() -> ModelMiddleware:
 
         context_part_index = -1
         for i, part in enumerate(user_message.content):
-            # Access metadata safely through RootModel
             part_metadata = part.root.metadata
             if isinstance(part_metadata, Metadata) and part_metadata.root.get('purpose') == 'context':
                 context_part_index = i
@@ -128,16 +248,403 @@ def augment_with_context() -> ModelMiddleware:
     return middleware
 
 
-def last_user_message(messages: list[Message]) -> Message | None:
-    """Finds the last message with the role 'user' in a list of messages.
+def download_request_media(
+    *,
+    max_bytes: int | None = None,
+    filter_fn: Callable[[MediaPart], bool] | None = None,
+) -> ModelMiddleware:
+    """Download referenced HTTP(S) media URLs and inline them as data URIs.
+
+    Iterates over all message parts in the request. For each ``MediaPart``
+    whose URL starts with ``http``, the middleware downloads the content and
+    replaces the URL with an inline ``data:`` URI.
+
+    Matches the JS ``downloadRequestMedia()`` middleware.
 
     Args:
-        messages: A list of message dictionaries.
+        max_bytes: Optional maximum number of bytes to download per media.
+        filter_fn: Optional predicate to decide which ``MediaPart`` objects
+            to download. If the filter returns ``False``, the part is left
+            unchanged.
 
     Returns:
-        The last message with the role 'user', or None if no such message exists.
+        A ``ModelMiddleware`` function.
     """
-    for i in range(len(messages) - 1, -1, -1):
-        if messages[i].role == 'user':
-            return messages[i]
-    return None
+
+    async def middleware(
+        req: GenerateRequest,
+        ctx: ActionRunContext,
+        next_fn: ModelMiddlewareNext,
+    ) -> GenerateResponse:
+        client = get_cached_client(cache_key='download-request-media', timeout=60.0)
+
+        new_messages: list[Message] = []
+        for message in req.messages:
+            new_content: list[Part] = []
+            for part in message.content:
+                if not part_has_media(part) or not isinstance(part.root, MediaPart):
+                    new_content.append(part)
+                    continue
+
+                media = part.root.media
+                if not media.url.startswith('http'):
+                    new_content.append(part)
+                    continue
+
+                if filter_fn and not filter_fn(part.root):
+                    new_content.append(part)
+                    continue
+
+                response = await client.get(media.url)
+                if response.status_code != 200:
+                    raise GenkitError(
+                        message=f"HTTP error {response.status_code} downloading media '{media.url}'",
+                        status='INTERNAL',
+                    )
+
+                raw_bytes = response.content
+                if max_bytes and len(raw_bytes) > max_bytes:
+                    raw_bytes = raw_bytes[:max_bytes]
+
+                content_type = media.content_type or response.headers.get('content-type', '')
+                b64 = base64.b64encode(raw_bytes).decode('ascii')
+                data_uri = f'data:{content_type};base64,{b64}'
+
+                new_content.append(Part(root=MediaPart(media=Media(url=data_uri, content_type=content_type))))
+            new_messages.append(Message(role=message.role, content=new_content))
+
+        new_req = req.model_copy(update={'messages': new_messages})
+        return await next_fn(new_req, ctx)
+
+    return middleware
+
+
+def validate_support(
+    *,
+    name: str,
+    supports: Supports | None = None,
+) -> ModelMiddleware:
+    """Validate that a GenerateRequest does not include unsupported features.
+
+    Raises a ``GenkitError`` with ``INVALID_ARGUMENT`` if the request contains
+    media, tools, or multiturn when the model explicitly marks them as
+    unsupported (``False``).
+
+    Matches the JS ``validateSupport()`` middleware.
+
+    Args:
+        name: The model name (used in error messages).
+        supports: A ``Supports`` object describing model capabilities. If
+            ``None``, all features are assumed supported.
+
+    Returns:
+        A ``ModelMiddleware`` function.
+    """
+
+    async def middleware(
+        req: GenerateRequest,
+        ctx: ActionRunContext,
+        next_fn: ModelMiddlewareNext,
+    ) -> GenerateResponse:
+        if supports is None:
+            return await next_fn(req, ctx)
+
+        def invalid(message: str) -> None:
+            raise GenkitError(
+                message=(f"Model '{name}' does not support {message}. Request: {req.model_dump_json(indent=2)}"),
+                status='INVALID_ARGUMENT',
+            )
+
+        if supports.media is False and has_media_in_messages(req.messages):
+            invalid('media, but media was provided')
+
+        if supports.tools is False and req.tools:
+            invalid('tool use, but tools were provided')
+
+        if supports.multiturn is False and len(req.messages) > 1:
+            invalid(f'multiple messages, but {len(req.messages)} were provided')
+
+        return await next_fn(req, ctx)
+
+    return middleware
+
+
+def simulate_system_prompt(
+    *,
+    preface: str = 'SYSTEM INSTRUCTIONS:\n',
+    acknowledgement: str = 'Understood.',
+) -> ModelMiddleware:
+    """Simulate system prompts for models that don't support them natively.
+
+    Converts the first ``system`` message into a user/model exchange:
+    - The system message content is prepended with ``preface`` and sent as
+      a ``user`` message.
+    - A short ``model`` message with ``acknowledgement`` follows.
+
+    Matches the JS ``simulateSystemPrompt()`` middleware.
+
+    Args:
+        preface: Text prepended to the system message content.
+        acknowledgement: The model's simulated acknowledgement.
+
+    Returns:
+        A ``ModelMiddleware`` function.
+    """
+
+    async def middleware(
+        req: GenerateRequest,
+        ctx: ActionRunContext,
+        next_fn: ModelMiddlewareNext,
+    ) -> GenerateResponse:
+        messages = list(req.messages)
+        idx = find_system_message_index(messages)
+        if idx >= 0:
+            system_content = messages[idx].content
+            messages[idx : idx + 1] = [
+                Message(
+                    role='user',
+                    content=[Part(root=TextPart(text=preface)), *system_content],
+                ),
+                Message(
+                    role='model',
+                    content=[Part(root=TextPart(text=acknowledgement))],
+                ),
+            ]
+
+        new_req = req.model_copy(update={'messages': messages})
+        return await next_fn(new_req, ctx)
+
+    return middleware
+
+
+def simulate_constrained_generation(
+    *,
+    instructions_renderer: Callable[[dict[str, Any]], str] | None = None,
+) -> ModelMiddleware:
+    """Simulate constrained generation by injecting JSON schema instructions.
+
+    When the request has ``output.constrained`` set and a schema, this
+    middleware injects generation instructions into the user message and
+    then removes the constrained/format/schema fields so the model
+    generates unconstrained text.
+
+    Matches the JS ``simulateConstrainedGeneration()`` middleware.
+
+    Args:
+        instructions_renderer: Optional custom function to render the
+            schema into instruction text.
+
+    Returns:
+        A ``ModelMiddleware`` function.
+    """
+    renderer = instructions_renderer or _default_constrained_generation_instructions
+
+    async def middleware(
+        req: GenerateRequest,
+        ctx: ActionRunContext,
+        next_fn: ModelMiddlewareNext,
+    ) -> GenerateResponse:
+        if not (req.output and req.output.constrained and req.output.schema):
+            return await next_fn(req, ctx)
+
+        instructions = renderer(req.output.schema)
+        new_messages = inject_instructions(req.messages, instructions)
+
+        new_output = OutputConfig(
+            constrained=False,
+            format=None,
+            content_type=None,
+            schema=None,
+        )
+
+        new_req = req.model_copy(
+            update={
+                'messages': new_messages,
+                'output': new_output,
+            }
+        )
+        return await next_fn(new_req, ctx)
+
+    return middleware
+
+
+def retry(
+    *,
+    max_retries: int = 3,
+    statuses: list[StatusName] | None = None,
+    initial_delay_ms: int = 1000,
+    max_delay_ms: int = 60000,
+    backoff_factor: int = 2,
+    no_jitter: bool = False,
+    on_error: Callable[[Exception, int], None] | None = None,
+) -> ModelMiddleware:
+    """Retry model requests with exponential backoff and optional jitter.
+
+    On transient errors (matching the configured status codes), the
+    middleware retries up to ``max_retries`` times with exponentially
+    increasing delay.
+
+    Matches the JS ``retry()`` middleware.
+
+    Example::
+
+        response = await ai.generate(
+            model='googleai/gemini-2.0-flash',
+            prompt='Hello',
+            use=[
+                retry(
+                    max_retries=2,
+                    initial_delay_ms=1000,
+                    backoff_factor=2,
+                ),
+            ],
+        )
+
+    Args:
+        max_retries: Maximum number of retry attempts. Default: 3.
+        statuses: List of status names that trigger a retry. Defaults to
+            ``UNAVAILABLE``, ``DEADLINE_EXCEEDED``, ``RESOURCE_EXHAUSTED``,
+            ``ABORTED``, ``INTERNAL``.
+        initial_delay_ms: Initial delay between retries in milliseconds.
+        max_delay_ms: Maximum delay cap in milliseconds.
+        backoff_factor: Multiplicative factor for exponential backoff.
+        no_jitter: If ``True``, disable random jitter on delay.
+        on_error: Optional callback invoked on each retry attempt with
+            the error and attempt number (1-based).
+
+    Returns:
+        A ``ModelMiddleware`` function.
+    """
+    retry_statuses = statuses or DEFAULT_RETRY_STATUSES
+
+    async def middleware(
+        req: GenerateRequest,
+        ctx: ActionRunContext,
+        next_fn: ModelMiddlewareNext,
+    ) -> GenerateResponse:
+        last_error: Exception | None = None
+        current_delay = initial_delay_ms
+
+        for attempt in range(max_retries + 1):
+            try:
+                return await next_fn(req, ctx)
+            except Exception as e:
+                last_error = e
+                if attempt < max_retries:
+                    should_retry = False
+                    if isinstance(e, GenkitError):
+                        if e.status in retry_statuses:
+                            should_retry = True
+                    else:
+                        should_retry = True
+
+                    if should_retry:
+                        if on_error:
+                            on_error(e, attempt + 1)
+
+                        delay_s = current_delay / 1000.0
+                        if not no_jitter:
+                            jitter = random.uniform(0, 1)
+                            delay_s += jitter
+
+                        await asyncio.sleep(delay_s)
+                        current_delay = min(
+                            current_delay * backoff_factor,
+                            max_delay_ms,
+                        )
+                        continue
+
+                raise
+
+        if last_error:
+            raise last_error
+        raise RuntimeError('retry middleware: unexpected state')
+
+    return middleware
+
+
+def fallback(
+    *,
+    models: list[str],
+    statuses: list[StatusName] | None = None,
+    on_error: Callable[[Exception], None] | None = None,
+) -> ModelMiddleware:
+    """Falls back to alternative models when the primary model fails.
+
+    If the primary model raises a ``GenkitError`` with a status in the
+    configured list, the middleware tries each fallback model in order.
+
+    Matches the JS ``fallback()`` middleware. In the Python version,
+    fallback models are specified by name (string) rather than by
+    ``ModelArgument``, because the model action is resolved at call time
+    via the action run context.
+
+    Example::
+
+        response = await ai.generate(
+            model='googleai/gemini-2.0-flash',
+            prompt='Hello',
+            use=[
+                fallback(
+                    models=['googleai/gemini-1.5-flash-latest'],
+                    statuses=['RESOURCE_EXHAUSTED'],
+                ),
+            ],
+        )
+
+    Args:
+        models: List of fallback model names to try in order.
+        statuses: List of status names that trigger fallback. Defaults to
+            ``UNAVAILABLE``, ``DEADLINE_EXCEEDED``, ``RESOURCE_EXHAUSTED``,
+            ``ABORTED``, ``INTERNAL``, ``NOT_FOUND``, ``UNIMPLEMENTED``.
+        on_error: Optional callback invoked on each error before fallback.
+
+    Returns:
+        A ``ModelMiddleware`` function.
+    """
+    fallback_statuses = statuses or DEFAULT_FALLBACK_STATUSES
+
+    async def middleware(
+        req: GenerateRequest,
+        ctx: ActionRunContext,
+        next_fn: ModelMiddlewareNext,
+    ) -> GenerateResponse:
+        try:
+            return await next_fn(req, ctx)
+        except GenkitError as e:
+            if e.status not in fallback_statuses:
+                raise
+
+            if on_error:
+                on_error(e)
+
+            last_error: Exception = e
+            for model_name in models:
+                try:
+                    registry: Registry = cast('Registry', ctx.context.get('registry'))
+                    if registry is None:
+                        raise GenkitError(
+                            message='fallback middleware requires registry in context',
+                            status='INTERNAL',
+                        )
+                    model_action = await registry.resolve_model(model_name)
+                    if model_action is None:
+                        raise GenkitError(
+                            message=f"Fallback model '{model_name}' not found",
+                            status='NOT_FOUND',
+                        )
+                    result = await model_action.arun(req)
+                    return result.response
+                except GenkitError as e2:
+                    last_error = e2
+                    if e2.status in fallback_statuses:
+                        if on_error:
+                            on_error(e2)
+                        continue
+                    raise
+                except Exception as e2:
+                    raise e2 from e
+
+            raise last_error from e
+
+    return middleware

--- a/py/packages/genkit/tests/genkit/blocks/middleware_test.py
+++ b/py/packages/genkit/tests/genkit/blocks/middleware_test.py
@@ -15,58 +15,269 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-"""Tests for the action module."""
+"""Tests for model middleware functions.
+
+Covers extracted utilities (part_has_media, has_media_in_messages,
+find_system_message_index, last_user_message, context_item_template)
+and middleware factories (augment_with_context, retry, validate_support,
+simulate_system_prompt, simulate_constrained_generation).
+"""
 
 import asyncio
+import json
+from unittest.mock import AsyncMock
 
 import pytest
 
-from genkit.blocks.middleware import augment_with_context
+from genkit.blocks.middleware import (
+    DEFAULT_FALLBACK_STATUSES,
+    DEFAULT_RETRY_STATUSES,
+    augment_with_context,
+    context_item_template,
+    find_system_message_index,
+    has_media_in_messages,
+    last_user_message,
+    part_has_media,
+    retry,
+    simulate_constrained_generation,
+    simulate_system_prompt,
+    validate_support,
+)
 from genkit.core.action import ActionRunContext
+from genkit.core.error import GenkitError
 from genkit.core.typing import (
     DocumentData,
     DocumentPart,
     GenerateRequest,
     GenerateResponse,
+    Media,
+    MediaPart,
     Message,
     Metadata,
+    OutputConfig,
     Part,
     Role,
+    Supports,
     TextPart,
+    ToolDefinition,
 )
 
 
-async def run_augmenter(req: GenerateRequest) -> GenerateRequest:
-    """Helper to run the augment_with_context middleware."""
-    augmenter = augment_with_context()
-    req_future = asyncio.Future()
+def _make_text_part(text: str = 'Hello') -> Part:
+    return Part(root=TextPart(text=text))
 
-    async def next(req: GenerateRequest, _: ActionRunContext) -> GenerateResponse:
+
+def _make_media_part(url: str = 'https://example.com/img.png', content_type: str = 'image/png') -> Part:
+    return Part(root=MediaPart(media=Media(url=url, content_type=content_type)))
+
+
+def _make_message(role: str = 'user', text: str = 'Hello') -> Message:
+    return Message(role=role, content=[_make_text_part(text)])
+
+
+def _make_request(
+    messages: list[Message] | None = None,
+    tools: list[ToolDefinition] | None = None,
+    output: OutputConfig | None = None,
+) -> GenerateRequest:
+    """Create a minimal GenerateRequest for testing."""
+    if messages is None:
+        messages = [_make_message()]
+    return GenerateRequest(messages=messages, tools=tools, output=output)
+
+
+def _make_response(text: str = 'response') -> GenerateResponse:
+    """Create a minimal GenerateResponse for testing."""
+    return GenerateResponse(
+        message=Message(
+            role='model',
+            content=[Part(root=TextPart(text=text))],
+        ),
+    )
+
+
+def _make_ctx() -> ActionRunContext:
+    """Create a minimal ActionRunContext for testing."""
+    return ActionRunContext(context={})
+
+
+async def _run_augmenter(req: GenerateRequest) -> GenerateRequest:
+    """Helper to run the augment_with_context middleware and capture the request."""
+    augmenter = augment_with_context()
+    req_future: asyncio.Future[GenerateRequest] = asyncio.Future()
+
+    async def next_fn(req: GenerateRequest, _: ActionRunContext) -> GenerateResponse:
         req_future.set_result(req)
         return GenerateResponse(message=Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))]))
 
-    await augmenter(req, ActionRunContext(), next)
-
+    await augmenter(req, ActionRunContext(), next_fn)
     return req_future.result()
+
+
+# -- part_has_media --
+
+
+def test_part_has_media_true_for_media_part() -> None:
+    """Returns True for a Part containing a MediaPart."""
+    got = part_has_media(_make_media_part())
+    if got is not True:
+        pytest.fail(f'part_has_media(media_part) = {got}, want True')
+
+
+def test_part_has_media_false_for_text_part() -> None:
+    """Returns False for a Part containing a TextPart."""
+    got = part_has_media(_make_text_part())
+    if got is not False:
+        pytest.fail(f'part_has_media(text_part) = {got}, want False')
+
+
+# -- has_media_in_messages --
+
+
+def test_has_media_in_messages_true() -> None:
+    """Returns True when at least one message contains media."""
+    msgs = [
+        Message(role='user', content=[_make_text_part(), _make_media_part()]),
+    ]
+    got = has_media_in_messages(msgs)
+    if got is not True:
+        pytest.fail(f'has_media_in_messages = {got}, want True')
+
+
+def test_has_media_in_messages_false() -> None:
+    """Returns False when no messages contain media."""
+    msgs = [
+        Message(role='user', content=[_make_text_part()]),
+        Message(role='model', content=[_make_text_part('reply')]),
+    ]
+    got = has_media_in_messages(msgs)
+    if got is not False:
+        pytest.fail(f'has_media_in_messages = {got}, want False')
+
+
+def test_has_media_in_messages_empty() -> None:
+    """Returns False for empty message list."""
+    got = has_media_in_messages([])
+    if got is not False:
+        pytest.fail(f'has_media_in_messages([]) = {got}, want False')
+
+
+# -- find_system_message_index --
+
+
+def test_find_system_message_index_found() -> None:
+    """Returns the index of the first system message."""
+    msgs = [
+        _make_message('user', 'hi'),
+        _make_message('system', 'instructions'),
+        _make_message('user', 'hello'),
+    ]
+    got = find_system_message_index(msgs)
+    want = 1
+    if got != want:
+        pytest.fail(f'find_system_message_index = {got}, want {want}')
+
+
+def test_find_system_message_index_first_position() -> None:
+    """Returns 0 when system message is first."""
+    msgs = [
+        _make_message('system', 'sys'),
+        _make_message('user', 'hi'),
+    ]
+    got = find_system_message_index(msgs)
+    if got != 0:
+        pytest.fail(f'find_system_message_index = {got}, want 0')
+
+
+def test_find_system_message_index_not_found() -> None:
+    """Returns -1 when no system message exists."""
+    msgs = [_make_message('user', 'hi')]
+    got = find_system_message_index(msgs)
+    if got != -1:
+        pytest.fail(f'find_system_message_index = {got}, want -1')
+
+
+def test_find_system_message_index_empty() -> None:
+    """Returns -1 for empty message list."""
+    got = find_system_message_index([])
+    if got != -1:
+        pytest.fail(f'find_system_message_index([]) = {got}, want -1')
+
+
+# -- last_user_message --
+
+
+def test_last_user_message_found() -> None:
+    """Returns the last user message."""
+    msgs = [
+        _make_message('user', 'first'),
+        _make_message('model', 'reply'),
+        _make_message('user', 'second'),
+    ]
+    got = last_user_message(msgs)
+    assert got is not None, 'last_user_message returned None, want Message'
+    got_text = str(got.content[0].root.text)
+    if got_text != 'second':
+        pytest.fail(f'last_user_message text = {got_text!r}, want "second"')
+
+
+def test_last_user_message_not_found() -> None:
+    """Returns None when no user messages exist."""
+    msgs = [_make_message('model', 'reply')]
+    got = last_user_message(msgs)
+    if got is not None:
+        pytest.fail(f'last_user_message = {got}, want None')
+
+
+def test_last_user_message_empty() -> None:
+    """Returns None for empty list."""
+    got = last_user_message([])
+    if got is not None:
+        pytest.fail(f'last_user_message([]) = {got}, want None')
+
+
+# -- context_item_template --
+
+
+def test_context_item_template_uses_index() -> None:
+    """Uses the index as citation when no metadata ref/id."""
+    doc = DocumentData(content=[DocumentPart(root=TextPart(text='hello world'))])
+    got = context_item_template(doc, 0)
+    want = '- [0]: hello world\n'
+    if got != want:
+        pytest.fail(f'context_item_template = {got!r}, want {want!r}')
+
+
+def test_context_item_template_uses_metadata_ref() -> None:
+    """Uses metadata 'ref' field as citation when available."""
+    doc = DocumentData(
+        content=[DocumentPart(root=TextPart(text='content'))],
+        metadata={'ref': 'doc-1'},
+    )
+    got = context_item_template(doc, 5)
+    want = '- [doc-1]: content\n'
+    if got != want:
+        pytest.fail(f'context_item_template = {got!r}, want {want!r}')
+
+
+# -- augment_with_context --
 
 
 @pytest.mark.asyncio
 async def test_augment_with_context_ignores_no_docs() -> None:
-    """Test simple prompt rendering."""
+    """Request passes through unchanged when no docs are present."""
     req = GenerateRequest(
         messages=[
             Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))]),
         ],
     )
-
-    transformed_req = await run_augmenter(req)
-
+    transformed_req = await _run_augmenter(req)
     assert transformed_req == req
 
 
 @pytest.mark.asyncio
 async def test_augment_with_context_adds_docs_as_context() -> None:
-    """Test simple prompt rendering."""
+    """Documents are rendered and appended to the last user message."""
     req = GenerateRequest(
         messages=[
             Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))]),
@@ -77,7 +288,7 @@ async def test_augment_with_context_adds_docs_as_context() -> None:
         ],
     )
 
-    transformed_req = await run_augmenter(req)
+    transformed_req = await _run_augmenter(req)
 
     assert transformed_req == GenerateRequest(
         messages=[
@@ -106,7 +317,7 @@ async def test_augment_with_context_adds_docs_as_context() -> None:
 
 @pytest.mark.asyncio
 async def test_augment_with_context_should_not_modify_non_pending_part() -> None:
-    """Test simple prompt rendering."""
+    """Non-pending context parts are left unchanged."""
     req = GenerateRequest(
         messages=[
             Message(
@@ -126,15 +337,13 @@ async def test_augment_with_context_should_not_modify_non_pending_part() -> None
             DocumentData(content=[DocumentPart(root=TextPart(text='doc content 1'))]),
         ],
     )
-
-    transformed_req = await run_augmenter(req)
-
+    transformed_req = await _run_augmenter(req)
     assert transformed_req == req
 
 
 @pytest.mark.asyncio
 async def test_augment_with_context_with_purpose_part() -> None:
-    """Test simple prompt rendering."""
+    """Pending context parts are replaced with rendered documents."""
     req = GenerateRequest(
         messages=[
             Message(
@@ -155,7 +364,7 @@ async def test_augment_with_context_with_purpose_part() -> None:
         ],
     )
 
-    transformed_req = await run_augmenter(req)
+    transformed_req = await _run_augmenter(req)
 
     assert transformed_req == GenerateRequest(
         messages=[
@@ -178,3 +387,422 @@ async def test_augment_with_context_with_purpose_part() -> None:
             DocumentData(content=[DocumentPart(root=TextPart(text='doc content 1'))]),
         ],
     )
+
+
+# -- retry --
+
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_on_first_attempt() -> None:
+    """Passes through on first successful call."""
+    mw = retry(max_retries=3)
+    next_fn = AsyncMock(return_value=_make_response())
+    result = await mw(_make_request(), _make_ctx(), next_fn)
+
+    got = next_fn.await_count
+    want = 1
+    if got != want:
+        pytest.fail(f'next_fn call count = {got}, want {want}')
+    assert result.message is not None, 'expected message in response, got None'
+
+
+@pytest.mark.asyncio
+async def test_retry_retries_on_transient_error() -> None:
+    """Retries on UNAVAILABLE then succeeds."""
+    mw = retry(max_retries=2, initial_delay_ms=1, no_jitter=True)
+    next_fn = AsyncMock(
+        side_effect=[
+            GenkitError(message='unavailable', status='UNAVAILABLE'),
+            _make_response('recovered'),
+        ]
+    )
+    result = await mw(_make_request(), _make_ctx(), next_fn)
+
+    got = next_fn.await_count
+    want = 2
+    if got != want:
+        pytest.fail(f'next_fn call count = {got}, want {want}')
+    assert result.message is not None, 'expected message in response, got None'
+    got_text = str(result.message.content[0].root.text)
+    if got_text != 'recovered':
+        pytest.fail(f'response text = {got_text!r}, want "recovered"')
+
+
+@pytest.mark.asyncio
+async def test_retry_raises_on_non_retryable_status() -> None:
+    """Raises immediately on non-retryable statuses."""
+    mw = retry(max_retries=3, initial_delay_ms=1)
+    next_fn = AsyncMock(side_effect=GenkitError(message='bad request', status='INVALID_ARGUMENT'))
+    with pytest.raises(GenkitError) as exc_info:
+        await mw(_make_request(), _make_ctx(), next_fn)
+
+    got = exc_info.value.status
+    want = 'INVALID_ARGUMENT'
+    if got != want:
+        pytest.fail(f'error status = {got!r}, want {want!r}')
+    if next_fn.await_count != 1:
+        pytest.fail(f'expected 1 call, got {next_fn.await_count}')
+
+
+@pytest.mark.asyncio
+async def test_retry_exhausts_all_attempts() -> None:
+    """Raises after exhausting all retries."""
+    mw = retry(max_retries=2, initial_delay_ms=1, no_jitter=True)
+    next_fn = AsyncMock(side_effect=GenkitError(message='unavailable', status='UNAVAILABLE'))
+    with pytest.raises(GenkitError) as exc_info:
+        await mw(_make_request(), _make_ctx(), next_fn)
+
+    got = exc_info.value.status
+    want = 'UNAVAILABLE'
+    if got != want:
+        pytest.fail(f'error status = {got!r}, want {want!r}')
+    # 1 initial + 2 retries = 3 total
+    got_count = next_fn.await_count
+    want_count = 3
+    if got_count != want_count:
+        pytest.fail(f'next_fn call count = {got_count}, want {want_count}')
+
+
+@pytest.mark.asyncio
+async def test_retry_calls_on_error_callback() -> None:
+    """Calls on_error for each retry attempt."""
+    errors: list[tuple[Exception, int]] = []
+
+    def on_error(e: Exception, attempt: int) -> None:
+        errors.append((e, attempt))
+
+    mw = retry(max_retries=2, initial_delay_ms=1, no_jitter=True, on_error=on_error)
+    next_fn = AsyncMock(
+        side_effect=[
+            GenkitError(message='fail1', status='UNAVAILABLE'),
+            GenkitError(message='fail2', status='UNAVAILABLE'),
+            _make_response(),
+        ]
+    )
+    await mw(_make_request(), _make_ctx(), next_fn)
+
+    got = len(errors)
+    want = 2
+    if got != want:
+        pytest.fail(f'on_error call count = {got}, want {want}')
+    if errors[0][1] != 1:
+        pytest.fail(f'first on_error attempt = {errors[0][1]}, want 1')
+    if errors[1][1] != 2:
+        pytest.fail(f'second on_error attempt = {errors[1][1]}, want 2')
+
+
+@pytest.mark.asyncio
+async def test_retry_custom_statuses() -> None:
+    """Respects custom status list."""
+    mw = retry(
+        max_retries=1,
+        statuses=['NOT_FOUND'],
+        initial_delay_ms=1,
+        no_jitter=True,
+    )
+    next_fn = AsyncMock(
+        side_effect=[
+            GenkitError(message='not found', status='NOT_FOUND'),
+            _make_response('found'),
+        ]
+    )
+    result = await mw(_make_request(), _make_ctx(), next_fn)
+
+    got = next_fn.await_count
+    want = 2
+    if got != want:
+        pytest.fail(f'next_fn call count = {got}, want {want}')
+    assert result.message is not None, 'expected message in response, got None'
+
+
+@pytest.mark.asyncio
+async def test_retry_non_genkit_error_is_retried() -> None:
+    """Non-GenkitError exceptions are always retried."""
+    mw = retry(max_retries=1, initial_delay_ms=1, no_jitter=True)
+    next_fn = AsyncMock(
+        side_effect=[
+            ConnectionError('network fail'),
+            _make_response('ok'),
+        ]
+    )
+    result = await mw(_make_request(), _make_ctx(), next_fn)
+
+    got = next_fn.await_count
+    want = 2
+    if got != want:
+        pytest.fail(f'next_fn call count = {got}, want {want}')
+    assert result.message is not None, 'expected message in response, got None'
+
+
+# -- validate_support --
+
+
+@pytest.mark.asyncio
+async def test_validate_support_passes_when_supports_is_none() -> None:
+    """No validation when supports is None."""
+    mw = validate_support(name='test-model')
+    next_fn = AsyncMock(return_value=_make_response())
+    result = await mw(_make_request(), _make_ctx(), next_fn)
+    assert result.message is not None, 'expected message in response, got None'
+
+
+@pytest.mark.asyncio
+async def test_validate_support_passes_when_all_supported() -> None:
+    """No error when all features are marked supported."""
+    mw = validate_support(
+        name='test-model',
+        supports=Supports(media=True, tools=True, multiturn=True),
+    )
+    next_fn = AsyncMock(return_value=_make_response())
+    req = _make_request(
+        messages=[
+            _make_message('user', 'hi'),
+            _make_message('model', 'hey'),
+        ],
+    )
+    result = await mw(req, _make_ctx(), next_fn)
+    assert result.message is not None, 'expected message in response, got None'
+
+
+@pytest.mark.asyncio
+async def test_validate_support_raises_on_unsupported_tools() -> None:
+    """Raises INVALID_ARGUMENT when tools are provided but not supported."""
+    mw = validate_support(
+        name='test-model',
+        supports=Supports(tools=False),
+    )
+    next_fn = AsyncMock(return_value=_make_response())
+    req = _make_request(
+        tools=[ToolDefinition(name='my_tool', description='A tool', input_schema={})],
+    )
+    with pytest.raises(GenkitError) as exc_info:
+        await mw(req, _make_ctx(), next_fn)
+    if 'tool use' not in str(exc_info.value):
+        pytest.fail(f'expected "tool use" in error, got {exc_info.value!r}')
+
+
+@pytest.mark.asyncio
+async def test_validate_support_raises_on_unsupported_multiturn() -> None:
+    """Raises INVALID_ARGUMENT when multiturn is not supported."""
+    mw = validate_support(
+        name='test-model',
+        supports=Supports(multiturn=False),
+    )
+    next_fn = AsyncMock(return_value=_make_response())
+    req = _make_request(
+        messages=[
+            _make_message('user', 'hi'),
+            _make_message('model', 'hey'),
+        ],
+    )
+    with pytest.raises(GenkitError) as exc_info:
+        await mw(req, _make_ctx(), next_fn)
+    if 'multiple messages' not in str(exc_info.value):
+        pytest.fail(f'expected "multiple messages" in error, got {exc_info.value!r}')
+
+
+@pytest.mark.asyncio
+async def test_validate_support_raises_on_unsupported_media() -> None:
+    """Raises INVALID_ARGUMENT when media is provided but not supported."""
+    mw = validate_support(
+        name='test-model',
+        supports=Supports(media=False),
+    )
+    next_fn = AsyncMock(return_value=_make_response())
+    req = _make_request(
+        messages=[
+            Message(role='user', content=[_make_media_part()]),
+        ],
+    )
+    with pytest.raises(GenkitError) as exc_info:
+        await mw(req, _make_ctx(), next_fn)
+    if 'media' not in str(exc_info.value):
+        pytest.fail(f'expected "media" in error, got {exc_info.value!r}')
+
+
+# -- simulate_system_prompt --
+
+
+@pytest.mark.asyncio
+async def test_simulate_system_prompt_converts_system_message() -> None:
+    """System message is converted to user + model exchange."""
+    mw = simulate_system_prompt()
+    captured_req: GenerateRequest | None = None
+
+    async def next_fn(req: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        nonlocal captured_req
+        captured_req = req
+        return _make_response()
+
+    req = _make_request(
+        messages=[
+            _make_message('system', 'Be helpful'),
+            _make_message('user', 'Hello'),
+        ],
+    )
+    await mw(req, _make_ctx(), next_fn)
+
+    assert captured_req is not None, 'next_fn was not called'
+
+    got_len = len(captured_req.messages)
+    want_len = 3
+    if got_len != want_len:
+        pytest.fail(f'message count = {got_len}, want {want_len}')
+
+    got_role_0 = captured_req.messages[0].role
+    if got_role_0 != 'user':
+        pytest.fail(f'messages[0].role = {got_role_0!r}, want "user"')
+
+    got_text_0 = str(captured_req.messages[0].content[0].root.text)
+    if 'SYSTEM INSTRUCTIONS' not in got_text_0:
+        pytest.fail(f'expected "SYSTEM INSTRUCTIONS" in first part, got {got_text_0!r}')
+
+    got_role_1 = captured_req.messages[1].role
+    if got_role_1 != 'model':
+        pytest.fail(f'messages[1].role = {got_role_1!r}, want "model"')
+
+    got_ack = str(captured_req.messages[1].content[0].root.text)
+    if got_ack != 'Understood.':
+        pytest.fail(f'acknowledgement = {got_ack!r}, want "Understood."')
+
+    got_role_2 = captured_req.messages[2].role
+    if got_role_2 != 'user':
+        pytest.fail(f'messages[2].role = {got_role_2!r}, want "user"')
+
+
+@pytest.mark.asyncio
+async def test_simulate_system_prompt_custom_preface_and_ack() -> None:
+    """Custom preface and acknowledgement are used."""
+    mw = simulate_system_prompt(preface='[SYS]: ', acknowledgement='OK.')
+    captured_req: GenerateRequest | None = None
+
+    async def next_fn(req: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        nonlocal captured_req
+        captured_req = req
+        return _make_response()
+
+    req = _make_request(
+        messages=[
+            _make_message('system', 'rules'),
+            _make_message('user', 'hi'),
+        ],
+    )
+    await mw(req, _make_ctx(), next_fn)
+
+    assert captured_req is not None, 'next_fn was not called'
+
+    got_preface = str(captured_req.messages[0].content[0].root.text)
+    if got_preface != '[SYS]: ':
+        pytest.fail(f'preface = {got_preface!r}, want "[SYS]: "')
+
+    got_ack = str(captured_req.messages[1].content[0].root.text)
+    if got_ack != 'OK.':
+        pytest.fail(f'acknowledgement = {got_ack!r}, want "OK."')
+
+
+@pytest.mark.asyncio
+async def test_simulate_system_prompt_no_system_message() -> None:
+    """No system message means request passes through unchanged."""
+    mw = simulate_system_prompt()
+    next_fn = AsyncMock(return_value=_make_response())
+    req = _make_request()
+    result = await mw(req, _make_ctx(), next_fn)
+    assert result.message is not None, 'expected message in response, got None'
+
+
+# -- simulate_constrained_generation --
+
+
+@pytest.mark.asyncio
+async def test_simulate_constrained_generation_injects_schema() -> None:
+    """Schema instructions are injected, constrained flag is cleared."""
+    mw = simulate_constrained_generation()
+    captured_req: GenerateRequest | None = None
+
+    async def next_fn(req: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        nonlocal captured_req
+        captured_req = req
+        return _make_response()
+
+    schema = {'type': 'object', 'properties': {'name': {'type': 'string'}}}
+    req = _make_request(
+        output=OutputConfig(constrained=True, schema=schema),
+    )
+    await mw(req, _make_ctx(), next_fn)
+
+    assert captured_req is not None, 'next_fn was not called'
+    assert captured_req.output is not None, 'expected output in request, got None'
+    if captured_req.output.constrained is not False:
+        pytest.fail(f'output.constrained = {captured_req.output.constrained!r}, want False')
+    if captured_req.output.schema is not None:
+        pytest.fail(f'output.schema = {captured_req.output.schema!r}, want None')
+
+
+@pytest.mark.asyncio
+async def test_simulate_constrained_generation_no_schema_passes_through() -> None:
+    """Without schema, request passes through unchanged."""
+    mw = simulate_constrained_generation()
+    next_fn = AsyncMock(return_value=_make_response())
+    req = _make_request()
+    result = await mw(req, _make_ctx(), next_fn)
+    assert result.message is not None, 'expected message in response, got None'
+
+
+@pytest.mark.asyncio
+async def test_simulate_constrained_generation_custom_renderer() -> None:
+    """Custom instructions renderer is used."""
+
+    def custom_renderer(schema: dict[str, object]) -> str:
+        return f'OUTPUT JSON: {json.dumps(schema)}'
+
+    mw = simulate_constrained_generation(instructions_renderer=custom_renderer)
+    captured_req: GenerateRequest | None = None
+
+    async def next_fn(req: GenerateRequest, ctx: ActionRunContext) -> GenerateResponse:
+        nonlocal captured_req
+        captured_req = req
+        return _make_response()
+
+    schema = {'type': 'string'}
+    req = _make_request(
+        output=OutputConfig(constrained=True, schema=schema),
+    )
+    await mw(req, _make_ctx(), next_fn)
+
+    assert captured_req is not None, 'next_fn was not called'
+    assert captured_req.output is not None, 'expected output in request, got None'
+    if captured_req.output.constrained is not False:
+        pytest.fail(f'output.constrained = {captured_req.output.constrained!r}, want False')
+
+
+# -- default status lists --
+
+
+def test_retry_statuses_match_js() -> None:
+    """Default retry statuses match the JS canonical implementation."""
+    want = [
+        'UNAVAILABLE',
+        'DEADLINE_EXCEEDED',
+        'RESOURCE_EXHAUSTED',
+        'ABORTED',
+        'INTERNAL',
+    ]
+    got = DEFAULT_RETRY_STATUSES
+    if got != want:
+        pytest.fail(f'DEFAULT_RETRY_STATUSES = {got!r}, want {want!r}')
+
+
+def test_fallback_statuses_match_js() -> None:
+    """Default fallback statuses match the JS canonical implementation."""
+    want = [
+        'UNAVAILABLE',
+        'DEADLINE_EXCEEDED',
+        'RESOURCE_EXHAUSTED',
+        'ABORTED',
+        'INTERNAL',
+        'NOT_FOUND',
+        'UNIMPLEMENTED',
+    ]
+    got = DEFAULT_FALLBACK_STATUSES
+    if got != want:
+        pytest.fail(f'DEFAULT_FALLBACK_STATUSES = {got!r}, want {want!r}')


### PR DESCRIPTION
## Summary

Adds missing model middleware functions to the Python SDK to achieve parity with the JavaScript SDK. Extracts common functionality into unit-testable standalone utilities.

### Middleware added

| Middleware | Purpose |
|---|---|
| `download_request_media` | Inline HTTP media as data URIs |
| `validate_support` | Check model capability support |
| `simulate_system_prompt` | Fold system prompt into user messages |
| `simulate_constrained_generation` | Inject JSON schema instructions |
| `retry` | Exponential backoff with jitter |
| `fallback` | Cascade to fallback models on failure |

### Extracted utilities (unit-testable, no async needed)

| Utility | Purpose |
|---|---|
| `part_has_media()` | Safe check for media in any Part variant |
| `has_media_in_messages()` | Scan messages for media parts |
| `find_system_message_index()` | Locate first system message |
| `last_user_message()` | Locate last user message |
| `context_item_template()` | Render document for context injection |

### Other improvements

- Switch from stdlib `logging` to `genkit.core.logging.get_logger` (structlog)
- Move `get_cached_client` import to module level (no in-function imports)
- Update `GEMINI.md` logging section with `get_logger` pattern
- 38 tests total covering all middleware and utilities

### Test coverage

- 14 utility tests for extracted functions
- 4 augment_with_context tests (existing)
- 7 retry tests (transient, non-retryable, exhaustion, callbacks, custom statuses)
- 4 validate_support tests (None, all-supported, tools, multiturn, media)
- 3 simulate_system_prompt tests
- 3 simulate_constrained_generation tests  
- 2 default status list parity tests (JS canonical match)

### JS parity reference

All middleware matches the canonical JS implementation in `js/ai/src/model/middleware.ts`.