### PR TITLE
feat(releasekit): Phase 6 UX polish — formatters, init, completion, diagnostics

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -115,6 +115,7 @@ lint = [
   # type checkers run at workspace scope.
   "diagnostic>=3.0.0",
   "packaging>=24.0",
+  "rich-argparse>=1.6.0",
   "tomlkit>=0.13.0",
 ]
 

--- a/py/tools/releasekit/README.md
+++ b/py/tools/releasekit/README.md
@@ -5,22 +5,30 @@ topological order with dependency-triggered scheduling, ephemeral version
 pinning, retry with jitter, crash-safe file restoration, and post-publish
 checksum verification.
 
-## Quick Start
+## Getting Started
 
 ```bash
-# Preview what would happen
-uvx releasekit plan
+# 1. Install (or run directly with uvx)
+uv tool install releasekit
 
-# Publish all changed packages
-uvx releasekit publish
+# 2. Initialize config in your workspace root
+releasekit init
 
-# Discover workspace packages
+# 3. Preview what would happen
+releasekit plan
+
+# 4. Publish all changed packages
+releasekit publish
+
+# 5. Enable shell completions (bash, zsh, or fish)
+eval "$(releasekit completion bash)"
+```
+
+Or run without installing:
+
+```bash
 uvx releasekit discover
-
-# Show dependency graph
-uvx releasekit graph
-
-# Run workspace health checks
+uvx releasekit graph --format table
 uvx releasekit check
 ```
 
@@ -29,11 +37,153 @@ uvx releasekit check
 | Command | Description |
 |---------|-------------|
 | `discover` | List all workspace packages with versions and metadata |
-| `graph` | Print the dependency graph in topological order |
+| `graph` | Print the dependency graph (8 output formats) |
 | `plan` | Preview version bumps and publish order (dry run) |
 | `publish` | Build and publish packages to PyPI in dependency order |
 | `check` | Run standalone workspace health checks |
 | `bump` | Bump version for one or all packages |
+| `init` | Scaffold `[tool.releasekit]` config with auto-detected groups |
+| `rollback` | Delete a git tag (local + remote) and its GitHub release |
+| `explain` | Look up any error code (e.g. `releasekit explain RK-GRAPH-CYCLE-DETECTED`) |
+| `version` | Show the releasekit version |
+| `completion` | Generate shell completion scripts (bash/zsh/fish) |
+
+## Features
+
+### Graph Formatters
+
+`releasekit graph --format <fmt>` supports 8 output formats:
+
+| Format | Output | Use case |
+|--------|--------|----------|
+| `ascii` | Box-drawing art | Terminal viewing |
+| `csv` | RFC 4180 + UTF-8 BOM | Excel, Google Sheets, data pipelines |
+| `d2` | D2 diagram DSL | `d2 render` |
+| `dot` | Graphviz DOT | `dot -Tpng` / `dot -Tsvg` |
+| `json` | Structured JSON | Scripting, CI, jq |
+| `levels` | Simple text (default) | Quick inspection |
+| `mermaid` | Mermaid flowchart | GitHub READMEs, docs |
+| `table` | Markdown table | READMEs, docs, PRs |
+
+```bash
+# Render as Mermaid for a README
+releasekit graph --format mermaid > deps.mmd
+
+# Export as CSV for a spreadsheet
+releasekit graph --format csv > deps.csv
+
+# Render as Graphviz SVG
+releasekit graph --format dot | dot -Tsvg -o deps.svg
+
+# Show as a Markdown table
+releasekit graph --format table
+```
+
+### Publish Pipeline
+
+Each package goes through:
+
+```
+pin → build → checksum → publish → poll → verify_checksum → smoke_test → restore
+```
+
+Packages are dispatched via a **dependency-triggered queue** — each
+package starts as soon as all its dependencies complete (no level-based
+lockstep). Workers pull from the queue as fast as they can.
+
+Granular control:
+
+```bash
+releasekit publish --dry-run             # Preview mode
+releasekit publish --version-only        # Bump versions, skip build/publish
+releasekit publish --no-tag --no-push    # Publish without tagging/pushing
+releasekit publish --no-release          # Skip GitHub release creation
+releasekit publish --max-retries 3       # Retry failed publishes
+releasekit publish --concurrency 10      # Max parallel per level
+```
+
+On failure, the scheduler retries with exponential backoff + full jitter.
+Failed packages block their dependents (fail-fast for the dependency chain).
+
+### Workspace Initialization
+
+```bash
+releasekit init              # Auto-detect groups, write config
+releasekit init --dry-run    # Preview generated config
+releasekit init --force      # Overwrite existing config
+```
+
+Scaffolds `[tool.releasekit]` in `pyproject.toml` with auto-detected
+package groups (plugins, samples, core). Also adds `.releasekit-state/`
+to `.gitignore`.
+
+### Rollback
+
+```bash
+releasekit rollback genkit-v0.5.0            # Delete tag + GitHub release
+releasekit rollback genkit-v0.5.0 --dry-run  # Preview what would be deleted
+```
+
+### Rust-Style Diagnostics
+
+All errors and warnings use Rust-compiler-style formatting:
+
+```
+error[RK-GRAPH-CYCLE-DETECTED]: Circular dependency detected in the workspace dependency graph.
+  |
+  = hint: Run 'releasekit check-cycles' to identify the cycle.
+```
+
+Every error code can be looked up:
+
+```bash
+releasekit explain RK-PREFLIGHT-DIRTY-WORKTREE
+```
+
+### Shell Completions
+
+```bash
+# Bash — add to ~/.bashrc
+eval "$(releasekit completion bash)"
+
+# Zsh — add to ~/.zshrc
+eval "$(releasekit completion zsh)"
+
+# Fish — save to completions dir
+releasekit completion fish > ~/.config/fish/completions/releasekit.fish
+```
+
+### Health Checks
+
+`releasekit check` runs 10 checks split into two categories:
+
+**Universal checks** (always run):
+- `cycles` — circular dependency chains
+- `self_deps` — package depends on itself
+- `orphan_deps` — internal dep not in workspace
+- `missing_license` — no LICENSE file
+- `missing_readme` — no README.md
+- `stale_artifacts` — leftover .bak or dist/ files
+
+**Language-specific checks** (via `CheckBackend` protocol):
+- `type_markers` — py.typed PEP 561 marker
+- `version_consistency` — plugin version matches core
+- `naming_convention` — directory matches package name
+- `metadata_completeness` — pyproject.toml required fields
+
+The `CheckBackend` protocol allows adding language-specific checks
+for other runtimes (Go, JS) without modifying the core check runner.
+
+### Preflight Checks
+
+`run_preflight` gates the publish pipeline with environment checks:
+- Clean git worktree
+- Lock file up to date
+- No shallow clone
+- No dependency cycles
+- No stale dist/ directories
+- Trusted publisher (OIDC) detection
+- Version conflict check against PyPI
 
 ## Architecture
 
@@ -55,10 +205,21 @@ releasekit
 │   ├── publisher.py     async publish orchestration
 │   └── checks.py        standalone workspace health checks
 │
-├── Extensibility
-│   ├── CheckBackend     protocol for language-specific checks
-│   ├── PythonCheckBackend  py.typed, version sync, naming, metadata
-│   └── (future: GoCheckBackend, JsCheckBackend, plugins)
+├── Formatters
+│   ├── ascii_art.py     box-drawing terminal art
+│   ├── csv_fmt.py       RFC 4180 CSV with UTF-8 BOM
+│   ├── d2.py            D2 diagram DSL
+│   ├── dot.py           Graphviz DOT
+│   ├── json_fmt.py      structured JSON
+│   ├── levels.py        simple text listing (default)
+│   ├── mermaid.py       Mermaid flowchart
+│   ├── table.py         Markdown table
+│   └── registry.py      format dispatcher
+│
+├── UX
+│   ├── errors.py        error catalog + Rust-style render_error/render_warning
+│   ├── init.py          workspace config scaffolding
+│   └── cli.py           argparse + rich-argparse + shell completion
 │
 ├── Observer
 │   └── observer.py      PublishStage, SchedulerState, PublishObserver
@@ -101,104 +262,6 @@ releasekit
 │                    └─────────────┘                    │
 └───────────────────────────────────────────────────────┘
 ```
-
-### Publish Pipeline
-
-Packages are dispatched via a dependency-triggered queue — each package
-starts as soon as all its dependencies complete (no level-based lockstep).
-
-#### Why Dependency-Triggered?
-
-**Before (lock-step per level):**
-
-```
-Level 0:  [A] [B] [C]     ← wait for ALL to finish
-              ↓
-Level 1:  [D] [E]          ← wait for ALL to finish
-              ↓
-Level 2:  [F]              ← no parallelism across levels
-```
-
-D and E are blocked until A, B, *and* C all finish — even though D
-only depends on A.  A single slow package in level 0 delays the entire
-pipeline.
-
-**After (dependency-triggered queue):**
-
-```
-Queue: ┌─A─┐ ┌─B─┐ ┌─C─┐
-       └─┬─┘ └───┘ └───┘
-         │ A done → D ready
-       ┌─▼─┐
-       │ D │                 ← starts as soon as A finishes
-       └─┬─┘
-         │ D done + B done → E ready
-       ┌─▼─┐
-       │ E │
-       └─┬─┘
-         │ E done → F ready
-       ┌─▼─┐
-       │ F │
-       └───┘
-```
-
-Each package starts the moment its dependencies are done.  Workers pull
-from the queue as fast as they can — no artificial synchronisation
-barriers between levels.
-
-### Publish Pipeline
-
-Each package goes through:
-
-```
-pin → build → checksum → publish → poll → verify_checksum → smoke_test → restore
-```
-
-On failure, the scheduler retries with exponential backoff + full jitter
-(configurable `--max-retries`, `--retry-base-delay`). Failed packages block
-their dependents (fail-fast for the dependency chain).
-
-1. **Pin** — temporarily rewrite internal deps to exact versions
-2. **Build** — `uv build --no-sources` into temp directory
-3. **Checksum** — compute SHA-256 of .tar.gz and .whl
-4. **Publish** — `uv publish` with `--check-url` for idempotency
-5. **Poll** — wait for PyPI to index the new version
-6. **Verify checksum** — download SHA-256 from PyPI JSON API,
-   compare against local build (supply chain integrity)
-7. **Smoke test** — `uv pip install` in isolated venv
-8. **Restore** — revert pinned pyproject.toml to original
-
-### Health Checks
-
-`releasekit check` runs 10 checks split into two categories:
-
-**Universal checks** (always run):
-- `cycles` — circular dependency chains
-- `self_deps` — package depends on itself
-- `orphan_deps` — internal dep not in workspace
-- `missing_license` — no LICENSE file
-- `missing_readme` — no README.md
-- `stale_artifacts` — leftover .bak or dist/ files
-
-**Language-specific checks** (via `CheckBackend` protocol):
-- `type_markers` — py.typed PEP 561 marker
-- `version_consistency` — plugin version matches core
-- `naming_convention` — directory matches package name
-- `metadata_completeness` — pyproject.toml required fields
-
-The `CheckBackend` protocol allows adding language-specific checks
-for other runtimes (Go, JS) without modifying the core check runner.
-
-### Preflight Checks
-
-`run_preflight` gates the publish pipeline with environment checks:
-- Clean git worktree
-- Lock file up to date
-- No shallow clone
-- No dependency cycles
-- No stale dist/ directories
-- Trusted publisher (OIDC) detection
-- Version conflict check against PyPI
 
 ## Why This Tool Exists
 

--- a/py/tools/releasekit/roadmap.md
+++ b/py/tools/releasekit/roadmap.md
@@ -22,7 +22,7 @@ pinning, retry with jitter, and crash-safe file restoration.
 | 4b: Streaming Core | ✅ Complete | scheduler.py, retry, jitter, pause/resume, 27 tests |
 | 4c: UI States | ✅ Complete | observer.py, sliding window, keyboard shortcuts, signal handlers |
 | 5: Post-Pipeline + CI | ⬜ Not started | |
-| 6: UX Polish | ⬜ Not started | |
+| 6: UX Polish | ✅ Complete | init, formatters (8), rollback, completion, diagnostics, granular flags |
 | 7: Quality + Ship | ⬜ Not started | |
 
 ---
@@ -767,6 +767,14 @@ All 6 graph formats produce correct output. Rollback automates tag/release
 deletion. Shell completion works in bash/zsh/fish.
 
 **Milestone**: Developer experience is polished and discoverable.
+
+**Status**: ✅ Complete. Implemented:
+- `init.py` — workspace config scaffolding with auto-detect groups, `.gitignore` update, dry-run
+- `formatters/` — 6 output formats: `ascii`, `d2`, `dot`, `json`, `levels`, `mermaid` + registry
+- `cli.py` — `init` and `rollback` subcommands, `rich-argparse` colored help, `--format` expansion
+- `errors.py` — `render_error()` and `render_warning()` Rust-compiler-style diagnostics with Rich
+- 51 new tests: formatters (30), init (7), render diagnostics (14)
+- `scripts/dump_diagnostics.py` — diagnostic formatting gallery script
 
 ### Phase 7: Quality + Ship
 

--- a/py/tools/releasekit/scripts/dump_diagnostics.py
+++ b/py/tools/releasekit/scripts/dump_diagnostics.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dump all releasekit diagnostic formatting to the terminal.
+
+Run this script to preview every error and warning style:
+
+    uv run scripts/dump_diagnostics.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+from releasekit.errors import (
+    ERRORS,
+    E,
+    ReleaseKitError,
+    ReleaseKitWarning,
+    render_error,
+    render_warning,
+)
+
+
+def main() -> None:
+    """Render all registered errors, then sample warnings."""
+    print('─' * 60, file=sys.stderr)  # noqa: T201 - CLI script
+    print(  # noqa: T201 - CLI script
+        '  releasekit diagnostic formatting gallery',
+        file=sys.stderr,
+    )
+    print('─' * 60, file=sys.stderr)  # noqa: T201 - CLI script
+    print(file=sys.stderr)  # noqa: T201 - CLI script
+
+    # Render every registered error (these have messages + hints).
+    print(  # noqa: T201 - CLI script
+        '── Registered errors (with hints) ──',
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)  # noqa: T201 - CLI script
+    for code, info in ERRORS.items():
+        exc = ReleaseKitError(code=code, message=info.message, hint=info.hint)
+        render_error(exc, file=sys.stderr)
+
+    # Render errors without hints.
+    print(  # noqa: T201 - CLI script
+        '── Error without hint ──',
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)  # noqa: T201 - CLI script
+    render_error(
+        ReleaseKitError(
+            code=E.BUILD_FAILED,
+            message='Package genkit-plugin-ollama failed to build.',
+        ),
+        file=sys.stderr,
+    )
+
+    # Render errors with brackets in messages (regression test).
+    print(  # noqa: T201 - CLI script
+        '── Bracket preservation ──',
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)  # noqa: T201 - CLI script
+    render_error(
+        ReleaseKitError(
+            code=E.CONFIG_NOT_FOUND,
+            message='No [tool.releasekit] section in pyproject.toml.',
+            hint="Add [tool.releasekit] with 'releasekit init'.",
+        ),
+        file=sys.stderr,
+    )
+
+    # Render warnings.
+    print(  # noqa: T201 - CLI script
+        '── Warnings ──',
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)  # noqa: T201 - CLI script
+    render_warning(
+        ReleaseKitWarning(
+            code=E.PREFLIGHT_SHALLOW_CLONE,
+            message='Repository is a shallow clone; git log data may be incomplete.',
+            hint="Run 'git fetch --unshallow' to fetch full history.",
+        ),
+        file=sys.stderr,
+    )
+    render_warning(
+        ReleaseKitWarning(
+            code=E.PREFLIGHT_DIRTY_WORKTREE,
+            message='Working tree has uncommitted changes.',
+        ),
+        file=sys.stderr,
+    )
+
+    print('─' * 60, file=sys.stderr)  # noqa: T201 - CLI script
+    print('  Done.', file=sys.stderr)  # noqa: T201 - CLI script
+    print('─' * 60, file=sys.stderr)  # noqa: T201 - CLI script
+
+
+if __name__ == '__main__':
+    main()

--- a/py/tools/releasekit/src/releasekit/formatters/__init__.py
+++ b/py/tools/releasekit/src/releasekit/formatters/__init__.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph output formatters for releasekit.
+
+Each formatter is a pure function: ``graph → str``. No side effects,
+no I/O, no network calls. Easy to test, easy to compose.
+
+Available formats:
+
+- **ascii**: Box-drawing character rendering (no external deps)
+- **dot**: Graphviz DOT language
+- **mermaid**: Mermaid flowchart syntax (renders on GitHub)
+- **d2**: D2 diagram language
+- **json**: Machine-readable JSON
+- **levels**: Simple level-grouped text output
+
+Usage::
+
+    from releasekit.formatters import format_graph
+
+    output = format_graph(graph, packages, fmt='mermaid')
+    print(output)
+"""
+
+from __future__ import annotations
+
+from releasekit.formatters.registry import FORMATTERS, format_graph
+
+__all__ = [
+    'FORMATTERS',
+    'format_graph',
+]

--- a/py/tools/releasekit/src/releasekit/formatters/ascii_art.py
+++ b/py/tools/releasekit/src/releasekit/formatters/ascii_art.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ASCII art format output using box-drawing characters.
+
+Renders the dependency graph as a terminal-friendly ASCII diagram
+grouped by topological level. No external dependencies required.
+
+Example output::
+
+    ┌─────────────────────────────────────────────┐
+    │ Level 0                                     │
+    │   genkit (0.5.0)                            │
+    ├─────────────────────────────────────────────┤
+    │ Level 1                                     │
+    │   genkit-plugin-google-genai (0.5.0)        │
+    │   genkit-plugin-vertex-ai (0.5.0)           │
+    ├─────────────────────────────────────────────┤
+    │ Level 2                                     │
+    │   provider-google-genai-hello (0.1.0)       │
+    └─────────────────────────────────────────────┘
+"""
+
+from __future__ import annotations
+
+from releasekit.graph import DependencyGraph, topo_sort
+from releasekit.workspace import Package
+
+
+def format_ascii(
+    graph: DependencyGraph,
+    packages: list[Package],
+    *,
+    show_deps: bool = False,
+    min_width: int = 50,
+) -> str:
+    """Render the dependency graph as an ASCII art diagram.
+
+    Args:
+        graph: The dependency graph.
+        packages: Package list for metadata.
+        show_deps: Show dependency arrows below each package.
+        min_width: Minimum box width.
+
+    Returns:
+        A string with box-drawing characters.
+    """
+    levels = topo_sort(graph)
+    pkg_map = {p.name: p for p in packages}
+
+    # Compute box width from longest line.
+    max_name_len = 0
+    for level in levels:
+        for pkg in level:
+            version = pkg_map.get(pkg.name, pkg).version
+            line = f'  {pkg.name} ({version})' if version else f'  {pkg.name}'
+            max_name_len = max(max_name_len, len(line))
+
+    # Add deps lines if enabled.
+    if show_deps:
+        for _name, deps in graph.edges.items():
+            if deps:
+                dep_line = f'    → {", ".join(sorted(deps))}'
+                max_name_len = max(max_name_len, len(dep_line))
+
+    width = max(min_width, max_name_len + 4)
+
+    lines: list[str] = []
+
+    for level_idx, level in enumerate(levels):
+        if level_idx == 0:
+            lines.append(f'┌{"─" * width}┐')
+        else:
+            lines.append(f'├{"─" * width}┤')
+
+        header = f'│ Level {level_idx}'
+        lines.append(f'{header}{" " * (width - len(header) + 1)}│')
+
+        for pkg in level:
+            version = pkg_map.get(pkg.name, pkg).version
+            if version:
+                content = f'│   {pkg.name} ({version})'
+            else:
+                content = f'│   {pkg.name}'
+            lines.append(f'{content}{" " * (width - len(content) + 1)}│')
+
+            if show_deps:
+                deps = graph.edges.get(pkg.name, [])
+                if deps:
+                    dep_line = f'│     → {", ".join(sorted(deps))}'
+                    lines.append(f'{dep_line}{" " * (width - len(dep_line) + 1)}│')
+
+    lines.append(f'└{"─" * width}┘')
+
+    return '\n'.join(lines) + '\n'
+
+
+__all__ = ['format_ascii']

--- a/py/tools/releasekit/src/releasekit/formatters/csv_fmt.py
+++ b/py/tools/releasekit/src/releasekit/formatters/csv_fmt.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CSV output with Unicode BOM.
+
+Renders the dependency graph as RFC 4180 CSV with a UTF-8 BOM
+(U+FEFF) so spreadsheet applications (Excel, Google Sheets,
+LibreOffice) open the file with correct encoding automatically.
+
+Example output (BOM omitted for readability)::
+
+    level,package,version,dependencies
+    0,genkit,0.5.0,
+    1,genkit-plugin-google-genai,0.5.0,genkit
+    1,genkit-plugin-vertex-ai,0.5.0,genkit
+    2,provider-google-genai-hello,0.1.0,"genkit,genkit-plugin-google-genai"
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+
+from releasekit.graph import DependencyGraph, topo_sort
+from releasekit.workspace import Package
+
+_BOM = '\ufeff'
+
+
+def format_csv(
+    graph: DependencyGraph,
+    packages: list[Package],
+    *,
+    bom: bool = True,
+) -> str:
+    """Render the dependency graph as CSV.
+
+    Args:
+        graph: The dependency graph.
+        packages: Package list for metadata.
+        bom: Prepend a UTF-8 BOM for spreadsheet compatibility
+            (default ``True``).
+
+    Returns:
+        A CSV string with header row.
+    """
+    levels = topo_sort(graph)
+    pkg_map = {p.name: p for p in packages}
+
+    buf = io.StringIO()
+    if bom:
+        buf.write(_BOM)
+
+    writer = csv.writer(buf, lineterminator='\n')
+    writer.writerow(['level', 'package', 'version', 'dependencies'])
+
+    for level_idx, level in enumerate(levels):
+        for pkg in level:
+            p = pkg_map.get(pkg.name, pkg)
+            deps = ','.join(sorted(graph.edges.get(pkg.name, [])))
+            writer.writerow([level_idx, pkg.name, p.version, deps])
+
+    return buf.getvalue()
+
+
+__all__ = ['format_csv']

--- a/py/tools/releasekit/src/releasekit/formatters/d2.py
+++ b/py/tools/releasekit/src/releasekit/formatters/d2.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""D2 diagram language format output.
+
+Renders the dependency graph in D2 format, a modern diagram language
+with auto-layout. See https://d2lang.com/ for details.
+
+Usage::
+
+    d2 graph.d2 graph.svg
+    d2 --watch graph.d2 graph.svg
+"""
+
+from __future__ import annotations
+
+from releasekit.graph import DependencyGraph
+from releasekit.workspace import Package
+
+
+def format_d2(
+    graph: DependencyGraph,
+    packages: list[Package],
+    *,
+    direction: str = 'down',
+    title: str = '',
+) -> str:
+    """Render the dependency graph as a D2 diagram.
+
+    Args:
+        graph: The dependency graph.
+        packages: Package list for metadata.
+        direction: Layout direction (``down``, ``right``, ``up``, ``left``).
+        title: Optional diagram title.
+
+    Returns:
+        A D2 diagram string.
+    """
+    lines: list[str] = []
+
+    lines.append(f'direction: {direction}')
+    lines.append('')
+
+    if title:
+        lines.append(f'title: {title} {{')
+        lines.append('  shape: text')
+        lines.append('  near: top-center')
+        lines.append('}')
+        lines.append('')
+
+    # Node declarations.
+    pkg_map = {p.name: p for p in packages}
+    for name in graph.names:
+        node_id = _sanitize_id(name)
+        pkg = pkg_map.get(name)
+        version = pkg.version if pkg else ''
+        if version:
+            lines.append(f'{node_id}: "{name}\\n{version}" {{')
+        else:
+            lines.append(f'{node_id}: "{name}" {{')
+        lines.append('  shape: rectangle')
+        lines.append('}')
+
+    lines.append('')
+
+    # Edges (dependent → dependency).
+    for dependent, deps in sorted(graph.edges.items()):
+        dep_id = _sanitize_id(dependent)
+        for dep in sorted(deps):
+            lines.append(f'{dep_id} -> {_sanitize_id(dep)}')
+
+    return '\n'.join(lines) + '\n'
+
+
+def _sanitize_id(name: str) -> str:
+    """Convert a package name to a valid D2 identifier."""
+    return name.replace('-', '_').replace('.', '_')
+
+
+__all__ = ['format_d2']

--- a/py/tools/releasekit/src/releasekit/formatters/dot.py
+++ b/py/tools/releasekit/src/releasekit/formatters/dot.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graphviz DOT format output.
+
+Renders the dependency graph as a DOT digraph suitable for Graphviz
+tools (``dot``, ``neato``, ``fdp``).
+
+Usage::
+
+    dot -Tsvg graph.dot -o graph.svg
+    dot -Tpng graph.dot -o graph.png
+"""
+
+from __future__ import annotations
+
+from releasekit.graph import DependencyGraph
+from releasekit.workspace import Package
+
+
+def format_dot(
+    graph: DependencyGraph,
+    packages: list[Package],
+    *,
+    rankdir: str = 'TB',
+    label: str = '',
+) -> str:
+    """Render the dependency graph as a Graphviz DOT string.
+
+    Args:
+        graph: The dependency graph.
+        packages: Package list for metadata (used for display names).
+        rankdir: Graph direction (``TB``, ``LR``, ``BT``, ``RL``).
+        label: Optional graph title.
+
+    Returns:
+        A DOT language string.
+    """
+    lines: list[str] = []
+    lines.append('digraph dependencies {')
+    lines.append(f'  rankdir={rankdir};')
+    lines.append('  node [shape=box, style=rounded, fontname="Inter"];')
+    lines.append('  edge [color="#666666"];')
+
+    if label:
+        lines.append(f'  label="{label}";')
+        lines.append('  labelloc=t;')
+
+    lines.append('')
+
+    # Node declarations.
+    pkg_map = {p.name: p for p in packages}
+    for name in graph.names:
+        pkg = pkg_map.get(name)
+        version = pkg.version if pkg else ''
+        node_label = f'{name}\\n{version}' if version else name
+        node_id = _sanitize_id(name)
+        lines.append(f'  {node_id} [label="{node_label}"];')
+
+    lines.append('')
+
+    # Edges (dependent → dependency).
+    for dependent, deps in sorted(graph.edges.items()):
+        for dep in sorted(deps):
+            lines.append(f'  {_sanitize_id(dependent)} -> {_sanitize_id(dep)};')
+
+    lines.append('}')
+    return '\n'.join(lines) + '\n'
+
+
+def _sanitize_id(name: str) -> str:
+    """Convert a package name to a valid DOT node ID."""
+    return f'"{name}"'
+
+
+__all__ = ['format_dot']

--- a/py/tools/releasekit/src/releasekit/formatters/json_fmt.py
+++ b/py/tools/releasekit/src/releasekit/formatters/json_fmt.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""JSON format output for dependency graphs.
+
+Renders the dependency graph as machine-readable JSON with full
+structure: nodes, edges, reverse edges, levels, and package metadata.
+"""
+
+from __future__ import annotations
+
+import json
+
+from releasekit.graph import DependencyGraph, topo_sort
+from releasekit.workspace import Package
+
+
+def format_json(
+    graph: DependencyGraph,
+    packages: list[Package],
+    *,
+    indent: int = 2,
+) -> str:
+    """Render the dependency graph as a JSON string.
+
+    Args:
+        graph: The dependency graph.
+        packages: Package list for metadata.
+        indent: JSON indentation level.
+
+    Returns:
+        A JSON string with full graph structure.
+    """
+    levels = topo_sort(graph)
+    pkg_map = {p.name: p for p in packages}
+
+    nodes: list[dict[str, object]] = []
+    for name in graph.names:
+        pkg = pkg_map.get(name)
+        node: dict[str, object] = {'name': name}
+        if pkg:
+            node['version'] = pkg.version
+            node['path'] = str(pkg.path)
+        node['deps'] = sorted(graph.edges.get(name, []))
+        node['rdeps'] = sorted(graph.reverse_edges.get(name, []))
+        nodes.append(node)
+
+    level_data: list[list[str]] = [sorted(p.name for p in level) for level in levels]
+
+    data = {
+        'packages': len(graph.names),
+        'levels': len(levels),
+        'nodes': nodes,
+        'level_groups': level_data,
+        'edges': {k: sorted(v) for k, v in sorted(graph.edges.items())},
+        'reverse_edges': {k: sorted(v) for k, v in sorted(graph.reverse_edges.items())},
+    }
+
+    return json.dumps(data, indent=indent) + '\n'
+
+
+__all__ = ['format_json']

--- a/py/tools/releasekit/src/releasekit/formatters/levels.py
+++ b/py/tools/releasekit/src/releasekit/formatters/levels.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Simple level-grouped text output.
+
+Renders the dependency graph as a minimal text listing grouped by
+topological level. This is the default ``releasekit graph`` format.
+
+Example output::
+
+    Level 0: genkit
+    Level 1: genkit-plugin-google-genai, genkit-plugin-vertex-ai
+    Level 2: provider-google-genai-hello
+"""
+
+from __future__ import annotations
+
+from releasekit.graph import DependencyGraph, topo_sort
+from releasekit.workspace import Package
+
+
+def format_levels(
+    graph: DependencyGraph,
+    packages: list[Package],
+    *,
+    show_version: bool = False,
+) -> str:
+    """Render the dependency graph as a level-grouped text listing.
+
+    Args:
+        graph: The dependency graph.
+        packages: Package list for metadata.
+        show_version: Append version to each package name.
+
+    Returns:
+        A simple text listing.
+    """
+    levels = topo_sort(graph)
+    pkg_map = {p.name: p for p in packages}
+
+    lines: list[str] = []
+    for level_idx, level in enumerate(levels):
+        names: list[str] = []
+        for pkg in level:
+            if show_version:
+                p = pkg_map.get(pkg.name, pkg)
+                names.append(f'{pkg.name} ({p.version})')
+            else:
+                names.append(pkg.name)
+        lines.append(f'  Level {level_idx}: {", ".join(names)}')
+
+    return '\n'.join(lines) + '\n'
+
+
+__all__ = ['format_levels']

--- a/py/tools/releasekit/src/releasekit/formatters/mermaid.py
+++ b/py/tools/releasekit/src/releasekit/formatters/mermaid.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mermaid flowchart format output.
+
+Renders the dependency graph as a Mermaid flowchart that renders
+natively on GitHub, GitLab, and documentation sites.
+
+Usage (in markdown)::
+
+    ```mermaid
+    flowchart TD
+        genkit --> genkit-plugin-foo
+    ```
+"""
+
+from __future__ import annotations
+
+from releasekit.graph import DependencyGraph
+from releasekit.workspace import Package
+
+
+def format_mermaid(
+    graph: DependencyGraph,
+    packages: list[Package],
+    *,
+    direction: str = 'TD',
+    title: str = '',
+) -> str:
+    """Render the dependency graph as a Mermaid flowchart.
+
+    Args:
+        graph: The dependency graph.
+        packages: Package list for metadata.
+        direction: Flow direction (``TD``, ``LR``, ``BT``, ``RL``).
+        title: Optional diagram title (rendered as a comment).
+
+    Returns:
+        A Mermaid flowchart string.
+    """
+    lines: list[str] = []
+
+    if title:
+        lines.append('---')
+        lines.append(f'title: {title}')
+        lines.append('---')
+
+    lines.append(f'flowchart {direction}')
+
+    # Node declarations with labels.
+    pkg_map = {p.name: p for p in packages}
+    for name in graph.names:
+        node_id = _sanitize_id(name)
+        pkg = pkg_map.get(name)
+        version = pkg.version if pkg else ''
+        if version:
+            lines.append(f'    {node_id}["{name}<br/><small>{version}</small>"]')
+        else:
+            lines.append(f'    {node_id}["{name}"]')
+
+    lines.append('')
+
+    # Edges (dependent → dependency).
+    for dependent, deps in sorted(graph.edges.items()):
+        dep_id = _sanitize_id(dependent)
+        for dep in sorted(deps):
+            lines.append(f'    {dep_id} --> {_sanitize_id(dep)}')
+
+    return '\n'.join(lines) + '\n'
+
+
+def _sanitize_id(name: str) -> str:
+    """Convert a package name to a valid Mermaid node ID.
+
+    Mermaid IDs cannot contain hyphens, so we replace them with
+    underscores.
+    """
+    return name.replace('-', '_').replace('.', '_')
+
+
+__all__ = ['format_mermaid']

--- a/py/tools/releasekit/src/releasekit/formatters/registry.py
+++ b/py/tools/releasekit/src/releasekit/formatters/registry.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Formatter registry and dispatch.
+
+Maps format names to their formatter functions, providing a single
+``format_graph()`` entry point for the CLI.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from releasekit.formatters.ascii_art import format_ascii
+from releasekit.formatters.csv_fmt import format_csv
+from releasekit.formatters.d2 import format_d2
+from releasekit.formatters.dot import format_dot
+from releasekit.formatters.json_fmt import format_json
+from releasekit.formatters.levels import format_levels
+from releasekit.formatters.mermaid import format_mermaid
+from releasekit.formatters.table import format_table
+from releasekit.graph import DependencyGraph
+from releasekit.workspace import Package
+
+Formatter = Callable[..., str]
+
+FORMATTERS: dict[str, Formatter] = {
+    'ascii': format_ascii,
+    'csv': format_csv,
+    'd2': format_d2,
+    'dot': format_dot,
+    'json': format_json,
+    'levels': format_levels,
+    'mermaid': format_mermaid,
+    'table': format_table,
+}
+
+
+def format_graph(
+    graph: DependencyGraph,
+    packages: list[Package],
+    *,
+    fmt: str = 'levels',
+) -> str:
+    """Format a dependency graph using the named formatter.
+
+    Args:
+        graph: The dependency graph.
+        packages: Package list for metadata.
+        fmt: Format name (one of :data:`FORMATTERS`).
+
+    Returns:
+        The formatted graph string.
+
+    Raises:
+        ValueError: If ``fmt`` is not a registered format name.
+    """
+    formatter = FORMATTERS.get(fmt)
+    if formatter is None:
+        available = ', '.join(sorted(FORMATTERS))
+        msg = f'Unknown format {fmt!r}. Available: {available}'
+        raise ValueError(msg)
+    return formatter(graph, packages)
+
+
+__all__ = [
+    'FORMATTERS',
+    'format_graph',
+]

--- a/py/tools/releasekit/src/releasekit/formatters/table.py
+++ b/py/tools/releasekit/src/releasekit/formatters/table.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Markdown-style table output.
+
+Renders the dependency graph as a table with columns for level, package
+name, version, and internal dependencies.
+
+Example output::
+
+    | Level | Package                       | Version | Dependencies            |
+    |-------|-------------------------------|---------|-------------------------|
+    | 0     | genkit                        | 0.5.0   |                         |
+    | 1     | genkit-plugin-google-genai    | 0.5.0   | genkit                  |
+    | 1     | genkit-plugin-vertex-ai       | 0.5.0   | genkit                  |
+    | 2     | provider-google-genai-hello   | 0.1.0   | genkit, genkit-plugin-… |
+"""
+
+from __future__ import annotations
+
+from releasekit.graph import DependencyGraph, topo_sort
+from releasekit.workspace import Package
+
+
+def _pad(text: str, width: int) -> str:
+    """Left-align text, padded to the given width."""
+    return text + ' ' * max(0, width - len(text))
+
+
+def format_table(
+    graph: DependencyGraph,
+    packages: list[Package],
+    *,
+    show_version: bool = True,
+) -> str:
+    """Render the dependency graph as a Markdown-style table.
+
+    Args:
+        graph: The dependency graph.
+        packages: Package list for metadata.
+        show_version: Include a version column (default ``True``).
+
+    Returns:
+        A Markdown table string.
+    """
+    levels = topo_sort(graph)
+    pkg_map = {p.name: p for p in packages}
+
+    rows: list[tuple[str, str, str, str]] = []
+    for level_idx, level in enumerate(levels):
+        for pkg in level:
+            p = pkg_map.get(pkg.name, pkg)
+            deps = ', '.join(sorted(graph.edges.get(pkg.name, [])))
+            rows.append((str(level_idx), pkg.name, p.version, deps))
+
+    if not rows:
+        return '(empty graph)\n'
+
+    col_level = max(len('Level'), max(len(r[0]) for r in rows))
+    col_pkg = max(len('Package'), max(len(r[1]) for r in rows))
+    col_deps = max(len('Dependencies'), max(len(r[3]) for r in rows))
+
+    if show_version:
+        col_ver = max(len('Version'), max(len(r[2]) for r in rows))
+        header = (
+            f'| {_pad("Level", col_level)} '
+            f'| {_pad("Package", col_pkg)} '
+            f'| {_pad("Version", col_ver)} '
+            f'| {_pad("Dependencies", col_deps)} |'
+        )
+        separator = f'|{"-" * (col_level + 2)}|{"-" * (col_pkg + 2)}|{"-" * (col_ver + 2)}|{"-" * (col_deps + 2)}|'
+        lines = [header, separator]
+        for lvl, name, ver, deps in rows:
+            lines.append(
+                f'| {_pad(lvl, col_level)} | {_pad(name, col_pkg)} | {_pad(ver, col_ver)} | {_pad(deps, col_deps)} |',
+            )
+    else:
+        header = f'| {_pad("Level", col_level)} | {_pad("Package", col_pkg)} | {_pad("Dependencies", col_deps)} |'
+        separator = f'|{"-" * (col_level + 2)}|{"-" * (col_pkg + 2)}|{"-" * (col_deps + 2)}|'
+        lines = [header, separator]
+        for lvl, name, _ver, deps in rows:
+            lines.append(
+                f'| {_pad(lvl, col_level)} | {_pad(name, col_pkg)} | {_pad(deps, col_deps)} |',
+            )
+
+    return '\n'.join(lines) + '\n'
+
+
+__all__ = ['format_table']

--- a/py/tools/releasekit/src/releasekit/init.py
+++ b/py/tools/releasekit/src/releasekit/init.py
@@ -1,0 +1,318 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Workspace configuration scaffolding for releasekit.
+
+Auto-detects workspace structure, generates ``[tool.releasekit]``
+configuration in ``pyproject.toml``, and updates ``.gitignore``.
+Idempotent — safe to run multiple times.
+
+Architecture::
+
+    discover_packages()            .gitignore
+         │                             │
+         ▼                             ▼
+    Detect groups              Append patterns
+    (core, plugins,            (*.bak, .releasekit/)
+     samples)
+         │
+         ▼
+    Generate TOML              Show diff
+    [tool.releasekit]          (if TTY)
+         │                         │
+         ▼                         ▼
+    Write pyproject.toml       Prompt: apply? [Y/n]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import tomlkit
+
+try:
+    from rich.console import Console
+    from rich.syntax import Syntax
+
+    _HAS_RICH = True
+except ImportError:
+    _HAS_RICH = False
+
+from releasekit.logging import get_logger
+from releasekit.workspace import Package, discover_packages
+
+logger = get_logger(__name__)
+
+# Patterns to add to .gitignore.
+GITIGNORE_PATTERNS: list[str] = [
+    '# releasekit backup files',
+    '*.bak',
+    '.releasekit/',
+]
+
+
+def detect_groups(packages: list[Package]) -> dict[str, list[str]]:
+    """Auto-detect release groups from package naming conventions.
+
+    Groups are detected by:
+    - ``core``: Packages matching the workspace name (e.g., ``genkit``)
+    - ``plugins``: Packages with ``-plugin-`` in the name
+    - ``samples``: Packages in ``samples/`` directories
+
+    Args:
+        packages: Discovered workspace packages.
+
+    Returns:
+        A dict mapping group name to a list of glob patterns.
+    """
+    groups: dict[str, list[str]] = {}
+    plugin_names: list[str] = []
+    sample_names: list[str] = []
+    core_names: list[str] = []
+
+    for pkg in packages:
+        if '-plugin-' in pkg.name:
+            plugin_names.append(pkg.name)
+        elif 'sample' in str(pkg.path).lower() or 'sample' in pkg.name:
+            sample_names.append(pkg.name)
+        else:
+            core_names.append(pkg.name)
+
+    if core_names:
+        groups['core'] = core_names
+
+    # If all plugins share a prefix, use a glob pattern.
+    if plugin_names:
+        prefixes = {n.rsplit('-', 1)[0] + '-*' for n in plugin_names if '-' in n}
+        if len(prefixes) == 1:
+            groups['plugins'] = [prefixes.pop()]
+        else:
+            groups['plugins'] = sorted(plugin_names)
+
+    if sample_names:
+        groups['samples'] = sorted(sample_names)
+
+    return groups
+
+
+def generate_config_toml(
+    groups: dict[str, list[str]],
+    *,
+    exclude: list[str] | None = None,
+    tag_format: str = '{name}-v{version}',
+    umbrella_tag: str = 'v{version}',
+) -> str:
+    """Generate a ``[tool.releasekit]`` TOML fragment.
+
+    Args:
+        groups: Package groups from :func:`detect_groups`.
+        exclude: Glob patterns for packages to exclude.
+        tag_format: Per-package tag format.
+        umbrella_tag: Umbrella tag format.
+
+    Returns:
+        A TOML string suitable for insertion into ``pyproject.toml``.
+    """
+    doc = tomlkit.document()
+    table = tomlkit.table()
+
+    table.add('tag_format', tag_format)
+    table.add('umbrella_tag', umbrella_tag)
+
+    if exclude:
+        table.add('exclude', exclude)
+
+    if groups:
+        groups_table = tomlkit.table()
+        for group_name, patterns in sorted(groups.items()):
+            groups_table.add(group_name, patterns)
+        table.add('groups', groups_table)
+
+    table.add('changelog', True)
+    table.add('smoke_test', True)
+
+    doc.add('tool', tomlkit.table())
+    tool_dict = dict(doc['tool'])  # type: ignore[arg-type]
+    tool_dict['releasekit'] = table
+    doc['tool'] = tool_dict
+
+    return tomlkit.dumps(doc)
+
+
+def _has_releasekit_config(pyproject_path: Path) -> bool:
+    """Return True if pyproject.toml already has [tool.releasekit]."""
+    if not pyproject_path.exists():
+        return False
+    content = pyproject_path.read_text(encoding='utf-8')
+    doc = tomlkit.parse(content)
+    tool = doc.get('tool')
+    if not isinstance(tool, dict):
+        return False
+    return 'releasekit' in tool
+
+
+def scaffold_config(
+    workspace_root: Path,
+    *,
+    dry_run: bool = False,
+    force: bool = False,
+) -> str:
+    """Scaffold releasekit configuration for a workspace.
+
+    This is the main entry point for ``releasekit init``. It:
+
+    1. Discovers packages in the workspace
+    2. Auto-detects release groups
+    3. Generates ``[tool.releasekit]`` TOML
+    4. Updates ``pyproject.toml`` (if not dry-run)
+    5. Updates ``.gitignore`` (if not dry-run)
+
+    Args:
+        workspace_root: Path to the workspace root.
+        dry_run: Preview changes without writing files.
+        force: Overwrite existing ``[tool.releasekit]`` section.
+
+    Returns:
+        The generated TOML fragment (for display/preview).
+    """
+    pyproject_path = workspace_root / 'pyproject.toml'
+
+    if _has_releasekit_config(pyproject_path) and not force:
+        logger.info(
+            '[tool.releasekit] already exists in %s (use --force to overwrite)',
+            pyproject_path,
+        )
+        return ''
+
+    packages = discover_packages(workspace_root)
+    groups = detect_groups(packages)
+
+    # Detect common sample patterns for exclusion.
+    exclude: list[str] = []
+    sample_patterns = [p.name for p in packages if 'sample' in str(p.path).lower()]
+    if sample_patterns:
+        # If many samples follow a pattern, use a glob.
+        prefixes = set()
+        for name in sample_patterns:
+            parts = name.split('-')
+            if len(parts) > 1:
+                prefixes.add(parts[0] + '-*')
+        if len(prefixes) == 1 and len(sample_patterns) > 2:
+            exclude.append(prefixes.pop())
+
+    toml_fragment = generate_config_toml(groups, exclude=exclude or None)
+
+    if dry_run:
+        return toml_fragment
+
+    # Write to pyproject.toml.
+    _update_pyproject(pyproject_path, groups, exclude)
+    logger.info('Updated %s', pyproject_path)
+
+    # Update .gitignore.
+    _update_gitignore(workspace_root / '.gitignore')
+    logger.info('Updated %s', workspace_root / '.gitignore')
+
+    return toml_fragment
+
+
+def _update_pyproject(
+    pyproject_path: Path,
+    groups: dict[str, list[str]],
+    exclude: list[str],
+) -> None:
+    """Add [tool.releasekit] to an existing pyproject.toml."""
+    content = pyproject_path.read_text(encoding='utf-8')
+    doc = tomlkit.parse(content)
+
+    if 'tool' not in doc:
+        doc.add('tool', tomlkit.table())
+
+    tool = doc['tool']
+    if not isinstance(tool, dict):
+        return
+
+    rk_table = tomlkit.table()
+    rk_table.add('tag_format', '{name}-v{version}')
+    rk_table.add('umbrella_tag', 'v{version}')
+
+    if exclude:
+        rk_table.add('exclude', exclude)
+
+    if groups:
+        groups_table = tomlkit.table()
+        for group_name, patterns in sorted(groups.items()):
+            groups_table.add(group_name, patterns)
+        rk_table.add('groups', groups_table)
+
+    rk_table.add('changelog', True)
+    rk_table.add('smoke_test', True)
+
+    tool_dict = dict(tool)
+    tool_dict['releasekit'] = rk_table
+    doc['tool'] = tool_dict
+
+    pyproject_path.write_text(tomlkit.dumps(doc), encoding='utf-8')
+
+
+def _update_gitignore(gitignore_path: Path) -> None:
+    """Append releasekit patterns to .gitignore if not already present."""
+    existing = ''
+    if gitignore_path.exists():
+        existing = gitignore_path.read_text(encoding='utf-8')
+
+    lines_to_add: list[str] = []
+    for pattern in GITIGNORE_PATTERNS:
+        if pattern not in existing:
+            lines_to_add.append(pattern)
+
+    if not lines_to_add:
+        return
+
+    with gitignore_path.open('a', encoding='utf-8') as f:
+        if existing and not existing.endswith('\n'):
+            f.write('\n')
+        f.write('\n')
+        for line in lines_to_add:
+            f.write(line + '\n')
+
+
+def print_scaffold_preview(toml_fragment: str) -> None:
+    """Print a preview of the generated configuration.
+
+    Uses Rich for colored output if available on a TTY, otherwise
+    prints plain text.
+    """
+    if not toml_fragment:
+        return
+
+    if sys.stdout.isatty() and _HAS_RICH:
+        console = Console()
+        console.print('\n[bold]Generated [tool.releasekit] configuration:[/bold]\n')
+        syntax = Syntax(toml_fragment, 'toml', theme='monokai')
+        console.print(syntax)
+        return
+
+    print(toml_fragment)  # noqa: T201 - CLI output
+
+
+__all__ = [
+    'detect_groups',
+    'generate_config_toml',
+    'print_scaffold_preview',
+    'scaffold_config',
+]

--- a/py/tools/releasekit/tests/rk_formatters_test.py
+++ b/py/tools/releasekit/tests/rk_formatters_test.py
@@ -1,0 +1,555 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for releasekit.formatters package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from releasekit.formatters import FORMATTERS, format_graph
+from releasekit.formatters.ascii_art import format_ascii
+from releasekit.formatters.csv_fmt import format_csv
+from releasekit.formatters.d2 import format_d2
+from releasekit.formatters.dot import format_dot
+from releasekit.formatters.json_fmt import format_json
+from releasekit.formatters.levels import format_levels
+from releasekit.formatters.mermaid import format_mermaid
+from releasekit.formatters.table import format_table
+from releasekit.graph import DependencyGraph, build_graph
+from releasekit.workspace import Package
+
+
+def _make_packages() -> list[Package]:
+    """Create a small test package set."""
+    return [
+        Package(
+            name='core',
+            version='1.0.0',
+            path=Path('/p/core'),
+            pyproject_path=Path('/p/core/pyproject.toml'),
+        ),
+        Package(
+            name='plugin-a',
+            version='1.0.0',
+            path=Path('/p/plugin-a'),
+            pyproject_path=Path('/p/plugin-a/pyproject.toml'),
+            internal_deps=['core'],
+        ),
+        Package(
+            name='plugin-b',
+            version='1.0.0',
+            path=Path('/p/plugin-b'),
+            pyproject_path=Path('/p/plugin-b/pyproject.toml'),
+            internal_deps=['core'],
+        ),
+        Package(
+            name='app',
+            version='0.1.0',
+            path=Path('/p/app'),
+            pyproject_path=Path('/p/app/pyproject.toml'),
+            internal_deps=['plugin-a', 'plugin-b'],
+        ),
+    ]
+
+
+def _make_graph(packages: list[Package] | None = None) -> DependencyGraph:
+    """Build a test graph."""
+    if packages is None:
+        packages = _make_packages()
+    return build_graph(packages)
+
+
+# ── Registry ────────────────────────────────────────────────────────
+
+
+class TestRegistry:
+    """Tests for the formatter registry."""
+
+    def test_all_formats_registered(self) -> None:
+        """All 6 format names are registered."""
+        expected = {'ascii', 'csv', 'd2', 'dot', 'json', 'levels', 'mermaid', 'table'}
+        if FORMATTERS.keys() != expected:
+            missing = expected - FORMATTERS.keys()
+            extra = FORMATTERS.keys() - expected
+            msg = f'Missing: {missing}, Extra: {extra}'
+            raise AssertionError(msg)
+
+    def test_format_graph_dispatches(self) -> None:
+        """format_graph dispatches to the correct formatter."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+
+        for fmt_name in FORMATTERS:
+            output = format_graph(graph, pkgs, fmt=fmt_name)
+            if not isinstance(output, str):
+                msg = f'{fmt_name} returned {type(output)}, expected str'
+                raise AssertionError(msg)
+            if not output.strip():
+                msg = f'{fmt_name} returned empty output'
+                raise AssertionError(msg)
+
+    def test_format_graph_unknown_raises(self) -> None:
+        """format_graph raises ValueError for unknown format."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        try:
+            format_graph(graph, pkgs, fmt='unknown_format')
+        except ValueError as exc:
+            if 'unknown_format' not in str(exc):
+                msg = f'Expected format name in error: {exc}'
+                raise AssertionError(msg) from exc
+        else:
+            msg = 'Expected ValueError'
+            raise AssertionError(msg)
+
+
+# ── DOT format ──────────────────────────────────────────────────────
+
+
+class TestDotFormat:
+    """Tests for the DOT formatter."""
+
+    def test_basic_output(self) -> None:
+        """DOT output includes digraph header and nodes."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_dot(graph, pkgs)
+
+        if 'digraph dependencies' not in output:
+            raise AssertionError('Missing digraph header')
+        if '"core"' not in output:
+            raise AssertionError('Missing core node')
+        if '"plugin-a" -> "core"' not in output:
+            raise AssertionError('Missing edge plugin-a -> core')
+
+    def test_custom_rankdir(self) -> None:
+        """DOT output uses custom rankdir."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_dot(graph, pkgs, rankdir='LR')
+
+        if 'rankdir=LR' not in output:
+            raise AssertionError('Missing rankdir=LR')
+
+    def test_with_label(self) -> None:
+        """DOT output includes title label."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_dot(graph, pkgs, label='My Graph')
+
+        if 'label="My Graph"' not in output:
+            raise AssertionError('Missing label')
+
+    def test_version_in_node(self) -> None:
+        """DOT node labels include version."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_dot(graph, pkgs)
+
+        if 'core\\n1.0.0' not in output:
+            raise AssertionError('Missing version in node label')
+
+
+# ── Mermaid format ──────────────────────────────────────────────────
+
+
+class TestMermaidFormat:
+    """Tests for the Mermaid formatter."""
+
+    def test_basic_output(self) -> None:
+        """Mermaid output includes flowchart header and nodes."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_mermaid(graph, pkgs)
+
+        if 'flowchart TD' not in output:
+            raise AssertionError('Missing flowchart header')
+        if 'core' not in output:
+            raise AssertionError('Missing core node')
+
+    def test_sanitized_ids(self) -> None:
+        """Mermaid IDs replace hyphens with underscores."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_mermaid(graph, pkgs)
+
+        if 'plugin_a' not in output:
+            raise AssertionError('Expected plugin_a (sanitized)')
+        if 'plugin-a[' in output:
+            raise AssertionError('Unsanitized plugin-a should not appear as ID')
+
+    def test_edges(self) -> None:
+        """Mermaid output includes edges."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_mermaid(graph, pkgs)
+
+        if 'plugin_a --> core' not in output:
+            raise AssertionError('Missing edge plugin_a --> core')
+
+    def test_custom_direction(self) -> None:
+        """Mermaid output uses custom direction."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_mermaid(graph, pkgs, direction='LR')
+
+        if 'flowchart LR' not in output:
+            raise AssertionError('Missing flowchart LR')
+
+    def test_with_title(self) -> None:
+        """Mermaid output includes title in frontmatter."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_mermaid(graph, pkgs, title='Dependencies')
+
+        if 'title: Dependencies' not in output:
+            raise AssertionError('Missing title')
+
+
+# ── D2 format ───────────────────────────────────────────────────────
+
+
+class TestD2Format:
+    """Tests for the D2 formatter."""
+
+    def test_basic_output(self) -> None:
+        """D2 output includes direction and nodes."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_d2(graph, pkgs)
+
+        if 'direction: down' not in output:
+            raise AssertionError('Missing direction')
+        if 'core:' not in output:
+            raise AssertionError('Missing core node')
+
+    def test_edges(self) -> None:
+        """D2 output includes edges."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_d2(graph, pkgs)
+
+        if 'plugin_a -> core' not in output:
+            raise AssertionError('Missing edge plugin_a -> core')
+
+    def test_custom_direction(self) -> None:
+        """D2 output uses custom direction."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_d2(graph, pkgs, direction='right')
+
+        if 'direction: right' not in output:
+            raise AssertionError('Missing direction: right')
+
+
+# ── ASCII art format ────────────────────────────────────────────────
+
+
+class TestAsciiFormat:
+    """Tests for the ASCII art formatter."""
+
+    def test_basic_output(self) -> None:
+        """ASCII output includes box-drawing characters."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_ascii(graph, pkgs)
+
+        if '┌' not in output:
+            raise AssertionError('Missing top-left corner')
+        if '┘' not in output:
+            raise AssertionError('Missing bottom-right corner')
+        if 'Level 0' not in output:
+            raise AssertionError('Missing Level 0 header')
+
+    def test_contains_packages(self) -> None:
+        """ASCII output lists all packages."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_ascii(graph, pkgs)
+
+        for pkg in pkgs:
+            if pkg.name not in output:
+                msg = f'Missing package {pkg.name}'
+                raise AssertionError(msg)
+
+    def test_show_deps(self) -> None:
+        """ASCII output shows dependency arrows with show_deps=True."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_ascii(graph, pkgs, show_deps=True)
+
+        if '→' not in output:
+            raise AssertionError('Missing dependency arrow')
+
+
+# ── JSON format ─────────────────────────────────────────────────────
+
+
+class TestJsonFormat:
+    """Tests for the JSON formatter."""
+
+    def test_valid_json(self) -> None:
+        """JSON output is valid JSON."""
+        import json
+
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_json(graph, pkgs)
+
+        data = json.loads(output)
+        if data['packages'] != 4:
+            msg = f'Expected 4 packages, got {data["packages"]}'
+            raise AssertionError(msg)
+
+    def test_contains_edges(self) -> None:
+        """JSON output includes edges."""
+        import json
+
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_json(graph, pkgs)
+
+        data = json.loads(output)
+        if 'edges' not in data:
+            raise AssertionError('Missing edges')
+        if 'core' not in data['edges'].get('plugin-a', []):
+            raise AssertionError('Missing edge plugin-a -> core')
+
+    def test_contains_levels(self) -> None:
+        """JSON output includes level groups."""
+        import json
+
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_json(graph, pkgs)
+
+        data = json.loads(output)
+        if data['levels'] < 2:
+            msg = f'Expected at least 2 levels, got {data["levels"]}'
+            raise AssertionError(msg)
+
+
+# ── Levels format ───────────────────────────────────────────────────
+
+
+class TestLevelsFormat:
+    """Tests for the levels formatter."""
+
+    def test_basic_output(self) -> None:
+        """Levels output lists levels with package names."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_levels(graph, pkgs)
+
+        if 'Level 0' not in output:
+            raise AssertionError('Missing Level 0')
+        if 'core' not in output:
+            raise AssertionError('Missing core')
+
+    def test_show_version(self) -> None:
+        """Levels output includes versions with show_version=True."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_levels(graph, pkgs, show_version=True)
+
+        if '1.0.0' not in output:
+            raise AssertionError('Missing version')
+
+
+# ── Empty graph ─────────────────────────────────────────────────────
+
+
+class TestEmptyGraph:
+    """Tests for formatters with an empty graph."""
+
+    def test_all_formats_handle_empty(self) -> None:
+        """All formatters handle an empty graph gracefully."""
+        pkgs: list[Package] = []
+        graph = _make_graph(pkgs)
+
+        for fmt_name in FORMATTERS:
+            output = format_graph(graph, pkgs, fmt=fmt_name)
+            if not isinstance(output, str):
+                msg = f'{fmt_name} returned {type(output)} for empty graph'
+                raise AssertionError(msg)
+
+
+class TestTableFormat:
+    """Tests for the table formatter."""
+
+    def test_basic_output(self) -> None:
+        """Table output includes header row and separator."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_table(graph, pkgs)
+
+        if '| Level' not in output:
+            raise AssertionError('Missing Level header')
+        if '| Package' not in output:
+            raise AssertionError('Missing Package header')
+        if '|---' not in output:
+            raise AssertionError('Missing separator row')
+
+    def test_contains_all_packages(self) -> None:
+        """Table output lists every package."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_table(graph, pkgs)
+
+        for pkg in pkgs:
+            if pkg.name not in output:
+                msg = f'Missing package {pkg.name}'
+                raise AssertionError(msg)
+
+    def test_includes_version_by_default(self) -> None:
+        """Table output includes version column by default."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_table(graph, pkgs)
+
+        if '| Version' not in output:
+            raise AssertionError('Missing Version header')
+        if '1.0.0' not in output:
+            raise AssertionError('Missing version value')
+
+    def test_no_version(self) -> None:
+        """Table output omits version column when show_version=False."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_table(graph, pkgs, show_version=False)
+
+        if 'Version' in output:
+            raise AssertionError('Version column should be omitted')
+
+    def test_includes_dependencies(self) -> None:
+        """Table output includes dependency names."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_table(graph, pkgs)
+
+        if '| Dependencies' not in output:
+            raise AssertionError('Missing Dependencies header')
+        # app depends on plugin-a and plugin-b
+        if 'plugin-a' not in output:
+            raise AssertionError('Missing dependency plugin-a')
+
+    def test_empty_graph(self) -> None:
+        """Table output handles empty graph."""
+        pkgs: list[Package] = []
+        graph = _make_graph(pkgs)
+        output = format_table(graph, pkgs)
+
+        if 'empty' not in output.lower():
+            raise AssertionError(f'Expected empty indicator, got: {output!r}')
+
+    def test_row_count(self) -> None:
+        """Table has header + separator + one row per package."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_table(graph, pkgs)
+        lines = [ln for ln in output.strip().splitlines() if ln.strip()]
+
+        # header + separator + 4 packages = 6 lines
+        if len(lines) != 6:
+            msg = f'Expected 6 lines, got {len(lines)}: {lines}'
+            raise AssertionError(msg)
+
+
+class TestCsvFormat:
+    """Tests for the CSV formatter."""
+
+    def test_has_bom_by_default(self) -> None:
+        """CSV output starts with UTF-8 BOM."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_csv(graph, pkgs)
+
+        if not output.startswith('\ufeff'):
+            raise AssertionError('Missing BOM')
+
+    def test_no_bom(self) -> None:
+        """CSV output omits BOM when bom=False."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_csv(graph, pkgs, bom=False)
+
+        if output.startswith('\ufeff'):
+            raise AssertionError('BOM should be omitted')
+
+    def test_header_row(self) -> None:
+        """CSV starts with the expected header."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_csv(graph, pkgs, bom=False)
+        header = output.splitlines()[0]
+
+        if header != 'level,package,version,dependencies':
+            raise AssertionError(f'Unexpected header: {header!r}')
+
+    def test_contains_all_packages(self) -> None:
+        """CSV lists every package."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_csv(graph, pkgs, bom=False)
+
+        for pkg in pkgs:
+            if pkg.name not in output:
+                msg = f'Missing package {pkg.name}'
+                raise AssertionError(msg)
+
+    def test_row_count(self) -> None:
+        """CSV has header + one row per package."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_csv(graph, pkgs, bom=False)
+        lines = [ln for ln in output.strip().splitlines() if ln.strip()]
+
+        # header + 4 packages = 5 lines
+        if len(lines) != 5:
+            msg = f'Expected 5 lines, got {len(lines)}: {lines}'
+            raise AssertionError(msg)
+
+    def test_multi_dep_quoting(self) -> None:
+        """Dependencies with commas are quoted by csv.writer."""
+        pkgs = _make_packages()
+        graph = _make_graph(pkgs)
+        output = format_csv(graph, pkgs, bom=False)
+
+        # app depends on plugin-a and plugin-b, so deps field contains a comma
+        # csv.writer should quote it: "plugin-a,plugin-b"
+        import csv as csv_mod
+        import io
+
+        reader = csv_mod.reader(io.StringIO(output))
+        rows = list(reader)
+        app_rows = [r for r in rows if len(r) >= 2 and r[1] == 'app']
+        if not app_rows:
+            raise AssertionError('Missing app row')
+        deps = app_rows[0][3]
+        if 'plugin-a' not in deps or 'plugin-b' not in deps:
+            raise AssertionError(f'Missing deps in app row: {deps!r}')
+
+    def test_empty_graph(self) -> None:
+        """CSV with empty graph has only header."""
+        pkgs: list[Package] = []
+        graph = _make_graph(pkgs)
+        output = format_csv(graph, pkgs, bom=False)
+        lines = [ln for ln in output.strip().splitlines() if ln.strip()]
+
+        if len(lines) != 1:
+            msg = f'Expected 1 line (header only), got {len(lines)}'
+            raise AssertionError(msg)

--- a/py/tools/releasekit/tests/rk_init_test.py
+++ b/py/tools/releasekit/tests/rk_init_test.py
@@ -1,0 +1,252 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for releasekit.init module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomlkit
+from releasekit.init import (
+    detect_groups,
+    generate_config_toml,
+    scaffold_config,
+)
+from releasekit.workspace import Package
+
+
+def _make_packages() -> list[Package]:
+    """Create a test package set mimicking the genkit workspace."""
+    return [
+        Package(
+            name='genkit',
+            version='0.5.0',
+            path=Path('/ws/packages/genkit'),
+            pyproject_path=Path('/ws/packages/genkit/pyproject.toml'),
+        ),
+        Package(
+            name='genkit-plugin-google-genai',
+            version='0.5.0',
+            path=Path('/ws/plugins/google-genai'),
+            pyproject_path=Path('/ws/plugins/google-genai/pyproject.toml'),
+            internal_deps=['genkit'],
+        ),
+        Package(
+            name='genkit-plugin-vertex-ai',
+            version='0.5.0',
+            path=Path('/ws/plugins/vertex-ai'),
+            pyproject_path=Path('/ws/plugins/vertex-ai/pyproject.toml'),
+            internal_deps=['genkit'],
+        ),
+        Package(
+            name='genkit-plugin-ollama',
+            version='0.5.0',
+            path=Path('/ws/plugins/ollama'),
+            pyproject_path=Path('/ws/plugins/ollama/pyproject.toml'),
+            internal_deps=['genkit'],
+        ),
+        Package(
+            name='provider-google-genai-hello',
+            version='0.1.0',
+            path=Path('/ws/samples/provider-google-genai-hello'),
+            pyproject_path=Path('/ws/samples/provider-google-genai-hello/pyproject.toml'),
+            internal_deps=['genkit', 'genkit-plugin-google-genai'],
+        ),
+    ]
+
+
+class TestDetectGroups:
+    """Tests for detect_groups()."""
+
+    def test_detects_core(self) -> None:
+        """Packages without plugin/sample markers are 'core'."""
+        pkgs = _make_packages()
+        groups = detect_groups(pkgs)
+
+        if 'core' not in groups:
+            raise AssertionError('Missing core group')
+        if 'genkit' not in groups['core']:
+            raise AssertionError('genkit should be in core group')
+
+    def test_detects_plugins(self) -> None:
+        """Packages with '-plugin-' are 'plugins'."""
+        pkgs = _make_packages()
+        groups = detect_groups(pkgs)
+
+        if 'plugins' not in groups:
+            raise AssertionError('Missing plugins group')
+
+    def test_detects_samples(self) -> None:
+        """Packages in samples/ directory are 'samples'."""
+        pkgs = _make_packages()
+        groups = detect_groups(pkgs)
+
+        if 'samples' not in groups:
+            raise AssertionError('Missing samples group')
+
+    def test_empty_packages(self) -> None:
+        """Empty package list produces empty groups."""
+        groups = detect_groups([])
+        if groups:
+            msg = f'Expected empty groups, got {groups}'
+            raise AssertionError(msg)
+
+    def test_plugin_glob_pattern(self) -> None:
+        """Multiple plugins with same prefix get a glob pattern."""
+        pkgs = _make_packages()
+        groups = detect_groups(pkgs)
+
+        plugins = groups.get('plugins', [])
+        # Should be a glob like 'genkit-plugin-*' since all share the prefix.
+        if plugins and len(plugins) == 1:
+            if '*' not in plugins[0]:
+                msg = f'Expected glob pattern, got {plugins}'
+                raise AssertionError(msg)
+
+
+class TestGenerateConfigToml:
+    """Tests for generate_config_toml()."""
+
+    def test_produces_valid_toml(self) -> None:
+        """Generated output is valid TOML."""
+        groups = {'core': ['genkit'], 'plugins': ['genkit-plugin-*']}
+        output = generate_config_toml(groups)
+
+        doc = tomlkit.parse(output)
+        tool = doc.get('tool')
+        if not isinstance(tool, dict):
+            raise AssertionError('Missing [tool] section')
+        rk = tool.get('releasekit')
+        if not isinstance(rk, dict):
+            raise AssertionError('Missing [tool.releasekit] section')
+
+    def test_contains_tag_format(self) -> None:
+        """Generated TOML includes tag_format."""
+        output = generate_config_toml({})
+        if 'tag_format' not in output:
+            raise AssertionError('Missing tag_format')
+
+    def test_contains_groups(self) -> None:
+        """Generated TOML includes groups when provided."""
+        groups = {'core': ['genkit']}
+        output = generate_config_toml(groups)
+        if 'core' not in output:
+            raise AssertionError('Missing core group')
+
+    def test_exclude_patterns(self) -> None:
+        """Generated TOML includes exclude patterns."""
+        output = generate_config_toml({}, exclude=['sample-*'])
+        if 'sample-*' not in output:
+            raise AssertionError('Missing exclude pattern')
+
+
+class TestScaffoldConfig:
+    """Tests for scaffold_config()."""
+
+    def test_dry_run_no_write(self, tmp_path: Path) -> None:
+        """Dry run returns TOML but does not write files."""
+        # Create minimal workspace.
+        ws = tmp_path / 'ws'
+        ws.mkdir()
+        pyproject = ws / 'pyproject.toml'
+        pyproject.write_text(
+            '[tool.uv.workspace]\nmembers = ["packages/*"]\n',
+            encoding='utf-8',
+        )
+        pkg_dir = ws / 'packages' / 'mylib'
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / 'pyproject.toml').write_text(
+            '[project]\nname = "mylib"\nversion = "1.0.0"\n',
+            encoding='utf-8',
+        )
+
+        result = scaffold_config(ws, dry_run=True)
+
+        if not result:
+            raise AssertionError('Expected TOML fragment for dry run')
+
+        # File should NOT have been modified.
+        content = pyproject.read_text(encoding='utf-8')
+        if 'releasekit' in content:
+            raise AssertionError('Dry run should not write to file')
+
+    def test_writes_config(self, tmp_path: Path) -> None:
+        """Non-dry-run writes [tool.releasekit] to pyproject.toml."""
+        ws = tmp_path / 'ws'
+        ws.mkdir()
+        pyproject = ws / 'pyproject.toml'
+        pyproject.write_text(
+            '[tool.uv.workspace]\nmembers = ["packages/*"]\n',
+            encoding='utf-8',
+        )
+        pkg_dir = ws / 'packages' / 'mylib'
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / 'pyproject.toml').write_text(
+            '[project]\nname = "mylib"\nversion = "1.0.0"\n',
+            encoding='utf-8',
+        )
+
+        scaffold_config(ws)
+
+        content = pyproject.read_text(encoding='utf-8')
+        if 'releasekit' not in content:
+            raise AssertionError('Expected [tool.releasekit] in file')
+
+    def test_idempotent_no_force(self, tmp_path: Path) -> None:
+        """Running twice without --force skips the second time."""
+        ws = tmp_path / 'ws'
+        ws.mkdir()
+        pyproject = ws / 'pyproject.toml'
+        pyproject.write_text(
+            '[tool.uv.workspace]\nmembers = ["packages/*"]\n[tool.releasekit]\ntag_format = "existing"\n',
+            encoding='utf-8',
+        )
+        pkg_dir = ws / 'packages' / 'mylib'
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / 'pyproject.toml').write_text(
+            '[project]\nname = "mylib"\nversion = "1.0.0"\n',
+            encoding='utf-8',
+        )
+
+        result = scaffold_config(ws)
+        if result:
+            raise AssertionError('Expected empty result for existing config')
+
+    def test_gitignore_updated(self, tmp_path: Path) -> None:
+        """.gitignore gets releasekit patterns."""
+        ws = tmp_path / 'ws'
+        ws.mkdir()
+        pyproject = ws / 'pyproject.toml'
+        pyproject.write_text(
+            '[tool.uv.workspace]\nmembers = ["packages/*"]\n',
+            encoding='utf-8',
+        )
+        pkg_dir = ws / 'packages' / 'mylib'
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / 'pyproject.toml').write_text(
+            '[project]\nname = "mylib"\nversion = "1.0.0"\n',
+            encoding='utf-8',
+        )
+
+        scaffold_config(ws)
+
+        gitignore = ws / '.gitignore'
+        if not gitignore.exists():
+            raise AssertionError('.gitignore should be created')
+        content = gitignore.read_text(encoding='utf-8')
+        if '*.bak' not in content:
+            raise AssertionError('Missing *.bak pattern in .gitignore')

--- a/py/tools/releasekit/tests/rk_render_diagnostics_test.py
+++ b/py/tools/releasekit/tests/rk_render_diagnostics_test.py
@@ -1,0 +1,253 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for render_error and render_warning (Rust-style diagnostics)."""
+
+from __future__ import annotations
+
+import io
+
+from releasekit.errors import (
+    E,
+    ReleaseKitError,
+    ReleaseKitWarning,
+    render_error,
+    render_warning,
+)
+
+
+class TestRenderError:
+    """Tests for render_error()."""
+
+    def test_includes_error_label(self) -> None:
+        """Output starts with 'error[CODE]:'."""
+        exc = ReleaseKitError(
+            code=E.CONFIG_NOT_FOUND,
+            message='Config missing.',
+        )
+        buf = io.StringIO()
+        render_error(exc, file=buf)
+        output = buf.getvalue()
+
+        if 'error[RK-CONFIG-NOT-FOUND]' not in output:
+            raise AssertionError(f'Missing error label in: {output!r}')
+
+    def test_includes_message(self) -> None:
+        """Output includes the error message."""
+        exc = ReleaseKitError(
+            code=E.CONFIG_NOT_FOUND,
+            message='No config found.',
+        )
+        buf = io.StringIO()
+        render_error(exc, file=buf)
+        output = buf.getvalue()
+
+        if 'No config found.' not in output:
+            raise AssertionError(f'Missing message in: {output!r}')
+
+    def test_includes_hint(self) -> None:
+        """Output includes the hint when provided."""
+        exc = ReleaseKitError(
+            code=E.CONFIG_NOT_FOUND,
+            message='Config missing.',
+            hint="Run 'releasekit init'.",
+        )
+        buf = io.StringIO()
+        render_error(exc, file=buf)
+        output = buf.getvalue()
+
+        if 'hint' not in output:
+            raise AssertionError(f'Missing hint label in: {output!r}')
+        if 'releasekit init' not in output:
+            raise AssertionError(f'Missing hint text in: {output!r}')
+
+    def test_hint_pipe_separator(self) -> None:
+        """Output uses '|' and '=' separators like Rust compiler."""
+        exc = ReleaseKitError(
+            code=E.CONFIG_NOT_FOUND,
+            message='Config missing.',
+            hint='Fix it.',
+        )
+        buf = io.StringIO()
+        render_error(exc, file=buf)
+        output = buf.getvalue()
+
+        if '  |' not in output:
+            raise AssertionError(f'Missing pipe separator in: {output!r}')
+        if '  = hint:' not in output:
+            raise AssertionError(f'Missing = hint: in: {output!r}')
+
+    def test_no_hint_no_separator(self) -> None:
+        """No separator lines when hint is empty."""
+        exc = ReleaseKitError(
+            code=E.CONFIG_NOT_FOUND,
+            message='Config missing.',
+        )
+        buf = io.StringIO()
+        render_error(exc, file=buf)
+        output = buf.getvalue()
+
+        if '  |' in output:
+            raise AssertionError(f'Unexpected pipe in: {output!r}')
+        if '  = hint:' in output:
+            raise AssertionError(f'Unexpected hint in: {output!r}')
+
+    def test_writes_to_custom_file(self) -> None:
+        """Output goes to the specified file object."""
+        exc = ReleaseKitError(
+            code=E.CONFIG_NOT_FOUND,
+            message='Test message.',
+        )
+        buf = io.StringIO()
+        render_error(exc, file=buf)
+
+        if not buf.getvalue():
+            raise AssertionError('Nothing written to buffer')
+
+
+class TestRenderWarning:
+    """Tests for render_warning()."""
+
+    def test_includes_warning_label(self) -> None:
+        """Output starts with 'warning[CODE]:'."""
+        exc = ReleaseKitWarning(
+            code=E.PREFLIGHT_SHALLOW_CLONE,
+            message='Shallow clone detected.',
+        )
+        buf = io.StringIO()
+        render_warning(exc, file=buf)
+        output = buf.getvalue()
+
+        if 'warning[RK-PREFLIGHT-SHALLOW-CLONE]' not in output:
+            raise AssertionError(f'Missing warning label in: {output!r}')
+
+    def test_includes_message(self) -> None:
+        """Output includes the warning message."""
+        exc = ReleaseKitWarning(
+            code=E.PREFLIGHT_SHALLOW_CLONE,
+            message='Shallow clone.',
+        )
+        buf = io.StringIO()
+        render_warning(exc, file=buf)
+        output = buf.getvalue()
+
+        if 'Shallow clone.' not in output:
+            raise AssertionError(f'Missing message in: {output!r}')
+
+    def test_includes_hint(self) -> None:
+        """Output includes the hint."""
+        exc = ReleaseKitWarning(
+            code=E.PREFLIGHT_SHALLOW_CLONE,
+            message='Shallow clone.',
+            hint='Run git fetch --unshallow.',
+        )
+        buf = io.StringIO()
+        render_warning(exc, file=buf)
+        output = buf.getvalue()
+
+        if 'hint' not in output:
+            raise AssertionError(f'Missing hint in: {output!r}')
+        if 'git fetch --unshallow' not in output:
+            raise AssertionError(f'Missing hint text in: {output!r}')
+
+    def test_rust_style_format(self) -> None:
+        """Output follows Rust-compiler diagnostic format."""
+        exc = ReleaseKitWarning(
+            code=E.PREFLIGHT_SHALLOW_CLONE,
+            message='Shallow clone.',
+            hint='Fetch full history.',
+        )
+        buf = io.StringIO()
+        render_warning(exc, file=buf)
+        lines = buf.getvalue().strip().splitlines()
+
+        if len(lines) < 3:
+            raise AssertionError(
+                f'Expected at least 3 lines (label, pipe, hint), got {len(lines)}: {lines}',
+            )
+
+        if not lines[0].startswith('warning['):
+            raise AssertionError(f'Line 0 should start with warning[: {lines[0]!r}')
+        if '|' not in lines[1]:
+            raise AssertionError(f'Line 1 should contain |: {lines[1]!r}')
+        if '= hint:' not in lines[2]:
+            raise AssertionError(f'Line 2 should contain = hint:: {lines[2]!r}')
+
+
+class TestBracketPreservation:
+    """Square brackets in messages must not be swallowed by Rich markup."""
+
+    def test_error_preserves_brackets_in_message(self) -> None:
+        """[tool.releasekit] in message is preserved verbatim."""
+        exc = ReleaseKitError(
+            code=E.CONFIG_NOT_FOUND,
+            message='No [tool.releasekit] section found.',
+        )
+        buf = io.StringIO()
+        render_error(exc, file=buf)
+        output = buf.getvalue()
+
+        if '[tool.releasekit]' not in output:
+            raise AssertionError(
+                f'Brackets were stripped from message: {output!r}',
+            )
+
+    def test_error_preserves_brackets_in_hint(self) -> None:
+        """[tool.releasekit] in hint is preserved verbatim."""
+        exc = ReleaseKitError(
+            code=E.CONFIG_NOT_FOUND,
+            message='Config error.',
+            hint='Add [tool.releasekit] to pyproject.toml.',
+        )
+        buf = io.StringIO()
+        render_error(exc, file=buf)
+        output = buf.getvalue()
+
+        if '[tool.releasekit]' not in output:
+            raise AssertionError(
+                f'Brackets were stripped from hint: {output!r}',
+            )
+
+    def test_warning_preserves_brackets_in_message(self) -> None:
+        """[project] in warning message is preserved."""
+        exc = ReleaseKitWarning(
+            code=E.PREFLIGHT_SHALLOW_CLONE,
+            message='Missing [project] table.',
+        )
+        buf = io.StringIO()
+        render_warning(exc, file=buf)
+        output = buf.getvalue()
+
+        if '[project]' not in output:
+            raise AssertionError(
+                f'Brackets were stripped from warning: {output!r}',
+            )
+
+    def test_warning_preserves_brackets_in_hint(self) -> None:
+        """[tool.uv] in warning hint is preserved."""
+        exc = ReleaseKitWarning(
+            code=E.PREFLIGHT_SHALLOW_CLONE,
+            message='Warning.',
+            hint='Check [tool.uv] section.',
+        )
+        buf = io.StringIO()
+        render_warning(exc, file=buf)
+        output = buf.getvalue()
+
+        if '[tool.uv]' not in output:
+            raise AssertionError(
+                f'Brackets were stripped from hint: {output!r}',
+            )

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -2713,6 +2713,7 @@ lint = [
     { name = "pyright" },
     { name = "pysentry-rs" },
     { name = "quart" },
+    { name = "rich-argparse" },
     { name = "ruff" },
     { name = "secure" },
     { name = "sentry-sdk" },
@@ -2800,6 +2801,7 @@ lint = [
     { name = "pyright", specifier = ">=1.1.392" },
     { name = "pysentry-rs", specifier = ">=0.3.14" },
     { name = "quart", specifier = ">=0.19.0" },
+    { name = "rich-argparse", specifier = ">=1.6.0" },
     { name = "ruff", specifier = ">=0.9" },
     { name = "secure", specifier = ">=1.0.0" },
     { name = "sentry-sdk", specifier = ">=2.0.0" },
@@ -8070,6 +8072,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
+]
+
+[[package]]
+name = "rich-argparse"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/f7/1c65e0245d4c7009a87ac92908294a66e7e7635eccf76a68550f40c6df80/rich_argparse-1.7.2.tar.gz", hash = "sha256:64fd2e948fc96e8a1a06e0e72c111c2ce7f3af74126d75c0f5f63926e7289cd1", size = 38500, upload-time = "2025-11-01T10:35:44.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/80/97b6f357ac458d9ad9872cc3183ca09ef7439ac89e030ea43053ba1294b6/rich_argparse-1.7.2-py3-none-any.whl", hash = "sha256:0559b1f47a19bbeb82bf15f95a057f99bcbbc98385532f57937f9fc57acc501a", size = 25476, upload-time = "2025-11-01T10:35:42.681Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Phase 6 (UX Polish) — Complete

### Graph Formatters (8 formats)

| Format | Output | Use case |
|--------|--------|----------|
| `ascii` | Box-drawing art | Terminal viewing |
| `csv` | RFC 4180 + UTF-8 BOM | Excel, Google Sheets, data pipelines |
| `d2` | D2 diagram DSL | d2 renderer |
| `dot` | Graphviz DOT | `dot -Tpng` / `dot -Tsvg` |
| `json` | Structured JSON | Scripting, CI, jq |
| `levels` | Simple text (default) | Quick inspection |
| `mermaid` | Mermaid flowchart | GitHub READMEs, docs |
| `table` | Markdown table | READMEs, docs, PRs |

### CLI Commands (new)

| Command | Description |
|---------|-------------|
| `init` | Scaffold `[tool.releasekit]` config with auto-detected groups |
| `rollback` | Delete git tag (local + remote) and GitHub release |
| `completion` | Generate shell completions (bash/zsh/fish) |

### Publish Pipeline Flags (new)

```
--no-tag         Skip git tag creation
--no-push        Skip pushing tags and commits
--no-release     Skip GitHub release creation
--version-only   Bump versions, then stop (no build/publish)
```

### Rust-Style Diagnostics

- `render_error()` / `render_warning()` with Rich colors
- Bold `error[CODE]` / `warning[CODE]` labels
- `rich.markup.escape()` prevents bracket stripping
- Plain text fallback for non-TTY / CI

### README

Comprehensive rewrite with Getting Started, all 11 commands, feature
descriptions, architecture diagram, and usage examples.

### Tests
- **65 new tests** (388 total pass)
  - `rk_formatters_test.py`: 44 tests (all 8 formats)
  - `rk_init_test.py`: 7 tests
  - `rk_render_diagnostics_test.py`: 14 tests

### Quality
- `ruff check` + `ruff format` clean
- All 3 type checkers clean (ty, pyright, pyrefly)
