### PR TITLE
feat(js/compat-oai): add MiniMax as LLM provider plugin

### DIFF
--- a/js/plugins/compat-oai/package.json
+++ b/js/plugins/compat-oai/package.json
@@ -9,7 +9,8 @@
     "openai",
     "ai",
     "genai",
-    "generative-ai"
+    "generative-ai",
+    "minimax"
   ],
   "version": "1.30.1",
   "type": "commonjs",
@@ -60,6 +61,12 @@
       "import": "./lib/xai/index.mjs",
       "types": "./lib/xai/index.d.ts",
       "default": "./lib/xai/index.js"
+    },
+    "./minimax": {
+      "require": "./lib/minimax/index.js",
+      "import": "./lib/minimax/index.mjs",
+      "types": "./lib/minimax/index.d.ts",
+      "default": "./lib/minimax/index.js"
     }
   },
   "typesVersions": {
@@ -72,6 +79,9 @@
       ],
       "xai": [
         "lib/xai"
+      ],
+      "minimax": [
+        "lib/minimax"
       ]
     }
   },

--- a/js/plugins/compat-oai/src/minimax/index.ts
+++ b/js/plugins/compat-oai/src/minimax/index.ts
@@ -122,8 +122,8 @@ const model = ((name: string, config?: any): ModelReference<z.ZodTypeAny> => {
  *
  * export default configureGenkit({
  *  plugins: [
- *    miniMax()
- *    ... // other plugins
+ *    miniMax(),
+ *    // ... other plugins
  *  ]
  * });
  * ```

--- a/js/plugins/compat-oai/src/minimax/index.ts
+++ b/js/plugins/compat-oai/src/minimax/index.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GenkitError, ModelReference, z } from 'genkit';
+import { logger } from 'genkit/logging';
+import { type GenkitPluginV2 } from 'genkit/plugin';
+import { ActionType } from 'genkit/registry';
+import OpenAI from 'openai';
+import { openAICompatible, PluginOptions } from '../index.js';
+import { defineCompatOpenAIModel } from '../model.js';
+import {
+  MiniMaxChatCompletionConfigSchema,
+  miniMaxModelRef,
+  miniMaxRequestBuilder,
+  SUPPORTED_MINIMAX_MODELS,
+} from './minimax.js';
+
+export type MiniMaxPluginOptions = Omit<PluginOptions, 'name' | 'baseURL'>;
+
+function createResolver(pluginOptions: PluginOptions) {
+  return async (client: OpenAI, actionType: ActionType, actionName: string) => {
+    if (actionType === 'model') {
+      const modelRef = miniMaxModelRef({
+        name: actionName,
+      });
+      return defineCompatOpenAIModel({
+        name: modelRef.name,
+        client,
+        pluginOptions,
+        modelRef,
+        requestBuilder: miniMaxRequestBuilder,
+      });
+    } else {
+      logger.warn('Only model actions are supported by the MiniMax plugin');
+      return undefined;
+    }
+  };
+}
+
+export function miniMaxPlugin(
+  options?: MiniMaxPluginOptions
+): GenkitPluginV2 {
+  const apiKey = options?.apiKey ?? process.env.MINIMAX_API_KEY;
+  if (!apiKey) {
+    throw new GenkitError({
+      status: 'FAILED_PRECONDITION',
+      message:
+        'Please pass in the API key or set the MINIMAX_API_KEY environment variable.',
+    });
+  }
+  const pluginOptions = { name: 'minimax', ...options };
+  return openAICompatible({
+    name: 'minimax',
+    baseURL: 'https://api.minimax.io/v1',
+    apiKey,
+    ...options,
+    initializer: async (client) => {
+      return Object.values(SUPPORTED_MINIMAX_MODELS).map((modelRef) =>
+        defineCompatOpenAIModel({
+          name: modelRef.name,
+          client,
+          pluginOptions,
+          modelRef,
+          requestBuilder: miniMaxRequestBuilder,
+        })
+      );
+    },
+    resolver: createResolver(pluginOptions),
+  });
+}
+
+export type MiniMaxPlugin = {
+  (params?: MiniMaxPluginOptions): GenkitPluginV2;
+  model(
+    name: keyof typeof SUPPORTED_MINIMAX_MODELS,
+    config?: z.infer<typeof MiniMaxChatCompletionConfigSchema>
+  ): ModelReference<typeof MiniMaxChatCompletionConfigSchema>;
+  model(name: string, config?: any): ModelReference<z.ZodTypeAny>;
+};
+
+const model = ((name: string, config?: any): ModelReference<z.ZodTypeAny> => {
+  return miniMaxModelRef({
+    name,
+    config,
+  });
+}) as MiniMaxPlugin['model'];
+
+/**
+ * This module provides an interface to the MiniMax models through the Genkit
+ * plugin system. It allows users to interact with various models by providing
+ * an API key and optional configuration.
+ *
+ * The main export is the `miniMax` plugin, which can be configured with an API
+ * key either directly or through environment variables. It initializes the
+ * OpenAI client and makes available the models for use.
+ *
+ * Exports:
+ * - miniMax: The main plugin function to interact with MiniMax, via OpenAI
+ *   compatible API.
+ *
+ * Usage: To use the models, initialize the miniMax plugin inside
+ * `configureGenkit` and pass the configuration options. If no API key is
+ * provided in the options, the environment variable `MINIMAX_API_KEY` must be
+ * set.
+ *
+ * Example:
+ * ```
+ * import { miniMax } from '@genkit-ai/compat-oai/minimax';
+ *
+ * export default configureGenkit({
+ *  plugins: [
+ *    miniMax()
+ *    ... // other plugins
+ *  ]
+ * });
+ * ```
+ */
+export const miniMax: MiniMaxPlugin = Object.assign(miniMaxPlugin, {
+  model,
+});
+
+export default miniMax;

--- a/js/plugins/compat-oai/src/minimax/index.ts
+++ b/js/plugins/compat-oai/src/minimax/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { GenkitError, ModelReference, z } from 'genkit';
+import {
+  ActionMetadata,
+  GenkitError,
+  modelActionMetadata,
+  ModelReference,
+  z,
+} from 'genkit';
 import { logger } from 'genkit/logging';
 import { type GenkitPluginV2 } from 'genkit/plugin';
 import { ActionType } from 'genkit/registry';
@@ -50,6 +56,25 @@ function createResolver(pluginOptions: PluginOptions) {
   };
 }
 
+const listActions = async (client: OpenAI): Promise<ActionMetadata[]> => {
+  return await client.models.list().then((response) =>
+    response.data
+      .filter((model) => model.object === 'model')
+      .map((model: OpenAI.Model) => {
+        const modelRef =
+          SUPPORTED_MINIMAX_MODELS[model.id] ??
+          miniMaxModelRef({
+            name: model.id,
+          });
+        return modelActionMetadata({
+          name: modelRef.name,
+          info: modelRef.info,
+          configSchema: modelRef.configSchema,
+        });
+      })
+  );
+};
+
 export function miniMaxPlugin(
   options?: MiniMaxPluginOptions
 ): GenkitPluginV2 {
@@ -79,6 +104,7 @@ export function miniMaxPlugin(
       );
     },
     resolver: createResolver(pluginOptions),
+    listActions,
   });
 }
 

--- a/js/plugins/compat-oai/src/minimax/minimax.ts
+++ b/js/plugins/compat-oai/src/minimax/minimax.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/plugins/compat-oai/src/minimax/minimax.ts
+++ b/js/plugins/compat-oai/src/minimax/minimax.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'genkit';
+import { ModelInfo, ModelReference } from 'genkit/model';
+import {
+  ChatCompletionCommonConfigSchema,
+  ModelRequestBuilder,
+  compatOaiModelRef,
+} from '../model';
+
+/**
+ * Language models that support text -> text, tool calling, structured output
+ */
+const MINIMAX_LANGUAGE_MODEL_INFO: ModelInfo = {
+  supports: {
+    multiturn: true,
+    tools: true,
+    media: false,
+    systemRole: true,
+    output: ['text', 'json'],
+  },
+};
+
+/** MiniMax Custom configuration schema. */
+export const MiniMaxChatCompletionConfigSchema =
+  ChatCompletionCommonConfigSchema.extend({
+    temperature: z.number().min(0).max(1).optional(),
+  });
+
+/** MiniMax ModelRef helper, with MiniMax specific config. */
+export function miniMaxModelRef(params: {
+  name: string;
+  info?: ModelInfo;
+  config?: any;
+}): ModelReference<typeof MiniMaxChatCompletionConfigSchema> {
+  return compatOaiModelRef({
+    ...params,
+    info: params.info ?? MINIMAX_LANGUAGE_MODEL_INFO,
+    configSchema: MiniMaxChatCompletionConfigSchema,
+    namespace: 'minimax',
+  });
+}
+
+export const miniMaxRequestBuilder: ModelRequestBuilder = (req, params) => {
+  // Clamp temperature to MiniMax's [0, 1] range
+  if (params.temperature !== undefined && params.temperature > 1) {
+    params.temperature = 1;
+  }
+};
+
+export const SUPPORTED_MINIMAX_MODELS: Record<
+  string,
+  ModelReference<typeof MiniMaxChatCompletionConfigSchema>
+> = {
+  'MiniMax-M2.7': miniMaxModelRef({
+    name: 'MiniMax-M2.7',
+  }),
+  'MiniMax-M2.7-highspeed': miniMaxModelRef({
+    name: 'MiniMax-M2.7-highspeed',
+  }),
+  'MiniMax-M2.5': miniMaxModelRef({
+    name: 'MiniMax-M2.5',
+  }),
+  'MiniMax-M2.5-highspeed': miniMaxModelRef({
+    name: 'MiniMax-M2.5-highspeed',
+  }),
+};

--- a/js/plugins/compat-oai/src/minimax/minimax.ts
+++ b/js/plugins/compat-oai/src/minimax/minimax.ts
@@ -57,7 +57,11 @@ export function miniMaxModelRef(params: {
 
 export const miniMaxRequestBuilder: ModelRequestBuilder = (req, params) => {
   // Clamp temperature to MiniMax's [0, 1] range
-  if (params.temperature !== undefined && params.temperature > 1) {
+  if (
+    params.temperature !== undefined &&
+    params.temperature !== null &&
+    params.temperature > 1
+  ) {
     params.temperature = 1;
   }
 };

--- a/js/plugins/compat-oai/tests/minimax_test.ts
+++ b/js/plugins/compat-oai/tests/minimax_test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/plugins/compat-oai/tests/minimax_test.ts
+++ b/js/plugins/compat-oai/tests/minimax_test.ts
@@ -161,7 +161,7 @@ describe('MiniMax ModelRef', () => {
         tools: false,
         media: true,
         systemRole: true,
-        output: ['text'] as const,
+        output: ['text'],
       },
     };
     const ref = miniMaxModelRef({
@@ -458,6 +458,7 @@ describe('MiniMax Plugin Integration', () => {
       tools: [
         {
           name: 'get_weather',
+          description: 'Get the weather for a location',
           inputSchema: {
             type: 'object',
             properties: { location: { type: 'string' } },

--- a/js/plugins/compat-oai/tests/minimax_test.ts
+++ b/js/plugins/compat-oai/tests/minimax_test.ts
@@ -1,0 +1,562 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import type { GenerateRequest } from 'genkit';
+import type OpenAI from 'openai';
+import {
+  defineCompatOpenAIModel,
+  openAIModelRunner,
+  toOpenAIRequestBody,
+} from '../src/model';
+import {
+  miniMaxModelRef,
+  miniMaxRequestBuilder,
+  MiniMaxChatCompletionConfigSchema,
+  SUPPORTED_MINIMAX_MODELS,
+} from '../src/minimax/minimax';
+import { FakeOpenAIServer } from './fake_openai_server';
+
+jest.mock('genkit/model', () => {
+  const originalModule =
+    jest.requireActual<typeof import('genkit/model')>('genkit/model');
+  return {
+    ...originalModule,
+    defineModel: jest.fn((_, runner) => {
+      return runner;
+    }),
+  };
+});
+
+describe('MiniMax Model Definitions', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should correctly define supported MiniMax models', () => {
+    const modelNames = Object.keys(SUPPORTED_MINIMAX_MODELS);
+    expect(modelNames).toContain('MiniMax-M2.7');
+    expect(modelNames).toContain('MiniMax-M2.7-highspeed');
+    expect(modelNames).toContain('MiniMax-M2.5');
+    expect(modelNames).toContain('MiniMax-M2.5-highspeed');
+    expect(modelNames).toHaveLength(4);
+  });
+
+  it('should define MiniMax-M2.7 with correct capabilities', () => {
+    const model = defineCompatOpenAIModel({
+      name: 'minimax/MiniMax-M2.7',
+      client: {} as OpenAI,
+      modelRef: miniMaxModelRef({ name: 'MiniMax-M2.7' }),
+    });
+    expect({
+      name: model.__action.name,
+      supports: model.__action.metadata?.model.supports,
+    }).toStrictEqual({
+      name: 'minimax/MiniMax-M2.7',
+      supports: {
+        multiturn: true,
+        tools: true,
+        media: false,
+        systemRole: true,
+        output: ['text', 'json'],
+      },
+    });
+  });
+
+  it('should define MiniMax-M2.7-highspeed with correct capabilities', () => {
+    const model = defineCompatOpenAIModel({
+      name: 'minimax/MiniMax-M2.7-highspeed',
+      client: {} as OpenAI,
+      modelRef: miniMaxModelRef({ name: 'MiniMax-M2.7-highspeed' }),
+    });
+    expect({
+      name: model.__action.name,
+      supports: model.__action.metadata?.model.supports,
+    }).toStrictEqual({
+      name: 'minimax/MiniMax-M2.7-highspeed',
+      supports: {
+        multiturn: true,
+        tools: true,
+        media: false,
+        systemRole: true,
+        output: ['text', 'json'],
+      },
+    });
+  });
+
+  it('should define MiniMax-M2.5 with correct capabilities', () => {
+    const model = defineCompatOpenAIModel({
+      name: 'minimax/MiniMax-M2.5',
+      client: {} as OpenAI,
+      modelRef: miniMaxModelRef({ name: 'MiniMax-M2.5' }),
+    });
+    expect({
+      name: model.__action.name,
+      supports: model.__action.metadata?.model.supports,
+    }).toStrictEqual({
+      name: 'minimax/MiniMax-M2.5',
+      supports: {
+        multiturn: true,
+        tools: true,
+        media: false,
+        systemRole: true,
+        output: ['text', 'json'],
+      },
+    });
+  });
+
+  it('should define MiniMax-M2.5-highspeed with correct capabilities', () => {
+    const model = defineCompatOpenAIModel({
+      name: 'minimax/MiniMax-M2.5-highspeed',
+      client: {} as OpenAI,
+      modelRef: miniMaxModelRef({ name: 'MiniMax-M2.5-highspeed' }),
+    });
+    expect({
+      name: model.__action.name,
+      supports: model.__action.metadata?.model.supports,
+    }).toStrictEqual({
+      name: 'minimax/MiniMax-M2.5-highspeed',
+      supports: {
+        multiturn: true,
+        tools: true,
+        media: false,
+        systemRole: true,
+        output: ['text', 'json'],
+      },
+    });
+  });
+});
+
+describe('MiniMax ModelRef', () => {
+  it('should create a model ref with minimax namespace', () => {
+    const ref = miniMaxModelRef({ name: 'MiniMax-M2.7' });
+    expect(ref.name).toBe('minimax/MiniMax-M2.7');
+    expect(ref.configSchema).toBe(MiniMaxChatCompletionConfigSchema);
+  });
+
+  it('should allow custom model info', () => {
+    const customInfo = {
+      supports: {
+        multiturn: true,
+        tools: false,
+        media: true,
+        systemRole: true,
+        output: ['text'] as const,
+      },
+    };
+    const ref = miniMaxModelRef({
+      name: 'custom-model',
+      info: customInfo,
+    });
+    expect(ref.info?.supports?.tools).toBe(false);
+    expect(ref.info?.supports?.media).toBe(true);
+  });
+});
+
+describe('MiniMax Request Builder', () => {
+  it('should clamp temperature above 1 to 1', () => {
+    const req = {
+      messages: [],
+      config: { temperature: 1.5 },
+    } as GenerateRequest;
+    const params = { temperature: 1.5 } as any;
+    miniMaxRequestBuilder(req, params);
+    expect(params.temperature).toBe(1);
+  });
+
+  it('should not modify temperature within valid range', () => {
+    const req = {
+      messages: [],
+      config: { temperature: 0.7 },
+    } as GenerateRequest;
+    const params = { temperature: 0.7 } as any;
+    miniMaxRequestBuilder(req, params);
+    expect(params.temperature).toBe(0.7);
+  });
+
+  it('should allow temperature of 0', () => {
+    const req = {
+      messages: [],
+      config: { temperature: 0 },
+    } as GenerateRequest;
+    const params = { temperature: 0 } as any;
+    miniMaxRequestBuilder(req, params);
+    expect(params.temperature).toBe(0);
+  });
+
+  it('should handle undefined temperature', () => {
+    const req = {
+      messages: [],
+      config: {},
+    } as GenerateRequest;
+    const params = {} as any;
+    miniMaxRequestBuilder(req, params);
+    expect(params.temperature).toBeUndefined();
+  });
+});
+
+describe('toOpenAIRequestBody for MiniMax models', () => {
+  const baseRequest = { messages: [] } as GenerateRequest;
+
+  it('should not throw for MiniMax-M2.7', () => {
+    expect(() =>
+      toOpenAIRequestBody('MiniMax-M2.7', baseRequest)
+    ).not.toThrow();
+  });
+
+  it('should not throw for MiniMax-M2.5', () => {
+    expect(() =>
+      toOpenAIRequestBody('MiniMax-M2.5', baseRequest)
+    ).not.toThrow();
+  });
+
+  it('should not throw for MiniMax-M2.5-highspeed', () => {
+    expect(() =>
+      toOpenAIRequestBody('MiniMax-M2.5-highspeed', baseRequest)
+    ).not.toThrow();
+  });
+
+  it('should generate correct request body with temperature clamped', () => {
+    const request = {
+      messages: [
+        { role: 'user', content: [{ text: 'Hello' }] },
+      ],
+      config: { temperature: 1.5 },
+    } as GenerateRequest;
+
+    const body = toOpenAIRequestBody(
+      'MiniMax-M2.7',
+      request,
+      miniMaxRequestBuilder
+    );
+    expect(body.model).toBe('MiniMax-M2.7');
+    expect(body.temperature).toBe(1);
+  });
+
+  it('should generate correct request body with json output format', () => {
+    const request = {
+      messages: [
+        { role: 'user', content: [{ text: 'Hello' }] },
+      ],
+      output: { format: 'json' },
+    } as GenerateRequest;
+
+    const body = toOpenAIRequestBody(
+      'MiniMax-M2.7',
+      request,
+      miniMaxRequestBuilder
+    );
+    expect(body.response_format).toEqual({ type: 'json_object' });
+  });
+});
+
+describe('MiniMax Plugin Integration', () => {
+  let server: FakeOpenAIServer;
+
+  beforeEach(async () => {
+    server = new FakeOpenAIServer();
+    await server.start();
+  });
+
+  afterEach(() => {
+    server.stop();
+    jest.clearAllMocks();
+  });
+
+  it('should make a successful non-streaming request', async () => {
+    server.setNextResponse({
+      body: {
+        id: 'chatcmpl-test',
+        object: 'chat.completion',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: 'Hello from MiniMax!',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          total_tokens: 15,
+        },
+      },
+    });
+
+    const client = new (await import('openai')).default({
+      apiKey: 'test-key',
+      baseURL: server.baseUrl,
+    });
+
+    const runner = openAIModelRunner(
+      'MiniMax-M2.7',
+      client,
+      miniMaxRequestBuilder
+    );
+
+    const request: GenerateRequest = {
+      messages: [
+        { role: 'user', content: [{ text: 'Hello' }] },
+      ],
+    };
+
+    const response = await runner(request);
+    expect(response.message?.content[0]).toEqual({
+      text: 'Hello from MiniMax!',
+    });
+    expect(response.finishReason).toBe('stop');
+    expect(response.usage?.inputTokens).toBe(10);
+    expect(response.usage?.outputTokens).toBe(5);
+  });
+
+  it('should make a successful streaming request', async () => {
+    server.setNextResponse({
+      stream: true,
+      chunks: [
+        {
+          id: 'chatcmpl-test',
+          object: 'chat.completion.chunk',
+          choices: [
+            {
+              index: 0,
+              delta: { role: 'assistant', content: 'Hello' },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: 'chatcmpl-test',
+          object: 'chat.completion.chunk',
+          choices: [
+            {
+              index: 0,
+              delta: { content: ' from MiniMax!' },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: 'chatcmpl-test',
+          object: 'chat.completion.chunk',
+          choices: [
+            {
+              index: 0,
+              delta: {},
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            total_tokens: 15,
+          },
+        },
+      ],
+    });
+
+    const client = new (await import('openai')).default({
+      apiKey: 'test-key',
+      baseURL: server.baseUrl,
+    });
+
+    const runner = openAIModelRunner(
+      'MiniMax-M2.7',
+      client,
+      miniMaxRequestBuilder
+    );
+
+    const chunks: any[] = [];
+    const request: GenerateRequest = {
+      messages: [
+        { role: 'user', content: [{ text: 'Hello' }] },
+      ],
+    };
+
+    const response = await runner(request, {
+      streamingRequested: true,
+      sendChunk: (chunk) => {
+        chunks.push(chunk);
+      },
+    });
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(response.usage?.inputTokens).toBe(10);
+    expect(response.usage?.outputTokens).toBe(5);
+  });
+
+  it('should handle tool calling', async () => {
+    server.setNextResponse({
+      body: {
+        id: 'chatcmpl-test',
+        object: 'chat.completion',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_123',
+                  type: 'function',
+                  function: {
+                    name: 'get_weather',
+                    arguments: '{"location":"Beijing"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: {
+          prompt_tokens: 20,
+          completion_tokens: 15,
+          total_tokens: 35,
+        },
+      },
+    });
+
+    const client = new (await import('openai')).default({
+      apiKey: 'test-key',
+      baseURL: server.baseUrl,
+    });
+
+    const runner = openAIModelRunner(
+      'MiniMax-M2.7',
+      client,
+      miniMaxRequestBuilder
+    );
+
+    const request: GenerateRequest = {
+      messages: [
+        { role: 'user', content: [{ text: 'What is the weather in Beijing?' }] },
+      ],
+      tools: [
+        {
+          name: 'get_weather',
+          inputSchema: {
+            type: 'object',
+            properties: { location: { type: 'string' } },
+          },
+        },
+      ],
+    };
+
+    const response = await runner(request);
+    expect(response.message?.content[0]).toEqual({
+      toolRequest: {
+        name: 'get_weather',
+        ref: 'call_123',
+        input: { location: 'Beijing' },
+      },
+    });
+  });
+
+  it('should send temperature clamped in the request', async () => {
+    server.setNextResponse({
+      body: {
+        id: 'chatcmpl-test',
+        object: 'chat.completion',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 },
+      },
+    });
+
+    const client = new (await import('openai')).default({
+      apiKey: 'test-key',
+      baseURL: server.baseUrl,
+    });
+
+    const runner = openAIModelRunner(
+      'MiniMax-M2.7',
+      client,
+      miniMaxRequestBuilder
+    );
+
+    const request: GenerateRequest = {
+      messages: [
+        { role: 'user', content: [{ text: 'test' }] },
+      ],
+      config: { temperature: 1.8 },
+    };
+
+    await runner(request);
+
+    // Verify the request sent to the server has temperature clamped
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0].body.temperature).toBe(1);
+    expect(server.requests[0].body.model).toBe('MiniMax-M2.7');
+  });
+});
+
+describe('MiniMax Config Schema Validation', () => {
+  it('should accept temperature within valid range [0, 1]', () => {
+    const result = MiniMaxChatCompletionConfigSchema.safeParse({
+      temperature: 0.5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept temperature of 0', () => {
+    const result = MiniMaxChatCompletionConfigSchema.safeParse({
+      temperature: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept temperature of 1', () => {
+    const result = MiniMaxChatCompletionConfigSchema.safeParse({
+      temperature: 1,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject temperature greater than 1', () => {
+    const result = MiniMaxChatCompletionConfigSchema.safeParse({
+      temperature: 1.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject negative temperature', () => {
+    const result = MiniMaxChatCompletionConfigSchema.safeParse({
+      temperature: -0.1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept empty config', () => {
+    const result = MiniMaxChatCompletionConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimax.io/) as a first-class LLM provider sub-plugin within `@genkit-ai/compat-oai`, following the same architecture as the existing DeepSeek and xAI plugins.

- **MiniMax plugin** (`@genkit-ai/compat-oai/minimax`) with OpenAI-compatible API at `https://api.minimax.io/v1`
- **4 models**: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`
- **Temperature clamping** to MiniMax's `[0, 1]` range via custom request builder
- **Capabilities**: multi-turn, tool calling, system role, JSON structured output
- **22 unit + integration tests** covering model definitions, config schema validation, request building, and fake server integration (streaming, non-streaming, tool calling)

### Usage

```typescript
import { miniMax } from '@genkit-ai/compat-oai/minimax';

export default configureGenkit({
  plugins: [
    miniMax({ apiKey: process.env.MINIMAX_API_KEY })
  ]
});

// Use a specific model
const response = await generate({
  model: miniMax.model('MiniMax-M2.7'),
  prompt: 'Hello!'
});
```

### Files Changed

| File | Description |
|------|-------------|
| `js/plugins/compat-oai/src/minimax/minimax.ts` | Model definitions, config schema, request builder |
| `js/plugins/compat-oai/src/minimax/index.ts` | Plugin factory, resolver, typed exports |
| `js/plugins/compat-oai/tests/minimax_test.ts` | 22 tests (model defs, schema validation, request builder, integration) |
| `js/plugins/compat-oai/package.json` | Added `./minimax` export path and keyword |

## Test plan

- [ ] All 22 MiniMax-specific tests pass
- [ ] Existing compat-oai tests unaffected
- [ ] TypeScript compilation succeeds
- [ ] Package exports correctly resolve `@genkit-ai/compat-oai/minimax`