### PR TITLE
feat(js/core): add overwrite option in definePrompt

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -129,6 +129,7 @@ export interface PromptConfig<
   toolChoice?: ToolChoice;
   use?: ModelMiddleware[];
   context?: ActionContext;
+  overwrite?: boolean;
 }
 
 /**
@@ -238,7 +239,8 @@ export function definePrompt<
     registry,
     `${options.name}${options.variant ? `.${options.variant}` : ''}`,
     Promise.resolve(options),
-    options.metadata
+    options.metadata,
+    options.overwrite
   );
 }
 
@@ -250,7 +252,8 @@ function definePromptAsync<
   registry: Registry,
   name: string,
   optionsPromise: PromiseLike<PromptConfig<I, O, CustomOptions>>,
-  metadata?: Record<string, any>
+  metadata?: Record<string, any>,
+  overwrite?: boolean
 ): ExecutablePrompt<z.infer<I>, O, CustomOptions> {
   const promptCache = {} as PromptCache;
 
@@ -379,7 +382,8 @@ function definePromptAsync<
     (action) => {
       (action as PromptAction<I>).__executablePrompt =
         executablePrompt as never as ExecutablePrompt<z.infer<I>>;
-    }
+    },
+    { overwrite }
   ) as Promise<PromptAction<I>>;
 
   const executablePromptActionConfig = lazy(() =>
@@ -411,7 +415,8 @@ function definePromptAsync<
     (action) => {
       (action as ExecutablePromptAction<I>).__executablePrompt =
         executablePrompt as never as ExecutablePrompt<z.infer<I>>;
-    }
+    },
+    { overwrite }
   ) as Promise<ExecutablePromptAction<I>>;
 
   const executablePrompt = wrapInExecutablePrompt({

--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -211,6 +211,7 @@ export type ActionParams<
   use?: Middleware<z.infer<I>, z.infer<O>, z.infer<S>>[];
   streamSchema?: S;
   actionType: ActionType;
+  overwrite?: boolean;
 };
 
 export type ActionAsyncParams<
@@ -509,7 +510,9 @@ export function defineAction<
     return await runInActionRuntimeContext(() => fn(i, options));
   });
   act.__action.actionType = config.actionType;
-  registry.registerAction(config.actionType, act);
+  registry.registerAction(config.actionType, act, {
+    overwrite: config.overwrite,
+  });
   return act;
 }
 
@@ -530,7 +533,8 @@ export function defineActionAsync<
         actionId: string;
       },
   config: PromiseLike<ActionAsyncParams<I, O, S>>,
-  onInit?: (action: Action<I, O, S>) => void
+  onInit?: (action: Action<I, O, S>) => void,
+  opts?: { overwrite?: boolean }
 ): PromiseLike<Action<I, O, S>> {
   const actionName =
     typeof name === 'string' ? name : `${name.pluginId}/${name.actionId}`;
@@ -550,7 +554,7 @@ export function defineActionAsync<
       return act;
     })
   );
-  registry.registerActionAsync(actionType, actionName, actionPromise);
+  registry.registerActionAsync(actionType, actionName, actionPromise, opts);
   return actionPromise;
 }
 

--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -275,7 +275,7 @@ export class Registry {
   registerAction<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
     type: ActionType,
     action: Action<I, O>,
-    opts?: { namespace?: string }
+    opts?: { namespace?: string; overwrite?: boolean }
   ) {
     if (type !== action.__action.actionType) {
       throw new GenkitError({
@@ -291,7 +291,7 @@ export class Registry {
     }
     const key = `/${type}/${action.__action.name}`;
     logger.debug(`registering ${key}`);
-    if (this.actionsById.hasOwnProperty(key)) {
+    if (!opts?.overwrite && this.actionsById.hasOwnProperty(key)) {
       logger.error(
         `ERROR: ${key} already has an entry in the registry. Overwriting.`
       );
@@ -310,14 +310,14 @@ export class Registry {
     type: ActionType,
     name: string,
     action: PromiseLike<Action<I, O>>,
-    opts?: { namespace?: string }
+    opts?: { namespace?: string; overwrite?: boolean }
   ) {
     if (opts?.namespace && !name.startsWith(`${opts.namespace}/`)) {
       name = `${opts.namespace}/${name}`;
     }
     const key = `/${type}/${name}`;
     logger.debug(`registering ${key} (async)`);
-    if (this.actionsById.hasOwnProperty(key)) {
+    if (!opts?.overwrite && this.actionsById.hasOwnProperty(key)) {
       logger.error(
         `ERROR: ${key} already has an entry in the registry. Overwriting.`
       );


### PR DESCRIPTION
Description here... Help the reviewer by:
 - Added an overwrite flag to avoid displaying excessive log messages
 - Current Genkit implementation primarily focuses on static declarations during app initialization.
(In my personal backend development, I faced a problem with excessive logging during the dynamic prompt management process, especially when applying changes post-initialization.)

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
