### PR TITLE
chore(js/ai): expand GenerationUsageSchema with metadata

### DIFF
--- a/js/ai/src/model-types.ts
+++ b/js/ai/src/model-types.ts
@@ -267,6 +267,7 @@ export const GenerationUsageSchema = z.object({
   inputAudioFiles: z.number().optional(),
   outputAudioFiles: z.number().optional(),
   custom: z.record(z.number()).optional(),
+  metadata: z.record(z.unknown()).optional(),
   thoughtsTokens: z.number().optional(),
   cachedContentTokens: z.number().optional(),
 });


### PR DESCRIPTION
Why? Because usage is not just numbers, sometimes it includes things like service_tier strings or other relevant metadata. 

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
