### PR TITLE
fix(go/ai): move input.default into input map for DevUI compatibility

### DIFF
--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -303,8 +303,10 @@ func (p *prompt) Render(ctx context.Context, input any) (*GenerateActionOptions,
 
 	// TODO: This is hacky; we should have a helper that fetches the metadata.
 	if input == nil {
-		if inputMeta, ok := p.Desc().Metadata["prompt"].(map[string]any)["input"].(map[string]any); ok {
-			input = inputMeta["default"]
+		if promptMeta, ok := p.Desc().Metadata["prompt"].(map[string]any); ok {
+			if inputMeta, ok := promptMeta["input"].(map[string]any); ok {
+				input = inputMeta["default"]
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Move `DefaultInput` into the `input` map as `"default"` so the DevUI receives it at the expected location (`input.default`), matching the dotprompt spec and the DevUI's `PromptFrontmatterSchema`.

## Changes

- `go/ai/prompt.go`:
  - Move `DefaultInput` from top-level `"defaultInput"` key into `input` map as `"default"`
  - Update `Render()` to read default input from `input["default"]` with safe type assertions

## Testing

- `go vet ./ai/...` passes
- The `input.default` field is now at the location expected by the DevUI

Fixes #4536
