### PR TITLE
fix(py/genkit): add missing SPDX-License-Identifier header to resource.py

### DIFF
--- a/py/packages/genkit/src/genkit/blocks/resource.py
+++ b/py/packages/genkit/src/genkit/blocks/resource.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 """Resource module for defining and managing resources.
 


### PR DESCRIPTION
Adds the missing `# SPDX-License-Identifier: Apache-2.0` comment to `py/packages/genkit/src/genkit/blocks/resource.py`, which was flagged by the license header check in `releasekit check`.