### PR TITLE
fix(releasekit): add set_upstream to VCS push and fail fast on errors

### DIFF
--- a/.github/workflows/releasekit-uv.yml
+++ b/.github/workflows/releasekit-uv.yml
@@ -206,6 +206,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history needed for conventional commit parsing
+          fetch-tags: true  # Tags needed for changelog since-tag ranges
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv and setup Python
@@ -277,6 +278,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv and setup Python
@@ -345,6 +347,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Install system dependencies
         run: |

--- a/py/tools/releasekit/github/workflows/releasekit-pnpm.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-pnpm.yml
@@ -205,6 +205,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv and setup Python
@@ -280,6 +281,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv and setup Python
@@ -360,6 +362,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv and setup Python
@@ -424,6 +427,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Install uv and setup Python
         uses: astral-sh/setup-uv@v5

--- a/py/tools/releasekit/github/workflows/releasekit-uv.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-uv.yml
@@ -208,6 +208,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history needed for conventional commit parsing
+          fetch-tags: true  # Tags needed for changelog since-tag ranges
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv and setup Python
@@ -279,6 +280,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv and setup Python
@@ -347,6 +349,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Install system dependencies
         run: |

--- a/py/tools/releasekit/src/releasekit/backends/vcs/__init__.py
+++ b/py/tools/releasekit/src/releasekit/backends/vcs/__init__.py
@@ -170,6 +170,7 @@ class VCS(Protocol):
         *,
         tags: bool = False,
         remote: str = 'origin',
+        set_upstream: bool = True,
         dry_run: bool = False,
     ) -> CommandResult:
         """Push commits and/or tags.
@@ -177,6 +178,7 @@ class VCS(Protocol):
         Args:
             tags: Also push tags.
             remote: Remote name.
+            set_upstream: Set upstream tracking for new branches.
             dry_run: Log the command without executing.
         """
         ...

--- a/py/tools/releasekit/src/releasekit/backends/vcs/git.py
+++ b/py/tools/releasekit/src/releasekit/backends/vcs/git.py
@@ -223,13 +223,16 @@ class GitCLIBackend:
         *,
         tags: bool = False,
         remote: str = 'origin',
+        set_upstream: bool = True,
         dry_run: bool = False,
     ) -> CommandResult:
         """Push commits and/or tags."""
         cmd_parts = ['push', remote]
+        if set_upstream:
+            cmd_parts.append('--set-upstream')
         if tags:
             cmd_parts.append('--tags')
-        log.info('push', remote=remote, tags=tags)
+        log.info('push', remote=remote, tags=tags, set_upstream=set_upstream)
         return await asyncio.to_thread(self._git, *cmd_parts, dry_run=dry_run)
 
     async def list_tags(self, *, pattern: str = '') -> list[str]:

--- a/py/tools/releasekit/src/releasekit/backends/vcs/mercurial.py
+++ b/py/tools/releasekit/src/releasekit/backends/vcs/mercurial.py
@@ -261,18 +261,24 @@ class MercurialCLIBackend:
         *,
         tags: bool = False,
         remote: str = 'origin',
+        set_upstream: bool = True,
         dry_run: bool = False,
     ) -> CommandResult:
         """Push changesets to a remote path.
 
         Mercurial pushes all new changesets by default (tags are
         changesets, so they're included automatically).
+
+        Note:
+            ``set_upstream`` is accepted for protocol compatibility but
+            ignored — Mercurial does not have Git-style upstream tracking
+            branches.
         """
         # Mercurial uses "default" as the default remote, not "origin".
         hg_remote = 'default' if remote == 'origin' else remote
         cmd_parts = ['push', hg_remote]
 
-        log.info('push', remote=hg_remote, tags=tags)
+        log.info('push', remote=hg_remote, tags=tags, set_upstream=set_upstream)
         return await asyncio.to_thread(self._hg, *cmd_parts, dry_run=dry_run)
 
     async def list_tags(self, *, pattern: str = '') -> list[str]:

--- a/py/tools/releasekit/tests/rk_changelog_test.py
+++ b/py/tools/releasekit/tests/rk_changelog_test.py
@@ -123,6 +123,7 @@ class FakeVCS:
         *,
         tags: bool = False,
         remote: str = 'origin',
+        set_upstream: bool = True,
         dry_run: bool = False,
     ) -> CommandResult:
         """No-op push."""

--- a/py/tools/releasekit/tests/rk_commitback_test.py
+++ b/py/tools/releasekit/tests/rk_commitback_test.py
@@ -49,7 +49,14 @@ class FakeVCS:
         self.commits.append(message)
         return _OK
 
-    async def push(self, *, tags: bool = False, remote: str = 'origin', dry_run: bool = False) -> CommandResult:
+    async def push(
+        self,
+        *,
+        tags: bool = False,
+        remote: str = 'origin',
+        set_upstream: bool = True,
+        dry_run: bool = False,
+    ) -> CommandResult:
         """Record push call."""
         self.pushes += 1
         return _OK

--- a/py/tools/releasekit/tests/rk_preflight_test.py
+++ b/py/tools/releasekit/tests/rk_preflight_test.py
@@ -131,6 +131,7 @@ class FakeVCS:
         *,
         tags: bool = False,
         remote: str = 'origin',
+        set_upstream: bool = True,
         dry_run: bool = False,
     ) -> CommandResult:
         """No-op push."""

--- a/py/tools/releasekit/tests/rk_prepare_test.py
+++ b/py/tools/releasekit/tests/rk_prepare_test.py
@@ -213,7 +213,14 @@ class _FakeVCS:
         """Delete tag."""
         return _OK
 
-    async def push(self, *, tags: bool = False, remote: str = 'origin', dry_run: bool = False) -> CommandResult:
+    async def push(
+        self,
+        *,
+        tags: bool = False,
+        remote: str = 'origin',
+        set_upstream: bool = True,
+        dry_run: bool = False,
+    ) -> CommandResult:
         """Push."""
         return _OK
 

--- a/py/tools/releasekit/tests/rk_publisher_test.py
+++ b/py/tools/releasekit/tests/rk_publisher_test.py
@@ -130,6 +130,7 @@ class FakeVCS:
         *,
         tags: bool = False,
         remote: str = 'origin',
+        set_upstream: bool = True,
         dry_run: bool = False,
     ) -> CommandResult:
         """Push."""

--- a/py/tools/releasekit/tests/rk_release_notes_test.py
+++ b/py/tools/releasekit/tests/rk_release_notes_test.py
@@ -97,7 +97,14 @@ class FakeVCS:
         """No-op delete_tag."""
         return _OK
 
-    async def push(self, *, tags: bool = False, remote: str = 'origin', dry_run: bool = False) -> CommandResult:
+    async def push(
+        self,
+        *,
+        tags: bool = False,
+        remote: str = 'origin',
+        set_upstream: bool = True,
+        dry_run: bool = False,
+    ) -> CommandResult:
         """No-op push."""
         return _OK
 

--- a/py/tools/releasekit/tests/rk_release_test.py
+++ b/py/tools/releasekit/tests/rk_release_test.py
@@ -122,6 +122,7 @@ class FakeVCS:
         *,
         tags: bool = False,
         remote: str = 'origin',
+        set_upstream: bool = True,
         dry_run: bool = False,
     ) -> CommandResult:
         """Push."""

--- a/py/tools/releasekit/tests/rk_tags_test.py
+++ b/py/tools/releasekit/tests/rk_tags_test.py
@@ -91,6 +91,7 @@ class FakeVCS:
         *,
         tags: bool = False,
         remote: str = 'origin',
+        set_upstream: bool = True,
         dry_run: bool = False,
     ) -> CommandResult:
         """Push tags (records for assertion)."""

--- a/py/tools/releasekit/tests/rk_versioning_test.py
+++ b/py/tools/releasekit/tests/rk_versioning_test.py
@@ -131,6 +131,7 @@ class FakeVCS:
         *,
         tags: bool = False,
         remote: str = 'origin',
+        set_upstream: bool = True,
         dry_run: bool = False,
     ) -> CommandResult:
         """No-op push."""


### PR DESCRIPTION
Releasekit's prepare command was silently succeeding when `git push`
or PR creation failed, because the push result was unchecked and the
forge result fell back to an empty string. This made CI runs appear
green when the release branch or PR wasn't actually created.

- Add `set_upstream` parameter to the VCS `push()` protocol, Git, and
  Mercurial backends so new release branches track their remote
- Check `push()` and create_pr() results in `prepare_release()` and
  raise `RuntimeError` on failure instead of silently continuing
- Add `fetch-tags: true` to all `actions/checkout` steps across the
  three releasekit workflow templates — required for changelog
  since-tag range resolution
- Update all FakeVCS test doubles to match the new `push()` signature
