### PR TITLE
fix(go): handle loosely formatted JSON markdown blocks

### DIFF
--- a/go/internal/base/json.go
+++ b/go/internal/base/json.go
@@ -165,10 +165,13 @@ func SchemaAsMap(s *jsonschema.Schema) map[string]any {
 }
 
 // jsonMarkdownRegex matches fenced code blocks with "json" language identifier (case-insensitive).
-var jsonMarkdownRegex = regexp.MustCompile("(?si)```json\\s*(.*?)```")
+var jsonMarkdownRegex = regexp.MustCompile("(?si)```\\s*json\\s*(.*?)```")
 
 // plainMarkdownRegex matches fenced code blocks without any language identifier.
 var plainMarkdownRegex = regexp.MustCompile("(?s)```\\s*\\n(.*?)```")
+
+// implicitJSONRegex matches fenced code blocks with no language identifier that start with { or [
+var implicitJSONRegex = regexp.MustCompile("(?si)```\\s*([{\\[].*?)```")
 
 // ExtractJSONFromMarkdown returns the contents of the first fenced code block in
 // the markdown text md. It matches code blocks with "json" identifier (case-insensitive)
@@ -182,6 +185,12 @@ func ExtractJSONFromMarkdown(md string) string {
 
 	// Fall back to plain code blocks (no language identifier)
 	matches = plainMarkdownRegex.FindStringSubmatch(md)
+	if len(matches) >= 2 {
+		return strings.TrimSpace(matches[1])
+	}
+
+	// Fall back to implicit JSON blocks (no language identifier, starts with { or [)
+	matches = implicitJSONRegex.FindStringSubmatch(md)
 	if len(matches) >= 2 {
 		return strings.TrimSpace(matches[1])
 	}

--- a/go/internal/base/json_test.go
+++ b/go/internal/base/json_test.go
@@ -103,6 +103,21 @@ func TestExtractJSONFromMarkdown(t *testing.T) {
 			in:   "```\n{\"plain\": true}\n``` then ```json\n{\"json\": true}\n```",
 			want: "{\"json\": true}",
 		},
+		{
+			desc: "json block with spaces",
+			in:   "``` json\n{\"a\": 1}\n```",
+			want: "{\"a\": 1}",
+		},
+		{
+			desc: "implicit json block",
+			in:   "```{\"a\": 1}```",
+			want: "{\"a\": 1}",
+		},
+		{
+			desc: "implicit json block array",
+			in:   "```[1, 2]```",
+			want: "[1, 2]",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
Fix for a bug where `ai.Generate` could generate loosely formated JSON Markdown code blocks.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
