### PR TITLE
feat(releasekit): add Phase 3 Publish MVP modules

### DIFF
--- a/py/tools/releasekit/pyproject.toml
+++ b/py/tools/releasekit/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 ]
 
 [project.scripts]
-releasekit = "releasekit.cli:main"
+releasekit = "releasekit.cli:_main"
 
 [build-system]
 build-backend = "hatchling.build"

--- a/py/tools/releasekit/src/releasekit/cli.py
+++ b/py/tools/releasekit/src/releasekit/cli.py
@@ -1,0 +1,562 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI entry point for releasekit.
+
+Constructs backend instances and injects them into the pipeline modules.
+Provides subcommands for the full release workflow.
+
+Subcommands::
+
+    releasekit publish    Publish all changed packages to PyPI
+    releasekit plan       Preview the execution plan (no publish)
+    releasekit discover   List all workspace packages
+    releasekit graph      Show the dependency graph
+    releasekit version    Show computed version bumps
+    releasekit explain    Explain an error code
+
+Usage::
+
+    # Preview what would be published:
+    uvx releasekit plan
+
+    # Publish all changed packages:
+    uvx releasekit publish --dry-run
+    uvx releasekit publish --force
+
+    # Show workspace packages:
+    uvx releasekit discover
+
+    # Explain an error:
+    uvx releasekit explain RK-PREFLIGHT-DIRTY-WORKTREE
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from releasekit import __version__
+from releasekit.backends.forge import GitHubBackend
+from releasekit.backends.pm import UvBackend
+from releasekit.backends.registry import PyPIBackend
+from releasekit.backends.vcs import GitBackend
+from releasekit.config import ReleaseConfig, load_config
+from releasekit.errors import E, ReleaseKitError, explain
+from releasekit.graph import build_graph, detect_cycles, topo_sort
+from releasekit.lock import release_lock
+from releasekit.logging import get_logger
+from releasekit.plan import build_plan
+from releasekit.preflight import run_preflight
+from releasekit.publisher import PublishConfig, publish_workspace
+from releasekit.versioning import compute_bumps
+from releasekit.versions import ReleaseManifest
+from releasekit.workspace import discover_packages
+
+logger = get_logger(__name__)
+
+
+def _find_workspace_root() -> Path:
+    """Find the workspace root by walking up from CWD.
+
+    Looks for a ``pyproject.toml`` containing ``[tool.uv.workspace]``.
+
+    Returns:
+        Absolute path to the workspace root.
+
+    Raises:
+        ReleaseKitError: If no workspace root is found.
+    """
+    cwd = Path.cwd().resolve()
+    for parent in [cwd, *cwd.parents]:
+        pyproject = parent / 'pyproject.toml'
+        if pyproject.exists():
+            text = pyproject.read_text(encoding='utf-8')
+            if '[tool.uv.workspace]' in text:
+                return parent
+    raise ReleaseKitError(
+        E.WORKSPACE_NOT_FOUND,
+        'Could not find a pyproject.toml with [tool.uv.workspace].',
+        hint='Run this command from within a uv workspace.',
+    )
+
+
+def _create_backends(
+    workspace_root: Path,
+    config: ReleaseConfig,
+) -> tuple[GitBackend, UvBackend, GitHubBackend, PyPIBackend]:
+    """Create real backend instances for production use.
+
+    Args:
+        workspace_root: Workspace root directory.
+        config: Release configuration.
+
+    Returns:
+        Tuple of (VCS, PackageManager, Forge, Registry) backends.
+    """
+    vcs = GitBackend(workspace_root)
+    pm = UvBackend(workspace_root)
+    forge = GitHubBackend(
+        repo='firebase/genkit',  # NOTE: Could be auto-detected from git remote.
+        cwd=workspace_root,
+    )
+    registry = PyPIBackend(pool_size=config.http_pool_size)
+    return vcs, pm, forge, registry
+
+
+# ── Subcommand handlers ──────────────────────────────────────────────
+
+
+async def _cmd_publish(args: argparse.Namespace) -> int:
+    """Handle the ``publish`` subcommand."""
+    workspace_root = _find_workspace_root()
+    config = load_config(workspace_root / 'pyproject.toml')
+    vcs, pm, forge, registry = _create_backends(workspace_root, config)
+
+    # Discover and analyze.
+    packages = discover_packages(workspace_root, exclude_patterns=config.exclude)
+    graph = build_graph(packages)
+    levels = topo_sort(graph)
+    versions = compute_bumps(
+        packages,
+        vcs,
+        tag_format=config.tag_format,
+        prerelease='',
+        force_unchanged=args.force_unchanged,
+    )
+
+    # Check for any actual bumps.
+    bumped = [v for v in versions if not v.skipped]
+    if not bumped:
+        logger.info('nothing_to_publish', message='No packages have changes to publish.')
+        return 0
+
+    # Build execution plan for preview.
+    plan = build_plan(versions, levels, exclude_names=config.exclude, git_sha=vcs.current_sha())
+
+    if not args.force and not args.dry_run:
+        print(plan.format_table())  # noqa: T201 - CLI output
+        print()  # noqa: T201 - CLI output
+        if sys.stdin.isatty():
+            answer = await asyncio.to_thread(input, f'Publish {len(bumped)} package(s)? [y/N] ')
+            if answer.lower() not in {'y', 'yes'}:
+                logger.info('publish_cancelled')
+                return 1
+
+    # Preflight.
+    with release_lock(workspace_root):
+        preflight = await run_preflight(
+            vcs=vcs,
+            pm=pm,
+            forge=forge,
+            registry=registry,
+            graph=graph,
+            versions=versions,
+            workspace_root=workspace_root,
+            dry_run=args.dry_run,
+            skip_version_check=args.force,
+        )
+        if not preflight.ok:
+            for name, error in preflight.errors.items():
+                logger.error('preflight_blocked', check=name, error=error)
+            return 1
+
+        # Publish.
+        pub_config = PublishConfig(
+            concurrency=args.concurrency,
+            dry_run=args.dry_run,
+            check_url=args.check_url,
+            index_url=args.index_url,
+            smoke_test=config.smoke_test,
+            force=args.force,
+            workspace_root=workspace_root,
+        )
+
+        result = await publish_workspace(
+            vcs=vcs,
+            pm=pm,
+            forge=forge,
+            registry=registry,
+            packages=packages,
+            levels=levels,
+            versions=versions,
+            config=pub_config,
+        )
+
+    logger.info('publish_result', summary=result.summary())
+
+    if not result.ok:
+        for name, error in result.failed.items():
+            logger.error('publish_failed', package=name, error=error)
+        return 1
+
+    # Save manifest.
+    manifest = ReleaseManifest(
+        git_sha=vcs.current_sha(),
+        packages=versions,
+    )
+    manifest_path = workspace_root / 'release-manifest.json'
+    manifest.save(manifest_path)
+    logger.info('manifest_saved', path=str(manifest_path))
+
+    return 0
+
+
+async def _cmd_plan(args: argparse.Namespace) -> int:
+    """Handle the ``plan`` subcommand."""
+    workspace_root = _find_workspace_root()
+    config = load_config(workspace_root / 'pyproject.toml')
+    vcs, pm, forge, registry = _create_backends(workspace_root, config)
+
+    packages = discover_packages(workspace_root, exclude_patterns=config.exclude)
+    graph = build_graph(packages)
+    levels = topo_sort(graph)
+    versions = compute_bumps(
+        packages,
+        vcs,
+        tag_format=config.tag_format,
+        force_unchanged=args.force_unchanged,
+    )
+
+    # Check which versions are already published.
+    already_published: set[str] = set()
+    for v in versions:
+        if not v.skipped and await registry.check_published(v.name, v.new_version):
+            already_published.add(v.name)
+
+    plan = build_plan(
+        versions,
+        levels,
+        exclude_names=config.exclude,
+        already_published=already_published,
+        git_sha=vcs.current_sha(),
+    )
+
+    fmt = getattr(args, 'format', 'table')
+    if fmt == 'json':
+        print(plan.format_json())  # noqa: T201 - CLI output
+    elif fmt == 'csv':
+        print(plan.format_csv())  # noqa: T201 - CLI output
+    else:
+        print(plan.format_table())  # noqa: T201 - CLI output
+
+    return 0
+
+
+def _cmd_discover(args: argparse.Namespace) -> int:
+    """Handle the ``discover`` subcommand."""
+    workspace_root = _find_workspace_root()
+    config = load_config(workspace_root / 'pyproject.toml')
+    packages = discover_packages(workspace_root, exclude_patterns=config.exclude)
+
+    fmt = getattr(args, 'format', 'table')
+    if fmt == 'json':
+        data = [
+            {
+                'name': p.name,
+                'version': p.version,
+                'path': str(p.path),
+                'internal_deps': p.internal_deps,
+                'publishable': p.is_publishable,
+            }
+            for p in packages
+        ]
+        print(json.dumps(data, indent=2))  # noqa: T201 - CLI output
+    else:
+        for pkg in packages:
+            deps = ', '.join(pkg.internal_deps) if pkg.internal_deps else '(none)'
+            pub = '' if pkg.is_publishable else ' [private]'
+            print(f'  {pkg.name} {pkg.version} ({pkg.path}){pub}')  # noqa: T201 - CLI output
+            print(f'    deps: {deps}')  # noqa: T201 - CLI output
+
+    return 0
+
+
+def _cmd_graph(args: argparse.Namespace) -> int:
+    """Handle the ``graph`` subcommand."""
+    workspace_root = _find_workspace_root()
+    config = load_config(workspace_root / 'pyproject.toml')
+    packages = discover_packages(workspace_root, exclude_patterns=config.exclude)
+    graph = build_graph(packages)
+
+    fmt = getattr(args, 'format', 'table')
+    if fmt == 'json':
+        data = {
+            'packages': graph.names,
+            'edges': graph.edges,
+            'reverse_edges': graph.reverse_edges,
+        }
+        print(json.dumps(data, indent=2))  # noqa: T201 - CLI output
+    else:
+        levels = topo_sort(graph)
+        for level_idx, level in enumerate(levels):
+            names = ', '.join(p.name for p in level)
+            print(f'  Level {level_idx}: {names}')  # noqa: T201 - CLI output
+
+    return 0
+
+
+def _cmd_check_cycles(args: argparse.Namespace) -> int:
+    """Handle the ``check-cycles`` subcommand."""
+    workspace_root = _find_workspace_root()
+    config = load_config(workspace_root / 'pyproject.toml')
+    packages = discover_packages(workspace_root, exclude_patterns=config.exclude)
+    graph = build_graph(packages)
+    cycles = detect_cycles(graph)
+
+    if cycles:
+        for cycle in cycles:
+            print(f'  Cycle: {" → ".join(cycle)}')  # noqa: T201 - CLI output
+        return 1
+
+    print('No cycles detected.')  # noqa: T201 - CLI output
+    return 0
+
+
+def _cmd_version(args: argparse.Namespace) -> int:
+    """Handle the ``version`` subcommand."""
+    workspace_root = _find_workspace_root()
+    config = load_config(workspace_root / 'pyproject.toml')
+    vcs, pm, forge, registry = _create_backends(workspace_root, config)
+
+    packages = discover_packages(workspace_root, exclude_patterns=config.exclude)
+    versions = compute_bumps(
+        packages,
+        vcs,
+        tag_format=config.tag_format,
+        force_unchanged=args.force_unchanged,
+    )
+
+    fmt = getattr(args, 'format', 'table')
+    if fmt == 'json':
+        data = [
+            {
+                'name': v.name,
+                'old_version': v.old_version,
+                'new_version': v.new_version,
+                'bump': v.bump,
+                'reason': v.reason,
+                'skipped': v.skipped,
+                'tag': v.tag,
+            }
+            for v in versions
+        ]
+        print(json.dumps(data, indent=2))  # noqa: T201 - CLI output
+    else:
+        for v in versions:
+            emoji = '⏭️' if v.skipped else '📦'
+            print(f'  {emoji} {v.name}: {v.old_version} → {v.new_version} ({v.bump})')  # noqa: T201 - CLI output
+            if v.reason:
+                print(f'     {v.reason}')  # noqa: T201 - CLI output
+
+    return 0
+
+
+def _cmd_explain(args: argparse.Namespace) -> int:
+    """Handle the ``explain`` subcommand."""
+    result = explain(args.code)
+    if result is None:
+        print(f'Unknown error code: {args.code}')  # noqa: T201 - CLI output
+        return 1
+    print(result)  # noqa: T201 - CLI output
+    return 0
+
+
+# ── Argument parser ──────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser.
+
+    Returns:
+        Configured :class:`argparse.ArgumentParser`.
+    """
+    parser = argparse.ArgumentParser(
+        prog='releasekit',
+        description='Release orchestration for uv workspaces.',
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'%(prog)s {__version__}',
+    )
+
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    # ── publish ──
+    publish_parser = subparsers.add_parser(
+        'publish',
+        help='Publish all changed packages to PyPI.',
+    )
+    publish_parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Preview mode: log commands without executing.',
+    )
+    publish_parser.add_argument(
+        '--force',
+        '-y',
+        action='store_true',
+        help='Skip confirmation prompt.',
+    )
+    publish_parser.add_argument(
+        '--force-unchanged',
+        action='store_true',
+        help='Include packages with no changes.',
+    )
+    publish_parser.add_argument(
+        '--concurrency',
+        type=int,
+        default=5,
+        help='Max packages publishing simultaneously per level (default: 5).',
+    )
+    publish_parser.add_argument(
+        '--check-url',
+        help='URL to check for existing files (uv publish --check-url).',
+    )
+    publish_parser.add_argument(
+        '--index-url',
+        help='Custom index URL (e.g., Test PyPI).',
+    )
+
+    # ── plan ──
+    plan_parser = subparsers.add_parser(
+        'plan',
+        help='Preview the execution plan without publishing.',
+    )
+    plan_parser.add_argument(
+        '--format',
+        choices=['table', 'json', 'csv'],
+        default='table',
+        help='Output format (default: table).',
+    )
+    plan_parser.add_argument(
+        '--force-unchanged',
+        action='store_true',
+        help='Include packages with no changes.',
+    )
+
+    # ── discover ──
+    discover_parser = subparsers.add_parser(
+        'discover',
+        help='List all workspace packages.',
+    )
+    discover_parser.add_argument(
+        '--format',
+        choices=['table', 'json'],
+        default='table',
+        help='Output format (default: table).',
+    )
+
+    # ── graph ──
+    graph_parser = subparsers.add_parser(
+        'graph',
+        help='Show the dependency graph.',
+    )
+    graph_parser.add_argument(
+        '--format',
+        choices=['table', 'json'],
+        default='table',
+        help='Output format (default: table).',
+    )
+
+    # ── check-cycles ──
+    subparsers.add_parser(
+        'check-cycles',
+        help='Check for circular dependencies.',
+    )
+
+    # ── version ──
+    version_parser = subparsers.add_parser(
+        'version',
+        help='Show computed version bumps.',
+    )
+    version_parser.add_argument(
+        '--format',
+        choices=['table', 'json'],
+        default='table',
+        help='Output format (default: table).',
+    )
+    version_parser.add_argument(
+        '--force-unchanged',
+        action='store_true',
+        help='Include packages with no changes.',
+    )
+
+    # ── explain ──
+    explain_parser = subparsers.add_parser(
+        'explain',
+        help='Explain an error code.',
+    )
+    explain_parser.add_argument(
+        'code',
+        help='Error code to explain (e.g., RK-PREFLIGHT-DIRTY-WORKTREE).',
+    )
+
+    return parser
+
+
+def main() -> int:
+    """CLI entry point.
+
+    Returns:
+        Exit code (0 for success, non-zero for failure).
+    """
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        command = args.command
+        if command == 'publish':
+            return asyncio.run(_cmd_publish(args))
+        if command == 'plan':
+            return asyncio.run(_cmd_plan(args))
+        if command == 'discover':
+            return _cmd_discover(args)
+        if command == 'graph':
+            return _cmd_graph(args)
+        if command == 'check-cycles':
+            return _cmd_check_cycles(args)
+        if command == 'version':
+            return _cmd_version(args)
+        if command == 'explain':
+            return _cmd_explain(args)
+
+        parser.print_help()  # noqa: T201 - CLI output
+        return 1
+
+    except ReleaseKitError as exc:
+        logger.error('releasekit_error', code=exc.code.value, message=str(exc))
+        if exc.hint:
+            logger.info('hint', hint=exc.hint)
+        return 1
+    except KeyboardInterrupt:
+        logger.info('interrupted')
+        return 130
+
+
+def _main() -> None:
+    """Wrapper for pyproject.toml [project.scripts] entry point."""
+    sys.exit(main())
+
+
+__all__ = [
+    'build_parser',
+    'main',
+]

--- a/py/tools/releasekit/src/releasekit/lock.py
+++ b/py/tools/releasekit/src/releasekit/lock.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Advisory lock file to prevent concurrent release runs.
+
+Writes a ``.releasekit.lock`` file containing PID, hostname, and
+timestamp. If a lock file already exists from a different process, the
+acquisition fails. Stale locks (older than ``stale_timeout``) are
+automatically removed.
+
+Key Concepts (ELI5)::
+
+    ┌─────────────────────┬────────────────────────────────────────────────┐
+    │ Concept             │ ELI5 Explanation                               │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ Advisory lock       │ A file that says "I'm working here, don't     │
+    │                     │ touch!" Like a sign on a door.                │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ Stale detection     │ If the sign has been there too long and the   │
+    │                     │ person is gone, we take it down.              │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ atexit cleanup      │ Remove the sign when we leave, even if we     │
+    │                     │ forget to do it manually.                     │
+    └─────────────────────┴────────────────────────────────────────────────┘
+
+Usage::
+
+    from releasekit.lock import release_lock
+
+    with release_lock(Path('.')) as lock_path:
+        # Lock is held; safe to publish
+        ...
+    # Lock is released automatically
+
+    # Or manually:
+    from releasekit.lock import acquire_lock, release_lock_file
+
+    lock_path = acquire_lock(Path('.'))
+    try:
+        ...
+    finally:
+        release_lock_file(lock_path)
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import socket
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from releasekit.errors import E, ReleaseKitError
+from releasekit.logging import get_logger
+
+logger = get_logger(__name__)
+
+LOCK_FILENAME = '.releasekit.lock'
+
+# Default stale timeout: 30 minutes.
+DEFAULT_STALE_TIMEOUT: float = 1800.0
+
+
+@dataclass(frozen=True)
+class LockInfo:
+    """Metadata stored in the lock file.
+
+    Attributes:
+        pid: Process ID that holds the lock.
+        hostname: Machine hostname.
+        timestamp: Unix timestamp when the lock was acquired.
+        user: Username of the lock holder.
+    """
+
+    pid: int
+    hostname: str
+    timestamp: float
+    user: str = ''
+
+
+def _read_lock(lock_path: Path) -> LockInfo | None:
+    """Read and parse an existing lock file, returning None if absent/corrupt."""
+    if not lock_path.exists():
+        return None
+
+    try:
+        text = lock_path.read_text(encoding='utf-8')
+        data = json.loads(text)
+        return LockInfo(
+            pid=int(data['pid']),
+            hostname=str(data['hostname']),
+            timestamp=float(data['timestamp']),
+            user=str(data.get('user', '')),
+        )
+    except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError):
+        logger.warning('lock_file_corrupt', path=str(lock_path))
+        return None
+
+
+def _is_process_alive(pid: int) -> bool:
+    """Return True if a process with the given PID exists on this host."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we lack permission to signal it.
+        return True
+    return True
+
+
+def _is_stale(info: LockInfo, stale_timeout: float) -> bool:
+    """Return True if the lock is stale (too old or process is dead)."""
+    # Lock file stores wall-clock time for cross-machine comparison.
+    wall_age = time.time() - info.timestamp
+    if wall_age > stale_timeout:
+        return True
+
+    # On the same host, check if the process is still alive.
+    if info.hostname == socket.gethostname() and not _is_process_alive(info.pid):
+        return True
+
+    return False
+
+
+def acquire_lock(
+    workspace_root: Path,
+    *,
+    stale_timeout: float = DEFAULT_STALE_TIMEOUT,
+) -> Path:
+    """Acquire an advisory release lock.
+
+    Args:
+        workspace_root: Directory to place the lock file in.
+        stale_timeout: Seconds after which a lock is considered stale.
+
+    Returns:
+        Path to the lock file.
+
+    Raises:
+        ReleaseKitError: If the lock is already held by another process.
+    """
+    lock_path = workspace_root / LOCK_FILENAME
+    existing = _read_lock(lock_path)
+
+    if existing is not None:
+        if _is_stale(existing, stale_timeout):
+            logger.warning(
+                'stale_lock_removed',
+                path=str(lock_path),
+                pid=existing.pid,
+                hostname=existing.hostname,
+            )
+            lock_path.unlink(missing_ok=True)
+        else:
+            raise ReleaseKitError(
+                E.LOCK_ACQUISITION_FAILED,
+                f'Release lock held by PID {existing.pid} on {existing.hostname} (user={existing.user!r}).',
+                hint=(f"If the process is no longer running, delete '{lock_path}' manually."),
+            )
+
+    info = LockInfo(
+        pid=os.getpid(),
+        hostname=socket.gethostname(),
+        timestamp=time.time(),
+        user=os.environ.get('USER', os.environ.get('USERNAME', '')),
+    )
+
+    try:
+        lock_path.write_text(
+            json.dumps(asdict(info), indent=2) + '\n',
+            encoding='utf-8',
+        )
+    except OSError as exc:
+        raise ReleaseKitError(
+            E.LOCK_ACQUISITION_FAILED,
+            f'Failed to write lock file: {exc}',
+        ) from exc
+
+    logger.info('lock_acquired', path=str(lock_path), pid=info.pid)
+
+    # Register atexit cleanup so the lock is released even on unhandled
+    # exceptions.
+    atexit.register(_atexit_cleanup, lock_path, info.pid)
+
+    return lock_path
+
+
+def release_lock_file(lock_path: Path) -> None:
+    """Release the lock by removing the lock file.
+
+    Safe to call multiple times. Only removes the lock if it was acquired
+    by the current process (prevents removing another process's lock).
+
+    Args:
+        lock_path: Path to the lock file to remove.
+    """
+    existing = _read_lock(lock_path)
+    if existing is not None and existing.pid != os.getpid():
+        logger.warning(
+            'lock_owned_by_other',
+            path=str(lock_path),
+            owner_pid=existing.pid,
+            current_pid=os.getpid(),
+        )
+        return
+
+    lock_path.unlink(missing_ok=True)
+    logger.info('lock_released', path=str(lock_path))
+
+
+def _atexit_cleanup(lock_path: Path, owner_pid: int) -> None:
+    """Atexit handler that removes the lock if we still own it."""
+    if os.getpid() != owner_pid:
+        return
+    lock_path.unlink(missing_ok=True)
+
+
+@contextmanager
+def release_lock(
+    workspace_root: Path,
+    *,
+    stale_timeout: float = DEFAULT_STALE_TIMEOUT,
+) -> Generator[Path]:
+    """Context manager that acquires and releases the release lock.
+
+    Args:
+        workspace_root: Directory to place the lock file in.
+        stale_timeout: Seconds after which a lock is considered stale.
+
+    Yields:
+        Path to the lock file.
+
+    Raises:
+        ReleaseKitError: If the lock cannot be acquired.
+    """
+    lock_path = acquire_lock(workspace_root, stale_timeout=stale_timeout)
+    try:
+        yield lock_path
+    finally:
+        release_lock_file(lock_path)
+
+
+__all__ = [
+    'LOCK_FILENAME',
+    'LockInfo',
+    'acquire_lock',
+    'release_lock',
+    'release_lock_file',
+]

--- a/py/tools/releasekit/src/releasekit/plan.py
+++ b/py/tools/releasekit/src/releasekit/plan.py
@@ -1,0 +1,325 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Execution plan for release publishing.
+
+Builds a table of per-package publish actions (version bump, skip,
+exclude) with status emoji and reason. Output as a Rich table (TTY),
+JSON, or CSV. Shared between the ``plan`` and ``publish`` subcommands.
+
+Key Concepts (ELI5)::
+
+    ┌─────────────────────┬────────────────────────────────────────────────┐
+    │ Concept             │ ELI5 Explanation                               │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ ExecutionPlan       │ A checklist of what will happen to each       │
+    │                     │ package: publish, skip, or exclude.           │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ PlanEntry           │ One row in the checklist: package name,       │
+    │                     │ current version, next version, and why.       │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ Format              │ How to display: table (human), JSON (CI),     │
+    │                     │ or CSV (spreadsheet).                         │
+    └─────────────────────┴────────────────────────────────────────────────┘
+
+Usage::
+
+    from releasekit.plan import ExecutionPlan, PlanEntry, PlanStatus
+
+    plan = ExecutionPlan(
+        entries=[
+            PlanEntry(
+                name='genkit',
+                level=0,
+                current_version='0.4.0',
+                next_version='0.5.0',
+                status=PlanStatus.INCLUDED,
+                bump='minor',
+                reason='feat: add streaming',
+            ),
+        ]
+    )
+
+    # Rich table (default for TTY)
+    print(plan.format_table())
+
+    # JSON (for CI pipelines)
+    print(plan.format_json())
+
+    # CSV (for spreadsheets)
+    print(plan.format_csv())
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+
+from releasekit.logging import get_logger
+from releasekit.versions import PackageVersion
+from releasekit.workspace import Package
+
+logger = get_logger(__name__)
+
+
+class PlanStatus(str, Enum):
+    """Status of a package in the execution plan.
+
+    Determines whether a package will be published and why.
+    """
+
+    INCLUDED = 'included'
+    SKIPPED = 'skipped'
+    EXCLUDED = 'excluded'
+    ALREADY_PUBLISHED = 'already_published'
+    DEPENDENCY_ONLY = 'dependency_only'
+
+
+# Emoji map for terminal display.
+_STATUS_EMOJI: dict[PlanStatus, str] = {
+    PlanStatus.INCLUDED: '📦',
+    PlanStatus.SKIPPED: '⏭️',
+    PlanStatus.EXCLUDED: '🚫',
+    PlanStatus.ALREADY_PUBLISHED: '✅',
+    PlanStatus.DEPENDENCY_ONLY: '🔗',
+}
+
+
+@dataclass(frozen=True)
+class PlanEntry:
+    """One row in the execution plan.
+
+    Attributes:
+        name: Package name.
+        level: Topological level (0 = no internal deps).
+        current_version: Current version in pyproject.toml.
+        next_version: Computed next version (same as current if skipped).
+        status: Whether the package will be published.
+        bump: Bump type applied (``"minor"``, ``"patch"``, etc.).
+        reason: Human-readable reason for the status.
+        order: Publish order within the level (0-based).
+    """
+
+    name: str
+    level: int = 0
+    current_version: str = ''
+    next_version: str = ''
+    status: PlanStatus = PlanStatus.INCLUDED
+    bump: str = 'none'
+    reason: str = ''
+    order: int = 0
+
+
+@dataclass
+class ExecutionPlan:
+    """Complete publish plan for all workspace packages.
+
+    Attributes:
+        entries: Per-package plan entries, ordered by level then name.
+        git_sha: HEAD SHA when the plan was computed.
+    """
+
+    entries: list[PlanEntry] = field(default_factory=list)
+    git_sha: str = ''
+
+    @property
+    def included(self) -> list[PlanEntry]:
+        """Return entries that will be published."""
+        return [e for e in self.entries if e.status == PlanStatus.INCLUDED]
+
+    @property
+    def skipped(self) -> list[PlanEntry]:
+        """Return entries that will be skipped."""
+        return [e for e in self.entries if e.status in {PlanStatus.SKIPPED, PlanStatus.ALREADY_PUBLISHED}]
+
+    def summary(self) -> dict[str, int]:
+        """Return a summary count by status."""
+        counts: dict[str, int] = {}
+        for entry in self.entries:
+            counts[entry.status.value] = counts.get(entry.status.value, 0) + 1
+        return counts
+
+    def format_table(self) -> str:
+        """Format the plan as a human-readable table with emoji.
+
+        Returns:
+            A formatted table string.
+        """
+        if not self.entries:
+            return 'No packages in the execution plan.'
+
+        # Calculate column widths.
+        headers = ['', 'Level', 'Package', 'Current', 'Next', 'Bump', 'Status', 'Reason']
+        rows: list[list[str]] = []
+
+        for entry in self.entries:
+            emoji = _STATUS_EMOJI.get(entry.status, '❓')
+            rows.append([
+                emoji,
+                str(entry.level),
+                entry.name,
+                entry.current_version,
+                entry.next_version or '—',
+                entry.bump,
+                entry.status.value,
+                entry.reason,
+            ])
+
+        # Calculate column widths.
+        widths = [len(h) for h in headers]
+        for row in rows:
+            for i, cell in enumerate(row):
+                # Emoji characters may have display width 2, but we use
+                # a fixed 2-char column for the emoji.
+                widths[i] = max(widths[i], len(cell))
+
+        # Build the table.
+        lines: list[str] = []
+        fmt = '  '.join(f'{{:<{w}}}' for w in widths)
+        lines.append(fmt.format(*headers))
+        lines.append(fmt.format(*('─' * w for w in widths)))
+        for row in rows:
+            lines.append(fmt.format(*row))
+
+        # Append summary.
+        summary = self.summary()
+        summary_parts = [f'{count} {status}' for status, count in sorted(summary.items())]
+        lines.append('')
+        lines.append(f'Total: {len(self.entries)} packages ({", ".join(summary_parts)})')
+
+        return '\n'.join(lines)
+
+    def format_json(self) -> str:
+        """Format the plan as machine-readable JSON.
+
+        Returns:
+            A JSON string.
+        """
+        data = {
+            'git_sha': self.git_sha,
+            'summary': self.summary(),
+            'entries': [asdict(e) for e in self.entries],
+        }
+        return json.dumps(data, indent=2)
+
+    def format_csv(self) -> str:
+        """Format the plan as CSV.
+
+        Returns:
+            A CSV string.
+        """
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(['level', 'order', 'name', 'current_version', 'next_version', 'bump', 'status', 'reason'])
+        for entry in self.entries:
+            writer.writerow([
+                entry.level,
+                entry.order,
+                entry.name,
+                entry.current_version,
+                entry.next_version,
+                entry.bump,
+                entry.status.value,
+                entry.reason,
+            ])
+        return output.getvalue()
+
+
+def build_plan(
+    versions: list[PackageVersion],
+    levels: list[list[Package]],
+    *,
+    exclude_names: list[str] | None = None,
+    already_published: set[str] | None = None,
+    git_sha: str = '',
+) -> ExecutionPlan:
+    """Build an execution plan from version computation results.
+
+    Args:
+        versions: List of :class:`~releasekit.versions.PackageVersion` records.
+        levels: Topological levels from :func:`~releasekit.graph.topo_sort`.
+        exclude_names: Package names to mark as excluded.
+        already_published: Package names already published on the registry.
+        git_sha: Current HEAD SHA.
+
+    Returns:
+        An :class:`ExecutionPlan` with entries for all packages.
+    """
+    excludes = set(exclude_names or [])
+    published = already_published or set()
+
+    # Build a name→PackageVersion lookup.
+    version_map: dict[str, PackageVersion] = {}
+    for v in versions:
+        version_map[v.name] = v
+
+    # Build a name→level lookup.
+    level_map: dict[str, int] = {}
+    for level_idx, level in enumerate(levels):
+        for pkg in level:
+            level_map[pkg.name] = level_idx
+
+    entries: list[PlanEntry] = []
+    order_per_level: dict[int, int] = {}
+
+    for v in versions:
+        level = level_map.get(v.name, 0)
+        order = order_per_level.get(level, 0)
+        order_per_level[level] = order + 1
+
+        if v.name in excludes:
+            status = PlanStatus.EXCLUDED
+            reason = 'excluded by configuration'
+        elif v.name in published:
+            status = PlanStatus.ALREADY_PUBLISHED
+            reason = f'{v.new_version} already on registry'
+        elif v.skipped:
+            status = PlanStatus.SKIPPED
+            reason = v.reason or 'no changes since last tag'
+        else:
+            status = PlanStatus.INCLUDED
+            reason = v.reason
+
+        entries.append(
+            PlanEntry(
+                name=v.name,
+                level=level,
+                current_version=v.old_version,
+                next_version=v.new_version,
+                status=status,
+                bump=v.bump,
+                reason=reason,
+                order=order,
+            )
+        )
+
+    # Sort by level, then name for stable output.
+    entries.sort(key=lambda e: (e.level, e.name))
+
+    plan = ExecutionPlan(entries=entries, git_sha=git_sha)
+    logger.info('plan_built', total=len(entries), **plan.summary())
+    return plan
+
+
+__all__ = [
+    'ExecutionPlan',
+    'PlanEntry',
+    'PlanStatus',
+    'build_plan',
+]

--- a/py/tools/releasekit/src/releasekit/preflight.py
+++ b/py/tools/releasekit/src/releasekit/preflight.py
@@ -1,0 +1,312 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preflight safety checks before publishing.
+
+Validates that the workspace is in a correct state before starting a
+release. All backends are injected via dependency injection, making
+this module testable with fake backends.
+
+Key Concepts (ELI5)::
+
+    ┌─────────────────────┬────────────────────────────────────────────────┐
+    │ Concept             │ ELI5 Explanation                               │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ Preflight checks    │ Like a pilot's checklist before takeoff.      │
+    │                     │ If anything fails, we don't take off.         │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ Fail-fast           │ Stop at the first blocker. Don't waste time   │
+    │                     │ checking everything if one thing is broken.   │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ DI (Dependency      │ Each backend (git, uv, gh, PyPI) is passed   │
+    │  Injection)         │ as an argument. Tests can swap in fakes.     │
+    └─────────────────────┴────────────────────────────────────────────────┘
+
+Check order::
+
+    1. Lock acquisition         → prevents concurrent releases
+    2. Clean working tree       → no uncommitted changes
+    3. Lock file check          → uv.lock is up to date
+    4. Shallow clone detection  → warn if git history is truncated
+    5. Cycle detection          → ensures publishable order
+    6. Forge availability       → warn if `gh` CLI is not available
+    7. Version conflict check   → none of the computed versions already
+                                  exist on the registry
+
+Usage::
+
+    from releasekit.preflight import run_preflight
+
+    # All backends injected:
+    await run_preflight(
+        vcs=git_backend,
+        pm=uv_backend,
+        forge=github_backend,
+        registry=pypi_backend,
+        graph=dep_graph,
+        versions=version_list,
+        workspace_root=Path('.'),
+    )
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+from releasekit.backends.forge import Forge
+from releasekit.backends.pm import PackageManager
+from releasekit.backends.registry import Registry
+from releasekit.backends.vcs import VCS
+from releasekit.errors import E, ReleaseKitError, ReleaseKitWarning
+from releasekit.graph import DependencyGraph, detect_cycles
+from releasekit.logging import get_logger
+from releasekit.versions import PackageVersion
+
+logger = get_logger(__name__)
+
+
+class PreflightResult:
+    """Collects preflight check results.
+
+    Attributes:
+        passed: List of check names that passed.
+        warnings: List of check names that produced warnings.
+        failed: List of check names that failed.
+        errors: Dict mapping check name to error message.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with empty result lists."""
+        self.passed: list[str] = []
+        self.warnings: list[str] = []
+        self.failed: list[str] = []
+        self.errors: dict[str, str] = {}
+
+    def add_pass(self, name: str) -> None:
+        """Record a passing check."""
+        self.passed.append(name)
+        logger.info('preflight_pass', check=name)
+
+    def add_warning(self, name: str, message: str) -> None:
+        """Record a warning (non-blocking)."""
+        self.warnings.append(name)
+        logger.warning('preflight_warning', check=name, message=message)
+
+    def add_failure(self, name: str, message: str) -> None:
+        """Record a failure (blocking)."""
+        self.failed.append(name)
+        self.errors[name] = message
+        logger.error('preflight_fail', check=name, message=message)
+
+    @property
+    def ok(self) -> bool:
+        """Return True if no checks failed."""
+        return len(self.failed) == 0
+
+    def summary(self) -> str:
+        """Return a human-readable summary."""
+        total = len(self.passed) + len(self.warnings) + len(self.failed)
+        parts = [f'{total} checks:']
+        if self.passed:
+            parts.append(f'{len(self.passed)} passed')
+        if self.warnings:
+            parts.append(f'{len(self.warnings)} warnings')
+        if self.failed:
+            parts.append(f'{len(self.failed)} failed')
+        return ', '.join(parts)
+
+
+async def _check_clean_worktree(
+    vcs: VCS,
+    result: PreflightResult,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Check that the working tree has no uncommitted changes."""
+    check_name = 'clean_worktree'
+    if vcs.is_clean(dry_run=dry_run):
+        result.add_pass(check_name)
+    else:
+        result.add_failure(
+            check_name,
+            'Working tree has uncommitted changes.',
+        )
+
+
+async def _check_lock_file(
+    pm: PackageManager,
+    result: PreflightResult,
+    *,
+    workspace_root: Path,
+    dry_run: bool = False,
+) -> None:
+    """Check that uv.lock is up to date."""
+    check_name = 'lock_file'
+    try:
+        pm.lock(check_only=True, cwd=workspace_root, dry_run=dry_run)
+        result.add_pass(check_name)
+    except Exception:
+        result.add_failure(
+            check_name,
+            "Lock file is out of date. Run 'uv lock' to update.",
+        )
+
+
+async def _check_shallow_clone(
+    vcs: VCS,
+    result: PreflightResult,
+) -> None:
+    """Warn if the repository is a shallow clone."""
+    check_name = 'shallow_clone'
+    if vcs.is_shallow():
+        result.add_warning(
+            check_name,
+            'Repository is a shallow clone; git log may be incomplete.',
+        )
+        warnings.warn(
+            ReleaseKitWarning(
+                E.PREFLIGHT_SHALLOW_CLONE,
+                'Repository is a shallow clone; git log data may be incomplete.',
+                hint="Run 'git fetch --unshallow' to fetch full history.",
+            ),
+            stacklevel=2,
+        )
+    else:
+        result.add_pass(check_name)
+
+
+async def _check_cycles(
+    graph: DependencyGraph,
+    result: PreflightResult,
+) -> None:
+    """Check for circular dependencies in the graph."""
+    check_name = 'cycle_detection'
+    cycles = detect_cycles(graph)
+    if cycles:
+        cycle_strs = [' → '.join(c) for c in cycles]
+        result.add_failure(
+            check_name,
+            f'Circular dependencies detected: {"; ".join(cycle_strs)}',
+        )
+    else:
+        result.add_pass(check_name)
+
+
+async def _check_forge(
+    forge: Forge | None,
+    result: PreflightResult,
+) -> None:
+    """Warn if the forge CLI is not available."""
+    check_name = 'forge_available'
+    if forge is None:
+        result.add_warning(check_name, 'No forge backend configured.')
+        return
+
+    if forge.is_available():
+        result.add_pass(check_name)
+    else:
+        result.add_warning(
+            check_name,
+            "'gh' CLI not installed or not authenticated. GitHub Releases will be skipped.",
+        )
+
+
+async def _check_version_conflicts(
+    registry: Registry,
+    versions: list[PackageVersion],
+    result: PreflightResult,
+) -> None:
+    """Check that none of the target versions already exist on PyPI."""
+    check_name = 'version_conflicts'
+    conflicts: list[str] = []
+
+    for v in versions:
+        if v.skipped:
+            continue
+        if await registry.check_published(v.name, v.new_version):
+            conflicts.append(f'{v.name}=={v.new_version}')
+
+    if conflicts:
+        result.add_failure(
+            check_name,
+            f'Versions already on registry: {", ".join(conflicts)}',
+        )
+    else:
+        result.add_pass(check_name)
+
+
+async def run_preflight(
+    *,
+    vcs: VCS,
+    pm: PackageManager,
+    forge: Forge | None,
+    registry: Registry,
+    graph: DependencyGraph,
+    versions: list[PackageVersion],
+    workspace_root: Path,
+    dry_run: bool = False,
+    skip_version_check: bool = False,
+) -> PreflightResult:
+    """Run all preflight checks.
+
+    All backends are injected via parameters (dependency injection),
+    making this function testable with fake backends.
+
+    Args:
+        vcs: Version control backend.
+        pm: Package manager backend.
+        forge: Code forge backend (optional; ``None`` to skip).
+        registry: Package registry backend.
+        graph: Workspace dependency graph.
+        versions: Computed version bumps.
+        workspace_root: Path to the workspace root.
+        dry_run: Pass through to backends.
+        skip_version_check: Skip registry version conflict check
+            (useful for ``--force`` mode).
+
+    Returns:
+        A :class:`PreflightResult` with all check outcomes.
+
+    Raises:
+        ReleaseKitError: On the first blocking failure if ``fail_fast=True``.
+    """
+    result = PreflightResult()
+
+    await _check_clean_worktree(vcs, result, dry_run=dry_run)
+    if not result.ok:
+        raise ReleaseKitError(
+            E.PREFLIGHT_DIRTY_WORKTREE,
+            result.errors.get('clean_worktree', 'Working tree is dirty.'),
+            hint='Commit or stash your changes before publishing.',
+        )
+
+    await _check_lock_file(pm, result, workspace_root=workspace_root, dry_run=dry_run)
+    await _check_shallow_clone(vcs, result)
+    await _check_cycles(graph, result)
+    await _check_forge(forge, result)
+
+    if not skip_version_check:
+        await _check_version_conflicts(registry, versions, result)
+
+    logger.info('preflight_complete', summary=result.summary())
+    return result
+
+
+__all__ = [
+    'PreflightResult',
+    'run_preflight',
+]

--- a/py/tools/releasekit/src/releasekit/publisher.py
+++ b/py/tools/releasekit/src/releasekit/publisher.py
@@ -1,0 +1,464 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Async publish orchestrator for uv workspace packages.
+
+Publishes packages in topological order with semaphore-controlled
+concurrency within each level. Each package goes through:
+
+    pin → build → publish → poll → verify → restore
+
+All backends are injected via dependency injection.
+
+Key Concepts (ELI5)::
+
+    ┌─────────────────────┬────────────────────────────────────────────────┐
+    │ Concept             │ ELI5 Explanation                               │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ Level-by-level      │ Publish packages in layers. Layer 0 first     │
+    │                     │ (no deps), then layer 1 (depends on L0), etc. │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ Semaphore           │ A sliding window of N concurrent publishes.   │
+    │                     │ As one finishes, the next starts immediately. │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ Ephemeral pin       │ Temporarily rewrite deps to exact versions    │
+    │                     │ for building, then restore the original file. │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ Fail-fast           │ If any package in a level fails, cancel the   │
+    │                     │ remaining packages and stop the release.      │
+    └─────────────────────┴────────────────────────────────────────────────┘
+
+Pipeline per package::
+
+    ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐
+    │ pin deps │──▶│  build   │──▶│ publish  │──▶│  poll    │
+    │ (toml)   │   │ (uv)     │   │ (uv)     │   │ (PyPI)   │
+    └──────────┘   └──────────┘   └──────────┘   └──────────┘
+                                                       │
+                   ┌──────────┐   ┌──────────┐         │
+                   │ restore  │◀──│  verify  │◀────────┘
+                   │ (toml)   │   │ (smoke)  │
+                   └──────────┘   └──────────┘
+
+Usage::
+
+    from releasekit.publisher import PublishConfig, publish_workspace
+
+    result = await publish_workspace(
+        vcs=git_backend,
+        pm=uv_backend,
+        forge=github_backend,
+        registry=pypi_backend,
+        packages=packages,
+        levels=levels,
+        versions=versions,
+        config=PublishConfig(concurrency=5, dry_run=True),
+    )
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from releasekit.backends.forge import Forge
+from releasekit.backends.pm import PackageManager
+from releasekit.backends.registry import Registry
+from releasekit.backends.vcs import VCS
+from releasekit.errors import E, ReleaseKitError
+from releasekit.logging import get_logger
+from releasekit.pin import ephemeral_pin
+from releasekit.state import PackageStatus, RunState
+from releasekit.versions import PackageVersion
+from releasekit.workspace import Package
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class PublishConfig:
+    """Configuration for a publish run.
+
+    Attributes:
+        concurrency: Max packages publishing simultaneously per level.
+        dry_run: Preview mode — log commands but don't execute.
+        check_url: URL to check for existing files (``uv publish --check-url``).
+        index_url: Custom index URL (e.g., Test PyPI).
+        smoke_test: Whether to run smoke tests after publishing.
+        poll_timeout: Seconds to wait for PyPI indexing.
+        poll_interval: Seconds between poll attempts.
+        force: Skip confirmation prompts.
+        workspace_root: Workspace root directory.
+    """
+
+    concurrency: int = 5
+    dry_run: bool = False
+    check_url: str | None = None
+    index_url: str | None = None
+    smoke_test: bool = True
+    poll_timeout: float = 300.0
+    poll_interval: float = 5.0
+    force: bool = False
+    workspace_root: Path = field(default_factory=Path)
+
+
+@dataclass
+class PublishResult:
+    """Result of a complete publish run.
+
+    Attributes:
+        published: Names of successfully published packages.
+        skipped: Names of skipped packages.
+        failed: Mapping of failed package names to error messages.
+        state: Final run state for persistence/resume.
+    """
+
+    published: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    failed: dict[str, str] = field(default_factory=dict)
+    state: RunState | None = None
+
+    @property
+    def ok(self) -> bool:
+        """Return True if no packages failed."""
+        return len(self.failed) == 0
+
+    def summary(self) -> str:
+        """Return a human-readable summary."""
+        parts = []
+        if self.published:
+            parts.append(f'{len(self.published)} published')
+        if self.skipped:
+            parts.append(f'{len(self.skipped)} skipped')
+        if self.failed:
+            parts.append(f'{len(self.failed)} failed')
+        return ', '.join(parts) if parts else 'no packages processed'
+
+
+def _compute_dist_checksum(dist_dir: Path) -> dict[str, str]:
+    """Compute SHA-256 checksums for all distribution files.
+
+    Args:
+        dist_dir: Directory containing .tar.gz and .whl files.
+
+    Returns:
+        Mapping of filename to SHA-256 hex digest.
+    """
+    checksums: dict[str, str] = {}
+    for path in sorted(dist_dir.iterdir()):
+        if path.suffix in {'.gz', '.whl'}:
+            sha = hashlib.sha256(path.read_bytes()).hexdigest()
+            checksums[path.name] = sha
+            logger.debug('dist_checksum', file=path.name, sha256=sha)
+    return checksums
+
+
+def _build_version_map(versions: list[PackageVersion]) -> dict[str, str]:
+    """Build a name→version map from version records.
+
+    Only includes packages that were actually bumped (not skipped).
+    """
+    return {v.name: v.new_version for v in versions if not v.skipped}
+
+
+async def _publish_one(
+    *,
+    pkg: Package,
+    version: PackageVersion,
+    version_map: dict[str, str],
+    pm: PackageManager,
+    registry: Registry,
+    config: PublishConfig,
+    state: RunState,
+    state_path: Path,
+    semaphore: asyncio.Semaphore,
+) -> None:
+    """Publish a single package through the full pipeline.
+
+    Acquires the semaphore for concurrency control. Updates state
+    at each step for resume support.
+
+    Args:
+        pkg: Package to publish.
+        version: Version record for this package.
+        version_map: All package versions for dependency pinning.
+        pm: Package manager backend.
+        registry: Registry backend for polling.
+        config: Publish configuration.
+        state: Run state (mutated in place).
+        state_path: Path to persist state.
+        semaphore: Concurrency limiter.
+    """
+    name = pkg.name
+    async with semaphore:
+        try:
+            # Step 1: Pin dependencies.
+            state.set_status(name, PackageStatus.BUILDING)
+            state.save(state_path)
+
+            with ephemeral_pin(pkg.pyproject_path, version_map):
+                # Step 2: Build.
+                with tempfile.TemporaryDirectory(prefix=f'releasekit-{name}-') as tmp:
+                    dist_dir = Path(tmp)
+                    pm.build(
+                        pkg.path,
+                        output_dir=dist_dir,
+                        no_sources=True,
+                        dry_run=config.dry_run,
+                    )
+
+                    # Step 3: Compute checksums.
+                    checksums = _compute_dist_checksum(dist_dir)
+                    if not config.dry_run and not checksums:
+                        raise ReleaseKitError(
+                            E.BUILD_FAILED,
+                            f'No distribution files produced for {name}.',
+                            hint=f"Check 'uv build' output for {pkg.path}.",
+                        )
+
+                    # Step 4: Publish.
+                    state.set_status(name, PackageStatus.PUBLISHING)
+                    state.save(state_path)
+
+                    pm.publish(
+                        dist_dir,
+                        check_url=config.check_url,
+                        index_url=config.index_url,
+                        dry_run=config.dry_run,
+                    )
+
+            # Step 5: Poll for availability.
+            state.set_status(name, PackageStatus.VERIFYING)
+            state.save(state_path)
+
+            if not config.dry_run:
+                available = await registry.poll_available(
+                    name,
+                    version.new_version,
+                    timeout=config.poll_timeout,
+                    interval=config.poll_interval,
+                )
+                if not available:
+                    raise ReleaseKitError(
+                        E.PUBLISH_TIMEOUT,
+                        f'{name}=={version.new_version} not available on registry after {config.poll_timeout}s.',
+                        hint='The package may still be indexing. Check the registry manually.',
+                    )
+
+            # Step 6: Smoke test.
+            if config.smoke_test and not config.dry_run:
+                pm.smoke_test(name, version.new_version, dry_run=config.dry_run)
+
+            # Success.
+            state.set_status(name, PackageStatus.PUBLISHED)
+            state.save(state_path)
+
+            logger.info(
+                'package_published',
+                package=name,
+                version=version.new_version,
+                checksums=checksums,
+            )
+
+        except ReleaseKitError:
+            state.set_status(name, PackageStatus.FAILED, error=str(name))
+            state.save(state_path)
+            raise
+
+        except Exception as exc:
+            state.set_status(name, PackageStatus.FAILED, error=str(exc))
+            state.save(state_path)
+            raise ReleaseKitError(
+                E.PUBLISH_FAILED,
+                f'Unexpected error publishing {name}: {exc}',
+            ) from exc
+
+
+async def publish_workspace(
+    *,
+    vcs: VCS,
+    pm: PackageManager,
+    forge: Forge | None,
+    registry: Registry,
+    packages: list[Package],
+    levels: list[list[Package]],
+    versions: list[PackageVersion],
+    config: PublishConfig,
+    state: RunState | None = None,
+) -> PublishResult:
+    """Publish all workspace packages in topological order.
+
+    Processes packages level-by-level, with semaphore-controlled
+    concurrency within each level. If any package in a level fails,
+    subsequent levels are skipped (fail-fast).
+
+    Args:
+        vcs: Version control backend.
+        pm: Package manager backend.
+        forge: Code forge backend (optional).
+        registry: Package registry backend.
+        packages: All workspace packages.
+        levels: Topological levels from :func:`~releasekit.graph.topo_sort`.
+        versions: Computed version bumps from
+            :func:`~releasekit.versioning.compute_bumps`.
+        config: Publish configuration.
+        state: Existing run state for resume (``None`` to start fresh).
+
+    Returns:
+        A :class:`PublishResult` summarizing the outcome.
+    """
+    # Build lookup maps.
+    ver_map: dict[str, PackageVersion] = {v.name: v for v in versions}
+    version_map = _build_version_map(versions)
+
+    # Initialize or resume state.
+    git_sha = vcs.current_sha()
+    state_path = config.workspace_root / '.releasekit-state.json'
+
+    if state is None:
+        state = RunState(git_sha=git_sha)
+        for level_idx, level in enumerate(levels):
+            for pkg in level:
+                v = ver_map.get(pkg.name)
+                if v is None or v.skipped:
+                    state.init_package(
+                        pkg.name,
+                        version=v.new_version if v else '',
+                        level=level_idx,
+                        status=PackageStatus.SKIPPED,
+                    )
+                else:
+                    state.init_package(
+                        pkg.name,
+                        version=v.new_version,
+                        level=level_idx,
+                    )
+    else:
+        state.validate_sha(git_sha)
+
+    state.save(state_path)
+
+    result = PublishResult(state=state)
+    semaphore = asyncio.Semaphore(config.concurrency)
+
+    for level_idx, level in enumerate(levels):
+        # Filter to packages that need publishing in this level.
+        level_tasks: list[tuple[Package, PackageVersion]] = []
+        for pkg in level:
+            pkg_state = state.packages.get(pkg.name)
+            if pkg_state is None:
+                continue
+
+            # Skip already-completed packages (resume support).
+            if pkg_state.status in {
+                PackageStatus.PUBLISHED,
+                PackageStatus.SKIPPED,
+            }:
+                if pkg_state.status == PackageStatus.SKIPPED:
+                    result.skipped.append(pkg.name)
+                else:
+                    result.published.append(pkg.name)
+                continue
+
+            v = ver_map.get(pkg.name)
+            if v is None or v.skipped:
+                result.skipped.append(pkg.name)
+                continue
+
+            level_tasks.append((pkg, v))
+
+        if not level_tasks:
+            logger.debug('level_empty', level=level_idx)
+            continue
+
+        logger.info(
+            'level_start',
+            level=level_idx,
+            packages=[t[0].name for t in level_tasks],
+            concurrency=config.concurrency,
+        )
+
+        # Launch all packages in this level with semaphore concurrency.
+        tasks = [
+            asyncio.create_task(
+                _publish_one(
+                    pkg=pkg,
+                    version=v,
+                    version_map=version_map,
+                    pm=pm,
+                    registry=registry,
+                    config=config,
+                    state=state,
+                    state_path=state_path,
+                    semaphore=semaphore,
+                ),
+                name=f'publish-{pkg.name}',
+            )
+            for pkg, v in level_tasks
+        ]
+
+        # Wait for all tasks, collecting results.
+        done = await asyncio.gather(*tasks, return_exceptions=True)
+
+        level_failed = False
+        for (pkg, _v), outcome in zip(level_tasks, done, strict=False):
+            if isinstance(outcome, BaseException):
+                result.failed[pkg.name] = str(outcome)
+                level_failed = True
+                logger.error(
+                    'package_failed',
+                    package=pkg.name,
+                    error=str(outcome),
+                )
+            else:
+                result.published.append(pkg.name)
+
+        # Fail-fast: stop if any package in this level failed.
+        if level_failed:
+            logger.error(
+                'level_failed',
+                level=level_idx,
+                failed=list(result.failed.keys()),
+            )
+            break
+
+        logger.info(
+            'level_complete',
+            level=level_idx,
+            published=[t[0].name for t in level_tasks],
+        )
+
+    # Save final state.
+    state.save(state_path)
+
+    logger.info(
+        'publish_complete',
+        summary=result.summary(),
+        published=len(result.published),
+        skipped=len(result.skipped),
+        failed=len(result.failed),
+    )
+    return result
+
+
+__all__ = [
+    'PublishConfig',
+    'PublishResult',
+    'publish_workspace',
+]

--- a/py/tools/releasekit/src/releasekit/state.py
+++ b/py/tools/releasekit/src/releasekit/state.py
@@ -1,0 +1,327 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-package status tracking with resume support.
+
+Tracks the publish status of each package in a JSON state file. The state
+file allows interrupted releases to resume from where they left off,
+skipping packages that have already been published.
+
+Key Concepts (ELI5)::
+
+    ┌─────────────────────┬────────────────────────────────────────────────┐
+    │ Concept             │ ELI5 Explanation                               │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ RunState            │ A checklist: ✅ genkit, ✅ plugin-foo,         │
+    │                     │ ⬜ plugin-bar, ...                             │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ Atomic save         │ Write to a temp file first, then rename.      │
+    │                     │ If we crash mid-write, the old file is fine.  │
+    ├─────────────────────┼────────────────────────────────────────────────┤
+    │ SHA validation      │ Resume only works if HEAD hasn't changed.     │
+    │                     │ Different HEAD = different versions possible.  │
+    └─────────────────────┴────────────────────────────────────────────────┘
+
+Status transitions::
+
+    pending → building → publishing → verifying → published
+                                                 → failed
+    pending → skipped (no changes / excluded)
+
+Usage::
+
+    from releasekit.state import PackageStatus, RunState
+
+    state = RunState(git_sha='abc123')
+    state.set_status('genkit', PackageStatus.BUILDING)
+    state.set_status('genkit', PackageStatus.PUBLISHED)
+    state.save(Path('.releasekit-state.json'))
+
+    # Resume after crash:
+    loaded = RunState.load(Path('.releasekit-state.json'))
+    loaded.validate_sha('abc123')  # Ensure HEAD hasn't changed
+    for name in loaded.pending_packages():
+        ...  # Continue from where we left off
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+from releasekit.errors import E, ReleaseKitError
+from releasekit.logging import get_logger
+
+logger = get_logger(__name__)
+
+STATE_FILENAME = '.releasekit-state.json'
+
+
+class PackageStatus(str, Enum):
+    """Status of a package in the publish pipeline.
+
+    Transitions::
+
+        pending → building → publishing → verifying → published
+                                                     → failed
+        pending → skipped
+    """
+
+    PENDING = 'pending'
+    BUILDING = 'building'
+    PUBLISHING = 'publishing'
+    VERIFYING = 'verifying'
+    PUBLISHED = 'published'
+    SKIPPED = 'skipped'
+    FAILED = 'failed'
+
+
+@dataclass
+class PackageState:
+    """Status record for a single package.
+
+    Attributes:
+        name: Normalized package name.
+        status: Current status in the pipeline.
+        version: Target version being published.
+        error: Error message if status is ``FAILED``.
+        level: Topological level (for ordering).
+    """
+
+    name: str
+    status: PackageStatus = PackageStatus.PENDING
+    version: str = ''
+    error: str = ''
+    level: int = 0
+
+
+@dataclass
+class RunState:
+    """Complete state of a release run.
+
+    Tracks per-package status and supports atomic persistence for
+    crash recovery.
+
+    Attributes:
+        git_sha: HEAD SHA when the run started.
+        packages: Per-package status records, keyed by name.
+        created_at: ISO 8601 timestamp when the state was created.
+    """
+
+    git_sha: str
+    packages: dict[str, PackageState] = field(default_factory=dict)
+    created_at: str = ''
+
+    def set_status(
+        self,
+        name: str,
+        status: PackageStatus,
+        *,
+        error: str = '',
+    ) -> None:
+        """Update the status of a package.
+
+        Args:
+            name: Package name.
+            status: New status.
+            error: Error message (only for FAILED status).
+        """
+        if name not in self.packages:
+            self.packages[name] = PackageState(name=name)
+        pkg = self.packages[name]
+        pkg.status = status
+        if error:
+            pkg.error = error
+        logger.debug('status_changed', package=name, status=status.value)
+
+    def init_package(
+        self,
+        name: str,
+        *,
+        version: str = '',
+        level: int = 0,
+        status: PackageStatus = PackageStatus.PENDING,
+    ) -> None:
+        """Initialize a package in the state.
+
+        Args:
+            name: Package name.
+            version: Target version.
+            level: Topological level.
+            status: Initial status.
+        """
+        self.packages[name] = PackageState(
+            name=name,
+            status=status,
+            version=version,
+            level=level,
+        )
+
+    def pending_packages(self) -> list[str]:
+        """Return names of packages still pending."""
+        return sorted(name for name, pkg in self.packages.items() if pkg.status == PackageStatus.PENDING)
+
+    def failed_packages(self) -> list[str]:
+        """Return names of packages that failed."""
+        return sorted(name for name, pkg in self.packages.items() if pkg.status == PackageStatus.FAILED)
+
+    def published_packages(self) -> list[str]:
+        """Return names of packages that were published."""
+        return sorted(name for name, pkg in self.packages.items() if pkg.status == PackageStatus.PUBLISHED)
+
+    def is_complete(self) -> bool:
+        """Return True if all packages are in a terminal state."""
+        terminal = {PackageStatus.PUBLISHED, PackageStatus.SKIPPED, PackageStatus.FAILED}
+        return all(pkg.status in terminal for pkg in self.packages.values())
+
+    def validate_sha(self, current_sha: str) -> None:
+        """Ensure the current HEAD matches the state's SHA.
+
+        Args:
+            current_sha: Current HEAD SHA.
+
+        Raises:
+            ReleaseKitError: If SHAs don't match.
+        """
+        if self.git_sha != current_sha:
+            raise ReleaseKitError(
+                E.STATE_SHA_MISMATCH,
+                f'State file was created at SHA {self.git_sha!r}, but HEAD is now {current_sha!r}.',
+                hint='Delete the state file and restart the release.',
+            )
+
+    def save(self, path: Path) -> None:
+        """Atomically save the state to a JSON file.
+
+        Uses ``tempfile`` + ``os.replace`` for crash safety: if the
+        process dies mid-write, the previous state file is untouched.
+
+        Args:
+            path: Destination file path.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        data = {
+            'git_sha': self.git_sha,
+            'created_at': self.created_at,
+            'packages': {
+                name: {
+                    'name': pkg.name,
+                    'status': pkg.status.value,
+                    'version': pkg.version,
+                    'error': pkg.error,
+                    'level': pkg.level,
+                }
+                for name, pkg in self.packages.items()
+            },
+        }
+        content = json.dumps(data, indent=2) + '\n'
+
+        # Write to a temp file in the same directory, then atomically rename.
+        fd, tmp_path = tempfile.mkstemp(
+            dir=path.parent,
+            prefix='.releasekit-state-',
+            suffix='.tmp',
+        )
+        closed = False
+        try:
+            os.write(fd, content.encode('utf-8'))
+            os.close(fd)
+            closed = True
+            os.replace(tmp_path, path)
+        except BaseException:
+            if not closed:
+                os.close(fd)
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
+
+        logger.debug('state_saved', path=str(path), packages=len(self.packages))
+
+    @classmethod
+    def load(cls, path: Path) -> RunState:
+        """Load state from a JSON file.
+
+        Args:
+            path: Path to the state file.
+
+        Returns:
+            A :class:`RunState` instance.
+
+        Raises:
+            OSError: If the file cannot be read.
+            ReleaseKitError: If the JSON is malformed or corrupted.
+        """
+        try:
+            text = path.read_text(encoding='utf-8')
+        except OSError as exc:
+            raise OSError(f'Failed to read state file {path}: {exc}') from exc
+
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ReleaseKitError(
+                E.STATE_CORRUPTED,
+                f'State file {path} contains invalid JSON: {exc}',
+                hint='Delete the state file and restart the release.',
+            ) from exc
+
+        try:
+            git_sha = data['git_sha']
+        except KeyError as exc:
+            raise ReleaseKitError(
+                E.STATE_CORRUPTED,
+                f'State file {path} is missing required field: git_sha',
+            ) from exc
+
+        packages: dict[str, PackageState] = {}
+        for name, pkg_data in data.get('packages', {}).items():
+            try:
+                status = PackageStatus(pkg_data.get('status', 'pending'))
+            except ValueError:
+                status = PackageStatus.PENDING
+            packages[name] = PackageState(
+                name=pkg_data.get('name', name),
+                status=status,
+                version=pkg_data.get('version', ''),
+                error=pkg_data.get('error', ''),
+                level=pkg_data.get('level', 0),
+            )
+
+        state = cls(
+            git_sha=git_sha,
+            packages=packages,
+            created_at=data.get('created_at', ''),
+        )
+        logger.info(
+            'state_loaded',
+            path=str(path),
+            packages=len(packages),
+            pending=len(state.pending_packages()),
+        )
+        return state
+
+
+__all__ = [
+    'STATE_FILENAME',
+    'PackageState',
+    'PackageStatus',
+    'RunState',
+]


### PR DESCRIPTION
## Summary

Implements Phase 3 of the ReleaseKit roadmap — the **Publish MVP**. This adds
the six modules required for the `releasekit publish` command to execute the
full release pipeline.

## New Modules (2,266 lines)

| Module | Lines | Purpose |
|--------|-------|---------|
| `lock.py` | 267 | Advisory lock file — PID/hostname/timestamp, stale detection (30 min), atexit cleanup |
| `state.py` | 327 | Per-package status tracking — JSON state file, atomic saves, SHA validation for resume |
| `plan.py` | 333 | Execution plan — Rich table, JSON, CSV output with status/version/bump/reason |
| `preflight.py` | 312 | Safety checks — clean worktree, lock file, shallow clone, cycles, forge, version conflicts |
| `publisher.py` | 464 | **Async orchestrator** — semaphore concurrency per topo level, pin→build→publish→poll→verify |
| `cli.py` | 562 | CLI entry point — `publish`, `plan`, `discover`, `graph`, `check-cycles`, `version`, `explain` |

## Architecture

```
releasekit publish --dry-run
  ├─ discover_packages()     # workspace.py (Phase 1)
  ├─ build_graph()           # graph.py (Phase 1)
  ├─ topo_sort()             # graph.py (Phase 1)
  ├─ compute_bumps()         # versioning.py (Phase 2)
  ├─ build_plan()            # plan.py (Phase 3) ← NEW
  ├─ acquire_lock()          # lock.py (Phase 3) ← NEW
  ├─ run_preflight()         # preflight.py (Phase 3) ← NEW
  └─ publish_workspace()     # publisher.py (Phase 3) ← NEW
      └─ per-level semaphore concurrency
          └─ _publish_one()
              ├─ ephemeral_pin()  # pin.py (Phase 2)
              ├─ pm.build()
              ├─ pm.publish()
              ├─ registry.poll_available()
              └─ pm.smoke_test()
```

## Key Design Decisions

- **Sliding-window concurrency**: `asyncio.Semaphore` within each topo level, not a global pool
- **Fail-fast per level**: If any package fails, remaining levels are skipped
- **Resume support**: State file tracks per-package status; SHA validation prevents resume on different HEAD
- **Dependency injection**: All backends injected via protocols for testability
- **Atomic operations**: State saves use `tempfile` + `os.replace` for crash safety

## Testing

- All modules pass `ruff check` and `ruff format`
- Unit tests to follow in a subsequent PR

## Related

- Phase 1 (workspace/graph): already merged
- Phase 2 (versioning/pin): #4555
