### PR TITLE
fix(retriever): enforce schema-based validation for options to prevent runtime crashes

### DIFF
--- a/genkit-tools/common/src/types/retriever.ts
+++ b/genkit-tools/common/src/types/retriever.ts
@@ -25,7 +25,7 @@ import { DocumentDataSchema } from './document';
  */
 export const RetrieverRequestSchema = z.object({
   query: DocumentDataSchema,
-  options: z.any().optional(),
+  options: z.undefined(),
 });
 export type RetrieverRequest = z.infer<typeof RetrieverRequestSchema>;
 
@@ -40,6 +40,4 @@ export type RetrieverResponse = z.infer<typeof RetrieverResponseSchema>;
 /**
  * Zod schema of common retriever options.
  */
-export const CommonRetrieverOptionsSchema = z.object({
-  k: z.number().describe('Number of documents to retrieve').optional(),
-});
+export const CommonRetrieverOptionsSchema = z.object({});

--- a/genkit-tools/common/src/types/retriever.ts
+++ b/genkit-tools/common/src/types/retriever.ts
@@ -24,9 +24,9 @@ import { DocumentDataSchema } from './document';
  * Zod schema for retriever request.
  */
 export const RetrieverRequestSchema = z.object({
-  query: DocumentDataSchema,
-  options: z.undefined(),
-});
+   query: DocumentDataSchema,
+   options: z.unknown().optional(),
+ });
 export type RetrieverRequest = z.infer<typeof RetrieverRequestSchema>;
 
 /**

--- a/genkit-tools/common/src/types/retriever.ts
+++ b/genkit-tools/common/src/types/retriever.ts
@@ -24,9 +24,9 @@ import { DocumentDataSchema } from './document';
  * Zod schema for retriever request.
  */
 export const RetrieverRequestSchema = z.object({
-   query: DocumentDataSchema,
-   options: z.unknown().optional(),
- });
+  query: DocumentDataSchema,
+  options: z.undefined(),
+});
 export type RetrieverRequest = z.infer<typeof RetrieverRequestSchema>;
 
 /**

--- a/js/ai/src/retriever.ts
+++ b/js/ai/src/retriever.ts
@@ -41,7 +41,7 @@ export type IndexerFn<IndexerOptions extends z.ZodTypeAny> = (
 
 const RetrieverRequestSchema = z.object({
   query: DocumentDataSchema,
-  options: z.any().optional(),
+  options: z.undefined(),
 });
 
 const RetrieverResponseSchema = z.object({
@@ -52,7 +52,7 @@ type RetrieverResponse = z.infer<typeof RetrieverResponseSchema>;
 
 const IndexerRequestSchema = z.object({
   documents: z.array(DocumentDataSchema),
-  options: z.any().optional(),
+  options: z.undefined(),
 });
 
 /**
@@ -269,6 +269,15 @@ export async function retrieve<CustomOptions extends z.ZodTypeAny>(
   if (!retriever) {
     throw new Error('Unable to resolve the retriever');
   }
+
+  // Validate options using the retriever's configSchema if available
+  if (retriever.__configSchema) {
+    const result = retriever.__configSchema.safeParse(params.options);
+    if (!result.success) {
+      throw new Error(`Invalid retriever options: ${result.error.message}`);
+    }
+  }
+
   const response = await retriever({
     query:
       typeof params.query === 'string'
@@ -315,6 +324,15 @@ export async function index<CustomOptions extends z.ZodTypeAny>(
   if (!indexer) {
     throw new Error('Unable to utilize the provided indexer');
   }
+
+  // Validate options using the indexer's configSchema if available
+  if (indexer.__configSchema) {
+    const result = indexer.__configSchema.safeParse(params.options);
+    if (!result.success) {
+      throw new Error(`Invalid indexer options: ${result.error.message}`);
+    }
+  }
+
   return await indexer({
     documents: params.documents,
     options: params.options,
@@ -324,9 +342,7 @@ export async function index<CustomOptions extends z.ZodTypeAny>(
 /**
  * Zod schema of common retriever options.
  */
-export const CommonRetrieverOptionsSchema = z.object({
-  k: z.number().describe('Number of documents to retrieve').optional(),
-});
+export const CommonRetrieverOptionsSchema = z.object({});
 
 /**
  * A retriver reference object.

--- a/js/ai/src/retriever.ts
+++ b/js/ai/src/retriever.ts
@@ -40,9 +40,9 @@ export type IndexerFn<IndexerOptions extends z.ZodTypeAny> = (
 ) => Promise<void>;
 
 const RetrieverRequestSchema = z.object({
-  query: DocumentDataSchema,
-  options: z.undefined(),
-});
+   query: DocumentDataSchema,
+   options: z.unknown().optional(),
+ });
 
 const RetrieverResponseSchema = z.object({
   documents: z.array(DocumentDataSchema),
@@ -51,9 +51,9 @@ const RetrieverResponseSchema = z.object({
 type RetrieverResponse = z.infer<typeof RetrieverResponseSchema>;
 
 const IndexerRequestSchema = z.object({
-  documents: z.array(DocumentDataSchema),
-  options: z.undefined(),
-});
+   documents: z.array(DocumentDataSchema),
+   options: z.unknown().optional(),
+ });
 
 /**
  * Zod schema of retriever info metadata.
@@ -270,13 +270,7 @@ export async function retrieve<CustomOptions extends z.ZodTypeAny>(
     throw new Error('Unable to resolve the retriever');
   }
 
-  // Validate options using the retriever's configSchema if available
-  if (retriever.__configSchema) {
-    const result = retriever.__configSchema.safeParse(params.options);
-    if (!result.success) {
-      throw new Error(`Invalid retriever options: ${result.error.message}`);
-    }
-  }
+
 
   const response = await retriever({
     query:
@@ -325,13 +319,7 @@ export async function index<CustomOptions extends z.ZodTypeAny>(
     throw new Error('Unable to utilize the provided indexer');
   }
 
-  // Validate options using the indexer's configSchema if available
-  if (indexer.__configSchema) {
-    const result = indexer.__configSchema.safeParse(params.options);
-    if (!result.success) {
-      throw new Error(`Invalid indexer options: ${result.error.message}`);
-    }
-  }
+
 
   return await indexer({
     documents: params.documents,

--- a/js/ai/src/retriever.ts
+++ b/js/ai/src/retriever.ts
@@ -270,7 +270,13 @@ export async function retrieve<CustomOptions extends z.ZodTypeAny>(
     throw new Error('Unable to resolve the retriever');
   }
 
-
+  // Validate options using the retriever's configSchema if available
+  if (retriever.__configSchema) {
+    const result = retriever.__configSchema.safeParse(params.options);
+    if (!result.success) {
+      throw new Error(`Invalid retriever options: ${result.error.message}`);
+    }
+  }
 
   const response = await retriever({
     query:
@@ -319,7 +325,13 @@ export async function index<CustomOptions extends z.ZodTypeAny>(
     throw new Error('Unable to utilize the provided indexer');
   }
 
-
+  // Validate options using the indexer's configSchema if available
+  if (indexer.__configSchema) {
+    const result = indexer.__configSchema.safeParse(params.options);
+    if (!result.success) {
+      throw new Error(`Invalid indexer options: ${result.error.message}`);
+    }
+  }
 
   return await indexer({
     documents: params.documents,


### PR DESCRIPTION
## Summary

Fixes a mismatch between TypeScript types and runtime behavior in retrievers.

Previously, `options` was defined as `z.any().optional()`, allowing invalid calls without required fields (e.g., `k` for Pinecone), leading to runtime crashes.

## Changes

- Removed `z.any()` usage for `options`
- Removed global `k` from common schema
- Added runtime validation using plugin-defined `__configSchema` for both retriever and indexer

## Result

- Prevents runtime crashes due to missing required options
- Aligns TypeScript types with actual plugin requirements
- Enables flexible, plugin-specific validation