### PR TITLE
fix(py): fix tox test error for cohere plugin

### DIFF
--- a/py/plugins/cohere/src/genkit/plugins/cohere/converters.py
+++ b/py/plugins/cohere/src/genkit/plugins/cohere/converters.py
@@ -46,7 +46,6 @@ from cohere.types import (
     AssistantChatMessageV2,
     AssistantMessageResponse,
     SystemChatMessageV2,
-    TextAssistantMessageV2ContentItem,
     ToolCallV2,
     ToolCallV2Function,
     ToolChatMessageV2,
@@ -55,6 +54,11 @@ from cohere.types import (
     Usage,
     UserChatMessageV2,
 )
+
+try:
+    from cohere.types import TextAssistantMessageV2ContentItem
+except ImportError:
+    from cohere.types import TextAssistantMessageV2ContentOneItem as TextAssistantMessageV2ContentItem
 from cohere.v2.types.v2chat_response import V2ChatResponse
 from genkit.core.typing import (
     FinishReason,

--- a/py/plugins/cohere/tests/cohere_models_test.py
+++ b/py/plugins/cohere/tests/cohere_models_test.py
@@ -25,7 +25,11 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from cohere.types import TextAssistantMessageV2ContentItem
+
+try:
+    from cohere.types import TextAssistantMessageV2ContentItem
+except ImportError:
+    from cohere.types import TextAssistantMessageV2ContentOneItem as TextAssistantMessageV2ContentItem
 from cohere.v2.types.v2chat_stream_response import (
     ContentDeltaV2ChatStreamResponse,
     MessageEndV2ChatStreamResponse,


### PR DESCRIPTION
Cohere Plugin Compatibility: The Cohere SDK recently introduced inconsistent naming for internal types (specifically TextAssistantMessageV2ContentItem vs. TextAssistantMessageV2ContentOneItem) across different minor versions. This was causing ImportError failures in environments with version skew (e.g., local .venv vs. 
tox environments). This PR implements a robust import strategy to handle both variants.