### PR TITLE
chore(go): deprecate gemini-3-pro-preview and claude-3-haiku@20240307

### DIFF
--- a/go/plugins/googlegenai/README.md
+++ b/go/plugins/googlegenai/README.md
@@ -83,7 +83,7 @@ Genkit automatically discovers available models supported by the [Go GenAI SDK](
 
 Commonly used models include:
 
-- **Gemini Series**: `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-flash`, `gemini-2.5-pro`
+- **Gemini Series**: `gemini-3-flash-preview`, `gemini-2.5-flash`, `gemini-2.5-pro`
 - **Imagen Series**: `imagen-3.0-generate-001`
 - **Veo Series**: `veo-3.0-generate-001`
 

--- a/go/plugins/googlegenai/googleai_live_test.go
+++ b/go/plugins/googlegenai/googleai_live_test.go
@@ -581,7 +581,7 @@ func TestGoogleAILive(t *testing.T) {
 		}
 	})
 	t.Run("multipart tool", func(t *testing.T) {
-		m := googlegenai.GoogleAIModel(g, "gemini-3-pro-preview")
+		m := googlegenai.GoogleAIModel(g, "gemini-2.5-pro")
 		img64, err := fetchImgAsBase64()
 		if err != nil {
 			t.Fatal(err)

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -107,6 +107,13 @@ const (
 )
 
 var (
+	// deprecatedGenAIModels are filtered out of dynamic discovery so they
+	// are not registered as callable actions. This guards against the provider
+	// still returning a post-shutdown model from the list API.
+	deprecatedGenAIModels = map[string]struct{}{
+		"gemini-3-pro-preview": {},
+	}
+
 	// eventually, Vertex AI and Google AI models will match, in the meantime,
 	// keep them sepparated
 	vertexAIModels = []string{
@@ -373,6 +380,9 @@ func listGenaiModels(ctx context.Context, client *genai.Client) (genaiModels, er
 
 		name := strings.TrimPrefix(item.Name, "publishers/google/")
 		name = strings.TrimPrefix(name, "models/")
+		if isDeprecatedGenAIModel(name) {
+			continue
+		}
 
 		// The Vertex AI backend does not populate SupportedActions,
 		// so we fall back to name-based categorization.
@@ -398,4 +408,9 @@ func listGenaiModels(ctx context.Context, client *genai.Client) (genaiModels, er
 	}
 
 	return models, nil
+}
+
+func isDeprecatedGenAIModel(name string) bool {
+	_, ok := deprecatedGenAIModels[name]
+	return ok
 }

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -380,32 +380,39 @@ func listGenaiModels(ctx context.Context, client *genai.Client) (genaiModels, er
 
 		name := strings.TrimPrefix(item.Name, "publishers/google/")
 		name = strings.TrimPrefix(name, "models/")
-		if _, ok := deprecatedGenAIModels[name]; ok {
-			continue
-		}
-
-		// The Vertex AI backend does not populate SupportedActions,
-		// so we fall back to name-based categorization.
-		if slices.Contains(item.SupportedActions, "embedContent") || strings.Contains(name, "embed") {
-			models.embedders = append(models.embedders, name)
-			continue
-		}
-
-		if strings.Contains(name, "imagen") {
-			models.imagen = append(models.imagen, name)
-			continue
-		}
-
-		if strings.Contains(name, "veo") {
-			models.veo = append(models.veo, name)
-			continue
-		}
-
-		// Only include models with known generative prefixes.
-		if strings.HasPrefix(name, "gemini") || strings.HasPrefix(name, "gemma") {
-			models.gemini = append(models.gemini, name)
-		}
+		categorizeModel(&models, name, item.SupportedActions)
 	}
 
 	return models, nil
+}
+
+// categorizeModel routes a discovered model name into the appropriate bucket
+// of m. It returns true if the name was placed and false if the model was
+// filtered out or did not match any known prefix.
+//
+// supportedActions is the list of API actions advertised by the provider for
+// this model. The Vertex AI backend does not populate it, so name-based
+// matching is used as a fallback.
+func categorizeModel(m *genaiModels, name string, supportedActions []string) bool {
+	if _, ok := deprecatedGenAIModels[name]; ok {
+		return false
+	}
+
+	if slices.Contains(supportedActions, "embedContent") || strings.Contains(name, "embed") {
+		m.embedders = append(m.embedders, name)
+		return true
+	}
+	if strings.Contains(name, "imagen") {
+		m.imagen = append(m.imagen, name)
+		return true
+	}
+	if strings.Contains(name, "veo") {
+		m.veo = append(m.veo, name)
+		return true
+	}
+	if strings.HasPrefix(name, "gemini") || strings.HasPrefix(name, "gemma") {
+		m.gemini = append(m.gemini, name)
+		return true
+	}
+	return false
 }

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -380,7 +380,7 @@ func listGenaiModels(ctx context.Context, client *genai.Client) (genaiModels, er
 
 		name := strings.TrimPrefix(item.Name, "publishers/google/")
 		name = strings.TrimPrefix(name, "models/")
-		if isDeprecatedGenAIModel(name) {
+		if _, ok := deprecatedGenAIModels[name]; ok {
 			continue
 		}
 
@@ -408,9 +408,4 @@ func listGenaiModels(ctx context.Context, client *genai.Client) (genaiModels, er
 	}
 
 	return models, nil
-}
-
-func isDeprecatedGenAIModel(name string) bool {
-	_, ok := deprecatedGenAIModels[name]
-	return ok
 }

--- a/go/plugins/googlegenai/models_test.go
+++ b/go/plugins/googlegenai/models_test.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package googlegenai
+
+import "testing"
+
+func TestIsDeprecatedGenAIModel(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"gemini-3-pro-preview", true},
+		{"gemini-2.5-pro", false},
+		{"gemini-2.5-flash", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDeprecatedGenAIModel(tc.name); got != tc.want {
+				t.Errorf("isDeprecatedGenAIModel(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/plugins/googlegenai/models_test.go
+++ b/go/plugins/googlegenai/models_test.go
@@ -18,7 +18,7 @@ package googlegenai
 
 import "testing"
 
-func TestIsDeprecatedGenAIModel(t *testing.T) {
+func TestDeprecatedGenAIModels(t *testing.T) {
 	tests := []struct {
 		name string
 		want bool
@@ -30,8 +30,9 @@ func TestIsDeprecatedGenAIModel(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isDeprecatedGenAIModel(tc.name); got != tc.want {
-				t.Errorf("isDeprecatedGenAIModel(%q) = %v, want %v", tc.name, got, tc.want)
+			_, got := deprecatedGenAIModels[tc.name]
+			if got != tc.want {
+				t.Errorf("deprecatedGenAIModels[%q] presence = %v, want %v", tc.name, got, tc.want)
 			}
 		})
 	}

--- a/go/plugins/googlegenai/models_test.go
+++ b/go/plugins/googlegenai/models_test.go
@@ -16,24 +16,102 @@
 
 package googlegenai
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
-func TestDeprecatedGenAIModels(t *testing.T) {
+func TestCategorizeModel(t *testing.T) {
 	tests := []struct {
-		name string
-		want bool
+		name             string
+		modelName        string
+		supportedActions []string
+		wantPlaced       bool
+		// pickBucket returns the slice that should have received modelName.
+		// nil means "no bucket should have received it."
+		pickBucket func(*genaiModels) []string
 	}{
-		{"gemini-3-pro-preview", true},
-		{"gemini-2.5-pro", false},
-		{"gemini-2.5-flash", false},
-		{"", false},
+		{
+			name:       "deprecated model is filtered out",
+			modelName:  "gemini-3-pro-preview",
+			wantPlaced: false,
+			pickBucket: nil,
+		},
+		{
+			name:             "embedder via supportedActions",
+			modelName:        "text-embedding-004",
+			supportedActions: []string{"embedContent"},
+			wantPlaced:       true,
+			pickBucket:       func(m *genaiModels) []string { return m.embedders },
+		},
+		{
+			name:       "embedder via name fallback",
+			modelName:  "text-embedding-005",
+			wantPlaced: true,
+			pickBucket: func(m *genaiModels) []string { return m.embedders },
+		},
+		{
+			name:       "imagen routed to imagen bucket",
+			modelName:  "imagen-3.0-generate-001",
+			wantPlaced: true,
+			pickBucket: func(m *genaiModels) []string { return m.imagen },
+		},
+		{
+			name:       "veo routed to veo bucket",
+			modelName:  "veo-3.0-generate-001",
+			wantPlaced: true,
+			pickBucket: func(m *genaiModels) []string { return m.veo },
+		},
+		{
+			name:       "gemini routed to gemini bucket",
+			modelName:  "gemini-2.5-pro",
+			wantPlaced: true,
+			pickBucket: func(m *genaiModels) []string { return m.gemini },
+		},
+		{
+			name:       "gemma routed to gemini bucket",
+			modelName:  "gemma-2",
+			wantPlaced: true,
+			pickBucket: func(m *genaiModels) []string { return m.gemini },
+		},
+		{
+			name:       "unknown prefix is skipped",
+			modelName:  "totally-unrelated-model",
+			wantPlaced: false,
+			pickBucket: nil,
+		},
 	}
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, got := deprecatedGenAIModels[tc.name]
-			if got != tc.want {
-				t.Errorf("deprecatedGenAIModels[%q] presence = %v, want %v", tc.name, got, tc.want)
+			var m genaiModels
+			got := categorizeModel(&m, tc.modelName, tc.supportedActions)
+			if got != tc.wantPlaced {
+				t.Fatalf("categorizeModel placed=%v, want %v", got, tc.wantPlaced)
+			}
+			if tc.pickBucket == nil {
+				return
+			}
+			bucket := tc.pickBucket(&m)
+			if !slices.Contains(bucket, tc.modelName) {
+				t.Errorf("expected %q in bucket, got %v", tc.modelName, bucket)
 			}
 		})
+	}
+}
+
+func TestListGenaiModelsFiltersDeprecated(t *testing.T) {
+	// Drives the same categorization the live loop would, without touching
+	// the SDK. Proves a deprecated name dropped at categorization time never
+	// reaches any bucket — which is the contract listGenaiModels relies on.
+	var m genaiModels
+	categorizeModel(&m, "gemini-3-pro-preview", nil)
+	categorizeModel(&m, "gemini-2.5-pro", nil)
+
+	if slices.Contains(m.gemini, "gemini-3-pro-preview") {
+		t.Errorf("deprecated model leaked into gemini bucket: %v", m.gemini)
+	}
+	if !slices.Contains(m.gemini, "gemini-2.5-pro") {
+		t.Errorf("expected gemini-2.5-pro in bucket, got %v", m.gemini)
 	}
 }

--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -55,6 +55,7 @@ func DefineModel(client anthropic.Client, provider, name string, info ai.ModelOp
 		Supports:     info.Supports,
 		Versions:     info.Versions,
 		ConfigSchema: configSchema,
+		Stage:        info.Stage,
 	}
 
 	return ai.NewModel(api.NewName(provider, name), meta, func(

--- a/go/plugins/internal/anthropic/anthropic_test.go
+++ b/go/plugins/internal/anthropic/anthropic_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -424,6 +425,43 @@ func TestToAnthropicRequest_StructuredOutput(t *testing.T) {
 
 	if diff := cmp.Diff(wantSchema, got.OutputConfig.Format.Schema); diff != "" {
 		t.Errorf("OutputConfig schema mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDefineModel_PropagatesStage(t *testing.T) {
+	tests := []struct {
+		name  string
+		stage ai.ModelStage
+	}{
+		{"deprecated", ai.ModelStageDeprecated},
+		{"unstable", ai.ModelStageUnstable},
+		{"unset", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := DefineModel(anthropic.Client{}, "anthropic", "claude-3-haiku@20240307", ai.ModelOptions{
+				Label: "test",
+				Stage: tt.stage,
+			})
+
+			desc, ok := m.(interface{ Desc() api.ActionDesc })
+			if !ok {
+				t.Fatalf("Model does not expose Desc(); cannot read action metadata")
+			}
+
+			modelMeta, ok := desc.Desc().Metadata["model"].(map[string]any)
+			if !ok {
+				t.Fatalf("metadata[\"model\"] not a map[string]any: %T", desc.Desc().Metadata["model"])
+			}
+			got, ok := modelMeta["stage"].(ai.ModelStage)
+			if !ok {
+				t.Fatalf("metadata[\"model\"][\"stage\"] not ai.ModelStage: %T", modelMeta["stage"])
+			}
+			if got != tt.stage {
+				t.Errorf("stage = %q, want %q", got, tt.stage)
+			}
+		})
 	}
 }
 

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -40,6 +40,7 @@ var AnthropicModels = map[string]ai.ModelOptions{
 	"claude-3-haiku@20240307": {
 		Label:    "Claude 3 Haiku",
 		Supports: &internal.Multimodal,
+		Stage:    ai.ModelStageDeprecated,
 	},
 	"claude-3-opus@20240229": {
 		Label:    "Claude 3 Opus",

--- a/go/samples/multipart-tools/main.go
+++ b/go/samples/multipart-tools/main.go
@@ -46,7 +46,7 @@ func main() {
 	// Define a simple flow that uses the multipart tool
 	genkit.DefineStreamingFlow(g, "cardFlow", func(ctx context.Context, input any, cb ai.ModelStreamCallback) (string, error) {
 		resp, err := genkit.Generate(ctx, g,
-			ai.WithModelName("googleai/gemini-3-pro-preview"),
+			ai.WithModelName("googleai/gemini-2.5-pro"),
 			ai.WithConfig(&genai.GenerateContentConfig{
 				Temperature: genai.Ptr[float32](1.0),
 				ThinkingConfig: &genai.ThinkingConfig{


### PR DESCRIPTION
## Summary


Deprecates two Go P0 models from the parity tracker, treating each according to its shutdown status:

Supersedes https://github.com/genkit-ai/genkit/pull/5127

- **`gemini-3-pro-preview`** (GoogleAI) — shutdown reached 2026-03-09. Removed from samples, the live test, README, and filtered out of dynamic discovery as a defensive guard in case the provider list API still returns it.
- **`claude-3-haiku@20240307`** (Vertex Model Garden) — shutdown 2026-08-23. Rather than hard-removing ~4 months before the provider shutdown (which would silently break existing users), the entry is kept in `AnthropicModels` with `Stage: ai.ModelStageDeprecated`. The existing middleware at `go/ai/model_middleware.go:259` already emits a warn log on generate for deprecated models, so users get a migration window. A follow-up after Aug 23 can hard-remove.

This is the first use of `ai.ModelStageDeprecated` in a Go plugin; the constant and middleware have existed since the `ModelStage` enum was introduced but have never been wired up by a plugin. It follows the same Stage-field pattern already used for `ModelStageStable` / `ModelStageUnstable` elsewhere in `googlegenai/models.go` and other plugins.

### Latent bug fix

`go/plugins/internal/anthropic/anthropic.go` was reconstructing `ai.ModelOptions` in `DefineModel` but dropping `info.Stage`. Any Anthropic model with `Stage` set would have that field silently discarded before registration, preventing the middleware warning from firing. Propagates `Stage` through.

### Relation to existing work

Supersedes #5127 — same scope, but keeps haiku callable-with-warning through its shutdown window instead of immediately returning nil, and adds the missing Stage propagation.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet` clean on changed packages
- [x] `go test ./plugins/googlegenai/` — new `TestIsDeprecatedGenAIModel` passes (4 cases)
- [x] `go test ./plugins/internal/anthropic/ ./plugins/vertexai/modelgarden/` pass
- [x] `go test ./ai/...` pass (middleware validation still happy)
- [ ] Live smoke: run `go/samples/multipart-tools/main.go` with a real API key to confirm the sample still works on `gemini-2.5-pro`
- [ ] Live smoke: call `ai.Generate` with `claude-3-haiku@20240307` and confirm the `"model is deprecated and may be removed in a future release"` warn log fires