### PR TITLE
feat(compat-oai): add Novita AI provider plugin

### DIFF
--- a/js/plugins/compat-oai/package.json
+++ b/js/plugins/compat-oai/package.json
@@ -60,6 +60,12 @@
       "import": "./lib/xai/index.mjs",
       "types": "./lib/xai/index.d.ts",
       "default": "./lib/xai/index.js"
+    },
+    "./novita": {
+      "require": "./lib/novita/index.js",
+      "import": "./lib/novita/index.mjs",
+      "types": "./lib/novita/index.d.ts",
+      "default": "./lib/novita/index.js"
     }
   },
   "typesVersions": {
@@ -72,6 +78,9 @@
       ],
       "xai": [
         "lib/xai"
+      ],
+      "novita": [
+        "lib/novita"
       ]
     }
   },

--- a/js/plugins/compat-oai/src/novita/index.ts
+++ b/js/plugins/compat-oai/src/novita/index.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ActionMetadata,
+  GenkitError,
+  modelActionMetadata,
+  ModelReference,
+  z,
+} from 'genkit';
+import { logger } from 'genkit/logging';
+import { type GenkitPluginV2 } from 'genkit/plugin';
+import { ActionType } from 'genkit/registry';
+import OpenAI from 'openai';
+import { openAICompatible, PluginOptions } from '../index.js';
+import {
+  ChatCompletionCommonConfigSchema,
+  defineCompatOpenAIModel,
+} from '../model.js';
+import {
+  novitaModelRef,
+  SUPPORTED_NOVITA_MODELS,
+} from './novita.js';
+
+export type NovitaPluginOptions = Omit<PluginOptions, 'name' | 'baseURL'>;
+
+function createResolver(pluginOptions: PluginOptions) {
+  return async (client: OpenAI, actionType: ActionType, actionName: string) => {
+    if (actionType === 'model') {
+      const modelRef = novitaModelRef({ name: actionName });
+      return defineCompatOpenAIModel({
+        name: modelRef.name,
+        client,
+        pluginOptions,
+        modelRef,
+      });
+    } else {
+      logger.warn('Only model actions are supported by the Novita plugin');
+      return undefined;
+    }
+  };
+}
+
+const listActions = async (client: OpenAI): Promise<ActionMetadata[]> => {
+  return await client.models.list().then((response) =>
+    response.data
+      .filter((model) => model.object === 'model')
+      .map((model: OpenAI.Model) => {
+        const modelRef =
+          SUPPORTED_NOVITA_MODELS[
+            model.id as keyof typeof SUPPORTED_NOVITA_MODELS
+          ] ?? novitaModelRef({ name: model.id });
+        return modelActionMetadata({
+          name: modelRef.name,
+          info: modelRef.info,
+          configSchema: modelRef.configSchema,
+        });
+      })
+  );
+};
+
+export function novitaPlugin(
+  options?: NovitaPluginOptions
+): GenkitPluginV2 {
+  const apiKey = options?.apiKey ?? process.env.NOVITA_API_KEY;
+  if (!apiKey) {
+    throw new GenkitError({
+      status: 'FAILED_PRECONDITION',
+      message:
+        'Please pass in the API key or set the NOVITA_API_KEY environment variable.',
+    });
+  }
+  const pluginOptions = { name: 'novita', ...options };
+  return openAICompatible({
+    name: 'novita',
+    baseURL: 'https://api.novita.ai/openai',
+    apiKey,
+    ...options,
+    initializer: async (client) => {
+      return Object.values(SUPPORTED_NOVITA_MODELS).map((modelRef) =>
+        defineCompatOpenAIModel({
+          name: modelRef.name,
+          client,
+          pluginOptions,
+          modelRef,
+        })
+      );
+    },
+    resolver: createResolver(pluginOptions),
+    listActions,
+  });
+}
+
+export type NovitaPlugin = {
+  (params?: NovitaPluginOptions): GenkitPluginV2;
+  model(
+    name: keyof typeof SUPPORTED_NOVITA_MODELS,
+    config?: z.infer<typeof ChatCompletionCommonConfigSchema>
+  ): ModelReference<typeof ChatCompletionCommonConfigSchema>;
+  model(name: string, config?: any): ModelReference<z.ZodTypeAny>;
+};
+
+const model = ((name: string, config?: any): ModelReference<z.ZodTypeAny> => {
+  return novitaModelRef({ name, config });
+}) as NovitaPlugin['model'];
+
+/**
+ * This module provides an interface to Novita AI models through the Genkit
+ * plugin system. It allows users to interact with various models by providing
+ * an API key and optional configuration.
+ *
+ * The main export is the `novita` plugin, which can be configured with an API
+ * key either directly or through environment variables. It initializes the
+ * OpenAI-compatible client and makes available the models for use.
+ *
+ * Exports:
+ * - novita: The main plugin function to interact with Novita AI, via OpenAI
+ *   compatible API.
+ *
+ * Usage: To use the models, initialize the novita plugin inside
+ * `configureGenkit` and pass the configuration options. If no API key is
+ * provided in the options, the environment variable `NOVITA_API_KEY` must be
+ * set.
+ *
+ * Example:
+ * ```
+ * import { novita } from '@genkit-ai/compat-oai/novita';
+ *
+ * export default configureGenkit({
+ *  plugins: [
+ *    novita()
+ *    ... // other plugins
+ *  ]
+ * });
+ * ```
+ */
+export const novita: NovitaPlugin = Object.assign(novitaPlugin, {
+  model,
+});
+
+export default novita;

--- a/js/plugins/compat-oai/src/novita/novita.ts
+++ b/js/plugins/compat-oai/src/novita/novita.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ModelInfo, ModelReference } from 'genkit/model';
+import {
+  ChatCompletionCommonConfigSchema,
+  compatOaiModelRef,
+} from '../model';
+
+/** Novita ModelRef helper, with Novita-specific config. */
+export function novitaModelRef(params: {
+  name: string;
+  info?: ModelInfo;
+  config?: any;
+}): ModelReference<typeof ChatCompletionCommonConfigSchema> {
+  return compatOaiModelRef({
+    ...params,
+    configSchema: ChatCompletionCommonConfigSchema,
+    info: params.info ?? {
+      supports: {
+        multiturn: true,
+        tools: true,
+        media: false,
+        systemRole: true,
+        output: ['text', 'json'],
+        constrained: 'all',
+      },
+    },
+    namespace: 'novita',
+  });
+}
+
+export const SUPPORTED_NOVITA_MODELS = {
+  'moonshotai/kimi-k2.5': novitaModelRef({
+    name: 'moonshotai/kimi-k2.5',
+    info: {
+      supports: {
+        multiturn: true,
+        tools: true,
+        media: true,
+        systemRole: true,
+        output: ['text', 'json'],
+        constrained: 'all',
+      },
+    },
+  }),
+  'zai-org/glm-5': novitaModelRef({ name: 'zai-org/glm-5' }),
+  'minimax/minimax-m2.5': novitaModelRef({ name: 'minimax/minimax-m2.5' }),
+};

--- a/js/plugins/compat-oai/tests/novita_test.ts
+++ b/js/plugins/compat-oai/tests/novita_test.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import type OpenAI from 'openai';
+import { defineCompatOpenAIModel } from '../src/model';
+import {
+  novitaModelRef,
+  SUPPORTED_NOVITA_MODELS,
+} from '../src/novita/novita';
+
+jest.mock('genkit/model', () => {
+  const originalModule =
+    jest.requireActual<typeof import('genkit/model')>('genkit/model');
+  return {
+    ...originalModule,
+    defineModel: jest.fn((_, runner) => {
+      return runner;
+    }),
+  };
+});
+
+describe('novitaModelRef', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should prefix names with novita namespace', () => {
+    const ref = novitaModelRef({ name: 'moonshotai/kimi-k2.5' });
+    expect(ref.name).toBe('novita/moonshotai/kimi-k2.5');
+  });
+
+  it('should not double-prefix names already in novita namespace', () => {
+    const ref = novitaModelRef({ name: 'novita/moonshotai/kimi-k2.5' });
+    expect(ref.name).toBe('novita/moonshotai/kimi-k2.5');
+  });
+});
+
+describe('SUPPORTED_NOVITA_MODELS', () => {
+  it('should define all three chat models', () => {
+    const keys = Object.keys(SUPPORTED_NOVITA_MODELS);
+    expect(keys).toContain('moonshotai/kimi-k2.5');
+    expect(keys).toContain('zai-org/glm-5');
+    expect(keys).toContain('minimax/minimax-m2.5');
+  });
+
+  it('kimi-k2.5 should support vision (media)', () => {
+    const ref = SUPPORTED_NOVITA_MODELS['moonshotai/kimi-k2.5'];
+    expect(ref.info?.supports?.media).toBe(true);
+  });
+
+  it('glm-5 and minimax-m2.5 should not support media', () => {
+    expect(
+      SUPPORTED_NOVITA_MODELS['zai-org/glm-5'].info?.supports?.media
+    ).toBe(false);
+    expect(
+      SUPPORTED_NOVITA_MODELS['minimax/minimax-m2.5'].info?.supports?.media
+    ).toBe(false);
+  });
+
+  it('all models should support tools and json output', () => {
+    for (const ref of Object.values(SUPPORTED_NOVITA_MODELS)) {
+      expect(ref.info?.supports?.tools).toBe(true);
+      expect(ref.info?.supports?.output).toContain('json');
+    }
+  });
+});
+
+describe('novita defineCompatOpenAIModel', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should correctly define kimi-k2.5 model', () => {
+    const modelRef = SUPPORTED_NOVITA_MODELS['moonshotai/kimi-k2.5'];
+    const model = defineCompatOpenAIModel({
+      name: modelRef.name,
+      client: {} as OpenAI,
+      modelRef,
+    });
+    expect({
+      name: model.__action.name,
+      supports: model.__action.metadata?.model.supports,
+    }).toStrictEqual({
+      name: 'novita/moonshotai/kimi-k2.5',
+      supports: {
+        multiturn: true,
+        tools: true,
+        media: true,
+        systemRole: true,
+        output: ['text', 'json'],
+        constrained: 'all',
+      },
+    });
+  });
+
+  it('should correctly define glm-5 model', () => {
+    const modelRef = SUPPORTED_NOVITA_MODELS['zai-org/glm-5'];
+    const model = defineCompatOpenAIModel({
+      name: modelRef.name,
+      client: {} as OpenAI,
+      modelRef,
+    });
+    expect({
+      name: model.__action.name,
+      supports: model.__action.metadata?.model.supports,
+    }).toStrictEqual({
+      name: 'novita/zai-org/glm-5',
+      supports: {
+        multiturn: true,
+        tools: true,
+        media: false,
+        systemRole: true,
+        output: ['text', 'json'],
+        constrained: 'all',
+      },
+    });
+  });
+});
+
+describe('novitaPlugin auth', () => {
+  it('should throw if no API key is provided', async () => {
+    const savedEnv = process.env.NOVITA_API_KEY;
+    delete process.env.NOVITA_API_KEY;
+    try {
+      const { novitaPlugin } = await import('../src/novita/index.js');
+      expect(() => novitaPlugin()).toThrow('NOVITA_API_KEY');
+    } finally {
+      if (savedEnv !== undefined) {
+        process.env.NOVITA_API_KEY = savedEnv;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds [Novita AI](https://novita.ai) as a new OpenAI-compatible provider in the `@genkit-ai/compat-oai` plugin, following the same pattern as the existing DeepSeek and xAI providers.

### Changes

- **`js/plugins/compat-oai/src/novita/novita.ts`** — model definitions for the three supported chat models
- **`js/plugins/compat-oai/src/novita/index.ts`** — plugin entry (`novitaPlugin`, `novita` export)
- **`js/plugins/compat-oai/package.json`** — adds `./novita` export path
- **`js/plugins/compat-oai/tests/novita_test.ts`** — unit tests

### Supported models

| Model ID | Vision | Tools | Constrained output |
|---|---|---|---|
| `moonshotai/kimi-k2.5` | ✅ | ✅ | ✅ |
| `zai-org/glm-5` | ❌ | ✅ | ✅ |
| `minimax/minimax-m2.5` | ❌ | ✅ | ✅ |

### Usage

```ts
import { novita } from '@genkit-ai/compat-oai/novita';

const ai = genkit({
  plugins: [novita({ apiKey: process.env.NOVITA_API_KEY })],
});

const response = await ai.generate({
  model: novita.model('moonshotai/kimi-k2.5'),
  prompt: 'Hello!',
});
```

Auth: pass `apiKey` in plugin options, or set the `NOVITA_API_KEY` environment variable.

Base URL: `https://api.novita.ai/openai` (OpenAI-compatible).