### PR TITLE
fix(ci): python genkit v0.5.0 tags

### DIFF
--- a/.github/workflows/releasekit-uv.yml
+++ b/.github/workflows/releasekit-uv.yml
@@ -153,6 +153,16 @@ on:
         required: false
         default: '2'
         type: string
+      auth_method:
+        description: 'Authentication method (auto = detect from configured secrets)'
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - app
+          - pat
+          - github-token
   push:
     branches: [main]
     paths:
@@ -186,10 +196,94 @@ env:
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════
+  # AUTH: Resolve token (GitHub App → PAT → GITHUB_TOKEN)
+  #
+  # Supports three auth modes in priority order:
+  #   1. GitHub App  — set RELEASEKIT_APP_ID (variable) +
+  #                    RELEASEKIT_APP_PRIVATE_KEY (secret).
+  #                    Passes CLA, triggers CI on Release PRs.
+  #   2. PAT         — set RELEASEKIT_TOKEN (secret).
+  #                    Passes CLA, triggers CI on Release PRs.
+  #   3. GITHUB_TOKEN — built-in, no setup needed.
+  #                    PRs will NOT trigger CI and may fail CLA checks.
+  # ═══════════════════════════════════════════════════════════════════════
+  auth:
+    name: Resolve Auth Token
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      token: ${{ steps.resolve.outputs.token }}
+      git-user-name: ${{ steps.resolve.outputs.git-user-name }}
+      git-user-email: ${{ steps.resolve.outputs.git-user-email }}
+    steps:
+      # Option 1: GitHub App (preferred — passes CLA, triggers CI).
+      - name: Generate GitHub App token
+        if: >
+          (inputs.auth_method == 'auto' || inputs.auth_method == 'app' || inputs.auth_method == '')
+          && vars.RELEASEKIT_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASEKIT_APP_ID }}
+          private-key: ${{ secrets.RELEASEKIT_APP_PRIVATE_KEY }}
+
+      - name: Get App bot user ID
+        if: steps.app-token.outcome == 'success'
+        id: app-user
+        run: |
+          if ! user_id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id 2>/dev/null); then
+            echo "::warning::Failed to fetch App bot user ID — using 0 as fallback"
+            user_id=0
+          fi
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Resolve: App > PAT > GITHUB_TOKEN (respects auth_method override).
+      - name: Resolve token and identity
+        id: resolve
+        run: |
+          AUTH="${{ inputs.auth_method || 'auto' }}"
+
+          # App token — used when auth=auto (and available) or auth=app.
+          if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
+            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+            echo "::notice::Using GitHub App token (${{ steps.app-token.outputs.app-slug }})"
+
+          # PAT — used when auth=auto (and available) or auth=pat.
+          elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
+            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Using Personal Access Token"
+
+          # GITHUB_TOKEN — fallback or explicit. Uses repo variables for
+          # git identity if set, so CLA can pass with a signed identity.
+          else
+            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            if [ -n "$GIT_USER_NAME" ]; then
+              echo "::notice::Using GITHUB_TOKEN with custom identity ($GIT_USER_NAME)"
+            else
+              echo "::warning::Using GITHUB_TOKEN — PRs will not trigger CI and may fail CLA checks. Set RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL repo variables to use a CLA-signed identity."
+            fi
+          fi
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
+          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
+          GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
+
+  # ═══════════════════════════════════════════════════════════════════════
   # PREPARE: Compute bumps and open/update Release PR
   # ═══════════════════════════════════════════════════════════════════════
   prepare:
     name: Prepare Release PR
+    needs: auth
     if: |
       (github.event_name == 'push' &&
        !startsWith(github.event.head_commit.message, 'chore(release):') &&
@@ -204,8 +298,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-releasekit
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
           releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
       - uses: ./.github/actions/run-releasekit
         id: prepare
@@ -218,13 +314,14 @@ jobs:
           prerelease: ${{ inputs.prerelease }}
           force: ${{ inputs.force_prepare }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ needs.auth.outputs.token }}
 
   # ═══════════════════════════════════════════════════════════════════════
   # RELEASE: Tag merge commit and create GitHub Release
   # ═══════════════════════════════════════════════════════════════════════
   release:
     name: Tag and Release
+    needs: auth
     if: |
       (github.event_name == 'pull_request' &&
        github.event.pull_request.merged == true &&
@@ -238,8 +335,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-releasekit
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
           releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
       - uses: ./.github/actions/run-releasekit
         id: release
@@ -250,14 +349,14 @@ jobs:
           dry-run: ${{ env.DRY_RUN }}
           show-plan: "true"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ needs.auth.outputs.token }}
 
   # ═══════════════════════════════════════════════════════════════════════
   # PUBLISH: Build and publish packages to PyPI
   # ═══════════════════════════════════════════════════════════════════════
   publish:
     name: Publish to ${{ inputs.target || 'pypi' }}
-    needs: release
+    needs: [auth, release]
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -269,7 +368,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-releasekit
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
           releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           install-system-deps: "true"
           workspace-dir: ${{ env.WORKSPACE_DIR }}
@@ -374,7 +473,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [release, publish, verify]
+    needs: [auth, release, publish, verify]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -382,6 +481,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
           event-type: genkit-python-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'

--- a/bin/add_license
+++ b/bin/add_license
@@ -55,6 +55,8 @@ fi
   -ignore '**/coverage/**/*' \
   -ignore '**/develop-eggs/**/*' \
   -ignore '**/dist/**/*' \
+  -ignore '**/lib/**/*' \
+  -ignore '**/next-env.d.ts' \
   -ignore '**/node_modules/**/*' \
   -ignore '**/pnpm-lock.yaml' \
   -ignore '.nx/**/*' \

--- a/bin/check_license
+++ b/bin/check_license
@@ -60,6 +60,8 @@ export PATH="${GOPATH}:${PATH}"
   -ignore '**/coverage/**/*' \
   -ignore '**/develop-eggs/**/*' \
   -ignore '**/dist/**/*' \
+  -ignore '**/lib/**/*' \
+  -ignore '**/next-env.d.ts' \
   -ignore '**/node_modules/**/*' \
   -ignore '**/pnpm-lock.yaml' \
   -ignore '.nx/**/*' \

--- a/py/tools/releasekit/github/workflows/releasekit-cargo.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-cargo.yml
@@ -174,6 +174,12 @@ on:
         required: false
       GEMINI_API_KEY:
         required: false
+      RELEASEKIT_APP_PRIVATE_KEY:
+        description: 'GitHub App private key for CLA-passing commits'
+        required: false
+      RELEASEKIT_TOKEN:
+        description: 'Personal Access Token fallback'
+        required: false
   workflow_dispatch:
     inputs:
       action:
@@ -240,6 +246,16 @@ on:
         description: 'Override codename theme (e.g. galaxies, animals)'
         required: false
         type: string
+      auth_method:
+        description: 'Authentication method (auto = detect from configured secrets)'
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - app
+          - pat
+          - github-token
   push:
     branches: [main]
     paths:
@@ -266,10 +282,69 @@ env:
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════
+  # AUTH: Resolve token (GitHub App → PAT → GITHUB_TOKEN)
+  # ═══════════════════════════════════════════════════════════════════════
+  auth:
+    name: Resolve Auth Token
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      token: ${{ steps.resolve.outputs.token }}
+      git-user-name: ${{ steps.resolve.outputs.git-user-name }}
+      git-user-email: ${{ steps.resolve.outputs.git-user-email }}
+    steps:
+      - name: Generate GitHub App token
+        if: >
+          (inputs.auth_method == 'auto' || inputs.auth_method == 'app' || inputs.auth_method == '')
+          && vars.RELEASEKIT_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASEKIT_APP_ID }}
+          private-key: ${{ secrets.RELEASEKIT_APP_PRIVATE_KEY }}
+
+      - name: Get App bot user ID
+        if: steps.app-token.outcome == 'success'
+        id: app-user
+        run: |
+          if ! user_id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id 2>/dev/null); then
+            echo "::warning::Failed to fetch App bot user ID — using 0 as fallback"
+            user_id=0
+          fi
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Resolve token and identity
+        id: resolve
+        run: |
+          AUTH="${{ inputs.auth_method || 'auto' }}"
+          if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
+            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+          elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
+            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+          else
+            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
+          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
+          GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
+
+  # ═══════════════════════════════════════════════════════════════════════
   # PREPARE: Compute bumps and open/update Release PR
   # ═══════════════════════════════════════════════════════════════════════
   prepare:
     name: Prepare Release PR
+    needs: auth
     if: |
       (github.event_name == 'push' &&
        !startsWith(github.event.head_commit.message, 'chore(release):') &&
@@ -285,7 +360,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - name: Run releasekit prepare
         id: rk
@@ -308,6 +383,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   release:
     name: Tag and Release
+    needs: auth
     if: |
       (github.event_name == 'pull_request' &&
        github.event.pull_request.merged == true &&
@@ -322,7 +398,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - name: Run releasekit release
         id: rk
@@ -342,7 +418,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   publish:
     name: Publish to crates.io
-    needs: release
+    needs: [auth, release]
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -396,7 +472,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [release, publish]
+    needs: [auth, release, publish]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -404,6 +480,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
           event-type: genkit-rust-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'

--- a/py/tools/releasekit/github/workflows/releasekit-dart.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-dart.yml
@@ -174,6 +174,12 @@ on:
         required: false
       GEMINI_API_KEY:
         required: false
+      RELEASEKIT_APP_PRIVATE_KEY:
+        description: 'GitHub App private key for CLA-passing commits'
+        required: false
+      RELEASEKIT_TOKEN:
+        description: 'Personal Access Token fallback'
+        required: false
   workflow_dispatch:
     inputs:
       action:
@@ -240,6 +246,16 @@ on:
         description: 'Override codename theme (e.g. galaxies, animals)'
         required: false
         type: string
+      auth_method:
+        description: 'Authentication method (auto = detect from configured secrets)'
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - app
+          - pat
+          - github-token
   push:
     branches: [main]
     paths:
@@ -266,10 +282,69 @@ env:
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════
+  # AUTH: Resolve token (GitHub App → PAT → GITHUB_TOKEN)
+  # ═══════════════════════════════════════════════════════════════════════
+  auth:
+    name: Resolve Auth Token
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      token: ${{ steps.resolve.outputs.token }}
+      git-user-name: ${{ steps.resolve.outputs.git-user-name }}
+      git-user-email: ${{ steps.resolve.outputs.git-user-email }}
+    steps:
+      - name: Generate GitHub App token
+        if: >
+          (inputs.auth_method == 'auto' || inputs.auth_method == 'app' || inputs.auth_method == '')
+          && vars.RELEASEKIT_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASEKIT_APP_ID }}
+          private-key: ${{ secrets.RELEASEKIT_APP_PRIVATE_KEY }}
+
+      - name: Get App bot user ID
+        if: steps.app-token.outcome == 'success'
+        id: app-user
+        run: |
+          if ! user_id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id 2>/dev/null); then
+            echo "::warning::Failed to fetch App bot user ID — using 0 as fallback"
+            user_id=0
+          fi
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Resolve token and identity
+        id: resolve
+        run: |
+          AUTH="${{ inputs.auth_method || 'auto' }}"
+          if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
+            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+          elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
+            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+          else
+            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
+          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
+          GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
+
+  # ═══════════════════════════════════════════════════════════════════════
   # PREPARE: Compute bumps and open/update Release PR
   # ═══════════════════════════════════════════════════════════════════════
   prepare:
     name: Prepare Release PR
+    needs: auth
     if: |
       (github.event_name == 'push' &&
        !startsWith(github.event.head_commit.message, 'chore(release):') &&
@@ -285,7 +360,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - uses: subosito/flutter-action@v2
         with:
@@ -314,6 +389,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   release:
     name: Tag and Release
+    needs: auth
     if: |
       (github.event_name == 'pull_request' &&
        github.event.pull_request.merged == true &&
@@ -328,7 +404,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - name: Run releasekit release
         id: rk
@@ -348,7 +424,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   publish:
     name: Publish to pub.dev
-    needs: release
+    needs: [auth, release]
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -403,7 +479,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [release, publish]
+    needs: [auth, release, publish]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -411,6 +487,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
           event-type: genkit-dart-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'

--- a/py/tools/releasekit/github/workflows/releasekit-go.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-go.yml
@@ -167,6 +167,12 @@ on:
         required: false
       GEMINI_API_KEY:
         required: false
+      RELEASEKIT_APP_PRIVATE_KEY:
+        description: 'GitHub App private key for CLA-passing commits'
+        required: false
+      RELEASEKIT_TOKEN:
+        description: 'Personal Access Token fallback'
+        required: false
   workflow_dispatch:
     inputs:
       action:
@@ -233,6 +239,16 @@ on:
         description: 'Override codename theme (e.g. galaxies, animals)'
         required: false
         type: string
+      auth_method:
+        description: 'Authentication method (auto = detect from configured secrets)'
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - app
+          - pat
+          - github-token
   push:
     branches: [main]
     paths:
@@ -258,10 +274,69 @@ env:
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════
+  # AUTH: Resolve token (GitHub App → PAT → GITHUB_TOKEN)
+  # ═══════════════════════════════════════════════════════════════════════
+  auth:
+    name: Resolve Auth Token
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      token: ${{ steps.resolve.outputs.token }}
+      git-user-name: ${{ steps.resolve.outputs.git-user-name }}
+      git-user-email: ${{ steps.resolve.outputs.git-user-email }}
+    steps:
+      - name: Generate GitHub App token
+        if: >
+          (inputs.auth_method == 'auto' || inputs.auth_method == 'app' || inputs.auth_method == '')
+          && vars.RELEASEKIT_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASEKIT_APP_ID }}
+          private-key: ${{ secrets.RELEASEKIT_APP_PRIVATE_KEY }}
+
+      - name: Get App bot user ID
+        if: steps.app-token.outcome == 'success'
+        id: app-user
+        run: |
+          if ! user_id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id 2>/dev/null); then
+            echo "::warning::Failed to fetch App bot user ID — using 0 as fallback"
+            user_id=0
+          fi
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Resolve token and identity
+        id: resolve
+        run: |
+          AUTH="${{ inputs.auth_method || 'auto' }}"
+          if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
+            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+          elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
+            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+          else
+            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
+          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
+          GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
+
+  # ═══════════════════════════════════════════════════════════════════════
   # PREPARE: Compute bumps and open/update Release PR
   # ═══════════════════════════════════════════════════════════════════════
   prepare:
     name: Prepare Release PR
+    needs: auth
     if: |
       (github.event_name == 'push' &&
        !startsWith(github.event.head_commit.message, 'chore(release):') &&
@@ -277,7 +352,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - uses: actions/setup-go@v5
         with:
@@ -305,6 +380,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   release:
     name: Tag and Release
+    needs: auth
     if: |
       (github.event_name == 'pull_request' &&
        github.event.pull_request.merged == true &&
@@ -319,7 +395,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - name: Run releasekit release
         id: rk
@@ -339,7 +415,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   publish:
     name: Verify on Go Proxy
-    needs: release
+    needs: [auth, release]
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -384,7 +460,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [release, publish]
+    needs: [auth, release, publish]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -392,6 +468,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
           event-type: genkit-go-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'

--- a/py/tools/releasekit/github/workflows/releasekit-gradle.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-gradle.yml
@@ -189,6 +189,12 @@ on:
         required: false
       GEMINI_API_KEY:
         required: false
+      RELEASEKIT_APP_PRIVATE_KEY:
+        description: 'GitHub App private key for CLA-passing commits'
+        required: false
+      RELEASEKIT_TOKEN:
+        description: 'Personal Access Token fallback'
+        required: false
   workflow_dispatch:
     inputs:
       action:
@@ -263,6 +269,16 @@ on:
         description: 'Override codename theme (e.g. galaxies, animals)'
         required: false
         type: string
+      auth_method:
+        description: 'Authentication method (auto = detect from configured secrets)'
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - app
+          - pat
+          - github-token
   push:
     branches: [main]
     paths:
@@ -290,10 +306,69 @@ env:
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════
+  # AUTH: Resolve token (GitHub App → PAT → GITHUB_TOKEN)
+  # ═══════════════════════════════════════════════════════════════════════
+  auth:
+    name: Resolve Auth Token
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      token: ${{ steps.resolve.outputs.token }}
+      git-user-name: ${{ steps.resolve.outputs.git-user-name }}
+      git-user-email: ${{ steps.resolve.outputs.git-user-email }}
+    steps:
+      - name: Generate GitHub App token
+        if: >
+          (inputs.auth_method == 'auto' || inputs.auth_method == 'app' || inputs.auth_method == '')
+          && vars.RELEASEKIT_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASEKIT_APP_ID }}
+          private-key: ${{ secrets.RELEASEKIT_APP_PRIVATE_KEY }}
+
+      - name: Get App bot user ID
+        if: steps.app-token.outcome == 'success'
+        id: app-user
+        run: |
+          if ! user_id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id 2>/dev/null); then
+            echo "::warning::Failed to fetch App bot user ID — using 0 as fallback"
+            user_id=0
+          fi
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Resolve token and identity
+        id: resolve
+        run: |
+          AUTH="${{ inputs.auth_method || 'auto' }}"
+          if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
+            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+          elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
+            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+          else
+            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
+          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
+          GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
+
+  # ═══════════════════════════════════════════════════════════════════════
   # PREPARE: Compute bumps and open/update Release PR
   # ═══════════════════════════════════════════════════════════════════════
   prepare:
     name: Prepare Release PR
+    needs: auth
     if: |
       (github.event_name == 'push' &&
        !startsWith(github.event.head_commit.message, 'chore(release):') &&
@@ -309,7 +384,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - uses: actions/setup-java@v4
         with:
@@ -341,6 +416,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   release:
     name: Tag and Release
+    needs: auth
     if: |
       (github.event_name == 'pull_request' &&
        github.event.pull_request.merged == true &&
@@ -355,7 +431,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - name: Run releasekit release
         id: rk
@@ -375,7 +451,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   publish:
     name: Publish to ${{ inputs.target || 'maven-central' }}
-    needs: release
+    needs: [auth, release]
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -437,7 +513,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [release, publish]
+    needs: [auth, release, publish]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -445,6 +521,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
           event-type: genkit-java-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'

--- a/py/tools/releasekit/github/workflows/releasekit-pnpm.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-pnpm.yml
@@ -172,6 +172,12 @@ on:
         required: false
       GEMINI_API_KEY:
         required: false
+      RELEASEKIT_APP_PRIVATE_KEY:
+        description: 'GitHub App private key for CLA-passing commits'
+        required: false
+      RELEASEKIT_TOKEN:
+        description: 'Personal Access Token fallback'
+        required: false
   workflow_dispatch:
     inputs:
       action:
@@ -245,6 +251,16 @@ on:
         description: 'Override codename theme (e.g. galaxies, animals)'
         required: false
         type: string
+      auth_method:
+        description: 'Authentication method (auto = detect from configured secrets)'
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - app
+          - pat
+          - github-token
   push:
     branches: [main]
     paths:
@@ -274,10 +290,69 @@ env:
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════
+  # AUTH: Resolve token (GitHub App → PAT → GITHUB_TOKEN)
+  # ═══════════════════════════════════════════════════════════════════════
+  auth:
+    name: Resolve Auth Token
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      token: ${{ steps.resolve.outputs.token }}
+      git-user-name: ${{ steps.resolve.outputs.git-user-name }}
+      git-user-email: ${{ steps.resolve.outputs.git-user-email }}
+    steps:
+      - name: Generate GitHub App token
+        if: >
+          (inputs.auth_method == 'auto' || inputs.auth_method == 'app' || inputs.auth_method == '')
+          && vars.RELEASEKIT_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASEKIT_APP_ID }}
+          private-key: ${{ secrets.RELEASEKIT_APP_PRIVATE_KEY }}
+
+      - name: Get App bot user ID
+        if: steps.app-token.outcome == 'success'
+        id: app-user
+        run: |
+          if ! user_id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id 2>/dev/null); then
+            echo "::warning::Failed to fetch App bot user ID — using 0 as fallback"
+            user_id=0
+          fi
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Resolve token and identity
+        id: resolve
+        run: |
+          AUTH="${{ inputs.auth_method || 'auto' }}"
+          if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
+            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+          elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
+            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+          else
+            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
+          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
+          GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
+
+  # ═══════════════════════════════════════════════════════════════════════
   # PREPARE: Compute bumps and open/update Release PRs
   # ═══════════════════════════════════════════════════════════════════════
   prepare-js:
     name: "Prepare Release PR (JS)"
+    needs: auth
     if: |
       (github.event_name == 'push' &&
        !startsWith(github.event.head_commit.message, 'chore(release):') &&
@@ -293,7 +368,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -323,6 +398,7 @@ jobs:
 
   prepare-js-cli:
     name: "Prepare Release PR (JS CLI)"
+    needs: auth
     if: |
       (github.event_name == 'push' &&
        !startsWith(github.event.head_commit.message, 'chore(release):') &&
@@ -338,7 +414,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -371,6 +447,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   release-js:
     name: "Tag and Release (JS)"
+    needs: auth
     if: |
       (github.event_name == 'pull_request' &&
        github.event.pull_request.merged == true &&
@@ -385,7 +462,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - name: Run releasekit release
         id: rk
@@ -405,7 +482,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   publish-js:
     name: "Publish to npm"
-    needs: release-js
+    needs: [auth, release-js]
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -464,7 +541,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify-js:
     name: "Notify Downstream (JS)"
-    needs: [release-js, publish-js]
+    needs: [auth, release-js, publish-js]
     if: success() && needs.publish-js.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -472,6 +549,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
           event-type: genkit-js-release
           client-payload: '{"release_url": "${{ needs.release-js.outputs.release_url }}"}'

--- a/py/tools/releasekit/github/workflows/releasekit-uv.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-uv.yml
@@ -171,6 +171,12 @@ on:
         required: false
       GEMINI_API_KEY:
         required: false
+      RELEASEKIT_APP_PRIVATE_KEY:
+        description: 'GitHub App private key for CLA-passing commits'
+        required: false
+      RELEASEKIT_TOKEN:
+        description: 'Personal Access Token fallback'
+        required: false
   workflow_dispatch:
     inputs:
       action:
@@ -245,6 +251,16 @@ on:
         description: 'Override codename theme (e.g. galaxies, animals)'
         required: false
         type: string
+      auth_method:
+        description: 'Authentication method (auto = detect from configured secrets)'
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - app
+          - pat
+          - github-token
   push:
     branches: [main]
     paths:
@@ -279,10 +295,94 @@ env:
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════
+  # AUTH: Resolve token (GitHub App → PAT → GITHUB_TOKEN)
+  #
+  # Supports three auth modes in priority order:
+  #   1. GitHub App  — set RELEASEKIT_APP_ID (variable) +
+  #                    RELEASEKIT_APP_PRIVATE_KEY (secret).
+  #                    Passes CLA, triggers CI on Release PRs.
+  #   2. PAT         — set RELEASEKIT_TOKEN (secret).
+  #                    Passes CLA, triggers CI on Release PRs.
+  #   3. GITHUB_TOKEN — built-in, no setup needed.
+  #                    PRs will NOT trigger CI and may fail CLA checks.
+  # ═══════════════════════════════════════════════════════════════════════
+  auth:
+    name: Resolve Auth Token
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      token: ${{ steps.resolve.outputs.token }}
+      git-user-name: ${{ steps.resolve.outputs.git-user-name }}
+      git-user-email: ${{ steps.resolve.outputs.git-user-email }}
+    steps:
+      # Option 1: GitHub App (preferred — passes CLA, triggers CI).
+      - name: Generate GitHub App token
+        if: >
+          (inputs.auth_method == 'auto' || inputs.auth_method == 'app' || inputs.auth_method == '')
+          && vars.RELEASEKIT_APP_ID != ''
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASEKIT_APP_ID }}
+          private-key: ${{ secrets.RELEASEKIT_APP_PRIVATE_KEY }}
+
+      - name: Get App bot user ID
+        if: steps.app-token.outcome == 'success'
+        id: app-user
+        run: |
+          if ! user_id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id 2>/dev/null); then
+            echo "::warning::Failed to fetch App bot user ID — using 0 as fallback"
+            user_id=0
+          fi
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Resolve: App > PAT > GITHUB_TOKEN (respects auth_method override).
+      - name: Resolve token and identity
+        id: resolve
+        run: |
+          AUTH="${{ inputs.auth_method || 'auto' }}"
+
+          # App token — used when auth=auto (and available) or auth=app.
+          if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
+            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+            echo "::notice::Using GitHub App token (${{ steps.app-token.outputs.app-slug }})"
+
+          # PAT — used when auth=auto (and available) or auth=pat.
+          elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
+            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Using Personal Access Token"
+
+          # GITHUB_TOKEN — fallback or explicit. Uses repo variables for
+          # git identity if set, so CLA can pass with a signed identity.
+          else
+            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
+            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            if [ -n "$GIT_USER_NAME" ]; then
+              echo "::notice::Using GITHUB_TOKEN with custom identity ($GIT_USER_NAME)"
+            else
+              echo "::warning::Using GITHUB_TOKEN — PRs will not trigger CI and may fail CLA checks. Set RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL repo variables to use a CLA-signed identity."
+            fi
+          fi
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
+          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
+          GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
+
+  # ═══════════════════════════════════════════════════════════════════════
   # PREPARE: Compute bumps and open/update Release PR
   # ═══════════════════════════════════════════════════════════════════════
   prepare:
     name: Prepare Release PR
+    needs: auth
     if: |
       (github.event_name == 'push' &&
        !startsWith(github.event.head_commit.message, 'chore(release):') &&
@@ -298,7 +398,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - name: Run releasekit prepare
         id: rk
@@ -314,6 +414,9 @@ jobs:
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ needs.auth.outputs.token }}
+          RELEASEKIT_GIT_USER_NAME: ${{ needs.auth.outputs.git-user-name }}
+          RELEASEKIT_GIT_USER_EMAIL: ${{ needs.auth.outputs.git-user-email }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -321,6 +424,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   release:
     name: Tag and Release
+    needs: auth
     if: |
       (github.event_name == 'pull_request' &&
        github.event.pull_request.merged == true &&
@@ -335,7 +439,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
 
       - name: Run releasekit release
         id: rk
@@ -348,6 +452,9 @@ jobs:
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ needs.auth.outputs.token }}
+          RELEASEKIT_GIT_USER_NAME: ${{ needs.auth.outputs.git-user-name }}
+          RELEASEKIT_GIT_USER_EMAIL: ${{ needs.auth.outputs.git-user-email }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -355,7 +462,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   publish:
     name: Publish to ${{ inputs.target || 'pypi' }}
-    needs: release
+    needs: [auth, release]
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -415,7 +522,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [release, publish]
+    needs: [auth, release, publish]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -423,6 +530,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ needs.auth.outputs.token }}
           event-type: genkit-python-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'

--- a/py/tools/releasekit/src/releasekit/backends/vcs/__init__.py
+++ b/py/tools/releasekit/src/releasekit/backends/vcs/__init__.py
@@ -129,6 +129,7 @@ class VCS(Protocol):
         self,
         tag_name: str,
         *,
+        ref: str | None = None,
         message: str | None = None,
         dry_run: bool = False,
     ) -> CommandResult:
@@ -136,6 +137,7 @@ class VCS(Protocol):
 
         Args:
             tag_name: Tag name (e.g. ``"genkit-v0.5.0"``).
+            ref: Commit SHA to tag. Defaults to HEAD if ``None``.
             message: Tag message. Defaults to the tag name.
             dry_run: Log the command without executing.
         """

--- a/py/tools/releasekit/src/releasekit/backends/vcs/git.py
+++ b/py/tools/releasekit/src/releasekit/backends/vcs/git.py
@@ -178,19 +178,19 @@ class GitCLIBackend:
         self,
         tag_name: str,
         *,
+        ref: str | None = None,
         message: str | None = None,
         dry_run: bool = False,
     ) -> CommandResult:
         """Create an annotated tag."""
         tag_message = message or tag_name
-        log.info('tag', tag=tag_name)
+        log.info('tag', tag=tag_name, ref=ref or 'HEAD')
+        args = ['tag', '-a', tag_name, '-m', tag_message]
+        if ref:
+            args.append(ref)
         return await asyncio.to_thread(
             self._git,
-            'tag',
-            '-a',
-            tag_name,
-            '-m',
-            tag_message,
+            *args,
             dry_run=dry_run,
         )
 

--- a/py/tools/releasekit/src/releasekit/backends/vcs/mercurial.py
+++ b/py/tools/releasekit/src/releasekit/backends/vcs/mercurial.py
@@ -209,6 +209,7 @@ class MercurialCLIBackend:
         self,
         tag_name: str,
         *,
+        ref: str | None = None,
         message: str | None = None,
         dry_run: bool = False,
     ) -> CommandResult:
@@ -219,13 +220,14 @@ class MercurialCLIBackend:
         tags, which are refs.
         """
         tag_message = message or tag_name
-        log.info('tag', tag=tag_name)
+        log.info('tag', tag=tag_name, ref=ref or '.')
+        args = ['tag', '-m', tag_message]
+        if ref:
+            args.extend(['-r', ref])
+        args.append(tag_name)
         return await asyncio.to_thread(
             self._hg,
-            'tag',
-            '-m',
-            tag_message,
-            tag_name,
+            *args,
             dry_run=dry_run,
         )
 

--- a/py/tools/releasekit/tests/_fakes/_vcs.py
+++ b/py/tools/releasekit/tests/_fakes/_vcs.py
@@ -162,6 +162,7 @@ class FakeVCS:
         self,
         tag_name: str,
         *,
+        ref: str | None = None,
         message: str | None = None,
         dry_run: bool = False,
     ) -> CommandResult:

--- a/py/tools/releasekit/tests/rk_invariants_test.py
+++ b/py/tools/releasekit/tests/rk_invariants_test.py
@@ -76,6 +76,7 @@ class _FakeVCS(_BaseFakeVCS):
         self,
         tag_name: str,
         *,
+        ref: str | None = None,
         message: str | None = None,
         dry_run: bool = False,
     ) -> CommandResult:

--- a/py/tools/releasekit/tests/rk_tags_test.py
+++ b/py/tools/releasekit/tests/rk_tags_test.py
@@ -50,6 +50,7 @@ class FakeVCS(_BaseFakeVCS):
         self,
         tag_name: str,
         *,
+        ref: str | None = None,
         message: str | None = None,
         dry_run: bool = False,
     ) -> CommandResult:
@@ -691,7 +692,14 @@ class TestCreateTagsSecondary:
         call_count = 0
 
         class FailSecondaryVCS(FakeVCS):
-            async def tag(self, tag_name: str, *, message: str | None = None, dry_run: bool = False) -> CommandResult:
+            async def tag(
+                self,
+                tag_name: str,
+                *,
+                ref: str | None = None,
+                message: str | None = None,
+                dry_run: bool = False,
+            ) -> CommandResult:
                 """Tag."""
                 nonlocal call_count
                 call_count += 1

--- a/releasekit.toml
+++ b/releasekit.toml
@@ -14,9 +14,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-forge      = "github"
-repo_name  = "genkit"
-repo_owner = "firebase"
+forge              = "github"
+repo_name          = "genkit"
+repo_owner         = "firebase"
+pr_title_template  = "chore(release): genkit python v{version}"
 
 # ---------------------------------------------------------------------------
 # Global options (valid top-level keys)


### PR DESCRIPTION
## Summary

Adds CI authentication and bootstrap infrastructure for the releasekit release pipeline.

### Auth job (3-tier: App → PAT → GITHUB_TOKEN)

All 8 release workflows (1 live + 7 sample templates) now include an `auth` job with:

- **GitHub App** (preferred) — passes CLA, triggers downstream CI
- **Personal Access Token** — passes CLA, triggers downstream CI
- **GITHUB_TOKEN** (fallback) — zero setup, but PRs won't trigger CI

Each mode resolves git identity (user name + email) for commit attribution:
- App: uses `<app-slug>[bot]` identity with API-fetched user ID
- PAT: uses `RELEASEKIT_GIT_USER_NAME`/`RELEASEKIT_GIT_USER_EMAIL` repo variables (falls back to `releasekit[bot]`)
- GITHUB_TOKEN: uses the same repo variables (falls back to `github-actions[bot]`)

This means CLA checks can pass even with GITHUB_TOKEN by setting repo variables to a CLA-signed identity.

### `auth_method` dropdown

All workflows now include an `auth_method` choice in the workflow dispatch UI:

| Value | Behavior |
|-------|----------|
| `auto` | Auto-detect from configured secrets (default) |
| `app` | Force GitHub App token |
| `pat` | Force PAT |
| `github-token` | Force built-in GITHUB_TOKEN |

### Bootstrap tags

- **`bootstrap_tags.py`** — Standalone PEP 723 script that reads `releasekit.toml`, discovers all workspace packages using `library_dirs`, and creates per-package tags at the `bootstrap_sha` commit
- 24 tags pushed to origin (23 per-package + 1 umbrella `py/v0.5.0`)

### Code review fixes

- Added `RELEASEKIT_GIT_USER_NAME`/`RELEASEKIT_GIT_USER_EMAIL` env vars to prepare and release job steps
- Added error handling for `gh api` call when fetching App bot user ID (falls back to `user_id=0`)
- Unified identity resolution across all 8 workflows (non-uv workflows previously only resolved token, not identity)
- `bootstrap_tags.py` now reads `library_dirs` from `releasekit.toml` instead of hardcoding `['packages', 'plugins']`
- Restored `logging` module calls (previously stripped as `pass` placeholders for T20 compliance)

### Documentation

Added to `README.md`:
- **CI Authentication** section with setup instructions for all 3 auth modes
- **`auth_method` dropdown** reference table
- **Bootstrap Tags** section with usage examples

### Setup instructions

To configure CLA-passing identity with GITHUB_TOKEN (no App/PAT needed):

1. Go to `https://github.com/firebase/genkit/settings/variables/actions`
2. Add `RELEASEKIT_GIT_USER_NAME` = your name
3. Add `RELEASEKIT_GIT_USER_EMAIL` = your CLA-signed email

### Follow-up

- [ ] `releasekit init` could auto-create bootstrap tags when `bootstrap_sha` is set (instead of requiring a separate script)
- [ ] Configure GitHub App or PAT for full CI integration (GITHUB_TOKEN PRs don't trigger downstream workflows)

### Files changed

| File | Change |
|------|--------|
| `.github/workflows/releasekit-uv.yml` | Auth job + identity + `auth_method` |
| `py/tools/releasekit/github/workflows/releasekit-uv.yml` | Auth job + identity + `auth_method` |
| `py/tools/releasekit/github/workflows/releasekit-cargo.yml` | Auth job + identity + `auth_method` |
| `py/tools/releasekit/github/workflows/releasekit-dart.yml` | Auth job + identity + `auth_method` |
| `py/tools/releasekit/github/workflows/releasekit-go.yml` | Auth job + identity + `auth_method` |
| `py/tools/releasekit/github/workflows/releasekit-gradle.yml` | Auth job + identity + `auth_method` |
| `py/tools/releasekit/github/workflows/releasekit-pnpm.yml` | Auth job + identity + `auth_method` |
| `py/tools/releasekit/scripts/bootstrap_tags.py` | Dynamic discovery + logging |
| `py/tools/releasekit/README.md` | Auth + bootstrap docs |
