### PR TITLE
feat(genkit): add programmatic dataset store APIs

### DIFF
--- a/go/genkit/datasets.go
+++ b/go/genkit/datasets.go
@@ -1,0 +1,412 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package genkit
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var datasetIDPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_.-]{4,34}[A-Za-z0-9]$`)
+
+// DatasetType identifies the target surface the dataset is intended for.
+type DatasetType string
+
+const (
+	DatasetTypeUnknown          DatasetType = "UNKNOWN"
+	DatasetTypeFlow             DatasetType = "FLOW"
+	DatasetTypeModel            DatasetType = "MODEL"
+	DatasetTypeExecutablePrompt DatasetType = "EXECUTABLE_PROMPT"
+)
+
+// DatasetSchema describes the shape of the dataset's input and reference values.
+type DatasetSchema struct {
+	InputSchema     map[string]any `json:"inputSchema,omitempty"`
+	ReferenceSchema map[string]any `json:"referenceSchema,omitempty"`
+}
+
+// InferenceSample is the user-facing dataset item shape.
+type InferenceSample struct {
+	TestCaseID string `json:"testCaseId,omitempty"`
+	Input      any    `json:"input"`
+	Reference  any    `json:"reference,omitempty"`
+}
+
+// DatasetSample is the persisted dataset item shape used by the developer UI.
+type DatasetSample struct {
+	TestCaseID string `json:"testCaseId"`
+	Input      any    `json:"input"`
+	Reference  any    `json:"reference,omitempty"`
+}
+
+// CreateDatasetRequest defines the payload for creating a dataset.
+type CreateDatasetRequest struct {
+	Data         []InferenceSample `json:"data"`
+	DatasetID    string            `json:"datasetId,omitempty"`
+	DatasetType  DatasetType       `json:"datasetType"`
+	Schema       *DatasetSchema    `json:"schema,omitempty"`
+	MetricRefs   []string          `json:"metricRefs,omitempty"`
+	TargetAction string            `json:"targetAction,omitempty"`
+}
+
+// UpdateDatasetRequest defines the payload for updating a dataset.
+type UpdateDatasetRequest struct {
+	DatasetID    string            `json:"datasetId"`
+	Data         []InferenceSample `json:"data,omitempty"`
+	Schema       *DatasetSchema    `json:"schema,omitempty"`
+	MetricRefs   []string          `json:"metricRefs,omitempty"`
+	TargetAction string            `json:"targetAction,omitempty"`
+}
+
+// DatasetMetadata contains the dataset metadata shown in the developer UI.
+type DatasetMetadata struct {
+	DatasetID    string         `json:"datasetId"`
+	Size         int            `json:"size"`
+	Schema       *DatasetSchema `json:"schema,omitempty"`
+	DatasetType  DatasetType    `json:"datasetType"`
+	TargetAction string         `json:"targetAction,omitempty"`
+	MetricRefs   []string       `json:"metricRefs"`
+	Version      int            `json:"version"`
+	CreateTime   string         `json:"createTime"`
+	UpdateTime   string         `json:"updateTime"`
+}
+
+// LocalFileDatasetStore is the default DatasetStore implementation used by the
+// current developer UI. It persists datasets as index.json plus one
+// <datasetId>.json file under .genkit/datasets.
+type LocalFileDatasetStore struct {
+	storeRoot string
+	indexFile string
+	now       func() time.Time
+}
+
+// NewLocalFileDatasetStore creates a dataset store rooted at the provided path.
+func NewLocalFileDatasetStore(storeRoot string) (*LocalFileDatasetStore, error) {
+	if storeRoot == "" {
+		return nil, errors.New("store root is required")
+	}
+	if err := os.MkdirAll(storeRoot, 0755); err != nil {
+		return nil, fmt.Errorf("create dataset store root: %w", err)
+	}
+
+	store := &LocalFileDatasetStore{
+		storeRoot: storeRoot,
+		indexFile: filepath.Join(storeRoot, "index.json"),
+		now:       time.Now,
+	}
+
+	if _, err := os.Stat(store.indexFile); errors.Is(err, os.ErrNotExist) {
+		if err := store.writeMetadataMap(map[string]DatasetMetadata{}); err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, fmt.Errorf("stat dataset index: %w", err)
+	}
+
+	return store, nil
+}
+
+// DefaultDatasetStore creates the default dataset store for this project.
+//
+// Today this is a LocalFileDatasetStore so datasets render in the current
+// developer UI. If Genkit adds remote dataset persistence later, introduce that
+// abstraction at the consumer boundary rather than coupling callers to the
+// current file layout.
+func DefaultDatasetStore() (*LocalFileDatasetStore, error) {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return nil, err
+	}
+	return NewLocalFileDatasetStore(filepath.Join(projectRoot, ".genkit", "datasets"))
+}
+
+// CreateDataset writes a new dataset and its metadata using the developer UI's
+// current on-disk format.
+func (s *LocalFileDatasetStore) CreateDataset(req CreateDatasetRequest) (*DatasetMetadata, error) {
+	metadataMap, err := s.readMetadataMap()
+	if err != nil {
+		return nil, err
+	}
+
+	datasetID, err := s.generateDatasetID(req.DatasetID, metadataMap)
+	if err != nil {
+		return nil, err
+	}
+
+	dataset := normalizeInferenceDataset(req.Data)
+	if err := writeJSONFile(s.datasetFilePath(datasetID), dataset); err != nil {
+		return nil, fmt.Errorf("write dataset: %w", err)
+	}
+
+	now := s.now().String()
+	metricRefs := cloneStrings(req.MetricRefs)
+	metadata := DatasetMetadata{
+		DatasetID:    datasetID,
+		Size:         len(dataset),
+		Schema:       req.Schema,
+		DatasetType:  req.DatasetType,
+		TargetAction: req.TargetAction,
+		MetricRefs:   metricRefs,
+		Version:      1,
+		CreateTime:   now,
+		UpdateTime:   now,
+	}
+	metadataMap[datasetID] = metadata
+
+	if err := s.writeMetadataMap(metadataMap); err != nil {
+		return nil, err
+	}
+	return &metadata, nil
+}
+
+// UpdateDataset merges the provided samples into an existing dataset and bumps
+// the dataset version when sample data changes.
+func (s *LocalFileDatasetStore) UpdateDataset(req UpdateDatasetRequest) (*DatasetMetadata, error) {
+	filePath := s.datasetFilePath(req.DatasetID)
+	if _, err := os.Stat(filePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, errors.New("update dataset failed: dataset not found")
+		}
+		return nil, fmt.Errorf("stat dataset: %w", err)
+	}
+
+	metadataMap, err := s.readMetadataMap()
+	if err != nil {
+		return nil, err
+	}
+	prevMetadata, ok := metadataMap[req.DatasetID]
+	if !ok {
+		return nil, errors.New("update dataset failed: dataset metadata not found")
+	}
+
+	newSize := prevMetadata.Size
+	version := prevMetadata.Version
+	if req.Data != nil {
+		patched, err := s.patchDataset(req.DatasetID, normalizeInferenceDataset(req.Data))
+		if err != nil {
+			return nil, err
+		}
+		newSize = len(patched)
+		version++
+	}
+
+	newMetadata := DatasetMetadata{
+		DatasetID:    req.DatasetID,
+		Size:         newSize,
+		Schema:       firstNonNil(req.Schema, prevMetadata.Schema),
+		DatasetType:  prevMetadata.DatasetType,
+		TargetAction: firstNonEmpty(req.TargetAction, prevMetadata.TargetAction),
+		MetricRefs:   firstNonNilStrings(req.MetricRefs, prevMetadata.MetricRefs),
+		Version:      version,
+		CreateTime:   prevMetadata.CreateTime,
+		UpdateTime:   s.now().String(),
+	}
+	metadataMap[req.DatasetID] = newMetadata
+
+	if err := s.writeMetadataMap(metadataMap); err != nil {
+		return nil, err
+	}
+	return &newMetadata, nil
+}
+
+// GetDataset reads the persisted samples for a dataset ID.
+func (s *LocalFileDatasetStore) GetDataset(datasetID string) ([]DatasetSample, error) {
+	var dataset []DatasetSample
+	if err := readJSONFile(s.datasetFilePath(datasetID), &dataset); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("dataset not found for dataset ID %s", datasetID)
+		}
+		return nil, fmt.Errorf("read dataset: %w", err)
+	}
+	return dataset, nil
+}
+
+// ListDatasets returns all dataset metadata records sorted by dataset ID.
+func (s *LocalFileDatasetStore) ListDatasets() ([]DatasetMetadata, error) {
+	metadataMap, err := s.readMetadataMap()
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, 0, len(metadataMap))
+	for datasetID := range metadataMap {
+		ids = append(ids, datasetID)
+	}
+	slices.Sort(ids)
+
+	metadatas := make([]DatasetMetadata, 0, len(ids))
+	for _, datasetID := range ids {
+		metadatas = append(metadatas, metadataMap[datasetID])
+	}
+	return metadatas, nil
+}
+
+// DeleteDataset removes a dataset file and its metadata entry.
+func (s *LocalFileDatasetStore) DeleteDataset(datasetID string) error {
+	if err := os.Remove(s.datasetFilePath(datasetID)); err != nil {
+		return fmt.Errorf("delete dataset: %w", err)
+	}
+
+	metadataMap, err := s.readMetadataMap()
+	if err != nil {
+		return err
+	}
+	delete(metadataMap, datasetID)
+	return s.writeMetadataMap(metadataMap)
+}
+
+func (s *LocalFileDatasetStore) patchDataset(datasetID string, patch []DatasetSample) ([]DatasetSample, error) {
+	existing, err := s.GetDataset(datasetID)
+	if err != nil {
+		return nil, err
+	}
+
+	byID := make(map[string]DatasetSample, len(existing))
+	order := make([]string, 0, len(existing))
+	for _, sample := range existing {
+		byID[sample.TestCaseID] = sample
+		order = append(order, sample.TestCaseID)
+	}
+
+	for _, sample := range patch {
+		if _, exists := byID[sample.TestCaseID]; !exists {
+			order = append(order, sample.TestCaseID)
+		}
+		byID[sample.TestCaseID] = sample
+	}
+
+	patched := make([]DatasetSample, 0, len(order))
+	for _, id := range order {
+		patched = append(patched, byID[id])
+	}
+
+	if err := writeJSONFile(s.datasetFilePath(datasetID), patched); err != nil {
+		return nil, fmt.Errorf("write patched dataset: %w", err)
+	}
+	return patched, nil
+}
+
+func (s *LocalFileDatasetStore) readMetadataMap() (map[string]DatasetMetadata, error) {
+	metadataMap := map[string]DatasetMetadata{}
+	if err := readJSONFile(s.indexFile, &metadataMap); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return metadataMap, nil
+		}
+		return nil, fmt.Errorf("read dataset index: %w", err)
+	}
+	return metadataMap, nil
+}
+
+func (s *LocalFileDatasetStore) writeMetadataMap(metadataMap map[string]DatasetMetadata) error {
+	if metadataMap == nil {
+		metadataMap = map[string]DatasetMetadata{}
+	}
+	if err := writeJSONFile(s.indexFile, metadataMap); err != nil {
+		return fmt.Errorf("write dataset index: %w", err)
+	}
+	return nil
+}
+
+func (s *LocalFileDatasetStore) generateDatasetID(datasetID string, metadataMap map[string]DatasetMetadata) (string, error) {
+	if datasetID == "" {
+		for {
+			candidate := uuid.New().String()
+			if _, exists := metadataMap[candidate]; !exists {
+				return candidate, nil
+			}
+		}
+	}
+	if !datasetIDPattern.MatchString(datasetID) {
+		return "", errors.New("invalid datasetId provided. ID must be alphanumeric, with hyphens, dots and dashes. Is must start with an alphabet, end with an alphabet or a number, and must be 6-36 characters long.")
+	}
+	if _, exists := metadataMap[datasetID]; exists {
+		return "", fmt.Errorf("dataset ID not unique: %s", datasetID)
+	}
+	return datasetID, nil
+}
+
+func (s *LocalFileDatasetStore) datasetFilePath(datasetID string) string {
+	return filepath.Join(s.storeRoot, datasetID+".json")
+}
+
+func normalizeInferenceDataset(data []InferenceSample) []DatasetSample {
+	dataset := make([]DatasetSample, 0, len(data))
+	for _, sample := range data {
+		testCaseID := sample.TestCaseID
+		if testCaseID == "" {
+			testCaseID = uuid.New().String()
+		}
+		dataset = append(dataset, DatasetSample{
+			TestCaseID: testCaseID,
+			Input:      sample.Input,
+			Reference:  sample.Reference,
+		})
+	}
+	return dataset
+}
+
+func writeJSONFile(path string, value any) error {
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, bytes, 0644)
+}
+
+func readJSONFile(path string, dest any) error {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(bytes, dest)
+}
+
+func firstNonEmpty(value string, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}
+
+func firstNonNil[T any](value *T, fallback *T) *T {
+	if value != nil {
+		return value
+	}
+	return fallback
+}
+
+func firstNonNilStrings(value []string, fallback []string) []string {
+	if value != nil {
+		return cloneStrings(value)
+	}
+	return cloneStrings(fallback)
+}
+
+func cloneStrings(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	return append([]string(nil), values...)
+}

--- a/go/genkit/datasets_test.go
+++ b/go/genkit/datasets_test.go
@@ -1,0 +1,170 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package genkit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLocalFileDatasetStoreLifecycle(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewLocalFileDatasetStore(root)
+	if err != nil {
+		t.Fatalf("NewLocalFileDatasetStore() error = %v", err)
+	}
+
+	now := time.Date(2026, time.April, 13, 10, 30, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	metadata, err := store.CreateDataset(CreateDatasetRequest{
+		DatasetID:    "dataset-1-123456",
+		DatasetType:  DatasetTypeFlow,
+		TargetAction: "/flow/my-flow",
+		Schema: &DatasetSchema{
+			InputSchema: map[string]any{"type": "string"},
+		},
+		Data: []InferenceSample{
+			{Input: "hello", Reference: "world"},
+			{TestCaseID: "sample-2", Input: map[string]any{"foo": "bar"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateDataset() error = %v", err)
+	}
+
+	if metadata.Size != 2 || metadata.Version != 1 {
+		t.Fatalf("CreateDataset() metadata = %+v", metadata)
+	}
+	if metadata.DatasetType != DatasetTypeFlow {
+		t.Fatalf("CreateDataset() datasetType = %q", metadata.DatasetType)
+	}
+
+	datasetPath := filepath.Join(root, "dataset-1-123456.json")
+	rawDataset, err := os.ReadFile(datasetPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", datasetPath, err)
+	}
+	var persisted []DatasetSample
+	if err := json.Unmarshal(rawDataset, &persisted); err != nil {
+		t.Fatalf("Unmarshal(dataset) error = %v", err)
+	}
+	if len(persisted) != 2 || persisted[0].TestCaseID == "" || persisted[1].TestCaseID != "sample-2" {
+		t.Fatalf("persisted dataset = %+v", persisted)
+	}
+
+	listed, err := store.ListDatasets()
+	if err != nil {
+		t.Fatalf("ListDatasets() error = %v", err)
+	}
+	if len(listed) != 1 || listed[0].DatasetID != "dataset-1-123456" {
+		t.Fatalf("ListDatasets() = %+v", listed)
+	}
+
+	fetched, err := store.GetDataset("dataset-1-123456")
+	if err != nil {
+		t.Fatalf("GetDataset() error = %v", err)
+	}
+	if len(fetched) != 2 {
+		t.Fatalf("GetDataset() len = %d, want 2", len(fetched))
+	}
+
+	now = now.Add(time.Minute)
+	updated, err := store.UpdateDataset(UpdateDatasetRequest{
+		DatasetID:    "dataset-1-123456",
+		TargetAction: "/flow/other-flow",
+		MetricRefs:   []string{"/evaluator/faithfulness"},
+		Data: []InferenceSample{
+			{TestCaseID: persisted[0].TestCaseID, Input: "updated", Reference: "world"},
+			{Input: "new sample"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateDataset() error = %v", err)
+	}
+
+	if updated.Version != 2 || updated.Size != 3 {
+		t.Fatalf("UpdateDataset() metadata = %+v", updated)
+	}
+	if updated.TargetAction != "/flow/other-flow" {
+		t.Fatalf("UpdateDataset() targetAction = %q", updated.TargetAction)
+	}
+	if len(updated.MetricRefs) != 1 || updated.MetricRefs[0] != "/evaluator/faithfulness" {
+		t.Fatalf("UpdateDataset() metricRefs = %+v", updated.MetricRefs)
+	}
+
+	afterUpdate, err := store.GetDataset("dataset-1-123456")
+	if err != nil {
+		t.Fatalf("GetDataset(after update) error = %v", err)
+	}
+	if len(afterUpdate) != 3 || afterUpdate[0].Input != "updated" {
+		t.Fatalf("GetDataset(after update) = %+v", afterUpdate)
+	}
+
+	if err := store.DeleteDataset("dataset-1-123456"); err != nil {
+		t.Fatalf("DeleteDataset() error = %v", err)
+	}
+	if _, err := os.Stat(datasetPath); !os.IsNotExist(err) {
+		t.Fatalf("dataset file still exists, err = %v", err)
+	}
+	listed, err = store.ListDatasets()
+	if err != nil {
+		t.Fatalf("ListDatasets(after delete) error = %v", err)
+	}
+	if len(listed) != 0 {
+		t.Fatalf("ListDatasets(after delete) = %+v", listed)
+	}
+}
+
+func TestDefaultDatasetStoreUsesProjectRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, "go.mod"), []byte("module example.com/test\n"), 0644); err != nil {
+		t.Fatalf("WriteFile(go.mod) error = %v", err)
+	}
+
+	child := filepath.Join(projectRoot, "nested")
+	if err := os.MkdirAll(child, 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+	if err := os.Chdir(child); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+
+	store, err := DefaultDatasetStore()
+	if err != nil {
+		t.Fatalf("DefaultDatasetStore() error = %v", err)
+	}
+
+	want, err := filepath.EvalSymlinks(filepath.Join(projectRoot, ".genkit", "datasets"))
+	if err != nil {
+		want = filepath.Join(projectRoot, ".genkit", "datasets")
+	}
+	if store.storeRoot != want {
+		t.Fatalf("DefaultDatasetStore() root = %q, want %q", store.storeRoot, want)
+	}
+}

--- a/go/genkit/doc.go
+++ b/go/genkit/doc.go
@@ -167,6 +167,15 @@ Load prompts from .prompt files by specifying a prompt directory:
 	// Or with type parameters for structured I/O
 	recipePrompt := genkit.LookupDataPrompt[RecipeRequest, *Recipe](g, "recipe")
 
+# Developer UI datasets
+
+The `genkit` package also includes a local dataset store for evaluation and
+prompt-testing workflows in the Developer UI. The current UI reads datasets from
+`.genkit/datasets`, so [DefaultDatasetStore] and [NewLocalFileDatasetStore]
+persist the matching `index.json` and `<datasetId>.json` files. This lets Go
+applications define datasets programmatically while keeping them visible in
+local tooling.
+
 When using .prompt files with custom output schemas, register the schema first:
 
 	genkit.DefineSchemaFor[Recipe](g)

--- a/go/genkit/example_test.go
+++ b/go/genkit/example_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/firebase/genkit/go/ai"
@@ -319,4 +320,34 @@ func ExampleLookupPrompt() {
 
 	fmt.Println("Found prompt:", prompt.Name())
 	// Output: Found prompt: greeting
+}
+
+// This example demonstrates creating a dataset in the same local format used by
+// the Developer UI today.
+func ExampleLocalFileDatasetStore_CreateDataset() {
+	root, err := os.MkdirTemp("", "genkit-datasets-example-")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	store, err := genkit.NewLocalFileDatasetStore(root)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	metadata, err := store.CreateDataset(genkit.CreateDatasetRequest{
+		DatasetID:    "recipes-123456",
+		DatasetType:  genkit.DatasetTypeFlow,
+		TargetAction: "/flow/recipeGenerator",
+		Data: []genkit.InferenceSample{
+			{Input: map[string]any{"ingredient": "avocado"}},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%s v%d (%d samples)\n", metadata.DatasetID, metadata.Version, metadata.Size)
+	// Output: recipes-123456 v1 (1 samples)
 }

--- a/js/genkit/README.md
+++ b/js/genkit/README.md
@@ -150,6 +150,34 @@ For more details see: https://genkit.dev/docs/deploy-node
 
 But you can also deploy to [Firebase](https://genkit.dev/docs/firebase/) or [Cloud Run](https://genkit.dev/docs/cloud-run/), etc.
 
+## Manage local eval datasets
+
+Genkit also exposes a local dataset store for the current Developer UI dataset
+format. That lets you define datasets programmatically and still have them
+render in the UI.
+
+```ts
+import { datasetStoreForProjectRoot } from 'genkit';
+
+const store = await datasetStoreForProjectRoot();
+
+await store.createDataset({
+  datasetId: 'recipes-123456',
+  datasetType: 'FLOW',
+  targetAction: '/flow/recipeGeneratorFlow',
+  data: [
+    {
+      input: { ingredient: 'avocado' },
+      reference: { title: 'Avocado Toast' },
+    },
+  ],
+});
+```
+
+Today the default store writes `.genkit/datasets/index.json` plus one
+`${datasetId}.json` file per dataset. Keeping callers on the store API leaves
+room for a different backend later without changing call sites.
+
 ## Next steps
 
 Now that you’re set up to make model requests with Genkit, learn how to use more

--- a/js/genkit/src/datasets.ts
+++ b/js/genkit/src/datasets.ts
@@ -1,0 +1,296 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+/** The target surface a dataset is intended for. */
+export type DatasetType =
+  | 'UNKNOWN'
+  | 'FLOW'
+  | 'MODEL'
+  | 'EXECUTABLE_PROMPT';
+
+/** JSON schema hints for dataset `input` and `reference` fields. */
+export interface DatasetSchema {
+  inputSchema?: Record<string, unknown>;
+  referenceSchema?: Record<string, unknown>;
+}
+
+/** User-facing sample shape accepted when creating or updating a dataset. */
+export interface InferenceSample {
+  testCaseId?: string;
+  input: unknown;
+  reference?: unknown;
+}
+
+/** Persisted dataset sample shape used by the developer UI. */
+export interface DatasetSample {
+  testCaseId: string;
+  input: unknown;
+  reference?: unknown;
+}
+
+/** Request payload for creating a dataset. */
+export interface CreateDatasetRequest {
+  data: InferenceSample[];
+  datasetId?: string;
+  datasetType: DatasetType;
+  schema?: DatasetSchema;
+  metricRefs?: string[];
+  targetAction?: string;
+}
+
+/** Request payload for updating a dataset. */
+export interface UpdateDatasetRequest {
+  datasetId: string;
+  data?: InferenceSample[];
+  schema?: DatasetSchema;
+  metricRefs?: string[];
+  targetAction?: string;
+}
+
+/** Metadata shown for a dataset in the developer UI. */
+export interface DatasetMetadata {
+  datasetId: string;
+  size: number;
+  schema?: DatasetSchema;
+  datasetType: DatasetType;
+  targetAction?: string;
+  metricRefs: string[];
+  version: number;
+  createTime: string;
+  updateTime: string;
+}
+
+/**
+ * DatasetStore is the narrow persistence boundary for eval datasets.
+ *
+ * The current developer UI expects the local `.genkit/datasets` file layout,
+ * but callers should depend on this interface so a remote datastore can be
+ * introduced later without changing the programmatic API.
+ */
+export interface DatasetStore {
+  createDataset(req: CreateDatasetRequest): Promise<DatasetMetadata>;
+  updateDataset(req: UpdateDatasetRequest): Promise<DatasetMetadata>;
+  getDataset(datasetId: string): Promise<DatasetSample[]>;
+  listDatasets(): Promise<DatasetMetadata[]>;
+  deleteDataset(datasetId: string): Promise<void>;
+}
+
+const DATASET_ID_RE = /^[A-Za-z][A-Za-z0-9_.-]{4,34}[A-Za-z0-9]$/;
+
+/**
+ * LocalFileDatasetStore is the default DatasetStore implementation used by the
+ * current developer UI. It persists `index.json` plus one `${datasetId}.json`
+ * file under `.genkit/datasets`.
+ */
+export class LocalFileDatasetStore implements DatasetStore {
+  readonly storeRoot: string;
+  readonly indexFile: string;
+
+  /** Creates a store rooted at a dataset directory. */
+  constructor(storeRoot: string) {
+    this.storeRoot = storeRoot;
+    this.indexFile = path.join(storeRoot, 'index.json');
+  }
+
+  /** Returns the default local dataset store for a project root. */
+  static async forProjectRoot(projectRoot = process.cwd()) {
+    const store = new LocalFileDatasetStore(
+      path.join(projectRoot, '.genkit', 'datasets')
+    );
+    await store.ensureInitialized();
+    return store;
+  }
+
+  /** Creates a dataset using the current developer UI file format. */
+  async createDataset(req: CreateDatasetRequest): Promise<DatasetMetadata> {
+    await this.ensureInitialized();
+    const metadataMap = await this.readMetadataMap();
+    const datasetId = this.generateDatasetId(req.datasetId, metadataMap);
+    const dataset = normalizeInferenceDataset(req.data);
+
+    await writeFile(
+      this.datasetFilePath(datasetId),
+      JSON.stringify(dataset),
+      'utf8'
+    );
+
+    const now = new Date().toString();
+    const metadata: DatasetMetadata = {
+      datasetId,
+      size: dataset.length,
+      schema: req.schema,
+      datasetType: req.datasetType,
+      targetAction: req.targetAction,
+      metricRefs: [...(req.metricRefs ?? [])],
+      version: 1,
+      createTime: now,
+      updateTime: now,
+    };
+    metadataMap[datasetId] = metadata;
+    await this.writeMetadataMap(metadataMap);
+    return metadata;
+  }
+
+  /** Updates a dataset and increments its version when sample data changes. */
+  async updateDataset(req: UpdateDatasetRequest): Promise<DatasetMetadata> {
+    await this.ensureInitialized();
+    const filePath = this.datasetFilePath(req.datasetId);
+    const metadataMap = await this.readMetadataMap();
+    const prevMetadata = metadataMap[req.datasetId];
+    if (!prevMetadata) {
+      throw new Error('Update dataset failed: dataset metadata not found');
+    }
+
+    let newSize = prevMetadata.size;
+    let version = prevMetadata.version;
+    if (req.data) {
+      const patched = await this.patchDataset(
+        req.datasetId,
+        normalizeInferenceDataset(req.data)
+      );
+      newSize = patched.length;
+      version += 1;
+    } else {
+      await readFile(filePath, 'utf8');
+    }
+
+    const metadata: DatasetMetadata = {
+      datasetId: req.datasetId,
+      size: newSize,
+      schema: req.schema ?? prevMetadata.schema,
+      datasetType: prevMetadata.datasetType,
+      targetAction: req.targetAction ?? prevMetadata.targetAction,
+      metricRefs: req.metricRefs ? [...req.metricRefs] : [...prevMetadata.metricRefs],
+      version,
+      createTime: prevMetadata.createTime,
+      updateTime: new Date().toString(),
+    };
+    metadataMap[req.datasetId] = metadata;
+    await this.writeMetadataMap(metadataMap);
+    return metadata;
+  }
+
+  /** Reads the persisted samples for a dataset ID. */
+  async getDataset(datasetId: string): Promise<DatasetSample[]> {
+    const raw = await readFile(this.datasetFilePath(datasetId), 'utf8');
+    return JSON.parse(raw) as DatasetSample[];
+  }
+
+  /** Lists all dataset metadata records sorted by dataset ID. */
+  async listDatasets(): Promise<DatasetMetadata[]> {
+    const metadataMap = await this.readMetadataMap();
+    return Object.keys(metadataMap)
+      .sort()
+      .map((datasetId) => metadataMap[datasetId]);
+  }
+
+  /** Deletes a dataset file and its metadata entry. */
+  async deleteDataset(datasetId: string): Promise<void> {
+    await rm(this.datasetFilePath(datasetId));
+    const metadataMap = await this.readMetadataMap();
+    delete metadataMap[datasetId];
+    await this.writeMetadataMap(metadataMap);
+  }
+
+  private async ensureInitialized() {
+    await mkdir(this.storeRoot, { recursive: true });
+    try {
+      await readFile(this.indexFile, 'utf8');
+    } catch {
+      await writeFile(this.indexFile, JSON.stringify({}), 'utf8');
+    }
+  }
+
+  private async readMetadataMap(): Promise<Record<string, DatasetMetadata>> {
+    const raw = await readFile(this.indexFile, 'utf8');
+    return JSON.parse(raw) as Record<string, DatasetMetadata>;
+  }
+
+  private async writeMetadataMap(
+    metadataMap: Record<string, DatasetMetadata>
+  ): Promise<void> {
+    await writeFile(this.indexFile, JSON.stringify(metadataMap), 'utf8');
+  }
+
+  private async patchDataset(
+    datasetId: string,
+    patch: DatasetSample[]
+  ): Promise<DatasetSample[]> {
+    const existing = await this.getDataset(datasetId);
+    const datasetMap = new Map(existing.map((item) => [item.testCaseId, item]));
+    for (const sample of patch) {
+      datasetMap.set(sample.testCaseId, sample);
+    }
+    const merged = Array.from(datasetMap.values());
+    await writeFile(
+      this.datasetFilePath(datasetId),
+      JSON.stringify(merged),
+      'utf8'
+    );
+    return merged;
+  }
+
+  private generateDatasetId(
+    datasetId: string | undefined,
+    metadataMap: Record<string, DatasetMetadata>
+  ) {
+    if (!datasetId) {
+      let generated = randomUUID();
+      while (metadataMap[generated]) {
+        generated = randomUUID();
+      }
+      return generated;
+    }
+    if (!DATASET_ID_RE.test(datasetId)) {
+      throw new Error(
+        'Invalid datasetId provided. ID must be alphanumeric, with hyphens, dots and dashes. Is must start with an alphabet, end with an alphabet or a number, and must be 6-36 characters long.'
+      );
+    }
+    if (metadataMap[datasetId]) {
+      throw new Error(`Dataset ID not unique: ${datasetId}`);
+    }
+    return datasetId;
+  }
+
+  private datasetFilePath(datasetId: string) {
+    return path.join(this.storeRoot, `${datasetId}.json`);
+  }
+}
+
+/**
+ * Returns the default DatasetStore for the current project.
+ *
+ * Today this is file-backed so datasets render in the current developer UI.
+ * Callers should keep using the DatasetStore interface so a remote
+ * implementation can be swapped in later if needed.
+ */
+export async function datasetStoreForProjectRoot(
+  projectRoot = process.cwd()
+): Promise<DatasetStore> {
+  return LocalFileDatasetStore.forProjectRoot(projectRoot);
+}
+
+function normalizeInferenceDataset(data: InferenceSample[]): DatasetSample[] {
+  return data.map((sample) => ({
+    testCaseId: sample.testCaseId ?? randomUUID(),
+    input: sample.input,
+    reference: sample.reference,
+  }));
+}

--- a/js/genkit/src/index.ts
+++ b/js/genkit/src/index.ts
@@ -26,4 +26,5 @@
  * @module /
  */
 export * from './common.js';
+export * from './datasets.js';
 export { Genkit, genkit, type GenkitOptions } from './genkit.js';

--- a/js/genkit/tests/datasets_test.ts
+++ b/js/genkit/tests/datasets_test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'node:assert';
+import { access, mkdtemp, readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { LocalFileDatasetStore } from '../src/index.js';
+
+describe('LocalFileDatasetStore', () => {
+  it('persists datasets in the developer UI format', async () => {
+    const isolatedStore = new LocalFileDatasetStore(
+      await mkdtemp(path.join(os.tmpdir(), 'genkit-datasets-'))
+    );
+
+    const created = await isolatedStore.createDataset({
+      datasetId: 'dataset-1-123456',
+      datasetType: 'FLOW',
+      targetAction: '/flow/my-flow',
+      data: [{ input: 'hello', reference: 'world' }],
+    });
+
+    assert.strictEqual(created.datasetId, 'dataset-1-123456');
+    assert.strictEqual(created.version, 1);
+
+    const listed = await isolatedStore.listDatasets();
+    assert.strictEqual(listed.length, 1);
+
+    const fetched = await isolatedStore.getDataset('dataset-1-123456');
+    assert.strictEqual(fetched.length, 1);
+    assert.ok(fetched[0].testCaseId);
+
+    const updated = await isolatedStore.updateDataset({
+      datasetId: 'dataset-1-123456',
+      metricRefs: ['/evaluator/faithfulness'],
+      data: [{ testCaseId: fetched[0].testCaseId, input: 'updated' }],
+    });
+    assert.strictEqual(updated.version, 2);
+    assert.deepStrictEqual(updated.metricRefs, ['/evaluator/faithfulness']);
+
+    const indexRaw = await readFile(
+      path.join(isolatedStore.storeRoot, 'index.json'),
+      'utf8'
+    );
+    const index = JSON.parse(indexRaw) as Record<string, { datasetId: string }>;
+    assert.strictEqual(index['dataset-1-123456'].datasetId, 'dataset-1-123456');
+
+    await isolatedStore.deleteDataset('dataset-1-123456');
+    await assert.rejects(
+      access(path.join(isolatedStore.storeRoot, 'dataset-1-123456.json'))
+    );
+  });
+});


### PR DESCRIPTION
Add local dataset store APIs in Go and TypeScript for creating, reading, updating, listing, and deleting evaluation datasets in the same .genkit/datasets format used by the current Developer UI.

This keeps datasets renderable in the local UI while giving applications a supported way to define them programmatically. The change also adds tests, Go examples, and README/package documentation for the new API surface.

 - I decided to implement what I thought would work for my feature request: #5068

If we like the direction of this I'll go through the UI testing as well. I am hoping to at least figure out if this is the right direction first then adjust / test.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [ ] Tested (manually, unit tested, etc.) 
- [X] Docs updated (updated docs or a docs bug required)
