### PR TITLE
fix(ci): use working-directory and RELEASEKIT_DIR for consistent paths

### DIFF
--- a/.github/workflows/releasekit-uv.yml
+++ b/.github/workflows/releasekit-uv.yml
@@ -119,9 +119,8 @@ jobs:
           python-version: "3.12"
 
       - name: Install releasekit
-        run: |
-          cd ${{ env.RELEASEKIT_DIR }}
-          uv sync
+        working-directory: ${{ env.RELEASEKIT_DIR }}
+        run: uv sync
 
       - name: Configure git identity
         run: |
@@ -131,8 +130,7 @@ jobs:
       - name: Run releasekit prepare
         id: prepare
         run: |
-          cd ${{ env.WORKSPACE_DIR }}
-          OUTPUT=$(uv run --directory ../tools/releasekit releasekit --workspace py prepare 2>&1) || {
+          OUTPUT=$(uv run --directory ${{ env.RELEASEKIT_DIR }} releasekit --workspace py prepare 2>&1) || {
             echo "::warning::releasekit prepare exited with non-zero status"
             echo "has_bumps=false" >> "$GITHUB_OUTPUT"
             echo "$OUTPUT"
@@ -180,9 +178,8 @@ jobs:
           python-version: "3.12"
 
       - name: Install releasekit
-        run: |
-          cd ${{ env.RELEASEKIT_DIR }}
-          uv sync
+        working-directory: ${{ env.RELEASEKIT_DIR }}
+        run: uv sync
 
       - name: Configure git identity
         run: |
@@ -191,9 +188,8 @@ jobs:
 
       - name: Preview execution plan
         run: |
-          cd ${{ env.WORKSPACE_DIR }}
           echo "::group::Execution Plan (ASCII)"
-          uv run --directory ../tools/releasekit releasekit --workspace py plan --format full 2>&1 || true
+          uv run --directory ${{ env.RELEASEKIT_DIR }} releasekit --workspace py plan --format full 2>&1 || true
           echo "::endgroup::"
           if [ "${{ env.DRY_RUN }}" = "true" ]; then
             echo "::notice::DRY RUN — no tags or releases will be created"
@@ -206,12 +202,11 @@ jobs:
       - name: Run releasekit release
         id: release
         run: |
-          cd ${{ env.WORKSPACE_DIR }}
           DRY_RUN_FLAG=""
           if [ "${{ env.DRY_RUN }}" = "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
-          OUTPUT=$(uv run --directory ../tools/releasekit releasekit --workspace py release $DRY_RUN_FLAG 2>&1)
+          OUTPUT=$(uv run --directory ${{ env.RELEASEKIT_DIR }} releasekit --workspace py release $DRY_RUN_FLAG 2>&1)
           echo "$OUTPUT"
 
           # Parse release URL
@@ -249,18 +244,18 @@ jobs:
           enable-cache: true
           python-version: "3.12"
 
-      - name: Install workspace + releasekit
-        run: |
-          cd ${{ env.WORKSPACE_DIR }}
-          uv sync
-          cd tools/releasekit
-          uv sync
+      - name: Install workspace
+        working-directory: ${{ env.WORKSPACE_DIR }}
+        run: uv sync
+
+      - name: Install releasekit
+        working-directory: ${{ env.RELEASEKIT_DIR }}
+        run: uv sync
 
       - name: Preview execution plan
         run: |
-          cd ${{ env.WORKSPACE_DIR }}
           echo "::group::Execution Plan (ASCII)"
-          uv run --directory tools/releasekit releasekit --workspace py plan --format full 2>&1 || true
+          uv run --directory ${{ env.RELEASEKIT_DIR }} releasekit --workspace py plan --format full 2>&1 || true
           echo "::endgroup::"
           if [ "${{ env.DRY_RUN }}" = "true" ]; then
             echo "::notice::DRY RUN — no packages will be published"
@@ -270,9 +265,7 @@ jobs:
 
       - name: Run releasekit publish
         run: |
-          cd ${{ env.WORKSPACE_DIR }}
-
-          cmd=(uv run --directory tools/releasekit releasekit --workspace py publish --force)
+          cmd=(uv run --directory ${{ env.RELEASEKIT_DIR }} releasekit --workspace py publish --force)
 
           if [ "${{ env.DRY_RUN }}" = "true" ]; then
             cmd+=(--dry-run)

--- a/py/tools/releasekit/github/workflows/releasekit-pnpm.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-pnpm.yml
@@ -122,9 +122,8 @@ jobs:
           cache-dependency-path: js/pnpm-lock.yaml
 
       - name: Install releasekit
-        run: |
-          cd ${{ env.RELEASEKIT_DIR }}
-          uv sync
+        working-directory: ${{ env.RELEASEKIT_DIR }}
+        run: uv sync
 
       - name: Configure git identity
         run: |
@@ -185,9 +184,8 @@ jobs:
           cache-dependency-path: genkit-tools/pnpm-lock.yaml
 
       - name: Install releasekit
-        run: |
-          cd ${{ env.RELEASEKIT_DIR }}
-          uv sync
+        working-directory: ${{ env.RELEASEKIT_DIR }}
+        run: uv sync
 
       - name: Configure git identity
         run: |
@@ -244,9 +242,8 @@ jobs:
           python-version: "3.12"
 
       - name: Install releasekit
-        run: |
-          cd ${{ env.RELEASEKIT_DIR }}
-          uv sync
+        working-directory: ${{ env.RELEASEKIT_DIR }}
+        run: uv sync
 
       - name: Configure git identity
         run: |
@@ -313,19 +310,16 @@ jobs:
           cache-dependency-path: js/pnpm-lock.yaml
 
       - name: Install JS dependencies
-        run: |
-          cd js
-          pnpm install --frozen-lockfile
+        working-directory: js
+        run: pnpm install --frozen-lockfile
 
       - name: Build JS packages
-        run: |
-          cd js
-          pnpm build
+        working-directory: js
+        run: pnpm build
 
       - name: Install releasekit
-        run: |
-          cd ${{ env.RELEASEKIT_DIR }}
-          uv sync
+        working-directory: ${{ env.RELEASEKIT_DIR }}
+        run: uv sync
 
       - name: Preview execution plan
         run: |

--- a/py/tools/releasekit/github/workflows/releasekit-uv.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-uv.yml
@@ -119,9 +119,8 @@ jobs:
           python-version: "3.12"
 
       - name: Install releasekit
-        run: |
-          cd ${{ env.RELEASEKIT_DIR }}
-          uv sync
+        working-directory: ${{ env.RELEASEKIT_DIR }}
+        run: uv sync
 
       - name: Configure git identity
         run: |
@@ -131,8 +130,7 @@ jobs:
       - name: Run releasekit prepare
         id: prepare
         run: |
-          cd ${{ env.WORKSPACE_DIR }}
-          OUTPUT=$(uv run --directory ../tools/releasekit releasekit --workspace py prepare 2>&1) || {
+          OUTPUT=$(uv run --directory ${{ env.RELEASEKIT_DIR }} releasekit --workspace py prepare 2>&1) || {
             echo "::warning::releasekit prepare exited with non-zero status"
             echo "has_bumps=false" >> "$GITHUB_OUTPUT"
             echo "$OUTPUT"
@@ -180,9 +178,8 @@ jobs:
           python-version: "3.12"
 
       - name: Install releasekit
-        run: |
-          cd ${{ env.RELEASEKIT_DIR }}
-          uv sync
+        working-directory: ${{ env.RELEASEKIT_DIR }}
+        run: uv sync
 
       - name: Configure git identity
         run: |
@@ -191,9 +188,8 @@ jobs:
 
       - name: Preview execution plan
         run: |
-          cd ${{ env.WORKSPACE_DIR }}
           echo "::group::Execution Plan (ASCII)"
-          uv run --directory ../tools/releasekit releasekit --workspace py plan --format full 2>&1 || true
+          uv run --directory ${{ env.RELEASEKIT_DIR }} releasekit --workspace py plan --format full 2>&1 || true
           echo "::endgroup::"
           if [ "${{ env.DRY_RUN }}" = "true" ]; then
             echo "::notice::DRY RUN — no tags or releases will be created"
@@ -206,12 +202,11 @@ jobs:
       - name: Run releasekit release
         id: release
         run: |
-          cd ${{ env.WORKSPACE_DIR }}
           DRY_RUN_FLAG=""
           if [ "${{ env.DRY_RUN }}" = "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
-          OUTPUT=$(uv run --directory ../tools/releasekit releasekit --workspace py release $DRY_RUN_FLAG 2>&1)
+          OUTPUT=$(uv run --directory ${{ env.RELEASEKIT_DIR }} releasekit --workspace py release $DRY_RUN_FLAG 2>&1)
           echo "$OUTPUT"
 
           # Parse release URL
@@ -249,18 +244,18 @@ jobs:
           enable-cache: true
           python-version: "3.12"
 
-      - name: Install workspace + releasekit
-        run: |
-          cd ${{ env.WORKSPACE_DIR }}
-          uv sync
-          cd tools/releasekit
-          uv sync
+      - name: Install workspace
+        working-directory: ${{ env.WORKSPACE_DIR }}
+        run: uv sync
+
+      - name: Install releasekit
+        working-directory: ${{ env.RELEASEKIT_DIR }}
+        run: uv sync
 
       - name: Preview execution plan
         run: |
-          cd ${{ env.WORKSPACE_DIR }}
           echo "::group::Execution Plan (ASCII)"
-          uv run --directory tools/releasekit releasekit --workspace py plan --format full 2>&1 || true
+          uv run --directory ${{ env.RELEASEKIT_DIR }} releasekit --workspace py plan --format full 2>&1 || true
           echo "::endgroup::"
           if [ "${{ env.DRY_RUN }}" = "true" ]; then
             echo "::notice::DRY RUN — no packages will be published"
@@ -270,9 +265,7 @@ jobs:
 
       - name: Run releasekit publish
         run: |
-          cd ${{ env.WORKSPACE_DIR }}
-
-          cmd=(uv run --directory tools/releasekit releasekit --workspace py publish --force)
+          cmd=(uv run --directory ${{ env.RELEASEKIT_DIR }} releasekit --workspace py publish --force)
 
           if [ "${{ env.DRY_RUN }}" = "true" ]; then
             cmd+=(--dry-run)


### PR DESCRIPTION
fix(ci): use working-directory and RELEASEKIT_DIR for consistent paths

The uv workflow was using `cd` followed by relative paths for
`--directory`, which was fragile and inconsistent with GitHub Actions
best practices.

- Replace all `cd` + `uv sync` patterns with `working-directory:` step
  keyword across all three releasekit workflow templates
- Use `${{ env.RELEASEKIT_DIR }}` (repo-root-absolute) for all
  `uv run --directory` calls, matching the convention already used
  in the pnpm workflow's `uv run` commands
- Split the combined "Install workspace + releasekit" step into two
  separate steps for clarity

Applies to: releasekit-uv.yml (live + template), releasekit-pnpm.yml