### PR TITLE
release(py): Release 0.5.1 (alpha)

### DIFF
--- a/py/packages/genkit/pyproject.toml
+++ b/py/packages/genkit/pyproject.toml
@@ -75,7 +75,7 @@ license = "Apache-2.0"
 name = "genkit"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.optional-dependencies]
 dev-local-vectorstore = ["genkit-plugin-dev-local-vectorstore"]

--- a/py/plugins/amazon-bedrock/pyproject.toml
+++ b/py/plugins/amazon-bedrock/pyproject.toml
@@ -71,7 +71,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-amazon-bedrock"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/anthropic/pyproject.toml
+++ b/py/plugins/anthropic/pyproject.toml
@@ -58,7 +58,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-anthropic"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/checks/pyproject.toml
+++ b/py/plugins/checks/pyproject.toml
@@ -64,7 +64,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-checks"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/cloudflare-workers-ai/pyproject.toml
+++ b/py/plugins/cloudflare-workers-ai/pyproject.toml
@@ -68,7 +68,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-cloudflare-workers-ai"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/cohere/pyproject.toml
+++ b/py/plugins/cohere/pyproject.toml
@@ -59,7 +59,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-cohere"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/compat-oai/pyproject.toml
+++ b/py/plugins/compat-oai/pyproject.toml
@@ -58,7 +58,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-compat-oai"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/deepseek/pyproject.toml
+++ b/py/plugins/deepseek/pyproject.toml
@@ -57,7 +57,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-deepseek"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/dev-local-vectorstore/pyproject.toml
+++ b/py/plugins/dev-local-vectorstore/pyproject.toml
@@ -66,7 +66,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-dev-local-vectorstore"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/evaluators/pyproject.toml
+++ b/py/plugins/evaluators/pyproject.toml
@@ -65,7 +65,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-evaluators"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/fastapi/pyproject.toml
+++ b/py/plugins/fastapi/pyproject.toml
@@ -52,7 +52,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-fastapi"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/firebase/pyproject.toml
+++ b/py/plugins/firebase/pyproject.toml
@@ -65,7 +65,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-firebase"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.optional-dependencies]
 # Telemetry export uses the Google Cloud telemetry exporters (Cloud Trace/Monitoring).

--- a/py/plugins/flask/pyproject.toml
+++ b/py/plugins/flask/pyproject.toml
@@ -64,7 +64,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-flask"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/google-cloud/pyproject.toml
+++ b/py/plugins/google-cloud/pyproject.toml
@@ -66,7 +66,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-google-cloud"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/google-genai/pyproject.toml
+++ b/py/plugins/google-genai/pyproject.toml
@@ -66,7 +66,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-google-genai"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/huggingface/pyproject.toml
+++ b/py/plugins/huggingface/pyproject.toml
@@ -59,7 +59,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-huggingface"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/mcp/pyproject.toml
+++ b/py/plugins/mcp/pyproject.toml
@@ -58,7 +58,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-mcp"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/microsoft-foundry/pyproject.toml
+++ b/py/plugins/microsoft-foundry/pyproject.toml
@@ -68,7 +68,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-microsoft-foundry"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/mistral/pyproject.toml
+++ b/py/plugins/mistral/pyproject.toml
@@ -58,7 +58,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-mistral"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/observability/pyproject.toml
+++ b/py/plugins/observability/pyproject.toml
@@ -68,7 +68,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-observability"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.optional-dependencies]
 sentry = ["sentry-sdk>=2.0.0"]

--- a/py/plugins/ollama/pyproject.toml
+++ b/py/plugins/ollama/pyproject.toml
@@ -59,7 +59,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-ollama"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/vertex-ai/pyproject.toml
+++ b/py/plugins/vertex-ai/pyproject.toml
@@ -69,7 +69,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-vertex-ai"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"

--- a/py/plugins/xai/pyproject.toml
+++ b/py/plugins/xai/pyproject.toml
@@ -59,7 +59,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-xai"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/firebase/genkit/issues"


### PR DESCRIPTION
# Genkit Python SDK v0.5.1

Next release of Genkit Python is here! Focused on async correctness, plugin reliability, and new provider support.

## Highlights

- **Anthropic** — cache control and PDF document support
- **DeepSeek** — reasoning content extraction for R1 models

## Async fixes

Several plugins were still using synchronous clients internally, causing event loop issues. This release migrates them all to proper async:

- DeepSeek: sync `OpenAI` → `AsyncOpenAI`
- Compat-OAI: sync → `AsyncOpenAI`
- Vertex AI: async client creation with threaded credential refresh
- Dev Local Vectorstore: `pathlib` → `aiofiles`
- Amazon Bedrock `boto3` → `aiboto3`

## Other notable fixes

- Fixed dotprompt deadlock
- Fixed streaming tool requests in Anthropic plugin
- Structured output support for xAI/Grok
- Nullable JSON Schema handling in Gemini plugin
- Data URI redaction in debug logs
- Graceful SIGTERM shutdown in dev runner
- Firebase telemetry refactor with lazy-loaded Google Cloud exporters

## Contributors

Yesudeep Mangalapilly, Elisa Shen, Jeff Huang, Niraj Nepal, Prashant Kumar
