### PR TITLE
fix(go): allow WithPromptFS and WithPromptDir to be used together

### DIFF
--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -69,9 +69,6 @@ func (o *genkitOptions) apply(gOpts *genkitOptions) error {
 		if gOpts.PromptDir != "" {
 			return errors.New("cannot set prompt directory more than once (WithPromptDir)")
 		}
-		if gOpts.PromptFS != nil {
-			return errors.New("cannot use WithPromptDir together with WithPromptFS")
-		}
 		gOpts.PromptDir = o.PromptDir
 	}
 
@@ -79,11 +76,7 @@ func (o *genkitOptions) apply(gOpts *genkitOptions) error {
 		if gOpts.PromptFS != nil {
 			return errors.New("cannot set prompt filesystem more than once (WithPromptFS)")
 		}
-		if gOpts.PromptDir != "" {
-			return errors.New("cannot use WithPromptFS together with WithPromptDir")
-		}
 		gOpts.PromptFS = o.PromptFS
-		gOpts.PromptDir = o.PromptDir
 	}
 
 	if len(o.Plugins) > 0 {


### PR DESCRIPTION
Fixes #4799

Removes the validation checks that prevented using `WithPromptFS` and `WithPromptDir` together. The options now work as documented - `WithPromptDir` specifies the subdirectory within the embedded filesystem (defaults to "prompts" if not set).

Includes tests covering both custom and default directory scenarios.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
