### PR TITLE
fix(conform,anthropic): native executors, tool schema handling, and CLI consolidation

### DIFF
--- a/js/plugins/anthropic/src/runner/base.ts
+++ b/js/plugins/anthropic/src/runner/base.ts
@@ -400,12 +400,20 @@ export abstract class BaseRunner<ApiTypes extends RunnerTypes> {
 
   /**
    * Converts a Genkit ToolDefinition to an Anthropic Tool object.
+   *
+   * Anthropic requires `input_schema.type` to be present (usually `"object"`).
+   * Genkit's `ToolDefinition` may have an empty schema (e.g. from `z.void()`)
+   * which lacks the `type` field. We default to `{ type: "object" }` to
+   * prevent 400 errors from the Anthropic API.
    */
   protected toAnthropicTool(tool: ToolDefinition): RunnerTool<ApiTypes> {
+    const schema = tool.inputSchema || {};
+    const inputSchema =
+      'type' in schema ? schema : { ...schema, type: 'object' as const };
     return {
       name: tool.name,
       description: tool.description,
-      input_schema: tool.inputSchema,
+      input_schema: inputSchema,
     } as RunnerTool<ApiTypes>;
   }
 

--- a/py/plugins/xai/src/genkit/plugins/xai/converters.py
+++ b/py/plugins/xai/src/genkit/plugins/xai/converters.py
@@ -46,10 +46,16 @@ __all__ = [
 DEFAULT_MAX_OUTPUT_TOKENS = 4096
 
 FINISH_REASON_MAP: dict[str, FinishReason] = {
+    # OpenAI-style finish reasons (used by some SDK versions).
     'STOP': FinishReason.STOP,
     'LENGTH': FinishReason.LENGTH,
     'TOOL_CALLS': FinishReason.STOP,
     'CONTENT_FILTER': FinishReason.OTHER,
+    # xAI protobuf enum names (REASON_-prefixed).
+    'REASON_STOP': FinishReason.STOP,
+    'REASON_LENGTH': FinishReason.LENGTH,
+    'REASON_TOOL_CALLS': FinishReason.STOP,
+    'REASON_CONTENT_FILTER': FinishReason.OTHER,
 }
 
 

--- a/py/plugins/xai/tests/xai_converters_test.py
+++ b/py/plugins/xai/tests/xai_converters_test.py
@@ -54,6 +54,22 @@ class TestMapFinishReasonXai:
         """Test Content filter."""
         assert map_finish_reason('CONTENT_FILTER') == FinishReason.OTHER
 
+    def test_reason_stop(self) -> None:
+        """Test xAI protobuf REASON_STOP maps to STOP."""
+        assert map_finish_reason('REASON_STOP') == FinishReason.STOP
+
+    def test_reason_length(self) -> None:
+        """Test xAI protobuf REASON_LENGTH maps to LENGTH."""
+        assert map_finish_reason('REASON_LENGTH') == FinishReason.LENGTH
+
+    def test_reason_tool_calls(self) -> None:
+        """Test xAI protobuf REASON_TOOL_CALLS maps to STOP."""
+        assert map_finish_reason('REASON_TOOL_CALLS') == FinishReason.STOP
+
+    def test_reason_content_filter(self) -> None:
+        """Test xAI protobuf REASON_CONTENT_FILTER maps to OTHER."""
+        assert map_finish_reason('REASON_CONTENT_FILTER') == FinishReason.OTHER
+
     def test_none_defaults_to_unknown(self) -> None:
         """Test None defaults to unknown."""
         assert map_finish_reason(None) == FinishReason.UNKNOWN
@@ -63,8 +79,17 @@ class TestMapFinishReasonXai:
         assert map_finish_reason('NEW_REASON') == FinishReason.UNKNOWN
 
     def test_finish_reason_map_keys(self) -> None:
-        """Test Finish reason map keys."""
-        expected = {'STOP', 'LENGTH', 'TOOL_CALLS', 'CONTENT_FILTER'}
+        """Test Finish reason map includes both OpenAI-style and protobuf keys."""
+        expected = {
+            'STOP',
+            'LENGTH',
+            'TOOL_CALLS',
+            'CONTENT_FILTER',
+            'REASON_STOP',
+            'REASON_LENGTH',
+            'REASON_TOOL_CALLS',
+            'REASON_CONTENT_FILTER',
+        }
         assert FINISH_REASON_MAP.keys() == expected, f'keys = {set(FINISH_REASON_MAP.keys())}'
 
 

--- a/py/tests/conform/conform.toml
+++ b/py/tests/conform/conform.toml
@@ -31,6 +31,10 @@ max-retries      = 2
 retry-base-delay = 1.0
 test-concurrency = 3
 
+# Runner type: auto (default), native, reflection, or in-process.
+# auto: uses the per-runtime default-runner (see below).
+runner = "auto"
+
 # Timeouts (seconds).  These are global defaults; override per-plugin
 # or per-model in the sections below.
 action-timeout  = 120.0 # Per LLM action call (model generate request)
@@ -93,15 +97,18 @@ cwd           = "../../.."
 entry-command = ["uv", "run", "--project", "py", "--active"]
 plugins-dir   = "../../plugins"
 specs-dir     = "."
+default-runner = "in-process"  # Python runs in-process by default
 
 [conform.runtimes.js]
 cwd           = "../../../js"
 entry-command = ["npx", "tsx"]
 plugins-dir   = "../../../js/plugins"
 specs-dir     = "."
+default-runner = "native"  # JS uses native JSONL-over-stdio executor
 
 [conform.runtimes.go]
 cwd           = "../../../go"
 entry-command = ["go", "run"]
 plugins-dir   = "../../../go/plugins"
 specs-dir     = "."
+default-runner = "native"  # Go uses native JSONL-over-stdio executor

--- a/py/tests/conform/google-genai/model-conformance.yaml
+++ b/py/tests/conform/google-genai/model-conformance.yaml
@@ -1,1 +1,113 @@
-../../../../js/plugins/google-genai/tests/model-tests-tts.yaml
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- model: googleai/imagen-4.0-generate-001
+  supports:
+    - output-image
+- model: googleai/gemini-2.5-flash-preview-tts
+  tests:
+    - name: TTS Test
+      input:
+        messages:
+          - role: user
+            content:
+              - text: 'Hello world'
+        config:
+          responseModalities: ['AUDIO']
+      validators:
+        - valid-media:audio
+- model: googleai/gemini-2.5-pro
+  supports:
+    - tool-request
+    - structured-output
+    - multiturn
+    - system-role
+    - input-image-base64
+    - input-image-url
+    - input-video-youtube
+- model: googleai/gemini-3-pro-preview
+  supports:
+    - tool-request
+    - structured-output
+    - multiturn
+    - system-role
+    - input-image-base64
+    - input-image-url
+    - input-video-youtube
+  tests:
+    - name: Reasoning conformance
+      input:
+        messages:
+          - role: user
+            content:
+              - text: A banana farmer harvest 10 bananas but he eats 3 and sells 4. How many bananas are remaining?
+        config:
+          thinkingConfig:
+            thinkingBudget: 1024
+            includeThoughts: true
+      validators:
+        - reasoning
+
+    - name: Streaming conformance
+      stream: true
+      input:
+        messages:
+          - role: user
+            content: [{ text: 'Count to 10' }]
+      validators:
+        - text-not-empty
+
+    - name: Tool Response Conformance
+      input:
+        messages:
+          - role: user
+            content:
+              - text: 'What is the weather in New York? Use the tool.'
+          - role: model
+            content:
+              - toolRequest:
+                  name: weather
+                  input:
+                    city: New York
+                metadata:
+                  thoughtSignature: CvABAXLI2nxTZfKU3MkzLiGBrX62oq77vN2kHjT8pwwXRjtzbCqC07pPhIZ31sS+2kUFDh/kUY4SOvZzjjtP8UxI5GSFRWlX8yVDrDFo17RN/urwc1QuaMMzy66eQubpPRDEwfi6S5IKxZq0kRX6cSceB4NVCQAAAU8sYJwqWFL9CIaGac4lzF+34VvMWFLqdb40oe7/gw/KK1fqAeqDs+FJLksA+Q5qpHn3BETcqT0AuFe01IB2EVA7Us+/N3VGonw61F5cFNjHXO1jIYDybl3MXR9M5T5QB1a3EyicYXSX5/+bCmny1ka4kInbtzEqMMuv
+          - role: tool
+            content:
+              - toolResponse:
+                  name: weather
+                  output: '21C'
+        tools:
+          - name: weather
+            description: Get the weather for a city
+            inputSchema:
+              type: object
+              properties:
+                city:
+                  type: string
+              required:
+                - city
+      validators:
+        - text-includes:21
+
+- model: googleai/gemini-2.5-flash
+  supports:
+    - tool-request
+    - structured-output
+    - multiturn
+    - system-role
+    - input-image-base64
+    - input-image-url
+    - input-video-youtube

--- a/py/tools/conform/docs/architecture.md
+++ b/py/tools/conform/docs/architecture.md
@@ -19,8 +19,8 @@ log_redact.py     ← Structlog processor to truncate data URIs in logs
    ↑
 ┌──────────────┬──────────────────┬──────────────────────┐
 │ checker.py   │ runner.py        │ util_test_model.py   │
-│ (check-plugin)│ (--use-cli)     │ (check-model default)│
-│              │ legacy CLI runner│ ActionRunner Protocol │
+│ (check-plugin)│ (--runner cli)  │ (check-model default)│
+│              │ genkit CLI runner│ ActionRunner Protocol │
 └──────────────┴──────────────────┴──────────────────────┘
    ↑                                      ↑
    │              ┌────────────┬──────────┘
@@ -67,8 +67,9 @@ Three implementations:
 | Runner | When | How |
 |--------|------|-----|
 | `InProcessRunner` | Python runtime (default) | Imports entry point, calls `action.arun_raw()` via Genkit SDK |
+| `NativeExecRunner` | `--runner native` | JSONL-over-stdio subprocess (Python/JS/Go) |
 | `ReflectionRunner` | JS/Go/other runtimes | Subprocess + async HTTP to reflection server |
-| genkit CLI (legacy) | `--use-cli` flag | Delegates to `genkit dev:test-model` via `runner.py` |
+| genkit CLI | `--runner cli` | Delegates to `genkit dev:test-model` via `runner.py` |
 
 ### Runtime Protocol
 

--- a/py/tools/conform/docs/configuration.md
+++ b/py/tools/conform/docs/configuration.md
@@ -187,6 +187,7 @@ CLI flags override TOML values.  All flags below are per-subcommand
 |------|----------|-------------|
 | `--config FILE` | — | Path to `conform.toml` (auto-discovered if omitted) |
 | `--runtime NAME` | — | Filter to a single runtime |
+| `--runner TYPE` | — | Runner type: `auto`, `native`, `reflection`, `in-process`, or `cli` |
 | `--specs-dir DIR` | `runtimes.<name>.specs-dir` | Override specs directory |
 | `--plugins-dir DIR` | `runtimes.<name>.plugins-dir` | Override plugins directory |
 | `-j N` | `concurrency` | Max concurrent plugins |

--- a/py/tools/conform/docs/index.md
+++ b/py/tools/conform/docs/index.md
@@ -13,7 +13,7 @@ It uses a **native runner** by default:
 - **Python runtime** — imports the entry point in-process (no subprocess,
   no HTTP).  **No genkit CLI dependency.**
 - **JS/Go runtimes** — communicates with reflection servers via async HTTP.
-- **Legacy fallback** — `--use-cli` flag delegates to `genkit dev:test-model`.
+- **CLI fallback** — `--runner cli` delegates to `genkit dev:test-model`.
 
 ## Quick start
 
@@ -21,7 +21,7 @@ It uses a **native runner** by default:
 # From anywhere in the repo
 py/bin/conform check-model                 # Run all plugins (all runtimes)
 py/bin/conform check-model anthropic xai   # Run specific plugins
-py/bin/conform check-model --use-cli       # Legacy genkit CLI runner
+py/bin/conform check-model --runner cli     # Genkit CLI runner
 py/bin/conform --runtime python check-model  # Single runtime only
 py/bin/conform check-plugin                # Verify plugin files exist
 py/bin/conform list                        # Show runtimes and env-var readiness

--- a/py/tools/conform/docs/usage.md
+++ b/py/tools/conform/docs/usage.md
@@ -47,10 +47,10 @@ Plain-text log lines (no live table), full output on failure:
 conform check-model -v
 ```
 
-### Fallback to legacy genkit CLI
+### Fallback to genkit CLI
 
 ```bash
-conform check-model --use-cli
+conform check-model --runner cli
 ```
 
 This delegates to `genkit dev:test-model` via subprocess.

--- a/py/tools/conform/src/conform/executors/__init__.py
+++ b/py/tools/conform/src/conform/executors/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native conformance executors for all runtimes.
+
+This package contains the executor implementations:
+
+- ``conformance_native.py``  — Python (JSONL-over-stdio subprocess)
+- ``conformance_native.go``  — Go (JSONL-over-stdio subprocess)
+- ``conformance_native.ts``  — TypeScript (JSONL-over-stdio subprocess)
+- ``in_process_runner.py``   — Python (in-process via ``ai.generate()``)
+"""

--- a/py/tools/conform/src/conform/executors/conformance_native.go
+++ b/py/tools/conform/src/conform/executors/conformance_native.go
@@ -1,0 +1,391 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Native conformance executor for Go plugins.
+//
+// Protocol: JSONL-over-stdio.
+//
+//  1. Receives --plugin <name> as a CLI argument.
+//  2. Initializes the matching plugin via a registry map.
+//  3. Prints {"ready": true}\n to stdout.
+//  4. Reads one JSON line from stdin per request.
+//  5. Calls genkit.Generate() natively.
+//  6. Writes one JSON line to stdout with the response.
+//  7. Repeats until stdin closes.
+//
+// Driven by the Python `conform` tool:
+//
+//	conform check-model --runtime go --runner native
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	anthropicSDK "github.com/anthropics/anthropic-sdk-go"
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/anthropic"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/plugins/ollama"
+)
+
+// pluginInitFunc returns the genkit.GenkitOption to initialize a specific plugin.
+type pluginInitFunc func() genkit.GenkitOption
+
+// pluginRegistry maps conform plugin names to their init functions.
+var pluginRegistry = map[string]pluginInitFunc{
+	"google-genai": func() genkit.GenkitOption { return genkit.WithPlugins(&googlegenai.GoogleAI{}) },
+	"vertex-ai":    func() genkit.GenkitOption { return genkit.WithPlugins(&googlegenai.VertexAI{}) },
+	"anthropic":    func() genkit.GenkitOption { return genkit.WithPlugins(&anthropic.Anthropic{}) },
+	"ollama": func() genkit.GenkitOption {
+		return genkit.WithPlugins(&ollama.Ollama{
+			ServerAddress: "http://localhost:11434",
+		})
+	},
+}
+
+// nativeRequest is the JSON structure received from conform on stdin.
+type nativeRequest struct {
+	Model  string         `json:"model"`
+	Input  map[string]any `json:"input"`
+	Stream bool           `json:"stream"`
+}
+
+// nativeResponse is the JSON structure sent back to conform on stdout.
+type nativeResponse struct {
+	Response map[string]any   `json:"response"`
+	Chunks   []map[string]any `json:"chunks"`
+	Error    string           `json:"error,omitempty"`
+}
+
+// buildMessages converts raw YAML/JSON messages into Genkit messages.
+func buildMessages(raw []any) []*ai.Message {
+	var msgs []*ai.Message
+	for _, m := range raw {
+		mmap, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		role, _ := mmap["role"].(string)
+		contentRaw, _ := mmap["content"].([]any)
+
+		var parts []*ai.Part
+		for _, c := range contentRaw {
+			cmap, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			if text, ok := cmap["text"].(string); ok {
+				parts = append(parts, ai.NewTextPart(text))
+			}
+			if media, ok := cmap["media"].(map[string]any); ok {
+				url, _ := media["url"].(string)
+				ct, _ := media["contentType"].(string)
+				parts = append(parts, ai.NewMediaPart(ct, url))
+			}
+		}
+
+		msg := &ai.Message{
+			Role:    ai.Role(role),
+			Content: parts,
+		}
+		msgs = append(msgs, msg)
+	}
+	return msgs
+}
+
+// toolCache tracks already-defined tools to avoid re-registration panics.
+// The registry doesn't allow defining the same action name twice.
+var toolCache = map[string]ai.ToolRef{}
+
+// buildTools creates placeholder tools from raw tool definitions.
+// Tools are defined once and cached; subsequent requests with the same
+// tool name reuse the existing registration.
+func buildTools(g *genkit.Genkit, raw []any) []ai.ToolRef {
+	var tools []ai.ToolRef
+	for _, t := range raw {
+		tmap, ok := t.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := tmap["name"].(string)
+		if name == "" {
+			continue
+		}
+
+		if cached, exists := toolCache[name]; exists {
+			tools = append(tools, cached)
+			continue
+		}
+
+		description, _ := tmap["description"].(string)
+
+		type ToolInput struct {
+			City string `json:"city,omitempty"`
+		}
+
+		tool := genkit.DefineTool(
+			g,
+			name,
+			description,
+			func(ctx *ai.ToolContext, input *ToolInput) (string, error) {
+				return "21C", nil
+			},
+		)
+		toolCache[name] = tool
+		tools = append(tools, tool)
+	}
+	return tools
+}
+
+// serializeResponse converts a ModelResponse to a JSON-friendly map.
+func serializeResponse(resp *ai.ModelResponse) map[string]any {
+	if resp == nil {
+		return map[string]any{}
+	}
+
+	result := map[string]any{}
+
+	if resp.Message != nil {
+		msgMap := map[string]any{
+			"role": string(resp.Message.Role),
+		}
+		var contentList []map[string]any
+		for _, p := range resp.Message.Content {
+			part := map[string]any{}
+			if p.IsText() {
+				part["text"] = p.Text
+			}
+			if p.IsToolRequest() && p.ToolRequest != nil {
+				part["toolRequest"] = map[string]any{
+					"name":  p.ToolRequest.Name,
+					"input": p.ToolRequest.Input,
+					"ref":   p.ToolRequest.Ref,
+				}
+			}
+			if p.IsMedia() {
+				part["media"] = map[string]any{
+					"url":         p.Text,
+					"contentType": p.ContentType,
+				}
+			}
+			contentList = append(contentList, part)
+		}
+		msgMap["content"] = contentList
+		result["message"] = msgMap
+	}
+
+	if resp.FinishReason != "" {
+		result["finishReason"] = string(resp.FinishReason)
+	}
+
+	if resp.Usage != nil {
+		result["usage"] = map[string]any{
+			"inputTokens":  resp.Usage.InputTokens,
+			"outputTokens": resp.Usage.OutputTokens,
+			"totalTokens":  resp.Usage.TotalTokens,
+		}
+	}
+
+	return result
+}
+
+// serializeChunk converts a ModelResponseChunk to a JSON-friendly map.
+func serializeChunk(c *ai.ModelResponseChunk) map[string]any {
+	if c == nil {
+		return map[string]any{}
+	}
+	result := map[string]any{}
+	var contentList []map[string]any
+	for _, p := range c.Content {
+		part := map[string]any{}
+		if p.IsText() {
+			part["text"] = p.Text
+		}
+		if p.IsToolRequest() && p.ToolRequest != nil {
+			part["toolRequest"] = map[string]any{
+				"name":  p.ToolRequest.Name,
+				"input": p.ToolRequest.Input,
+				"ref":   p.ToolRequest.Ref,
+			}
+		}
+		contentList = append(contentList, part)
+	}
+	result["content"] = contentList
+	return result
+}
+
+// handleRequest processes a single native request and returns the response.
+func handleRequest(ctx context.Context, g *genkit.Genkit, req *nativeRequest) *nativeResponse {
+	// Build generate options.
+	opts := []ai.GenerateOption{
+		ai.WithModelName(req.Model),
+		ai.WithReturnToolRequests(true),
+	}
+
+	// Config — plugin-specific handling.
+	// Each plugin validates config against its own schema, so we can't use
+	// a generic GenerationCommonConfig for all plugins.
+	if strings.HasPrefix(req.Model, "anthropic/") {
+		// Anthropic requires MaxTokens.  Use the SDK's native type.
+		cfg := &anthropicSDK.MessageNewParams{MaxTokens: 4096}
+		if cfgRaw, ok := req.Input["config"].(map[string]any); ok {
+			if v, ok := cfgRaw["maxOutputTokens"].(float64); ok {
+				cfg.MaxTokens = int64(v)
+			}
+		}
+		opts = append(opts, ai.WithConfig(cfg))
+	} else if cfgRaw, ok := req.Input["config"].(map[string]any); ok {
+		// For other plugins, pass the raw map.  The framework will
+		// validate it against the model's registered schema.
+		opts = append(opts, ai.WithConfig(cfgRaw))
+	}
+
+	// Messages.
+	if msgs, ok := req.Input["messages"].([]any); ok {
+		builtMsgs := buildMessages(msgs)
+		if len(builtMsgs) > 0 {
+			opts = append(opts, ai.WithMessages(builtMsgs...))
+		}
+	}
+
+	// Tools.
+	if toolsRaw, ok := req.Input["tools"].([]any); ok {
+		tools := buildTools(g, toolsRaw)
+		if len(tools) > 0 {
+			opts = append(opts, ai.WithTools(tools...))
+		}
+	}
+
+	// Output format.
+	if output, ok := req.Input["output"].(map[string]any); ok {
+		if format, ok := output["format"].(string); ok && format == "json" {
+			opts = append(opts, ai.WithOutputFormat(ai.OutputFormatJSON))
+		}
+	}
+
+	// Streaming.
+	var chunks []*ai.ModelResponseChunk
+	if req.Stream {
+		opts = append(opts, ai.WithStreaming(func(ctx context.Context, c *ai.ModelResponseChunk) error {
+			chunks = append(chunks, c)
+			return nil
+		}))
+	}
+
+	// Execute.
+	resp, err := genkit.Generate(ctx, g, opts...)
+	if err != nil {
+		return &nativeResponse{
+			Error: err.Error(),
+		}
+	}
+
+	if resp == nil {
+		return &nativeResponse{
+			Error: "generate returned nil response",
+		}
+	}
+
+	// Serialize chunks.
+	var chunkMaps []map[string]any
+	for _, c := range chunks {
+		chunkMaps = append(chunkMaps, serializeChunk(c))
+	}
+
+	return &nativeResponse{
+		Response: serializeResponse(resp),
+		Chunks:   chunkMaps,
+	}
+}
+
+func main() {
+	pluginName := flag.String("plugin", "", "Plugin name (e.g. google-genai, anthropic)")
+	flag.Parse()
+
+	if *pluginName == "" {
+		fmt.Fprintf(os.Stderr, "error: --plugin is required\n")
+		fmt.Fprintf(os.Stderr, "available plugins: %s\n", strings.Join(availablePlugins(), ", "))
+		os.Exit(1)
+	}
+
+	initFn, ok := pluginRegistry[*pluginName]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "error: unknown plugin %q\n", *pluginName)
+		fmt.Fprintf(os.Stderr, "available plugins: %s\n", strings.Join(availablePlugins(), ", "))
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	// Initialize the plugin.
+	g := genkit.Init(ctx, initFn())
+
+	// Signal readiness.
+	readyLine, _ := json.Marshal(map[string]any{"ready": true})
+	fmt.Fprintf(os.Stdout, "%s\n", readyLine)
+	os.Stdout.Sync()
+
+	// Read requests from stdin, one JSON line per request.
+	scanner := bufio.NewScanner(os.Stdin)
+	// Increase scanner buffer for large requests (e.g. base64 images).
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var req nativeRequest
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			resp := nativeResponse{Error: fmt.Sprintf("invalid request JSON: %v", err)}
+			out, _ := json.Marshal(resp)
+			fmt.Fprintf(os.Stdout, "%s\n", out)
+			os.Stdout.Sync()
+			continue
+		}
+
+		result := handleRequest(ctx, g, &req)
+		out, err := json.Marshal(result)
+		if err != nil {
+			errResp := nativeResponse{Error: fmt.Sprintf("failed to marshal response: %v", err)}
+			out, _ = json.Marshal(errResp)
+		}
+		fmt.Fprintf(os.Stdout, "%s\n", out)
+		os.Stdout.Sync()
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "stdin read error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// availablePlugins returns sorted list of registered plugin names.
+func availablePlugins() []string {
+	var names []string
+	for k := range pluginRegistry {
+		names = append(names, k)
+	}
+	return names
+}

--- a/py/tools/conform/src/conform/executors/conformance_native.py
+++ b/py/tools/conform/src/conform/executors/conformance_native.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+r"""Python native conformance executor (JSONL-over-stdio).
+
+Protocol: JSONL-over-stdio (same as Go and JS executors).
+
+1. Receives ``--plugin <name>`` as a CLI argument.
+2. Initializes the matching plugin via a registry map.
+3. Prints ``{"ready": true}\\n`` to stdout.
+4. Reads one JSON line from stdin per request.
+5. Calls ``ai.generate()`` natively.
+6. Writes one JSON line to stdout with the response.
+7. Repeats until stdin closes.
+
+Driven by the Python ``conform`` tool::
+
+    conform check-model --runtime python --runner native
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+import traceback
+from typing import Any, cast
+
+import structlog
+
+from genkit.ai import Genkit
+from genkit.codec import dump_dict
+
+# ---------------------------------------------------------------------------
+# Plugin registry — maps conform plugin names to Genkit init functions.
+# Each function returns a configured ``Genkit`` instance.
+# ---------------------------------------------------------------------------
+
+
+def _init_google_genai() -> Genkit:
+    """Initialize the Google GenAI plugin."""
+    from genkit.plugins.google_genai import GoogleAI
+
+    return Genkit(plugins=[GoogleAI()])
+
+
+def _init_vertex_ai() -> Genkit:
+    """Initialize the Vertex AI plugin."""
+    from genkit.plugins.vertex_ai import ModelGardenPlugin
+
+    return Genkit(plugins=[ModelGardenPlugin()])
+
+
+def _init_anthropic() -> Genkit:
+    """Initialize the Anthropic plugin."""
+    from genkit.plugins.anthropic import Anthropic
+
+    return Genkit(plugins=[Anthropic()])
+
+
+def _init_ollama() -> Genkit:
+    """Initialize the Ollama plugin."""
+    from genkit.plugins.ollama import Ollama
+    from genkit.plugins.ollama.models import ModelDefinition
+
+    return Genkit(
+        plugins=[
+            Ollama(
+                models=[
+                    ModelDefinition(name='llama3.2'),
+                    ModelDefinition(name='llama3.2:1b'),
+                ],
+            ),
+        ],
+    )
+
+
+def _init_amazon_bedrock() -> Genkit:
+    """Initialize the Amazon Bedrock plugin."""
+    from genkit.plugins.amazon_bedrock import AmazonBedrock
+
+    return Genkit(plugins=[AmazonBedrock()])
+
+
+def _init_compat_oai() -> Genkit:
+    """Initialize the OpenAI compat plugin."""
+    from genkit.plugins.compat_oai import OpenAI
+
+    return Genkit(plugins=[OpenAI()])
+
+
+def _init_deepseek() -> Genkit:
+    """Initialize the DeepSeek plugin."""
+    from genkit.plugins.deepseek import DeepSeek
+
+    return Genkit(plugins=[DeepSeek()])
+
+
+def _init_mistral() -> Genkit:
+    """Initialize the Mistral plugin."""
+    from genkit.plugins.mistral import Mistral
+
+    return Genkit(plugins=[Mistral()])
+
+
+def _init_xai() -> Genkit:
+    """Initialize the xAI plugin."""
+    from genkit.plugins.xai import XAI
+
+    return Genkit(plugins=[XAI()])
+
+
+def _init_cohere() -> Genkit:
+    """Initialize the Cohere plugin."""
+    from genkit.plugins.cohere import Cohere
+
+    return Genkit(plugins=[Cohere()])
+
+
+def _init_cloudflare_workers_ai() -> Genkit:
+    """Initialize the Cloudflare Workers AI plugin."""
+    from genkit.plugins.cloudflare_workers_ai import CloudflareWorkersAI
+
+    return Genkit(plugins=[CloudflareWorkersAI()])
+
+
+def _init_huggingface() -> Genkit:
+    """Initialize the Hugging Face plugin."""
+    from genkit.plugins.huggingface import HuggingFace
+
+    return Genkit(plugins=[HuggingFace()])
+
+
+def _init_microsoft_foundry() -> Genkit:
+    """Initialize the Microsoft Foundry plugin."""
+    from genkit.plugins.microsoft_foundry import MicrosoftFoundry
+
+    return Genkit(plugins=[MicrosoftFoundry()])
+
+
+PLUGIN_REGISTRY: dict[str, Any] = {
+    'google-genai': _init_google_genai,
+    'vertex-ai': _init_vertex_ai,
+    'anthropic': _init_anthropic,
+    'ollama': _init_ollama,
+    'amazon-bedrock': _init_amazon_bedrock,
+    'compat-oai': _init_compat_oai,
+    'deepseek': _init_deepseek,
+    'mistral': _init_mistral,
+    'xai': _init_xai,
+    'cohere': _init_cohere,
+    'cloudflare-workers-ai': _init_cloudflare_workers_ai,
+    'huggingface': _init_huggingface,
+    'microsoft-foundry': _init_microsoft_foundry,
+}
+
+# ---------------------------------------------------------------------------
+# Ephemeral tool registration (for tool conformance tests).
+# ---------------------------------------------------------------------------
+
+
+def _register_ephemeral_tool(
+    ai: Genkit,
+    name: str,
+    tool_def: dict[str, Any],
+) -> None:
+    """Register a no-op tool so generate() can resolve its definition."""
+    from genkit.core.action.types import ActionKind
+
+    registry = ai.registry
+    with registry._lock:  # pyright: ignore[reportPrivateUsage]
+        tool_entries = registry._entries.get(  # pyright: ignore[reportPrivateUsage]
+            cast('ActionKind', ActionKind.TOOL),
+            {},
+        )
+        if name in tool_entries:
+            return
+
+    description = tool_def.get('description', '')
+    input_schema = tool_def.get('inputSchema')
+
+    async def noop_tool(input_data: Any, ctx: Any) -> dict[str, str]:  # noqa: ANN401
+        """No-op tool stub for conformance testing."""
+        return {'result': 'noop'}
+
+    action = registry.register_action(
+        kind=cast('ActionKind', ActionKind.TOOL),
+        name=name,
+        fn=noop_tool,
+        description=description,
+        metadata={'tool': {'type': 'tool'}},
+    )
+    if input_schema:
+        action._input_schema = input_schema  # pyright: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
+# Request handling.
+# ---------------------------------------------------------------------------
+
+
+async def handle_request(
+    ai: Genkit,
+    req: dict[str, Any],
+) -> dict[str, Any]:
+    """Handle a single JSONL request."""
+    try:
+        model_name = req['model']
+        input_data = req.get('input', {})
+        stream = req.get('stream', False)
+
+        messages = input_data.get('messages', [])
+        output_config = input_data.get('output')
+        tools_defs = input_data.get('tools')
+        config = input_data.get('config')
+
+        # Convert raw message dicts to Message objects.
+        from genkit.core.typing import Message, OutputConfig, Part
+
+        msg_objects = [Message.model_validate(m) for m in messages]
+
+        # Separate system messages.
+        system_parts: list[Part] | None = None
+        non_system_messages: list[Message] = []
+        for msg in msg_objects:
+            if msg.role == 'system':
+                system_parts = msg.content
+            else:
+                non_system_messages.append(msg)
+
+        # Build output config.
+        output_obj: OutputConfig | None = None
+        if output_config:
+            output_obj = OutputConfig.model_validate(output_config)
+
+        # Register ephemeral tools.
+        tool_names: list[str] | None = None
+        if tools_defs:
+            tool_names = []
+            for tdef in tools_defs:
+                t_name = tdef['name']
+                tool_names.append(t_name)
+                _register_ephemeral_tool(ai, t_name, tdef)
+
+        chunks: list[dict[str, Any]] = []
+
+        if stream:
+            stream_iter, response_future = ai.generate_stream(
+                model=model_name,
+                system=system_parts,
+                messages=non_system_messages,
+                tools=tool_names,
+                config=config,
+                output=output_obj,
+                return_tool_requests=True,
+            )
+            async for chunk in stream_iter:
+                chunks.append(cast(dict[str, Any], dump_dict(chunk)))
+            result = await response_future
+        else:
+            result = await ai.generate(
+                model=model_name,
+                system=system_parts,
+                messages=non_system_messages,
+                tools=tool_names,
+                config=config,
+                output=output_obj,
+                return_tool_requests=True,
+            )
+
+        response = cast(dict[str, Any], dump_dict(result))
+        return {'response': response, 'chunks': chunks}
+
+    except Exception:
+        return {
+            'response': None,
+            'chunks': [],
+            'error': traceback.format_exc(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Main entry point.
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    """Run the JSONL-over-stdio loop."""
+    # CRITICAL: Redirect all logging to stderr BEFORE plugin initialization.
+    # Plugins use structlog (via genkit.core.logging) which defaults to stdout.
+    # Since this executor uses JSONL-over-stdio, ANY non-JSON line on stdout
+    # causes the conform runner to fail with "invalid JSON".
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.DEBUG,
+        format='%(message)s',
+    )
+    structlog.configure(
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+    )
+
+    parser = argparse.ArgumentParser(
+        description='Python native conformance executor',
+    )
+    parser.add_argument(
+        '--plugin',
+        required=True,
+        choices=sorted(PLUGIN_REGISTRY.keys()),
+        help='Plugin name to initialize.',
+    )
+    args = parser.parse_args()
+
+    init_fn = PLUGIN_REGISTRY[args.plugin]
+    ai = init_fn()
+
+    # Signal readiness.
+    sys.stdout.write(json.dumps({'ready': True}) + '\n')
+    sys.stdout.flush()
+
+    # Read requests from stdin, one JSON line at a time.
+    for line in sys.stdin:
+        trimmed = line.strip()
+        if not trimmed:
+            continue
+
+        try:
+            req = json.loads(trimmed)
+        except json.JSONDecodeError:
+            err_resp = {
+                'response': None,
+                'chunks': [],
+                'error': f'Invalid request JSON: {trimmed[:200]}',
+            }
+            sys.stdout.write(json.dumps(err_resp) + '\n')
+            sys.stdout.flush()
+            continue
+
+        result = await handle_request(ai, req)
+        sys.stdout.write(json.dumps(result) + '\n')
+        sys.stdout.flush()
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/py/tools/conform/src/conform/executors/conformance_native.ts
+++ b/py/tools/conform/src/conform/executors/conformance_native.ts
@@ -1,0 +1,227 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Generic native conformance executor for JS/TS plugins.
+ *
+ * Protocol: JSONL-over-stdio.
+ *
+ * 1. Receives --plugin <name> as a CLI argument.
+ * 2. Initializes the matching plugin via a registry map.
+ * 3. Prints {"ready": true}\n to stdout.
+ * 4. Reads one JSON line from stdin per request.
+ * 5. Calls ai.generate() natively.
+ * 6. Writes one JSON line to stdout with the response.
+ * 7. Repeats until stdin closes.
+ *
+ * Driven by the Python `conform` tool:
+ *
+ *   conform check-model --runtime js --runner native
+ */
+
+import { parseArgs } from 'node:util';
+import * as readline from 'readline';
+import { genkit, type Genkit } from 'genkit';
+import { googleAI, vertexAI } from '@genkit-ai/google-genai';
+import { anthropic } from '@genkit-ai/anthropic';
+import { ollama } from 'genkitx-ollama';
+import type {
+    GenerateResponseData,
+    GenerateResponseChunkData,
+    MessageData,
+    ToolDefinition,
+} from '@genkit-ai/ai';
+
+
+interface NativeRequest {
+    model: string;
+    input: {
+        messages: MessageData[];
+        tools?: ToolDefinition[];
+        output?: {
+            format?: string;
+            schema?: Record<string, unknown>;
+            constrained?: boolean;
+        };
+        config?: Record<string, unknown>;
+    };
+    stream: boolean;
+}
+
+interface NativeResponse {
+    response: Record<string, unknown> | null;
+    chunks: Record<string, unknown>[];
+    error?: string;
+}
+
+
+type PluginInitFunc = () => Genkit;
+
+const pluginRegistry: Record<string, PluginInitFunc> = {
+    'google-genai': () => genkit({ plugins: [googleAI()] }),
+    'vertex-ai': () => genkit({ plugins: [vertexAI()] }),
+    'anthropic': () => genkit({ plugins: [anthropic()] }),
+    'ollama': () => genkit({ plugins: [ollama()] }),
+};
+
+
+async function handleRequest(
+    ai: Genkit,
+    req: NativeRequest
+): Promise<NativeResponse> {
+    try {
+        const generateOptions: Record<string, unknown> = {
+            model: req.model,
+            messages: req.input.messages,
+            returnToolRequests: true,
+        };
+
+        // Tools — define placeholder tools with the schema from the test definition.
+        if (req.input.tools && req.input.tools.length > 0) {
+            const tools = req.input.tools.map((toolDef) =>
+                ai.defineTool(
+                    {
+                        name: toolDef.name,
+                        description: toolDef.description ?? '',
+                        // Pass the JSON schema from the test definition so that
+                        // provider plugins receive a valid input_schema (e.g.
+                        // Anthropic requires `type: "object"` to be present).
+                        inputJsonSchema: toolDef.inputSchema ?? {
+                            type: 'object' as const,
+                            properties: {},
+                        },
+                    },
+                    async () => '21C'
+                )
+            );
+            generateOptions.tools = tools;
+        }
+
+        // Output format — pass format and optional jsonSchema.
+        if (req.input.output?.format) {
+            const outputConfig: Record<string, unknown> = {
+                format: req.input.output.format,
+            };
+            if (req.input.output.schema) {
+                outputConfig.jsonSchema = req.input.output.schema;
+            }
+            generateOptions.output = outputConfig;
+        }
+
+        // Config.
+        if (req.input.config) {
+            generateOptions.config = req.input.config;
+        }
+
+        // Execute.
+        let responseData: GenerateResponseData;
+        const chunks: GenerateResponseChunkData[] = [];
+
+        if (req.stream) {
+            const { response: respPromise, stream } = await ai.generateStream(
+                generateOptions as Parameters<typeof ai.generateStream>[0]
+            );
+            for await (const chunk of stream) {
+                chunks.push(chunk.toJSON());
+            }
+            const resp = await respPromise;
+            responseData = resp.toJSON();
+        } else {
+            const resp = await ai.generate(
+                generateOptions as Parameters<typeof ai.generate>[0]
+            );
+            responseData = resp.toJSON();
+        }
+
+        return {
+            response: responseData as unknown as Record<string, unknown>,
+            chunks: chunks as unknown as Record<string, unknown>[],
+        };
+    } catch (err: unknown) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        return {
+            response: null,
+            chunks: [],
+            error: errMsg,
+        };
+    }
+}
+
+
+async function main(): Promise<void> {
+    const { values } = parseArgs({
+        options: {
+            plugin: { type: 'string' },
+        },
+        strict: true,
+    });
+
+    const pluginName = values.plugin;
+    if (!pluginName) {
+        process.stderr.write(
+            `error: --plugin is required\navailable plugins: ${Object.keys(pluginRegistry).join(', ')}\n`
+        );
+        process.exit(1);
+    }
+
+    const initFn = pluginRegistry[pluginName];
+    if (!initFn) {
+        process.stderr.write(
+            `error: unknown plugin "${pluginName}"\navailable plugins: ${Object.keys(pluginRegistry).join(', ')}\n`
+        );
+        process.exit(1);
+    }
+
+    // Initialize plugin.
+    const ai = initFn();
+
+    // Signal readiness.
+    process.stdout.write(JSON.stringify({ ready: true }) + '\n');
+
+    // Read requests from stdin, one JSON line at a time.
+    const rl = readline.createInterface({
+        input: process.stdin,
+        crlfDelay: Infinity,
+    });
+
+    for await (const line of rl) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+
+        let req: NativeRequest;
+        try {
+            req = JSON.parse(trimmed);
+        } catch {
+            const errResp: NativeResponse = {
+                response: null,
+                chunks: [],
+                error: `Invalid request JSON: ${trimmed.slice(0, 200)}`,
+            };
+            process.stdout.write(JSON.stringify(errResp) + '\n');
+            continue;
+        }
+
+        const result = await handleRequest(ai, req);
+        process.stdout.write(JSON.stringify(result) + '\n');
+    }
+}
+
+main().catch((err) => {
+    process.stderr.write(`Fatal error: ${err}\n`);
+    process.exit(1);
+});

--- a/py/tools/conform/src/conform/executors/in_process_runner.py
+++ b/py/tools/conform/src/conform/executors/in_process_runner.py
@@ -1,0 +1,248 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python in-process conformance executor.
+
+Runs model actions in-process via ``ai.generate()`` by importing the
+plugin's conformance entry point and calling its ``Genkit`` instance
+directly.  This exercises the full framework pipeline (format parsing,
+``extract_json``, output processing) — matching the real user experience.
+
+Protocol (in-process — no subprocess):
+
+1.  Imports the conformance entry point module.
+2.  Extracts the ``ai`` (``Genkit``) instance from module scope.
+3.  For each test, calls ``ai.generate()`` or ``ai.generate_stream()``.
+4.  Returns serialized response and streaming chunks.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import traceback
+from pathlib import Path
+from typing import Any, cast
+
+from rich.console import Console
+
+from genkit.codec import dump_dict
+
+console = Console(stderr=True)
+
+
+class InProcessRunner:
+    """Run model actions in-process via ``ai.generate()``.
+
+    The entry point (e.g. ``conformance_entry.py``) creates a ``Genkit``
+    instance at module level, registering all model actions.  We import
+    it, grab the ``ai`` instance, and call ``ai.generate()`` so the full
+    framework pipeline (format parsing, ``extract_json``, output
+    processing) is exercised — matching the real user experience.
+    """
+
+    def __init__(self, entry_path: Path) -> None:
+        """Initialize with the path to the conformance entry point."""
+        self._entry_path = entry_path
+        self._ai: Any = None  # noqa: ANN401
+
+    async def _load(self) -> None:
+        """Import the entry point module and extract the Genkit instance."""
+        if self._ai is not None:
+            return
+
+        # Import the module by file path without executing __main__ block.
+        spec = importlib.util.spec_from_file_location(
+            '_conform_entry',
+            str(self._entry_path),
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f'Cannot load entry point: {self._entry_path}')
+
+        module = importlib.util.module_from_spec(spec)
+
+        # Ensure the entry point's directory is on sys.path so relative
+        # imports work (e.g. if the entry point imports sibling modules).
+        entry_dir = str(self._entry_path.parent)
+        if entry_dir not in sys.path:
+            sys.path.insert(0, entry_dir)
+
+        spec.loader.exec_module(module)
+
+        # Find the Genkit instance — by convention it's named `ai`.
+        ai = getattr(module, 'ai', None)
+        if ai is None:
+            raise RuntimeError(
+                f'Entry point {self._entry_path} does not expose an `ai` (Genkit) instance at module level.'
+            )
+        self._ai = ai
+        console.print('[dim]Loaded entry point in-process.[/dim]')
+
+    async def run_action(
+        self,
+        key: str,
+        input_data: dict[str, Any],
+        *,
+        stream: bool = False,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Run a model action via ``ai.generate()`` in-process.
+
+        Converts the raw test input (GenerateRequest-shaped dict) into
+        ``ai.generate()`` keyword arguments so the full framework
+        pipeline is exercised, including output format handling
+        (``extract_json`` for JSON output) and streaming chunk wrapping.
+        """
+        try:
+            return await self._run_action_impl(key, input_data, stream=stream)
+        except Exception:
+            # Match the native subprocess executor's error contract:
+            # wrap exceptions in RuntimeError with the full traceback so
+            # that _run_single_test can display a clean error message
+            # instead of receiving a raw GenkitError whose __str__
+            # embeds a multi-line traceback in the message itself.
+            raise RuntimeError(f'In-process executor error: {traceback.format_exc()}') from None
+
+    async def _run_action_impl(
+        self,
+        key: str,
+        input_data: dict[str, Any],
+        *,
+        stream: bool = False,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Inner implementation of run_action (no exception wrapping)."""
+        await self._load()
+
+        # Extract model name from the action key.
+        # e.g. "/model/googleai/gemini-2.5-flash" -> "googleai/gemini-2.5-flash"
+        model_name = key.removeprefix('/model/')
+
+        # Extract fields from the GenerateRequest-shaped input.
+        messages = input_data.get('messages', [])
+        output_config = input_data.get('output')
+        tools_defs = input_data.get('tools')
+        config = input_data.get('config')
+
+        # Convert raw message dicts to Message objects.
+        from genkit.core.typing import Message, OutputConfig, Part
+
+        msg_objects = [Message.model_validate(m) for m in messages]
+
+        # Separate system messages from user/model messages.
+        # ai.generate() takes system as a separate argument.
+        system_parts: list[Part] | None = None
+        non_system_messages: list[Message] = []
+        for msg in msg_objects:
+            if msg.role == 'system':
+                system_parts = msg.content
+            else:
+                non_system_messages.append(msg)
+
+        # Build output config if present.
+        output_obj: OutputConfig | None = None
+        if output_config:
+            output_obj = OutputConfig.model_validate(output_config)
+
+        # For tool definitions: the test cases contain inline tool
+        # definitions (with inputSchema), but ai.generate() resolves
+        # tools by name from the registry.  We register ephemeral tools
+        # in the registry so generate() can resolve them.
+        tool_names: list[str] | None = None
+        if tools_defs:
+            tool_names = []
+            for tdef in tools_defs:
+                t_name = tdef['name']
+                tool_names.append(t_name)
+                # Register a no-op tool so the framework can resolve its
+                # definition.  The conformance tests only check that the
+                # model *requests* the tool — they never execute it.
+                _register_ephemeral_tool(self._ai, t_name, tdef)
+
+        chunks: list[dict[str, Any]] = []
+
+        if stream:
+            # Use generate_stream for streaming tests.
+            stream_iter, response_future = self._ai.generate_stream(
+                model=model_name,
+                system=system_parts,
+                messages=non_system_messages,
+                tools=tool_names,
+                config=config,
+                output=output_obj,
+                return_tool_requests=True,
+            )
+            # Consume the stream to collect chunks.
+            async for chunk in stream_iter:
+                chunks.append(cast(dict[str, Any], dump_dict(chunk)))
+            result = await response_future
+        else:
+            result = await self._ai.generate(
+                model=model_name,
+                system=system_parts,
+                messages=non_system_messages,
+                tools=tool_names,
+                config=config,
+                output=output_obj,
+                return_tool_requests=True,
+            )
+
+        response = cast(dict[str, Any], dump_dict(result))
+        return response, chunks
+
+    async def close(self) -> None:
+        """No resources to clean up for in-process runner."""
+
+
+def _register_ephemeral_tool(
+    ai: Any,  # noqa: ANN401
+    name: str,
+    tool_def: dict[str, Any],
+) -> None:
+    """Register a no-op tool so generate() can resolve its definition.
+
+    Conformance tests provide inline tool definitions.  ``ai.generate()``
+    resolves tools by name from the registry, so we register lightweight
+    stubs whose only purpose is to carry the correct ``input_schema``
+    and ``description`` so ``to_tool_definition()`` can build the right
+    ``ToolDefinition`` for the model.
+    """
+    from genkit.core.action.types import ActionKind
+
+    registry = ai.registry
+
+    # Only register if not already present.
+    with registry._lock:  # pyright: ignore[reportPrivateUsage]
+        tool_entries = registry._entries.get(cast(ActionKind, ActionKind.TOOL), {})  # pyright: ignore[reportPrivateUsage]
+        if name in tool_entries:
+            return
+
+    description = tool_def.get('description', '')
+    input_schema = tool_def.get('inputSchema')
+
+    async def noop_tool(input_data: Any, ctx: Any) -> dict[str, str]:  # noqa: ANN401
+        """No-op tool stub for conformance testing."""
+        return {'result': 'noop'}
+
+    action = registry.register_action(
+        kind=cast(ActionKind, ActionKind.TOOL),
+        name=name,
+        fn=noop_tool,
+        description=description,
+        metadata={'tool': {'type': 'tool'}},
+    )
+    # Override input schema from the test definition so the model
+    # receives the correct JSON Schema for this tool.
+    if input_schema:
+        action._input_schema = input_schema  # pyright: ignore[reportPrivateUsage]

--- a/py/tools/releasekit/docs/docs/ai-release-notes-plan.md
+++ b/py/tools/releasekit/docs/docs/ai-release-notes-plan.md
@@ -1,0 +1,621 @@
+# AI-Powered Release Intelligence — Implementation Plan
+
+## Problem Statement
+
+With 67+ packages in the Genkit monorepo, raw per-package changelogs
+concatenated into the Release PR body exceed GitHub's **65,536-character
+limit**. The current fix (collapsible `<details>` + progressive
+truncation) is a workaround. The real solution is AI-powered
+summarization that produces release notes comparable to hand-written
+ones like [py/v0.5.0](https://github.com/firebase/genkit/releases/tag/py%2Fv0.5.0).
+
+Beyond summarization, the same infrastructure enables: enhanced
+changelogs, breaking change detection, migration guide generation,
+platform-tailored announcements, security advisory drafting, and
+contextual error hints — all using the Genkit SDK as a dogfooding
+showcase.
+
+## Design Principles
+
+1. **CI-friendly by default** — Default to Ollama + `gemma3:4b`
+   (~2.3 GB). Small enough for fast CI download, capable enough for
+   structured summarization. No API key, no cloud account, no egress.
+2. **Graceful fallback** — If Ollama isn't running or the model isn't
+   pulled, fall back to the existing truncation logic. Never block a
+   release on AI availability.
+3. **Dogfooding** — Use the Genkit SDK (`ai.generate()` with Pydantic
+   structured output) so releasekit is itself a Genkit showcase.
+4. **Configurable** — Cloud models (Google GenAI, Vertex AI, Anthropic)
+   configurable via `releasekit.toml`, env vars, or CLI flags.
+5. **Deterministic-ish** — Low temperature (0.2), cached by content
+   hash. Same changelogs → same summary (modulo model non-determinism).
+6. **Cacheable** — Both the Ollama model binary (`~/.ollama/models/`)
+   and the summary output (content-hash keyed) are cacheable in CI.
+
+---
+
+## Task Dependency Graph
+
+```
+T1: Output schema (ReleaseSummary Pydantic model)
+    └── no deps
+
+T2: AI config schema ([ai] section in ReleaseConfig)
+    └── no deps
+
+T3: Optional deps in pyproject.toml
+    └── no deps
+
+T4: Env var support (RELEASEKIT_AI_MODEL, RELEASEKIT_AI_PROVIDER)
+    └── T2
+
+T5: Prompt engineering (system prompt + output instructions)
+    └── T1
+
+T6: Core summarize.py (Genkit init, generate, retry)
+    └── T1, T2, T3, T5
+
+T7: Content-hash caching
+    └── T6
+
+T8: Fallback logic (summarize-or-truncate)
+    └── T6, T7
+
+T9: Wire into prepare.py (_build_pr_body)
+    └── T8
+
+T10: Wire into release_notes.py (GitHub Release body)
+    └── T8
+
+T11: CLI flags (--summarize, --no-summarize, --model)
+    └── T4, T9
+
+T12: Tests — output schema
+    └── T1
+
+T13: Tests — config schema
+    └── T2, T4
+
+T14: Tests — summarize.py (mock model)
+    └── T6, T7
+
+T15: Tests — prepare.py integration
+    └── T9
+
+T16: Tests — release_notes.py integration
+    └── T10
+
+T17: Tests — CLI flags
+    └── T11
+
+T18: Documentation (README, roadmap status)
+    └── T11, T17
+```
+
+### Reverse Topological Sort (leaf-first)
+
+```
+Level 0 (no deps):     T1, T2, T3
+Level 1 (deps on L0):  T4, T5, T12
+Level 2 (deps on L1):  T6, T13
+Level 3 (deps on L2):  T7, T14
+Level 4 (deps on L3):  T8
+Level 5 (deps on L4):  T9, T10
+Level 6 (deps on L5):  T11, T15, T16
+Level 7 (deps on L6):  T17, T18
+```
+
+---
+
+## Implementation Phases
+
+### Phase A: Foundation (Level 0–1) — No Genkit dependency yet
+
+**Goal**: Data models, config schema, and prompt template. All pure
+Python, fully testable without Genkit or Ollama.
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **T1** | `schemas_ai.py` | `ReleaseSummary` + `ReleaseStats` Pydantic models. JSON schema export for prompt instruction. | ~60 |
+| **T2** | `config.py` | Add `[ai]` section support: `AiConfig` dataclass with `provider`, `model`, `temperature`, `max_output_tokens`. Validation. | ~80 |
+| **T3** | `pyproject.toml` | Add `genkit`, `genkit-plugin-ollama`, `genkit-plugin-google-genai` as **optional** deps under `[project.optional-dependencies] ai = [...]`. | ~10 |
+| **T4** | `config.py` | Env var overrides: `RELEASEKIT_AI_PROVIDER`, `RELEASEKIT_AI_MODEL`. Priority: CLI > env > config > default. | ~30 |
+| **T5** | `prompts.py` | System prompt template + user prompt builder. Takes changelog data dict, returns formatted prompt. Few-shot reference output section. | ~100 |
+| **T12** | `tests/rk_schemas_ai_test.py` | Test schema validation, JSON schema export, field constraints. | ~40 |
+
+**Deliverable**: `ReleaseSummary` schema is defined, config reads
+`[ai]` section, prompt templates are ready. No runtime Genkit
+dependency yet.
+
+**Verify**: `pytest tests/rk_schemas_ai_test.py tests/rk_config_test.py` passes.
+
+---
+
+### Phase B: Core Summarization (Level 2–3) — Genkit integration
+
+**Goal**: `summarize.py` module that accepts changelogs and returns
+a `ReleaseSummary`. Uses Genkit with a mock model in tests.
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **T6** | `summarize.py` | Core module. `summarize_changelogs(changelogs, config) -> ReleaseSummary`. Lazy Genkit init (import-time guard for optional dep). Provider selection. Structured output via `ai.generate(output=ReleaseSummary)`. Retry on transient failures. | ~200 |
+| **T7** | `summarize.py` | Content-hash cache. SHA-256 of sorted changelog content → cached `ReleaseSummary` JSON on disk (`.releasekit-cache/summaries/`). Skip re-summarization if hash matches. | ~60 |
+| **T13** | `tests/rk_config_test.py` | Test `[ai]` config parsing, env var overrides, defaults. | ~50 |
+| **T14** | `tests/rk_summarize_test.py` | Test with mock Genkit model. Verify prompt construction, schema compliance, caching, retry logic, graceful import failure. | ~120 |
+
+**Key design for T6** — lazy import with CI-optimized defaults:
+
+```python
+# summarize.py
+
+# CI-friendly default: gemma3:4b is ~2.3 GB (vs 12b at ~8 GB).
+# Fast download, fast inference, good enough for structured summarization.
+_DEFAULT_PROVIDER = 'ollama'
+_DEFAULT_MODEL = 'gemma3:4b'
+
+def _get_ai():
+    """Lazy-init Genkit. Returns None if genkit is not installed."""
+    try:
+        from genkit import Genkit  # noqa: PLC0415
+        ...
+    except ImportError:
+        return None
+```
+
+This keeps `genkit` as an optional dependency — releasekit works
+without it (falls back to truncation).
+
+**Deliverable**: `summarize_changelogs()` works end-to-end with Ollama
+(manual test) and with a mock model (automated test).
+
+**Verify**:
+- `pytest tests/rk_summarize_test.py` passes (mock model).
+- Manual: `ollama pull gemma3:12b && python -c "from releasekit.summarize import ..."` works.
+
+---
+
+### Phase C: Integration (Level 4–5) — Wire into existing modules
+
+**Goal**: Summarization integrated into `prepare.py` and
+`release_notes.py` with graceful fallback.
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **T8** | `summarize.py` | `summarize_or_truncate()` — orchestrator function. Tries AI summarization, falls back to existing `_build_pr_body()` truncation logic on failure. Returns `(body: str, used_ai: bool)`. | ~40 |
+| **T9** | `prepare.py` | Update `_build_pr_body()` call site. When `config.ai.provider` is set and `--summarize` is active, call `summarize_or_truncate()` instead of the truncation path. | ~30 |
+| **T10** | `release_notes.py` | Add `summarize_release_notes()` function that uses AI summary for the GitHub Release body (no char limit). Full changelogs in `<details>` below. | ~50 |
+
+**Fallback chain in T8**:
+
+```
+1. Try AI summarization (summarize_changelogs)
+   ├── Success → return AI summary
+   └── Failure (ImportError, ConnectionError, timeout, bad output)
+       │
+       ▼
+2. Fall back to truncation (_build_pr_body current logic)
+   └── Always succeeds (no external dependency)
+```
+
+**Deliverable**: `releasekit prepare` uses AI when available, falls
+back silently when not.
+
+**Verify**: `pytest tests/rk_prepare_test.py tests/rk_release_notes_test.py` passes.
+
+---
+
+### Phase D: CLI + Polish (Level 6–7) — User-facing flags
+
+**Goal**: CLI flags, full test coverage, documentation.
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **T11** | `cli.py` | Add `--summarize` (flag, default off initially), `--no-summarize`, `--model <provider/model>` to `prepare` subcommand. | ~40 |
+| **T15** | `tests/rk_prepare_test.py` | Integration tests: AI path (mock), truncation path, fallback on failure. | ~60 |
+| **T16** | `tests/rk_release_notes_test.py` | Test `summarize_release_notes()` with mock model. | ~40 |
+| **T17** | `tests/rk_cli_test.py` | Test `--summarize`, `--no-summarize`, `--model` flag parsing. | ~30 |
+| **T18** | `README.md`, `roadmap.md` | Document AI summarization config, CLI flags, supported models. Update Phase 10 status. | ~50 |
+
+**Deliverable**: Feature is complete, documented, and tested.
+
+**Verify**: Full test suite passes, `bin/lint` clean.
+
+---
+
+## Summary Table
+
+| Phase | Roadmap Phase | Tasks | Deps | Est. Lines | Key Risk |
+|-------|--------------|-------|------|-----------|----------|
+| **A: Foundation** | 10 | T1–T5, T12 | None | ~320 | None (pure Python) |
+| **B: Core** | 10 | T6–T7, T13–T14 | Phase A | ~430 | Genkit optional import, mock model fidelity |
+| **C: Integration** | 10 | T8–T10 | Phase B | ~120 | Fallback correctness |
+| **D: CLI + Polish** | 10 | T11, T15–T18 | Phase C | ~220 | None |
+| **E: Changelog Intel** | 11 | E1–S3 | Phase D | ~1,090 | Diff size, model context windows |
+| **F: Content Gen** | 12 | M1–H3 | Phase D (+11 optional) | ~980 | Migration code quality |
+| **G: Final Polish** | 10–12 | Docs, integration tests | Phase E+F | ~100 | None |
+| **Total** | — | **51 tasks** | — | **~3,260** | — |
+
+---
+
+## File Layout (all AI files)
+
+```
+src/releasekit/
+├── schemas_ai.py            # T1: ReleaseSummary, ReleaseStats, BreakingChangeReport,
+│                            #     ClassificationReport, MigrationEntry, SecurityAdvisory
+├── prompts.py               # T5: System/user prompt templates (all features)
+├── summarize.py             # T6–T8: Core summarization + cache + fallback
+├── enhance.py               # E1: Changelog enhancement (commit → user-friendly)
+├── detect_breaking.py       # B1: Breaking change detection from diffs
+├── classify.py              # C1: Semantic version classification
+├── scope.py                 # S1: Commit scoping for multi-package commits
+├── migration.py             # M1: Migration guide generation
+├── announce_ai.py           # A1: Platform-tailored announcements
+├── advisory.py              # V1: Security advisory drafting
+├── hints_ai.py              # H1: Contextual error hint generation
+├── config.py                # T2, T4: [ai] section (existing file, updated)
+├── prepare.py               # T9: Wire AI into _build_pr_body (existing)
+├── release_notes.py         # T10: AI summary for GitHub Release (existing)
+├── changelog.py             # E2: Wire enhancement (existing)
+├── versioning.py            # B3, C3, S2: Wire intelligence (existing)
+├── announce.py              # A2: Wire tailoring (existing)
+├── errors.py                # H2: Wire AI hints (existing)
+└── cli.py                   # T11+: All --ai flags (existing)
+
+tests/
+├── rk_schemas_ai_test.py    # T12: All AI dataclass schemas
+├── rk_summarize_test.py     # T14: Summarization + caching
+├── rk_enhance_test.py       # E4: Changelog enhancement
+├── rk_detect_breaking_test.py # B6: Breaking change detection
+├── rk_classify_test.py      # C4: Version classification
+├── rk_scope_test.py         # S3: Commit scoping
+├── rk_migration_test.py     # M5: Migration guides
+├── rk_announce_ai_test.py   # A4: Announcement tailoring
+├── rk_advisory_test.py      # V4: Security advisory
+├── rk_hints_ai_test.py      # H3: Error hints
+├── rk_config_test.py        # T13 (existing, updated)
+├── rk_prepare_test.py       # T15 (existing, updated)
+├── rk_release_notes_test.py # T16 (existing, updated)
+└── rk_cli_test.py           # T17 (existing, updated)
+```
+
+---
+
+## Config Reference
+
+```toml
+# releasekit.toml
+
+[ai]
+# Provider: "ollama" (default), "google-genai", "vertex-ai", "anthropic"
+provider         = "ollama"
+
+# Model name (provider-specific).
+# Ollama (CI-friendly, no API key):
+#   gemma3:4b   — ~2.3 GB, fast, good structured output (DEFAULT)
+#   gemma3:1b   — ~815 MB, very fast, min quality for summaries
+#   qwen2.5:3b  — ~1.9 GB, strong at structured tasks
+#   llama3.2:3b — ~2.0 GB, Meta's compact model
+#   phi4-mini   — ~2.2 GB, Microsoft's small reasoning model
+# Ollama (local dev, higher quality):
+#   gemma3:12b  — ~8 GB, best local quality
+#   llama3.1:8b — ~4.7 GB, strong general-purpose
+#   qwen2.5:7b  — ~4.4 GB, excellent structured output
+#   phi4:14b    — ~9 GB, best local reasoning
+# Cloud (API key required):
+#   gemini-2.0-flash       — Google GenAI / Vertex AI
+#   claude-3-5-sonnet      — Anthropic
+model            = "gemma3:4b"
+
+# Temperature (0.0–1.0). Lower = more factual for summarization.
+temperature      = 0.2
+
+# Maximum output tokens.
+max_output_tokens = 4096
+
+# Enable/disable AI features globally.
+enabled          = true
+
+# Which AI features to enable (all enabled when [ai] is present).
+# Set to false to disable individual features.
+[ai.features]
+summarize        = true    # Phase 10: Release note summarization
+enhance          = true    # Phase 11a: Changelog enhancement
+detect_breaking  = true    # Phase 11b: Breaking change detection
+classify         = false   # Phase 11c: Semantic version classification (advisory)
+scope            = false   # Phase 11d: Commit scoping (advisory)
+migration_guide  = true    # Phase 12a: Migration guide generation
+tailor_announce  = false   # Phase 12b: Announcement tailoring
+draft_advisory   = false   # Phase 12c: Security advisory drafting
+ai_hints         = false   # Phase 12d: Contextual error hints
+```
+
+**Environment variable overrides**:
+
+```bash
+RELEASEKIT_AI_PROVIDER=google-genai
+RELEASEKIT_AI_MODEL=gemini-2.0-flash
+RELEASEKIT_AI_ENABLED=false
+```
+
+**CLI flag overrides** (highest priority):
+
+```bash
+releasekit prepare --summarize                              # Force on
+releasekit prepare --no-summarize                           # Force off
+releasekit prepare --model ollama/gemma3:4b                 # Override model
+releasekit prepare --model google-genai/gemini-2.0-flash    # Cloud model
+releasekit prepare --enhance-changelog                      # Enhance entries
+releasekit prepare --migration-guide                        # Generate guides
+releasekit check --detect-breaking                          # Scan for missed breaks
+releasekit version --ai-classify                            # Second-opinion bumps
+releasekit announce --ai-tailor                             # Platform-tailored
+releasekit advisory --draft                                 # Draft GHSA from OSV
+```
+
+---
+
+## Testing Strategy
+
+1. **Unit tests (mock model)** — All tests use a mock Genkit model
+   that returns canned responses. No Ollama or network required.
+   This is the standard Genkit testing pattern.
+
+2. **Integration test (manual)** — Run `releasekit prepare --summarize
+   --dry-run` against the real genkit workspace with Ollama running.
+   Verify output quality manually.
+
+3. **Fallback test** — Verify that when `genkit` is not installed
+   (or Ollama is down), every feature silently falls back to its
+   non-AI behavior without errors.
+
+4. **Cache test** — Run summarization twice with same changelogs,
+   verify second call returns cached result (no model invocation).
+
+---
+
+## Ollama Model Caching in CI
+
+Ollama stores downloaded models as blob files under `~/.ollama/models/`.
+This directory is fully cacheable — no server state, just files.
+
+### GitHub Actions cache
+
+```yaml
+# .github/workflows/release.yml
+
+- name: Cache Ollama model
+  uses: actions/cache@v4
+  with:
+    path: ~/.ollama/models
+    # Key on the model name — cache busts only when we change models.
+    key: ollama-gemma3-4b
+
+- name: Install Ollama
+  run: curl -fsSL https://ollama.com/install.sh | sh
+
+- name: Pull model (cache miss only)
+  run: ollama pull gemma3:4b
+  # On cache hit, this is a no-op (~0s).
+  # On cache miss, downloads ~2.3 GB (~30s on GitHub runners).
+
+- name: Prepare release
+  run: releasekit prepare --summarize
+```
+
+### Model size comparison (CI impact)
+
+| Model | Download | Cached pull | Inference (67 pkgs) | Quality |
+|-------|----------|-------------|--------------------|---------
+| `gemma3:1b` | ~815 MB | ~0s | ~5s | ★★★ |
+| `gemma3:4b` | ~2.3 GB | ~0s | ~10s | ★★★★ |
+| `qwen2.5:3b` | ~1.9 GB | ~0s | ~8s | ★★★★ |
+| `gemma3:12b` | ~8 GB | ~0s | ~30s | ★★★★★ |
+
+**Recommendation**: `gemma3:4b` is the sweet spot for CI — fast enough
+to not slow down the release pipeline, small enough that even a cache
+miss is tolerable (~30s on GitHub's 10 Gbps runners), and capable
+enough for high-quality structured summarization.
+
+For **local development** with higher-quality output, users can
+override to `gemma3:12b` in their `releasekit.toml` or via
+`--model ollama/gemma3:12b`.
+
+### Docker-based caching (alternative)
+
+For self-hosted runners or Cloud Build, bake the model into a custom
+image:
+
+```dockerfile
+FROM ollama/ollama:latest
+RUN ollama pull gemma3:4b
+```
+
+---
+
+## Phase E: Changelog & Version Intelligence (Roadmap Phase 11)
+
+**Goal**: Use the Phase A–D infrastructure to improve changelog
+quality and version accuracy. All features share the same model
+config, Genkit lazy init, and caching layer.
+
+**Prerequisite**: Phase D complete.
+
+### E1: Changelog Enhancement
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **E1** | `enhance.py` | `enhance_changelog(changelog, config) -> Changelog`. Batch-rewrites all `ChangelogEntry.description` fields into user-friendly sentences via a single `ai.generate()` call. Preserves PR/issue references. Returns enhanced changelog with originals in metadata. | ~120 |
+| **E2** | `changelog.py` | Add `enhance` kwarg to `generate_changelog()`. When set, pipes output through `enhance_changelog()` before rendering. | ~20 |
+| **E3** | `cli.py` | Add `--enhance-changelog` flag to `prepare` and `tag` subcommands. | ~15 |
+| **E4** | `tests/rk_enhance_test.py` | Mock model tests: batch rewrite, reference preservation, fallback on failure, empty changelog, idempotency. | ~80 |
+
+### E2: Breaking Change Detection
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **B1** | `detect_breaking.py` | `detect_breaking_changes(commits, vcs, config) -> list[BreakingChangeReport]`. For each commit not tagged as breaking, gets diff via `vcs.diff(sha)`, sends to AI for classification. Returns `BreakingChangeReport` with confidence score and affected symbols. | ~180 |
+| **B2** | `detect_breaking.py` | `BreakingChangeReport` dataclass: `sha`, `message`, `is_breaking`, `confidence`, `reason`, `affected_symbols`. | ~30 |
+| **B3** | `versioning.py` | Validation pass. After conventional commit parsing, run `detect_breaking_changes()` on non-breaking commits. Warn if AI detects missed breaking changes (never auto-upgrade bump). | ~40 |
+| **B4** | `checks/` | Add `ai_breaking_change` check to `releasekit check`. Scans unreleased commits. | ~50 |
+| **B5** | `cli.py` | Add `--detect-breaking` to `version` and `check` subcommands. | ~15 |
+| **B6** | `tests/rk_detect_breaking_test.py` | Mock tests: signature change, removed function, renamed class, false positive (internal rename), confidence thresholds. | ~120 |
+
+### E3: Semantic Version Classification
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **C1** | `classify.py` | `classify_commits(commits, vcs, config) -> list[ClassificationReport]`. Gets diff, classifies as patch/minor/major. Flags disagreements with conventional commit prefix. | ~120 |
+| **C2** | `classify.py` | `ClassificationReport` dataclass: `sha`, `conventional_bump`, `ai_bump`, `confidence`, `reason`, `disagreement`. | ~25 |
+| **C3** | `versioning.py` | Optional validation pass. Log warnings for disagreements. `--ai-classify` enables it. | ~30 |
+| **C4** | `tests/rk_classify_test.py` | Mock tests: agreement, disagreement, missing prefix, confidence filtering. | ~80 |
+
+### E4: Commit Scoping
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **S1** | `scope.py` | `scope_commit(commit, packages, vcs, config) -> list[ScopeResult]`. Ranks packages by relevance for multi-package commits. | ~80 |
+| **S2** | `versioning.py` | Use AI scoping when a commit touches multiple package paths. Falls back to path heuristic. | ~25 |
+| **S3** | `tests/rk_scope_test.py` | Mock tests: single-package, multi-package, cross-cutting refactor, utility file. | ~60 |
+
+**Phase E totals**: 17 tasks, ~1,090 est. lines.
+
+---
+
+## Phase F: Content Generation (Roadmap Phase 12)
+
+**Goal**: Generate user-facing content from release data.
+
+**Prerequisite**: Phase D complete. Phase E optional but enriches
+output (breaking change data feeds migration guides).
+
+### F1: Migration Guide Generation
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **M1** | `migration.py` | `generate_migration_guide(breaking_changes, vcs, config) -> MigrationGuide`. Gets diff for each breaking change, generates before/after code with explanation. Structured output: `MigrationEntry(change, before_code, after_code, explanation)`. | ~150 |
+| **M2** | `migration.py` | `MigrationGuide` + `MigrationEntry` dataclasses. `render_migration_guide(guide) -> str` as markdown. | ~40 |
+| **M3** | `release_notes.py` | Add "Migration Guide" section after "Breaking Changes" in release notes. | ~30 |
+| **M4** | `cli.py` | Add `--migration-guide` flag to `prepare` and `tag`. | ~10 |
+| **M5** | `tests/rk_migration_test.py` | Mock tests: function rename, param change, type change, no breaks (empty). | ~80 |
+
+### F2: Announcement Tailoring
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **A1** | `announce_ai.py` | `tailor_announcement(summary, platform, config) -> str`. Platform-specific prompts: `slack` (markdown + emoji), `twitter` (280 chars), `discord` (community), `linkedin` (professional). | ~120 |
+| **A2** | `announce.py` | Wire into `send_announcement()`. When `--ai-tailor` is set, replace template rendering with AI content. | ~30 |
+| **A3** | `cli.py` | Add `--ai-tailor` to `announce`. | ~10 |
+| **A4** | `tests/rk_announce_ai_test.py` | Mock tests per platform: char limits, markdown, tone. | ~80 |
+
+### F3: Security Advisory Drafting
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **V1** | `advisory.py` | `draft_advisory(osv_record, config) -> SecurityAdvisory`. Generates: summary, impact, affected versions, remediation, CVSS plain-English explanation. | ~120 |
+| **V2** | `advisory.py` | `SecurityAdvisory` dataclass + `render_advisory()` as GHSA markdown. | ~40 |
+| **V3** | `cli.py` | Add `releasekit advisory --draft` subcommand. | ~30 |
+| **V4** | `tests/rk_advisory_test.py` | Mock tests: critical CVE, moderate issue, multiple versions. | ~60 |
+
+### F4: Contextual Error Hints
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **H1** | `hints_ai.py` | `generate_hint(error, context, config) -> str`. Context: config values, recent logs, environment (CI/local), error code. Returns actionable hint. | ~100 |
+| **H2** | `errors.py` | Wire into `render_error()` when `--verbose` is active and AI is available. Append below static hint. | ~20 |
+| **H3** | `tests/rk_hints_ai_test.py` | Mock tests: publish failed, build failed, config error. | ~60 |
+
+**Phase F totals**: 16 tasks, ~980 est. lines.
+
+---
+
+## Phase G: Final Polish (All Roadmap Phases 10–12)
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **G1** | `README.md` | Document all AI features, config, CLI flags, supported models. | ~50 |
+| **G2** | `roadmap.md` | Update Phase 10–12 status to ✅ Complete. | ~10 |
+| **G3** | Integration tests | End-to-end test: `prepare --summarize --enhance-changelog --migration-guide --detect-breaking` with mock model. | ~40 |
+
+**Phase G totals**: 3 tasks, ~100 est. lines.
+
+---
+
+## Cross-Phase Dependency Graph
+
+```
+Phase A: Foundation (schemas, config, prompts)
+    │
+    ▼
+Phase B: Core Summarization (summarize.py + cache)
+    │
+    ▼
+Phase C: Integration (prepare.py + release_notes.py)
+    │
+    ▼
+Phase D: CLI + Polish (--summarize flags, tests, docs)
+    │
+    ├──────────────────────────────┐
+    ▼                              ▼
+Phase E: Changelog Intel        Phase F: Content Gen
+(11a enhance, 11b breaking,     (12a migration, 12b announce,
+ 11c classify, 11d scope)        12c advisory, 12d hints)
+    │                              │
+    │    12a optionally uses       │
+    │    11b breaking data         │
+    │         │                    │
+    └─────────┼────────────────────┘
+              ▼
+         Phase G: Final Polish
+         (docs, integration tests)
+```
+
+**Key insight**: Phases E and F are **independent of each other** and
+can be worked on in parallel. They both depend only on Phase D
+(the core summarization infrastructure). Phase 12a (migration guides)
+is enriched by Phase 11b (breaking change detection) but works
+without it by using conventional commit `BREAKING CHANGE:` footers.
+
+---
+
+## Grand Total
+
+| Phase | Roadmap | Tasks | Est. Lines | Focus |
+|-------|---------|-------|-----------|-------|
+| A | 10 | 6 | ~320 | Foundation |
+| B | 10 | 4 | ~430 | Core summarization |
+| C | 10 | 3 | ~120 | Wire into existing modules |
+| D | 10 | 5 | ~220 | CLI + tests |
+| E | 11 | 17 | ~1,090 | Changelog & version intelligence |
+| F | 12 | 16 | ~980 | Content generation |
+| G | 10–12 | 3 | ~100 | Final polish |
+| **Total** | — | **54** | **~3,260** | — |
+
+---
+
+## Open Questions
+
+1. **Default on or off?** — Should `--summarize` be opt-in (flag) or
+   default-on when `[ai]` is configured? Recommendation: **opt-in
+   initially** (`--summarize` flag), then default-on in a future
+   release once battle-tested.
+
+2. **Cache location** — `.releasekit-cache/summaries/` in the workspace
+   root? Or `~/.cache/releasekit/`? Recommendation: workspace-local
+   so CI builds are isolated.
+
+3. **Prompt tuning** — Should the system prompt be configurable via
+   `releasekit.toml`? Recommendation: **no** (too complex). Ship with
+   a well-tested default prompt. Allow template override in a future
+   release if needed.
+
+4. **Token budget** — With 67 packages × ~500 lines of changelog,
+   the input might exceed model context windows. Recommendation:
+   pass per-package *summaries* (first heading + top 10 entries) to
+   the model, not full changelogs. Full changelogs go in `<details>`.
+
+5. **Feature granularity** — Should each AI feature have its own
+   `[ai.features.X]` toggle, or should `[ai] enabled = true` enable
+   all? Recommendation: Per-feature toggles with sensible defaults
+   (summarize + enhance + detect_breaking on, others off).
+

--- a/py/tools/releasekit/docs/docs/roadmap.md
+++ b/py/tools/releasekit/docs/docs/roadmap.md
@@ -939,6 +939,52 @@ Phase 9: Polyglot Backends ▼    ✅ COMPLETE
 │                                                         │
 │  ✓ Full polyglot support across 7 ecosystems            │
 │  ✓ Supply chain security (Sigstore, SLSA, SBOM, OIDC)   │
+└───────────────────────────┬─────────────────────────────┘
+                            │
+Phase 10: AI Release Notes  ▼    🔲 PLANNED
+┌─────────────────────────────────────────────────────────┐
+│  summarize.py ──► genkit (ai.generate), changelog       │
+│    + Structured output via Pydantic schema               │
+│    + Configurable: Ollama (default) / Google GenAI /     │
+│      Vertex AI / Anthropic                               │
+│  prepare.py (update) ──► summarize.py                    │
+│    + Summarize-or-truncate fallback                      │
+│  release_notes.py (update) ──► summarize.py              │
+│    + AI summary for GitHub Release body                  │
+│                                                         │
+│  🟨 releasekit prepare --summarize                      │
+│  🟨 Default: ollama/gemma3:4b (CI-friendly, no API key) │
+└───────────────────────────┬─────────────────────────────┘
+                            │
+Phase 11: AI Changelog &    ▼    🔲 PLANNED
+           Version Intel
+┌─────────────────────────────────────────────────────────┐
+│  enhance.py ──► summarize.py, changelog.py              │
+│    + Rewrite commit messages into user-friendly entries  │
+│  detect_breaking.py ──► summarize.py, versioning.py     │
+│    + AI diff analysis for missed breaking changes        │
+│  classify.py ──► summarize.py, versioning.py            │
+│    + Semantic version classification from diffs          │
+│  scope.py ──► summarize.py, versioning.py               │
+│    + AI commit scoping for multi-package commits         │
+│                                                         │
+│  🔲 releasekit version --ai-classify                    │
+│  🔲 releasekit check --detect-breaking                  │
+└───────────────────────────┬─────────────────────────────┘
+                            │
+Phase 12: AI Content Gen    ▼    🔲 PLANNED
+┌─────────────────────────────────────────────────────────┐
+│  migration.py ──► summarize.py, release_notes.py        │
+│    + Auto-generate migration guides from breaking diffs  │
+│  announce_ai.py ──► summarize.py, announce.py           │
+│    + Platform-tailored announcements (Slack/X/LinkedIn)  │
+│  advisory.py ──► summarize.py, osv.py                   │
+│    + Draft security advisories from OSV data             │
+│  hints_ai.py ──► summarize.py, errors.py                │
+│    + Contextual error hints from config + state          │
+│                                                         │
+│  🔲 releasekit announce --ai-tailor                     │
+│  🔲 releasekit advisory --draft                         │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -1726,6 +1772,481 @@ Writing bootstrap_sha = "b71a3d20c74b71583edbc652e5b26117caad43f4" to releasekit
 - Works across multiple workspaces (e.g. `py` + `js` in the same repo).
 - The classification logic reuses `tag_format` parsing from
   `versioning.py`, ensuring consistency with how releasekit creates tags.
+
+### Phase 10: AI-Powered Release Notes  🔲 Planned
+
+Use Genkit to generate human-quality release summaries from raw
+changelogs, eliminating the 65,536-character PR body limit problem
+entirely and producing release notes comparable to hand-written ones
+like [Genkit Python SDK v0.5.0](https://github.com/firebase/genkit/releases/tag/py%2Fv0.5.0).
+
+**Problem**: With 67+ packages, raw changelogs concatenated into the
+PR body exceed GitHub's 65,536-character limit. The current fix
+(collapsible `<details>` blocks + progressive truncation) is a
+workaround. The real solution is to summarize the changelogs into a
+concise, structured release summary.
+
+**Approach**: Use Genkit's `ai.generate()` with a structured output
+schema to produce a release summary from the full changelog data.
+The model processes all package changelogs (no truncation) and outputs
+a structured summary with sections for overview, highlights, breaking
+changes, migration notes, and per-package summaries.
+
+| Module | Description | Est. Lines |
+|--------|-------------|-----------|
+| `summarize.py` | Genkit-based changelog summarization. Accepts full changelog data, produces structured release summary via `ai.generate()` with JSON output schema. Configurable model provider. Caching to avoid re-summarizing unchanged changelogs. | ~300 |
+| `prepare.py` (update) | Wire summarization into `_build_pr_body()`. When a model is configured, summarize instead of truncate. Fall back to current truncation logic if no model is available or summarization fails. | ~50 |
+| `release_notes.py` (update) | Use the same summarization for GitHub Release body (richer format, no character limit). Include per-package changelogs in collapsible sections below the summary. | ~50 |
+
+**Model configuration** (`releasekit.toml`):
+
+```toml
+[ai]
+# Provider: "ollama" (default, no API key), "google-genai", "vertex-ai"
+provider         = "ollama"
+# Model name (provider-specific)
+model            = "gemma3:4b"
+# Temperature for summarization (low = more factual)
+temperature      = 0.2
+# Max output tokens
+max_output_tokens = 4096
+```
+
+**Local models via Ollama** (no API key required):
+
+**CI-friendly models** (small download, fast inference, no API key):
+
+| Model | Download | Speed | Quality | Notes |
+|-------|----------|-------|---------|-------|
+| `gemma3:4b` | ~2.3 GB | ★★★★★ | ★★★★ | **Default.** Best CI trade-off: fast download, fast inference, good structured output. |
+| `gemma3:1b` | ~815 MB | ★★★★★ | ★★★ | Smallest download. Minimum viable quality. |
+| `qwen2.5:3b` | ~1.9 GB | ★★★★★ | ★★★★ | Strong at structured tasks. |
+| `llama3.2:3b` | ~2.0 GB | ★★★★★ | ★★★ | Meta's compact model. |
+
+**Local dev models** (higher quality, larger download):
+
+| Model | Download | Speed | Quality | Notes |
+|-------|----------|-------|---------|-------|
+| `gemma3:12b` | ~8 GB | ★★★ | ★★★★★ | Best local quality. Recommended for local dev. |
+| `llama3.1:8b` | ~4.7 GB | ★★★★ | ★★★★ | Strong general-purpose model. |
+| `qwen2.5:7b` | ~4.4 GB | ★★★★ | ★★★★ | Excellent at structured output. |
+
+**Ollama model caching in CI**: Ollama stores models as blob files
+under `~/.ollama/models/`. Cache this directory in GitHub Actions
+(`actions/cache@v4`) keyed on the model name. On cache hit, `ollama
+pull` is a no-op (~0s). On cache miss, `gemma3:4b` downloads in ~30s
+on GitHub's 10 Gbps runners.
+
+**Cloud models** (API key required, higher quality):
+
+| Provider | Model | Notes |
+|----------|-------|-------|
+| `google-genai` | `gemini-2.0-flash` | Fast, high quality, generous free tier. |
+| `vertex-ai` | `gemini-2.0-flash` | Same model, enterprise auth (ADC). |
+| `anthropic` | `claude-3-5-sonnet` | Excellent at structured summarization. |
+
+**Output schema** (Pydantic model for structured generation):
+
+```python
+class ReleaseSummary(BaseModel):
+    """Structured release summary generated by AI."""
+    overview: str                    # 2-3 sentence overview
+    highlights: list[str]            # Top 5-10 user-facing highlights
+    breaking_changes: list[str]      # Breaking changes with migration notes
+    new_plugins: list[str]           # New plugins/packages added
+    deprecations: list[str]          # Deprecated features
+    security_fixes: list[str]        # Security-related fixes
+    package_summaries: dict[str, str]  # Per-package one-line summary
+    contributors: list[str]          # Contributor handles (from commits)
+    stats: ReleaseStats              # Commit count, files changed, etc.
+
+class ReleaseStats(BaseModel):
+    """Quantitative release statistics."""
+    commit_count: int
+    packages_changed: int
+    files_changed: int
+    days_since_last_release: int
+```
+
+**Reference output** (modeled after [py/v0.5.0](https://github.com/firebase/genkit/releases/tag/py%2Fv0.5.0)):
+
+```markdown
+# Release: Genkit Python SDK v0.6.0
+
+## Overview
+This release includes 67 packages with 42 commits since v0.5.0.
+Key themes: new Cloudflare Workers AI plugin, improved structured
+output across all providers, and performance optimizations.
+
+## What's New
+### New Plugins
+- `genkit-plugin-cloudflare-workers-ai` — Cloudflare Workers AI
+### Core Framework
+- Structured output: array and enum formats (JS SDK parity)
+- Circuit breaker for LLM API protection
+- Response caching with stampede prevention
+
+## Breaking Changes
+- `PluginV2.initialize()` is now async (#4512)
+  **Migration**: Add `await` to all `initialize()` calls.
+
+## Package Summaries
+| Package | Summary |
+|---------|---------|
+| `genkit` | Core framework: async init, new output formats |
+| `genkit-plugin-google-genai` | Gemini 2.0 Flash support |
+| ... | ... |
+```
+
+**Fallback behavior**: If no model is configured or summarization
+fails (network error, Ollama not running, etc.), `_build_pr_body()`
+falls back to the current truncation logic (summary table +
+collapsible details + progressive dropping). The AI summary is a
+best-effort enhancement, never a hard dependency.
+
+**CLI integration**:
+
+```bash
+# Summarize with default model (ollama/gemma3:4b)
+releasekit prepare --summarize
+
+# Summarize with a specific model
+releasekit prepare --summarize --model google-genai/gemini-2.0-flash
+
+# Skip summarization (use truncation fallback)
+releasekit prepare --no-summarize
+
+# Preview summary without creating PR
+releasekit prepare --dry-run --summarize
+```
+
+**Implementation notes**:
+
+- Uses Genkit's `ai.generate()` with `output=ReleaseSummary` for
+  typed structured output — dogfooding the SDK.
+- Changelog data is passed as the user prompt (no retrieval needed,
+  all data is local).
+- System prompt instructs the model to be factual, avoid
+  hallucination, and preserve PR/issue references from commits.
+- Caches summaries by content hash to avoid re-summarizing on
+  `prepare` re-runs (idempotent).
+- Model selection follows the configurability principle:
+  `CLI flag > env var (RELEASEKIT_AI_MODEL) > releasekit.toml > default`.
+
+**Done when**: `releasekit prepare --summarize` produces a GitHub
+Release-quality summary from raw changelogs. PR body fits within
+the 65,536-character limit with room to spare. Release notes match
+the quality of hand-written ones like py/v0.5.0.
+
+**Milestone**: First release tool that uses AI to generate
+production-quality release notes, dogfooding the Genkit SDK.
+
+### Phase 11: AI Changelog & Version Intelligence  🔲 Planned
+
+Uses the Phase 10 AI infrastructure (`summarize.py`, `AiConfig`,
+Genkit lazy init) to improve changelog quality and version accuracy.
+All features share the same model config and caching layer.
+
+**Prerequisites**: Phase 10 complete (AI config, Genkit integration,
+`summarize.py` module with lazy import and fallback patterns).
+
+#### 11a. Changelog Enhancement (`enhance.py`)
+
+**Problem**: Raw conventional commit messages are terse developer-speak.
+Users want human-readable changelogs.
+
+**What it does**: Rewrites each `ChangelogEntry.description` into a
+user-friendly sentence. Preserves PR/issue references. Optionally
+groups related entries.
+
+```
+Input:  "fix(auth): handle null token edge case in refresh flow (#4521)"
+Output: "Fixed a crash that could occur when refreshing authentication
+         tokens after a session timeout. (#4521)"
+```
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **E1** | `enhance.py` | `enhance_changelog(changelog, config) -> Changelog`. Rewrites each entry description via `ai.generate()`. Batch: sends all entries in one prompt for efficiency + consistency. Returns enhanced `Changelog` with original preserved in metadata. | ~120 |
+| **E2** | `changelog.py` | Add `--enhance` flag to `generate_changelog()`. When set, pipes output through `enhance_changelog()` before rendering. | ~20 |
+| **E3** | `cli.py` | Add `--enhance-changelog` flag to `prepare` and `tag` subcommands. | ~15 |
+| **E4** | `tests/rk_enhance_test.py` | Mock model tests: batch rewrite, reference preservation, fallback on failure, empty changelog. | ~80 |
+
+**Fallback**: If AI fails, return the original changelog unchanged.
+
+**Done when**: `releasekit prepare --enhance-changelog` produces
+user-friendly changelogs. Raw entries preserved as fallback.
+
+#### 11b. Breaking Change Detection (`detect_breaking.py`)
+
+**Problem**: Developers forget `BREAKING CHANGE:` footers. A `feat:`
+commit might silently break the public API. Missed breaking changes
+cause surprise failures for downstream users.
+
+**What it does**: Analyzes the **diff** of each commit against the
+public API surface and classifies whether it's truly breaking:
+- Removed/renamed public function, class, or constant
+- Changed function signature (new required param, removed param)
+- Changed return type or exception types
+- Changed default values in ways that alter behavior
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **B1** | `detect_breaking.py` | `detect_breaking_changes(commits, vcs, config) -> list[BreakingChangeReport]`. For each commit, gets diff via `vcs.diff(sha)`, sends to AI with the prompt "classify this diff as breaking/non-breaking and explain why". Returns a `BreakingChangeReport` with confidence score. | ~180 |
+| **B2** | `detect_breaking.py` | `BreakingChangeReport` dataclass: `sha`, `message`, `is_breaking`, `confidence` (0.0–1.0), `reason`, `affected_symbols` (list of function/class names). | ~30 |
+| **B3** | `versioning.py` | Integrate as validation pass. After conventional commit parsing, run `detect_breaking_changes()` on commits classified as non-breaking. Warn (or upgrade bump) if AI detects a missed breaking change. | ~40 |
+| **B4** | `checks/` | Add `ai_breaking_change` health check to `releasekit check`. Scans unreleased commits for missed breaking changes. | ~50 |
+| **B5** | `cli.py` | Add `--detect-breaking` flag to `version` and `check` subcommands. | ~15 |
+| **B6** | `tests/rk_detect_breaking_test.py` | Mock model tests: signature change, removed function, renamed class, false positive (internal rename), confidence thresholds. | ~120 |
+
+**Key design**: The AI doesn't *decide* the version bump — it *warns*.
+The developer reviews the report and confirms. This avoids AI
+hallucinations from silently changing release versions.
+
+**Fallback**: If AI fails, skip detection (no warnings). Never block
+a release on AI availability.
+
+**Done when**: `releasekit check --detect-breaking` flags commits
+where a breaking change was likely missed. `releasekit version
+--detect-breaking` warns before computing bumps.
+
+#### 11c. Semantic Version Classification (`classify.py`)
+
+**Problem**: When conventional commit prefixes are missing or wrong,
+version bumps may be incorrect. A `chore:` commit that changes a
+public interface should be a minor bump, not skipped.
+
+**What it does**: Second-opinion classification. For each commit,
+analyzes the diff and message to independently classify as `patch`,
+`minor`, or `major`. Flags disagreements with the conventional commit
+classification.
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **C1** | `classify.py` | `classify_commits(commits, vcs, config) -> list[ClassificationReport]`. Gets diff for each commit, sends to AI with "classify as patch/minor/major". Returns classification + confidence. | ~120 |
+| **C2** | `classify.py` | `ClassificationReport` dataclass: `sha`, `conventional_bump`, `ai_bump`, `confidence`, `reason`, `disagreement` (bool). | ~25 |
+| **C3** | `versioning.py` | Optional validation pass after bump computation. Log warnings for disagreements. `--ai-classify` flag enables it. | ~30 |
+| **C4** | `tests/rk_classify_test.py` | Mock model tests: agreement cases, disagreement cases, missing prefix, confidence filtering. | ~80 |
+
+**Fallback**: If AI fails, use conventional commit classification
+(the existing behavior). AI is advisory only.
+
+#### 11d. Commit Scoping (`scope.py`)
+
+**Problem**: When a commit touches files in multiple packages, which
+package gets the changelog entry? Path heuristics (longest prefix
+match) can be wrong for cross-cutting commits.
+
+**What it does**: Analyzes commit message + diff paths to determine
+the primary package affected. Returns a ranked list of packages.
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **S1** | `scope.py` | `scope_commit(commit, packages, vcs, config) -> list[ScopeResult]`. Ranks packages by relevance. Uses diff paths + message content. | ~80 |
+| **S2** | `versioning.py` | Use `scope_commit()` when a commit touches multiple package paths. Replace longest-prefix heuristic with AI scoping (when enabled). | ~25 |
+| **S3** | `tests/rk_scope_test.py` | Mock tests: single-package commit, multi-package commit, cross-cutting refactor, utility file commit. | ~60 |
+
+**Fallback**: If AI fails, fall back to path heuristic (existing behavior).
+
+---
+
+**Phase 11 Totals**:
+
+| Sub-phase | Tasks | Est. Lines |
+|-----------|-------|-----------|
+| 11a: Changelog Enhancement | E1–E4 | ~235 |
+| 11b: Breaking Change Detection | B1–B6 | ~435 |
+| 11c: Version Classification | C1–C4 | ~255 |
+| 11d: Commit Scoping | S1–S3 | ~165 |
+| **Total** | **17 tasks** | **~1,090** |
+
+**Implementation order** (within Phase 11):
+
+```
+11a (Changelog Enhancement)
+    └── depends on Phase 10 only
+
+11b (Breaking Change Detection)
+    └── depends on Phase 10 only
+
+11c (Version Classification)
+    └── depends on 11b (shares BreakingChangeReport pattern)
+
+11d (Commit Scoping)
+    └── depends on Phase 10 only (independent)
+```
+
+All four sub-phases can be implemented in parallel after Phase 10.
+11c benefits from 11b's patterns but is not blocked by it.
+
+### Phase 12: AI Content Generation  🔲 Planned
+
+Uses Phase 10 infrastructure + Phase 11 data (breaking change reports,
+enhanced changelogs) to generate user-facing content.
+
+**Prerequisites**: Phase 10 complete. Phase 11 optional but enhances
+output quality (breaking change data feeds migration guides).
+
+#### 12a. Migration Guide Generation (`migration.py`)
+
+**Problem**: Breaking changes need migration guides. Hand-writing
+these for every release is labor-intensive and often skipped.
+
+**What it does**: For each breaking change (from 11b or conventional
+commit `BREAKING CHANGE:` footers), generates a migration snippet
+with before/after code examples.
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **M1** | `migration.py` | `generate_migration_guide(breaking_changes, vcs, config) -> MigrationGuide`. For each breaking change, gets the diff and generates before/after code with explanation. Uses structured output: `MigrationEntry(change, before_code, after_code, explanation)`. | ~150 |
+| **M2** | `migration.py` | `MigrationGuide` + `MigrationEntry` dataclasses. `render_migration_guide(guide) -> str` as markdown. | ~40 |
+| **M3** | `release_notes.py` | Integrate migration guide into release notes. Add "Migration Guide" section after "Breaking Changes" when entries exist. | ~30 |
+| **M4** | `cli.py` | Add `--migration-guide` flag to `prepare` and `tag`. | ~10 |
+| **M5** | `tests/rk_migration_test.py` | Mock tests: function rename, param change, type change, no breaking changes (empty guide). | ~80 |
+
+**Fallback**: If AI fails, include raw breaking change descriptions
+without migration examples.
+
+**Done when**: `releasekit prepare --summarize --migration-guide`
+produces release notes with a migration guide section.
+
+#### 12b. Announcement Tailoring (`announce_ai.py`)
+
+**Problem**: The same template goes to Slack, Discord, Twitter,
+LinkedIn. Each platform has different conventions.
+
+**What it does**: Takes the `ReleaseSummary` from Phase 10 and
+generates platform-specific announcements.
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **A1** | `announce_ai.py` | `tailor_announcement(summary, platform, config) -> str`. Platform-specific prompt templates. Supports: `slack` (markdown + emoji), `twitter` (280 chars), `discord` (community tone), `linkedin` (professional paragraph). | ~120 |
+| **A2** | `announce.py` | Wire `tailor_announcement()` into the existing `send_announcement()` flow. When `--ai-tailor` is set, replace template rendering with AI-generated content. | ~30 |
+| **A3** | `cli.py` | Add `--ai-tailor` flag to `announce` subcommand. | ~10 |
+| **A4** | `tests/rk_announce_ai_test.py` | Mock tests per platform: char limits (Twitter), markdown formatting (Slack), tone (LinkedIn). | ~80 |
+
+**Example outputs**:
+
+```
+Slack:  🚀 *Genkit Python SDK v0.6.0* — 67 packages, 42 commits
+        • New: Cloudflare Workers AI plugin
+        • Improved structured output across all providers
+        <https://github.com/firebase/genkit/releases/tag/py/v0.6.0|Full notes>
+
+Twitter: 🚀 Genkit Python SDK v0.6.0 is out! New Cloudflare Workers AI
+         plugin, improved structured output, and performance boosts
+         across 67 packages. Release notes → [link]
+
+LinkedIn: We're excited to announce Genkit Python SDK v0.6.0, a
+          significant update with 42 commits across 67 packages.
+          This release introduces the Cloudflare Workers AI plugin...
+```
+
+**Fallback**: If AI fails, use the existing template-based
+announcements (current behavior).
+
+#### 12c. Security Advisory Drafting (`advisory.py`)
+
+**Problem**: When `osv.py` finds vulnerabilities, someone has to
+write a GHSA advisory. These are formulaic but tedious.
+
+**What it does**: Generates a draft GitHub Security Advisory from
+OSV vulnerability data.
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **V1** | `advisory.py` | `draft_advisory(osv_record, config) -> SecurityAdvisory`. Takes OSV data (CVE ID, affected versions, description) and generates: summary, impact description, affected package/versions, remediation steps, CVSS explanation in plain English. | ~120 |
+| **V2** | `advisory.py` | `SecurityAdvisory` dataclass + `render_advisory()` as GHSA-compatible markdown. | ~40 |
+| **V3** | `cli.py` | Add `releasekit advisory --draft` subcommand. Reads OSV scan results, generates drafts. | ~30 |
+| **V4** | `tests/rk_advisory_test.py` | Mock tests: critical CVE, moderate issue, multiple affected versions. | ~60 |
+
+**Fallback**: If AI fails, output raw OSV data in a structured
+template (no AI enhancement).
+
+#### 12d. Contextual Error Hints (`hints_ai.py`)
+
+**Problem**: Static error hints can't account for the user's specific
+config, environment, and what they were trying to do.
+
+**What it does**: When `--verbose` is set and an error occurs,
+generates a contextual hint based on the error, config state, and
+recent actions.
+
+| Task | Module | What | Est. Lines |
+|------|--------|------|-----------|
+| **H1** | `hints_ai.py` | `generate_hint(error, context, config) -> str`. Context includes: config values, recent log lines, environment (CI vs local), error code. Returns an actionable hint. | ~100 |
+| **H2** | `errors.py` | Wire `generate_hint()` into `render_error()` when `--verbose` is active and AI is available. Append AI hint below the static hint. | ~20 |
+| **H3** | `tests/rk_hints_ai_test.py` | Mock tests: publish failed (token expired), build failed (missing dep), config error (typo). | ~60 |
+
+**Example**:
+
+```
+error[RK-PUBLISH-FAILED]: uv publish failed for genkit-plugin-x (exit 1)
+  |
+  = hint: Check that your PyPI token is valid and has upload permissions.
+
+  AI analysis (--verbose):
+    Your PYPI_TOKEN was last rotated 47 days ago. The error output
+    mentions "403 Forbidden", which typically indicates an expired or
+    revoked token. Run 'pypi-token check' to verify, then update the
+    PYPI_TOKEN secret in your GitHub repository settings.
+```
+
+**Fallback**: If AI fails, show only the static hint (existing behavior).
+
+---
+
+**Phase 12 Totals**:
+
+| Sub-phase | Tasks | Est. Lines |
+|-----------|-------|-----------|
+| 12a: Migration Guides | M1–M5 | ~310 |
+| 12b: Announcement Tailoring | A1–A4 | ~240 |
+| 12c: Security Advisory Draft | V1–V4 | ~250 |
+| 12d: Contextual Error Hints | H1–H3 | ~180 |
+| **Total** | **16 tasks** | **~980** |
+
+**Implementation order** (within Phase 12):
+
+```
+12a (Migration Guides)
+    └── depends on Phase 10 + optionally 11b (breaking change data)
+
+12b (Announcement Tailoring)
+    └── depends on Phase 10 only (uses ReleaseSummary)
+
+12c (Security Advisory)
+    └── depends on Phase 10 only (uses OSV data)
+
+12d (Error Hints)
+    └── depends on Phase 10 only (independent)
+```
+
+All four sub-phases can be implemented in parallel after Phase 10.
+12a benefits from 11b's breaking change reports but can work with
+conventional commit `BREAKING CHANGE:` footers alone.
+
+---
+
+## AI Feature Summary (Phases 10–12)
+
+| Phase | Feature | Est. Lines | Key Module | Priority |
+|-------|---------|-----------|-----------|----------|
+| **10** | Release note summarization | ~1,090 | `summarize.py` | **Critical** |
+| **11a** | Changelog enhancement | ~235 | `enhance.py` | High |
+| **11b** | Breaking change detection | ~435 | `detect_breaking.py` | High |
+| **11c** | Version classification | ~255 | `classify.py` | Medium |
+| **11d** | Commit scoping | ~165 | `scope.py` | Low |
+| **12a** | Migration guide generation | ~310 | `migration.py` | Medium |
+| **12b** | Announcement tailoring | ~240 | `announce_ai.py` | Medium |
+| **12c** | Security advisory drafting | ~250 | `advisory.py` | Low |
+| **12d** | Contextual error hints | ~180 | `hints_ai.py` | Low |
+| | **Grand total** | **~3,160** | | |
+
+All features share the Phase 10 foundation: same `AiConfig`, same
+model selection, same Genkit lazy init, same caching layer, same
+fallback pattern. Each feature is independently deployable and
+independently testable with mock models.
 
 ---
 


### PR DESCRIPTION
## Summary

Cross-language conformance infrastructure improvements: adds native executors for all
three runtimes (Python, JS, Go), fixes tool schema handling for Anthropic, consolidates
the `--use-cli` flag into `--runner cli`, and adds exception capture to the in-process
runner.

## Changes

### Conform Tool — Native Executors (`py/tools/conform/src/conform/executors/`)

Added JSONL-over-stdio native executors for all three runtimes. These run as
subprocesses managed by the `NativeExecRunner` and communicate via newline-delimited
JSON — no reflection server or HTTP overhead needed.

- **`conformance_native.py`** — Python native executor. Imports the plugin, initializes
  Genkit, and handles generate requests directly. Captures exceptions with full
  tracebacks.
- **`conformance_native.ts`** — JS/TS native executor. Uses `@genkit-ai/ai` to define
  tools and call `ai.generate()`. Fixed tool schema handling to pass `inputJsonSchema`
  from test definitions so providers like Anthropic receive valid `type: "object"`
  schemas. Fixed output format handling to correctly set `output` config even without
  an explicit schema.
- **`conformance_native.go`** — Go native executor. Uses the Genkit Go SDK with
  plugin-specific initialization.
- **`in_process_runner.py`** — Added `try/except` to `run_action()` that captures the
  full traceback via `traceback.format_exc()` and re-raises as `RuntimeError`. Previously,
  raw `GenkitError` exceptions propagated without the underlying cause visible.

### Conform Tool — CLI Consolidation

- **Merged `--use-cli` into `--runner`** — The `--use-cli` boolean flag has been removed.
  The genkit CLI runner is now just another choice in `--runner`: `auto`, `native`,
  `reflection`, `in-process`, or `cli`. This is cleaner (one flag instead of two that
  could conflict) and opens the door for `--runner cli` with JS and Go runtimes.
- **Updated all docs** — README, architecture, configuration, index, and usage docs
  updated to reflect the unified `--runner` flag with all 5 choices.
- **Added `NativeExecRunner` to runner tables** in all docs.

### Conform Tool — Config & Runner Resolution

- **`config.py`** — Added `default_runner` and `native_entry_filename` fields to
  `RuntimeConfig`. Python defaults to `in-process`, JS/Go default to `native`.
- **`util_test_model.py`** — Added `NativeExecRunner` class (JSONL-over-stdio subprocess
  management with asyncio lock serialization), `_resolve_runner_type()` for auto-selecting
  the best runner per runtime, and `_find_native_entry()` for discovering native executor
  files. Restructured runner selection into a single `if/elif/else` chain to satisfy
  pyrefly's unbound-name analysis.
- **`conform.toml`** — Added `native-entry-filename` configuration for each runtime.

### Conformance Spec — google-genai

- Replaced the `model-conformance.yaml` symlink in `py/tests/conform/google-genai/`
  with a real copy of the file. Symlinks don't work well across runtimes and platforms.

### JS Anthropic Plugin — Tool Schema Fix

- **`runner/base.ts`** (`toAnthropicTool`) — Ensured `input_schema` always includes
  `type: "object"` as a fallback. Anthropic rejects schemas without a `type` field,
  which can happen when Genkit produces schemas from `z.void()` or empty definitions.

### xAI Plugin — Zero-Width Space Handling

- **`converters.py`** — Added stripping of zero-width spaces (`\u200b`) from `finish_reason`
  values returned by the xAI API.
- **`xai_converters_test.py`** — Added test coverage for the zero-width space stripping.

### ReleaseKit — Docs

- **`ai-release-notes-plan.md`** — Roadmap for AI-assisted release notes generation.
- **`roadmap.md`** — Updated ReleaseKit roadmap.

## Testing

- All **147 conform tool tests** pass.
- All **171 Anthropic JS plugin tests** pass.
- All **62 xAI Python plugin tests** pass.
- `bin/lint` passes (ruff, ty, pyrefly, pyright).
