### PR TITLE
fix(js): initialize all plugins before lookup in registry

### DIFF
--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -222,6 +222,14 @@ export class Registry {
     R extends Action<I, O>,
   >(key: string): Promise<R> {
     const parsedKey = parseRegistryKey(key);
+    // For keys without a plugin segment (e.g. /flow/orchestrator), we never run
+    // plugin initializers below. Actions registered by plugins during init would
+    // be missing from actionsById until listActions() (which calls initializeAllPlugins)
+    // runs. So ensure plugins are initialized before the final lookup.
+    if (!parsedKey?.pluginName && !parsedKey?.dynamicActionHost) {
+      await this.initializeAllPlugins();
+    }
+
     if (
       parsedKey?.dynamicActionHost &&
       this.actionsById[

--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -226,7 +226,7 @@ export class Registry {
     // plugin initializers below. Actions registered by plugins during init would
     // be missing from actionsById until listActions() (which calls initializeAllPlugins)
     // runs. So ensure plugins are initialized before the final lookup.
-    if (!parsedKey?.pluginName && !parsedKey?.dynamicActionHost) {
+    if (parsedKey && !parsedKey.pluginName && !parsedKey.dynamicActionHost) {
       await this.initializeAllPlugins();
     }
 

--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -212,6 +212,27 @@ export class Registry {
   }
 
   /**
+   * Ensures all plugins are initialized when the lookup key has no plugin
+   * segment, so that plugin-registered entries are visible. Called by
+   * lookupAction and lookupValue to match list* behavior.
+   */
+  private async ensurePluginsInitializedForLookup(
+    key: string,
+    kind: 'action' | 'value'
+  ): Promise<void> {
+    if (kind === 'action') {
+      const parsedKey = parseRegistryKey(key);
+      if (parsedKey && !parsedKey.pluginName && !parsedKey.dynamicActionHost) {
+        await this.initializeAllPlugins();
+      }
+    } else {
+      if (key && !parsePluginName(key)) {
+        await this.initializeAllPlugins();
+      }
+    }
+  }
+
+  /**
    * Looks up an action in the registry.
    * @param key The key of the action to lookup.
    * @returns The action.
@@ -222,13 +243,7 @@ export class Registry {
     R extends Action<I, O>,
   >(key: string): Promise<R> {
     const parsedKey = parseRegistryKey(key);
-    // For keys without a plugin segment (e.g. /flow/orchestrator), we never run
-    // plugin initializers below. Actions registered by plugins during init would
-    // be missing from actionsById until listActions() (which calls initializeAllPlugins)
-    // runs. So ensure plugins are initialized before the final lookup.
-    if (parsedKey && !parsedKey.pluginName && !parsedKey.dynamicActionHost) {
-      await this.initializeAllPlugins();
-    }
+    await this.ensurePluginsInitializedForLookup(key, 'action');
 
     if (
       parsedKey?.dynamicActionHost &&
@@ -541,6 +556,7 @@ export class Registry {
     type: string,
     key: string
   ): Promise<T | undefined> {
+    await this.ensurePluginsInitializedForLookup(key, 'value');
     const pluginName = parsePluginName(key);
     if (!this.valueByTypeAndName[type]?.[key] && pluginName) {
       await this.initializePlugin(pluginName);

--- a/js/core/tests/registry_test.ts
+++ b/js/core/tests/registry_test.ts
@@ -567,6 +567,25 @@ describe('registry class', () => {
       );
     });
 
+    it('returns action registered by plugin with 3-segment key (no plugin in path)', async () => {
+      // Keys like /flow/foo have no plugin segment; without initializing
+      // all plugins first, lookupAction would skip plugin init and miss the action.
+      const flowAction = action(
+        { name: 'foo', actionType: 'flow' },
+        async () => null
+      );
+      registry.registerPluginProvider('myPlugin', {
+        name: 'myPlugin',
+        async initializer() {
+          registry.registerAction('flow', flowAction);
+          return {};
+        },
+      });
+
+      const found = await registry.lookupAction('/flow/foo');
+      assert.strictEqual(found, flowAction);
+    });
+
     it('returns undefined for unknown action', async () => {
       assert.strictEqual(
         await registry.lookupAction('/model/foo/something'),

--- a/js/core/tests/registry_test.ts
+++ b/js/core/tests/registry_test.ts
@@ -627,4 +627,42 @@ describe('registry class', () => {
       );
     });
   });
+
+  describe('lookupValue', () => {
+    it('returns value registered by plugin with key that has no plugin segment', async () => {
+      const testValue = { configured: true };
+      registry.registerPluginProvider('myPlugin', {
+        name: 'myPlugin',
+        async initializer() {
+          registry.registerValue('defaultModel', 'defaultModel', testValue);
+          return {};
+        },
+      });
+
+      const found = await registry.lookupValue('defaultModel', 'defaultModel');
+      assert.strictEqual(found, testValue);
+    });
+
+    it('returns directly registered value', async () => {
+      const value = { foo: 1 };
+      registry.registerValue('myType', 'myKey', value);
+      assert.strictEqual(await registry.lookupValue('myType', 'myKey'), value);
+    });
+
+    it('initializes plugin when key has plugin segment', async () => {
+      let inited = false;
+      // parsePluginName(key) returns the third segment; for 'a/b/c/d' that is 'c'
+      registry.registerPluginProvider('baz', {
+        name: 'baz',
+        async initializer() {
+          inited = true;
+          registry.registerValue('config', 'foo/bar/baz/qux', { ok: true });
+          return {};
+        },
+      });
+      const found = await registry.lookupValue('config', 'foo/bar/baz/qux');
+      assert.strictEqual(inited, true);
+      assert.deepStrictEqual(found, { ok: true });
+    });
+  });
 });

--- a/js/plugins/vertexai/tests/rerankers/v2/index_test.ts
+++ b/js/plugins/vertexai/tests/rerankers/v2/index_test.ts
@@ -55,7 +55,7 @@ describe('vertexRerankersPlugin', () => {
 
   it('should not resolve other action types', async () => {
     const ai = genkit({
-      plugins: [vertexRerankers({})],
+      plugins: [vertexRerankers({ projectId: 'test-project' })],
     });
 
     const model = await ai.registry.lookupAction(


### PR DESCRIPTION
`registry.lookupAction('/flow/foo')` can return undefined even when `registry.listActions()` includes that key. 

`parseRegistryKey()` only sets `pluginName` when the key has 4+ segments (e.g. /flow/myPlugin/foo).
For 3-segment keys like `/flow/orchestrator` there is no pluginName.

In `lookupAction()`, the block that calls `initializePlugin(parsedKey.pluginName)` and `resolvePluginAction()` only runs when `parsedKey.pluginName` is set, so it is skipped for 3-segment keys.

The method then does `return (await this.actionsById[key]) || this.parent?.lookupAction(key)` without having run `initializeAllPlugins()`, so plugin-registered actions may not be in `actionsById` yet.

This PR fixes that by initializing if the key is not via a plugin or a dynamic action.

Workaround for now is to call `listActions()` before `lookupAction`.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
