### PR TITLE
feat(py): pass span_id in on_trace_start and set X-Genkit-Span-Id header

### DIFF
--- a/py/packages/genkit/src/genkit/core/action/_action.py
+++ b/py/packages/genkit/src/genkit/core/action/_action.py
@@ -143,7 +143,7 @@ class ActionRunContext:
         self,
         on_chunk: StreamingCallback | None = None,
         context: dict[str, object] | None = None,
-        on_trace_start: Callable[[str], None] | None = None,
+        on_trace_start: Callable[[str, str], None] | None = None,
     ) -> None:
         """Initializes an ActionRunContext instance.
 
@@ -156,12 +156,12 @@ class ActionRunContext:
             context: An optional dictionary containing context data to be made
                      available within the action execution. Defaults to an empty
                      dictionary.
-            on_trace_start: A callable to be invoked with the trace ID when
-                            the trace is started.
+            on_trace_start: A callable to be invoked with the trace ID and span
+                            ID when the trace is started.
         """
         self._on_chunk: StreamingCallback = on_chunk if on_chunk is not None else noop_streaming_callback
         self._context: dict[str, object] = context if context is not None else {}
-        self._on_trace_start: Callable[[str], None] = on_trace_start if on_trace_start else lambda _: None
+        self._on_trace_start: Callable[[str, str], None] = on_trace_start if on_trace_start else lambda _t, _s: None
 
     @property
     def context(self) -> dict[str, object]:
@@ -345,7 +345,7 @@ class Action(Generic[InputT, OutputT, ChunkT]):
         input: InputT | None = None,
         on_chunk: StreamingCallback | None = None,
         context: dict[str, object] | None = None,
-        on_trace_start: Callable[[str], None] | None = None,
+        on_trace_start: Callable[[str, str], None] | None = None,
         _telemetry_labels: dict[str, object] | None = None,
     ) -> ActionResponse[OutputT]:
         """Executes the action asynchronously with the given input.
@@ -361,7 +361,7 @@ class Action(Generic[InputT, OutputT, ChunkT]):
             on_chunk: An optional callback function to receive streaming output chunks.
             context: An optional dictionary containing context data for the execution.
             on_trace_start: An optional callback to be invoked with the trace ID
-                            when the trace is started.
+                            and span ID when the trace is started.
             telemetry_labels: Optional labels for telemetry.
 
         Returns:
@@ -385,7 +385,7 @@ class Action(Generic[InputT, OutputT, ChunkT]):
         raw_input: InputT | None = None,
         on_chunk: StreamingCallback | None = None,
         context: dict[str, object] | None = None,
-        on_trace_start: Callable[[str], None] | None = None,
+        on_trace_start: Callable[[str, str], None] | None = None,
         telemetry_labels: dict[str, object] | None = None,
     ) -> ActionResponse[OutputT]:
         """Executes the action asynchronously with raw, unvalidated input.
@@ -402,7 +402,7 @@ class Action(Generic[InputT, OutputT, ChunkT]):
             on_chunk: An optional callback function to receive streaming output chunks.
             context: An optional dictionary containing context data for the execution.
             on_trace_start: An optional callback to be invoked with the trace ID
-                            when the trace is started.
+                            and span ID when the trace is started.
             telemetry_labels: Optional labels for telemetry.
 
         Returns:
@@ -577,9 +577,10 @@ def _make_tracing_wrappers(
         afn = ensure_async(fn)
         start_time = time.perf_counter()
         with tracer.start_as_current_span(name) as span:
-            # Format trace_id as 32-char hex string (OpenTelemetry standard format)
+            # Format trace_id and span_id as hex strings (OpenTelemetry standard format)
             trace_id = format(span.get_span_context().trace_id, '032x')
-            ctx._on_trace_start(trace_id)  # pyright: ignore[reportPrivateUsage]
+            span_id = format(span.get_span_context().span_id, '016x')
+            ctx._on_trace_start(trace_id, span_id)  # pyright: ignore[reportPrivateUsage]
             record_input_metadata(
                 span=span,
                 kind=kind,
@@ -607,7 +608,7 @@ def _make_tracing_wrappers(
 
             output = _record_latency(output, start_time)
             record_output_metadata(span, output=output)
-            return ActionResponse(response=output, trace_id=trace_id)
+            return ActionResponse(response=output, trace_id=trace_id, span_id=span_id)
 
     def sync_tracing_wrapper(input: object | None, ctx: ActionRunContext) -> ActionResponse[Any]:
         """Wrap the function in a sync tracing wrapper.
@@ -621,9 +622,10 @@ def _make_tracing_wrappers(
         """
         start_time = time.perf_counter()
         with tracer.start_as_current_span(name) as span:
-            # Format trace_id as 32-char hex string (OpenTelemetry standard format)
+            # Format trace_id and span_id as hex strings (OpenTelemetry standard format)
             trace_id = format(span.get_span_context().trace_id, '032x')
-            ctx._on_trace_start(trace_id)  # pyright: ignore[reportPrivateUsage]
+            span_id = format(span.get_span_context().span_id, '016x')
+            ctx._on_trace_start(trace_id, span_id)  # pyright: ignore[reportPrivateUsage]
             record_input_metadata(
                 span=span,
                 kind=kind,
@@ -651,6 +653,6 @@ def _make_tracing_wrappers(
 
             output = _record_latency(output, start_time)
             record_output_metadata(span, output=output)
-            return ActionResponse(response=output, trace_id=trace_id)
+            return ActionResponse(response=output, trace_id=trace_id, span_id=span_id)
 
     return sync_tracing_wrapper, async_tracing_wrapper

--- a/py/packages/genkit/src/genkit/core/action/types.py
+++ b/py/packages/genkit/src/genkit/core/action/types.py
@@ -68,6 +68,7 @@ class ActionResponse(BaseModel, Generic[ResponseT]):
     Attributes:
         response: The actual response data from the action execution.
         trace_id: A unique identifier for tracing the action execution.
+        span_id: The span ID of the root action span.
     """
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
@@ -76,6 +77,7 @@ class ActionResponse(BaseModel, Generic[ResponseT]):
 
     response: ResponseT
     trace_id: str
+    span_id: str = ''
 
 
 class ActionMetadataKey(StrEnum):

--- a/py/packages/genkit/src/genkit/core/reflection.py
+++ b/py/packages/genkit/src/genkit/core/reflection.py
@@ -345,7 +345,7 @@ def create_reflection_asgi_app(
         # Wrap execution to track the task for cancellation support
         task = asyncio.current_task()
 
-        def on_trace_start(trace_id: str) -> None:
+        def on_trace_start(trace_id: str, span_id: str) -> None:
             if task:
                 active_actions[trace_id] = task
 
@@ -365,7 +365,7 @@ def create_reflection_asgi_app(
         _action_input: object,
         context: dict[str, Any],
         version: str,
-        on_trace_start: Callable[[str], None],
+        on_trace_start: Callable[[str, str], None],
     ) -> StreamingResponse:
         """Handle streaming action execution with early header flushing.
 
@@ -391,11 +391,13 @@ def create_reflection_asgi_app(
         # Event to signal when trace ID is available
         trace_id_event: asyncio.Event = asyncio.Event()
         run_trace_id: str | None = None
+        run_span_id: str | None = None
 
-        def wrapped_on_trace_start(tid: str) -> None:
-            nonlocal run_trace_id
+        def wrapped_on_trace_start(tid: str, sid: str) -> None:
+            nonlocal run_trace_id, run_span_id
             run_trace_id = tid
-            on_trace_start(tid)
+            run_span_id = sid
+            on_trace_start(tid, sid)
             trace_id_event.set()  # Signal that trace ID is ready
 
         async def run_action_task() -> None:
@@ -415,7 +417,7 @@ def create_reflection_asgi_app(
                 )
                 final_response = {
                     'result': dump_dict(output.response),
-                    'telemetry': {'traceId': output.trace_id},
+                    'telemetry': {'traceId': output.trace_id, 'spanId': output.span_id},
                 }
                 chunk_queue.put_nowait(json.dumps(final_response))
 
@@ -449,6 +451,8 @@ def create_reflection_asgi_app(
         }
         if run_trace_id:
             headers['X-Genkit-Trace-Id'] = run_trace_id  # pyright: ignore[reportUnreachable]
+        if run_span_id:
+            headers['X-Genkit-Span-Id'] = run_span_id  # pyright: ignore[reportUnreachable]
 
         async def stream_generator() -> AsyncGenerator[str, None]:
             """Yield chunks from the queue as they arrive."""
@@ -476,7 +480,7 @@ def create_reflection_asgi_app(
         _action_input: object,
         context: dict[str, Any],
         version: str,
-        on_trace_start: Callable[[str], None],
+        on_trace_start: Callable[[str, str], None],
     ) -> StreamingResponse:
         """Handle standard (non-streaming) action execution with early header flushing.
 
@@ -498,13 +502,15 @@ def create_reflection_asgi_app(
         # Event to signal when trace ID is available
         trace_id_event: asyncio.Event = asyncio.Event()
         run_trace_id: str | None = None
+        run_span_id: str | None = None
         action_result: dict[str, Any] | None = None
         action_error: Exception | None = None
 
-        def wrapped_on_trace_start(tid: str) -> None:
-            nonlocal run_trace_id
+        def wrapped_on_trace_start(tid: str, sid: str) -> None:
+            nonlocal run_trace_id, run_span_id
             run_trace_id = tid
-            on_trace_start(tid)
+            run_span_id = sid
+            on_trace_start(tid, sid)
             trace_id_event.set()  # Signal that trace ID is ready
 
         async def run_action_and_get_result() -> None:
@@ -517,7 +523,7 @@ def create_reflection_asgi_app(
                 )
                 action_result = {
                     'result': dump_dict(output.response),
-                    'telemetry': {'traceId': output.trace_id},
+                    'telemetry': {'traceId': output.trace_id, 'spanId': output.span_id},
                 }
             except Exception as e:
                 action_error = e
@@ -552,6 +558,8 @@ def create_reflection_asgi_app(
         }
         if run_trace_id:
             headers['X-Genkit-Trace-Id'] = run_trace_id  # pyright: ignore[reportUnreachable]
+        if run_span_id:
+            headers['X-Genkit-Span-Id'] = run_span_id  # pyright: ignore[reportUnreachable]
 
         return StreamingResponse(
             body_generator(),


### PR DESCRIPTION
## Summary

Achieves parity with the JS SDK where `onTraceStart` receives both `traceId` and `spanId`, and the reflection server sets both `X-Genkit-Trace-Id` and `X-Genkit-Span-Id` response headers.

### JS SDK reference

In the JS SDK (`js/core/src/action.ts` L118):
```typescript
onTraceStart?: (traceInfo: { traceId: string; spanId: string }) => void;
```

And in `js/core/src/reflection.ts` L247:
```typescript
response.setHeader('X-Genkit-Span-Id', spanId);
```

### Changes

| File | Change |
|---|---|
| `action/types.py` | Add `span_id: str = ''` to `ActionResponse` |
| `action/_action.py` | Change `on_trace_start` from `Callable[[str], None]` to `Callable[[str, str], None]` |
| `action/_action.py` | Extract `span_id` from OTel span context (16-char hex) in both sync/async wrappers |
| `reflection.py` | Set `X-Genkit-Span-Id` header in streaming and standard handlers |
| `reflection.py` | Include `spanId` in telemetry response body |
| `reflection_test.py` | Add `span_id` to mock outputs, verify `spanId` in response |

### Backward compatibility

The `span_id` field on `ActionResponse` defaults to `''` so existing code that constructs `ActionResponse` without `span_id` continues to work.