### PR TITLE
chore: update macos-14 runner to macos-15-intel for darwin-x64 builds

### DIFF
--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -28,7 +28,7 @@ jobs:
             target: linux-x64
           - os: ubuntu-24.04-arm
             target: linux-arm64
-          - os: macos-14  # x64/Intel
+          - os: macos-15-intel  # x64/Intel
             target: darwin-x64
           - os: macos-latest  # ARM64/M1
             target: darwin-arm64
@@ -112,7 +112,7 @@ jobs:
             target: linux-x64
           - os: ubuntu-24.04-arm
             target: linux-arm64
-          - os: macos-14
+          - os: macos-15-intel
             target: darwin-x64
           - os: macos-latest
             target: darwin-arm64


### PR DESCRIPTION
macos-14 is the wrong runner (it's arm)

Fixes #3842

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
