### PR TITLE
chore(py): fix release script

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -54,11 +54,9 @@ jobs:
             py/packages/genkit
             py/plugins/anthropic
             py/plugins/compat-oai
-            py/plugins/dev-local-vectorstore
             py/plugins/google-cloud
             py/plugins/google-genai
             py/plugins/ollama
-            py/plugins/firebase
             py/plugins/flask
             py/plugins/vertex-ai
           )
@@ -77,6 +75,7 @@ jobs:
 
           if [ ${#FAILED[@]} -gt 0 ]; then
             echo "::error::Failed packages: ${FAILED[*]}"
+            exit 1
           fi
 
       - name: Publish to PyPI
@@ -98,5 +97,6 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           VERSION="${TAG#py/v}"
+          [[ "$VERSION" == "$TAG" ]] && VERSION="${TAG#release/py/}"
           pip install "genkit==${VERSION}"
           python -c "from genkit.ai import Genkit; print('ok')"

--- a/.github/workflows/release_rc_python.yml
+++ b/.github/workflows/release_rc_python.yml
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Release Python RC: Run workflow → enter target version (e.g. 0.5.2) → publishes 0.5.2-rc.1, 0.5.2-rc.2, etc.
+# Creates branch release/py/X.Y.Z-rc.N with bumped versions, pushes it, tags it. Publish workflow (tag-triggered) uses that branch.
 
 name: Release Python RC
 
@@ -32,22 +33,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Checkout main so we can branch from it. Token needed for push later.
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GENKIT_RELEASER_GITHUB_TOKEN }}
           fetch-depth: 0
 
+      # Ensure we're on latest main and have tags (for RC numbering)
       - name: Pull latest & fetch tags
         run: git pull origin main && git fetch --tags
 
-      - name: Validate target version
-        run: |
-          TARGET="${{ inputs.target_version }}"
-          if ! [[ "$TARGET" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: target_version must be X.Y.Z (e.g., 0.6.0)"
-            exit 1
-          fi
-
+      # uv used for uv lock after bump
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -57,29 +53,31 @@ jobs:
       - name: Create release branch & bump version
         id: rc
         run: |
-          git config user.email "genkit-releaser@google.com" && git config user.name "genkit-releaser"
+          set -e
           TARGET="${{ inputs.target_version }}"
-          BRANCH="release/py/${TARGET}"
-          if git show-ref --quiet "refs/remotes/origin/${BRANCH}"; then
-            git fetch origin "${BRANCH}" && git checkout -B "${BRANCH}" "origin/${BRANCH}"
-          else
-            git checkout -b "${BRANCH}"
-          fi
-          EXISTING=$(git tag -l "py/v${TARGET}-rc.*" 2>/dev/null || true)
-          if [ -z "$EXISTING" ]; then RC_NUM=1; else
-            RC_NUM=$(($(echo "$EXISTING" | sed -n 's/.*-rc\.\([0-9]*\)$/\1/p' | sort -n | tail -1) + 1))
-          fi
-          CUR=$(grep '^version = ' py/packages/genkit/pyproject.toml | cut -d'"' -f2)
+          [[ "$TARGET" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Error: target_version must be X.Y.Z"; exit 1; }
+          # Next RC number: find highest existing py/v0.5.2-rc.N, add 1 (or 1 if none)
+          EXISTING=$(git tag -l "py/v${TARGET}-rc.*" 2>/dev/null | sed -n 's/.*-rc\.\([0-9]*\)$/\1/p' | sort -n | tail -1)
+          RC_NUM=$((${EXISTING:-0} + 1))
           NEW="${TARGET}-rc.${RC_NUM}"
+          BRANCH="release/py/${NEW}"
           echo "new=${NEW}" >> $GITHUB_OUTPUT
+          # Read current version from genkit; bump all packages that match
+          CUR=$(grep '^version = ' py/packages/genkit/pyproject.toml | cut -d'"' -f2)
+          git config user.email "genkit-releaser@google.com" && git config user.name "genkit-releaser"
+          git checkout -b "${BRANCH}"
           cd py
           for f in packages/genkit/pyproject.toml plugins/*/pyproject.toml; do
             [ -f "$f" ] && grep -q "version = \"$CUR\"" "$f" && sed -i "s/version = \"$CUR\"/version = \"$NEW\"/" "$f"
           done
           uv lock && cd ..
-          git add py/ && git commit -m "chore(py): bump version to $NEW" && git push origin "${BRANCH}"
+          git add py/
+          git diff --staged --quiet && { echo "::error::No version changes - $CUR may not match pyproject.toml files"; exit 1; }
+          git commit -m "chore(py): bump version to $NEW"
+          git push origin HEAD:"refs/heads/${BRANCH}"
 
+      # Tag points at our release branch so Publish Python (tag-triggered) checks out correct version
       - name: Create tag & GitHub release
         env:
           GH_TOKEN: ${{ secrets.GENKIT_RELEASER_GITHUB_TOKEN }}
-        run: gh release create "py/v${{ steps.rc.outputs.new }}" --title "Genkit Python SDK v${{ steps.rc.outputs.new }}" --notes "Release candidate." --prerelease
+        run: gh release create "py/v${{ steps.rc.outputs.new }}" --target "release/py/${{ steps.rc.outputs.new }}" --title "Genkit Python SDK v${{ steps.rc.outputs.new }}" --notes "Release candidate." --prerelease

--- a/py/docs/release_playbook.md
+++ b/py/docs/release_playbook.md
@@ -7,9 +7,19 @@ Use the **Release Python RC** workflow in GitHub Actions:
 1. Go to Actions → Release Python RC
 2. Click "Run workflow"
 3. Enter target version (e.g., `0.5.2`)
-4. The workflow infers the next RC (`0.5.2-rc.1`, `0.5.2-rc.2`, …) and publishes it
+4. The workflow infers the next RC (`0.5.2-rc.1`, `0.5.2-rc.2`, …) and runs the full flow
 
-No PR required. The workflow bumps version, commits to the release branch, creates the tag and GitHub release, and triggers publish to PyPI.
+**What the workflow does:**
+
+1. Creates branch `release/py/0.5.2-rc.1` (one branch per RC)
+2. Bumps all `pyproject.toml` versions from current (e.g. 0.5.1) to the RC version
+3. Commits and pushes to that branch
+4. Creates tag `py/v0.5.2-rc.1` pointing at the release branch
+5. Tag push triggers **Publish Python**, which builds and publishes to PyPI
+
+No PR required.
+
+**If you need to re-run publish** (e.g. it failed): Go to Actions → Publish Python → Run workflow → select the release branch (e.g. `release/py/0.5.2-rc.1`) from the branch dropdown → Run.
 
 ## Stable release steps
 
@@ -22,39 +32,13 @@ No PR required. The workflow bumps version, commits to the release branch, creat
 
 ## Workflow: `publish_python.yml`
 
-Three jobs: **build** → **publish** → **verify**.
+**Triggers:** Tag push (`py/v*`) or manual `workflow_dispatch`. When triggered by tag, it checks out the tag (which points at the release branch). When run manually, **select the release branch** (e.g. `release/py/0.5.2-rc.1`) from the "Use workflow from" dropdown — otherwise it will build from main.
 
-- **build**: `uv build` all packages in order (starting with core genkit, then plugins, then more plugins that depend on previous plugins), upload as artifact. All-or-nothing — if one fails to build, nothing gets published.
-- **publish**: `pypa/gh-action-pypi-publish@release/v1` with OIDC trusted publishing. `skip-existing: true` so re-runs are safe.
+**Two jobs:** publish → verify
+
+- **publish**: Builds all packages with `uv build`, then uploads to PyPI via `pypa/gh-action-pypi-publish`. All-or-nothing — if any build fails, the job fails.
 - **verify**: `pip install genkit==<version>` + import test.
 
 ## Auth
 
-OIDC trusted publishing. No API tokens. PyPI is configured to trust:
-
-| Field | Value |
-|---|---|
-| Owner | `firebase` |
-| Repository | `genkit` |
-| Workflow | `publish_python.yml` |
-| Environment | `pypi_github_publishing` |
-
-Already set up from v0.5.0. Don't rename the workflow file or this breaks.
-
-## Failures
-
-| What | Recovery |
-|---|---|
-| Build fails | Fix, re-run |
-| Publish fails midway | Re-run publish job (`skip-existing` skips uploaded packages) |
-| Bad package on PyPI | Can't overwrite. Yank it, do a patch release |
-
-
-## If something goes wrong
-
-```bash
-# Delete a bad tag/release and redo
-git tag -d py/v0.7.1 && git push origin :refs/tags/py/v0.7.1
-```
-
-PyPI doesn't allow re-uploading the same version. Bump to a patch release instead.
+OIDC trusted publishing. No API tokens. PyPI is configured to trust: Owner `firebase`, Repository `genkit`, Workflow `publish_python.yml`, Environment `pypi_github_publishing`. Already set up from v0.5.0. Don't rename the workflow file or this breaks.


### PR DESCRIPTION
After testing it two things broke:
-> Tried to publish removed plugins
-> release_rc_python.yaml was not correctly updating the version in pyproject.toml files and creating a RC-specific release branch

Fix the script to do that and also cleaned up release playbook a bit.