### PR TITLE
Add ServerSpec to module exports

### DIFF
--- a/py/packages/genkit/src/genkit/ai/__init__.py
+++ b/py/packages/genkit/src/genkit/ai/__init__.py
@@ -104,6 +104,7 @@ from genkit.core.plugin import Plugin
 
 from ._aio import Genkit, Output
 from ._registry import FlowWrapper, GenkitRegistry, SimpleRetrieverOptions
+from ._server import ServerSpec
 
 __all__ = [
     # Version info
@@ -135,4 +136,6 @@ __all__ = [
     'tool_response',
     # Plugin
     'Plugin',
+    # Server
+    'ServerSpec',
 ]


### PR DESCRIPTION
This pull request adds a new import and export for the `ServerSpec` class in the `py/packages/genkit/src/genkit/ai/__init__.py` file, making it available as part of the module's public API.

API surface update:

* Added `ServerSpec` to the imports from `._server` and included it in the `__all__` list, making it publicly accessible from the `genkit.ai` module.

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
