### PR TITLE
fix(py/core): redact data URIs in generate debug logs

### DIFF
--- a/py/packages/genkit/src/genkit/blocks/generate.py
+++ b/py/packages/genkit/src/genkit/blocks/generate.py
@@ -18,7 +18,6 @@
 
 import copy
 import re
-import re
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -67,7 +66,6 @@ logger = get_logger(__name__)
 # Matches data URIs: everything up to the first comma is the media-type +
 # parameters (e.g. "data:audio/L16;codec=pcm;rate=24000;base64,").
 _DATA_URI_RE = re.compile(r'data:[^,]{0,200},(?=.{100})', re.ASCII)
-_DATA_URI_MAX_LEN = 100
 
 
 def _redact_data_uris(obj: Any) -> Any:  # noqa: ANN401
@@ -79,7 +77,7 @@ def _redact_data_uris(obj: Any) -> Any:  # noqa: ANN401
     """
     if isinstance(obj, str):
         m = _DATA_URI_RE.match(obj)
-        if m and len(obj) > _DATA_URI_MAX_LEN:
+        if m:
             return f'{m.group()}...<{len(obj) - m.end()} bytes>'
         return obj
     if isinstance(obj, dict):


### PR DESCRIPTION
## Summary

Debug logs for generate requests/responses included full base64-encoded data URIs (images, audio), making logs unreadable and consuming excessive memory/disk when multimodal inputs are used (e.g., conformance tests with image inputs).

## What changed

| File | Change | Why |
|------|--------|-----|
| `generate.py` | Add `_redact_data_uris()` function | Recursively truncate data: URIs in dicts/lists |
| `generate.py` | Apply to request/response debug logs | Keeps type prefix, hides payload |

**Before:** `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA...` (20,000+ chars)
**After:** `data:image/png;base64,...<19850 bytes>`

## Impact

Makes debug logs readable when processing multimodal requests.

See:

<img width="1093" height="1147" alt="Screenshot 2026-02-12 at 1 03 13 AM" src="https://github.com/user-attachments/assets/76c16513-bf8d-4e26-b2ad-6b2d62b18bf9" />
