### PR TITLE
chore(py): Remove incorrect Do Not Upload label to dev local vectorstore

### DIFF
--- a/py/plugins/dev-local-vectorstore/pyproject.toml
+++ b/py/plugins/dev-local-vectorstore/pyproject.toml
@@ -41,7 +41,6 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
   "Typing :: Typed",
   "License :: OSI Approved :: Apache Software License",
-  "Private :: Do Not Upload",
 ]
 dependencies = [
   "aiofiles>=24.1.0",


### PR DESCRIPTION
This was incorrectly added recently. This package is already on PyPI. We should be publishing dev-local-vectorstore, it is part of our samples and we expect developers to interact with this plugin.