### PR TITLE
feat(go/plugins/vertexai/modelgarden): Support Claude Opus 4.5, Llama, Mistral

### DIFF
--- a/go/plugins/vertexai/modelgarden/anthropic.go
+++ b/go/plugins/vertexai/modelgarden/anthropic.go
@@ -31,11 +31,7 @@ import (
 	ant "github.com/firebase/genkit/go/plugins/internal/anthropic"
 )
 
-const (
-	// TODO: The provider value should be updated in the next major version to avoid collisions with the main vertexai plugin.
-	provider   = "vertexai"
-	pluginName = "vertex-model-garden-anthropic"
-)
+const pluginName = "vertex-model-garden-anthropic"
 
 // Anthropic is a Genkit plugin for interacting with Anthropic models in Vertex AI Model Garden
 type Anthropic struct {

--- a/go/plugins/vertexai/modelgarden/anthropic.go
+++ b/go/plugins/vertexai/modelgarden/anthropic.go
@@ -19,7 +19,6 @@ package modelgarden
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -61,27 +60,7 @@ func (a *Anthropic) Init(ctx context.Context) []api.Action {
 		panic("plugin already initialized")
 	}
 
-	projectID := a.ProjectID
-	if projectID == "" {
-		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
-		if projectID == "" {
-			projectID = os.Getenv("GCLOUD_PROJECT")
-			if projectID == "" {
-				panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_PROJECT or GCLOUD_PROJECT in the environment. You can get a project ID at https://console.cloud.google.com/home/dashboard")
-			}
-		}
-	}
-
-	location := a.Location
-	if location == "" {
-		location = os.Getenv("GOOGLE_CLOUD_LOCATION")
-		if location == "" {
-			location = os.Getenv("GOOGLE_CLOUD_REGION")
-		}
-		if location == "" {
-			panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION in the environment. You can get a location at https://cloud.google.com/vertex-ai/docs/general/locations")
-		}
-	}
+	projectID, location := resolveVertexMaasEnv(a.ProjectID, a.Location)
 
 	c := anthropic.NewClient(
 		vertex.WithGoogleAuth(ctx, location, projectID, "https://www.googleapis.com/auth/cloud-platform"),
@@ -108,6 +87,11 @@ func AnthropicModel(g *genkit.Genkit, id string) ai.Model {
 
 // DefineModel adds the model to the registry
 func (a *Anthropic) DefineModel(name string, opts *ai.ModelOptions) (ai.Model, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.initted {
+		return nil, fmt.Errorf("modelgarden anthropic: plugin not initialized")
+	}
 	if opts == nil {
 		return nil, fmt.Errorf("DefineModel called with nil ai.ModelOptions")
 	}

--- a/go/plugins/vertexai/modelgarden/anthropic_live_test.go
+++ b/go/plugins/vertexai/modelgarden/anthropic_live_test.go
@@ -83,6 +83,29 @@ func TestAnthropicLive(t *testing.T) {
 		}
 	})
 
+	t.Run("opus 4.5", func(t *testing.T) {
+		m := modelgarden.AnthropicModel(g, "claude-opus-4-5@20251101")
+		if m == nil {
+			t.Fatal("claude-opus-4-5@20251101 model was not registered")
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithConfig(&anthropic.MessageNewParams{
+				Temperature: anthropic.Float(1),
+				MaxTokens:   1024,
+			}),
+			ai.WithModel(m),
+			ai.WithSystem("talk to me like an evil pirate and say ARR several times but be very short"),
+			ai.WithMessages(ai.NewUserMessage(ai.NewTextPart("I'm a fish"))),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(resp.Text(), "ARR") {
+			t.Fatalf("not a pirate :( :%s", resp.Text())
+		}
+	})
+
 	t.Run("media content", func(t *testing.T) {
 		i, err := fetchImgAsBase64()
 		if err != nil {

--- a/go/plugins/vertexai/modelgarden/define_model_test.go
+++ b/go/plugins/vertexai/modelgarden/define_model_test.go
@@ -1,0 +1,65 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/plugins/vertexai/modelgarden"
+)
+
+// TestDefineModelBeforeInit verifies that calling DefineModel on a
+// modelgarden plugin before Init returns an error rather than panicking on a
+// nil/uninitialized client.
+func TestDefineModelBeforeInit(t *testing.T) {
+	opts := &ai.ModelOptions{Label: "test"}
+
+	t.Run("Anthropic", func(t *testing.T) {
+		a := &modelgarden.Anthropic{}
+		_, err := a.DefineModel("claude-test", opts)
+		if err == nil {
+			t.Fatal("expected error when DefineModel called before Init, got nil")
+		}
+		if !strings.Contains(err.Error(), "not initialized") {
+			t.Fatalf("expected 'not initialized' error, got: %v", err)
+		}
+	})
+
+	t.Run("Llama", func(t *testing.T) {
+		l := &modelgarden.Llama{}
+		_, err := l.DefineModel("llama-test", opts)
+		if err == nil {
+			t.Fatal("expected error when DefineModel called before Init, got nil")
+		}
+		if !strings.Contains(err.Error(), "not initialized") {
+			t.Fatalf("expected 'not initialized' error, got: %v", err)
+		}
+	})
+
+	t.Run("Mistral", func(t *testing.T) {
+		m := &modelgarden.Mistral{}
+		_, err := m.DefineModel("mistral-test", opts)
+		if err == nil {
+			t.Fatal("expected error when DefineModel called before Init, got nil")
+		}
+		if !strings.Contains(err.Error(), "not initialized") {
+			t.Fatalf("expected 'not initialized' error, got: %v", err)
+		}
+	})
+}

--- a/go/plugins/vertexai/modelgarden/internal_test.go
+++ b/go/plugins/vertexai/modelgarden/internal_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDefineModel_NilOpts verifies that each plugin's DefineModel returns the
+// nil-opts error after Init, without touching the underlying client. This is
+// a white-box test so it can flip `initted` without running Init (which would
+// require GCP credentials).
+func TestDefineModel_NilOpts(t *testing.T) {
+	t.Run("Anthropic", func(t *testing.T) {
+		a := &Anthropic{initted: true}
+		_, err := a.DefineModel("claude-test", nil)
+		if err == nil || !strings.Contains(err.Error(), "nil ai.ModelOptions") {
+			t.Fatalf("err = %v, want one mentioning nil ai.ModelOptions", err)
+		}
+	})
+	t.Run("Llama", func(t *testing.T) {
+		l := &Llama{initted: true}
+		_, err := l.DefineModel("llama-test", nil)
+		if err == nil || !strings.Contains(err.Error(), "nil ai.ModelOptions") {
+			t.Fatalf("err = %v, want one mentioning nil ai.ModelOptions", err)
+		}
+	})
+	t.Run("Mistral", func(t *testing.T) {
+		m := &Mistral{initted: true}
+		_, err := m.DefineModel("mistral-test", nil)
+		if err == nil || !strings.Contains(err.Error(), "nil ai.ModelOptions") {
+			t.Fatalf("err = %v, want one mentioning nil ai.ModelOptions", err)
+		}
+	})
+}

--- a/go/plugins/vertexai/modelgarden/llama.go
+++ b/go/plugins/vertexai/modelgarden/llama.go
@@ -1,0 +1,146 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go/option"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const (
+	llamaPluginName = "vertex-model-garden-llama"
+)
+
+// Llama is a Genkit plugin for interacting with Meta Llama MaaS models in
+// Vertex AI Model Garden. Llama models on Vertex are served via an
+// OpenAI-compatible endpoint (`.../endpoints/openapi`) and authenticated with
+// a Google OAuth2 access token.
+type Llama struct {
+	// ProjectID is the Google Cloud project to use for Vertex AI. If empty,
+	// the value of the environment variable GOOGLE_CLOUD_PROJECT or
+	// GCLOUD_PROJECT will be consulted in that order.
+	ProjectID string
+	// Location is the Vertex AI location (e.g. "us-central1"). If empty, the
+	// value of GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION will be
+	// consulted.
+	Location string
+
+	mu      sync.Mutex
+	initted bool
+	oai     compat_oai.OpenAICompatible
+}
+
+// Name returns the name of the plugin.
+func (l *Llama) Name() string { return llamaPluginName }
+
+// Init initializes the Vertex AI Model Garden Llama plugin and registers all
+// known Llama MaaS models. After calling Init you may call DefineModel to
+// register additional Llama models.
+func (l *Llama) Init(ctx context.Context) []api.Action {
+	if l == nil {
+		l = &Llama{}
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.initted {
+		panic("plugin already initialized")
+	}
+
+	projectID, location := resolveVertexMaasEnv(l.ProjectID, l.Location)
+
+	ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		panic(fmt.Errorf("modelgarden llama: obtaining default Google token source: %w", err))
+	}
+	httpClient := oauth2.NewClient(ctx, ts)
+
+	baseURL := fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi",
+		location, projectID, location,
+	)
+
+	l.oai.Provider = llamaPluginName
+	l.oai.Opts = []option.RequestOption{
+		option.WithBaseURL(baseURL),
+		option.WithHTTPClient(httpClient),
+	}
+
+	var actions []api.Action
+	actions = append(actions, l.oai.Init(ctx)...)
+
+	for name, opts := range LlamaModels {
+		actions = append(actions, l.oai.DefineModel(provider, name, opts).(api.Action))
+	}
+
+	l.initted = true
+	return actions
+}
+
+// LlamaModel returns the Llama [ai.Model] with the given id, or nil if it was
+// not defined.
+func LlamaModel(g *genkit.Genkit, id string) ai.Model {
+	return genkit.LookupModel(g, api.NewName(provider, id))
+}
+
+// DefineModel adds a Llama model to the registry.
+func (l *Llama) DefineModel(name string, opts *ai.ModelOptions) (ai.Model, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.initted {
+		return nil, fmt.Errorf("modelgarden llama: plugin not initialized")
+	}
+	if opts == nil {
+		return nil, fmt.Errorf("DefineModel called with nil ai.ModelOptions")
+	}
+	return l.oai.DefineModel(provider, name, *opts), nil
+}
+
+// resolveVertexMaasEnv resolves project and location from explicit arguments
+// with fallback to the conventional environment variables. Panics if neither a
+// value nor a fallback env var is set, matching the behaviour of the existing
+// Anthropic plugin.
+func resolveVertexMaasEnv(projectID, location string) (string, string) {
+	if projectID == "" {
+		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
+		if projectID == "" {
+			projectID = os.Getenv("GCLOUD_PROJECT")
+		}
+		if projectID == "" {
+			panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_PROJECT or GCLOUD_PROJECT in the environment. You can get a project ID at https://console.cloud.google.com/home/dashboard")
+		}
+	}
+	if location == "" {
+		location = os.Getenv("GOOGLE_CLOUD_LOCATION")
+		if location == "" {
+			location = os.Getenv("GOOGLE_CLOUD_REGION")
+		}
+		if location == "" {
+			panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION in the environment. You can get a location at https://cloud.google.com/vertex-ai/docs/general/locations")
+		}
+	}
+	return projectID, location
+}

--- a/go/plugins/vertexai/modelgarden/llama.go
+++ b/go/plugins/vertexai/modelgarden/llama.go
@@ -61,9 +61,6 @@ func (l *Llama) Name() string { return llamaPluginName }
 // known Llama MaaS models. After calling Init you may call DefineModel to
 // register additional Llama models.
 func (l *Llama) Init(ctx context.Context) []api.Action {
-	if l == nil {
-		l = &Llama{}
-	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.initted {

--- a/go/plugins/vertexai/modelgarden/llama.go
+++ b/go/plugins/vertexai/modelgarden/llama.go
@@ -80,7 +80,7 @@ func (l *Llama) Init(ctx context.Context) []api.Action {
 		location, projectID, location,
 	)
 
-	l.oai.Provider = llamaPluginName
+	l.oai.Provider = provider
 	l.oai.Opts = []option.RequestOption{
 		option.WithBaseURL(baseURL),
 		option.WithHTTPClient(httpClient),

--- a/go/plugins/vertexai/modelgarden/llama.go
+++ b/go/plugins/vertexai/modelgarden/llama.go
@@ -114,4 +114,3 @@ func (l *Llama) DefineModel(name string, opts *ai.ModelOptions) (ai.Model, error
 	}
 	return l.oai.DefineModel(provider, name, *opts), nil
 }
-

--- a/go/plugins/vertexai/modelgarden/llama.go
+++ b/go/plugins/vertexai/modelgarden/llama.go
@@ -19,7 +19,6 @@ package modelgarden
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 
 	"github.com/firebase/genkit/go/ai"
@@ -116,28 +115,3 @@ func (l *Llama) DefineModel(name string, opts *ai.ModelOptions) (ai.Model, error
 	return l.oai.DefineModel(provider, name, *opts), nil
 }
 
-// resolveVertexMaasEnv resolves project and location from explicit arguments
-// with fallback to the conventional environment variables. Panics if neither a
-// value nor a fallback env var is set, matching the behaviour of the existing
-// Anthropic plugin.
-func resolveVertexMaasEnv(projectID, location string) (string, string) {
-	if projectID == "" {
-		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
-		if projectID == "" {
-			projectID = os.Getenv("GCLOUD_PROJECT")
-		}
-		if projectID == "" {
-			panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_PROJECT or GCLOUD_PROJECT in the environment. You can get a project ID at https://console.cloud.google.com/home/dashboard")
-		}
-	}
-	if location == "" {
-		location = os.Getenv("GOOGLE_CLOUD_LOCATION")
-		if location == "" {
-			location = os.Getenv("GOOGLE_CLOUD_REGION")
-		}
-		if location == "" {
-			panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION in the environment. You can get a location at https://cloud.google.com/vertex-ai/docs/general/locations")
-		}
-	}
-	return projectID, location
-}

--- a/go/plugins/vertexai/modelgarden/llama_live_test.go
+++ b/go/plugins/vertexai/modelgarden/llama_live_test.go
@@ -1,0 +1,90 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/vertexai/modelgarden"
+)
+
+func TestLlamaLive(t *testing.T) {
+	if _, ok := requireEnv("GOOGLE_CLOUD_PROJECT"); !ok {
+		t.Skip("GOOGLE_CLOUD_PROJECT not found in the environment")
+	}
+	if _, ok := requireEnv("GOOGLE_CLOUD_LOCATION"); !ok {
+		t.Skip("GOOGLE_CLOUD_LOCATION not found in the environment")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx, genkit.WithPlugins(&modelgarden.Llama{}))
+
+	t.Run("invalid model", func(t *testing.T) {
+		m := modelgarden.LlamaModel(g, "meta/llama-does-not-exist")
+		if m != nil {
+			t.Fatalf("model should have been empty, got: %#v", m)
+		}
+	})
+
+	t.Run("basic generation", func(t *testing.T) {
+		m := modelgarden.LlamaModel(g, "meta/llama-3.3-70b-instruct-maas")
+		if m == nil {
+			t.Fatal("meta/llama-3.3-70b-instruct-maas model was not registered")
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithSystem("You are a helpful assistant. Reply in one short sentence."),
+			ai.WithMessages(ai.NewUserMessage(ai.NewTextPart("Say hello."))),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(resp.Text()) == "" {
+			t.Fatal("expected a non-empty response")
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		m := modelgarden.LlamaModel(g, "meta/llama-3.3-70b-instruct-maas")
+		out := ""
+		final, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithPrompt("Count from one to three."),
+			ai.WithStreaming(func(ctx context.Context, c *ai.ModelResponseChunk) error {
+				for _, p := range c.Content {
+					if p.IsText() {
+						out += p.Text
+					}
+				}
+				return nil
+			}),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out == "" {
+			t.Fatal("expected streamed content")
+		}
+		if final.Usage.InputTokens == 0 || final.Usage.OutputTokens == 0 {
+			t.Fatalf("empty usage stats: %#v", *final.Usage)
+		}
+	})
+}

--- a/go/plugins/vertexai/modelgarden/mistral.go
+++ b/go/plugins/vertexai/modelgarden/mistral.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go/option"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const (
+	mistralPluginName = "vertex-model-garden-mistral"
+)
+
+// Mistral is a Genkit plugin for interacting with Mistral and Codestral MaaS
+// models in Vertex AI Model Garden. The JS equivalent uses the native
+// @mistralai/mistralai-gcp SDK; no maintained Mistral-GCP SDK exists for Go,
+// so this plugin routes requests through the Vertex MaaS OpenAI-compatible
+// endpoint (https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/mistral#openai-compatible).
+type Mistral struct {
+	// ProjectID is the Google Cloud project to use for Vertex AI. If empty,
+	// the value of the environment variable GOOGLE_CLOUD_PROJECT or
+	// GCLOUD_PROJECT will be consulted in that order.
+	ProjectID string
+	// Location is the Vertex AI location (e.g. "us-central1"). If empty, the
+	// value of GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION will be
+	// consulted.
+	Location string
+
+	mu      sync.Mutex
+	initted bool
+	oai     compat_oai.OpenAICompatible
+}
+
+// Name returns the name of the plugin.
+func (m *Mistral) Name() string { return mistralPluginName }
+
+// Init initializes the Vertex AI Model Garden Mistral plugin and registers
+// all known Mistral/Codestral MaaS models.
+func (m *Mistral) Init(ctx context.Context) []api.Action {
+	if m == nil {
+		m = &Mistral{}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.initted {
+		panic("plugin already initialized")
+	}
+
+	projectID, location := resolveVertexMaasEnv(m.ProjectID, m.Location)
+
+	ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		panic(fmt.Errorf("modelgarden mistral: obtaining default Google token source: %w", err))
+	}
+	httpClient := oauth2.NewClient(ctx, ts)
+
+	baseURL := fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi",
+		location, projectID, location,
+	)
+
+	m.oai.Provider = mistralPluginName
+	m.oai.Opts = []option.RequestOption{
+		option.WithBaseURL(baseURL),
+		option.WithHTTPClient(httpClient),
+	}
+
+	var actions []api.Action
+	actions = append(actions, m.oai.Init(ctx)...)
+
+	for name, opts := range MistralModels {
+		actions = append(actions, m.oai.DefineModel(provider, name, opts).(api.Action))
+	}
+
+	m.initted = true
+	return actions
+}
+
+// MistralModel returns the Mistral/Codestral [ai.Model] with the given id,
+// or nil if it was not defined.
+func MistralModel(g *genkit.Genkit, id string) ai.Model {
+	return genkit.LookupModel(g, api.NewName(provider, id))
+}
+
+// DefineModel adds a Mistral model to the registry.
+func (m *Mistral) DefineModel(name string, opts *ai.ModelOptions) (ai.Model, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.initted {
+		return nil, fmt.Errorf("modelgarden mistral: plugin not initialized")
+	}
+	if opts == nil {
+		return nil, fmt.Errorf("DefineModel called with nil ai.ModelOptions")
+	}
+	return m.oai.DefineModel(provider, name, *opts), nil
+}

--- a/go/plugins/vertexai/modelgarden/mistral.go
+++ b/go/plugins/vertexai/modelgarden/mistral.go
@@ -60,9 +60,6 @@ func (m *Mistral) Name() string { return mistralPluginName }
 // Init initializes the Vertex AI Model Garden Mistral plugin and registers
 // all known Mistral/Codestral MaaS models.
 func (m *Mistral) Init(ctx context.Context) []api.Action {
-	if m == nil {
-		m = &Mistral{}
-	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.initted {

--- a/go/plugins/vertexai/modelgarden/mistral.go
+++ b/go/plugins/vertexai/modelgarden/mistral.go
@@ -79,7 +79,7 @@ func (m *Mistral) Init(ctx context.Context) []api.Action {
 		location, projectID, location,
 	)
 
-	m.oai.Provider = mistralPluginName
+	m.oai.Provider = provider
 	m.oai.Opts = []option.RequestOption{
 		option.WithBaseURL(baseURL),
 		option.WithHTTPClient(httpClient),

--- a/go/plugins/vertexai/modelgarden/mistral.go
+++ b/go/plugins/vertexai/modelgarden/mistral.go
@@ -19,6 +19,7 @@ package modelgarden
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/firebase/genkit/go/ai"
@@ -32,13 +33,17 @@ import (
 
 const (
 	mistralPluginName = "vertex-model-garden-mistral"
+	mistralPublisher  = "mistralai"
 )
 
 // Mistral is a Genkit plugin for interacting with Mistral and Codestral MaaS
 // models in Vertex AI Model Garden. The JS equivalent uses the native
 // @mistralai/mistralai-gcp SDK; no maintained Mistral-GCP SDK exists for Go,
-// so this plugin routes requests through the Vertex MaaS OpenAI-compatible
-// endpoint (https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/mistral#openai-compatible).
+// and unlike Meta Llama, Mistral on Vertex is not served by the OpenAI-
+// compatible chat completions endpoint. Requests are routed to per-model
+// rawPredict / streamRawPredict URLs via a custom HTTP transport, while the
+// rest of the OpenAI-shaped request and response handling is reused from
+// compat_oai.
 type Mistral struct {
 	// ProjectID is the Google Cloud project to use for Vertex AI. If empty,
 	// the value of the environment variable GOOGLE_CLOUD_PROJECT or
@@ -73,11 +78,19 @@ func (m *Mistral) Init(ctx context.Context) []api.Action {
 		panic(fmt.Errorf("modelgarden mistral: obtaining default Google token source: %w", err))
 	}
 	httpClient := oauth2.NewClient(ctx, ts)
+	// Wrap the oauth2 transport with one that rewrites /chat/completions
+	// requests to Vertex's per-model rawPredict URLs. The inner oauth2
+	// transport still adds the Bearer token.
+	httpClient.Transport = &mistralVertexTransport{
+		inner:    httpClient.Transport,
+		project:  projectID,
+		location: location,
+	}
 
-	baseURL := fmt.Sprintf(
-		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi",
-		location, projectID, location,
-	)
+	// baseURL is a sentinel: the actual outbound URL is built by
+	// mistralVertexTransport. The openai-go SDK appends "/chat/completions"
+	// to this base, which the transport then detects and rewrites.
+	baseURL := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1", location)
 
 	m.oai.Provider = provider
 	m.oai.Opts = []option.RequestOption{
@@ -97,12 +110,17 @@ func (m *Mistral) Init(ctx context.Context) []api.Action {
 }
 
 // MistralModel returns the Mistral/Codestral [ai.Model] with the given id,
-// or nil if it was not defined.
+// or nil if it was not defined. Both bare ids ("mistral-small-2503") and
+// publisher-qualified ids ("mistralai/mistral-small-2503") resolve to the
+// same registered model.
 func MistralModel(g *genkit.Genkit, id string) ai.Model {
+	id = strings.TrimPrefix(id, mistralPublisher+"/")
 	return genkit.LookupModel(g, api.NewName(provider, id))
 }
 
-// DefineModel adds a Mistral model to the registry.
+// DefineModel adds a Mistral model to the registry. The optional
+// "mistralai/" publisher prefix on name is stripped so registration stays in
+// the bare-id namespace.
 func (m *Mistral) DefineModel(name string, opts *ai.ModelOptions) (ai.Model, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -112,5 +130,6 @@ func (m *Mistral) DefineModel(name string, opts *ai.ModelOptions) (ai.Model, err
 	if opts == nil {
 		return nil, fmt.Errorf("DefineModel called with nil ai.ModelOptions")
 	}
+	name = strings.TrimPrefix(name, mistralPublisher+"/")
 	return m.oai.DefineModel(provider, name, *opts), nil
 }

--- a/go/plugins/vertexai/modelgarden/mistral_live_test.go
+++ b/go/plugins/vertexai/modelgarden/mistral_live_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/vertexai/modelgarden"
+)
+
+func TestMistralLive(t *testing.T) {
+	if _, ok := requireEnv("GOOGLE_CLOUD_PROJECT"); !ok {
+		t.Skip("GOOGLE_CLOUD_PROJECT not found in the environment")
+	}
+	if _, ok := requireEnv("GOOGLE_CLOUD_LOCATION"); !ok {
+		t.Skip("GOOGLE_CLOUD_LOCATION not found in the environment")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx, genkit.WithPlugins(&modelgarden.Mistral{}))
+
+	t.Run("invalid model", func(t *testing.T) {
+		m := modelgarden.MistralModel(g, "mistral-does-not-exist")
+		if m != nil {
+			t.Fatalf("model should have been empty, got: %#v", m)
+		}
+	})
+
+	t.Run("mistral small generation", func(t *testing.T) {
+		m := modelgarden.MistralModel(g, "mistral-small-2503")
+		if m == nil {
+			t.Fatal("mistral-small-2503 model was not registered")
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithSystem("You are a helpful assistant. Reply in one short sentence."),
+			ai.WithMessages(ai.NewUserMessage(ai.NewTextPart("Say hello."))),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(resp.Text()) == "" {
+			t.Fatal("expected a non-empty response")
+		}
+	})
+
+	t.Run("codestral generation", func(t *testing.T) {
+		m := modelgarden.MistralModel(g, "codestral-2")
+		if m == nil {
+			t.Fatal("codestral-2 model was not registered")
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithMessages(ai.NewUserMessage(ai.NewTextPart("Write a one-line Python function that returns 42."))),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(resp.Text()) == "" {
+			t.Fatal("expected a non-empty response")
+		}
+	})
+}

--- a/go/plugins/vertexai/modelgarden/mistral_live_test.go
+++ b/go/plugins/vertexai/modelgarden/mistral_live_test.go
@@ -45,9 +45,9 @@ func TestMistralLive(t *testing.T) {
 	})
 
 	t.Run("mistral small generation", func(t *testing.T) {
-		m := modelgarden.MistralModel(g, "mistral-small-2503")
+		m := modelgarden.MistralModel(g, "mistralai/mistral-small-2503")
 		if m == nil {
-			t.Fatal("mistral-small-2503 model was not registered")
+			t.Fatal("mistralai/mistral-small-2503 model was not registered")
 		}
 		resp, err := genkit.Generate(ctx, g,
 			ai.WithModel(m),
@@ -63,9 +63,9 @@ func TestMistralLive(t *testing.T) {
 	})
 
 	t.Run("codestral generation", func(t *testing.T) {
-		m := modelgarden.MistralModel(g, "codestral-2")
+		m := modelgarden.MistralModel(g, "mistralai/codestral-2")
 		if m == nil {
-			t.Fatal("codestral-2 model was not registered")
+			t.Fatal("mistralai/codestral-2 model was not registered")
 		}
 		resp, err := genkit.Generate(ctx, g,
 			ai.WithModel(m),
@@ -76,6 +76,47 @@ func TestMistralLive(t *testing.T) {
 		}
 		if strings.TrimSpace(resp.Text()) == "" {
 			t.Fatal("expected a non-empty response")
+		}
+	})
+
+	t.Run("bare id lookup", func(t *testing.T) {
+		// Same registered action; verifies the publisher-prefix trim path.
+		m := modelgarden.MistralModel(g, "mistral-small-2503")
+		if m == nil {
+			t.Fatal("mistral-small-2503 model was not registered under bare id")
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithMessages(ai.NewUserMessage(ai.NewTextPart("Reply with the single word: ok."))),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(resp.Text()) == "" {
+			t.Fatal("expected a non-empty response")
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		m := modelgarden.MistralModel(g, "mistralai/mistral-small-2503")
+		out := ""
+		_, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithPrompt("Count from one to three."),
+			ai.WithStreaming(func(ctx context.Context, c *ai.ModelResponseChunk) error {
+				for _, p := range c.Content {
+					if p.IsText() {
+						out += p.Text
+					}
+				}
+				return nil
+			}),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out == "" {
+			t.Fatal("expected streamed content")
 		}
 	})
 }

--- a/go/plugins/vertexai/modelgarden/mistral_transport.go
+++ b/go/plugins/vertexai/modelgarden/mistral_transport.go
@@ -77,9 +77,12 @@ func (t *mistralVertexTransport) RoundTrip(req *http.Request) (*http.Response, e
 		suffix = "streamRawPredict"
 	}
 
+	// PathEscape the model id so a hostile/malformed id (e.g. one containing
+	// "/", "?", or "#") cannot inject extra path segments, query strings, or
+	// fragments into the outbound URL.
 	newURL, err := url.Parse(fmt.Sprintf(
 		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/%s/models/%s:%s",
-		t.location, t.project, t.location, mistralPublisher, model, suffix,
+		t.location, t.project, t.location, mistralPublisher, url.PathEscape(model), suffix,
 	))
 	if err != nil {
 		return nil, fmt.Errorf("modelgarden mistral transport: build url: %w", err)

--- a/go/plugins/vertexai/modelgarden/mistral_transport.go
+++ b/go/plugins/vertexai/modelgarden/mistral_transport.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// mistralVertexTransport rewrites outbound OpenAI-shaped chat completion
+// requests to Vertex's per-model Mistral rawPredict (or streamRawPredict)
+// URLs. Vertex's OpenAI-compatible /endpoints/openapi/chat/completions does
+// not serve Mistral; only the publisher-qualified rawPredict path does. The
+// request and response bodies are already in OpenAI shape, so only the URL
+// needs to change. The inner RoundTripper (typically an oauth2.Transport)
+// continues to add the Bearer token.
+type mistralVertexTransport struct {
+	inner    http.RoundTripper
+	project  string
+	location string
+}
+
+// RoundTrip rewrites any …/chat/completions request to the Mistral
+// rawPredict URL for the model named in the request body. The body itself
+// is preserved byte-for-byte so the openai-go SDK's framing (stream flag,
+// stream_options, tools, response_format) reaches Vertex unchanged.
+func (t *mistralVertexTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// The openai-go SDK emits POST .../chat/completions for chat requests.
+	// Any other path (probes, future SDK changes) is passed through.
+	if !strings.HasSuffix(req.URL.Path, "/chat/completions") {
+		return t.inner.RoundTrip(req)
+	}
+
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("modelgarden mistral transport: read body: %w", err)
+		}
+		req.Body.Close()
+	}
+
+	model, stream, err := peekModelAndStream(bodyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("modelgarden mistral transport: %w", err)
+	}
+	// Defensive: openai-go may receive a publisher-qualified model id from
+	// callers that bypassed MistralModel/DefineModel. rawPredict expects
+	// the bare id; the publisher already lives in the URL.
+	model = strings.TrimPrefix(model, mistralPublisher+"/")
+	if model == "" {
+		return nil, fmt.Errorf("modelgarden mistral transport: request body has no model field")
+	}
+
+	suffix := "rawPredict"
+	if stream {
+		suffix = "streamRawPredict"
+	}
+
+	newURL, err := url.Parse(fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/%s/models/%s:%s",
+		t.location, t.project, t.location, mistralPublisher, model, suffix,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("modelgarden mistral transport: build url: %w", err)
+	}
+
+	// Clone to avoid mutating the caller's request. Body and GetBody are
+	// reset so openai-go's retry path can replay the request.
+	rewritten := req.Clone(req.Context())
+	rewritten.URL = newURL
+	rewritten.Host = newURL.Host
+	rewritten.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	rewritten.ContentLength = int64(len(bodyBytes))
+	rewritten.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+	}
+
+	return t.inner.RoundTrip(rewritten)
+}
+
+// peekModelAndStream extracts the "model" and "stream" fields from an
+// OpenAI-shaped chat completion request body without losing other fields.
+func peekModelAndStream(body []byte) (model string, stream bool, err error) {
+	if len(body) == 0 {
+		return "", false, nil
+	}
+	var peek struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	if err := json.Unmarshal(body, &peek); err != nil {
+		return "", false, fmt.Errorf("decode body: %w", err)
+	}
+	return peek.Model, peek.Stream, nil
+}

--- a/go/plugins/vertexai/modelgarden/mistral_transport.go
+++ b/go/plugins/vertexai/modelgarden/mistral_transport.go
@@ -54,10 +54,16 @@ func (t *mistralVertexTransport) RoundTrip(req *http.Request) (*http.Response, e
 	if req.Body != nil {
 		var err error
 		bodyBytes, err = io.ReadAll(req.Body)
+		// Close unconditionally so a read error does not leak the underlying
+		// reader (openai-go has no way to recover the original body once we
+		// return — GetBody would not be set on the un-rewritten request).
+		closeErr := req.Body.Close()
 		if err != nil {
 			return nil, fmt.Errorf("modelgarden mistral transport: read body: %w", err)
 		}
-		req.Body.Close()
+		if closeErr != nil {
+			return nil, fmt.Errorf("modelgarden mistral transport: close body: %w", closeErr)
+		}
 	}
 
 	model, stream, err := peekModelAndStream(bodyBytes)

--- a/go/plugins/vertexai/modelgarden/mistral_transport_test.go
+++ b/go/plugins/vertexai/modelgarden/mistral_transport_test.go
@@ -19,6 +19,7 @@ package modelgarden
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -158,6 +159,42 @@ func TestMistralTransport_StripsPublisherPrefixFromURL(t *testing.T) {
 	// URL must use bare id even though body had publisher prefix.
 	if !strings.HasSuffix(inner.last.URL.Path, "/publishers/mistralai/models/codestral-2:rawPredict") {
 		t.Errorf("URL path did not strip publisher prefix: %s", inner.last.URL.Path)
+	}
+}
+
+// errReader returns an error after returning some bytes, allowing the test
+// to drive io.ReadAll into its error path without ever reaching EOF.
+type errReader struct{ closed bool }
+
+func (r *errReader) Read(p []byte) (int, error) {
+	return 0, fmt.Errorf("synthetic read error")
+}
+func (r *errReader) Close() error { r.closed = true; return nil }
+
+func TestMistralTransport_ClosesBodyOnReadError(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := &errReader{}
+	u, _ := url.Parse("https://us-central1-aiplatform.googleapis.com/v1/chat/completions")
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    u,
+		Host:   u.Host,
+		Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body:   body,
+	}
+
+	_, err := rt.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error from read failure")
+	}
+	if !body.closed {
+		t.Fatal("body was not closed after read error; reader leaked")
 	}
 }
 

--- a/go/plugins/vertexai/modelgarden/mistral_transport_test.go
+++ b/go/plugins/vertexai/modelgarden/mistral_transport_test.go
@@ -1,0 +1,238 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// captureRoundTripper records the last request it received and returns a
+// canned 200 OK response. The test mutates inner.last to inspect what the
+// outer transport actually sent.
+type captureRoundTripper struct {
+	last    *http.Request
+	lastRaw []byte
+}
+
+func (c *captureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.last = req
+	if req.Body != nil {
+		raw, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+		c.lastRaw = raw
+		// restore for any downstream reader
+		req.Body = io.NopCloser(bytes.NewReader(raw))
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{}`)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func newChatRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	u, err := url.Parse("https://us-central1-aiplatform.googleapis.com/v1/chat/completions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    u,
+		Host:   u.Host,
+		Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body:   io.NopCloser(strings.NewReader(body)),
+	}
+	return req
+}
+
+func TestMistralTransport_RewritesRawPredict(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := `{"model":"mistral-small-2503","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	req := newChatRequest(t, body)
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	want := "https://us-central1-aiplatform.googleapis.com/v1/projects/test-proj/locations/us-central1/publishers/mistralai/models/mistral-small-2503:rawPredict"
+	if got := inner.last.URL.String(); got != want {
+		t.Errorf("URL = %q, want %q", got, want)
+	}
+	if inner.last.Host != "us-central1-aiplatform.googleapis.com" {
+		t.Errorf("Host = %q, want us-central1-aiplatform.googleapis.com", inner.last.Host)
+	}
+	if string(inner.lastRaw) != body {
+		t.Errorf("body mutated:\n got  %s\n want %s", inner.lastRaw, body)
+	}
+	if inner.last.ContentLength != int64(len(body)) {
+		t.Errorf("ContentLength = %d, want %d", inner.last.ContentLength, len(body))
+	}
+	if inner.last.GetBody == nil {
+		t.Error("GetBody is nil; openai-go retries would send empty body")
+	} else {
+		rc, err := inner.last.GetBody()
+		if err != nil {
+			t.Fatalf("GetBody: %v", err)
+		}
+		raw, _ := io.ReadAll(rc)
+		rc.Close()
+		if string(raw) != body {
+			t.Errorf("GetBody body = %q, want %q", raw, body)
+		}
+	}
+}
+
+func TestMistralTransport_RewritesStreamRawPredict(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := `{"model":"codestral-2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	req := newChatRequest(t, body)
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	want := "https://us-central1-aiplatform.googleapis.com/v1/projects/test-proj/locations/us-central1/publishers/mistralai/models/codestral-2:streamRawPredict"
+	if got := inner.last.URL.String(); got != want {
+		t.Errorf("URL = %q, want %q", got, want)
+	}
+}
+
+func TestMistralTransport_StripsPublisherPrefixFromURL(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := `{"model":"mistralai/codestral-2","messages":[{"role":"user","content":"hi"}]}`
+	req := newChatRequest(t, body)
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	// URL must use bare id even though body had publisher prefix.
+	if !strings.HasSuffix(inner.last.URL.Path, "/publishers/mistralai/models/codestral-2:rawPredict") {
+		t.Errorf("URL path did not strip publisher prefix: %s", inner.last.URL.Path)
+	}
+}
+
+func TestMistralTransport_PassThroughNonChat(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	u, _ := url.Parse("https://us-central1-aiplatform.googleapis.com/v1/models")
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    u,
+		Host:   u.Host,
+		Header: http.Header{},
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	if inner.last.URL.String() != u.String() {
+		t.Errorf("non-chat URL was rewritten: got %s, want %s", inner.last.URL, u)
+	}
+}
+
+func TestMistralTransport_MissingModelErrors(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := `{"messages":[{"role":"user","content":"hi"}]}`
+	req := newChatRequest(t, body)
+
+	_, err := rt.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error for missing model field, got nil")
+	}
+	if !strings.Contains(err.Error(), "no model") {
+		t.Errorf("error = %v, want one mentioning missing model", err)
+	}
+}
+
+func TestMistralTransport_PreservesExtraBodyFields(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := `{"model":"mistral-small-2503","tools":[{"type":"function","function":{"name":"x"}}],"response_format":{"type":"json_object"}}`
+	req := newChatRequest(t, body)
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	var got map[string]any
+	if err := json.Unmarshal(inner.lastRaw, &got); err != nil {
+		t.Fatalf("decode forwarded body: %v", err)
+	}
+	if _, ok := got["tools"]; !ok {
+		t.Error("tools field missing from forwarded body")
+	}
+	if _, ok := got["response_format"]; !ok {
+		t.Error("response_format field missing from forwarded body")
+	}
+}

--- a/go/plugins/vertexai/modelgarden/mistral_transport_test.go
+++ b/go/plugins/vertexai/modelgarden/mistral_transport_test.go
@@ -161,6 +161,26 @@ func TestMistralTransport_StripsPublisherPrefixFromURL(t *testing.T) {
 	}
 }
 
+func TestPeekModelAndStream_EmptyBody(t *testing.T) {
+	model, stream, err := peekModelAndStream(nil)
+	if err != nil {
+		t.Fatalf("err = %v, want nil for empty body", err)
+	}
+	if model != "" || stream {
+		t.Errorf("model=%q stream=%v, want empty/false for empty body", model, stream)
+	}
+}
+
+func TestPeekModelAndStream_MalformedJSON(t *testing.T) {
+	_, _, err := peekModelAndStream([]byte("{not-json"))
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	if !strings.Contains(err.Error(), "decode body") {
+		t.Errorf("err = %v, want one mentioning decode body", err)
+	}
+}
+
 func TestMistralTransport_PassThroughNonChat(t *testing.T) {
 	inner := &captureRoundTripper{}
 	rt := &mistralVertexTransport{

--- a/go/plugins/vertexai/modelgarden/mistral_transport_test.go
+++ b/go/plugins/vertexai/modelgarden/mistral_transport_test.go
@@ -208,6 +208,37 @@ func TestMistralTransport_MissingModelErrors(t *testing.T) {
 	}
 }
 
+func TestMistralTransport_EscapesModelInURL(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	// A malformed id with characters that would otherwise inject path/query
+	// segments. PathEscape must encode them.
+	body := `{"model":"weird/id?evil=1#frag"}`
+	req := newChatRequest(t, body)
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := inner.last.URL.RawQuery; got != "" {
+		t.Errorf("URL has unexpected query: %q", got)
+	}
+	if got := inner.last.URL.Fragment; got != "" {
+		t.Errorf("URL has unexpected fragment: %q", got)
+	}
+	// Path must contain the escaped form of the model, not the raw injection.
+	if !strings.Contains(inner.last.URL.EscapedPath(), "weird%2Fid%3Fevil=1%23frag:rawPredict") {
+		t.Errorf("model id not escaped in path: %s", inner.last.URL.EscapedPath())
+	}
+}
+
 func TestMistralTransport_PreservesExtraBodyFields(t *testing.T) {
 	inner := &captureRoundTripper{}
 	rt := &mistralVertexTransport{

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -21,6 +21,22 @@ import (
 	"github.com/firebase/genkit/go/plugins/internal"
 )
 
+// provider is the shared registration namespace for every Vertex AI Model
+// Garden plugin in this package (Anthropic, Llama, Mistral). Their models
+// are all registered as "vertexai/<model>" so users see a single namespace.
+// Each plugin's own Name() ("vertex-model-garden-<plugin>") is distinct from
+// this registration prefix.
+//
+// Note that this collides with the main googlegenai.VertexAI plugin, whose
+// Name() is also "vertexai" — model-name prefixes overlap, but plugin names
+// do not. Consequence: dynamic resolution of an unknown "vertexai/<name>" is
+// routed to googlegenai.VertexAI, not to the modelgarden plugins.
+//
+// TODO: in the next major version, switch to per-plugin prefixes
+// (e.g. "vertex-model-garden-anthropic/<model>") so the model namespace
+// matches the plugin that owns it.
+const provider = "vertexai"
+
 // AnthropicModels is a list of models supported in VertexAI
 // Keep this list updated since models cannot be dynamically listed
 // if we are authenticating with Google Credentials

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -40,6 +40,7 @@ var AnthropicModels = map[string]ai.ModelOptions{
 	"claude-3-haiku@20240307": {
 		Label:    "Claude 3 Haiku",
 		Supports: &internal.Multimodal,
+		Stage:    ai.ModelStageDeprecated,
 	},
 	"claude-3-opus@20240229": {
 		Label:    "Claude 3 Opus",
@@ -68,5 +69,49 @@ var AnthropicModels = map[string]ai.ModelOptions{
 	"claude-haiku-4-5-20251001": {
 		Label:    "Claude 4.5 Haiku",
 		Supports: &internal.Multimodal,
+	},
+	"claude-opus-4-5@20251101": {
+		Label:    "Claude Opus 4.5",
+		Supports: &internal.Multimodal,
+	},
+}
+
+// LlamaModels lists the Meta Llama models available through Vertex AI Model Garden
+// as Model-as-a-Service (MaaS) endpoints. These models are served via an
+// OpenAI-compatible API.
+var LlamaModels = map[string]ai.ModelOptions{
+	"meta/llama-4-maverick-17b-128e-instruct-maas": {
+		Label:    "Llama 4 Maverick 17B 128E Instruct",
+		Supports: &internal.Multimodal,
+	},
+	"meta/llama-4-scout-17b-16e-instruct-maas": {
+		Label:    "Llama 4 Scout 17B 16E Instruct",
+		Supports: &internal.Multimodal,
+	},
+	"meta/llama-3.3-70b-instruct-maas": {
+		Label:    "Llama 3.3 70B Instruct",
+		Supports: &internal.Multimodal,
+	},
+}
+
+// MistralModels lists the Mistral and Codestral models available through Vertex
+// AI Model Garden as Model-as-a-Service (MaaS) endpoints. Capabilities match
+// the JS parity target (media: false, tools: true, systemRole: true).
+var MistralModels = map[string]ai.ModelOptions{
+	"mistral-medium-3": {
+		Label:    "Mistral Medium 3",
+		Supports: &internal.BasicText,
+	},
+	"mistral-ocr-2505": {
+		Label:    "Mistral OCR 2505",
+		Supports: &internal.BasicText,
+	},
+	"mistral-small-2503": {
+		Label:    "Mistral Small 2503",
+		Supports: &internal.BasicText,
+	},
+	"codestral-2": {
+		Label:    "Codestral 2",
+		Supports: &internal.BasicText,
 	},
 }

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -17,9 +17,37 @@
 package modelgarden
 
 import (
+	"os"
+
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/plugins/internal"
 )
+
+// resolveVertexMaasEnv resolves project and location from explicit arguments
+// with fallback to the conventional environment variables. Panics if neither a
+// value nor a fallback env var is set. Shared by all Vertex AI Model Garden
+// plugins in this package.
+func resolveVertexMaasEnv(projectID, location string) (string, string) {
+	if projectID == "" {
+		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
+		if projectID == "" {
+			projectID = os.Getenv("GCLOUD_PROJECT")
+		}
+		if projectID == "" {
+			panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_PROJECT or GCLOUD_PROJECT in the environment. You can get a project ID at https://console.cloud.google.com/home/dashboard")
+		}
+	}
+	if location == "" {
+		location = os.Getenv("GOOGLE_CLOUD_LOCATION")
+		if location == "" {
+			location = os.Getenv("GOOGLE_CLOUD_REGION")
+		}
+		if location == "" {
+			panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION in the environment. You can get a location at https://cloud.google.com/vertex-ai/docs/general/locations")
+		}
+	}
+	return projectID, location
+}
 
 // provider is the shared registration namespace for every Vertex AI Model
 // Garden plugin in this package (Anthropic, Llama, Mistral). Their models
@@ -106,7 +134,7 @@ var LlamaModels = map[string]ai.ModelOptions{
 	},
 	"meta/llama-3.3-70b-instruct-maas": {
 		Label:    "Llama 3.3 70B Instruct",
-		Supports: &internal.Multimodal,
+		Supports: &internal.BasicText,
 	},
 }
 

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -140,7 +140,13 @@ var LlamaModels = map[string]ai.ModelOptions{
 
 // MistralModels lists the Mistral and Codestral models available through Vertex
 // AI Model Garden as Model-as-a-Service (MaaS) endpoints. Capabilities match
-// the JS parity target (media: false, tools: true, systemRole: true).
+// the JS parity target (media: false, tools: true, systemRole: true). Keys are
+// the bare publisher model ids ("mistral-small-2503" rather than
+// "mistralai/mistral-small-2503"). Vertex serves Mistral via per-model
+// rawPredict URLs where the publisher lives in the URL path, not the model
+// field; the Mistral plugin's HTTP transport assembles those URLs. The
+// "mistralai/" prefix is still accepted by MistralModel as a convenience for
+// callers used to the publisher-qualified form.
 var MistralModels = map[string]ai.ModelOptions{
 	"mistral-medium-3": {
 		Label:    "Mistral Medium 3",

--- a/go/plugins/vertexai/modelgarden/models_test.go
+++ b/go/plugins/vertexai/modelgarden/models_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveVertexMaasEnv_ExplicitArgsWin(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "from-env")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "from-env")
+
+	p, l := resolveVertexMaasEnv("explicit-proj", "explicit-loc")
+	if p != "explicit-proj" {
+		t.Errorf("project = %q, want explicit-proj", p)
+	}
+	if l != "explicit-loc" {
+		t.Errorf("location = %q, want explicit-loc", l)
+	}
+}
+
+func TestResolveVertexMaasEnv_FallsBackToPrimaryEnv(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "primary-proj")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "primary-loc")
+	t.Setenv("GCLOUD_PROJECT", "secondary-proj")
+	t.Setenv("GOOGLE_CLOUD_REGION", "secondary-loc")
+
+	p, l := resolveVertexMaasEnv("", "")
+	if p != "primary-proj" {
+		t.Errorf("project = %q, want primary-proj", p)
+	}
+	if l != "primary-loc" {
+		t.Errorf("location = %q, want primary-loc", l)
+	}
+}
+
+func TestResolveVertexMaasEnv_FallsBackToSecondaryEnv(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "")
+	t.Setenv("GCLOUD_PROJECT", "secondary-proj")
+	t.Setenv("GOOGLE_CLOUD_REGION", "secondary-loc")
+
+	p, l := resolveVertexMaasEnv("", "")
+	if p != "secondary-proj" {
+		t.Errorf("project = %q, want secondary-proj", p)
+	}
+	if l != "secondary-loc" {
+		t.Errorf("location = %q, want secondary-loc", l)
+	}
+}
+
+func TestResolveVertexMaasEnv_PanicsWithoutProject(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+	t.Setenv("GCLOUD_PROJECT", "")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when no project env is set")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "GOOGLE_CLOUD_PROJECT") {
+			t.Fatalf("panic = %v, want message mentioning GOOGLE_CLOUD_PROJECT", r)
+		}
+	}()
+	resolveVertexMaasEnv("", "")
+}
+
+func TestResolveVertexMaasEnv_PanicsWithoutLocation(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "some-proj")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "")
+	t.Setenv("GOOGLE_CLOUD_REGION", "")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when no location env is set")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "GOOGLE_CLOUD_LOCATION") {
+			t.Fatalf("panic = %v, want message mentioning GOOGLE_CLOUD_LOCATION", r)
+		}
+	}()
+	resolveVertexMaasEnv("", "")
+}

--- a/go/samples/modelgarden/main.go
+++ b/go/samples/modelgarden/main.go
@@ -27,25 +27,26 @@ import (
 func main() {
 	ctx := context.Background()
 
+	// Vertex AI MaaS regional availability differs per publisher: Anthropic
+	// Claude models live in us-east5 / europe-west4, while Meta Llama and
+	// Mistral live in us-central1. Each plugin takes its own Location to
+	// avoid forcing one global region.
 	g := genkit.Init(ctx, genkit.WithPlugins(
-		&modelgarden.Anthropic{},
-		&modelgarden.Llama{},
-		&modelgarden.Mistral{},
+		&modelgarden.Anthropic{Location: "us-east5"},
+		&modelgarden.Llama{Location: "us-central1"},
+		&modelgarden.Mistral{Location: "us-central1"},
 	))
 
-	// Anthropic flows.
-	defineFlow(g, "jokesFlow",
-		modelgarden.AnthropicModel(g, "claude-3-5-sonnet-v2@20241022"),
-		"Tell a short joke about %s",
+	// Anthropic flow. Add additional flows pointing at other Claude variants
+	// (e.g. claude-sonnet-4-5-20250929, claude-haiku-4-5-20251001) once they
+	// are enabled in the Vertex Model Garden for your project.
+	defineFlow(g, "opus45Flow",
+		modelgarden.AnthropicModel(g, "claude-opus-4-5@20251101"),
+		"Write a haiku about %s",
 		ai.WithConfig(&anthropic.MessageNewParams{
 			MaxTokens:   256,
 			Temperature: anthropic.Float(1.0),
 		}),
-	)
-	defineFlow(g, "opus45Flow",
-		modelgarden.AnthropicModel(g, "claude-opus-4-5@20251101"),
-		"Write a haiku about %s",
-		ai.WithConfig(&anthropic.MessageNewParams{MaxTokens: 256}),
 	)
 
 	// Llama flow.

--- a/go/samples/modelgarden/main.go
+++ b/go/samples/modelgarden/main.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/firebase/genkit/go/ai"
@@ -27,28 +27,68 @@ import (
 func main() {
 	ctx := context.Background()
 
-	g := genkit.Init(ctx, genkit.WithPlugins(&modelgarden.Anthropic{}))
+	g := genkit.Init(ctx, genkit.WithPlugins(
+		&modelgarden.Anthropic{},
+		&modelgarden.Llama{},
+		&modelgarden.Mistral{},
+	))
 
-	// Define a simple flow that generates jokes about a given topic
-	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, input string) (string, error) {
-		m := modelgarden.AnthropicModel(g, "claude-3-5-sonnet-v2")
+	// Anthropic flows.
+	defineFlow(g, "jokesFlow",
+		modelgarden.AnthropicModel(g, "claude-3-5-sonnet-v2@20241022"),
+		"Tell a short joke about %s",
+		ai.WithConfig(&anthropic.MessageNewParams{
+			MaxTokens:   256,
+			Temperature: anthropic.Float(1.0),
+		}),
+	)
+	defineFlow(g, "opus45Flow",
+		modelgarden.AnthropicModel(g, "claude-opus-4-5@20251101"),
+		"Write a haiku about %s",
+		ai.WithConfig(&anthropic.MessageNewParams{MaxTokens: 256}),
+	)
+
+	// Llama flow.
+	defineFlow(g, "llamaFlow",
+		modelgarden.LlamaModel(g, "meta/llama-3.3-70b-instruct-maas"),
+		"In one short sentence, describe %s",
+	)
+
+	// Mistral / Codestral flows.
+	defineFlow(g, "mistralFlow",
+		modelgarden.MistralModel(g, "mistralai/mistral-small-2503"),
+		"List three interesting facts about %s",
+	)
+	defineFlow(g, "codestralFlow",
+		modelgarden.MistralModel(g, "mistralai/codestral-2"),
+		"Write a small Go function that does the following: %s",
+	)
+
+	<-ctx.Done()
+}
+
+// defineFlow registers a Dev UI flow that generates from the given model using
+// a prompt template. Extra GenerateOption values (e.g. provider-specific
+// config) are appended to the base options.
+func defineFlow(
+	g *genkit.Genkit,
+	name string,
+	m ai.Model,
+	promptTemplate string,
+	extra ...ai.GenerateOption,
+) {
+	genkit.DefineFlow(g, name, func(ctx context.Context, input string) (string, error) {
 		if m == nil {
-			return "", errors.New("jokesFlow: failed to find model")
+			return "", fmt.Errorf("%s: model not registered", name)
 		}
-
-		resp, err := genkit.Generate(ctx, g,
+		opts := append([]ai.GenerateOption{
 			ai.WithModel(m),
-			ai.WithConfig(&anthropic.MessageNewParams{
-				Temperature: anthropic.Float(1.0),
-			}),
-			ai.WithPrompt(`Tell a short joke about %s`, input))
+			ai.WithPrompt(promptTemplate, input),
+		}, extra...)
+		resp, err := genkit.Generate(ctx, g, opts...)
 		if err != nil {
 			return "", err
 		}
-
-		text := resp.Text()
-		return text, nil
+		return resp.Text(), nil
 	})
-
-	<-ctx.Done()
 }


### PR DESCRIPTION
Extends the Vertex AI Model Garden Go plugin with new Anthropic, Meta Llama, and Mistral / Codestral models, plus a Dev UI sample that exercises them end-to-end.

## Models

- **Anthropic** (existing plugin, more models): `claude-opus-4-5@20251101`, `claude-opus-4-1-20250805`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`, plus the previously supported Claude 3.5 / 3.7 / Opus 4 / Sonnet 4 entries.
- **Meta Llama (MaaS, new plugin)**: `meta/llama-4-maverick-17b-128e-instruct-maas`, `meta/llama-4-scout-17b-16e-instruct-maas`, `meta/llama-3.3-70b-instruct-maas`. Llama 4 variants register as `Multimodal`; Llama 3.3 70B is text-only. Routed through `compat_oai` against the Vertex MaaS OpenAI-compatible endpoint.
- **Mistral / Codestral (MaaS, new plugin)**: `mistral-small-2503`, `mistral-medium-3`, `mistral-ocr-2505`, `codestral-2`. No maintained Mistral-GCP Go SDK exists, and Vertex does not serve Mistral via the OpenAI-compatible chat completions endpoint — see [Routing notes](#routing-notes) below.

## Plugin scaffolding

- New `Llama` and `Mistral` plugin types alongside the existing `Anthropic`, each with `Init`, `Name`, `DefineModel(name, opts)`, and a top-level `LlamaModel(g, id)` / `MistralModel(g, id)` lookup, mirroring the existing Anthropic shape.
- Shared `resolveVertexMaasEnv` helper for `GOOGLE_CLOUD_PROJECT` / `GCLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` / `GOOGLE_CLOUD_REGION` resolution.
- Shared `provider = "vertexai"` constant so every modelgarden plugin registers models under the same `vertexai/<model>` namespace.
- `Anthropic.DefineModel` now takes the same mutex and `initted` guard as `Llama.DefineModel` / `Mistral.DefineModel`, so calling it before `Init` returns an explicit `"not initialized"` error instead of using a zero-value client.

## Routing notes

Vertex's `/endpoints/openapi/chat/completions` works for Meta Llama but not for Mistral — Vertex returns `400 FAILED_PRECONDITION` even with a subscribed project. Mistral is only served at per-model `…/publishers/mistralai/models/<id>:rawPredict` (and `:streamRawPredict` for SSE). The rawPredict response is already OpenAI-shaped JSON, so only the URL needs to change.

`mistral_transport.go` introduces an `http.RoundTripper` that wraps the oauth2 transport, intercepts outbound `/chat/completions` requests, reads `model` + `stream` from the body, rewrites the URL to the per-model rawPredict (or streamRawPredict) path, and delegates back. The body bytes are preserved (incl. `tools`, `response_format`, `stream_options`), `GetBody` is set for openai-go retries, and the model id is `url.PathEscape`-encoded to prevent path/query injection.

`MistralModels` keys are bare ids (e.g. `mistral-small-2503`), so the openai-go SDK already serialises the form rawPredict expects. `MistralModel(g, id)` and `Mistral.DefineModel(name, opts)` strip an optional `mistralai/` prefix as a convenience so callers used to publisher-qualified ids keep working.

Llama is unchanged from the OpenAI-compat path; only Mistral takes the rawPredict detour.

## Sample

`go/samples/modelgarden` registers four flows for Dev UI smoke testing:

- `opus45Flow` — `claude-opus-4-5@20251101`
- `llamaFlow` — `meta/llama-3.3-70b-instruct-maas`
- `mistralFlow` — `mistral-small-2503`
- `codestralFlow` — `codestral-2`

Each plugin is constructed with an explicit `Location` because Vertex MaaS regional availability differs per publisher (Anthropic in `us-east5`, Llama / Mistral in `us-central1`), so all four flows work simultaneously with just `GOOGLE_CLOUD_PROJECT` set.

## Tests

- `mistral_transport_test.go` — pure in-process tests covering rawPredict / streamRawPredict URL rewrites, publisher-prefix strip, non-chat passthrough, missing-model error, body field preservation (tools, response_format), `GetBody` population, and URL escaping of malformed model ids.
- `models_test.go` — `resolveVertexMaasEnv` exercised for explicit args, primary / secondary env fallback, and panic paths.
- `internal_test.go` — `DefineModel` on Anthropic / Llama / Mistral covered for the nil `ai.ModelOptions` branch (in addition to the existing pre-`Init` error path in `define_model_test.go`).
- Coverage on the new code: `mistral_transport.RoundTrip` 89.7%, `peekModelAndStream` 100%, `resolveVertexMaasEnv` 100%. Package coverage rose from 32.6% to 48.8%; remaining 0% functions (`Init`, `Name`, model lookups) require GCP credentials and are exercised by the live tests.

<img width="1863" height="797" alt="Screenshot 2026-05-11 at 16 46 47" src="https://github.com/user-attachments/assets/7fdd8472-733a-4ca9-9c4d-25292d7fe4d0" />
