### PR TITLE
fix(js/genkit): Explicitly allow null types in promptDir

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -875,7 +875,7 @@ export async function prompt<
 >(
   registry: Registry,
   name: string,
-  options?: { variant?: string; dir?: string }
+  options?: { variant?: string; dir?: string | null }
 ): Promise<ExecutablePrompt<I, O, CustomOptions>> {
   return await lookupPrompt<I, O, CustomOptions>(
     registry,

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -360,7 +360,7 @@ export class Genkit implements HasRegistry {
       `${name}${options?.variant ? `.${options?.variant}` : ''}`,
       prompt(this.registry, name, {
         ...options,
-        dir: this.options.promptDir ?? './prompts',
+        dir: this.options.promptDir === undefined ? './prompts' : this.options.promptDir,
       })
     );
   }

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -360,7 +360,10 @@ export class Genkit implements HasRegistry {
       `${name}${options?.variant ? `.${options?.variant}` : ''}`,
       prompt(this.registry, name, {
         ...options,
-        dir: this.options.promptDir === undefined ? './prompts' : this.options.promptDir,
+        dir:
+          this.options.promptDir === undefined
+            ? './prompts'
+            : this.options.promptDir,
       })
     );
   }

--- a/js/genkit/src/genkit.ts
+++ b/js/genkit/src/genkit.ts
@@ -160,8 +160,8 @@ export type PromptFn<
 export interface GenkitOptions {
   /** List of plugins to load. */
   plugins?: (GenkitPlugin | GenkitPluginV2)[];
-  /** Directory where dotprompts are stored. */
-  promptDir?: string;
+  /** Directory where dotprompts are stored. Set to `null` to disable automatic prompt loading. */
+  promptDir?: string | null;
   /** Default model to use if no model is specified. */
   model?: ModelArgument<any>;
   /** Additional runtime context data for flows and tools. */

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -1057,6 +1057,19 @@ describe('prompt', () => {
     });
   });
 
+  it('does not auto-load prompts when promptDir is null', async () => {
+    const aiWithoutPromptDir = genkit({
+      model: 'echoModel',
+      promptDir: null,
+    });
+
+    const prompt = aiWithoutPromptDir.prompt('test');
+    const response = prompt();
+    await assert.rejects(response, {
+      message: 'NOT_FOUND: Prompt test not found',
+    });
+  });
+
   it('loads from from the sub folder', async () => {
     const testPrompt = ai.prompt('sub/test'); // see tests/prompts/sub folder
 


### PR DESCRIPTION
Description here... Help the reviewer by:
 - Runtime already treats promptDir: null as an opt-out for automatic `./prompts` loading.
 - The problem is that while runtime logic seems to treat null values ​​specially and allow them, type does not.
 - This change aligns the type definition with existing behavior and adds coverage for the null opt-out case.

In `genkit.ts` `(972-978 line)`
```
private configure() {
...
if (this.options.promptDir !== null) {
      loadPromptFolder(
        this.registry,
        this.options.promptDir ?? './prompts',
        ''
      );
    }
...
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
