### PR TITLE
fix(py): telemetry fixes — Gemini config fields, thinking tokens, span error recording

### DIFF
--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -25,6 +25,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, ClassVar, Generic, cast, get_type_hints
 
+from opentelemetry import trace as trace_api
 from opentelemetry.trace import Span
 from opentelemetry.util import types as otel_types
 from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
@@ -585,6 +586,9 @@ def _make_tracing_wrapper(
                         case _:
                             raise ValueError('action fn must have 0-2 args')
                 except Exception as e:
+                    span.set_attribute("genkit:state", "error")
+                    span.set_status(status=trace_api.StatusCode.ERROR, description=str(e))
+                    span.record_exception(e)
                     # Re-raise existing GenkitError instances to avoid double-wrapping
                     if isinstance(e, GenkitError):
                         raise

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -216,7 +216,7 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
                 schema = request.output_schema
     """
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='forbid', populate_by_name=True)
+    model_config: ClassVar[ConfigDict] = ConfigDict(alias_generator=to_camel, extra='allow', populate_by_name=True)
     # Veneer types for IDE/typing (validators wrap MessageData->Message, DocumentData->Document)
     messages: list[Message]  # pyright: ignore[reportIncompatibleVariableOverride]
     docs: list[Document] | None = None  # pyright: ignore[reportIncompatibleVariableOverride]

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -1467,6 +1467,8 @@ class GeminiModel:
                 if response.usage_metadata
                 else None,
                 total_tokens=float(response.usage_metadata.total_token_count or 0) if response.usage_metadata else None,
+                thoughts_tokens=float(response.usage_metadata.thoughts_token_count or 0) if response.usage_metadata and response.usage_metadata.thoughts_token_count else None,
+                cached_content_tokens=float(response.usage_metadata.cached_content_token_count or 0) if response.usage_metadata and response.usage_metadata.cached_content_token_count else None,
             ),
         )
 
@@ -1816,5 +1818,7 @@ class GeminiModel:
             usage.input_tokens = response.usage.input_tokens
             usage.output_tokens = response.usage.output_tokens
             usage.total_tokens = response.usage.total_tokens
+            usage.thoughts_tokens = response.usage.thoughts_tokens
+            usage.cached_content_tokens = response.usage.cached_content_tokens
 
         return usage


### PR DESCRIPTION
## Summary

Three pre-release bug fixes from the Bug Bash (March 18, 2026).

## Changes

### Unblock Gemini-specific config fields
**File:** `py/packages/genkit/src/genkit/_core/_model.py`

`ModelRequest` was using `extra='forbid'`, which caused Pydantic to reject any Gemini-specific config fields (code execution, context cache, search grounding, file search, function calling config). Every other config model in the codebase uses `extra='allow'` — this was the only exception. Changed to `extra='allow'`.

### Map thinking tokens and cached content tokens from Gemini response
**File:** `py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py`

`thoughts_token_count` and `cached_content_token_count` from `usage_metadata` were not being mapped to `GenerationUsage.thoughts_tokens` and `cached_content_tokens`. The type fields already existed — the plugin just wasn't populating them. Fixed in both streaming and non-streaming paths.

### Record exception details to span on action failure
**File:** `py/packages/genkit/src/genkit/_core/_action.py`

The action tracing wrapper caught exceptions but never called `span.set_status()` or `span.record_exception()`, so failed traces had no error detail in the Dev UI. Added the same pattern already used correctly in `_tracing.py`.

## Testing
- Any generate() call with Gemini-specific config fields should no longer throw "Extra inputs are not permitted"
-`response.usage.thoughts_tokens` now populated for Gemini 2.5 thinking models
- Failed action traces now include `exception.message` and `exception.stacktrace` in Dev UI