### PR TITLE
feat(py/plugins/google-genai): Support tuned Gemini endpoint models

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -102,6 +102,7 @@ from google.genai.client import DebugConfig
 from google.genai.types import HttpOptions, HttpOptionsDict
 
 import genkit.plugins.google_genai.constants as const
+from genkit import ModelInfo
 from genkit._core._action import ActionRunContext
 from genkit._core._model import ModelRequest, ModelResponse
 from genkit.embedder import EmbedderOptions, EmbedderSupports, embedder_action_metadata
@@ -123,9 +124,11 @@ from genkit.plugins.google_genai.evaluators import (
 from genkit.plugins.google_genai.models.embedder import EMBEDDER_DIMENSIONS, Embedder
 from genkit.plugins.google_genai.models.gemini import (
     SUPPORTED_MODELS,
+    GeminiConfigSchema,
     GeminiModel,
     get_model_config_schema,
     google_model_info,
+    is_tuned_gemini_name,
 )
 from genkit.plugins.google_genai.models.imagen import (
     SUPPORTED_MODELS as IMAGE_SUPPORTED_MODELS,
@@ -893,8 +896,16 @@ class VertexAI(Plugin):
         # Extract local name (remove plugin prefix)
         clean_name = name.replace(VERTEXAI_PLUGIN_NAME + '/', '') if name.startswith(VERTEXAI_PLUGIN_NAME) else name
 
-        # Determine model type and create model metadata/config schema
-        if clean_name.lower().startswith('image'):
+        # Determine model type and create model metadata/config schema.
+        # Tuned Gemini endpoints (endpoints/ID or projects/.../endpoints/ID)
+        # route through GeminiModel with the standard Gemini config schema.
+        if is_tuned_gemini_name(clean_name):
+            model_ref = ModelInfo(
+                label=f'{PLUGIN_DISPLAY_NAME[VERTEXAI_PLUGIN_NAME]} - {clean_name}',
+                supports=google_model_info('gemini').supports,
+            )
+            config_schema = GeminiConfigSchema
+        elif clean_name.lower().startswith('image'):
             model_ref = vertexai_image_model_info(clean_name)
             IMAGE_SUPPORTED_MODELS[clean_name] = model_ref
             config_schema = ImagenConfigSchema
@@ -907,7 +918,9 @@ class VertexAI(Plugin):
             config_schema = get_model_config_schema(clean_name)
 
         async def _run(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
-            if clean_name.lower().startswith('image'):
+            if is_tuned_gemini_name(clean_name):
+                model = GeminiModel(clean_name, self._runtime_client())
+            elif clean_name.lower().startswith('image'):
                 model = ImagenModel(clean_name, self._runtime_client())
             elif is_veo_model(clean_name):
                 model = VeoModel(clean_name, self._runtime_client())

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -977,6 +977,64 @@ def is_gemma_model(name: str) -> bool:
     return name.startswith('gemma-')
 
 
+def is_tuned_gemini_name(name: str) -> bool:
+    """Check whether a model name refers to a Vertex AI tuned Gemini endpoint.
+
+    Accepts both the short form (``endpoints/ID``) and the fully qualified
+    resource path (``projects/PROJECT/locations/LOCATION/endpoints/ID``).
+    Mirrors ``isTunedGeminiName`` in the Go plugin.
+
+    Args:
+        name: The model name to check.
+
+    Returns:
+        True if this is a tuned endpoint name.
+
+    Example:
+        >>> is_tuned_gemini_name('endpoints/1234567890')
+        True
+        >>> is_tuned_gemini_name('projects/p/locations/us-central1/endpoints/9')
+        True
+        >>> is_tuned_gemini_name('gemini-2.5-flash')
+        False
+    """
+    if name.startswith('endpoints/'):
+        return True
+    return name.startswith('projects/') and '/endpoints/' in name
+
+
+def resolve_vertex_model_name(client: genai.Client, name: str) -> str:
+    """Prepare a model name for the google-genai SDK.
+
+    The SDK's internal model-name transformer prefixes unqualified names with
+    ``publishers/google/models/``, which is wrong for tuned endpoints. For a
+    short-form ``endpoints/ID`` this expands to the fully qualified
+    ``projects/PROJECT/locations/LOCATION/endpoints/ID`` using the client's
+    configured project and location so the SDK passes it through unchanged.
+    Non-tuned names are returned as-is. Mirrors
+    ``gemini.go:resolveVertexModelName`` in the Go plugin.
+
+    Args:
+        client: The genai.Client whose project/location to use.
+        name: The incoming model name.
+
+    Returns:
+        A name safe to hand to ``client.aio.models.generate_content``.
+    """
+    if not is_tuned_gemini_name(name):
+        return name
+    if name.startswith('projects/'):
+        return name
+    api_client = getattr(client, '_api_client', None)
+    if api_client is None or not getattr(api_client, 'vertexai', False):
+        return name
+    project = getattr(api_client, 'project', None) or ''
+    location = getattr(api_client, 'location', None) or ''
+    if not project or not location:
+        return name
+    return f'projects/{project}/locations/{location}/{name}'
+
+
 def get_model_config_schema(name: str) -> type[GeminiConfigSchema]:
     """Get the appropriate config schema for a dynamically discovered model.
 
@@ -1359,7 +1417,7 @@ class GeminiModel:
         client = client or self._client
         try:
             response = await client.aio.models.generate_content(
-                model=model_name,
+                model=resolve_vertex_model_name(client, model_name),
                 contents=cast(genai_types.ContentListUnion, request_contents),
                 config=request_cfg,
             )
@@ -1483,7 +1541,7 @@ class GeminiModel:
         client = client or self._client
         try:
             generator = await client.aio.models.generate_content_stream(
-                model=model_name,
+                model=resolve_vertex_model_name(client, model_name),
                 contents=cast(genai_types.ContentListUnion, request_contents),
                 config=request_cfg,
             )

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -1000,7 +1000,7 @@ def is_tuned_gemini_name(name: str) -> bool:
     """
     if name.startswith('endpoints/'):
         return True
-    return name.startswith('projects/') and '/endpoints/' in name
+    return name.startswith('projects/') and '/locations/' in name and '/endpoints/' in name
 
 
 def resolve_vertex_model_name(client: genai.Client, name: str) -> str:

--- a/py/plugins/google-genai/test/tuned_gemini_test.py
+++ b/py/plugins/google-genai/test/tuned_gemini_test.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Vertex AI tuned Gemini endpoint routing helpers."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from genkit.plugins.google_genai.models.gemini import (
+    is_tuned_gemini_name,
+    resolve_vertex_model_name,
+)
+
+
+@pytest.mark.parametrize(
+    'name,expected',
+    [
+        ('endpoints/1234567890', True),
+        ('projects/p/locations/us-central1/endpoints/9', True),
+        ('gemini-2.5-flash', False),
+        ('imagen-4.0-generate-001', False),
+        ('projects/p/locations/us-central1/publishers/google/models/gemini-2.5-flash', False),
+        ('', False),
+    ],
+)
+def test_is_tuned_gemini_name(name: str, expected: bool) -> None:
+    """is_tuned_gemini_name recognises both short and fully qualified forms."""
+    assert is_tuned_gemini_name(name) is expected
+
+
+def _vertex_client(project: str = 'my-proj', location: str = 'us-central1') -> SimpleNamespace:
+    return SimpleNamespace(_api_client=SimpleNamespace(vertexai=True, project=project, location=location))
+
+
+def _googleai_client() -> SimpleNamespace:
+    return SimpleNamespace(_api_client=SimpleNamespace(vertexai=False, project=None, location=None))
+
+
+def test_resolve_short_form_expands_with_project_and_location() -> None:
+    """Short-form endpoints/ID is expanded to the full resource path on Vertex."""
+    client = _vertex_client()
+    got = resolve_vertex_model_name(client, 'endpoints/9876')
+    assert got == 'projects/my-proj/locations/us-central1/endpoints/9876'
+
+
+def test_resolve_full_form_passes_through() -> None:
+    """Fully qualified projects/.../endpoints/... paths are returned unchanged."""
+    client = _vertex_client()
+    name = 'projects/other/locations/us-east1/endpoints/42'
+    assert resolve_vertex_model_name(client, name) == name
+
+
+def test_resolve_non_tuned_name_passes_through() -> None:
+    """Non-tuned names (e.g. gemini-2.5-flash) are unchanged so the SDK transformer still applies."""
+    client = _vertex_client()
+    assert resolve_vertex_model_name(client, 'gemini-2.5-flash') == 'gemini-2.5-flash'
+
+
+def test_resolve_on_googleai_backend_is_noop() -> None:
+    """Tuned endpoints are a Vertex-only concept; on GoogleAI, leave the name alone."""
+    client = _googleai_client()
+    assert resolve_vertex_model_name(client, 'endpoints/1') == 'endpoints/1'
+
+
+def test_resolve_without_project_or_location_leaves_name() -> None:
+    """If the client lacks project/location, defer to the SDK rather than building a bad path."""
+    client = _vertex_client(project='', location='')
+    assert resolve_vertex_model_name(client, 'endpoints/1') == 'endpoints/1'

--- a/py/plugins/google-genai/test/tuned_gemini_test.py
+++ b/py/plugins/google-genai/test/tuned_gemini_test.py
@@ -31,6 +31,7 @@ from genkit.plugins.google_genai.models.gemini import (
     [
         ('endpoints/1234567890', True),
         ('projects/p/locations/us-central1/endpoints/9', True),
+        ('projects/p/endpoints/9', False),
         ('gemini-2.5-flash', False),
         ('imagen-4.0-generate-001', False),
         ('projects/p/locations/us-central1/publishers/google/models/gemini-2.5-flash', False),


### PR DESCRIPTION
Accepts Vertex AI tuned Gemini endpoints addressed either by the short form `endpoints/ID` or the fully qualified `projects/PROJECT/locations/LOCATION/endpoints/ID`.

`is_tuned_gemini_name()` and `resolve_vertex_model_name()` helpers in `gemini.py` handle the classification and path expansion; both `generate_content` call sites wrap the model name through the resolver so the SDK receives a fully qualified path and skips its default `publishers/google/models/` prefix. `VertexAI._resolve_model` routes these names through `GeminiModel`.

Mirrors Go PR #5178 and the JS behaviour in `js/plugins/google-genai/src/vertexai/client.ts`.

## Testing
<img width="1299" height="782" alt="image" src="https://github.com/user-attachments/assets/66a6960a-8ae3-4513-bdf0-e43f740df973" />