### PR TITLE
feat(go): add HandlerFunc for error-returning handlers

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -488,6 +488,31 @@ r.Post("/joke", genkit.Handler(jokeFlow))
 http.ListenAndServe(":8080", r)
 ```
 
+### Frameworks with Centralized Error Handling
+
+`genkit.HandlerFunc` returns:
+
+```go
+func(http.ResponseWriter, *http.Request) error
+```
+
+This is useful for frameworks that support centralized error handling and middleware chains, and expect handlers to return an error.
+
+For example, Echo natively supports handlers that return error, so `genkit.HandlerFunc` can be adapted directly:
+
+```go
+e := echo.New()
+h := genkit.HandlerFunc(jokeFlow)
+
+e.POST("/joke", func(c *echo.Context) error {
+	  return h(c.Response(), c.Request())
+})
+
+e.Start(":8080")
+```
+
+Any error returned by `genkit.HandlerFunc` will be handled by Echo's middleware stack.
+
 ---
 
 ## Model Providers


### PR DESCRIPTION
Fixes #4801

Adds `genkit.HandlerFunc` that returns errors instead of writing them to responses, enabling integration with frameworks expecting error-returning handlers (Echo, Fiber, etc).

`genkit.Handler` is now just a wrapper for `genkit.HandlerFunc`. All existing tests for `genkit.Handler` have been adapted for `genkit.HandlerFunc`, since it now holds the business logic. Added tests for `genkit.Handler` verify the error wrapping behavior.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
