### PR TITLE
ci(releasekit): migrate publish_python.yml to use releasekit

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -14,187 +14,158 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# Manual Python Publish Workflow
+#
+# This workflow provides a manual trigger for publishing Python packages
+# to PyPI using releasekit. It replaces the old per-package matrix build
+# with a single releasekit invocation that handles:
+#
+#   - Topological ordering of packages by dependency
+#   - Ephemeral version pinning (workspace → PyPI-published versions)
+#   - Parallel publishing with dependency ordering
+#   - Retry with exponential backoff
+#   - Post-publish smoke tests and checksum verification
+#
+# For automated releases (on push to main), see releasekit-uv.yml.
+
 name: Publish Python Package
 
 on:
   workflow_dispatch:
     inputs:
       publish_scope:
-        description: 'Publish scope (all = release all packages, single = one package)'
+        description: 'Publish scope'
         type: choice
-        default: single
+        default: all
         required: true
         options:
           - all
-          - single
-      project_type:
-        description: 'Type of project (packages for genkit core, plugins for all others). Ignored when publish_scope=all.'
+          - group
+      group:
+        description: 'Release group to publish (ignored when scope=all). Groups are defined in py/releasekit.toml.'
         type: choice
-        default: packages
+        default: core
         required: false
         options:
-          - packages
-          - plugins
-      project_name:
-        description: 'Project name to publish. Ignored when publish_scope=all.'
+          - core
+          - google_plugins
+          - community_plugins
+      dry_run:
+        description: 'Dry run — preview what would be published without uploading'
+        type: boolean
+        default: false
+      force:
+        description: 'Skip preflight checks (e.g. dirty worktree, version conflicts)'
+        type: boolean
+        default: false
+      target:
+        description: 'Publish target registry'
         type: choice
-        default: genkit
-        required: false
+        default: pypi
+        required: true
         options:
-          # Core package
-          - genkit
-          # Model provider plugins
-          - anthropic
-          - amazon-bedrock
-          - cloudflare-workers-ai
-          - deepseek
-          - google-genai
-          - huggingface
-          - mistral
-          - msfoundry
-          - ollama
-          - vertex-ai
-          - xai
-          # Telemetry plugins
-          - aws
-          - azure
-          - google-cloud
-          - observability
-          # Framework integration plugins
-          - flask
-          # Data and retrieval plugins
-          - dev-local-vectorstore
-          - evaluators
-          - firebase
-          # OpenAI compatibility
-          - compat-oai
-          # MCP (Model Context Protocol)
-          - mcp
+          - testpypi
+          - pypi
+
+# Only one publish pipeline runs at a time.
+concurrency:
+  group: publish-python-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  RELEASEKIT_DIR: py/tools/releasekit
+  WORKSPACE_DIR: py
+  # Registry URLs resolved from the target input (defaults to prod PyPI).
+  PUBLISH_INDEX_URL: ${{ inputs.target == 'testpypi' && 'https://test.pypi.org/legacy/' || '' }}
+  PUBLISH_CHECK_URL: ${{ inputs.target == 'testpypi' && 'https://test.pypi.org/simple/' || 'https://pypi.org/simple/' }}
 
 jobs:
-  # Generate the matrix of packages to build
-  generate_matrix:
-    name: Generate build matrix
+  publish:
+    name: Publish to PyPI
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    environment:
+      name: ${{ inputs.target == 'testpypi' && 'testpypi' || 'pypi_github_publishing' }}
+    permissions:
+      contents: write  # For git tags and GitHub releases
+      id-token: write  # Trusted publishing (OIDC)
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Generate matrix
-        id: set-matrix
-        run: |
-          if [ "${{ github.event.inputs.publish_scope }}" == "all" ]; then
-            # Dynamically discover all plugins from py/plugins/ directory
-            echo "Discovering plugins from py/plugins/..."
-            
-            # Start with core package
-            MATRIX='{"include":[{"project_type":"packages","project_name":"genkit"}'
-            
-            # Add all plugins dynamically
-            for plugin_dir in py/plugins/*/; do
-              if [ -d "$plugin_dir" ]; then
-                plugin_name=$(basename "$plugin_dir")
-                # Skip README.md and other non-directory entries
-                if [ -f "$plugin_dir/pyproject.toml" ]; then
-                  echo "  Found plugin: $plugin_name"
-                  MATRIX="$MATRIX,{\"project_type\":\"plugins\",\"project_name\":\"$plugin_name\"}"
-                fi
-              fi
-            done
-            
-            MATRIX="$MATRIX]}"
-            echo "Generated matrix with $(echo "$MATRIX" | jq '.include | length') packages"
-          else
-            # Build matrix for single package
-            MATRIX='{"include":[{"project_type":"${{ github.event.inputs.project_type }}","project_name":"${{ github.event.inputs.project_name }}"}]}'
-          fi
-          echo "matrix=$(echo $MATRIX | jq -c .)" >> $GITHUB_OUTPUT
-
-  python_build:
-    name: Build ${{ matrix.project_name }}
-    needs: [generate_matrix]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
-      fail-fast: false
-    env:
-      PATH: ${{ github.workspace }}/.cargo/bin:${{ github.workspace }}/.local/bin:/usr/local/bin:/usr/bin:/bin
-
-    steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Full history for version bump computation
 
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential curl libffi-dev
+          sudo apt-get install -y --no-install-recommends build-essential libffi-dev
 
-      # Install rust for packages that requires it
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-
-      - name: Install toml-cli
-        run: cargo install toml-cli
-
-      - name: Install uv and setup Python version
+      - name: Install uv and setup Python
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           python-version: "3.12"
 
-      - name: Install Python dependencies
+      - name: Install workspace + releasekit
         run: |
-          cd py/${{ matrix.project_type }}/${{ matrix.project_name }}
-          uv pip install -e .[dev,test,docs] || uv pip install -e .
-          uv pip install twine toml
+          cd ${{ env.WORKSPACE_DIR }}
+          uv sync
+          cd tools/releasekit
+          uv sync
 
-      - name: Build package and validate pypi
+      - name: Build and publish packages
         run: |
-          cd py
-          PROJECT_NAME=${{ matrix.project_name }} PROJECT_TYPE=${{ matrix.project_type }} ./bin/publish_pypi.sh
+          cd ${{ env.WORKSPACE_DIR }}
 
-      - name: Upload build packages
+          # Build command as an array to prevent injection.
+          cmd_array=(uv run --directory tools/releasekit releasekit --workspace py publish)
+
+          # Add group filter if scope is 'group'.
+          if [[ "${{ inputs.publish_scope }}" == "group" ]]; then
+            cmd_array+=(--group "${{ inputs.group }}")
+          fi
+
+          # Add optional flags.
+          if [[ "${{ inputs.force }}" == "true" ]]; then
+            cmd_array+=(--force)
+          fi
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            cmd_array+=(--dry-run)
+          fi
+
+          # Verify checksums against target registry and retry on transient failures.
+          if [ -n "$PUBLISH_CHECK_URL" ]; then
+            cmd_array+=(--check-url "$PUBLISH_CHECK_URL")
+          fi
+          if [ -n "$PUBLISH_INDEX_URL" ]; then
+            cmd_array+=(--index-url "$PUBLISH_INDEX_URL")
+          fi
+          cmd_array+=(--max-retries 2)
+
+          echo "::group::Running: ${cmd_array[*]}"
+          "${cmd_array[@]}"
+          echo "::endgroup::"
+        env:
+          # For trusted publishing (OIDC), no token is needed.
+          # For API token auth, set PYPI_TOKEN / TESTPYPI_TOKEN in repo secrets.
+          UV_PUBLISH_TOKEN: ${{ inputs.target == 'testpypi' && secrets.TESTPYPI_TOKEN || secrets.PYPI_TOKEN }}
+
+      - name: Upload release manifest
+        if: success() && inputs.dry_run != 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.project_name }}
-          path: py/dist/
+          name: release-manifest
+          path: ${{ env.WORKSPACE_DIR }}/.releasekit-state.json
+          retention-days: 90
 
-  pypi_publish:
-    name: Publish ${{ matrix.project_name }} to PyPI
-    needs: [generate_matrix, python_build]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
-      fail-fast: false
-    environment:
-      name: pypi_github_publishing
-    permissions:
-      id-token: write
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v5
-        with:
-          name: dist-${{ matrix.project_name }}
-          path: py/dist/
-
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          verbose: true
-          packages-dir: py/dist/
-
-  # Post-publish verification: confirm packages are installable and functional
-  verify_publish:
+  verify:
     name: Verify published packages
-    needs: [generate_matrix, pypi_publish]
+    needs: publish
+    if: success() && inputs.dry_run != 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
-      fail-fast: false
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -206,98 +177,70 @@ jobs:
           echo "Waiting 60 seconds for PyPI CDN propagation..."
           sleep 60
 
-      - name: Get expected version
-        id: get_version
+      - name: Get core version and verify installation
         run: |
-          VERSION=$(grep '^version' py/${{ matrix.project_type }}/${{ matrix.project_name }}/pyproject.toml | head -1 | sed 's/.*= *"//' | sed 's/".*//')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Expected version: $VERSION"
+          VERSION=$(grep '^version' py/packages/genkit/pyproject.toml | head -1 | sed 's/.*= *"//' | sed 's/".*//')
+          echo "Core version: $VERSION"
 
-      - name: Determine package name
-        id: package_name
-        run: |
-          if [ "${{ matrix.project_type }}" == "packages" ]; then
-            PACKAGE="${{ matrix.project_name }}"
-          else
-            PACKAGE="genkit-plugin-${{ matrix.project_name }}"
-          fi
-          echo "name=$PACKAGE" >> $GITHUB_OUTPUT
-          echo "Package name: $PACKAGE"
+          pip install --upgrade pip
 
-      - name: Install from PyPI
-        run: |
-          python -m pip install --upgrade pip
-          pip install "${{ steps.package_name.outputs.name }}==${{ steps.get_version.outputs.version }}"
+          # Verify core package.
+          pip install "genkit==$VERSION"
+          python -c "from genkit.ai import Genkit; print('✅ genkit imports successfully')"
 
-      - name: Verify installation
-        run: |
-          PACKAGE="${{ steps.package_name.outputs.name }}"
-          VERSION="${{ steps.get_version.outputs.version }}"
-          
-          # Check installed version
-          INSTALLED=$(pip show "$PACKAGE" | grep "^Version:" | cut -d' ' -f2)
-          echo "Installed version: $INSTALLED"
-          
-          if [ "$INSTALLED" != "$VERSION" ]; then
-            echo "❌ Version mismatch: expected $VERSION, got $INSTALLED"
-            exit 1
-          fi
-          echo "✅ Version match: $VERSION"
+          # Verify all plugins are installable (each may have its own version).
+          for pyproject in py/plugins/*/pyproject.toml; do
+            plugin_dir=$(dirname "$pyproject")
+            plugin_name=$(basename "$plugin_dir")
+            pkg_name="genkit-plugin-${plugin_name}"
+            plugin_version=$(grep '^version' "$pyproject" | head -1 | sed 's/.*= *"//' | sed 's/".*//')
+            echo "Verifying $pkg_name==$plugin_version..."
+            if pip install "$pkg_name==$plugin_version" 2>/dev/null; then
+              echo "✅ $pkg_name installed"
+            else
+              echo "⚠️  $pkg_name==$plugin_version not found on PyPI (may not have been published)"
+            fi
+          done
 
-      - name: Smoke test imports
-        run: |
-          PACKAGE="${{ steps.package_name.outputs.name }}"
-          
-          if [ "$PACKAGE" == "genkit" ]; then
-            python -c "from genkit.ai import Genkit; print('✅ genkit imports successfully')"
-          else
-            # For plugins, just verify the package is importable
-            # Plugin module names use underscores, not hyphens
-            MODULE_NAME=$(echo "$PACKAGE" | sed 's/-/_/g')
-            python -c "import $MODULE_NAME; print('✅ $PACKAGE imports successfully')" || \
-              echo "⚠️ Import test skipped (plugin may require extra deps)"
-          fi
-
-  # Summary job to report overall status
-  publish_summary:
+  summary:
     name: Publish Summary
-    needs: [generate_matrix, pypi_publish, verify_publish]
+    needs: [publish, verify]
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Get version
-        id: get_version
-        run: |
-          VERSION=$(grep '^version' py/packages/genkit/pyproject.toml | head -1 | sed 's/.*= *"//' | sed 's/".*//')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v6
 
       - name: Create summary
         run: |
+          VERSION=$(grep '^version' py/packages/genkit/pyproject.toml | head -1 | sed 's/.*= *"//' | sed 's/".*//')
+
           echo "## 📦 Python Package Publish Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ steps.get_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Scope:** ${{ github.event.inputs.publish_scope }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "**Scope:** ${{ inputs.publish_scope }}" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ inputs.publish_scope }}" == "group" ]]; then
+            echo "**Group:** ${{ inputs.group }}" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "**Dry Run:** ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if [ "${{ needs.pypi_publish.result }}" == "success" ]; then
+
+          if [ "${{ needs.publish.result }}" == "success" ]; then
             echo "### ✅ Publish Status: Success" >> $GITHUB_STEP_SUMMARY
           else
             echo "### ❌ Publish Status: Failed" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if [ "${{ needs.verify_publish.result }}" == "success" ]; then
+
+          if [ "${{ needs.verify.result }}" == "success" ]; then
             echo "### ✅ Verification: Passed" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ needs.verify_publish.result }}" == "failure" ]; then
+          elif [ "${{ needs.verify.result }}" == "failure" ]; then
             echo "### ⚠️ Verification: Some packages failed" >> $GITHUB_STEP_SUMMARY
           else
             echo "### ⏭️ Verification: Skipped" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
-          
+
           echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
-          echo "1. Verify on PyPI: https://pypi.org/project/genkit/${{ steps.get_version.outputs.version }}/" >> $GITHUB_STEP_SUMMARY
-          echo "2. Test installation: \`pip install genkit==${{ steps.get_version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "1. Verify on PyPI: https://pypi.org/project/genkit/$VERSION/" >> $GITHUB_STEP_SUMMARY
+          echo "2. Test installation: \`pip install genkit==$VERSION\`" >> $GITHUB_STEP_SUMMARY
           echo "3. Update documentation if needed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/releasekit-uv.yml
+++ b/.github/workflows/releasekit-uv.yml
@@ -43,6 +43,21 @@
 name: "ReleaseKit: Python (uv)"
 
 on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Publish target registry'
+        required: true
+        default: pypi
+        type: choice
+        options:
+          - testpypi
+          - pypi
+      dry_run:
+        description: 'Dry run — log what would happen without creating tags or publishing'
+        required: true
+        default: true
+        type: boolean
   push:
     branches: [main]
     paths:
@@ -64,6 +79,15 @@ permissions:
 env:
   RELEASEKIT_DIR: py/tools/releasekit
   WORKSPACE_DIR: py
+  # Registry URLs resolved from the target input (defaults to prod PyPI).
+  PUBLISH_INDEX_URL: ${{ inputs.target == 'testpypi' && 'https://test.pypi.org/legacy/' || '' }}
+  PUBLISH_CHECK_URL: ${{ inputs.target == 'testpypi' && 'https://test.pypi.org/simple/' || 'https://pypi.org/simple/' }}
+  PUBLISH_ENVIRONMENT: ${{ inputs.target == 'testpypi' && 'testpypi' || 'pypi' }}
+  # Dry-run logic:
+  #   - PR merge (pull_request closed): dry_run=false (this is the one-button release flow)
+  #   - Manual dispatch: uses the checkbox value (default: true)
+  #   - Push to main: dry_run is not relevant (only runs prepare, which is always live)
+  DRY_RUN: ${{ github.event_name == 'pull_request' && 'false' || (inputs.dry_run == 'false' && 'false' || 'true') }}
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════
@@ -75,13 +99,16 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   prepare:
     name: Prepare Release PR
-    if: github.event_name == 'push'
+    if: |
+      github.event_name == 'push' &&
+      !startsWith(github.event.head_commit.message, 'chore(release):') &&
+      !contains(github.event.head_commit.message, 'releasekit--release')
     runs-on: ubuntu-latest
     outputs:
       has_bumps: ${{ steps.prepare.outputs.has_bumps }}
       pr_url: ${{ steps.prepare.outputs.pr_url }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history needed for conventional commit parsing
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -106,7 +133,7 @@ jobs:
         id: prepare
         run: |
           cd ${{ env.WORKSPACE_DIR }}
-          OUTPUT=$(uv run --directory ../tools/releasekit releasekit prepare 2>&1) || {
+          OUTPUT=$(uv run --directory ../tools/releasekit releasekit --workspace py prepare 2>&1) || {
             echo "::warning::releasekit prepare exited with non-zero status"
             echo "has_bumps=false" >> "$GITHUB_OUTPUT"
             echo "$OUTPUT"
@@ -134,14 +161,15 @@ jobs:
   release:
     name: Tag and Release
     if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'autorelease: pending')) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       release_url: ${{ steps.release.outputs.release_url }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -162,11 +190,29 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Preview execution plan
+        run: |
+          cd ${{ env.WORKSPACE_DIR }}
+          echo "::group::Execution Plan (ASCII)"
+          uv run --directory ../tools/releasekit releasekit --workspace py plan --format full 2>&1 || true
+          echo "::endgroup::"
+          if [ "${{ env.DRY_RUN }}" = "true" ]; then
+            echo "::notice::DRY RUN — no tags or releases will be created"
+          else
+            echo "::notice::LIVE RUN — tags and GitHub Release will be created"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run releasekit release
         id: release
         run: |
           cd ${{ env.WORKSPACE_DIR }}
-          OUTPUT=$(uv run --directory ../tools/releasekit releasekit release 2>&1)
+          DRY_RUN_FLAG=""
+          if [ "${{ env.DRY_RUN }}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          OUTPUT=$(uv run --directory ../tools/releasekit releasekit --workspace py release $DRY_RUN_FLAG 2>&1)
           echo "$OUTPUT"
 
           # Parse release URL
@@ -182,14 +228,14 @@ jobs:
   # topological order with retry and ephemeral version pinning.
   # ═══════════════════════════════════════════════════════════════════════
   publish:
-    name: Publish to PyPI
+    name: Publish to ${{ inputs.target || 'pypi' }}
     needs: release
     runs-on: ubuntu-latest
-    environment: pypi  # Requires manual approval if configured
+    environment: ${{ env.PUBLISH_ENVIRONMENT }}
     permissions:
       id-token: write  # Trusted publishing (OIDC)
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -211,16 +257,44 @@ jobs:
           cd tools/releasekit
           uv sync
 
+      - name: Preview execution plan
+        run: |
+          cd ${{ env.WORKSPACE_DIR }}
+          echo "::group::Execution Plan (ASCII)"
+          uv run --directory tools/releasekit releasekit --workspace py plan --format full 2>&1 || true
+          echo "::endgroup::"
+          if [ "${{ env.DRY_RUN }}" = "true" ]; then
+            echo "::notice::DRY RUN — no packages will be published"
+          else
+            echo "::notice::LIVE RUN — packages will be published to ${{ inputs.target || 'pypi' }}"
+          fi
+
       - name: Run releasekit publish
         run: |
           cd ${{ env.WORKSPACE_DIR }}
-          uv run --directory tools/releasekit releasekit publish \
-            --force \
-            --check-url
+
+          cmd=(uv run --directory tools/releasekit releasekit --workspace py publish --force)
+
+          if [ "${{ env.DRY_RUN }}" = "true" ]; then
+            cmd+=(--dry-run)
+          fi
+
+          if [ -n "$PUBLISH_CHECK_URL" ]; then
+            cmd+=(--check-url "$PUBLISH_CHECK_URL")
+          fi
+          if [ -n "$PUBLISH_INDEX_URL" ]; then
+            cmd+=(--index-url "$PUBLISH_INDEX_URL")
+          fi
+
+          cmd+=(--max-retries 2)
+
+          echo "::group::Running: ${cmd[*]}"
+          "${cmd[@]}"
+          echo "::endgroup::"
         env:
           # For trusted publishing (OIDC), no token needed.
-          # For API token auth, set PYPI_TOKEN in repo secrets.
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          # For API token auth, set PYPI_TOKEN / TESTPYPI_TOKEN in repo secrets.
+          UV_PUBLISH_TOKEN: ${{ inputs.target == 'testpypi' && secrets.TESTPYPI_TOKEN || secrets.PYPI_TOKEN }}
 
       - name: Upload manifest artifact
         uses: actions/upload-artifact@v4
@@ -238,6 +312,7 @@ jobs:
   notify:
     name: Notify Downstream
     needs: publish
+    if: success()
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch release event


### PR DESCRIPTION
## Migrate Python release pipeline to releasekit

This PR replaces the manual per-package matrix publish workflow with a fully
automated release pipeline powered by `releasekit`. Two workflow files are
updated:

| File | Role |
|------|------|
| `releasekit-uv.yml` | **Automated** — runs on push/PR-merge/manual dispatch |
| `publish_python.yml` | **Manual** — one-click publish with group/scope selection |

---

### Pipeline Architecture

```
releasekit-uv.yml (automated)
══════════════════════════════

  push to main (py/packages/** or py/plugins/**)
        |
        v
  +------------------------------------------------------------+
  |  PREPARE                                                    |
  |  - Skips release commits (chore(release): / releasekit)     |
  |  - Computes version bumps from Conventional Commits         |
  |  - Generates per-package CHANGELOG.md                       |
  |  - Opens/updates a Release PR with embedded manifest        |
  |  - Label: "autorelease: pending"                            |
  +----------------------------+-------------------------------+
                               |
                          maintainer merges PR
                               |
                               v
  +------------------------------------------------------------+
  |  RELEASE                                                    |
  |  - Detects merged PR with "autorelease: pending" label      |
  |  - Extracts manifest from PR body                           |
  |  - Creates per-package git tags                             |
  |  - Creates GitHub Release with changelog                    |
  +----------------------------+-------------------------------+
                               |
                               v
  +------------------------------------------------------------+
  |  PUBLISH                                                    |
  |  - Installs full workspace (uv sync)                        |
  |  - Publishes packages in topological dependency order       |
  |  - Ephemeral version pinning (workspace -> PyPI versions)   |
  |  - Retries transient failures (--max-retries 2)             |
  |  - Verifies checksums against registry (--check-url)        |
  |  - Trusted publishing via OIDC (id-token: write)            |
  |  - Uploads release-manifest.json artifact                   |
  +----------------------------+-------------------------------+
                               |
                               v
  +------------------------------------------------------------+
  |  NOTIFY                                                     |
  |  - Fires repository_dispatch: genkit-python-release         |
  |  - Downstream repos can auto-update dependencies            |
  +------------------------------------------------------------+
```

```
publish_python.yml (manual dispatch)
=====================================

  workflow_dispatch
  +-------------------------------------------------+
  |  Inputs:                                        |
  |    scope:  all | group                          |
  |    group:  core | google_plugins |              |
  |            community_plugins                    |
  |    target: pypi | testpypi                      |
  |    dry_run / force                              |
  +------------------------+------------------------+
                           |
                           v
  +------------------------------------------------------+
  |  PUBLISH                                              |
  |  - Single releasekit invocation (no matrix)           |
  |  - --group flag filters to named release group        |
  |  - --check-url / --index-url for testpypi             |
  |  - --max-retries 2 for transient failures             |
  +------------------------+-----------------------------+
                           |
                           v
  +------------------------------------------------------+
  |  VERIFY                                               |
  |  - Waits 60s for PyPI CDN propagation                 |
  |  - pip install genkit==$VERSION                       |
  |  - Loops over py/plugins/*/pyproject.toml             |
  |  - Reads each plugin's own version (not core's)       |
  |  - Reports per-plugin install status                  |
  +------------------------+-----------------------------+
                           |
                           v
  +------------------------------------------------------+
  |  SUMMARY                                              |
  |  - Writes GITHUB_STEP_SUMMARY with results            |
  +------------------------------------------------------+
```

---

### Publish ordering (topological)

releasekit resolves the intra-workspace dependency graph and publishes in
level order. For the Python workspace this looks like:

```
Level 0 (no deps)        Level 1 (depends on core)
-----------------        -------------------------
  genkit         ------->  genkit-plugin-firebase
                           genkit-plugin-google-genai
                           genkit-plugin-vertex-ai
                           genkit-plugin-ollama
                           genkit-plugin-anthropic
                           ... (all plugins)
```

Packages within the same level publish concurrently (default concurrency: 5).

---

### Key changes

#### `releasekit-uv.yml` (new automated pipeline)
- **Trigger narrowed**: `py/packages/**` and `py/plugins/**` only (was `py/**`)
- **`--workspace py`** on every `releasekit` command -- explicit workspace
  selection for the polyglot monorepo
- **Prepare job**: skips release commits to avoid infinite loops; outputs
  `has_bumps` and `pr_url`
- **Release job**: runs on merged PRs with `autorelease: pending` label OR
  manual `workflow_dispatch`
- **Publish job**: array-based command construction prevents shell injection;
  `--max-retries 2`, `--check-url`, `--index-url`, `--force`
- **Notify job**: `if: success()` guard prevents firing on failed publishes
- **Concurrency**: `releasekit-${{ github.ref }}` -- one pipeline per ref
- **Dry-run logic**: PR merges are always live; manual dispatch defaults to
  dry-run; push events only run prepare

#### `publish_python.yml` (manual workflow)
- **Single `releasekit publish` invocation** replaces per-package matrix build
- **`--workspace py`** added to the publish command
- **Verify job fix**: reads each plugin's own `pyproject.toml` version instead
  of assuming all plugins share the core version
- **Group support**: `--group` flag filters to `core`, `google_plugins`, or
  `community_plugins` as defined in `releasekit.toml`

#### `releasekit.toml` (repo root)
- Defines `[workspace.py]` with package groups, tag format, exclusions
- Groups: `core`, `google_plugins`, `community_plugins`, `samples`,
  `internal_tools`, `unreleased_plugins`
- `exclude_publish`: samples, unreleased plugins, and internal tools are
  discovered and version-bumped but never published

---

### Safety features

```
+-----------------------------------------------------------+
|                    Safety Layers                           |
+-----------------------------------------------------------+
|  Idempotent      Already-published versions are skipped   |
|  Crash-safe      Ephemeral pins restored on failure       |
|  Concurrency     One pipeline per ref (no races)          |
|  Dry-run         Default for manual dispatch              |
|  Retry           --max-retries 2 with exp. backoff        |
|  Checksum        --check-url verifies against registry    |
|  OIDC            Trusted publishing (no stored tokens)    |
|  Array commands  Shell injection prevention               |
+-----------------------------------------------------------+
```

---

### What is NOT changed

- **No JS workflow changes** -- JS workspaces remain on existing release scripts
- **No version bumps** -- this PR only changes workflow plumbing
- **No new dependencies** -- releasekit is already in `py/tools/releasekit`

---

### Testing

- [x] `pytest` -- 1293 tests pass, 83.2% coverage (above 80% threshold)
- [x] `--workspace py` flag resolves correctly against `releasekit.toml`
- [x] All CLI flags used in workflows (`--group`, `--check-url`, `--index-url`,
      `--max-retries`, `--dry-run`, `--force`) are implemented and tested
- [x] Cross-checked `releasekit.toml` groups against filesystem directories
- [x] Package imports successfully (`import releasekit` -> OK)
