### PR TITLE
fix(ci): fix dry_run boolean comparison in releasekit workflow

### DIFF
--- a/.github/workflows/releasekit-uv.yml
+++ b/.github/workflows/releasekit-uv.yml
@@ -297,7 +297,7 @@ env:
   #   - PR merge (pull_request closed): dry_run=false (this is the one-button release flow)
   #   - Manual dispatch: uses the checkbox value (default: true)
   #   - Push to main: dry_run is not relevant (only runs prepare, which is always live)
-  DRY_RUN: ${{ github.event_name == 'pull_request' && 'false' || (inputs.dry_run == 'false' && 'false' || 'true') }}
+  DRY_RUN: ${{ github.event_name == 'pull_request' && 'false' || (inputs.dry_run && 'true' || 'false') }}
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

**Critical fix:** The `dry_run` boolean comparison in `releasekit-uv.yml` was broken, causing every `workflow_dispatch` run to execute in dry-run mode regardless of the checkbox value.

### Root Cause

`inputs.dry_run` is declared as `type: boolean` (line 209), but the `DRY_RUN` env var expression compared it to the **string** `'false'`:

```yaml
# BROKEN: boolean false != string 'false' → always evaluates to true
DRY_RUN: ${{ ... || (inputs.dry_run == 'false' && 'false' || 'true') }}
```

In GitHub Actions expressions, `false == 'false'` returns `false` (type mismatch), so the inner expression always short-circuits to `'true'`.

### Fix

Use the boolean directly without string comparison:

```yaml
# FIXED: boolean false is falsy → correctly resolves to 'false'
DRY_RUN: ${{ ... || (inputs.dry_run && 'true' || 'false') }}
```

### Impact

This explains why the v0.6.0 release dispatch with `dry_run=false` still ran in dry-run mode — tags were "created" but never pushed, and no GitHub Release was created.

### Truth Table

| Event | `inputs.dry_run` | Result |
|-------|-----------------|--------|
| `pull_request` (merge) | n/a | `false` ✅ |
| `workflow_dispatch` | `true` (checked) | `true` ✅ |
| `workflow_dispatch` | `false` (unchecked) | `false` ✅ |
| `push` | undefined | `false` ✅ |
