### PR TITLE
fix(py): Fix pyproject.toml on fastapi plugin

### DIFF
--- a/py/plugins/fastapi/pyproject.toml
+++ b/py/plugins/fastapi/pyproject.toml
@@ -66,5 +66,4 @@ build-backend = "hatchling.build"
 requires      = ["hatchling"]
 
 [tool.hatch.build.targets.wheel]
-only-include = ["src/genkit/plugins/fastapi"]
-sources      = ["src"]
+packages = ["src/genkit"]


### PR DESCRIPTION
This PR fixes a bug preventing the genkit-plugin-fastapi package from being uploaded to PyPI (returning a 400 Bad Request: Duplicate filename in local headers error)