### PR TITLE
fix(ci): fix invalid YAML and expression errors in releasekit-uv workflow

### DIFF
--- a/.github/workflows/releasekit-uv.yml
+++ b/.github/workflows/releasekit-uv.yml
@@ -488,7 +488,10 @@ jobs:
   verify:
     name: Verify Published Packages
     needs: publish
-    if: success() && env.DRY_RUN != 'true'
+    if: >-
+      success() &&
+      (github.event_name == 'pull_request' ||
+       inputs.dry_run == false)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -537,7 +540,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [publish, verify]
+    needs: [release, publish, verify]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/bin/lint
+++ b/bin/lint
@@ -72,11 +72,90 @@ run_check "📜 Dep License Check"   uv run --directory "${PY_DIR}" liccheck -s 
 run_check "🔍 Consistency Checks"  "${PY_DIR}/bin/check_consistency"
 run_check "📦 Releasekit Checks"   uv run --directory "${TOP_DIR}/py/tools/releasekit" releasekit check
 
+# Actionlint (GitHub Actions workflow validation)
+_run_actionlint() {
+  if ! command -v actionlint &> /dev/null; then
+    echo "⚠️  actionlint not found."
+    # Auto-install prompt (only if stdin is a terminal)
+    if [ -t 0 ]; then
+      read -r -p "    Install actionlint via 'go install'? [Y/n] " answer
+      case "${answer:-Y}" in
+        [Yy]*)
+          if command -v go &> /dev/null; then
+            go install github.com/rhysd/actionlint/cmd/actionlint@latest
+          elif command -v brew &> /dev/null; then
+            brew install actionlint
+          else
+            echo "    ❌ Neither 'go' nor 'brew' found. Install manually:"
+            echo "       https://github.com/rhysd/actionlint#quick-start"
+            return 0
+          fi
+          echo "✅ actionlint installed. Please re-run the linter."
+          return 0
+          ;;
+        *)
+          echo "    Skipping actionlint (install: go install github.com/rhysd/actionlint/cmd/actionlint@latest)"
+          return 0
+          ;;
+      esac
+    else
+      echo "    Skipping (install: go install github.com/rhysd/actionlint/cmd/actionlint@latest)"
+      return 0
+    fi
+  fi
+  local workflow_files=()
+  local workflow_dirs=(
+    "${TOP_DIR}/.github/workflows"
+    "${TOP_DIR}/py/tools/releasekit/github/workflows"
+  )
+  for dir in "${workflow_dirs[@]}"; do
+    while IFS= read -r -d '' f; do
+      workflow_files+=("$f")
+    done < <(find "${dir}" \( -name '*.yml' -o -name '*.yaml' \) -type f -print0 2>/dev/null)
+  done
+
+  if [ ${#workflow_files[@]} -eq 0 ]; then
+    echo "ℹ️  No workflow files found — skipping"
+    return 0
+  fi
+
+  # -ignore 'shellcheck' suppresses all embedded shellcheck warnings since
+  # we already run shellcheck separately. Actionlint's shellcheck integration
+  # also produces false positives for ${{ }} expression expansions.
+  if actionlint -ignore 'shellcheck' "${workflow_files[@]}" 2>&1; then
+    echo "✅ All ${#workflow_files[@]} workflow files pass actionlint"
+  else
+    return 1
+  fi
+}
+run_check "🔧 Actionlint"  _run_actionlint
+
 # Shellcheck (inline — slightly more complex, but still read-only)
 _run_shellcheck() {
   if ! command -v shellcheck &> /dev/null; then
-    echo "⚠️  shellcheck not installed (brew install shellcheck) - skipping"
-    return 0
+    echo "⚠️  shellcheck not found."
+    if [ -t 0 ]; then
+      read -r -p "    Install shellcheck via 'brew install'? [Y/n] " answer
+      case "${answer:-Y}" in
+        [Yy]*)
+          if command -v brew &> /dev/null; then
+            brew install shellcheck
+          else
+            echo "    ❌ 'brew' not found. Install manually: https://github.com/koalaman/shellcheck#installing"
+            return 0
+          fi
+          echo "✅ shellcheck installed. Please re-run the linter."
+          return 0
+          ;;
+        *)
+          echo "    Skipping shellcheck (install: brew install shellcheck)"
+          return 0
+          ;;
+      esac
+    else
+      echo "    Skipping (install: brew install shellcheck)"
+      return 0
+    fi
   fi
   local shell_errors=0
   local shell_scripts=()

--- a/py/tools/releasekit/github/workflows/releasekit-cargo.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-cargo.yml
@@ -299,7 +299,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: publish
+    needs: [release, publish]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/py/tools/releasekit/github/workflows/releasekit-dart.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-dart.yml
@@ -305,7 +305,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: publish
+    needs: [release, publish]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/py/tools/releasekit/github/workflows/releasekit-go.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-go.yml
@@ -288,7 +288,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: publish
+    needs: [release, publish]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/py/tools/releasekit/github/workflows/releasekit-gradle.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-gradle.yml
@@ -329,7 +329,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: publish
+    needs: [release, publish]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/py/tools/releasekit/github/workflows/releasekit-pnpm.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-pnpm.yml
@@ -357,7 +357,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify-js:
     name: "Notify Downstream (JS)"
-    needs: publish-js
+    needs: [release-js, publish-js]
     if: success() && needs.publish-js.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/py/tools/releasekit/github/workflows/releasekit-uv.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-uv.yml
@@ -311,7 +311,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: publish
+    needs: [release, publish]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
fix(ci): fix invalid YAML and expression errors in releasekit-uv workflow

The releasekit-uv.yml workflow had three bugs that caused CI failures:

- Duplicate `env:` keys on the prepare and publish steps. YAML does not
  allow duplicate keys at the same mapping level; GitHub Actions rejected
  the file at parse time. Fixed by merging each pair into a single block.
- `env.DRY_RUN` used in a job-level `if:` condition. The `env` context is
  only available in step-level expressions; job-level `if:` can only use
  `github`, `inputs`, `needs`, etc. Fixed by inlining the expression.
- `needs.release` referenced in the notify job but `release` was missing
  from its `needs:` list. Fixed by adding it.

Also adds actionlint to bin/lint so workflow files are validated during
local linting. Both actionlint and shellcheck now prompt for auto-install
when missing (interactive terminals only; CI silently skips).

Changes:
- .github/workflows/releasekit-uv.yml: merge duplicate env blocks, inline
  DRY_RUN expression in verify job, add release to notify needs
- bin/lint: add actionlint check with auto-install prompt, update
  shellcheck to use the same auto-install pattern