### PR TITLE
fix(cli): properly parse project name on windows

### DIFF
--- a/genkit-tools/common/src/utils/utils.ts
+++ b/genkit-tools/common/src/utils/utils.ts
@@ -85,7 +85,7 @@ export async function findServersDir(projectRoot: string): Promise<string> {
  * @returns project name
  */
 export function projectNameFromGenkitFilePath(filePath: string): string {
-  const parts = filePath.split('/');
+  const parts = filePath.split(/[/\\]/); // <-- Supports Windows & POSIX
   const basePath = parts
     .slice(
       0,

--- a/genkit-tools/common/src/utils/utils.ts
+++ b/genkit-tools/common/src/utils/utils.ts
@@ -85,7 +85,7 @@ export async function findServersDir(projectRoot: string): Promise<string> {
  * @returns project name
  */
 export function projectNameFromGenkitFilePath(filePath: string): string {
-  const parts = filePath.split(/[/\\]/); // <-- Supports Windows & POSIX
+  const parts = filePath.split(path.sep);
   const basePath = parts
     .slice(
       0,


### PR DESCRIPTION
### **Issue Description**
**Describe the bug**
When launching the Genkit Developer UI (`genkit start`) on a Windows machine without explicitly specifying a `name` inside `genkit({ ... })`, the Developer UI displays `"unknown"` for the project name (and falls back to something like `unknown (1234-3100)`). 

This happens because `projectNameFromGenkitFilePath` inside `@genkit-ai/tools-common` relies on splitting the `.genkit` runtime file path using a hardcoded forward slash (`/`). Because Windows file paths predominantly use backslashes (`\`), the function fails to locate the `.genkit` directory in the path string, resulting in the fallback `"unknown"`.

**To Reproduce**
1. Initialize a Genkit project on a Windows machine.
2. Ensure you have not explicitly provided a `name` property to your `genkit()` initialization.
3. Start the dev server using `genkit start -- tsx --watch backend/index.ts`.
4. Open the Developer UI and observe that the app name defaults to `unknown` instead of the actual project directory or package name.

**Expected behavior**
The Developer UI should correctly parse the project name from the file path on Windows exactly as it does on macOS and Linux.

**Proposed Fix**
Updating `projectNameFromGenkitFilePath` to split the file path using a regular expression that accounts for both forward slashes and backslashes `/[/\\]/` resolves this issue entirely and remains safely cross-platform.

**File:** `@genkit-ai/tools-common/src/utils/utils.ts`

**Current Code:**
```typescript
export function projectNameFromGenkitFilePath(filePath: string) {
  const parts = filePath.split('/'); // <-- Fails on Windows
  const basePath = parts
    .slice(0, Math.max(parts.findIndex((value) => value === '.genkit'), 0))
    .join('/');
  return basePath === '' ? 'unknown' : path.basename(basePath);
}
```

**Proposed Code:**
```typescript
export function projectNameFromGenkitFilePath(filePath: string) {
  const parts = filePath.split(/[/\\]/); // <-- Supports Windows & POSIX
  const basePath = parts
    .slice(0, Math.max(parts.findIndex((value) => value === '.genkit'), 0))
    .join('/');
  return basePath === '' ? 'unknown' : path.basename(basePath);
}
```
