### PR TITLE
fix(py): correct evaluator scoring bug

### DIFF
--- a/py/plugins/evaluators/src/genkit/plugins/evaluators/helpers.py
+++ b/py/plugins/evaluators/src/genkit/plugins/evaluators/helpers.py
@@ -90,10 +90,10 @@ def _configure_evaluator(ai: Genkit, param: MetricConfig) -> None:
                 assert datapoint.output is not None, 'output is required'
                 output_string = datapoint.output if isinstance(datapoint.output, str) else json.dumps(datapoint.output)
                 input_string = datapoint.input if isinstance(datapoint.input, str) else json.dumps(datapoint.input)
-                prompt_function = await load_prompt_file(_get_prompt_path('faithfulness_long_form.prompt'))
+                prompt_function = await load_prompt_file(_get_prompt_path('answer_relevancy.prompt'))
                 context = ' '.join(json.dumps(e) for e in (datapoint.context or []))
                 prompt = await render_text(
-                    prompt_function, {'input': input_string, 'output': output_string, 'context': context}
+                    prompt_function, {'question': input_string, 'answer': output_string, 'context': context}
                 )
 
                 response = await ai.generate(


### PR DESCRIPTION
Fixed two bugs:
1. ANSWER_RELEVANCY evaluator is incorrectly loading the faithfulness_long_form.prompt file. 
2. The evaluator is passing input and output to the prompt template, but the prompt template expects question and answer. This caused the question and answer to be empty in the actual prompt sent to the LLM, leading to the failure.
