### PR TITLE
fix(py): resolve embedder output schema 

### DIFF
--- a/py/packages/genkit/src/genkit/core/registry.py
+++ b/py/packages/genkit/src/genkit/core/registry.py
@@ -119,11 +119,7 @@ class Registry:
         self._loading_actions: set[str] = set()
 
         # Initialize Dotprompt with schema_resolver to match JS SDK pattern
-        # Use async function to avoid thread pool deadlock in resolve_json_schema
-        async def async_schema_resolver(name: str) -> dict[str, object] | str:
-            return self.lookup_schema(name) or name
-
-        self.dotprompt: Dotprompt = Dotprompt(schema_resolver=async_schema_resolver)
+        self.dotprompt: Dotprompt = Dotprompt(schema_resolver=lambda name: self.lookup_schema(name) or name)
         # TODO(#4352): Figure out how to set this.
         self.api_stability: str = 'stable'
 

--- a/py/plugins/google-genai/tests/google_genai_plugin_test.py
+++ b/py/plugins/google-genai/tests/google_genai_plugin_test.py
@@ -215,6 +215,21 @@ async def test_vertexai_resolve_model(mock_list_models: MagicMock, mock_client: 
     assert action.name == 'vertexai/gemini-2.0-flash'
 
 
+@patch('genkit.plugins.google_genai.google.genai.client.Client')
+@patch('genkit.plugins.google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_vertexai_resolve_embedder(mock_list_models: MagicMock, mock_client: MagicMock) -> None:
+    """Test VertexAI plugin resolves embedder actions."""
+    mock_list_models.return_value = GenaiModels()
+
+    plugin = VertexAI(project='test-project')
+    action = await plugin.resolve(ActionKind.EMBEDDER, 'vertexai/gemini-embedding-001')
+
+    assert action is not None
+    assert action.kind == ActionKind.EMBEDDER
+    assert action.name == 'vertexai/gemini-embedding-001'
+
+
 def test_embedding_task_types() -> None:
     """Test EmbeddingTaskType enum values."""
     assert EmbeddingTaskType.RETRIEVAL_QUERY is not None

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "genkit-plugin-huggingface",
   "genkit-plugin-observability",
   "liccheck>=0.9.2",
-  "setuptools>=75.0.0,<82",  # Required by liccheck (provides pkg_resources, removed in setuptools 82+)
+  "setuptools>=75.0.0,<82",                   # Required by liccheck (provides pkg_resources, removed in setuptools 82+)
   "mcp>=1.25.0",
   "python-multipart>=0.0.22",
   "strenum>=0.4.15; python_version < '3.11'",
@@ -480,12 +480,12 @@ extraPaths = [
   "plugins/vertex-ai/src",
   "plugins/xai/src",
 ]
-pythonVersion          = "3.10"
-reportMissingImports   = true
+pythonVersion = "3.10"
+reportMissingImports = true
 reportMissingTypeStubs = false
-typeCheckingMode       = "basic"
-venv                   = ".venv"
-venvPath               = "."
+typeCheckingMode = "basic"
+venv = ".venv"
+venvPath = "."
 
 # Pyrefly type checking configuration (Meta's new type checker).
 #


### PR DESCRIPTION
This PR is to solve the problem of recipe prompt failing in framework-prompt-demo sample. 
- Explicitly set input/output schemas in GoogleAI and VertexAI plugins to ensure they are visible in Dev UI.

