### PR TITLE
feat(ollama): detect model capabilities dynamically via /api/show

### DIFF
--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -164,8 +164,16 @@ func (o *Ollama) listLocalModels(ctx context.Context) ([]ollamaLocalModel, error
 }
 
 func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.ModelOptions) ai.Model {
-	// Detect capabilities before acquiring the lock to avoid holding it
-	// during HTTP I/O.
+	// Check the init guard first under a brief lock — before any I/O — so
+	// that a forgotten Init() panics immediately rather than after a timeout.
+	o.mu.Lock()
+	if !o.initted {
+		o.mu.Unlock()
+		panic("ollama.Init not called")
+	}
+	o.mu.Unlock()
+
+	// Detect capabilities outside the lock to avoid holding it during HTTP I/O.
 	var modelOpts ai.ModelOptions
 	if opts != nil {
 		modelOpts = *opts
@@ -184,11 +192,9 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 		}
 	}
 
+	// Re-acquire lock for the registration step.
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	if !o.initted {
-		panic("ollama.Init not called")
-	}
 	meta := &ai.ModelOptions{
 		Label:        "Ollama - " + model.Name,
 		Supports:     modelOpts.Supports,

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -164,13 +164,9 @@ func (o *Ollama) listLocalModels(ctx context.Context) ([]ollamaLocalModel, error
 }
 
 func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.ModelOptions) ai.Model {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	if !o.initted {
-		panic("ollama.Init not called")
-	}
+	// Detect capabilities before acquiring the lock to avoid holding it
+	// during HTTP I/O.
 	var modelOpts ai.ModelOptions
-
 	if opts != nil {
 		modelOpts = *opts
 	} else {
@@ -178,12 +174,20 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 		// /api/show. This replaces the hardcoded allowlist approach so that
 		// newly released models (e.g. gemma4) work automatically without
 		// code changes. Falls back to the static list for older servers.
-		caps := o.getModelCapabilities(context.Background(), model.Name)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout)*time.Second)
+		defer cancel()
+		caps := o.getModelCapabilities(ctx, model.Name)
 		modelOpts = ai.ModelOptions{
 			Label:    model.Name,
 			Supports: modelSupportsFromCapabilities(caps, model.Name),
 			Versions: []string{},
 		}
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if !o.initted {
+		panic("ollama.Init not called")
 	}
 	meta := &ai.ModelOptions{
 		Label:        "Ollama - " + model.Name,
@@ -425,6 +429,10 @@ func (o *Ollama) ListActions(ctx context.Context) []api.ActionDesc {
 		if strings.Contains(name, "embed") {
 			continue
 		}
+		// Check for context cancellation before each potentially slow HTTP call.
+		if ctx.Err() != nil {
+			break
+		}
 		// Query each model's actual capabilities from the Ollama server.
 		caps := o.getModelCapabilities(ctx, name)
 		supports := modelSupportsFromCapabilities(caps, name)
@@ -442,7 +450,9 @@ func (o *Ollama) ResolveAction(atype api.ActionType, name string) api.Action {
 		return nil
 	}
 	// Query the model's actual capabilities from the Ollama server.
-	caps := o.getModelCapabilities(context.Background(), name)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout)*time.Second)
+	defer cancel()
+	caps := o.getModelCapabilities(ctx, name)
 	supports := modelSupportsFromCapabilities(caps, name)
 	model := o.newModel(name, ai.ModelOptions{Supports: supports})
 	if action, ok := model.(api.Action); ok {

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -80,10 +80,64 @@ type ollamaTagsResponse struct {
 	Models []ollamaLocalModel `json:"models"`
 }
 
-// ollamaLocalModel represents a locally available Ollama model.
+// ollamaLocalModel represents a locally available Ollama model from /api/tags.
 type ollamaLocalModel struct {
 	Name  string `json:"name"`
 	Model string `json:"model"`
+}
+
+// ollamaShowResponse represents the response from POST /api/show.
+type ollamaShowResponse struct {
+	Capabilities []string `json:"capabilities"`
+}
+
+// getModelCapabilities calls POST /api/show to retrieve the model's capabilities.
+// Returns nil if the endpoint is unavailable or the model doesn't report capabilities.
+func (o *Ollama) getModelCapabilities(ctx context.Context, modelName string) []string {
+	body, err := json.Marshal(map[string]string{"model": modelName})
+	if err != nil {
+		return nil
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", o.ServerAddress+"/api/show", bytes.NewReader(body))
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	var showResp ollamaShowResponse
+	if err := json.NewDecoder(resp.Body).Decode(&showResp); err != nil {
+		return nil
+	}
+	return showResp.Capabilities
+}
+
+// modelSupportsFromCapabilities derives ModelSupports from capabilities reported
+// by the Ollama /api/show endpoint. Falls back to the static allowlists when
+// the server doesn't report capabilities (older Ollama versions).
+func modelSupportsFromCapabilities(caps []string, modelName string) *ai.ModelSupports {
+	if len(caps) > 0 {
+		return &ai.ModelSupports{
+			Multiturn:  true,
+			SystemRole: true,
+			Tools:      slices.Contains(caps, "tools"),
+			Media:      slices.Contains(caps, "vision") || slices.Contains(caps, "audio"),
+		}
+	}
+	// Fallback: use static allowlists for older Ollama servers that don't
+	// report capabilities via /api/show.
+	return &ai.ModelSupports{
+		Multiturn:  true,
+		SystemRole: true,
+		Tools:      slices.Contains(toolSupportedModels, modelName),
+		Media:      slices.Contains(mediaSupportedModels, modelName),
+	}
 }
 
 // listLocalModels calls GET /api/tags to list locally installed Ollama models.
@@ -120,16 +174,14 @@ func (o *Ollama) DefineModel(g *genkit.Genkit, model ModelDefinition, opts *ai.M
 	if opts != nil {
 		modelOpts = *opts
 	} else {
-		// Check if the model supports tools (must be a chat model and in the supported list)
-		supportsTools := model.Type == "chat" && slices.Contains(toolSupportedModels, model.Name)
+		// Query the Ollama server for the model's actual capabilities via
+		// /api/show. This replaces the hardcoded allowlist approach so that
+		// newly released models (e.g. gemma4) work automatically without
+		// code changes. Falls back to the static list for older servers.
+		caps := o.getModelCapabilities(context.Background(), model.Name)
 		modelOpts = ai.ModelOptions{
-			Label: model.Name,
-			Supports: &ai.ModelSupports{
-				Multiturn:  true,
-				SystemRole: true,
-				Media:      slices.Contains(mediaSupportedModels, model.Name),
-				Tools:      supportsTools,
-			},
+			Label:    model.Name,
+			Supports: modelSupportsFromCapabilities(caps, model.Name),
 			Versions: []string{},
 		}
 	}
@@ -373,7 +425,10 @@ func (o *Ollama) ListActions(ctx context.Context) []api.ActionDesc {
 		if strings.Contains(name, "embed") {
 			continue
 		}
-		model := o.newModel(name, ai.ModelOptions{Supports: &defaultOllamaSupports})
+		// Query each model's actual capabilities from the Ollama server.
+		caps := o.getModelCapabilities(ctx, name)
+		supports := modelSupportsFromCapabilities(caps, name)
+		model := o.newModel(name, ai.ModelOptions{Supports: supports})
 		if action, ok := model.(api.Action); ok {
 			actions = append(actions, action.Desc())
 		}
@@ -386,7 +441,10 @@ func (o *Ollama) ResolveAction(atype api.ActionType, name string) api.Action {
 	if atype != api.ActionTypeModel {
 		return nil
 	}
-	model := o.newModel(name, ai.ModelOptions{Supports: &defaultOllamaSupports})
+	// Query the model's actual capabilities from the Ollama server.
+	caps := o.getModelCapabilities(context.Background(), name)
+	supports := modelSupportsFromCapabilities(caps, name)
+	model := o.newModel(name, ai.ModelOptions{Supports: supports})
 	if action, ok := model.(api.Action); ok {
 		return action
 	}

--- a/go/plugins/ollama/ollama_test.go
+++ b/go/plugins/ollama/ollama_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
@@ -494,4 +495,78 @@ func TestTranslateChatResponse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetModelCapabilities(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/show" {
+			var req map[string]string
+			json.NewDecoder(r.Body).Decode(&req)
+			caps := map[string][]string{
+				"gemma4:e2b":  {"completion", "vision", "audio", "tools", "thinking"},
+				"llama3.2":    {"completion", "tools"},
+				"nomic-embed": {"embedding"},
+			}
+			json.NewEncoder(w).Encode(map[string]any{"capabilities": caps[req["model"]]})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	o := &Ollama{ServerAddress: server.URL, client: &http.Client{}, initted: true}
+
+	t.Run("gemma4 reports tools capability", func(t *testing.T) {
+		caps := o.getModelCapabilities(context.Background(), "gemma4:e2b")
+		if !slices.Contains(caps, "tools") {
+			t.Errorf("expected 'tools' in capabilities, got %v", caps)
+		}
+	})
+
+	t.Run("embed model has no tools", func(t *testing.T) {
+		caps := o.getModelCapabilities(context.Background(), "nomic-embed")
+		if slices.Contains(caps, "tools") {
+			t.Error("embed model should not have tools capability")
+		}
+	})
+
+	t.Run("unknown model returns empty", func(t *testing.T) {
+		caps := o.getModelCapabilities(context.Background(), "unknown-model")
+		if len(caps) > 0 {
+			t.Errorf("expected empty capabilities for unknown model, got %v", caps)
+		}
+	})
+}
+
+func TestModelSupportsFromCapabilities(t *testing.T) {
+	t.Run("dynamic capabilities with tools and vision", func(t *testing.T) {
+		s := modelSupportsFromCapabilities([]string{"completion", "vision", "tools"}, "gemma4")
+		if !s.Tools {
+			t.Error("expected Tools=true")
+		}
+		if !s.Media {
+			t.Error("expected Media=true (vision)")
+		}
+	})
+
+	t.Run("no tools in capabilities", func(t *testing.T) {
+		s := modelSupportsFromCapabilities([]string{"completion"}, "some-model")
+		if s.Tools {
+			t.Error("expected Tools=false")
+		}
+	})
+
+	t.Run("fallback to static list for qwen2.5", func(t *testing.T) {
+		s := modelSupportsFromCapabilities(nil, "qwen2.5")
+		if !s.Tools {
+			t.Error("expected Tools=true from static fallback")
+		}
+	})
+
+	t.Run("fallback for unknown model", func(t *testing.T) {
+		s := modelSupportsFromCapabilities(nil, "brand-new-model")
+		if s.Tools {
+			t.Error("expected Tools=false for unknown model")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Replace the hardcoded `toolSupportedModels` and `mediaSupportedModels` allowlists in the Ollama plugin with dynamic capability detection from Ollama's `/api/show` endpoint.

## Problem

The Ollama plugin maintains static string arrays of model names that support tools and media. Newly released models (e.g. `gemma4`, which Ollama reports as tool-capable via its API) don't work with tool calling until someone manually updates these lists and ships a new Genkit release. This creates an unnecessary maintenance burden and blocks users from using new models with tools.

## Solution

Ollama's `POST /api/show` endpoint returns a `capabilities` array (e.g. `["completion", "vision", "tools", "thinking"]`) that accurately reports what each model supports. This PR queries that endpoint when determining model capabilities, falling back to the existing static lists when the server doesn't report capabilities (older Ollama versions).

## Changes

- `go/plugins/ollama/ollama.go`:
  - Add `getModelCapabilities()` — queries `/api/show` for a model's capabilities
  - Add `modelSupportsFromCapabilities()` — derives `ModelSupports` from capability strings, with static-list fallback
  - Update `DefineModel()` to use dynamic detection when no explicit opts provided
  - Update `ListActions()` and `ResolveAction()` to use dynamic detection
- `go/plugins/ollama/ollama_test.go`:
  - Add `TestGetModelCapabilities` — mock server tests for tools/no-tools/unknown models
  - Add `TestModelSupportsFromCapabilities` — unit tests for dynamic and fallback paths

## Backward Compatibility

- When `/api/show` returns capabilities → used directly (new behavior)
- When `/api/show` doesn't return capabilities or fails → falls back to existing static allowlists (existing behavior preserved)
- Explicit `ModelOptions` passed to `DefineModel()` are still respected (no change)

## Testing

All existing tests pass. New tests cover:
- Capability detection from mock `/api/show` endpoint
- Fallback to static lists when no capabilities reported
- Models in the static list still work via fallback
- Unknown models default to no tools/media

🤖 Generated with [Claude Code](https://claude.com/claude-code)