### PR TITLE
refactor(py/plugins): remove some deprecated models

### DIFF
--- a/py/plugins/anthropic/src/genkit/plugins/anthropic/model_info.py
+++ b/py/plugins/anthropic/src/genkit/plugins/anthropic/model_info.py
@@ -23,17 +23,6 @@ from genkit import (
 )
 
 # Model definitions
-CLAUDE_3_HAIKU = ModelInfo(
-    label='Anthropic - Claude 3 Haiku',
-    versions=['claude-3-haiku-20240307'],
-    supports=Supports(
-        multiturn=True,
-        media=True,
-        tools=True,
-        system_role=True,
-    ),
-)
-
 CLAUDE_3_5_HAIKU = ModelInfo(
     label='Anthropic - Claude 3.5 Haiku',
     versions=['claude-3-5-haiku-20241022'],
@@ -149,7 +138,6 @@ CLAUDE_OPUS_4_6 = ModelInfo(
 )
 
 SUPPORTED_ANTHROPIC_MODELS: dict[str, ModelInfo] = {
-    'claude-3-haiku': CLAUDE_3_HAIKU,
     'claude-3-5-haiku': CLAUDE_3_5_HAIKU,
     'claude-3-5-sonnet': CLAUDE_3_5_SONNET,
     'claude-sonnet-4': CLAUDE_SONNET_4,

--- a/py/plugins/anthropic/tests/anthropic_plugin_test.py
+++ b/py/plugins/anthropic/tests/anthropic_plugin_test.py
@@ -152,7 +152,8 @@ async def test_anthropic_runtime_clients_are_loop_local(mock_client_ctor: MagicM
 
 def test_supported_models() -> None:
     """Test that all supported models have proper metadata."""
-    assert len(SUPPORTED_MODELS) == 10
+    assert len(SUPPORTED_MODELS) == 9
+    assert 'claude-3-haiku' not in SUPPORTED_MODELS
     for _name, info in SUPPORTED_MODELS.items():
         assert info.label is not None
         assert info.label.startswith('Anthropic - ')

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/context_caching/constants.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/context_caching/constants.py
@@ -21,7 +21,6 @@ CONTEXT_CACHE_SUPPORTED_MODELS = [
     'gemini-2.0-flash',
     'gemini-2.0-flash-001',
     'gemini-3-flash-preview',
-    'gemini-3-pro-preview',
 ]
 
 INVALID_ARGUMENT_MESSAGES = {

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -789,7 +789,6 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     | `gemini-2.5-pro-preview-03-25`       | Gemini 2.5 Pro Preview 03-25         | Supported    |
     | `gemini-2.5-pro-preview-05-06`       | Gemini 2.5 Pro Preview 05-06         | Supported    |
     | `gemini-3-flash-preview`             | Gemini 3 Flash Preview               | Supported    |
-    | `gemini-3-pro-preview`               | Gemini 3 Pro Preview                 | Supported    |
     | `gemini-2.5-pro`                     | Gemini 2.5 Pro                       | Supported    |
     | `gemini-2.5-flash`                   | Gemini 2.5 Flash                     | Supported    |
     | `gemini-2.5-flash-lite`              | Gemini 2.5 Flash Lite                | Supported    |
@@ -814,7 +813,6 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_2_5_PRO_PREVIEW_03_25 = 'gemini-2.5-pro-preview-03-25'
     GEMINI_2_5_PRO_PREVIEW_05_06 = 'gemini-2.5-pro-preview-05-06'
     GEMINI_3_FLASH_PREVIEW = 'gemini-3-flash-preview'
-    GEMINI_3_PRO_PREVIEW = 'gemini-3-pro-preview'
     GEMINI_2_5_PRO = 'gemini-2.5-pro'
     GEMINI_2_5_FLASH = 'gemini-2.5-flash'
     GEMINI_2_5_FLASH_LITE = 'gemini-2.5-flash-lite'
@@ -849,7 +847,6 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     | `gemini-2.5-pro-preview-03-25`       | Gemini 2.5 Pro Preview 03-25         | Supported  |
     | `gemini-2.5-pro-preview-05-06`       | Gemini 2.5 Pro Preview 05-06         | Supported  |
     | `gemini-3-flash-preview`             | Gemini 3 Flash Preview               | Supported  |
-    | `gemini-3-pro-preview`               | Gemini 3 Pro Preview                 | Supported  |
     | `gemini-2.5-pro`                     | Gemini 2.5 Pro                       | Supported  |
     | `gemini-2.5-flash`                   | Gemini 2.5 Flash                     | Supported  |
     | `gemini-2.5-flash-lite`              | Gemini 2.5 Flash Lite                | Supported  |
@@ -874,7 +871,6 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_2_5_PRO_PREVIEW_03_25 = 'gemini-2.5-pro-preview-03-25'
     GEMINI_2_5_PRO_PREVIEW_05_06 = 'gemini-2.5-pro-preview-05-06'
     GEMINI_3_FLASH_PREVIEW = 'gemini-3-flash-preview'
-    GEMINI_3_PRO_PREVIEW = 'gemini-3-pro-preview'
     GEMINI_2_5_PRO = 'gemini-2.5-pro'
     GEMINI_2_5_FLASH = 'gemini-2.5-flash'
     GEMINI_2_5_FLASH_LITE = 'gemini-2.5-flash-lite'


### PR DESCRIPTION
## Context

The following models are deprecated and should be removed from 'supported' or 'known' models. All deprecations are P0.

- gemini-3-pro-preview (GoogleAI): Shutdown Date March 9, 2026.
- claude-3-haiku@20240307 (Vertex Model Garden): Shutdown Date August 23, 2026.

## Summary


- Removes deprecated gemini-3-pro-preview from Python Google GenAI known/supported model surfaces.
- Removes deprecated Claude 3 Haiku (claude-3-haiku-20240307 / claude-3-haiku) from Python known model maps.
- Updates affected tests to reflect the reduced supported-model set.

## Checklist
[x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
[x] Tested (manually, unit tested, etc.)
[x] Docs updated (updated docs or a docs bug required)