### PR TITLE
fix(py): Cache list actions endpoint and use correct embeddings model for google genai plugin

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -102,6 +102,8 @@ from google.genai.client import DebugConfig
 from google.genai.types import HttpOptions, HttpOptionsDict
 
 import genkit.plugins.google_genai.constants as const
+from genkit._core._action import ActionRunContext
+from genkit._core._model import ModelRequest, ModelResponse
 from genkit.embedder import EmbedderOptions, EmbedderSupports, embedder_action_metadata
 from genkit.evaluator import EvalFnResponse, EvalRequest
 from genkit.model import BackgroundAction, model_action_metadata
@@ -401,6 +403,7 @@ class GoogleAI(Plugin):
         }
         # Single loop-local client accessor used everywhere in plugin runtime paths.
         self._runtime_client = loop_local_client(lambda: genai.client.Client(**self._client_kwargs))
+        self._list_actions_cache: list[ActionMetadata] | None = None
 
     async def init(self) -> list[Action]:
         """Initialize the plugin.
@@ -575,7 +578,7 @@ class GoogleAI(Plugin):
             SUPPORTED_MODELS[clean_name] = model_ref
             config_schema = get_model_config_schema(clean_name)
 
-        async def _run(request: Any, ctx: Any) -> Any:  # noqa: ANN401
+        async def _run(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
             if clean_name.lower().startswith('image'):
                 model = ImagenModel(clean_name, self._runtime_client())
             else:
@@ -614,6 +617,8 @@ class GoogleAI(Plugin):
                 - info (dict): The metadata dictionary describing the model configuration and properties.
                 - config_schema (type): The schema class used for validating the model's configuration.
         """
+        if self._list_actions_cache is not None:
+            return self._list_actions_cache
         genai_models = _list_genai_models(self._runtime_client(), is_vertex=False)
         actions_list = []
 
@@ -657,6 +662,7 @@ class GoogleAI(Plugin):
                 )
             )
 
+        self._list_actions_cache = actions_list
         return actions_list
 
 
@@ -759,6 +765,7 @@ class VertexAI(Plugin):
         }
         # Single loop-local client accessor used everywhere in plugin runtime paths.
         self._runtime_client = loop_local_client(lambda: genai.client.Client(**self._client_kwargs))
+        self._list_actions_cache: list[ActionMetadata] | None = None
 
     async def init(self) -> list[Action]:
         """Initialize the plugin.
@@ -899,7 +906,7 @@ class VertexAI(Plugin):
             SUPPORTED_MODELS[clean_name] = model_ref
             config_schema = get_model_config_schema(clean_name)
 
-        async def _run(request: Any, ctx: Any) -> Any:  # noqa: ANN401
+        async def _run(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
             if clean_name.lower().startswith('image'):
                 model = ImagenModel(clean_name, self._runtime_client())
             elif is_veo_model(clean_name):
@@ -940,6 +947,8 @@ class VertexAI(Plugin):
                 - info (dict): The metadata dictionary describing the model configuration and properties.
                 - config_schema (type): The schema class used for validating the model's configuration.
         """
+        if self._list_actions_cache is not None:
+            return self._list_actions_cache
         genai_models = _list_genai_models(self._runtime_client(), is_vertex=True)
         actions_list = []
 
@@ -996,6 +1005,7 @@ class VertexAI(Plugin):
                 )
             )
 
+        self._list_actions_cache = actions_list
         return actions_list
 
 

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
@@ -17,6 +17,7 @@
 """Google-Genai embedder model."""
 
 import sys
+import warnings
 from typing import Any, cast
 
 if sys.version_info < (3, 11):
@@ -65,7 +66,9 @@ class EmbeddingTaskType(StrEnum):
 
 def default_embedder_info(name: str) -> dict[str, Any]:
     """Returns default info for embedders given a name."""
-    return {'dimensions': 768, 'label': f'Google AI - {name}', 'supports': {'input': ['text']}}
+    # gemini-embedding-001 outputs 3072 dimensions; legacy models use 768
+    dimensions = 3072 if 'gemini-embedding' in name else 768
+    return {'dimensions': dimensions, 'label': f'Google AI - {name}', 'supports': {'input': ['text']}}
 
 
 class Embedder:
@@ -94,10 +97,21 @@ class Embedder:
         Returns:
             EmbedResponse
         """
+        # text-embedding-004 was deprecated Jan 2026 and returns 404. Redirect to
+        # gemini-embedding-001 (3072 dims vs 768). Existing vectors are incompatible.
+        model = self._version
+        if str(model) == 'text-embedding-004':
+            warnings.warn(
+                'text-embedding-004 is deprecated (removed Jan 2026). '
+                'Using gemini-embedding-001 instead. Note: different dimensions (3072 vs 768).',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            model = 'gemini-embedding-001'
         contents = await self._build_contents(request)
         config = self._genkit_to_googleai_cfg(request)
         response = await self._client.aio.models.embed_content(
-            model=self._version,
+            model=model,
             contents=cast(genai_types.ContentListUnion, contents),
             config=config,
         )

--- a/py/plugins/google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_embedder_test.py
@@ -47,9 +47,12 @@ async def test_embedding(mocker: MockerFixture, version: GeminiEmbeddingModels) 
 
     response = await embedder.generate(request)
 
+    # text-embedding-004 is redirected to gemini-embedding-001 (deprecated Jan 2026, returns 404)
+    expected_model = 'gemini-embedding-001' if str(version) == 'text-embedding-004' else version
+
     googleai_client_mock.assert_has_calls([
         mocker.call.aio.models.embed_content(
-            model=version,
+            model=expected_model,
             contents=[genai.types.Content(parts=[genai.types.Part.from_text(text=request_text)])],
             config=None,
         )


### PR DESCRIPTION
Noticed that Dev UI was slow because list actions endpoint takes ~3 seconds. Caching that endpoint in the plugin now. 

Also `text-embedding-004` is deprecated. Remove recommendations for that model. 