### PR TITLE
feat(go/plugins/vertexai): Model Garden support for Claude 4.6 and 4.7

### DIFF
--- a/go/plugins/vertexai/modelgarden/anthropic_live_test.go
+++ b/go/plugins/vertexai/modelgarden/anthropic_live_test.go
@@ -257,6 +257,38 @@ func TestAnthropicLive(t *testing.T) {
 			t.Fatalf("empty usage stats: %#v", *final.Usage)
 		}
 	})
+
+	t.Run("claude 4.6 / 4.7 smoke", func(t *testing.T) {
+		for _, id := range []string{
+			"claude-sonnet-4-6",
+			"claude-opus-4-6",
+			"claude-opus-4-7",
+		} {
+			t.Run(id, func(t *testing.T) {
+				m := modelgarden.AnthropicModel(g, id)
+				if m == nil {
+					t.Fatalf("model %s not registered", id)
+				}
+				resp, err := genkit.Generate(ctx, g,
+					ai.WithConfig(&anthropic.MessageNewParams{
+						Temperature: anthropic.Float(1),
+						MaxTokens:   64,
+					}),
+					ai.WithModel(m),
+					ai.WithMessages(ai.NewUserMessage(ai.NewTextPart("Reply with the single word: pong"))),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if resp.Text() == "" {
+					t.Fatalf("empty response from %s", id)
+				}
+				if resp.Usage.InputTokens == 0 || resp.Usage.OutputTokens == 0 {
+					t.Fatalf("empty usage stats from %s: %#v", id, *resp.Usage)
+				}
+			})
+		}
+	})
 }
 
 func fetchImgAsBase64() (string, error) {

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -70,11 +70,11 @@ var AnthropicModels = map[string]ai.ModelOptions{
 		Supports: &internal.Multimodal,
 	},
 	"claude-sonnet-4-6": {
-		Label:    "Claude Sonnet 4.6",
+		Label:    "Claude 4.6 Sonnet",
 		Supports: &internal.Multimodal,
 	},
 	"claude-opus-4-6": {
-		Label:    "Claude Opus 4.6",
+		Label:    "Claude 4.6 Opus",
 		Supports: &internal.Multimodal,
 	},
 }

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -69,4 +69,12 @@ var AnthropicModels = map[string]ai.ModelOptions{
 		Label:    "Claude 4.5 Haiku",
 		Supports: &internal.Multimodal,
 	},
+	"claude-sonnet-4-6": {
+		Label:    "Claude Sonnet 4.6",
+		Supports: &internal.Multimodal,
+	},
+	"claude-opus-4-6": {
+		Label:    "Claude Opus 4.6",
+		Supports: &internal.Multimodal,
+	},
 }

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -77,4 +77,8 @@ var AnthropicModels = map[string]ai.ModelOptions{
 		Label:    "Claude 4.6 Opus",
 		Supports: &internal.Multimodal,
 	},
+	"claude-opus-4-7": {
+		Label:    "Claude 4.7 Opus",
+		Supports: &internal.Multimodal,
+	},
 }

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -69,6 +69,9 @@ var AnthropicModels = map[string]ai.ModelOptions{
 		Label:    "Claude 4.5 Haiku",
 		Supports: &internal.Multimodal,
 	},
+	// Starting with the 4.6 generation, Anthropic's Vertex AI IDs are dateless
+	// pinned snapshots (not evergreen pointers).
+	// See https://docs.claude.com/en/docs/about-claude/models/overview
 	"claude-sonnet-4-6": {
 		Label:    "Claude 4.6 Sonnet",
 		Supports: &internal.Multimodal,

--- a/go/samples/basic/main.go
+++ b/go/samples/basic/main.go
@@ -34,14 +34,17 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 
+	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 	"github.com/firebase/genkit/go/plugins/server"
+	"github.com/firebase/genkit/go/plugins/vertexai/modelgarden"
 	"google.golang.org/genai"
 )
 
@@ -52,7 +55,10 @@ func main() {
 	// Config parameter, the Google AI plugin will get the API key from the
 	// GEMINI_API_KEY or GOOGLE_API_KEY environment variable, which is the recommended
 	// practice.
-	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+	g := genkit.Init(ctx, genkit.WithPlugins(
+		&googlegenai.GoogleAI{},
+		&modelgarden.Anthropic{},
+	))
 
 	// Define a non-streaming flow that generates jokes about a given topic.
 	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, input string) (string, error) {
@@ -93,6 +99,42 @@ func main() {
 			return resp.Text(), nil
 		},
 	)
+
+	// Vertex Model Garden - Claude Sonnet 4.6.
+	genkit.DefineFlow(g, "claudeSonnet46VertexModelGardenFlow", func(ctx context.Context, input string) (string, error) {
+		if input == "" {
+			input = "airplane food"
+		}
+		m := modelgarden.AnthropicModel(g, "claude-sonnet-4-6")
+		if m == nil {
+			return "", errors.New("claudeSonnet46VertexModelGardenFlow: failed to find model")
+		}
+		return genkit.GenerateText(ctx, g,
+			ai.WithModel(m),
+			ai.WithConfig(&anthropic.MessageNewParams{
+				MaxTokens: 1024,
+			}),
+			ai.WithPrompt("Share a joke about %s.", input),
+		)
+	})
+
+	// Vertex Model Garden - Claude Opus 4.6.
+	genkit.DefineFlow(g, "claudeOpus46VertexModelGardenFlow", func(ctx context.Context, input string) (string, error) {
+		if input == "" {
+			input = "airplane food"
+		}
+		m := modelgarden.AnthropicModel(g, "claude-opus-4-6")
+		if m == nil {
+			return "", errors.New("claudeOpus46VertexModelGardenFlow: failed to find model")
+		}
+		return genkit.GenerateText(ctx, g,
+			ai.WithModel(m),
+			ai.WithConfig(&anthropic.MessageNewParams{
+				MaxTokens: 1024,
+			}),
+			ai.WithPrompt("Share a joke about %s.", input),
+		)
+	})
 
 	// Optionally, start a web server to make the flow callable via HTTP.
 	mux := http.NewServeMux()

--- a/go/samples/basic/main.go
+++ b/go/samples/basic/main.go
@@ -34,17 +34,14 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
 
-	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 	"github.com/firebase/genkit/go/plugins/server"
-	"github.com/firebase/genkit/go/plugins/vertexai/modelgarden"
 	"google.golang.org/genai"
 )
 
@@ -57,7 +54,6 @@ func main() {
 	// practice.
 	g := genkit.Init(ctx, genkit.WithPlugins(
 		&googlegenai.GoogleAI{},
-		&modelgarden.Anthropic{},
 	))
 
 	// Define a non-streaming flow that generates jokes about a given topic.
@@ -99,42 +95,6 @@ func main() {
 			return resp.Text(), nil
 		},
 	)
-
-	// Vertex Model Garden - Claude Sonnet 4.6.
-	genkit.DefineFlow(g, "claudeSonnet46VertexModelGardenFlow", func(ctx context.Context, input string) (string, error) {
-		if input == "" {
-			input = "airplane food"
-		}
-		m := modelgarden.AnthropicModel(g, "claude-sonnet-4-6")
-		if m == nil {
-			return "", errors.New("claudeSonnet46VertexModelGardenFlow: failed to find model")
-		}
-		return genkit.GenerateText(ctx, g,
-			ai.WithModel(m),
-			ai.WithConfig(&anthropic.MessageNewParams{
-				MaxTokens: 1024,
-			}),
-			ai.WithPrompt("Share a joke about %s.", input),
-		)
-	})
-
-	// Vertex Model Garden - Claude Opus 4.6.
-	genkit.DefineFlow(g, "claudeOpus46VertexModelGardenFlow", func(ctx context.Context, input string) (string, error) {
-		if input == "" {
-			input = "airplane food"
-		}
-		m := modelgarden.AnthropicModel(g, "claude-opus-4-6")
-		if m == nil {
-			return "", errors.New("claudeOpus46VertexModelGardenFlow: failed to find model")
-		}
-		return genkit.GenerateText(ctx, g,
-			ai.WithModel(m),
-			ai.WithConfig(&anthropic.MessageNewParams{
-				MaxTokens: 1024,
-			}),
-			ai.WithPrompt("Share a joke about %s.", input),
-		)
-	})
 
 	// Optionally, start a web server to make the flow callable via HTTP.
 	mux := http.NewServeMux()

--- a/go/samples/basic/main.go
+++ b/go/samples/basic/main.go
@@ -52,9 +52,7 @@ func main() {
 	// Config parameter, the Google AI plugin will get the API key from the
 	// GEMINI_API_KEY or GOOGLE_API_KEY environment variable, which is the recommended
 	// practice.
-	g := genkit.Init(ctx, genkit.WithPlugins(
-		&googlegenai.GoogleAI{},
-	))
+	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
 
 	// Define a non-streaming flow that generates jokes about a given topic.
 	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, input string) (string, error) {

--- a/go/samples/modelgarden/main.go
+++ b/go/samples/modelgarden/main.go
@@ -50,5 +50,41 @@ func main() {
 		return text, nil
 	})
 
+	// Vertex Model Garden - Claude Sonnet 4.6.
+	genkit.DefineFlow(g, "claudeSonnet46VertexModelGardenFlow", func(ctx context.Context, input string) (string, error) {
+		if input == "" {
+			input = "airplane food"
+		}
+		m := modelgarden.AnthropicModel(g, "claude-sonnet-4-6")
+		if m == nil {
+			return "", errors.New("claudeSonnet46VertexModelGardenFlow: failed to find model")
+		}
+		return genkit.GenerateText(ctx, g,
+			ai.WithModel(m),
+			ai.WithConfig(&anthropic.MessageNewParams{
+				MaxTokens: 1024,
+			}),
+			ai.WithPrompt("Share a joke about %s.", input),
+		)
+	})
+
+	// Vertex Model Garden - Claude Opus 4.6.
+	genkit.DefineFlow(g, "claudeOpus46VertexModelGardenFlow", func(ctx context.Context, input string) (string, error) {
+		if input == "" {
+			input = "airplane food"
+		}
+		m := modelgarden.AnthropicModel(g, "claude-opus-4-6")
+		if m == nil {
+			return "", errors.New("claudeOpus46VertexModelGardenFlow: failed to find model")
+		}
+		return genkit.GenerateText(ctx, g,
+			ai.WithModel(m),
+			ai.WithConfig(&anthropic.MessageNewParams{
+				MaxTokens: 1024,
+			}),
+			ai.WithPrompt("Share a joke about %s.", input),
+		)
+	})
+
 	<-ctx.Done()
 }

--- a/go/samples/modelgarden/main.go
+++ b/go/samples/modelgarden/main.go
@@ -86,5 +86,23 @@ func main() {
 		)
 	})
 
+	// Vertex Model Garden - Claude Opus 4.7.
+	genkit.DefineFlow(g, "claudeOpus47VertexModelGardenFlow", func(ctx context.Context, input string) (string, error) {
+		if input == "" {
+			input = "airplane food"
+		}
+		m := modelgarden.AnthropicModel(g, "claude-opus-4-7")
+		if m == nil {
+			return "", errors.New("claudeOpus47VertexModelGardenFlow: failed to find model")
+		}
+		return genkit.GenerateText(ctx, g,
+			ai.WithModel(m),
+			ai.WithConfig(&anthropic.MessageNewParams{
+				MaxTokens: 1024,
+			}),
+			ai.WithPrompt("Share a joke about %s.", input),
+		)
+	})
+
 	<-ctx.Done()
 }


### PR DESCRIPTION
## Summary

- Registers three Claude models in the Vertex Model Garden plugin:
    - `claude-sonnet-4-6` (Claude 4.6 Sonnet)
    - `claude-opus-4-6` (Claude 4.6 Opus)
    - `claude-opus-4-7` (Claude 4.7 Opus)

- Adds matching demo flows in `go/samples/modelgarden/main.go`:
    - `claudeSonnet46VertexModelGardenFlow`
    - `claudeOpus46VertexModelGardenFlow`
    - `claudeOpus47VertexModelGardenFlow`

- Each sample flow passes `MaxTokens` in the Anthropic request config so Model Garden requests are valid.

## Test plan

- [x] `gofmt` on changed Go files
- [x] `go test ./go/plugins/vertexai/modelgarden/...`
- [x] `go build ./go/plugins/vertexai/modelgarden/... ./go/samples/modelgarden/...`
- [x] `go vet` clean
- [x] Dev UI reflection verified for:
    - `/model/vertexai/claude-sonnet-4-6`
    - `/model/vertexai/claude-opus-4-6`
    - `/model/vertexai/claude-opus-4-7`
    - `/flow/claudeSonnet46VertexModelGardenFlow`
    - `/flow/claudeOpus46VertexModelGardenFlow`
    - `/flow/claudeOpus47VertexModelGardenFlow`
- [x] Manual flow execution: Sonnet 4.6 returns text successfully.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tested (package tests + manual Dev UI run)
- [ ] Docs updated (not required for this code-only change)

Closes #136
Closes #137

# Smoke tests

Opus 4.7:
<img width="2400" height="1838" alt="image" src="https://github.com/user-attachments/assets/2a5a12d9-1189-492c-9a04-9b3ffe01e6b5" />
Opus 4.6:
<img width="2400" height="1838" alt="image" src="https://github.com/user-attachments/assets/ce84f552-5173-409b-b83d-7c95a9abc181" />

Sonnet 4.6:
<img width="2400" height="1838" alt="image" src="https://github.com/user-attachments/assets/0fb6f160-e1ec-4cd9-bd0d-d91311b4d698" />
