### PR TITLE
refactor(py): flatten *Options classes into kwargs on define_* methods

### DIFF
--- a/py/packages/genkit/src/genkit/__init__.py
+++ b/py/packages/genkit/src/genkit/__init__.py
@@ -45,7 +45,6 @@ from genkit.ai import (
     OutputOptions,
     PromptGenerateOptions,
     ResumeOptions,
-    SimpleRetrieverOptions,
     ToolRunContext,
     tool_response,
 )
@@ -107,7 +106,6 @@ __all__ = [
     'OutputOptions',
     'PromptGenerateOptions',
     'ResumeOptions',
-    'SimpleRetrieverOptions',
     'ToolRunContext',
     'tool_response',
     # Version info

--- a/py/packages/genkit/src/genkit/ai/__init__.py
+++ b/py/packages/genkit/src/genkit/ai/__init__.py
@@ -103,7 +103,7 @@ from genkit.core.action.types import ActionKind
 from genkit.core.plugin import Plugin
 
 from ._aio import Genkit, Output
-from ._registry import FlowWrapper, GenkitRegistry, SimpleRetrieverOptions
+from ._registry import FlowWrapper, GenkitRegistry
 
 __all__ = [
     # Version info
@@ -126,7 +126,6 @@ __all__ = [
     # Registry and flow
     'FlowWrapper',
     'GenkitRegistry',
-    'SimpleRetrieverOptions',
     # Response types
     'GenerateResponseWrapper',
     'GenerateStreamResponse',

--- a/py/packages/genkit/src/genkit/ai/_registry.py
+++ b/py/packages/genkit/src/genkit/ai/_registry.py
@@ -63,7 +63,7 @@ from genkit.blocks.dap import (
     define_dynamic_action_provider as define_dap_block,
 )
 from genkit.blocks.document import Document
-from genkit.blocks.embedding import EmbedderFn, EmbedderOptions
+from genkit.blocks.embedding import EmbedderFn, EmbedderSupports, embedder_action_metadata
 from genkit.blocks.evaluator import BatchEvaluatorFn, EvaluatorFn
 from genkit.blocks.formats.types import FormatDef
 from genkit.blocks.interfaces import Input, Output
@@ -78,14 +78,13 @@ from genkit.blocks.prompt import (
 from genkit.blocks.reranker import (
     RankedDocument,
     RerankerFn,
-    RerankerOptions,
     RerankerRef,
+    RerankerSupports,
     define_reranker as define_reranker_block,
     rerank as rerank_block,
 )
 from genkit.blocks.resource import (
     FlexibleResourceFn,
-    ResourceOptions,
     define_resource as define_resource_block,
 )
 from genkit.blocks.retriever import IndexerFn, RetrieverFn
@@ -145,31 +144,10 @@ def get_func_description(func: Callable[..., Any], description: str | None = Non
     return ''
 
 
-R = TypeVar('R')
-
-
-class SimpleRetrieverOptions(BaseModel, Generic[R]):
-    """Configuration options for `define_simple_retriever`.
-
-    This class defines how items returned by a simple retriever handler are
-    mapped into Genkit `DocumentData` objects.
-
-    Attributes:
-        name: The unique name of the retriever.
-        content: Specifies how to extract content from the returned items.
-            Can be a string key (for dict items) or a callable that transforms the item.
-        metadata: Specifies how to extract metadata from the returned items.
-            Can be a list of keys (for dict items) or a callable that transforms the item.
-        config_schema: Optional Pydantic schema or JSON schema for retriever configuration.
-    """
-
-    name: str
-    content: str | Callable[[R], str | list[DocumentPart]] | None = None
-    metadata: list[str] | Callable[[R], dict[str, Any]] | None = None
-    config_schema: type[BaseModel] | dict[str, Any] | None = None
-
-
-def _item_to_document(item: R, options: SimpleRetrieverOptions[R]) -> DocumentData:
+def _item_to_document(
+    item: R,
+    content: str | Callable[[R], str | list[DocumentPart]] | None,
+) -> DocumentData:
     """Internal helper to convert a raw item to a Genkit DocumentData."""
     if isinstance(item, (Document, DocumentData)):
         return item
@@ -177,46 +155,50 @@ def _item_to_document(item: R, options: SimpleRetrieverOptions[R]) -> DocumentDa
     if isinstance(item, str):
         return Document.from_text(item)
 
-    if callable(options.content):
-        transformed = options.content(item)
+    if callable(content):
+        transformed = content(item)
         if isinstance(transformed, str):
             return Document.from_text(transformed)
         else:
             # transformed is list[DocumentPart]
             return DocumentData(content=transformed)
 
-    if isinstance(options.content, str) and isinstance(item, dict):
+    if isinstance(content, str) and isinstance(item, dict):
         item_dict = cast(dict[str, object], item)
-        return Document.from_text(str(item_dict[options.content]))
+        return Document.from_text(str(item_dict[content]))
 
-    if options.content is None and isinstance(item, str):
+    if content is None and isinstance(item, str):
         return Document.from_text(item)
 
     raise ValueError(f'Cannot convert item to document without content option. Item: {item}')
 
 
-def _item_to_metadata(item: R, options: SimpleRetrieverOptions[R]) -> dict[str, Any] | None:
+def _item_to_metadata(
+    item: R,
+    content: str | Callable[[R], str | list[DocumentPart]] | None,
+    metadata: list[str] | Callable[[R], dict[str, Any]] | None,
+) -> dict[str, Any] | None:
     """Internal helper to extract metadata from a raw item for a Document."""
     if isinstance(item, str):
         return None
 
-    if isinstance(options.metadata, list) and isinstance(item, dict):
+    if isinstance(metadata, list) and isinstance(item, dict):
         item_dict = cast(dict[str, object], item)
         result: dict[str, Any] = {}
-        for key in options.metadata:
+        for key in metadata:
             str_key = str(key)
             value = item_dict.get(str_key)
             if value is not None:
                 result[str_key] = value
         return result
 
-    if callable(options.metadata):
-        return options.metadata(item)
+    if callable(metadata):
+        return metadata(item)
 
-    if options.metadata is None and isinstance(item, dict):
+    if metadata is None and isinstance(item, dict):
         out = cast(dict[str, Any], item.copy())
-        if isinstance(options.content, str) and options.content in out:
-            del out[options.content]
+        if isinstance(content, str) and content in out:
+            del out[content]
         return out
 
     return None
@@ -476,7 +458,7 @@ class GenkitRegistry:
         Example:
             ```python
             from genkit.ai import Genkit
-            from genkit.blocks.dap import DapConfig, DapCacheConfig
+            from genkit.blocks.dap import DapConfig
 
             ai = Genkit()
 
@@ -497,7 +479,7 @@ class GenkitRegistry:
                 config=DapConfig(
                     name='mcp-tools',
                     description='Tools from MCP server',
-                    cache_config=DapCacheConfig(ttl_millis=10000),
+                    cache_ttl_millis=10000,
                 ),
                 fn=get_tools,
             )
@@ -646,8 +628,12 @@ class GenkitRegistry:
 
     def define_simple_retriever(
         self,
-        options: SimpleRetrieverOptions[R] | str,
+        name: str,
         handler: Callable[[DocumentData, Any], list[R] | Awaitable[list[R]]],
+        *,
+        content: str | Callable[[R], str | list[DocumentPart]] | None = None,
+        metadata: list[str] | Callable[[R], dict[str, Any]] | None = None,
+        config_schema: type[BaseModel] | dict[str, Any] | None = None,
         description: str | None = None,
     ) -> Action:
         """Define a simple retriever action.
@@ -656,32 +642,36 @@ class GenkitRegistry:
         that can be used for prompt augmentation.
 
         Args:
-            options: Configuration options for the retriever, or just the name.
+            name: Unique name of the retriever.
             handler: A function that queries a datastore and returns items
                 from which to extract documents.
+            content: Specifies how to extract content from returned items.
+                Can be a string key (for dict items) or a callable.
+            metadata: Specifies how to extract metadata from returned items.
+                Can be a list of keys (for dict items) or a callable.
+            config_schema: Optional Pydantic schema or JSON schema for retriever configuration.
             description: Optional description for the retriever.
 
         Returns:
             The registered Action for the retriever.
         """
-        if isinstance(options, str):
-            options = SimpleRetrieverOptions(name=options)
+        content_opt = content
+        metadata_opt = metadata
 
         async def retriever_fn(query: Document, options_obj: Any) -> RetrieverResponse:  # noqa: ANN401
-
             items = await ensure_async(handler)(query, options_obj)
             docs = []
             for item in items:
-                doc = _item_to_document(item, options)
+                doc = _item_to_document(item, content_opt)
                 if not isinstance(item, str):
-                    doc.metadata = _item_to_metadata(item, options)
+                    doc.metadata = _item_to_metadata(item, content_opt, metadata_opt)
                 docs.append(doc)
             return RetrieverResponse(documents=docs)
 
         return self.define_retriever(
-            name=options.name,
+            name=name,
             fn=retriever_fn,
-            config_schema=options.config_schema,
+            config_schema=config_schema,
             description=description,
         )
 
@@ -729,8 +719,10 @@ class GenkitRegistry:
         self,
         name: str,
         fn: RerankerFn[Any],
+        *,
         config_schema: type[BaseModel] | dict[str, object] | None = None,
-        metadata: dict[str, object] | None = None,
+        label: str | None = None,
+        supports: RerankerSupports | None = None,
         description: str | None = None,
     ) -> Action:
         """Define a reranker action.
@@ -742,8 +734,9 @@ class GenkitRegistry:
             name: Name of the reranker.
             fn: Function implementing the reranker behavior. Should accept
                 (query_doc, documents, options) and return RerankerResponse.
-            config_schema: Optional schema for reranker configuration.
-            metadata: Optional metadata for the reranker.
+            config_schema: Optional schema for reranker configuration options.
+            label: Human-readable label for the reranker.
+            supports: Capability information for the reranker.
             description: Optional description for the reranker.
 
         Returns:
@@ -757,35 +750,16 @@ class GenkitRegistry:
             ...     return RerankerResponse(documents=[...])
             >>> ai.define_reranker('my-reranker', my_reranker)
         """
-        # Extract label and config from metadata
-        reranker_label: str = name
-        reranker_config_schema: dict[str, object] | None = None
-
-        # Check if metadata has reranker info
-        if metadata and 'reranker' in metadata:
-            existing = metadata['reranker']
-            if isinstance(existing, dict):
-                existing_dict = cast(dict[str, object], existing)
-                label_val = existing_dict.get('label')
-                if isinstance(label_val, str) and label_val:
-                    reranker_label = label_val
-                opts_val = existing_dict.get('customOptions')
-                if isinstance(opts_val, dict):
-                    reranker_config_schema = cast(dict[str, object], opts_val)
-
-        # Override with config_schema if provided
-        if config_schema:
-            reranker_config_schema = to_json_schema(config_schema)
+        reranker_config_schema = to_json_schema(config_schema) if config_schema else None
 
         reranker_description = get_func_description(fn, description)
         return define_reranker_block(
             self.registry,
             name=name,
             fn=fn,
-            options=RerankerOptions(
-                config_schema=reranker_config_schema,
-                label=reranker_label,
-            ),
+            config_schema=reranker_config_schema,
+            label=label or name,
+            supports=supports,
             description=reranker_description,
         )
 
@@ -1130,17 +1104,24 @@ class GenkitRegistry:
         self,
         name: str,
         fn: EmbedderFn,
-        options: EmbedderOptions | None = None,
+        *,
+        config_schema: type[BaseModel] | dict[str, object] | None = None,
+        label: str | None = None,
+        supports: EmbedderSupports | None = None,
+        dimensions: int | None = None,
         metadata: dict[str, object] | None = None,
         description: str | None = None,
     ) -> Action:
         """Define a custom embedder action.
 
         Args:
-            name: Name of the model.
+            name: Name of the embedder.
             fn: Function implementing the embedder behavior.
-            options: Optional options for the embedder.
-            metadata: Optional metadata for the model.
+            config_schema: Optional schema for embedder configuration options.
+            label: Human-readable label for the embedder.
+            supports: Capability information for the embedder.
+            dimensions: Size of the embedding vector.
+            metadata: Optional metadata for the embedder.
             description: Optional description for the embedder.
         """
         embedder_meta: dict[str, object] = dict(metadata) if metadata else {}
@@ -1152,15 +1133,14 @@ class GenkitRegistry:
             embedder_info = {}
         embedder_meta['embedder'] = embedder_info
 
-        if options:
-            if options.label:
-                embedder_info['label'] = options.label
-            if options.dimensions:
-                embedder_info['dimensions'] = options.dimensions
-            if options.supports:
-                embedder_info['supports'] = options.supports.model_dump(exclude_none=True, by_alias=True)
-            if options.config_schema:
-                embedder_info['customOptions'] = to_json_schema(options.config_schema)
+        if label:
+            embedder_info['label'] = label
+        if dimensions:
+            embedder_info['dimensions'] = dimensions
+        if supports:
+            embedder_info['supports'] = supports.model_dump(exclude_none=True, by_alias=True)
+        if config_schema:
+            embedder_info['customOptions'] = to_json_schema(config_schema)
 
         embedder_description = get_func_description(fn, description)
         return self.registry.register_action(
@@ -1587,8 +1567,7 @@ class GenkitRegistry:
 
     def define_resource(
         self,
-        opts: 'ResourceOptions | None' = None,
-        fn: 'FlexibleResourceFn | None' = None,
+        fn: 'FlexibleResourceFn',
         *,
         name: str | None = None,
         uri: str | None = None,
@@ -1599,33 +1578,25 @@ class GenkitRegistry:
         """Define a resource action.
 
         Args:
-            opts: Options defining the resource (e.g. uri, template, name).
             fn: Function implementing the resource behavior.
-            name: Optional name for the resource.
-            uri: Optional URI for the resource.
-            template: Optional URI template for the resource.
+            name: Resource name (defaults to uri or template).
+            uri: The URI of the resource.
+            template: The URI template (e.g. ``my://resource/{id}``).
             description: Optional description for the resource.
             metadata: Optional metadata for the resource.
 
         Returns:
             The registered Action for the resource.
         """
-        if fn is None:
-            raise ValueError('A function `fn` must be provided to define a resource.')
-        if opts is None:
-            opts = {}
-        if name:
-            opts['name'] = name
-        if uri:
-            opts['uri'] = uri
-        if template:
-            opts['template'] = template
-        if description:
-            opts['description'] = description
-        if metadata:
-            opts['metadata'] = metadata
-
-        return define_resource_block(self.registry, opts, fn)
+        return define_resource_block(
+            self.registry,
+            fn,
+            name=name,
+            uri=uri,
+            template=template,
+            description=description,
+            metadata=metadata,
+        )
 
 
 class FlowWrapper(Generic[P, CallT, T, ChunkT]):

--- a/py/packages/genkit/src/genkit/blocks/background_model.py
+++ b/py/packages/genkit/src/genkit/blocks/background_model.py
@@ -279,26 +279,6 @@ def _ensure_operation(response: Any) -> Operation:  # noqa: ANN401
     raise TypeError(f'Expected Operation, got {type(response)}')
 
 
-class DefineBackgroundModelOptions(BaseModel):
-    """Options for defining a background model.
-
-    Matches JS DefineBackgroundModelOptions from js/ai/src/model.ts.
-
-    Attributes:
-        name: Unique name for this background model.
-        label: Human-readable label (defaults to name).
-        versions: Known version names for this model.
-        supports: Model capability information.
-        config_schema: Custom options schema for this model.
-    """
-
-    name: str
-    label: str | None = None
-    versions: list[str] | None = None
-    supports: dict[str, Any] | None = None
-    config_schema: type | dict[str, Any] | None = None
-
-
 def define_background_model(
     registry: Registry,
     name: str,

--- a/py/packages/genkit/src/genkit/blocks/dap.py
+++ b/py/packages/genkit/src/genkit/blocks/dap.py
@@ -142,33 +142,22 @@ DapMetadata = dict[str, list[ActionMetadataLike]]
 
 
 @dataclass
-class DapCacheConfig:
-    """Configuration for DAP caching behavior.
-
-    Attributes:
-        ttl_millis: Time-to-live for cache in milliseconds.
-            - Negative: No caching (always fetch fresh)
-            - Zero/None: Default (3000 milliseconds)
-            - Positive: Cache validity duration in milliseconds
-    """
-
-    ttl_millis: int | None = None
-
-
-@dataclass
 class DapConfig:
     """Configuration for a Dynamic Action Provider.
 
     Attributes:
         name: Unique name for this DAP (used as prefix for actions).
         description: Human-readable description of what this DAP provides.
-        cache_config: Optional caching configuration.
+        cache_ttl_millis: TTL for the action cache in milliseconds.
+            - Negative: No caching (always fetch fresh)
+            - Zero/None: Default (3000 milliseconds)
+            - Positive: Cache validity duration in milliseconds
         metadata: Additional metadata to attach to the DAP action.
     """
 
     name: str
     description: str | None = None
-    cache_config: DapCacheConfig | None = None
+    cache_ttl_millis: int | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -199,7 +188,7 @@ class SimpleCache:
         self._fetch_task: asyncio.Task[DapValue] | None = None
 
         # Determine TTL (default 3000ms)
-        ttl = config.cache_config.ttl_millis if config.cache_config else None
+        ttl = config.cache_ttl_millis
         self._ttl_millis = 3000 if ttl is None or ttl == 0 else ttl
 
     async def get_or_fetch(self, skip_trace: bool = False) -> DapValue:
@@ -464,7 +453,7 @@ def define_dynamic_action_provider(
             config=DapConfig(
                 name='mcp-tools',
                 description='Tools from MCP server',
-                cache_config=DapCacheConfig(ttl_millis=10000),
+                cache_ttl_millis=10000,
             ),
             fn=get_tools,
         )
@@ -503,7 +492,6 @@ def define_dynamic_action_provider(
 
 __all__ = [
     'ActionMetadataLike',
-    'DapCacheConfig',
     'DapConfig',
     'DapFn',
     'DapMetadata',

--- a/py/packages/genkit/src/genkit/blocks/embedding.py
+++ b/py/packages/genkit/src/genkit/blocks/embedding.py
@@ -51,8 +51,6 @@ Key Components:
     +===================+======================================================+
     | EmbedderRef       | Reference to an embedder with optional configuration |
     +-------------------+------------------------------------------------------+
-    | EmbedderOptions   | Configuration options for defining embedders         |
-    +-------------------+------------------------------------------------------+
     | EmbedderSupports  | Declares what input types an embedder supports       |
     +-------------------+------------------------------------------------------+
     | Embedder          | Runtime wrapper around an embedder action            |
@@ -92,7 +90,6 @@ from collections.abc import Callable
 from typing import Any, ClassVar, cast
 
 from pydantic import BaseModel, ConfigDict
-from pydantic.alias_generators import to_camel
 
 from genkit.blocks.document import Document
 from genkit.core.action import Action, ActionMetadata
@@ -108,17 +105,6 @@ class EmbedderSupports(BaseModel):
 
     input: list[str] | None = None
     multilingual: bool | None = None
-
-
-class EmbedderOptions(BaseModel):
-    """Configuration options for an embedder."""
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
-
-    config_schema: dict[str, Any] | None = None
-    label: str | None = None
-    supports: EmbedderSupports | None = None
-    dimensions: int | None = None
 
 
 class EmbedderRef(BaseModel):
@@ -170,30 +156,36 @@ EmbedderFn = Callable[[EmbedRequest], EmbedResponse]
 
 def embedder_action_metadata(
     name: str,
-    options: EmbedderOptions | None = None,
+    *,
+    config_schema: dict[str, Any] | None = None,
+    label: str | None = None,
+    supports: EmbedderSupports | None = None,
+    dimensions: int | None = None,
 ) -> ActionMetadata:
     """Creates metadata for an embedder action.
 
     Args:
         name: The name of the embedder.
-        options: Configuration options for the embedder.
+        config_schema: Optional JSON schema for embedder configuration options.
+        label: Human-readable label for the embedder.
+        supports: Capability information for the embedder.
+        dimensions: Size of the embedding vector.
 
     Returns:
         The action metadata for the embedder.
     """
-    options = options if options is not None else EmbedderOptions()
     embedder_metadata_dict: dict[str, object] = {'embedder': {}}
     embedder_info = cast(dict[str, object], embedder_metadata_dict['embedder'])
 
-    if options.label:
-        embedder_info['label'] = options.label
+    if label:
+        embedder_info['label'] = label
 
-    embedder_info['dimensions'] = options.dimensions
+    embedder_info['dimensions'] = dimensions
 
-    if options.supports:
-        embedder_info['supports'] = options.supports.model_dump(exclude_none=True, by_alias=True)
+    if supports:
+        embedder_info['supports'] = supports.model_dump(exclude_none=True, by_alias=True)
 
-    embedder_info['customOptions'] = options.config_schema if options.config_schema else None
+    embedder_info['customOptions'] = config_schema if config_schema else None
 
     return ActionMetadata(
         kind=cast(ActionKind, ActionKind.EMBEDDER),

--- a/py/packages/genkit/src/genkit/blocks/reranker.py
+++ b/py/packages/genkit/src/genkit/blocks/reranker.py
@@ -125,7 +125,6 @@ from collections.abc import Awaitable, Callable
 from typing import Any, ClassVar, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict
-from pydantic.alias_generators import to_camel
 
 from genkit.blocks.document import Document
 from genkit.core.action import Action, ActionMetadata
@@ -216,16 +215,6 @@ class RerankerInfo(BaseModel):
     supports: RerankerSupports | None = None
 
 
-class RerankerOptions(BaseModel):
-    """Configuration options for a reranker."""
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
-
-    config_schema: dict[str, Any] | None = None
-    label: str | None = None
-    supports: RerankerSupports | None = None
-
-
 class RerankerRef(BaseModel):
     """Reference to a reranker with configuration.
 
@@ -243,27 +232,31 @@ class RerankerRef(BaseModel):
 
 def reranker_action_metadata(
     name: str,
-    options: RerankerOptions | None = None,
+    *,
+    config_schema: dict[str, Any] | None = None,
+    label: str | None = None,
+    supports: RerankerSupports | None = None,
 ) -> ActionMetadata:
     """Creates action metadata for a reranker.
 
     Args:
         name: The name of the reranker.
-        options: Optional configuration options for the reranker.
+        config_schema: Optional JSON schema for reranker configuration options.
+        label: Human-readable label for the reranker.
+        supports: Capability information for the reranker.
 
     Returns:
         An ActionMetadata instance for the reranker.
     """
-    options = options if options is not None else RerankerOptions()
     reranker_metadata_dict: dict[str, Any] = {'reranker': {}}
 
-    if options.label:
-        reranker_metadata_dict['reranker']['label'] = options.label
+    if label:
+        reranker_metadata_dict['reranker']['label'] = label
 
-    if options.supports:
-        reranker_metadata_dict['reranker']['supports'] = options.supports.model_dump(exclude_none=True, by_alias=True)
+    if supports:
+        reranker_metadata_dict['reranker']['supports'] = supports.model_dump(exclude_none=True, by_alias=True)
 
-    reranker_metadata_dict['reranker']['customOptions'] = options.config_schema if options.config_schema else None
+    reranker_metadata_dict['reranker']['customOptions'] = config_schema if config_schema else None
 
     return ActionMetadata(
         kind=cast(ActionKind, ActionKind.RERANKER),
@@ -298,7 +291,10 @@ def define_reranker(
     registry: Registry,
     name: str,
     fn: RerankerFn[Any],
-    options: RerankerOptions | None = None,
+    *,
+    config_schema: dict[str, Any] | None = None,
+    label: str | None = None,
+    supports: RerankerSupports | None = None,
     description: str | None = None,
 ) -> Action:
     """Defines and registers a reranker action.
@@ -310,7 +306,9 @@ def define_reranker(
         registry: The registry to register the reranker in.
         name: The name of the reranker.
         fn: The reranker function that implements the reranking logic.
-        options: Optional configuration options for the reranker.
+        config_schema: Optional JSON schema for reranker configuration options.
+        label: Human-readable label for the reranker.
+        supports: Capability information for the reranker.
         description: Optional description for the reranker action.
 
     Returns:
@@ -329,7 +327,7 @@ def define_reranker(
         ...     )
         >>> define_reranker(registry, 'my-reranker', my_reranker)
     """
-    metadata = reranker_action_metadata(name, options)
+    metadata = reranker_action_metadata(name, config_schema=config_schema, label=label, supports=supports)
 
     async def wrapper(
         request: RerankerRequest,

--- a/py/packages/genkit/src/genkit/blocks/resource.py
+++ b/py/packages/genkit/src/genkit/blocks/resource.py
@@ -25,7 +25,7 @@ and return content (`ResourceOutput`) containing `Part`s.
 import inspect
 import re
 from collections.abc import Awaitable, Callable
-from typing import Any, Protocol, TypedDict, cast
+from typing import Any, Protocol, cast
 
 from pydantic import BaseModel
 
@@ -34,26 +34,6 @@ from genkit.core.action import Action, ActionRunContext
 from genkit.core.action.types import ActionKind
 from genkit.core.registry import Registry
 from genkit.core.typing import Metadata, Part
-
-
-class ResourceOptions(TypedDict, total=False):
-    """Options for defining a resource.
-
-    Attributes:
-        name: Resource name. If not specified, uri or template will be used as name.
-        uri: The URI of the resource. Can contain template variables for simple matches,
-             but `template` is preferred for pattern matching.
-        template: The URI template (ex. `my://resource/{id}`). See RFC6570 for specification.
-                  Used for matching variable resources.
-        description: A description of the resource, used for documentation and discovery.
-        metadata: Arbitrary metadata to attach to the resource action.
-    """
-
-    name: str
-    uri: str
-    template: str
-    description: str
-    metadata: dict[str, Any]
 
 
 class ResourceInput(BaseModel):
@@ -159,7 +139,16 @@ async def lookup_resource_by_name(registry: Registry, name: str) -> Action:
     return resource
 
 
-def define_resource(registry: Registry, opts: ResourceOptions, fn: FlexibleResourceFn) -> Action:
+def define_resource(
+    registry: Registry,
+    fn: FlexibleResourceFn,
+    *,
+    name: str | None = None,
+    uri: str | None = None,
+    template: str | None = None,
+    description: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Action:
     """Defines a resource and registers it with the given registry.
 
     This creates a resource action that can handle requests for a specific URI
@@ -167,15 +156,19 @@ def define_resource(registry: Registry, opts: ResourceOptions, fn: FlexibleResou
 
     Args:
         registry: The registry to register the resource with.
-        opts: Options defining the resource (name, uri, template, etc.).
         fn: The function that implements resource content retrieval.
+        name: Resource name (defaults to uri or template).
+        uri: The URI of the resource.
+        template: The URI template (e.g. ``my://resource/{id}``).
+        description: Human-readable description of the resource.
+        metadata: Arbitrary metadata to attach to the resource action.
 
     Returns:
         The registered `Action` for the resource.
     """
-    action = dynamic_resource(opts, fn)
+    action = dynamic_resource(fn, name=name, uri=uri, template=template, description=description, metadata=metadata)
 
-    cast(MatchableAction, cast(object, action)).matches = create_matcher(opts.get('uri'), opts.get('template'))
+    cast(MatchableAction, cast(object, action)).matches = create_matcher(uri, template)
 
     # Mark as not dynamic since it's being registered
     action.metadata['dynamic'] = False
@@ -185,23 +178,43 @@ def define_resource(registry: Registry, opts: ResourceOptions, fn: FlexibleResou
     return action
 
 
-def resource(opts: ResourceOptions, fn: FlexibleResourceFn) -> Action:
+def resource(
+    fn: FlexibleResourceFn,
+    *,
+    name: str | None = None,
+    uri: str | None = None,
+    template: str | None = None,
+    description: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Action:
     """Defines a dynamic resource action without immediate registration.
 
     This is an alias for `dynamic_resource`. Useful for defining resources that
     might be registered later or used as standalone actions.
 
     Args:
-        opts: Options defining the resource.
         fn: The resource implementation function.
+        name: Resource name (defaults to uri or template).
+        uri: The URI of the resource.
+        template: The URI template.
+        description: Human-readable description.
+        metadata: Arbitrary metadata.
 
     Returns:
         The created `Action`.
     """
-    return dynamic_resource(opts, fn)
+    return dynamic_resource(fn, name=name, uri=uri, template=template, description=description, metadata=metadata)
 
 
-def dynamic_resource(opts: ResourceOptions, fn: FlexibleResourceFn) -> Action:
+def dynamic_resource(
+    fn: FlexibleResourceFn,
+    *,
+    name: str | None = None,
+    uri: str | None = None,
+    template: str | None = None,
+    description: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Action:
     """Defines a dynamic resource action.
 
     Creates an `Action` of kind `RESOURCE` that wraps the provided function.
@@ -211,20 +224,24 @@ def dynamic_resource(opts: ResourceOptions, fn: FlexibleResourceFn) -> Action:
     3. Post-processing of output to attach metadata (like parent resource info).
 
     Args:
-        opts: Options including `uri` or `template` for matching.
         fn: The function performing the resource retrieval.
+        name: Resource name (defaults to uri or template).
+        uri: The URI of the resource.
+        template: The URI template for matching variable resources.
+        description: Human-readable description.
+        metadata: Arbitrary metadata.
 
     Returns:
         An `Action` configured as a resource.
 
     Raises:
-        ValueError: If neither `uri` nor `template` is provided in options.
+        ValueError: If neither `uri` nor `template` is provided.
     """
-    uri = opts.get('uri') or opts.get('template')
-    if not uri:
+    resolved_uri = uri or template
+    if not resolved_uri:
         raise ValueError('must specify either uri or template options')
 
-    matcher = create_matcher(opts.get('uri'), opts.get('template'))
+    matcher = create_matcher(uri, template)
 
     async def wrapped_fn(input_data: ResourceInput, ctx: ActionRunContext) -> ResourcePayload:
         if isinstance(input_data, dict):
@@ -267,7 +284,6 @@ def dynamic_resource(opts: ResourceOptions, fn: FlexibleResourceFn) -> Action:
                         p.metadata = {}  # pyright: ignore[reportAttributeAccessIssue]
                         p_metadata = p.metadata
 
-                    template = opts.get('template')
                     if 'resource' in p_metadata:
                         if 'parent' not in p_metadata['resource']:
                             p_metadata['resource']['parent'] = {'uri': input_data.uri}
@@ -295,21 +311,22 @@ def dynamic_resource(opts: ResourceOptions, fn: FlexibleResourceFn) -> Action:
         except Exception:
             raise
 
-    name = opts.get('name') or uri
+    resolved_name = name or resolved_uri
 
     act = Action(
-        name=name,
+        name=resolved_name,
         kind=cast(ActionKind, ActionKind.RESOURCE),
         fn=wrapped_fn,
         metadata={
             'resource': {
-                'uri': opts.get('uri'),
-                'template': opts.get('template'),
+                'uri': uri,
+                'template': template,
             },
             'dynamic': True,
+            **(metadata or {}),
         },
-        description=opts.get('description'),
-        span_metadata={'genkit:metadata:resource:uri': uri},
+        description=description,
+        span_metadata={'genkit:metadata:resource:uri': resolved_uri},
     )
     act.matches = matcher
     return act

--- a/py/packages/genkit/src/genkit/blocks/retriever.py
+++ b/py/packages/genkit/src/genkit/blocks/retriever.py
@@ -117,7 +117,6 @@ from collections.abc import Awaitable, Callable
 from typing import Any, ClassVar, Generic, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict
-from pydantic.alias_generators import to_camel
 
 from genkit.blocks.document import Document
 from genkit.core.action import ActionMetadata
@@ -172,16 +171,6 @@ class RetrieverInfo(BaseModel):
     supports: RetrieverSupports | None = None
 
 
-class RetrieverOptions(BaseModel):
-    """Configuration options for a retriever."""
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
-
-    config_schema: dict[str, Any] | None = None
-    label: str | None = None
-    supports: RetrieverSupports | None = None
-
-
 class RetrieverRef(BaseModel):
     """Reference to a retriever with configuration."""
 
@@ -195,20 +184,22 @@ class RetrieverRef(BaseModel):
 
 def retriever_action_metadata(
     name: str,
-    options: RetrieverOptions | None = None,
+    *,
+    config_schema: dict[str, Any] | None = None,
+    label: str | None = None,
+    supports: RetrieverSupports | None = None,
 ) -> ActionMetadata:
     """Creates action metadata for a retriever."""
-    options = options if options is not None else RetrieverOptions()
     retriever_metadata_dict: dict[str, object] = {'retriever': {}}
     retriever_info = cast(dict[str, object], retriever_metadata_dict['retriever'])
 
-    if options.label:
-        retriever_info['label'] = options.label
+    if label:
+        retriever_info['label'] = label
 
-    if options.supports:
-        retriever_info['supports'] = options.supports.model_dump(exclude_none=True, by_alias=True)
+    if supports:
+        retriever_info['supports'] = supports.model_dump(exclude_none=True, by_alias=True)
 
-    retriever_info['customOptions'] = options.config_schema if options.config_schema else None
+    retriever_info['customOptions'] = config_schema if config_schema else None
     return ActionMetadata(
         kind=cast(ActionKind, ActionKind.RETRIEVER),
         name=name,
@@ -246,16 +237,6 @@ class IndexerInfo(BaseModel):
     supports: RetrieverSupports | None = None
 
 
-class IndexerOptions(BaseModel):
-    """Configuration options for an indexer."""
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
-
-    config_schema: dict[str, Any] | None = None
-    label: str | None = None
-    supports: RetrieverSupports | None = None
-
-
 class IndexerRef(BaseModel):
     """Reference to an indexer with configuration."""
 
@@ -269,20 +250,22 @@ class IndexerRef(BaseModel):
 
 def indexer_action_metadata(
     name: str,
-    options: IndexerOptions | None = None,
+    *,
+    config_schema: dict[str, Any] | None = None,
+    label: str | None = None,
+    supports: RetrieverSupports | None = None,
 ) -> ActionMetadata:
     """Creates action metadata for an indexer."""
-    options = options if options is not None else IndexerOptions()
     indexer_metadata_dict: dict[str, object] = {'indexer': {}}
     indexer_info = cast(dict[str, object], indexer_metadata_dict['indexer'])
 
-    if options.label:
-        indexer_info['label'] = options.label
+    if label:
+        indexer_info['label'] = label
 
-    if options.supports:
-        indexer_info['supports'] = options.supports.model_dump(exclude_none=True, by_alias=True)
+    if supports:
+        indexer_info['supports'] = supports.model_dump(exclude_none=True, by_alias=True)
 
-    indexer_info['customOptions'] = options.config_schema if options.config_schema else None
+    indexer_info['customOptions'] = config_schema if config_schema else None
 
     return ActionMetadata(
         kind=cast(ActionKind, ActionKind.INDEXER),
@@ -307,10 +290,13 @@ def define_retriever(
     registry: Registry,
     name: str,
     fn: RetrieverFn[Any],
-    options: RetrieverOptions | None = None,
+    *,
+    config_schema: dict[str, Any] | None = None,
+    label: str | None = None,
+    supports: RetrieverSupports | None = None,
 ) -> None:
     """Defines and registers a retriever action."""
-    metadata = retriever_action_metadata(name, options)
+    metadata = retriever_action_metadata(name, config_schema=config_schema, label=label, supports=supports)
 
     async def wrapper(
         request: RetrieverRequest,
@@ -336,10 +322,13 @@ def define_indexer(
     registry: Registry,
     name: str,
     fn: IndexerFn[Any],
-    options: IndexerOptions | None = None,
+    *,
+    config_schema: dict[str, Any] | None = None,
+    label: str | None = None,
+    supports: RetrieverSupports | None = None,
 ) -> None:
     """Defines and registers an indexer action."""
-    metadata = indexer_action_metadata(name, options)
+    metadata = indexer_action_metadata(name, config_schema=config_schema, label=label, supports=supports)
 
     async def wrapper(
         request: IndexerRequest,

--- a/py/plugins/amazon-bedrock/src/genkit/plugins/amazon_bedrock/plugin.py
+++ b/py/plugins/amazon-bedrock/src/genkit/plugins/amazon_bedrock/plugin.py
@@ -67,7 +67,7 @@ import aioboto3
 from botocore.config import Config
 
 from genkit.ai import Plugin
-from genkit.blocks.embedding import EmbedderOptions, EmbedderSupports, embedder_action_metadata
+from genkit.blocks.embedding import EmbedderSupports, embedder_action_metadata
 from genkit.blocks.model import model_action_metadata
 from genkit.core.action import Action, ActionMetadata
 from genkit.core.logging import get_logger
@@ -508,12 +508,10 @@ class AmazonBedrock(Plugin):
             name=name,
             fn=embed_fn,
             metadata=embedder_action_metadata(
-                name=name,
-                options=EmbedderOptions(
-                    label=embedder_info['label'],
-                    supports=EmbedderSupports(input=embedder_info['supports']['input']),
-                    dimensions=embedder_info.get('dimensions'),
-                ),
+                name,
+                label=embedder_info['label'],
+                supports=EmbedderSupports(input=embedder_info['supports']['input']),
+                dimensions=embedder_info.get('dimensions'),
             ).metadata,
         )
 
@@ -540,12 +538,10 @@ class AmazonBedrock(Plugin):
         for model_id, embed_info in SUPPORTED_EMBEDDING_MODELS.items():
             actions.append(
                 embedder_action_metadata(
-                    name=bedrock_name(model_id),
-                    options=EmbedderOptions(
-                        label=embed_info['label'],
-                        supports=EmbedderSupports(input=embed_info['supports']['input']),
-                        dimensions=embed_info.get('dimensions'),
-                    ),
+                    bedrock_name(model_id),
+                    label=embed_info['label'],
+                    supports=EmbedderSupports(input=embed_info['supports']['input']),
+                    dimensions=embed_info.get('dimensions'),
                 )
             )
 

--- a/py/plugins/compat-oai/src/genkit/plugins/compat_oai/openai_plugin.py
+++ b/py/plugins/compat-oai/src/genkit/plugins/compat_oai/openai_plugin.py
@@ -24,7 +24,7 @@ from openai import AsyncOpenAI
 from openai.types import Model
 
 from genkit.ai import Plugin
-from genkit.blocks.embedding import EmbedderOptions, EmbedderSupports, embedder_action_metadata
+from genkit.blocks.embedding import EmbedderSupports, embedder_action_metadata
 from genkit.blocks.model import model_action_metadata
 from genkit.core.action import Action, ActionMetadata
 from genkit.core.action.types import ActionKind
@@ -411,12 +411,10 @@ class OpenAI(Plugin):
             name=name,
             fn=embed_fn,
             metadata=embedder_action_metadata(
-                name=name,
-                options=EmbedderOptions(
-                    label=embedder_info['label'],
-                    supports=EmbedderSupports(input=embedder_info['supports']['input']),
-                    dimensions=embedder_info.get('dimensions'),
-                ),
+                name,
+                label=embedder_info['label'],
+                supports=EmbedderSupports(input=embedder_info['supports']['input']),
+                dimensions=embedder_info.get('dimensions'),
             ).metadata,
         )
 
@@ -438,11 +436,9 @@ class OpenAI(Plugin):
             if model_type == _ModelType.EMBEDDER:
                 actions.append(
                     embedder_action_metadata(
-                        name=open_ai_name(name),
-                        options=EmbedderOptions(
-                            label=f'OpenAI Embedding - {name}',
-                            supports=EmbedderSupports(input=['text']),
-                        ),
+                        open_ai_name(name),
+                        label=f'OpenAI Embedding - {name}',
+                        supports=EmbedderSupports(input=['text']),
                     )
                 )
             elif model_type in _DEFAULT_SUPPORTS:

--- a/py/plugins/dev-local-vectorstore/src/genkit/plugins/dev_local_vectorstore/plugin_api.py
+++ b/py/plugins/dev-local-vectorstore/src/genkit/plugins/dev_local_vectorstore/plugin_api.py
@@ -20,8 +20,6 @@ from typing import Any
 
 from genkit.ai import Genkit
 from genkit.blocks.retriever import (
-    IndexerOptions,
-    RetrieverOptions,
     indexer_action_metadata,
     retriever_action_metadata,
 )
@@ -65,11 +63,9 @@ def define_dev_local_vector_store(
         name=name,
         fn=retriever.retrieve,
         metadata=retriever_action_metadata(
-            name=name,
-            options=RetrieverOptions(
-                label=name,
-                config_schema=to_json_schema(RetrieverOptionsSchema),
-            ),
+            name,
+            label=name,
+            config_schema=to_json_schema(RetrieverOptionsSchema),
         ).metadata,
     )
 
@@ -86,8 +82,8 @@ def define_dev_local_vector_store(
         name=name,
         fn=indexer.index,
         metadata=indexer_action_metadata(
-            name=name,
-            options=IndexerOptions(label=name),
+            name,
+            label=name,
         ).metadata,
     )
 

--- a/py/plugins/firebase/src/genkit/plugins/firebase/firestore.py
+++ b/py/plugins/firebase/src/genkit/plugins/firebase/firestore.py
@@ -24,7 +24,7 @@ from google.cloud.firestore_v1 import DocumentSnapshot
 from google.cloud.firestore_v1.base_vector_query import DistanceMeasure
 
 from genkit.ai import Genkit
-from genkit.blocks.retriever import RetrieverOptions, retriever_action_metadata
+from genkit.blocks.retriever import retriever_action_metadata
 from genkit.core.action.types import ActionKind
 from genkit.core.typing import DocumentPart
 from genkit.plugins.firebase.retriever import FirestoreRetriever
@@ -95,8 +95,8 @@ def define_firestore_vector_store(
         name=action_name,
         fn=retriever.retrieve,
         metadata=retriever_action_metadata(
-            name=action_name,
-            options=RetrieverOptions(label=name),
+            action_name,
+            label=name,
         ).metadata,
     )
 

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -104,7 +104,7 @@ import genkit.plugins.google_genai.constants as const
 from genkit.ai import GENKIT_CLIENT_HEADER, Plugin
 from genkit.blocks.background_model import BackgroundAction
 from genkit.blocks.document import Document
-from genkit.blocks.embedding import EmbedderOptions, EmbedderSupports, embedder_action_metadata
+from genkit.blocks.embedding import EmbedderSupports, embedder_action_metadata
 from genkit.blocks.model import model_action_metadata
 from genkit.blocks.reranker import reranker_action_metadata
 from genkit.core.action import Action, ActionMetadata
@@ -293,12 +293,10 @@ def _create_embedder_action(name: str, client: genai.Client, plugin_name: str) -
     embedder_info = default_embedder_info(clean_name)
 
     action_metadata = embedder_action_metadata(
-        name=name,
-        options=EmbedderOptions(
-            label=embedder_info.get('label'),
-            supports=EmbedderSupports(input=embedder_info.get('supports', {}).get('input')),
-            dimensions=embedder_info.get('dimensions'),
-        ),
+        name,
+        label=embedder_info.get('label'),
+        supports=EmbedderSupports(input=embedder_info.get('supports', {}).get('input')),
+        dimensions=embedder_info.get('dimensions'),
     )
 
     action = Action(
@@ -642,12 +640,10 @@ class GoogleAI(Plugin):
             embed_info = default_embedder_info(name)
             actions_list.append(
                 embedder_action_metadata(
-                    name=googleai_name(name),
-                    options=EmbedderOptions(
-                        label=embed_info.get('label'),
-                        supports=EmbedderSupports(input=embed_info.get('supports', {}).get('input')),
-                        dimensions=embed_info.get('dimensions'),
-                    ),
+                    googleai_name(name),
+                    label=embed_info.get('label'),
+                    supports=EmbedderSupports(input=embed_info.get('supports', {}).get('input')),
+                    dimensions=embed_info.get('dimensions'),
                 )
             )
 
@@ -991,7 +987,7 @@ class VertexAI(Plugin):
 
             return RerankerResponse(documents=response_docs)
 
-        metadata = reranker_action_metadata(name)
+        metadata = reranker_action_metadata(name, label=name)
 
         return Action(
             kind=ActionKind.RERANKER,
@@ -1044,12 +1040,10 @@ class VertexAI(Plugin):
             embed_info = default_embedder_info(name)
             actions_list.append(
                 embedder_action_metadata(
-                    name=vertexai_name(name),
-                    options=EmbedderOptions(
-                        label=embed_info.get('label'),
-                        supports=EmbedderSupports(input=embed_info.get('supports', {}).get('input')),
-                        dimensions=embed_info.get('dimensions'),
-                    ),
+                    vertexai_name(name),
+                    label=embed_info.get('label'),
+                    supports=EmbedderSupports(input=embed_info.get('supports', {}).get('input')),
+                    dimensions=embed_info.get('dimensions'),
                 )
             )
 

--- a/py/plugins/microsoft-foundry/src/genkit/plugins/microsoft_foundry/plugin.py
+++ b/py/plugins/microsoft-foundry/src/genkit/plugins/microsoft_foundry/plugin.py
@@ -125,7 +125,7 @@ import httpx
 from openai import APIError, AsyncAzureOpenAI, AsyncOpenAI
 
 from genkit.ai import Plugin
-from genkit.blocks.embedding import EmbedderOptions, EmbedderSupports, embedder_action_metadata
+from genkit.blocks.embedding import EmbedderSupports, embedder_action_metadata
 from genkit.blocks.model import model_action_metadata
 from genkit.core.action import Action, ActionMetadata
 from genkit.core.logging import get_logger
@@ -717,12 +717,10 @@ class MicrosoftFoundry(Plugin):
             name=name,
             fn=embed_fn,
             metadata=embedder_action_metadata(
-                name=name,
-                options=EmbedderOptions(
-                    label=embedder_info['label'],
-                    supports=EmbedderSupports(input=embedder_info['supports']['input']),
-                    dimensions=embedder_info.get('dimensions'),
-                ),
+                name,
+                label=embedder_info['label'],
+                supports=EmbedderSupports(input=embedder_info['supports']['input']),
+                dimensions=embedder_info.get('dimensions'),
             ).metadata,
         )
 
@@ -764,12 +762,10 @@ class MicrosoftFoundry(Plugin):
                     )
                     actions.append(
                         embedder_action_metadata(
-                            name=microsoft_foundry_name(model_id),
-                            options=EmbedderOptions(
-                                label=embed_info['label'],
-                                supports=EmbedderSupports(input=embed_info['supports']['input']),
-                                dimensions=embed_info.get('dimensions'),
-                            ),
+                            microsoft_foundry_name(model_id),
+                            label=embed_info['label'],
+                            supports=EmbedderSupports(input=embed_info['supports']['input']),
+                            dimensions=embed_info.get('dimensions'),
                         )
                     )
         else:
@@ -788,12 +784,10 @@ class MicrosoftFoundry(Plugin):
             for embed_name, embed_info in SUPPORTED_EMBEDDING_MODELS.items():
                 actions.append(
                     embedder_action_metadata(
-                        name=microsoft_foundry_name(embed_name),
-                        options=EmbedderOptions(
-                            label=embed_info['label'],
-                            supports=EmbedderSupports(input=embed_info['supports']['input']),
-                            dimensions=embed_info.get('dimensions'),
-                        ),
+                        microsoft_foundry_name(embed_name),
+                        label=embed_info['label'],
+                        supports=EmbedderSupports(input=embed_info['supports']['input']),
+                        dimensions=embed_info.get('dimensions'),
                     )
                 )
 

--- a/py/plugins/mistral/src/genkit/plugins/mistral/plugin.py
+++ b/py/plugins/mistral/src/genkit/plugins/mistral/plugin.py
@@ -27,7 +27,6 @@ from mistralai import Mistral as MistralClient
 
 from genkit.ai import Plugin
 from genkit.blocks.embedding import (
-    EmbedderOptions,
     EmbedderSupports,
     EmbedRequest,
     EmbedResponse,
@@ -217,12 +216,10 @@ class Mistral(Plugin):
             name=name,
             fn=embed_fn,
             metadata=embedder_action_metadata(
-                name=name,
-                options=EmbedderOptions(
-                    label=embedder_info['label'],
-                    supports=EmbedderSupports(input=embedder_info['supports']['input']),
-                    dimensions=embedder_info.get('dimensions'),
-                ),
+                name,
+                label=embedder_info['label'],
+                supports=EmbedderSupports(input=embedder_info['supports']['input']),
+                dimensions=embedder_info.get('dimensions'),
             ).metadata,
         )
 
@@ -248,12 +245,10 @@ class Mistral(Plugin):
         for embed_model, embed_info in SUPPORTED_EMBEDDING_MODELS.items():
             actions_list.append(
                 embedder_action_metadata(
-                    name=mistral_name(embed_model),
-                    options=EmbedderOptions(
-                        label=embed_info['label'],
-                        supports=EmbedderSupports(input=embed_info['supports']['input']),
-                        dimensions=embed_info.get('dimensions'),
-                    ),
+                    mistral_name(embed_model),
+                    label=embed_info['label'],
+                    supports=EmbedderSupports(input=embed_info['supports']['input']),
+                    dimensions=embed_info.get('dimensions'),
                 )
             )
 

--- a/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
@@ -22,7 +22,7 @@ import structlog
 
 import ollama as ollama_api
 from genkit.ai import Plugin
-from genkit.blocks.embedding import EmbedderOptions, EmbedderSupports, embedder_action_metadata
+from genkit.blocks.embedding import EmbedderSupports, embedder_action_metadata
 from genkit.blocks.model import model_action_metadata
 from genkit.core.action import Action, ActionMetadata
 from genkit.core.registry import ActionKind
@@ -229,12 +229,10 @@ class Ollama(Plugin):
             if 'embed' in name:
                 actions.append(
                     embedder_action_metadata(
-                        name=ollama_name(name),
-                        options=EmbedderOptions(
-                            config_schema=to_json_schema(ollama_api.Options),
-                            label=f'Ollama Embedding - {name}',
-                            supports=EmbedderSupports(input=['text']),
-                        ),
+                        ollama_name(name),
+                        config_schema=to_json_schema(ollama_api.Options),
+                        label=f'Ollama Embedding - {name}',
+                        supports=EmbedderSupports(input=['text']),
                     )
                 )
             else:

--- a/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/vector_search.py
+++ b/py/plugins/vertex-ai/src/genkit/plugins/vertex_ai/vector_search.py
@@ -37,7 +37,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from genkit.ai import Genkit
 from genkit.blocks.document import Document
-from genkit.blocks.retriever import RetrieverOptions, retriever_action_metadata
+from genkit.blocks.retriever import retriever_action_metadata
 from genkit.core.action.types import ActionKind
 from genkit.core.schema import to_json_schema
 from genkit.core.typing import (
@@ -446,11 +446,9 @@ def define_vertex_vector_search_big_query(
         name=name,
         fn=retriever.retrieve,
         metadata=retriever_action_metadata(
-            name=name,
-            options=RetrieverOptions(
-                label=name,
-                config_schema=to_json_schema(RetrieverOptionsSchema),
-            ),
+            name,
+            label=name,
+            config_schema=to_json_schema(RetrieverOptionsSchema),
         ).metadata,
     )
 
@@ -500,11 +498,9 @@ def define_vertex_vector_search_firestore(
         name=name,
         fn=retriever.retrieve,
         metadata=retriever_action_metadata(
-            name=name,
-            options=RetrieverOptions(
-                label=name,
-                config_schema=to_json_schema(RetrieverOptionsSchema),
-            ),
+            name,
+            label=name,
+            config_schema=to_json_schema(RetrieverOptionsSchema),
         ).metadata,
     )
 


### PR DESCRIPTION
## Summary

Removes eight Options wrapper classes (`EmbedderOptions`, `RetrieverOptions`, `IndexerOptions`, `RerankerOptions`, `ResourceOptions`, `SimpleRetrieverOptions`, `DapCacheConfig`, `DefineBackgroundModelOptions`) and replaces them with explicit keyword arguments directly on the relevant `define_*` / metadata-helper functions.

### Motivation

The options objects were thin wrappers that added indirection without value. Callers now pass kwargs directly, which is more Pythonic, easier to discover via IDE auto-complete, and reduces the public API surface.

### Changes

**Core blocks (`py/packages/genkit/src/genkit/blocks/`)**

| File | What changed |
|------|-------------|
| `embedding.py` | Removed `EmbedderOptions`; `embedder_action_metadata` now takes `*, config_schema, label, supports, dimensions` |
| `retriever.py` | Removed `RetrieverOptions`, `IndexerOptions`; `retriever_action_metadata`, `indexer_action_metadata`, `define_retriever`, `define_indexer` all take `*, config_schema, label, supports` |
| `reranker.py` | Removed `RerankerOptions`; `reranker_action_metadata` and `define_reranker` take `*, config_schema, label, supports` |
| `resource.py` | Removed `ResourceOptions` TypedDict; `define_resource`, `resource`, `dynamic_resource` take `fn, *, name, uri, template, description, metadata` |
| `dap.py` | Collapsed `DapCacheConfig` into `DapConfig.cache_ttl_millis`; removed `DapCacheConfig` from `__all__` |
| `background_model.py` | Removed dead `DefineBackgroundModelOptions` class |

**Registry (`py/packages/genkit/src/genkit/ai/_registry.py`)**

- Removed `SimpleRetrieverOptions` class
- `define_simple_retriever(name, handler, *, content, metadata, config_schema, description)`
- `define_embedder(name, fn, *, config_schema, label, supports, dimensions, metadata, description)`
- `define_reranker(name, fn, *, config_schema, label, supports, description)`
- `define_resource(fn, *, name, uri, template, description, metadata)`
- Removed `SimpleRetrieverOptions` from `genkit.__init__` and `genkit.ai.__init__` exports

**Plugin callers updated**

| Plugin | Method(s) updated |
|--------|-------------------|
| `ollama` | `embedder_action_metadata` |
| `compat-oai` | `embedder_action_metadata` (×2) |
| `google-genai` | `embedder_action_metadata` (×3), `reranker_action_metadata` |
| `amazon-bedrock` | `embedder_action_metadata` (×2) |
| `mistral` | `embedder_action_metadata` (×2) |
| `microsoft-foundry` | `embedder_action_metadata` (×3) |
| `vertex-ai` | `retriever_action_metadata` (×2) |
| `dev-local-vectorstore` | `retriever_action_metadata`, `indexer_action_metadata` |
| `firebase` | `retriever_action_metadata` |

## Migration

```python
# Before
define_embedder(
    name="my-embedder",
    fn=embed_fn,
    options=EmbedderOptions(label="My Embedder", dimensions=1536),
)

# After
define_embedder(
    name="my-embedder",
    fn=embed_fn,
    label="My Embedder",
    dimensions=1536,
)
```

```python
# Before (DapConfig)
DapConfig(cache_config=DapCacheConfig(ttl_millis=60_000))

# After
DapConfig(cache_ttl_millis=60_000)
```