### PR TITLE
feat(go/plugins/googlegenai): Add Gemini 3.1 Flash preview models

### DIFF
--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -90,6 +90,9 @@ const (
 
 	gemini25Pro = "gemini-2.5-pro"
 
+	gemini31FlashLitePreview  = "gemini-3.1-flash-lite-preview"
+	gemini31FlashImagePreview = "gemini-3.1-flash-image-preview"
+
 	imagen3Generate001     = "imagen-3.0-generate-001"
 	imagen3FastGenerate001 = "imagen-3.0-fast-generate-001"
 
@@ -115,6 +118,8 @@ var (
 		gemini25Flash,
 		gemini25FlashLite,
 		gemini25Pro,
+		gemini31FlashLitePreview,
+		gemini31FlashImagePreview,
 
 		imagen3Generate001,
 		imagen3FastGenerate001,
@@ -130,6 +135,8 @@ var (
 		gemini25Flash,
 		gemini25FlashLite,
 		gemini25Pro,
+		gemini31FlashLitePreview,
+		gemini31FlashImagePreview,
 
 		veo20Generate001,
 		veo30Generate001,
@@ -170,6 +177,18 @@ var (
 			Versions: []string{},
 			Supports: &Multimodal,
 			Stage:    ai.ModelStageStable,
+		},
+		gemini31FlashLitePreview: {
+			Label:    "Gemini 3.1 Flash Lite Preview",
+			Versions: []string{},
+			Supports: &Multimodal,
+			Stage:    ai.ModelStageUnstable,
+		},
+		gemini31FlashImagePreview: {
+			Label:    "Gemini 3.1 Flash Image Preview",
+			Versions: []string{},
+			Supports: &Multimodal,
+			Stage:    ai.ModelStageUnstable,
 		},
 	}
 

--- a/go/samples/imagen-gemini/main.go
+++ b/go/samples/imagen-gemini/main.go
@@ -44,7 +44,7 @@ func generateGemini31Lite(ctx context.Context, g *genkit.Genkit, modelName, inpu
 	return genkit.GenerateText(ctx, g,
 		ai.WithModel(googlegenai.ModelRef(modelName, &genai.GenerateContentConfig{
 			ThinkingConfig: &genai.ThinkingConfig{
-				ThinkingBudget: genai.Ptr[int32](0),
+				ThinkingLevel: genai.ThinkingLevelMinimal,
 			},
 		})),
 		ai.WithPrompt("Write one funny sentence about %s.", prompt),
@@ -61,7 +61,7 @@ func generateGemini31Image(ctx context.Context, g *genkit.Genkit, modelName, inp
 		ai.WithModel(googlegenai.ModelRef(modelName, &genai.GenerateContentConfig{
 			ResponseModalities: []string{"IMAGE", "TEXT"},
 			ThinkingConfig: &genai.ThinkingConfig{
-				ThinkingBudget: genai.Ptr[int32](0),
+				ThinkingLevel: genai.ThinkingLevelMinimal,
 			},
 		})),
 		ai.WithPrompt("Generate an image of %s and include a short caption.", prompt),

--- a/go/samples/imagen-gemini/main.go
+++ b/go/samples/imagen-gemini/main.go
@@ -18,21 +18,90 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 	"google.golang.org/genai"
 )
 
+type imageFlowResult struct {
+	Model   string   `json:"model"`
+	Prompt  string   `json:"prompt"`
+	Caption string   `json:"caption"`
+	Images  []string `json:"images"`
+}
+
+func generateGemini31Lite(ctx context.Context, g *genkit.Genkit, modelName, input string) (string, error) {
+	prompt := input
+	if prompt == "" {
+		prompt = "bananas"
+	}
+
+	return genkit.GenerateText(ctx, g,
+		ai.WithModel(googlegenai.ModelRef(modelName, &genai.GenerateContentConfig{
+			ThinkingConfig: &genai.ThinkingConfig{
+				ThinkingBudget: genai.Ptr[int32](0),
+			},
+		})),
+		ai.WithPrompt("Write one funny sentence about %s.", prompt),
+	)
+}
+
+func generateGemini31Image(ctx context.Context, g *genkit.Genkit, modelName, input string) (*imageFlowResult, error) {
+	prompt := input
+	if prompt == "" {
+		prompt = "a robot cat wearing sunglasses"
+	}
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModel(googlegenai.ModelRef(modelName, &genai.GenerateContentConfig{
+			ResponseModalities: []string{"IMAGE", "TEXT"},
+			ThinkingConfig: &genai.ThinkingConfig{
+				ThinkingBudget: genai.Ptr[int32](0),
+			},
+		})),
+		ai.WithPrompt("Generate an image of %s and include a short caption.", prompt),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not generate image response: %w", err)
+	}
+
+	out := &imageFlowResult{
+		Model:   modelName,
+		Prompt:  prompt,
+		Caption: resp.Text(),
+		Images:  []string{},
+	}
+	for _, p := range resp.Message.Content {
+		if !p.IsMedia() || p.Text == "" {
+			continue
+		}
+		imageData := p.Text
+		// Preserve existing URIs (data:, http(s), gs://, etc.); wrap only raw base64
+		// image content for preview clients.
+		if !strings.HasPrefix(imageData, "data:") &&
+			!strings.Contains(imageData, "://") {
+			imageData = fmt.Sprintf("data:%s;base64,%s", p.ContentType, imageData)
+		}
+		out.Images = append(out.Images, imageData)
+	}
+
+	return out, nil
+}
+
 func main() {
 	ctx := context.Background()
 
-	// Initialize Genkit with the Google AI plugin. When you pass nil for the
-	// Config parameter, the Google AI plugin will get the API key from the
-	// GEMINI_API_KEY or GOOGLE_API_KEY environment variable, which is the recommended
-	// practice.
-	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+	plugins := []api.Plugin{&googlegenai.GoogleAI{}}
+	hasVertex := hasVertexAIConfig()
+	if hasVertex {
+		plugins = append(plugins, &googlegenai.VertexAI{})
+	}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugins...))
 
 	// Define a simple flow that generates an image of a given topic
 	genkit.DefineFlow(g, "imageFlow", func(ctx context.Context, input string) ([]string, error) {
@@ -68,5 +137,30 @@ func main() {
 		return story, nil
 	})
 
+	genkit.DefineFlow(g, "gemini31LiteGoogleAIFlow", func(ctx context.Context, input string) (string, error) {
+		return generateGemini31Lite(ctx, g, "googleai/gemini-3.1-flash-lite-preview", input)
+	})
+
+	genkit.DefineFlow(g, "gemini31ImageGoogleAIFlow", func(ctx context.Context, input string) (*imageFlowResult, error) {
+		return generateGemini31Image(ctx, g, "googleai/gemini-3.1-flash-image-preview", input)
+	})
+
+	if hasVertex {
+		genkit.DefineFlow(g, "gemini31LiteVertexAIFlow", func(ctx context.Context, input string) (string, error) {
+			return generateGemini31Lite(ctx, g, "vertexai/gemini-3.1-flash-lite-preview", input)
+		})
+
+		genkit.DefineFlow(g, "gemini31ImageVertexAIFlow", func(ctx context.Context, input string) (*imageFlowResult, error) {
+			return generateGemini31Image(ctx, g, "vertexai/gemini-3.1-flash-image-preview", input)
+		})
+	}
+
 	<-ctx.Done()
+}
+
+func hasVertexAIConfig() bool {
+	if os.Getenv("GOOGLE_CLOUD_PROJECT") == "" {
+		return false
+	}
+	return os.Getenv("GOOGLE_CLOUD_LOCATION") != "" || os.Getenv("GOOGLE_CLOUD_REGION") != ""
 }

--- a/go/samples/imagen-gemini/main.go
+++ b/go/samples/imagen-gemini/main.go
@@ -96,6 +96,13 @@ func generateGemini31Image(ctx context.Context, g *genkit.Genkit, modelName, inp
 func main() {
 	ctx := context.Background()
 
+	// Initialize Genkit with the Google AI plugin. When you pass nil for the
+	// Config parameter, the Google AI plugin will get the API key from the
+	// GEMINI_API_KEY or GOOGLE_API_KEY environment variable, which is the recommended
+	// practice. The Vertex AI plugin is added conditionally when GOOGLE_CLOUD_PROJECT
+	// and a location are set, so the gemini-3.1 Vertex flows only register when
+	// that config is present. Vertex's gemini-3.1-flash-*-preview models are
+	// Global-only — set GOOGLE_CLOUD_LOCATION=global.
 	plugins := []api.Plugin{&googlegenai.GoogleAI{}}
 	hasVertex := hasVertexAIConfig()
 	if hasVertex {


### PR DESCRIPTION
Adds the two Gemini 3.1 preview models on both backends:

- `gemini-3.1-flash-lite-preview`
- `gemini-3.1-flash-image-preview`

Registered as Multimodal / `ModelStageUnstable` on GoogleAI and VertexAI. Also extends the `imagen-gemini` sample with two generate helpers (text-only and image+caption) and four flows exercising both models on each backend, gated by a `hasVertexAIConfig()` check so GoogleAI-only environments still run.

Closes the four `gemini-3.1-flash-*-preview` rows on the Go parity tracker.

## Test plan

- [x] `go test ./plugins/googlegenai/...`
- [x] `go build ./samples/imagen-gemini/...`
- [x] Live: run the sample with `GEMINI_API_KEY` (and optionally `GOOGLE_CLOUD_PROJECT`/`GOOGLE_CLOUD_LOCATION`) and invoke the four new flows from the dev UI.


Evidence of manual testing:
<img width="412" height="235" alt="Screenshot 2026-04-23 at 13 04 19" src="https://github.com/user-attachments/assets/4f5e746b-6d86-4d78-bc15-505b6dad09f9" />

## gemini31LiteGoogleAIFlow
<img width="1359" height="741" alt="Screenshot 2026-04-23 at 13 02 41" src="https://github.com/user-attachments/assets/d89eb6b9-28c4-4fcf-ac52-ad75392d5f3c" />

<img width="1434" height="804" alt="Screenshot 2026-04-23 at 13 06 50" src="https://github.com/user-attachments/assets/af95a386-2993-4671-b677-8a2a72cb6256" />
