### PR TITLE
chore(py): publish evaluators plugin

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -60,6 +60,7 @@ jobs:
             py/plugins/fastapi
             py/plugins/flask
             py/plugins/vertex-ai
+            py/plugins/evaluators
           )
 
           FAILED=()

--- a/py/plugins/evaluators/pyproject.toml
+++ b/py/plugins/evaluators/pyproject.toml
@@ -49,5 +49,4 @@ build-backend = "hatchling.build"
 requires      = ["hatchling"]
 
 [tool.hatch.build.targets.wheel]
-only-include = ["src/genkit/plugins/evaluators"]
-sources      = ["src"]
+packages = ["src/genkit"]


### PR DESCRIPTION
This plugin was never published, but it should have been.