### PR TITLE
fix(releasekit): fix tag creation and add fail-fast validation

### DIFF
--- a/.github/actions/setup-releasekit/action.yml
+++ b/.github/actions/setup-releasekit/action.yml
@@ -160,10 +160,11 @@ runs:
         git config user.email "${{ inputs.git-user-email }}"
 
     # ── 8. Restore clean worktree ────────────────────────────────────
-    # uv sync may regenerate uv.lock (e.g. --no-dev vs full install),
-    # leaving the worktree dirty. The publish preflight requires a
-    # clean worktree (RK-PREFLIGHT-DIRTY-WORKTREE), so reset any
-    # setup-induced changes.
+    # uv sync may regenerate uv.lock (e.g. --no-dev vs full install)
+    # or create untracked files, leaving the worktree dirty. The
+    # publish preflight requires a clean worktree
+    # (RK-PREFLIGHT-DIRTY-WORKTREE), so hard-reset tracked files and
+    # clean untracked files/directories.
     - name: Restore clean worktree
       shell: bash
-      run: git checkout -- .
+      run: git reset --hard && git clean -fd

--- a/py/tools/releasekit/src/releasekit/backends/forge/github.py
+++ b/py/tools/releasekit/src/releasekit/backends/forge/github.py
@@ -288,15 +288,19 @@ class GitHubCLIBackend:
         """
         # Ensure all labels exist before adding them to the PR.
         # gh pr edit --add-label fails if the label doesn't exist.
-        for label in labels:
-            await asyncio.to_thread(
-                self._gh,
-                'label',
-                'create',
-                label,
-                '--force',
-                dry_run=dry_run,
+        await asyncio.gather(
+            *(
+                asyncio.to_thread(
+                    self._gh,
+                    'label',
+                    'create',
+                    label,
+                    '--force',
+                    dry_run=dry_run,
+                )
+                for label in labels
             )
+        )
 
         cmd_parts = ['pr', 'edit', str(pr_number)]
         for label in labels:


### PR DESCRIPTION
## Summary

Fixes three issues that caused the v0.6.0 Python release to silently fail:

### 1. Missing `label` in `format_tag()` calls (root cause of v0.6.0 failure)

The tag format in `releasekit.toml` uses `{label}/{name}-v{version}` where
`{label}` should resolve to `py`. However, `create_tags()` accepted a `label`
parameter but never forwarded it to the three `format_tag()` calls. This
produced malformed tags like `/genkit-v0.6.0` instead of `py/genkit-v0.6.0`.

All 68 tags were "created" locally with the leading `/` and "pushed" without
error, but never actually reached the remote because git silently rejects
invalid ref names.

**Fix:** Pass `label=label` to all three `format_tag()` calls (primary tag,
secondary tag, umbrella tag). Note: `delete_tags()` already had the correct
`label=label` forwarding.

### 2. No fail-fast on invalid tag names

When tags had invalid names (leading `/`), the release process continued
silently — creating, pushing, and even attempting GitHub Release creation
for invalid refs. There was no validation step to catch obvious formatting
errors before git operations.

**Fix:** Added `validate_tag_name()` function that checks tag names against
git ref format rules (no leading/trailing `/`, no `..`, no spaces, etc.).
Added a fail-fast pre-validation loop at the start of `create_tags()` that
validates ALL planned tag names before creating any, raising `ValueError`
with a descriptive message if any are invalid.

### 3. Incomplete worktree cleanup in setup-releasekit

`git checkout -- .` only reverts tracked file modifications. If `uv sync`
creates untracked files (e.g. `.venv/`, `__pycache__/`), the worktree
remains dirty and the `RK-PREFLIGHT-DIRTY-WORKTREE` check fails.

**Fix:** Use `git reset --hard && git clean -fd` which handles both tracked
modifications and untracked files/directories.

## Files Changed

- **`py/tools/releasekit/src/releasekit/tags.py`** — Fix `format_tag()` calls,
  add `validate_tag_name()`, add fail-fast pre-validation
- **`py/tools/releasekit/tests/rk_tags_test.py`** — Regression tests for
  label placeholder, tag validation, and fail-fast behavior (12 new tests)
- **`.github/actions/setup-releasekit/action.yml`** — Use `git reset --hard
  && git clean -fd` for robust worktree cleanup

## Testing

All 54 tests pass:
```
tests/rk_tags_test.py ............................................. [100%]
54 passed in 2.71s
```
