### PR TITLE
feat(py): add Gemini 3.1 preview support to python

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -311,6 +311,17 @@ def _create_embedder_action(
     return action
 
 
+def _is_global_vertex_gemini_model(name: str) -> bool:
+    """Return True when a Vertex Gemini model should use global location.
+
+    Gemini 3.1 preview models are only available in `global` for many projects.
+    Keep this predicate narrow so other models continue using the plugin's
+    configured location.
+    """
+    lower_name = name.lower()
+    return lower_name.startswith('gemini-3.1-') and 'preview' in lower_name
+
+
 class GoogleAI(Plugin):
     """GoogleAI plugin for Genkit with dynamic model discovery.
 
@@ -765,6 +776,9 @@ class VertexAI(Plugin):
         }
         # Single loop-local client accessor used everywhere in plugin runtime paths.
         self._runtime_client = loop_local_client(lambda: genai.client.Client(**self._client_kwargs))
+        # Gemini 3.1 preview models frequently require `global` location.
+        global_client_kwargs = {**self._client_kwargs, 'location': 'global'}
+        self._global_runtime_client = loop_local_client(lambda: genai.client.Client(**global_client_kwargs))
         self._list_actions_cache: list[ActionMetadata] | None = None
 
     async def init(self) -> list[Action]:
@@ -907,12 +921,15 @@ class VertexAI(Plugin):
             config_schema = get_model_config_schema(clean_name)
 
         async def _run(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+            model_client_getter = (
+                self._global_runtime_client if _is_global_vertex_gemini_model(clean_name) else self._runtime_client
+            )
             if clean_name.lower().startswith('image'):
                 model = ImagenModel(clean_name, self._runtime_client())
             elif is_veo_model(clean_name):
                 model = VeoModel(clean_name, self._runtime_client())
             else:
-                model = GeminiModel(clean_name, self._runtime_client())
+                model = GeminiModel(clean_name, model_client_getter())
             return await model.generate(request, ctx)
 
         return Action(

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -406,15 +406,17 @@ class GoogleAI(Plugin):
                 'Gemini api key should be passed in plugin params or as a GEMINI_API_KEY environment variable'
             )
 
-        self._client_kwargs: dict[str, Any] = {
-            'vertexai': self._vertexai,
-            'api_key': api_key,
-            'credentials': credentials,
-            'debug_config': debug_config,
-            'http_options': _inject_attribution_headers(http_options, base_url, api_version),
-        }
+        resolved_http_options = _inject_attribution_headers(http_options, base_url, api_version)
         # Single loop-local client accessor used everywhere in plugin runtime paths.
-        self._runtime_client = loop_local_client(lambda: genai.client.Client(**self._client_kwargs))
+        self._runtime_client = loop_local_client(
+            lambda: genai.client.Client(
+                vertexai=self._vertexai,
+                api_key=api_key,
+                credentials=credentials,
+                debug_config=debug_config,
+                http_options=resolved_http_options,
+            )
+        )
         self._list_actions_cache: list[ActionMetadata] | None = None
 
     async def init(self) -> list[Action]:
@@ -765,20 +767,31 @@ class VertexAI(Plugin):
         self._project = project if project else os.getenv(const.GCLOUD_PROJECT)
         self._location = location if location else const.DEFAULT_REGION
 
-        self._client_kwargs: dict[str, Any] = {
-            'vertexai': self._vertexai,
-            'api_key': api_key,
-            'credentials': credentials,
-            'project': self._project,
-            'location': self._location,
-            'debug_config': debug_config,
-            'http_options': _inject_attribution_headers(http_options, base_url, api_version),
-        }
+        resolved_http_options = _inject_attribution_headers(http_options, base_url, api_version)
         # Single loop-local client accessor used everywhere in plugin runtime paths.
-        self._runtime_client = loop_local_client(lambda: genai.client.Client(**self._client_kwargs))
+        self._runtime_client = loop_local_client(
+            lambda: genai.client.Client(
+                vertexai=self._vertexai,
+                api_key=api_key,
+                credentials=credentials,
+                project=self._project,
+                location=self._location,
+                debug_config=debug_config,
+                http_options=resolved_http_options,
+            )
+        )
         # Gemini 3.1 preview models frequently require `global` location.
-        global_client_kwargs = {**self._client_kwargs, 'location': 'global'}
-        self._global_runtime_client = loop_local_client(lambda: genai.client.Client(**global_client_kwargs))
+        self._global_runtime_client = loop_local_client(
+            lambda: genai.client.Client(
+                vertexai=self._vertexai,
+                api_key=api_key,
+                credentials=credentials,
+                project=self._project,
+                location='global',
+                debug_config=debug_config,
+                http_options=resolved_http_options,
+            )
+        )
         self._list_actions_cache: list[ActionMetadata] | None = None
 
     async def init(self) -> list[Action]:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -946,7 +946,23 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMMA_3N_E4B_IT = 'gemma-3n-e4b-it'
 
 
-SUPPORTED_MODELS = {}
+SUPPORTED_MODELS = {
+    'gemini-1.5-pro': GEMINI_1_5_PRO,
+    'gemini-1.5-flash': GEMINI_1_5_FLASH,
+    'gemini-1.5-flash-8b': GEMINI_1_5_FLASH_8B,
+    'gemini-2.0-flash': GEMINI_2_0_FLASH,
+    'gemini-2.0-flash-lite': GEMINI_2_0_FLASH_LITE,
+    'gemini-2.0-pro-exp-02-05': GEMINI_2_0_PRO_EXP_02_05,
+    'gemini-2.0-flash-exp': GEMINI_2_0_FLASH_EXP_IMAGEN,
+    'gemini-2.0-flash-thinking-exp-01-21': GEMINI_2_0_FLASH_THINKING_EXP_01_21,
+    'gemini-2.5-pro-exp-03-25': GEMINI_2_5_PRO_EXP_03_25,
+    'gemini-2.5-pro-preview-03-25': GEMINI_2_5_PRO_PREVIEW_03_25,
+    'gemini-2.5-pro-preview-05-06': GEMINI_2_5_PRO_PREVIEW_05_06,
+    'gemini-2.5-flash-preview-04-17': GEMINI_2_5_FLASH_PREVIEW_04_17,
+    'gemini-3.1-flash-lite-preview': GEMINI_3_1_FLASH_LITE_PREVIEW,
+    'gemini-3.1-pro-preview-customtools': GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS,
+    'gemini-3.1-pro-preview': GEMINI_3_1_PRO_PREVIEW,
+}
 
 
 DEFAULT_SUPPORTS_MODEL = Supports(

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -1630,7 +1630,8 @@ class GeminiModel:
             model metadata.
         """
         if self._version in SUPPORTED_MODELS:
-            supports = SUPPORTED_MODELS[self._version].supports.model_dump(by_alias=True, exclude_none=True)
+            supports_info = SUPPORTED_MODELS[self._version].supports or DEFAULT_SUPPORTS_MODEL
+            supports = supports_info.model_dump(by_alias=True, exclude_none=True)
         else:
             # Fallback to default supports for models not explicitly listed
             supports = DEFAULT_SUPPORTS_MODEL.model_dump(by_alias=True, exclude_none=True)

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -112,6 +112,9 @@ The following models are currently supported by GoogleAI API:
 | `gemini-2.0-flash-thinking-exp-01-21`| Gemini 2.0 Flash Thinking Exp 01-21  | Supported  |
 | `gemini-2.5-pro-preview-03-25`       | Gemini 2.5 Pro Preview 03-25         | Supported  |
 | `gemini-2.5-pro-preview-05-06`       | Gemini 2.5 Pro Preview 05-06         | Supported  |
+| `gemini-3.1-flash-lite-preview`      | Gemini 3.1 Flash Lite Preview        | Supported  |
+| `gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools  | Supported  |
+| `gemini-3.1-pro-preview`             | Gemini 3.1 Pro Preview               | Supported  |
 
 
 The following models are currently supported by VertexAI API:
@@ -129,6 +132,8 @@ The following models are currently supported by VertexAI API:
 | `gemini-2.0-flash-thinking-exp-01-21`| Gemini 2.0 Flash Thinking Exp 01-21  | Supported    |
 | `gemini-2.5-pro-preview-03-25`       | Gemini 2.5 Pro Preview 03-25         | Supported    |
 | `gemini-2.5-pro-preview-05-06`       | Gemini 2.5 Pro Preview 05-06         | Supported  |
+| `gemini-3.1-flash-lite-preview`      | Gemini 3.1 Flash Lite Preview        | Supported    |
+| `gemini-3.1-pro-preview`             | Gemini 3.1 Pro Preview               | Supported    |
 """
 
 import sys
@@ -717,6 +722,45 @@ GEMINI_2_5_FLASH_PREVIEW_04_17 = ModelInfo(
     ),
 )
 
+GEMINI_3_1_FLASH_LITE_PREVIEW = ModelInfo(
+    label='Google AI - Gemini 3.1 Flash Lite Preview',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained=Constrained.NO_TOOLS,
+        output=['text', 'json'],
+    ),
+)
+
+GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS = ModelInfo(
+    label='Google AI - Gemini 3.1 Pro Preview Custom Tools',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained=Constrained.NO_TOOLS,
+        output=['text', 'json'],
+    ),
+)
+
+GEMINI_3_1_PRO_PREVIEW = ModelInfo(
+    label='Google AI - Gemini 3.1 Pro Preview',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained=Constrained.NO_TOOLS,
+        output=['text', 'json'],
+    ),
+)
+
 GENERIC_GEMINI_MODEL = ModelInfo(
     label='Google AI - Gemini',
     supports=Supports(
@@ -800,6 +844,8 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     | `gemini-3-pro-image-preview`         | Gemini 3 Pro Image Preview           | Supported    |
     | `gemini-2.5-flash-image-preview`     | Gemini 2.5 Flash Image Preview       | Supported    |
     | `gemini-2.5-flash-image`             | Gemini 2.5 Flash Image               | Supported    |
+    | `gemini-3.1-flash-lite-preview`      | Gemini 3.1 Flash Lite Preview        | Supported    |
+    | `gemini-3.1-pro-preview`             | Gemini 3.1 Pro Preview               | Supported    |
     | `gemma-3-12b-it`                     | Gemma 3 12B IT                       | Supported    |
     | `gemma-3-1b-it`                      | Gemma 3 1B IT                        | Supported    |
     | `gemma-3-27b-it`                     | Gemma 3 27B IT                       | Supported    |
@@ -825,6 +871,8 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_3_PRO_IMAGE_PREVIEW = 'gemini-3-pro-image-preview'
     GEMINI_2_5_FLASH_IMAGE_PREVIEW = 'gemini-2.5-flash-image-preview'
     GEMINI_2_5_FLASH_IMAGE = 'gemini-2.5-flash-image'
+    GEMINI_3_1_FLASH_LITE_PREVIEW = 'gemini-3.1-flash-lite-preview'
+    GEMINI_3_1_PRO_PREVIEW = 'gemini-3.1-pro-preview'
     GEMMA_3_12B_IT = 'gemma-3-12b-it'
     GEMMA_3_1B_IT = 'gemma-3-1b-it'
     GEMMA_3_27B_IT = 'gemma-3-27b-it'
@@ -860,6 +908,9 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     | `gemini-3-pro-image-preview`         | Gemini 3 Pro Image Preview           | Supported  |
     | `gemini-2.5-flash-image-preview`     | Gemini 2.5 Flash Image Preview       | Supported  |
     | `gemini-2.5-flash-image`             | Gemini 2.5 Flash Image               | Supported  |
+    | `gemini-3.1-flash-lite-preview`      | Gemini 3.1 Flash Lite Preview        | Supported  |
+    | `gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools  | Supported  |
+    | `gemini-3.1-pro-preview`             | Gemini 3.1 Pro Preview               | Supported  |
     | `gemma-3-12b-it`                     | Gemma 3 12B IT                       | Supported  |
     | `gemma-3-1b-it`                      | Gemma 3 1B IT                        | Supported  |
     | `gemma-3-27b-it`                     | Gemma 3 27B IT                       | Supported  |
@@ -885,6 +936,9 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_3_PRO_IMAGE_PREVIEW = 'gemini-3-pro-image-preview'
     GEMINI_2_5_FLASH_IMAGE_PREVIEW = 'gemini-2.5-flash-image-preview'
     GEMINI_2_5_FLASH_IMAGE = 'gemini-2.5-flash-image'
+    GEMINI_3_1_FLASH_LITE_PREVIEW = 'gemini-3.1-flash-lite-preview'
+    GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS = 'gemini-3.1-pro-preview-customtools'
+    GEMINI_3_1_PRO_PREVIEW = 'gemini-3.1-pro-preview'
     GEMMA_3_12B_IT = 'gemma-3-12b-it'
     GEMMA_3_1B_IT = 'gemma-3-1b-it'
     GEMMA_3_27B_IT = 'gemma-3-27b-it'

--- a/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
@@ -47,6 +47,7 @@ from genkit import (
 from genkit.plugin_api import to_json_schema
 from genkit.plugins.google_genai.models.gemini import (
     DEFAULT_SUPPORTS_MODEL,
+    GEMINI_3_1_PRO_PREVIEW,
     GeminiModel,
     GoogleAIGeminiVersion,
     VertexAIGeminiVersion,
@@ -367,6 +368,12 @@ def test_google_model_info(input: str, expected: ModelInfo) -> None:
     model_info = google_model_info(input)
 
     assert model_info == expected
+
+
+def test_google_model_info_known_uses_registered_metadata() -> None:
+    """Known models should return explicit metadata from SUPPORTED_MODELS."""
+    model_info = google_model_info('gemini-3.1-pro-preview')
+    assert model_info == GEMINI_3_1_PRO_PREVIEW
 
 
 @pytest.fixture

--- a/py/plugins/google-genai/tests/google_genai_plugin_test.py
+++ b/py/plugins/google-genai/tests/google_genai_plugin_test.py
@@ -296,9 +296,7 @@ async def test_vertexai_uses_global_client_for_gemini_31_preview(
 
     plugin = VertexAI(project='test-project', location='us-central1')
     action = plugin._resolve_model('vertexai/gemini-3.1-pro-preview')
-    await action(
-        ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='ping'))])])
-    )
+    await action(ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='ping'))])]))
 
     assert mock_gemini_model.call_args is not None
     used_client = mock_gemini_model.call_args.args[1]
@@ -328,9 +326,7 @@ async def test_vertexai_uses_default_client_for_non_gemini_31_preview(
 
     plugin = VertexAI(project='test-project', location='us-central1')
     action = plugin._resolve_model('vertexai/gemini-2.0-flash')
-    await action(
-        ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='ping'))])])
-    )
+    await action(ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='ping'))])]))
 
     assert mock_gemini_model.call_args is not None
     used_client = mock_gemini_model.call_args.args[1]
@@ -363,9 +359,7 @@ def test_googleai_gemini_version_enum() -> None:
     # Check that the enum has at least one value
     assert len(list(GoogleAIGeminiVersion)) > 0
     assert GoogleAIGeminiVersion.GEMINI_3_1_FLASH_LITE_PREVIEW.value == 'gemini-3.1-flash-lite-preview'
-    assert (
-        GoogleAIGeminiVersion.GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS.value == 'gemini-3.1-pro-preview-customtools'
-    )
+    assert GoogleAIGeminiVersion.GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS.value == 'gemini-3.1-pro-preview-customtools'
     assert GoogleAIGeminiVersion.GEMINI_3_1_PRO_PREVIEW.value == 'gemini-3.1-pro-preview'
 
 

--- a/py/plugins/google-genai/tests/google_genai_plugin_test.py
+++ b/py/plugins/google-genai/tests/google_genai_plugin_test.py
@@ -20,11 +20,11 @@ import asyncio
 import os
 import queue
 import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from genkit import ActionKind
+from genkit import ActionKind, Message, ModelRequest, ModelResponse, Part, Role, TextPart
 from genkit.plugins.google_genai import (
     EmbeddingTaskType,
     GeminiConfigSchema,
@@ -273,6 +273,70 @@ async def test_vertexai_resolve_embedder(mock_list_models: MagicMock, mock_clien
     assert action.name == 'vertexai/gemini-embedding-001'
 
 
+@patch('genkit.plugins.google_genai.google.genai.client.Client')
+@patch('genkit.plugins.google_genai.google.GeminiModel')
+@pytest.mark.asyncio
+async def test_vertexai_uses_global_client_for_gemini_31_preview(
+    mock_gemini_model: MagicMock, mock_client_ctor: MagicMock
+) -> None:
+    """VertexAI routes Gemini 3.1 preview calls to global location."""
+    clients_by_location: dict[str | None, MagicMock] = {}
+
+    def _new_client(**kwargs: object) -> MagicMock:
+        location = kwargs.get('location') if isinstance(kwargs, dict) else None
+        location_str = str(location) if location is not None else None
+        client = MagicMock(name=f'client-{location_str}')
+        clients_by_location[location_str] = client
+        return client
+
+    mock_client_ctor.side_effect = _new_client
+    mock_gemini_model.return_value.generate = AsyncMock(
+        return_value=ModelResponse(message=Message(role=Role.MODEL, content=[]))
+    )
+
+    plugin = VertexAI(project='test-project', location='us-central1')
+    action = plugin._resolve_model('vertexai/gemini-3.1-pro-preview')
+    await action(
+        ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='ping'))])])
+    )
+
+    assert mock_gemini_model.call_args is not None
+    used_client = mock_gemini_model.call_args.args[1]
+    assert used_client is clients_by_location.get('global')
+
+
+@patch('genkit.plugins.google_genai.google.genai.client.Client')
+@patch('genkit.plugins.google_genai.google.GeminiModel')
+@pytest.mark.asyncio
+async def test_vertexai_uses_default_client_for_non_gemini_31_preview(
+    mock_gemini_model: MagicMock, mock_client_ctor: MagicMock
+) -> None:
+    """VertexAI keeps configured location for non-Gemini 3.1 preview models."""
+    clients_by_location: dict[str | None, MagicMock] = {}
+
+    def _new_client(**kwargs: object) -> MagicMock:
+        location = kwargs.get('location') if isinstance(kwargs, dict) else None
+        location_str = str(location) if location is not None else None
+        client = MagicMock(name=f'client-{location_str}')
+        clients_by_location[location_str] = client
+        return client
+
+    mock_client_ctor.side_effect = _new_client
+    mock_gemini_model.return_value.generate = AsyncMock(
+        return_value=ModelResponse(message=Message(role=Role.MODEL, content=[]))
+    )
+
+    plugin = VertexAI(project='test-project', location='us-central1')
+    action = plugin._resolve_model('vertexai/gemini-2.0-flash')
+    await action(
+        ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='ping'))])])
+    )
+
+    assert mock_gemini_model.call_args is not None
+    used_client = mock_gemini_model.call_args.args[1]
+    assert used_client is clients_by_location.get('us-central1')
+
+
 def test_embedding_task_types() -> None:
     """Test EmbeddingTaskType enum values."""
     assert EmbeddingTaskType.RETRIEVAL_QUERY is not None
@@ -298,12 +362,19 @@ def test_googleai_gemini_version_enum() -> None:
     """Test GoogleAIGeminiVersion enum has values."""
     # Check that the enum has at least one value
     assert len(list(GoogleAIGeminiVersion)) > 0
+    assert GoogleAIGeminiVersion.GEMINI_3_1_FLASH_LITE_PREVIEW.value == 'gemini-3.1-flash-lite-preview'
+    assert (
+        GoogleAIGeminiVersion.GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS.value == 'gemini-3.1-pro-preview-customtools'
+    )
+    assert GoogleAIGeminiVersion.GEMINI_3_1_PRO_PREVIEW.value == 'gemini-3.1-pro-preview'
 
 
 def test_vertexai_gemini_version_enum() -> None:
     """Test VertexAIGeminiVersion enum has values."""
     # Check that the enum has at least one value
     assert len(list(VertexAIGeminiVersion)) > 0
+    assert VertexAIGeminiVersion.GEMINI_3_1_FLASH_LITE_PREVIEW.value == 'gemini-3.1-flash-lite-preview'
+    assert VertexAIGeminiVersion.GEMINI_3_1_PRO_PREVIEW.value == 'gemini-3.1-pro-preview'
 
 
 def test_gemini_config_schema() -> None:

--- a/py/samples/prompts/README.md
+++ b/py/samples/prompts/README.md
@@ -14,4 +14,5 @@ To inspect the flows in Dev UI instead:
 genkit start -- uv run src/main.py
 ```
 
-Try `generate_recipe`, `generate_robot_recipe`, and `tell_story`.
+Try `generate_recipe`, `generate_recipe_with_pro_preview`, `generate_recipe_with_pro_preview_customtools`, `generate_robot_recipe`, and `tell_story`.
+This sample uses `googleai/gemini-3.1-flash-lite-preview` by default and includes explicit Gemini 3.1 Pro Preview flows.

--- a/py/samples/prompts/src/main.py
+++ b/py/samples/prompts/src/main.py
@@ -26,7 +26,7 @@ from genkit.plugins.google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],
-    model='googleai/gemini-3-flash-preview',
+    model='googleai/gemini-3.1-flash-lite-preview',
     prompt_dir=Path(__file__).resolve().parent.parent / 'prompts',
 )
 
@@ -66,6 +66,19 @@ class ChefInput(BaseModel):
     food: str = Field(default='banana bread', description='The food to create a recipe for')
 
 
+class PantryTipInput(BaseModel):
+    """Input for pantry tip tool."""
+
+    food: str = Field(description='Food to provide a pantry tip for')
+
+
+@ai.tool()
+async def get_pantry_tip(input: PantryTipInput) -> str:
+    """Return one quick pantry tip for a requested food."""
+
+    return f'Use extra-ripe bananas and a pinch of salt to boost flavor in {input.food}.'
+
+
 @ai.flow(name='generate_recipe')
 async def chef_flow(input: ChefInput) -> Recipe:
     """Call the default `recipe.prompt` template."""
@@ -74,6 +87,40 @@ async def chef_flow(input: ChefInput) -> Recipe:
     if not response.output:
         raise ValueError('Model did not return a recipe.')
     return Recipe.model_validate(response.output)
+
+
+@ai.flow(name='generate_recipe_with_pro_preview')
+async def chef_flow_pro_preview(input: ChefInput) -> str:
+    """Use Gemini 3.1 Pro Preview directly."""
+
+    response = await ai.generate(
+        model='googleai/gemini-3.1-pro-preview',
+        prompt=f'Create a short 5-step recipe for {input.food}.',
+        config={
+            'thinking_config': {'thinking_budget': 128},
+            'max_output_tokens': 512,
+        },
+    )
+    return response.text
+
+
+@ai.flow(name='generate_recipe_with_pro_preview_customtools')
+async def chef_flow_pro_preview_customtools(input: ChefInput) -> str:
+    """Use Gemini 3.1 Pro Preview Custom Tools with a simple tool call."""
+
+    response = await ai.generate(
+        model='googleai/gemini-3.1-pro-preview-customtools',
+        prompt=(
+            f'Create a short 5-step recipe for {input.food}. '
+            'Call the get_pantry_tip tool exactly once with {"food": "<food name>"} before your final answer.'
+        ),
+        tools=['get_pantry_tip'],
+        config={
+            'thinking_config': {'thinking_budget': 128},
+            'max_output_tokens': 512,
+        },
+    )
+    return response.text
 
 
 @ai.flow(name='generate_robot_recipe')
@@ -110,6 +157,8 @@ async def main() -> None:
     """Run the prompt demos once."""
     try:
         print(await chef_flow(ChefInput()))  # noqa: T201
+        print(await chef_flow_pro_preview(ChefInput()))  # noqa: T201
+        print(await chef_flow_pro_preview_customtools(ChefInput()))  # noqa: T201
         print(await robot_chef_flow(ChefInput()))  # noqa: T201
     except Exception as error:
         print(f'Set GEMINI_API_KEY to a valid value before running this sample directly.\n{error}')  # noqa: T201

--- a/py/samples/tool-interrupts/src/main.py
+++ b/py/samples/tool-interrupts/src/main.py
@@ -30,7 +30,7 @@ from genkit.plugins.google_genai.models import gemini
 
 ai = Genkit(
     plugins=[GoogleAI()],
-    model=f'googleai/{gemini.GoogleAIGeminiVersion.GEMINI_3_FLASH_PREVIEW}',
+    model=f'googleai/{gemini.GoogleAIGeminiVersion.GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS}',
 )
 
 

--- a/py/samples/vertexai-imagen/README.md
+++ b/py/samples/vertexai-imagen/README.md
@@ -15,4 +15,6 @@ To explore it in Dev UI instead:
 genkit start -- uv run src/main.py
 ```
 
-Run `draw_image_with_imagen`.
+Run `draw_image_with_imagen`, `summarize_with_gemini_31_pro`, and `rewrite_with_gemini_31_flash_lite`.
+
+Note: Gemini 3.1 preview flows use the Vertex plugin's global routing fallback.

--- a/py/samples/vertexai-imagen/src/main.py
+++ b/py/samples/vertexai-imagen/src/main.py
@@ -53,11 +53,35 @@ async def draw_image_with_imagen() -> ModelResponse:
     )
 
 
+@ai.flow()
+async def summarize_with_gemini_31_pro() -> str:
+    """Summarize text with Gemini 3.1 Pro Preview on Vertex AI."""
+
+    response = await ai.generate(
+        model='vertexai/gemini-3.1-pro-preview',
+        prompt='Summarize why multimodal models are useful in two short bullet points.',
+    )
+    return response.text
+
+
+@ai.flow()
+async def rewrite_with_gemini_31_flash_lite() -> str:
+    """Rewrite text with Gemini 3.1 Flash Lite Preview on Vertex AI."""
+
+    response = await ai.generate(
+        model='vertexai/gemini-3.1-flash-lite-preview',
+        prompt='Rewrite this sentence to be clearer: "The build maybe failed because env was not configured right".',
+    )
+    return response.text
+
+
 async def main() -> None:
-    """Run the Imagen sample once."""
+    """Run the Vertex AI sample once."""
     try:
         response = await draw_image_with_imagen()
         print(response.model_dump_json(indent=2))  # noqa: T201
+        print(await summarize_with_gemini_31_pro())  # noqa: T201
+        print(await rewrite_with_gemini_31_flash_lite())  # noqa: T201
     except Exception as error:
         message = 'Set GOOGLE_CLOUD_PROJECT and Application Default Credentials before running this sample directly.'
         print(f'{message}\n{error}')  # noqa: T201


### PR DESCRIPTION
## Summary

- Adds Python support for new Gemini 3.1 preview models:

  - googleai/gemini-3.1-flash-lite-preview
  
<img width="1683" height="847" alt="image" src="https://github.com/user-attachments/assets/18afcf74-94ec-42bb-acd0-835d7b847411" />

  - googleai/gemini-3.1-pro-preview-customtools
  
<img width="1682" height="801" alt="image" src="https://github.com/user-attachments/assets/f9f1547a-9ff6-4779-9fcf-3cdd9fbebe59" />

  - googleai/gemini-3.1-pro-preview
  
<img width="1678" height="661" alt="image" src="https://github.com/user-attachments/assets/19fc29c2-213a-45de-b9ee-06d708ddf276" />

  - vertexai/gemini-3.1-flash-lite-preview
  
<img width="1673" height="805" alt="image" src="https://github.com/user-attachments/assets/5a48dbc6-30ac-42c3-9c0f-e0a0f56f301a" />

  - vertexai/gemini-3.1-pro-preview
<img width="1690" height="690" alt="image" src="https://github.com/user-attachments/assets/10b49f5b-5c79-4bc4-8bf8-29653584d444" />

- Updates Vertex plugin routing so Gemini 3.1 preview models default to global location (while non-3.1-preview models keep configured region).

- Updates samples/Dev UI flows so all 5 models can be exercised directly:

  - prompts sample now includes explicit GoogleAI Pro preview flows.
  - vertexai-imagen sample includes explicit Vertex Gemini 3.1 preview flows.

- Adds/updates tests for enum support and Vertex global-routing behavior.
## Issue

Checklist:
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
