### PR TITLE
fix(py/anthropic): fix streaming tool requests and structured output

### DIFF
--- a/py/plugins/anthropic/tests/anthropic_models_test.py
+++ b/py/plugins/anthropic/tests/anthropic_models_test.py
@@ -230,9 +230,9 @@ async def test_streaming_generation() -> None:
     mock_client = MagicMock()
 
     chunks = [
-        MagicMock(type='content_block_delta', delta=MagicMock(text='Hello')),
-        MagicMock(type='content_block_delta', delta=MagicMock(text=' world')),
-        MagicMock(type='content_block_delta', delta=MagicMock(text='!')),
+        MagicMock(type='content_block_delta', delta=MagicMock(type='text_delta', text='Hello')),
+        MagicMock(type='content_block_delta', delta=MagicMock(type='text_delta', text=' world')),
+        MagicMock(type='content_block_delta', delta=MagicMock(type='text_delta', text='!')),
     ]
 
     final_content = [MagicMock(type='text', text='Hello world!')]
@@ -278,9 +278,148 @@ async def test_streaming_generation() -> None:
     assert final_part.root.text == 'Hello world!'
 
 
-# ---------------------------------------------------------------------------
-# Cache control tests
-# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_streaming_tool_request() -> None:
+    """Test streaming generation with tool use blocks."""
+    sample_request = _create_sample_request()
+
+    mock_client = MagicMock()
+
+    # Simulate: text chunk, then tool_use block (start + json deltas + stop).
+    tool_block = MagicMock(type='tool_use', id='tool_abc', name='get_weather')
+    chunks = [
+        MagicMock(type='content_block_delta', delta=MagicMock(type='text_delta', text='Let me check.')),
+        MagicMock(type='content_block_start', index=1, content_block=tool_block),
+        MagicMock(
+            type='content_block_delta',
+            index=1,
+            delta=MagicMock(type='input_json_delta', partial_json='{"location"'),
+        ),
+        MagicMock(
+            type='content_block_delta',
+            index=1,
+            delta=MagicMock(type='input_json_delta', partial_json=': "Paris"}'),
+        ),
+        MagicMock(type='content_block_stop', index=1),
+    ]
+
+    final_content = [
+        MagicMock(type='text', text='Let me check.'),
+        MagicMock(type='tool_use', id='tool_abc', name='get_weather', input={'location': 'Paris'}),
+    ]
+    mock_stream = MockStreamManager(chunks, final_content=final_content)
+    mock_client.messages.stream.return_value = mock_stream
+
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    ctx = MagicMock()
+    ctx.is_streaming = True
+    collected_chunks: list[GenerateResponseChunk] = []
+    ctx.send_chunk = lambda chunk: collected_chunks.append(chunk)
+
+    response = await model.generate(sample_request, ctx)
+
+    # Should have 2 chunks: one text, one tool request.
+    assert len(collected_chunks) == 2
+
+    text_part = collected_chunks[0].content[0].root
+    assert isinstance(text_part, TextPart)
+    assert text_part.text == 'Let me check.'
+
+    tool_part = collected_chunks[1].content[0].root
+    assert isinstance(tool_part, ToolRequestPart)
+    assert tool_part.tool_request.name == 'get_weather'
+    assert tool_part.tool_request.ref == 'tool_abc'
+    assert tool_part.tool_request.input == {'location': 'Paris'}
+
+    # Final response should also contain the tool request.
+    assert response.message is not None
+    assert len(response.message.content) == 2
+
+
+class TestStripMarkdownFences:
+    """Tests for _strip_markdown_fences."""
+
+    def test_strips_json_fences(self) -> None:
+        """Strips ```json ... ``` fences."""
+        text = '```json\n{"name": "John", "age": 30}\n```'
+        assert AnthropicModel._strip_markdown_fences(text) == '{"name": "John", "age": 30}'
+
+    def test_strips_plain_fences(self) -> None:
+        """Strips ``` ... ``` fences without language tag."""
+        text = '```\n{"name": "John"}\n```'
+        assert AnthropicModel._strip_markdown_fences(text) == '{"name": "John"}'
+
+    def test_strips_fences_with_surrounding_whitespace(self) -> None:
+        """Strips fences even with leading/trailing whitespace."""
+        text = '  \n```json\n{"a": 1}\n```\n  '
+        assert AnthropicModel._strip_markdown_fences(text) == '{"a": 1}'
+
+    def test_preserves_plain_json(self) -> None:
+        """Does not alter valid JSON without fences."""
+        text = '{"name": "John", "age": 30}'
+        assert AnthropicModel._strip_markdown_fences(text) == text
+
+    def test_preserves_non_json_text(self) -> None:
+        """Does not alter plain text."""
+        text = 'Hello, world!'
+        assert AnthropicModel._strip_markdown_fences(text) == text
+
+    def test_strips_multiline_json_in_fences(self) -> None:
+        """Strips fences around multiline JSON."""
+        text = '```json\n{\n  "name": "John",\n  "age": 30\n}\n```'
+        result = AnthropicModel._strip_markdown_fences(text)
+        assert result == '{\n  "name": "John",\n  "age": 30\n}'
+
+
+class TestMaybeStripFences:
+    """Tests for _maybe_strip_fences."""
+
+    def test_strips_fences_for_json_output(self) -> None:
+        """Strips markdown fences when JSON output is requested."""
+        model = AnthropicModel(model_name='claude-sonnet-4', client=MagicMock())
+        request = GenerateRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
+            output=OutputConfig(format='json', schema={'type': 'object'}),
+        )
+        parts = [Part(root=TextPart(text='```json\n{"a": 1}\n```'))]
+        result = model._maybe_strip_fences(request, parts)
+        assert result[0].root.text == '{"a": 1}'
+
+    def test_no_op_for_text_output(self) -> None:
+        """Does not modify responses when output format is not json."""
+        model = AnthropicModel(model_name='claude-sonnet-4', client=MagicMock())
+        request = GenerateRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
+            output=OutputConfig(format='text'),
+        )
+        fenced = '```json\n{"a": 1}\n```'
+        parts = [Part(root=TextPart(text=fenced))]
+        result = model._maybe_strip_fences(request, parts)
+        assert result[0].root.text == fenced
+
+    def test_no_op_for_no_output(self) -> None:
+        """Does not modify responses when no output config is set."""
+        model = AnthropicModel(model_name='claude-sonnet-4', client=MagicMock())
+        request = GenerateRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
+        )
+        fenced = '```json\n{"a": 1}\n```'
+        parts = [Part(root=TextPart(text=fenced))]
+        result = model._maybe_strip_fences(request, parts)
+        assert result[0].root.text == fenced
+
+    def test_no_op_when_no_fences(self) -> None:
+        """Does not modify clean JSON responses."""
+        model = AnthropicModel(model_name='claude-sonnet-4', client=MagicMock())
+        request = GenerateRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
+            output=OutputConfig(format='json', schema={'type': 'object'}),
+        )
+        text = '{"name": "John"}'
+        parts = [Part(root=TextPart(text=text))]
+        result = model._maybe_strip_fences(request, parts)
+        assert result is parts
 
 
 def test_cache_control_on_text_block() -> None:
@@ -384,11 +523,6 @@ async def test_no_cache_tokens_when_caching_not_used() -> None:
     response = await model.generate(request)
     assert response.usage is not None
     assert response.usage.custom is None
-
-
-# ---------------------------------------------------------------------------
-# PDF / Document support tests
-# ---------------------------------------------------------------------------
 
 
 def test_pdf_base64_becomes_document_block() -> None:
@@ -496,8 +630,8 @@ def test_pdf_with_cache_control() -> None:
     assert blocks[0]['cache_control'] == {'type': 'ephemeral'}
 
 
-def test_structured_output_injects_json_instruction() -> None:
-    """Test that JSON schema is injected into system prompt when output format is JSON."""
+def test_structured_output_uses_native_output_config() -> None:
+    """Test that JSON schema uses native output_config when schema is provided."""
     mock_client = MagicMock()
     model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
 
@@ -511,6 +645,23 @@ def test_structured_output_injects_json_instruction() -> None:
 
     params = model._build_params(request)
 
+    assert 'output_config' in params
+    assert params['output_config']['format']['type'] == 'json_schema'
+    assert params['output_config']['format']['schema']['additionalProperties'] is False
+
+
+def test_structured_output_falls_back_to_system_prompt() -> None:
+    """Test that JSON without schema falls back to system prompt instruction."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    request = GenerateRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate JSON'))])],
+        output=OutputConfig(format='json'),
+    )
+
+    params = model._build_params(request)
+
+    assert 'output_config' not in params
     assert 'system' in params
-    assert 'Output valid JSON matching this schema' in params['system']
-    assert '"name":' in params['system']
+    assert 'Output valid JSON' in params['system']

--- a/py/plugins/compat-oai/tests/compat_oai_model_test.py
+++ b/py/plugins/compat-oai/tests/compat_oai_model_test.py
@@ -388,6 +388,7 @@ class TestCleanJsonResponse:
             ),
         )
         cleaned = model._clean_json_response(response, request)
+        assert cleaned.message is not None
         assert cleaned.message.content[0].root.text == '{"name": "John", "level": 5}'
 
     def test_no_op_for_gpt_model(self) -> None:
@@ -406,6 +407,7 @@ class TestCleanJsonResponse:
             ),
         )
         result = model._clean_json_response(response, request)
+        assert result.message is not None
         assert result.message.content[0].root.text == fenced_text
 
     def test_no_op_for_text_output(self) -> None:
@@ -421,6 +423,7 @@ class TestCleanJsonResponse:
             message=Message(role=Role.MODEL, content=[Part(root=TextPart(text=text))]),
         )
         result = model._clean_json_response(response, request)
+        assert result.message is not None
         assert result.message.content[0].root.text == text
 
     def test_no_op_for_no_output(self) -> None:
@@ -435,6 +438,7 @@ class TestCleanJsonResponse:
             message=Message(role=Role.MODEL, content=[Part(root=TextPart(text=text))]),
         )
         result = model._clean_json_response(response, request)
+        assert result.message is not None
         assert result.message.content[0].root.text == text
 
     def test_no_op_when_no_fences(self) -> None:


### PR DESCRIPTION
Two conformance failures fixed:

1. Streaming tool requests: handle content_block_start, input_json_delta,
   and content_block_stop events so tool calls are emitted as chunks.
   Previously only text_delta events were processed.

2. Structured output: strip markdown fences from JSON responses. Anthropic
   models wrap JSON in ```json ... ``` even when instructed to output
   valid JSON. Added _strip_markdown_fences() and _maybe_strip_fences().

Structured Output:
- Use Anthropic's native structured outputs API (output_config with
  json_schema format) instead of injecting schema into system prompt.
  This guarantees valid JSON in both streaming and non-streaming paths,
  matching the JS plugin's approach.
- Add _to_anthropic_schema() to recursively set additionalProperties:
  false on object types per Anthropic's requirements.
- Keep system prompt fallback for schema-less JSON requests.
- Add _strip_markdown_fences() as a safety net for non-streaming
  responses where models may still wrap JSON in fences.

Streaming Tool Requests:
- Handle content_block_start, input_json_delta, and content_block_stop
  events in _generate_streaming(). Previously only text_delta events
  were processed, so tool calls were never emitted as streamed chunks.

Tests:
- Add test_streaming_tool_request for streaming tool use blocks.
- Add TestStripMarkdownFences and TestMaybeStripFences test classes.
- Add test_structured_output_uses_native_output_config and
  test_structured_output_falls_back_to_system_prompt.
- Fix existing streaming test mocks to include delta.type.
