### PR TITLE
feat(py): Add DAP helpers to registry + fix business logic in Registry.list_actions()

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -666,9 +666,8 @@ class Genkit:
 
     def _initialize_registry(self, model: str | None, plugins: list[Plugin] | None) -> None:
         """Initialize the registry with default model and plugins."""
-        self.registry.default_model = model
         if model:
-            self.registry.register_value('defaultModel', model, model)
+            self.registry.register_value('defaultModel', 'defaultModel', model)
         for fmt in built_in_formats:
             self.define_format(fmt)
 
@@ -1131,7 +1130,7 @@ class Genkit:
     ) -> Operation:
         """Generate content using a long-running model, returning an Operation to poll."""
         # Resolve the model and check for long_running support
-        resolved_model = model or self.registry.default_model
+        resolved_model = model or cast(str | None, self.registry.lookup_value('defaultModel', 'defaultModel'))
         if not resolved_model:
             raise GenkitError(
                 status='INVALID_ARGUMENT',

--- a/py/packages/genkit/src/genkit/_ai/_embedding.py
+++ b/py/packages/genkit/src/genkit/_ai/_embedding.py
@@ -23,11 +23,11 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 from typing_extensions import Never
 
-from genkit._core._action import Action, ActionKind, ActionMetadata, get_func_description
+from genkit._core._action import Action, ActionKind, get_func_description
 from genkit._core._model import Document
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
-from genkit._core._typing import EmbedRequest, EmbedResponse
+from genkit._core._typing import ActionMetadata, EmbedRequest, EmbedResponse
 
 
 class EmbedderSupports(BaseModel):
@@ -103,7 +103,7 @@ def embedder_action_metadata(
     embedder_info['customOptions'] = options.config_schema if options.config_schema else None
 
     return ActionMetadata(
-        kind=ActionKind.EMBEDDER,
+        action_type=ActionKind.EMBEDDER,
         name=name,
         input_json_schema=to_json_schema(EmbedRequest),
         output_json_schema=to_json_schema(EmbedResponse),

--- a/py/packages/genkit/src/genkit/_ai/_evaluator.py
+++ b/py/packages/genkit/src/genkit/_ai/_evaluator.py
@@ -25,12 +25,13 @@ from typing import Any, ClassVar, TypeVar, cast
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
-from genkit._core._action import Action, ActionKind, ActionMetadata
+from genkit._core._action import Action, ActionKind
 from genkit._core._logger import get_logger
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
 from genkit._core._tracing import run_in_new_span
 from genkit._core._typing import (
+    ActionMetadata,
     BaseDataPoint,
     EvalFnResponse,
     EvalRequest,
@@ -76,7 +77,7 @@ def evaluator_action_metadata(
 ) -> ActionMetadata:
     """Create ActionMetadata for an evaluator action."""
     return ActionMetadata(
-        kind=ActionKind.EVALUATOR,
+        action_type=ActionKind.EVALUATOR,
         name=name,
         input_json_schema=to_json_schema(EvalRequest),
         output_json_schema=to_json_schema(list[EvalFnResponse]),

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -594,7 +594,7 @@ async def resolve_parameters(
     registry: Registry, request: GenerateActionOptions
 ) -> tuple[Action[Any, Any, Any], list[Action[Any, Any, Any]], FormatDef | None]:
     """Resolve model, tools, and format from registry for a generation request."""
-    model = request.model if request.model is not None else registry.default_model
+    model = request.model if request.model is not None else cast(str | None, registry.lookup_value('defaultModel', 'defaultModel'))
     if not model:
         raise Exception('No model configured.')
 

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -594,7 +594,11 @@ async def resolve_parameters(
     registry: Registry, request: GenerateActionOptions
 ) -> tuple[Action[Any, Any, Any], list[Action[Any, Any, Any]], FormatDef | None]:
     """Resolve model, tools, and format from registry for a generation request."""
-    model = request.model if request.model is not None else cast(str | None, registry.lookup_value('defaultModel', 'defaultModel'))
+    model = (
+        request.model
+        if request.model is not None
+        else cast(str | None, registry.lookup_value('defaultModel', 'defaultModel'))
+    )
     if not model:
         raise Exception('No model configured.')
 

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -26,7 +26,6 @@ from pydantic import BaseModel
 from genkit._core._action import (
     Action,
     ActionKind,
-    ActionMetadata,
     ActionRunContext,
     get_func_description,
 )
@@ -44,7 +43,7 @@ from genkit._core._model import (
 )
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
-from genkit._core._typing import ModelInfo
+from genkit._core._typing import ActionMetadata, ModelInfo
 
 # Type alias for model functions (must be async)
 # Use ctx.send_chunk() for streaming
@@ -59,7 +58,7 @@ def model_action_metadata(
     """Create ActionMetadata for a model action."""
     info = info if info is not None else {}
     return ActionMetadata(
-        kind=ActionKind.MODEL,
+        action_type=ActionKind.MODEL,
         name=name,
         input_json_schema=to_json_schema(ModelRequest),
         output_json_schema=to_json_schema(ModelResponse),

--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -382,7 +382,7 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
             resources=opts.get('resources') or self._resources,
         )
 
-        model = prompt_config.model or self._registry.default_model
+        model = prompt_config.model or cast(str | None, self._registry.lookup_value('defaultModel', 'defaultModel'))
         if model is None:
             raise GenkitError(status='INVALID_ARGUMENT', message='No model configured.')
 
@@ -635,7 +635,7 @@ def _resolve_output_schema(
 
 async def to_generate_action_options(registry: Registry, options: PromptConfig) -> GenerateActionOptions:
     """Convert PromptConfig to GenerateActionOptions."""
-    model = options.model or registry.default_model
+    model = options.model or cast(str | None, registry.lookup_value('defaultModel', 'defaultModel'))
     if model is None:
         raise GenkitError(status='INVALID_ARGUMENT', message='No model configured.')
 

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -229,6 +229,11 @@ def extract_action_args_and_types(
 # =============================================================================
 
 
+# Attribute name used to attach a ``DynamicActionProvider`` (cache + helpers)
+# onto the placeholder ``Action`` registered for a DAP. The registry only
+# stores the ``Action``; the provider rides along on it as a Python attribute.
+# Code holding the ``Action`` recovers the provider via
+# ``getattr(action, GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR, None)``.
 GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR = '_genkit_dynamic_action_provider'
 
 

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -546,20 +546,6 @@ class Action(Generic[InputT, OutputT, ChunkT]):
             self._metadata[ActionMetadataKey.OUTPUT_KEY] = self._output_schema
 
 
-class ActionMetadata(BaseModel):
-    """Action metadata for registry and reflection."""
-
-    kind: ActionKind
-    name: str
-    description: str | None = None
-    input_schema: object | None = None
-    input_json_schema: dict[str, object] | None = None
-    output_schema: object | None = None
-    output_json_schema: dict[str, object] | None = None
-    stream_schema: object | None = None
-    metadata: dict[str, object] | None = None
-
-
 def _make_tracing_wrapper(
     name: str,
     kind: ActionKind,

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -274,7 +274,7 @@ def parse_action_key(key: str) -> tuple[ActionKind, str]:
     return kind, name
 
 
-def create_action_key(kind: ActionKind, name: str) -> str:
+def create_action_key(kind: ActionKind | str, name: str) -> str:
     """Create '/<kind>/<name>' key."""
     return f'/{kind}/{name}'
 

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -19,6 +19,7 @@
 import asyncio
 import inspect
 import json
+import re
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Mapping
 from contextlib import contextmanager
@@ -237,21 +238,19 @@ def parse_dap_qualified_name(name: str) -> tuple[str, str, str] | None:
     Used when the action key kind is ``dynamic-action-provider`` and the name
     references a nested action exposed by a provider (e.g. MCP tools).
 
+    Pattern: ``[provider]:[inner_kind]/[inner_name]`` — no slashes in the
+    provider segment (``plugin/foo`` is not a valid provider host).
+
     Returns:
         ``(provider_name, inner_kind, inner_name)`` if the string matches the
         pattern; otherwise ``None`` so callers can treat the name as a plain
         dynamic-action-provider id.
     """
-    if ':' not in name or '/' not in name:
+    # Pattern: [provider]:[inner_kind]/[inner_name]; no '/' or ':' in provider.
+    match = re.match(r'^([^/:]+):([^/:]+)/(.+)$', name)
+    if not match:
         return None
-    colon = name.index(':')
-    provider = name[:colon]
-    rest = name[colon + 1 :]
-    if '/' in provider:
-        return None
-    if '/' not in rest:
-        return None
-    inner_kind, inner_name = rest.split('/', 1)
+    provider, inner_kind, inner_name = match.groups()
     if not provider or not inner_kind or not inner_name:
         return None
     return (provider, inner_kind, inner_name)

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -247,6 +247,8 @@ def parse_dap_qualified_name(name: str) -> tuple[str, str, str] | None:
     colon = name.index(':')
     provider = name[:colon]
     rest = name[colon + 1 :]
+    if '/' in provider:
+        return None
     if '/' not in rest:
         return None
     inner_kind, inner_name = rest.split('/', 1)

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -228,6 +228,33 @@ def extract_action_args_and_types(
 # =============================================================================
 
 
+GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR = '_genkit_dynamic_action_provider'
+
+
+def parse_dap_qualified_name(name: str) -> tuple[str, str, str] | None:
+    """Parse DAP-qualified segment ``provider:innerKind/innerName``.
+
+    Used when the action key kind is ``dynamic-action-provider`` and the name
+    references a nested action exposed by a provider (e.g. MCP tools).
+
+    Returns:
+        ``(provider_name, inner_kind, inner_name)`` if the string matches the
+        pattern; otherwise ``None`` so callers can treat the name as a plain
+        dynamic-action-provider id.
+    """
+    if ':' not in name or '/' not in name:
+        return None
+    colon = name.index(':')
+    provider = name[:colon]
+    rest = name[colon + 1 :]
+    if '/' not in rest:
+        return None
+    inner_kind, inner_name = rest.split('/', 1)
+    if not provider or not inner_kind or not inner_name:
+        return None
+    return (provider, inner_kind, inner_name)
+
+
 def parse_action_key(key: str) -> tuple[ActionKind, str]:
     """Parse '/<kind>/<name>' key into (ActionKind, name)."""
     tokens = key.split('/')

--- a/py/packages/genkit/src/genkit/_core/_dap.py
+++ b/py/packages/genkit/src/genkit/_core/_dap.py
@@ -116,8 +116,8 @@ class DynamicActionProvider:
             return [m for m in metadata_list if str(m.get('name', '')).startswith(prefix)]
         return [m for m in metadata_list if m.get('name') == action_name]
 
-    async def get_action_metadata_record(self, dap_prefix: str) -> dict[str, ActionMetadata]:
-        """Get all actions as a reflection metadata record, keyed by full DAP key."""
+    async def list_action_metadata_by_key(self, dap_prefix: str) -> dict[str, ActionMetadata]:
+        """List every child action's reflection metadata, keyed by its fully-qualified DAP key."""
         result = await self._get_or_fetch(skip_trace=True)
         dap_actions: dict[str, ActionMetadata] = {}
         for action_type, actions in result.items():
@@ -170,5 +170,9 @@ def define_dynamic_action_provider(
     )
 
     dap = DynamicActionProvider(action, fn, cache_ttl_millis)
+    # Attach the provider to the registered Action so anyone holding the
+    # Action (e.g. ``Registry.resolve_action_by_key`` for a DAP-qualified key,
+    # or ``Registry.list_actions`` expanding children for reflection) can
+    # recover the cache and helpers via ``getattr(action, ATTR, None)``.
     setattr(action, GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR, dap)
     return dap

--- a/py/packages/genkit/src/genkit/_core/_dap.py
+++ b/py/packages/genkit/src/genkit/_core/_dap.py
@@ -21,7 +21,11 @@ import time
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
-from genkit._core._action import Action, ActionKind
+from genkit._core._action import (
+    GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR,
+    Action,
+    ActionKind,
+)
 from genkit._core._registry import Registry
 
 ActionMetadataLike = Mapping[str, object]
@@ -151,4 +155,6 @@ def define_dynamic_action_provider(
         metadata={**(metadata or {}), 'type': 'dynamic-action-provider'},
     )
 
-    return DynamicActionProvider(action, fn, cache_ttl_millis)
+    dap = DynamicActionProvider(action, fn, cache_ttl_millis)
+    setattr(action, GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR, dap)
+    return dap

--- a/py/packages/genkit/src/genkit/_core/_dap.py
+++ b/py/packages/genkit/src/genkit/_core/_dap.py
@@ -25,8 +25,10 @@ from genkit._core._action import (
     GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR,
     Action,
     ActionKind,
+    create_action_key,
 )
 from genkit._core._registry import Registry
+from genkit._core._typing import ActionMetadata
 
 ActionMetadataLike = Mapping[str, object]
 DapValue = dict[str, list[Action[Any, Any]]]
@@ -114,15 +116,27 @@ class DynamicActionProvider:
             return [m for m in metadata_list if str(m.get('name', '')).startswith(prefix)]
         return [m for m in metadata_list if m.get('name') == action_name]
 
-    async def get_action_metadata_record(self, dap_prefix: str) -> dict[str, ActionMetadataLike]:
-        """Get all actions as metadata record for reflection API."""
+    async def get_action_metadata_record(self, dap_prefix: str) -> dict[str, ActionMetadata]:
+        """Get all actions as a reflection metadata record, keyed by full DAP key."""
         result = await self._get_or_fetch(skip_trace=True)
-        dap_actions: dict[str, ActionMetadataLike] = {}
+        dap_actions: dict[str, ActionMetadata] = {}
         for action_type, actions in result.items():
             for action in actions:
                 if not action.name:
                     raise ValueError(f'Invalid metadata from {dap_prefix} - name required')
-                dap_actions[f'{dap_prefix}:{action_type}/{action.name}'] = action.metadata or {}
+                key = create_action_key(
+                    ActionKind.DYNAMIC_ACTION_PROVIDER,
+                    f'{dap_prefix}:{action_type}/{action.name}',
+                )
+                dap_actions[key] = ActionMetadata(
+                    key=key,
+                    action_type=action_type,
+                    name=action.name,
+                    description=action.description,
+                    input_schema=action.input_schema,
+                    output_schema=action.output_schema,
+                    metadata=dict(action.metadata) if action.metadata else None,
+                )
         return dap_actions
 
 

--- a/py/packages/genkit/src/genkit/_core/_plugin.py
+++ b/py/packages/genkit/src/genkit/_core/_plugin.py
@@ -18,7 +18,8 @@
 
 import abc
 
-from genkit._core._action import Action, ActionKind, ActionMetadata
+from genkit._core._action import Action, ActionKind
+from genkit._core._typing import ActionMetadata
 
 
 class Plugin(abc.ABC):
@@ -38,7 +39,12 @@ class Plugin(abc.ABC):
 
     @abc.abstractmethod
     async def list_actions(self) -> list[ActionMetadata]:
-        """Return advertised actions for dev UI/reflection listing."""
+        """Return advertised actions for dev UI/reflection listing.
+
+        ``ActionMetadata.action_type`` must be set (typically ``ActionKind.*``) and
+        ``ActionMetadata.name`` must match resolution keys (typically
+        ``{plugin.name}/localName`` for plugin-backed actions).
+        """
         ...
 
     async def model(self, name: str) -> Action | None:

--- a/py/packages/genkit/src/genkit/_core/_reflection.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection.py
@@ -147,7 +147,7 @@ def create_reflection_asgi_app(
     active_actions: dict[str, asyncio.Task[Any]] = {}
 
     async def health(_: Request) -> JSONResponse:
-        await registry.list_actions()
+        await registry.initialize_all_plugins()
         return JSONResponse({'status': 'OK'})
 
     async def terminate(_: Request) -> JSONResponse:
@@ -156,8 +156,24 @@ def create_reflection_asgi_app(
         return JSONResponse({'status': 'OK'})
 
     async def actions(_: Request) -> JSONResponse:
-        # Full catalog: list_resolvable_actions (plugins, registered, DAP; merged with parent).
-        return JSONResponse(await registry.list_resolvable_actions(), headers={'x-genkit-version': version})
+        # Full catalog: plugins, registered actions, DAP expansions; merged with parent.
+        actions = await registry.list_actions()
+
+        def omit_none(payload: dict[str, Any]) -> dict[str, Any]:
+            return {key: value for key, value in payload.items() if value is not None}
+
+        response: dict[str, dict[str, Any]] = {}
+        for key, action in actions.items():
+            response[key] = omit_none({
+                'key': key,
+                'name': action.name,
+                'description': action.description,
+                'metadata': action.metadata,
+                'inputSchema': action.input_schema or action.input_json_schema,
+                'outputSchema': action.output_schema or action.output_json_schema,
+            })
+
+        return JSONResponse(response, headers={'x-genkit-version': version})
 
     async def values(req: Request) -> JSONResponse:
         if req.query_params.get('type') != 'defaultModel':
@@ -194,8 +210,8 @@ def create_reflection_asgi_app(
         return await runner.stream_response(version)
 
     async def reflection_startup() -> None:
-        # Eagerly initialize plugins and enumerate concrete actions before handling traffic.
-        await registry.list_actions()
+        # Eagerly initialize plugins so init()-registered actions exist before handling traffic.
+        await registry.initialize_all_plugins()
 
     startup_hooks: list[LifecycleHook] = [reflection_startup]
     if on_startup is not None:

--- a/py/packages/genkit/src/genkit/_core/_reflection.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection.py
@@ -36,7 +36,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
-from genkit._core._action import Action, ActionKind
+from genkit._core._action import Action
 from genkit._core._constants import GENKIT_VERSION
 from genkit._core._error import get_reflection_json
 from genkit._core._logger import get_logger
@@ -138,53 +138,6 @@ class ActionRunner:
         return StreamingResponse(gen(), media_type='text/plain' if self.stream else 'application/json', headers=headers)
 
 
-async def _get_actions_payload(registry: Registry) -> dict[str, dict[str, Any]]:
-    actions: dict[str, dict[str, Any]] = {}
-
-    for kind in ActionKind.__members__.values():
-        for name, action in (await registry.resolve_actions_by_kind(kind)).items():
-            key = f'/{kind}/{name}'
-            actions[key] = {
-                'key': key,
-                'name': action.name,
-                'type': action.kind,
-                'description': action.description,
-                'inputSchema': action.input_schema,
-                'outputSchema': action.output_schema,
-                'metadata': action.metadata,
-            }
-
-    for meta in await registry.list_actions() or []:
-        try:
-            key = f'/{meta.kind}/{meta.name}'
-        except Exception as exc:
-            logger.warning('Skipping invalid plugin metadata: %s', exc)
-            continue
-
-        advertised = {
-            'key': key,
-            'name': meta.name,
-            'type': meta.kind,
-            'description': getattr(meta, 'description', None),
-            'inputSchema': getattr(meta, 'input_json_schema', None),
-            'outputSchema': getattr(meta, 'output_json_schema', None),
-            'metadata': getattr(meta, 'metadata', None),
-        }
-
-        if key not in actions:
-            actions[key] = advertised
-        else:
-            existing = actions[key]
-            for f in ('description', 'inputSchema', 'outputSchema'):
-                if not existing.get(f) and advertised.get(f):
-                    existing[f] = advertised[f]
-            if isinstance(existing.get('metadata'), dict) and isinstance(advertised.get('metadata'), dict):
-                # isinstance checks above guarantee both are dicts, but ty can't narrow .get() results
-                existing['metadata'] = {**advertised['metadata'], **existing['metadata']}  # ty: ignore[invalid-argument-type]
-
-    return actions
-
-
 def create_reflection_asgi_app(
     registry: Registry,
     on_startup: LifecycleHook | None = None,
@@ -194,6 +147,7 @@ def create_reflection_asgi_app(
     active_actions: dict[str, asyncio.Task[Any]] = {}
 
     async def health(_: Request) -> JSONResponse:
+        await registry.list_actions()
         return JSONResponse({'status': 'OK'})
 
     async def terminate(_: Request) -> JSONResponse:
@@ -202,7 +156,8 @@ def create_reflection_asgi_app(
         return JSONResponse({'status': 'OK'})
 
     async def actions(_: Request) -> JSONResponse:
-        return JSONResponse(await _get_actions_payload(registry), headers={'x-genkit-version': version})
+        # Full catalog via Registry.list_resolvable_actions (plugins on this node + registered + DAP, merged with parent).
+        return JSONResponse(await registry.list_resolvable_actions(), headers={'x-genkit-version': version})
 
     async def values(req: Request) -> JSONResponse:
         if req.query_params.get('type') != 'defaultModel':
@@ -238,6 +193,14 @@ def create_reflection_asgi_app(
         )
         return await runner.stream_response(version)
 
+    async def reflection_startup() -> None:
+        # Eagerly initialize plugins and enumerate concrete actions before handling traffic.
+        await registry.list_actions()
+
+    startup_hooks: list[LifecycleHook] = [reflection_startup]
+    if on_startup is not None:
+        startup_hooks.append(on_startup)
+
     app = Starlette(
         routes=[
             Route('/api/__health', health, methods=['GET']),
@@ -258,7 +221,7 @@ def create_reflection_asgi_app(
                 expose_headers=['X-Genkit-Trace-Id', 'X-Genkit-Span-Id', 'x-genkit-version'],
             )
         ],
-        on_startup=[on_startup] if on_startup else [],
+        on_startup=startup_hooks,
         on_shutdown=[on_shutdown] if on_shutdown else [],
     )
     app.active_actions = active_actions  # type: ignore[attr-defined]

--- a/py/packages/genkit/src/genkit/_core/_reflection.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection.py
@@ -156,7 +156,7 @@ def create_reflection_asgi_app(
         return JSONResponse({'status': 'OK'})
 
     async def actions(_: Request) -> JSONResponse:
-        # Full catalog via Registry.list_resolvable_actions (plugins on this node + registered + DAP, merged with parent).
+        # Full catalog: list_resolvable_actions (plugins, registered, DAP; merged with parent).
         return JSONResponse(await registry.list_resolvable_actions(), headers={'x-genkit-version': version})
 
     async def values(req: Request) -> JSONResponse:

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 from typing_extensions import Never, TypeVar
 
 from genkit._core._action import (
+    GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR,
     Action,
     ActionKind,
     ActionMetadata,
@@ -33,6 +34,7 @@ from genkit._core._action import (
     ActionRunContext,
     SpanAttributeValue,
     parse_action_key,
+    parse_dap_qualified_name,
 )
 from genkit._core._logger import get_logger
 from genkit._core._model import (
@@ -448,15 +450,30 @@ class Registry:
                 else:
                     providers_dict = {}
                 providers = list(providers_dict.values())
-            for provider in providers:
+            for provider_action in providers:
+                dap = getattr(provider_action, GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR, None)
+                if dap is not None:
+                    try:
+                        resolved = await dap.get_action(str(kind), name)
+                        if resolved is not None:
+                            self.register_action_instance(resolved)
+                            return await self._trigger_lazy_loading(resolved)
+                    except Exception as e:
+                        logger.debug(
+                            f'Dynamic action provider {provider_action.name} failed for {kind}/{name}',
+                            exc_info=e,
+                        )
+                        continue
+                    continue
                 try:
-                    response = await provider.run({'kind': kind, 'name': name})
-                    if response.response:
-                        self.register_action_instance(response.response)
-                        return await self._trigger_lazy_loading(response.response)
+                    response = await provider_action.run({'kind': kind, 'name': name})
+                    legacy = response.response
+                    if isinstance(legacy, Action):
+                        self.register_action_instance(legacy)
+                        return await self._trigger_lazy_loading(legacy)
                 except Exception as e:
                     logger.debug(
-                        f'Dynamic action provider {provider.name} failed for {kind}/{name}',
+                        f'Dynamic action provider {provider_action.name} failed for {kind}/{name}',
                         exc_info=e,
                     )
                     continue
@@ -466,20 +483,51 @@ class Registry:
     async def resolve_action_by_key(self, key: str) -> Action | None:
         """Resolve an action using its combined key string.
 
-        The key format is `<kind>/<name>`, where kind must be a valid
-        `ActionKind` and name may be prefixed with plugin namespace or unprefixed.
+        The key format is ``/<kind>/<name>``, where kind must be a valid
+        ``ActionKind`` and name may be prefixed with plugin namespace or
+        unprefixed.
+
+        For nested actions exposed by a dynamic action provider, use
+        ``/dynamic-action-provider/<provider>:<innerKind>/<innerName>`` (for
+        example ``/dynamic-action-provider/my-mcp:tool/echo``).
 
         Args:
-            key: The action key in the format `<kind>/<name>`.
+            key: The action key in the format ``/<kind>/<name>``.
 
         Returns:
-            The `Action` instance if found, None otherwise.
+            The ``Action`` instance if found, None otherwise.
 
         Raises:
             ValueError: If the key format is invalid, the kind is not a valid
-                `ActionKind`, or an unprefixed name is ambiguous.
+                ``ActionKind``, or an unprefixed name is ambiguous.
         """
         kind, name = parse_action_key(key)
+        if kind == ActionKind.DYNAMIC_ACTION_PROVIDER:
+            dap_parts = parse_dap_qualified_name(name)
+            if dap_parts is not None:
+                provider_name, inner_kind_str, inner_name = dap_parts
+                provider_action = await self.resolve_action(
+                    ActionKind.DYNAMIC_ACTION_PROVIDER,
+                    provider_name,
+                )
+                if provider_action is None:
+                    return None
+                dap = getattr(provider_action, GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR, None)
+                if dap is None:
+                    return None
+                try:
+                    resolved = await dap.get_action(inner_kind_str, inner_name)
+                except Exception as e:
+                    logger.debug(
+                        f'Dynamic action provider {provider_name} failed for '
+                        f'qualified key {inner_kind_str}/{inner_name}',
+                        exc_info=e,
+                    )
+                    return None
+                if resolved is None:
+                    return None
+                self.register_action_instance(resolved)
+                return await self._trigger_lazy_loading(resolved)
         return await self.resolve_action(kind, name)
 
     async def list_actions(self, allowed_kinds: list[ActionKind] | None = None) -> list[ActionMetadata]:

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -128,7 +128,9 @@ class Registry:
             return self.lookup_schema(name) or name
 
         # Children share the parent's Dotprompt instance (prompts are global).
-        self.dotprompt: Dotprompt = parent.dotprompt if parent is not None else Dotprompt(schema_resolver=async_schema_resolver)
+        self.dotprompt: Dotprompt = (
+            parent.dotprompt if parent is not None else Dotprompt(schema_resolver=async_schema_resolver)
+        )
         # TODO(#4352): Figure out how to set this.
         self.api_stability: str = 'stable'
 

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -16,6 +16,8 @@
 
 """Registry for managing Genkit resources and actions."""
 
+from __future__ import annotations
+
 import asyncio
 import threading
 from collections.abc import Awaitable, Callable
@@ -98,7 +100,7 @@ class Registry:
             action names and their corresponding Action instances.
     """
 
-    def __init__(self, parent: 'Registry | None' = None) -> None:
+    def __init__(self, parent: Registry | None = None) -> None:
         """Initialize a Registry instance.
 
         Args:
@@ -147,7 +149,7 @@ class Registry:
     # Child registry support
     # -------------------------------------------------------------------------
 
-    def new_child(self) -> 'Registry':
+    def new_child(self) -> Registry:
         """Create a cheap child registry that inherits from this registry.
 
         Child registries are used to create short-lived, ephemeral scopes (e.g.
@@ -161,7 +163,7 @@ class Registry:
         return Registry(parent=self)
 
     @property
-    def parent(self) -> 'Registry | None':
+    def parent(self) -> Registry | None:
         """The parent registry, or ``None`` if this is a root registry."""
         return self._parent
 
@@ -506,29 +508,17 @@ class Registry:
                 providers = list(providers_dict.values())
             for provider_action in providers:
                 dap = getattr(provider_action, GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR, None)
-                if dap is not None:
-                    try:
-                        resolved = await dap.get_action(str(kind), name)
-                        if resolved is not None:
-                            return resolved
-                    except Exception as e:
-                        logger.debug(
-                            f'Dynamic action provider {provider_action.name} failed for {kind}/{name}',
-                            exc_info=e,
-                        )
-                        continue
+                if dap is None:
                     continue
                 try:
-                    response = await provider_action.run({'kind': kind, 'name': name})
-                    legacy = response.response
-                    if isinstance(legacy, Action):
-                        return legacy
+                    resolved = await dap.get_action(str(kind), name)
+                    if resolved is not None:
+                        return resolved
                 except Exception as e:
                     logger.debug(
                         f'Dynamic action provider {provider_action.name} failed for {kind}/{name}',
                         exc_info=e,
                     )
-                    continue
 
         # Final fallback: delegate to parent registry.
         if self._parent is not None:

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from collections.abc import Awaitable, Callable
-from typing import cast
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any, cast
 
 from dotpromptz.dotprompt import Dotprompt
 from pydantic import BaseModel
@@ -35,6 +35,7 @@ from genkit._core._action import (
     ActionName,
     ActionRunContext,
     SpanAttributeValue,
+    create_action_key,
     parse_action_key,
     parse_dap_qualified_name,
 )
@@ -80,6 +81,44 @@ ActionFn = (
 )
 
 
+def _reflection_payload_for_registered_action(action: Action) -> dict[str, Any]:
+    key = create_action_key(action.kind, action.name)
+    return {
+        'key': key,
+        'name': action.name,
+        'type': action.kind,
+        'description': action.description,
+        'inputSchema': action.input_schema,
+        'outputSchema': action.output_schema,
+        'metadata': action.metadata,
+    }
+
+
+def _reflection_payload_for_plugin_metadata(meta: ActionMetadata) -> dict[str, Any]:
+    key = f'/{meta.kind}/{meta.name}'
+    return {
+        'key': key,
+        'name': meta.name,
+        'type': meta.kind,
+        'description': meta.description,
+        'inputSchema': meta.input_json_schema,
+        'outputSchema': meta.output_json_schema,
+        'metadata': meta.metadata,
+    }
+
+
+def _reflection_payload_for_dap_metadata(full_key: str, meta: Mapping[str, object]) -> dict[str, Any]:
+    return {
+        'key': full_key,
+        'name': meta.get('name'),
+        'type': meta.get('type'),
+        'description': meta.get('description'),
+        'inputSchema': meta.get('inputSchema') or meta.get('input_json_schema'),
+        'outputSchema': meta.get('outputSchema') or meta.get('output_json_schema'),
+        'metadata': dict(meta),
+    }
+
+
 class Registry:
     """Central repository for Genkit resources.
 
@@ -122,8 +161,8 @@ class Registry:
         # https://github.com/firebase/genkit/issues/4491).
         self._loading_actions: set[str] = set()
 
-        # Initialize Dotprompt with schema_resolver to match JS SDK pattern
-        # Use async function to avoid thread pool deadlock in resolve_json_schema
+        # Dotprompt resolves ``output.schema`` names via the registry's stored schemas.
+        # Async resolver avoids thread-pool deadlock in ``resolve_json_schema``.
         async def async_schema_resolver(name: str) -> dict[str, object] | str:
             return self.lookup_schema(name) or name
 
@@ -146,6 +185,7 @@ class Registry:
         #   reflection server schedules coroutines onto that loop.)
         self._plugins: dict[str, Plugin] = {}
         self._plugin_init_tasks: dict[str, asyncio.Task[None]] = {}
+        self._all_plugins_initialized: bool = False
 
     # -------------------------------------------------------------------------
     # Child registry support
@@ -261,6 +301,118 @@ class Registry:
             await self._trigger_lazy_loading(action)
         return actions
 
+    async def list_actions(self) -> dict[str, Action]:
+        """Return every concrete :class:`Action` in ``_entries``, keyed by ``/<kind>/<name>``.
+
+        Ensures plugins are initialized first so ``init()``-registered actions appear.
+        Merges with the parent registry when present; on duplicate keys the child wins.
+        For advertised-only and DAP-expanded metadata (reflection catalog), use
+        :meth:`list_resolvable_actions`.
+
+        Returns:
+            Map of action key string to :class:`Action` instance.
+        """
+        await self.initialize_all_plugins()
+        local: dict[str, Action] = {}
+        for kind in ActionKind.__members__.values():
+            for name, action in (await self.resolve_actions_by_kind(kind)).items():
+                local[create_action_key(kind, name)] = action
+        if self._parent is None:
+            return local
+        parent_actions = await self._parent.list_actions()
+        return {**parent_actions, **local}
+
+    async def list_resolvable_actions(self) -> dict[str, dict[str, Any]]:
+        """Return reflection metadata for plugins, registered actions, and DAP-expanded tools.
+
+        Builds plugin rows from each plugin's ``list_actions()``, then fills registered
+        actions and DAP expansions via :meth:`list_actions` (which initializes plugins).
+        Merges with parent's list_resolvable_actions() output (prefer child entries on duplicate keys).
+
+        Returns:
+            Map of action key to reflection-style payload dicts (``key``, ``name``, ``type``, etc.).
+        """
+        local: dict[str, dict[str, Any]] = {}
+
+        with self._lock:
+            plugins = list(self._plugins.items())
+        for plugin_name, plugin in plugins:
+            try:
+                plugin_metas = await plugin.list_actions()
+            except Exception:
+                logger.exception('Error listing actions for plugin %s', plugin_name)
+                continue
+            for meta in plugin_metas or []:
+                if not meta.name:
+                    raise ValueError(f'Invalid ActionMetadata from {plugin_name}: name required')
+                if '/' not in meta.name:
+                    meta = meta.model_copy(update={'name': f'{plugin_name}/{meta.name}'})
+                key = f'/{meta.kind}/{meta.name}'
+                local[key] = _reflection_payload_for_plugin_metadata(meta)
+
+        actions_dict = await self.list_actions()
+        actions = actions_dict.items()
+        for key, action in actions:
+            local[key] = _reflection_payload_for_registered_action(action)
+            dap = getattr(action, GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR, None)
+            if dap is None:
+                continue
+            try:
+                # Record keys use the provider action ``name``; see
+                # :meth:`DynamicActionProvider.get_action_metadata_record`.
+                record = await dap.get_action_metadata_record(action.name)
+            except Exception:
+                logger.exception(
+                    'Error listing actions for Dynamic Action Provider %s',
+                    action.name,
+                )
+                continue
+            for record_key, meta in record.items():
+                full_key = create_action_key(ActionKind.DYNAMIC_ACTION_PROVIDER, record_key)
+                local[full_key] = _reflection_payload_for_dap_metadata(full_key, meta)
+                parts = parse_dap_qualified_name(record_key)
+                if parts is None:
+                    continue
+                _provider, inner_kind_str, inner_name = parts
+                try:
+                    inner_kind = ActionKind(inner_kind_str)
+                except ValueError:
+                    logger.debug(
+                        "Unrecognized ActionKind '%s' in DAP record key '%s' from provider '%s'",
+                        inner_kind_str,
+                        record_key,
+                        action.name,
+                    )
+                    continue
+               
+                canonical = create_action_key(inner_kind, inner_name)
+                if canonical in local:
+                    continue
+                try:
+                    nested = await dap.get_action(inner_kind_str, inner_name)
+                except Exception as e:
+                    logger.debug(
+                        'DAP %s failed resolving nested action %s/%s for canonical catalog row',
+                        action.name,
+                        inner_kind_str,
+                        inner_name,
+                        exc_info=e,
+                    )
+                    nested = None
+                if nested is not None:
+                    local[canonical] = _reflection_payload_for_registered_action(nested)
+                else:
+                    canon_payload = dict(_reflection_payload_for_dap_metadata(full_key, meta))
+                    canon_payload['key'] = canonical
+                    canon_payload['name'] = inner_name
+                    canon_payload['type'] = inner_kind
+                    local[canonical] = canon_payload
+
+        if self._parent is None:
+            return local
+        parent_resolvable = await self._parent.list_resolvable_actions()
+        return {**parent_resolvable, **local}
+
     def register_value(self, kind: str, name: str, value: object) -> None:
         """Registers a value with a given kind and name.
 
@@ -330,6 +482,20 @@ class Registry:
             if plugin.name in self._plugins:
                 raise ValueError(f'Plugin {plugin.name} already registered')
             self._plugins[plugin.name] = plugin
+            self._all_plugins_initialized = False
+
+    async def initialize_all_plugins(self) -> None:
+        """Run ``init()`` for every plugin on this registry exactly once (until a new plugin is registered).
+
+        Used before enumerating registered actions so plugin-registered entries exist in ``_entries``.
+        """
+        if self._all_plugins_initialized:
+            return
+        with self._lock:
+            plugin_names = list(self._plugins.keys())
+        for name in plugin_names:
+            await self._ensure_plugin_initialized(name)
+        self._all_plugins_initialized = True
 
     async def _ensure_plugin_initialized(self, plugin_name: str) -> None:
         """Ensure a plugin is initialized exactly once.
@@ -576,52 +742,6 @@ class Registry:
                     return None
                 return resolved
         return await self.resolve_action(kind, name)
-
-    async def list_actions(self, allowed_kinds: list[ActionKind] | None = None) -> list[ActionMetadata]:
-        """List all actions advertised by plugins.
-
-        This method returns the advertised set of actions from all registered
-        plugins. It does NOT trigger plugin initialization and does NOT consult
-        the registry's internal action store.
-
-        For a child registry, parent actions are included but child actions with
-        the same (kind, name) take precedence.
-
-        Args:
-            allowed_kinds: Optional list of action kinds to filter by.
-
-        Returns:
-            A list of ActionMetadata objects describing available actions.
-
-        Raises:
-            ValueError: If a plugin returns invalid ActionMetadata.
-        """
-        metas: list[ActionMetadata] = []
-        seen: set[tuple[ActionKind, str]] = set()
-        with self._lock:
-            plugins = list(self._plugins.items())
-        for plugin_name, plugin in plugins:
-            plugin_metas = await plugin.list_actions()
-            for meta in plugin_metas or []:
-                if not meta.name:
-                    raise ValueError(f'Invalid ActionMetadata from {plugin_name}: name required')
-
-                # Normalize metadata name
-                if '/' not in meta.name:
-                    meta = meta.model_copy(update={'name': f'{plugin_name}/{meta.name}'})
-
-                if allowed_kinds and meta.kind not in allowed_kinds:
-                    continue
-                seen.add((meta.kind, meta.name))
-                metas.append(meta)
-
-        # Include parent actions not shadowed by local plugins.
-        if self._parent is not None:
-            for parent_meta in await self._parent.list_actions(allowed_kinds):
-                if (parent_meta.kind, parent_meta.name) not in seen:
-                    metas.append(parent_meta)
-
-        return metas
 
     def register_schema(self, name: str, schema: dict[str, object], schema_type: type[BaseModel] | None = None) -> None:
         """Registers a schema by name.

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from collections.abc import Awaitable, Callable
-from typing import Any, cast
+from typing import cast
 
 from dotpromptz.dotprompt import Dotprompt
 from pydantic import BaseModel

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -384,8 +384,8 @@ class Registry:
                         action.name,
                     )
                     continue
-               
-                canonical = create_action_key(inner_kind, inner_name)
+
+                canonical = create_action_key(inner_kind_str, inner_name)
                 if canonical in local:
                     continue
                 try:

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -86,6 +86,11 @@ class Registry:
     plugins, and schemas. It provides methods for registering new resources and
     looking them up at runtime.
 
+    Supports a **child registry** pattern (see ``new_child``): a child registry
+    delegates lookups to its parent when a name is not found locally.  This is
+    used to create cheap, ephemeral registries scoped to a single generate call
+    (for DAP-resolved tools) without polluting the root registry.
+
     This class is thread-safe and can be safely shared between multiple threads.
 
     Attributes:
@@ -93,10 +98,17 @@ class Registry:
             action names and their corresponding Action instances.
     """
 
-    default_model: str | None = None
+    def __init__(self, parent: 'Registry | None' = None) -> None:
+        """Initialize a Registry instance.
 
-    def __init__(self) -> None:
-        """Initialize an empty Registry instance."""
+        Args:
+            parent: Optional parent registry.  When provided this is a *child*
+                registry that falls back to the parent for any lookup that
+                returns ``None`` locally.  Use ``new_child()`` as the
+                preferred factory rather than passing ``parent`` directly.
+        """
+        self._parent: Registry | None = parent
+        self._default_model: str | None = None
         self._entries: ActionStore = {}
         self._value_by_kind_and_name: dict[str, dict[str, object]] = {}
         self._schemas_by_name: dict[str, dict[str, object]] = {}
@@ -113,7 +125,8 @@ class Registry:
         async def async_schema_resolver(name: str) -> dict[str, object] | str:
             return self.lookup_schema(name) or name
 
-        self.dotprompt: Dotprompt = Dotprompt(schema_resolver=async_schema_resolver)
+        # Children share the parent's Dotprompt instance (prompts are global).
+        self.dotprompt: Dotprompt = parent.dotprompt if parent is not None else Dotprompt(schema_resolver=async_schema_resolver)
         # TODO(#4352): Figure out how to set this.
         self.api_stability: str = 'stable'
 
@@ -129,6 +142,44 @@ class Registry:
         #   reflection server schedules coroutines onto that loop.)
         self._plugins: dict[str, Plugin] = {}
         self._plugin_init_tasks: dict[str, asyncio.Task[None]] = {}
+
+    # -------------------------------------------------------------------------
+    # Child registry support
+    # -------------------------------------------------------------------------
+
+    def new_child(self) -> 'Registry':
+        """Create a cheap child registry that inherits from this registry.
+
+        Child registries are used to create short-lived, ephemeral scopes (e.g.
+        per-generate-call tool registrations from a DAP) without polluting the
+        root registry.  Any lookup that fails locally falls back to this parent.
+        Writes on the child never propagate back to the parent.
+
+        Returns:
+            A new ``Registry`` whose parent is ``self``.
+        """
+        return Registry(parent=self)
+
+    @property
+    def parent(self) -> 'Registry | None':
+        """The parent registry, or ``None`` if this is a root registry."""
+        return self._parent
+
+    @property
+    def is_child(self) -> bool:
+        """``True`` if this registry has a parent."""
+        return self._parent is not None
+
+    @property
+    def default_model(self) -> str | None:
+        """The default model name, falling back to parent if not set locally."""
+        if self._default_model is not None:
+            return self._default_model
+        return self._parent.default_model if self._parent is not None else None
+
+    @default_model.setter
+    def default_model(self, value: str | None) -> None:
+        self._default_model = value
 
     def register_action(
         self,
@@ -240,10 +291,13 @@ class Registry:
             name: The name of the value (e.g., "json", "text").
 
         Returns:
-            The value or None if not found.
+            The value or None if not found.  Falls back to parent registry.
         """
         with self._lock:
-            return self._value_by_kind_and_name.get(kind, {}).get(name)
+            local = self._value_by_kind_and_name.get(kind, {}).get(name)
+        if local is not None:
+            return local
+        return self._parent.lookup_value(kind, name) if self._parent is not None else None
 
     def list_values(self, kind: str) -> list[str]:
         """List all values registered for a specific kind.
@@ -456,8 +510,7 @@ class Registry:
                     try:
                         resolved = await dap.get_action(str(kind), name)
                         if resolved is not None:
-                            self.register_action_instance(resolved)
-                            return await self._trigger_lazy_loading(resolved)
+                            return resolved
                     except Exception as e:
                         logger.debug(
                             f'Dynamic action provider {provider_action.name} failed for {kind}/{name}',
@@ -469,14 +522,17 @@ class Registry:
                     response = await provider_action.run({'kind': kind, 'name': name})
                     legacy = response.response
                     if isinstance(legacy, Action):
-                        self.register_action_instance(legacy)
-                        return await self._trigger_lazy_loading(legacy)
+                        return legacy
                 except Exception as e:
                     logger.debug(
                         f'Dynamic action provider {provider_action.name} failed for {kind}/{name}',
                         exc_info=e,
                     )
                     continue
+
+        # Final fallback: delegate to parent registry.
+        if self._parent is not None:
+            return await self._parent.resolve_action(kind, name)
 
         return None
 
@@ -526,8 +582,7 @@ class Registry:
                     return None
                 if resolved is None:
                     return None
-                self.register_action_instance(resolved)
-                return await self._trigger_lazy_loading(resolved)
+                return resolved
         return await self.resolve_action(kind, name)
 
     async def list_actions(self, allowed_kinds: list[ActionKind] | None = None) -> list[ActionMetadata]:
@@ -536,6 +591,9 @@ class Registry:
         This method returns the advertised set of actions from all registered
         plugins. It does NOT trigger plugin initialization and does NOT consult
         the registry's internal action store.
+
+        For a child registry, parent actions are included but child actions with
+        the same (kind, name) take precedence.
 
         Args:
             allowed_kinds: Optional list of action kinds to filter by.
@@ -547,6 +605,7 @@ class Registry:
             ValueError: If a plugin returns invalid ActionMetadata.
         """
         metas: list[ActionMetadata] = []
+        seen: set[tuple[ActionKind, str]] = set()
         with self._lock:
             plugins = list(self._plugins.items())
         for plugin_name, plugin in plugins:
@@ -561,7 +620,15 @@ class Registry:
 
                 if allowed_kinds and meta.kind not in allowed_kinds:
                     continue
+                seen.add((meta.kind, meta.name))
                 metas.append(meta)
+
+        # Include parent actions not shadowed by local plugins.
+        if self._parent is not None:
+            for parent_meta in await self._parent.list_actions(allowed_kinds):
+                if (parent_meta.kind, parent_meta.name) not in seen:
+                    metas.append(parent_meta)
+
         return metas
 
     def register_schema(self, name: str, schema: dict[str, object], schema_type: type[BaseModel] | None = None) -> None:
@@ -593,10 +660,13 @@ class Registry:
             name: The name of the schema to look up.
 
         Returns:
-            The schema data if found, None otherwise.
+            The schema data if found, None otherwise.  Falls back to parent.
         """
         with self._lock:
-            return self._schemas_by_name.get(name)
+            local = self._schemas_by_name.get(name)
+        if local is not None:
+            return local
+        return self._parent.lookup_schema(name) if self._parent is not None else None
 
     def lookup_schema_type(self, name: str) -> type[BaseModel] | None:
         """Looks up a schema's Pydantic type by name.
@@ -605,10 +675,13 @@ class Registry:
             name: The name of the schema to look up.
 
         Returns:
-            The Pydantic model class if found, None otherwise.
+            The Pydantic model class if found, None otherwise.  Falls back to parent.
         """
         with self._lock:
-            return self._schema_types_by_name.get(name)
+            local = self._schema_types_by_name.get(name)
+        if local is not None:
+            return local
+        return self._parent.lookup_schema_type(name) if self._parent is not None else None
 
     # ===== Typed Action Lookups =====
     #

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 from dotpromptz.dotprompt import Dotprompt
@@ -31,7 +31,6 @@ from genkit._core._action import (
     GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR,
     Action,
     ActionKind,
-    ActionMetadata,
     ActionName,
     ActionRunContext,
     SpanAttributeValue,
@@ -47,6 +46,7 @@ from genkit._core._model import (
 )
 from genkit._core._plugin import Plugin
 from genkit._core._typing import (
+    ActionMetadata,
     EmbedRequest,
     EmbedResponse,
     EvalRequest,
@@ -94,28 +94,17 @@ def _reflection_payload_for_registered_action(action: Action) -> dict[str, Any]:
     }
 
 
-def _reflection_payload_for_plugin_metadata(meta: ActionMetadata) -> dict[str, Any]:
-    key = f'/{meta.kind}/{meta.name}'
+def _reflection_payload_for_action_metadata(meta: ActionMetadata) -> dict[str, Any]:
+    """Adapt an :class:`ActionMetadata` into the reflection payload dict shape."""
+    key = meta.key or f'/{meta.action_type}/{meta.name}'
     return {
         'key': key,
         'name': meta.name,
-        'type': meta.kind,
+        'type': meta.action_type,
         'description': meta.description,
-        'inputSchema': meta.input_json_schema,
-        'outputSchema': meta.output_json_schema,
-        'metadata': meta.metadata,
-    }
-
-
-def _reflection_payload_for_dap_metadata(full_key: str, meta: Mapping[str, object]) -> dict[str, Any]:
-    return {
-        'key': full_key,
-        'name': meta.get('name'),
-        'type': meta.get('type'),
-        'description': meta.get('description'),
-        'inputSchema': meta.get('inputSchema') or meta.get('input_json_schema'),
-        'outputSchema': meta.get('outputSchema') or meta.get('output_json_schema'),
-        'metadata': dict(meta),
+        'inputSchema': meta.input_schema or meta.input_json_schema,
+        'outputSchema': meta.output_schema or meta.output_json_schema,
+        'metadata': dict(meta.metadata) if meta.metadata else None,
     }
 
 
@@ -345,10 +334,10 @@ class Registry:
             for meta in plugin_metas or []:
                 if not meta.name:
                     raise ValueError(f'Invalid ActionMetadata from {plugin_name}: name required')
-                if '/' not in meta.name:
-                    meta = meta.model_copy(update={'name': f'{plugin_name}/{meta.name}'})
-                key = f'/{meta.kind}/{meta.name}'
-                local[key] = _reflection_payload_for_plugin_metadata(meta)
+                if not meta.action_type:
+                    raise ValueError(f'Invalid ActionMetadata from {plugin_name}: action_type required')
+                key = f'/{meta.action_type}/{meta.name}'
+                local[key] = _reflection_payload_for_action_metadata(meta)
 
         actions_dict = await self.list_actions()
         actions = actions_dict.items()
@@ -367,46 +356,8 @@ class Registry:
                     action.name,
                 )
                 continue
-            for record_key, meta in record.items():
-                full_key = create_action_key(ActionKind.DYNAMIC_ACTION_PROVIDER, record_key)
-                local[full_key] = _reflection_payload_for_dap_metadata(full_key, meta)
-                parts = parse_dap_qualified_name(record_key)
-                if parts is None:
-                    continue
-                _provider, inner_kind_str, inner_name = parts
-                try:
-                    inner_kind = ActionKind(inner_kind_str)
-                except ValueError:
-                    logger.debug(
-                        "Unrecognized ActionKind '%s' in DAP record key '%s' from provider '%s'",
-                        inner_kind_str,
-                        record_key,
-                        action.name,
-                    )
-                    continue
-
-                canonical = create_action_key(inner_kind_str, inner_name)
-                if canonical in local:
-                    continue
-                try:
-                    nested = await dap.get_action(inner_kind_str, inner_name)
-                except Exception as e:
-                    logger.debug(
-                        'DAP %s failed resolving nested action %s/%s for canonical catalog row',
-                        action.name,
-                        inner_kind_str,
-                        inner_name,
-                        exc_info=e,
-                    )
-                    nested = None
-                if nested is not None:
-                    local[canonical] = _reflection_payload_for_registered_action(nested)
-                else:
-                    canon_payload = dict(_reflection_payload_for_dap_metadata(full_key, meta))
-                    canon_payload['key'] = canonical
-                    canon_payload['name'] = inner_name
-                    canon_payload['type'] = inner_kind
-                    local[canonical] = canon_payload
+            for full_key, meta in record.items():
+                local[full_key] = _reflection_payload_for_action_metadata(meta)
 
         if self._parent is None:
             return local

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -38,6 +38,7 @@ from genkit._core._action import (
     parse_action_key,
     parse_dap_qualified_name,
 )
+from genkit._core._error import GenkitError
 from genkit._core._logger import get_logger
 from genkit._core._model import (
     ModelRequest,
@@ -81,31 +82,17 @@ ActionFn = (
 )
 
 
-def _reflection_payload_for_registered_action(action: Action) -> dict[str, Any]:
-    key = create_action_key(action.kind, action.name)
-    return {
-        'key': key,
-        'name': action.name,
-        'type': action.kind,
-        'description': action.description,
-        'inputSchema': action.input_schema,
-        'outputSchema': action.output_schema,
-        'metadata': action.metadata,
-    }
-
-
-def _reflection_payload_for_action_metadata(meta: ActionMetadata) -> dict[str, Any]:
-    """Adapt an :class:`ActionMetadata` into the reflection payload dict shape."""
-    key = meta.key or f'/{meta.action_type}/{meta.name}'
-    return {
-        'key': key,
-        'name': meta.name,
-        'type': meta.action_type,
-        'description': meta.description,
-        'inputSchema': meta.input_schema or meta.input_json_schema,
-        'outputSchema': meta.output_schema or meta.output_json_schema,
-        'metadata': dict(meta.metadata) if meta.metadata else None,
-    }
+def _action_metadata_for_registered_action(action: Action) -> ActionMetadata:
+    """Build an ``ActionMetadata`` row for a directly-registered :class:`Action`."""
+    return ActionMetadata(
+        key=create_action_key(action.kind, action.name),
+        action_type=action.kind,
+        name=action.name,
+        description=action.description,
+        input_schema=action.input_schema,
+        output_schema=action.output_schema,
+        metadata=dict(action.metadata) if action.metadata else None,
+    )
 
 
 class Registry:
@@ -138,7 +125,6 @@ class Registry:
                 preferred factory rather than passing ``parent`` directly.
         """
         self._parent: Registry | None = parent
-        self._default_model: str | None = None
         self._entries: ActionStore = {}
         self._value_by_kind_and_name: dict[str, dict[str, object]] = {}
         self._schemas_by_name: dict[str, dict[str, object]] = {}
@@ -152,11 +138,14 @@ class Registry:
 
         # Dotprompt resolves ``output.schema`` names via the registry's stored schemas.
         # Async resolver avoids thread-pool deadlock in ``resolve_json_schema``.
-        async def async_schema_resolver(name: str) -> dict[str, object] | str:
-            return self.lookup_schema(name) or name
+        async def async_schema_resolver(name: str) -> dict[str, object]:
+            schema = self.lookup_schema(name)
+            if schema is None:
+                raise GenkitError(status='NOT_FOUND', message=f"Schema '{name}' not found")
+            return schema
 
         # Children share the parent's Dotprompt instance (prompts are global).
-        self.dotprompt: Dotprompt = (
+        self._dotprompt: Dotprompt = (
             parent.dotprompt if parent is not None else Dotprompt(schema_resolver=async_schema_resolver)
         )
         # TODO(#4352): Figure out how to set this.
@@ -204,15 +193,15 @@ class Registry:
         return self._parent is not None
 
     @property
-    def default_model(self) -> str | None:
-        """The default model name, falling back to parent if not set locally."""
-        if self._default_model is not None:
-            return self._default_model
-        return self._parent.default_model if self._parent is not None else None
+    def dotprompt(self) -> Dotprompt:
+        """The shared :class:`Dotprompt` instance for this registry tree.
 
-    @default_model.setter
-    def default_model(self, value: str | None) -> None:
-        self._default_model = value
+        Mutations (partials, helpers) propagate to all sibling and descendant
+        registries because the instance is shared. Use :func:`define_partial`
+        and :func:`define_helper` rather than mutating the returned instance
+        directly, so the public surface stays stable.
+        """
+        return self._dotprompt
 
     def register_action(
         self,
@@ -290,79 +279,65 @@ class Registry:
             await self._trigger_lazy_loading(action)
         return actions
 
-    async def list_actions(self) -> dict[str, Action]:
-        """Return every concrete :class:`Action` in ``_entries``, keyed by ``/<kind>/<name>``.
-
-        Ensures plugins are initialized first so ``init()``-registered actions appear.
-        Merges with the parent registry when present; on duplicate keys the child wins.
-        For advertised-only and DAP-expanded metadata (reflection catalog), use
-        :meth:`list_resolvable_actions`.
-
-        Returns:
-            Map of action key string to :class:`Action` instance.
-        """
-        await self.initialize_all_plugins()
-        local: dict[str, Action] = {}
-        for kind in ActionKind.__members__.values():
-            for name, action in (await self.resolve_actions_by_kind(kind)).items():
-                local[create_action_key(kind, name)] = action
-        if self._parent is None:
-            return local
-        parent_actions = await self._parent.list_actions()
-        return {**parent_actions, **local}
-
-    async def list_resolvable_actions(self) -> dict[str, dict[str, Any]]:
+    async def list_actions(self) -> dict[str, ActionMetadata]:
         """Return reflection metadata for plugins, registered actions, and DAP-expanded tools.
 
-        Builds plugin rows from each plugin's ``list_actions()``, then fills registered
-        actions and DAP expansions via :meth:`list_actions` (which initializes plugins).
-        Merges with parent's list_resolvable_actions() output (prefer child entries on duplicate keys).
+        Initializes plugins, advertises plugin rows from each plugin's ``list_actions()``,
+        then fills registered :class:`Action` rows and expands DAP-provided actions. Merges
+        with the parent registry's catalog; entries from this registry win on duplicate keys.
 
         Returns:
-            Map of action key to reflection-style payload dicts (``key``, ``name``, ``type``, etc.).
+            Map of action key string to typed :class:`ActionMetadata`.
         """
-        local: dict[str, dict[str, Any]] = {}
+        await self.initialize_all_plugins()
 
+        catalog: dict[str, ActionMetadata] = {}
+
+        # 1. Plugin-advertised rows: actions the plugin claims it can resolve on demand.
         with self._lock:
             plugins = list(self._plugins.items())
         for plugin_name, plugin in plugins:
             try:
-                plugin_metas = await plugin.list_actions()
+                advertised = await plugin.list_actions()
             except Exception:
                 logger.exception('Error listing actions for plugin %s', plugin_name)
                 continue
-            for meta in plugin_metas or []:
+            for meta in advertised or []:
                 if not meta.name:
                     raise ValueError(f'Invalid ActionMetadata from {plugin_name}: name required')
                 if not meta.action_type:
                     raise ValueError(f'Invalid ActionMetadata from {plugin_name}: action_type required')
                 key = f'/{meta.action_type}/{meta.name}'
-                local[key] = _reflection_payload_for_action_metadata(meta)
+                catalog[key] = meta.model_copy(update={'key': key})
 
-        actions_dict = await self.list_actions()
-        actions = actions_dict.items()
-        for key, action in actions:
-            local[key] = _reflection_payload_for_registered_action(action)
-            dap = getattr(action, GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR, None)
-            if dap is None:
-                continue
-            try:
-                # Record keys use the provider action ``name``; see
-                # :meth:`DynamicActionProvider.get_action_metadata_record`.
-                record = await dap.get_action_metadata_record(action.name)
-            except Exception:
-                logger.exception(
-                    'Error listing actions for Dynamic Action Provider %s',
-                    action.name,
-                )
-                continue
-            for full_key, meta in record.items():
-                local[full_key] = _reflection_payload_for_action_metadata(meta)
+        # 2. Concrete registered actions, plus DAP-expanded actions if the action is a provider.
+        for kind in ActionKind.__members__.values():
+            for name, action in (await self.resolve_actions_by_kind(kind)).items():
+                key = create_action_key(kind, name)
+                catalog[key] = _action_metadata_for_registered_action(action)
 
+                dap = getattr(action, GENKIT_DYNAMIC_ACTION_PROVIDER_ATTR, None)
+                if dap is None:
+                    continue
+                try:
+                    # DAP action keys are prefixed with the provider action's ``name``;
+                    # see :meth:`DynamicActionProvider.list_action_metadata_by_key`.
+                    dap_actions = await dap.list_action_metadata_by_key(action.name)
+                except Exception:
+                    logger.exception(
+                        'Error listing actions for Dynamic Action Provider %s',
+                        action.name,
+                    )
+                    continue
+                # ``list_action_metadata_by_key`` already populates each entry's ``meta.key``
+                # to match its DAP action key, so we can merge straight into the catalog.
+                catalog.update(dap_actions)
+
+        # 3. Merge in parent registry's catalog; entries from this registry win on duplicate keys.
         if self._parent is None:
-            return local
-        parent_resolvable = await self._parent.list_resolvable_actions()
-        return {**parent_resolvable, **local}
+            return catalog
+        parent_catalog = await self._parent.list_actions()
+        return {**parent_catalog, **catalog}
 
     def register_value(self, kind: str, name: str, value: object) -> None:
         """Registers a value with a given kind and name.
@@ -406,17 +381,22 @@ class Registry:
             return local
         return self._parent.lookup_value(kind, name) if self._parent is not None else None
 
-    def list_values(self, kind: str) -> list[str]:
-        """List all values registered for a specific kind.
+    def list_values(self, kind: str) -> dict[str, object]:
+        """List all values registered for a specific kind, merged with the parent registry.
+
+        Entries from this registry win on duplicate names.
 
         Args:
-            kind: The kind of values to list (e.g., "defaultModel").
+            kind: The kind of values to list (e.g., ``"defaultModel"``, ``"format"``).
 
         Returns:
-            A list of registered value names.
+            Map of value name to value object.
         """
         with self._lock:
-            return list(self._value_by_kind_and_name.get(kind, {}).keys())
+            local = dict(self._value_by_kind_and_name.get(kind, {}))
+        if self._parent is None:
+            return local
+        return {**self._parent.list_values(kind), **local}
 
     def register_plugin(self, plugin: Plugin) -> None:
         """Register a plugin with the registry.

--- a/py/packages/genkit/src/genkit/plugin_api/__init__.py
+++ b/py/packages/genkit/src/genkit/plugin_api/__init__.py
@@ -18,7 +18,6 @@
 
 # Base class and framework primitives
 from genkit._core._action import Action, ActionKind, ActionRunContext
-from genkit._core._typing import ActionMetadata
 from genkit._core._constants import GENKIT_CLIENT_HEADER, GENKIT_VERSION
 from genkit._core._context import ContextProvider, RequestData
 from genkit._core._environment import is_dev_environment
@@ -30,6 +29,7 @@ from genkit._core._schema import to_json_schema
 from genkit._core._trace._adjusting_exporter import AdjustingTraceExporter, RedactedSpan
 from genkit._core._trace._path import to_display_path
 from genkit._core._tracing import add_custom_exporter, tracer
+from genkit._core._typing import ActionMetadata
 
 # Embedder domain re-exports
 from genkit.embedder import (

--- a/py/packages/genkit/src/genkit/plugin_api/__init__.py
+++ b/py/packages/genkit/src/genkit/plugin_api/__init__.py
@@ -17,7 +17,8 @@
 """Framework primitives for plugin authors."""
 
 # Base class and framework primitives
-from genkit._core._action import Action, ActionKind, ActionMetadata, ActionRunContext
+from genkit._core._action import Action, ActionKind, ActionRunContext
+from genkit._core._typing import ActionMetadata
 from genkit._core._constants import GENKIT_CLIENT_HEADER, GENKIT_VERSION
 from genkit._core._context import ContextProvider, RequestData
 from genkit._core._environment import is_dev_environment

--- a/py/packages/genkit/tests/genkit/ai/ai_plugin_test.py
+++ b/py/packages/genkit/tests/genkit/ai/ai_plugin_test.py
@@ -23,7 +23,8 @@
 import pytest
 
 from genkit import Genkit, Message, ModelResponse, Part, Plugin, Role, TextPart
-from genkit._core._action import Action, ActionMetadata, ActionRunContext
+from genkit._core._action import Action, ActionRunContext
+from genkit._core._typing import ActionMetadata
 from genkit._core._model import ModelRequest
 from genkit._core._registry import ActionKind
 from genkit._core._typing import FinishReason
@@ -62,7 +63,7 @@ class AsyncResolveOnlyPlugin(Plugin):
         """List available actions."""
         return [
             ActionMetadata(
-                kind=ActionKind.MODEL,
+                action_type=ActionKind.MODEL,
                 name=f'{self.name}/lazy-model',
             )
         ]
@@ -101,7 +102,7 @@ class AsyncInitPlugin(Plugin):
         """List available actions."""
         return [
             ActionMetadata(
-                kind=ActionKind.MODEL,
+                action_type=ActionKind.MODEL,
                 name=f'{self.name}/init-model',
             )
         ]

--- a/py/packages/genkit/tests/genkit/ai/ai_plugin_test.py
+++ b/py/packages/genkit/tests/genkit/ai/ai_plugin_test.py
@@ -24,10 +24,9 @@ import pytest
 
 from genkit import Genkit, Message, ModelResponse, Part, Plugin, Role, TextPart
 from genkit._core._action import Action, ActionRunContext
-from genkit._core._typing import ActionMetadata
 from genkit._core._model import ModelRequest
 from genkit._core._registry import ActionKind
-from genkit._core._typing import FinishReason
+from genkit._core._typing import ActionMetadata, FinishReason
 
 
 class AsyncResolveOnlyPlugin(Plugin):

--- a/py/packages/genkit/tests/genkit/ai/ai_registry_test.py
+++ b/py/packages/genkit/tests/genkit/ai/ai_registry_test.py
@@ -169,7 +169,7 @@ class TestDefineDynamicActionProvider:
         assert hasattr(result, 'get_action')
         assert hasattr(result, 'list_action_metadata')
         assert hasattr(result, 'invalidate_cache')
-        assert hasattr(result, 'get_action_metadata_record')
+        assert hasattr(result, 'list_action_metadata_by_key')
 
 
 if __name__ == '__main__':

--- a/py/packages/genkit/tests/genkit/ai/dap_test.py
+++ b/py/packages/genkit/tests/genkit/ai/dap_test.py
@@ -223,7 +223,7 @@ async def test_gets_action_metadata_record(registry: Registry, tool1: Action, to
 
     dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
 
-    record = await dap.get_action_metadata_record('my-dap')
+    record = await dap.list_action_metadata_by_key('my-dap')
     tool1_key = '/dynamic-action-provider/my-dap:tool/tool1'
     tool2_key = '/dynamic-action-provider/my-dap:tool/tool2'
     flow1_key = '/dynamic-action-provider/my-dap:flow/tool1'
@@ -375,7 +375,7 @@ async def test_zero_ttl_uses_default(registry: Registry, tool1: Action, tool2: A
 
 
 @pytest.mark.asyncio
-async def test_get_action_metadata_record_raises_on_missing_name(registry: Registry) -> None:
+async def test_list_action_metadata_by_key_raises_on_missing_name(registry: Registry) -> None:
     async def nameless_fn(input: str) -> str:
         return 'nameless'
 
@@ -393,7 +393,7 @@ async def test_get_action_metadata_record_raises_on_missing_name(registry: Regis
     dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
 
     with pytest.raises(ValueError, match='name required'):
-        await dap.get_action_metadata_record('my-dap')
+        await dap.list_action_metadata_by_key('my-dap')
 
 
 def test_define_dap_with_full_options(registry: Registry) -> None:

--- a/py/packages/genkit/tests/genkit/ai/dap_test.py
+++ b/py/packages/genkit/tests/genkit/ai/dap_test.py
@@ -223,13 +223,26 @@ async def test_gets_action_metadata_record(registry: Registry, tool1: Action, to
 
     dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
 
-    record = await dap.get_action_metadata_record('dap/my-dap')
-    assert 'dap/my-dap:tool/tool1' in record
-    assert 'dap/my-dap:tool/tool2' in record
-    assert 'dap/my-dap:flow/tool1' in record
-    assert record['dap/my-dap:tool/tool1'] == tool1.metadata
-    assert record['dap/my-dap:tool/tool2'] == tool2.metadata
-    assert record['dap/my-dap:flow/tool1'] == tool1.metadata
+    record = await dap.get_action_metadata_record('my-dap')
+    tool1_key = '/dynamic-action-provider/my-dap:tool/tool1'
+    tool2_key = '/dynamic-action-provider/my-dap:tool/tool2'
+    flow1_key = '/dynamic-action-provider/my-dap:flow/tool1'
+    assert tool1_key in record
+    assert tool2_key in record
+    assert flow1_key in record
+    tool1_meta = record[tool1_key]
+    assert tool1_meta.key == tool1_key
+    assert tool1_meta.name == 'tool1'
+    assert tool1_meta.action_type == 'tool'
+    assert tool1_meta.description == tool1.description
+    assert tool1_meta.input_schema == tool1.input_schema
+    assert tool1_meta.output_schema == tool1.output_schema
+    assert tool1_meta.metadata == tool1.metadata
+    assert record[tool2_key].name == 'tool2'
+    assert record[tool2_key].action_type == 'tool'
+    assert record[tool2_key].metadata == tool2.metadata
+    assert record[flow1_key].name == 'tool1'
+    assert record[flow1_key].action_type == 'flow'
     assert call_count == 1
 
 
@@ -380,7 +393,7 @@ async def test_get_action_metadata_record_raises_on_missing_name(registry: Regis
     dap = define_dynamic_action_provider(registry, 'my-dap', dap_fn)
 
     with pytest.raises(ValueError, match='name required'):
-        await dap.get_action_metadata_record('dap/my-dap')
+        await dap.get_action_metadata_record('my-dap')
 
 
 def test_define_dap_with_full_options(registry: Registry) -> None:

--- a/py/packages/genkit/tests/genkit/ai/embedding_test.py
+++ b/py/packages/genkit/tests/genkit/ai/embedding_test.py
@@ -74,7 +74,7 @@ def test_embedder_action_metadata_with_supports_and_config_schema() -> None:
     )
     assert isinstance(action_metadata, ActionMetadata)
     assert action_metadata.metadata is not None
-    metadata = cast(dict[str, Any], action_metadata.metadata)
+    metadata = action_metadata.metadata
     embedder_meta = cast(dict[str, Any], metadata['embedder'])
     assert embedder_meta['label'] == 'Advanced Embedder'
     assert embedder_meta['dimensions'] == options.dimensions

--- a/py/packages/genkit/tests/genkit/ai/embedding_test.py
+++ b/py/packages/genkit/tests/genkit/ai/embedding_test.py
@@ -30,9 +30,9 @@ from genkit._ai._embedding import (
     create_embedder_ref,
     embedder_action_metadata,
 )
-from genkit._core._action import Action, ActionMetadata, ActionResponse
+from genkit._core._action import Action, ActionResponse
 from genkit._core._schema import to_json_schema
-from genkit._core._typing import Embedding, EmbedRequest, EmbedResponse
+from genkit._core._typing import ActionMetadata, Embedding, EmbedRequest, EmbedResponse
 
 
 def test_embedder_action_metadata() -> None:

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -9,8 +9,8 @@ import pytest
 
 from genkit import Message, ModelRequest, ModelResponse, ModelResponseChunk, ModelUsage
 from genkit._ai._model import text_from_content
-from genkit._core._action import ActionMetadata
 from genkit._core._typing import (
+    ActionMetadata,
     DocumentPart,
     Media,
     MediaPart,

--- a/py/packages/genkit/tests/genkit/ai/resource_integration_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resource_integration_test.py
@@ -17,13 +17,11 @@
 
 """Integration tests for Genkit resources."""
 
-from typing import cast
-
 import pytest
 
 from genkit import Message, ModelResponse
 from genkit._ai._generate import generate_action
-from genkit._ai._resource import ResourceInput, ResourceOutput, define_resource, resource
+from genkit._ai._resource import ResourceInput, ResourceOutput, define_resource
 from genkit._core._action import ActionRunContext
 from genkit._core._model import GenerateActionOptions, ModelRequest
 from genkit._core._registry import ActionKind, Registry
@@ -66,49 +64,5 @@ async def test_generate_with_resources() -> None:
 
     response = await generate_action(registry, options)
     # Part also uses RootModel, access via root
-    assert response.message is not None
-    assert response.message.content[0].root.text == 'Done'
-
-
-@pytest.mark.asyncio
-async def test_dynamic_action_provider_resource() -> None:
-    """Test dynamic action provider with resources."""
-    registry = Registry()
-
-    # Register a dynamic provider that handles any "dynamic://*" uri
-    async def provider_fn(input: dict[str, object], ctx: ActionRunContext) -> object:
-        kind = cast(ActionKind, input['kind'])
-        name = cast(str, input['name'])
-        if kind == ActionKind.RESOURCE and name.startswith('dynamic://'):
-
-            async def dyn_res_fn(input: ResourceInput, ctx: ActionRunContext) -> ResourceOutput:
-                return ResourceOutput(content=[Part(root=TextPart(text=f'Dynamic content for {input.uri}'))])
-
-            return resource({'uri': name}, dyn_res_fn)
-        return None
-
-    # Register the provider as an action (it effectively acts as a factory)
-    # Note: Accessing internal structure for test setup as register_action expects specific signature
-    # But we want to register it under DYNAMIC_ACTION_PROVIDER kind.
-    registry.register_action(kind=ActionKind.DYNAMIC_ACTION_PROVIDER, name='test-provider', fn=provider_fn)
-
-    # Register mock model
-    # Register mock model
-    async def mock_model(input: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
-        # Verify docs are empty
-        assert not input.docs
-        # Verify dynamic hydration
-        assert input.messages[0].content[0].root.text == 'Dynamic content for dynamic://bar'
-        return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='Done'))]))
-
-    registry.register_action(ActionKind.MODEL, 'mock-model', mock_model)
-
-    options = GenerateActionOptions(
-        model='mock-model',
-        messages=[Message(role=Role.USER, content=[Part(root=ResourcePart(resource=Resource1(uri='dynamic://bar')))])],
-        resources=['dynamic://bar'],
-    )
-
-    response = await generate_action(registry, options)
     assert response.message is not None
     assert response.message.content[0].root.text == 'Done'

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -16,6 +16,7 @@ from genkit._core._action import (
     ActionRunContext,
     create_action_key,
     parse_action_key,
+    parse_dap_qualified_name,
     parse_plugin_name_from_action_name,
 )
 from genkit._core._error import GenkitError
@@ -70,6 +71,15 @@ def test_parse_action_key_invalid_format() -> None:
     for key in invalid_keys:
         with pytest.raises(ValueError, match='Invalid action key format'):
             parse_action_key(key)
+
+
+def test_parse_dap_qualified_name() -> None:
+    """Parse provider:innerKind/innerName segments."""
+    assert parse_dap_qualified_name('my-dap:tool/echo') == ('my-dap', 'tool', 'echo')
+    assert parse_dap_qualified_name('plugin/foo:model/bar') == ('plugin/foo', 'model', 'bar')
+    assert parse_dap_qualified_name('plain-name') is None
+    assert parse_dap_qualified_name('no-slash:toolonly') is None
+    assert parse_dap_qualified_name(':tool/x') is None
 
 
 def test_create_action_key() -> None:

--- a/py/packages/genkit/tests/genkit/core/action_test.py
+++ b/py/packages/genkit/tests/genkit/core/action_test.py
@@ -76,7 +76,7 @@ def test_parse_action_key_invalid_format() -> None:
 def test_parse_dap_qualified_name() -> None:
     """Parse provider:innerKind/innerName segments."""
     assert parse_dap_qualified_name('my-dap:tool/echo') == ('my-dap', 'tool', 'echo')
-    assert parse_dap_qualified_name('plugin/foo:model/bar') == ('plugin/foo', 'model', 'bar')
+    assert parse_dap_qualified_name('plugin/foo:model/bar') is None
     assert parse_dap_qualified_name('plain-name') is None
     assert parse_dap_qualified_name('no-slash:toolonly') is None
     assert parse_dap_qualified_name(':tool/x') is None

--- a/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
+++ b/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
@@ -48,6 +48,7 @@ from httpx import ASGITransport, AsyncClient
 from genkit._core._action import ActionKind
 from genkit._core._reflection import create_reflection_asgi_app
 from genkit._core._registry import Registry
+from genkit._core._typing import ActionMetadata
 
 
 @pytest.fixture
@@ -66,8 +67,8 @@ async def asgi_client(mock_registry: MagicMock) -> AsyncIterator[AsyncClient]:
     Returns:
         An AsyncClient configured to make requests to the test ASGI app.
     """
+    mock_registry.initialize_all_plugins = AsyncMock(return_value=None)
     mock_registry.list_actions = AsyncMock(return_value={})
-    mock_registry.list_resolvable_actions = AsyncMock(return_value={})
     app = create_reflection_asgi_app(mock_registry)
     transport = ASGITransport(app=app)
     client = AsyncClient(transport=transport, base_url='http://test')
@@ -88,22 +89,24 @@ async def test_health_check(asgi_client: AsyncClient) -> None:
 async def test_list_actions(asgi_client: AsyncClient, mock_registry: MagicMock) -> None:
     """Test that the actions list endpoint returns registered actions."""
 
-    async def mock_list_resolvable() -> dict[str, dict[str, object]]:
+    async def mock_list_actions() -> dict[str, ActionMetadata]:
         return {
-            '/custom/action1': {
-                'key': '/custom/action1',
-                'name': 'action1',
-                'type': ActionKind.CUSTOM,
-            }
+            '/custom/action1': ActionMetadata(
+                key='/custom/action1',
+                action_type=ActionKind.CUSTOM,
+                name='action1',
+            )
         }
 
-    mock_registry.list_resolvable_actions = mock_list_resolvable
+    mock_registry.list_actions = mock_list_actions
     response = await asgi_client.get('/api/actions')
     assert response.status_code == 200
     result = response.json()
     assert '/custom/action1' in result
     assert result['/custom/action1']['name'] == 'action1'
-    assert result['/custom/action1']['type'] == 'custom'
+    assert result['/custom/action1']['key'] == '/custom/action1'
+    assert 'type' not in result['/custom/action1']
+    assert 'actionType' not in result['/custom/action1']
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
+++ b/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
@@ -66,6 +66,8 @@ async def asgi_client(mock_registry: MagicMock) -> AsyncIterator[AsyncClient]:
     Returns:
         An AsyncClient configured to make requests to the test ASGI app.
     """
+    mock_registry.list_actions = AsyncMock(return_value={})
+    mock_registry.list_resolvable_actions = AsyncMock(return_value={})
     app = create_reflection_asgi_app(mock_registry)
     transport = ASGITransport(app=app)
     client = AsyncClient(transport=transport, base_url='http://test')
@@ -86,21 +88,16 @@ async def test_health_check(asgi_client: AsyncClient) -> None:
 async def test_list_actions(asgi_client: AsyncClient, mock_registry: MagicMock) -> None:
     """Test that the actions list endpoint returns registered actions."""
 
-    # Mock the async list_actions method to return a list of ActionMetadata
-    async def mock_list_actions_async(allowed_kinds: list[ActionKind] | None = None) -> list[ActionMetadata]:
-        return [
-            ActionMetadata(
-                kind=ActionKind.CUSTOM,
-                name='action1',
-            )
-        ]
+    async def mock_list_resolvable() -> dict[str, dict[str, object]]:
+        return {
+            '/custom/action1': {
+                'key': '/custom/action1',
+                'name': 'action1',
+                'type': ActionKind.CUSTOM,
+            }
+        }
 
-    # Mock resolve_actions_by_kind to return empty dict (no registered actions in this test)
-    async def mock_resolve_actions_by_kind(kind: ActionKind) -> dict:
-        return {}
-
-    mock_registry.list_actions = mock_list_actions_async
-    mock_registry.resolve_actions_by_kind = mock_resolve_actions_by_kind
+    mock_registry.list_resolvable_actions = mock_list_resolvable
     response = await asgi_client.get('/api/actions')
     assert response.status_code == 200
     result = response.json()

--- a/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
+++ b/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
@@ -45,7 +45,7 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
-from genkit._core._action import ActionKind, ActionMetadata
+from genkit._core._action import ActionKind
 from genkit._core._reflection import create_reflection_asgi_app
 from genkit._core._registry import Registry
 

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -188,3 +188,108 @@ async def test_trigger_lazy_loading_reentrant_guard() -> None:
     assert resolved.name == 'self_ref'
     # Factory should have been called exactly once (re-entrant call skipped)
     assert call_count == 1
+
+
+# =============================================================================
+# Child registry tests
+# =============================================================================
+
+@pytest.mark.asyncio
+async def test_new_child_is_child() -> None:
+    """new_child() returns a child whose is_child is True."""
+    parent = Registry()
+    child = parent.new_child()
+    assert child.is_child
+    assert not parent.is_child
+    assert child.parent is parent
+
+
+@pytest.mark.asyncio
+async def test_child_resolves_parent_action() -> None:
+    """Child registry falls back to parent for resolve_action."""
+    parent = Registry()
+    action = parent.register_action(name='shared', kind=ActionKind.CUSTOM, fn=_identity)
+
+    child = parent.new_child()
+    got = await child.resolve_action(ActionKind.CUSTOM, 'shared')
+    assert got is action
+
+
+@pytest.mark.asyncio
+async def test_child_action_does_not_pollute_parent() -> None:
+    """Actions registered on child are invisible to parent."""
+    parent = Registry()
+    child = parent.new_child()
+    child.register_action(name='child_only', kind=ActionKind.CUSTOM, fn=_identity)
+
+    assert await parent.resolve_action(ActionKind.CUSTOM, 'child_only') is None
+    assert await child.resolve_action(ActionKind.CUSTOM, 'child_only') is not None
+
+
+@pytest.mark.asyncio
+async def test_child_shadows_parent_action() -> None:
+    """Child action with the same name takes precedence over parent."""
+    parent = Registry()
+    parent_action = parent.register_action(name='shared', kind=ActionKind.CUSTOM, fn=_identity)
+
+    child = parent.new_child()
+
+    async def child_fn(x: object) -> object:
+        return x
+
+    child_action = child.register_action(name='shared', kind=ActionKind.CUSTOM, fn=child_fn)
+
+    assert await child.resolve_action(ActionKind.CUSTOM, 'shared') is child_action
+    assert await parent.resolve_action(ActionKind.CUSTOM, 'shared') is parent_action
+
+
+def test_child_inherits_default_model() -> None:
+    """Child inherits default_model from parent if not set locally."""
+    parent = Registry()
+    parent.default_model = 'gemini-pro'
+
+    child = parent.new_child()
+    assert child.default_model == 'gemini-pro'
+
+    child.default_model = 'gemini-flash'
+    assert child.default_model == 'gemini-flash'
+    assert parent.default_model == 'gemini-pro'
+
+
+def test_child_inherits_lookup_value() -> None:
+    """Child falls back to parent for lookup_value."""
+    parent = Registry()
+    parent.register_value('format', 'json', {'json': True})
+
+    child = parent.new_child()
+    assert child.lookup_value('format', 'json') == {'json': True}
+
+    # Local override shadows parent
+    child.register_value('format', 'json', {'json': False})
+    assert child.lookup_value('format', 'json') == {'json': False}
+    assert parent.lookup_value('format', 'json') == {'json': True}
+
+
+@pytest.mark.asyncio
+async def test_child_list_actions_includes_parent_plugin() -> None:
+    """list_actions on child includes parent-plugin actions not shadowed locally."""
+
+    class ParentPlugin(Plugin):
+        name = 'parentplugin'
+
+        async def init(self) -> list[Action]:
+            return []
+
+        async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
+            return None
+
+        async def list_actions(self) -> list[ActionMetadata]:
+            return [ActionMetadata(kind=ActionKind.MODEL, name='my-model')]
+
+    parent = Registry()
+    parent.register_plugin(ParentPlugin())
+
+    child = parent.new_child()
+    metas = await child.list_actions()
+    names = [m.name for m in metas]
+    assert 'parentplugin/my-model' in names

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -13,9 +13,9 @@ import pytest
 
 from genkit import Genkit, Plugin
 from genkit._core._action import Action, ActionKind, create_action_key
-from genkit._core._typing import ActionMetadata
 from genkit._core._dap import DapValue, define_dynamic_action_provider
 from genkit._core._registry import Registry
+from genkit._core._typing import ActionMetadata
 
 
 async def _identity(x: object) -> object:

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -13,6 +13,7 @@ import pytest
 
 from genkit import Genkit, Plugin
 from genkit._core._action import Action, ActionKind, ActionMetadata
+from genkit._core._dap import DapValue, define_dynamic_action_provider
 from genkit._core._registry import Registry
 
 
@@ -52,6 +53,54 @@ async def test_resolve_action_by_key_invalid_format() -> None:
     registry = Registry()
     with pytest.raises(ValueError, match='Invalid action key format'):
         await registry.resolve_action_by_key('invalid_key')
+
+
+@pytest.mark.asyncio
+async def test_resolve_action_via_dynamic_action_provider() -> None:
+    """Registry resolves actions supplied only by a DAP via get_action."""
+    registry = Registry()
+
+    async def tool_fn(x: str) -> str:
+        return x
+
+    inner = Action(
+        name='inner-tool',
+        kind=ActionKind.TOOL,
+        fn=tool_fn,
+        metadata={'name': 'inner-tool'},
+    )
+
+    async def dap_fn() -> DapValue:
+        return {'tool': [inner]}
+
+    define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    got = await registry.resolve_action(ActionKind.TOOL, 'inner-tool')
+    assert got is inner
+
+
+@pytest.mark.asyncio
+async def test_resolve_action_by_key_dap_qualified() -> None:
+    """DAP-qualified keys resolve nested actions."""
+    registry = Registry()
+
+    async def tool_fn(x: str) -> str:
+        return x
+
+    inner = Action(
+        name='inner-tool',
+        kind=ActionKind.TOOL,
+        fn=tool_fn,
+        metadata={'name': 'inner-tool'},
+    )
+
+    async def dap_fn() -> DapValue:
+        return {'tool': [inner]}
+
+    define_dynamic_action_provider(registry, 'my-dap', dap_fn)
+
+    got = await registry.resolve_action_by_key('/dynamic-action-provider/my-dap:tool/inner-tool')
+    assert got is inner
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -194,6 +194,7 @@ async def test_trigger_lazy_loading_reentrant_guard() -> None:
 # Child registry tests
 # =============================================================================
 
+
 @pytest.mark.asyncio
 async def test_new_child_is_child() -> None:
     """new_child() returns a child whose is_child is True."""

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -12,7 +12,8 @@ functionality, ensuring proper registration and management of Genkit resources.
 import pytest
 
 from genkit import Genkit, Plugin
-from genkit._core._action import Action, ActionKind, ActionMetadata, create_action_key
+from genkit._core._action import Action, ActionKind, create_action_key
+from genkit._core._typing import ActionMetadata
 from genkit._core._dap import DapValue, define_dynamic_action_provider
 from genkit._core._registry import Registry
 
@@ -124,7 +125,7 @@ async def test_resolve_action_from_plugin() -> None:
             return Action(name=name, fn=model_fn, kind=action_type)
 
         async def list_actions(self) -> list[ActionMetadata]:
-            return [ActionMetadata(kind=ActionKind.MODEL, name='foo')]
+            return [ActionMetadata(action_type=ActionKind.MODEL, name='myplugin/foo')]
 
     ai = Genkit(plugins=[MyPlugin()])
 
@@ -285,7 +286,7 @@ async def test_child_resolvable_includes_parent_plugin() -> None:
             return None
 
         async def list_actions(self) -> list[ActionMetadata]:
-            return [ActionMetadata(kind=ActionKind.MODEL, name='my-model')]
+            return [ActionMetadata(action_type=ActionKind.MODEL, name='parentplugin/my-model')]
 
     parent = Registry()
     parent.register_plugin(ParentPlugin())
@@ -312,7 +313,7 @@ async def test_child_resolvable_local_tool_shadows_parent_plugin_metadata() -> N
         async def list_actions(self) -> list[ActionMetadata]:
             return [
                 ActionMetadata(
-                    kind=ActionKind.TOOL,
+                    action_type=ActionKind.TOOL,
                     name='parentplugin/shared-name',
                     description='from parent plugin',
                 )
@@ -353,7 +354,7 @@ async def test_child_resolvable_dap_tool_shadows_parent_plugin_metadata() -> Non
         async def list_actions(self) -> list[ActionMetadata]:
             return [
                 ActionMetadata(
-                    kind=ActionKind.TOOL,
+                    action_type=ActionKind.TOOL,
                     name='parentplugin/mcp-tool',
                     description='stale parent schema',
                 )
@@ -379,19 +380,14 @@ async def test_child_resolvable_dap_tool_shadows_parent_plugin_metadata() -> Non
     define_dynamic_action_provider(child, 'mcp', dap_fn)
 
     catalog = await child.list_resolvable_actions()
-    entry = catalog['/tool/parentplugin/mcp-tool']
-    assert entry['description'] == 'from mcp'
-    assert entry['description'] != 'stale parent schema'
+    qualified = create_action_key(ActionKind.DYNAMIC_ACTION_PROVIDER, 'mcp:tool/parentplugin/mcp-tool')
+    assert catalog[qualified]['description'] == 'from mcp'
+    assert catalog['/tool/parentplugin/mcp-tool']['description'] == 'stale parent schema'
 
 
 @pytest.mark.asyncio
 async def test_list_resolvable_registered_canonical_coexists_with_qualified_dap_rows() -> None:
-    """Same canonical tool path from registration and from DAP: both catalog shapes appear.
-
-    The qualified DAP metadata row (under ``dynamic-action-provider``) is always merged;
-    the canonical ``/tool/...`` row prefers the action already in the registry when both
-    would describe the same path.
-    """
+    """Registered ``/tool/...`` row coexists with DAP ``/dynamic-action-provider/...`` rows when shortnames collide."""
     tool_name = 'suite/same-canonical'
 
     async def registered_fn(_: str) -> str:

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -129,8 +129,8 @@ async def test_resolve_action_from_plugin() -> None:
 
     ai = Genkit(plugins=[MyPlugin()])
 
-    catalog = await ai.registry.list_resolvable_actions()
-    assert catalog['/model/myplugin/foo']['name'] == 'myplugin/foo'
+    catalog = await ai.registry.list_actions()
+    assert catalog['/model/myplugin/foo'].name == 'myplugin/foo'
 
     action = await ai.registry.resolve_action(ActionKind.MODEL, 'myplugin/foo')
 
@@ -246,16 +246,16 @@ async def test_child_shadows_parent_action() -> None:
 
 
 def test_child_inherits_default_model() -> None:
-    """Child inherits default_model from parent if not set locally."""
+    """Child falls back to parent for the default model singleton entry."""
     parent = Registry()
-    parent.default_model = 'gemini-pro'
+    parent.register_value('defaultModel', 'defaultModel', 'gemini-pro')
 
     child = parent.new_child()
-    assert child.default_model == 'gemini-pro'
+    assert child.lookup_value('defaultModel', 'defaultModel') == 'gemini-pro'
 
-    child.default_model = 'gemini-flash'
-    assert child.default_model == 'gemini-flash'
-    assert parent.default_model == 'gemini-pro'
+    child.register_value('defaultModel', 'defaultModel', 'gemini-flash')
+    assert child.lookup_value('defaultModel', 'defaultModel') == 'gemini-flash'
+    assert parent.lookup_value('defaultModel', 'defaultModel') == 'gemini-pro'
 
 
 def test_child_inherits_lookup_value() -> None:
@@ -274,7 +274,7 @@ def test_child_inherits_lookup_value() -> None:
 
 @pytest.mark.asyncio
 async def test_child_resolvable_includes_parent_plugin() -> None:
-    """list_resolvable_actions on child includes parent plugin rows not shadowed locally."""
+    """list_actions on child includes parent plugin rows not shadowed locally."""
 
     class ParentPlugin(Plugin):
         name = 'parentplugin'
@@ -292,9 +292,9 @@ async def test_child_resolvable_includes_parent_plugin() -> None:
     parent.register_plugin(ParentPlugin())
 
     child = parent.new_child()
-    catalog = await child.list_resolvable_actions()
+    catalog = await child.list_actions()
     assert '/model/parentplugin/my-model' in catalog
-    assert catalog['/model/parentplugin/my-model']['name'] == 'parentplugin/my-model'
+    assert catalog['/model/parentplugin/my-model'].name == 'parentplugin/my-model'
 
 
 @pytest.mark.asyncio
@@ -332,10 +332,10 @@ async def test_child_resolvable_local_tool_shadows_parent_plugin_metadata() -> N
         description='from child registry',
     )
 
-    catalog = await child.list_resolvable_actions()
+    catalog = await child.list_actions()
     entry = catalog['/tool/parentplugin/shared-name']
-    assert entry['description'] == 'from child registry'
-    assert entry['description'] != 'from parent plugin'
+    assert entry.description == 'from child registry'
+    assert entry.description != 'from parent plugin'
 
 
 @pytest.mark.asyncio
@@ -379,14 +379,14 @@ async def test_child_resolvable_dap_tool_shadows_parent_plugin_metadata() -> Non
 
     define_dynamic_action_provider(child, 'mcp', dap_fn)
 
-    catalog = await child.list_resolvable_actions()
+    catalog = await child.list_actions()
     qualified = create_action_key(ActionKind.DYNAMIC_ACTION_PROVIDER, 'mcp:tool/parentplugin/mcp-tool')
-    assert catalog[qualified]['description'] == 'from mcp'
-    assert catalog['/tool/parentplugin/mcp-tool']['description'] == 'stale parent schema'
+    assert catalog[qualified].description == 'from mcp'
+    assert catalog['/tool/parentplugin/mcp-tool'].description == 'stale parent schema'
 
 
 @pytest.mark.asyncio
-async def test_list_resolvable_registered_canonical_coexists_with_qualified_dap_rows() -> None:
+async def test_list_actions_registered_canonical_coexists_with_qualified_dap_rows() -> None:
     """Registered ``/tool/...`` row coexists with DAP ``/dynamic-action-provider/...`` rows when shortnames collide."""
     tool_name = 'suite/same-canonical'
 
@@ -416,7 +416,7 @@ async def test_list_resolvable_registered_canonical_coexists_with_qualified_dap_
 
     define_dynamic_action_provider(registry, 'mcp', dap_fn)
 
-    catalog = await registry.list_resolvable_actions()
+    catalog = await registry.list_actions()
 
     canonical = create_action_key(ActionKind.TOOL, tool_name)
     record_key = f'mcp:tool/{tool_name}'
@@ -424,9 +424,9 @@ async def test_list_resolvable_registered_canonical_coexists_with_qualified_dap_
     provider_key = create_action_key(ActionKind.DYNAMIC_ACTION_PROVIDER, 'mcp')
 
     assert canonical in catalog
-    assert catalog[canonical]['description'] == 'from registry registration'
+    assert catalog[canonical].description == 'from registry registration'
 
     assert qualified in catalog
-    assert catalog[qualified]['key'] == qualified
+    assert catalog[qualified].key == qualified
 
     assert provider_key in catalog

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -12,7 +12,7 @@ functionality, ensuring proper registration and management of Genkit resources.
 import pytest
 
 from genkit import Genkit, Plugin
-from genkit._core._action import Action, ActionKind, ActionMetadata
+from genkit._core._action import Action, ActionKind, ActionMetadata, create_action_key
 from genkit._core._dap import DapValue, define_dynamic_action_provider
 from genkit._core._registry import Registry
 
@@ -128,8 +128,8 @@ async def test_resolve_action_from_plugin() -> None:
 
     ai = Genkit(plugins=[MyPlugin()])
 
-    metas = await ai.registry.list_actions()
-    assert metas == [ActionMetadata(kind=ActionKind.MODEL, name='myplugin/foo')]
+    catalog = await ai.registry.list_resolvable_actions()
+    assert catalog['/model/myplugin/foo']['name'] == 'myplugin/foo'
 
     action = await ai.registry.resolve_action(ActionKind.MODEL, 'myplugin/foo')
 
@@ -272,8 +272,8 @@ def test_child_inherits_lookup_value() -> None:
 
 
 @pytest.mark.asyncio
-async def test_child_list_actions_includes_parent_plugin() -> None:
-    """list_actions on child includes parent-plugin actions not shadowed locally."""
+async def test_child_resolvable_includes_parent_plugin() -> None:
+    """list_resolvable_actions on child includes parent plugin rows not shadowed locally."""
 
     class ParentPlugin(Plugin):
         name = 'parentplugin'
@@ -291,6 +291,146 @@ async def test_child_list_actions_includes_parent_plugin() -> None:
     parent.register_plugin(ParentPlugin())
 
     child = parent.new_child()
-    metas = await child.list_actions()
-    names = [m.name for m in metas]
-    assert 'parentplugin/my-model' in names
+    catalog = await child.list_resolvable_actions()
+    assert '/model/parentplugin/my-model' in catalog
+    assert catalog['/model/parentplugin/my-model']['name'] == 'parentplugin/my-model'
+
+
+@pytest.mark.asyncio
+async def test_child_resolvable_local_tool_shadows_parent_plugin_metadata() -> None:
+    """A tool registered on the child must not inherit parent plugin metadata for the same name."""
+
+    class ParentPlugin(Plugin):
+        name = 'parentplugin'
+
+        async def init(self) -> list[Action]:
+            return []
+
+        async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
+            return None
+
+        async def list_actions(self) -> list[ActionMetadata]:
+            return [
+                ActionMetadata(
+                    kind=ActionKind.TOOL,
+                    name='parentplugin/shared-name',
+                    description='from parent plugin',
+                )
+            ]
+
+    async def local_tool(_: str) -> str:
+        return 'local'
+
+    parent = Registry()
+    parent.register_plugin(ParentPlugin())
+    child = parent.new_child()
+    child.register_action(
+        kind=ActionKind.TOOL,
+        name='parentplugin/shared-name',
+        fn=local_tool,
+        description='from child registry',
+    )
+
+    catalog = await child.list_resolvable_actions()
+    entry = catalog['/tool/parentplugin/shared-name']
+    assert entry['description'] == 'from child registry'
+    assert entry['description'] != 'from parent plugin'
+
+
+@pytest.mark.asyncio
+async def test_child_resolvable_dap_tool_shadows_parent_plugin_metadata() -> None:
+    """DAP-exposed nested actions must shadow parent plugin metadata for the same (kind, name)."""
+
+    class ParentPlugin(Plugin):
+        name = 'parentplugin'
+
+        async def init(self) -> list[Action]:
+            return []
+
+        async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
+            return None
+
+        async def list_actions(self) -> list[ActionMetadata]:
+            return [
+                ActionMetadata(
+                    kind=ActionKind.TOOL,
+                    name='parentplugin/mcp-tool',
+                    description='stale parent schema',
+                )
+            ]
+
+    async def mcp_tool_fn(_: str) -> str:
+        return 'mcp'
+
+    mcp_tool = Action(
+        kind=ActionKind.TOOL,
+        name='parentplugin/mcp-tool',
+        fn=mcp_tool_fn,
+        description='from mcp',
+    )
+
+    parent = Registry()
+    parent.register_plugin(ParentPlugin())
+    child = parent.new_child()
+
+    async def dap_fn() -> DapValue:
+        return {'tool': [mcp_tool]}
+
+    define_dynamic_action_provider(child, 'mcp', dap_fn)
+
+    catalog = await child.list_resolvable_actions()
+    entry = catalog['/tool/parentplugin/mcp-tool']
+    assert entry['description'] == 'from mcp'
+    assert entry['description'] != 'stale parent schema'
+
+
+@pytest.mark.asyncio
+async def test_list_resolvable_registered_canonical_coexists_with_qualified_dap_rows() -> None:
+    """Same canonical tool path from registration and from DAP: both catalog shapes appear.
+
+    The qualified DAP metadata row (under ``dynamic-action-provider``) is always merged;
+    the canonical ``/tool/...`` row prefers the action already in the registry when both
+    would describe the same path.
+    """
+    tool_name = 'suite/same-canonical'
+
+    async def registered_fn(_: str) -> str:
+        return 'registered'
+
+    async def dap_nested_fn(_: str) -> str:
+        return 'dap'
+
+    dap_nested = Action(
+        kind=ActionKind.TOOL,
+        name=tool_name,
+        fn=dap_nested_fn,
+        description='from dap nested',
+    )
+
+    registry = Registry()
+    registry.register_action(
+        kind=ActionKind.TOOL,
+        name=tool_name,
+        fn=registered_fn,
+        description='from registry registration',
+    )
+
+    async def dap_fn() -> DapValue:
+        return {'tool': [dap_nested]}
+
+    define_dynamic_action_provider(registry, 'mcp', dap_fn)
+
+    catalog = await registry.list_resolvable_actions()
+
+    canonical = create_action_key(ActionKind.TOOL, tool_name)
+    record_key = f'mcp:tool/{tool_name}'
+    qualified = create_action_key(ActionKind.DYNAMIC_ACTION_PROVIDER, record_key)
+    provider_key = create_action_key(ActionKind.DYNAMIC_ACTION_PROVIDER, 'mcp')
+
+    assert canonical in catalog
+    assert catalog[canonical]['description'] == 'from registry registration'
+
+    assert qualified in catalog
+    assert catalog[qualified]['key'] == qualified
+
+    assert provider_key in catalog

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -998,7 +998,7 @@ class VertexAI(Plugin):
             actions_list.append(
                 ActionMetadata(
                     name=evaluator_name,
-                    kind=ActionKind.EVALUATOR,
+                    action_type=ActionKind.EVALUATOR,
                     input_json_schema=to_json_schema(EvalRequest),
                     output_json_schema=to_json_schema(list[EvalFnResponse]),
                     metadata={'type': 'evaluator'},

--- a/py/plugins/google-genai/test/google_plugin_test.py
+++ b/py/plugins/google-genai/test/google_plugin_test.py
@@ -158,15 +158,15 @@ async def test_googleai_initialize(mock_client_cls: MagicMock) -> None:
 
     # init returns known models and embedders
     assert len(result) > 0, 'Should initialize with known models and embedders'
-    assert all(hasattr(action, 'kind') for action in result), 'All actions should have a kind'
+    assert all(action.action_type is not None for action in result), 'All actions should have an action_type'
     assert all(hasattr(action, 'name') for action in result), 'All actions should have a name'
     assert all(action.name.startswith('googleai/') for action in result), (
         "All actions should be namespaced with 'googleai/'"
     )
 
     # Verify we have both models and embedders
-    model_actions = [a for a in result if a.kind == ActionKind.MODEL]
-    embedder_actions = [a for a in result if a.kind == ActionKind.EMBEDDER]
+    model_actions = [a for a in result if a.action_type == ActionKind.MODEL]
+    embedder_actions = [a for a in result if a.action_type == ActionKind.EMBEDDER]
     assert len(model_actions) > 0, 'Should have at least one model'
     assert len(embedder_actions) > 0, 'Should have at least one embedder'
 
@@ -286,7 +286,7 @@ async def test_googleai_list_actions(googleai_plugin_instance: GoogleAI) -> None
     # Check Embedder
     action2 = next(a for a in result if a.name == googleai_name('gemini-embedding-001'))
     assert action2 is not None
-    assert action2.kind == ActionKind.EMBEDDER
+    assert action2.action_type == ActionKind.EMBEDDER
 
     # Check TTS
     action3 = next(a for a in result if a.name == googleai_name('gemini-2.0-flash-tts'))
@@ -592,7 +592,7 @@ async def test_vertexai_initialize(vertexai_plugin_instance: VertexAI) -> None:
     result = await plugin.list_actions()
 
     assert len(result) > 0, 'Should initialize with known models and embedders'
-    assert all(hasattr(action, 'kind') for action in result), 'All actions should have a kind'
+    assert all(action.action_type is not None for action in result), 'All actions should have an action_type'
 
     # ... (rest of test unchanged)
 
@@ -602,8 +602,8 @@ async def test_vertexai_initialize(vertexai_plugin_instance: VertexAI) -> None:
     )
 
     # Verify we have both models and embedders
-    model_actions = [a for a in result if a.kind == ActionKind.MODEL]
-    embedder_actions = [a for a in result if a.kind == ActionKind.EMBEDDER]
+    model_actions = [a for a in result if a.action_type == ActionKind.MODEL]
+    embedder_actions = [a for a in result if a.action_type == ActionKind.EMBEDDER]
     assert len(model_actions) > 0, 'Should have at least one model'
     assert len(embedder_actions) > 0, 'Should have at least one embedder'
 
@@ -795,7 +795,7 @@ async def test_vertexai_list_actions(vertexai_plugin_instance: VertexAI) -> None
     # Verify Imagen
     action3 = next(a for a in result if a.name == vertexai_name('imagen-3.0-generate-001'))
     assert action3 is not None
-    assert action3.kind == ActionKind.MODEL
+    assert action3.action_type == ActionKind.MODEL
 
     # Verify Veo
     action4 = next(a for a in result if a.name == vertexai_name('veo-2.0-generate-001'))


### PR DESCRIPTION
- Wires Dynamic Action Provider (DAP) into Registry.resolve_action: define_dynamic_action_provider now attaches the DynamicActionProvider to the registered DAP Action, and resolution uses get_action(kind, name). Hand-registered providers that still resolve via run({kind, name}) → Action keep working.
- Adds parse_dap_qualified_name and resolve_action_by_key support for /dynamic-action-provider/<provider>:<innerKind>/<innerName>.

Update 4/23: 
I ended up making a few more related improvements to the code, this was the most natural place to put it to prevent merge conflicts.
- Refactor: Removed hand-written ActionMetadata class; re-use the shared `ActionMetadata` type provided through the type generation script.

Update 4/28:
- Refactor: Simplified the logic in unify `list_actions()` and `list_resolvable_actions()`.