### PR TITLE
feat(ci): standardize releasekit-uv workflow to use composite action pattern

### DIFF
--- a/.github/actions/run-releasekit/action.yml
+++ b/.github/actions/run-releasekit/action.yml
@@ -106,11 +106,46 @@ inputs:
       Registry URL for uploading packages (publish only).
     required: false
     default: ""
+  no-ai:
+    description: >-
+      Disable all AI features (summarization, codenames).
+    required: false
+    default: "false"
+  model:
+    description: >-
+      Override AI model (e.g. "ollama/gemma3:12b", "gemini-pro").
+    required: false
+    default: ""
+  codename-theme:
+    description: >-
+      Override codename theme (e.g. "galaxies", "animals").
+    required: false
+    default: ""
   show-plan:
     description: >-
       Show the execution plan before running the command.
     required: false
     default: "false"
+  tag:
+    description: >-
+      Git tag to roll back (rollback only).
+    required: false
+    default: ""
+  all-tags:
+    description: >-
+      Delete ALL tags pointing to the same commit (rollback only).
+    required: false
+    default: "false"
+  yank:
+    description: >-
+      Also yank/deprecate versions from the package registry (rollback only).
+    required: false
+    default: "false"
+  yank-reason:
+    description: >-
+      Reason for yanking (rollback only).
+    required: false
+    default: ""
 
 outputs:
   has_bumps:
@@ -131,15 +166,15 @@ runs:
       if: inputs.show-plan == 'true'
       shell: bash
       env:
-        RK_DIR: ${{ inputs.releasekit-dir }}
-        RK_WORKSPACE: ${{ inputs.workspace }}
-        RK_DRY_RUN: ${{ inputs.dry-run }}
+        RELEASEKIT_DIR: ${{ inputs.releasekit-dir }}
+        RELEASEKIT_WORKSPACE: ${{ inputs.workspace }}
+        RELEASEKIT_DRY_RUN: ${{ inputs.dry-run }}
       run: |
         echo "::group::Execution Plan"
-        uv run --directory "$RK_DIR" \
-          releasekit --workspace "$RK_WORKSPACE" plan --format full 2>&1 || true
+        uv run --directory "$RELEASEKIT_DIR" \
+          releasekit --workspace "$RELEASEKIT_WORKSPACE" plan --format full 2>&1 || true
         echo "::endgroup::"
-        if [ "$RK_DRY_RUN" = "true" ]; then
+        if [ "$RELEASEKIT_DRY_RUN" = "true" ]; then
           echo "::notice::DRY RUN — no side effects"
         else
           echo "::notice::LIVE RUN"
@@ -150,57 +185,91 @@ runs:
       id: run
       shell: bash
       env:
-        RK_COMMAND: ${{ inputs.command }}
-        RK_WORKSPACE: ${{ inputs.workspace }}
-        RK_DIR: ${{ inputs.releasekit-dir }}
-        RK_DRY_RUN: ${{ inputs.dry-run }}
-        RK_FORCE: ${{ inputs.force }}
-        RK_GROUP: ${{ inputs.group }}
-        RK_BUMP_TYPE: ${{ inputs.bump-type }}
-        RK_PRERELEASE: ${{ inputs.prerelease }}
-        RK_CONCURRENCY: ${{ inputs.concurrency }}
-        RK_MAX_RETRIES: ${{ inputs.max-retries }}
-        RK_CHECK_URL: ${{ inputs.check-url }}
-        RK_INDEX_URL: ${{ inputs.index-url }}
+        RELEASEKIT_COMMAND: ${{ inputs.command }}
+        RELEASEKIT_WORKSPACE: ${{ inputs.workspace }}
+        RELEASEKIT_DIR: ${{ inputs.releasekit-dir }}
+        RELEASEKIT_DRY_RUN: ${{ inputs.dry-run }}
+        RELEASEKIT_FORCE: ${{ inputs.force }}
+        RELEASEKIT_GROUP: ${{ inputs.group }}
+        RELEASEKIT_BUMP_TYPE: ${{ inputs.bump-type }}
+        RELEASEKIT_PRERELEASE: ${{ inputs.prerelease }}
+        RELEASEKIT_CONCURRENCY: ${{ inputs.concurrency }}
+        RELEASEKIT_MAX_RETRIES: ${{ inputs.max-retries }}
+        RELEASEKIT_CHECK_URL: ${{ inputs.check-url }}
+        RELEASEKIT_INDEX_URL: ${{ inputs.index-url }}
+        RELEASEKIT_NO_AI: ${{ inputs.no-ai }}
+        RELEASEKIT_MODEL: ${{ inputs.model }}
+        RELEASEKIT_CODENAME_THEME: ${{ inputs.codename-theme }}
+        RELEASEKIT_TAG: ${{ inputs.tag }}
+        RELEASEKIT_ALL_TAGS: ${{ inputs.all-tags }}
+        RELEASEKIT_YANK: ${{ inputs.yank }}
+        RELEASEKIT_YANK_REASON: ${{ inputs.yank-reason }}
       run: |
         set -euo pipefail
 
-        cmd=(uv run --directory "$RK_DIR" releasekit --workspace "$RK_WORKSPACE" "$RK_COMMAND")
+        cmd=(uv run --directory "$RELEASEKIT_DIR" releasekit --workspace "$RELEASEKIT_WORKSPACE" "$RELEASEKIT_COMMAND")
 
         # ── Common flags ──────────────────────────────────────────
-        if [ "$RK_DRY_RUN" = "true" ]; then
+        if [ "$RELEASEKIT_DRY_RUN" = "true" ]; then
           cmd+=(--dry-run)
         fi
-        if [ "$RK_FORCE" = "true" ]; then
+        if [ "$RELEASEKIT_FORCE" = "true" ]; then
           cmd+=(--force)
         fi
-        if [ -n "$RK_GROUP" ]; then
-          cmd+=(--group "$RK_GROUP")
+        if [ -n "$RELEASEKIT_GROUP" ]; then
+          cmd+=(--group "$RELEASEKIT_GROUP")
         fi
 
         # ── prepare-specific flags ────────────────────────────────
-        if [ "$RK_COMMAND" = "prepare" ]; then
-          if [ "$RK_BUMP_TYPE" != "auto" ] && [ -n "$RK_BUMP_TYPE" ]; then
-            cmd+=(--bump "$RK_BUMP_TYPE")
+        if [ "$RELEASEKIT_COMMAND" = "prepare" ]; then
+          if [ "$RELEASEKIT_BUMP_TYPE" != "auto" ] && [ -n "$RELEASEKIT_BUMP_TYPE" ]; then
+            cmd+=(--bump "$RELEASEKIT_BUMP_TYPE")
           fi
-          if [ -n "$RK_PRERELEASE" ]; then
-            cmd+=(--prerelease "$RK_PRERELEASE")
+          if [ -n "$RELEASEKIT_PRERELEASE" ]; then
+            cmd+=(--prerelease "$RELEASEKIT_PRERELEASE")
           fi
         fi
 
         # ── publish-specific flags ────────────────────────────────
-        if [ "$RK_COMMAND" = "publish" ]; then
-          if [ -n "$RK_CHECK_URL" ]; then
-            cmd+=(--check-url "$RK_CHECK_URL")
+        if [ "$RELEASEKIT_COMMAND" = "publish" ]; then
+          if [ -n "$RELEASEKIT_CHECK_URL" ]; then
+            cmd+=(--check-url "$RELEASEKIT_CHECK_URL")
           fi
-          if [ -n "$RK_INDEX_URL" ]; then
-            cmd+=(--index-url "$RK_INDEX_URL")
+          if [ -n "$RELEASEKIT_INDEX_URL" ]; then
+            cmd+=(--index-url "$RELEASEKIT_INDEX_URL")
           fi
-          if [ -n "$RK_CONCURRENCY" ] && [ "$RK_CONCURRENCY" != "0" ]; then
-            cmd+=(--concurrency "$RK_CONCURRENCY")
+          if [ -n "$RELEASEKIT_CONCURRENCY" ] && [ "$RELEASEKIT_CONCURRENCY" != "0" ]; then
+            cmd+=(--concurrency "$RELEASEKIT_CONCURRENCY")
           fi
-          if [ -n "$RK_MAX_RETRIES" ] && [ "$RK_MAX_RETRIES" != "0" ]; then
-            cmd+=(--max-retries "$RK_MAX_RETRIES")
+          if [ -n "$RELEASEKIT_MAX_RETRIES" ] && [ "$RELEASEKIT_MAX_RETRIES" != "0" ]; then
+            cmd+=(--max-retries "$RELEASEKIT_MAX_RETRIES")
+          fi
+        fi
+
+        # ── AI flags ─────────────────────────────────────────────
+        if [ "$RELEASEKIT_NO_AI" = "true" ]; then
+          cmd+=(--no-ai)
+        fi
+        if [ -n "$RELEASEKIT_MODEL" ]; then
+          cmd+=(--model "$RELEASEKIT_MODEL")
+        fi
+        if [ -n "$RELEASEKIT_CODENAME_THEME" ]; then
+          cmd+=(--codename-theme "$RELEASEKIT_CODENAME_THEME")
+        fi
+
+        # ── rollback-specific flags ─────────────────────────────
+        if [ "$RELEASEKIT_COMMAND" = "rollback" ]; then
+          if [ -n "$RELEASEKIT_TAG" ]; then
+            cmd+=(--tag "$RELEASEKIT_TAG")
+          fi
+          if [ "$RELEASEKIT_ALL_TAGS" = "true" ]; then
+            cmd+=(--all-tags)
+          fi
+          if [ "$RELEASEKIT_YANK" = "true" ]; then
+            cmd+=(--yank)
+          fi
+          if [ -n "$RELEASEKIT_YANK_REASON" ]; then
+            cmd+=(--yank-reason "$RELEASEKIT_YANK_REASON")
           fi
         fi
 
@@ -211,7 +280,7 @@ runs:
         echo "::endgroup::"
 
         if [ "${EXIT_CODE:-0}" -ne 0 ]; then
-          echo "::error::releasekit $RK_COMMAND failed with exit code $EXIT_CODE"
+          echo "::error::releasekit $RELEASEKIT_COMMAND failed with exit code $EXIT_CODE"
           echo ""
           echo "────────────────────────────────────────"
           echo "Last 50 lines of output (for diagnosis):"
@@ -222,7 +291,7 @@ runs:
         fi
 
         # ── Parse outputs ─────────────────────────────────────────
-        if [ "$RK_COMMAND" = "prepare" ]; then
+        if [ "$RELEASEKIT_COMMAND" = "prepare" ]; then
           PR_URL=$(echo "$OUTPUT" | sed -n 's/.*Release PR: //p' | tail -1)
           if [ -n "$PR_URL" ]; then
             echo "has_bumps=true" >> "$GITHUB_OUTPUT"
@@ -232,7 +301,7 @@ runs:
           fi
         fi
 
-        if [ "$RK_COMMAND" = "release" ]; then
+        if [ "$RELEASEKIT_COMMAND" = "release" ]; then
           RELEASE_URL=$(echo "$OUTPUT" | sed -n 's/.*release_url=//p' | tail -1)
           if [ -n "$RELEASE_URL" ]; then
             echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/releasekit-uv.yml
+++ b/.github/workflows/releasekit-uv.yml
@@ -61,14 +61,69 @@
 #   │  concurrency:    [0] max parallel publish (0 = auto)        │
 #   └─────────────────────────────────────────────────────────────┘
 #
+# ── Job Dependency Graph ───────────────────────────────────────────
+#
+#   ┌───────┐
+#   │ auth  │  Resolve token: App → PAT → GITHUB_TOKEN
+#   └───┬───┘
+#       │ outputs: token, auth-method, git-user-name, git-user-email
+#       │
+#       ├──────────────────────┐
+#       │                      │
+#       ▼                      ▼
+#   ┌─────────┐          ┌─────────┐
+#   │ prepare │          │ release │
+#   │ (push)  │          │ (merge) │
+#   └─────────┘          └────┬────┘
+#                             │ needs: [auth]
+#                             │
+#                             ▼
+#                        ┌─────────┐
+#                        │ publish │
+#                        │ (PyPI)  │
+#                        └────┬────┘
+#                             │ needs: [auth, release]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ verify │  pip install + import check
+#                        └────┬───┘
+#                             │ needs: [publish]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ notify │
+#                        └────────┘
+#                          needs: [auth, release, publish, verify]
+#
+# ── Token Resolution (Sentinel Pattern) ───────────────────────────
+#
+#   The auth job resolves a token and outputs it for downstream jobs.
+#   Because secrets.GITHUB_TOKEN cannot cross job boundaries, the auth
+#   job outputs the literal string "GITHUB_TOKEN" as a sentinel when
+#   falling back to the built-in token.
+#
+#   auth job                          downstream job
+#   ────────                          ──────────────
+#   App token available?
+#     yes ──► output real token  ──►  use token directly
+#     no  ──► PAT available?
+#               yes ──► output PAT ─► use token directly
+#               no  ──► output       ┌─────────────────────────────┐
+#                       "GITHUB_TOKEN"│ RESOLVED_TOKEN =            │
+#                       (sentinel)   │   auth-method == 'github-   │
+#                                    │   token' ? secrets.GITHUB_  │
+#                                    │   TOKEN : needs.auth.token  │
+#                                    └─────────────────────────────┘
+#
 # ── Trigger Matrix ──────────────────────────────────────────────────
 #
 #   Event              │ Jobs that run
-#   ───────────────────┼──────────────────────────────────
+#   ───────────────────┼──────────────────────────────────────────
 #   push to main       │ prepare
-#   PR merged          │ release → publish → notify
+#   PR merged          │ release → publish → verify → notify
 #   dispatch: prepare  │ prepare
-#   dispatch: release  │ release → publish → notify
+#   dispatch: release  │ release → publish → verify → notify
 #
 # ── Inputs Reference ────────────────────────────────────────────────
 #
@@ -84,9 +139,46 @@
 #   skip_publish   │ boolean │ false   │ Tag + release, skip registry
 #   concurrency    │ string  │ 0       │ Max parallel publish jobs
 #   max_retries    │ string  │ 2       │ Retry failed publishes (0 = off)
+#   no_ai          │ boolean │ false   │ Disable AI features
+#   model          │ string  │ (chain) │ Override AI model
+#   codename_theme │ string  │ (cfg)   │ Override codename theme
 #
-# The workflow is idempotent: re-running any step is safe because
-# releasekit skips already-created tags and already-published versions.
+# ── Required Configuration ─────────────────────────────────────────
+#
+#   Repository Variables (Settings → Variables → Actions):
+#
+#     RELEASEKIT_APP_ID        — GitHub App ID (for App-based auth)
+#     RELEASEKIT_GIT_USER_NAME — Git committer name for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
+#     RELEASEKIT_GIT_USER_EMAIL— Git committer email for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
+#
+#   Repository Secrets (Settings → Secrets → Actions):
+#
+#     RELEASEKIT_APP_PRIVATE_KEY — GitHub App private key (PEM)
+#     RELEASEKIT_TOKEN           — PAT fallback (if no App configured)
+#     GEMINI_API_KEY             — Gemini API key (for AI features)
+#
+#   If neither RELEASEKIT_APP_ID nor RELEASEKIT_TOKEN is set, the
+#   workflow falls back to GITHUB_TOKEN. In that case, set
+#   RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL to use
+#   a CLA-signed identity (otherwise PRs may fail CLA checks).
+#
+# ── Idempotency & Resumability ─────────────────────────────────────
+#
+#   Every job is idempotent — re-running a failed workflow is safe:
+#
+#     auth     Stateless; always resolves a fresh token.
+#     prepare  Updates the existing Release PR instead of duplicating.
+#     release  Skips tags and GitHub Releases that already exist.
+#     publish  Skips versions already present on the registry.
+#     verify   Re-verifies; always safe to repeat.
+#     notify   Dispatches repository_dispatch (downstream deduplicates).
+#
+#   To resume after a failure, use "Re-run failed jobs" in the GitHub
+#   Actions UI. Only the failed jobs re-run; successful jobs keep their
+#   outputs. No special flags or state files are needed.
+#
 # ══════════════════════════════════════════════════════════════════════
 
 name: "ReleaseKit: Python (uv)"
@@ -153,6 +245,19 @@ on:
         required: false
         default: '2'
         type: string
+      no_ai:
+        description: 'Disable all AI features (summarization, codenames)'
+        required: false
+        default: false
+        type: boolean
+      model:
+        description: 'Override AI model (e.g. ollama/gemma3:12b)'
+        required: false
+        type: string
+      codename_theme:
+        description: 'Override codename theme (e.g. galaxies, animals)'
+        required: false
+        type: string
       auth_method:
         description: 'Authentication method (auto = detect from configured secrets)'
         required: false
@@ -212,7 +317,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
+      # When the fallback is GITHUB_TOKEN, we output the literal string
+      # "GITHUB_TOKEN" as a sentinel because the actual secret cannot
+      # cross job boundaries.  Downstream jobs must substitute their own
+      # secrets.GITHUB_TOKEN when they see this sentinel.
       token: ${{ steps.resolve.outputs.token }}
+      auth-method: ${{ steps.resolve.outputs.auth-method }}
       git-user-name: ${{ steps.resolve.outputs.git-user-name }}
       git-user-email: ${{ steps.resolve.outputs.git-user-email }}
     steps:
@@ -247,24 +357,33 @@ jobs:
 
           # App token — used when auth=auto (and available) or auth=app.
           if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
-            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+            { echo "token=$APP_TOKEN"
+              echo "auth-method=app"
+              echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]"
+              echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+            } >> "$GITHUB_OUTPUT"
             echo "::notice::Using GitHub App token (${{ steps.app-token.outputs.app-slug }})"
 
           # PAT — used when auth=auto (and available) or auth=pat.
           elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
-            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=$PAT_TOKEN"
+              echo "auth-method=pat"
+              echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
             echo "::notice::Using Personal Access Token"
 
           # GITHUB_TOKEN — fallback or explicit. Uses repo variables for
           # git identity if set, so CLA can pass with a signed identity.
+          # NOTE: We output the sentinel "GITHUB_TOKEN" instead of the
+          # actual secret because secrets.GITHUB_TOKEN cannot be passed
+          # across job boundaries via outputs.
           else
-            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=GITHUB_TOKEN"
+              echo "auth-method=github-token"
+              echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
             if [ -n "$GIT_USER_NAME" ]; then
               echo "::notice::Using GITHUB_TOKEN with custom identity ($GIT_USER_NAME)"
             else
@@ -274,7 +393,6 @@ jobs:
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
-          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
           GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
 
@@ -294,11 +412,15 @@ jobs:
     outputs:
       has_bumps: ${{ steps.prepare.outputs.has_bumps }}
       pr_url: ${{ steps.prepare.outputs.pr_url }}
+    env:
+      # Resolve the sentinel: use the job's own GITHUB_TOKEN when auth
+      # fell back to the built-in token (it cannot cross job boundaries).
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-releasekit
         with:
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
           releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           git-user-name: ${{ needs.auth.outputs.git-user-name }}
           git-user-email: ${{ needs.auth.outputs.git-user-email }}
@@ -313,8 +435,11 @@ jobs:
           bump-type: ${{ inputs.bump_type }}
           prerelease: ${{ inputs.prerelease }}
           force: ${{ inputs.force_prepare }}
+          no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
+          model: ${{ inputs.model }}
+          codename-theme: ${{ inputs.codename_theme }}
         env:
-          GH_TOKEN: ${{ needs.auth.outputs.token }}
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
 
   # ═══════════════════════════════════════════════════════════════════════
   # RELEASE: Tag merge commit and create GitHub Release
@@ -331,11 +456,13 @@ jobs:
     timeout-minutes: 10
     outputs:
       release_url: ${{ steps.release.outputs.release_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-releasekit
         with:
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
           releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           git-user-name: ${{ needs.auth.outputs.git-user-name }}
           git-user-email: ${{ needs.auth.outputs.git-user-email }}
@@ -348,8 +475,11 @@ jobs:
           releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
           show-plan: "true"
+          no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
+          model: ${{ inputs.model }}
+          codename-theme: ${{ inputs.codename_theme }}
         env:
-          GH_TOKEN: ${{ needs.auth.outputs.token }}
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
 
   # ═══════════════════════════════════════════════════════════════════════
   # PUBLISH: Build and publish packages to PyPI
@@ -364,11 +494,13 @@ jobs:
     permissions:
       id-token: write    # Trusted publishing (OIDC) + Sigstore signing
       attestations: write  # PEP 740 attestations
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-releasekit
         with:
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
           releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           install-system-deps: "true"
           workspace-dir: ${{ env.WORKSPACE_DIR }}
@@ -387,6 +519,9 @@ jobs:
           check-url: ${{ env.PUBLISH_CHECK_URL }}
           index-url: ${{ env.PUBLISH_INDEX_URL }}
           show-plan: "true"
+          no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
+          model: ${{ inputs.model }}
+          codename-theme: ${{ inputs.codename_theme }}
         env:
           UV_PUBLISH_TOKEN: ${{ inputs.target == 'testpypi' && secrets.TESTPYPI_TOKEN || secrets.PYPI_TOKEN }}
 
@@ -444,6 +579,7 @@ jobs:
           sleep 60
 
       - name: Get core version and verify installation
+        continue-on-error: true  # Propagation delays should not fail the pipeline
         run: |
           VERSION=$(grep '^version' py/packages/genkit/pyproject.toml | head -1 | sed 's/.*= *"//' | sed 's/".*//')
           echo "Core version: $VERSION"
@@ -461,7 +597,7 @@ jobs:
             pkg_name="genkit-plugin-${plugin_name}"
             plugin_version=$(grep '^version' "$pyproject" | head -1 | sed 's/.*= *"//' | sed 's/".*//')
             echo "Verifying $pkg_name==$plugin_version..."
-            if pip install "$pkg_name==$plugin_version" 2>/dev/null; then
+            if pip install "$pkg_name==$plugin_version"; then
               echo "✅ $pkg_name installed"
             else
               echo "⚠️  $pkg_name==$plugin_version not found on PyPI (may not have been published)"
@@ -481,6 +617,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
           event-type: genkit-python-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'

--- a/py/tools/releasekit/src/releasekit/prepare.py
+++ b/py/tools/releasekit/src/releasekit/prepare.py
@@ -260,6 +260,8 @@ async def prepare_release(
     ws_config: WorkspaceConfig,
     dry_run: bool = False,
     force: bool = False,
+    prerelease: str = '',
+    bump_override: str = '',
 ) -> PrepareResult:
     """Run the prepare step: bump versions, generate changelogs, open Release PR.
 
@@ -277,6 +279,10 @@ async def prepare_release(
         ws_config: Per-workspace configuration.
         dry_run: If True, skip all side effects.
         force: If True, skip preflight and force bumps.
+        prerelease: Prerelease label (e.g. ``"rc.1"``). If set, all bumps
+            produce prerelease versions.
+        bump_override: Override bump type (``"patch"``, ``"minor"``,
+            ``"major"``). Empty string means auto-detect from commits.
 
     Returns:
         A :class:`PrepareResult` with bumped packages and PR URL.
@@ -296,6 +302,8 @@ async def prepare_release(
         packages,
         vcs,
         tag_format=ws_config.tag_format,
+        prerelease=prerelease,
+        force_unchanged=bool(bump_override),
         graph=propagate_graph,
         synchronize=ws_config.synchronize,
         major_on_zero=ws_config.major_on_zero,


### PR DESCRIPTION
## Summary

Rewrite the live `.github/` ReleaseKit workflow and composite action to use the `setup-releasekit` + `run-releasekit` pattern. Includes the `cli.py` and `prepare.py` source changes required by the workflow.

## Files changed (4)

| File | Change |
|------|--------|
| `.github/actions/run-releasekit/action.yml` | Add `no-ai`, `model`, `codename-theme` inputs; fix SC2129 |
| `.github/workflows/releasekit-uv.yml` | Rewrite to composite action pattern; add Required Configuration header |
| `py/tools/releasekit/src/releasekit/cli.py` | Update for new action inputs |
| `py/tools/releasekit/src/releasekit/prepare.py` | Update for new composite action interface |

Split from #4716. Template workflows + docs are in #4718.