### PR TITLE
feat(trace-filter): Add string contains filter

### DIFF
--- a/genkit-tools/common/src/types/apis.ts
+++ b/genkit-tools/common/src/types/apis.ts
@@ -43,6 +43,7 @@ export const TraceQueryFilterSchema = z.object({
   gte: z.record(z.string(), z.number()).optional(),
   lt: z.record(z.string(), z.number()).optional(),
   lte: z.record(z.string(), z.number()).optional(),
+  contains: z.record(z.string(), FilterValueSchema).optional(),
 });
 
 export type TraceQueryFilter = z.infer<typeof TraceQueryFilterSchema>;

--- a/genkit-tools/telemetry-server/src/file-trace-store.ts
+++ b/genkit-tools/telemetry-server/src/file-trace-store.ts
@@ -458,7 +458,7 @@ function isFilterMatch(
   filter?: TraceQueryFilter
 ): boolean {
   if (!filter) return true;
-  const { eq, neq, gt, gte, lt, lte } = filter;
+  const { eq, neq, gt, gte, lt, lte, contains } = filter;
   if (eq) {
     for (const k of Object.keys(eq)) {
       const filterVal = eq[k];
@@ -505,6 +505,19 @@ function isFilterMatch(
     for (const k of Object.keys(lte)) {
       const val = d[k];
       if (typeof val !== 'number' || val > lte[k]) return false;
+    }
+  }
+  if (contains) {
+    for (const k of Object.keys(contains)) {
+      const filterVal = contains[k];
+      const val = d[k];
+      if (typeof val !== 'string') return false;
+      const match = Array.isArray(filterVal)
+        ? filterVal.some((fv) =>
+            val.toLowerCase().includes(`${fv}`.toLowerCase())
+          )
+        : val.toLowerCase().includes(`${filterVal}`.toLowerCase());
+      if (!match) return false;
     }
   }
   return true;

--- a/genkit-tools/telemetry-server/tests/file_store_test.ts
+++ b/genkit-tools/telemetry-server/tests/file_store_test.ts
@@ -601,6 +601,72 @@ describe('index', () => {
     );
   });
 
+  it('should support contains filters (case-insensitive)', () => {
+    const spanA = span(TRACE_ID_1, SPAN_A, 100, 100);
+    spanA.displayName = 'Flow with Banana';
+    spanA.attributes['genkit:type'] = 'FruitFlow';
+
+    const spanB = span(TRACE_ID_2, SPAN_B, 200, 200);
+    spanB.displayName = 'Another Apple Flow';
+    spanB.attributes['genkit:type'] = 'fruitflow';
+
+    const spanC = span(TRACE_ID_3, SPAN_C, 200, 200);
+    spanC.displayName = 'Cherry Flow';
+    spanC.attributes['genkit:type'] = 'Other';
+
+    index.add({
+      traceId: TRACE_ID_1,
+      spans: { [SPAN_A]: spanA },
+    } as TraceData);
+    index.add({
+      traceId: TRACE_ID_2,
+      spans: { [SPAN_B]: spanB },
+    } as TraceData);
+    index.add({
+      traceId: TRACE_ID_3,
+      spans: { [SPAN_C]: spanC },
+    } as TraceData);
+
+    // Test basic contains (case-insensitive)
+    assert.deepStrictEqual(
+      index
+        .search({
+          limit: 5,
+          filter: {
+            contains: { name: 'apple' },
+          },
+        })
+        .data.map((d) => d.id),
+      [TRACE_ID_2]
+    );
+
+    // Test contains with array (OR behavior)
+    assert.deepStrictEqual(
+      index
+        .search({
+          limit: 5,
+          filter: {
+            contains: { name: ['BANANA', 'cherry'] },
+          },
+        })
+        .data.map((d) => d.id),
+      [TRACE_ID_3, TRACE_ID_1]
+    );
+
+    // Test contains on type
+    assert.deepStrictEqual(
+      index
+        .search({
+          limit: 5,
+          filter: {
+            contains: { type: 'FRUIT' },
+          },
+        })
+        .data.map((d) => d.id),
+      [TRACE_ID_2, TRACE_ID_1]
+    );
+  });
+
   it('should support mixed type array filters (number and string)', () => {
     const spanA = span(TRACE_ID_1, SPAN_A, 100, 100);
     spanA.displayName = 'flowA';


### PR DESCRIPTION
Add new string contains filtering so we can query for partial name matches from the dev UI

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.) - Unit tested
- [ ] Docs updated (updated docs or a docs bug required)
