### PR TITLE
fix(js): duplicate sample project names

### DIFF
--- a/js/testapps/ollama/package.json
+++ b/js/testapps/ollama/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "basic-gemini",
+  "name": "basic-ollama",
   "version": "1.0.0",
   "description": "",
   "main": "lib/index.js",

--- a/js/testapps/rag/package.json
+++ b/js/testapps/rag/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rag",
+  "name": "rag-testapp",
   "version": "1.0.0",
   "description": "",
   "main": "lib/index.js",

--- a/js/testapps/vertexai-vector-search-bigquery/package.json
+++ b/js/testapps/vertexai-vector-search-bigquery/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vertex-vector-search",
+  "name": "vertex-vector-search-bigquery",
   "version": "1.0.0",
   "description": "",
   "main": "lib/index.js",

--- a/js/testapps/vertexai-vector-search-custom/package.json
+++ b/js/testapps/vertexai-vector-search-custom/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vertex-vector-search",
+  "name": "vertex-vector-search-custom",
   "version": "1.0.0",
   "description": "",
   "main": "lib/index.js",

--- a/js/testapps/vertexai-vector-search-firestore/package.json
+++ b/js/testapps/vertexai-vector-search-firestore/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vertex-vector-search",
+  "name": "vertex-vector-search-firestore",
   "version": "1.0.0",
   "description": "",
   "main": "lib/index.js",


### PR DESCRIPTION
This PR updates the `package.json` names for several JS test apps to resolve duplicate project name issues.

## Changes

- Renamed failing test apps to have unique package names:
  - `js/testapps/ollama`: `basic-gemini` -> `basic-ollama`
  - `js/testapps/rag`: `rag` -> `rag-testapp`
  - `js/testapps/vertexai-vector-search-bigquery`: `vertex-vector-search` -> `vertex-vector-search-bigquery`
  - `js/testapps/vertexai-vector-search-custom`: `vertex-vector-search` -> `vertex-vector-search-custom`
  - `js/testapps/vertexai-vector-search-firestore`: `vertex-vector-search` -> `vertex-vector-search-firestore`
