### PR TITLE
fix(js/ai): pass input.default from dotprompt to DevUI reflection API

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -116,6 +116,7 @@ export interface PromptConfig<
   input?: {
     schema?: I;
     jsonSchema?: JSONSchema7;
+    default?: Record<string, any>;
   };
   system?: string | Part | Part[] | PartsResolver<z.infer<I>>;
   prompt?: string | Part | Part[] | PartsResolver<z.infer<I>>;

--- a/py/samples/framework-evaluator-demo/prompts/hello.prompt
+++ b/py/samples/framework-evaluator-demo/prompts/hello.prompt
@@ -1,8 +1,11 @@
 ---
+model: googleai/gemini-3-flash-preview
 config:
   temperature: 0.75
   topK: 10
 input:
+  default:
+    query: "fibonacci function"
   schema:
     query: string
 ---

--- a/py/samples/framework-prompt-demo/prompts/recipe.prompt
+++ b/py/samples/framework-prompt-demo/prompts/recipe.prompt
@@ -1,6 +1,8 @@
 ---
 model: googleai/gemini-3-flash-preview
 input:
+  default:
+    food: "banana bread"
   schema:
     food: string
     ingredients?(array): string

--- a/py/samples/framework-prompt-demo/prompts/story.prompt
+++ b/py/samples/framework-prompt-demo/prompts/story.prompt
@@ -1,6 +1,9 @@
 ---
 model: googleai/gemini-3-flash-preview
 input:
+  default:
+    subject: "a brave little toaster"
+    personality: "courageous"
   schema:
     subject: string
     personality?: string

--- a/py/samples/web-endpoints-hello/prompts/code_review.prompt
+++ b/py/samples/web-endpoints-hello/prompts/code_review.prompt
@@ -1,6 +1,9 @@
 ---
 model: googleai/gemini-3-flash-preview
 input:
+  default:
+    code: "def add(a, b):\n    return a + b"
+    language: "python"
   schema:
     code: string
     language?: string


### PR DESCRIPTION
## Summary

Pass `input.default` from dotprompt metadata through to the DevUI reflection API response so that prompt input forms can be pre-filled with default values.

## Changes

- `js/ai/src/prompt.ts`: Add `default` key to the `input` object in both:
  - `promptMetadata()` function (used by `DefinePrompt`)
  - Dotprompt file loading path (used when loading `.prompt` files)

## Testing

The `input.default` field is now included in the reflection API response when a `.prompt` file specifies default input values in its frontmatter.

Fixes #4534
