### PR TITLE
fix(py/plugins/flask): remove self-referencing cyclical dependency using releasekit

### DIFF
--- a/py/plugins/flask/pyproject.toml
+++ b/py/plugins/flask/pyproject.toml
@@ -42,7 +42,6 @@ classifiers = [
 dependencies = [
   "genkit",
   "genkit-plugin-google-genai",
-  "genkit-plugin-flask",
   "pydantic>=2.10.5",
   "flask",
 ]

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -2433,7 +2433,6 @@ dependencies = [
 requires-dist = [
     { name = "flask" },
     { name = "genkit", editable = "packages/genkit" },
-    { name = "genkit-plugin-flask", editable = "plugins/flask" },
     { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
     { name = "pydantic", specifier = ">=2.10.5" },
 ]


### PR DESCRIPTION
## Bug

Fixes #4562

`genkit-plugin-flask` listed **itself** as a dependency in its own `pyproject.toml`:

```toml
dependencies = [
  "genkit",
  "genkit-plugin-google-genai",
  "genkit-plugin-flask",      # ← self-referencing!
  "pydantic>=2.10.5",
  "flask",
]
```

This created a circular dependency cycle: `genkit-plugin-flask → genkit-plugin-flask`.

## How it was found

This was discovered during a **`releasekit` dry run** (Phase 4 development, PR #4558).

`releasekit` builds a dependency graph of all 60 workspace packages and runs
topological sort to determine the correct publish order. As part of its preflight
checks, it runs cycle detection on the graph. The `check-cycles` subcommand
flagged this immediately:

```
$ releasekit check-cycles
discovered_packages  count=60
built_dependency_graph  edges=118 packages=60
cycles_detected  count=1
  Cycle: genkit-plugin-flask → genkit-plugin-flask
```

The `publish --dry-run` command also failed with:

```
releasekit_error  code=RK-GRAPH-CYCLE-DETECTED
  message="Circular dependencies detected: ['genkit-plugin-flask → genkit-plugin-flask']"
  hint="Remove circular dependencies between packages."
```

```
genkit/py/tools/releasekit on  feat/releasekit-check [$]  Yesudeep Mangalapilly [yesudeep@google.com] is 📦 v0.1.0 via 🐍 v3.14.3 
zsh❯ uv run releasekit check
2026-02-10 17:11:18 [debug    ] no_releasekit_config           path=/Users/yesudeep/code/github.com/firebase/genkit/py/pyproject.toml
2026-02-10 17:11:18 [debug    ] expanded_member_globs          count=60 excludes=['*/shared', 'samples/sample-test', 'testapps/*'] members=['packages/*', 'plugins/*', 'samples/*']
2026-02-10 17:11:18 [info     ] discovered_packages            count=60
2026-02-10 17:11:18 [debug    ] built_dependency_graph         edges=118 packages=60
2026-02-10 17:11:18 [warning  ] cycles_detected                count=1
2026-02-10 17:11:18 [error    ] preflight_fail                 check=cycles message='Circular dependencies: genkit-plugin-flask → genkit-plugin-flask'
2026-02-10 17:11:18 [error    ] preflight_fail                 check=self_deps message='Packages depend on themselves: genkit-plugin-flask'
2026-02-10 17:11:18 [info     ] preflight_pass                 check=orphan_deps
2026-02-10 17:11:18 [error    ] preflight_fail                 check=missing_license message='Missing LICENSE file: provider-cohere-hello'
2026-02-10 17:11:18 [info     ] preflight_pass                 check=missing_readme
2026-02-10 17:11:18 [info     ] preflight_pass                 check=missing_py_typed
2026-02-10 17:11:18 [info     ] preflight_pass                 check=version_consistency
2026-02-10 17:11:18 [info     ] preflight_pass                 check=naming_convention
2026-02-10 17:11:18 [warning  ] preflight_warning              check=metadata_completeness message='Incomplete metadata: framework-evaluator-demo: missing license; provider-amazon-bedrock-hello: missing license; provider-anthropic-hello: missing license; provider-cloudflare-workers-ai-hello: missing license; provider-cohere-hello: missing license; provider-deepseek-hello: missing license; provider-google-genai-media-models-demo: missing license; provider-huggingface-hello: missing license; provider-mistral-hello: missing license; provider-xai-hello: missing license'
2026-02-10 17:11:18 [info     ] preflight_pass                 check=stale_artifacts
2026-02-10 17:11:18 [info     ] checks_complete                summary='10 checks:, 6 passed, 1 warnings, 3 failed'
  ✅ orphan_deps
  ✅ missing_readme
  ✅ missing_py_typed
  ✅ version_consistency
  ✅ naming_convention
  ✅ stale_artifacts
  ⚠️  metadata_completeness: Incomplete metadata: framework-evaluator-demo: missing license; provider-amazon-bedrock-hello: missing license; provider-anthropic-hello: missing license; provider-cloudflare-workers-ai-hello: missing license; provider-cohere-hello: missing license; provider-deepseek-hello: missing license; provider-google-genai-media-models-demo: missing license; provider-huggingface-hello: missing license; provider-mistral-hello: missing license; provider-xai-hello: missing license
  ❌ cycles: Circular dependencies: genkit-plugin-flask → genkit-plugin-flask
  ❌ self_deps: Packages depend on themselves: genkit-plugin-flask
  ❌ missing_license: Missing LICENSE file: provider-cohere-hello

  10 checks:, 6 passed, 1 warnings, 3 failed
  ```

## Fix

Removed the self-referencing `"genkit-plugin-flask"` line from the flask plugin's
own `dependencies` list. After the fix:

```
$ releasekit check-cycles
No cycles detected.

$ releasekit publish --dry-run --force
publish_complete  published=60 skipped=0 failed=0
```

All 60 packages pass the full dry-run pipeline (pin → build → publish → poll → verify).

## Why this matters

Self-referencing dependencies cause:
- **`pip install` infinite loops** or resolution failures
- **Topological sort failures** in release tooling (packages cannot be ordered)
- **Silent build issues** where the package resolves to a stale PyPI version of itself
  instead of the local workspace version