### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/scripts/cli-releases/promote_cli_gcs.sh
+++ b/scripts/cli-releases/promote_cli_gcs.sh
@@ -199,7 +199,7 @@ for platform in "${PLATFORMS[@]}"; do
 
   # Check if versioned file already exists.
   if [[ "$DRY_RUN" == "false" ]]; then
-    if gsutil -q stat "$versioned_path"; then
+    if gcloud storage objects list --stat --fetch-encrypted-object-hashes "$versioned_path" >/dev/null 2>&1; then
       echo "Version $VERSION for $platform already exists in GCS, skipping upload."
       continue
     fi
@@ -208,7 +208,7 @@ for platform in "${PLATFORMS[@]}"; do
   # Upload versioned binary
   echo "Uploading $source_file to $versioned_path"
   if [[ "$DRY_RUN" == "false" ]]; then
-    gsutil -h "Cache-Control:public, max-age=3600" cp "$source_file" "$versioned_path"
+    gcloud storage cp --cache-control="public, max-age=3600" "$source_file" "$versioned_path"
   else
     echo "[DRY RUN] Would upload to: $versioned_path"
   fi
@@ -217,7 +217,7 @@ for platform in "${PLATFORMS[@]}"; do
   latest_path="gs://$BUCKET/$CHANNEL/$platform/$latest_name"
   echo "Copying to $latest_path"
   if [[ "$DRY_RUN" == "false" ]]; then
-    gsutil -h "Cache-Control:public, max-age=300" cp "$source_file" "$latest_path"
+    gcloud storage cp --cache-control="public, max-age=300" "$source_file" "$latest_path"
   else
     echo "[DRY RUN] Would copy to: $latest_path (overwriting)"
   fi


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
