### PR TITLE
feat(releasekit): standardize template workflows and update docs

### DIFF
--- a/py/tools/releasekit/action.yml
+++ b/py/tools/releasekit/action.yml
@@ -304,7 +304,7 @@ runs:
 
         # Command-specific flags.
         case "$INPUT_COMMAND" in
-          publish|prepare|release)
+          publish|prepare)
             cmd+=(--forge-backend "$INPUT_FORGE_BACKEND")
             ;;
         esac

--- a/py/tools/releasekit/docs/docs/guides/ci-cd.md
+++ b/py/tools/releasekit/docs/docs/guides/ci-cd.md
@@ -5,8 +5,14 @@ description: Automate releases with GitHub Actions, GitLab CI, and more.
 
 # CI/CD Integration
 
-ReleaseKit ships as both a CLI tool and a **GitHub Action** for
-seamless CI integration.
+ReleaseKit provides two **composite actions** for GitHub Actions:
+
+- **`setup-releasekit`** — installs uv, Python, releasekit (with AI
+  extras), optionally Ollama, and configures git identity.
+- **`run-releasekit`** — builds and runs the `releasekit` CLI command
+  with structured inputs and parses outputs.
+
+These actions are used together in every job to keep workflows DRY.
 
 ## Release Flow
 
@@ -16,12 +22,12 @@ sequenceDiagram
     participant Main as main branch
     participant RK as ReleaseKit
     participant PR as Release PR
-    participant PyPI as Registry
+    participant Reg as Registry
 
     Dev->>Main: Push conventional commits
     Main->>RK: trigger: releasekit prepare
     RK->>RK: compute_bumps()
-    RK->>RK: bump pyproject.toml
+    RK->>RK: bump version files
     RK->>RK: generate changelogs
     RK->>PR: Open Release PR
 
@@ -33,145 +39,210 @@ sequenceDiagram
     RK->>RK: Create git tags
     RK->>RK: Create GitHub Release
 
-    Note over RK,PyPI: If publish_from = "ci"
-    RK->>PyPI: releasekit publish
-    PyPI-->>RK: Verify checksums
+    RK->>Reg: releasekit publish
+    Reg-->>RK: Verify availability
+
+    RK->>RK: Notify downstream
 ```
 
-## GitHub Action
+## Job Dependency Graph
 
-### Basic Usage
+Every ReleaseKit workflow follows this pattern:
 
-```yaml
-name: Release
-on:
-  push:
-    branches: [main]
-
-jobs:
-  release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write  # For OIDC trusted publishing
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Full history for version computation
-
-      - uses: ./py/tools/releasekit
-        with:
-          command: prepare
-          working-directory: py
+```
+auth → prepare   (on push to main)
+auth → release → publish → verify → notify   (on PR merge / dispatch)
 ```
 
-### Two-Step Release (Prepare + Publish)
+The **auth** job resolves a token (GitHub App → PAT → GITHUB_TOKEN)
+and outputs `token`, `auth-method`, `git-user-name`, and
+`git-user-email` for downstream jobs.
+
+## GitHub Actions — Composite Actions
+
+### Minimal Example (Prepare)
 
 ```yaml
-name: Release
-on:
-  push:
-    branches: [main]
-  pull_request:
-    types: [closed]
-
 jobs:
-  # Step 1: On push to main, prepare a Release PR
   prepare:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-      - uses: ./py/tools/releasekit
+          token: ${{ secrets.GITHUB_TOKEN }}
+          releasekit-dir: py/tools/releasekit
+          git-user-name: github-actions[bot]
+          git-user-email: github-actions[bot]@users.noreply.github.com
+
+      - uses: ./.github/actions/run-releasekit
+        id: prepare
         with:
           command: prepare
-          working-directory: py
-          forge-backend: api
-
-  # Step 2: On Release PR merge, tag + publish
-  publish:
-    if: >-
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Preview execution plan
-        run: |
-          cd py
-          uv run releasekit plan --format full
-
-      - uses: ./py/tools/releasekit
-        with:
-          command: release
-          working-directory: py
-          forge-backend: api
-
-      - name: Preview execution plan
-        run: |
-          cd py
-          uv run releasekit plan --format full
-
-      - uses: ./py/tools/releasekit
-        with:
-          command: publish
-          working-directory: py
-          concurrency: "5"
-          max-retries: "2"
+          workspace: py
+          releasekit-dir: py/tools/releasekit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-### Action Inputs
+### Full Pipeline (Auth → Prepare / Release → Publish → Verify → Notify)
+
+See the sample workflows in
+[`py/tools/releasekit/github/workflows/`](https://github.com/firebase/genkit/tree/main/py/tools/releasekit/github/workflows)
+for complete, production-ready examples for each ecosystem:
+
+| Workflow | Ecosystem | Registry |
+|----------|-----------|----------|
+| `releasekit-uv.yml` | Python (uv) | PyPI |
+| `releasekit-pnpm.yml` | JavaScript (pnpm) | npm |
+| `releasekit-cargo.yml` | Rust (Cargo) | crates.io |
+| `releasekit-dart.yml` | Dart (pub) | pub.dev |
+| `releasekit-go.yml` | Go | Go module proxy |
+| `releasekit-gradle.yml` | Java/Kotlin (Gradle) | Maven Central |
+| `releasekit-rollback.yml` | Any | — |
+
+### setup-releasekit Inputs
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `command` | `plan` | Subcommand: `publish`, `plan`, `prepare`, `release`, `check`, `discover`, `version`, `rollback` |
-| `group` | `""` | Release group name (from `releasekit.toml` groups) |
-| `dry-run` | `"false"` | Preview mode |
-| `force` | `"false"` | Skip confirmations and preflight checks |
-| `forge-backend` | `"api"` | `cli` (needs `gh`) or `api` (REST, needs `GITHUB_TOKEN`) |
-| `check-url` | `""` | URL for `uv publish --check-url` |
-| `index-url` | `""` | Custom registry URL (e.g., Test PyPI) |
-| `concurrency` | `"5"` | Max packages publishing simultaneously |
-| `max-retries` | `"2"` | Retry count with exponential backoff |
-| `python-version` | `"3.12"` | Python version to install |
-| `uv-version` | `"latest"` | uv version to install |
-| `working-directory` | `"."` | Path to workspace root |
-| `extra-args` | `""` | Additional CLI arguments |
+| `token` | `""` | GitHub token for checkout and API calls |
+| `releasekit-dir` | `py/tools/releasekit` | Path to the releasekit source directory |
+| `git-user-name` | `""` | Git committer name |
+| `git-user-email` | `""` | Git committer email |
+| `enable-ollama` | `"true"` | Install Ollama for local AI models |
 
-### Action Outputs
+### run-releasekit Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `command` | *(required)* | Subcommand: `prepare`, `release`, `publish`, `rollback` |
+| `workspace` | *(required)* | Workspace name (e.g. `py`, `go`, `js`) |
+| `releasekit-dir` | `py/tools/releasekit` | Path to the releasekit source directory |
+| `dry-run` | `"false"` | Simulate without side effects |
+| `force` | `"false"` | Skip preflight checks |
+| `group` | `""` | Target a specific release group |
+| `bump-type` | `""` | Override semver bump (auto/patch/minor/major) |
+| `prerelease` | `""` | Prerelease suffix (e.g. `rc.1`) |
+| `concurrency` | `"0"` | Max parallel publish jobs (0 = auto) |
+| `max-retries` | `"0"` | Retry failed publishes |
+| `check-url` | `""` | Registry URL for version existence checks |
+| `index-url` | `""` | Custom registry URL for uploads |
+| `show-plan` | `"false"` | Show execution plan before running |
+| `no-ai` | `"false"` | Disable AI features (summarization, codenames) |
+| `model` | `""` | Override AI model (e.g. `ollama/gemma3:12b`) |
+| `codename-theme` | `""` | Override codename theme (e.g. `galaxies`) |
+| `tag` | `""` | Git tag to roll back (rollback only) |
+| `all-tags` | `"false"` | Delete all tags on same commit (rollback only) |
+| `yank` | `"false"` | Yank from registry (rollback only) |
+| `yank-reason` | `""` | Reason for yanking (rollback only) |
+
+### run-releasekit Outputs
 
 | Output | Description |
 |--------|-------------|
-| `exit-code` | Exit code from the releasekit command |
-| `plan-json` | JSON output (only when `command=plan`) |
+| `has_bumps` | `"true"` if prepare found version bumps |
+| `pr_url` | URL of the Release PR (prepare only) |
+| `release_url` | URL of the GitHub Release (release only) |
+
+## Required Configuration
+
+### Repository Variables (Settings → Variables → Actions)
+
+| Variable | Description |
+|----------|-------------|
+| `RELEASEKIT_APP_ID` | GitHub App ID (for App-based auth) |
+| `RELEASEKIT_GIT_USER_NAME` | Git committer name for CLA-signed identity |
+| `RELEASEKIT_GIT_USER_EMAIL` | Git committer email for CLA-signed identity |
+
+### Repository Secrets (Settings → Secrets → Actions)
+
+| Secret | Description |
+|--------|-------------|
+| `RELEASEKIT_APP_PRIVATE_KEY` | GitHub App private key (PEM) |
+| `RELEASEKIT_TOKEN` | PAT fallback (if no App configured) |
+| `GEMINI_API_KEY` | Gemini API key (for AI features) |
+
+Ecosystem-specific secrets:
+
+| Secret | Ecosystem | Description |
+|--------|-----------|-------------|
+| `NPM_TOKEN` | JS (pnpm) | npm access token |
+| `CARGO_REGISTRY_TOKEN` | Rust | crates.io API token |
+| `PUB_CREDENTIALS_JSON` | Dart | pub.dev service account JSON key |
+| `OSSRH_USERNAME` | Java | Sonatype OSSRH username |
+| `OSSRH_PASSWORD` | Java | Sonatype OSSRH password/token |
+| `GPG_SIGNING_KEY` | Java | GPG private key (base64-encoded) |
+| `GPG_PASSPHRASE` | Java | GPG key passphrase |
+
+!!! note "GITHUB_TOKEN fallback"
+    If neither `RELEASEKIT_APP_ID` nor `RELEASEKIT_TOKEN` is set, the
+    workflow falls back to `GITHUB_TOKEN`. In that case, set
+    `RELEASEKIT_GIT_USER_NAME` and `RELEASEKIT_GIT_USER_EMAIL` to use
+    a CLA-signed identity — otherwise PRs will not trigger CI and may
+    fail CLA checks.
 
 ## OIDC Trusted Publishing
 
-For PyPI trusted publishing (no tokens needed):
+For PyPI trusted publishing (no tokens needed), the publish job uses
+an `environment` and job-level permissions:
 
 ```yaml
-permissions:
-  id-token: write  # Required for OIDC
+publish:
+  environment: pypi
+  permissions:
+    id-token: write      # Trusted publishing (OIDC)
+    attestations: write  # PEP 740 attestations
+  steps:
+    - uses: actions/checkout@v6
+    - uses: ./.github/actions/setup-releasekit
+      with:
+        token: ${{ env.RESOLVED_TOKEN }}
+        releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+        enable-ollama: "false"
 
-steps:
-  - uses: ./py/tools/releasekit
-    with:
-      command: publish
+    - uses: ./.github/actions/run-releasekit
+      with:
+        command: publish
+        workspace: py
+        releasekit-dir: ${{ env.RELEASEKIT_DIR }}
 ```
 
 ReleaseKit's preflight checks will warn if trusted publishing is not
 configured.
+
+## Idempotency & Resumability
+
+Every job in the workflow is **idempotent** — re-running a failed
+workflow is always safe. ReleaseKit checks state before acting:
+
+| Job | What happens on re-run |
+|-----|------------------------|
+| **auth** | Stateless; always resolves a fresh token |
+| **prepare** | Updates the existing Release PR instead of creating a duplicate |
+| **release** | Skips tags and GitHub Releases that already exist |
+| **publish** | Skips versions already present on the registry |
+| **verify** | Re-verifies; always safe to repeat |
+| **notify** | Dispatches `repository_dispatch` (downstream deduplicates) |
+
+### Resuming a failed workflow
+
+1. Go to **Actions** → find the failed run
+2. Click **"Re-run failed jobs"** (not "Re-run all jobs")
+3. Only the failed jobs re-run; successful jobs keep their outputs
+
+No special flags or state files are needed.
+
+### Resuming from the CLI
+
+If a `publish` run was interrupted mid-way (e.g., 3 of 5 packages
+published), just re-run:
+
+```bash
+releasekit publish
+```
+
+ReleaseKit polls each registry before uploading. If a version already
+exists, it skips that package and moves to the next one.
 
 ## GitLab CI
 
@@ -230,20 +301,26 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          releasekit-dir: py/tools/releasekit
 
       - name: Check if release needed
         id: check
         run: |
           uv run releasekit should-release || echo "skip=true" >> "$GITHUB_OUTPUT"
 
-      - uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
         if: steps.check.outputs.skip != 'true'
         with:
           command: prepare
-          working-directory: py
+          workspace: py
+          releasekit-dir: py/tools/releasekit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Configuration
@@ -279,15 +356,20 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v6
 
-      - uses: ./py/tools/releasekit
+      - uses: ./.github/actions/setup-releasekit
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          releasekit-dir: py/tools/releasekit
+
+      - uses: ./.github/actions/run-releasekit
         with:
           command: publish
-          extra-args: "--if-needed"
-          working-directory: py
+          workspace: py
+          releasekit-dir: py/tools/releasekit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Configuration

--- a/py/tools/releasekit/docs/docs/guides/rollback.md
+++ b/py/tools/releasekit/docs/docs/guides/rollback.md
@@ -262,18 +262,28 @@ jobs:
     The rollback workflow defaults to `dry_run: true` so you always
     preview before making changes. Uncheck the box to execute for real.
 
-!!! tip "Simpler with the reusable action"
-    The rollback step above can be replaced with a single action call:
+!!! tip "Simpler with the composite actions"
+    The rollback step above can be replaced with two action calls:
 
     ```yaml
-    - uses: ./py/tools/releasekit
+    - uses: ./.github/actions/setup-releasekit
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+        enable-ollama: "false"
+
+    - uses: ./.github/actions/run-releasekit
       with:
         command: rollback
+        workspace: ${{ inputs.workspace }}
+        releasekit-dir: ${{ env.RELEASEKIT_DIR }}
         tag: ${{ inputs.tag }}
-        dry-run: ${{ inputs.dry_run }}
+        dry-run: ${{ inputs.dry_run && 'true' || 'false' }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     ```
 
-    The action handles Python/uv setup, git config, and job summaries
+    The actions handle Python/uv setup, git config, and job summaries
     automatically. See the [Workflow Templates](workflow-templates.md) guide for a
     production-ready rollback workflow.
 

--- a/py/tools/releasekit/docs/docs/guides/workflow-templates.md
+++ b/py/tools/releasekit/docs/docs/guides/workflow-templates.md
@@ -8,17 +8,25 @@ description: Production-ready GitHub Actions workflows for common release patter
 Copy-paste these GitHub Actions workflows and customize them for your
 project. Each template is progressively more advanced.
 
-!!! tip "Reusable Composite Action"
-    ReleaseKit ships a **reusable composite action** (`action.yml`) that
-    handles Python/uv setup, git config, command building, output
-    parsing, and job summary generation automatically. Instead of
+!!! tip "Reusable Composite Actions"
+    ReleaseKit ships two **composite actions** — `setup-releasekit`
+    (Python/uv setup, git config, Ollama) and `run-releasekit`
+    (command building, output parsing, job summaries). Instead of
     writing inline shell steps, you can use:
 
     ```yaml
-    - uses: ./py/tools/releasekit
+    - uses: ./.github/actions/setup-releasekit
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        releasekit-dir: py/tools/releasekit
+
+    - uses: ./.github/actions/run-releasekit
       with:
         command: publish
         workspace: py
+        releasekit-dir: py/tools/releasekit
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     ```
 
     See the [production-ready templates](#workflow-templates) below for

--- a/py/tools/releasekit/docs/mkdocs.yml
+++ b/py/tools/releasekit/docs/mkdocs.yml
@@ -195,5 +195,7 @@ nav:
       - License Data Verification: internals/license-data.md
   - Planning:
       - Roadmap: roadmap.md
+      - AI Release Notes Plan: ai-release-notes-plan.md
+      - Workflow Migration Plan: release-workflow-migration.md
       - Competitive Gap Analysis: competitive-gap-analysis.md
       - "Slide Deck \u2197": slides/index.html

--- a/py/tools/releasekit/github/actions/run-releasekit/action.yml
+++ b/py/tools/releasekit/github/actions/run-releasekit/action.yml
@@ -106,11 +106,46 @@ inputs:
       Registry URL for uploading packages (publish only).
     required: false
     default: ""
+  no-ai:
+    description: >-
+      Disable all AI features (summarization, codenames).
+    required: false
+    default: "false"
+  model:
+    description: >-
+      Override AI model (e.g. "ollama/gemma3:12b", "gemini-pro").
+    required: false
+    default: ""
+  codename-theme:
+    description: >-
+      Override codename theme (e.g. "galaxies", "animals").
+    required: false
+    default: ""
   show-plan:
     description: >-
       Show the execution plan before running the command.
     required: false
     default: "false"
+  tag:
+    description: >-
+      Git tag to roll back (rollback only).
+    required: false
+    default: ""
+  all-tags:
+    description: >-
+      Delete ALL tags pointing to the same commit (rollback only).
+    required: false
+    default: "false"
+  yank:
+    description: >-
+      Also yank/deprecate versions from the package registry (rollback only).
+    required: false
+    default: "false"
+  yank-reason:
+    description: >-
+      Reason for yanking (rollback only).
+    required: false
+    default: ""
 
 outputs:
   has_bumps:
@@ -131,15 +166,15 @@ runs:
       if: inputs.show-plan == 'true'
       shell: bash
       env:
-        RK_DIR: ${{ inputs.releasekit-dir }}
-        RK_WORKSPACE: ${{ inputs.workspace }}
-        RK_DRY_RUN: ${{ inputs.dry-run }}
+        RELEASEKIT_DIR: ${{ inputs.releasekit-dir }}
+        RELEASEKIT_WORKSPACE: ${{ inputs.workspace }}
+        RELEASEKIT_DRY_RUN: ${{ inputs.dry-run }}
       run: |
         echo "::group::Execution Plan"
-        uv run --directory "$RK_DIR" \
-          releasekit --workspace "$RK_WORKSPACE" plan --format full 2>&1 || true
+        uv run --directory "$RELEASEKIT_DIR" \
+          releasekit --workspace "$RELEASEKIT_WORKSPACE" plan --format full 2>&1 || true
         echo "::endgroup::"
-        if [ "$RK_DRY_RUN" = "true" ]; then
+        if [ "$RELEASEKIT_DRY_RUN" = "true" ]; then
           echo "::notice::DRY RUN — no side effects"
         else
           echo "::notice::LIVE RUN"
@@ -150,57 +185,91 @@ runs:
       id: run
       shell: bash
       env:
-        RK_COMMAND: ${{ inputs.command }}
-        RK_WORKSPACE: ${{ inputs.workspace }}
-        RK_DIR: ${{ inputs.releasekit-dir }}
-        RK_DRY_RUN: ${{ inputs.dry-run }}
-        RK_FORCE: ${{ inputs.force }}
-        RK_GROUP: ${{ inputs.group }}
-        RK_BUMP_TYPE: ${{ inputs.bump-type }}
-        RK_PRERELEASE: ${{ inputs.prerelease }}
-        RK_CONCURRENCY: ${{ inputs.concurrency }}
-        RK_MAX_RETRIES: ${{ inputs.max-retries }}
-        RK_CHECK_URL: ${{ inputs.check-url }}
-        RK_INDEX_URL: ${{ inputs.index-url }}
+        RELEASEKIT_COMMAND: ${{ inputs.command }}
+        RELEASEKIT_WORKSPACE: ${{ inputs.workspace }}
+        RELEASEKIT_DIR: ${{ inputs.releasekit-dir }}
+        RELEASEKIT_DRY_RUN: ${{ inputs.dry-run }}
+        RELEASEKIT_FORCE: ${{ inputs.force }}
+        RELEASEKIT_GROUP: ${{ inputs.group }}
+        RELEASEKIT_BUMP_TYPE: ${{ inputs.bump-type }}
+        RELEASEKIT_PRERELEASE: ${{ inputs.prerelease }}
+        RELEASEKIT_CONCURRENCY: ${{ inputs.concurrency }}
+        RELEASEKIT_MAX_RETRIES: ${{ inputs.max-retries }}
+        RELEASEKIT_CHECK_URL: ${{ inputs.check-url }}
+        RELEASEKIT_INDEX_URL: ${{ inputs.index-url }}
+        RELEASEKIT_NO_AI: ${{ inputs.no-ai }}
+        RELEASEKIT_MODEL: ${{ inputs.model }}
+        RELEASEKIT_CODENAME_THEME: ${{ inputs.codename-theme }}
+        RELEASEKIT_TAG: ${{ inputs.tag }}
+        RELEASEKIT_ALL_TAGS: ${{ inputs.all-tags }}
+        RELEASEKIT_YANK: ${{ inputs.yank }}
+        RELEASEKIT_YANK_REASON: ${{ inputs.yank-reason }}
       run: |
         set -euo pipefail
 
-        cmd=(uv run --directory "$RK_DIR" releasekit --workspace "$RK_WORKSPACE" "$RK_COMMAND")
+        cmd=(uv run --directory "$RELEASEKIT_DIR" releasekit --workspace "$RELEASEKIT_WORKSPACE" "$RELEASEKIT_COMMAND")
 
         # ── Common flags ──────────────────────────────────────────
-        if [ "$RK_DRY_RUN" = "true" ]; then
+        if [ "$RELEASEKIT_DRY_RUN" = "true" ]; then
           cmd+=(--dry-run)
         fi
-        if [ "$RK_FORCE" = "true" ]; then
+        if [ "$RELEASEKIT_FORCE" = "true" ]; then
           cmd+=(--force)
         fi
-        if [ -n "$RK_GROUP" ]; then
-          cmd+=(--group "$RK_GROUP")
+        if [ -n "$RELEASEKIT_GROUP" ]; then
+          cmd+=(--group "$RELEASEKIT_GROUP")
         fi
 
         # ── prepare-specific flags ────────────────────────────────
-        if [ "$RK_COMMAND" = "prepare" ]; then
-          if [ "$RK_BUMP_TYPE" != "auto" ] && [ -n "$RK_BUMP_TYPE" ]; then
-            cmd+=(--bump "$RK_BUMP_TYPE")
+        if [ "$RELEASEKIT_COMMAND" = "prepare" ]; then
+          if [ "$RELEASEKIT_BUMP_TYPE" != "auto" ] && [ -n "$RELEASEKIT_BUMP_TYPE" ]; then
+            cmd+=(--bump "$RELEASEKIT_BUMP_TYPE")
           fi
-          if [ -n "$RK_PRERELEASE" ]; then
-            cmd+=(--prerelease "$RK_PRERELEASE")
+          if [ -n "$RELEASEKIT_PRERELEASE" ]; then
+            cmd+=(--prerelease "$RELEASEKIT_PRERELEASE")
           fi
         fi
 
         # ── publish-specific flags ────────────────────────────────
-        if [ "$RK_COMMAND" = "publish" ]; then
-          if [ -n "$RK_CHECK_URL" ]; then
-            cmd+=(--check-url "$RK_CHECK_URL")
+        if [ "$RELEASEKIT_COMMAND" = "publish" ]; then
+          if [ -n "$RELEASEKIT_CHECK_URL" ]; then
+            cmd+=(--check-url "$RELEASEKIT_CHECK_URL")
           fi
-          if [ -n "$RK_INDEX_URL" ]; then
-            cmd+=(--index-url "$RK_INDEX_URL")
+          if [ -n "$RELEASEKIT_INDEX_URL" ]; then
+            cmd+=(--index-url "$RELEASEKIT_INDEX_URL")
           fi
-          if [ -n "$RK_CONCURRENCY" ] && [ "$RK_CONCURRENCY" != "0" ]; then
-            cmd+=(--concurrency "$RK_CONCURRENCY")
+          if [ -n "$RELEASEKIT_CONCURRENCY" ] && [ "$RELEASEKIT_CONCURRENCY" != "0" ]; then
+            cmd+=(--concurrency "$RELEASEKIT_CONCURRENCY")
           fi
-          if [ -n "$RK_MAX_RETRIES" ] && [ "$RK_MAX_RETRIES" != "0" ]; then
-            cmd+=(--max-retries "$RK_MAX_RETRIES")
+          if [ -n "$RELEASEKIT_MAX_RETRIES" ] && [ "$RELEASEKIT_MAX_RETRIES" != "0" ]; then
+            cmd+=(--max-retries "$RELEASEKIT_MAX_RETRIES")
+          fi
+        fi
+
+        # ── AI flags ─────────────────────────────────────────────
+        if [ "$RELEASEKIT_NO_AI" = "true" ]; then
+          cmd+=(--no-ai)
+        fi
+        if [ -n "$RELEASEKIT_MODEL" ]; then
+          cmd+=(--model "$RELEASEKIT_MODEL")
+        fi
+        if [ -n "$RELEASEKIT_CODENAME_THEME" ]; then
+          cmd+=(--codename-theme "$RELEASEKIT_CODENAME_THEME")
+        fi
+
+        # ── rollback-specific flags ─────────────────────────────
+        if [ "$RELEASEKIT_COMMAND" = "rollback" ]; then
+          if [ -n "$RELEASEKIT_TAG" ]; then
+            cmd+=(--tag "$RELEASEKIT_TAG")
+          fi
+          if [ "$RELEASEKIT_ALL_TAGS" = "true" ]; then
+            cmd+=(--all-tags)
+          fi
+          if [ "$RELEASEKIT_YANK" = "true" ]; then
+            cmd+=(--yank)
+          fi
+          if [ -n "$RELEASEKIT_YANK_REASON" ]; then
+            cmd+=(--yank-reason "$RELEASEKIT_YANK_REASON")
           fi
         fi
 
@@ -211,12 +280,12 @@ runs:
         echo "::endgroup::"
 
         if [ "${EXIT_CODE:-0}" -ne 0 ]; then
-          echo "::error::releasekit $RK_COMMAND failed with exit code $EXIT_CODE"
+          echo "::error::releasekit $RELEASEKIT_COMMAND failed with exit code $EXIT_CODE"
           exit "$EXIT_CODE"
         fi
 
         # ── Parse outputs ─────────────────────────────────────────
-        if [ "$RK_COMMAND" = "prepare" ]; then
+        if [ "$RELEASEKIT_COMMAND" = "prepare" ]; then
           PR_URL=$(echo "$OUTPUT" | sed -n 's/.*Release PR: //p' | tail -1)
           if [ -n "$PR_URL" ]; then
             echo "has_bumps=true" >> "$GITHUB_OUTPUT"
@@ -226,7 +295,7 @@ runs:
           fi
         fi
 
-        if [ "$RK_COMMAND" = "release" ]; then
+        if [ "$RELEASEKIT_COMMAND" = "release" ]; then
           RELEASE_URL=$(echo "$OUTPUT" | sed -n 's/.*release_url=//p' | tail -1)
           if [ -n "$RELEASE_URL" ]; then
             echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"

--- a/py/tools/releasekit/github/workflows/releasekit-cargo.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-cargo.yml
@@ -64,14 +64,69 @@
 #   │  max_retries:    [2] retry failed publishes                 │
 #   └─────────────────────────────────────────────────────────────┘
 #
+# ── Job Dependency Graph ───────────────────────────────────────────
+#
+#   ┌───────┐
+#   │ auth  │  Resolve token: App → PAT → GITHUB_TOKEN
+#   └───┬───┘
+#       │ outputs: token, auth-method, git-user-name, git-user-email
+#       │
+#       ├──────────────────────┐
+#       │                      │
+#       ▼                      ▼
+#   ┌─────────┐          ┌─────────┐
+#   │ prepare │          │ release │
+#   │ (push)  │          │ (merge) │
+#   └─────────┘          └────┬────┘
+#                             │ needs: [auth]
+#                             │
+#                             ▼
+#                        ┌─────────┐
+#                        │ publish │
+#                        │(crates) │
+#                        └────┬────┘
+#                             │ needs: [auth, release]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ verify │  cargo search check
+#                        └────┬───┘
+#                             │ needs: [publish]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ notify │
+#                        └────────┘
+#                          needs: [auth, release, publish, verify]
+#
+# ── Token Resolution (Sentinel Pattern) ───────────────────────────
+#
+#   The auth job resolves a token and outputs it for downstream jobs.
+#   Because secrets.GITHUB_TOKEN cannot cross job boundaries, the auth
+#   job outputs the literal string "GITHUB_TOKEN" as a sentinel when
+#   falling back to the built-in token.
+#
+#   auth job                          downstream job
+#   ────────                          ──────────────
+#   App token available?
+#     yes ──► output real token  ──►  use token directly
+#     no  ──► PAT available?
+#               yes ──► output PAT ─► use token directly
+#               no  ──► output       ┌─────────────────────────────┐
+#                       "GITHUB_TOKEN"│ RESOLVED_TOKEN =            │
+#                       (sentinel)   │   auth-method == 'github-   │
+#                                    │   token' ? secrets.GITHUB_  │
+#                                    │   TOKEN : needs.auth.token  │
+#                                    └─────────────────────────────┘
+#
 # ── Trigger Matrix ──────────────────────────────────────────────────
 #
 #   Event              │ Jobs that run
 #   ───────────────────┼──────────────────────────────────
 #   push to main       │ prepare
-#   PR merged          │ release → publish → notify
+#   PR merged          │ release → publish → verify → notify
 #   dispatch: prepare  │ prepare
-#   dispatch: release  │ release → publish → notify
+#   dispatch: release  │ release → publish → verify → notify
 #
 # ── Inputs Reference ────────────────────────────────────────────────
 #
@@ -90,18 +145,45 @@
 #   model          │ string  │ (chain) │ Override AI model
 #   codename_theme │ string  │ (cfg)   │ Override codename theme
 #
-# ── Authentication ──────────────────────────────────────────────────
+# ── Required Configuration ─────────────────────────────────────────
 #
-# Publishing to crates.io requires an API token. Set the following
-# secret in your repository:
+#   Repository Variables (Settings → Variables → Actions):
 #
-#   CARGO_REGISTRY_TOKEN — crates.io API token
+#     RELEASEKIT_APP_ID        — GitHub App ID (for App-based auth)
+#     RELEASEKIT_GIT_USER_NAME — Git committer name for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
+#     RELEASEKIT_GIT_USER_EMAIL— Git committer email for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
 #
-# Generate one at https://crates.io/settings/tokens with the
-# "publish-new" and "publish-update" scopes.
+#   Repository Secrets (Settings → Secrets → Actions):
 #
-# The workflow is idempotent: re-running any step is safe because
-# releasekit skips already-created tags and already-published versions.
+#     RELEASEKIT_APP_PRIVATE_KEY — GitHub App private key (PEM)
+#     RELEASEKIT_TOKEN           — PAT fallback (if no App configured)
+#     GEMINI_API_KEY             — Gemini API key (for AI features)
+#     CARGO_REGISTRY_TOKEN       — crates.io API token
+#                                  (https://crates.io/settings/tokens,
+#                                  scopes: publish-new, publish-update)
+#
+#   If neither RELEASEKIT_APP_ID nor RELEASEKIT_TOKEN is set, the
+#   workflow falls back to GITHUB_TOKEN. In that case, set
+#   RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL to use
+#   a CLA-signed identity (otherwise PRs may fail CLA checks).
+#
+# ── Idempotency & Resumability ─────────────────────────────────────
+#
+#   Every job is idempotent — re-running a failed workflow is safe:
+#
+#     auth     Stateless; always resolves a fresh token.
+#     prepare  Updates the existing Release PR instead of duplicating.
+#     release  Skips tags and GitHub Releases that already exist.
+#     publish  Skips versions already present on crates.io.
+#     verify   Re-verifies; always safe to repeat.
+#     notify   Dispatches repository_dispatch (downstream deduplicates).
+#
+#   To resume after a failure, use "Re-run failed jobs" in the GitHub
+#   Actions UI. Only the failed jobs re-run; successful jobs keep their
+#   outputs. No special flags or state files are needed.
+#
 # ══════════════════════════════════════════════════════════════════════
 
 name: "ReleaseKit: Rust (Cargo)"
@@ -273,6 +355,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write        # Sigstore keyless signing (SLSA provenance)
 
 env:
   RELEASEKIT_DIR: py/tools/releasekit
@@ -290,6 +373,7 @@ jobs:
     timeout-minutes: 2
     outputs:
       token: ${{ steps.resolve.outputs.token }}
+      auth-method: ${{ steps.resolve.outputs.auth-method }}
       git-user-name: ${{ steps.resolve.outputs.git-user-name }}
       git-user-email: ${{ steps.resolve.outputs.git-user-email }}
     steps:
@@ -315,27 +399,50 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      # Resolve: App > PAT > GITHUB_TOKEN (respects auth_method override).
       - name: Resolve token and identity
         id: resolve
         run: |
           AUTH="${{ inputs.auth_method || 'auto' }}"
+
+          # App token — used when auth=auto (and available) or auth=app.
           if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
-            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+            { echo "token=$APP_TOKEN"
+              echo "auth-method=app"
+              echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]"
+              echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::Using GitHub App token (${{ steps.app-token.outputs.app-slug }})"
+
+          # PAT — used when auth=auto (and available) or auth=pat.
           elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
-            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=$PAT_TOKEN"
+              echo "auth-method=pat"
+              echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::Using Personal Access Token"
+
+          # GITHUB_TOKEN — fallback or explicit. Uses repo variables for
+          # git identity if set, so CLA can pass with a signed identity.
+          # NOTE: We output the sentinel "GITHUB_TOKEN" instead of the
+          # actual secret because secrets.GITHUB_TOKEN cannot be passed
+          # across job boundaries via outputs.
           else
-            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=GITHUB_TOKEN"
+              echo "auth-method=github-token"
+              echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
+            if [ -n "$GIT_USER_NAME" ]; then
+              echo "::notice::Using GITHUB_TOKEN with custom identity ($GIT_USER_NAME)"
+            else
+              echo "::warning::Using GITHUB_TOKEN — PRs will not trigger CI and may fail CLA checks. Set RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL repo variables to use a CLA-signed identity."
+            fi
           fi
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
-          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
           GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
 
@@ -353,29 +460,34 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      has_bumps: ${{ steps.rk.outputs.has-bumps }}
-      pr_url: ${{ steps.rk.outputs.pr-url }}
+      has_bumps: ${{ steps.prepare.outputs.has_bumps }}
+      pr_url: ${{ steps.prepare.outputs.pr_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
-      - name: Run releasekit prepare
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: prepare
         with:
           command: prepare
           workspace: rust
-          force: ${{ inputs.force_prepare && 'true' || 'false' }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           group: ${{ inputs.group }}
           bump-type: ${{ inputs.bump_type }}
           prerelease: ${{ inputs.prerelease }}
+          force: ${{ inputs.force_prepare }}
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -392,25 +504,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      release_url: ${{ steps.rk.outputs.release-url }}
+      release_url: ${{ steps.release.outputs.release_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
-      - name: Run releasekit release
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: release
         with:
           command: release
           workspace: rust
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -422,11 +540,15 @@ jobs:
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          enable-ollama: "false"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -441,17 +563,17 @@ jobs:
         working-directory: ${{ env.WORKSPACE_DIR }}
         run: cargo build --release
 
-      - name: Run releasekit publish
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
         with:
           command: publish
           workspace: rust
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
           force: "true"
           group: ${{ inputs.group }}
-          concurrency: ${{ inputs.concurrency || '0' }}
-          max-retries: ${{ inputs.max_retries || '2' }}
+          concurrency: ${{ inputs.concurrency }}
+          max-retries: ${{ inputs.max_retries }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
@@ -460,19 +582,48 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
       - name: Upload manifest artifact
-        if: success() && env.DRY_RUN != 'true'
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: release-manifest-rust
-          path: ${{ env.WORKSPACE_DIR }}/.releasekit-state.json
+          path: ${{ env.WORKSPACE_DIR }}/release-manifest.json
           retention-days: 90
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # VERIFY: Check published crates are available
+  # ═══════════════════════════════════════════════════════════════════════
+  verify:
+    name: Verify Published Crates
+    needs: publish
+    if: >-
+      success() &&
+      (github.event_name == 'pull_request' ||
+       inputs.dry_run == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+      - name: Wait for crates.io propagation
+        run: |
+          echo "Waiting 30 seconds for crates.io index propagation..."
+          sleep 30
+
+      - name: Verify crate is available
+        continue-on-error: true  # Propagation delays should not fail the pipeline
+        run: |
+          cargo search genkit --limit 1
+          echo "✅ crate search succeeded"
 
   # ═══════════════════════════════════════════════════════════════════════
   # NOTIFY: Post-release notifications
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [auth, release, publish]
+    needs: [auth, release, publish, verify]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -480,6 +631,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
           event-type: genkit-rust-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'

--- a/py/tools/releasekit/github/workflows/releasekit-dart.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-dart.yml
@@ -64,14 +64,69 @@
 #   │  max_retries:    [2] retry failed publishes                 │
 #   └─────────────────────────────────────────────────────────────┘
 #
+# ── Job Dependency Graph ───────────────────────────────────────────
+#
+#   ┌───────┐
+#   │ auth  │  Resolve token: App → PAT → GITHUB_TOKEN
+#   └───┬───┘
+#       │ outputs: token, auth-method, git-user-name, git-user-email
+#       │
+#       ├──────────────────────┐
+#       │                      │
+#       ▼                      ▼
+#   ┌─────────┐          ┌─────────┐
+#   │ prepare │          │ release │
+#   │ (push)  │          │ (merge) │
+#   └─────────┘          └────┬────┘
+#                             │ needs: [auth]
+#                             │
+#                             ▼
+#                        ┌─────────┐
+#                        │ publish │
+#                        │(pub.dev)│
+#                        └────┬────┘
+#                             │ needs: [auth, release]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ verify │  pub.dev availability check
+#                        └────┬───┘
+#                             │ needs: [publish]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ notify │
+#                        └────────┘
+#                          needs: [auth, release, publish, verify]
+#
+# ── Token Resolution (Sentinel Pattern) ───────────────────────────
+#
+#   The auth job resolves a token and outputs it for downstream jobs.
+#   Because secrets.GITHUB_TOKEN cannot cross job boundaries, the auth
+#   job outputs the literal string "GITHUB_TOKEN" as a sentinel when
+#   falling back to the built-in token.
+#
+#   auth job                          downstream job
+#   ────────                          ──────────────
+#   App token available?
+#     yes ──► output real token  ──►  use token directly
+#     no  ──► PAT available?
+#               yes ──► output PAT ─► use token directly
+#               no  ──► output       ┌─────────────────────────────┐
+#                       "GITHUB_TOKEN"│ RESOLVED_TOKEN =            │
+#                       (sentinel)   │   auth-method == 'github-   │
+#                                    │   token' ? secrets.GITHUB_  │
+#                                    │   TOKEN : needs.auth.token  │
+#                                    └─────────────────────────────┘
+#
 # ── Trigger Matrix ──────────────────────────────────────────────────
 #
 #   Event              │ Jobs that run
 #   ───────────────────┼──────────────────────────────────
 #   push to main       │ prepare
-#   PR merged          │ release → publish → notify
+#   PR merged          │ release → publish → verify → notify
 #   dispatch: prepare  │ prepare
-#   dispatch: release  │ release → publish → notify
+#   dispatch: release  │ release → publish → verify → notify
 #
 # ── Inputs Reference ────────────────────────────────────────────────
 #
@@ -90,18 +145,44 @@
 #   model          │ string  │ (chain) │ Override AI model
 #   codename_theme │ string  │ (cfg)   │ Override codename theme
 #
-# ── Authentication ──────────────────────────────────────────────────
+# ── Required Configuration ─────────────────────────────────────────
 #
-# Publishing to pub.dev requires a Google Cloud service account with
-# the "Service Account Token Creator" role. Set the following secrets:
+#   Repository Variables (Settings → Variables → Actions):
 #
-#   PUB_CREDENTIALS_JSON — JSON key file for the service account
+#     RELEASEKIT_APP_ID        — GitHub App ID (for App-based auth)
+#     RELEASEKIT_GIT_USER_NAME — Git committer name for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
+#     RELEASEKIT_GIT_USER_EMAIL— Git committer email for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
 #
-# Alternatively, use Workload Identity Federation for keyless auth
-# in Google Cloud environments.
+#   Repository Secrets (Settings → Secrets → Actions):
 #
-# The workflow is idempotent: re-running any step is safe because
-# releasekit skips already-created tags and already-published versions.
+#     RELEASEKIT_APP_PRIVATE_KEY — GitHub App private key (PEM)
+#     RELEASEKIT_TOKEN           — PAT fallback (if no App configured)
+#     GEMINI_API_KEY             — Gemini API key (for AI features)
+#     PUB_CREDENTIALS_JSON       — pub.dev service account JSON key
+#                                  (or use Workload Identity Federation)
+#
+#   If neither RELEASEKIT_APP_ID nor RELEASEKIT_TOKEN is set, the
+#   workflow falls back to GITHUB_TOKEN. In that case, set
+#   RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL to use
+#   a CLA-signed identity (otherwise PRs may fail CLA checks).
+#
+# ── Idempotency & Resumability ─────────────────────────────────────
+#
+#   Every job is idempotent — re-running a failed workflow is safe:
+#
+#     auth     Stateless; always resolves a fresh token.
+#     prepare  Updates the existing Release PR instead of duplicating.
+#     release  Skips tags and GitHub Releases that already exist.
+#     publish  Skips versions already present on pub.dev.
+#     verify   Re-verifies; always safe to repeat.
+#     notify   Dispatches repository_dispatch (downstream deduplicates).
+#
+#   To resume after a failure, use "Re-run failed jobs" in the GitHub
+#   Actions UI. Only the failed jobs re-run; successful jobs keep their
+#   outputs. No special flags or state files are needed.
+#
 # ══════════════════════════════════════════════════════════════════════
 
 name: "ReleaseKit: Dart (pub)"
@@ -273,6 +354,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write        # Sigstore keyless signing (SLSA provenance)
 
 env:
   RELEASEKIT_DIR: py/tools/releasekit
@@ -290,6 +372,7 @@ jobs:
     timeout-minutes: 2
     outputs:
       token: ${{ steps.resolve.outputs.token }}
+      auth-method: ${{ steps.resolve.outputs.auth-method }}
       git-user-name: ${{ steps.resolve.outputs.git-user-name }}
       git-user-email: ${{ steps.resolve.outputs.git-user-email }}
     steps:
@@ -315,27 +398,50 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      # Resolve: App > PAT > GITHUB_TOKEN (respects auth_method override).
       - name: Resolve token and identity
         id: resolve
         run: |
           AUTH="${{ inputs.auth_method || 'auto' }}"
+
+          # App token — used when auth=auto (and available) or auth=app.
           if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
-            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+            { echo "token=$APP_TOKEN"
+              echo "auth-method=app"
+              echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]"
+              echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::Using GitHub App token (${{ steps.app-token.outputs.app-slug }})"
+
+          # PAT — used when auth=auto (and available) or auth=pat.
           elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
-            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=$PAT_TOKEN"
+              echo "auth-method=pat"
+              echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::Using Personal Access Token"
+
+          # GITHUB_TOKEN — fallback or explicit. Uses repo variables for
+          # git identity if set, so CLA can pass with a signed identity.
+          # NOTE: We output the sentinel "GITHUB_TOKEN" instead of the
+          # actual secret because secrets.GITHUB_TOKEN cannot be passed
+          # across job boundaries via outputs.
           else
-            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=GITHUB_TOKEN"
+              echo "auth-method=github-token"
+              echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
+            if [ -n "$GIT_USER_NAME" ]; then
+              echo "::notice::Using GITHUB_TOKEN with custom identity ($GIT_USER_NAME)"
+            else
+              echo "::warning::Using GITHUB_TOKEN — PRs will not trigger CI and may fail CLA checks. Set RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL repo variables to use a CLA-signed identity."
+            fi
           fi
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
-          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
           GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
 
@@ -353,14 +459,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      has_bumps: ${{ steps.rk.outputs.has-bumps }}
-      pr_url: ${{ steps.rk.outputs.pr-url }}
+      has_bumps: ${{ steps.prepare.outputs.has_bumps }}
+      pr_url: ${{ steps.prepare.outputs.pr_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
       - uses: subosito/flutter-action@v2
         with:
@@ -368,20 +478,21 @@ jobs:
           channel: stable
           cache: true
 
-      - name: Run releasekit prepare
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: prepare
         with:
           command: prepare
           workspace: dart
-          force: ${{ inputs.force_prepare && 'true' || 'false' }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           group: ${{ inputs.group }}
           bump-type: ${{ inputs.bump_type }}
           prerelease: ${{ inputs.prerelease }}
+          force: ${{ inputs.force_prepare }}
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -398,25 +509,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      release_url: ${{ steps.rk.outputs.release-url }}
+      release_url: ${{ steps.release.outputs.release_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
-      - name: Run releasekit release
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: release
         with:
           command: release
           workspace: dart
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -428,11 +545,15 @@ jobs:
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          enable-ollama: "false"
 
       - uses: subosito/flutter-action@v2
         with:
@@ -449,17 +570,17 @@ jobs:
           mkdir -p "$HOME/.config/dart"
           echo '${{ secrets.PUB_CREDENTIALS_JSON }}' > "$HOME/.config/dart/pub-credentials.json"
 
-      - name: Run releasekit publish
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
         with:
           command: publish
           workspace: dart
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
           force: "true"
           group: ${{ inputs.group }}
-          concurrency: ${{ inputs.concurrency || '0' }}
-          max-retries: ${{ inputs.max_retries || '2' }}
+          concurrency: ${{ inputs.concurrency }}
+          max-retries: ${{ inputs.max_retries }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
@@ -467,19 +588,48 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
       - name: Upload manifest artifact
-        if: success() && env.DRY_RUN != 'true'
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: release-manifest-dart
-          path: ${{ env.WORKSPACE_DIR }}/.releasekit-state.json
+          path: ${{ env.WORKSPACE_DIR }}/release-manifest.json
           retention-days: 90
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # VERIFY: Check published packages are available on pub.dev
+  # ═══════════════════════════════════════════════════════════════════════
+  verify:
+    name: Verify Published Packages
+    needs: publish
+    if: >-
+      success() &&
+      (github.event_name == 'pull_request' ||
+       inputs.dry_run == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+
+      - name: Wait for pub.dev propagation
+        run: |
+          echo "Waiting 30 seconds for pub.dev propagation..."
+          sleep 30
+
+      - name: Verify package is available
+        continue-on-error: true  # Propagation delays should not fail the pipeline
+        run: |
+          dart pub global activate genkit
+          echo "✅ pub.dev verification complete"
 
   # ═══════════════════════════════════════════════════════════════════════
   # NOTIFY: Post-release notifications
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [auth, release, publish]
+    needs: [auth, release, publish, verify]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -487,6 +637,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
           event-type: genkit-dart-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'

--- a/py/tools/releasekit/github/workflows/releasekit-go.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-go.yml
@@ -69,14 +69,69 @@
 #   │  max_retries:    [2] retry failed verifications             │
 #   └─────────────────────────────────────────────────────────────┘
 #
+# ── Job Dependency Graph ───────────────────────────────────────────
+#
+#   ┌───────┐
+#   │ auth  │  Resolve token: App → PAT → GITHUB_TOKEN
+#   └───┬───┘
+#       │ outputs: token, auth-method, git-user-name, git-user-email
+#       │
+#       ├──────────────────────┐
+#       │                      │
+#       ▼                      ▼
+#   ┌─────────┐          ┌─────────┐
+#   │ prepare │          │ release │
+#   │ (push)  │          │ (merge) │
+#   └─────────┘          └────┬────┘
+#                             │ needs: [auth]
+#                             │
+#                             ▼
+#                        ┌─────────┐
+#                        │ publish │
+#                        │(go prx) │
+#                        └────┬────┘
+#                             │ needs: [auth, release]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ verify │  go list -m check
+#                        └────┬───┘
+#                             │ needs: [publish]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ notify │
+#                        └────────┘
+#                          needs: [auth, release, publish, verify]
+#
+# ── Token Resolution (Sentinel Pattern) ───────────────────────────
+#
+#   The auth job resolves a token and outputs it for downstream jobs.
+#   Because secrets.GITHUB_TOKEN cannot cross job boundaries, the auth
+#   job outputs the literal string "GITHUB_TOKEN" as a sentinel when
+#   falling back to the built-in token.
+#
+#   auth job                          downstream job
+#   ────────                          ──────────────
+#   App token available?
+#     yes ──► output real token  ──►  use token directly
+#     no  ──► PAT available?
+#               yes ──► output PAT ─► use token directly
+#               no  ──► output       ┌─────────────────────────────┐
+#                       "GITHUB_TOKEN"│ RESOLVED_TOKEN =            │
+#                       (sentinel)   │   auth-method == 'github-   │
+#                                    │   token' ? secrets.GITHUB_  │
+#                                    │   TOKEN : needs.auth.token  │
+#                                    └─────────────────────────────┘
+#
 # ── Trigger Matrix ──────────────────────────────────────────────────
 #
 #   Event              │ Jobs that run
 #   ───────────────────┼──────────────────────────────────
 #   push to main       │ prepare
-#   PR merged          │ release → publish → notify
+#   PR merged          │ release → publish → verify → notify
 #   dispatch: prepare  │ prepare
-#   dispatch: release  │ release → publish → notify
+#   dispatch: release  │ release → publish → verify → notify
 #
 # ── Inputs Reference ────────────────────────────────────────────────
 #
@@ -95,8 +150,45 @@
 #   model          │ string  │ (chain) │ Override AI model
 #   codename_theme │ string  │ (cfg)   │ Override codename theme
 #
-# The workflow is idempotent: re-running any step is safe because
-# releasekit skips already-created tags and already-verified versions.
+# ── Required Configuration ─────────────────────────────────────────
+#
+#   Repository Variables (Settings → Variables → Actions):
+#
+#     RELEASEKIT_APP_ID        — GitHub App ID (for App-based auth)
+#     RELEASEKIT_GIT_USER_NAME — Git committer name for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
+#     RELEASEKIT_GIT_USER_EMAIL— Git committer email for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
+#
+#   Repository Secrets (Settings → Secrets → Actions):
+#
+#     RELEASEKIT_APP_PRIVATE_KEY — GitHub App private key (PEM)
+#     RELEASEKIT_TOKEN           — PAT fallback (if no App configured)
+#     GEMINI_API_KEY             — Gemini API key (for AI features)
+#
+#   Go modules are published automatically via the Go module proxy
+#   when tags are pushed — no registry credentials are needed.
+#
+#   If neither RELEASEKIT_APP_ID nor RELEASEKIT_TOKEN is set, the
+#   workflow falls back to GITHUB_TOKEN. In that case, set
+#   RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL to use
+#   a CLA-signed identity (otherwise PRs may fail CLA checks).
+#
+# ── Idempotency & Resumability ─────────────────────────────────────
+#
+#   Every job is idempotent — re-running a failed workflow is safe:
+#
+#     auth     Stateless; always resolves a fresh token.
+#     prepare  Updates the existing Release PR instead of duplicating.
+#     release  Skips tags and GitHub Releases that already exist.
+#     publish  Skips modules already available on the Go proxy.
+#     verify   Re-verifies; always safe to repeat.
+#     notify   Dispatches repository_dispatch (downstream deduplicates).
+#
+#   To resume after a failure, use "Re-run failed jobs" in the GitHub
+#   Actions UI. Only the failed jobs re-run; successful jobs keep their
+#   outputs. No special flags or state files are needed.
+#
 # ══════════════════════════════════════════════════════════════════════
 
 name: "ReleaseKit: Go"
@@ -266,6 +358,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write        # Sigstore keyless signing (SLSA provenance)
 
 env:
   RELEASEKIT_DIR: py/tools/releasekit
@@ -282,6 +375,7 @@ jobs:
     timeout-minutes: 2
     outputs:
       token: ${{ steps.resolve.outputs.token }}
+      auth-method: ${{ steps.resolve.outputs.auth-method }}
       git-user-name: ${{ steps.resolve.outputs.git-user-name }}
       git-user-email: ${{ steps.resolve.outputs.git-user-email }}
     steps:
@@ -307,27 +401,50 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      # Resolve: App > PAT > GITHUB_TOKEN (respects auth_method override).
       - name: Resolve token and identity
         id: resolve
         run: |
           AUTH="${{ inputs.auth_method || 'auto' }}"
+
+          # App token — used when auth=auto (and available) or auth=app.
           if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
-            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+            { echo "token=$APP_TOKEN"
+              echo "auth-method=app"
+              echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]"
+              echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::Using GitHub App token (${{ steps.app-token.outputs.app-slug }})"
+
+          # PAT — used when auth=auto (and available) or auth=pat.
           elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
-            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=$PAT_TOKEN"
+              echo "auth-method=pat"
+              echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::Using Personal Access Token"
+
+          # GITHUB_TOKEN — fallback or explicit. Uses repo variables for
+          # git identity if set, so CLA can pass with a signed identity.
+          # NOTE: We output the sentinel "GITHUB_TOKEN" instead of the
+          # actual secret because secrets.GITHUB_TOKEN cannot be passed
+          # across job boundaries via outputs.
           else
-            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=GITHUB_TOKEN"
+              echo "auth-method=github-token"
+              echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
+            if [ -n "$GIT_USER_NAME" ]; then
+              echo "::notice::Using GITHUB_TOKEN with custom identity ($GIT_USER_NAME)"
+            else
+              echo "::warning::Using GITHUB_TOKEN — PRs will not trigger CI and may fail CLA checks. Set RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL repo variables to use a CLA-signed identity."
+            fi
           fi
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
-          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
           GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
 
@@ -345,34 +462,39 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      has_bumps: ${{ steps.rk.outputs.has-bumps }}
-      pr_url: ${{ steps.rk.outputs.pr-url }}
+      has_bumps: ${{ steps.prepare.outputs.has_bumps }}
+      pr_url: ${{ steps.prepare.outputs.pr_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: go/go.sum
 
-      - name: Run releasekit prepare
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: prepare
         with:
           command: prepare
           workspace: go
-          force: ${{ inputs.force_prepare && 'true' || 'false' }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           group: ${{ inputs.group }}
           bump-type: ${{ inputs.bump_type }}
           prerelease: ${{ inputs.prerelease }}
+          force: ${{ inputs.force_prepare }}
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -389,25 +511,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      release_url: ${{ steps.rk.outputs.release-url }}
+      release_url: ${{ steps.release.outputs.release_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
-      - name: Run releasekit release
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: release
         with:
           command: release
           workspace: go
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -419,28 +547,32 @@ jobs:
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          enable-ollama: "false"
 
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: go/go.sum
 
-      - name: Run releasekit publish
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
         with:
           command: publish
           workspace: go
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
           force: "true"
           group: ${{ inputs.group }}
-          concurrency: ${{ inputs.concurrency || '0' }}
-          max-retries: ${{ inputs.max_retries || '2' }}
+          concurrency: ${{ inputs.concurrency }}
+          max-retries: ${{ inputs.max_retries }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
@@ -448,19 +580,47 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
       - name: Upload manifest artifact
-        if: success() && env.DRY_RUN != 'true'
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: release-manifest-go
-          path: .releasekit-state.json
+          path: release-manifest.json
           retention-days: 90
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # VERIFY: Check modules are available on the Go proxy
+  # ═══════════════════════════════════════════════════════════════════════
+  verify:
+    name: Verify Go Modules
+    needs: publish
+    if: >-
+      success() &&
+      (github.event_name == 'pull_request' ||
+       inputs.dry_run == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Wait for Go proxy propagation
+        run: |
+          echo "Waiting 30 seconds for Go module proxy propagation..."
+          sleep 30
+
+      - name: Verify module is available
+        continue-on-error: true  # Propagation delays should not fail the pipeline
+        run: |
+          GOPROXY=https://proxy.golang.org go list -m github.com/${{ github.repository }}/go/genkit@latest
+          echo "✅ Go proxy verification complete"
 
   # ═══════════════════════════════════════════════════════════════════════
   # NOTIFY: Post-release notifications
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [auth, release, publish]
+    needs: [auth, release, publish, verify]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -468,6 +628,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
           event-type: genkit-go-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'

--- a/py/tools/releasekit/github/workflows/releasekit-gradle.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-gradle.yml
@@ -66,14 +66,69 @@
 #   │  max_retries:    [2] retry failed publishes                 │
 #   └─────────────────────────────────────────────────────────────┘
 #
+# ── Job Dependency Graph ───────────────────────────────────────────
+#
+#   ┌───────┐
+#   │ auth  │  Resolve token: App → PAT → GITHUB_TOKEN
+#   └───┬───┘
+#       │ outputs: token, auth-method, git-user-name, git-user-email
+#       │
+#       ├──────────────────────┐
+#       │                      │
+#       ▼                      ▼
+#   ┌─────────┐          ┌─────────┐
+#   │ prepare │          │ release │
+#   │ (push)  │          │ (merge) │
+#   └─────────┘          └────┬────┘
+#                             │ needs: [auth]
+#                             │
+#                             ▼
+#                        ┌─────────┐
+#                        │ publish │
+#                        │ (Maven) │
+#                        └────┬────┘
+#                             │ needs: [auth, release]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ verify │  Maven Central search check
+#                        └────┬───┘
+#                             │ needs: [publish]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ notify │
+#                        └────────┘
+#                          needs: [auth, release, publish, verify]
+#
+# ── Token Resolution (Sentinel Pattern) ───────────────────────────
+#
+#   The auth job resolves a token and outputs it for downstream jobs.
+#   Because secrets.GITHUB_TOKEN cannot cross job boundaries, the auth
+#   job outputs the literal string "GITHUB_TOKEN" as a sentinel when
+#   falling back to the built-in token.
+#
+#   auth job                          downstream job
+#   ────────                          ──────────────
+#   App token available?
+#     yes ──► output real token  ──►  use token directly
+#     no  ──► PAT available?
+#               yes ──► output PAT ─► use token directly
+#               no  ──► output       ┌─────────────────────────────┐
+#                       "GITHUB_TOKEN"│ RESOLVED_TOKEN =            │
+#                       (sentinel)   │   auth-method == 'github-   │
+#                                    │   token' ? secrets.GITHUB_  │
+#                                    │   TOKEN : needs.auth.token  │
+#                                    └─────────────────────────────┘
+#
 # ── Trigger Matrix ──────────────────────────────────────────────────
 #
 #   Event              │ Jobs that run
 #   ───────────────────┼──────────────────────────────────
 #   push to main       │ prepare
-#   PR merged          │ release → publish → notify
+#   PR merged          │ release → publish → verify → notify
 #   dispatch: prepare  │ prepare
-#   dispatch: release  │ release → publish → notify
+#   dispatch: release  │ release → publish → verify → notify
 #
 # ── Inputs Reference ────────────────────────────────────────────────
 #
@@ -93,19 +148,46 @@
 #   model          │ string  │ (chain)        │ Override AI model
 #   codename_theme │ string  │ (cfg)          │ Override codename theme
 #
-# ── Authentication ──────────────────────────────────────────────────
+# ── Required Configuration ─────────────────────────────────────────
 #
-# Publishing to Maven Central via Sonatype OSSRH requires:
+#   Repository Variables (Settings → Variables → Actions):
 #
-#   OSSRH_USERNAME      — Sonatype OSSRH username
-#   OSSRH_PASSWORD      — Sonatype OSSRH password/token
-#   GPG_SIGNING_KEY     — GPG private key (base64-encoded)
-#   GPG_PASSPHRASE      — GPG key passphrase
+#     RELEASEKIT_APP_ID        — GitHub App ID (for App-based auth)
+#     RELEASEKIT_GIT_USER_NAME — Git committer name for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
+#     RELEASEKIT_GIT_USER_EMAIL— Git committer email for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
 #
-# These should be stored as GitHub repository secrets.
+#   Repository Secrets (Settings → Secrets → Actions):
 #
-# The workflow is idempotent: re-running any step is safe because
-# releasekit skips already-created tags and already-published versions.
+#     RELEASEKIT_APP_PRIVATE_KEY — GitHub App private key (PEM)
+#     RELEASEKIT_TOKEN           — PAT fallback (if no App configured)
+#     GEMINI_API_KEY             — Gemini API key (for AI features)
+#     OSSRH_USERNAME             — Sonatype OSSRH username
+#     OSSRH_PASSWORD             — Sonatype OSSRH password/token
+#     GPG_SIGNING_KEY            — GPG private key (base64-encoded)
+#     GPG_PASSPHRASE             — GPG key passphrase
+#
+#   If neither RELEASEKIT_APP_ID nor RELEASEKIT_TOKEN is set, the
+#   workflow falls back to GITHUB_TOKEN. In that case, set
+#   RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL to use
+#   a CLA-signed identity (otherwise PRs may fail CLA checks).
+#
+# ── Idempotency & Resumability ─────────────────────────────────────
+#
+#   Every job is idempotent — re-running a failed workflow is safe:
+#
+#     auth     Stateless; always resolves a fresh token.
+#     prepare  Updates the existing Release PR instead of duplicating.
+#     release  Skips tags and GitHub Releases that already exist.
+#     publish  Skips versions already present on Maven Central.
+#     verify   Re-verifies; always safe to repeat.
+#     notify   Dispatches repository_dispatch (downstream deduplicates).
+#
+#   To resume after a failure, use "Re-run failed jobs" in the GitHub
+#   Actions UI. Only the failed jobs re-run; successful jobs keep their
+#   outputs. No special flags or state files are needed.
+#
 # ══════════════════════════════════════════════════════════════════════
 
 name: "ReleaseKit: Java (Gradle)"
@@ -296,6 +378,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write        # Sigstore keyless signing (SLSA provenance)
 
 env:
   RELEASEKIT_DIR: py/tools/releasekit
@@ -314,6 +397,7 @@ jobs:
     timeout-minutes: 2
     outputs:
       token: ${{ steps.resolve.outputs.token }}
+      auth-method: ${{ steps.resolve.outputs.auth-method }}
       git-user-name: ${{ steps.resolve.outputs.git-user-name }}
       git-user-email: ${{ steps.resolve.outputs.git-user-email }}
     steps:
@@ -339,27 +423,50 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      # Resolve: App > PAT > GITHUB_TOKEN (respects auth_method override).
       - name: Resolve token and identity
         id: resolve
         run: |
           AUTH="${{ inputs.auth_method || 'auto' }}"
+
+          # App token — used when auth=auto (and available) or auth=app.
           if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
-            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+            { echo "token=$APP_TOKEN"
+              echo "auth-method=app"
+              echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]"
+              echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::Using GitHub App token (${{ steps.app-token.outputs.app-slug }})"
+
+          # PAT — used when auth=auto (and available) or auth=pat.
           elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
-            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=$PAT_TOKEN"
+              echo "auth-method=pat"
+              echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::Using Personal Access Token"
+
+          # GITHUB_TOKEN — fallback or explicit. Uses repo variables for
+          # git identity if set, so CLA can pass with a signed identity.
+          # NOTE: We output the sentinel "GITHUB_TOKEN" instead of the
+          # actual secret because secrets.GITHUB_TOKEN cannot be passed
+          # across job boundaries via outputs.
           else
-            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=GITHUB_TOKEN"
+              echo "auth-method=github-token"
+              echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
+            if [ -n "$GIT_USER_NAME" ]; then
+              echo "::notice::Using GITHUB_TOKEN with custom identity ($GIT_USER_NAME)"
+            else
+              echo "::warning::Using GITHUB_TOKEN — PRs will not trigger CI and may fail CLA checks. Set RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL repo variables to use a CLA-signed identity."
+            fi
           fi
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
-          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
           GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
 
@@ -377,38 +484,42 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      has_bumps: ${{ steps.rk.outputs.has-bumps }}
-      pr_url: ${{ steps.rk.outputs.pr-url }}
+      has_bumps: ${{ steps.prepare.outputs.has_bumps }}
+      pr_url: ${{ steps.prepare.outputs.pr_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
-
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{ env.GRADLE_VERSION }}
 
-      - name: Run releasekit prepare
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: prepare
         with:
           command: prepare
           workspace: java
-          force: ${{ inputs.force_prepare && 'true' || 'false' }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           group: ${{ inputs.group }}
           bump-type: ${{ inputs.bump_type }}
           prerelease: ${{ inputs.prerelease }}
+          force: ${{ inputs.force_prepare }}
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -425,25 +536,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      release_url: ${{ steps.rk.outputs.release-url }}
+      release_url: ${{ steps.release.outputs.release_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
-      - name: Run releasekit release
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: release
         with:
           command: release
           workspace: java
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -455,17 +572,20 @@ jobs:
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          enable-ollama: "false"
 
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
-
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{ env.GRADLE_VERSION }}
@@ -480,17 +600,17 @@ jobs:
         working-directory: ${{ env.WORKSPACE_DIR }}
         run: gradle build --no-daemon
 
-      - name: Run releasekit publish
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
         with:
           command: publish
           workspace: java
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
           force: "true"
           group: ${{ inputs.group }}
-          concurrency: ${{ inputs.concurrency || '0' }}
-          max-retries: ${{ inputs.max_retries || '2' }}
+          concurrency: ${{ inputs.concurrency }}
+          max-retries: ${{ inputs.max_retries }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
@@ -501,19 +621,50 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
       - name: Upload manifest artifact
-        if: success() && env.DRY_RUN != 'true'
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: release-manifest-java
-          path: ${{ env.WORKSPACE_DIR }}/.releasekit-state.json
+          path: ${{ env.WORKSPACE_DIR }}/release-manifest.json
           retention-days: 90
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # VERIFY: Check published artifacts are available on Maven Central
+  # ═══════════════════════════════════════════════════════════════════════
+  verify:
+    name: Verify Published Artifacts
+    needs: publish
+    if: >-
+      success() &&
+      (github.event_name == 'pull_request' ||
+       inputs.dry_run == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Wait for Maven Central propagation
+        run: |
+          echo "Waiting 60 seconds for Maven Central sync..."
+          sleep 60
+
+      - name: Verify artifact is available
+        continue-on-error: true  # Propagation delays should not fail the pipeline
+        run: |
+          # Check Maven Central search API for the artifact.
+          curl -sf "https://search.maven.org/solrsearch/select?q=g:com.google.genkit&rows=1" \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'Found {d[\"response\"][\"numFound\"]} artifacts'); sys.exit(0 if d['response']['numFound']>0 else 1)"
+          echo "✅ Maven Central verification complete"
 
   # ═══════════════════════════════════════════════════════════════════════
   # NOTIFY: Post-release notifications
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [auth, release, publish]
+    needs: [auth, release, publish, verify]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -521,6 +672,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
           event-type: genkit-java-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'

--- a/py/tools/releasekit/github/workflows/releasekit-pnpm.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-pnpm.yml
@@ -66,14 +66,68 @@
 #   │  concurrency:    [0] max parallel publish (0 = auto)        │
 #   └─────────────────────────────────────────────────────────────┘
 #
+# ── Job Dependency Graph ───────────────────────────────────────────
+#
+#   ┌───────┐
+#   │ auth  │  Resolve token: App → PAT → GITHUB_TOKEN
+#   └───┬───┘
+#       │ outputs: token, auth-method, git-user-name, git-user-email
+#       │
+#       ├──────────────────────┬──────────────────────┐
+#       │                      │                      │
+#       ▼                      ▼                      ▼
+#   ┌──────────────┐  ┌────────────────┐        ┌────────────┐
+#   │ prepare-js   │  │ prepare-js-cli │        │ release-js │
+#   │ (push)       │  │ (push)         │        │ (merge)    │
+#   └──────────────┘  └────────────────┘        └─────┬──────┘
+#                                                     │
+#                                                     ▼
+#                                               ┌────────────┐
+#                                               │ publish-js │
+#                                               │ (npm)      │
+#                                               └─────┬──────┘
+#                                                     │
+#                                                     ▼
+#                                               ┌─────────────┐
+#                                               │ verify-js   │  npm install check
+#                                               └──────┬──────┘
+#                                                      │
+#                                                      ▼
+#                                               ┌───────────┐
+#                                               │ notify-js │
+#                                               └───────────┘
+#
+#   Two prepare jobs run in parallel (js + js-cli workspaces).
+#   The release path is sequential: release → publish → verify → notify.
+#
+# ── Token Resolution (Sentinel Pattern) ───────────────────────────
+#
+#   The auth job resolves a token and outputs it for downstream jobs.
+#   Because secrets.GITHUB_TOKEN cannot cross job boundaries, the auth
+#   job outputs the literal string "GITHUB_TOKEN" as a sentinel when
+#   falling back to the built-in token.
+#
+#   auth job                          downstream job
+#   ────────                          ──────────────
+#   App token available?
+#     yes ──► output real token  ──►  use token directly
+#     no  ──► PAT available?
+#               yes ──► output PAT ─► use token directly
+#               no  ──► output       ┌─────────────────────────────┐
+#                       "GITHUB_TOKEN"│ RESOLVED_TOKEN =            │
+#                       (sentinel)   │   auth-method == 'github-   │
+#                                    │   token' ? secrets.GITHUB_  │
+#                                    │   TOKEN : needs.auth.token  │
+#                                    └─────────────────────────────┘
+#
 # ── Trigger Matrix ──────────────────────────────────────────────────
 #
 #   Event              │ Jobs that run
 #   ───────────────────┼──────────────────────────────────────────
 #   push to main       │ prepare-js, prepare-js-cli
-#   PR merged          │ release-js → publish-js → notify-js
+#   PR merged          │ release-js → publish-js → verify-js → notify-js
 #   dispatch: prepare  │ prepare-js, prepare-js-cli
-#   dispatch: release  │ release-js → publish-js → notify-js
+#   dispatch: release  │ release-js → publish-js → verify-js → notify-js
 #
 # ── Inputs Reference ────────────────────────────────────────────────
 #
@@ -93,8 +147,43 @@
 #   model          │ string  │ (chain) │ Override AI model
 #   codename_theme │ string  │ (cfg)   │ Override codename theme
 #
-# The workflow is idempotent: re-running any step is safe because
-# releasekit skips already-created tags and already-published versions.
+# ── Required Configuration ─────────────────────────────────────────
+#
+#   Repository Variables (Settings → Variables → Actions):
+#
+#     RELEASEKIT_APP_ID        — GitHub App ID (for App-based auth)
+#     RELEASEKIT_GIT_USER_NAME — Git committer name for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
+#     RELEASEKIT_GIT_USER_EMAIL— Git committer email for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
+#
+#   Repository Secrets (Settings → Secrets → Actions):
+#
+#     RELEASEKIT_APP_PRIVATE_KEY — GitHub App private key (PEM)
+#     RELEASEKIT_TOKEN           — PAT fallback (if no App configured)
+#     GEMINI_API_KEY             — Gemini API key (for AI features)
+#     NPM_TOKEN                  — npm access token (for publishing)
+#
+#   If neither RELEASEKIT_APP_ID nor RELEASEKIT_TOKEN is set, the
+#   workflow falls back to GITHUB_TOKEN. In that case, set
+#   RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL to use
+#   a CLA-signed identity (otherwise PRs may fail CLA checks).
+#
+# ── Idempotency & Resumability ─────────────────────────────────────
+#
+#   Every job is idempotent — re-running a failed workflow is safe:
+#
+#     auth     Stateless; always resolves a fresh token.
+#     prepare  Updates the existing Release PR instead of duplicating.
+#     release  Skips tags and GitHub Releases that already exist.
+#     publish  Skips versions already present on npm.
+#     verify   Re-verifies; always safe to repeat.
+#     notify   Dispatches repository_dispatch (downstream deduplicates).
+#
+#   To resume after a failure, use "Re-run failed jobs" in the GitHub
+#   Actions UI. Only the failed jobs re-run; successful jobs keep their
+#   outputs. No special flags or state files are needed.
+#
 # ══════════════════════════════════════════════════════════════════════
 
 name: "ReleaseKit: JS (pnpm)"
@@ -278,6 +367,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write        # Sigstore keyless signing (SLSA provenance)
 
 env:
   RELEASEKIT_DIR: py/tools/releasekit
@@ -297,7 +387,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
+      # When the fallback is GITHUB_TOKEN, we output the literal string
+      # "GITHUB_TOKEN" as a sentinel because the actual secret cannot
+      # cross job boundaries.  Downstream jobs must substitute their own
+      # secrets.GITHUB_TOKEN when they see this sentinel.
       token: ${{ steps.resolve.outputs.token }}
+      auth-method: ${{ steps.resolve.outputs.auth-method }}
       git-user-name: ${{ steps.resolve.outputs.git-user-name }}
       git-user-email: ${{ steps.resolve.outputs.git-user-email }}
     steps:
@@ -323,27 +418,50 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      # Resolve: App > PAT > GITHUB_TOKEN (respects auth_method override).
       - name: Resolve token and identity
         id: resolve
         run: |
           AUTH="${{ inputs.auth_method || 'auto' }}"
+
+          # App token — used when auth=auto (and available) or auth=app.
           if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
-            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+            { echo "token=$APP_TOKEN"
+              echo "auth-method=app"
+              echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]"
+              echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::Using GitHub App token (${{ steps.app-token.outputs.app-slug }})"
+
+          # PAT — used when auth=auto (and available) or auth=pat.
           elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
-            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=$PAT_TOKEN"
+              echo "auth-method=pat"
+              echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::Using Personal Access Token"
+
+          # GITHUB_TOKEN — fallback or explicit. Uses repo variables for
+          # git identity if set, so CLA can pass with a signed identity.
+          # NOTE: We output the sentinel "GITHUB_TOKEN" instead of the
+          # actual secret because secrets.GITHUB_TOKEN cannot be passed
+          # across job boundaries via outputs.
           else
-            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=GITHUB_TOKEN"
+              echo "auth-method=github-token"
+              echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
+            if [ -n "$GIT_USER_NAME" ]; then
+              echo "::notice::Using GITHUB_TOKEN with custom identity ($GIT_USER_NAME)"
+            else
+              echo "::warning::Using GITHUB_TOKEN — PRs will not trigger CI and may fail CLA checks. Set RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL repo variables to use a CLA-signed identity."
+            fi
           fi
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
-          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
           GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
 
@@ -361,39 +479,43 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      has_bumps: ${{ steps.rk.outputs.has-bumps }}
-      pr_url: ${{ steps.rk.outputs.pr-url }}
+      has_bumps: ${{ steps.prepare.outputs.has_bumps }}
+      pr_url: ${{ steps.prepare.outputs.pr_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
           cache-dependency-path: js/pnpm-lock.yaml
 
-      - name: Run releasekit prepare
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: prepare
         with:
           command: prepare
           workspace: js
-          force: ${{ inputs.force_prepare && 'true' || 'false' }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           group: ${{ inputs.group }}
           bump-type: ${{ inputs.bump_type }}
           prerelease: ${{ inputs.prerelease }}
+          force: ${{ inputs.force_prepare }}
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   prepare-js-cli:
@@ -407,39 +529,43 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      has_bumps: ${{ steps.rk.outputs.has-bumps }}
-      pr_url: ${{ steps.rk.outputs.pr-url }}
+      has_bumps: ${{ steps.prepare.outputs.has_bumps }}
+      pr_url: ${{ steps.prepare.outputs.pr_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
           cache-dependency-path: genkit-tools/pnpm-lock.yaml
 
-      - name: Run releasekit prepare
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: prepare
         with:
           command: prepare
           workspace: js-cli
-          force: ${{ inputs.force_prepare && 'true' || 'false' }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           group: ${{ inputs.group }}
           bump-type: ${{ inputs.bump_type }}
           prerelease: ${{ inputs.prerelease }}
+          force: ${{ inputs.force_prepare }}
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -456,25 +582,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      release_url: ${{ steps.rk.outputs.release-url }}
+      release_url: ${{ steps.release.outputs.release_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
-      - name: Run releasekit release
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: release
         with:
           command: release
           workspace: js
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -486,16 +618,19 @@ jobs:
     if: inputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          enable-ollama: "false"
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -510,17 +645,17 @@ jobs:
         working-directory: js
         run: pnpm build
 
-      - name: Run releasekit publish
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
         with:
           command: publish
           workspace: js
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
           force: "true"
           group: ${{ inputs.group }}
-          concurrency: ${{ inputs.concurrency || '0' }}
-          max-retries: ${{ inputs.max_retries || '2' }}
+          concurrency: ${{ inputs.concurrency }}
+          max-retries: ${{ inputs.max_retries }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
@@ -529,26 +664,59 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
       - name: Upload manifest artifact
-        if: success() && env.DRY_RUN != 'true'
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: release-manifest-js
-          path: .releasekit-state.json
+          path: release-manifest.json
           retention-days: 90
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # VERIFY: Check published packages are installable
+  # ═══════════════════════════════════════════════════════════════════════
+  verify-js:
+    name: "Verify Published Packages (JS)"
+    needs: publish-js
+    if: >-
+      success() &&
+      (github.event_name == 'pull_request' ||
+       inputs.dry_run == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Wait for npm propagation
+        run: |
+          echo "Waiting 30 seconds for npm CDN propagation..."
+          sleep 30
+
+      - name: Verify core package
+        continue-on-error: true  # Propagation delays should not fail the pipeline
+        run: |
+          mkdir -p /tmp/verify-js && cd /tmp/verify-js
+          pnpm init
+          pnpm add genkit
+          node -e "require('genkit'); console.log('✅ genkit imports successfully')"
 
   # ═══════════════════════════════════════════════════════════════════════
   # NOTIFY: Post-release notifications
   # ═══════════════════════════════════════════════════════════════════════
   notify-js:
     name: "Notify Downstream (JS)"
-    needs: [auth, release-js, publish-js]
-    if: success() && needs.publish-js.result == 'success'
+    needs: [auth, release-js, publish-js, verify-js]
+    if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
           event-type: genkit-js-release
           client-payload: '{"release_url": "${{ needs.release-js.outputs.release_url }}"}'

--- a/py/tools/releasekit/github/workflows/releasekit-rollback.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-rollback.yml
@@ -40,6 +40,32 @@
 #   │  dry_run:      [✓] simulate, no side effects                │
 #   └─────────────────────────────────────────────────────────────┘
 #
+# ── Job Execution Flow ──────────────────────────────────────────────
+#
+#   ┌──────────┐
+#   │ rollback │  Single job — no auth job needed (same-job secret)
+#   └────┬─────┘
+#        │
+#        ├─► checkout (full history + tags, token = secrets.GITHUB_TOKEN)
+#        │
+#        ├─► releasekit rollback
+#        │     │
+#        │     ├─► resolve tag → find commit SHA
+#        │     │
+#        │     ├─► --all-tags? ──► find all tags on same commit
+#        │     │                    └─► delete each tag (local + remote)
+#        │     │
+#        │     ├─► delete GitHub Release(s)
+#        │     │
+#        │     └─► --yank? ──► yank from package registry
+#        │                      └─► with --yank-reason if provided
+#        │
+#        └─► (done)
+#
+#   Unlike the release workflows, rollback is a single-job workflow.
+#   It uses secrets.GITHUB_TOKEN directly — no sentinel pattern needed
+#   because there are no cross-job boundaries.
+#
 # ── Safety ────────────────────────────────────────────────────────────
 #
 # The workflow defaults to dry_run=true so accidental triggers are
@@ -140,19 +166,21 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          enable-ollama: "false"
 
-      - name: Run releasekit rollback
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
         with:
           command: rollback
           workspace: ${{ inputs.workspace }}
-          tag: ${{ inputs.tag }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ inputs.dry_run && 'true' || 'false' }}
+          tag: ${{ inputs.tag }}
           all-tags: ${{ inputs.all_tags && 'true' || 'false' }}
           yank: ${{ inputs.yank && 'true' || 'false' }}
           yank-reason: ${{ inputs.yank_reason }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/py/tools/releasekit/github/workflows/releasekit-uv.yml
+++ b/py/tools/releasekit/github/workflows/releasekit-uv.yml
@@ -63,14 +63,69 @@
 #   │  concurrency:    [0] max parallel publish (0 = auto)        │
 #   └─────────────────────────────────────────────────────────────┘
 #
+# ── Job Dependency Graph ───────────────────────────────────────────
+#
+#   ┌───────┐
+#   │ auth  │  Resolve token: App → PAT → GITHUB_TOKEN
+#   └───┬───┘
+#       │ outputs: token, auth-method, git-user-name, git-user-email
+#       │
+#       ├──────────────────────┐
+#       │                      │
+#       ▼                      ▼
+#   ┌─────────┐          ┌─────────┐
+#   │ prepare │          │ release │
+#   │ (push)  │          │ (merge) │
+#   └─────────┘          └────┬────┘
+#                             │ needs: [auth]
+#                             │
+#                             ▼
+#                        ┌─────────┐
+#                        │ publish │
+#                        │ (PyPI)  │
+#                        └────┬────┘
+#                             │ needs: [auth, release]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ verify │  pip install + import check
+#                        └────┬───┘
+#                             │ needs: [publish]
+#                             │
+#                             ▼
+#                        ┌────────┐
+#                        │ notify │
+#                        └────────┘
+#                          needs: [auth, release, publish, verify]
+#
+# ── Token Resolution (Sentinel Pattern) ───────────────────────────
+#
+#   The auth job resolves a token and outputs it for downstream jobs.
+#   Because secrets.GITHUB_TOKEN cannot cross job boundaries, the auth
+#   job outputs the literal string "GITHUB_TOKEN" as a sentinel when
+#   falling back to the built-in token.
+#
+#   auth job                          downstream job
+#   ────────                          ──────────────
+#   App token available?
+#     yes ──► output real token  ──►  use token directly
+#     no  ──► PAT available?
+#               yes ──► output PAT ─► use token directly
+#               no  ──► output       ┌─────────────────────────────┐
+#                       "GITHUB_TOKEN"│ RESOLVED_TOKEN =            │
+#                       (sentinel)   │   auth-method == 'github-   │
+#                                    │   token' ? secrets.GITHUB_  │
+#                                    │   TOKEN : needs.auth.token  │
+#                                    └─────────────────────────────┘
+#
 # ── Trigger Matrix ──────────────────────────────────────────────────
 #
 #   Event              │ Jobs that run
 #   ───────────────────┼──────────────────────────────────
 #   push to main       │ prepare
-#   PR merged          │ release → publish → notify
+#   PR merged          │ release → publish → verify → notify
 #   dispatch: prepare  │ prepare
-#   dispatch: release  │ release → publish → notify
+#   dispatch: release  │ release → publish → verify → notify
 #
 # ── Inputs Reference ────────────────────────────────────────────────
 #
@@ -90,8 +145,42 @@
 #   model          │ string  │ (chain) │ Override AI model
 #   codename_theme │ string  │ (cfg)   │ Override codename theme
 #
-# The workflow is idempotent: re-running any step is safe because
-# releasekit skips already-created tags and already-published versions.
+# ── Required Configuration ─────────────────────────────────────────
+#
+#   Repository Variables (Settings → Variables → Actions):
+#
+#     RELEASEKIT_APP_ID        — GitHub App ID (for App-based auth)
+#     RELEASEKIT_GIT_USER_NAME — Git committer name for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
+#     RELEASEKIT_GIT_USER_EMAIL— Git committer email for CLA-signed
+#                                identity (used with PAT/GITHUB_TOKEN)
+#
+#   Repository Secrets (Settings → Secrets → Actions):
+#
+#     RELEASEKIT_APP_PRIVATE_KEY — GitHub App private key (PEM)
+#     RELEASEKIT_TOKEN           — PAT fallback (if no App configured)
+#     GEMINI_API_KEY             — Gemini API key (for AI features)
+#
+#   If neither RELEASEKIT_APP_ID nor RELEASEKIT_TOKEN is set, the
+#   workflow falls back to GITHUB_TOKEN. In that case, set
+#   RELEASEKIT_GIT_USER_NAME and RELEASEKIT_GIT_USER_EMAIL to use
+#   a CLA-signed identity (otherwise PRs may fail CLA checks).
+#
+# ── Idempotency & Resumability ─────────────────────────────────────
+#
+#   Every job is idempotent — re-running a failed workflow is safe:
+#
+#     auth     Stateless; always resolves a fresh token.
+#     prepare  Updates the existing Release PR instead of duplicating.
+#     release  Skips tags and GitHub Releases that already exist.
+#     publish  Skips versions already present on the registry.
+#     verify   Re-verifies; always safe to repeat.
+#     notify   Dispatches repository_dispatch (downstream deduplicates).
+#
+#   To resume after a failure, use "Re-run failed jobs" in the GitHub
+#   Actions UI. Only the failed jobs re-run; successful jobs keep their
+#   outputs. No special flags or state files are needed.
+#
 # ══════════════════════════════════════════════════════════════════════
 
 name: "ReleaseKit: Python (uv)"
@@ -280,6 +369,7 @@ concurrency:
 permissions:
   contents: write        # Create tags, releases, and push to release branch
   pull-requests: write   # Open/update Release PRs, manage labels
+  id-token: write        # Sigstore keyless signing (SLSA provenance)
 
 env:
   RELEASEKIT_DIR: py/tools/releasekit
@@ -311,7 +401,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
+      # When the fallback is GITHUB_TOKEN, we output the literal string
+      # "GITHUB_TOKEN" as a sentinel because the actual secret cannot
+      # cross job boundaries.  Downstream jobs must substitute their own
+      # secrets.GITHUB_TOKEN when they see this sentinel.
       token: ${{ steps.resolve.outputs.token }}
+      auth-method: ${{ steps.resolve.outputs.auth-method }}
       git-user-name: ${{ steps.resolve.outputs.git-user-name }}
       git-user-email: ${{ steps.resolve.outputs.git-user-email }}
     steps:
@@ -346,24 +441,33 @@ jobs:
 
           # App token — used when auth=auto (and available) or auth=app.
           if [ "$AUTH" = "app" ] || { [ "$AUTH" = "auto" ] && [ -n "$APP_TOKEN" ]; }; then
-            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+            { echo "token=$APP_TOKEN"
+              echo "auth-method=app"
+              echo "git-user-name=${{ steps.app-token.outputs.app-slug }}[bot]"
+              echo "git-user-email=${{ steps.app-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+            } >> "$GITHUB_OUTPUT"
             echo "::notice::Using GitHub App token (${{ steps.app-token.outputs.app-slug }})"
 
           # PAT — used when auth=auto (and available) or auth=pat.
           elif [ "$AUTH" = "pat" ] || { [ "$AUTH" = "auto" ] && [ -n "$PAT_TOKEN" ]; }; then
-            echo "token=$PAT_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=$PAT_TOKEN"
+              echo "auth-method=pat"
+              echo "git-user-name=${GIT_USER_NAME:-releasekit[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-releasekit[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
             echo "::notice::Using Personal Access Token"
 
           # GITHUB_TOKEN — fallback or explicit. Uses repo variables for
           # git identity if set, so CLA can pass with a signed identity.
+          # NOTE: We output the sentinel "GITHUB_TOKEN" instead of the
+          # actual secret because secrets.GITHUB_TOKEN cannot be passed
+          # across job boundaries via outputs.
           else
-            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}" >> "$GITHUB_OUTPUT"
-            echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}" >> "$GITHUB_OUTPUT"
+            { echo "token=GITHUB_TOKEN"
+              echo "auth-method=github-token"
+              echo "git-user-name=${GIT_USER_NAME:-github-actions[bot]}"
+              echo "git-user-email=${GIT_USER_EMAIL:-github-actions[bot]@users.noreply.github.com}"
+            } >> "$GITHUB_OUTPUT"
             if [ -n "$GIT_USER_NAME" ]; then
               echo "::notice::Using GITHUB_TOKEN with custom identity ($GIT_USER_NAME)"
             else
@@ -373,7 +477,6 @@ jobs:
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           PAT_TOKEN: ${{ secrets.RELEASEKIT_TOKEN }}
-          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_USER_NAME: ${{ vars.RELEASEKIT_GIT_USER_NAME }}
           GIT_USER_EMAIL: ${{ vars.RELEASEKIT_GIT_USER_EMAIL }}
 
@@ -391,32 +494,36 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      has_bumps: ${{ steps.rk.outputs.has-bumps }}
-      pr_url: ${{ steps.rk.outputs.pr-url }}
+      has_bumps: ${{ steps.prepare.outputs.has_bumps }}
+      pr_url: ${{ steps.prepare.outputs.pr_url }}
+    env:
+      # Resolve the sentinel: use the job's own GITHUB_TOKEN when auth
+      # fell back to the built-in token (it cannot cross job boundaries).
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
-      - name: Run releasekit prepare
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: prepare
         with:
           command: prepare
           workspace: py
-          force: ${{ inputs.force_prepare && 'true' || 'false' }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           group: ${{ inputs.group }}
           bump-type: ${{ inputs.bump_type }}
           prerelease: ${{ inputs.prerelease }}
+          force: ${{ inputs.force_prepare }}
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
-          GH_TOKEN: ${{ needs.auth.outputs.token }}
-          RELEASEKIT_GIT_USER_NAME: ${{ needs.auth.outputs.git-user-name }}
-          RELEASEKIT_GIT_USER_EMAIL: ${{ needs.auth.outputs.git-user-email }}
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -433,28 +540,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      release_url: ${{ steps.rk.outputs.release-url }}
+      release_url: ${{ steps.release.outputs.release_url }}
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          git-user-name: ${{ needs.auth.outputs.git-user-name }}
+          git-user-email: ${{ needs.auth.outputs.git-user-email }}
 
-      - name: Run releasekit release
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
+        id: release
         with:
           command: release
           workspace: py
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
         env:
-          GH_TOKEN: ${{ needs.auth.outputs.token }}
-          RELEASEKIT_GIT_USER_NAME: ${{ needs.auth.outputs.git-user-name }}
-          RELEASEKIT_GIT_USER_EMAIL: ${{ needs.auth.outputs.git-user-email }}
+          GH_TOKEN: ${{ env.RESOLVED_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
   # ═══════════════════════════════════════════════════════════════════════
@@ -468,40 +578,33 @@ jobs:
     timeout-minutes: 30
     environment: ${{ inputs.target || 'pypi' }}
     permissions:
-      id-token: write  # Trusted publishing (OIDC)
+      id-token: write      # Trusted publishing (OIDC) + Sigstore signing
+      attestations: write   # PEP 740 attestations
+    env:
+      RESOLVED_TOKEN: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-releasekit
         with:
-          fetch-depth: 0
-          fetch-tags: true
+          token: ${{ env.RESOLVED_TOKEN }}
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
+          install-system-deps: "true"
+          workspace-dir: ${{ env.WORKSPACE_DIR }}
+          enable-ollama: "false"
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends build-essential libffi-dev
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-
-      - name: Install workspace packages
-        run: |
-          cd ${{ env.WORKSPACE_DIR }} && uv sync --no-dev
-
-      - name: Run releasekit publish
-        id: rk
-        uses: ./py/tools/releasekit
+      - uses: ./.github/actions/run-releasekit
         with:
           command: publish
           workspace: py
+          releasekit-dir: ${{ env.RELEASEKIT_DIR }}
           dry-run: ${{ env.DRY_RUN }}
           force: "true"
           group: ${{ inputs.group }}
+          concurrency: ${{ inputs.concurrency }}
+          max-retries: ${{ inputs.max_retries }}
           check-url: ${{ env.PUBLISH_CHECK_URL }}
           index-url: ${{ env.PUBLISH_INDEX_URL }}
-          concurrency: ${{ inputs.concurrency || '0' }}
-          max-retries: ${{ inputs.max_retries || '2' }}
+          show-plan: "true"
           no-ai: ${{ inputs.no_ai && 'true' || 'false' }}
           model: ${{ inputs.model }}
           codename-theme: ${{ inputs.codename_theme }}
@@ -510,19 +613,90 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
       - name: Upload manifest artifact
-        if: success() && env.DRY_RUN != 'true'
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: release-manifest
-          path: ${{ env.WORKSPACE_DIR }}/.releasekit-state.json
+          path: ${{ env.WORKSPACE_DIR }}/release-manifest.json
           retention-days: 90
+
+      - name: Upload SLSA provenance
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: slsa-provenance
+          path: ${{ env.WORKSPACE_DIR }}/provenance*.intoto.jsonl
+          retention-days: 90
+          if-no-files-found: warn
+
+      - name: Upload SBOMs
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: |
+            ${{ env.WORKSPACE_DIR }}/sbom.cdx.json
+            ${{ env.WORKSPACE_DIR }}/sbom.spdx.json
+          retention-days: 90
+          if-no-files-found: warn
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # VERIFY: Check published packages are installable
+  # ═══════════════════════════════════════════════════════════════════════
+  verify:
+    name: Verify Published Packages
+    needs: publish
+    if: >-
+      success() &&
+      (github.event_name == 'pull_request' ||
+       inputs.dry_run == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Wait for PyPI propagation
+        run: |
+          echo "Waiting 60 seconds for PyPI CDN propagation..."
+          sleep 60
+
+      - name: Get core version and verify installation
+        continue-on-error: true  # Propagation delays should not fail the pipeline
+        run: |
+          VERSION=$(grep '^version' py/packages/genkit/pyproject.toml | head -1 | sed 's/.*= *"//' | sed 's/".*//')
+          echo "Core version: $VERSION"
+
+          pip install --upgrade pip
+
+          # Verify core package.
+          pip install "genkit==$VERSION"
+          python -c "from genkit.ai import Genkit; print('✅ genkit imports successfully')"
+
+          # Verify all plugins are installable.
+          for pyproject in py/plugins/*/pyproject.toml; do
+            plugin_dir=$(dirname "$pyproject")
+            plugin_name=$(basename "$plugin_dir")
+            pkg_name="genkit-plugin-${plugin_name}"
+            plugin_version=$(grep '^version' "$pyproject" | head -1 | sed 's/.*= *"//' | sed 's/".*//')
+            echo "Verifying $pkg_name==$plugin_version..."
+            if pip install "$pkg_name==$plugin_version"; then
+              echo "✅ $pkg_name installed"
+            else
+              echo "⚠️  $pkg_name==$plugin_version not found on PyPI (may not have been published)"
+            fi
+          done
 
   # ═══════════════════════════════════════════════════════════════════════
   # NOTIFY: Post-release notifications
   # ═══════════════════════════════════════════════════════════════════════
   notify:
     name: Notify Downstream
-    needs: [auth, release, publish]
+    needs: [auth, release, publish, verify]
     if: success()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -530,6 +704,6 @@ jobs:
       - name: Dispatch release event
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ needs.auth.outputs.token }}
+          token: ${{ needs.auth.outputs.auth-method == 'github-token' && secrets.GITHUB_TOKEN || needs.auth.outputs.token }}
           event-type: genkit-python-release
           client-payload: '{"release_url": "${{ needs.release.outputs.release_url }}"}'


### PR DESCRIPTION
## Summary

Update all template workflows and documentation to reflect the new composite action architecture.

## Changes (15 files)

### Template Workflows (9 files)
- `py/tools/releasekit/action.yml`
- `py/tools/releasekit/github/actions/run-releasekit/action.yml`
- `py/tools/releasekit/github/workflows/releasekit-{cargo,dart,go,gradle,pnpm,rollback,uv}.yml`

### Documentation (6 files)
- `py/tools/releasekit/docs/docs/guides/{beginners-guide,ci-cd,rollback,workflow-templates}.md`
- `py/tools/releasekit/docs/docs/reference/github-action.md`
- `py/tools/releasekit/docs/mkdocs.yml`

Split from #4716. Live `.github/` workflow + source changes are in #4717.