### PR TITLE
fix(py/genkit): add explicit Transfer-Encoding: chunked to standard action response

### DIFF
--- a/py/packages/genkit/src/genkit/core/reflection.py
+++ b/py/packages/genkit/src/genkit/core/reflection.py
@@ -555,6 +555,7 @@ def create_reflection_asgi_app(
 
         headers = {
             'x-genkit-version': version,
+            'Transfer-Encoding': 'chunked',
         }
         if run_trace_id:
             headers['X-Genkit-Trace-Id'] = run_trace_id  # pyright: ignore[reportUnreachable]


### PR DESCRIPTION
## Summary

The streaming action handler already set `Transfer-Encoding: chunked` explicitly for early header flushing, but the standard action handler (which also uses `StreamingResponse` for early trace ID header flushing) relied on Starlette to set it implicitly.

This adds the explicit header to ensure consistent behavior across both response types, matching the JS SDK which explicitly sets `Transfer-Encoding: chunked` in its response headers.

## Changes

- `py/packages/genkit/src/genkit/core/reflection.py`: Add `Transfer-Encoding: chunked` to `run_standard_action` headers dict

## Testing

- All reflection server tests pass (`7 passed`)
- Full test suite (`500+ tests`) passes