### PR TITLE
ci(py/genkit): select plugins and core to publish and some minor fixes

### DIFF
--- a/py/tools/releasekit/src/releasekit/prepare.py
+++ b/py/tools/releasekit/src/releasekit/prepare.py
@@ -117,7 +117,7 @@ from releasekit.preflight import run_preflight
 from releasekit.tags import format_tag
 from releasekit.utils.date import utc_iso, utc_today
 from releasekit.versioning import compute_bumps
-from releasekit.versions import PackageVersion, ReleaseManifest
+from releasekit.versions import PackageVersion, ReleaseManifest, resolve_umbrella_version
 from releasekit.workspace import Package, discover_packages
 
 logger = get_logger(__name__)
@@ -408,7 +408,7 @@ async def prepare_release(
 
     # 7. Build and save manifest.
     git_sha = await vcs.current_sha()
-    umbrella_version = bumped[0].new_version if bumped else '0.0.0'
+    umbrella_version = resolve_umbrella_version(bumped, core_package=ws_config.core_package)
     umbrella_tag = format_tag(ws_config.umbrella_tag, version=umbrella_version, label=ws_config.label)
     manifest = ReleaseManifest(
         git_sha=git_sha,

--- a/py/tools/releasekit/src/releasekit/release.py
+++ b/py/tools/releasekit/src/releasekit/release.py
@@ -111,7 +111,7 @@ from releasekit.config import ReleaseConfig, WorkspaceConfig
 from releasekit.logging import get_logger
 from releasekit.release_notes import generate_release_notes, render_release_notes
 from releasekit.tags import TagResult, create_tags
-from releasekit.versions import PackageVersion, ReleaseManifest
+from releasekit.versions import PackageVersion, ReleaseManifest, resolve_umbrella_version
 
 logger = get_logger(__name__)
 
@@ -280,7 +280,7 @@ async def tag_release(
     release_body = render_release_notes(release_notes)
 
     # 3. Create tags and Release.
-    umbrella_version = bumped[0].new_version
+    umbrella_version = resolve_umbrella_version(bumped, core_package=ws_config.core_package)
     manifest_file = manifest_path
     if manifest_file is None and not dry_run:
         # Save manifest to temp file for the release asset.
@@ -302,6 +302,7 @@ async def tag_release(
         forge=forge,
         tag_format=ws_config.tag_format,
         umbrella_tag_format=ws_config.umbrella_tag,
+        core_package=ws_config.core_package,
         label=ws_config.label,
         release_body=release_body,
         release_title=f'Release v{umbrella_version}',

--- a/py/tools/releasekit/src/releasekit/versions.py
+++ b/py/tools/releasekit/src/releasekit/versions.py
@@ -178,7 +178,34 @@ class ReleaseManifest:
         return manifest
 
 
+def resolve_umbrella_version(
+    bumped: list[PackageVersion],
+    core_package: str = '',
+) -> str:
+    """Pick the umbrella version from the core package, falling back to the first bumped.
+
+    The umbrella tag should reflect the core package's version (e.g. ``genkit``),
+    not whichever package happens to sort first in dependency order.
+
+    Args:
+        bumped: List of bumped :class:`PackageVersion` records.
+        core_package: Name of the core package (from ``ws_config.core_package``).
+
+    Returns:
+        The version string to use for the umbrella tag, or ``'0.0.0'`` if
+        *bumped* is empty.
+    """
+    if not bumped:
+        return '0.0.0'
+    if core_package:
+        for pkg in bumped:
+            if pkg.name == core_package:
+                return pkg.new_version
+    return bumped[0].new_version
+
+
 __all__ = [
     'PackageVersion',
     'ReleaseManifest',
+    'resolve_umbrella_version',
 ]

--- a/releasekit.toml
+++ b/releasekit.toml
@@ -132,8 +132,11 @@ tag_format = "{label}/{name}-v{version}"
 tool = "uv"
 umbrella_tag = "{label}/v{version}"
 
-# Packages listed here are discovered, checked, and version-bumped
-# but skipped during publish. Use "group:<name>" to reference a group.
+# Packages listed here are discovered and checked but NOT version-bumped.
+exclude_bump = []
+
+# Packages listed here are version-bumped (changelogs, versions stay in
+# sync) but skipped during publish. Use "group:<name>" to reference a group.
 exclude_publish = [
   "group:samples",
   "group:unreleased_plugins",
@@ -144,7 +147,6 @@ exclude_publish = [
 community_plugins = [
   "genkit-plugin-amazon-bedrock",
   "genkit-plugin-anthropic",
-  "genkit-plugin-checks",
   "genkit-plugin-cloudflare-workers-ai",
   "genkit-plugin-cohere",
   "genkit-plugin-compat-oai",
@@ -217,7 +219,18 @@ samples = [
   "web-multi-server",
   "web-short-n-long",
 ]
-unreleased_plugins = []
+unreleased_plugins = [
+  "genkit-plugin-amazon-bedrock",        # TODO: Future release.
+  "genkit-plugin-checks",                # TODO: Wait for GA.
+  "genkit-plugin-cloudflare-workers-ai", # TODO: Future release.
+  "genkit-plugin-cohere",                # TODO: Future release.
+  "genkit-plugin-firebase",              # TODO: Pending AIM telemetry,
+  "genkit-plugin-huggingface",           # TODO: Future release.
+  "genkit-plugin-mcp",                   # TODO: Not implemented.
+  "genkit-plugin-microsoft-foundry",     # TODO: Future release.
+  "genkit-plugin-mistral",               # TODO: Future release.
+  "genkit-plugin-observability",         # TODO: Future release.
+]
 
 # ---------------------------------------------------------------------------
 # Go workspace (ready — uncomment to activate)


### PR DESCRIPTION
```
zsh❯ py/bin/releasekit plan --bumped --publishable
2026-02-17T22:16:17.010158Z [warning  ] non_conventional_commit        [releasekit.versioning] package=genkit sha=a15c4ec2 subject='elisa/fix/core framework improvements (#4649)'
   Level  Package                     Current  Next   Bump   Status    Reason                                                                                                        
─  ─────  ──────────────────────────  ───────  ─────  ─────  ────────  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────
📦  0      genkit                      0.5.0    0.6.0  minor  included  fix: Path fix for logging (#4642)                                                                             
📦  1      genkit-plugin-anthropic     0.5.0    0.6.0  minor  included  fix(releasekit): replace literal null byte with git %x00 escape in changelog format (#4661)                   
📦  1      genkit-plugin-compat-oai    0.5.0    0.6.0  minor  included  fix(releasekit): replace literal null byte with git %x00 escape in changelog format (#4661)                   
📦  1      genkit-plugin-evaluators    0.5.0    0.6.0  minor  included  feat(releasekit): add Forge protocol extensions, transitive propagation, and multi-backend conformance (#4577)
📦  1      genkit-plugin-fastapi       0.5.0    0.6.0  minor  included  fix(py): address releasekit check warnings for metadata and grouping (#4595)                                  
📦  1      genkit-plugin-google-cloud  0.5.0    0.6.0  minor  included  fix: Fixed firebase telemetry , refactored telemetry implementation fixed failing tests (#4530)               
📦  1      genkit-plugin-google-genai  0.5.0    0.6.0  minor  included  fix(py): update google-genai evaluators and cleanup sample-test (#4648)                                       
📦  1      genkit-plugin-ollama        0.5.0    0.6.0  minor  included  fix(releasekit): replace literal null byte with git %x00 escape in changelog format (#4661)                   
📦  1      genkit-plugin-xai           0.5.0    0.6.0  minor  included  fix(conform,anthropic): native executors, tool schema handling, and CLI consolidation (#4698)                 
📦  2      genkit-plugin-deepseek      0.5.0    0.6.0  minor  included  fix(releasekit): replace literal null byte with git %x00 escape in changelog format (#4661)                   
📦  2      genkit-plugin-flask         0.5.0    0.6.0  minor  included  feat(releasekit): add Forge protocol extensions, transitive propagation, and multi-backend conformance (#4577)
📦  2      genkit-plugin-vertex-ai     0.5.0    0.6.0  minor  included  fix(py/vertex-ai): async client creation with threaded credential refresh (#4608)                             
Umbrella version: 0.6.0
Total: 12 packages (12 included)
```