### PR TITLE
fix(py/compat-oai): map string role 'model' to 'assistant' for OpenAI API

### DIFF
--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/utils.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/utils.py
@@ -310,12 +310,16 @@ class MessageConverter:
     _openai_role_map: dict[Role, str] = {Role.MODEL: 'assistant'}
     _genkit_role_map: dict[str, Role] = {'assistant': Role.MODEL}
 
+    # String-level fallback for when the role arrives as a plain str
+    # (e.g. from JSON deserialization) rather than a Role enum instance.
+    _openai_str_role_map: dict[str, str] = {'model': 'assistant'}
+
     @classmethod
     def _get_openai_role(cls, role: Role | str) -> str:
         """Convert a Role to its OpenAI string representation."""
         if isinstance(role, Role):
             return cls._openai_role_map.get(role, role.value)
-        return str(role)
+        return cls._openai_str_role_map.get(str(role), str(role))
 
     @classmethod
     def to_openai(cls, message: Message) -> list[dict]:


### PR DESCRIPTION
## Summary

`_get_openai_role()` only handled `Role` enum instances (`Role.MODEL` → `'assistant'`) but silently passed plain strings through unchanged. When a message role arrives as the raw string `'model'` (e.g. from JSON deserialization via the reflection API), `isinstance(role, Role)` is `False`, so the unmapped string `'model'` was sent directly to the OpenAI API, which rejects it:

```
Invalid value: 'model'. Supported values are: 'system', 'assistant', 'user', 'function', 'tool', and 'developer'.
```

## Root cause

`Role` is a `StrEnum`. While `Role.MODEL == 'model'` is `True` (value equality), `isinstance('model', Role)` is `False` — a plain `str` is not a `Role` instance. The `_get_openai_role` method only checked `isinstance`, so plain strings fell through to `return str(role)`.

## What changed

| File | Change | Why |
|------|--------|-----|
| `models/utils.py` | Add `_openai_str_role_map = {'model': 'assistant'}` | String-level fallback for plain str roles |
| `models/utils.py` | Use fallback map in `_get_openai_role()` | Map `'model'` → `'assistant'` even when role is a plain str |

## Impact

Fixes multiturn conformance tests for all compat-oai consumers:
- `openai/gpt-4o`, `openai/gpt-4o-mini` — Multiturn Conformance
- `deepseek/deepseek-chat`, `deepseek/deepseek-reasoner` — Multiturn Conformance
- Any other plugin using `MessageConverter.to_openai()`

## Testing

Verified via `conform check-model --runtime python`.