### PR TITLE
feat(go/plugins/googlegenai): register Veo 3.1 models

### DIFF
--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -93,9 +93,13 @@ const (
 	imagen3Generate001     = "imagen-3.0-generate-001"
 	imagen3FastGenerate001 = "imagen-3.0-fast-generate-001"
 
-	veo20Generate001     = "veo-2.0-generate-001"
-	veo30Generate001     = "veo-3.0-generate-001"
-	veo30FastGenerate001 = "veo-3.0-fast-generate-001"
+	veo20Generate001         = "veo-2.0-generate-001"
+	veo30Generate001         = "veo-3.0-generate-001"
+	veo30FastGenerate001     = "veo-3.0-fast-generate-001"
+	veo31Generate001         = "veo-3.1-generate-001"
+	veo31FastGenerate001     = "veo-3.1-fast-generate-001"
+	veo31GeneratePreview     = "veo-3.1-generate-preview"
+	veo31FastGeneratePreview = "veo-3.1-fast-generate-preview"
 
 	embedding001                      = "embedding-001"
 	textembeddinggecko003             = "textembedding-gecko@003"
@@ -122,6 +126,8 @@ var (
 		veo20Generate001,
 		veo30Generate001,
 		veo30FastGenerate001,
+		veo31Generate001,
+		veo31FastGenerate001,
 	}
 
 	googleAIModels = []string{
@@ -134,6 +140,8 @@ var (
 		veo20Generate001,
 		veo30Generate001,
 		veo30FastGenerate001,
+		veo31GeneratePreview,
+		veo31FastGeneratePreview,
 	}
 
 	supportedGeminiModels = map[string]ai.ModelOptions{
@@ -206,6 +214,30 @@ var (
 			Versions: []string{},
 			Supports: &VeoSupports,
 			Stage:    ai.ModelStageStable,
+		},
+		veo31Generate001: {
+			Label:    "Veo 3.1 Generate 001",
+			Versions: []string{},
+			Supports: &VeoSupports,
+			Stage:    ai.ModelStageStable,
+		},
+		veo31FastGenerate001: {
+			Label:    "Veo 3.1 Fast Generate 001",
+			Versions: []string{},
+			Supports: &VeoSupports,
+			Stage:    ai.ModelStageStable,
+		},
+		veo31GeneratePreview: {
+			Label:    "Veo 3.1 Generate Preview",
+			Versions: []string{},
+			Supports: &VeoSupports,
+			Stage:    ai.ModelStageUnstable,
+		},
+		veo31FastGeneratePreview: {
+			Label:    "Veo 3.1 Fast Generate Preview",
+			Versions: []string{},
+			Supports: &VeoSupports,
+			Stage:    ai.ModelStageUnstable,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Adds the four Veo 3.1 video-generation models to the Go googlegenai plugin so they resolve through the existing background-model / \`GenerateOperation\` flow.

- **GoogleAI:** \`veo-3.1-generate-preview\`, \`veo-3.1-fast-generate-preview\` (both \`ModelStageUnstable\`)
- **VertexAI:** \`veo-3.1-generate-001\`, \`veo-3.1-fast-generate-001\` (both \`ModelStageStable\`)

All four entries reuse the existing \`VeoSupports\` capability set — no plumbing changes required because the background-model routing already keys off the Veo classification (\`ModelTypeVeo\` in \`model_type.go\`).

This also fixes a latent reference: \`go/samples/veo/main.go\` on \`main\` already hard-codes \`googleai/veo-3.1-generate-preview\` as its model, so the sample would fail at startup until these registrations land.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./plugins/googlegenai/...\`
- [ ] Live smoke test against GoogleAI: run the \`text-to-video\` flow in \`go/samples/veo\` with \`GOOGLE_API_KEY\` set, confirm \`veo-3.1-generate-preview\` returns a playable video (requires Veo access).
- [ ] Live smoke test against VertexAI: set model name to \`vertexai/veo-3.1-generate-001\` in the same sample and re-run with \`GOOGLE_CLOUD_PROJECT\` + \`GOOGLE_CLOUD_LOCATION\`.

## Follow-ups (not in this PR)

- Adding Dev UI flows for each new model (the current sample exercises only the default flow) would make manual testing easier — happy to add in a follow-up if reviewers want it here instead.