### PR TITLE
fix(py): fix double generate span in model runner

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -108,7 +108,7 @@ def define_generate_action(registry: Registry) -> None:
         ctx: ActionRunContext,
     ) -> ModelResponse:
         on_chunk = cast(Callable[[ModelResponseChunk], None], ctx.streaming_callback) if ctx.is_streaming else None
-        return await generate_action(
+        return await _generate_action(
             registry=registry,
             raw_request=input,
             on_chunk=on_chunk,
@@ -131,7 +131,11 @@ async def generate_action(
     middleware: list[ModelMiddleware] | None = None,
     context: dict[str, Any] | None = None,
 ) -> ModelResponse:
-    """Execute a generation request with tool calling and middleware support."""
+    """Run generation with a util ``generate`` span.
+
+    The registered ``/util/generate`` action calls `_generate_action` directly
+    so reflection runs do not stack another util span on the action span.
+    """
     span_name = 'generate'
     with run_in_new_span(
         SpanMetadata(name=span_name),
@@ -335,9 +339,7 @@ async def _generate_action(
         # No message in response, return as-is
         return response
 
-    # Stamp output format metadata on message for Dev UI rendering.
-    # Mirrors JS GenerateResponse constructor which sets message.metadata.generate.output
-    # so the Dev UI knows to render the output as formatted JSON vs plain text.
+    # Stamp output format metadata on message so the Dev UI can render formatted JSON vs plain text.
     out = raw_request.output
     if out and (out.content_type or out.format):
         generate_output: dict[str, str] = {}


### PR DESCRIPTION
Dev UI should be calling `_generate_action()` directly, which runs the generation logic without a new span. Since Dev UI is calling a registered action, there is a `generate` span already created.

`generate_action()` is reserved for the `ai.generate()` case. Since `ai.generate()` doesn't actually call a registered action, we have to inject the `generate` span manually there.