### PR TITLE
fix(js): reflection context is always an object for runAction

### DIFF
--- a/js/core/src/reflection.ts
+++ b/js/core/src/reflection.ts
@@ -263,7 +263,7 @@ export class ReflectionServer {
               response.write(JSON.stringify(chunk) + '\n');
             };
             const result = await action.run(input, {
-              context,
+              context: context || {},
               onChunk: callback,
               telemetryLabels,
               onTraceStart: onTraceStartCallback,
@@ -304,7 +304,7 @@ export class ReflectionServer {
         } else {
           // Non-streaming: send JSON response
           const result = await action.run(input, {
-            context,
+            context: context || {},
             telemetryLabels,
             onTraceStart: onTraceStartCallback,
             abortSignal: abortController.signal,


### PR DESCRIPTION
In the reflection API, when we `POST /api/runAction`, the reflection server forwards context from the request body. When the client (e.g. Dev UI) omits it, context is `undefined` and is passed through to `action.run()`:

```ts
const { key, input, context, telemetryLabels } = request.body;
// ...
await action.run(input, { context, ... });
```

That leads to `runWithContext(undefined, actFn)`. In that case no context is stored in async context, so `getContext()` / `ai.currentContext()` returns `undefined` for the whole run. Any code that assumes a run-scoped context object then breaks. So if something like a plugin wants to write to context, e.g. `getContext().someKey = value`, `getContext()` is `undefined`.

So the actual problem is in code that writes to context (plugins or flows) and assumes `getContext()` is a mutable object. The reflection fix (defaulting to `{}`) makes that assumption valid for runs started via the reflection API.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
