### PR TITLE
fix(microsoft-foundry): conform tests and sanitize credentials to prevent Unicode encoding errors

### DIFF
--- a/.github/workflows/releasekit-uv.yml
+++ b/.github/workflows/releasekit-uv.yml
@@ -236,6 +236,7 @@ jobs:
           INPUT_BUMP_TYPE: ${{ inputs.bump_type }}
           INPUT_PRERELEASE: ${{ inputs.prerelease }}
           INPUT_FORCE_PREPARE: ${{ inputs.force_prepare }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -270,8 +271,6 @@ jobs:
           else
             echo "has_bumps=false" >> "$GITHUB_OUTPUT"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ═══════════════════════════════════════════════════════════════════════
   # RELEASE: Tag merge commit and create GitHub Release
@@ -411,6 +410,9 @@ jobs:
           INPUT_GROUP: ${{ inputs.group }}
           INPUT_CONCURRENCY: ${{ inputs.concurrency }}
           INPUT_MAX_RETRIES: ${{ inputs.max_retries }}
+          # For trusted publishing (OIDC), no token needed.
+          # For API token auth, set PYPI_TOKEN / TESTPYPI_TOKEN in repo secrets.
+          UV_PUBLISH_TOKEN: ${{ inputs.target == 'testpypi' && secrets.TESTPYPI_TOKEN || secrets.PYPI_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -448,10 +450,6 @@ jobs:
             echo "::error::releasekit publish failed with exit code $EXIT_CODE"
             exit $EXIT_CODE
           fi
-        env:
-          # For trusted publishing (OIDC), no token needed.
-          # For API token auth, set PYPI_TOKEN / TESTPYPI_TOKEN in repo secrets.
-          UV_PUBLISH_TOKEN: ${{ inputs.target == 'testpypi' && secrets.TESTPYPI_TOKEN || secrets.PYPI_TOKEN }}
 
       - name: Upload manifest artifact
         if: success()

--- a/py/samples/setup.sh
+++ b/py/samples/setup.sh
@@ -527,8 +527,28 @@ _install_ollama() {
             fi
             ;;
         Linux)
-            echo -e "  ${BLUE}→${NC} Installing Ollama..."
-            curl -fsSL https://ollama.com/install.sh | sh
+            # Prefer system package manager when the package is available,
+            # then fall back to the official curl installer.
+            local installed_via_pkg=false
+            if [[ "$PKG_MGR" == "apt" ]]; then
+                if apt-cache show ollama &>/dev/null 2>&1; then
+                    echo -e "  ${BLUE}→${NC} Installing Ollama via apt..."
+                    sudo apt-get update -qq
+                    sudo apt-get install -y -qq ollama
+                    installed_via_pkg=true
+                fi
+            elif [[ "$PKG_MGR" == "dnf" ]]; then
+                if dnf info ollama &>/dev/null 2>&1; then
+                    echo -e "  ${BLUE}→${NC} Installing Ollama via dnf..."
+                    sudo dnf install -y -q ollama
+                    installed_via_pkg=true
+                fi
+            fi
+
+            if ! $installed_via_pkg; then
+                echo -e "  ${BLUE}→${NC} Installing Ollama via official installer..."
+                curl -fsSL https://ollama.com/install.sh | sh
+            fi
             ;;
         *)
             echo "  Visit: https://ollama.com/download"

--- a/py/tools/conform/src/conform/types.py
+++ b/py/tools/conform/src/conform/types.py
@@ -106,6 +106,15 @@ class Runtime(Protocol):
 
 
 @dataclass
+class FailedTest:
+    """A single failed test case — used for the end-of-run error summary."""
+
+    test_name: str
+    model: str
+    error: str
+
+
+@dataclass
 class PluginResult:
     """Result of running conformance tests for a single plugin.
 
@@ -128,3 +137,4 @@ class PluginResult:
     tests_custom: int = 0
     tests_passed: int = 0
     tests_failed: int = 0
+    failed_tests: list[FailedTest] = field(default_factory=list)


### PR DESCRIPTION
## Summary

Credentials (API keys, endpoint URLs, API versions) copied from web UIs
like Azure Portal often contain invisible Unicode characters such as
zero-width spaces (U+200B). These propagate through the OpenAI SDK's
request chain and cause `UnicodeEncodeError: 'ascii' codec can't encode
character '\u200b'` failures deep inside the HTTP transport layer,
particularly on Linux systems with ASCII-defaulting locales.

This PR also fixes two usability issues reported by users setting up
Genkit samples on fresh Linux VMs (GCE Debian): the `genkit` CLI not
being found, and `uv` not being on PATH after running `setup.sh`.

Fixes: https://github.com/firebase/genkit/issues/4688
Fixes: https://github.com/firebase/genkit/issues/4684

## Changes

### Credential sanitization (`microsoft-foundry` plugin)

- Add `_sanitize_credential()` with precompiled regex for 10 categories
  of invisible Unicode characters (zero-width spaces, BOMs, non-breaking
  spaces, directional marks, word joiners, line/paragraph separators)
- Apply sanitization to `api_key`, `endpoint`, and `api_version` in
  `MicrosoftFoundry.__init__`
- Add `TestSanitizeCredential` test class with 9 tests covering None
  passthrough, individual character types, combined stripping, and an
  integration test verifying env var sanitization during init

### Sample scripts (`_common.sh`, `setup.sh`)

- **Auto-discover tool paths**: Add `_ensure_tool_paths()` that sources
  `~/.environment` and adds common install directories (`~/.local/bin`,
  `~/.local/share/pnpm`, `~/.cargo/bin`, npm global prefix) to PATH.
  This fixes `uv: command not found` when tools were installed by
  `setup.sh` but the user has not sourced `~/.environment` yet.
- **Pre-flight check for genkit CLI**: `genkit_start_with_browser()` now
  detects a missing `genkit` command and interactively offers to install
  pnpm + genkit-cli, instead of the cryptic `stdbuf: failed to run
  command 'genkit': No such file or directory` error.
- **Prefer package manager for Ollama on Linux**: `_install_ollama()` in
  both `setup.sh` and `_common.sh` now tries `apt`/`dnf` before falling
  back to the curl installer, matching the pattern used by other tools.
