### PR TITLE
feat(py/plugins/google-genai): Add Virtual Try-On 001 on VertexAI

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -139,6 +139,13 @@ from genkit.plugins.google_genai.models.veo import (
     is_veo_model,
     veo_model_info,
 )
+from genkit.plugins.google_genai.models.virtual_try_on import (
+    VERTEXAI_KNOWN_VIRTUAL_TRY_ON_MODELS,
+    VirtualTryOnConfig,
+    VirtualTryOnModel,
+    is_virtual_try_on_model,
+    virtual_try_on_model_info,
+)
 
 
 class GenaiModels:
@@ -785,6 +792,11 @@ class VertexAI(Plugin):
         for name in genai_models.veo:
             actions.append(self._resolve_model(vertexai_name(name)))
 
+        # Virtual try-on models are not surfaced by client.models.list(); inject
+        # the hardcoded known-model list so they're addressable.
+        for name in VERTEXAI_KNOWN_VIRTUAL_TRY_ON_MODELS:
+            actions.append(self._resolve_model(vertexai_name(name)))
+
         for name in genai_models.embedders:
             actions.append(self._resolve_embedder(vertexai_name(name)))
 
@@ -894,7 +906,10 @@ class VertexAI(Plugin):
         clean_name = name.replace(VERTEXAI_PLUGIN_NAME + '/', '') if name.startswith(VERTEXAI_PLUGIN_NAME) else name
 
         # Determine model type and create model metadata/config schema
-        if clean_name.lower().startswith('image'):
+        if is_virtual_try_on_model(clean_name):
+            model_ref = virtual_try_on_model_info(clean_name)
+            config_schema = VirtualTryOnConfig
+        elif clean_name.lower().startswith('image'):
             model_ref = vertexai_image_model_info(clean_name)
             IMAGE_SUPPORTED_MODELS[clean_name] = model_ref
             config_schema = ImagenConfigSchema
@@ -907,7 +922,9 @@ class VertexAI(Plugin):
             config_schema = get_model_config_schema(clean_name)
 
         async def _run(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
-            if clean_name.lower().startswith('image'):
+            if is_virtual_try_on_model(clean_name):
+                model = VirtualTryOnModel(clean_name, self._runtime_client())
+            elif clean_name.lower().startswith('image'):
                 model = ImagenModel(clean_name, self._runtime_client())
             elif is_veo_model(clean_name):
                 model = VeoModel(clean_name, self._runtime_client())
@@ -976,6 +993,15 @@ class VertexAI(Plugin):
                     name=vertexai_name(name),
                     info=veo_model_info(name).model_dump(by_alias=True),
                     config_schema=VeoConfigSchema,
+                )
+            )
+
+        for name in VERTEXAI_KNOWN_VIRTUAL_TRY_ON_MODELS:
+            actions_list.append(
+                model_action_metadata(
+                    name=vertexai_name(name),
+                    info=virtual_try_on_model_info(name).model_dump(by_alias=True),
+                    config_schema=VirtualTryOnConfig,
                 )
             )
 

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -169,10 +169,7 @@ from genkit import (
 )
 from genkit._core._typing import GenerationCommonConfig
 from genkit.model import Candidate, FinishReason, get_basic_usage_stats
-from genkit.plugin_api import (
-    ActionRunContext,
-    StatusName,
-)
+from genkit.plugin_api import ActionRunContext
 
 
 def _to_dict(obj: JsonAny) -> JsonAny:  # noqa: ANN401
@@ -183,7 +180,7 @@ def _to_dict(obj: JsonAny) -> JsonAny:  # noqa: ANN401
 from genkit.plugins.google_genai.models._deprecations import (  # noqa: E402
     deprecated_enum_metafactory,
 )
-from genkit.plugins.google_genai.models.utils import PartConverter  # noqa: E402
+from genkit.plugins.google_genai.models.utils import PartConverter, client_error_to_genkit_status  # noqa: E402
 
 
 class HarmCategory(StrEnum):
@@ -1364,20 +1361,8 @@ class GeminiModel:
                 config=request_cfg,
             )
         except ClientError as e:
-            status: StatusName = 'INTERNAL'
-            if e.code == 400:
-                status = 'INVALID_ARGUMENT'
-            elif e.code == 401:
-                status = 'UNAUTHENTICATED'
-            elif e.code == 403:
-                status = 'PERMISSION_DENIED'
-            elif e.code == 404:
-                status = 'NOT_FOUND'
-            elif e.code == 429:
-                status = 'RESOURCE_EXHAUSTED'
-
             raise GenkitError(
-                status=status,
+                status=client_error_to_genkit_status(e),
                 message=e.message or 'Unknown error',
                 cause=e,
             ) from e
@@ -1488,20 +1473,8 @@ class GeminiModel:
                 config=request_cfg,
             )
         except ClientError as e:
-            status: StatusName = 'INTERNAL'
-            if e.code == 400:
-                status = 'INVALID_ARGUMENT'
-            elif e.code == 401:
-                status = 'UNAUTHENTICATED'
-            elif e.code == 403:
-                status = 'PERMISSION_DENIED'
-            elif e.code == 404:
-                status = 'NOT_FOUND'
-            elif e.code == 429:
-                status = 'RESOURCE_EXHAUSTED'
-
             raise GenkitError(
-                status=status,
+                status=client_error_to_genkit_status(e),
                 message=e.message or 'Unknown error',
                 cause=e,
             ) from e

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/utils.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/utils.py
@@ -51,6 +51,7 @@ from typing import cast
 from urllib.parse import urlparse
 
 from google import genai
+from google.genai.errors import ClientError
 
 from genkit import (
     CustomPart,
@@ -66,7 +67,22 @@ from genkit import (
     ToolResponse,
     ToolResponsePart,
 )
-from genkit.plugin_api import get_cached_client
+from genkit.plugin_api import StatusName, get_cached_client
+
+
+def client_error_to_genkit_status(error: ClientError) -> StatusName:
+    """Map Google GenAI HTTP errors to Genkit status names."""
+    if error.code == 400:
+        return 'INVALID_ARGUMENT'
+    if error.code == 401:
+        return 'UNAUTHENTICATED'
+    if error.code == 403:
+        return 'PERMISSION_DENIED'
+    if error.code == 404:
+        return 'NOT_FOUND'
+    if error.code == 429:
+        return 'RESOURCE_EXHAUSTED'
+    return 'INTERNAL'
 
 
 class PartConverter:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
@@ -1,0 +1,272 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Virtual Try-On image editing model for Google Vertex AI plugin.
+
+Virtual Try-On takes a photo of a person and one or more photos of products
+(garments) and returns an image of the person wearing the product. It is
+available through Vertex AI only.
+
+Callers identify which image is which by setting a ``type`` key in the
+``ai.Part`` metadata — ``personImage`` for the model's photo and
+``productImage`` for each garment. The string values match the Go and JS
+conventions so the same request shape works across runtimes.
+"""
+
+import base64
+import json
+import sys
+import urllib.parse
+from typing import Any
+
+if sys.version_info < (3, 11):
+    from strenum import StrEnum
+else:
+    from enum import StrEnum
+
+from google import genai
+from pydantic import BaseModel, ConfigDict, Field
+
+from genkit import (
+    FinishReason,
+    Media,
+    MediaPart,
+    Message,
+    ModelInfo,
+    ModelRequest,
+    ModelResponse,
+    Part,
+    Role,
+    Supports,
+)
+from genkit.plugin_api import ActionRunContext, tracer
+
+
+class VirtualTryOnVersion(StrEnum):
+    """Supported virtual try-on image editing models."""
+
+    VIRTUAL_TRY_ON_001 = 'virtual-try-on-001'
+
+
+# Virtual Try-On models available on the Vertex AI backend. Hardcoded because
+# client.models.list() does not always surface them, and they must be visible
+# in the plugin's Init / list_actions output to be selectable.
+VERTEXAI_KNOWN_VIRTUAL_TRY_ON_MODELS: tuple[str, ...] = (VirtualTryOnVersion.VIRTUAL_TRY_ON_001,)
+
+
+# Metadata keys used to tag input images. Users attach
+# ``metadata={'type': PART_METADATA_TYPE_PERSON_IMAGE}`` to the person photo
+# and ``{'type': PART_METADATA_TYPE_PRODUCT_IMAGE}`` to each garment.
+PART_METADATA_TYPE_PERSON_IMAGE = 'personImage'
+PART_METADATA_TYPE_PRODUCT_IMAGE = 'productImage'
+
+
+def is_virtual_try_on_model(name: str) -> bool:
+    """Check whether a model name denotes a virtual try-on model."""
+    return name.startswith('virtual-try-on-')
+
+
+class VirtualTryOnOutputOptions(BaseModel):
+    """Output image format controls."""
+
+    mime_type: str | None = Field(default=None, alias='mimeType')
+    compression_quality: int | None = Field(default=None, alias='compressionQuality')
+
+    model_config = ConfigDict(populate_by_name=True, extra='allow')
+
+
+class VirtualTryOnConfig(BaseModel):
+    """Configuration for a virtual-try-on request.
+
+    Mirrors the JS ``ImagenTryOnConfigSchema`` in
+    ``js/plugins/google-genai/src/vertexai/imagen.ts``.
+    """
+
+    sample_count: int | None = Field(default=None, ge=1, alias='sampleCount')
+    seed: int | None = Field(default=None)
+    base_steps: int | None = Field(default=None, ge=1, le=100, alias='baseSteps')
+    person_generation: str | None = Field(default=None, alias='personGeneration')
+    safety_setting: str | None = Field(default=None, alias='safetySetting')
+    storage_uri: str | None = Field(default=None, alias='storageUri')
+    output_options: VirtualTryOnOutputOptions | None = Field(default=None, alias='outputOptions')
+    location: str | None = Field(default=None)
+
+    model_config = ConfigDict(populate_by_name=True, extra='allow')
+
+
+VIRTUAL_TRY_ON_SUPPORTS = Supports(
+    media=True,
+    multiturn=False,
+    tools=False,
+    system_role=True,
+    output=['media'],
+)
+
+
+VIRTUAL_TRY_ON_MODEL_INFO = ModelInfo(
+    label='Vertex AI - Virtual Try-On',
+    supports=VIRTUAL_TRY_ON_SUPPORTS,
+)
+
+
+def virtual_try_on_model_info(version: str) -> ModelInfo:
+    """ModelInfo for a virtual try-on model."""
+    if version == VirtualTryOnVersion.VIRTUAL_TRY_ON_001:
+        return ModelInfo(label='Vertex AI - Virtual Try-On 001', supports=VIRTUAL_TRY_ON_SUPPORTS)
+    return ModelInfo(label=f'Vertex AI - {version}', supports=VIRTUAL_TRY_ON_SUPPORTS)
+
+
+def _extract_media_by_type(request: ModelRequest, part_type: str) -> list[dict[str, Any]]:
+    """Collect input images tagged with the given metadata type.
+
+    Handles both data URIs (extracting base64 payload) and ``gs://`` URIs
+    (passed through as ``gcsUri``).
+    """
+    out: list[dict[str, Any]] = []
+    for message in request.messages:
+        for part in message.content:
+            root = part.root
+            # Only media parts can carry image input
+            if not isinstance(root, MediaPart):
+                continue
+            metadata = getattr(root, 'metadata', None) or {}
+            if metadata.get('type') != part_type:
+                continue
+            url = root.media.url or ''
+            if url.startswith('gs://'):
+                out.append({'image': {'gcsUri': url}})
+                continue
+            # data:<mime>[;base64],<payload>
+            if url.startswith('data:'):
+                prefix, _, payload = url.partition(',')
+                if not payload:
+                    continue
+                if ';base64' in prefix:
+                    out.append({'image': {'bytesBase64Encoded': payload}})
+                else:
+                    # Non-base64 data URIs are rare; decode percent-encoding
+                    # and re-encode as base64 for the Vertex API.
+                    decoded = urllib.parse.unquote_to_bytes(payload)
+                    out.append({'image': {'bytesBase64Encoded': base64.b64encode(decoded).decode('ascii')}})
+    return out
+
+
+def _to_virtual_try_on_request(request: ModelRequest, config: VirtualTryOnConfig | dict | None) -> dict[str, Any]:
+    """Build the Vertex predict request body for virtual try-on."""
+    persons = _extract_media_by_type(request, PART_METADATA_TYPE_PERSON_IMAGE)
+    products = _extract_media_by_type(request, PART_METADATA_TYPE_PRODUCT_IMAGE)
+    if not persons:
+        raise ValueError(f"virtual try-on requires a media part with metadata.type='{PART_METADATA_TYPE_PERSON_IMAGE}'")
+    if not products:
+        raise ValueError(
+            f"virtual try-on requires at least one media part with metadata.type='{PART_METADATA_TYPE_PRODUCT_IMAGE}'"
+        )
+
+    instance: dict[str, Any] = {
+        'personImage': persons[0],
+        'productImages': products,
+    }
+
+    parameters: dict[str, Any] = {}
+    if isinstance(config, VirtualTryOnConfig):
+        # The ``location`` field is a plugin-level override; it is not a Vertex
+        # request parameter, so exclude it from the wire payload.
+        parameters = config.model_dump(by_alias=True, exclude_none=True, exclude={'location'})
+    elif isinstance(config, dict):
+        parameters = {k: v for k, v in config.items() if k not in ('location', 'Location') and v is not None}
+
+    return {
+        'instances': [instance],
+        'parameters': parameters,
+    }
+
+
+def _from_virtual_try_on_response(response: dict[str, Any]) -> list[Part]:
+    """Convert a virtual-try-on predict response to MediaParts."""
+    content: list[Part] = []
+    for prediction in response.get('predictions') or []:
+        b64 = prediction.get('bytesBase64Encoded') or ''
+        mime_type = prediction.get('mimeType') or 'image/png'
+        content.append(
+            Part(
+                root=MediaPart(
+                    media=Media(
+                        url=f'data:{mime_type};base64,{b64}',
+                        content_type=mime_type,
+                    )
+                )
+            )
+        )
+    return content
+
+
+class VirtualTryOnModel:
+    """Virtual-try-on model driver."""
+
+    def __init__(self, version: str | VirtualTryOnVersion, client: genai.Client) -> None:
+        """Initialize the virtual try-on model.
+
+        Args:
+            version: The virtual try-on model version.
+            client: The configured Vertex AI genai.Client.
+        """
+        self._version = version
+        self._client = client
+
+    def _get_config(self, request: ModelRequest) -> VirtualTryOnConfig | dict | None:
+        if request.config is None:
+            return None
+        if isinstance(request.config, VirtualTryOnConfig):
+            return request.config
+        if isinstance(request.config, dict):
+            return VirtualTryOnConfig.model_validate(request.config)
+        # Fall back to generic dict coercion for BaseModel instances
+        if isinstance(request.config, BaseModel):
+            return VirtualTryOnConfig.model_validate(request.config.model_dump())
+        return None
+
+    async def generate(self, request: ModelRequest, _: ActionRunContext) -> ModelResponse:
+        """Handle a virtual-try-on generation request."""
+        api_client = getattr(self._client, '_api_client', None)
+        if api_client is None or not getattr(api_client, 'vertexai', False):
+            raise ValueError('Virtual Try-On is only available through the Vertex AI backend')
+
+        config = self._get_config(request)
+        payload = _to_virtual_try_on_request(request, config)
+        path = f'publishers/google/models/{self._version}:predict'
+
+        with tracer.start_as_current_span('virtual_try_on_predict') as span:
+            span.set_attribute(
+                'genkit:input',
+                json.dumps({'model': self._version, 'body': payload}, default=str),
+            )
+            http_response = await api_client.async_request('POST', path, payload)
+            body = http_response.body if hasattr(http_response, 'body') else http_response
+            response = json.loads(body) if isinstance(body, (bytes, bytearray, str)) else body
+            span.set_attribute('genkit:output', json.dumps(response, default=str))
+
+        if not response.get('predictions'):
+            # Vertex returning zero predictions almost always means safety
+            # filters blocked the output — surface it as a blocked response.
+            return ModelResponse(
+                message=Message(role=Role.MODEL, content=[]),
+                finish_reason=FinishReason.BLOCKED,
+                finish_message='virtual try-on: no predictions returned (likely content-filtered)',
+            )
+
+        return ModelResponse(
+            message=Message(role=Role.MODEL, content=_from_virtual_try_on_response(response)),
+        )

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
@@ -38,10 +38,12 @@ else:
     from enum import StrEnum
 
 from google import genai
+from google.genai.errors import ClientError
 from pydantic import BaseModel, ConfigDict, Field
 
 from genkit import (
     FinishReason,
+    GenkitError,
     Media,
     MediaPart,
     Message,
@@ -53,6 +55,7 @@ from genkit import (
     Supports,
 )
 from genkit.plugin_api import ActionRunContext, tracer
+from genkit.plugins.google_genai.models.utils import client_error_to_genkit_status
 
 
 class VirtualTryOnVersion(StrEnum):
@@ -253,7 +256,14 @@ class VirtualTryOnModel:
                 'genkit:input',
                 json.dumps({'model': self._version, 'body': payload}, default=str),
             )
-            http_response = await api_client.async_request('POST', path, payload)
+            try:
+                http_response = await api_client.async_request('POST', path, payload)
+            except ClientError as e:
+                raise GenkitError(
+                    status=client_error_to_genkit_status(e),
+                    message=e.message or 'Unknown error',
+                    cause=e,
+                ) from e
             body = http_response.body if hasattr(http_response, 'body') else http_response
             response = json.loads(body) if isinstance(body, (bytes, bytearray, str)) else body
             span.set_attribute('genkit:output', json.dumps(response, default=str))

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
@@ -186,7 +186,7 @@ def _virtual_try_on_image_from_url(url: str) -> dict[str, Any]:
     if url.startswith(('http://', 'https://')):
         raise GenkitError(
             status='INVALID_ARGUMENT',
-            message='virtual try-on does not support http(s) URIs. Please specify a Cloud Storage URI.',
+            message='virtual try-on does not support http(s) URIs. Please specify a Cloud Storage (gs://) or data URI.',
         )
     if url.startswith('data:'):
         prefix, _, payload = url.partition(',')

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
@@ -39,7 +39,7 @@ else:
 
 from google import genai
 from google.genai.errors import ClientError
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from genkit import (
     FinishReason,
@@ -56,6 +56,15 @@ from genkit import (
 )
 from genkit.plugin_api import ActionRunContext, tracer
 from genkit.plugins.google_genai.models.utils import client_error_to_genkit_status
+
+_VIRTUAL_TRY_ON_UNAVAILABLE_ERRORS = (ConnectionError, TimeoutError, OSError)
+
+
+def _virtual_try_on_request_error_status(error: Exception) -> str:
+    """Map non-ClientError request failures to a Genkit status name."""
+    if isinstance(error, _VIRTUAL_TRY_ON_UNAVAILABLE_ERRORS):
+        return 'UNAVAILABLE'
+    return 'INTERNAL'
 
 
 class VirtualTryOnVersion(StrEnum):
@@ -204,10 +213,17 @@ def _to_virtual_try_on_request(request: ModelRequest, config: VirtualTryOnConfig
     persons = _extract_media_by_type(request, PART_METADATA_TYPE_PERSON_IMAGE)
     products = _extract_media_by_type(request, PART_METADATA_TYPE_PRODUCT_IMAGE)
     if not persons:
-        raise ValueError(f"virtual try-on requires a media part with metadata.type='{PART_METADATA_TYPE_PERSON_IMAGE}'")
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=f"virtual try-on requires a media part with metadata.type='{PART_METADATA_TYPE_PERSON_IMAGE}'",
+        )
     if not products:
-        raise ValueError(
-            f"virtual try-on requires at least one media part with metadata.type='{PART_METADATA_TYPE_PRODUCT_IMAGE}'"
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=(
+                'virtual try-on requires at least one media part with '
+                f"metadata.type='{PART_METADATA_TYPE_PRODUCT_IMAGE}'"
+            ),
         )
 
     instance: dict[str, Any] = {
@@ -229,12 +245,56 @@ def _to_virtual_try_on_request(request: ModelRequest, config: VirtualTryOnConfig
     }
 
 
+def _parse_virtual_try_on_response_body(body: object) -> dict[str, Any]:
+    """Decode and validate the top-level Vertex predict response."""
+    try:
+        response = json.loads(body) if isinstance(body, (bytes, bytearray, str)) else body
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        raise GenkitError(
+            status='INTERNAL',
+            message=f'virtual try-on returned a malformed response body: {str(e)}',
+            cause=e,
+        ) from e
+
+    if not isinstance(response, dict):
+        raise GenkitError(
+            status='INTERNAL',
+            message=f'virtual try-on returned an unexpected response body: {type(response).__name__}',
+        )
+
+    predictions = response.get('predictions')
+    if predictions is not None and not isinstance(predictions, list):
+        raise GenkitError(
+            status='INTERNAL',
+            message='virtual try-on returned an unexpected predictions value',
+        )
+
+    return response
+
+
 def _from_virtual_try_on_response(response: dict[str, Any]) -> list[Part]:
     """Convert a virtual-try-on predict response to MediaParts."""
     content: list[Part] = []
     for prediction in response.get('predictions') or []:
-        b64 = prediction.get('bytesBase64Encoded') or ''
-        mime_type = prediction.get('mimeType') or 'image/png'
+        if not isinstance(prediction, dict):
+            raise GenkitError(
+                status='INTERNAL',
+                message='virtual try-on returned an unexpected prediction value',
+            )
+        b64 = prediction.get('bytesBase64Encoded')
+        if not isinstance(b64, str) or not b64:
+            raise GenkitError(
+                status='INTERNAL',
+                message='virtual try-on returned a prediction without image data',
+            )
+        mime_type = prediction.get('mimeType')
+        if mime_type is not None and not isinstance(mime_type, str):
+            raise GenkitError(
+                status='INTERNAL',
+                message='virtual try-on returned an unexpected mimeType value',
+            )
+        if not mime_type:
+            mime_type = 'image/png'
         content.append(
             Part(
                 root=MediaPart(
@@ -266,18 +326,28 @@ class VirtualTryOnModel:
             return None
         if isinstance(request.config, VirtualTryOnConfig):
             return request.config
-        if isinstance(request.config, dict):
-            return VirtualTryOnConfig.model_validate(request.config)
-        # Fall back to generic dict coercion for BaseModel instances
-        if isinstance(request.config, BaseModel):
-            return VirtualTryOnConfig.model_validate(request.config.model_dump())
+        try:
+            if isinstance(request.config, dict):
+                return VirtualTryOnConfig.model_validate(request.config)
+            # Fall back to generic dict coercion for BaseModel instances
+            if isinstance(request.config, BaseModel):
+                return VirtualTryOnConfig.model_validate(request.config.model_dump())
+        except ValidationError as e:
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message='The virtual try-on configuration is invalid',
+                cause=e,
+            ) from e
         return None
 
     async def generate(self, request: ModelRequest, _: ActionRunContext) -> ModelResponse:
         """Handle a virtual-try-on generation request."""
         api_client = getattr(self._client, '_api_client', None)
         if api_client is None or not getattr(api_client, 'vertexai', False):
-            raise ValueError('Virtual Try-On is only available through the Vertex AI backend')
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message='Virtual Try-On is only available through the Vertex AI backend',
+            )
 
         config = self._get_config(request)
         payload = _to_virtual_try_on_request(request, config)
@@ -296,11 +366,25 @@ class VirtualTryOnModel:
                     message=e.message or 'Unknown error',
                     cause=e,
                 ) from e
+            except GenkitError:
+                raise
+            except Exception as e:
+                raise GenkitError(
+                    status=_virtual_try_on_request_error_status(e),
+                    message=f'virtual try-on request failed: {type(e).__name__}: {str(e)}',
+                    cause=e,
+                ) from e
             body = http_response.body if hasattr(http_response, 'body') else http_response
-            response = json.loads(body) if isinstance(body, (bytes, bytearray, str)) else body
+            response = _parse_virtual_try_on_response_body(body)
             span.set_attribute('genkit:output', json.dumps(response, default=str))
 
-        if not response.get('predictions'):
+        if 'predictions' not in response:
+            raise GenkitError(
+                status='INTERNAL',
+                message='virtual try-on returned a response without predictions',
+            )
+
+        if not response['predictions']:
             # Vertex returning zero predictions almost always means safety
             # filters blocked the output — surface it as a blocked response.
             return ModelResponse(

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
@@ -26,6 +26,7 @@ Callers identify which image is which by setting a ``type`` key in the
 conventions so the same request shape works across runtimes.
 """
 
+import asyncio
 import base64
 import json
 import sys
@@ -57,7 +58,7 @@ from genkit import (
 from genkit.plugin_api import ActionRunContext, StatusName, tracer
 from genkit.plugins.google_genai.models.utils import client_error_to_genkit_status
 
-_VIRTUAL_TRY_ON_UNAVAILABLE_ERRORS = (ConnectionError, TimeoutError, OSError)
+_VIRTUAL_TRY_ON_UNAVAILABLE_ERRORS = (ConnectionError, OSError, asyncio.TimeoutError)
 
 
 def _virtual_try_on_request_error_status(error: Exception) -> StatusName:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
@@ -91,6 +91,33 @@ class VirtualTryOnOutputOptions(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra='allow')
 
 
+def _inline_virtual_try_on_config_schema(schema: dict[str, Any], _: type[Any]) -> None:
+    """Inline nested outputOptions so the model config UI can render it."""
+    properties = schema.get('properties')
+    if not isinstance(properties, dict):
+        return
+
+    properties['outputOptions'] = {
+        'additionalProperties': True,
+        'default': None,
+        'description': 'Output image format controls.',
+        'properties': {
+            'mimeType': {
+                'anyOf': [{'type': 'string'}, {'type': 'null'}],
+                'default': None,
+                'title': 'Mime type',
+            },
+            'compressionQuality': {
+                'anyOf': [{'type': 'integer'}, {'type': 'null'}],
+                'default': None,
+                'title': 'Compression quality',
+            },
+        },
+        'title': 'Output options',
+        'type': 'object',
+    }
+
+
 class VirtualTryOnConfig(BaseModel):
     """Configuration for a virtual-try-on request.
 
@@ -99,15 +126,20 @@ class VirtualTryOnConfig(BaseModel):
     """
 
     sample_count: int | None = Field(default=None, ge=1, alias='sampleCount')
+    storage_uri: str | None = Field(default=None, alias='storageUri')
     seed: int | None = Field(default=None)
     base_steps: int | None = Field(default=None, ge=1, le=100, alias='baseSteps')
-    person_generation: str | None = Field(default=None, alias='personGeneration')
     safety_setting: str | None = Field(default=None, alias='safetySetting')
-    storage_uri: str | None = Field(default=None, alias='storageUri')
+    person_generation: str | None = Field(default=None, alias='personGeneration')
+    add_watermark: bool | None = Field(default=None, alias='addWatermark')
+    enhance_prompt: bool | None = Field(default=None, alias='enhancePrompt')
     output_options: VirtualTryOnOutputOptions | None = Field(default=None, alias='outputOptions')
-    location: str | None = Field(default=None)
 
-    model_config = ConfigDict(populate_by_name=True, extra='allow')
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra='allow',
+        json_schema_extra=_inline_virtual_try_on_config_schema,
+    )
 
 
 VIRTUAL_TRY_ON_SUPPORTS = Supports(
@@ -185,8 +217,8 @@ def _to_virtual_try_on_request(request: ModelRequest, config: VirtualTryOnConfig
 
     parameters: dict[str, Any] = {}
     if isinstance(config, VirtualTryOnConfig):
-        # The ``location`` field is a plugin-level override; it is not a Vertex
-        # request parameter, so exclude it from the wire payload.
+        # Drop legacy location overrides if callers still pass them as extra
+        # config; location is not a Vertex predict request parameter.
         parameters = config.model_dump(by_alias=True, exclude_none=True, exclude={'location'})
     elif isinstance(config, dict):
         parameters = {k: v for k, v in config.items() if k not in ('location', 'Location') and v is not None}

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
@@ -30,7 +30,7 @@ import base64
 import json
 import sys
 import urllib.parse
-from typing import Any
+from typing import Any, cast
 
 if sys.version_info < (3, 11):
     from strenum import StrEnum
@@ -54,13 +54,13 @@ from genkit import (
     Role,
     Supports,
 )
-from genkit.plugin_api import ActionRunContext, tracer
+from genkit.plugin_api import ActionRunContext, StatusName, tracer
 from genkit.plugins.google_genai.models.utils import client_error_to_genkit_status
 
 _VIRTUAL_TRY_ON_UNAVAILABLE_ERRORS = (ConnectionError, TimeoutError, OSError)
 
 
-def _virtual_try_on_request_error_status(error: Exception) -> str:
+def _virtual_try_on_request_error_status(error: Exception) -> StatusName:
     """Map non-ClientError request failures to a Genkit status name."""
     if isinstance(error, _VIRTUAL_TRY_ON_UNAVAILABLE_ERRORS):
         return 'UNAVAILABLE'
@@ -279,6 +279,7 @@ def _parse_virtual_try_on_response_body(body: object) -> dict[str, Any]:
             message=f'virtual try-on returned an unexpected response body: {type(response).__name__}',
         )
 
+    response = cast(dict[str, Any], response)
     predictions = response.get('predictions')
     if predictions is not None and not isinstance(predictions, list):
         raise GenkitError(

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/virtual_try_on.py
@@ -173,6 +173,38 @@ def virtual_try_on_model_info(version: str) -> ModelInfo:
     return ModelInfo(label=f'Vertex AI - {version}', supports=VIRTUAL_TRY_ON_SUPPORTS)
 
 
+def _virtual_try_on_image_from_url(url: str) -> dict[str, Any]:
+    """Convert a tagged media URL into a Vertex virtual-try-on image payload."""
+    if not url:
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message='virtual try-on requires a media URL for tagged input images',
+        )
+    if url.startswith('gs://'):
+        return {'image': {'gcsUri': url}}
+    if url.startswith(('http://', 'https://')):
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message='virtual try-on does not support http(s) URIs. Please specify a Cloud Storage URI.',
+        )
+    if url.startswith('data:'):
+        prefix, _, payload = url.partition(',')
+        if not payload:
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message='virtual try-on requires image data in data URIs',
+            )
+        if ';base64' in prefix:
+            return {'image': {'bytesBase64Encoded': payload}}
+        # Non-base64 data URIs are rare; decode percent-encoding and re-encode as base64.
+        decoded = urllib.parse.unquote_to_bytes(payload)
+        return {'image': {'bytesBase64Encoded': base64.b64encode(decoded).decode('ascii')}}
+    raise GenkitError(
+        status='INVALID_ARGUMENT',
+        message='virtual try-on only supports gs:// or data: image URIs',
+    )
+
+
 def _extract_media_by_type(request: ModelRequest, part_type: str) -> list[dict[str, Any]]:
     """Collect input images tagged with the given metadata type.
 
@@ -189,22 +221,7 @@ def _extract_media_by_type(request: ModelRequest, part_type: str) -> list[dict[s
             metadata = getattr(root, 'metadata', None) or {}
             if metadata.get('type') != part_type:
                 continue
-            url = root.media.url or ''
-            if url.startswith('gs://'):
-                out.append({'image': {'gcsUri': url}})
-                continue
-            # data:<mime>[;base64],<payload>
-            if url.startswith('data:'):
-                prefix, _, payload = url.partition(',')
-                if not payload:
-                    continue
-                if ';base64' in prefix:
-                    out.append({'image': {'bytesBase64Encoded': payload}})
-                else:
-                    # Non-base64 data URIs are rare; decode percent-encoding
-                    # and re-encode as base64 for the Vertex API.
-                    decoded = urllib.parse.unquote_to_bytes(payload)
-                    out.append({'image': {'bytesBase64Encoded': base64.b64encode(decoded).decode('ascii')}})
+            out.append(_virtual_try_on_image_from_url(root.media.url or ''))
     return out
 
 

--- a/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Virtual Try-On model implementation."""
+
+import base64
+
+import pytest
+from pytest_mock import MockerFixture
+
+from genkit import (
+    ActionRunContext,
+    FinishReason,
+    Media,
+    MediaPart,
+    Message,
+    ModelRequest,
+    Part,
+    Role,
+)
+from genkit.plugins.google_genai.models.virtual_try_on import (
+    PART_METADATA_TYPE_PERSON_IMAGE,
+    PART_METADATA_TYPE_PRODUCT_IMAGE,
+    VirtualTryOnConfig,
+    VirtualTryOnModel,
+    VirtualTryOnVersion,
+    _extract_media_by_type,
+    _to_virtual_try_on_request,
+    is_virtual_try_on_model,
+)
+
+
+def _person_part(url: str) -> Part:
+    return Part(
+        root=MediaPart(
+            media=Media(url=url, content_type='image/png'),
+            metadata={'type': PART_METADATA_TYPE_PERSON_IMAGE},
+        )
+    )
+
+
+def _product_part(url: str) -> Part:
+    return Part(
+        root=MediaPart(
+            media=Media(url=url, content_type='image/png'),
+            metadata={'type': PART_METADATA_TYPE_PRODUCT_IMAGE},
+        )
+    )
+
+
+def _request_with(parts: list[Part]) -> ModelRequest:
+    return ModelRequest(messages=[Message(role=Role.USER, content=parts)])
+
+
+def test_is_virtual_try_on_model() -> None:
+    """is_virtual_try_on_model recognises virtual-try-on-* names."""
+    assert is_virtual_try_on_model('virtual-try-on-001')
+    assert is_virtual_try_on_model('virtual-try-on-future')
+    assert not is_virtual_try_on_model('imagen-4.0-generate-001')
+    assert not is_virtual_try_on_model('gemini-2.5-flash')
+
+
+def test_extract_media_by_type_gcs() -> None:
+    """gs:// URIs are passed through as gcsUri."""
+    req = _request_with([_person_part('gs://bucket/person.png')])
+    got = _extract_media_by_type(req, PART_METADATA_TYPE_PERSON_IMAGE)
+    assert got == [{'image': {'gcsUri': 'gs://bucket/person.png'}}]
+
+
+def test_extract_media_by_type_data_base64() -> None:
+    """data:*;base64,* URIs are extracted as bytesBase64Encoded."""
+    payload = base64.b64encode(b'\x89PNG').decode('ascii')
+    url = f'data:image/png;base64,{payload}'
+    req = _request_with([_product_part(url)])
+    got = _extract_media_by_type(req, PART_METADATA_TYPE_PRODUCT_IMAGE)
+    assert got == [{'image': {'bytesBase64Encoded': payload}}]
+
+
+def test_extract_media_by_type_ignores_other_types() -> None:
+    """Parts whose metadata.type does not match are skipped."""
+    req = _request_with([_person_part('gs://b/p.png')])
+    got = _extract_media_by_type(req, PART_METADATA_TYPE_PRODUCT_IMAGE)
+    assert got == []
+
+
+def test_to_virtual_try_on_request_requires_person() -> None:
+    """Missing personImage raises a descriptive ValueError."""
+    req = _request_with([_product_part('gs://b/shirt.png')])
+    with pytest.raises(ValueError, match='personImage'):
+        _to_virtual_try_on_request(req, None)
+
+
+def test_to_virtual_try_on_request_requires_product() -> None:
+    """Missing productImage raises a descriptive ValueError."""
+    req = _request_with([_person_part('gs://b/person.png')])
+    with pytest.raises(ValueError, match='productImage'):
+        _to_virtual_try_on_request(req, None)
+
+
+def test_to_virtual_try_on_request_shape() -> None:
+    """Resulting body has one instance with personImage and all productImages."""
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+        _product_part('gs://b/hat.png'),
+    ])
+    cfg = VirtualTryOnConfig(sample_count=2, person_generation='allow_adult')
+    body = _to_virtual_try_on_request(req, cfg)
+    assert body == {
+        'instances': [
+            {
+                'personImage': {'image': {'gcsUri': 'gs://b/person.png'}},
+                'productImages': [
+                    {'image': {'gcsUri': 'gs://b/shirt.png'}},
+                    {'image': {'gcsUri': 'gs://b/hat.png'}},
+                ],
+            }
+        ],
+        'parameters': {
+            'sampleCount': 2,
+            'personGeneration': 'allow_adult',
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_blocked_when_no_predictions(mocker: MockerFixture) -> None:
+    """Empty predictions should surface as a FinishReasonBlocked response, not raise."""
+    client = mocker.MagicMock()
+    client._api_client.vertexai = True
+
+    class _FakeResp:
+        body = '{"predictions": []}'
+
+    client._api_client.async_request = mocker.AsyncMock(return_value=_FakeResp())
+
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+    ])
+    model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
+    resp = await model.generate(req, ActionRunContext())
+    assert resp.finish_reason == FinishReason.BLOCKED
+    assert resp.message is not None
+    assert resp.message.content == []
+
+
+@pytest.mark.asyncio
+async def test_generate_emits_media_parts(mocker: MockerFixture) -> None:
+    """A non-empty predict response is converted into MediaPart data URLs."""
+    client = mocker.MagicMock()
+    client._api_client.vertexai = True
+
+    image_b64 = base64.b64encode(b'\x89PNG\r\n\x1a\n').decode('ascii')
+
+    class _FakeResp:
+        body = '{"predictions": [{"bytesBase64Encoded": "' + image_b64 + '", "mimeType": "image/png"}]}'
+
+    client._api_client.async_request = mocker.AsyncMock(return_value=_FakeResp())
+
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+    ])
+    model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
+    resp = await model.generate(req, ActionRunContext())
+
+    assert resp.message is not None
+    assert len(resp.message.content) == 1
+    part = resp.message.content[0].root
+    assert isinstance(part, MediaPart)
+    assert part.media.content_type == 'image/png'
+    assert part.media.url == f'data:image/png;base64,{image_b64}'

--- a/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
@@ -99,6 +99,30 @@ def test_extract_media_by_type_ignores_other_types() -> None:
     assert got == []
 
 
+def test_extract_media_by_type_rejects_http_url() -> None:
+    """http(s) URIs on tagged images should raise INVALID_ARGUMENT."""
+    req = _request_with([_person_part('https://example.com/person.png')])
+    with pytest.raises(GenkitError, match='http') as exc_info:
+        _extract_media_by_type(req, PART_METADATA_TYPE_PERSON_IMAGE)
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+def test_extract_media_by_type_rejects_empty_data_uri() -> None:
+    """Tagged data URIs without payload should raise INVALID_ARGUMENT."""
+    req = _request_with([_product_part('data:image/png;base64,')])
+    with pytest.raises(GenkitError, match='image data') as exc_info:
+        _extract_media_by_type(req, PART_METADATA_TYPE_PRODUCT_IMAGE)
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+def test_extract_media_by_type_rejects_unsupported_url() -> None:
+    """Tagged images with unsupported schemes should raise INVALID_ARGUMENT."""
+    req = _request_with([_person_part('file:///tmp/person.png')])
+    with pytest.raises(GenkitError, match='gs:// or data:') as exc_info:
+        _extract_media_by_type(req, PART_METADATA_TYPE_PERSON_IMAGE)
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
 def test_to_virtual_try_on_request_requires_person() -> None:
     """Missing personImage raises a Genkit INVALID_ARGUMENT error."""
     req = _request_with([_product_part('gs://b/shirt.png')])

--- a/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
@@ -19,11 +19,13 @@
 import base64
 
 import pytest
+from google.genai.errors import ClientError
 from pytest_mock import MockerFixture
 
 from genkit import (
     ActionRunContext,
     FinishReason,
+    GenkitError,
     Media,
     MediaPart,
     Message,
@@ -156,6 +158,28 @@ async def test_generate_blocked_when_no_predictions(mocker: MockerFixture) -> No
     assert resp.finish_reason == FinishReason.BLOCKED
     assert resp.message is not None
     assert resp.message.content == []
+
+
+@pytest.mark.asyncio
+async def test_generate_maps_client_error_to_genkit_error(mocker: MockerFixture) -> None:
+    """HTTP errors from the direct predict call should use Genkit status names."""
+    client = mocker.MagicMock()
+    client._api_client.vertexai = True
+    client._api_client.async_request = mocker.AsyncMock(
+        side_effect=ClientError(429, {'error': {'message': 'quota exceeded'}})
+    )
+
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+    ])
+    model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(req, ActionRunContext())
+
+    assert exc_info.value.status == 'RESOURCE_EXHAUSTED'
+    assert exc_info.value.original_message == 'quota exceeded'
 
 
 @pytest.mark.asyncio

--- a/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
@@ -107,6 +107,8 @@ def test_extract_media_by_type_rejects_http_url() -> None:
     with pytest.raises(GenkitError, match='http') as exc_info:
         _extract_media_by_type(req, PART_METADATA_TYPE_PERSON_IMAGE)
     assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'Cloud Storage (gs://)' in exc_info.value.original_message
+    assert 'data URI' in exc_info.value.original_message
 
 
 def test_extract_media_by_type_rejects_empty_data_uri() -> None:

--- a/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
@@ -38,6 +38,7 @@ from genkit.plugins.google_genai.models.virtual_try_on import (
     PART_METADATA_TYPE_PRODUCT_IMAGE,
     VirtualTryOnConfig,
     VirtualTryOnModel,
+    VirtualTryOnOutputOptions,
     VirtualTryOnVersion,
     _extract_media_by_type,
     _to_virtual_try_on_request,
@@ -119,7 +120,17 @@ def test_to_virtual_try_on_request_shape() -> None:
         _product_part('gs://b/shirt.png'),
         _product_part('gs://b/hat.png'),
     ])
-    cfg = VirtualTryOnConfig(sample_count=2, person_generation='allow_adult')
+    cfg = VirtualTryOnConfig(
+        sample_count=2,
+        storage_uri='gs://b/out/',
+        seed=123,
+        base_steps=32,
+        safety_setting='block_few',
+        person_generation='allow_adult',
+        add_watermark=False,
+        enhance_prompt=True,
+        output_options=VirtualTryOnOutputOptions(mime_type='image/jpeg', compression_quality=80),
+    )
     body = _to_virtual_try_on_request(req, cfg)
     assert body == {
         'instances': [
@@ -133,9 +144,32 @@ def test_to_virtual_try_on_request_shape() -> None:
         ],
         'parameters': {
             'sampleCount': 2,
+            'storageUri': 'gs://b/out/',
+            'seed': 123,
+            'baseSteps': 32,
+            'safetySetting': 'block_few',
             'personGeneration': 'allow_adult',
+            'addWatermark': False,
+            'enhancePrompt': True,
+            'outputOptions': {
+                'mimeType': 'image/jpeg',
+                'compressionQuality': 80,
+            },
         },
     }
+
+
+def test_virtual_try_on_config_schema_excludes_location() -> None:
+    """location should not appear as a UI-configurable model parameter."""
+    assert 'location' not in VirtualTryOnConfig.model_json_schema()['properties']
+
+
+def test_virtual_try_on_config_schema_inlines_output_options() -> None:
+    """outputOptions should expose child fields directly for model config UI."""
+    output_options = VirtualTryOnConfig.model_json_schema()['properties']['outputOptions']
+    assert output_options['type'] == 'object'
+    assert output_options['properties']['mimeType']['title'] == 'Mime type'
+    assert output_options['properties']['compressionQuality']['title'] == 'Compression quality'
 
 
 @pytest.mark.asyncio

--- a/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
@@ -160,12 +160,12 @@ def test_to_virtual_try_on_request_shape() -> None:
 
 
 def test_virtual_try_on_config_schema_excludes_location() -> None:
-    """location should not appear as a UI-configurable model parameter."""
+    """Location should not appear as a UI-configurable model parameter."""
     assert 'location' not in VirtualTryOnConfig.model_json_schema()['properties']
 
 
 def test_virtual_try_on_config_schema_inlines_output_options() -> None:
-    """outputOptions should expose child fields directly for model config UI."""
+    """OutputOptions should expose child fields directly for model config UI."""
     output_options = VirtualTryOnConfig.model_json_schema()['properties']['outputOptions']
     assert output_options['type'] == 'object'
     assert output_options['properties']['mimeType']['title'] == 'Mime type'

--- a/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
@@ -17,6 +17,7 @@
 """Tests for the Virtual Try-On model implementation."""
 
 import base64
+from typing import Any, cast
 
 import pytest
 from google.genai.errors import ClientError
@@ -293,7 +294,7 @@ async def test_generate_rejects_invalid_config(mocker: MockerFixture) -> None:
         _person_part('gs://b/person.png'),
         _product_part('gs://b/shirt.png'),
     ])
-    req.config = {'sampleCount': 0}
+    req.config = cast(Any, {'sampleCount': 0})
     model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
 
     with pytest.raises(GenkitError) as exc_info:

--- a/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
@@ -16,6 +16,7 @@
 
 """Tests for the Virtual Try-On model implementation."""
 
+import asyncio
 import base64
 from typing import Any, cast
 
@@ -310,6 +311,25 @@ async def test_generate_maps_transport_error_to_unavailable(mocker: MockerFixtur
     client = mocker.MagicMock()
     client._api_client.vertexai = True
     client._api_client.async_request = mocker.AsyncMock(side_effect=ConnectionError('network down'))
+
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+    ])
+    model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(req, ActionRunContext())
+
+    assert exc_info.value.status == 'UNAVAILABLE'
+
+
+@pytest.mark.asyncio
+async def test_generate_maps_async_timeout_to_unavailable(mocker: MockerFixture) -> None:
+    """Async timeouts from the predict call should use Genkit UNAVAILABLE."""
+    client = mocker.MagicMock()
+    client._api_client.vertexai = True
+    client._api_client.async_request = mocker.AsyncMock(side_effect=asyncio.TimeoutError('timed out'))
 
     req = _request_with([
         _person_part('gs://b/person.png'),

--- a/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_virtual_try_on_test.py
@@ -100,17 +100,19 @@ def test_extract_media_by_type_ignores_other_types() -> None:
 
 
 def test_to_virtual_try_on_request_requires_person() -> None:
-    """Missing personImage raises a descriptive ValueError."""
+    """Missing personImage raises a Genkit INVALID_ARGUMENT error."""
     req = _request_with([_product_part('gs://b/shirt.png')])
-    with pytest.raises(ValueError, match='personImage'):
+    with pytest.raises(GenkitError, match='personImage') as exc_info:
         _to_virtual_try_on_request(req, None)
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
 
 
 def test_to_virtual_try_on_request_requires_product() -> None:
-    """Missing productImage raises a descriptive ValueError."""
+    """Missing productImage raises a Genkit INVALID_ARGUMENT error."""
     req = _request_with([_person_part('gs://b/person.png')])
-    with pytest.raises(ValueError, match='productImage'):
+    with pytest.raises(GenkitError, match='productImage') as exc_info:
         _to_virtual_try_on_request(req, None)
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
 
 
 def test_to_virtual_try_on_request_shape() -> None:
@@ -214,6 +216,151 @@ async def test_generate_maps_client_error_to_genkit_error(mocker: MockerFixture)
 
     assert exc_info.value.status == 'RESOURCE_EXHAUSTED'
     assert exc_info.value.original_message == 'quota exceeded'
+
+
+@pytest.mark.asyncio
+async def test_generate_requires_vertex_backend(mocker: MockerFixture) -> None:
+    """Virtual Try-On should fail with a Genkit status outside Vertex AI."""
+    client = mocker.MagicMock()
+    client._api_client.vertexai = False
+
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+    ])
+    model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(req, ActionRunContext())
+
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+
+
+@pytest.mark.asyncio
+async def test_generate_rejects_malformed_response_body(mocker: MockerFixture) -> None:
+    """Malformed Vertex responses should surface as Genkit INTERNAL errors."""
+    client = mocker.MagicMock()
+    client._api_client.vertexai = True
+
+    class _FakeResp:
+        body = '{not json'
+
+    client._api_client.async_request = mocker.AsyncMock(return_value=_FakeResp())
+
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+    ])
+    model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(req, ActionRunContext())
+
+    assert exc_info.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_generate_rejects_invalid_config(mocker: MockerFixture) -> None:
+    """Invalid model config should surface as Genkit INVALID_ARGUMENT."""
+    client = mocker.MagicMock()
+    client._api_client.vertexai = True
+
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+    ])
+    req.config = {'sampleCount': 0}
+    model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(req, ActionRunContext())
+
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    client._api_client.async_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_maps_transport_error_to_unavailable(mocker: MockerFixture) -> None:
+    """Transport failures from the predict call should use Genkit UNAVAILABLE."""
+    client = mocker.MagicMock()
+    client._api_client.vertexai = True
+    client._api_client.async_request = mocker.AsyncMock(side_effect=ConnectionError('network down'))
+
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+    ])
+    model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(req, ActionRunContext())
+
+    assert exc_info.value.status == 'UNAVAILABLE'
+
+
+@pytest.mark.asyncio
+async def test_generate_maps_unexpected_request_error_to_internal(mocker: MockerFixture) -> None:
+    """Unexpected request failures should use Genkit INTERNAL."""
+    client = mocker.MagicMock()
+    client._api_client.vertexai = True
+    client._api_client.async_request = mocker.AsyncMock(side_effect=RuntimeError('boom'))
+
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+    ])
+    model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(req, ActionRunContext())
+
+    assert exc_info.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_generate_rejects_prediction_without_image_data(mocker: MockerFixture) -> None:
+    """Predictions missing image bytes should surface as Genkit INTERNAL errors."""
+    client = mocker.MagicMock()
+    client._api_client.vertexai = True
+
+    class _FakeResp:
+        body = '{"predictions": [{}]}'
+
+    client._api_client.async_request = mocker.AsyncMock(return_value=_FakeResp())
+
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+    ])
+    model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(req, ActionRunContext())
+
+    assert exc_info.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_generate_rejects_unknown_response_body(mocker: MockerFixture) -> None:
+    """Unknown Vertex response shapes should surface as Genkit INTERNAL errors."""
+    client = mocker.MagicMock()
+    client._api_client.vertexai = True
+
+    class _FakeResp:
+        body = '{"unexpected": true}'
+
+    client._api_client.async_request = mocker.AsyncMock(return_value=_FakeResp())
+
+    req = _request_with([
+        _person_part('gs://b/person.png'),
+        _product_part('gs://b/shirt.png'),
+    ])
+    model = VirtualTryOnModel(VirtualTryOnVersion.VIRTUAL_TRY_ON_001, client)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(req, ActionRunContext())
+
+    assert exc_info.value.status == 'INTERNAL'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds `virtual-try-on-001` image editing to the VertexAI backend.

Callers tag input images with `metadata={'type': 'personImage' | 'productImage'}` on the `ai.Part` — same convention as the Go PR #5177. The google-genai Python SDK does not expose a VTO method, so the model driver issues the `:predict` call directly through the SDK's authenticated `_api_client.async_request`, reusing the plugin's existing credentials / quota headers / tracing. Empty predictions surface as a `FinishReason.BLOCKED` response, not an exception.

## Testing
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/e6cd9fca-d295-4754-b66c-1e1df06f48bc" />
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/3e1c5f00-70fb-4257-aeca-5699a9797709" />
<img width="1299" height="782" alt="image" src="https://github.com/user-attachments/assets/2d95faf3-a420-48bc-b278-86d5cffec5b0" />
<img width="1250" height="718" alt="image" src="https://github.com/user-attachments/assets/0d6cf673-adf9-484d-8ec8-a293d2cc0147" />