### PR TITLE
fix(releasekit): skip git hooks in release commits and pushes

### DIFF
--- a/py/tools/releasekit/src/releasekit/backends/vcs/git.py
+++ b/py/tools/releasekit/src/releasekit/backends/vcs/git.py
@@ -172,7 +172,10 @@ class GitCLIBackend:
             await asyncio.to_thread(self._git, 'add', '-A', dry_run=dry_run)
 
         log.info('commit', message=message[:80])
-        return await asyncio.to_thread(self._git, 'commit', '-m', message, dry_run=dry_run)
+        # --no-verify skips pre-commit hooks (e.g. captainhook running
+        # pnpm i + bin/lint) that can hang for minutes on auto-generated
+        # release commits.
+        return await asyncio.to_thread(self._git, 'commit', '--no-verify', '-m', message, dry_run=dry_run)
 
     async def tag(
         self,
@@ -230,7 +233,8 @@ class GitCLIBackend:
         dry_run: bool = False,
     ) -> CommandResult:
         """Push commits and/or tags."""
-        cmd_parts = ['push']
+        # --no-verify skips pre-push hooks that can hang on release branches.
+        cmd_parts = ['push', '--no-verify']
         if force:
             cmd_parts.append('--force-with-lease')
         # --set-upstream is only meaningful for branch pushes, not tag-only pushes.

--- a/py/tools/releasekit/tests/rk_backends_vcs_git_test.py
+++ b/py/tools/releasekit/tests/rk_backends_vcs_git_test.py
@@ -269,6 +269,14 @@ class TestCommit:
             assert '-A' in calls[0]
 
     @pytest.mark.asyncio()
+    async def test_no_verify_flag(self, git: GitCLIBackend) -> None:
+        """Regression: commit must pass --no-verify to skip pre-commit hooks."""
+        with patch.object(git, '_git', return_value=_ok()) as m:
+            await git.commit('chore(release): v1.0.0')
+            commit_call = m.call_args_list[-1][0]
+            assert '--no-verify' in commit_call
+
+    @pytest.mark.asyncio()
     async def test_dry_run(self, git: GitCLIBackend) -> None:
         """Test dry run."""
         with patch.object(git, '_git', return_value=_ok()) as m:
@@ -348,6 +356,7 @@ class TestPush:
             await git.push()
             args = m.call_args[0]
             assert 'push' in args
+            assert '--no-verify' in args
             assert 'origin' in args
 
     @pytest.mark.asyncio()


### PR DESCRIPTION
Release commits are auto-generated version bumps and changelog updates. Running pre-commit hooks (captainhook → pnpm i → bin/lint) on these commits hangs for 5+ minutes and eventually times out (300s), blocking the `prepare` step entirely.

## Changes

- Add `--no-verify` to `git commit` in `GitCLIBackend.commit()`
- Add `--no-verify` to `git push` in `GitCLIBackend.push()`

## Evidence

```
command_timeout  cmd='git commit -m chore(release): genkit python v0.6.0' duration=300013.05 timeout=300
prepare_error    error="timed out after 300 seconds" step=prepare_release
```