### PR TITLE
fix(go): remove gemini-3-pro-preview and claude-3-haiku@20240307

### DIFF
--- a/go/plugins/googlegenai/README.md
+++ b/go/plugins/googlegenai/README.md
@@ -83,7 +83,7 @@ Genkit automatically discovers available models supported by the [Go GenAI SDK](
 
 Commonly used models include:
 
-- **Gemini Series**: `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-flash`, `gemini-2.5-pro`
+- **Gemini Series**: `gemini-3-flash-preview`, `gemini-2.5-flash`, `gemini-2.5-pro`
 - **Imagen Series**: `imagen-3.0-generate-001`
 - **Veo Series**: `veo-3.0-generate-001`
 

--- a/go/plugins/googlegenai/googleai_live_test.go
+++ b/go/plugins/googlegenai/googleai_live_test.go
@@ -581,7 +581,7 @@ func TestGoogleAILive(t *testing.T) {
 		}
 	})
 	t.Run("multipart tool", func(t *testing.T) {
-		m := googlegenai.GoogleAIModel(g, "gemini-3-pro-preview")
+		m := googlegenai.GoogleAIModel(g, "gemini-2.5-pro")
 		img64, err := fetchImgAsBase64()
 		if err != nil {
 			t.Fatal(err)

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -107,6 +107,10 @@ const (
 )
 
 var (
+	deprecatedGenAIModels = map[string]struct{}{
+		"gemini-3-pro-preview": {},
+	}
+
 	// eventually, Vertex AI and Google AI models will match, in the meantime,
 	// keep them sepparated
 	vertexAIModels = []string{
@@ -373,6 +377,9 @@ func listGenaiModels(ctx context.Context, client *genai.Client) (genaiModels, er
 
 		name := strings.TrimPrefix(item.Name, "publishers/google/")
 		name = strings.TrimPrefix(name, "models/")
+		if isDeprecatedGenAIModel(name) {
+			continue
+		}
 
 		// The Vertex AI backend does not populate SupportedActions,
 		// so we fall back to name-based categorization.
@@ -398,4 +405,9 @@ func listGenaiModels(ctx context.Context, client *genai.Client) (genaiModels, er
 	}
 
 	return models, nil
+}
+
+func isDeprecatedGenAIModel(name string) bool {
+	_, ok := deprecatedGenAIModels[name]
+	return ok
 }

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -37,10 +37,6 @@ var AnthropicModels = map[string]ai.ModelOptions{
 		Label:    "Claude 3 Sonnet",
 		Supports: &internal.Multimodal,
 	},
-	"claude-3-haiku@20240307": {
-		Label:    "Claude 3 Haiku",
-		Supports: &internal.Multimodal,
-	},
 	"claude-3-opus@20240229": {
 		Label:    "Claude 3 Opus",
 		Supports: &internal.Multimodal,

--- a/go/samples/multipart-tools/main.go
+++ b/go/samples/multipart-tools/main.go
@@ -46,7 +46,7 @@ func main() {
 	// Define a simple flow that uses the multipart tool
 	genkit.DefineStreamingFlow(g, "cardFlow", func(ctx context.Context, input any, cb ai.ModelStreamCallback) (string, error) {
 		resp, err := genkit.Generate(ctx, g,
-			ai.WithModelName("googleai/gemini-3-pro-preview"),
+			ai.WithModelName("googleai/gemini-2.5-pro"),
 			ai.WithConfig(&genai.GenerateContentConfig{
 				Temperature: genai.Ptr[float32](1.0),
 				ThinkingConfig: &genai.ThinkingConfig{


### PR DESCRIPTION
## Summary
- Remove deprecated model references in Go plugins:
  - `gemini-3-pro-preview` (GoogleAI)
  - `claude-3-haiku@20240307` (Vertex Model Garden)
- Update the affected Go sample and live test to use active model IDs without changing existing workflow logic.
- Keep docs aligned by removing deprecated model mention from the Go Google GenAI README.

## Changes
- `go/plugins/googlegenai/models.go`
  - Filter out deprecated dynamically listed models (`gemini-3-pro-preview`).
- `go/plugins/vertexai/modelgarden/models.go`
  - Remove deprecated Anthropic model entry (`claude-3-haiku@20240307`).
- `go/plugins/googlegenai/googleai_live_test.go`
  - Replace deprecated model usage with `gemini-2.5-pro`.
- `go/samples/multipart-tools/main.go`
  - Replace deprecated model usage with `googleai/gemini-2.5-pro`.
- `go/plugins/googlegenai/README.md`
  - Remove deprecated Gemini model mention.

## Issues
- Follows issue: https://github.com/invertase/genkit-private/issues/101

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)
