### PR TITLE
feat(js): allow middleware generate hook manipulate message/turn index

### DIFF
--- a/js/ai/src/chat.ts
+++ b/js/ai/src/chat.ts
@@ -28,10 +28,12 @@ import {
   type GenerateResponseChunk,
   type GenerateStreamOptions,
   type GenerateStreamResponse,
-  type GenerationCommonConfigSchema,
+} from './generate.js';
+import {
+  GenerationCommonConfigSchema,
   type MessageData,
-  type Part,
-} from './index.js';
+} from './model-types.js';
+import { type Part } from './parts.js';
 import {
   runWithSession,
   type BaseGenerateOptions,

--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -277,6 +277,11 @@ async function generateActionImpl(
     context,
   } = args;
 
+  const format = await resolveFormat(registry, rawRequest.output);
+
+  const sharedPreviousChunks: GenerateResponseChunkData[] = [];
+  const parser = format?.handler(rawRequest.output?.jsonSchema).parseChunk;
+
   if (middleware && middleware.length > 0) {
     const dispatchGenerate = async (
       index: number,
@@ -294,6 +299,7 @@ async function generateActionImpl(
           abortSignal: ctx.abortSignal,
           streamingCallback: ctx.onChunk,
           context: ctx.context,
+          sharedPreviousChunks,
         });
       }
       const currentMiddleware = middleware[index];
@@ -303,14 +309,14 @@ async function generateActionImpl(
               if (c instanceof GenerateResponseChunk) {
                 ctx.onChunk!(c);
               } else {
-                ctx.onChunk!(
-                  new GenerateResponseChunk(c, {
-                    index: c.index !== undefined ? c.index : messageIndex,
-                    role: c.role !== undefined ? c.role : 'model',
-                    previousChunks: [],
-                    parser: undefined,
-                  })
-                );
+                const chunk = new GenerateResponseChunk(c, {
+                  index: c.index !== undefined ? c.index : messageIndex,
+                  role: c.role !== undefined ? c.role : 'model',
+                  previousChunks: sharedPreviousChunks,
+                  parser: parser,
+                });
+                sharedPreviousChunks.push(c); // Accumulate raw data!
+                ctx.onChunk!(chunk);
               }
             }
           : undefined;
@@ -347,7 +353,10 @@ async function generateActionImpl(
       context,
     });
   } else {
-    return generateActionTurn(registry, args);
+    return generateActionTurn(registry, {
+      ...args,
+      sharedPreviousChunks,
+    });
   }
 }
 
@@ -361,6 +370,7 @@ async function generateActionTurn(
     abortSignal,
     streamingCallback,
     context,
+    sharedPreviousChunks,
   }: {
     rawRequest: GenerateActionOptions;
     middleware: GenerateMiddlewareDef[] | undefined;
@@ -369,6 +379,7 @@ async function generateActionTurn(
     abortSignal?: AbortSignal;
     streamingCallback?: StreamingCallback<GenerateResponseChunk>;
     context?: Record<string, any>;
+    sharedPreviousChunks: GenerateResponseChunkData[];
   }
 ): Promise<GenerateResponseData> {
   const { model, tools, resources, format } = await resolveParameters(
@@ -440,20 +451,18 @@ async function generateActionTurn(
     model
   );
 
-  const previousChunks: GenerateResponseChunkData[] = [];
-
   let chunkRole: Role = 'model';
   // convenience method to create a full chunk from role and data, append the chunk
-  // to the previousChunks array, and increment the message index as needed
+  // to the sharedPreviousChunks array, and increment the message index as needed
   const makeChunk = (
     role: Role,
     chunk: GenerateResponseChunkData
   ): GenerateResponseChunk => {
-    if (role !== chunkRole && previousChunks.length) messageIndex++;
+    if (role !== chunkRole && sharedPreviousChunks.length) messageIndex++;
     chunkRole = role;
 
-    const prevToSend = [...previousChunks];
-    previousChunks.push(chunk);
+    const prevToSend = [...sharedPreviousChunks];
+    sharedPreviousChunks.push(chunk);
 
     return new GenerateResponseChunk(chunk, {
       index: messageIndex,

--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -298,9 +298,26 @@ async function generateActionImpl(
       }
       const currentMiddleware = middleware[index];
       if (currentMiddleware.generate) {
+        const wrappedOnChunk = ctx.onChunk
+          ? (c: GenerateResponseChunk | GenerateResponseChunkData) => {
+              if (c instanceof GenerateResponseChunk) {
+                ctx.onChunk!(c);
+              } else {
+                ctx.onChunk!(
+                  new GenerateResponseChunk(c, {
+                    index: c.index !== undefined ? c.index : messageIndex,
+                    role: c.role !== undefined ? c.role : 'model',
+                    previousChunks: [],
+                    parser: undefined,
+                  })
+                );
+              }
+            }
+          : undefined;
+
         return currentMiddleware.generate(
           { request: request, currentTurn, messageIndex },
-          ctx,
+          { ...ctx, onChunk: wrappedOnChunk },
           async (modifiedEnvelope, opts) =>
             dispatchGenerate(
               index + 1,
@@ -326,22 +343,7 @@ async function generateActionImpl(
     };
     return dispatchGenerate(0, rawRequest, currentTurn, messageIndex, {
       abortSignal,
-      onChunk: streamingCallback
-        ? (c) => {
-            if (c instanceof GenerateResponseChunk) {
-              streamingCallback(c);
-            } else {
-              streamingCallback(
-                new GenerateResponseChunk(c, {
-                  index: messageIndex,
-                  role: 'model',
-                  previousChunks: [],
-                  parser: undefined,
-                })
-              );
-            }
-          }
-        : undefined,
+      onChunk: streamingCallback,
       context,
     });
   } else {

--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -312,7 +312,7 @@ async function generateActionImpl(
                 const chunk = new GenerateResponseChunk(c, {
                   index: c.index !== undefined ? c.index : messageIndex,
                   role: c.role !== undefined ? c.role : 'model',
-                  previousChunks: sharedPreviousChunks,
+                  previousChunks: [...sharedPreviousChunks],
                   parser: parser,
                 });
                 sharedPreviousChunks.push(c); // Accumulate raw data!

--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -280,12 +280,14 @@ async function generateActionImpl(
   if (middleware && middleware.length > 0) {
     const dispatchGenerate = async (
       index: number,
-      req: GenerateActionOptions,
+      request: GenerateActionOptions,
+      currentTurn: number,
+      messageIndex: number,
       ctx: ActionRunOptions<any>
     ): Promise<any> => {
       if (index === middleware.length) {
         return generateActionTurn(registry, {
-          rawRequest: req,
+          rawRequest: request,
           middleware,
           currentTurn,
           messageIndex,
@@ -296,16 +298,50 @@ async function generateActionImpl(
       }
       const currentMiddleware = middleware[index];
       if (currentMiddleware.generate) {
-        return currentMiddleware.generate(req, ctx, async (modifiedReq, opts) =>
-          dispatchGenerate(index + 1, modifiedReq || req, opts || ctx)
+        return currentMiddleware.generate(
+          { request: request, currentTurn, messageIndex },
+          ctx,
+          async (modifiedEnvelope, opts) =>
+            dispatchGenerate(
+              index + 1,
+              modifiedEnvelope.request || request,
+              modifiedEnvelope.currentTurn !== undefined
+                ? modifiedEnvelope.currentTurn
+                : currentTurn,
+              modifiedEnvelope.messageIndex !== undefined
+                ? modifiedEnvelope.messageIndex
+                : messageIndex,
+              opts || ctx
+            )
         );
       } else {
-        return dispatchGenerate(index + 1, req, ctx);
+        return dispatchGenerate(
+          index + 1,
+          request,
+          currentTurn,
+          messageIndex,
+          ctx
+        );
       }
     };
-    return dispatchGenerate(0, rawRequest, {
+    return dispatchGenerate(0, rawRequest, currentTurn, messageIndex, {
       abortSignal,
-      onChunk: streamingCallback,
+      onChunk: streamingCallback
+        ? (c) => {
+            if (c instanceof GenerateResponseChunk) {
+              streamingCallback(c);
+            } else {
+              streamingCallback(
+                new GenerateResponseChunk(c, {
+                  index: messageIndex,
+                  role: 'model',
+                  previousChunks: [],
+                  parser: undefined,
+                })
+              );
+            }
+          }
+        : undefined,
       context,
     });
   } else {

--- a/js/ai/src/generate/action.ts
+++ b/js/ai/src/generate/action.ts
@@ -321,11 +321,11 @@ async function generateActionImpl(
           async (modifiedEnvelope, opts) =>
             dispatchGenerate(
               index + 1,
-              modifiedEnvelope.request || request,
-              modifiedEnvelope.currentTurn !== undefined
+              modifiedEnvelope?.request || request,
+              modifiedEnvelope?.currentTurn !== undefined
                 ? modifiedEnvelope.currentTurn
                 : currentTurn,
-              modifiedEnvelope.messageIndex !== undefined
+              modifiedEnvelope?.messageIndex !== undefined
                 ? modifiedEnvelope.messageIndex
                 : messageIndex,
               opts || ctx

--- a/js/ai/src/generate/middleware.ts
+++ b/js/ai/src/generate/middleware.ts
@@ -22,6 +22,7 @@ import type { GenerateActionOptions } from '../model-types.js';
 import { type MiddlewareRef } from '../model-types.js';
 import {
   GenerateRequest,
+  GenerateResponseChunkData,
   GenerateResponseData,
   ToolRequestPart,
   ToolResponsePart,
@@ -98,11 +99,19 @@ export interface GenerateMiddlewareDef {
    * Can be used to inject request parameters, modify the response, or catch errors.
    */
   generate?: (
-    req: GenerateActionOptions,
-    ctx: ActionRunOptions<any>,
+    envelope: {
+      request: GenerateActionOptions;
+      currentTurn: number;
+      messageIndex: number;
+    },
+    ctx: ActionRunOptions<GenerateResponseChunkData>,
     next: (
-      req: GenerateActionOptions,
-      ctx: ActionRunOptions<any>
+      envelope: {
+        request: GenerateActionOptions;
+        currentTurn: number;
+        messageIndex: number;
+      },
+      ctx: ActionRunOptions<GenerateResponseChunkData>
     ) => Promise<GenerateResponseData>
   ) => Promise<GenerateResponseData>;
   /**
@@ -111,10 +120,10 @@ export interface GenerateMiddlewareDef {
    */
   model?: (
     req: GenerateRequest<any>,
-    ctx: ActionRunOptions<any>,
+    ctx: ActionRunOptions<GenerateResponseChunkData>,
     next: (
       req: GenerateRequest<any>,
-      ctx: ActionRunOptions<any>
+      ctx: ActionRunOptions<GenerateResponseChunkData>
     ) => Promise<GenerateResponseData>
   ) => Promise<GenerateResponseData>;
   /**

--- a/js/ai/tests/generate/middleware_test.ts
+++ b/js/ai/tests/generate/middleware_test.ts
@@ -19,7 +19,11 @@ import { initNodeFeatures } from '@genkit-ai/core/node';
 import { Registry } from '@genkit-ai/core/registry';
 import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
-import { generate, generateStream } from '../../src/generate.js';
+import {
+  GenerateResponseChunk,
+  generate,
+  generateStream,
+} from '../../src/generate.js';
 import {
   GenerateMiddlewareDef,
   generateMiddleware,
@@ -1059,6 +1063,63 @@ describe('generateMiddleware', () => {
       rawChunk.previousChunks,
       [],
       'Should have empty previousChunks'
+    );
+  });
+
+  it('accumulates middleware chunks into sharedPreviousChunks for subsequent model chunks', async () => {
+    const mockStreamingModel = defineModel(
+      registry,
+      { name: 'mockStreamingModel' },
+      async (req, streamingCallback) => {
+        if (streamingCallback) {
+          // The model emits a chunk
+          streamingCallback({ content: [{ text: 'model chunk' }] });
+        }
+        return {
+          message: { role: 'model', content: [{ text: 'done' }] },
+        };
+      }
+    );
+
+    const rawChunkMiddleware = generateMiddleware(
+      { name: 'rawChunk2' },
+      () => ({
+        generate: async (envelope, ctx, next) => {
+          if (ctx.onChunk) {
+            // Middleware emits a raw chunk BEFORE the model runs
+            ctx.onChunk({ content: [{ text: 'middleware chunk ' }] } as any);
+          }
+          return next(envelope, ctx);
+        },
+      })
+    );
+
+    const chunks: GenerateResponseChunk[] = [];
+    const { stream, response } = generateStream(registry, {
+      model: mockStreamingModel,
+      prompt: 'test',
+      use: [rawChunkMiddleware()],
+    });
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+    await response;
+
+    // We expect 2 chunks in the stream
+    assert.strictEqual(chunks.length, 2);
+    assert.strictEqual(chunks[0].text, 'middleware chunk ');
+    assert.strictEqual(chunks[1].text, 'model chunk');
+
+    // CRITICAL ASSERTION: The model chunk should have the middleware chunk in its previousChunks!
+    assert.strictEqual(chunks[1].previousChunks!.length, 1);
+    assert.strictEqual(
+      chunks[1].previousChunks![0].content[0].text,
+      'middleware chunk '
+    );
+    assert.strictEqual(
+      chunks[1].accumulatedText,
+      'middleware chunk model chunk'
     );
   });
 });

--- a/js/ai/tests/generate/middleware_test.ts
+++ b/js/ai/tests/generate/middleware_test.ts
@@ -387,7 +387,7 @@ describe('generateMiddleware', () => {
               ...ctx,
               onChunk: (chunk) => {
                 chunkIntercepts.push(`model_mw: ${chunk.content[0].text}`);
-                chunk.content[0].text = chunk.content[0].text.toUpperCase();
+                chunk.content[0].text = chunk.content[0].text?.toUpperCase();
                 originalOnChunk(chunk);
               },
             };
@@ -811,7 +811,7 @@ describe('generateMiddleware', () => {
     const testMiddleware = generateMiddleware({ name: 'testMw' }, () => ({
       generate: async (req, ctx, next) => {
         generateMiddlewareCallCount++;
-        const lastMsg = req.messages[req.messages.length - 1];
+        const lastMsg = req.request.messages[req.request.messages.length - 1];
         if (lastMsg?.role === 'tool') {
           seenToolResponseInGenerate = true;
         }
@@ -961,5 +961,104 @@ describe('generateMiddleware', () => {
       m.content.some((c) => c.toolResponse)
     );
     assert.ok(!hasToolResponse, 'Should not contain any tool response');
+  });
+
+  it('passes and respects envelope updates in generate middleware', async () => {
+    let receivedIndex = -1;
+    let receivedTurn = -1;
+
+    const mockModel = defineModel(
+      registry,
+      { name: 'mockModel' },
+      async () => ({
+        message: { role: 'model', content: [{ text: 'done' }] },
+      })
+    );
+
+    const testMiddleware = generateMiddleware({ name: 'test' }, () => ({
+      generate: async (envelope, ctx, next) => {
+        receivedIndex = envelope.messageIndex;
+        receivedTurn = envelope.currentTurn;
+        // Increment messageIndex by 5 and currentTurn by 2
+        return next(
+          {
+            ...envelope,
+            messageIndex: envelope.messageIndex + 5,
+            currentTurn: envelope.currentTurn + 2,
+          },
+          ctx
+        );
+      },
+    }));
+
+    let checkIndex = -1;
+    let checkTurn = -1;
+    const checkerMiddleware = generateMiddleware({ name: 'checker' }, () => ({
+      generate: async (envelope, ctx, next) => {
+        checkIndex = envelope.messageIndex;
+        checkTurn = envelope.currentTurn;
+        return next(envelope, ctx);
+      },
+    }));
+
+    await generate(registry, {
+      model: mockModel,
+      prompt: 'hi',
+      use: [testMiddleware(), checkerMiddleware()],
+    });
+
+    assert.strictEqual(receivedIndex, 0, 'Initial messageIndex should be 0');
+    assert.strictEqual(receivedTurn, 0, 'Initial currentTurn should be 0');
+    assert.strictEqual(
+      checkIndex,
+      5,
+      'Checker should see incremented messageIndex'
+    );
+    assert.strictEqual(
+      checkTurn,
+      2,
+      'Checker should see incremented currentTurn'
+    );
+  });
+
+  it('wraps raw chunks from middleware in GenerateResponseChunk', async () => {
+    const mockModel = defineModel(
+      registry,
+      { name: 'mockModel' },
+      async () => ({
+        message: { role: 'model', content: [{ text: 'done' }] },
+      })
+    );
+
+    const rawChunkMiddleware = generateMiddleware({ name: 'rawChunk' }, () => ({
+      generate: async (envelope, ctx, next) => {
+        if (ctx.onChunk) {
+          // Send a raw object instead of GenerateResponseChunk
+          ctx.onChunk({ content: [{ text: 'raw content' }] } as any);
+        }
+        return next(envelope, ctx);
+      },
+    }));
+
+    const chunks: any[] = [];
+    const { stream, response } = generateStream(registry, {
+      model: mockModel,
+      prompt: 'test',
+      use: [rawChunkMiddleware()],
+    });
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+    await response;
+
+    const rawChunk = chunks.find((c) => c.text === 'raw content');
+    assert.ok(rawChunk, 'Should find the raw content chunk');
+    assert.strictEqual(rawChunk.index, 0, 'Should have index 0');
+    assert.deepStrictEqual(
+      rawChunk.previousChunks,
+      [],
+      'Should have empty previousChunks'
+    );
   });
 });

--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -175,19 +175,18 @@ export type Action<
   I extends z.ZodTypeAny = z.ZodTypeAny,
   O extends z.ZodTypeAny = z.ZodTypeAny,
   S extends z.ZodTypeAny = z.ZodTypeAny,
-  RunOptions extends ActionRunOptions<S> = ActionRunOptions<S>,
+  RunOptions extends ActionRunOptions<z.infer<S>> = ActionRunOptions<
+    z.infer<S>
+  >,
 > = ((input?: z.infer<I>, options?: RunOptions) => Promise<z.infer<O>>) & {
   __action: ActionMetadata<I, O, S>;
   __registry?: Registry;
   run(
     input?: z.infer<I>,
-    options?: ActionRunOptions<z.infer<S>>
+    options?: RunOptions
   ): Promise<ActionResult<z.infer<O>>>;
 
-  stream(
-    input?: z.infer<I>,
-    opts?: ActionRunOptions<z.infer<S>>
-  ): StreamingResponse<O, S>;
+  stream(input?: z.infer<I>, opts?: RunOptions): StreamingResponse<O, S>;
 };
 
 /**

--- a/js/plugins/middleware/package.json
+++ b/js/plugins/middleware/package.json
@@ -10,7 +10,7 @@
     "genai",
     "generative-ai"
   ],
-  "version": "0.5.0-rc.0",
+  "version": "0.5.0-rc.1",
   "type": "commonjs",
   "scripts": {
     "check": "tsc",

--- a/js/plugins/middleware/src/fallback.ts
+++ b/js/plugins/middleware/src/fallback.ts
@@ -121,7 +121,11 @@ export const fallback: GenerateMiddleware<typeof FallbackOptionsSchema> =
                         ? normalizedModel.config
                         : (normalizedModel.config ?? req.config),
                     },
-                    ctx
+                    {
+                      context: ctx.context,
+                      abortSignal: ctx.abortSignal,
+                      onChunk: ctx.onChunk,
+                    }
                   );
                 } catch (e2) {
                   lastError = e2;

--- a/js/plugins/middleware/src/fallback.ts
+++ b/js/plugins/middleware/src/fallback.ts
@@ -121,11 +121,7 @@ export const fallback: GenerateMiddleware<typeof FallbackOptionsSchema> =
                         ? normalizedModel.config
                         : (normalizedModel.config ?? req.config),
                     },
-                    {
-                      context: ctx.context,
-                      abortSignal: ctx.abortSignal,
-                      onChunk: ctx.onChunk,
-                    }
+                    ctx
                   );
                 } catch (e2) {
                   lastError = e2;

--- a/js/plugins/middleware/src/filesystem.ts
+++ b/js/plugins/middleware/src/filesystem.ts
@@ -134,12 +134,23 @@ export const filesystem: GenerateMiddleware<typeof FilesystemOptionsSchema> =
             throw e;
           }
         },
-        generate: async (req, ctx, next) => {
+        generate: async (envelope, ctx, next) => {
+          const { request } = envelope;
+          let { messageIndex } = envelope;
           if (messageQueue.length > 0) {
-            req.messages.push(...messageQueue);
+            if (ctx.onChunk) {
+              for (const msg of messageQueue) {
+                ctx.onChunk({
+                  role: msg.role,
+                  index: messageIndex++,
+                  content: msg.content,
+                });
+              }
+            }
+            request.messages.push(...messageQueue);
             messageQueue.length = 0;
           }
-          return await next(req, ctx);
+          return await next({ ...envelope, request, messageIndex }, ctx);
         },
       };
     }

--- a/js/plugins/middleware/src/filesystem/read_file.ts
+++ b/js/plugins/middleware/src/filesystem/read_file.ts
@@ -25,9 +25,10 @@ export function defineReadFileTool(
   resolvePath: (requestedPath: string) => string,
   prefix?: string
 ): ToolAction {
+  const toolName = `${prefix || ''}read_file`;
   return tool(
     {
-      name: `${prefix || ''}read_file`,
+      name: toolName,
       description: 'Reads the contents of a file',
       inputSchema: z.object({
         filePath: z.string().describe('File path relative to root.'),
@@ -59,6 +60,10 @@ export function defineReadFileTool(
         const content = await fs.readFile(targetFile, 'utf8');
         parts.push({
           text: `<read_file path="${input.filePath}">\n${content}\n</read_file>`,
+          metadata: {
+            filePath: input.filePath,
+            filesystemMiddlewareTool: toolName,
+          },
         });
       }
 
@@ -68,7 +73,13 @@ export function defineReadFileTool(
       ) {
         messageQueue[messageQueue.length - 1].content.push(...parts);
       } else {
-        messageQueue.push({ role: 'user', content: parts });
+        messageQueue.push({
+          role: 'user',
+          content: parts,
+          metadata: {
+            filesystemMiddlewareTool: toolName,
+          },
+        });
       }
 
       return `File ${input.filePath} read successfully, see contents below`;

--- a/js/plugins/middleware/src/skills.ts
+++ b/js/plugins/middleware/src/skills.ts
@@ -137,9 +137,10 @@ export const skills: GenerateMiddleware<typeof SkillsOptionsSchema> =
 
       return {
         tools: [useSkillTool],
-        generate: async (req, ctx, next) => {
+        generate: async (envelope, ctx, next) => {
+          const { request } = envelope;
           await ensureSkillsScanned();
-          if (skillCache.size === 0) return next(req, ctx);
+          if (skillCache.size === 0) return next(envelope, ctx);
 
           const skillsList = Array.from(skillCache.entries())
             .map(([name, info]) => {
@@ -159,7 +160,7 @@ export const skills: GenerateMiddleware<typeof SkillsOptionsSchema> =
             `${skillsList}\n` +
             `</skills>`;
 
-          const messages = [...req.messages];
+          const messages = [...request.messages];
           let injectedPart: any | undefined;
           let injectedMsgIndex = -1;
           let injectedPartIndex = -1;
@@ -218,7 +219,7 @@ export const skills: GenerateMiddleware<typeof SkillsOptionsSchema> =
             }
           }
 
-          return next({ ...req, messages }, ctx);
+          return next({ ...envelope, request: { ...request, messages } }, ctx);
         },
       };
     }

--- a/js/plugins/middleware/tests/filesystem_test.ts
+++ b/js/plugins/middleware/tests/filesystem_test.ts
@@ -43,17 +43,26 @@ describe('filesystem middleware', () => {
     let turn = 0;
     return ai.defineModel(
       { name: `pm-${toolName}-${Math.random()}` },
-      async () => {
+      async (_, sendChunk) => {
         turn++;
         if (turn === 1) {
+          const content = [{ toolRequest: { name: toolName, input } }];
+          if (sendChunk) {
+            sendChunk({ content });
+          }
+
           return {
             message: {
               role: 'model',
-              content: [{ toolRequest: { name: toolName, input } }],
+              content,
             },
           };
         }
-        return { message: { role: 'model', content: [{ text: 'done' }] } };
+        const content = [{ text: 'done' }];
+        if (sendChunk) {
+          sendChunk({ content });
+        }
+        return { message: { role: 'model', content } };
       }
     );
   }
@@ -242,6 +251,48 @@ describe('filesystem middleware', () => {
       );
       assert.ok(userMsg);
       assert.ok(userMsg.content[0].text.includes('sub file'));
+    });
+
+    it('streams file contents when reading a file', async () => {
+      const ai = genkit({});
+      const pm = createToolModel(ai, 'read_file', { filePath: 'file1.txt' });
+
+      const { stream, response } = ai.generateStream({
+        model: pm,
+        prompt: 'test',
+        use: [filesystem({ rootDirectory: tempDir })],
+      });
+
+      const chunks: any[] = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      await response;
+
+      const indices = chunks.map((c) => c.index);
+      const uniqueIndices = [...new Set(indices)];
+
+      // We expect indices 0, 1, 2, 3
+      // 0: Model tool request
+      // 1: Tool response string
+      // 2: Injected file content <--- IMPORTANT
+      // 3: Final model response
+      assert.deepStrictEqual(
+        uniqueIndices,
+        [0, 1, 2, 3],
+        'Should have sequential message indices'
+      );
+
+      const fileContentChunk = chunks.find(
+        (c) => c.text && c.text.includes('hello world')
+      );
+      assert.ok(fileContentChunk, 'Stream should contain file content');
+      assert.strictEqual(
+        fileContentChunk.index,
+        2,
+        'File content should have index 2'
+      );
     });
 
     it('rejects reading outside root directory', async () => {


### PR DESCRIPTION
## Summary
This PR refactors the Genkit generate middleware API to allow hooks to observe and modify execution state (turn and message indices). This was necessary to fix a bug in the `filesystem` middleware where injected file contents were not being streamed to the user with correct sequence indices.
Additionally, this PR includes a fix for a broken `RunOptions` signature in the `Action` type in `js/core/src/action.ts`.
## Changes Made
### Core Framework (`js/ai`)
- **Middleware API Refactor**: Updated the `generate` hook in `GenerateMiddlewareDef` to receive an envelope containing `{ request, currentTurn, messageIndex }` instead of just the request object. This allows middleware to update indices when injecting messages.
- **Generate Action Loop**: Updated `generateActionImpl` to pass this envelope down the chain and respect updates to `currentTurn` and `messageIndex`.
- **Chunk Wrapping**: Added logic to automatically wrap raw data streamed by middleware into `GenerateResponseChunk` objects with safe defaults (`previousChunks: []`, `parser: undefined`) to avoid runtime errors.
### Plugins (`js/plugins/middleware`)
- **Filesystem Middleware**: Updated to use the new envelope API. It now correctly streams file contents injected by the `read_file` tool to the user's output stream using the correct sequential `messageIndex`.
- **Skills Middleware**: Updated to match the new envelope signature (pass-through).
### Core (`js/core`)
- **Action Type Fix**: Fixed broken `RunOptions` signature in the `Action` type in `js/core/src/action.ts`.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
