### PR TITLE
fix(go): preserve error chain in GenkitError via Unwrap

### DIFF
--- a/go/core/error.go
+++ b/go/core/error.go
@@ -71,7 +71,6 @@ func (e *UserFacingError) Error() string {
 
 // NewError creates a new GenkitError with a stack trace.
 func NewError(status StatusName, message string, args ...any) *GenkitError {
-	// Prevents a compile-time warning about non-constant message.
 	msg := message
 
 	ge := &GenkitError{
@@ -79,10 +78,11 @@ func NewError(status StatusName, message string, args ...any) *GenkitError {
 		Message: fmt.Sprintf(msg, args...),
 	}
 
-	// scan args for the last error to wrap it
-	for _, arg := range args {
-		if err, ok := arg.(error); ok {
+	// scan args for the last error to wrap it (Iterate backwards)
+	for i := len(args) - 1; i >= 0; i-- {
+		if err, ok := args[i].(error); ok {
 			ge.originalError = err
+			break
 		}
 	}
 

--- a/go/core/error.go
+++ b/go/core/error.go
@@ -107,13 +107,19 @@ func (e *GenkitError) Unwrap() error {
 
 // ToReflectionError returns a JSON-serializable representation for reflection API responses.
 func (e *GenkitError) ToReflectionError() ReflectionError {
-	errDetails := &ReflectionErrorDetails{}
+	var errDetails *ReflectionErrorDetails
 	if e.Details != nil {
-		if stackVal, ok := e.Details["stack"].(string); ok {
-			errDetails.Stack = &stackVal
-		}
-		if traceVal, ok := e.Details["traceId"].(string); ok {
-			errDetails.TraceID = &traceVal
+		stackVal, stackOk := e.Details["stack"].(string)
+		traceVal, traceOk := e.Details["traceId"].(string)
+
+		if stackOk || traceOk {
+			errDetails = &ReflectionErrorDetails{}
+			if stackOk {
+				errDetails.Stack = &stackVal
+			}
+			if traceOk {
+				errDetails.TraceID = &traceVal
+			}
 		}
 	}
 	return ReflectionError{

--- a/go/core/error_test.go
+++ b/go/core/error_test.go
@@ -157,8 +157,8 @@ func TestGenkitErrorToReflectionError(t *testing.T) {
 		if re.Message != "success" {
 			t.Errorf("Message = %q, want %q", re.Message, "success")
 		}
-		if re.Details.Stack != nil {
-			t.Error("expected nil stack")
+		if re.Details != nil {
+			t.Error("expected nil details")
 		}
 	})
 }

--- a/go/core/error_test.go
+++ b/go/core/error_test.go
@@ -163,21 +163,69 @@ func TestGenkitErrorToReflectionError(t *testing.T) {
 	})
 }
 
+// testCustomError is a helper type for the errors.As subtest.
+type testCustomError struct {
+	code int
+}
+
+func (e *testCustomError) Error() string {
+	return fmt.Sprintf("custom error %d", e.code)
+}
+
 func TestGenkitErrorUnwrap(t *testing.T) {
-	original := errors.New("original failure")
+	t.Run("errors.Is matches original cause", func(t *testing.T) {
+		original := errors.New("original failure")
+		gErr := NewError(INTERNAL, "something happened: %v", original)
 
-	// Use INTERNAL instead of StatusInternal
-	gErr := NewError(INTERNAL, "something happened: %v", original)
+		if !errors.Is(gErr, original) {
+			t.Errorf("expected errors.Is to return true, but got false")
+		}
+		if gErr.Unwrap() != original {
+			t.Errorf("Unwrap() returned wrong error")
+		}
+	})
 
-	// Verify errors.Is works (this is the most important check)
-	if !errors.Is(gErr, original) {
-		t.Errorf("expected errors.Is to return true, but got false")
-	}
+	t.Run("errors.As extracts typed cause", func(t *testing.T) {
+		cause := &testCustomError{code: 42}
+		ge := NewError(INTERNAL, "failed: %v", cause)
 
-	// Verify Unwrap works directly
-	if gErr.Unwrap() != original {
-		t.Errorf("Unwrap() returned wrong error")
-	}
+		var target *testCustomError
+		if !errors.As(ge, &target) {
+			t.Fatal("errors.As failed to find *testCustomError")
+		}
+		if target.code != 42 {
+			t.Errorf("target.code = %d, want 42", target.code)
+		}
+	})
+
+	t.Run("no args returns nil", func(t *testing.T) {
+		ge := NewError(INTERNAL, "no args error")
+
+		if ge.Unwrap() != nil {
+			t.Errorf("Unwrap() = %v, want nil", ge.Unwrap())
+		}
+	})
+
+	t.Run("multiple errors preserves the last one", func(t *testing.T) {
+		first := errors.New("first")
+		second := errors.New("second")
+		ge := NewError(INTERNAL, "two errors: %v %v", first, second)
+
+		if ge.Unwrap() != second {
+			t.Errorf("Unwrap() = %v, want %v (last error)", ge.Unwrap(), second)
+		}
+		if !errors.Is(ge, second) {
+			t.Error("errors.Is(ge, second) = false, want true")
+		}
+	})
+
+	t.Run("non-error args returns nil", func(t *testing.T) {
+		ge := NewError(INTERNAL, "value is %d and %s", 42, "hello")
+
+		if ge.Unwrap() != nil {
+			t.Errorf("Unwrap() = %v, want nil", ge.Unwrap())
+		}
+	})
 }
 
 func TestToReflectionError(t *testing.T) {

--- a/go/core/error_test.go
+++ b/go/core/error_test.go
@@ -163,6 +163,23 @@ func TestGenkitErrorToReflectionError(t *testing.T) {
 	})
 }
 
+func TestGenkitErrorUnwrap(t *testing.T) {
+	original := errors.New("original failure")
+
+	// Use INTERNAL instead of StatusInternal
+	gErr := NewError(INTERNAL, "something happened: %v", original)
+
+	// Verify errors.Is works (this is the most important check)
+	if !errors.Is(gErr, original) {
+		t.Errorf("expected errors.Is to return true, but got false")
+	}
+
+	// Verify Unwrap works directly
+	if gErr.Unwrap() != original {
+		t.Errorf("Unwrap() returned wrong error")
+	}
+}
+
 func TestToReflectionError(t *testing.T) {
 	t.Run("handles GenkitError directly", func(t *testing.T) {
 		ge := NewError(INVALID_ARGUMENT, "bad input")


### PR DESCRIPTION
## Summary

- `GenkitError` now preserves the original error chain, enabling `errors.Is()` and `errors.As()` to work as expected
- Adds `originalError` field and `Unwrap()` method to `GenkitError`
- `NewError` reverse-scans args to find the last `error` and stores it as the cause
- Adds defensive nil check for `Details` in `ToReflectionError()`
- Adds comprehensive `t.Run` subtests covering `errors.Is`, `errors.As`, no-args, multiple errors, and non-error args edge cases

## Credit

This PR is based on the work by @DEVMANISHOFFL in #4018 (commits cherry-picked with original authorship preserved). I added additional test coverage and resolved merge conflicts with the latest `main`.

Fixes #3811
Supersedes #4018

## Test plan

- [x] `go test ./core/ -run TestGenkitErrorUnwrap -v` — all 5 subtests pass
- [x] `go test ./core/` — full core package passes