### PR TITLE
fix(py/deepseek): migrate from sync OpenAI to AsyncOpenAI client

### DIFF
--- a/py/plugins/deepseek/src/genkit/plugins/deepseek/client.py
+++ b/py/plugins/deepseek/src/genkit/plugins/deepseek/client.py
@@ -18,7 +18,7 @@
 
 from typing import Any, cast
 
-from openai import OpenAI as _OpenAI
+from openai import AsyncOpenAI as _AsyncOpenAI
 
 # Official DeepSeek API endpoint
 # This is the standard endpoint and doesn't vary by region
@@ -28,7 +28,7 @@ DEFAULT_DEEPSEEK_API_URL = 'https://api.deepseek.com'
 class DeepSeekClient:
     """DeepSeek API client initialization."""
 
-    def __new__(cls, **deepseek_params: object) -> _OpenAI:
+    def __new__(cls, **deepseek_params: object) -> _AsyncOpenAI:
         """Initialize the DeepSeek client.
 
         Args:
@@ -38,9 +38,9 @@ class DeepSeekClient:
                 - Additional OpenAI client parameters.
 
         Returns:
-            Configured OpenAI client instance.
+            Configured async OpenAI client instance.
         """
         api_key = cast(str | None, deepseek_params.pop('api_key', None))
         base_url = cast(str, deepseek_params.pop('base_url', DEFAULT_DEEPSEEK_API_URL))
 
-        return _OpenAI(api_key=api_key, base_url=base_url, **cast(dict[str, Any], deepseek_params))
+        return _AsyncOpenAI(api_key=api_key, base_url=base_url, **cast(dict[str, Any], deepseek_params))

--- a/py/plugins/deepseek/tests/deepseek_plugin_test.py
+++ b/py/plugins/deepseek/tests/deepseek_plugin_test.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import structlog.testing
-from openai import OpenAI
+from openai import AsyncOpenAI
 
 from genkit.core.error import GenkitError
 from genkit.core.registry import ActionKind
@@ -164,7 +164,7 @@ def test_deepseek_client_initialization(mock_new: MagicMock) -> None:
 
 def test_deepseek_client_with_custom_base_url() -> None:
     """Test DeepSeekClient accepts custom base_url."""
-    with patch.object(OpenAI, '__init__', return_value=None) as mock_init:
+    with patch.object(AsyncOpenAI, '__init__', return_value=None) as mock_init:
         DeepSeekClient(api_key='test-key', base_url='https://custom.api.deepseek.com')
         mock_init.assert_called_once_with(
             api_key='test-key',
@@ -174,7 +174,7 @@ def test_deepseek_client_with_custom_base_url() -> None:
 
 def test_deepseek_client_default_base_url() -> None:
     """Test DeepSeekClient uses default base_url when not provided."""
-    with patch.object(OpenAI, '__init__', return_value=None) as mock_init:
+    with patch.object(AsyncOpenAI, '__init__', return_value=None) as mock_init:
         DeepSeekClient(api_key='test-key')
         mock_init.assert_called_once_with(
             api_key='test-key',


### PR DESCRIPTION
## Summary

The DeepSeek plugin was wrapping a synchronous `OpenAI` client. Since DeepSeek uses the compat-oai `OpenAIModel` (which now requires `AsyncOpenAI`), the client must be async.

## What changed

| File | Change | Why |
|------|--------|-----|
| `client.py` | `OpenAI` → `AsyncOpenAI` | Async client for non-blocking I/O |
| `models.py` | Type annotation `AsyncOpenAI` | Matches async client |
| `tests/` | Patch `AsyncOpenAI` instead of `OpenAI` | Tests match async client |

## Dependencies

Depends on #4605 (compat-oai async migration) — DeepSeek delegates to `OpenAIModel` from compat-oai.