### PR TITLE
feat(go/plugins/googlegenai): Support Lyria 002 music generation

### DIFF
--- a/go/plugins/googlegenai/actions.go
+++ b/go/plugins/googlegenai/actions.go
@@ -59,6 +59,15 @@ func listActions(ctx context.Context, client *genai.Client, provider string) []a
 		}
 	}
 
+	// Lyria music models
+	for _, name := range models.lyria {
+		opts := GetModelOptions(name, provider)
+		model := newModel(client, name, opts)
+		if actionDef, ok := model.(api.Action); ok {
+			actions = append(actions, actionDef.Desc())
+		}
+	}
+
 	// Embedders
 	for _, name := range models.embedders {
 		opts := GetEmbedderOptions(name, provider)

--- a/go/plugins/googlegenai/actions.go
+++ b/go/plugins/googlegenai/actions.go
@@ -40,6 +40,11 @@ func listActions(ctx context.Context, client *genai.Client, c catalog) []api.Act
 		actions = append(actions, newVeoModel(client, name, c.modelOptions(name)).Desc())
 	}
 
+	// Lyria music models
+	for _, name := range models.lyria {
+		actions = append(actions, newModel(client, name, c.modelOptions(name)).Desc())
+	}
+
 	// Embedders
 	for _, name := range models.embedders {
 		opts := c.embedderOptions(name)

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -118,6 +118,8 @@ func newModel(client *genai.Client, name string, opts ai.ModelOptions) ai.Model 
 		switch mt {
 		case ModelTypeImagen:
 			return generateImage(ctx, client, name, input, cb)
+		case ModelTypeLyria:
+			return generateMusic(ctx, client, name, input, cb)
 		default:
 			return generate(ctx, client, name, input, cb)
 		}

--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -89,6 +89,17 @@ func newModel(client *genai.Client, id string, opts ai.ModelOptions) *ai.ModelAc
 			})
 	}
 
+	// Lyria posts to a Vertex-only predict endpoint - the genai SDK has no
+	// music method - so it takes neither the generateContent path nor the
+	// media-download middleware. generateMusic reads the config off the
+	// request, which normalizeConfig has already converted to LyriaConfig.
+	if mt == ModelTypeLyria {
+		return ai.NewModelAction(api.NewName(provider, id), &opts,
+			func(ctx context.Context, input *ai.ModelRequest, _ LyriaConfig, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+				return generateMusic(ctx, client, id, input, cb)
+			})
+	}
+
 	// The gemini api doesn't support downloading media from http(s).
 	var download ai.ModelMiddleware
 	if opts.Supports != nil && opts.Supports.Media {

--- a/go/plugins/googlegenai/lyria.go
+++ b/go/plugins/googlegenai/lyria.go
@@ -1,0 +1,217 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package googlegenai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/internal/base"
+	"google.golang.org/genai"
+)
+
+// LyriaConfig controls a Vertex AI Lyria music generation request. It mirrors
+// the JS LyriaConfigSchema used for the lyria-002 legacy endpoint.
+type LyriaConfig struct {
+	// NegativePrompt optionally describes what to exclude from the generated audio.
+	NegativePrompt string `json:"negativePrompt,omitempty"`
+	// Seed, when set, makes generation deterministic. Mutually exclusive with SampleCount.
+	Seed *int `json:"seed,omitempty"`
+	// SampleCount is the number of audio clips to generate. Defaults to 1.
+	SampleCount int `json:"sampleCount,omitempty"`
+	// Location overrides the plugin-level Vertex AI location for this request.
+	// Lyria is typically only available in specific regions (e.g. "global").
+	Location string `json:"location,omitempty"`
+}
+
+type lyriaInstance struct {
+	Prompt         string `json:"prompt"`
+	NegativePrompt string `json:"negativePrompt,omitempty"`
+	Seed           *int   `json:"seed,omitempty"`
+}
+
+type lyriaParameters struct {
+	SampleCount int `json:"sampleCount,omitempty"`
+}
+
+type lyriaPredictRequest struct {
+	Instances  []lyriaInstance `json:"instances"`
+	Parameters lyriaParameters `json:"parameters"`
+}
+
+type lyriaPrediction struct {
+	BytesBase64Encoded string `json:"bytesBase64Encoded"`
+	MimeType           string `json:"mimeType"`
+}
+
+type lyriaPredictResponse struct {
+	Predictions []lyriaPrediction `json:"predictions"`
+}
+
+// lyriaConfigFromRequest extracts a *LyriaConfig from a model request. The
+// config may arrive as LyriaConfig, *LyriaConfig, map[string]any, or nil.
+func lyriaConfigFromRequest(input *ai.ModelRequest) (*LyriaConfig, error) {
+	var result LyriaConfig
+	switch config := input.Config.(type) {
+	case LyriaConfig:
+		result = config
+	case *LyriaConfig:
+		if config != nil {
+			result = *config
+		}
+	case map[string]any:
+		r, err := base.MapToStruct[LyriaConfig](config)
+		if err != nil {
+			return nil, core.NewPublicError(core.INVALID_ARGUMENT, fmt.Sprintf("The Lyria configuration settings are not in the correct format. Check that the names and values match what the model expects: %v", err), nil)
+		}
+		result = r
+	case nil:
+		// empty but valid config
+	default:
+		return nil, core.NewPublicError(core.INVALID_ARGUMENT, fmt.Sprintf("Invalid Lyria configuration type: %T. Expected *googlegenai.LyriaConfig.", input.Config), nil)
+	}
+	return &result, nil
+}
+
+// translateLyriaResponse converts a raw Lyria predict response into an
+// *ai.ModelResponse with one media part per returned audio clip.
+func translateLyriaResponse(resp *lyriaPredictResponse, input *ai.ModelRequest) *ai.ModelResponse {
+	msg := &ai.Message{Role: ai.RoleModel}
+	for _, p := range resp.Predictions {
+		url := fmt.Sprintf("data:%s;base64,%s", p.MimeType, p.BytesBase64Encoded)
+		msg.Content = append(msg.Content, ai.NewMediaPart(p.MimeType, url))
+	}
+	return &ai.ModelResponse{
+		FinishReason: ai.FinishReasonStop,
+		Message:      msg,
+		Request:      input,
+	}
+}
+
+// generateMusic calls the Vertex AI `predict` endpoint for Lyria music models.
+// The `google.golang.org/genai` SDK does not expose a music-specific method, so
+// this function issues the HTTPS call directly, reusing the authenticated
+// *http.Client that the plugin configured on the genai.Client (credentials,
+// quota project header, OpenTelemetry tracing).
+func generateMusic(
+	ctx context.Context,
+	client *genai.Client,
+	model string,
+	input *ai.ModelRequest,
+	cb func(context.Context, *ai.ModelResponseChunk) error,
+) (*ai.ModelResponse, error) {
+	if cb != nil {
+		return nil, fmt.Errorf("streaming mode not supported for music generation")
+	}
+
+	cc := client.ClientConfig()
+	if cc.Backend != genai.BackendVertexAI {
+		return nil, fmt.Errorf("lyria is only available through the Vertex AI backend")
+	}
+	if cc.HTTPClient == nil {
+		return nil, fmt.Errorf("lyria: genai.Client has no HTTP client configured")
+	}
+
+	cfg, err := lyriaConfigFromRequest(input)
+	if err != nil {
+		return nil, err
+	}
+
+	var parts []string
+	for _, m := range input.Messages {
+		if m.Role != ai.RoleUser {
+			continue
+		}
+		if text := m.Text(); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	userPrompt := strings.Join(parts, "\n")
+	if userPrompt == "" {
+		return nil, fmt.Errorf("error generating music: empty prompt detected")
+	}
+
+	req := lyriaPredictRequest{
+		Instances: []lyriaInstance{{
+			Prompt:         userPrompt,
+			NegativePrompt: cfg.NegativePrompt,
+			Seed:           cfg.Seed,
+		}},
+		Parameters: lyriaParameters{SampleCount: cfg.SampleCount},
+	}
+	if req.Parameters.SampleCount == 0 {
+		req.Parameters.SampleCount = 1
+	}
+
+	location := cc.Location
+	if cfg.Location != "" {
+		location = cfg.Location
+	}
+	if location == "" {
+		return nil, fmt.Errorf("lyria requires a Vertex AI location")
+	}
+	if cc.Project == "" {
+		return nil, fmt.Errorf("lyria requires a Vertex AI project id")
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("lyria: marshaling request: %w", err)
+	}
+
+	url := fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:predict",
+		location, cc.Project, location, model,
+	)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := cc.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("lyria: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("lyria: %s: %s", resp.Status, string(data))
+	}
+
+	var lp lyriaPredictResponse
+	if err := json.Unmarshal(data, &lp); err != nil {
+		return nil, fmt.Errorf("lyria: unmarshaling response: %w", err)
+	}
+	if len(lp.Predictions) == 0 {
+		return nil, fmt.Errorf("lyria: no predictions returned (possibly content-filtered)")
+	}
+
+	return translateLyriaResponse(&lp, input), nil
+}

--- a/go/plugins/googlegenai/lyria.go
+++ b/go/plugins/googlegenai/lyria.go
@@ -191,20 +191,40 @@ func generateMusic(
 		return nil, fmt.Errorf("lyria requires a Vertex AI project id")
 	}
 
+	url := lyriaPredictURL(location, cc.Project, model)
+	lp, err := doLyriaPredict(ctx, cc.HTTPClient, url, req)
+	if err != nil {
+		return nil, err
+	}
+	if len(lp.Predictions) == 0 {
+		return nil, fmt.Errorf("lyria: no predictions returned (possibly content-filtered)")
+	}
+
+	return translateLyriaResponse(lp, input), nil
+}
+
+// doLyriaPredict issues an authenticated POST to the Vertex AI Lyria
+// `:predict` endpoint at url. It attaches the standard Genkit client
+// header on top of whatever the supplied httpClient already injects
+// (credentials, quota project, OTel tracing).
+func doLyriaPredict(ctx context.Context, httpClient *http.Client, url string, req lyriaPredictRequest) (*lyriaPredictResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("lyria: marshaling request: %w", err)
 	}
-
-	url := lyriaPredictURL(location, cc.Project, model)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	for k, vs := range genkitClientHeader {
+		for _, v := range vs {
+			httpReq.Header.Add(k, v)
+		}
+	}
 
-	resp, err := cc.HTTPClient.Do(httpReq)
+	resp, err := httpClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("lyria: request failed: %w", err)
 	}
@@ -222,9 +242,5 @@ func generateMusic(
 	if err := json.Unmarshal(data, &lp); err != nil {
 		return nil, fmt.Errorf("lyria: unmarshaling response: %w", err)
 	}
-	if len(lp.Predictions) == 0 {
-		return nil, fmt.Errorf("lyria: no predictions returned (possibly content-filtered)")
-	}
-
-	return translateLyriaResponse(&lp, input), nil
+	return &lp, nil
 }

--- a/go/plugins/googlegenai/lyria.go
+++ b/go/plugins/googlegenai/lyria.go
@@ -95,13 +95,22 @@ func lyriaConfigFromRequest(input *ai.ModelRequest) (*LyriaConfig, error) {
 	return &result, nil
 }
 
+// defaultLyriaMimeType is the audio mime type assumed when Vertex does not
+// include one in a prediction. lyria-002 returns WAV (RIFF) bytes without
+// labeling them.
+const defaultLyriaMimeType = "audio/wav"
+
 // translateLyriaResponse converts a raw Lyria predict response into an
 // *ai.ModelResponse with one media part per returned audio clip.
 func translateLyriaResponse(resp *lyriaPredictResponse, input *ai.ModelRequest) *ai.ModelResponse {
 	msg := &ai.Message{Role: ai.RoleModel}
 	for _, p := range resp.Predictions {
-		url := fmt.Sprintf("data:%s;base64,%s", p.MimeType, p.BytesBase64Encoded)
-		msg.Content = append(msg.Content, ai.NewMediaPart(p.MimeType, url))
+		mime := p.MimeType
+		if mime == "" {
+			mime = defaultLyriaMimeType
+		}
+		url := fmt.Sprintf("data:%s;base64,%s", mime, p.BytesBase64Encoded)
+		msg.Content = append(msg.Content, ai.NewMediaPart(mime, url))
 	}
 	return &ai.ModelResponse{
 		FinishReason: ai.FinishReasonStop,

--- a/go/plugins/googlegenai/lyria.go
+++ b/go/plugins/googlegenai/lyria.go
@@ -116,20 +116,6 @@ func translateLyriaResponse(resp *lyriaPredictResponse, input *ai.ModelRequest) 
 	}
 }
 
-// warnLyriaCountMismatch logs a warning when Lyria returns fewer audio
-// predictions than were requested via SampleCount. Vertex silently truncates
-// in some cases (content filter, quota), and a silent drop is easy to miss.
-func warnLyriaCountMismatch(ctx context.Context, requested, received int) {
-	if received >= requested {
-		return
-	}
-	logger.FromContext(ctx).Warn(
-		"lyria returned fewer predictions than requested",
-		"requested", requested,
-		"received", received,
-	)
-}
-
 // lyriaPredictURL builds the Vertex AI `:predict` endpoint URL for a Lyria
 // music model in the given project + location. Mirrors the host + version
 // scheme in js/plugins/google-genai/src/vertexai/client.ts: the bare
@@ -216,7 +202,15 @@ func generateMusic(
 	if len(lp.Predictions) == 0 {
 		return nil, core.NewPublicError(core.INTERNAL, "lyria: no predictions returned (possibly content-filtered)", nil)
 	}
-	warnLyriaCountMismatch(ctx, req.Parameters.SampleCount, len(lp.Predictions))
+	// Vertex silently truncates the prediction count in some cases (content
+	// filter, quota); a silent drop is easy to miss, so warn.
+	if got := len(lp.Predictions); got < req.Parameters.SampleCount {
+		logger.FromContext(ctx).Warn(
+			"lyria returned fewer predictions than requested",
+			"requested", req.Parameters.SampleCount,
+			"received", got,
+		)
+	}
 
 	return translateLyriaResponse(lp, input), nil
 }

--- a/go/plugins/googlegenai/lyria.go
+++ b/go/plugins/googlegenai/lyria.go
@@ -109,6 +109,15 @@ func translateLyriaResponse(resp *lyriaPredictResponse, input *ai.ModelRequest) 
 	}
 }
 
+// lyriaPredictURL builds the Vertex AI `:predict` endpoint URL for a Lyria
+// music model in the given project + location.
+func lyriaPredictURL(location, project, model string) string {
+	return fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:predict",
+		location, project, location, model,
+	)
+}
+
 // generateMusic calls the Vertex AI `predict` endpoint for Lyria music models.
 // The `google.golang.org/genai` SDK does not expose a music-specific method, so
 // this function issues the HTTPS call directly, reusing the authenticated
@@ -180,10 +189,7 @@ func generateMusic(
 		return nil, fmt.Errorf("lyria: marshaling request: %w", err)
 	}
 
-	url := fmt.Sprintf(
-		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:predict",
-		location, cc.Project, location, model,
-	)
+	url := lyriaPredictURL(location, cc.Project, model)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {

--- a/go/plugins/googlegenai/lyria.go
+++ b/go/plugins/googlegenai/lyria.go
@@ -41,9 +41,6 @@ type LyriaConfig struct {
 	Seed *int `json:"seed,omitempty"`
 	// SampleCount is the number of audio clips to generate. Defaults to 1.
 	SampleCount int `json:"sampleCount,omitempty"`
-	// Location overrides the plugin-level Vertex AI location for this request.
-	// Lyria is typically only available in specific regions (e.g. "global").
-	Location string `json:"location,omitempty"`
 }
 
 type lyriaInstance struct {
@@ -204,18 +201,14 @@ func generateMusic(
 		req.Parameters.SampleCount = 1
 	}
 
-	location := cc.Location
-	if cfg.Location != "" {
-		location = cfg.Location
-	}
-	if location == "" {
+	if cc.Location == "" {
 		return nil, core.NewPublicError(core.INVALID_ARGUMENT, "lyria requires a Vertex AI location", nil)
 	}
 	if cc.Project == "" {
 		return nil, core.NewPublicError(core.INVALID_ARGUMENT, "lyria requires a Vertex AI project id", nil)
 	}
 
-	url := lyriaPredictURL(location, cc.Project, model)
+	url := lyriaPredictURL(cc.Location, cc.Project, model)
 	lp, err := doLyriaPredict(ctx, cc.HTTPClient, url, req)
 	if err != nil {
 		return nil, err

--- a/go/plugins/googlegenai/lyria.go
+++ b/go/plugins/googlegenai/lyria.go
@@ -34,6 +34,8 @@ import (
 
 // LyriaConfig controls a Vertex AI Lyria music generation request. It mirrors
 // the JS LyriaConfigSchema used for the lyria-002 legacy endpoint.
+//
+// Vertex AI backend only.
 type LyriaConfig struct {
 	// NegativePrompt optionally describes what to exclude from the generated audio.
 	NegativePrompt string `json:"negativePrompt,omitempty"`

--- a/go/plugins/googlegenai/lyria.go
+++ b/go/plugins/googlegenai/lyria.go
@@ -110,11 +110,18 @@ func translateLyriaResponse(resp *lyriaPredictResponse, input *ai.ModelRequest) 
 }
 
 // lyriaPredictURL builds the Vertex AI `:predict` endpoint URL for a Lyria
-// music model in the given project + location.
+// music model in the given project + location. Mirrors the host + version
+// scheme in js/plugins/google-genai/src/vertexai/client.ts: the bare
+// aiplatform host is used for the "global" location and a regional prefix
+// is added otherwise.
 func lyriaPredictURL(location, project, model string) string {
+	host := "aiplatform.googleapis.com"
+	if location != "global" {
+		host = location + "-" + host
+	}
 	return fmt.Sprintf(
-		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:predict",
-		location, project, location, model,
+		"https://%s/v1beta1/projects/%s/locations/%s/publishers/google/models/%s:predict",
+		host, project, location, model,
 	)
 }
 

--- a/go/plugins/googlegenai/lyria.go
+++ b/go/plugins/googlegenai/lyria.go
@@ -170,7 +170,7 @@ func generateMusic(
 		return nil, core.NewPublicError(core.FAILED_PRECONDITION, "Lyria is only available through the Vertex AI backend", nil)
 	}
 	if cc.HTTPClient == nil {
-		return nil, fmt.Errorf("lyria: genai.Client has no HTTP client configured")
+		return nil, core.NewPublicError(core.FAILED_PRECONDITION, "lyria: genai.Client has no HTTP client configured", nil)
 	}
 
 	cfg, err := lyriaConfigFromRequest(input)
@@ -221,7 +221,7 @@ func generateMusic(
 		return nil, err
 	}
 	if len(lp.Predictions) == 0 {
-		return nil, fmt.Errorf("lyria: no predictions returned (possibly content-filtered)")
+		return nil, core.NewPublicError(core.INTERNAL, "lyria: no predictions returned (possibly content-filtered)", nil)
 	}
 	warnLyriaCountMismatch(ctx, req.Parameters.SampleCount, len(lp.Predictions))
 
@@ -260,7 +260,7 @@ func doLyriaPredict(ctx context.Context, httpClient *http.Client, url string, re
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("lyria: %s: %s", resp.Status, string(data))
+		return nil, core.NewPublicError(core.INTERNAL, fmt.Sprintf("lyria: %s: %s", resp.Status, string(data)), nil)
 	}
 
 	var lp lyriaPredictResponse

--- a/go/plugins/googlegenai/lyria.go
+++ b/go/plugins/googlegenai/lyria.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/internal/base"
 	"google.golang.org/genai"
 )
@@ -107,6 +108,20 @@ func translateLyriaResponse(resp *lyriaPredictResponse, input *ai.ModelRequest) 
 		Message:      msg,
 		Request:      input,
 	}
+}
+
+// warnLyriaCountMismatch logs a warning when Lyria returns fewer audio
+// predictions than were requested via SampleCount. Vertex silently truncates
+// in some cases (content filter, quota), and a silent drop is easy to miss.
+func warnLyriaCountMismatch(ctx context.Context, requested, received int) {
+	if received >= requested {
+		return
+	}
+	logger.FromContext(ctx).Warn(
+		"lyria returned fewer predictions than requested",
+		"requested", requested,
+		"received", received,
+	)
 }
 
 // lyriaPredictURL builds the Vertex AI `:predict` endpoint URL for a Lyria
@@ -199,6 +214,7 @@ func generateMusic(
 	if len(lp.Predictions) == 0 {
 		return nil, fmt.Errorf("lyria: no predictions returned (possibly content-filtered)")
 	}
+	warnLyriaCountMismatch(ctx, req.Parameters.SampleCount, len(lp.Predictions))
 
 	return translateLyriaResponse(lp, input), nil
 }

--- a/go/plugins/googlegenai/lyria.go
+++ b/go/plugins/googlegenai/lyria.go
@@ -138,12 +138,12 @@ func generateMusic(
 	cb func(context.Context, *ai.ModelResponseChunk) error,
 ) (*ai.ModelResponse, error) {
 	if cb != nil {
-		return nil, fmt.Errorf("streaming mode not supported for music generation")
+		return nil, core.NewPublicError(core.INVALID_ARGUMENT, "streaming mode is not supported for Lyria music generation", nil)
 	}
 
 	cc := client.ClientConfig()
 	if cc.Backend != genai.BackendVertexAI {
-		return nil, fmt.Errorf("lyria is only available through the Vertex AI backend")
+		return nil, core.NewPublicError(core.FAILED_PRECONDITION, "Lyria is only available through the Vertex AI backend", nil)
 	}
 	if cc.HTTPClient == nil {
 		return nil, fmt.Errorf("lyria: genai.Client has no HTTP client configured")
@@ -165,7 +165,7 @@ func generateMusic(
 	}
 	userPrompt := strings.Join(parts, "\n")
 	if userPrompt == "" {
-		return nil, fmt.Errorf("error generating music: empty prompt detected")
+		return nil, core.NewPublicError(core.INVALID_ARGUMENT, "lyria requires a non-empty text prompt", nil)
 	}
 
 	req := lyriaPredictRequest{
@@ -185,10 +185,10 @@ func generateMusic(
 		location = cfg.Location
 	}
 	if location == "" {
-		return nil, fmt.Errorf("lyria requires a Vertex AI location")
+		return nil, core.NewPublicError(core.INVALID_ARGUMENT, "lyria requires a Vertex AI location", nil)
 	}
 	if cc.Project == "" {
-		return nil, fmt.Errorf("lyria requires a Vertex AI project id")
+		return nil, core.NewPublicError(core.INVALID_ARGUMENT, "lyria requires a Vertex AI project id", nil)
 	}
 
 	url := lyriaPredictURL(location, cc.Project, model)

--- a/go/plugins/googlegenai/lyria_test.go
+++ b/go/plugins/googlegenai/lyria_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -155,42 +154,6 @@ func TestLyriaPredictURL(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestWarnLyriaCountMismatch(t *testing.T) {
-	prev := slog.Default()
-	defer slog.SetDefault(prev)
-
-	var buf strings.Builder
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
-
-	t.Run("fewer than requested triggers warn", func(t *testing.T) {
-		buf.Reset()
-		warnLyriaCountMismatch(context.Background(), 4, 1)
-		out := buf.String()
-		if !strings.Contains(out, "level=WARN") {
-			t.Errorf("expected WARN log, got: %s", out)
-		}
-		if !strings.Contains(out, "requested=4") || !strings.Contains(out, "received=1") {
-			t.Errorf("log missing requested/received counts: %s", out)
-		}
-	})
-
-	t.Run("matching counts emit nothing", func(t *testing.T) {
-		buf.Reset()
-		warnLyriaCountMismatch(context.Background(), 2, 2)
-		if buf.Len() != 0 {
-			t.Errorf("expected no log, got: %s", buf.String())
-		}
-	})
-
-	t.Run("more than requested emits nothing", func(t *testing.T) {
-		buf.Reset()
-		warnLyriaCountMismatch(context.Background(), 1, 3)
-		if buf.Len() != 0 {
-			t.Errorf("expected no log, got: %s", buf.String())
-		}
-	})
 }
 
 func TestGenerateMusic_StreamingReturnsPublicError(t *testing.T) {

--- a/go/plugins/googlegenai/lyria_test.go
+++ b/go/plugins/googlegenai/lyria_test.go
@@ -17,6 +17,12 @@
 package googlegenai
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
@@ -150,6 +156,61 @@ func TestLyriaPredictURL(t *testing.T) {
 				t.Errorf("lyriaPredictURL() =\n  %s\nwant\n  %s", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDoLyriaPredict_AttachesGenkitClientHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get(xGoogApiClientHeader)
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"predictions":[{"bytesBase64Encoded":"AAAA","mimeType":"audio/wav"}]}`)
+	}))
+	defer srv.Close()
+
+	req := lyriaPredictRequest{
+		Instances:  []lyriaInstance{{Prompt: "jazz"}},
+		Parameters: lyriaParameters{SampleCount: 1},
+	}
+	resp, err := doLyriaPredict(context.Background(), srv.Client(), srv.URL, req)
+	if err != nil {
+		t.Fatalf("doLyriaPredict() error = %v", err)
+	}
+	if len(resp.Predictions) != 1 {
+		t.Fatalf("expected 1 prediction, got %d", len(resp.Predictions))
+	}
+	if !strings.HasPrefix(gotHeader, "genkit-go/") {
+		t.Errorf("x-goog-api-client = %q, want prefix %q", gotHeader, "genkit-go/")
+	}
+
+	var sent lyriaPredictRequest
+	if err := json.Unmarshal(gotBody, &sent); err != nil {
+		t.Fatalf("server got non-JSON body: %v", err)
+	}
+	if sent.Instances[0].Prompt != "jazz" {
+		t.Errorf("prompt forwarded = %q, want %q", sent.Instances[0].Prompt, "jazz")
+	}
+}
+
+func TestDoLyriaPredict_NonOKStatusReturnsError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"bad request"}`)
+	}))
+	defer srv.Close()
+
+	_, err := doLyriaPredict(context.Background(), srv.Client(), srv.URL, lyriaPredictRequest{})
+	if err == nil {
+		t.Fatal("expected error for 400 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error = %v, want it to mention 400", err)
 	}
 }
 

--- a/go/plugins/googlegenai/lyria_test.go
+++ b/go/plugins/googlegenai/lyria_test.go
@@ -117,6 +117,42 @@ func TestLyriaConfigFromRequest(t *testing.T) {
 	}
 }
 
+func TestLyriaPredictURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		location string
+		project  string
+		model    string
+		want     string
+	}{
+		{
+			name:     "global location uses bare aiplatform host",
+			location: "global",
+			project:  "my-proj",
+			model:    "lyria-002",
+			want:     "https://aiplatform.googleapis.com/v1beta1/projects/my-proj/locations/global/publishers/google/models/lyria-002:predict",
+		},
+		{
+			name:     "regional location uses host prefix",
+			location: "us-central1",
+			project:  "my-proj",
+			model:    "lyria-002",
+			want:     "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-proj/locations/us-central1/publishers/google/models/lyria-002:predict",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lyriaPredictURL(tt.location, tt.project, tt.model)
+			if got != tt.want {
+				t.Errorf("lyriaPredictURL() =\n  %s\nwant\n  %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTranslateLyriaResponse(t *testing.T) {
 	t.Parallel()
 

--- a/go/plugins/googlegenai/lyria_test.go
+++ b/go/plugins/googlegenai/lyria_test.go
@@ -268,6 +268,13 @@ func TestDoLyriaPredict_NonOKStatusReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "400") {
 		t.Errorf("error = %v, want it to mention 400", err)
 	}
+	var ufe *core.UserFacingError
+	if !errors.As(err, &ufe) {
+		t.Fatalf("error %T is not *core.UserFacingError: %v", err, err)
+	}
+	if ufe.Status != core.INTERNAL {
+		t.Errorf("status = %s, want INTERNAL", ufe.Status)
+	}
 }
 
 func TestTranslateLyriaResponse(t *testing.T) {

--- a/go/plugins/googlegenai/lyria_test.go
+++ b/go/plugins/googlegenai/lyria_test.go
@@ -309,6 +309,25 @@ func TestTranslateLyriaResponse(t *testing.T) {
 		}
 	})
 
+	t.Run("missing mime type defaults to audio/wav", func(t *testing.T) {
+		resp := &lyriaPredictResponse{
+			Predictions: []lyriaPrediction{
+				{BytesBase64Encoded: "UklGRg==", MimeType: ""},
+			},
+		}
+		res := translateLyriaResponse(resp, &ai.ModelRequest{})
+		if len(res.Message.Content) != 1 {
+			t.Fatalf("expected 1 part, got %d", len(res.Message.Content))
+		}
+		p := res.Message.Content[0]
+		if p.ContentType != "audio/wav" {
+			t.Errorf("ContentType = %q, want audio/wav (Vertex omits mimeType in real responses)", p.ContentType)
+		}
+		if p.Text != "data:audio/wav;base64,UklGRg==" {
+			t.Errorf("data URL = %q", p.Text)
+		}
+	})
+
 	t.Run("multiple predictions", func(t *testing.T) {
 		resp := &lyriaPredictResponse{
 			Predictions: []lyriaPrediction{

--- a/go/plugins/googlegenai/lyria_test.go
+++ b/go/plugins/googlegenai/lyria_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package googlegenai
+
+import (
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"google.golang.org/genai"
+)
+
+func TestLyriaConfigFromRequest(t *testing.T) {
+	t.Parallel()
+
+	seed := 42
+	tests := []struct {
+		name           string
+		request        *ai.ModelRequest
+		expectError    bool
+		expectSeed     *int
+		expectCount    int
+		expectNegative string
+		expectLocation string
+	}{
+		{
+			name: "valid config struct value",
+			request: &ai.ModelRequest{
+				Config: LyriaConfig{SampleCount: 2, NegativePrompt: "drums"},
+			},
+			expectCount:    2,
+			expectNegative: "drums",
+		},
+		{
+			name: "valid config struct pointer",
+			request: &ai.ModelRequest{
+				Config: &LyriaConfig{Seed: &seed, Location: "global"},
+			},
+			expectSeed:     &seed,
+			expectLocation: "global",
+		},
+		{
+			name: "nil config pointer",
+			request: &ai.ModelRequest{
+				Config: (*LyriaConfig)(nil),
+			},
+		},
+		{
+			name: "valid map config",
+			request: &ai.ModelRequest{
+				Config: map[string]any{
+					"sampleCount":    3,
+					"negativePrompt": "vocals",
+				},
+			},
+			expectCount:    3,
+			expectNegative: "vocals",
+		},
+		{
+			name:    "nil config",
+			request: &ai.ModelRequest{Config: nil},
+		},
+		{
+			name: "invalid config type",
+			request: &ai.ModelRequest{
+				Config: &genai.GenerateContentConfig{},
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid map values",
+			request: &ai.ModelRequest{
+				Config: map[string]any{"sampleCount": "not-a-number"},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := lyriaConfigFromRequest(tt.request)
+			if (err != nil) != tt.expectError {
+				t.Fatalf("lyriaConfigFromRequest() error = %v, expectError %v", err, tt.expectError)
+			}
+			if tt.expectError {
+				return
+			}
+			if got.SampleCount != tt.expectCount {
+				t.Errorf("SampleCount = %d, want %d", got.SampleCount, tt.expectCount)
+			}
+			if got.NegativePrompt != tt.expectNegative {
+				t.Errorf("NegativePrompt = %q, want %q", got.NegativePrompt, tt.expectNegative)
+			}
+			if got.Location != tt.expectLocation {
+				t.Errorf("Location = %q, want %q", got.Location, tt.expectLocation)
+			}
+			if (got.Seed == nil) != (tt.expectSeed == nil) {
+				t.Errorf("Seed nil mismatch: got %v want %v", got.Seed, tt.expectSeed)
+			}
+			if got.Seed != nil && tt.expectSeed != nil && *got.Seed != *tt.expectSeed {
+				t.Errorf("Seed = %d, want %d", *got.Seed, *tt.expectSeed)
+			}
+		})
+	}
+}
+
+func TestTranslateLyriaResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty predictions", func(t *testing.T) {
+		resp := &lyriaPredictResponse{}
+		res := translateLyriaResponse(resp, &ai.ModelRequest{})
+		if res.FinishReason != ai.FinishReasonStop {
+			t.Errorf("FinishReason = %s, want Stop", res.FinishReason)
+		}
+		if res.Message == nil || res.Message.Role != ai.RoleModel {
+			t.Errorf("expected Role=model, got %+v", res.Message)
+		}
+		if len(res.Message.Content) != 0 {
+			t.Errorf("expected 0 parts, got %d", len(res.Message.Content))
+		}
+	})
+
+	t.Run("single prediction", func(t *testing.T) {
+		resp := &lyriaPredictResponse{
+			Predictions: []lyriaPrediction{
+				{BytesBase64Encoded: "AAAA", MimeType: "audio/wav"},
+			},
+		}
+		res := translateLyriaResponse(resp, &ai.ModelRequest{})
+		if len(res.Message.Content) != 1 {
+			t.Fatalf("expected 1 part, got %d", len(res.Message.Content))
+		}
+		p := res.Message.Content[0]
+		if p.Kind != ai.PartMedia {
+			t.Errorf("Kind = %v, want PartMedia", p.Kind)
+		}
+		if p.ContentType != "audio/wav" {
+			t.Errorf("ContentType = %q, want audio/wav", p.ContentType)
+		}
+		if p.Text != "data:audio/wav;base64,AAAA" {
+			t.Errorf("data URL = %q", p.Text)
+		}
+	})
+
+	t.Run("multiple predictions", func(t *testing.T) {
+		resp := &lyriaPredictResponse{
+			Predictions: []lyriaPrediction{
+				{BytesBase64Encoded: "A", MimeType: "audio/wav"},
+				{BytesBase64Encoded: "B", MimeType: "audio/wav"},
+				{BytesBase64Encoded: "C", MimeType: "audio/mpeg"},
+			},
+		}
+		res := translateLyriaResponse(resp, &ai.ModelRequest{})
+		if len(res.Message.Content) != 3 {
+			t.Fatalf("expected 3 parts, got %d", len(res.Message.Content))
+		}
+		if res.Message.Content[2].ContentType != "audio/mpeg" {
+			t.Errorf("3rd part mime = %q, want audio/mpeg", res.Message.Content[2].ContentType)
+		}
+	})
+}

--- a/go/plugins/googlegenai/lyria_test.go
+++ b/go/plugins/googlegenai/lyria_test.go
@@ -19,6 +19,7 @@ package googlegenai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -26,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
 	"google.golang.org/genai"
 )
 
@@ -156,6 +158,23 @@ func TestLyriaPredictURL(t *testing.T) {
 				t.Errorf("lyriaPredictURL() =\n  %s\nwant\n  %s", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGenerateMusic_StreamingReturnsPublicError(t *testing.T) {
+	t.Parallel()
+
+	cb := func(context.Context, *ai.ModelResponseChunk) error { return nil }
+	_, err := generateMusic(context.Background(), nil, "lyria-002", &ai.ModelRequest{}, cb)
+	if err == nil {
+		t.Fatal("expected error for streaming callback, got nil")
+	}
+	var ufe *core.UserFacingError
+	if !errors.As(err, &ufe) {
+		t.Fatalf("error %T is not *core.UserFacingError: %v", err, err)
+	}
+	if ufe.Status != core.INVALID_ARGUMENT {
+		t.Errorf("status = %s, want INVALID_ARGUMENT", ufe.Status)
 	}
 }
 

--- a/go/plugins/googlegenai/lyria_test.go
+++ b/go/plugins/googlegenai/lyria_test.go
@@ -43,7 +43,6 @@ func TestLyriaConfigFromRequest(t *testing.T) {
 		expectSeed     *int
 		expectCount    int
 		expectNegative string
-		expectLocation string
 	}{
 		{
 			name: "valid config struct value",
@@ -56,10 +55,9 @@ func TestLyriaConfigFromRequest(t *testing.T) {
 		{
 			name: "valid config struct pointer",
 			request: &ai.ModelRequest{
-				Config: &LyriaConfig{Seed: &seed, Location: "global"},
+				Config: &LyriaConfig{Seed: &seed},
 			},
-			expectSeed:     &seed,
-			expectLocation: "global",
+			expectSeed: &seed,
 		},
 		{
 			name: "nil config pointer",
@@ -112,9 +110,6 @@ func TestLyriaConfigFromRequest(t *testing.T) {
 			}
 			if got.NegativePrompt != tt.expectNegative {
 				t.Errorf("NegativePrompt = %q, want %q", got.NegativePrompt, tt.expectNegative)
-			}
-			if got.Location != tt.expectLocation {
-				t.Errorf("Location = %q, want %q", got.Location, tt.expectLocation)
 			}
 			if (got.Seed == nil) != (tt.expectSeed == nil) {
 				t.Errorf("Seed nil mismatch: got %v want %v", got.Seed, tt.expectSeed)

--- a/go/plugins/googlegenai/lyria_test.go
+++ b/go/plugins/googlegenai/lyria_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -159,6 +160,42 @@ func TestLyriaPredictURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWarnLyriaCountMismatch(t *testing.T) {
+	prev := slog.Default()
+	defer slog.SetDefault(prev)
+
+	var buf strings.Builder
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	t.Run("fewer than requested triggers warn", func(t *testing.T) {
+		buf.Reset()
+		warnLyriaCountMismatch(context.Background(), 4, 1)
+		out := buf.String()
+		if !strings.Contains(out, "level=WARN") {
+			t.Errorf("expected WARN log, got: %s", out)
+		}
+		if !strings.Contains(out, "requested=4") || !strings.Contains(out, "received=1") {
+			t.Errorf("log missing requested/received counts: %s", out)
+		}
+	})
+
+	t.Run("matching counts emit nothing", func(t *testing.T) {
+		buf.Reset()
+		warnLyriaCountMismatch(context.Background(), 2, 2)
+		if buf.Len() != 0 {
+			t.Errorf("expected no log, got: %s", buf.String())
+		}
+	})
+
+	t.Run("more than requested emits nothing", func(t *testing.T) {
+		buf.Reset()
+		warnLyriaCountMismatch(context.Background(), 1, 3)
+		if buf.Len() != 0 {
+			t.Errorf("expected no log, got: %s", buf.String())
+		}
+	})
 }
 
 func TestGenerateMusic_StreamingReturnsPublicError(t *testing.T) {

--- a/go/plugins/googlegenai/model_type.go
+++ b/go/plugins/googlegenai/model_type.go
@@ -20,6 +20,7 @@ const (
 	ModelTypeImagen             // Image generation (imagen-*)
 	ModelTypeVeo                // Video generation (veo-*), long-running
 	ModelTypeEmbedder           // Embedding models (*embedding*)
+	ModelTypeLyria              // Music generation (lyria-*)
 )
 
 // ClassifyModel determines the model type from its name.
@@ -30,6 +31,8 @@ func ClassifyModel(name string) ModelType {
 		return ModelTypeVeo
 	case strings.HasPrefix(name, "imagen"), strings.HasPrefix(name, "image"):
 		return ModelTypeImagen
+	case strings.HasPrefix(name, "lyria"):
+		return ModelTypeLyria
 	case strings.HasPrefix(name, "gemini"), strings.HasPrefix(name, "gemma"):
 		return ModelTypeGemini
 	case strings.Contains(name, "embedding"):
@@ -61,6 +64,8 @@ func (mt ModelType) DefaultSupports() *ai.ModelSupports {
 		return &Media
 	case ModelTypeVeo:
 		return &VeoSupports
+	case ModelTypeLyria:
+		return &Media
 	default:
 		return nil
 	}
@@ -77,6 +82,8 @@ func (mt ModelType) DefaultConfig() any {
 		return &genai.GenerateVideosConfig{}
 	case ModelTypeEmbedder:
 		return &genai.EmbedContentConfig{}
+	case ModelTypeLyria:
+		return &LyriaConfig{}
 	default:
 		return nil
 	}

--- a/go/plugins/googlegenai/model_type.go
+++ b/go/plugins/googlegenai/model_type.go
@@ -20,6 +20,7 @@ const (
 	ModelTypeImagen             // Image generation (imagen-*)
 	ModelTypeVeo                // Video generation (veo-*), long-running
 	ModelTypeEmbedder           // Embedding models (*embedding*)
+	ModelTypeLyria              // Music generation (lyria-*)
 )
 
 // ClassifyModel determines the model type from its name.
@@ -30,6 +31,8 @@ func ClassifyModel(name string) ModelType {
 		return ModelTypeVeo
 	case strings.HasPrefix(name, "imagen"), strings.HasPrefix(name, "image"):
 		return ModelTypeImagen
+	case strings.HasPrefix(name, "lyria"):
+		return ModelTypeLyria
 	case strings.Contains(name, "embedding"):
 		// Covers: text-embedding-*, embedding-*, textembedding-*,
 		// multimodalembedding, gemini-embedding-*. Checked before the gemini
@@ -83,6 +86,8 @@ func (mt ModelType) DefaultSupports() *ai.ModelSupports {
 		return &Media
 	case ModelTypeVeo:
 		return &VeoSupports
+	case ModelTypeLyria:
+		return &Media
 	default:
 		return nil
 	}
@@ -98,6 +103,8 @@ func (mt ModelType) configSchema() map[string]any {
 		return imagenConfigSchema
 	case ModelTypeVeo:
 		return veoConfigSchema
+	case ModelTypeLyria:
+		return lyriaConfigSchema
 	default:
 		// Gemini models and unrecognized names speak generateContent, and so
 		// does an embedding-classified name defined as a model. Embedder
@@ -118,6 +125,8 @@ func (mt ModelType) DefaultConfig() any {
 		return &genai.GenerateVideosConfig{}
 	case ModelTypeEmbedder:
 		return &genai.EmbedContentConfig{}
+	case ModelTypeLyria:
+		return &LyriaConfig{}
 	default:
 		return nil
 	}

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -74,6 +74,12 @@ var (
 		ConfigSchema: configToMap(genai.GenerateVideosConfig{}),
 	}
 
+	defaultLyriaOpts = ai.ModelOptions{
+		Supports:     &Media,
+		Stage:        ai.ModelStageUnstable,
+		ConfigSchema: configToMap(LyriaConfig{}),
+	}
+
 	defaultEmbedOpts = ai.EmbedderOptions{
 		Supports:   &ai.EmbedderSupports{Input: []string{"text"}},
 		Dimensions: 768,
@@ -104,6 +110,8 @@ const (
 	veo31GeneratePreview     = "veo-3.1-generate-preview"
 	veo31FastGeneratePreview = "veo-3.1-fast-generate-preview"
 
+	lyria002 = "lyria-002"
+
 	embedding001                      = "embedding-001"
 	textembeddinggecko003             = "textembedding-gecko@003"
 	textembeddinggecko002             = "textembedding-gecko@002"
@@ -133,6 +141,8 @@ var (
 		veo30FastGenerate001,
 		veo31Generate001,
 		veo31FastGenerate001,
+
+		lyria002,
 	}
 
 	googleAIModels = []string{
@@ -209,6 +219,15 @@ var (
 		},
 		imagen3FastGenerate001: {
 			Label:    "Imagen 3 Fast Generate 001",
+			Versions: []string{},
+			Supports: &Media,
+			Stage:    ai.ModelStageStable,
+		},
+	}
+
+	supportedLyriaModels = map[string]ai.ModelOptions{
+		lyria002: {
+			Label:    "Lyria 002",
 			Versions: []string{},
 			Supports: &Media,
 			Stage:    ai.ModelStageStable,
@@ -339,6 +358,11 @@ func GetModelOptions(name, provider string) ai.ModelOptions {
 		if !ok {
 			opts = defaultVeoOpts
 		}
+	case ModelTypeLyria:
+		opts, ok = supportedLyriaModels[name]
+		if !ok {
+			opts = defaultLyriaOpts
+		}
 	default:
 		opts = defaultGeminiOpts
 	}
@@ -410,6 +434,7 @@ type genaiModels struct {
 	imagen    []string
 	embedders []string
 	veo       []string
+	lyria     []string
 }
 
 // listGenaiModels returns a list of supported models and embedders from the
@@ -439,6 +464,11 @@ func listGenaiModels(ctx context.Context, client *genai.Client) (genaiModels, er
 
 		if strings.Contains(name, "veo") {
 			models.veo = append(models.veo, name)
+			continue
+		}
+
+		if strings.HasPrefix(name, "lyria") {
+			models.lyria = append(models.lyria, name)
 			continue
 		}
 

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -77,6 +77,8 @@ var (
 	geminiConfigSchema = configToMap(genai.GenerateContentConfig{})
 	imagenConfigSchema = configToMap(genai.GenerateImagesConfig{})
 	veoConfigSchema    = configToMap(genai.GenerateVideosConfig{})
+
+	lyriaConfigSchema = configToMap(LyriaConfig{})
 )
 
 // Default options for unknown models of each type. Every catalog entry is
@@ -100,6 +102,12 @@ var (
 		Supports:     &VeoSupports,
 		Stage:        ai.ModelStageUnstable,
 		ConfigSchema: veoConfigSchema,
+	}
+
+	defaultLyriaOpts = ai.ModelOptions{
+		Supports:     &Media,
+		Stage:        ai.ModelStageUnstable,
+		ConfigSchema: configToMap(LyriaConfig{}),
 	}
 
 	defaultEmbedOpts = ai.EmbedderOptions{
@@ -157,6 +165,8 @@ const (
 	veo31FastGeneratePreview = "veo-3.1-fast-generate-preview"
 	veo31LiteGeneratePreview = "veo-3.1-lite-generate-preview"
 
+	lyria002 = "lyria-002"
+
 	textembedding005             = "text-embedding-005"
 	textembedding004             = "text-embedding-004"
 	textmultilingualembedding002 = "text-multilingual-embedding-002"
@@ -193,6 +203,8 @@ var (
 		veo31Generate001,
 		veo31FastGenerate001,
 		veo31LiteGenerate001,
+
+		lyria002,
 	}
 
 	googleAIModels = []string{
@@ -363,6 +375,15 @@ var (
 		},
 	}
 
+	supportedLyriaModels = map[string]ai.ModelOptions{
+		lyria002: {
+			Label:    "Lyria 002",
+			Versions: []string{},
+			Supports: &Media,
+			Stage:    ai.ModelStageStable,
+		},
+	}
+
 	supportedImagenModels = map[string]ai.ModelOptions{
 		imagen40FastGenerate001: {
 			Label:    "Imagen 4 Fast Generate 001",
@@ -501,6 +522,11 @@ func GetModelOptions(name, provider string) ai.ModelOptions {
 		if !ok {
 			opts = defaultVeoOpts
 		}
+	case ModelTypeLyria:
+		opts, ok = supportedLyriaModels[name]
+		if !ok {
+			opts = defaultLyriaOpts
+		}
 	default:
 		opts = defaultGeminiOpts
 	}
@@ -561,6 +587,7 @@ type genaiModels struct {
 	imagen    []string
 	embedders []string
 	veo       []string
+	lyria     []string
 }
 
 // listGenaiModels returns a list of supported models and embedders from the
@@ -590,6 +617,11 @@ func listGenaiModels(ctx context.Context, client *genai.Client) (genaiModels, er
 
 		if strings.Contains(name, "veo") {
 			models.veo = append(models.veo, name)
+			continue
+		}
+
+		if strings.HasPrefix(name, "lyria") {
+			models.lyria = append(models.lyria, name)
 			continue
 		}
 

--- a/go/plugins/googlegenai/refs.go
+++ b/go/plugins/googlegenai/refs.go
@@ -46,6 +46,17 @@ func VideoModelRef(name string, config *genai.GenerateVideosConfig) ai.ModelRef 
 	return ai.NewModelRef(name, config)
 }
 
+// --- Music generation (Lyria) ---
+
+// LyriaModelRef creates a ModelRef for a Lyria music generation model.
+//
+// Lyria is only available through the Vertex AI backend. Initialize
+// Genkit with &googlegenai.VertexAI{}; calls via the Google AI backend
+// will fail with FAILED_PRECONDITION.
+func LyriaModelRef(name string, config *LyriaConfig) ai.ModelRef {
+	return ai.NewModelRef(name, config)
+}
+
 // --- Embedders ---
 
 // EmbedderRef creates an EmbedderRef for an embedding model.

--- a/go/plugins/googlegenai/typed_config_test.go
+++ b/go/plugins/googlegenai/typed_config_test.go
@@ -51,6 +51,7 @@ func TestConfigSchemaMatchesDefaultConfig(t *testing.T) {
 		"gemini": ModelTypeGemini,
 		"imagen": ModelTypeImagen,
 		"veo":    ModelTypeVeo,
+		"lyria":  ModelTypeLyria,
 	} {
 		if !reflect.DeepEqual(mt.configSchema(), configToMap(mt.DefaultConfig())) {
 			t.Errorf("%s: configSchema() diverges from configToMap(DefaultConfig())", name)

--- a/go/plugins/googlegenai/vertexai_live_test.go
+++ b/go/plugins/googlegenai/vertexai_live_test.go
@@ -299,6 +299,32 @@ func TestVertexAILive(t *testing.T) {
 			t.Error("no media found in the response message")
 		}
 	})
+	t.Run("lyria music generation", func(t *testing.T) {
+		m := googlegenai.VertexAIModel(g, "lyria-002")
+		if m == nil {
+			t.Fatal("lyria-002 model was not registered")
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithMessages(ai.NewUserTextMessage("A short upbeat jazz piano riff")),
+			ai.WithConfig(&googlegenai.LyriaConfig{SampleCount: 1}),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.Message.Content) == 0 {
+			t.Fatal("empty response")
+		}
+		foundAudio := false
+		for _, part := range resp.Message.Content {
+			if part.Kind == ai.PartMedia && strings.HasPrefix(part.ContentType, "audio/") {
+				foundAudio = true
+			}
+		}
+		if !foundAudio {
+			t.Error("no audio media part found in Lyria response")
+		}
+	})
 	t.Run("constrained generation", func(t *testing.T) {
 		type outFormat struct {
 			Country string


### PR DESCRIPTION
Adds `lyria-002` (Vertex AI music generation) to the googlegenai plugin.

Introduces `ModelTypeLyria`, a `LyriaConfig` struct matching the JS `LyriaConfigSchema`, and a `generateMusic` function that calls the Vertex AI `:predict` endpoint directly — the `google.golang.org/genai` SDK has no Lyria-specific method. The HTTP call reuses the authenticated `*http.Client` the plugin configured on the `genai.Client` (credentials, `X-Goog-User-Project` header, OpenTelemetry tracing).

Mirrors `js/plugins/google-genai/src/vertexai/lyria.ts` (legacy `lyria-002` flow).

## Testing
<img width="1249" height="318" alt="image" src="https://github.com/user-attachments/assets/e4103fff-7f99-4fb9-bd3d-6da825007a49" />

<img width="1248" height="360" alt="image" src="https://github.com/user-attachments/assets/13d62cc1-10f2-4565-9958-fd0c7e850ea2" />