### PR TITLE
fix(py/genkit): add Changelog URL to core package metadata

### DIFF
--- a/py/packages/genkit/pyproject.toml
+++ b/py/packages/genkit/pyproject.toml
@@ -85,6 +85,7 @@ vertex-ai             = ["genkit-plugin-vertex-ai"]
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"
+"Changelog"     = "https://github.com/firebase/genkit/blob/main/py/packages/genkit/CHANGELOG.md"
 "Documentation" = "https://firebase.google.com/docs/genkit"
 "Homepage"      = "https://github.com/firebase/genkit"
 "Repository"    = "https://github.com/firebase/genkit/tree/main/py"


### PR DESCRIPTION
Add Changelog URL to genkit core `pyproject.toml` `[project.urls]` so PyPI displays a link to the changelog.

Related to #4594.