### PR TITLE
feat(releasekit): Phase 4 hardening — checksum verification + preflight checks

### DIFF
--- a/py/tools/releasekit/README.md
+++ b/py/tools/releasekit/README.md
@@ -1,8 +1,8 @@
 # releasekit
 
 Release orchestration for uv workspaces — publish Python packages in
-topological order with ephemeral version pinning, level gating, and
-crash-safe file restoration.
+topological order with ephemeral version pinning, level gating,
+crash-safe file restoration, and post-publish checksum verification.
 
 ## Quick Start
 
@@ -18,11 +18,105 @@ uvx releasekit discover
 
 # Show dependency graph
 uvx releasekit graph
+
+# Run workspace health checks
+uvx releasekit check
 ```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `discover` | List all workspace packages with versions and metadata |
+| `graph` | Print the dependency graph in topological order |
+| `plan` | Preview version bumps and publish order (dry run) |
+| `publish` | Build and publish packages to PyPI in dependency order |
+| `check` | Run standalone workspace health checks |
+| `bump` | Bump version for one or all packages |
+
+## Architecture
+
+```
+releasekit
+├── Backends (DI / Protocol-based)
+│   ├── VCS          git operations (tag, commit, push)
+│   ├── PackageManager  uv operations (build, publish, lock)
+│   ├── Registry     PyPI queries (poll, checksum verify)
+│   └── Forge        GitHub operations (release, PR)
+│
+├── Core Pipeline
+│   ├── workspace.py     discover packages from pyproject.toml
+│   ├── graph.py         build & topo-sort dependency graph
+│   ├── versions.py      semantic version bumping
+│   ├── pin.py           ephemeral dep pinning with crash-safe restore
+│   ├── preflight.py     pre-publish safety checks
+│   ├── publisher.py     async level-by-level orchestration
+│   └── checks.py        standalone workspace health checks
+│
+├── Extensibility
+│   ├── CheckBackend     protocol for language-specific checks
+│   ├── PythonCheckBackend  py.typed, version sync, naming, metadata
+│   └── (future: GoCheckBackend, JsCheckBackend, plugins)
+│
+└── UI
+    ├── RichProgressUI   live progress table (TTY)
+    ├── LogProgressUI    structured logs (CI)
+    └── NullProgressUI   no-op (tests)
+```
+
+### Publish Pipeline
+
+Each package goes through this pipeline per topological level:
+
+```
+pin → build → checksum → publish → poll → verify_checksum → smoke_test → restore
+```
+
+1. **Pin** — temporarily rewrite internal deps to exact versions
+2. **Build** — `uv build --no-sources` into temp directory
+3. **Checksum** — compute SHA-256 of .tar.gz and .whl
+4. **Publish** — `uv publish` with `--check-url` for idempotency
+5. **Poll** — wait for PyPI to index the new version
+6. **Verify checksum** — download SHA-256 from PyPI JSON API,
+   compare against local build (supply chain integrity)
+7. **Smoke test** — `uv pip install` in isolated venv
+8. **Restore** — revert pinned pyproject.toml to original
+
+### Health Checks
+
+`releasekit check` runs 10 checks split into two categories:
+
+**Universal checks** (always run):
+- `cycles` — circular dependency chains
+- `self_deps` — package depends on itself
+- `orphan_deps` — internal dep not in workspace
+- `missing_license` — no LICENSE file
+- `missing_readme` — no README.md
+- `stale_artifacts` — leftover .bak or dist/ files
+
+**Language-specific checks** (via `CheckBackend` protocol):
+- `type_markers` — py.typed PEP 561 marker
+- `version_consistency` — plugin version matches core
+- `naming_convention` — directory matches package name
+- `metadata_completeness` — pyproject.toml required fields
+
+The `CheckBackend` protocol allows adding language-specific checks
+for other runtimes (Go, JS) without modifying the core check runner.
+
+### Preflight Checks
+
+`run_preflight` gates the publish pipeline with environment checks:
+- Clean git worktree
+- Lock file up to date
+- No shallow clone
+- No dependency cycles
+- No stale dist/ directories
+- Trusted publisher (OIDC) detection
+- Version conflict check against PyPI
 
 ## Why This Tool Exists
 
-The genkit Python SDK is a uv workspace with 21+ packages that have
+The genkit Python SDK is a uv workspace with 60+ packages that have
 inter-dependencies. Publishing them to PyPI requires dependency-ordered
 builds with ephemeral version pinning — and no existing tool does this.
 

--- a/py/tools/releasekit/roadmap.md
+++ b/py/tools/releasekit/roadmap.md
@@ -497,9 +497,10 @@ publish → poll → verify) with zero failures.
 | Module | Description | Est. Lines | Status |
 |--------|-------------|-----------|--------|
 | `ui.py` | **Rich Live progress table** with observer pattern. `RichProgressUI` (TTY), `LogProgressUI` (CI), `NullProgressUI` (tests). 9 pipeline stages with emoji/color/progress bars. ETA estimation. Error panel. Auto-detects TTY via `create_progress_ui()`. Integrated into `publisher.py` via `PublishObserver` callbacks. | ~560 | ✅ Done (PR #4558) |
-| `checks.py` | **Standalone workspace health checks** (`releasekit check`). 10 checks: cycles, self_deps, orphan_deps, missing_license, missing_readme, missing_py_typed, version_consistency, naming_convention, metadata_completeness, stale_artifacts. Replaces `check-cycles`. Found flask self-dep bug (#4562). Checks are categorized as universal (cycles, self_deps, orphan_deps, missing_license, missing_readme, stale_artifacts) or Python-specific (missing_py_typed, version_consistency, naming_convention, metadata_completeness). | ~413 | ✅ Done (PR #4563) |
-| `preflight.py` (full) | Add: `pip-audit` vulnerability scan (warn by default, `--strict-audit` to block, `--skip-audit` to skip), metadata validation (wheel zip, METADATA fields, long description), trusted publisher check. OSS file checks moved to `checks.py`. | +100 | |
-| `publisher.py` (full) | Add: `--stage` two-phase (Test PyPI then real PyPI), `--index=testpypi`, manifest mode, `--resume-from-registry`, OIDC token handling, rate limiting, attestation passthrough (D-8), **SHA-256 post-publish checksum verification** (download from PyPI JSON API, compare against locally-computed checksums from `_compute_dist_checksum`, fail-fast on mismatch). | +220 | |
+| `checks.py` | **Standalone workspace health checks** (`releasekit check`) with `CheckBackend` protocol. 6 universal checks (cycles, self_deps, orphan_deps, missing_license, missing_readme, stale_artifacts) + 4 language-specific via `PythonCheckBackend` (type_markers, version_consistency, naming_convention, metadata_completeness). Extensible for future language backends. Found flask self-dep bug (#4562). | ~420 | ✅ Done (PR #4563) |
+| `preflight.py` (full) | Added: `dist_clean` (stale dist/ detection, blocking), `trusted_publisher` (OIDC check, advisory). Remaining: `pip-audit` vulnerability scan (warn by default, `--strict-audit` to block, `--skip-audit` to skip), metadata validation (wheel METADATA fields). | +80 | 🔶 Partial |
+| `registry.py` (full) | Added: `verify_checksum()` — downloads SHA-256 from PyPI JSON API (`urls[].digests.sha256`) and compares against locally-computed checksums. `ChecksumResult` dataclass with matched/mismatched/missing. | +100 | ✅ Done |
+| `publisher.py` (full) | Added: post-publish SHA-256 checksum verification (step 6), `verify_checksums` config flag. Remaining: `--stage` two-phase, `--index=testpypi`, manifest mode, `--resume-from-registry`, rate limiting, attestation passthrough (D-8). | +30 | 🔶 Partial |
 
 **`ui.py` — Rich Live Progress Table (Detailed Spec)**:
 
@@ -741,7 +742,7 @@ shell completion) is enhancement.
 | 1: Discovery | 3 (+tests) | ~420 | 783 src + 435 tests | ✅ Complete |
 | 2: Version + Pin | 4 (+tests) | ~500 | 1,023 src + ~550 tests | ✅ Complete |
 | 3: Publish MVP | 6 | ~960 | ~1,660 src | ✅ Complete |
-| 4: Harden | 4 (extended) | ~450 | ~973 src (ui.py + checks.py done) | 🔶 In progress |
+| 4: Harden | 5 (extended) | ~450 | ~973 src (ui.py + checks.py + registry.py done) | 🔶 In progress |
 | 4b: Streaming Publisher | 2 | ~250 | — | ⬜ Planned |
 | 5: Post-Pipeline | 4 (+CI workflow) | ~700 | — | ⬜ Not started |
 | 6: UX Polish | 3 (+ 6 formatters) | ~570 | — | ⬜ Not started |

--- a/py/tools/releasekit/src/releasekit/backends/registry.py
+++ b/py/tools/releasekit/src/releasekit/backends/registry.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
 from releasekit.logging import get_logger
@@ -85,6 +86,62 @@ class Registry(Protocol):
             package_name: Package name to query.
         """
         ...
+
+    async def verify_checksum(
+        self,
+        package_name: str,
+        version: str,
+        local_checksums: dict[str, str],
+    ) -> ChecksumResult:
+        """Verify local checksums against registry-published digests.
+
+        Downloads the SHA-256 digests from the registry API for the
+        given version, then compares each local file's checksum against
+        the registry's value.
+
+        Args:
+            package_name: Package name on the registry.
+            version: Version string to check.
+            local_checksums: Mapping of filename to local SHA-256 hex digest
+                (from ``_compute_dist_checksum``).
+
+        Returns:
+            A :class:`ChecksumResult` with matches, mismatches, and
+            files missing from the registry.
+        """
+        ...
+
+
+@dataclass(frozen=True)
+class ChecksumResult:
+    """Result of checksum verification against a registry.
+
+    Attributes:
+        matched: Files where local and registry checksums agree.
+        mismatched: Files where checksums differ.
+            Maps filename to ``(local_sha, registry_sha)``.
+        missing: Files not found on the registry.
+    """
+
+    matched: list[str] = field(default_factory=list)
+    mismatched: dict[str, tuple[str, str]] = field(default_factory=dict)
+    missing: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """Return True if all checksums match and none are missing."""
+        return not self.mismatched and not self.missing
+
+    def summary(self) -> str:
+        """Return a human-readable summary."""
+        parts: list[str] = []
+        if self.matched:
+            parts.append(f'{len(self.matched)} matched')
+        if self.mismatched:
+            parts.append(f'{len(self.mismatched)} mismatched')
+        if self.missing:
+            parts.append(f'{len(self.missing)} missing')
+        return ', '.join(parts) if parts else 'no files checked'
 
 
 class PyPIBackend:
@@ -186,8 +243,91 @@ class PyPIBackend:
                 log.warning('pypi_parse_error', package=package_name)
                 return None
 
+    async def verify_checksum(
+        self,
+        package_name: str,
+        version: str,
+        local_checksums: dict[str, str],
+    ) -> ChecksumResult:
+        """Verify local checksums against PyPI-published SHA-256 digests.
+
+        Uses the PyPI JSON API ``/pypi/{name}/{version}/json`` response,
+        which includes ``urls[].digests.sha256`` for each distribution file.
+        """
+        url = f'{self._base_url}/pypi/{package_name}/{version}/json'
+        async with http_client(pool_size=self._pool_size, timeout=self._timeout) as client:
+            response = await request_with_retry(client, 'GET', url)
+            if response.status_code != 200:
+                log.warning(
+                    'checksum_fetch_failed',
+                    package=package_name,
+                    version=version,
+                    status=response.status_code,
+                )
+                return ChecksumResult(missing=list(local_checksums.keys()))
+
+            try:
+                data = response.json()
+            except ValueError:
+                log.warning('checksum_parse_failed', package=package_name)
+                return ChecksumResult(missing=list(local_checksums.keys()))
+
+        # Build filename→sha256 map from PyPI response.
+        registry_checksums: dict[str, str] = {}
+        for file_info in data.get('urls', []):
+            filename = file_info.get('filename', '')
+            sha256 = file_info.get('digests', {}).get('sha256', '')
+            if filename and sha256:
+                registry_checksums[filename] = sha256
+
+        matched: list[str] = []
+        mismatched: dict[str, tuple[str, str]] = {}
+        missing: list[str] = []
+
+        for filename, local_sha in local_checksums.items():
+            registry_sha = registry_checksums.get(filename)
+            if registry_sha is None:
+                missing.append(filename)
+                log.warning(
+                    'checksum_file_missing',
+                    package=package_name,
+                    file=filename,
+                )
+            elif local_sha == registry_sha:
+                matched.append(filename)
+                log.debug(
+                    'checksum_match',
+                    package=package_name,
+                    file=filename,
+                    sha256=local_sha,
+                )
+            else:
+                mismatched[filename] = (local_sha, registry_sha)
+                log.error(
+                    'checksum_mismatch',
+                    package=package_name,
+                    file=filename,
+                    local_sha256=local_sha,
+                    registry_sha256=registry_sha,
+                )
+
+        result = ChecksumResult(
+            matched=matched,
+            mismatched=mismatched,
+            missing=missing,
+        )
+        log.info(
+            'checksum_verification',
+            package=package_name,
+            version=version,
+            summary=result.summary(),
+            ok=result.ok,
+        )
+        return result
+
 
 __all__ = [
+    'ChecksumResult',
     'PyPIBackend',
     'Registry',
 ]

--- a/py/tools/releasekit/src/releasekit/cli.py
+++ b/py/tools/releasekit/src/releasekit/cli.py
@@ -168,6 +168,7 @@ async def _cmd_publish(args: argparse.Namespace) -> int:
             pm=pm,
             forge=forge,
             registry=registry,
+            packages=packages,
             graph=graph,
             versions=versions,
             workspace_root=workspace_root,

--- a/py/tools/releasekit/tests/backends/rk_checksum_test.py
+++ b/py/tools/releasekit/tests/backends/rk_checksum_test.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for releasekit.backends.registry.ChecksumResult and verify_checksum."""
+
+from __future__ import annotations
+
+from releasekit.backends.registry import ChecksumResult
+
+
+class TestChecksumResult:
+    """Tests for ChecksumResult dataclass."""
+
+    def test_all_matched(self) -> None:
+        """All files matched yields ok=True."""
+        result = ChecksumResult(matched=['a.whl', 'b.tar.gz'])
+        if not result.ok:
+            raise AssertionError('Expected ok=True when all matched')
+        if '2 matched' not in result.summary():
+            raise AssertionError(f'Unexpected summary: {result.summary()}')
+
+    def test_mismatch_not_ok(self) -> None:
+        """Any mismatched file yields ok=False."""
+        result = ChecksumResult(
+            matched=['a.whl'],
+            mismatched={'b.tar.gz': ('abc', 'def')},
+        )
+        if result.ok:
+            raise AssertionError('Expected ok=False with mismatched files')
+        if '1 mismatched' not in result.summary():
+            raise AssertionError(f'Unexpected summary: {result.summary()}')
+
+    def test_missing_not_ok(self) -> None:
+        """Any missing file yields ok=False."""
+        result = ChecksumResult(missing=['c.whl'])
+        if result.ok:
+            raise AssertionError('Expected ok=False with missing files')
+        if '1 missing' not in result.summary():
+            raise AssertionError(f'Unexpected summary: {result.summary()}')
+
+    def test_empty_result(self) -> None:
+        """Empty result (no files checked) is ok."""
+        result = ChecksumResult()
+        if not result.ok:
+            raise AssertionError('Expected ok=True when empty')
+        if result.summary() != 'no files checked':
+            raise AssertionError(f'Unexpected summary: {result.summary()}')
+
+    def test_combined_summary(self) -> None:
+        """Summary includes matched, mismatched, and missing counts."""
+        result = ChecksumResult(
+            matched=['a.whl'],
+            mismatched={'b.tar.gz': ('abc', 'def')},
+            missing=['c.whl'],
+        )
+        summary = result.summary()
+        if '1 matched' not in summary:
+            raise AssertionError(f'Missing matched in: {summary}')
+        if '1 mismatched' not in summary:
+            raise AssertionError(f'Missing mismatched in: {summary}')
+        if '1 missing' not in summary:
+            raise AssertionError(f'Missing missing in: {summary}')


### PR DESCRIPTION
## Summary

Phase 4 hardening for releasekit: SHA-256 post-publish checksum verification, new preflight checks, comprehensive README, and extensible `CheckBackend` protocol integration.

## Changes

### SHA-256 Post-Publish Checksum Verification

Adds supply-chain integrity verification to the publish pipeline:

1. After `poll_available()` confirms a package is on PyPI, `verify_checksum()` downloads the SHA-256 digests from the PyPI JSON API (`urls[].digests.sha256`)
2. Compares each file's digest against the locally-computed checksum from the build step
3. Fails fast with `RK-PUBLISH-CHECKSUM-MISMATCH` on any mismatch

```
Pipeline: pin → build → checksum → publish → poll → verify_checksum → smoke_test → restore
                                                      ^^^^^^^^^^^^^^^^
                                                      NEW (step 6)
```

**Files:**
- `registry.py` — `verify_checksum()` method on `Registry` protocol + `PyPIBackend` implementation + `ChecksumResult` dataclass
- `publisher.py` — integrated as step 6 between poll and smoke test, gated by `PublishConfig.verify_checksums` flag

### Preflight Hardening

Two new preflight checks before publish:

| Check | Severity | What it catches |
|-------|----------|-----------------|
| `dist_clean` | ❌ error | Stale dist/ directories that could cause wrong version uploads |
| `trusted_publisher` | ⚠️ warning | CI publishing without OIDC (PyPI trusted publishers) |

**Files:**
- `preflight.py` — added `_check_dist_artifacts` and `_check_trusted_publisher`, plus `packages` parameter to `run_preflight`
- `cli.py` — pass `packages` to `run_preflight`

### README Overhaul

Complete rewrite covering:
- All 6 commands with descriptions
- Architecture diagram (backends, core pipeline, extensibility, UI)
- Full publish pipeline walkthrough (8 steps)
- Health check catalogue (6 universal + 4 language-specific)
- Preflight check catalogue (7 checks)

### Roadmap Updates

- Phase 4 table updated with completed and partial items
- Effort table updated with actual line counts

## Tests

5 new tests for `ChecksumResult` (216 total, all passing):
- `test_all_matched` — ok=True when all checksums match
- `test_mismatch_not_ok` — ok=False with mismatched files
- `test_missing_not_ok` — ok=False with missing files
- `test_empty_result` — edge case
- `test_combined_summary` — formatting
