### PR TITLE
fix(py/amazon-bedrock): use async for on AioEventStream in streaming

### DIFF
--- a/py/plugins/amazon-bedrock/src/genkit/plugins/amazon_bedrock/models/model.py
+++ b/py/plugins/amazon-bedrock/src/genkit/plugins/amazon_bedrock/models/model.py
@@ -365,7 +365,7 @@ class BedrockModel:
 
         # Process the event stream
         stream = response.get('stream', [])
-        for event in stream:
+        async for event in stream:
             # Handle content block delta (text chunks)
             if 'contentBlockDelta' in event:
                 delta = event['contentBlockDelta'].get('delta', {})


### PR DESCRIPTION
## Summary

aiobotocore's `converse_stream()` returns an `AioEventStream` that requires async iteration. The code was using sync `for event in stream:` which raises `NotImplementedError: Use async-for instead`, breaking all streaming conformance tests for Bedrock models.

## What changed

| File | Change | Why |
|------|--------|-----|
| `models/model.py:368` | `for event in stream:` → `async for event in stream:` | `AioEventStream` requires async iteration |

## Impact

Fixes streaming for all Amazon Bedrock models:
- Tool Request Conformance with streaming
- Multiturn Conformance with streaming
- Structured Output Conformance with streaming

## Testing

Verified via `conform check-model --runtime python --plugin amazon-bedrock`.