### PR TITLE
fix documentation link to go docs

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <a href="https://genkit.dev/go/docs">Documentation</a> &bull;
+  <a href="https://genkit.dev/docs/overview/?lang=go">Documentation</a> &bull;
   <a href="https://pkg.go.dev/github.com/firebase/genkit/go">API Reference</a> &bull;
   <a href="https://discord.gg/qXt5zzQKpc">Discord</a>
 </p>


### PR DESCRIPTION
Just fixing a small doc bug as the current URL takes us to a broken page.

Checklist (if applicable):
- [X] Docs updated (updated docs or a docs bug required)
