### PR TITLE
fix(js/core): Fix DAP resolution

### DIFF
--- a/js/core/src/registry.ts
+++ b/js/core/src/registry.ts
@@ -197,7 +197,7 @@ export class Registry {
     const parsedKey = parseRegistryKey(key);
     if (parsedKey?.dynamicActionHost) {
       const hostId = `/dynamic-action-provider/${parsedKey.dynamicActionHost}`;
-      const dap = await this.actionsById[hostId];
+      const dap = await this.lookupAction(hostId);
       if (!dap || !isDynamicActionProvider(dap)) {
         return [];
       }

--- a/js/core/tests/registry_test.ts
+++ b/js/core/tests/registry_test.ts
@@ -634,4 +634,25 @@ describe('registry class', () => {
       );
     });
   });
+
+  describe('resolveActionNames', () => {
+    it('resolves dynamic actions from parent registry', async () => {
+      const tool1 = action(
+        { name: 'fs/tool1', actionType: 'tool' },
+        async () => {}
+      );
+      defineDynamicActionProvider(registry, 'my-dap', async () => ({
+        tool: [tool1],
+      }));
+
+      const childRegistry = new Registry(registry);
+
+      const resolved = await childRegistry.resolveActionNames(
+        '/dynamic-action-provider/my-dap:tool/fs/tool1'
+      );
+      assert.deepStrictEqual(resolved, [
+        '/dynamic-action-provider/my-dap:tool/fs/tool1',
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Previously it would look in the current registry and that was where everything happened to be registered. But now there is a child registry instead and the DAP resolution now looks in the parent chain as well.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
