### PR TITLE
feat(js/plugins/google-genai): PayGo support for priority and flex

### DIFF
--- a/js/plugins/google-genai/src/common/types.ts
+++ b/js/plugins/google-genai/src/common/types.ts
@@ -483,6 +483,8 @@ export declare interface UsageMetadata {
   cachedContentTokenCount?: number;
   /** Optional. Number of tokens present in thoughts output. */
   thoughtsTokenCount?: number;
+  /** Optional. The traffic type for the request (e.g. ON_DEMAND_FLEX or ON_DEMAND_PRIORITY). */
+  trafficType?: string;
 }
 
 export const TaskTypeSchema = z.enum([

--- a/js/plugins/google-genai/src/vertexai/client.ts
+++ b/js/plugins/google-genai/src/vertexai/client.ts
@@ -337,12 +337,14 @@ function getAbortSignal(clientOptions: ClientOptions): AbortSignal | undefined {
 }
 
 async function getHeaders(clientOptions: ClientOptions): Promise<HeadersInit> {
+  const customHeaders = clientOptions.customHeaders || {};
   if (clientOptions.kind == 'express') {
     const headers: HeadersInit = {
       'x-goog-api-key': calculateApiKey(clientOptions.apiKey, undefined),
       'Content-Type': 'application/json',
       'X-Goog-Api-Client': getGenkitClientHeader(),
       'User-Agent': getGenkitClientHeader(),
+      ...customHeaders,
     };
     return headers;
   } else {
@@ -353,6 +355,7 @@ async function getHeaders(clientOptions: ClientOptions): Promise<HeadersInit> {
       'Content-Type': 'application/json',
       'X-Goog-Api-Client': getGenkitClientHeader(),
       'User-Agent': getGenkitClientHeader(),
+      ...customHeaders,
     };
     if (clientOptions.apiKey) {
       headers['x-goog-api-key'] = clientOptions.apiKey;

--- a/js/plugins/google-genai/src/vertexai/gemini.ts
+++ b/js/plugins/google-genai/src/vertexai/gemini.ts
@@ -294,6 +294,14 @@ export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
     })
     .passthrough()
     .optional(),
+  payGo: z
+    .enum(['priority', 'priority-only', 'flex', 'flex-only'])
+    .describe(
+      'PayGo consumption options. Priority provides more consistent performance than Standard PayGo. ' +
+        'Flex is a cost-effective option for non-critical workloads. ' +
+        'The "-only" options use only PayGo and no Provisioned Throughput.'
+    )
+    .optional(),
   thinkingConfig: z
     .object({
       includeThoughts: z
@@ -599,6 +607,7 @@ export function defineModel(
         location,
         safetySettings,
         labels: labelsFromConfig,
+        payGo,
         ...restOfConfig
       } = requestConfig;
 
@@ -606,6 +615,25 @@ export function defineModel(
         location,
         apiKey: apiKeyFromConfig,
       });
+
+      if (payGo) {
+        const payGoHeaders: Record<string, string> = {};
+        if (payGo === 'priority') {
+          payGoHeaders['X-Vertex-AI-LLM-Shared-Request-Type'] = 'priority';
+        } else if (payGo === 'priority-only') {
+          payGoHeaders['X-Vertex-AI-LLM-Request-Type'] = 'shared';
+          payGoHeaders['X-Vertex-AI-LLM-Shared-Request-Type'] = 'priority';
+        } else if (payGo === 'flex') {
+          payGoHeaders['X-Vertex-AI-LLM-Shared-Request-Type'] = 'flex';
+        } else if (payGo === 'flex-only') {
+          payGoHeaders['X-Vertex-AI-LLM-Request-Type'] = 'shared';
+          payGoHeaders['X-Vertex-AI-LLM-Shared-Request-Type'] = 'flex';
+        }
+        clientOpt.customHeaders = {
+          ...clientOpt.customHeaders,
+          ...payGoHeaders,
+        };
+      }
 
       const labels = toGeminiLabels(labelsFromConfig);
 

--- a/js/plugins/google-genai/src/vertexai/types.ts
+++ b/js/plugins/google-genai/src/vertexai/types.ts
@@ -105,6 +105,7 @@ interface BaseClientOptions {
   /** timeout in milli seconds. time out value needs to be non negative. */
   timeout?: number;
   signal?: AbortSignal;
+  customHeaders?: Record<string, string>;
 }
 
 export interface RegionalClientOptions extends BaseClientOptions {

--- a/js/plugins/google-genai/tests/vertexai/gemini_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/gemini_test.ts
@@ -255,6 +255,14 @@ describe('Vertex AI Gemini', () => {
         assert.strictEqual(body.labels, undefined);
 
         assert.deepStrictEqual(options.headers, getExpectedHeaders());
+        assert.strictEqual(
+          options.headers['X-Vertex-AI-LLM-Shared-Request-Type'],
+          undefined
+        );
+        assert.strictEqual(
+          options.headers['X-Vertex-AI-LLM-Request-Type'],
+          undefined
+        );
 
         assert.ok(result.result.candidates);
         assert.strictEqual(result.result.candidates.length, 1);
@@ -679,6 +687,90 @@ describe('Vertex AI Gemini', () => {
 
         assert.strictEqual(url, expectedUrl);
         assert.ok(url.includes(overrideLocation));
+      });
+
+      it('handles config.payGo priority spillover mode', async () => {
+        mockFetchResponse(defaultApiResponse);
+        const request: GenerateRequest<typeof GeminiConfigSchema> = {
+          ...minimalRequest,
+          config: { payGo: 'priority' },
+        };
+        const model = defineModel('gemini-2.5-flash', clientOptions);
+        await model.run(request);
+        sinon.assert.calledOnce(fetchStub);
+
+        const fetchHeaders = fetchStub.lastCall.args[1].headers;
+        assert.strictEqual(
+          fetchHeaders['X-Vertex-AI-LLM-Shared-Request-Type'],
+          'priority'
+        );
+        assert.strictEqual(
+          fetchHeaders['X-Vertex-AI-LLM-Request-Type'],
+          undefined
+        );
+      });
+
+      it('handles config.payGo priority-only mode', async () => {
+        mockFetchResponse(defaultApiResponse);
+        const request: GenerateRequest<typeof GeminiConfigSchema> = {
+          ...minimalRequest,
+          config: { payGo: 'priority-only' },
+        };
+        const model = defineModel('gemini-2.5-flash', clientOptions);
+        await model.run(request);
+        sinon.assert.calledOnce(fetchStub);
+
+        const fetchHeaders = fetchStub.lastCall.args[1].headers;
+        assert.strictEqual(
+          fetchHeaders['X-Vertex-AI-LLM-Shared-Request-Type'],
+          'priority'
+        );
+        assert.strictEqual(
+          fetchHeaders['X-Vertex-AI-LLM-Request-Type'],
+          'shared'
+        );
+      });
+
+      it('handles config.payGo flex spillover mode', async () => {
+        mockFetchResponse(defaultApiResponse);
+        const request: GenerateRequest<typeof GeminiConfigSchema> = {
+          ...minimalRequest,
+          config: { payGo: 'flex' },
+        };
+        const model = defineModel('gemini-2.5-flash', clientOptions);
+        await model.run(request);
+        sinon.assert.calledOnce(fetchStub);
+
+        const fetchHeaders = fetchStub.lastCall.args[1].headers;
+        assert.strictEqual(
+          fetchHeaders['X-Vertex-AI-LLM-Shared-Request-Type'],
+          'flex'
+        );
+        assert.strictEqual(
+          fetchHeaders['X-Vertex-AI-LLM-Request-Type'],
+          undefined
+        );
+      });
+
+      it('handles config.payGo flex-only mode', async () => {
+        mockFetchResponse(defaultApiResponse);
+        const request: GenerateRequest<typeof GeminiConfigSchema> = {
+          ...minimalRequest,
+          config: { payGo: 'flex-only' },
+        };
+        const model = defineModel('gemini-2.5-flash', clientOptions);
+        await model.run(request);
+        sinon.assert.calledOnce(fetchStub);
+
+        const fetchHeaders = fetchStub.lastCall.args[1].headers;
+        assert.strictEqual(
+          fetchHeaders['X-Vertex-AI-LLM-Shared-Request-Type'],
+          'flex'
+        );
+        assert.strictEqual(
+          fetchHeaders['X-Vertex-AI-LLM-Request-Type'],
+          'shared'
+        );
       });
     });
   }

--- a/js/testapps/basic-gemini/src/index-vertexai.ts
+++ b/js/testapps/basic-gemini/src/index-vertexai.ts
@@ -41,8 +41,7 @@ ai.defineFlow('basic-hi', async () => {
 ai.defineFlow('paygo', async () => {
   const response = await ai.generate({
     model: vertexAI.model('gemini-3.1-flash-lite-preview'),
-    prompt:
-      'You are a helpful AI assistant named Walt, say hello.',
+    prompt: 'You are a helpful AI assistant named Walt, say hello.',
     config: {
       payGo: 'priority', // or priority-only, flex, flex-only.
     },

--- a/js/testapps/basic-gemini/src/index-vertexai.ts
+++ b/js/testapps/basic-gemini/src/index-vertexai.ts
@@ -37,6 +37,20 @@ ai.defineFlow('basic-hi', async () => {
   return text;
 });
 
+// Flex/Priority PayGo
+ai.defineFlow('paygo', async () => {
+  const response = await ai.generate({
+    model: vertexAI.model('gemini-3.1-flash-lite-preview'),
+    prompt:
+      'You are a helpful AI assistant named Walt, say hello.',
+    config: {
+      payGo: 'priority', // or priority-only, flex, flex-only.
+    },
+  });
+
+  return response;
+});
+
 // Gemini 3.1 thinkingLevel config
 ai.defineFlow(
   {


### PR DESCRIPTION
Sample code: 
```
const response = await ai.generate({
    model: vertexAI.model('gemini-3.1-flash-lite-preview'),
    prompt:
      'You are a helpful AI assistant named Walt, say hello.',
    config: {
      payGo: 'priority', // or priority-only, flex, flex-only.
    },
  });
```

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
