### PR TITLE
feat(js): typed context

### DIFF
--- a/js/ai/src/tool.ts
+++ b/js/ai/src/tool.ts
@@ -22,7 +22,6 @@ import {
   stripUndefinedProps,
   z,
   type Action,
-  type ActionContext,
   type ActionRunOptions,
   type JSONSchema7,
 } from '@genkit-ai/core';
@@ -280,38 +279,56 @@ export function toToolDefinition(
   return out;
 }
 
-export interface ToolFnOptions extends ActionFnArg<never> {
+/**
+ * Options passed to tool callbacks. Context is typed as C & ActionContext when using defineTool with a typed Genkit instance (genkit<AppContext>()).
+ */
+export interface ToolFnOptions<C extends object = object>
+  extends ActionFnArg<never, C> {
   /**
    * A function that can be called during tool execution that will result in the tool
    * getting interrupted (immediately) and tool request returned to the upstream caller.
    */
   interrupt: (metadata?: Record<string, any>) => never;
-
-  context: ActionContext;
 }
 
-export type ToolFn<I extends z.ZodTypeAny, O extends z.ZodTypeAny> = (
+export type ToolFn<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+> = (
   input: z.infer<I>,
-  ctx: ToolFnOptions & ToolRunOptions
+  ctx: ToolFnOptions<C> & ToolRunOptions
 ) => Promise<z.infer<O>>;
 
-export type MultipartToolFn<I extends z.ZodTypeAny, O extends z.ZodTypeAny> = (
+export type MultipartToolFn<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+> = (
   input: z.infer<I>,
-  ctx: ToolFnOptions & ToolRunOptions
+  ctx: ToolFnOptions<C> & ToolRunOptions
 ) => Promise<{
   output?: z.infer<O>;
   content?: Part[];
 }>;
 
-export function defineTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
+export function defineTool<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+>(
   registry: Registry,
   config: { multipart: true } & ToolConfig<I, O>,
-  fn?: ToolFn<I, O>
+  fn?: ToolFn<I, O, C>
 ): MultipartToolAction<I, O>;
-export function defineTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
+export function defineTool<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+>(
   registry: Registry,
   config: ToolConfig<I, O>,
-  fn?: ToolFn<I, O>
+  fn?: ToolFn<I, O, C>
 ): ToolAction<I, O>;
 
 /**
@@ -319,17 +336,24 @@ export function defineTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
  *
  * A tool is an action that can be passed to a model to be called automatically if it so chooses.
  */
-export function defineTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
+export function defineTool<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+>(
   registry: Registry,
   config: { multipart?: true } & ToolConfig<I, O>,
-  fn?: ToolFn<I, O> | MultipartToolFn<I, O>
+  fn?: ToolFn<I, O, C> | MultipartToolFn<I, O, C>
 ): ToolAction<I, O> | MultipartToolAction<I, O> {
   const a = tool(config, fn);
   delete a.__action.metadata.dynamic;
   registry.registerAction(config.multipart ? 'tool.v2' : 'tool', a);
   if (!config.multipart) {
     // For non-multipart tools, we register a v2 tool action as well
-    registry.registerAction('tool.v2', basicToolV2(config, fn as ToolFn<I, O>));
+    registry.registerAction(
+      'tool.v2',
+      basicToolV2(config, fn as ToolFn<I, O, C>)
+    );
   }
   return a as ToolAction<I, O>;
 }
@@ -469,30 +493,40 @@ function interruptTool(registry?: Registry) {
   };
 }
 
-export function tool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
+export function tool<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+>(
   config: { multipart: true } & ToolConfig<I, O>,
-  fn?: ToolFn<I, O>
+  fn?: ToolFn<I, O, C>
 ): MultipartToolAction<I, O>;
-export function tool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
-  config: ToolConfig<I, O>,
-  fn?: ToolFn<I, O>
-): ToolAction<I, O>;
+export function tool<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+>(config: ToolConfig<I, O>, fn?: ToolFn<I, O, C>): ToolAction<I, O>;
 
 /**
  * Defines a dynamic tool. Dynamic tools are just like regular tools but will not be registered in the
  * Genkit registry and can be defined dynamically at runtime.
  */
-export function tool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
+export function tool<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+>(
   config: { multipart?: true } & ToolConfig<I, O>,
-  fn?: ToolFn<I, O> | MultipartToolFn<I, O>
+  fn?: ToolFn<I, O, C> | MultipartToolFn<I, O, C>
 ): ToolAction<I, O> | MultipartToolAction<I, O> {
   return config.multipart ? multipartTool(config, fn) : basicTool(config, fn);
 }
 
-function basicTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
-  config: ToolConfig<I, O>,
-  fn?: ToolFn<I, O>
-): ToolAction<I, O> {
+function basicTool<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+>(config: ToolConfig<I, O>, fn?: ToolFn<I, O, C>): ToolAction<I, O> {
   const a = action(
     {
       ...config,
@@ -506,7 +540,7 @@ function basicTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
           ...runOptions,
           context: { ...runOptions.context },
           interrupt,
-        });
+        } as unknown as ToolFnOptions<C> & ToolRunOptions);
       }
       return interrupt();
     }
@@ -515,24 +549,32 @@ function basicTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
   return a;
 }
 
-function basicToolV2<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
-  config: ToolConfig<I, O>,
-  fn?: ToolFn<I, O>
-): MultipartToolAction<I, O> {
+function basicToolV2<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+>(config: ToolConfig<I, O>, fn?: ToolFn<I, O, C>): MultipartToolAction<I, O> {
   return multipartTool(config, async (input, ctx) => {
     if (!fn) {
       const interrupt = interruptTool(ctx.registry);
       return interrupt();
     }
     return {
-      output: await fn(input, ctx),
+      output: await fn(
+        input,
+        ctx as unknown as ToolFnOptions<C> & ToolRunOptions
+      ),
     };
   });
 }
 
-function multipartTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
+function multipartTool<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+>(
   config: ToolConfig<I, O>,
-  fn?: MultipartToolFn<I, O>
+  fn?: MultipartToolFn<I, O, C>
 ): MultipartToolAction<I, O> {
   const a = action(
     {
@@ -553,7 +595,7 @@ function multipartTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
           ...runOptions,
           context: { ...runOptions.context },
           interrupt,
-        });
+        } as unknown as ToolFnOptions<C> & ToolRunOptions);
       }
       return interrupt() as any; // we cast to any because `interrupt` throws.
     }
@@ -568,10 +610,11 @@ function multipartTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
  *
  * @deprecated renamed to {@link tool}.
  */
-export function dynamicTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
-  config: ToolConfig<I, O>,
-  fn?: ToolFn<I, O>
-): DynamicToolAction<I, O> {
+export function dynamicTool<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
+>(config: ToolConfig<I, O>, fn?: ToolFn<I, O, C>): DynamicToolAction<I, O> {
   const t = basicTool(config, fn) as DynamicToolAction<I, O>;
   t.attach = (_: Registry) => t;
   return t;

--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -120,8 +120,9 @@ export interface ActionRunOptions<S> {
 
 /**
  * Options (side channel) data to pass to the model.
+ * @template C - Your app's context shape; ActionContext (auth, etc.) is merged in automatically, so you only declare your own fields.
  */
-export interface ActionFnArg<S> {
+export interface ActionFnArg<S, C extends object = object> {
   /**
    * Whether the caller of the action requested streaming.
    */
@@ -133,9 +134,9 @@ export interface ActionFnArg<S> {
   sendChunk: StreamingCallback<S>;
 
   /**
-   * Additional runtime context data (ex. auth context data).
+   * Runtime context (always set when the action runs). Typed as C & ActionContext so auth and other built-in context are always available.
    */
-  context?: ActionContext;
+  context: C & ActionContext;
 
   /**
    * Trace context containing trace and span IDs.

--- a/js/core/src/context.ts
+++ b/js/core/src/context.ts
@@ -21,7 +21,7 @@ import { UserFacingError } from './error.js';
 const contextAlsKey = 'core.auth.context';
 
 /**
- * Action side channel data, like auth and other invocation context infromation provided by the invoker.
+ * Action side channel data, like auth and other invocation context information provided by the invoker.
  */
 export interface ActionContext {
   /** Information about the currently authenticated user if provided. */

--- a/js/core/src/flow.ts
+++ b/js/core/src/flow.ts
@@ -16,6 +16,7 @@
 
 import type { z } from 'zod';
 import { ActionFnArg, action, type Action } from './action.js';
+import type { ActionContext } from './context.js';
 import { Registry, type HasRegistry } from './registry.js';
 import { SPAN_TYPE_ATTR, runInNewSpan } from './tracing.js';
 
@@ -53,22 +54,25 @@ export interface FlowConfig<
  * side-channel context data. The context itself is a function, a short-cut
  * for streaming callback.
  */
-export interface FlowSideChannel<S> extends ActionFnArg<S> {
+export interface FlowSideChannel<S, C extends object = object>
+  extends ActionFnArg<S, C> {
   (chunk: S): void;
 }
 
 /**
  * Function to be executed in the flow.
+ * @template C - Your app's context shape; ActionContext is merged in automatically in the callback's context.
  */
 export type FlowFn<
   I extends z.ZodTypeAny = z.ZodTypeAny,
   O extends z.ZodTypeAny = z.ZodTypeAny,
   S extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
 > = (
   /** Input to the flow. */
   input: z.infer<I>,
   /** Callback for streaming functions only. */
-  streamingCallback: FlowSideChannel<z.infer<S>>
+  streamingCallback: FlowSideChannel<z.infer<S>, C>
 ) => Promise<z.infer<O>> | z.infer<O>;
 
 /**
@@ -78,7 +82,8 @@ export function flow<
   I extends z.ZodTypeAny = z.ZodTypeAny,
   O extends z.ZodTypeAny = z.ZodTypeAny,
   S extends z.ZodTypeAny = z.ZodTypeAny,
->(config: FlowConfig<I, O, S> | string, fn: FlowFn<I, O, S>): Flow<I, O, S> {
+  C extends object = object,
+>(config: FlowConfig<I, O, S> | string, fn: FlowFn<I, O, S, C>): Flow<I, O, S> {
   const resolvedConfig: FlowConfig<I, O, S> =
     typeof config === 'string' ? { name: config } : config;
 
@@ -92,10 +97,11 @@ export function defineFlow<
   I extends z.ZodTypeAny = z.ZodTypeAny,
   O extends z.ZodTypeAny = z.ZodTypeAny,
   S extends z.ZodTypeAny = z.ZodTypeAny,
+  C extends object = object,
 >(
   registry: Registry,
   config: FlowConfig<I, O, S> | string,
-  fn: FlowFn<I, O, S>
+  fn: FlowFn<I, O, S, C>
 ): Flow<I, O, S> {
   const f = flow(config, fn);
 
@@ -111,7 +117,8 @@ function flowAction<
   I extends z.ZodTypeAny = z.ZodTypeAny,
   O extends z.ZodTypeAny = z.ZodTypeAny,
   S extends z.ZodTypeAny = z.ZodTypeAny,
->(config: FlowConfig<I, O, S>, fn: FlowFn<I, O, S>): Flow<I, O, S> {
+  C extends object = object,
+>(config: FlowConfig<I, O, S>, fn: FlowFn<I, O, S, C>): Flow<I, O, S> {
   return action(
     {
       actionType: 'flow',
@@ -126,13 +133,14 @@ function flowAction<
       { sendChunk, context, trace, abortSignal, streamingRequested }
     ) => {
       const ctx = sendChunk;
-      (ctx as FlowSideChannel<z.infer<S>>).sendChunk = sendChunk;
-      (ctx as FlowSideChannel<z.infer<S>>).context = context;
-      (ctx as FlowSideChannel<z.infer<S>>).trace = trace;
-      (ctx as FlowSideChannel<z.infer<S>>).abortSignal = abortSignal;
-      (ctx as FlowSideChannel<z.infer<S>>).streamingRequested =
+      (ctx as FlowSideChannel<z.infer<S>, C>).sendChunk = sendChunk;
+      (ctx as FlowSideChannel<z.infer<S>, C>).context = context as C &
+        ActionContext;
+      (ctx as FlowSideChannel<z.infer<S>, C>).trace = trace;
+      (ctx as FlowSideChannel<z.infer<S>, C>).abortSignal = abortSignal;
+      (ctx as FlowSideChannel<z.infer<S>, C>).streamingRequested =
         streamingRequested;
-      return fn(input, ctx as FlowSideChannel<z.infer<S>>);
+      return fn(input, ctx as FlowSideChannel<z.infer<S>, C>);
     }
   );
 }

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -156,16 +156,18 @@ export type PromptFn<
 
 /**
  * Options for initializing Genkit.
+ * When using genkit<AppContext>(), pass options that extend GenkitOptions<AppContext> so context is type-checked.
+ * Your C is merged with ActionContext (auth, etc.) in flow/tool callbacks — you only declare your own fields.
  */
-export interface GenkitOptions {
+export interface GenkitOptions<C extends object = object> {
   /** List of plugins to load. */
   plugins?: (GenkitPlugin | GenkitPluginV2)[];
   /** Directory where dotprompts are stored. */
   promptDir?: string;
   /** Default model to use if no model is specified. */
   model?: ModelArgument<any>;
-  /** Additional runtime context data for flows and tools. */
-  context?: ActionContext;
+  /** Additional runtime context data for flows and tools. Must match C when using genkit<C>(). */
+  context?: C;
   /** Display name that will be shown in developer tooling. */
   name?: string;
   /** Additional attribution information to include in the x-goog-api-client header. */
@@ -180,10 +182,12 @@ export interface GenkitOptions {
  * Registry keeps track of actions, flows, tools, and many other components. Reflection server exposes an API to inspect the registry and trigger executions of actions in the registry. Flow server exposes flows as HTTP endpoints for production use.
  *
  * There may be multiple Genkit instances in a single codebase.
+ *
+ * @template C - App context type for flow/tool callbacks and {@link currentContext}. Pass when calling {@link genkit}, e.g. `genkit<AppContext>({})`, so `context` is typed in all flows and tools without passing a type param each time.
  */
-export class Genkit implements HasRegistry {
+export class Genkit<C extends object = object> implements HasRegistry {
   /** Developer-configured options. */
-  readonly options: GenkitOptions;
+  readonly options: GenkitOptions<C>;
   /** Registry instance that is exclusively modified by this Genkit instance. */
   readonly registry: Registry;
   /** Reflection server for this registry. May be null if not started. */
@@ -195,7 +199,7 @@ export class Genkit implements HasRegistry {
     return this.registry.apiStability;
   }
 
-  constructor(options?: GenkitOptions) {
+  constructor(options?: GenkitOptions<C>) {
     this.options = options || {};
     this.registry = new Registry();
     if (this.options.context) {
@@ -216,6 +220,7 @@ export class Genkit implements HasRegistry {
 
   /**
    * Defines and registers a flow function.
+   * Context in the callback is typed from the instance's context type (from `genkit<AppContext>({})`).
    */
   defineFlow<
     I extends z.ZodTypeAny = z.ZodTypeAny,
@@ -223,7 +228,7 @@ export class Genkit implements HasRegistry {
     S extends z.ZodTypeAny = z.ZodTypeAny,
   >(
     config: FlowConfig<I, O, S> | string,
-    fn: FlowFn<I, O, S>
+    fn: FlowFn<I, O, S, C>
   ): Action<I, O, S> {
     const flow = defineFlow(this.registry, config, fn);
     this.flows.push(flow);
@@ -234,25 +239,27 @@ export class Genkit implements HasRegistry {
    * Defines and registers a tool that can return multiple parts of content.
    *
    * Tools can be passed to models by name or value during `generate` calls to be called automatically based on the prompt and situation.
+   * Context in the callback is typed from the instance (genkit<AppContext>()).
    */
   defineTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
     config: { multipart: true } & ToolConfig<I, O>,
-    fn: MultipartToolFn<I, O>
+    fn: MultipartToolFn<I, O, C>
   ): MultipartToolAction<I, O>;
 
   /**
    * Defines and registers a tool.
    *
    * Tools can be passed to models by name or value during `generate` calls to be called automatically based on the prompt and situation.
+   * Context in the callback is typed from the instance (genkit<AppContext>()).
    */
   defineTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
     config: ToolConfig<I, O>,
-    fn: ToolFn<I, O>
+    fn: ToolFn<I, O, C>
   ): ToolAction<I, O>;
 
   defineTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
     config: ({ multipart?: true } & ToolConfig<I, O>) | string,
-    fn: ToolFn<I, O> | MultipartToolFn<I, O>
+    fn: ToolFn<I, O, C> | MultipartToolFn<I, O, C>
   ): ToolAction<I, O> | MultipartToolAction<I, O> {
     return defineTool(this.registry, config as any, fn as any);
   }
@@ -263,7 +270,7 @@ export class Genkit implements HasRegistry {
    */
   dynamicTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
     config: ToolConfig<I, O>,
-    fn?: ToolFn<I, O>
+    fn?: ToolFn<I, O, C>
   ): ToolAction<I, O> {
     return dynamicTool(config, fn) as ToolAction<I, O>;
   }
@@ -298,6 +305,7 @@ export class Genkit implements HasRegistry {
 
   /**
    * Defines a new model and adds it to the registry.
+   * The runner's options.context is typed from the instance (genkit<AppContext>()).
    */
   defineModel<CustomOptionsSchema extends z.ZodTypeAny = z.ZodTypeAny>(
     options: {
@@ -305,7 +313,7 @@ export class Genkit implements HasRegistry {
     } & DefineModelOptions<CustomOptionsSchema>,
     runner: (
       request: GenerateRequest<CustomOptionsSchema>,
-      options: ActionFnArg<GenerateResponseChunkData>
+      options: ActionFnArg<GenerateResponseChunkData, C>
     ) => Promise<GenerateResponseData>
   ): ModelAction<CustomOptionsSchema>;
 
@@ -740,8 +748,14 @@ export class Genkit implements HasRegistry {
     CustomOptions extends z.ZodTypeAny = typeof GenerationCommonConfigSchema,
   >(
     opts:
-      | GenerateOptions<O, CustomOptions>
-      | PromiseLike<GenerateOptions<O, CustomOptions>>
+      | (Omit<GenerateOptions<O, CustomOptions>, 'context'> & {
+          context?: C & ActionContext;
+        })
+      | PromiseLike<
+          Omit<GenerateOptions<O, CustomOptions>, 'context'> & {
+            context?: C & ActionContext;
+          }
+        >
   ): Promise<GenerateResponse<z.infer<O>>>;
 
   async generate<
@@ -751,8 +765,14 @@ export class Genkit implements HasRegistry {
     options:
       | string
       | Part[]
-      | GenerateOptions<O, CustomOptions>
-      | PromiseLike<GenerateOptions<O, CustomOptions>>
+      | (Omit<GenerateOptions<O, CustomOptions>, 'context'> & {
+          context?: C & ActionContext;
+        })
+      | PromiseLike<
+          Omit<GenerateOptions<O, CustomOptions>, 'context'> & {
+            context?: C & ActionContext;
+          }
+        >
   ): Promise<GenerateResponse<z.infer<O>>> {
     let resolvedOptions: GenerateOptions<O, CustomOptions>;
     if (options instanceof Promise) {
@@ -844,8 +864,14 @@ export class Genkit implements HasRegistry {
     CustomOptions extends z.ZodTypeAny = typeof GenerationCommonConfigSchema,
   >(
     parts:
-      | GenerateOptions<O, CustomOptions>
-      | PromiseLike<GenerateOptions<O, CustomOptions>>
+      | (Omit<GenerateOptions<O, CustomOptions>, 'context'> & {
+          context?: C & ActionContext;
+        })
+      | PromiseLike<
+          Omit<GenerateOptions<O, CustomOptions>, 'context'> & {
+            context?: C & ActionContext;
+          }
+        >
   ): GenerateStreamResponse<z.infer<O>>;
 
   generateStream<
@@ -855,8 +881,14 @@ export class Genkit implements HasRegistry {
     options:
       | string
       | Part[]
-      | GenerateStreamOptions<O, CustomOptions>
-      | PromiseLike<GenerateStreamOptions<O, CustomOptions>>
+      | (Omit<GenerateStreamOptions<O, CustomOptions>, 'context'> & {
+          context?: C & ActionContext;
+        })
+      | PromiseLike<
+          Omit<GenerateStreamOptions<O, CustomOptions>, 'context'> & {
+            context?: C & ActionContext;
+          }
+        >
   ): GenerateStreamResponse<z.infer<O>> {
     if (typeof options === 'string' || Array.isArray(options)) {
       options = { prompt: options };
@@ -949,8 +981,8 @@ export class Genkit implements HasRegistry {
    * data set by HTTP server frameworks. If invoked outside of an action (e.g. flow or tool) will
    * return `undefined`.
    */
-  currentContext(): ActionContext | undefined {
-    return getContext();
+  currentContext(): (C & ActionContext) | undefined {
+    return getContext() as (C & ActionContext) | undefined;
   }
 
   /**
@@ -1080,9 +1112,15 @@ function registerActionV2(
  *
  * This will create a new Genkit registry, register the provided plugins, stores, and other configuration. This
  * should be called before any flows are registered.
+ *
+ * Pass your app's context type for typed `context` in flow/tool callbacks and {@link Genkit.currentContext}, e.g.
+ * `const ai = genkit<AppContext>({})`. If you omit the type argument, context in flows/tools is inferred as
+ * {@link ActionContext} and properties like context.hello are typed as `any` (no type safety).
  */
-export function genkit(options: GenkitOptions): Genkit {
-  return new Genkit(options);
+export function genkit<C extends object = object>(
+  options?: GenkitOptions<C>
+): Genkit<C> {
+  return new Genkit<C>(options);
 }
 
 const shutdown = async () => {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -1886,6 +1886,19 @@ importers:
         specifier: ^5.3.3
         version: 5.8.3
 
+  testapps/typed-context:
+    dependencies:
+      genkit:
+        specifier: workspace:*
+        version: link:../../genkit
+    devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
   testapps/vertexai-modelgarden:
     dependencies:
       '@genkit-ai/firebase':

--- a/js/testapps/typed-context/README.md
+++ b/js/testapps/typed-context/README.md
@@ -1,0 +1,78 @@
+# Express Integration
+
+Demonstrates integrating Genkit flows with an Express.js server — including
+authentication context, streaming responses, and the `expressHandler` utility.
+
+## Features Demonstrated
+
+| Feature | Endpoint | Description |
+|---------|----------|-------------|
+| Flow via `expressHandler` | `POST /jokeFlow` | Genkit flow exposed via Express with auth context |
+| Flow handler (no auth) | `POST /jokeHandler` | Flow exposed without auth validation |
+| Direct flow invocation | `GET /jokeWithFlow` | Call a flow directly from a route handler |
+| Raw streaming | `GET /jokeStream` | Chunked transfer encoding with `ai.generate` |
+| Auth context | `Authorization` header | Token-based auth with context validation |
+| Context providers | `auth()` factory | Reusable auth context provider pattern |
+
+## Setup
+
+### Prerequisites
+
+- **Node.js** (v18 or higher)
+- **pnpm** package manager
+
+### API Keys
+
+```bash
+export GEMINI_API_KEY='<your-api-key>'
+```
+
+### Build and Install
+
+From the repo root:
+
+```bash
+pnpm install
+pnpm run setup
+```
+
+## Run the Sample
+
+```bash
+pnpm build && pnpm start
+```
+
+The Express server starts on port `5000` (or `$PORT`).
+
+## Testing This Demo
+
+1. **Test with auth** (requires `Authorization: open sesame` header):
+   ```bash
+   curl http://localhost:5000/jokeFlow?stream=true \
+     -d '{"data": "banana"}' \
+     -H "Content-Type: application/json" \
+     -H "Authorization: open sesame"
+   ```
+
+2. **Test without auth**:
+   ```bash
+   curl http://localhost:5000/jokeHandler?stream=true \
+     -d '{"data": "banana"}' \
+     -H "Content-Type: application/json"
+   ```
+
+3. **Test direct flow invocation**:
+   ```bash
+   curl "http://localhost:5000/jokeWithFlow?subject=banana"
+   ```
+
+4. **Test raw streaming**:
+   ```bash
+   curl "http://localhost:5000/jokeStream?subject=banana"
+   ```
+
+5. **Expected behavior**:
+   - Authenticated requests (`open sesame`) succeed
+   - Unauthenticated requests return `PERMISSION_DENIED`
+   - Streaming endpoints deliver text incrementally
+   - `?stream=true` enables streaming on `expressHandler` endpoints

--- a/js/testapps/typed-context/README.md
+++ b/js/testapps/typed-context/README.md
@@ -1,33 +1,21 @@
-# Express Integration
+# Typed Context
 
-Demonstrates integrating Genkit flows with an Express.js server — including
-authentication context, streaming responses, and the `expressHandler` utility.
+Demonstrates **typed context** in Genkit: define an `AppContext` type, pass it to `genkit<AppContext>({...})`, and get typed `context` in flows, tools, `generate()` options, and `ai.currentContext()`.
 
-## Features Demonstrated
+## What this sample shows
 
-| Feature | Endpoint | Description |
-|---------|----------|-------------|
-| Flow via `expressHandler` | `POST /jokeFlow` | Genkit flow exposed via Express with auth context |
-| Flow handler (no auth) | `POST /jokeHandler` | Flow exposed without auth validation |
-| Direct flow invocation | `GET /jokeWithFlow` | Call a flow directly from a route handler |
-| Raw streaming | `GET /jokeStream` | Chunked transfer encoding with `ai.generate` |
-| Auth context | `Authorization` header | Token-based auth with context validation |
-| Context providers | `auth()` factory | Reusable auth context provider pattern |
+| Feature | Description |
+|--------|-------------|
+| **AppContext type** | Declare your app’s context shape (e.g. `echo`, `hello`, `userId`). |
+| **genkit&lt;AppContext&gt;()** | Create the instance with the type so `context` is typed everywhere. |
+| **Flows** | Flow callbacks receive `context: AppContext & ActionContext`. |
+| **Tools** | Tool callbacks receive the same typed context. |
+| **currentContext()** | `ai.currentContext()` returns `(AppContext & ActionContext) \| undefined`. |
+| **Override at run time** | Pass a different `context` when calling a flow or action. |
+
+If you call `genkit()` without the type argument, `context` in flows/tools is typed as `ActionContext` and properties like `context.hello` are `any`.
 
 ## Setup
-
-### Prerequisites
-
-- **Node.js** (v18 or higher)
-- **pnpm** package manager
-
-### API Keys
-
-```bash
-export GEMINI_API_KEY='<your-api-key>'
-```
-
-### Build and Install
 
 From the repo root:
 
@@ -36,43 +24,27 @@ pnpm install
 pnpm run setup
 ```
 
-## Run the Sample
+## Run the sample
+
+From this directory:
 
 ```bash
 pnpm build && pnpm start
 ```
 
-The Express server starts on port `5000` (or `$PORT`).
+Or run the source directly:
 
-## Testing This Demo
+```bash
+pnpm exec tsx src/index.ts
+```
 
-1. **Test with auth** (requires `Authorization: open sesame` header):
-   ```bash
-   curl http://localhost:5000/jokeFlow?stream=true \
-     -d '{"data": "banana"}' \
-     -H "Content-Type: application/json" \
-     -H "Authorization: open sesame"
-   ```
+## Example output
 
-2. **Test without auth**:
-   ```bash
-   curl http://localhost:5000/jokeHandler?stream=true \
-     -d '{"data": "banana"}' \
-     -H "Content-Type: application/json"
-   ```
-
-3. **Test direct flow invocation**:
-   ```bash
-   curl "http://localhost:5000/jokeWithFlow?subject=banana"
-   ```
-
-4. **Test raw streaming**:
-   ```bash
-   curl "http://localhost:5000/jokeStream?subject=banana"
-   ```
-
-5. **Expected behavior**:
-   - Authenticated requests (`open sesame`) succeed
-   - Unauthenticated requests return `PERMISSION_DENIED`
-   - Streaming endpoints deliver text incrementally
-   - `?stream=true` enables streaming on `expressHandler` endpoints
+```
+Echo with default context: foo
+Echo with overridden context: foo foo
+Greet: Hello, World!
+currentContext() without userId: test (user: anonymous)
+currentContext() with userId: test (user: user-123)
+Tool with typed context: Hello, Tool User!
+```

--- a/js/testapps/typed-context/package.json
+++ b/js/testapps/typed-context/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "typed-context",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "start": "node lib/index.js",
+    "compile": "tsc",
+    "build": "pnpm build:clean && pnpm compile",
+    "build:clean": "rimraf ./lib",
+    "build:watch": "tsc --watch",
+    "build-and-run": "pnpm build && node lib/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "genkit": "workspace:*"
+  },
+  "devDependencies": {
+    "rimraf": "^6.0.1",
+    "typescript": "^5.3.3"
+  }
+}

--- a/js/testapps/typed-context/src/index.ts
+++ b/js/testapps/typed-context/src/index.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Typed-context test app: defines an AppContext, creates genkit<AppContext>(),
+ * then runs flows and a tool that use typed context and currentContext().
+ */
+
+import { genkit, z } from 'genkit';
+import { logger } from 'genkit/logging';
+
+logger.setLogLevel('debug');
+
+// ---------------------------------------------------------------------------
+// App context type and Genkit instance
+// ---------------------------------------------------------------------------
+
+type AppContext = {
+  echo: (value: string) => string;
+  hello: (name: string) => string;
+  userId?: string;
+};
+
+const ai = genkit<AppContext>({
+  context: {
+    echo: (value) => value,
+    hello: (name) => `Hello, ${name}!`,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Flows and tool (context is typed as AppContext & ActionContext)
+// ---------------------------------------------------------------------------
+
+const echoFlow = ai.defineFlow(
+  {
+    name: 'echoWithContext',
+    inputSchema: z.string(),
+    outputSchema: z.string(),
+  },
+  async (input, { context }) => context.echo(input)
+);
+
+const greetFlow = ai.defineFlow(
+  {
+    name: 'greetWithContext',
+    inputSchema: z.object({ name: z.string() }),
+    outputSchema: z.string(),
+  },
+  async (input, { context }) => context.hello(input.name)
+);
+
+const flowWithCurrentContext = ai.defineFlow(
+  {
+    name: 'flowUsingCurrentContext',
+    inputSchema: z.string(),
+    outputSchema: z.string(),
+  },
+  async (input) => {
+    const ctx = ai.currentContext();
+    const userId = ctx?.userId ?? 'anonymous';
+    return `${input} (user: ${userId})`;
+  }
+);
+
+const getGreetingTool = ai.defineTool(
+  {
+    name: 'getGreeting',
+    description: 'Returns a greeting using the current context',
+    inputSchema: z.object({ name: z.string() }),
+    outputSchema: z.string(),
+  },
+  async (input, { context }) => context.hello(input.name)
+);
+
+// ---------------------------------------------------------------------------
+// Run examples (log output so you can see typed context in action)
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const echoAction = await ai.registry.lookupAction('/flow/echoWithContext');
+
+  console.log(
+    'Echo with default context:',
+    (await echoAction.run('foo')).result
+  );
+
+  console.log(
+    'Echo with overridden context:',
+    (
+      await echoFlow.run('foo', {
+        context: {
+          echo: (value: string) => `${value} ${value}`,
+          hello: (name: string) => `Hi, ${name}`,
+        },
+      })
+    ).result
+  );
+
+  console.log('Greet:', (await greetFlow.run({ name: 'World' })).result);
+
+  console.log(
+    'currentContext() without userId:',
+    (await flowWithCurrentContext.run('test')).result
+  );
+
+  console.log(
+    'currentContext() with userId:',
+    (
+      await flowWithCurrentContext.run('test', {
+        context: {
+          userId: 'user-123',
+          echo: (v: string) => v,
+          hello: (n: string) => `Hey ${n}`,
+        },
+      })
+    ).result
+  );
+
+  console.log(
+    'Tool with typed context:',
+    (await getGreetingTool.run({ name: 'Tool User' })).result
+  );
+}
+
+main().catch(console.error);

--- a/js/testapps/typed-context/tsconfig.json
+++ b/js/testapps/typed-context/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "noImplicitReturns": true,
+    "noUnusedLocals": false,
+    "outDir": "lib",
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2017",
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "compileOnSave": true,
+  "include": ["src"]
+}


### PR DESCRIPTION
Currently when dealing with Context in Genkit, the type returned everywhere is a static `ActionContext`, which looks like:

```ts
interface ActionContext {
    /** Information about the currently authenticated user if provided. */
    auth?: Record<string, any>;
    [additionalContext: string]: any;
}
```

When providing context within Genkit, e.g. within flows, you lose all type-safety:

```ts
const flow = ai.defineFlow(..., 
  async (input, { context }) => {
    context.hello('world');
  }
);

flow(..., {
  context: {
    hello: (value: string) => console.log(value),
  }
});
```

Here, `context.hello` is an `any` type. This means you end up having to write your own definitions, and casting context:

```ts
const flow = ai.defineFlow(..., 
  async (input, { context }) => {
    const ctx = context as unknown as { hello: (value: string) => void };
    ctx.hello('world');
  }
);
```

This then doesn't scale, as context is inherited everywhere, and it becomes a bit PITA to type, resulting in bad DX.

This PR enables typed and inferred context typing:

**Inferred:**

```ts
const ai = genkit({
  context: {
    hello: (name: string) => `Hello, ${name}!`,
  },
});

ai.defineFlow(..., 
  // context.hello is typed!
  async (input, { context }) => context.hello(input)
);
```

**Declared**:

```ts
type MyContext = {
  hello: (name: string) => void;
}

const ai = genkit<MyContext>({
  context: {
    hello: (name) => `Hello, ${name}!`,
  },
});

ai.defineFlow(..., 
  // context = MyContext & ActionContext
  async (input, { context }) => context.hello(input)
);
```

Additionally, context returned from actions is currently typed as `ActionContext | undefined`, which caused more issues having to do `context?.something`. However [looking at the code](https://github.com/firebase/genkit/blob/main/js/core/src/action.ts#L386-L388), context is always defined, even if the result is an empty object:

```ts
              context: {
                ...actionFn.__registry?.context,
                ...(options?.context ?? getContext()),
              },
``` 

So this PR also removes the `| undefined` type (happy to be proved wrong here!). Note, I don't think this is a breaking change.

Because this PR allows typed context, I'd of ideally liked to remove the `[additionalContext: string]: any;` within `ActionContext`:

```diff
interface ActionContext {
    /** Information about the currently authenticated user if provided. */
    auth?: Record<string, any>;
-    [additionalContext: string]: any;
}
```

However, technically I think this would end up being a breaking change since users relying on the `any` would all of a sudden get type errors.


Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
