### PR TITLE
Fix(google-genai): Correct Vertex AI Veo Base64 URI generation and fal…

### DIFF
--- a/js/plugins/google-genai/src/vertexai/converters.ts
+++ b/js/plugins/google-genai/src/vertexai/converters.ts
@@ -462,7 +462,7 @@ export function fromVeoOperation(
 
           return {
             media: {
-              url: veoMedia.gcsUri ?? '',
+              url: veoMedia.gcsUri ?? veoMedia.uri ?? '',
               contentType: veoMedia.mimeType,
             },
           };

--- a/js/plugins/google-genai/src/vertexai/converters.ts
+++ b/js/plugins/google-genai/src/vertexai/converters.ts
@@ -454,7 +454,7 @@ export function fromVeoOperation(
           if (veoMedia.bytesBase64Encoded) {
             return {
               media: {
-                url: `data:${veoMedia.mimeType}:base64,${veoMedia.bytesBase64Encoded}`,
+                url: `data:${veoMedia.mimeType};base64,${veoMedia.bytesBase64Encoded}`,
                 contentType: veoMedia.mimeType,
               },
             };

--- a/js/plugins/google-genai/src/vertexai/types.ts
+++ b/js/plugins/google-genai/src/vertexai/types.ts
@@ -306,6 +306,7 @@ export declare interface VeoMedia {
   bytesBase64Encoded?: string;
   gcsUri?: string;
   mimeType?: string;
+  uri?: string;
 }
 
 export declare interface VeoReferenceImage {

--- a/js/plugins/google-genai/tests/vertexai/converters_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/converters_test.ts
@@ -632,7 +632,7 @@ describe('Vertex AI Converters', () => {
               },
               {
                 media: {
-                  url: 'data:video/webm:base64,VID2DATA',
+                  url: 'data:video/webm;base64,VID2DATA',
                   contentType: 'video/webm',
                 },
               },


### PR DESCRIPTION
# Bug Report / PR Proposal: Vertex AI Veo 2.0 Plugin Issues in @genkit-ai/google-genai

**Environment:**
- **Genkit Core / Genkit CLI:** `v1.30.1`
- **Plugin (`@genkit-ai/google-genai`):** `v1.30.1`
- **Node.js:** `v24.14.0` 

This document outlines the issues discovered and our proposed solutions/fallbacks for the official Genkit SDK.

## Issue 1: Malformed Base64 Data URI from `fromVeoOperation`

**Description:**
When Veo 2.0 generates an output and returns the artifact as a Raw Base64 JSON payload, the SDK maps this payload cleanly but introduces a fatal typo in the URI string prefix. Browsers strictly parse Data URIs using a semicolon delimiter (`;base64,`), but the SDK explicitly constructs it using a colon (`:base64,`). 

**Location:**
`node_modules/@genkit-ai/google-genai/src/vertexai/converters.ts` at `fromVeoOperation()` mapping logic (specifically around `line 457`).

**Expected Structure:**
`data:video/mp4;base64,AAAA...`

**Actual Output:**
`data:video/mp4:base64,AAAA...`

**Impact:**
Because of this `\:` vs `\;` error, standard frontend `<video src="...">` or `<img src="...">` elements silently fail to render the media block. The user must actively run `.replace(':base64,', ';base64,')` inside their backend to patch the artifact URL before streaming it to the UI.

**Proposed PR Fix (`converters.ts`):**
```typescript
- url: `data:${veoMedia.mimeType}:base64,${veoMedia.bytesBase64Encoded}`,
+ url: `data:${veoMedia.mimeType};base64,${veoMedia.bytesBase64Encoded}`,
```

---

## Issue 2: GCS Storage URIs using `uri` Instead of `gcsUri`

**Description:**
Depending on the specific region or Google Cloud backend infrastructure routing (e.g. `us-central1`), the Vertex AI backend occasionally maps Veo 2.0 video outputs using the JSON key `uri` instead of `gcsUri` in the long-running operation polling payload. 

**Location:**
`node_modules/@genkit-ai/google-genai/src/vertexai/converters.ts`

**Impact:**
The `fromVeoOperation()` mapper explicitly isolates and filters for `veoMedia.gcsUri`. Since `gcsUri` is undefined, the flow resolves successfully, but the output `url` key is stripped entirely (returning `''`). This creates a ghost success state where the backend acknowledges a valid generation but the frontend receives no artifact.

**Our Current Workaround (`backend/genkit.ts`):**
To resolve this, we bypassed the SDK mapper entirelly, diving natively into the unmapped `operation.output.raw` object to catch both fallback values:

```typescript
// Fallback logic accessing the deep raw payload structure
const rawData = operation.output?.raw as any || {};
const fallbackUri = rawData.videos?.[0]?.uri || rawData.videos?.[0]?.gcsUri || rawData.videos?.[0]?.bytesBase64Encoded;
let finalUrl = video.media?.url || fallbackUri || '';

// Further mapping `gs://...` into standard public `https://storage.googleapis.com/...` paths for browser consumption
if (finalUrl.startsWith('gs://')) {
    finalUrl = finalUrl.replace('gs://', 'https://storage.googleapis.com/');
}
```

**Proposed PR Fix (`converters.ts`):**
Update the Veo response interface typing and the underlying `fromVeoOperation` mapper to explicitly check for both property variations during object hydration.

```typescript
  return {
    media: {
-     url: veoMedia.gcsUri ?? '',
+     url: veoMedia.gcsUri ?? veoMedia.uri ?? '',
      contentType: veoMedia.mimeType,
    },
  };
```

---

## Conclusion
Patching the `\;base64` regex typo and creating a wider catchment for `uri` vs `gcsUri` bucket definitions will make the Vertex AI Genkit API completely robust out-of-the-box, ensuring users don't face silent browser rejections for valid Vertex Veo generations.

Description here... Help the reviewer by:
 - linking to an issue that includes more details
 - if it's a new feature include samples of how to use the new feature
 - (optional if issue link is provided) if you fixed a bug include basic bug details

Checklist (if applicable):
- [ ] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
