### PR TITLE
fix(go/plugins/anthropic): resolve models using aliases

### DIFF
--- a/go/plugins/anthropic/anthropic.go
+++ b/go/plugins/anthropic/anthropic.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -211,6 +212,7 @@ func newModel(client anthropic.Client, name, apiModelName string, opts ai.ModelO
 }
 
 func resolveModelID(id string, availableModels []string) (string, bool) {
+	// First check for exact match
 	for _, m := range availableModels {
 		if m == id {
 			return m, true
@@ -219,10 +221,16 @@ func resolveModelID(id string, availableModels []string) (string, bool) {
 
 	var bestMatch string
 	prefix := id + "-"
+	// Suffix must be exactly 8 digits (YYYYMMDD)
+	dateSuffix := regexp.MustCompile(`^\d{8}$`)
+
 	for _, m := range availableModels {
 		if strings.HasPrefix(m, prefix) {
-			if m > bestMatch {
-				bestMatch = m
+			suffix := strings.TrimPrefix(m, prefix)
+			if dateSuffix.MatchString(suffix) {
+				if m > bestMatch {
+					bestMatch = m
+				}
 			}
 		}
 	}

--- a/go/plugins/anthropic/anthropic_test.go
+++ b/go/plugins/anthropic/anthropic_test.go
@@ -22,12 +22,13 @@ import (
 
 func TestResolveModelID(t *testing.T) {
 	availableModels := []string{
-		"claude-3-opus-20240229",
-		"claude-3-sonnet-20240229",
-		"claude-3-haiku-20240307",
-		"claude-3-5-sonnet-20240620",
-		"claude-3-5-sonnet-20241022",
-		"claude-3-5-haiku-20241022",
+		"claude-opus-4-6",
+		"claude-opus-4-5-20251101",
+		"claude-opus-4-1-20250805",
+		"claude-opus-4-20250514",
+		"claude-sonnet-4-5-20250929",
+		"claude-sonnet-4-20250514",
+		"claude-haiku-4-5-20251001",
 	}
 
 	tests := []struct {
@@ -35,14 +36,18 @@ func TestResolveModelID(t *testing.T) {
 		expected string
 		found    bool
 	}{
-		// Exact match
-		{"claude-3-opus-20240229", "claude-3-opus-20240229", true},
-		// Alias for Sonnet 3.5 (should pick latest)
-		{"claude-3-5-sonnet", "claude-3-5-sonnet-20241022", true},
-		// Alias for Haiku 3.5
-		{"claude-3-5-haiku", "claude-3-5-haiku-20241022", true},
-		// Alias for Sonnet 3
-		{"claude-3-sonnet", "claude-3-sonnet-20240229", true},
+		// Exact matches
+		{"claude-opus-4-6", "claude-opus-4-6", true},
+		{"claude-opus-4-1-20250805", "claude-opus-4-1-20250805", true},
+		{"claude-opus-4-20250514", "claude-opus-4-20250514", true},
+
+		// Aliases
+		{"claude-opus-4-5", "claude-opus-4-5-20251101", true},
+		{"claude-sonnet-4-5", "claude-sonnet-4-5-20250929", true},
+		{"claude-sonnet-4", "claude-sonnet-4-20250514", true},
+		{"claude-opus-4", "claude-opus-4-20250514", true},
+		{"claude-haiku-4-5", "claude-haiku-4-5-20251001", true},
+
 		// Non-existent
 		{"claude-2", "", false},
 	}


### PR DESCRIPTION
Providing a claude model using an alias without the `@YYYYMMDD` format will resolve into a valid model name

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
