### PR TITLE
feat(js/genkit): Added cancelOperation for backgroundModels

### DIFF
--- a/js/ai/src/cancel-operation.ts
+++ b/js/ai/src/cancel-operation.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GenkitError, Operation } from '@genkit-ai/core';
+import { Registry } from '@genkit-ai/core/registry';
+
+export async function cancelOperation<T = unknown>(
+  registry: Registry,
+  operation: Operation<T>
+): Promise<Operation<T>> {
+  if (!operation.action) {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: 'Provided operation is missing original request information',
+    });
+  }
+  const backgroundAction = await registry.lookupBackgroundAction(
+    operation.action
+  );
+  if (!backgroundAction) {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: `Failed to resolve background action from original request: ${operation.action}`,
+    });
+  }
+  if (!backgroundAction.supportsCancel) {
+    throw new GenkitError({
+      status: 'UNIMPLEMENTED',
+      message: `Background action ${operation.action} does not support cancellation.`,
+    });
+  }
+  return await backgroundAction.cancel(operation);
+}

--- a/js/ai/src/index.ts
+++ b/js/ai/src/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export { cancelOperation } from './cancel-operation.js';
 export { checkOperation } from './check-operation.js';
 export { Document, DocumentDataSchema, type DocumentData } from './document.js';
 export {

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  cancelOperation,
   checkOperation,
   defineHelper,
   definePartial,
@@ -883,6 +884,16 @@ export class Genkit implements HasRegistry {
    */
   checkOperation<T>(operation: Operation<T>): Promise<Operation<T>> {
     return checkOperation(this.registry, operation);
+  }
+
+  /**
+   * Cancels a given operation. Returns a new operation which will contain the updated status.
+   *
+   * @param operation
+   * @returns
+   */
+  cancelOperation<T>(operation: Operation<T>): Promise<Operation<T>> {
+    return cancelOperation(this.registry, operation);
   }
 
   /**

--- a/js/genkit/tests/generate_test.ts
+++ b/js/genkit/tests/generate_test.ts
@@ -1493,5 +1493,44 @@ describe('generate', () => {
         action: '/background-model/bkg-model',
       });
     });
+
+    it('cancels operation', async () => {
+      const newOp = {
+        id: '123',
+        done: true,
+        output: {
+          finishReason: 'stop',
+          message: {
+            role: 'model',
+            content: [{ text: 'cancelled' }],
+          },
+        },
+      } as Operation;
+
+      ai.defineBackgroundModel({
+        name: 'bkg-model',
+        async start(_) {
+          return {
+            id: '123',
+          };
+        },
+        async check(operation) {
+          return operation;
+        },
+        async cancel(operation) {
+          return { ...newOp };
+        },
+      });
+
+      const operation = await ai.cancelOperation({
+        action: '/background-model/bkg-model',
+        id: '123',
+      });
+
+      assert.deepStrictEqual(operation, {
+        ...newOp,
+        action: '/background-model/bkg-model',
+      });
+    });
   });
 });


### PR DESCRIPTION
## Usage

This PR introduces `ai.cancelOperation()`, allowing you to programmatically cancel long-running operations for background models that support it.

```typescript
const ai = genkit({
  plugins: [<your background model plugin>],
});

// Start a long-running operation
let { operation } = await ai.generate({ <your background model config and request> });

// ... later, if you need to cancel it ...
const canceledOperation = await ai.cancelOperation(operation);

console.log('Operation canceled:', canceledOperation);
```
Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
