### PR TITLE
feat(releasekit): add build/upload isolation and verify-install command

### DIFF
--- a/py/tools/releasekit/src/releasekit/backends/forge/github.py
+++ b/py/tools/releasekit/src/releasekit/backends/forge/github.py
@@ -38,6 +38,64 @@ from releasekit.logging import get_logger
 
 log = get_logger('releasekit.backends.github')
 
+# GitHub API rejects release bodies > 125,000 characters with
+# HTTP 422: Validation Failed — "body is too long".
+# We use a slightly lower limit to leave room for the truncation notice.
+_GITHUB_RELEASE_BODY_MAX_CHARS = 124_000
+
+_TRUNCATION_NOTICE = (
+    '\n\n---\n'
+    '> **Note:** Release notes were truncated because they exceeded '
+    "GitHub's 125,000 character limit. See the individual package "
+    'CHANGELOGs for full details.\n'
+)
+
+
+def _truncate_release_body(
+    body: str,
+    *,
+    max_chars: int = _GITHUB_RELEASE_BODY_MAX_CHARS,
+) -> str:
+    """Truncate release body to fit within GitHub's character limit.
+
+    Truncates at the last complete markdown section boundary (``## ``
+    heading) before the limit and appends a notice. This preserves
+    valid markdown structure.
+
+    Args:
+        body: The full release notes markdown.
+        max_chars: Maximum allowed characters (default: 124,000).
+
+    Returns:
+        The body, possibly truncated with a notice appended.
+    """
+    if len(body) <= max_chars:
+        return body
+
+    original_len = len(body)
+    budget = max_chars - len(_TRUNCATION_NOTICE)
+
+    # Find the last complete section heading (## ) within budget.
+    # This ensures we don't cut in the middle of a package's changelog.
+    truncated = body[:budget]
+    last_heading = truncated.rfind('\n## ')
+    if last_heading != -1:
+        truncated = truncated[:last_heading]
+    # else: no heading found, just hard-cut at budget (unlikely).
+
+    log.warning(
+        'release_body_truncated',
+        original_chars=original_len,
+        truncated_chars=len(truncated),
+        max_chars=max_chars,
+        hint=(
+            "Release notes exceeded GitHub's 125,000 character limit "
+            'and were truncated at the last complete package section.'
+        ),
+    )
+
+    return truncated + _TRUNCATION_NOTICE
+
 
 class GitHubCLIBackend:
     """Default :class:`~releasekit.backends.forge.Forge` implementation using the ``gh`` CLI.
@@ -92,7 +150,13 @@ class GitHubCLIBackend:
         assets: list[Path] | None = None,
         dry_run: bool = False,
     ) -> CommandResult:
-        """Create a GitHub Release."""
+        """Create a GitHub Release.
+
+        If the body exceeds GitHub's 125,000 character limit, it is
+        truncated at the last complete markdown section boundary to
+        avoid an HTTP 422 "body is too long" error.
+        """
+        body = _truncate_release_body(body)
         cmd_parts = ['release', 'create', tag]
         if title:
             cmd_parts.extend(['--title', title])

--- a/py/tools/releasekit/src/releasekit/cli.py
+++ b/py/tools/releasekit/src/releasekit/cli.py
@@ -682,6 +682,12 @@ async def _cmd_publish(args: argparse.Namespace) -> int:
         no_pep740 = getattr(args, 'no_pep740', False)
         want_pep740 = not no_pep740 and ws_config.pep740_attestations and ws_config.ecosystem == 'python'
 
+        # SLSA L3: build/upload isolation flags.
+        build_only = getattr(args, 'build_only', False)
+        upload_only = getattr(args, 'upload_only', False)
+        dist_dir_str = getattr(args, 'dist_dir', None)
+        dist_dir = Path(dist_dir_str) if dist_dir_str else None
+
         pub_config = PublishConfig(
             concurrency=args.concurrency,
             dry_run=args.dry_run,
@@ -702,6 +708,9 @@ async def _cmd_publish(args: argparse.Namespace) -> int:
             pep740_attestations=want_pep740,
             config_source=str(ws_root / 'releasekit.toml'),
             ecosystem=ws_config.ecosystem,
+            build_only=build_only,
+            upload_only=upload_only,
+            dist_dir=dist_dir,
         )
 
         # Resume support: load state from previous interrupted run.
@@ -756,6 +765,7 @@ async def _cmd_publish(args: argparse.Namespace) -> int:
     manifest = ReleaseManifest(
         git_sha=await vcs.current_sha(),
         packages=versions,
+        ecosystem=ws_config.ecosystem or '',
     )
     manifest_name = f'release-manifest--{ws_config.label}.json' if ws_config.label else 'release-manifest.json'
     manifest_path = ws_root / manifest_name
@@ -2206,6 +2216,37 @@ def _cmd_validate(args: argparse.Namespace) -> int:
     return 1 if report.failures else 0
 
 
+def _cmd_verify_install(args: argparse.Namespace) -> int:
+    """Handle the ``verify-install`` subcommand.
+
+    Verifies that published packages are installable from the registry
+    by reading a release manifest and installing each non-skipped package
+    using the ecosystem-appropriate package manager.
+    """
+    from releasekit.verify_install import load_manifest_specs, verify_packages
+
+    manifest_path = Path(args.manifest)
+    if not manifest_path.exists():
+        logger.error('manifest_not_found', path=str(manifest_path))
+        # List directory contents for debugging.
+        parent = manifest_path.parent
+        if parent.exists():
+            print(f'Contents of {parent}:')  # noqa: T201 - CLI output
+            for item in sorted(parent.iterdir()):
+                print(f'  {item.name}')  # noqa: T201 - CLI output
+        return 1
+
+    specs, manifest_ecosystem = load_manifest_specs(manifest_path)
+    # CLI --ecosystem overrides the manifest value.
+    ecosystem = getattr(args, 'ecosystem', '') or manifest_ecosystem
+    return verify_packages(
+        specs,
+        ecosystem=ecosystem,
+        import_check=getattr(args, 'import_check', ''),
+        index_url=getattr(args, 'index_url', ''),
+    )
+
+
 async def _cmd_should_release(args: argparse.Namespace) -> int:
     """Handle the ``should-release`` subcommand.
 
@@ -2780,6 +2821,39 @@ def build_parser() -> argparse.ArgumentParser:
         help='Delete any saved state file and start a fresh publish run.',
     )
 
+    # SLSA L3: build/upload isolation.
+    # --build-only builds artifacts + writes digests but does NOT upload.
+    # --upload-only uploads pre-built artifacts from --dist-dir.
+    # These flags enable splitting the publish job into separate CI jobs
+    # so the SLSA generator can attest artifacts between build and upload.
+    slsa_group = publish_parser.add_mutually_exclusive_group()
+    slsa_group.add_argument(
+        '--build-only',
+        action='store_true',
+        help=(
+            'Build artifacts and compute digests, but do NOT upload to the '
+            'registry. Artifacts are written to <workspace>/dist/. '
+            'Use with --upload-only in a separate job for SLSA L3 compliance.'
+        ),
+    )
+    slsa_group.add_argument(
+        '--upload-only',
+        action='store_true',
+        help=(
+            'Upload pre-built artifacts from --dist-dir to the registry. '
+            'Skips the build step entirely. Use after --build-only and '
+            'SLSA provenance generation for L3 compliance.'
+        ),
+    )
+    publish_parser.add_argument(
+        '--dist-dir',
+        metavar='PATH',
+        help=(
+            'Directory containing pre-built distribution artifacts '
+            '(used with --upload-only). Defaults to <workspace>/dist/.'
+        ),
+    )
+
     plan_parser = subparsers.add_parser(
         'plan',
         help='Preview the execution plan without publishing.',
@@ -3260,6 +3334,31 @@ def build_parser() -> argparse.ArgumentParser:
         help='Output format (default: table).',
     )
 
+    verify_install_parser = subparsers.add_parser(
+        'verify-install',
+        help='Verify published packages are installable from the registry.',
+    )
+    verify_install_parser.add_argument(
+        '--manifest',
+        required=True,
+        help='Path to the release manifest JSON file.',
+    )
+    verify_install_parser.add_argument(
+        '--import-check',
+        default='',
+        help='Python import statement to verify (e.g. "from genkit.ai import Genkit").',
+    )
+    verify_install_parser.add_argument(
+        '--index-url',
+        default='',
+        help='Custom registry URL (e.g. TestPyPI, npm mirror).',
+    )
+    verify_install_parser.add_argument(
+        '--ecosystem',
+        default='',
+        help='Override ecosystem from manifest (python, js, cargo, etc.).',
+    )
+
     # Add --prerelease to publish, plan, version, prepare.
     for p in (publish_parser, plan_parser, version_parser, prepare_parser):
         p.add_argument(
@@ -3363,6 +3462,8 @@ def main() -> int:
             return _cmd_compliance(args)
         if command == 'validate':
             return _cmd_validate(args)
+        if command == 'verify-install':
+            return _cmd_verify_install(args)
 
         parser.print_help()  # noqa: T201 - CLI output
         print(  # noqa: T201 - CLI output

--- a/py/tools/releasekit/src/releasekit/prepare.py
+++ b/py/tools/releasekit/src/releasekit/prepare.py
@@ -415,6 +415,7 @@ async def prepare_release(
         umbrella_tag=umbrella_tag,
         packages=versions,
         created_at=utc_iso(),
+        ecosystem=ws_config.ecosystem or '',
     )
     result.manifest = manifest
 

--- a/py/tools/releasekit/src/releasekit/publisher.py
+++ b/py/tools/releasekit/src/releasekit/publisher.py
@@ -146,6 +146,14 @@ class PublishConfig:
             to the repo root), recorded in the provenance predicate.
         ecosystem: Package ecosystem identifier (e.g. ``python``,
             ``js``) recorded in the provenance predicate.
+        build_only: Build artifacts and compute digests but do NOT
+            upload to the registry. Artifacts are written to a
+            persistent ``dist/`` directory under each package. Used
+            with ``upload_only`` in a separate CI job for SLSA L3.
+        upload_only: Upload pre-built artifacts from ``dist_dir``
+            without rebuilding. Skips the build step entirely.
+        dist_dir: Directory containing pre-built artifacts when
+            ``upload_only`` is True. Defaults to ``<workspace>/dist/``.
     """
 
     concurrency: int = 5
@@ -172,6 +180,9 @@ class PublishConfig:
     sbom_formats: list[str] = field(default_factory=lambda: ['cyclonedx', 'spdx'])
     config_source: str = ''
     ecosystem: str = ''
+    build_only: bool = False
+    upload_only: bool = False
+    dist_dir: Path | None = None
 
 
 @dataclass
@@ -482,38 +493,107 @@ async def _publish_one(
         state.set_status(name, PackageStatus.BUILDING)
         state.save(state_path)
 
-        with ephemeral_pin(pkg.manifest_path, version_map):
-            observer.on_stage(name, PublishStage.BUILDING)
-            with tempfile.TemporaryDirectory(prefix=f'releasekit-{name}-') as tmp:
-                dist_dir = Path(tmp)
+        # ── SLSA L3: upload-only mode ────────────────────────────────
+        # Skip the build step entirely; publish from pre-built artifacts.
+        if config.upload_only:
+            dist_dir = config.dist_dir or (config.workspace_root / 'dist')
+            pkg_dist = dist_dir / name
+            if not pkg_dist.exists():
+                raise ReleaseKitError(
+                    E.BUILD_FAILED,
+                    f'Distribution directory for {name} not found: {pkg_dist}',
+                    hint="Ensure artifacts were built into a per-package subdirectory during the 'build-only' step.",
+                )
+            checksums = _compute_dist_checksum(pkg_dist)
+
+            observer.on_stage(name, PublishStage.PUBLISHING)
+            state.set_status(name, PackageStatus.PUBLISHING)
+            state.save(state_path)
+
+            await pm.publish(
+                pkg_dist,
+                check_url=config.check_url,
+                registry_url=config.registry_url,
+                dist_tag=config.dist_tag or None,
+                publish_branch=config.publish_branch or None,
+                provenance=config.provenance,
+                dry_run=config.dry_run,
+            )
+
+        # ── SLSA L3: build-only mode ─────────────────────────────────
+        # Build to a persistent dist/ directory; do NOT upload.
+        elif config.build_only:
+            persistent_dist = config.dist_dir or (config.workspace_root / 'dist')
+            pkg_dist = persistent_dist / name
+            pkg_dist.mkdir(parents=True, exist_ok=True)
+
+            with ephemeral_pin(pkg.manifest_path, version_map):
+                observer.on_stage(name, PublishStage.BUILDING)
                 await pm.build(
                     pkg.path,
-                    output_dir=dist_dir,
+                    output_dir=pkg_dist,
                     no_sources=True,
                     dry_run=config.dry_run,
                 )
 
-                checksums = _compute_dist_checksum(dist_dir)
-                if not config.dry_run and not checksums:
-                    raise ReleaseKitError(
-                        E.BUILD_FAILED,
-                        f'No distribution files produced for {name}.',
-                        hint=f"Check 'uv build' output for {pkg.path}.",
+            checksums = _compute_dist_checksum(pkg_dist)
+            if not config.dry_run and not checksums:
+                raise ReleaseKitError(
+                    E.BUILD_FAILED,
+                    f'No distribution files produced for {name}.',
+                    hint=f"Check 'uv build' output for {pkg.path}.",
+                )
+
+            observer.on_stage(name, PublishStage.PUBLISHED)
+            state.set_status(name, PackageStatus.PUBLISHED)
+            state.save(state_path)
+
+            if checksums:
+                result.artifact_checksums[name] = dict(checksums)
+
+            logger.info(
+                'package_built',
+                package=name,
+                version=version.new_version,
+                dist_dir=str(pkg_dist),
+                checksums=checksums,
+            )
+            return
+
+        # ── Normal mode: build + publish in one step ─────────────────
+        else:
+            with ephemeral_pin(pkg.manifest_path, version_map):
+                observer.on_stage(name, PublishStage.BUILDING)
+                with tempfile.TemporaryDirectory(prefix=f'releasekit-{name}-') as tmp:
+                    dist_dir = Path(tmp)
+                    await pm.build(
+                        pkg.path,
+                        output_dir=dist_dir,
+                        no_sources=True,
+                        dry_run=config.dry_run,
                     )
 
-                observer.on_stage(name, PublishStage.PUBLISHING)
-                state.set_status(name, PackageStatus.PUBLISHING)
-                state.save(state_path)
+                    checksums = _compute_dist_checksum(dist_dir)
+                    if not config.dry_run and not checksums:
+                        raise ReleaseKitError(
+                            E.BUILD_FAILED,
+                            f'No distribution files produced for {name}.',
+                            hint=f"Check 'uv build' output for {pkg.path}.",
+                        )
 
-                await pm.publish(
-                    dist_dir,
-                    check_url=config.check_url,
-                    registry_url=config.registry_url,
-                    dist_tag=config.dist_tag or None,
-                    publish_branch=config.publish_branch or None,
-                    provenance=config.provenance,
-                    dry_run=config.dry_run,
-                )
+                    observer.on_stage(name, PublishStage.PUBLISHING)
+                    state.set_status(name, PackageStatus.PUBLISHING)
+                    state.save(state_path)
+
+                    await pm.publish(
+                        dist_dir,
+                        check_url=config.check_url,
+                        registry_url=config.registry_url,
+                        dist_tag=config.dist_tag or None,
+                        publish_branch=config.publish_branch or None,
+                        provenance=config.provenance,
+                        dry_run=config.dry_run,
+                    )
 
         observer.on_stage(name, PublishStage.POLLING)
         state.set_status(name, PackageStatus.VERIFYING)

--- a/py/tools/releasekit/src/releasekit/release.py
+++ b/py/tools/releasekit/src/releasekit/release.py
@@ -188,6 +188,7 @@ def extract_manifest(pr_body: str) -> ReleaseManifest | None:
         umbrella_tag=data.get('umbrella_tag', ''),
         packages=packages,
         created_at=data.get('created_at', ''),
+        ecosystem=data.get('ecosystem', ''),
     )
 
 

--- a/py/tools/releasekit/src/releasekit/verify_install.py
+++ b/py/tools/releasekit/src/releasekit/verify_install.py
@@ -1,0 +1,319 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+r"""Post-publish verification: install packages from the registry and smoke-test.
+
+Reads a :class:`~releasekit.versions.ReleaseManifest` and verifies that
+every non-skipped package can be installed from the registry. Supports
+multiple ecosystems (Python, npm, Go, Cargo, pub, Maven).
+
+Optionally runs a user-supplied Python import statement as a smoke test
+(Python ecosystem only).
+
+Usage (CLI)::
+
+    releasekit verify-install --manifest release-manifest--py.json
+    releasekit verify-install --manifest release-manifest--py.json \\
+        --import-check "from genkit.ai import Genkit"
+    releasekit verify-install --manifest release-manifest--py.json \\
+        --index-url https://test.pypi.org/simple/
+
+Usage (Python)::
+
+    from releasekit.verify_install import verify_packages, load_manifest_specs
+
+    specs, ecosystem = load_manifest_specs(Path("release-manifest--py.json"))
+    exit_code = verify_packages(specs, ecosystem=ecosystem)
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess  # noqa: S404 - validated inputs only
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from releasekit.logging import get_logger
+from releasekit.versions import ReleaseManifest
+
+logger = get_logger(__name__)
+
+
+# ── Data types ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PackageSpec:
+    """A package name + version to verify.
+
+    Attributes:
+        name: Normalized package name (e.g. ``"genkit"``).
+        version: Expected version string (e.g. ``"0.6.0"``).
+    """
+
+    name: str
+    version: str
+
+    def install_spec(self, ecosystem: str = 'python') -> str:
+        """Return the install specifier for the given ecosystem.
+
+        Args:
+            ecosystem: Package ecosystem (``"python"``, ``"js"``, etc.).
+
+        Returns:
+            Install specifier string (e.g. ``"genkit==0.6.0"`` for Python,
+            ``"genkit@0.6.0"`` for npm).
+        """
+        if ecosystem in ('js', 'javascript', 'npm', 'pnpm'):
+            return f'{self.name}@{self.version}'
+        if ecosystem in ('rust', 'cargo'):
+            return f'{self.name}@{self.version}'
+        # Python, Go, pub, Maven all use ==
+        return f'{self.name}=={self.version}'
+
+
+# ── GitHub Actions annotation helpers ─────────────────────────────────
+
+
+def _gh_warning(message: str) -> None:
+    """Emit a GitHub Actions warning annotation."""
+    print(f'::warning::{message}', flush=True)  # noqa: T201 - CI output
+
+
+def _gh_error(message: str) -> None:
+    """Emit a GitHub Actions error annotation."""
+    print(f'::error::{message}', flush=True)  # noqa: T201 - CI output
+
+
+# ── Manifest loading ─────────────────────────────────────────────────
+
+
+def load_manifest_specs(manifest_path: Path) -> tuple[list[PackageSpec], str]:
+    """Load a release manifest and return non-skipped packages + ecosystem.
+
+    Args:
+        manifest_path: Path to the release manifest JSON file.
+
+    Returns:
+        Tuple of (list of :class:`PackageSpec`, ecosystem string).
+
+    Raises:
+        FileNotFoundError: If the manifest file does not exist.
+        ValueError: If the JSON is malformed or missing required fields.
+    """
+    manifest: ReleaseManifest = ReleaseManifest.load(manifest_path)
+    specs: list[PackageSpec] = []
+    for pkg in manifest.bumped:
+        specs.append(PackageSpec(name=pkg.name, version=pkg.new_version))
+    return specs, manifest.ecosystem
+
+
+# ── Installation ─────────────────────────────────────────────────────
+
+
+def _install_python(spec: str, index_url: str = '') -> bool:
+    """Install a Python package via pip."""
+    cmd: list[str] = [sys.executable, '-m', 'pip', 'install', spec]
+    if index_url:
+        cmd.extend(['--index-url', index_url])
+    return subprocess.run(cmd, capture_output=True).returncode == 0  # noqa: S603 - spec validated by _validate_spec
+
+
+def _install_npm(spec: str, index_url: str = '') -> bool:
+    """Install an npm package globally."""
+    npm: str | None = shutil.which('npm')
+    if not npm:
+        _gh_error('npm not found on PATH')
+        return False
+    cmd: list[str] = [npm, 'install', '-g', spec]
+    if index_url:
+        cmd.extend(['--registry', index_url])
+    return subprocess.run(cmd, capture_output=True).returncode == 0  # noqa: S603 - spec validated by _validate_spec
+
+
+def _install_cargo(spec: str, index_url: str = '') -> bool:
+    """Install a Cargo crate."""
+    cargo: str | None = shutil.which('cargo')
+    if not cargo:
+        _gh_error('cargo not found on PATH')
+        return False
+    # cargo install name --version x.y.z
+    parts: list[str] = spec.split('@', 1)
+    cmd: list[str] = [cargo, 'install', parts[0]]
+    if len(parts) > 1:
+        cmd.extend(['--version', parts[1]])
+    if index_url:
+        cmd.extend(['--index', index_url])
+    return subprocess.run(cmd, capture_output=True).returncode == 0  # noqa: S603 - spec validated by _validate_spec
+
+
+def install_package(spec: str, *, ecosystem: str = 'python', index_url: str = '') -> bool:
+    """Install a package using the appropriate package manager.
+
+    Args:
+        spec: Install specifier (e.g. ``"genkit==0.6.0"``).
+        ecosystem: Package ecosystem identifier.
+        index_url: Optional custom registry URL.
+
+    Returns:
+        True if the install succeeded.
+    """
+    if ecosystem in ('python', 'uv', ''):
+        return _install_python(spec, index_url=index_url)
+    if ecosystem in ('js', 'javascript', 'npm', 'pnpm'):
+        return _install_npm(spec, index_url=index_url)
+    if ecosystem in ('rust', 'cargo'):
+        return _install_cargo(spec, index_url=index_url)
+    # Unsupported ecosystem — warn but don't fail.
+    _gh_warning(f'verify-install does not yet support ecosystem: {ecosystem}')
+    logger.warning('verify_install_unsupported_ecosystem', ecosystem=ecosystem)
+    return True
+
+
+# ── Import check ─────────────────────────────────────────────────────
+
+
+# SECURITY: Allowlist pattern for --import-check statements.
+# Only permit import/from...import syntax with optional print() wrappers.
+# This prevents arbitrary code execution via python -c.
+_SAFE_IMPORT_PATTERN: re.Pattern[str] = re.compile(
+    r'^\s*'
+    r'(?:from\s+[\w.]+\s+import\s+[\w., ]+'
+    r'|import\s+[\w., ]+)'
+    r'(?:\s*;\s*(?:from\s+[\w.]+\s+import\s+[\w., ]+|import\s+[\w., ]+|print\s*\([^)]*\)))*'
+    r'\s*$',
+)
+
+# SECURITY: Package name/version allowlist.
+# PEP 508 names: letters, digits, hyphens, underscores, dots.
+_SAFE_SPEC_PATTERN: re.Pattern[str] = re.compile(
+    r'^[A-Za-z0-9][A-Za-z0-9._-]*[=@][=]?[A-Za-z0-9._+-]+$',
+)
+
+
+def _validate_import_check(statement: str) -> bool:
+    """Return True if the statement looks like a safe import."""
+    return bool(_SAFE_IMPORT_PATTERN.match(statement))
+
+
+def _validate_spec(spec: str) -> bool:
+    """Return True if the install spec looks like a valid package==version."""
+    return bool(_SAFE_SPEC_PATTERN.match(spec))
+
+
+def run_import_check(statement: str) -> bool:
+    """Run a Python import statement and return True on success.
+
+    Args:
+        statement: Python statement to execute
+            (e.g. ``"from genkit.ai import Genkit"``).
+
+    Returns:
+        True if the statement executed without error.
+
+    Raises:
+        ValueError: If the statement does not look like a safe import.
+    """
+    if not _validate_import_check(statement):
+        raise ValueError(
+            f'Refusing to execute import check: statement does not match allowed import pattern: {statement!r}'
+        )
+    result: subprocess.CompletedProcess[bytes] = subprocess.run(  # noqa: S603 - statement validated by _validate_import_check
+        [sys.executable, '-c', statement],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+# ── Verification ─────────────────────────────────────────────────────
+
+
+def verify_packages(
+    packages: list[PackageSpec],
+    *,
+    ecosystem: str = 'python',
+    import_check: str = '',
+    index_url: str = '',
+) -> int:
+    """Install and verify all packages.
+
+    Args:
+        packages: List of packages to verify.
+        ecosystem: Package ecosystem (determines which installer to use).
+        import_check: Optional Python import statement to run after
+            installing all packages.
+        index_url: Optional custom registry URL.
+
+    Returns:
+        Exit code: 0 if all packages verified, 1 otherwise.
+    """
+    if not packages:
+        _gh_warning('No published packages found in manifest')
+        logger.info('verify_install_empty', message='No packages to verify')
+        return 0
+
+    print(f'Packages to verify ({len(packages)}, ecosystem={ecosystem or "python"}):')  # noqa: T201 - CLI output
+    for pkg in packages:
+        print(f'  {pkg.install_spec(ecosystem)}')  # noqa: T201 - CLI output
+    print(flush=True)  # noqa: T201 - CLI output
+
+    failed: list[str] = []
+    for pkg in packages:
+        spec: str = pkg.install_spec(ecosystem)
+        if not _validate_spec(spec):
+            _gh_error(f'Suspicious package spec rejected: {spec!r}')
+            failed.append(spec)
+            continue
+        print(f'Installing {spec}...', flush=True)  # noqa: T201 - CLI output
+        if install_package(spec, ecosystem=ecosystem, index_url=index_url):
+            print(f'✅ {pkg.name} installed')  # noqa: T201 - CLI output
+            logger.info('verify_install_ok', package=pkg.name, version=pkg.version)
+        else:
+            _gh_warning(f'{spec} failed to install from registry')
+            logger.error('verify_install_failed', package=pkg.name, version=pkg.version)
+            failed.append(spec)
+
+    # Run optional import check (Python only).
+    if import_check:
+        print(f'\nRunning import check: {import_check}', flush=True)  # noqa: T201 - CLI output
+        if run_import_check(import_check):
+            print('✅ Import check passed')  # noqa: T201 - CLI output
+            logger.info('verify_import_ok', statement=import_check)
+        else:
+            _gh_error(f'Import check failed: {import_check}')
+            logger.error('verify_import_failed', statement=import_check)
+            failed.append(f'import-check: {import_check}')
+
+    if failed:
+        _gh_error(f'{len(failed)} package(s) failed verification')
+        for spec in failed:
+            print(f'  ❌ {spec}')  # noqa: T201 - CLI output
+        return 1
+
+    print(f'\n✅ All {len(packages)} package(s) verified successfully')  # noqa: T201 - CLI output
+    logger.info('verify_install_complete', total=len(packages), failed=0)
+    return 0
+
+
+__all__ = [
+    'PackageSpec',
+    'install_package',
+    'load_manifest_specs',
+    'run_import_check',
+    'verify_packages',
+]

--- a/py/tools/releasekit/src/releasekit/versions.py
+++ b/py/tools/releasekit/src/releasekit/versions.py
@@ -106,12 +106,14 @@ class ReleaseManifest:
         umbrella_tag: The umbrella tag for this release (e.g. ``"v0.5.0"``).
         packages: List of per-package version records.
         created_at: ISO 8601 timestamp when the manifest was created.
+        ecosystem: Package ecosystem identifier (e.g. ``"python"``, ``"js"``).
     """
 
     git_sha: str
     umbrella_tag: str = ''
     packages: list[PackageVersion] = field(default_factory=list)
     created_at: str = ''
+    ecosystem: str = ''
 
     @property
     def bumped(self) -> list[PackageVersion]:
@@ -173,6 +175,7 @@ class ReleaseManifest:
             umbrella_tag=data.get('umbrella_tag', ''),
             packages=packages,
             created_at=data.get('created_at', ''),
+            ecosystem=data.get('ecosystem', ''),
         )
         logger.info('manifest_loaded', path=str(path), packages=len(packages))
         return manifest

--- a/py/tools/releasekit/tests/rk_backends_forge_github_test.py
+++ b/py/tools/releasekit/tests/rk_backends_forge_github_test.py
@@ -28,7 +28,7 @@ from unittest.mock import patch
 
 import pytest
 from releasekit.backends._run import CommandResult
-from releasekit.backends.forge.github import GitHubCLIBackend
+from releasekit.backends.forge.github import GitHubCLIBackend, _truncate_release_body
 
 
 def _ok(stdout: str = '', **kw: Any) -> CommandResult:  # noqa: ANN401
@@ -305,3 +305,41 @@ class TestMergePR:
             await gh.merge_pr(42, commit_message='chore: release')
             args = m.call_args[0]
             assert '--subject' in args
+
+
+class TestTruncateReleaseBody:
+    """Tests for _truncate_release_body."""
+
+    def test_under_limit_passthrough(self) -> None:
+        """Body under limit is returned unchanged."""
+        body = 'Short release notes.'
+        assert _truncate_release_body(body, max_chars=1000) == body
+
+    def test_over_limit_truncates_at_heading(self) -> None:
+        """Body over limit is truncated at the last ## heading boundary."""
+        section1 = '## Package A\n' + 'a' * 200 + '\n\n'
+        section2 = '## Package B\n' + 'b' * 200 + '\n\n'
+        section3 = '## Package C\n' + 'c' * 5000 + '\n\n'
+        body = section1 + section2 + section3
+
+        # Set limit so section3 doesn't fit (body > max_chars) but
+        # sections A+B fit within budget after subtracting the notice.
+        max_chars = len(section1 + section2) + 300
+        result = _truncate_release_body(body, max_chars=max_chars)
+
+        assert '## Package A' in result
+        assert '## Package B' in result
+        assert '## Package C' not in result
+
+    def test_truncation_notice_appended(self) -> None:
+        """Truncated body has a notice explaining why."""
+        body = '## Pkg\n' + 'x' * 200
+        result = _truncate_release_body(body, max_chars=100)
+
+        assert 'truncated' in result.lower()
+        assert 'CHANGELOG' in result
+
+    def test_exact_limit_passthrough(self) -> None:
+        """Body exactly at the limit is not truncated."""
+        body = 'x' * 1000
+        assert _truncate_release_body(body, max_chars=1000) == body

--- a/py/tools/releasekit/tests/rk_cli_test.py
+++ b/py/tools/releasekit/tests/rk_cli_test.py
@@ -259,6 +259,101 @@ class TestCompletionSubcommand:
             raise AssertionError(f'Expected fish, got {args.shell}')
 
 
+class TestVerifyInstallSubcommand:
+    """Tests for the verify-install subcommand arguments."""
+
+    def test_verify_install_requires_manifest(self) -> None:
+        """verify-install requires --manifest."""
+        parser = build_parser()
+        try:
+            parser.parse_args(['verify-install'])
+            raise AssertionError('Expected SystemExit for missing --manifest')
+        except SystemExit:
+            pass
+
+    def test_verify_install_manifest(self) -> None:
+        """verify-install --manifest works."""
+        parser = build_parser()
+        args = parser.parse_args(['verify-install', '--manifest', 'release-manifest.json'])
+        assert args.command == 'verify-install'
+        assert args.manifest == 'release-manifest.json'
+
+    def test_verify_install_all_flags(self) -> None:
+        """verify-install with all optional flags."""
+        parser = build_parser()
+        args = parser.parse_args([
+            'verify-install',
+            '--manifest',
+            'manifest.json',
+            '--import-check',
+            'from genkit.ai import Genkit',
+            '--index-url',
+            'https://test.pypi.org/simple/',
+            '--ecosystem',
+            'python',
+        ])
+        assert args.command == 'verify-install'
+        assert args.manifest == 'manifest.json'
+        assert args.import_check == 'from genkit.ai import Genkit'
+        assert args.index_url == 'https://test.pypi.org/simple/'
+        assert args.ecosystem == 'python'
+
+    def test_verify_install_defaults(self) -> None:
+        """verify-install optional flags default to empty strings."""
+        parser = build_parser()
+        args = parser.parse_args(['verify-install', '--manifest', 'm.json'])
+        assert args.import_check == ''
+        assert args.index_url == ''
+        assert args.ecosystem == ''
+
+
+class TestPublishBuildUploadFlags:
+    """Tests for publish --build-only / --upload-only / --dist-dir flags."""
+
+    def test_build_only(self) -> None:
+        """--build-only flag works."""
+        parser = build_parser()
+        args = parser.parse_args(['publish', '--build-only'])
+        assert args.build_only is True
+        assert args.upload_only is False
+
+    def test_upload_only(self) -> None:
+        """--upload-only flag works."""
+        parser = build_parser()
+        args = parser.parse_args(['publish', '--upload-only'])
+        assert args.upload_only is True
+        assert args.build_only is False
+
+    def test_build_only_and_upload_only_mutually_exclusive(self) -> None:
+        """--build-only and --upload-only cannot be used together."""
+        parser = build_parser()
+        try:
+            parser.parse_args(['publish', '--build-only', '--upload-only'])
+            raise AssertionError('Expected SystemExit for mutually exclusive flags')
+        except SystemExit:
+            pass
+
+    def test_dist_dir(self) -> None:
+        """--dist-dir flag works."""
+        parser = build_parser()
+        args = parser.parse_args(['publish', '--upload-only', '--dist-dir', '/workspace/dist'])
+        assert args.dist_dir == '/workspace/dist'
+        assert args.upload_only is True
+
+    def test_dist_dir_default_none(self) -> None:
+        """--dist-dir defaults to None."""
+        parser = build_parser()
+        args = parser.parse_args(['publish'])
+        assert args.dist_dir is None
+
+    def test_build_only_defaults_false(self) -> None:
+        """--build-only defaults to False."""
+        parser = build_parser()
+        args = parser.parse_args(['publish'])
+        assert args.build_only is False
+        assert args.upload_only is False
+
+
 class TestPlanSubcommand:
     """Tests for the plan subcommand."""
 

--- a/py/tools/releasekit/tests/rk_integration_test.py
+++ b/py/tools/releasekit/tests/rk_integration_test.py
@@ -854,3 +854,249 @@ class TestPlanStateConsistency:
         state.save(state_path)
         loaded = RunState.load(state_path)
         assert loaded.is_complete()
+
+
+class TestManifestVerifyInstallPipeline:
+    """End-to-end: save manifest → load_manifest_specs → verify_packages.
+
+    These tests exercise the real data path from manifest JSON on disk
+    through spec extraction and validation, catching field mismatches,
+    ecosystem wiring bugs, and security regex failures at runtime.
+    """
+
+    def test_manifest_to_specs_round_trip(self, tmp_path: Path) -> None:
+        """Manifest save → load_manifest_specs produces correct PackageSpecs."""
+        from releasekit.verify_install import PackageSpec, load_manifest_specs
+
+        manifest = ReleaseManifest(
+            git_sha='abc123',
+            ecosystem='python',
+            packages=[
+                PackageVersion(
+                    name='genkit',
+                    old_version='0.5.0',
+                    new_version='0.6.0',
+                    bump='minor',
+                ),
+                PackageVersion(
+                    name='genkit-tools',
+                    old_version='0.5.0',
+                    new_version='0.5.0',
+                    skipped=True,
+                    reason='unchanged',
+                ),
+                PackageVersion(
+                    name='genkit-plugin-foo',
+                    old_version='0.1.0',
+                    new_version='0.2.0',
+                    bump='minor',
+                ),
+            ],
+            created_at='2026-02-18T00:00:00Z',
+        )
+        path = tmp_path / 'manifest.json'
+        manifest.save(path)
+
+        specs, ecosystem = load_manifest_specs(path)
+
+        # Only non-skipped packages are returned.
+        assert ecosystem == 'python'
+        assert len(specs) == 2
+        assert specs[0] == PackageSpec(name='genkit', version='0.6.0')
+        assert specs[1] == PackageSpec(name='genkit-plugin-foo', version='0.2.0')
+
+        # install_spec produces valid specs for the ecosystem.
+        assert specs[0].install_spec(ecosystem) == 'genkit==0.6.0'
+        assert specs[1].install_spec(ecosystem) == 'genkit-plugin-foo==0.2.0'
+
+    def test_js_ecosystem_round_trip(self, tmp_path: Path) -> None:
+        """JS ecosystem manifest produces @-separated install specs."""
+        from releasekit.verify_install import load_manifest_specs
+
+        manifest = ReleaseManifest(
+            git_sha='def456',
+            ecosystem='js',
+            packages=[
+                PackageVersion(
+                    name='@genkit-ai/core',
+                    old_version='1.0.0',
+                    new_version='1.1.0',
+                    bump='minor',
+                ),
+            ],
+        )
+        path = tmp_path / 'manifest.json'
+        manifest.save(path)
+
+        specs, ecosystem = load_manifest_specs(path)
+        assert ecosystem == 'js'
+        assert len(specs) == 1
+        assert specs[0].install_spec(ecosystem) == '@genkit-ai/core@1.1.0'
+
+    def test_cargo_ecosystem_round_trip(self, tmp_path: Path) -> None:
+        """Cargo ecosystem manifest produces @-separated install specs."""
+        from releasekit.verify_install import load_manifest_specs
+
+        manifest = ReleaseManifest(
+            git_sha='789abc',
+            ecosystem='cargo',
+            packages=[
+                PackageVersion(
+                    name='genkit-rs',
+                    old_version='0.1.0',
+                    new_version='0.2.0',
+                    bump='minor',
+                ),
+            ],
+        )
+        path = tmp_path / 'manifest.json'
+        manifest.save(path)
+
+        specs, ecosystem = load_manifest_specs(path)
+        assert ecosystem == 'cargo'
+        assert specs[0].install_spec(ecosystem) == 'genkit-rs@0.2.0'
+
+    def test_verify_packages_rejects_adversarial_specs(self, tmp_path: Path) -> None:
+        """Adversarial package names are rejected by verify_packages (no mocks).
+
+        This is a security integration test: a malicious manifest with
+        shell-injection package names must be caught by _validate_spec
+        inside verify_packages, without any mocking.
+        """
+        from releasekit.verify_install import PackageSpec, verify_packages
+
+        adversarial_pkgs = [
+            PackageSpec(name='genkit; rm -rf /', version='0.6.0'),
+        ]
+        # verify_packages should reject the spec and return 1.
+        assert verify_packages(adversarial_pkgs, ecosystem='python') == 1
+
+    def test_verify_packages_rejects_command_injection_in_version(self) -> None:
+        """Command injection in version field is rejected."""
+        from releasekit.verify_install import PackageSpec, verify_packages
+
+        pkgs = [
+            PackageSpec(name='genkit', version='0.6.0; curl evil.com'),
+        ]
+        assert verify_packages(pkgs, ecosystem='python') == 1
+
+    def test_verify_packages_empty_manifest(self, tmp_path: Path) -> None:
+        """Empty manifest (all skipped) returns 0 from verify_packages."""
+        from releasekit.verify_install import load_manifest_specs, verify_packages
+
+        manifest = ReleaseManifest(
+            git_sha='abc',
+            ecosystem='python',
+            packages=[
+                PackageVersion(
+                    name='genkit',
+                    old_version='0.5.0',
+                    new_version='0.5.0',
+                    skipped=True,
+                ),
+            ],
+        )
+        path = tmp_path / 'manifest.json'
+        manifest.save(path)
+
+        specs, ecosystem = load_manifest_specs(path)
+        assert specs == []
+        assert verify_packages(specs, ecosystem=ecosystem) == 0
+
+    def test_spec_validation_accepts_all_ecosystems(self) -> None:
+        """install_spec output passes _validate_spec for all ecosystems."""
+        from releasekit.verify_install import PackageSpec, _validate_spec
+
+        spec = PackageSpec(name='genkit', version='0.6.0')
+        for eco in ('python', 'js', 'npm', 'pnpm', 'rust', 'cargo', 'go'):
+            install = spec.install_spec(eco)
+            assert _validate_spec(install), f'_validate_spec rejected {install!r} for ecosystem {eco}'
+
+    def test_cmd_verify_install_with_real_manifest(self, tmp_path: Path) -> None:
+        """_cmd_verify_install reads a real manifest and dispatches correctly.
+
+        Uses an unsupported ecosystem ('dart') so no real package manager
+        is invoked, but the full CLI path is exercised: argparse namespace
+        → manifest load → spec extraction → verify_packages.
+        """
+        import argparse
+
+        from releasekit.cli import _cmd_verify_install
+
+        manifest = ReleaseManifest(
+            git_sha='abc123',
+            ecosystem='dart',
+            packages=[
+                PackageVersion(
+                    name='genkit',
+                    old_version='0.5.0',
+                    new_version='0.6.0',
+                    bump='minor',
+                ),
+            ],
+        )
+        path = tmp_path / 'manifest.json'
+        manifest.save(path)
+
+        args = argparse.Namespace(
+            manifest=str(path),
+            ecosystem='',
+            import_check='',
+            index_url='',
+        )
+        # dart ecosystem is unsupported but returns 0 (warn-only).
+        result = _cmd_verify_install(args)
+        assert result == 0
+
+    def test_cmd_verify_install_missing_manifest(self, tmp_path: Path) -> None:
+        """_cmd_verify_install returns 1 for missing manifest file."""
+        import argparse
+
+        from releasekit.cli import _cmd_verify_install
+
+        args = argparse.Namespace(
+            manifest=str(tmp_path / 'nonexistent.json'),
+            ecosystem='',
+            import_check='',
+            index_url='',
+        )
+        result = _cmd_verify_install(args)
+        assert result == 1
+
+    def test_cmd_verify_install_ecosystem_override(self, tmp_path: Path) -> None:
+        """CLI --ecosystem overrides the manifest ecosystem value."""
+        import argparse
+
+        from releasekit.verify_install import load_manifest_specs
+
+        manifest = ReleaseManifest(
+            git_sha='abc',
+            ecosystem='python',
+            packages=[
+                PackageVersion(
+                    name='genkit',
+                    old_version='0.5.0',
+                    new_version='0.6.0',
+                    bump='minor',
+                ),
+            ],
+        )
+        path = tmp_path / 'manifest.json'
+        manifest.save(path)
+
+        # Simulate CLI --ecosystem override.
+        args = argparse.Namespace(
+            manifest=str(path),
+            ecosystem='dart',
+            import_check='',
+            index_url='',
+        )
+        from releasekit.cli import _cmd_verify_install
+
+        result = _cmd_verify_install(args)
+        # dart is unsupported but returns 0 (warn-only).
+        assert result == 0
+
+        # Verify the manifest ecosystem was 'python' but CLI overrode it.
+        _, manifest_eco = load_manifest_specs(path)
+        assert manifest_eco == 'python'

--- a/py/tools/releasekit/tests/rk_verify_install_test.py
+++ b/py/tools/releasekit/tests/rk_verify_install_test.py
@@ -1,0 +1,518 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for verify_install module.
+
+Covers all public and internal functions in verify_install.py:
+PackageSpec, install helpers, validation, import checks, and
+the verify_packages orchestrator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from releasekit.verify_install import (
+    PackageSpec,
+    _install_cargo,
+    _install_npm,
+    _install_python,
+    _validate_import_check,
+    _validate_spec,
+    install_package,
+    run_import_check,
+    verify_packages,
+)
+
+# ── PackageSpec ──────────────────────────────────────────────────────
+
+
+class TestPackageSpec:
+    """Tests for PackageSpec dataclass and install_spec method."""
+
+    def test_python_spec(self) -> None:
+        """Python ecosystem uses == separator."""
+        spec = PackageSpec(name='genkit', version='0.6.0')
+        assert spec.install_spec('python') == 'genkit==0.6.0'
+
+    def test_python_default(self) -> None:
+        """Default ecosystem is python."""
+        spec = PackageSpec(name='genkit', version='0.6.0')
+        assert spec.install_spec() == 'genkit==0.6.0'
+
+    @pytest.mark.parametrize('ecosystem', ['js', 'javascript', 'npm', 'pnpm'])
+    def test_js_spec(self, ecosystem: str) -> None:
+        """JS ecosystems use @ separator."""
+        spec = PackageSpec(name='genkit', version='1.0.0')
+        assert spec.install_spec(ecosystem) == 'genkit@1.0.0'
+
+    @pytest.mark.parametrize('ecosystem', ['rust', 'cargo'])
+    def test_cargo_spec(self, ecosystem: str) -> None:
+        """Cargo ecosystems use @ separator."""
+        spec = PackageSpec(name='genkit', version='0.6.0')
+        assert spec.install_spec(ecosystem) == 'genkit@0.6.0'
+
+    def test_go_spec(self) -> None:
+        """Go ecosystem uses == separator (default branch)."""
+        spec = PackageSpec(name='genkit', version='0.6.0')
+        assert spec.install_spec('go') == 'genkit==0.6.0'
+
+    def test_frozen(self) -> None:
+        """PackageSpec is immutable."""
+        spec = PackageSpec(name='genkit', version='0.6.0')
+        with pytest.raises(AttributeError):
+            spec.name = 'other'  # type: ignore[misc]
+
+
+# ── _install_python ──────────────────────────────────────────────────
+
+
+class TestInstallPython:
+    """Tests for _install_python."""
+
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_basic_spec(self, mock_run: MagicMock) -> None:
+        """Basic spec without index_url."""
+        mock_run.return_value.returncode = 0
+        assert _install_python('genkit==0.6.0') is True
+        cmd = mock_run.call_args[0][0]
+        assert 'genkit==0.6.0' in cmd
+        assert '--index-url' not in cmd
+
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_with_index_url(self, mock_run: MagicMock) -> None:
+        """Custom index URL is passed via --index-url."""
+        mock_run.return_value.returncode = 0
+        assert _install_python('genkit==0.6.0', index_url='https://test.pypi.org/simple/') is True
+        cmd = mock_run.call_args[0][0]
+        assert '--index-url' in cmd
+        idx = cmd.index('--index-url')
+        assert cmd[idx + 1] == 'https://test.pypi.org/simple/'
+
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_failure_returns_false(self, mock_run: MagicMock) -> None:
+        """Non-zero exit code returns False."""
+        mock_run.return_value.returncode = 1
+        assert _install_python('nonexistent==0.0.0') is False
+
+
+# ── _install_npm ─────────────────────────────────────────────────────
+
+
+class TestInstallNpm:
+    """Tests for _install_npm."""
+
+    @patch('releasekit.verify_install.shutil.which', return_value='/usr/bin/npm')
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_basic_spec(self, mock_run: MagicMock, _mock_which: MagicMock) -> None:
+        """Basic spec without registry."""
+        mock_run.return_value.returncode = 0
+        assert _install_npm('genkit@1.0.0') is True
+        cmd = mock_run.call_args[0][0]
+        assert 'genkit@1.0.0' in cmd
+        assert '--registry' not in cmd
+
+    @patch('releasekit.verify_install.shutil.which', return_value='/usr/bin/npm')
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_with_index_url(self, mock_run: MagicMock, _mock_which: MagicMock) -> None:
+        """Custom registry is passed via --registry."""
+        mock_run.return_value.returncode = 0
+        assert _install_npm('genkit@1.0.0', index_url='https://npm.pkg.github.com') is True
+        cmd = mock_run.call_args[0][0]
+        assert '--registry' in cmd
+        idx = cmd.index('--registry')
+        assert cmd[idx + 1] == 'https://npm.pkg.github.com'
+
+    @patch('releasekit.verify_install.shutil.which', return_value=None)
+    def test_npm_not_found(self, _mock_which: MagicMock) -> None:
+        """Returns False when npm is not on PATH."""
+        assert _install_npm('genkit@1.0.0') is False
+
+
+# ── _install_cargo ───────────────────────────────────────────────────
+
+
+class TestInstallCargo:
+    """Tests for _install_cargo."""
+
+    @patch('releasekit.verify_install.shutil.which', return_value='/usr/bin/cargo')
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_basic_spec_no_version(self, mock_run: MagicMock, _mock_which: MagicMock) -> None:
+        """Spec without version."""
+        mock_run.return_value.returncode = 0
+        assert _install_cargo('genkit') is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ['/usr/bin/cargo', 'install', 'genkit']
+
+    @patch('releasekit.verify_install.shutil.which', return_value='/usr/bin/cargo')
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_spec_with_version(self, mock_run: MagicMock, _mock_which: MagicMock) -> None:
+        """Spec with @version is split into --version flag."""
+        mock_run.return_value.returncode = 0
+        assert _install_cargo('genkit@0.6.0') is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ['/usr/bin/cargo', 'install', 'genkit', '--version', '0.6.0']
+
+    @patch('releasekit.verify_install.shutil.which', return_value='/usr/bin/cargo')
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_with_index_url(self, mock_run: MagicMock, _mock_which: MagicMock) -> None:
+        """Custom index URL is passed via --index (regression test)."""
+        mock_run.return_value.returncode = 0
+        assert _install_cargo('genkit@0.6.0', index_url='https://my-registry.example.com/index') is True
+        cmd = mock_run.call_args[0][0]
+        assert '--index' in cmd
+        idx = cmd.index('--index')
+        assert cmd[idx + 1] == 'https://my-registry.example.com/index'
+        assert cmd == [
+            '/usr/bin/cargo',
+            'install',
+            'genkit',
+            '--version',
+            '0.6.0',
+            '--index',
+            'https://my-registry.example.com/index',
+        ]
+
+    @patch('releasekit.verify_install.shutil.which', return_value='/usr/bin/cargo')
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_empty_index_url_not_added(self, mock_run: MagicMock, _mock_which: MagicMock) -> None:
+        """Empty index_url does not add --index flag."""
+        mock_run.return_value.returncode = 0
+        _install_cargo('genkit@0.6.0', index_url='')
+        cmd = mock_run.call_args[0][0]
+        assert '--index' not in cmd
+
+    @patch('releasekit.verify_install.shutil.which', return_value=None)
+    def test_cargo_not_found(self, _mock_which: MagicMock) -> None:
+        """Returns False when cargo is not on PATH."""
+        assert _install_cargo('genkit@0.6.0') is False
+
+    @patch('releasekit.verify_install.shutil.which', return_value='/usr/bin/cargo')
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_failure_returns_false(self, mock_run: MagicMock, _mock_which: MagicMock) -> None:
+        """Non-zero exit code returns False."""
+        mock_run.return_value.returncode = 1
+        assert _install_cargo('genkit@0.6.0') is False
+
+
+# ── install_package (dispatcher) ─────────────────────────────────────
+
+
+class TestInstallPackage:
+    """Tests for the install_package dispatcher."""
+
+    @patch('releasekit.verify_install._install_python', return_value=True)
+    def test_python_ecosystem(self, mock_install: MagicMock) -> None:
+        """Routes 'python' to _install_python."""
+        assert install_package('genkit==0.6.0', ecosystem='python') is True
+        mock_install.assert_called_once_with('genkit==0.6.0', index_url='')
+
+    @patch('releasekit.verify_install._install_python', return_value=True)
+    def test_uv_ecosystem(self, mock_install: MagicMock) -> None:
+        """Routes 'uv' to _install_python."""
+        assert install_package('genkit==0.6.0', ecosystem='uv') is True
+        mock_install.assert_called_once()
+
+    @patch('releasekit.verify_install._install_python', return_value=True)
+    def test_empty_ecosystem(self, mock_install: MagicMock) -> None:
+        """Routes '' (empty) to _install_python."""
+        assert install_package('genkit==0.6.0', ecosystem='') is True
+        mock_install.assert_called_once()
+
+    @patch('releasekit.verify_install._install_npm', return_value=True)
+    def test_js_ecosystem(self, mock_install: MagicMock) -> None:
+        """Routes 'js' to _install_npm."""
+        assert install_package('genkit@1.0.0', ecosystem='js') is True
+        mock_install.assert_called_once()
+
+    @patch('releasekit.verify_install._install_npm', return_value=True)
+    def test_pnpm_ecosystem(self, mock_install: MagicMock) -> None:
+        """Routes 'pnpm' to _install_npm."""
+        assert install_package('genkit@1.0.0', ecosystem='pnpm') is True
+        mock_install.assert_called_once()
+
+    @patch('releasekit.verify_install._install_cargo', return_value=True)
+    def test_rust_ecosystem(self, mock_install: MagicMock) -> None:
+        """Routes 'rust' to _install_cargo."""
+        assert install_package('genkit@0.6.0', ecosystem='rust') is True
+        mock_install.assert_called_once()
+
+    @patch('releasekit.verify_install._install_cargo', return_value=True)
+    def test_cargo_ecosystem(self, mock_install: MagicMock) -> None:
+        """Routes 'cargo' to _install_cargo."""
+        assert install_package('genkit@0.6.0', ecosystem='cargo') is True
+        mock_install.assert_called_once()
+
+    def test_unsupported_ecosystem_returns_true(self) -> None:
+        """Unsupported ecosystem warns but returns True."""
+        assert install_package('genkit==0.6.0', ecosystem='dart') is True
+
+    @patch('releasekit.verify_install._install_python', return_value=True)
+    def test_index_url_forwarded(self, mock_install: MagicMock) -> None:
+        """index_url is forwarded to the installer."""
+        install_package('genkit==0.6.0', ecosystem='python', index_url='https://test.pypi.org/simple/')
+        mock_install.assert_called_once_with('genkit==0.6.0', index_url='https://test.pypi.org/simple/')
+
+
+# ── Validation ───────────────────────────────────────────────────────
+
+
+class TestValidateImportCheck:
+    """Tests for _validate_import_check."""
+
+    def test_simple_import(self) -> None:
+        """Simple import statement is valid."""
+        assert _validate_import_check('import genkit') is True
+
+    def test_from_import(self) -> None:
+        """from...import statement is valid."""
+        assert _validate_import_check('from genkit.ai import Genkit') is True
+
+    def test_multi_import_semicolon(self) -> None:
+        """Semicolon-separated imports are valid."""
+        assert _validate_import_check('import genkit; import os') is True
+
+    def test_import_with_print(self) -> None:
+        """Import followed by print() is valid."""
+        assert _validate_import_check('from genkit import ai; print(ai)') is True
+
+    def test_arbitrary_code_rejected(self) -> None:
+        """Arbitrary code is rejected."""
+        assert _validate_import_check('import os; os.system("rm -rf /")') is False
+
+    def test_empty_string_rejected(self) -> None:
+        """Empty string is rejected."""
+        assert _validate_import_check('') is False
+
+    def test_shell_command_rejected(self) -> None:
+        """Shell commands are rejected."""
+        assert _validate_import_check('__import__("os").system("id")') is False
+
+
+class TestValidateSpec:
+    """Tests for _validate_spec."""
+
+    def test_python_spec(self) -> None:
+        """Python spec with == is valid."""
+        assert _validate_spec('genkit==0.6.0') is True
+
+    def test_npm_spec(self) -> None:
+        """Npm spec with @ is valid."""
+        assert _validate_spec('genkit@1.0.0') is True
+
+    def test_cargo_spec(self) -> None:
+        """Cargo spec with @ is valid."""
+        assert _validate_spec('genkit@0.6.0') is True
+
+    def test_prerelease_spec(self) -> None:
+        """Prerelease version is valid."""
+        assert _validate_spec('genkit==0.6.0a1') is True
+
+    def test_hyphenated_name(self) -> None:
+        """Hyphenated package name is valid."""
+        assert _validate_spec('my-package==1.0.0') is True
+
+    def test_dotted_name(self) -> None:
+        """Dotted package name is valid."""
+        assert _validate_spec('my.package==1.0.0') is True
+
+    def test_empty_rejected(self) -> None:
+        """Empty string is rejected."""
+        assert _validate_spec('') is False
+
+    def test_no_version_rejected(self) -> None:
+        """Bare name without version is rejected."""
+        assert _validate_spec('genkit') is False
+
+    def test_shell_injection_rejected(self) -> None:
+        """Shell injection attempt is rejected."""
+        assert _validate_spec('genkit==1.0; rm -rf /') is False
+
+
+# ── run_import_check ─────────────────────────────────────────────────
+
+
+class TestRunImportCheck:
+    """Tests for run_import_check."""
+
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_successful_import(self, mock_run: MagicMock) -> None:
+        """Successful import returns True."""
+        mock_run.return_value.returncode = 0
+        assert run_import_check('import os') is True
+
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_failed_import(self, mock_run: MagicMock) -> None:
+        """Failed import returns False."""
+        mock_run.return_value.returncode = 1
+        assert run_import_check('import nonexistent_module') is False
+
+    def test_unsafe_statement_raises(self) -> None:
+        """Unsafe statement raises ValueError."""
+        with pytest.raises(ValueError, match='Refusing to execute'):
+            run_import_check('__import__("os").system("id")')
+
+    @patch('releasekit.verify_install.subprocess.run')
+    def test_from_import(self, mock_run: MagicMock) -> None:
+        """from...import statement works."""
+        mock_run.return_value.returncode = 0
+        assert run_import_check('from os.path import join') is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd[-1] == 'from os.path import join'
+
+
+# ── verify_packages ──────────────────────────────────────────────────
+
+
+class TestVerifyPackages:
+    """Tests for the verify_packages orchestrator."""
+
+    def test_empty_packages_returns_zero(self) -> None:
+        """Empty package list returns 0."""
+        assert verify_packages([]) == 0
+
+    @patch('releasekit.verify_install.install_package', return_value=True)
+    def test_all_succeed(self, mock_install: MagicMock) -> None:
+        """All packages succeed returns 0."""
+        pkgs = [
+            PackageSpec(name='genkit', version='0.6.0'),
+            PackageSpec(name='genkit-tools', version='0.6.0'),
+        ]
+        assert verify_packages(pkgs, ecosystem='python') == 0
+        assert mock_install.call_count == 2
+
+    @patch('releasekit.verify_install.install_package', return_value=False)
+    def test_failure_returns_one(self, mock_install: MagicMock) -> None:
+        """Failed install returns 1."""
+        pkgs = [PackageSpec(name='genkit', version='0.6.0')]
+        assert verify_packages(pkgs, ecosystem='python') == 1
+
+    @patch('releasekit.verify_install.install_package', return_value=True)
+    @patch('releasekit.verify_install.run_import_check', return_value=True)
+    def test_import_check_pass(self, mock_import: MagicMock, mock_install: MagicMock) -> None:
+        """Successful import check returns 0."""
+        pkgs = [PackageSpec(name='genkit', version='0.6.0')]
+        assert verify_packages(pkgs, ecosystem='python', import_check='import genkit') == 0
+        mock_import.assert_called_once_with('import genkit')
+
+    @patch('releasekit.verify_install.install_package', return_value=True)
+    @patch('releasekit.verify_install.run_import_check', return_value=False)
+    def test_import_check_fail(self, mock_import: MagicMock, mock_install: MagicMock) -> None:
+        """Failed import check returns 1."""
+        pkgs = [PackageSpec(name='genkit', version='0.6.0')]
+        assert verify_packages(pkgs, ecosystem='python', import_check='import genkit') == 1
+
+    @patch('releasekit.verify_install.install_package', return_value=True)
+    def test_index_url_forwarded(self, mock_install: MagicMock) -> None:
+        """index_url is forwarded to install_package."""
+        pkgs = [PackageSpec(name='genkit', version='0.6.0')]
+        verify_packages(pkgs, ecosystem='python', index_url='https://test.pypi.org/simple/')
+        mock_install.assert_called_once_with(
+            'genkit==0.6.0',
+            ecosystem='python',
+            index_url='https://test.pypi.org/simple/',
+        )
+
+    def test_invalid_spec_rejected(self) -> None:
+        """Package with invalid spec is rejected."""
+        pkgs = [PackageSpec(name='genkit; rm -rf /', version='0.6.0')]
+        assert verify_packages(pkgs, ecosystem='python') == 1
+
+    @patch('releasekit.verify_install.install_package', side_effect=[True, False])
+    def test_partial_failure(self, mock_install: MagicMock) -> None:
+        """Mixed results: one pass, one fail returns 1."""
+        pkgs = [
+            PackageSpec(name='genkit', version='0.6.0'),
+            PackageSpec(name='genkit-tools', version='0.6.0'),
+        ]
+        assert verify_packages(pkgs, ecosystem='python') == 1
+
+    @patch('releasekit.verify_install.install_package', return_value=True)
+    def test_no_import_check_skipped(self, mock_install: MagicMock) -> None:
+        """Empty import_check is not run."""
+        pkgs = [PackageSpec(name='genkit', version='0.6.0')]
+        with patch('releasekit.verify_install.run_import_check') as mock_import:
+            verify_packages(pkgs, ecosystem='python', import_check='')
+            mock_import.assert_not_called()
+
+
+# ── load_manifest_specs ──────────────────────────────────────────────
+
+
+class TestLoadManifestSpecs:
+    """Tests for load_manifest_specs."""
+
+    def test_loads_bumped_packages(self, tmp_path: Path) -> None:
+        """Loads non-skipped packages from a manifest file."""
+        from releasekit.verify_install import load_manifest_specs
+        from releasekit.versions import PackageVersion, ReleaseManifest
+
+        manifest = ReleaseManifest(
+            git_sha='abc123',
+            ecosystem='python',
+            packages=[
+                PackageVersion(
+                    name='genkit',
+                    old_version='0.5.0',
+                    new_version='0.6.0',
+                    bump='minor',
+                ),
+                PackageVersion(
+                    name='genkit-tools',
+                    old_version='0.5.0',
+                    new_version='0.5.0',
+                    skipped=True,
+                ),
+                PackageVersion(
+                    name='genkit-plugin-foo',
+                    old_version='0.5.0',
+                    new_version='0.6.0',
+                    bump='minor',
+                ),
+            ],
+        )
+        path = tmp_path / 'manifest.json'
+        manifest.save(path)
+
+        specs, ecosystem = load_manifest_specs(path)
+        assert ecosystem == 'python'
+        assert len(specs) == 2
+        assert specs[0].name == 'genkit'
+        assert specs[0].version == '0.6.0'
+        assert specs[1].name == 'genkit-plugin-foo'
+        assert specs[1].version == '0.6.0'
+
+    def test_empty_manifest(self, tmp_path: Path) -> None:
+        """Empty manifest returns empty list."""
+        from releasekit.verify_install import load_manifest_specs
+        from releasekit.versions import ReleaseManifest
+
+        manifest = ReleaseManifest(git_sha='abc123', ecosystem='js')
+        path = tmp_path / 'manifest.json'
+        manifest.save(path)
+
+        specs, ecosystem = load_manifest_specs(path)
+        assert ecosystem == 'js'
+        assert specs == []
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        """Missing manifest file raises OSError."""
+        from releasekit.verify_install import load_manifest_specs
+
+        with pytest.raises(OSError):
+            load_manifest_specs(tmp_path / 'nonexistent.json')

--- a/py/tools/releasekit/tests/rk_versions_test.py
+++ b/py/tools/releasekit/tests/rk_versions_test.py
@@ -171,3 +171,74 @@ class TestReleaseManifest:
             raise AssertionError('Expected ValueError')
         except ValueError as exc:
             assert 'git_sha' in str(exc)
+
+    def test_ecosystem_round_trip(self, tmp_path: Path) -> None:
+        """The ecosystem field survives a save/load round-trip."""
+        original = ReleaseManifest(
+            git_sha='abc123',
+            ecosystem='python',
+            packages=[
+                PackageVersion(
+                    name='genkit',
+                    old_version='0.5.0',
+                    new_version='0.6.0',
+                    bump='minor',
+                ),
+            ],
+        )
+        path = tmp_path / 'manifest.json'
+        original.save(path)
+
+        loaded = ReleaseManifest.load(path)
+        assert loaded.ecosystem == 'python'
+
+    def test_ecosystem_default_empty(self) -> None:
+        """The ecosystem field defaults to empty string."""
+        m = ReleaseManifest(git_sha='abc123')
+        assert m.ecosystem == ''
+
+    def test_ecosystem_missing_in_json(self, tmp_path: Path) -> None:
+        """Loading a manifest without ecosystem defaults to empty string."""
+        path = tmp_path / 'no_ecosystem.json'
+        path.write_text('{"git_sha": "abc123", "packages": []}', encoding='utf-8')
+        loaded = ReleaseManifest.load(path)
+        assert loaded.ecosystem == ''
+
+
+class TestResolveUmbrellaVersion:
+    """Tests for resolve_umbrella_version."""
+
+    def test_empty_bumped(self) -> None:
+        """Empty list returns '0.0.0'."""
+        from releasekit.versions import resolve_umbrella_version
+
+        assert resolve_umbrella_version([]) == '0.0.0'
+
+    def test_core_package_found(self) -> None:
+        """Returns core package version when found."""
+        from releasekit.versions import resolve_umbrella_version
+
+        bumped = [
+            PackageVersion(name='genkit-plugin', old_version='0.4.0', new_version='0.5.0'),
+            PackageVersion(name='genkit', old_version='0.4.0', new_version='0.6.0'),
+        ]
+        assert resolve_umbrella_version(bumped, core_package='genkit') == '0.6.0'
+
+    def test_core_package_not_found(self) -> None:
+        """Falls back to first bumped when core package not in list."""
+        from releasekit.versions import resolve_umbrella_version
+
+        bumped = [
+            PackageVersion(name='genkit-plugin', old_version='0.4.0', new_version='0.5.0'),
+        ]
+        assert resolve_umbrella_version(bumped, core_package='genkit') == '0.5.0'
+
+    def test_no_core_package(self) -> None:
+        """Without core_package, returns first bumped version."""
+        from releasekit.versions import resolve_umbrella_version
+
+        bumped = [
+            PackageVersion(name='genkit-plugin', old_version='0.4.0', new_version='0.5.0'),
+            PackageVersion(name='genkit', old_version='0.4.0', new_version='0.6.0'),
+        ]
+        assert resolve_umbrella_version(bumped) == '0.5.0'


### PR DESCRIPTION
## Summary

Adds core Python logic for SLSA Build L3 compliance (build/upload isolation) and post-publish verification.

### Key Changes

- **Build/Upload Isolation Flags**:
  - `--build-only`: Builds artifacts (sdist/wheel) without uploading.
  - `--upload-only`: Uploads pre-built artifacts from `--dist-dir`.
  - Enables splitting CI into trusted build (no secrets) and upload (secrets) jobs.

- **New Subcommand: `verify-install`**:
  - Verifies published packages are installable from the registry.
  - Supports multiple ecosystems (Python, npm, Cargo).
  - Validates package specs and imports against strict security patterns.

- **Ecosystem Support**:
  - Adds `ecosystem` field to `ReleaseManifest` to track package types (python, npm, cargo, etc).

### Security

- **Input Validation**: Strict regex allowlists for package specs and import statements to prevent command injection.
- **Safe Subprocess**: Uses list-based `subprocess.run` (no `shell=True`).
