### PR TITLE
feat(py): add veo 3.x googleai support

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/veo.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/veo.py
@@ -104,6 +104,10 @@ class VeoVersion(StrEnum):
 
     VEO_2_0 = 'veo-2.0-generate-001'
     VEO_2_0_EXP = 'veo-2.0-generate-exp'
+    VEO_3_0 = 'veo-3.0-generate-001'
+    VEO_3_0_FAST = 'veo-3.0-fast-generate-001'
+    VEO_3_1_PREVIEW = 'veo-3.1-generate-preview'
+    VEO_3_1_FAST_PREVIEW = 'veo-3.1-fast-generate-preview'
     VEO_3_1 = 'veo-3.1-generate-001'
     VEO_3_1_FAST = 'veo-3.1-fast-generate-001'
 
@@ -134,6 +138,10 @@ class VeoConfigSchema(BaseModel):
     duration_seconds: int | None = Field(
         default=None, alias='durationSeconds', description='Length of video in seconds.'
     )
+    resolution: str | None = Field(
+        default=None, alias='resolution', description='Desired output resolution (e.g. "720p").'
+    )
+    seed: int | None = Field(default=None, alias='seed', description='Random seed for deterministic generation.')
     enhance_prompt: bool | None = Field(default=None, alias='enhancePrompt', description='Enable prompt enhancement.')
 
 

--- a/py/plugins/google-genai/tests/veo_test.py
+++ b/py/plugins/google-genai/tests/veo_test.py
@@ -21,6 +21,7 @@ start path) and Pydantic GenerateVideosResponse objects (from the check
 path where the SDK returns a model instance).
 """
 
+import pytest
 from google.genai import types as genai_types
 
 from genkit.plugins.google_genai.models.veo import (
@@ -51,12 +52,18 @@ class TestIsVeoModel:
 class TestVeoVersion:
     """Tests for VeoVersion enum convenience constants."""
 
-    def test_includes_new_googleai_veo_models(self) -> None:
-        """New Veo 3.0/3.1 GoogleAI model names are exposed."""
-        assert VeoVersion.VEO_3_1_PREVIEW.value == 'veo-3.1-generate-preview'
-        assert VeoVersion.VEO_3_1_FAST_PREVIEW.value == 'veo-3.1-fast-generate-preview'
-        assert VeoVersion.VEO_3_0.value == 'veo-3.0-generate-001'
-        assert VeoVersion.VEO_3_0_FAST.value == 'veo-3.0-fast-generate-001'
+    @pytest.mark.parametrize(
+        'version',
+        [
+            VeoVersion.VEO_3_1_PREVIEW,
+            VeoVersion.VEO_3_1_FAST_PREVIEW,
+            VeoVersion.VEO_3_0,
+            VeoVersion.VEO_3_0_FAST,
+        ],
+    )
+    def test_new_googleai_models_are_recognized(self, version: VeoVersion) -> None:
+        """New Veo 3.0/3.1 model constants map to valid Veo names."""
+        assert is_veo_model(version.value) is True
 
 
 class TestToVeoParameters:

--- a/py/plugins/google-genai/tests/veo_test.py
+++ b/py/plugins/google-genai/tests/veo_test.py
@@ -25,6 +25,7 @@ from google.genai import types as genai_types
 
 from genkit.plugins.google_genai.models.veo import (
     VeoConfigSchema,
+    VeoVersion,
     _from_veo_operation,
     _to_veo_parameters,
     is_veo_model,
@@ -47,6 +48,17 @@ class TestIsVeoModel:
         assert is_veo_model('gemini-2.0-flash') is False
 
 
+class TestVeoVersion:
+    """Tests for VeoVersion enum convenience constants."""
+
+    def test_includes_new_googleai_veo_models(self) -> None:
+        """New Veo 3.0/3.1 GoogleAI model names are exposed."""
+        assert VeoVersion.VEO_3_1_PREVIEW.value == 'veo-3.1-generate-preview'
+        assert VeoVersion.VEO_3_1_FAST_PREVIEW.value == 'veo-3.1-fast-generate-preview'
+        assert VeoVersion.VEO_3_0.value == 'veo-3.0-generate-001'
+        assert VeoVersion.VEO_3_0_FAST.value == 'veo-3.0-fast-generate-001'
+
+
 class TestToVeoParameters:
     """Tests for _to_veo_parameters."""
 
@@ -66,6 +78,13 @@ class TestToVeoParameters:
         result = _to_veo_parameters(config)
         assert result['aspectRatio'] == '16:9'
         assert result['durationSeconds'] == 5
+
+    def test_schema_config_includes_new_fields(self) -> None:
+        """VeoConfigSchema includes newer Veo parameters."""
+        config = VeoConfigSchema(resolution='1080p', seed=7)
+        result = _to_veo_parameters(config)
+        assert result['resolution'] == '1080p'
+        assert result['seed'] == 7
 
 
 class TestFromVeoOperation:

--- a/py/samples/google-genai-media/README.md
+++ b/py/samples/google-genai-media/README.md
@@ -14,4 +14,13 @@ To explore the flows in Dev UI instead:
 genkit start -- uv run src/main.py
 ```
 
-Flows: `generate_speech`, `generate_image`, `generate_video`.
+Flows: `generate_speech`, `generate_image`, `generate_video`, `generate_video_veo31`, `generate_video_veo31_fast`, `generate_video_veo30`, `generate_video_veo30_fast`.
+
+`generate_video` is configured for Dev UI testing of these Google AI Veo models:
+
+- `googleai/veo-3.1-generate-preview`
+- `googleai/veo-3.1-fast-generate-preview`
+- `googleai/veo-3.0-generate-001`
+- `googleai/veo-3.0-fast-generate-001`
+
+The flow input includes Veo config fields such as `aspect_ratio`, `duration_seconds`, `resolution`, and `seed`.

--- a/py/samples/google-genai-media/README.md
+++ b/py/samples/google-genai-media/README.md
@@ -14,13 +14,16 @@ To explore the flows in Dev UI instead:
 genkit start -- uv run src/main.py
 ```
 
-Flows: `generate_speech`, `generate_image`, `generate_video`, `generate_video_veo31`, `generate_video_veo31_fast`, `generate_video_veo30`, `generate_video_veo30_fast`.
+Flows: `generate_speech`, `generate_image`, `generate_video`.
 
-`generate_video` is configured for Dev UI testing of these Google AI Veo models:
+`generate_video` supports testing Veo models by setting `model` in flow input, for example:
 
 - `googleai/veo-3.1-generate-preview`
 - `googleai/veo-3.1-fast-generate-preview`
 - `googleai/veo-3.0-generate-001`
 - `googleai/veo-3.0-fast-generate-001`
+- `googleai/veo-3.1-generate-001`
+- `googleai/veo-3.1-fast-generate-001`
+- `googleai/veo-2.0-generate-001`
 
 The flow input includes Veo config fields such as `aspect_ratio`, `duration_seconds`, `resolution`, and `seed`.

--- a/py/samples/google-genai-media/src/main.py
+++ b/py/samples/google-genai-media/src/main.py
@@ -18,7 +18,7 @@
 
 import asyncio
 import time
-from typing import Any, Literal
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -47,28 +47,14 @@ class ImageInput(BaseModel):
 class VideoInput(BaseModel):
     """Input for Veo."""
 
-    model: Literal[
-        'googleai/veo-3.1-generate-preview',
-        'googleai/veo-3.1-fast-generate-preview',
-        'googleai/veo-3.0-generate-001',
-        'googleai/veo-3.0-fast-generate-001',
-        'googleai/veo-3.1-generate-001',
-        'googleai/veo-3.1-fast-generate-001',
-        'googleai/veo-2.0-generate-001',
-    ] = Field(default='googleai/veo-3.1-generate-preview', description='Veo model for generation')
-    prompt: str = Field(
-        default='A paper airplane gliding through a bright classroom, cinematic slow motion',
-        description='Video prompt',
+    model: str = Field(
+        default='googleai/veo-3.1-generate-preview',
+        description=(
+            'Veo model for generation, e.g. '
+            'googleai/veo-3.1-generate-preview, googleai/veo-3.1-fast-generate-preview, '
+            'googleai/veo-3.0-generate-001, googleai/veo-3.0-fast-generate-001'
+        ),
     )
-    aspect_ratio: str = Field(default='16:9', description='Video aspect ratio')
-    duration_seconds: int = Field(default=5, description='Video duration in seconds')
-    resolution: str | None = Field(default='720p', description='Output resolution (for supported models)')
-    seed: int | None = Field(default=None, description='Optional RNG seed')
-
-
-class VideoPresetInput(BaseModel):
-    """Input for fixed-model Veo flows in Dev UI."""
-
     prompt: str = Field(
         default='A paper airplane gliding through a bright classroom, cinematic slow motion',
         description='Video prompt',
@@ -132,24 +118,32 @@ async def _poll_video(operation: Operation, model_name: str) -> Operation:
     return operation
 
 
-async def _generate_video_for_model(input: VideoPresetInput, model_name: str) -> dict[str, str | int | None]:
-    """Generate one video for a specific Veo model."""
-    action = await lookup_background_action(ai.registry, f'/background-model/{model_name}')
+def _video_config(input: VideoInput) -> dict[str, Any]:
+    """Build Veo config while omitting unset optional fields."""
+    config = {
+        'aspect_ratio': input.aspect_ratio,
+        'duration_seconds': input.duration_seconds,
+        'resolution': input.resolution,
+        'seed': input.seed,
+    }
+    return {k: v for k, v in config.items() if v is not None}
+
+
+@ai.flow(name='generate_video')
+async def veo_video_generator(input: VideoInput) -> dict[str, str | int | None]:
+    """Generate one video by starting and polling a background model."""
+
+    action = await lookup_background_action(ai.registry, f'/background-model/{input.model}')
     if action is None:
-        raise ValueError(f'Veo background model not found: {model_name}')
+        raise ValueError(f'Veo background model not found: {input.model}')
 
     operation = await action.start(
         ModelRequest(
             messages=[Message(role=Role.USER, content=[Part(root=TextPart(text=input.prompt))])],
-            config={
-                'aspect_ratio': input.aspect_ratio,
-                'duration_seconds': input.duration_seconds,
-                'resolution': input.resolution,
-                'seed': input.seed,
-            },
+            config=_video_config(input),
         )
     )
-    operation = await _poll_video(operation, model_name)
+    operation = await _poll_video(operation, input.model)
 
     video_url = None
     if isinstance(operation.output, dict):
@@ -160,55 +154,11 @@ async def _generate_video_for_model(input: VideoPresetInput, model_name: str) ->
             video_url = media.get('url')
 
     return {
-        'model': model_name,
+        'model': input.model,
         'operation_id': operation.id,
         'video_url': video_url,
         'duration_seconds': input.duration_seconds,
     }
-
-
-@ai.flow(name='generate_video')
-async def veo_video_generator(input: VideoInput) -> dict[str, str | int | None]:
-    """Generate one video by starting and polling a background model."""
-
-    return await _generate_video_for_model(
-        VideoPresetInput(
-            prompt=input.prompt,
-            aspect_ratio=input.aspect_ratio,
-            duration_seconds=input.duration_seconds,
-            resolution=input.resolution,
-            seed=input.seed,
-        ),
-        input.model,
-    )
-
-
-@ai.flow(name='generate_video_veo31')
-async def veo31_video_generator(input: VideoPresetInput) -> dict[str, str | int | None]:
-    """Generate video with veo-3.1-generate-preview."""
-
-    return await _generate_video_for_model(input, 'googleai/veo-3.1-generate-preview')
-
-
-@ai.flow(name='generate_video_veo31_fast')
-async def veo31_fast_video_generator(input: VideoPresetInput) -> dict[str, str | int | None]:
-    """Generate video with veo-3.1-fast-generate-preview."""
-
-    return await _generate_video_for_model(input, 'googleai/veo-3.1-fast-generate-preview')
-
-
-@ai.flow(name='generate_video_veo30')
-async def veo30_video_generator(input: VideoPresetInput) -> dict[str, str | int | None]:
-    """Generate video with veo-3.0-generate-001."""
-
-    return await _generate_video_for_model(input, 'googleai/veo-3.0-generate-001')
-
-
-@ai.flow(name='generate_video_veo30_fast')
-async def veo30_fast_video_generator(input: VideoPresetInput) -> dict[str, str | int | None]:
-    """Generate video with veo-3.0-fast-generate-001."""
-
-    return await _generate_video_for_model(input, 'googleai/veo-3.0-fast-generate-001')
 
 
 async def main() -> None:

--- a/py/samples/google-genai-media/src/main.py
+++ b/py/samples/google-genai-media/src/main.py
@@ -18,7 +18,7 @@
 
 import asyncio
 import time
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -47,12 +47,33 @@ class ImageInput(BaseModel):
 class VideoInput(BaseModel):
     """Input for Veo."""
 
+    model: Literal[
+        'googleai/veo-3.1-generate-preview',
+        'googleai/veo-3.1-fast-generate-preview',
+        'googleai/veo-3.0-generate-001',
+        'googleai/veo-3.0-fast-generate-001',
+    ] = Field(default='googleai/veo-3.1-generate-preview', description='Veo model for generation')
     prompt: str = Field(
         default='A paper airplane gliding through a bright classroom, cinematic slow motion',
         description='Video prompt',
     )
     aspect_ratio: str = Field(default='16:9', description='Video aspect ratio')
     duration_seconds: int = Field(default=5, description='Video duration in seconds')
+    resolution: str | None = Field(default='720p', description='Output resolution (for supported models)')
+    seed: int | None = Field(default=None, description='Optional RNG seed')
+
+
+class VideoPresetInput(BaseModel):
+    """Input for fixed-model Veo flows in Dev UI."""
+
+    prompt: str = Field(
+        default='A paper airplane gliding through a bright classroom, cinematic slow motion',
+        description='Video prompt',
+    )
+    aspect_ratio: str = Field(default='16:9', description='Video aspect ratio')
+    duration_seconds: int = Field(default=5, description='Video duration in seconds')
+    resolution: str | None = Field(default='720p', description='Output resolution (for supported models)')
+    seed: int | None = Field(default=None, description='Optional RNG seed')
 
 
 def _first_media_url(response: Any) -> str | None:
@@ -92,12 +113,12 @@ async def imagen_image_generator(input: ImageInput) -> dict[str, str | None]:
     return {'model': 'googleai/imagen-3.0-generate-002', 'image_url': _first_media_url(response)}
 
 
-async def _poll_video(operation: Operation) -> Operation:
+async def _poll_video(operation: Operation, model_name: str) -> Operation:
     """Wait for a background video operation to finish."""
 
-    action = await lookup_background_action(ai.registry, '/background-model/googleai/veo-2.0-generate-001')
+    action = await lookup_background_action(ai.registry, f'/background-model/{model_name}')
     if action is None:
-        raise ValueError('Veo background model not found')
+        raise ValueError(f'Veo background model not found: {model_name}')
 
     started_at = time.monotonic()
     while not operation.done:
@@ -108,13 +129,11 @@ async def _poll_video(operation: Operation) -> Operation:
     return operation
 
 
-@ai.flow(name='generate_video')
-async def veo_video_generator(input: VideoInput) -> dict[str, str | int | None]:
-    """Generate one video by starting and polling a background model."""
-
-    action = await lookup_background_action(ai.registry, '/background-model/googleai/veo-2.0-generate-001')
+async def _generate_video_for_model(input: VideoPresetInput, model_name: str) -> dict[str, str | int | None]:
+    """Generate one video for a specific Veo model."""
+    action = await lookup_background_action(ai.registry, f'/background-model/{model_name}')
     if action is None:
-        raise ValueError('Veo background model not found')
+        raise ValueError(f'Veo background model not found: {model_name}')
 
     operation = await action.start(
         ModelRequest(
@@ -122,10 +141,12 @@ async def veo_video_generator(input: VideoInput) -> dict[str, str | int | None]:
             config=ModelConfig.model_validate({
                 'aspect_ratio': input.aspect_ratio,
                 'duration_seconds': input.duration_seconds,
+                'resolution': input.resolution,
+                'seed': input.seed,
             }),
         )
     )
-    operation = await _poll_video(operation)
+    operation = await _poll_video(operation, model_name)
 
     video_url = None
     if isinstance(operation.output, dict):
@@ -136,11 +157,55 @@ async def veo_video_generator(input: VideoInput) -> dict[str, str | int | None]:
             video_url = media.get('url')
 
     return {
-        'model': 'googleai/veo-2.0-generate-001',
+        'model': model_name,
         'operation_id': operation.id,
         'video_url': video_url,
         'duration_seconds': input.duration_seconds,
     }
+
+
+@ai.flow(name='generate_video')
+async def veo_video_generator(input: VideoInput) -> dict[str, str | int | None]:
+    """Generate one video by starting and polling a background model."""
+
+    return await _generate_video_for_model(
+        VideoPresetInput(
+            prompt=input.prompt,
+            aspect_ratio=input.aspect_ratio,
+            duration_seconds=input.duration_seconds,
+            resolution=input.resolution,
+            seed=input.seed,
+        ),
+        input.model,
+    )
+
+
+@ai.flow(name='generate_video_veo31')
+async def veo31_video_generator(input: VideoPresetInput) -> dict[str, str | int | None]:
+    """Generate video with veo-3.1-generate-preview."""
+
+    return await _generate_video_for_model(input, 'googleai/veo-3.1-generate-preview')
+
+
+@ai.flow(name='generate_video_veo31_fast')
+async def veo31_fast_video_generator(input: VideoPresetInput) -> dict[str, str | int | None]:
+    """Generate video with veo-3.1-fast-generate-preview."""
+
+    return await _generate_video_for_model(input, 'googleai/veo-3.1-fast-generate-preview')
+
+
+@ai.flow(name='generate_video_veo30')
+async def veo30_video_generator(input: VideoPresetInput) -> dict[str, str | int | None]:
+    """Generate video with veo-3.0-generate-001."""
+
+    return await _generate_video_for_model(input, 'googleai/veo-3.0-generate-001')
+
+
+@ai.flow(name='generate_video_veo30_fast')
+async def veo30_fast_video_generator(input: VideoPresetInput) -> dict[str, str | int | None]:
+    """Generate video with veo-3.0-fast-generate-001."""
+
+    return await _generate_video_for_model(input, 'googleai/veo-3.0-fast-generate-001')
 
 
 async def main() -> None:

--- a/py/samples/google-genai-media/src/main.py
+++ b/py/samples/google-genai-media/src/main.py
@@ -22,7 +22,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from genkit import Genkit, ModelConfig
+from genkit import Genkit
 from genkit._core._background import lookup_background_action
 from genkit._core._typing import Operation, Part, Role, TextPart
 from genkit.model import Message, ModelRequest
@@ -52,6 +52,9 @@ class VideoInput(BaseModel):
         'googleai/veo-3.1-fast-generate-preview',
         'googleai/veo-3.0-generate-001',
         'googleai/veo-3.0-fast-generate-001',
+        'googleai/veo-3.1-generate-001',
+        'googleai/veo-3.1-fast-generate-001',
+        'googleai/veo-2.0-generate-001',
     ] = Field(default='googleai/veo-3.1-generate-preview', description='Veo model for generation')
     prompt: str = Field(
         default='A paper airplane gliding through a bright classroom, cinematic slow motion',
@@ -138,12 +141,12 @@ async def _generate_video_for_model(input: VideoPresetInput, model_name: str) ->
     operation = await action.start(
         ModelRequest(
             messages=[Message(role=Role.USER, content=[Part(root=TextPart(text=input.prompt))])],
-            config=ModelConfig.model_validate({
+            config={
                 'aspect_ratio': input.aspect_ratio,
                 'duration_seconds': input.duration_seconds,
                 'resolution': input.resolution,
                 'seed': input.seed,
-            }),
+            },
         )
     )
     operation = await _poll_video(operation, model_name)


### PR DESCRIPTION
## Summary
- Add Python SDK support for additional GoogleAI Veo model constants:
  - `veo-3.1-generate-preview`
  - `veo-3.1-fast-generate-preview`
  - `veo-3.0-generate-001`
  - `veo-3.0-fast-generate-001`
- Extend Python `VeoConfigSchema` with newer Veo parameters used by these models (`resolution`, `seed`) while preserving existing aliases and passthrough behavior.
- Update `google-genai-media` sample with dedicated Dev UI flows per Veo model:
  - `generate_video_veo31`
  - `generate_video_veo31_fast`
  - `generate_video_veo30`
  - `generate_video_veo30_fast`
  - Keep existing generic `generate_video` flow for model-selectable testing.


## Examples

<img width="1249" height="864" alt="image" src="https://github.com/user-attachments/assets/dedbe05f-c2d0-4dd7-bb3f-c94a98538646" />
<img width="1375" height="881" alt="image" src="https://github.com/user-attachments/assets/50a9d89b-228f-4347-a919-db42f2c462e5" />
<img width="1677" height="774" alt="image" src="https://github.com/user-attachments/assets/1280e0f7-3539-4c07-9f92-d03b9fe5158c" />
<img width="1676" height="829" alt="image" src="https://github.com/user-attachments/assets/7ee2af62-b188-4b50-8e1c-5f09b3ebd582" />

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated
