### PR TITLE
fix(py): fix dotprompt deadlock

### DIFF
--- a/py/packages/genkit/src/genkit/core/registry.py
+++ b/py/packages/genkit/src/genkit/core/registry.py
@@ -119,7 +119,11 @@ class Registry:
         self._loading_actions: set[str] = set()
 
         # Initialize Dotprompt with schema_resolver to match JS SDK pattern
-        self.dotprompt: Dotprompt = Dotprompt(schema_resolver=lambda name: self.lookup_schema(name) or name)
+        # Use async function to avoid thread pool deadlock in resolve_json_schema
+        async def async_schema_resolver(name: str) -> dict[str, object] | str:
+            return self.lookup_schema(name) or name
+
+        self.dotprompt: Dotprompt = Dotprompt(schema_resolver=async_schema_resolver)
         # TODO(#4352): Figure out how to set this.
         self.api_stability: str = 'stable'
 


### PR DESCRIPTION
- Change Dotprompt schema_resolver to async to prevent thread pool deadlocks(The Problem: The recipe prompt uses a structured output schema. When Dotprompt tried to resolve this schema synchronously, it deadlocked the thread pool, causing the prompt execution to hang or fail).

