### PR TITLE
fix(py): fix structlog config blowaway, DeepSeek reasoning, and double JSON encoding

### DIFF
--- a/py/plugins/amazon-bedrock/src/genkit/plugins/amazon_bedrock/telemetry/tracing.py
+++ b/py/plugins/amazon-bedrock/src/genkit/plugins/amazon_bedrock/telemetry/tracing.py
@@ -364,7 +364,14 @@ class AwsTelemetry:
                 new_processors = list(processors)
                 # Insert before the last processor (usually the renderer)
                 new_processors.insert(max(0, len(new_processors) - 1), inject_xray_trace_context)
-                structlog.configure(processors=new_processors)
+                cfg = structlog.get_config()
+                structlog.configure(
+                    processors=new_processors,
+                    wrapper_class=cfg.get('wrapper_class'),
+                    context_class=cfg.get('context_class'),
+                    logger_factory=cfg.get('logger_factory'),
+                    cache_logger_on_first_use=cfg.get('cache_logger_on_first_use'),
+                )
                 logger.debug('Configured structlog for AWS X-Ray trace correlation')
 
         except Exception as e:

--- a/py/plugins/cloudflare-workers-ai/src/genkit/plugins/cloudflare_workers_ai/telemetry/tracing.py
+++ b/py/plugins/cloudflare-workers-ai/src/genkit/plugins/cloudflare_workers_ai/telemetry/tracing.py
@@ -315,7 +315,14 @@ class CfTelemetry:
                 new_processors = list(processors)
                 # Insert before the last processor (usually the renderer)
                 new_processors.insert(max(0, len(new_processors) - 1), inject_cf_trace_context)
-                structlog.configure(processors=new_processors)
+                cfg = structlog.get_config()
+                structlog.configure(
+                    processors=new_processors,
+                    wrapper_class=cfg.get('wrapper_class'),
+                    context_class=cfg.get('context_class'),
+                    logger_factory=cfg.get('logger_factory'),
+                    cache_logger_on_first_use=cfg.get('cache_logger_on_first_use'),
+                )
                 logger.debug('Configured structlog for trace correlation')
 
         except Exception as e:

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/utils.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/models/utils.py
@@ -367,6 +367,13 @@ class MessageConverter:
         for part in message.content:
             root = part.root
 
+            # Skip ReasoningPart — reasoning_content must not be sent back
+            # in multi-turn context. DeepSeek's API rejects it, and the JS
+            # canonical implementation naturally excludes it by using msg.text
+            # (which only returns text parts) for assistant messages.
+            if isinstance(root, ReasoningPart):
+                continue
+
             if isinstance(root, TextPart):
                 content_parts.append({'type': 'text', 'text': root.text})
 

--- a/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/tracing.py
+++ b/py/plugins/google-cloud/src/genkit/plugins/google_cloud/telemetry/tracing.py
@@ -395,7 +395,14 @@ class GcpTelemetry:
 
                 new_processors = list(processors)
                 new_processors.insert(max(0, len(new_processors) - 1), inject_trace_context)
-                structlog.configure(processors=new_processors)
+                cfg = structlog.get_config()
+                structlog.configure(
+                    processors=new_processors,
+                    wrapper_class=cfg.get('wrapper_class'),
+                    context_class=cfg.get('context_class'),
+                    logger_factory=cfg.get('logger_factory'),
+                    cache_logger_on_first_use=cfg.get('cache_logger_on_first_use'),
+                )
                 logger.debug('Configured structlog for GCP trace correlation')
 
         except Exception as e:

--- a/py/plugins/microsoft-foundry/src/genkit/plugins/microsoft_foundry/telemetry/tracing.py
+++ b/py/plugins/microsoft-foundry/src/genkit/plugins/microsoft_foundry/telemetry/tracing.py
@@ -455,7 +455,14 @@ class AzureTelemetry:
                 new_processors = list(processors)
                 # Insert before the last processor (usually the renderer)
                 new_processors.insert(max(0, len(new_processors) - 1), inject_azure_trace_context)
-                structlog.configure(processors=new_processors)
+                cfg = structlog.get_config()
+                structlog.configure(
+                    processors=new_processors,
+                    wrapper_class=cfg.get('wrapper_class'),
+                    context_class=cfg.get('context_class'),
+                    logger_factory=cfg.get('logger_factory'),
+                    cache_logger_on_first_use=cfg.get('cache_logger_on_first_use'),
+                )
                 logger.debug('Configured structlog for Azure trace correlation')
 
         except Exception as e:

--- a/py/plugins/observability/src/genkit/plugins/observability/__init__.py
+++ b/py/plugins/observability/src/genkit/plugins/observability/__init__.py
@@ -429,7 +429,14 @@ def _configure_logging() -> None:
             new_processors = list(processors)
             # Insert before the last processor (usually the renderer)
             new_processors.insert(max(0, len(new_processors) - 1), inject_observability_trace_context)
-            structlog.configure(processors=new_processors)
+            cfg = structlog.get_config()
+            structlog.configure(
+                processors=new_processors,
+                wrapper_class=cfg.get('wrapper_class'),
+                context_class=cfg.get('context_class'),
+                logger_factory=cfg.get('logger_factory'),
+                cache_logger_on_first_use=cfg.get('cache_logger_on_first_use'),
+            )
             logger.debug('Configured structlog for trace correlation')
 
     except Exception as e:


### PR DESCRIPTION
structlog config preservation (5 plugins):
- Changed structlog.configure(processors=...) to preserve existing
  config (wrapper_class, logger_factory, cache_logger_on_first_use)
  by merging via structlog.get_config() before overwriting.
- Affected: amazon-bedrock, cloudflare-workers-ai, google-cloud,
  microsoft-foundry, observability

DeepSeek multi-round reasoning (compat-oai):
- Skip ReasoningPart in MessageConverter.to_openai() so
  reasoning_content is not sent back in multi-turn context.
  DeepSeek's API rejects it, and the JS canonical impl naturally
  excludes it by using msg.text for assistant messages.
- Added 3 tests in compat_oai_utils_test.py.

Double JSON encoding (provider-compat-oai-hello):
- get_weather_flow and get_weather_flow_stream returned response.text
  (raw JSON string) with output=Output(schema=WeatherResponse), causing
  double encoding. Changed to return WeatherResponse.model_validate(
  response.output).
