### PR TITLE
feat(py/plugins/google-genai): Add Imagen 4 models on GoogleAI

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/__init__.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/__init__.py
@@ -218,7 +218,15 @@ from genkit.plugins.google_genai.models.gemini import (
     GoogleAIGeminiVersion,
     VertexAIGeminiVersion,
 )
-from genkit.plugins.google_genai.models.imagen import ImagenVersion
+from genkit.plugins.google_genai.models.imagen import (
+    ImagenAspectRatio,
+    ImagenConfig,
+    ImagenConfigSchema,
+    ImagenImageSize,
+    ImagenPersonGeneration,
+    ImagenVersion,
+    is_imagen_model,
+)
 from genkit.plugins.google_genai.models.lyria import LyriaConfig, LyriaVersion
 from genkit.plugins.google_genai.models.veo import VeoConfig, VeoVersion
 
@@ -244,7 +252,13 @@ __all__ = [
     GeminiConfigSchema.__name__,
     GeminiImageConfigSchema.__name__,
     GeminiTtsConfigSchema.__name__,
+    ImagenAspectRatio.__name__,
+    ImagenConfig.__name__,
+    ImagenConfigSchema.__name__,
+    ImagenImageSize.__name__,
+    ImagenPersonGeneration.__name__,
     ImagenVersion.__name__,
+    is_imagen_model.__name__,
     VeoVersion.__name__,
     VeoConfig.__name__,
     LyriaVersion.__name__,

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/__init__.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/__init__.py
@@ -219,13 +219,10 @@ from genkit.plugins.google_genai.models.gemini import (
     VertexAIGeminiVersion,
 )
 from genkit.plugins.google_genai.models.imagen import (
-    ImagenAspectRatio,
-    ImagenConfig,
     ImagenConfigSchema,
     ImagenImageSize,
     ImagenPersonGeneration,
     ImagenVersion,
-    is_imagen_model,
 )
 from genkit.plugins.google_genai.models.lyria import LyriaConfig, LyriaVersion
 from genkit.plugins.google_genai.models.veo import VeoConfig, VeoVersion
@@ -252,13 +249,10 @@ __all__ = [
     GeminiConfigSchema.__name__,
     GeminiImageConfigSchema.__name__,
     GeminiTtsConfigSchema.__name__,
-    ImagenAspectRatio.__name__,
-    ImagenConfig.__name__,
     ImagenConfigSchema.__name__,
     ImagenImageSize.__name__,
     ImagenPersonGeneration.__name__,
     ImagenVersion.__name__,
-    is_imagen_model.__name__,
     VeoVersion.__name__,
     VeoConfig.__name__,
     LyriaVersion.__name__,

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -424,11 +424,7 @@ class GoogleAI(Plugin):
         # Imagen Models: union the SDK-discovered list with the hardcoded
         # Google AI known-model list so users can select Imagen 4 even when
         # the SDK's models.list() doesn't surface them.
-        imagen_names: list[str] = list(genai_models.imagen)
-        for known in GOOGLEAI_KNOWN_IMAGEN_MODELS:
-            if known not in imagen_names:
-                imagen_names.append(known)
-        for name in imagen_names:
+        for name in dict.fromkeys(genai_models.imagen + list(GOOGLEAI_KNOWN_IMAGEN_MODELS)):
             actions.append(self._resolve_model(googleai_name(name)))
 
         # Veo Models (background models)
@@ -640,11 +636,7 @@ class GoogleAI(Plugin):
                 )
             )
 
-        imagen_names: list[str] = list(genai_models.imagen)
-        for known in GOOGLEAI_KNOWN_IMAGEN_MODELS:
-            if known not in imagen_names:
-                imagen_names.append(known)
-        for name in imagen_names:
+        for name in dict.fromkeys(genai_models.imagen + list(GOOGLEAI_KNOWN_IMAGEN_MODELS)):
             actions_list.append(
                 model_action_metadata(
                     name=googleai_name(name),

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -128,9 +128,11 @@ from genkit.plugins.google_genai.models.gemini import (
     google_model_info,
 )
 from genkit.plugins.google_genai.models.imagen import (
+    GOOGLEAI_KNOWN_IMAGEN_MODELS,
     SUPPORTED_MODELS as IMAGE_SUPPORTED_MODELS,
     ImagenConfigSchema,
     ImagenModel,
+    googleai_image_model_info,
     vertexai_image_model_info,
 )
 from genkit.plugins.google_genai.models.veo import (
@@ -419,8 +421,14 @@ class GoogleAI(Plugin):
         for name in genai_models.gemini:
             actions.append(self._resolve_model(googleai_name(name)))
 
-        # Imagen Models
-        for name in genai_models.imagen:
+        # Imagen Models: union the SDK-discovered list with the hardcoded
+        # Google AI known-model list so users can select Imagen 4 even when
+        # the SDK's models.list() doesn't surface them.
+        imagen_names: list[str] = list(genai_models.imagen)
+        for known in GOOGLEAI_KNOWN_IMAGEN_MODELS:
+            if known not in imagen_names:
+                imagen_names.append(known)
+        for name in imagen_names:
             actions.append(self._resolve_model(googleai_name(name)))
 
         # Veo Models (background models)
@@ -571,7 +579,7 @@ class GoogleAI(Plugin):
 
         # Determine model type and create model metadata/config schema
         if clean_name.lower().startswith('image'):
-            model_ref = vertexai_image_model_info(clean_name)
+            model_ref = googleai_image_model_info(clean_name)
             IMAGE_SUPPORTED_MODELS[clean_name] = model_ref
             config_schema = ImagenConfigSchema
         else:
@@ -632,11 +640,15 @@ class GoogleAI(Plugin):
                 )
             )
 
-        for name in genai_models.imagen:
+        imagen_names: list[str] = list(genai_models.imagen)
+        for known in GOOGLEAI_KNOWN_IMAGEN_MODELS:
+            if known not in imagen_names:
+                imagen_names.append(known)
+        for name in imagen_names:
             actions_list.append(
                 model_action_metadata(
                     name=googleai_name(name),
-                    info=vertexai_image_model_info(name).model_dump(by_alias=True),
+                    info=googleai_image_model_info(name).model_dump(by_alias=True),
                     config_schema=ImagenConfigSchema,
                 )
             )

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -133,6 +133,7 @@ from genkit.plugins.google_genai.models.imagen import (
     ImagenConfigSchema,
     ImagenModel,
     googleai_image_model_info,
+    is_imagen_model,
     vertexai_image_model_info,
 )
 from genkit.plugins.google_genai.models.veo import (
@@ -574,7 +575,7 @@ class GoogleAI(Plugin):
         clean_name = name.replace(GOOGLEAI_PLUGIN_NAME + '/', '') if name.startswith(GOOGLEAI_PLUGIN_NAME) else name
 
         # Determine model type and create model metadata/config schema
-        if clean_name.lower().startswith('image'):
+        if is_imagen_model(clean_name):
             model_ref = googleai_image_model_info(clean_name)
             IMAGE_SUPPORTED_MODELS[clean_name] = model_ref
             config_schema = ImagenConfigSchema
@@ -584,7 +585,7 @@ class GoogleAI(Plugin):
             config_schema = get_model_config_schema(clean_name)
 
         async def _run(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
-            if clean_name.lower().startswith('image'):
+            if is_imagen_model(clean_name):
                 model = ImagenModel(clean_name, self._runtime_client())
             else:
                 model = GeminiModel(clean_name, self._runtime_client())
@@ -898,7 +899,7 @@ class VertexAI(Plugin):
         clean_name = name.replace(VERTEXAI_PLUGIN_NAME + '/', '') if name.startswith(VERTEXAI_PLUGIN_NAME) else name
 
         # Determine model type and create model metadata/config schema
-        if clean_name.lower().startswith('image'):
+        if is_imagen_model(clean_name):
             model_ref = vertexai_image_model_info(clean_name)
             IMAGE_SUPPORTED_MODELS[clean_name] = model_ref
             config_schema = ImagenConfigSchema
@@ -911,7 +912,7 @@ class VertexAI(Plugin):
             config_schema = get_model_config_schema(clean_name)
 
         async def _run(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
-            if clean_name.lower().startswith('image'):
+            if is_imagen_model(clean_name):
                 model = ImagenModel(clean_name, self._runtime_client())
             elif is_veo_model(clean_name):
                 model = VeoModel(clean_name, self._runtime_client())

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -128,7 +128,6 @@ from genkit.plugins.google_genai.models.gemini import (
     google_model_info,
 )
 from genkit.plugins.google_genai.models.imagen import (
-    GOOGLEAI_KNOWN_IMAGEN_MODELS,
     SUPPORTED_MODELS as IMAGE_SUPPORTED_MODELS,
     ImagenConfigSchema,
     ImagenModel,

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -422,10 +422,7 @@ class GoogleAI(Plugin):
         for name in genai_models.gemini:
             actions.append(self._resolve_model(googleai_name(name)))
 
-        # Imagen Models: union the SDK-discovered list with the hardcoded
-        # Google AI known-model list so users can select Imagen 4 even when
-        # the SDK's models.list() doesn't surface them.
-        for name in dict.fromkeys(genai_models.imagen + list(GOOGLEAI_KNOWN_IMAGEN_MODELS)):
+        for name in genai_models.imagen:
             actions.append(self._resolve_model(googleai_name(name)))
 
         # Veo Models (background models)
@@ -637,7 +634,7 @@ class GoogleAI(Plugin):
                 )
             )
 
-        for name in dict.fromkeys(genai_models.imagen + list(GOOGLEAI_KNOWN_IMAGEN_MODELS)):
+        for name in genai_models.imagen:
             actions_list.append(
                 model_action_metadata(
                     name=googleai_name(name),

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -58,6 +58,20 @@ class ImagenVersion(StrEnum):
     IMAGEN3 = 'imagen-3.0-generate-002'
     IMAGEN3_FAST = 'imagen-3.0-fast-generate-001'
     IMAGEN2 = 'imagegeneration@006'
+    IMAGEN4 = 'imagen-4.0-generate-001'
+    IMAGEN4_FAST = 'imagen-4.0-fast-generate-001'
+    IMAGEN4_ULTRA = 'imagen-4.0-ultra-generate-001'
+
+
+# Imagen models available on the Google AI (Gemini API) backend. Hardcoded
+# here because the SDK's client.models.list() does not always surface them on
+# every environment, and they must be visible in Init / list_actions to be
+# selectable from user code.
+GOOGLEAI_KNOWN_IMAGEN_MODELS: tuple[str, ...] = (
+    ImagenVersion.IMAGEN4,
+    ImagenVersion.IMAGEN4_FAST,
+    ImagenVersion.IMAGEN4_ULTRA,
+)
 
 
 SUPPORTED_MODELS = {
@@ -91,6 +105,36 @@ SUPPORTED_MODELS = {
             output=['media'],
         ),
     ),
+    ImagenVersion.IMAGEN4: ModelInfo(
+        label='Google AI - Imagen 4',
+        supports=Supports(
+            media=True,
+            multiturn=False,
+            tools=False,
+            system_role=True,
+            output=['media'],
+        ),
+    ),
+    ImagenVersion.IMAGEN4_FAST: ModelInfo(
+        label='Google AI - Imagen 4 Fast',
+        supports=Supports(
+            media=True,
+            multiturn=False,
+            tools=False,
+            system_role=True,
+            output=['media'],
+        ),
+    ),
+    ImagenVersion.IMAGEN4_ULTRA: ModelInfo(
+        label='Google AI - Imagen 4 Ultra',
+        supports=Supports(
+            media=True,
+            multiturn=False,
+            tools=False,
+            system_role=True,
+            output=['media'],
+        ),
+    ),
 }
 
 DEFAULT_IMAGE_SUPPORT = Supports(
@@ -105,10 +149,7 @@ DEFAULT_IMAGE_SUPPORT = Supports(
 def vertexai_image_model_info(
     version: str,
 ) -> ModelInfo:
-    """Generates a ModelInfo object.
-
-    This function tries to get the best ModelInfo Supports
-    for the given version.
+    """Generates a ModelInfo object for the Vertex AI backend.
 
     Args:
         version: Version of the model.
@@ -118,6 +159,23 @@ def vertexai_image_model_info(
     """
     return ModelInfo(
         label=f'Vertex AI - {version}',
+        supports=DEFAULT_IMAGE_SUPPORT,
+    )
+
+
+def googleai_image_model_info(
+    version: str,
+) -> ModelInfo:
+    """Generates a ModelInfo object for the Google AI (Gemini API) backend.
+
+    Args:
+        version: Version of the model.
+
+    Returns:
+        ModelInfo object with a Google AI-prefixed label.
+    """
+    return ModelInfo(
+        label=f'Google AI - {version}',
         supports=DEFAULT_IMAGE_SUPPORT,
     )
 

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -144,7 +144,6 @@ DEFAULT_IMAGE_SUPPORT = Supports(
     system_role=True,
     output=['media'],
 )
-DEFAULT_NUMBER_OF_IMAGES = 1
 
 
 class ImagenAspectRatio(StrEnum):
@@ -204,7 +203,7 @@ class ImagenConfigSchema(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
 
     number_of_images: int | None = Field(
-        DEFAULT_NUMBER_OF_IMAGES,
+        None, # Don't silently change default behavior
         alias='numberOfImages',
         ge=1,
         le=4,
@@ -295,33 +294,33 @@ class ImagenModel:
         )
 
     def _get_config(self, request: ModelRequest) -> genai_types.GenerateImagesConfigOrDict | None:
-        request_config = self._with_default_config(request.config)
+        if request.config is None:
+            return None
+
+        request_config = self._normalize_config(request.config)
         ta = TypeAdapter(genai_types.GenerateImagesConfigOrDict)
         try:
             request_config = ImagenConfigSchema.model_validate(request_config).model_dump(
                 mode='json',
                 exclude_none=True,
             )
+            if not request_config:
+                return None
             return ta.validate_python(request_config)
         except ValidationError as e:
             raise ValueError(
                 'The configuration dictionary is invalid. Refer the documentation for available fields'
             ) from e
 
-    def _with_default_config(self, config: object | None) -> dict[str, object]:
-        """Set SDK defaults Genkit needs to show stable one-image behavior."""
+    def _normalize_config(self, config: object) -> dict[str, object]:
+        """Normalize supported config inputs without adding SDK defaults."""
         if isinstance(config, BaseModel):
             request_config = config.model_dump(exclude_none=True)
         elif isinstance(config, dict):
             request_config = dict(config)
-        elif config is None:
-            request_config = {}
         else:
             validated_config = TypeAdapter(genai_types.GenerateImagesConfigOrDict).validate_python(config)
             request_config = _to_dict(validated_config)
-
-        if 'number_of_images' not in request_config and 'numberOfImages' not in request_config:
-            request_config['number_of_images'] = DEFAULT_NUMBER_OF_IMAGES
 
         return request_config
 

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -203,7 +203,7 @@ class ImagenConfigSchema(BaseModel):
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
 
     number_of_images: int | None = Field(
-        None, # Don't silently change default behavior
+        None,  # Don't silently change default behavior
         alias='numberOfImages',
         ge=1,
         le=4,

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -33,6 +33,7 @@ from google.genai import types as genai_types
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError, WithJsonSchema
 
 from genkit import (
+    GenkitError,
     Media,
     MediaPart,
     Message,
@@ -281,7 +282,10 @@ class ImagenModel:
                 if isinstance(part.root, TextPart):
                     prompt.append(part.root.text)
                 else:
-                    raise ValueError('Non-text messages are not supported')
+                    raise GenkitError(
+                        status='INVALID_ARGUMENT',
+                        message='Non-text messages are not supported for Imagen models.',
+                    )
         return ' '.join(prompt)
 
     async def generate(self, request: ModelRequest, _: ActionRunContext) -> ModelResponse:
@@ -297,7 +301,10 @@ class ImagenModel:
         prompt = self._build_prompt(request)
         config = self._get_config(request)
         if request.tools:
-            raise ValueError('Tools are not supported for this model.')
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message='Tools are not supported for Imagen models.',
+            )
 
         with tracer.start_as_current_span('generate_images') as span:
             span.set_attribute(
@@ -335,8 +342,10 @@ class ImagenModel:
                 return None
             return ta.validate_python(request_config)
         except ValidationError as e:
-            raise ValueError(
-                'The configuration dictionary is invalid. Refer the documentation for available fields'
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message='The configuration dictionary is invalid. Refer to the documentation for available fields.',
+                cause=e,
             ) from e
 
     def _normalize_config(self, config: object) -> dict[str, object]:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -59,7 +59,7 @@ else:
     from enum import StrEnum
 
 from functools import cached_property
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from google import genai
 from google.genai import types as genai_types
@@ -359,7 +359,8 @@ class ImagenModel:
             )
             if not request_config:
                 return None
-            return ta.validate_python(request_config)
+            ta.validate_python(request_config)
+            return cast(genai_types.GenerateImagesConfigOrDict, request_config)
         except ValidationError as e:
             raise GenkitError(
                 status='INVALID_ARGUMENT',

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -17,6 +17,7 @@
 """Imagen model implementation for Google GenAI plugin."""
 
 import base64
+import json
 import sys
 
 if sys.version_info < (3, 11):
@@ -24,13 +25,12 @@ if sys.version_info < (3, 11):
 else:
     from enum import StrEnum
 
-import json
 from functools import cached_property
 from typing import Any
 
 from google import genai
 from google.genai import types as genai_types
-from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
 
 from genkit import (
     Media,
@@ -49,7 +49,7 @@ from genkit.plugin_api import ActionRunContext, tracer
 
 def _to_dict(obj: Any) -> Any:  # noqa: ANN401
     """Convert object to dict if it's a Pydantic model, otherwise return as-is."""
-    return obj.model_dump() if isinstance(obj, BaseModel) else obj
+    return obj.model_dump(mode='json') if isinstance(obj, BaseModel) else obj
 
 
 class ImagenVersion(StrEnum):
@@ -144,6 +144,31 @@ DEFAULT_IMAGE_SUPPORT = Supports(
     system_role=True,
     output=['media'],
 )
+DEFAULT_NUMBER_OF_IMAGES = 1
+
+
+class ImagenAspectRatio(StrEnum):
+    """Imagen output aspect ratios."""
+
+    RATIO_1_1 = '1:1'
+    RATIO_3_4 = '3:4'
+    RATIO_4_3 = '4:3'
+    RATIO_9_16 = '9:16'
+    RATIO_16_9 = '16:9'
+
+
+class ImagenImageSize(StrEnum):
+    """Imagen output image sizes."""
+
+    SIZE_1K = '1K'
+    SIZE_2K = '2K'
+
+
+class ImagenOutputMimeType(StrEnum):
+    """Imagen output MIME types."""
+
+    IMAGE_PNG = 'image/png'
+    IMAGE_JPEG = 'image/jpeg'
 
 
 def vertexai_image_model_info(
@@ -183,7 +208,97 @@ def googleai_image_model_info(
 class ImagenConfigSchema(BaseModel):
     """Imagen Config Schema."""
 
-    model_config = ConfigDict(extra='allow')
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
+
+    output_gcs_uri: str | None = Field(
+        None,
+        alias='outputGcsUri',
+        description='Cloud Storage URI used to store the generated images.',
+    )
+    negative_prompt: str | None = Field(
+        None,
+        alias='negativePrompt',
+        description='Description of what to discourage in the generated images.',
+    )
+    number_of_images: int | None = Field(
+        DEFAULT_NUMBER_OF_IMAGES,
+        alias='numberOfImages',
+        ge=1,
+        le=4,
+        description='Number of images to generate.',
+    )
+    aspect_ratio: ImagenAspectRatio | None = Field(
+        None,
+        alias='aspectRatio',
+        description='Aspect ratio of the generated images.',
+    )
+    guidance_scale: float | None = Field(
+        None,
+        alias='guidanceScale',
+        description=(
+            'Controls how much the model adheres to the text prompt. Large values '
+            'increase prompt alignment, but may compromise image quality.'
+        ),
+    )
+    seed: int | None = Field(
+        None,
+        description='Random seed for image generation. Not available when add_watermark is true.',
+    )
+    safety_filter_level: genai_types.SafetyFilterLevel | None = Field(
+        None,
+        alias='safetyFilterLevel',
+        description='Filter level for safety filtering.',
+    )
+    person_generation: genai_types.PersonGeneration | None = Field(
+        None,
+        alias='personGeneration',
+        description='Allows generation of people by the model.',
+    )
+    include_safety_attributes: bool | None = Field(
+        None,
+        alias='includeSafetyAttributes',
+        description='Whether to report safety scores of each generated image and the positive prompt.',
+    )
+    include_rai_reason: bool | None = Field(
+        None,
+        alias='includeRaiReason',
+        description='Whether to include the Responsible AI filter reason if an image is filtered.',
+    )
+    language: genai_types.ImagePromptLanguage | None = Field(
+        None,
+        description='Language of the text in the prompt.',
+    )
+    output_mime_type: ImagenOutputMimeType | None = Field(
+        None,
+        alias='outputMimeType',
+        description='MIME type of the generated image.',
+    )
+    output_compression_quality: int | None = Field(
+        None,
+        alias='outputCompressionQuality',
+        ge=0,
+        le=100,
+        description='Compression quality of the generated image, for image/jpeg only.',
+    )
+    add_watermark: bool | None = Field(
+        None,
+        alias='addWatermark',
+        description='Whether to add a watermark to the generated images.',
+    )
+    labels: dict[str, str] | None = Field(
+        None,
+        description='User-specified labels to track billing usage.',
+    )
+    image_size: ImagenImageSize | None = Field(
+        None,
+        alias='imageSize',
+        description='Largest dimension of the generated image. Not supported for Imagen 3 models.',
+    )
+    enhance_prompt: bool | None = Field(
+        None,
+        alias='enhancePrompt',
+        description='Whether to use prompt rewriting logic.',
+    )
 
 
 class ImagenModel:
@@ -254,19 +369,31 @@ class ImagenModel:
         )
 
     def _get_config(self, request: ModelRequest) -> genai_types.GenerateImagesConfigOrDict | None:
-        cfg = None
+        request_config = self._with_default_config(request.config)
+        ta = TypeAdapter(genai_types.GenerateImagesConfigOrDict)
+        try:
+            return ta.validate_python(request_config)
+        except ValidationError as e:
+            raise ValueError(
+                'The configuration dictionary is invalid. Refer the documentation for available fields'
+            ) from e
 
-        if request.config:
-            request_config = request.config
-            ta = TypeAdapter(genai_types.GenerateImagesConfigOrDict)
-            try:
-                cfg = ta.validate_python(request_config)
-            except ValidationError as e:
-                raise ValueError(
-                    'The configuration dictionary is invalid. Refer the documentation for available fields'
-                ) from e
+    def _with_default_config(self, config: object | None) -> dict[str, object]:
+        """Set SDK defaults Genkit needs to show stable one-image behavior."""
+        if isinstance(config, BaseModel):
+            request_config = config.model_dump(exclude_none=True)
+        elif isinstance(config, dict):
+            request_config = dict(config)
+        elif config is None:
+            request_config = {}
+        else:
+            validated_config = TypeAdapter(genai_types.GenerateImagesConfigOrDict).validate_python(config)
+            request_config = _to_dict(validated_config)
 
-        return cfg
+        if 'number_of_images' not in request_config and 'numberOfImages' not in request_config:
+            request_config['number_of_images'] = DEFAULT_NUMBER_OF_IMAGES
+
+        return request_config
 
     def _contents_from_response(self, response: genai_types.GenerateImagesResponse) -> list:
         """Retrieve contents from google-genai response.

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -164,13 +164,6 @@ class ImagenImageSize(StrEnum):
     SIZE_2K = '2K'
 
 
-class ImagenOutputMimeType(StrEnum):
-    """Imagen output MIME types."""
-
-    IMAGE_PNG = 'image/png'
-    IMAGE_JPEG = 'image/jpeg'
-
-
 def vertexai_image_model_info(
     version: str,
 ) -> ModelInfo:
@@ -208,18 +201,8 @@ def googleai_image_model_info(
 class ImagenConfigSchema(BaseModel):
     """Imagen Config Schema."""
 
-    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    model_config = ConfigDict(extra='forbid', populate_by_name=True)
 
-    output_gcs_uri: str | None = Field(
-        None,
-        alias='outputGcsUri',
-        description='Cloud Storage URI used to store the generated images.',
-    )
-    negative_prompt: str | None = Field(
-        None,
-        alias='negativePrompt',
-        description='Description of what to discourage in the generated images.',
-    )
     number_of_images: int | None = Field(
         DEFAULT_NUMBER_OF_IMAGES,
         alias='numberOfImages',
@@ -232,72 +215,15 @@ class ImagenConfigSchema(BaseModel):
         alias='aspectRatio',
         description='Aspect ratio of the generated images.',
     )
-    guidance_scale: float | None = Field(
-        None,
-        alias='guidanceScale',
-        description=(
-            'Controls how much the model adheres to the text prompt. Large values '
-            'increase prompt alignment, but may compromise image quality.'
-        ),
-    )
-    seed: int | None = Field(
-        None,
-        description='Random seed for image generation. Not available when add_watermark is true.',
-    )
-    safety_filter_level: genai_types.SafetyFilterLevel | None = Field(
-        None,
-        alias='safetyFilterLevel',
-        description='Filter level for safety filtering.',
-    )
     person_generation: genai_types.PersonGeneration | None = Field(
         None,
         alias='personGeneration',
         description='Allows generation of people by the model.',
     )
-    include_safety_attributes: bool | None = Field(
-        None,
-        alias='includeSafetyAttributes',
-        description='Whether to report safety scores of each generated image and the positive prompt.',
-    )
-    include_rai_reason: bool | None = Field(
-        None,
-        alias='includeRaiReason',
-        description='Whether to include the Responsible AI filter reason if an image is filtered.',
-    )
-    language: genai_types.ImagePromptLanguage | None = Field(
-        None,
-        description='Language of the text in the prompt.',
-    )
-    output_mime_type: ImagenOutputMimeType | None = Field(
-        None,
-        alias='outputMimeType',
-        description='MIME type of the generated image.',
-    )
-    output_compression_quality: int | None = Field(
-        None,
-        alias='outputCompressionQuality',
-        ge=0,
-        le=100,
-        description='Compression quality of the generated image, for image/jpeg only.',
-    )
-    add_watermark: bool | None = Field(
-        None,
-        alias='addWatermark',
-        description='Whether to add a watermark to the generated images.',
-    )
-    labels: dict[str, str] | None = Field(
-        None,
-        description='User-specified labels to track billing usage.',
-    )
     image_size: ImagenImageSize | None = Field(
         None,
         alias='imageSize',
         description='Largest dimension of the generated image. Not supported for Imagen 3 models.',
-    )
-    enhance_prompt: bool | None = Field(
-        None,
-        alias='enhancePrompt',
-        description='Whether to use prompt rewriting logic.',
     )
 
 
@@ -372,6 +298,10 @@ class ImagenModel:
         request_config = self._with_default_config(request.config)
         ta = TypeAdapter(genai_types.GenerateImagesConfigOrDict)
         try:
+            request_config = ImagenConfigSchema.model_validate(request_config).model_dump(
+                mode='json',
+                exclude_none=True,
+            )
             return ta.validate_python(request_config)
         except ValidationError as e:
             raise ValueError(

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -14,7 +14,43 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Imagen model implementation for Google GenAI plugin."""
+"""Imagen image generation models for Google GenAI plugin.
+
+Imagen is Google's image generation model family that creates images from text
+prompts. It supports both Google AI and Vertex AI backends.
+
+Architecture:
+    ```
+    ┌──────────────────────────────────────────────────────────────────────┐
+    │                     Imagen Image Generation Flow                      │
+    ├──────────────────────────────────────────────────────────────────────┤
+    │                                                                       │
+    │   Input                    Model                     Output           │
+    │   ┌─────────┐             ┌─────────┐             ┌─────────┐        │
+    │   │ Text    │ ─predict──► │ Imagen  │ ──────────► │ Image   │        │
+    │   │ Prompt  │             │ Model   │             │ (bytes) │        │
+    │   └─────────┘             └─────────┘             └─────────┘        │
+    │                                                                       │
+    └──────────────────────────────────────────────────────────────────────┘
+    ```
+
+Note:
+    Imagen models may be discovered dynamically through the SDK models.list()
+    API. Known Google AI Imagen models are also registered explicitly because
+    models.list() does not always surface them in every environment.
+
+Supported Models:
+    Google AI:
+        - imagen-4.0-generate-001
+        - imagen-4.0-fast-generate-001
+        - imagen-4.0-ultra-generate-001
+
+    Vertex AI:
+        - imagegeneration@006
+        - imagen-3.0-generate-002
+        - imagen-3.0-fast-generate-001
+        - Imagen 4 models when returned by models.list()
+"""
 
 import base64
 import json

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -46,10 +46,7 @@ Supported Models:
         - imagen-4.0-ultra-generate-001
 
     Vertex AI:
-        - imagegeneration@006
-        - imagen-3.0-generate-002
-        - imagen-3.0-fast-generate-001
-        - Imagen 4 models when returned by models.list()
+        - Imagen models returned by models.list()
 """
 
 import base64

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -251,7 +251,7 @@ def googleai_image_model_info(
 class ImagenConfigSchema(BaseModel):
     """Imagen Config Schema."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
 
     number_of_images: int | None = Field(
         None,  # Don't silently change default behavior

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -180,16 +180,6 @@ DEFAULT_IMAGE_SUPPORT = Supports(
 )
 
 
-class ImagenAspectRatio(StrEnum):
-    """Imagen output aspect ratios."""
-
-    RATIO_1_1 = '1:1'
-    RATIO_3_4 = '3:4'
-    RATIO_4_3 = '4:3'
-    RATIO_9_16 = '9:16'
-    RATIO_16_9 = '16:9'
-
-
 class ImagenImageSize(StrEnum):
     """Imagen output image sizes."""
 
@@ -281,10 +271,6 @@ class ImagenConfigSchema(BaseModel):
             'description': 'Largest dimension of the generated image.',
         }),
     ] = Field(None, alias='imageSize')
-
-
-# Alias for backwards compatibility with __init__.py exports.
-ImagenConfig = ImagenConfigSchema
 
 
 class ImagenModel:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/imagen.py
@@ -26,11 +26,11 @@ else:
     from enum import StrEnum
 
 from functools import cached_property
-from typing import Any
+from typing import Annotated, Any
 
 from google import genai
 from google.genai import types as genai_types
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError, WithJsonSchema
 
 from genkit import (
     Media,
@@ -163,6 +163,20 @@ class ImagenImageSize(StrEnum):
     SIZE_2K = '2K'
 
 
+class ImagenPersonGeneration(StrEnum):
+    """Controls whether Imagen may generate images of people."""
+
+    DONT_ALLOW = 'dont_allow'
+    ALLOW_ADULT = 'allow_adult'
+    ALLOW_ALL = 'allow_all'
+
+
+def is_imagen_model(name: str) -> bool:
+    """Return True when the model name refers to an Imagen image model."""
+    lower = name.lower()
+    return lower.startswith('imagen-') or lower.startswith('imagegeneration')
+
+
 def vertexai_image_model_info(
     version: str,
 ) -> ModelInfo:
@@ -209,21 +223,34 @@ class ImagenConfigSchema(BaseModel):
         le=4,
         description='Number of images to generate.',
     )
-    aspect_ratio: ImagenAspectRatio | None = Field(
+    aspect_ratio: str | None = Field(
         None,
         alias='aspectRatio',
-        description='Aspect ratio of the generated images.',
+        description=(
+            'Aspect ratio of the generated images (e.g. "1:1", "16:9", "9:16"). '
+            'Any ratio string supported by the model may be used.'
+        ),
     )
-    person_generation: genai_types.PersonGeneration | None = Field(
-        None,
-        alias='personGeneration',
-        description='Allows generation of people by the model.',
-    )
-    image_size: ImagenImageSize | None = Field(
-        None,
-        alias='imageSize',
-        description='Largest dimension of the generated image. Not supported for Imagen 3 models.',
-    )
+    person_generation: Annotated[
+        ImagenPersonGeneration | None,
+        WithJsonSchema({
+            'type': 'string',
+            'enum': [mode.value for mode in ImagenPersonGeneration],
+            'description': 'Allows generation of people by the model.',
+        }),
+    ] = Field(None, alias='personGeneration')
+    image_size: Annotated[
+        ImagenImageSize | None,
+        WithJsonSchema({
+            'type': 'string',
+            'enum': [size.value for size in ImagenImageSize],
+            'description': 'Largest dimension of the generated image.',
+        }),
+    ] = Field(None, alias='imageSize')
+
+
+# Alias for backwards compatibility with __init__.py exports.
+ImagenConfig = ImagenConfigSchema
 
 
 class ImagenModel:

--- a/py/plugins/google-genai/test/google_plugin_test.py
+++ b/py/plugins/google-genai/test/google_plugin_test.py
@@ -656,15 +656,15 @@ async def test_vertexai_resolve_action_embedder(
             False,
         ),
         (
-            'vertexai/image-gemini-pro-deluxe-max',
-            'vertexai/image-gemini-pro-deluxe-max',
-            'image-gemini-pro-deluxe-max',
+            'vertexai/imagen-3.0-generate-002',
+            'vertexai/imagen-3.0-generate-002',
+            'imagen-3.0-generate-002',
             True,
         ),
         (
-            'image-gemini-pro-deluxe-max',
-            'vertexai/image-gemini-pro-deluxe-max',
-            'image-gemini-pro-deluxe-max',
+            'imagen-3.0-fast-generate-001',
+            'vertexai/imagen-3.0-fast-generate-001',
+            'imagen-3.0-fast-generate-001',
             True,
         ),
         (

--- a/py/plugins/google-genai/test/google_plugin_test.py
+++ b/py/plugins/google-genai/test/google_plugin_test.py
@@ -656,15 +656,15 @@ async def test_vertexai_resolve_action_embedder(
             False,
         ),
         (
-            'vertexai/imagen-3.0-generate-002',
-            'vertexai/imagen-3.0-generate-002',
-            'imagen-3.0-generate-002',
+            'vertexai/imagen-gemini-pro-deluxe-max',
+            'vertexai/imagen-gemini-pro-deluxe-max',
+            'imagen-gemini-pro-deluxe-max',
             True,
         ),
         (
-            'imagen-3.0-fast-generate-001',
-            'vertexai/imagen-3.0-fast-generate-001',
-            'imagen-3.0-fast-generate-001',
+            'imagegeneration-gemini-pro-deluxe-max',
+            'vertexai/imagegeneration-gemini-pro-deluxe-max',
+            'imagegeneration-gemini-pro-deluxe-max',
             True,
         ),
         (

--- a/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
@@ -101,7 +101,6 @@ def test_imagen_config_schema_exposes_supported_options() -> None:
     schema = to_json_schema(ImagenConfigSchema)
     properties = schema['properties']
     number_of_images = properties['numberOfImages']
-
     assert set(properties) == {
         'numberOfImages',
         'imageSize',
@@ -110,6 +109,31 @@ def test_imagen_config_schema_exposes_supported_options() -> None:
     }
     assert number_of_images.get('default') is None
     assert number_of_images['anyOf'][0]['maximum'] == 4
+    assert properties['aspectRatio']['anyOf'][0]['type'] == 'string'
+    assert 'enum' not in properties['aspectRatio']
+    assert properties['personGeneration']['enum'] == ['dont_allow', 'allow_adult', 'allow_all']
+    assert properties['imageSize']['enum'] == ['1K', '2K']
+
+
+def test_imagen_config_accepts_custom_aspect_ratio(mocker: MockerFixture) -> None:
+    """Test aspect ratio accepts any string supported by the API."""
+    request = ModelRequest(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    Part(root=TextPart(text='draw a fox')),
+                ],
+            ),
+        ],
+        config={'aspect_ratio': '21:9'},
+    )
+    googleai_client_mock = mocker.AsyncMock()
+    imagen = ImagenModel(ImagenVersion.IMAGEN4, googleai_client_mock)
+
+    config = imagen._get_config(request)
+
+    assert config['aspect_ratio'] == '21:9'
 
 
 def test_imagen_config_does_not_set_image_count_when_omitted(mocker: MockerFixture) -> None:

--- a/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
@@ -35,7 +35,6 @@ from genkit import (
 )
 from genkit.plugin_api import to_json_schema
 from genkit.plugins.google_genai.models.imagen import (
-    DEFAULT_NUMBER_OF_IMAGES,
     ImagenConfigSchema,
     ImagenModel,
     ImagenVersion,
@@ -81,7 +80,7 @@ async def test_generate_media_response(mocker: MockerFixture, version: ImagenVer
         mocker.call.aio.models.generate_images(model=version, prompt=request_text, config=mocker.ANY)
     ])
     config = googleai_client_mock.aio.models.generate_images.call_args.kwargs['config']
-    assert config['number_of_images'] == DEFAULT_NUMBER_OF_IMAGES
+    assert config is None
     assert isinstance(response, ModelResponse)
     assert response.message is not None
     content = response.message.content[0]
@@ -109,8 +108,29 @@ def test_imagen_config_schema_exposes_supported_options() -> None:
         'aspectRatio',
         'personGeneration',
     }
-    assert number_of_images['default'] == DEFAULT_NUMBER_OF_IMAGES
+    assert number_of_images.get('default') is None
     assert number_of_images['anyOf'][0]['maximum'] == 4
+
+
+def test_imagen_config_does_not_set_image_count_when_omitted(mocker: MockerFixture) -> None:
+    """Test omitted image count lets the backend choose its default."""
+    request = ModelRequest(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    Part(root=TextPart(text='draw a fox')),
+                ],
+            ),
+        ],
+        config={},
+    )
+    googleai_client_mock = mocker.AsyncMock()
+    imagen = ImagenModel(ImagenVersion.IMAGEN4, googleai_client_mock)
+
+    config = imagen._get_config(request)
+
+    assert config is None
 
 
 def test_imagen_config_preserves_requested_image_count(mocker: MockerFixture) -> None:

--- a/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
@@ -103,13 +103,14 @@ def test_imagen_config_schema_exposes_supported_options() -> None:
     properties = schema['properties']
     number_of_images = properties['numberOfImages']
 
+    assert set(properties) == {
+        'numberOfImages',
+        'imageSize',
+        'aspectRatio',
+        'personGeneration',
+    }
     assert number_of_images['default'] == DEFAULT_NUMBER_OF_IMAGES
     assert number_of_images['anyOf'][0]['maximum'] == 4
-    assert 'aspectRatio' in properties
-    assert 'personGeneration' in properties
-    assert 'safetyFilterLevel' in properties
-    assert 'includeSafetyAttributes' in properties
-    assert 'enhancePrompt' in properties
 
 
 def test_imagen_config_preserves_requested_image_count(mocker: MockerFixture) -> None:
@@ -131,3 +132,23 @@ def test_imagen_config_preserves_requested_image_count(mocker: MockerFixture) ->
     config = imagen._get_config(request)
 
     assert config['number_of_images'] == 2
+
+
+def test_imagen_config_rejects_unsupported_options(mocker: MockerFixture) -> None:
+    """Test Imagen only accepts the supported Google AI options."""
+    request = ModelRequest(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    Part(root=TextPart(text='draw a fox')),
+                ],
+            ),
+        ],
+        config={'safetyFilterLevel': 'BLOCK_LOW_AND_ABOVE'},
+    )
+    googleai_client_mock = mocker.AsyncMock()
+    imagen = ImagenModel(ImagenVersion.IMAGEN4, googleai_client_mock)
+
+    with pytest.raises(ValueError, match='configuration dictionary is invalid'):
+        imagen._get_config(request)

--- a/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
@@ -33,7 +33,13 @@ from genkit import (
     Role,
     TextPart,
 )
-from genkit.plugins.google_genai.models.imagen import ImagenModel, ImagenVersion
+from genkit.plugin_api import to_json_schema
+from genkit.plugins.google_genai.models.imagen import (
+    DEFAULT_NUMBER_OF_IMAGES,
+    ImagenConfigSchema,
+    ImagenModel,
+    ImagenVersion,
+)
 
 
 @pytest.mark.asyncio
@@ -72,8 +78,10 @@ async def test_generate_media_response(mocker: MockerFixture, version: ImagenVer
     response = await imagen.generate(request, ctx)
 
     googleai_client_mock.assert_has_calls([
-        mocker.call.aio.models.generate_images(model=version, prompt=request_text, config=None)
+        mocker.call.aio.models.generate_images(model=version, prompt=request_text, config=mocker.ANY)
     ])
+    config = googleai_client_mock.aio.models.generate_images.call_args.kwargs['config']
+    assert config['number_of_images'] == DEFAULT_NUMBER_OF_IMAGES
     assert isinstance(response, ModelResponse)
     assert response.message is not None
     content = response.message.content[0]
@@ -87,3 +95,39 @@ async def test_generate_media_response(mocker: MockerFixture, version: ImagenVer
     assert data_url.startswith(f'data:{response_mimetype};base64,')
     encoded_data = data_url.split(',', 1)[1]
     assert base64.b64decode(encoded_data) == response_byte_string
+
+
+def test_imagen_config_schema_exposes_supported_options() -> None:
+    """Test Imagen config options are visible in action metadata."""
+    schema = to_json_schema(ImagenConfigSchema)
+    properties = schema['properties']
+    number_of_images = properties['numberOfImages']
+
+    assert number_of_images['default'] == DEFAULT_NUMBER_OF_IMAGES
+    assert number_of_images['anyOf'][0]['maximum'] == 4
+    assert 'aspectRatio' in properties
+    assert 'personGeneration' in properties
+    assert 'safetyFilterLevel' in properties
+    assert 'includeSafetyAttributes' in properties
+    assert 'enhancePrompt' in properties
+
+
+def test_imagen_config_preserves_requested_image_count(mocker: MockerFixture) -> None:
+    """Test explicit image count is not overwritten by default."""
+    request = ModelRequest(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    Part(root=TextPart(text='draw a fox')),
+                ],
+            ),
+        ],
+        config={'number_of_images': 2},
+    )
+    googleai_client_mock = mocker.AsyncMock()
+    imagen = ImagenModel(ImagenVersion.IMAGEN4, googleai_client_mock)
+
+    config = imagen._get_config(request)
+
+    assert config['number_of_images'] == 2

--- a/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
@@ -25,6 +25,7 @@ from pytest_mock import MockerFixture
 
 from genkit import (
     ActionRunContext,
+    GenkitError,
     MediaPart,
     Message,
     ModelRequest,
@@ -194,5 +195,5 @@ def test_imagen_config_rejects_unsupported_options(mocker: MockerFixture) -> Non
     googleai_client_mock = mocker.AsyncMock()
     imagen = ImagenModel(ImagenVersion.IMAGEN4, googleai_client_mock)
 
-    with pytest.raises(ValueError, match='configuration dictionary is invalid'):
+    with pytest.raises(GenkitError, match='configuration dictionary is invalid'):
         imagen._get_config(request)

--- a/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
@@ -25,7 +25,6 @@ from pytest_mock import MockerFixture
 
 from genkit import (
     ActionRunContext,
-    GenkitError,
     MediaPart,
     Message,
     ModelRequest,
@@ -179,8 +178,8 @@ def test_imagen_config_preserves_requested_image_count(mocker: MockerFixture) ->
     assert config['number_of_images'] == 2
 
 
-def test_imagen_config_rejects_unsupported_options(mocker: MockerFixture) -> None:
-    """Test Imagen only accepts the supported Google AI options."""
+def test_imagen_config_allows_extra_options(mocker: MockerFixture) -> None:
+    """Test Imagen preserves options not explicitly listed in the schema."""
     request = ModelRequest(
         messages=[
             Message(
@@ -190,10 +189,11 @@ def test_imagen_config_rejects_unsupported_options(mocker: MockerFixture) -> Non
                 ],
             ),
         ],
-        config={'safetyFilterLevel': 'BLOCK_LOW_AND_ABOVE'},
+        config={'safety_filter_level': 'BLOCK_LOW_AND_ABOVE'},
     )
     googleai_client_mock = mocker.AsyncMock()
     imagen = ImagenModel(ImagenVersion.IMAGEN4, googleai_client_mock)
 
-    with pytest.raises(GenkitError, match='configuration dictionary is invalid'):
-        imagen._get_config(request)
+    config = imagen._get_config(request)
+
+    assert config['safety_filter_level'] == 'BLOCK_LOW_AND_ABOVE'

--- a/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_imagen_test.py
@@ -178,8 +178,8 @@ def test_imagen_config_preserves_requested_image_count(mocker: MockerFixture) ->
     assert config['number_of_images'] == 2
 
 
-def test_imagen_config_allows_extra_options(mocker: MockerFixture) -> None:
-    """Test Imagen preserves options not explicitly listed in the schema."""
+def test_imagen_config_allows_vertexai_extra_options(mocker: MockerFixture) -> None:
+    """Test Vertex AI Imagen options not shown in Google AI metadata still pass through."""
     request = ModelRequest(
         messages=[
             Message(
@@ -192,7 +192,7 @@ def test_imagen_config_allows_extra_options(mocker: MockerFixture) -> None:
         config={'safety_filter_level': 'BLOCK_LOW_AND_ABOVE'},
     )
     googleai_client_mock = mocker.AsyncMock()
-    imagen = ImagenModel(ImagenVersion.IMAGEN4, googleai_client_mock)
+    imagen = ImagenModel(ImagenVersion.IMAGEN3, googleai_client_mock)
 
     config = imagen._get_config(request)
 

--- a/py/plugins/google-genai/tests/google_genai_plugin_test.py
+++ b/py/plugins/google-genai/tests/google_genai_plugin_test.py
@@ -42,6 +42,7 @@ from genkit.plugins.google_genai.google import (
     googleai_name,
     vertexai_name,
 )
+from genkit.plugins.google_genai.models.imagen import GOOGLEAI_KNOWN_IMAGEN_MODELS
 
 
 def test_googleai_name() -> None:
@@ -185,7 +186,7 @@ async def test_googleai_resolve_imagen_model(mock_list_models: MagicMock, mock_c
 @patch('genkit.plugins.google_genai.google._list_genai_models')
 @pytest.mark.asyncio
 async def test_googleai_init_registers_imagen_models(mock_list_models: MagicMock, mock_client: MagicMock) -> None:
-    """Test GoogleAI init registers Imagen models from dynamic discovery."""
+    """Test GoogleAI init registers Imagen models from dynamic discovery and the hardcoded Imagen 4 list."""
     models = GenaiModels()
     models.imagen = ['imagen-3.0-generate-002']
     mock_list_models.return_value = models
@@ -194,9 +195,11 @@ async def test_googleai_init_registers_imagen_models(mock_list_models: MagicMock
     actions = await plugin.init()
 
     imagen_actions = [a for a in actions if 'imagen' in a.name]
-    assert len(imagen_actions) == 1
-    assert imagen_actions[0].name == 'googleai/imagen-3.0-generate-002'
-    assert imagen_actions[0].kind == ActionKind.MODEL
+    names = {a.name for a in imagen_actions}
+    expected = {'googleai/imagen-3.0-generate-002'} | {googleai_name(m) for m in GOOGLEAI_KNOWN_IMAGEN_MODELS}
+    assert names == expected
+    for a in imagen_actions:
+        assert a.kind == ActionKind.MODEL
 
 
 @patch('genkit.plugins.google_genai.google.genai.client.Client')
@@ -212,8 +215,9 @@ async def test_googleai_list_actions_includes_imagen(mock_list_models: MagicMock
     actions_list = await plugin.list_actions()
 
     imagen_actions = [a for a in actions_list if 'imagen' in a.name]
-    assert len(imagen_actions) == 1
-    assert imagen_actions[0].name == 'googleai/imagen-3.0-generate-002'
+    names = {a.name for a in imagen_actions}
+    expected = {'googleai/imagen-3.0-generate-002'} | {googleai_name(m) for m in GOOGLEAI_KNOWN_IMAGEN_MODELS}
+    assert names == expected
 
 
 @patch('genkit.plugins.google_genai.google.genai.client.Client')

--- a/py/plugins/google-genai/tests/google_genai_plugin_test.py
+++ b/py/plugins/google-genai/tests/google_genai_plugin_test.py
@@ -42,7 +42,6 @@ from genkit.plugins.google_genai.google import (
     googleai_name,
     vertexai_name,
 )
-from genkit.plugins.google_genai.models.imagen import GOOGLEAI_KNOWN_IMAGEN_MODELS
 
 
 def test_googleai_name() -> None:
@@ -186,7 +185,7 @@ async def test_googleai_resolve_imagen_model(mock_list_models: MagicMock, mock_c
 @patch('genkit.plugins.google_genai.google._list_genai_models')
 @pytest.mark.asyncio
 async def test_googleai_init_registers_imagen_models(mock_list_models: MagicMock, mock_client: MagicMock) -> None:
-    """Test GoogleAI init registers Imagen models from dynamic discovery and the hardcoded Imagen 4 list."""
+    """Test GoogleAI init registers Imagen models from dynamic discovery."""
     models = GenaiModels()
     models.imagen = ['imagen-3.0-generate-002']
     mock_list_models.return_value = models
@@ -196,8 +195,7 @@ async def test_googleai_init_registers_imagen_models(mock_list_models: MagicMock
 
     imagen_actions = [a for a in actions if 'imagen' in a.name]
     names = {a.name for a in imagen_actions}
-    expected = {'googleai/imagen-3.0-generate-002'} | {googleai_name(m) for m in GOOGLEAI_KNOWN_IMAGEN_MODELS}
-    assert names == expected
+    assert names == {'googleai/imagen-3.0-generate-002'}
     for a in imagen_actions:
         assert a.kind == ActionKind.MODEL
 
@@ -216,8 +214,7 @@ async def test_googleai_list_actions_includes_imagen(mock_list_models: MagicMock
 
     imagen_actions = [a for a in actions_list if 'imagen' in a.name]
     names = {a.name for a in imagen_actions}
-    expected = {'googleai/imagen-3.0-generate-002'} | {googleai_name(m) for m in GOOGLEAI_KNOWN_IMAGEN_MODELS}
-    assert names == expected
+    assert names == {'googleai/imagen-3.0-generate-002'}
     for action in imagen_actions:
         custom_options = action.metadata['model']['customOptions']
         assert set(custom_options['properties']) == {

--- a/py/plugins/google-genai/tests/google_genai_plugin_test.py
+++ b/py/plugins/google-genai/tests/google_genai_plugin_test.py
@@ -218,6 +218,14 @@ async def test_googleai_list_actions_includes_imagen(mock_list_models: MagicMock
     names = {a.name for a in imagen_actions}
     expected = {'googleai/imagen-3.0-generate-002'} | {googleai_name(m) for m in GOOGLEAI_KNOWN_IMAGEN_MODELS}
     assert names == expected
+    for action in imagen_actions:
+        custom_options = action.metadata['model']['customOptions']
+        assert set(custom_options['properties']) == {
+            'numberOfImages',
+            'aspectRatio',
+            'personGeneration',
+            'imageSize',
+        }
 
 
 @patch('genkit.plugins.google_genai.google.genai.client.Client')


### PR DESCRIPTION
Adds the three Imagen 4 models on the GoogleAI (Gemini API) backend:

- `imagen-4.0-generate-001`
- `imagen-4.0-fast-generate-001`
- `imagen-4.0-ultra-generate-001`

Mirrors JS `js/plugins/google-genai/src/googleai/imagen.ts` KNOWN_MODELS. Also adds a `googleai_image_model_info` helper so GoogleAI imagen models no longer carry a "Vertex AI" label, and unions a hardcoded known-model list into the plugin's imagen enumeration so the models are visible in `Init` / `list_actions` even when the SDK's `client.models.list()` doesn't surface them.

## Testing
<img width="1247" height="429" alt="image" src="https://github.com/user-attachments/assets/052bef19-b7dc-4144-b2a7-ca8e2c3ca87c" />