### PR TITLE
feat(go/anthropic): add prompt caching support via message metadata

### DIFF
--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -224,8 +224,20 @@ func toAnthropicRequest(provider string, i *ai.ModelRequest) (*anthropic.Message
 	sysBlocks := []anthropic.TextBlockParam{}
 	for _, message := range i.Messages {
 		if message.Role == ai.RoleSystem {
-			// only text is supported for system messages
-			sysBlocks = append(sysBlocks, anthropic.TextBlockParam{Text: message.Text()})
+			block := anthropic.TextBlockParam{Text: message.Text()}
+			// Enable prompt caching if the message has cache metadata.
+			// Callers set Metadata["cache"] = map[string]any{"type": "ephemeral"}
+			// to mark system prompts for Anthropic's prompt caching feature.
+			if message.Metadata != nil {
+				if cacheVal, ok := message.Metadata["cache"]; ok && cacheVal != nil {
+					if cacheMap, ok := cacheVal.(map[string]any); ok {
+						if cacheType, ok := cacheMap["type"].(string); ok && cacheType == "ephemeral" {
+							block.CacheControl = anthropic.CacheControlEphemeralParam{Type: "ephemeral"}
+						}
+					}
+				}
+			}
+			sysBlocks = append(sysBlocks, block)
 		} else if message.Content[len(message.Content)-1].IsToolResponse() {
 			// if the last message is a ToolResponse, the conversation must continue
 			// and the ToolResponse message must be sent as a user
@@ -474,6 +486,12 @@ func toGenkitResponse(m *anthropic.Message) (*ai.ModelResponse, error) {
 		InputTokens:         int(m.Usage.InputTokens),
 		OutputTokens:        int(m.Usage.OutputTokens),
 		CachedContentTokens: int(m.Usage.CacheReadInputTokens),
+	}
+	// Track cache creation tokens in Custom metrics (no dedicated field in GenerationUsage)
+	if m.Usage.CacheCreationInputTokens > 0 {
+		r.Usage.Custom = map[string]float64{
+			"cacheCreationInputTokens": float64(m.Usage.CacheCreationInputTokens),
+		}
 	}
 	return &r, nil
 }

--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -226,15 +226,14 @@ func toAnthropicRequest(provider string, i *ai.ModelRequest) (*anthropic.Message
 		if message.Role == ai.RoleSystem {
 			block := anthropic.TextBlockParam{Text: message.Text()}
 			// Enable prompt caching if the message has cache metadata.
-			// Callers set Metadata["cache"] = map[string]any{"type": "ephemeral"}
-			// to mark system prompts for Anthropic's prompt caching feature.
-			if message.Metadata != nil {
-				if cacheVal, ok := message.Metadata["cache"]; ok && cacheVal != nil {
-					if cacheMap, ok := cacheVal.(map[string]any); ok {
-						if cacheType, ok := cacheMap["type"].(string); ok && cacheType == "ephemeral" {
-							block.CacheControl = anthropic.CacheControlEphemeralParam{Type: "ephemeral"}
-						}
-					}
+			// Supports both explicit {"type": "ephemeral"} and the generic
+			// {"ttlSeconds": N} used by ai.WithCacheTTL for cross-provider consistency.
+			// Anthropic only supports ephemeral caching regardless of TTL value.
+			if cache, ok := message.Metadata["cache"].(map[string]any); ok {
+				t, _ := cache["type"].(string)
+				_, hasTTL := cache["ttlSeconds"]
+				if t == "ephemeral" || hasTTL {
+					block.CacheControl = anthropic.CacheControlEphemeralParam{Type: "ephemeral"}
 				}
 			}
 			sysBlocks = append(sysBlocks, block)
@@ -489,9 +488,10 @@ func toGenkitResponse(m *anthropic.Message) (*ai.ModelResponse, error) {
 	}
 	// Track cache creation tokens in Custom metrics (no dedicated field in GenerationUsage)
 	if m.Usage.CacheCreationInputTokens > 0 {
-		r.Usage.Custom = map[string]float64{
-			"cacheCreationInputTokens": float64(m.Usage.CacheCreationInputTokens),
+		if r.Usage.Custom == nil {
+			r.Usage.Custom = make(map[string]float64)
 		}
+		r.Usage.Custom["cacheCreationInputTokens"] = float64(m.Usage.CacheCreationInputTokens)
 	}
 	return &r, nil
 }


### PR DESCRIPTION
Enable Anthropic's prompt caching feature for system messages in the Go plugin. When a system message has `Metadata["cache"] = map[string]any{"type": "ephemeral"}`, the corresponding `TextBlockParam` gets `CacheControl` set to ephemeral.

This follows the same pattern as the googlegenai plugin's cache support (which uses `Metadata["cache"]["ttlSeconds"]`), giving Go developers a consistent API for enabling caching across providers.

Also tracks `CacheCreationInputTokens` in `Usage.Custom` for cost tracking (cache reads were already tracked via `CachedContentTokens`).

**Fixes:** #817

**Changes:**
- `toAnthropicRequest`: check system message `Metadata` for cache config, set `CacheControl` on matching `TextBlockParam`
- `toGenkitResponse`: add `CacheCreationInputTokens` to `Usage.Custom` metrics

**Usage example:**
```go
resp, err := genkit.Generate(ctx, g,
    ai.WithMessages(&ai.Message{
        Role:    ai.RoleSystem,
        Content: []*ai.Part{ai.NewTextPart(systemPrompt)},
        Metadata: map[string]any{
            "cache": map[string]any{"type": "ephemeral"},
        },
    }),
    ai.WithPrompt(userPrompt),
    ai.WithModelName("anthropic/claude-sonnet-4-5-20250929"),
)
// resp.Usage.CachedContentTokens > 0 on cache hits
// resp.Usage.Custom["cacheCreationInputTokens"] > 0 on first call (cache write)
```

Anthropic's prompt caching reduces input token costs by up to 90% for repeated system prompts (cache reads are $0.30/MTok vs $3/MTok for Sonnet). Unlike Gemini's 32K minimum, Anthropic has no minimum token requirement for caching.

**Checklist:**
- [x] PR title follows https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested manually against Anthropic API with cache hit/miss verification
- [ ] Docs updated (docs bug needed for Go prompt caching guide)