### PR TITLE
feat(go): add background session flows via `Detach`

### DIFF
--- a/genkit-tools/common/src/types/agent.ts
+++ b/genkit-tools/common/src/types/agent.ts
@@ -33,9 +33,39 @@ export type Artifact = z.infer<typeof ArtifactSchema>;
 
 /**
  * Zod schema for snapshot event.
+ *
+ * - `turnEnd`: snapshot was triggered at the end of a turn.
+ * - `invocationEnd`: snapshot was triggered at the end of the invocation.
+ * - `detach`: snapshot was created when the client detached the invocation
+ *   and the flow continues in the background. Initially written with
+ *   `pending` status and rewritten with a terminal status once the
+ *   background work finishes.
  */
-export const SnapshotEventSchema = z.enum(['turnEnd', 'invocationEnd']);
+export const SnapshotEventSchema = z.enum([
+  'turnEnd',
+  'invocationEnd',
+  'detach',
+]);
 export type SnapshotEvent = z.infer<typeof SnapshotEventSchema>;
+
+/**
+ * Zod schema for a snapshot's lifecycle status.
+ *
+ * - `pending`: a detached invocation is still processing the queued inputs.
+ *   The snapshot will be rewritten with a terminal status once the flow exits.
+ * - `complete`: the snapshot captures a settled state.
+ * - `canceled`: the snapshot's invocation was cancelled via the
+ *   `cancelSnapshot` companion action while detached.
+ * - `error`: the invocation terminated with an error. The snapshot's `error`
+ *   field describes the failure and resume is rejected with that same error.
+ */
+export const SnapshotStatusSchema = z.enum([
+  'pending',
+  'complete',
+  'canceled',
+  'error',
+]);
+export type SnapshotStatus = z.infer<typeof SnapshotStatusSchema>;
 
 /**
  * Zod schema for session state.
@@ -56,6 +86,15 @@ export type SessionState = z.infer<typeof SessionStateSchema>;
  * Zod schema for session flow input (per-turn).
  */
 export const SessionFlowInputSchema = z.object({
+  /**
+   * Detach signals that the client wishes to disconnect after this input is
+   * accepted. The server writes a single pending snapshot capturing the
+   * queued inputs (this one and any others already buffered), returns
+   * SessionFlowOutput with that snapshot ID, and continues processing in a
+   * background context. The pending snapshot is finalized once all queued
+   * inputs are processed (or the snapshot is cancelled via `cancelSnapshot`).
+   */
+  detach: z.boolean().optional(),
   /** User's input messages for this turn. */
   messages: z.array(MessageSchema).optional(),
   /** Tool request parts to re-execute interrupted tools. */
@@ -111,9 +150,20 @@ export type SessionFlowOutput = z.infer<typeof SessionFlowOutputSchema>;
 export const TurnEndSchema = z.object({
   /**
    * ID of the snapshot persisted at the end of this turn. Empty if no
-   * snapshot was created (callback returned false or no store configured).
+   * snapshot was created (callback returned false, no store configured, or
+   * snapshots were suspended after detach).
    */
   snapshotId: z.string().optional(),
+  /**
+   * Zero-based index of the turn that just ended within this invocation. It
+   * restarts at 0 for each new invocation (resume, reconnect). Clients
+   * consuming a durable chunk stream use this field to anchor chunks to
+   * inputs: chunks emitted between `TurnEnd{turnIndex:N-1}` and
+   * `TurnEnd{turnIndex:N}` belong to the input at turn N. After detach,
+   * pair with `SessionSnapshot.startingTurnIndex` and
+   * `SessionSnapshot.pendingInputs` to recover input correspondence.
+   */
+  turnIndex: z.number(),
 });
 export type TurnEnd = z.infer<typeof TurnEndSchema>;
 
@@ -136,4 +186,123 @@ export const SessionFlowStreamChunkSchema = z.object({
 });
 export type SessionFlowStreamChunk = z.infer<
   typeof SessionFlowStreamChunkSchema
+>;
+
+/**
+ * Zod schema for the metadata projection of a session snapshot. It exists
+ * so callers (notably the detached-invocation heartbeat poller) can check
+ * status without paying for a full state read.
+ */
+export const SnapshotMetadataSchema = z.object({
+  /** Unique identifier for this snapshot (UUID). */
+  snapshotId: z.string(),
+  /** ID of the previous snapshot in this timeline. */
+  parentId: z.string().optional(),
+  /** When the snapshot was first written (RFC 3339). */
+  createdAt: z.string(),
+  /** When the snapshot was last written (RFC 3339). */
+  updatedAt: z.string().optional(),
+  /** What triggered this snapshot. */
+  event: SnapshotEventSchema,
+  /** Lifecycle state of this snapshot. Empty is treated as `complete`. */
+  status: SnapshotStatusSchema.optional(),
+  /** Failure message for a snapshot in `error` status. */
+  error: z.string().optional(),
+  /**
+   * Zero-based index of the first turn this snapshot covers within its
+   * invocation. For sync snapshots it is the index of the single turn that
+   * ended. For pending snapshots it is the index of the first input in
+   * `pendingInputs`; subsequent inputs map to startingTurnIndex+1, +2, etc.
+   */
+  startingTurnIndex: z.number(),
+});
+export type SnapshotMetadata = z.infer<typeof SnapshotMetadataSchema>;
+
+/**
+ * Zod schema for a persisted point-in-time capture of session state.
+ */
+export const SessionSnapshotSchema = SnapshotMetadataSchema.extend({
+  /**
+   * Inputs captured at detach time, in FIFO order. The first entry may be
+   * the input that was in flight when detach landed (its turn was
+   * suppressed because snapshots were suspended in the same atomic step
+   * that captured it); the rest were queued behind it. Set only on
+   * snapshots in `pending` status; cleared when the snapshot is finalized.
+   */
+  pendingInputs: z.array(SessionFlowInputSchema).optional(),
+  /**
+   * Conversation state. Empty on a pending snapshot (the queued inputs are
+   * in `pendingInputs` and the live state is not yet committed); populated
+   * on terminal snapshots.
+   */
+  state: SessionStateSchema,
+});
+export type SessionSnapshot = z.infer<typeof SessionSnapshotSchema>;
+
+/**
+ * Zod schema for the input of a session flow's `getSnapshot` companion
+ * action. The action is registered at `{flowName}/getSnapshot` when the
+ * flow is defined.
+ */
+export const GetSnapshotRequestSchema = z.object({
+  /** Identifies the snapshot to fetch. */
+  snapshotId: z.string(),
+});
+export type GetSnapshotRequest = z.infer<typeof GetSnapshotRequestSchema>;
+
+/**
+ * Zod schema for the output of the `getSnapshot` companion action. It is a
+ * client-facing view of the stored snapshot: identifying metadata plus the
+ * session state, with `WithSnapshotTransform` applied if configured.
+ */
+export const GetSnapshotResponseSchema = z.object({
+  /** Echoes the requested snapshot ID. */
+  snapshotId: z.string(),
+  /** When the snapshot record was first written (RFC 3339). */
+  createdAt: z.string().optional(),
+  /** When the snapshot record was last written (RFC 3339). */
+  updatedAt: z.string().optional(),
+  /** Lifecycle state of the snapshot. */
+  status: SnapshotStatusSchema.optional(),
+  /** Populated when status is `error`. */
+  error: z.string().optional(),
+  /**
+   * Zero-based index of the first turn this snapshot covers within its
+   * invocation.
+   */
+  startingTurnIndex: z.number(),
+  /** Queued inputs captured at detach time. Populated only when status is `pending`. */
+  pendingInputs: z.array(SessionFlowInputSchema).optional(),
+  /**
+   * Session state captured by the snapshot, after any configured transform.
+   * Empty when status is `pending` or `error`.
+   */
+  state: SessionStateSchema.optional(),
+});
+export type GetSnapshotResponse = z.infer<typeof GetSnapshotResponseSchema>;
+
+/**
+ * Zod schema for the input of the `cancelSnapshot` companion action.
+ */
+export const CancelSnapshotRequestSchema = z.object({
+  /** Identifies the snapshot whose invocation should be cancelled. */
+  snapshotId: z.string(),
+});
+export type CancelSnapshotRequest = z.infer<typeof CancelSnapshotRequestSchema>;
+
+/**
+ * Zod schema for the output of the `cancelSnapshot` companion action.
+ */
+export const CancelSnapshotResponseSchema = z.object({
+  /** Echoes the requested snapshot ID. */
+  snapshotId: z.string(),
+  /**
+   * Snapshot's status after the cancel attempt. For a pending snapshot
+   * this is `canceled`. For an already-terminal snapshot this is the
+   * existing terminal status (the cancel is a no-op).
+   */
+  status: SnapshotStatusSchema.optional(),
+});
+export type CancelSnapshotResponse = z.infer<
+  typeof CancelSnapshotResponseSchema
 >;

--- a/genkit-tools/common/src/types/agent.ts
+++ b/genkit-tools/common/src/types/agent.ts
@@ -54,8 +54,8 @@ export type SnapshotEvent = z.infer<typeof SnapshotEventSchema>;
  * - `pending`: a detached invocation is still processing the queued inputs.
  *   The snapshot will be rewritten with a terminal status once the flow exits.
  * - `complete`: the snapshot captures a settled state.
- * - `canceled`: the snapshot's invocation was cancelled via the
- *   `cancelSnapshot` companion action while detached.
+ * - `canceled`: the snapshot's invocation was aborted via the
+ *   `abortSnapshot` companion action while detached.
  * - `error`: the invocation terminated with an error. The snapshot's `error`
  *   field describes the failure and resume is rejected with that same error.
  */
@@ -91,8 +91,9 @@ export const SessionFlowInputSchema = z.object({
    * accepted. The server writes a single pending snapshot capturing the
    * queued inputs (this one and any others already buffered), returns
    * SessionFlowOutput with that snapshot ID, and continues processing in a
-   * background context. The pending snapshot is finalized once all queued
-   * inputs are processed (or the snapshot is cancelled via `cancelSnapshot`).
+   * background context. Streamed chunks emitted after detach are discarded;
+   * only the final session state is captured when the snapshot is
+   * finalized (or the snapshot is aborted via `abortSnapshot`).
    */
   detach: z.boolean().optional(),
   /** User's input messages for this turn. */
@@ -154,16 +155,6 @@ export const TurnEndSchema = z.object({
    * snapshots were suspended after detach).
    */
   snapshotId: z.string().optional(),
-  /**
-   * Zero-based index of the turn that just ended within this invocation. It
-   * restarts at 0 for each new invocation (resume, reconnect). Clients
-   * consuming a durable chunk stream use this field to anchor chunks to
-   * inputs: chunks emitted between `TurnEnd{turnIndex:N-1}` and
-   * `TurnEnd{turnIndex:N}` belong to the input at turn N. After detach,
-   * pair with `SessionSnapshot.startingTurnIndex` and
-   * `SessionSnapshot.pendingInputs` to recover input correspondence.
-   */
-  turnIndex: z.number(),
 });
 export type TurnEnd = z.infer<typeof TurnEndSchema>;
 
@@ -190,8 +181,8 @@ export type SessionFlowStreamChunk = z.infer<
 
 /**
  * Zod schema for the metadata projection of a session snapshot. It exists
- * so callers (notably the detached-invocation heartbeat poller) can check
- * status without paying for a full state read.
+ * so callers can identify a snapshot and check its lifecycle status without
+ * paying for a full state read.
  */
 export const SnapshotMetadataSchema = z.object({
   /** Unique identifier for this snapshot (UUID). */
@@ -208,13 +199,6 @@ export const SnapshotMetadataSchema = z.object({
   status: SnapshotStatusSchema.optional(),
   /** Failure message for a snapshot in `error` status. */
   error: z.string().optional(),
-  /**
-   * Zero-based index of the first turn this snapshot covers within its
-   * invocation. For sync snapshots it is the index of the single turn that
-   * ended. For pending snapshots it is the index of the first input in
-   * `pendingInputs`; subsequent inputs map to startingTurnIndex+1, +2, etc.
-   */
-  startingTurnIndex: z.number(),
 });
 export type SnapshotMetadata = z.infer<typeof SnapshotMetadataSchema>;
 
@@ -266,11 +250,6 @@ export const GetSnapshotResponseSchema = z.object({
   status: SnapshotStatusSchema.optional(),
   /** Populated when status is `error`. */
   error: z.string().optional(),
-  /**
-   * Zero-based index of the first turn this snapshot covers within its
-   * invocation.
-   */
-  startingTurnIndex: z.number(),
   /** Queued inputs captured at detach time. Populated only when status is `pending`. */
   pendingInputs: z.array(SessionFlowInputSchema).optional(),
   /**
@@ -282,27 +261,27 @@ export const GetSnapshotResponseSchema = z.object({
 export type GetSnapshotResponse = z.infer<typeof GetSnapshotResponseSchema>;
 
 /**
- * Zod schema for the input of the `cancelSnapshot` companion action.
+ * Zod schema for the input of the `abortSnapshot` companion action.
  */
-export const CancelSnapshotRequestSchema = z.object({
-  /** Identifies the snapshot whose invocation should be cancelled. */
+export const AbortSnapshotRequestSchema = z.object({
+  /** Identifies the snapshot whose invocation should be aborted. */
   snapshotId: z.string(),
 });
-export type CancelSnapshotRequest = z.infer<typeof CancelSnapshotRequestSchema>;
+export type AbortSnapshotRequest = z.infer<typeof AbortSnapshotRequestSchema>;
 
 /**
- * Zod schema for the output of the `cancelSnapshot` companion action.
+ * Zod schema for the output of the `abortSnapshot` companion action.
  */
-export const CancelSnapshotResponseSchema = z.object({
+export const AbortSnapshotResponseSchema = z.object({
   /** Echoes the requested snapshot ID. */
   snapshotId: z.string(),
   /**
-   * Snapshot's status after the cancel attempt. For a pending snapshot
+   * Snapshot's status after the abort attempt. For a pending snapshot
    * this is `canceled`. For an already-terminal snapshot this is the
-   * existing terminal status (the cancel is a no-op).
+   * existing terminal status (the abort is a no-op).
    */
   status: SnapshotStatusSchema.optional(),
 });
-export type CancelSnapshotResponse = z.infer<
-  typeof CancelSnapshotResponseSchema
+export type AbortSnapshotResponse = z.infer<
+  typeof AbortSnapshotResponseSchema
 >;

--- a/genkit-tools/common/src/types/agent.ts
+++ b/genkit-tools/common/src/types/agent.ts
@@ -285,3 +285,34 @@ export const AbortSnapshotResponseSchema = z.object({
 export type AbortSnapshotResponse = z.infer<
   typeof AbortSnapshotResponseSchema
 >;
+
+/**
+ * Who owns session state for an agent.
+ *
+ * - `server`: a session store is configured and snapshots are persisted
+ *   server-side.
+ * - `client`: no store; state flows through the agent's invocation init
+ *   and output payloads.
+ */
+export const AgentMetadataStateManagementSchema = z.enum(['server', 'client']);
+export type AgentMetadataStateManagement = z.infer<
+  typeof AgentMetadataStateManagementSchema
+>;
+
+/**
+ * Zod schema for the agent capability metadata placed under
+ * `metadata.agent` on a session flow's action descriptor. Lets the Dev
+ * UI and other reflective callers render the right surface (e.g. hide
+ * the Abort button when the configured store doesn't support it)
+ * without round-tripping through the reflection API.
+ */
+export const AgentMetadataSchema = z.object({
+  /** Who owns session state for this agent. */
+  stateManagement: AgentMetadataStateManagementSchema,
+  /**
+   * Whether the agent's invocations can be aborted. True only when the
+   * configured store implements the abort lifecycle.
+   */
+  abortable: z.boolean(),
+});
+export type AgentMetadata = z.infer<typeof AgentMetadataSchema>;

--- a/genkit-tools/common/src/types/agent.ts
+++ b/genkit-tools/common/src/types/agent.ts
@@ -38,8 +38,9 @@ export type Artifact = z.infer<typeof ArtifactSchema>;
  * - `invocationEnd`: snapshot was triggered at the end of the invocation.
  * - `detach`: snapshot was created when the client detached the invocation
  *   and the flow continues in the background. Initially written with
- *   `pending` status and rewritten with a terminal status once the
- *   background work finishes.
+ *   `pending` status (and empty state) and rewritten with a terminal
+ *   status and the final cumulative state once the background work
+ *   finishes.
  */
 export const SnapshotEventSchema = z.enum([
   'turnEnd',
@@ -52,7 +53,8 @@ export type SnapshotEvent = z.infer<typeof SnapshotEventSchema>;
  * Zod schema for a snapshot's lifecycle status.
  *
  * - `pending`: a detached invocation is still processing the queued inputs.
- *   The snapshot will be rewritten with a terminal status once the flow exits.
+ *   The snapshot's state is empty until the flow exits, at which point it
+ *   is rewritten with the cumulative final state and a terminal status.
  * - `complete`: the snapshot captures a settled state.
  * - `canceled`: the snapshot's invocation was aborted via the
  *   `abortSnapshot` companion action while detached.
@@ -88,11 +90,11 @@ export type SessionState = z.infer<typeof SessionStateSchema>;
 export const SessionFlowInputSchema = z.object({
   /**
    * Detach signals that the client wishes to disconnect after this input is
-   * accepted. The server writes a single pending snapshot capturing the
-   * queued inputs (this one and any others already buffered), returns
-   * SessionFlowOutput with that snapshot ID, and continues processing in a
-   * background context. Streamed chunks emitted after detach are discarded;
-   * only the final session state is captured when the snapshot is
+   * accepted. The server writes a single pending snapshot (with empty
+   * state), returns SessionFlowOutput with that snapshot ID, and continues
+   * processing any already-buffered inputs in a background context.
+   * Streamed chunks emitted after detach are not forwarded over the wire;
+   * only the final cumulative state is captured when the snapshot is
    * finalized (or the snapshot is aborted via `abortSnapshot`).
    */
   detach: z.boolean().optional(),
@@ -207,17 +209,10 @@ export type SnapshotMetadata = z.infer<typeof SnapshotMetadataSchema>;
  */
 export const SessionSnapshotSchema = SnapshotMetadataSchema.extend({
   /**
-   * Inputs captured at detach time, in FIFO order. The first entry may be
-   * the input that was in flight when detach landed (its turn was
-   * suppressed because snapshots were suspended in the same atomic step
-   * that captured it); the rest were queued behind it. Set only on
-   * snapshots in `pending` status; cleared when the snapshot is finalized.
-   */
-  pendingInputs: z.array(SessionFlowInputSchema).optional(),
-  /**
-   * Conversation state. Empty on a pending snapshot (the queued inputs are
-   * in `pendingInputs` and the live state is not yet committed); populated
-   * on terminal snapshots.
+   * Conversation state. Empty on a pending snapshot (the live state is
+   * not yet committed; the background invocation is still processing
+   * queued inputs); populated on terminal snapshots with the cumulative
+   * final state.
    */
   state: SessionStateSchema,
 });
@@ -250,8 +245,6 @@ export const GetSnapshotResponseSchema = z.object({
   status: SnapshotStatusSchema.optional(),
   /** Populated when status is `error`. */
   error: z.string().optional(),
-  /** Queued inputs captured at detach time. Populated only when status is `pending`. */
-  pendingInputs: z.array(SessionFlowInputSchema).optional(),
   /**
    * Session state captured by the snapshot, after any configured transform.
    * Empty when status is `pending` or `error`.

--- a/genkit-tools/genkit-schema.json
+++ b/genkit-tools/genkit-schema.json
@@ -23,6 +23,82 @@
       ],
       "additionalProperties": false
     },
+    "CancelSnapshotRequest": {
+      "type": "object",
+      "properties": {
+        "snapshotId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "snapshotId"
+      ],
+      "additionalProperties": false
+    },
+    "CancelSnapshotResponse": {
+      "type": "object",
+      "properties": {
+        "snapshotId": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/SnapshotStatus"
+        }
+      },
+      "required": [
+        "snapshotId"
+      ],
+      "additionalProperties": false
+    },
+    "GetSnapshotRequest": {
+      "type": "object",
+      "properties": {
+        "snapshotId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "snapshotId"
+      ],
+      "additionalProperties": false
+    },
+    "GetSnapshotResponse": {
+      "type": "object",
+      "properties": {
+        "snapshotId": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/SnapshotStatus"
+        },
+        "error": {
+          "type": "string"
+        },
+        "startingTurnIndex": {
+          "type": "number"
+        },
+        "pendingInputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SessionFlowInput"
+          }
+        },
+        "state": {
+          "$ref": "#/$defs/SessionState"
+        }
+      },
+      "required": [
+        "snapshotId",
+        "startingTurnIndex"
+      ],
+      "additionalProperties": false
+    },
     "SessionFlowInit": {
       "type": "object",
       "properties": {
@@ -38,6 +114,9 @@
     "SessionFlowInput": {
       "type": "object",
       "properties": {
+        "detach": {
+          "type": "boolean"
+        },
         "messages": {
           "type": "array",
           "items": {
@@ -105,6 +184,52 @@
       },
       "additionalProperties": false
     },
+    "SessionSnapshot": {
+      "type": "object",
+      "properties": {
+        "snapshotId": {
+          "type": "string"
+        },
+        "parentId": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "type": "string"
+        },
+        "event": {
+          "$ref": "#/$defs/SnapshotEvent"
+        },
+        "status": {
+          "$ref": "#/$defs/SnapshotStatus"
+        },
+        "error": {
+          "type": "string"
+        },
+        "startingTurnIndex": {
+          "type": "number"
+        },
+        "pendingInputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SessionFlowInput"
+          }
+        },
+        "state": {
+          "$ref": "#/$defs/SessionState"
+        }
+      },
+      "required": [
+        "snapshotId",
+        "createdAt",
+        "event",
+        "startingTurnIndex",
+        "state"
+      ],
+      "additionalProperties": false
+    },
     "SessionState": {
       "type": "object",
       "properties": {
@@ -129,7 +254,53 @@
       "type": "string",
       "enum": [
         "turnEnd",
-        "invocationEnd"
+        "invocationEnd",
+        "detach"
+      ]
+    },
+    "SnapshotMetadata": {
+      "type": "object",
+      "properties": {
+        "snapshotId": {
+          "$ref": "#/$defs/SessionSnapshot/properties/snapshotId"
+        },
+        "parentId": {
+          "$ref": "#/$defs/SessionSnapshot/properties/parentId"
+        },
+        "createdAt": {
+          "$ref": "#/$defs/SessionSnapshot/properties/createdAt"
+        },
+        "updatedAt": {
+          "$ref": "#/$defs/SessionSnapshot/properties/updatedAt"
+        },
+        "event": {
+          "$ref": "#/$defs/SnapshotEvent"
+        },
+        "status": {
+          "$ref": "#/$defs/SessionSnapshot/properties/status"
+        },
+        "error": {
+          "$ref": "#/$defs/SessionSnapshot/properties/error"
+        },
+        "startingTurnIndex": {
+          "$ref": "#/$defs/SessionSnapshot/properties/startingTurnIndex"
+        }
+      },
+      "required": [
+        "snapshotId",
+        "createdAt",
+        "event",
+        "startingTurnIndex"
+      ],
+      "additionalProperties": false
+    },
+    "SnapshotStatus": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "complete",
+        "canceled",
+        "error"
       ]
     },
     "TurnEnd": {
@@ -137,8 +308,14 @@
       "properties": {
         "snapshotId": {
           "type": "string"
+        },
+        "turnIndex": {
+          "type": "number"
         }
       },
+      "required": [
+        "turnIndex"
+      ],
       "additionalProperties": false
     },
     "DocumentData": {

--- a/genkit-tools/genkit-schema.json
+++ b/genkit-tools/genkit-schema.json
@@ -28,6 +28,29 @@
       ],
       "additionalProperties": false
     },
+    "AgentMetadata": {
+      "type": "object",
+      "properties": {
+        "stateManagement": {
+          "$ref": "#/$defs/AgentMetadataStateManagement"
+        },
+        "abortable": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "stateManagement",
+        "abortable"
+      ],
+      "additionalProperties": false
+    },
+    "AgentMetadataStateManagement": {
+      "type": "string",
+      "enum": [
+        "server",
+        "client"
+      ]
+    },
     "Artifact": {
       "type": "object",
       "properties": {

--- a/genkit-tools/genkit-schema.json
+++ b/genkit-tools/genkit-schema.json
@@ -1,28 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$defs": {
-    "Artifact": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "parts": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Part"
-          }
-        },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": {}
-        }
-      },
-      "required": [
-        "parts"
-      ],
-      "additionalProperties": false
-    },
     "AbortSnapshotRequest": {
       "type": "object",
       "properties": {
@@ -47,6 +25,28 @@
       },
       "required": [
         "snapshotId"
+      ],
+      "additionalProperties": false
+    },
+    "Artifact": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "parts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Part"
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "parts"
       ],
       "additionalProperties": false
     },

--- a/genkit-tools/genkit-schema.json
+++ b/genkit-tools/genkit-schema.json
@@ -23,7 +23,7 @@
       ],
       "additionalProperties": false
     },
-    "CancelSnapshotRequest": {
+    "AbortSnapshotRequest": {
       "type": "object",
       "properties": {
         "snapshotId": {
@@ -35,7 +35,7 @@
       ],
       "additionalProperties": false
     },
-    "CancelSnapshotResponse": {
+    "AbortSnapshotResponse": {
       "type": "object",
       "properties": {
         "snapshotId": {
@@ -80,9 +80,6 @@
         "error": {
           "type": "string"
         },
-        "startingTurnIndex": {
-          "type": "number"
-        },
         "pendingInputs": {
           "type": "array",
           "items": {
@@ -94,8 +91,7 @@
         }
       },
       "required": [
-        "snapshotId",
-        "startingTurnIndex"
+        "snapshotId"
       ],
       "additionalProperties": false
     },
@@ -208,9 +204,6 @@
         "error": {
           "type": "string"
         },
-        "startingTurnIndex": {
-          "type": "number"
-        },
         "pendingInputs": {
           "type": "array",
           "items": {
@@ -225,7 +218,6 @@
         "snapshotId",
         "createdAt",
         "event",
-        "startingTurnIndex",
         "state"
       ],
       "additionalProperties": false
@@ -281,16 +273,12 @@
         },
         "error": {
           "$ref": "#/$defs/SessionSnapshot/properties/error"
-        },
-        "startingTurnIndex": {
-          "$ref": "#/$defs/SessionSnapshot/properties/startingTurnIndex"
         }
       },
       "required": [
         "snapshotId",
         "createdAt",
-        "event",
-        "startingTurnIndex"
+        "event"
       ],
       "additionalProperties": false
     },
@@ -308,14 +296,8 @@
       "properties": {
         "snapshotId": {
           "type": "string"
-        },
-        "turnIndex": {
-          "type": "number"
         }
       },
-      "required": [
-        "turnIndex"
-      ],
       "additionalProperties": false
     },
     "DocumentData": {

--- a/genkit-tools/genkit-schema.json
+++ b/genkit-tools/genkit-schema.json
@@ -103,12 +103,6 @@
         "error": {
           "type": "string"
         },
-        "pendingInputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/SessionFlowInput"
-          }
-        },
         "state": {
           "$ref": "#/$defs/SessionState"
         }
@@ -226,12 +220,6 @@
         },
         "error": {
           "type": "string"
-        },
-        "pendingInputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/SessionFlowInput"
-          }
         },
         "state": {
           "$ref": "#/$defs/SessionState"

--- a/go/ai/exp/gen.go
+++ b/go/ai/exp/gen.go
@@ -46,6 +46,13 @@ type SessionFlowInit[State any] struct {
 
 // SessionFlowInput is the input sent to an session flow during a conversation turn.
 type SessionFlowInput struct {
+	// Detach signals that the client wishes to disconnect after this input is
+	// accepted. The server writes a single pending snapshot capturing the
+	// queued inputs (this one and any others already buffered), returns
+	// [SessionFlowOutput] with that snapshot ID, and continues processing in
+	// a background context. The pending snapshot is finalized once all queued
+	// inputs are processed (or the snapshot is cancelled via cancelSnapshot).
+	Detach bool `json:"detach,omitempty"`
 	// Messages contains the user's input for this turn.
 	Messages []*ai.Message `json:"messages,omitempty"`
 	// ToolRestarts contains tool request parts to re-execute interrupted tools.
@@ -119,6 +126,11 @@ const (
 	SnapshotEventTurnEnd SnapshotEvent = "turnEnd"
 	// InvocationEnd indicates the snapshot was triggered at the end of the invocation.
 	SnapshotEventInvocationEnd SnapshotEvent = "invocationEnd"
+	// Detach indicates the snapshot was created when the client detached the
+	// invocation and the flow continues in the background. The snapshot is
+	// initially written with [SnapshotStatusPending] and rewritten with a
+	// terminal status once the background work finishes.
+	SnapshotEventDetach SnapshotEvent = "detach"
 )
 
 // TurnEnd groups the signals emitted when a session flow turn finishes.
@@ -127,6 +139,14 @@ const (
 type TurnEnd struct {
 	// SnapshotID is the ID of the snapshot persisted at the end of this turn.
 	// Empty if no snapshot was created (callback returned false or no store
-	// configured).
+	// configured, or snapshots were suspended after detach).
 	SnapshotID string `json:"snapshotId,omitempty"`
+	// TurnIndex is the zero-based index of the turn that just ended within
+	// this invocation. It restarts at 0 for each new invocation (resume,
+	// reconnect). Clients consuming a durable chunk stream use this field
+	// to anchor chunks to inputs: chunks emitted between TurnEnd{turnIndex:N-1}
+	// and TurnEnd{turnIndex:N} belong to the input at turn N. After detach,
+	// pair with [SessionSnapshot.StartingTurnIndex] and
+	// [SessionSnapshot.PendingInputs] to recover input correspondence.
+	TurnIndex int `json:"turnIndex"`
 }

--- a/go/ai/exp/gen.go
+++ b/go/ai/exp/gen.go
@@ -50,8 +50,9 @@ type SessionFlowInput struct {
 	// accepted. The server writes a single pending snapshot capturing the
 	// queued inputs (this one and any others already buffered), returns
 	// [SessionFlowOutput] with that snapshot ID, and continues processing in
-	// a background context. The pending snapshot is finalized once all queued
-	// inputs are processed (or the snapshot is cancelled via cancelSnapshot).
+	// a background context. Streamed chunks emitted after detach are
+	// discarded; only the final session state is captured when the snapshot
+	// is finalized (or aborted via abortSnapshot).
 	Detach bool `json:"detach,omitempty"`
 	// Messages contains the user's input for this turn.
 	Messages []*ai.Message `json:"messages,omitempty"`
@@ -141,12 +142,4 @@ type TurnEnd struct {
 	// Empty if no snapshot was created (callback returned false or no store
 	// configured, or snapshots were suspended after detach).
 	SnapshotID string `json:"snapshotId,omitempty"`
-	// TurnIndex is the zero-based index of the turn that just ended within
-	// this invocation. It restarts at 0 for each new invocation (resume,
-	// reconnect). Clients consuming a durable chunk stream use this field
-	// to anchor chunks to inputs: chunks emitted between TurnEnd{turnIndex:N-1}
-	// and TurnEnd{turnIndex:N} belong to the input at turn N. After detach,
-	// pair with [SessionSnapshot.StartingTurnIndex] and
-	// [SessionSnapshot.PendingInputs] to recover input correspondence.
-	TurnIndex int `json:"turnIndex"`
 }

--- a/go/ai/exp/gen.go
+++ b/go/ai/exp/gen.go
@@ -22,6 +22,35 @@ import (
 	"github.com/firebase/genkit/go/ai"
 )
 
+// AgentMetadata is the value placed under metadata["agent"] on a session
+// flow's action descriptor. It exposes capability information so the Dev
+// UI and other reflective callers can render the right surface (e.g.
+// hide the Abort button when the configured store doesn't support it)
+// without round-tripping through the reflection API.
+type AgentMetadata struct {
+	// Abortable reports whether the agent's invocations can be aborted
+	// (true when the store implements [SnapshotAborter]).
+	Abortable bool `json:"abortable,omitempty"`
+	// StateManagement reports who owns session state.
+	StateManagement AgentMetadataStateManagement `json:"stateManagement,omitempty"`
+}
+
+// AgentMetadataStateManagement enumerates who owns session state for an
+// agent: "server" (a [SessionStore] is configured and snapshots are
+// persisted server-side) or "client" (no store; state flows through
+// invocation init / output).
+type AgentMetadataStateManagement string
+
+const (
+	// AgentMetadataStateManagementServer indicates the agent is wired with
+	// a [SessionStore] and persists snapshots server-side.
+	AgentMetadataStateManagementServer AgentMetadataStateManagement = "server"
+	// AgentMetadataStateManagementClient indicates the agent has no store;
+	// session state is client-managed and round-trips through invocation
+	// init and output.
+	AgentMetadataStateManagementClient AgentMetadataStateManagement = "client"
+)
+
 // Artifact represents a named collection of parts produced during a session.
 // Examples: generated files, images, code snippets, diagrams, etc.
 type Artifact struct {
@@ -50,9 +79,8 @@ type SessionFlowInput struct {
 	// accepted. The server writes a single pending snapshot capturing the
 	// queued inputs (this one and any others already buffered), returns
 	// [SessionFlowOutput] with that snapshot ID, and continues processing in
-	// a background context. Streamed chunks emitted after detach are
-	// discarded; only the final session state is captured when the snapshot
-	// is finalized (or aborted via abortSnapshot).
+	// a background context. The pending snapshot is finalized once all queued
+	// inputs are processed (or the snapshot is cancelled via cancelSnapshot).
 	Detach bool `json:"detach,omitempty"`
 	// Messages contains the user's input for this turn.
 	Messages []*ai.Message `json:"messages,omitempty"`

--- a/go/ai/exp/gen.go
+++ b/go/ai/exp/gen.go
@@ -76,11 +76,12 @@ type SessionFlowInit[State any] struct {
 // SessionFlowInput is the input sent to an session flow during a conversation turn.
 type SessionFlowInput struct {
 	// Detach signals that the client wishes to disconnect after this input is
-	// accepted. The server writes a single pending snapshot capturing the
-	// queued inputs (this one and any others already buffered), returns
-	// [SessionFlowOutput] with that snapshot ID, and continues processing in
-	// a background context. The pending snapshot is finalized once all queued
-	// inputs are processed (or the snapshot is cancelled via cancelSnapshot).
+	// accepted. The server writes a single pending snapshot (with empty
+	// state), returns [SessionFlowOutput] with that snapshot ID, and
+	// continues processing any already-buffered inputs in a background
+	// context. The pending snapshot is finalized with the cumulative final
+	// state once all queued inputs are processed (or the snapshot is
+	// cancelled via cancelSnapshot).
 	Detach bool `json:"detach,omitempty"`
 	// Messages contains the user's input for this turn.
 	Messages []*ai.Message `json:"messages,omitempty"`

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -19,7 +19,13 @@ package exp
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 )
+
+// DefaultHeartbeatInterval is the cadence at which a detached invocation
+// polls the cancelSnapshot status when [WithHeartbeatInterval] is not set.
+const DefaultHeartbeatInterval = 10 * time.Second
 
 // --- SessionFlowOption ---
 
@@ -28,9 +34,20 @@ type SessionFlowOption[State any] interface {
 	applySessionFlow(*sessionFlowOptions[State]) error
 }
 
+// SnapshotTransform rewrites session state before it is surfaced to a client.
+// It is applied to the State returned by the getSnapshot companion action and
+// to [SessionFlowOutput.State] when state is client-managed (no store).
+//
+// The input is a deep copy owned by the caller; the transform may mutate and
+// return it, or return a freshly-constructed value. The transform must not
+// modify any state that is persisted in the store.
+type SnapshotTransform[State any] = func(state SessionState[State]) SessionState[State]
+
 type sessionFlowOptions[State any] struct {
-	store    SessionStore[State]
-	callback SnapshotCallback[State]
+	store             SessionStore[State]
+	callback          SnapshotCallback[State]
+	transform         SnapshotTransform[State]
+	heartbeatInterval time.Duration
 }
 
 func (o *sessionFlowOptions[State]) applySessionFlow(opts *sessionFlowOptions[State]) error {
@@ -45,6 +62,18 @@ func (o *sessionFlowOptions[State]) applySessionFlow(opts *sessionFlowOptions[St
 			return errors.New("cannot set snapshot callback more than once (WithSnapshotCallback)")
 		}
 		opts.callback = o.callback
+	}
+	if o.transform != nil {
+		if opts.transform != nil {
+			return errors.New("cannot set snapshot transform more than once (WithSnapshotTransform)")
+		}
+		opts.transform = o.transform
+	}
+	if o.heartbeatInterval != 0 {
+		if opts.heartbeatInterval != 0 {
+			return errors.New("cannot set heartbeat interval more than once (WithHeartbeatInterval)")
+		}
+		opts.heartbeatInterval = o.heartbeatInterval
 	}
 	return nil
 }
@@ -72,6 +101,31 @@ func WithSnapshotOn[State any](events ...SnapshotEvent) SessionFlowOption[State]
 		_, ok := set[sc.Event]
 		return ok
 	})
+}
+
+// WithSnapshotTransform registers a transform that is applied to snapshot
+// state before it is returned to a client via the getSnapshot companion action
+// or via [SessionFlowOutput.State] when state is client-managed. Typical use
+// is PII redaction or stripping secrets. The transform is not applied to state
+// persisted in the store or to state passed to the user flow function.
+func WithSnapshotTransform[State any](transform SnapshotTransform[State]) SessionFlowOption[State] {
+	return &sessionFlowOptions[State]{transform: transform}
+}
+
+// WithHeartbeatInterval sets the cadence at which a detached invocation
+// polls its pending snapshot's status via the getSnapshotMetadata companion
+// action. If the polled status flips to [SnapshotStatusCanceled], the
+// invocation's context is cancelled so the flow stops promptly.
+//
+// The interval applies only after a client sends [SessionFlowInput.Detach]
+// and the flow transitions to background processing; foreground invocations
+// rely on normal context cancellation. The default is
+// [DefaultHeartbeatInterval]. Must be positive.
+func WithHeartbeatInterval[State any](d time.Duration) SessionFlowOption[State] {
+	if d <= 0 {
+		panic(fmt.Errorf("WithHeartbeatInterval: interval must be positive, got %s", d))
+	}
+	return &sessionFlowOptions[State]{heartbeatInterval: d}
 }
 
 // --- InvocationOption ---

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -19,13 +19,7 @@ package exp
 import (
 	"context"
 	"errors"
-	"fmt"
-	"time"
 )
-
-// DefaultHeartbeatInterval is the cadence at which a detached invocation
-// polls the cancelSnapshot status when [WithHeartbeatInterval] is not set.
-const DefaultHeartbeatInterval = 10 * time.Second
 
 // --- SessionFlowOption ---
 
@@ -44,10 +38,9 @@ type SessionFlowOption[State any] interface {
 type SnapshotTransform[State any] = func(state SessionState[State]) SessionState[State]
 
 type sessionFlowOptions[State any] struct {
-	store             SessionStore[State]
-	callback          SnapshotCallback[State]
-	transform         SnapshotTransform[State]
-	heartbeatInterval time.Duration
+	store     SessionStore[State]
+	callback  SnapshotCallback[State]
+	transform SnapshotTransform[State]
 }
 
 func (o *sessionFlowOptions[State]) applySessionFlow(opts *sessionFlowOptions[State]) error {
@@ -69,16 +62,14 @@ func (o *sessionFlowOptions[State]) applySessionFlow(opts *sessionFlowOptions[St
 		}
 		opts.transform = o.transform
 	}
-	if o.heartbeatInterval != 0 {
-		if opts.heartbeatInterval != 0 {
-			return errors.New("cannot set heartbeat interval more than once (WithHeartbeatInterval)")
-		}
-		opts.heartbeatInterval = o.heartbeatInterval
-	}
 	return nil
 }
 
-// WithSessionStore sets the store for persisting snapshots.
+// WithSessionStore sets the store for persisting snapshots. The store must
+// implement [SnapshotReader] and [SnapshotWriter] at minimum. Detach
+// support also requires [SnapshotAborter] and [SnapshotStatusSubscriber];
+// detach attempts on a store that lacks those interfaces are rejected at
+// runtime.
 func WithSessionStore[State any](store SessionStore[State]) SessionFlowOption[State] {
 	return &sessionFlowOptions[State]{store: store}
 }
@@ -110,22 +101,6 @@ func WithSnapshotOn[State any](events ...SnapshotEvent) SessionFlowOption[State]
 // persisted in the store or to state passed to the user flow function.
 func WithSnapshotTransform[State any](transform SnapshotTransform[State]) SessionFlowOption[State] {
 	return &sessionFlowOptions[State]{transform: transform}
-}
-
-// WithHeartbeatInterval sets the cadence at which a detached invocation
-// polls its pending snapshot's status via the getSnapshotMetadata companion
-// action. If the polled status flips to [SnapshotStatusCanceled], the
-// invocation's context is cancelled so the flow stops promptly.
-//
-// The interval applies only after a client sends [SessionFlowInput.Detach]
-// and the flow transitions to background processing; foreground invocations
-// rely on normal context cancellation. The default is
-// [DefaultHeartbeatInterval]. Must be positive.
-func WithHeartbeatInterval[State any](d time.Duration) SessionFlowOption[State] {
-	if d <= 0 {
-		panic(fmt.Errorf("WithHeartbeatInterval: interval must be positive, got %s", d))
-	}
-	return &sessionFlowOptions[State]{heartbeatInterval: d}
 }
 
 // --- InvocationOption ---

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -67,9 +67,8 @@ func (o *sessionFlowOptions[State]) applySessionFlow(opts *sessionFlowOptions[St
 
 // WithSessionStore sets the store for persisting snapshots. The store must
 // implement [SnapshotReader] and [SnapshotWriter] at minimum. Detach
-// support also requires [SnapshotAborter] and [SnapshotStatusSubscriber];
-// detach attempts on a store that lacks those interfaces are rejected at
-// runtime.
+// support also requires [SnapshotAborter]; detach attempts on a store
+// that lacks that interface are rejected at runtime.
 func WithSessionStore[State any](store SessionStore[State]) SessionFlowOption[State] {
 	return &sessionFlowOptions[State]{store: store}
 }

--- a/go/ai/exp/option.go
+++ b/go/ai/exp/option.go
@@ -28,19 +28,24 @@ type SessionFlowOption[State any] interface {
 	applySessionFlow(*sessionFlowOptions[State]) error
 }
 
-// SnapshotTransform rewrites session state before it is surfaced to a client.
-// It is applied to the State returned by the getSnapshot companion action and
-// to [SessionFlowOutput.State] when state is client-managed (no store).
+// StateTransform rewrites session state on its way out to a client. It
+// is applied to the State returned by the getSnapshot companion action
+// and to [SessionFlowOutput.State] when state is client-managed (no
+// store). It is not applied to state persisted in the store or to
+// state passed to the user flow function.
 //
-// The input is a deep copy owned by the caller; the transform may mutate and
-// return it, or return a freshly-constructed value. The transform must not
-// modify any state that is persisted in the store.
-type SnapshotTransform[State any] = func(state SessionState[State]) SessionState[State]
+// ctx is the request or invocation context: cancellation, deadlines,
+// and context-scoped values (e.g. the caller's identity for RBAC-aware
+// redaction) flow through here.
+//
+// The state input is a deep copy owned by the caller; the transform
+// may mutate and return it, or return a freshly-constructed value.
+type StateTransform[State any] = func(ctx context.Context, state SessionState[State]) SessionState[State]
 
 type sessionFlowOptions[State any] struct {
 	store     SessionStore[State]
 	callback  SnapshotCallback[State]
-	transform SnapshotTransform[State]
+	transform StateTransform[State]
 }
 
 func (o *sessionFlowOptions[State]) applySessionFlow(opts *sessionFlowOptions[State]) error {
@@ -58,7 +63,7 @@ func (o *sessionFlowOptions[State]) applySessionFlow(opts *sessionFlowOptions[St
 	}
 	if o.transform != nil {
 		if opts.transform != nil {
-			return errors.New("cannot set snapshot transform more than once (WithSnapshotTransform)")
+			return errors.New("cannot set state transform more than once (WithStateTransform)")
 		}
 		opts.transform = o.transform
 	}
@@ -93,12 +98,13 @@ func WithSnapshotOn[State any](events ...SnapshotEvent) SessionFlowOption[State]
 	})
 }
 
-// WithSnapshotTransform registers a transform that is applied to snapshot
-// state before it is returned to a client via the getSnapshot companion action
-// or via [SessionFlowOutput.State] when state is client-managed. Typical use
-// is PII redaction or stripping secrets. The transform is not applied to state
-// persisted in the store or to state passed to the user flow function.
-func WithSnapshotTransform[State any](transform SnapshotTransform[State]) SessionFlowOption[State] {
+// WithStateTransform registers a transform applied to session state on
+// its way out to a client via the getSnapshot companion action or via
+// [SessionFlowOutput.State] when state is client-managed. Typical use
+// is PII redaction or stripping secrets. The transform is not applied
+// to state persisted in the store or to state passed to the user flow
+// function.
+func WithStateTransform[State any](transform StateTransform[State]) SessionFlowOption[State] {
 	return &sessionFlowOptions[State]{transform: transform}
 }
 

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -24,10 +24,40 @@ import (
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/base"
 )
 
 // --- Snapshot ---
+
+// SnapshotStatus describes the lifecycle state of a snapshot. Snapshots
+// written for synchronous turns or invocations are always [SnapshotStatusComplete]
+// (an empty value is also treated as complete for backwards compatibility).
+//
+// When a client sets [SessionFlowInput.Detach], the server writes a single
+// snapshot with [SnapshotStatusPending] capturing the queued inputs and
+// returns its ID immediately. Background processing then either updates that
+// snapshot to [SnapshotStatusComplete] / [SnapshotStatusError] when the flow
+// finishes, or to [SnapshotStatusCanceled] if the client called
+// cancelSnapshot in the meantime.
+type SnapshotStatus string
+
+const (
+	// SnapshotStatusPending indicates a detached invocation is still
+	// processing the queued inputs. The snapshot will be rewritten with a
+	// terminal status once the flow exits.
+	SnapshotStatusPending SnapshotStatus = "pending"
+	// SnapshotStatusComplete indicates the snapshot captures a settled state.
+	SnapshotStatusComplete SnapshotStatus = "complete"
+	// SnapshotStatusCanceled indicates the snapshot's invocation was
+	// cancelled via the cancelSnapshot companion action while detached.
+	SnapshotStatusCanceled SnapshotStatus = "canceled"
+	// SnapshotStatusError indicates the invocation terminated with an error.
+	// The snapshot's Error field describes the failure and resume is
+	// rejected with that same error.
+	SnapshotStatusError SnapshotStatus = "error"
+)
 
 // SessionSnapshot is a persisted point-in-time capture of session state.
 type SessionSnapshot[State any] struct {
@@ -37,9 +67,35 @@ type SessionSnapshot[State any] struct {
 	ParentID string `json:"parentId,omitempty"`
 	// CreatedAt is when the snapshot was created.
 	CreatedAt time.Time `json:"createdAt"`
+	// UpdatedAt is when the snapshot was last written. For pending snapshots
+	// it equals CreatedAt; once the snapshot is finalized it reflects the
+	// terminal write.
+	UpdatedAt time.Time `json:"updatedAt,omitempty"`
 	// Event is what triggered this snapshot.
 	Event SnapshotEvent `json:"event"`
-	// State is the actual conversation state.
+	// Status is the lifecycle state of this snapshot. Empty is treated as
+	// [SnapshotStatusComplete] for backwards compatibility.
+	Status SnapshotStatus `json:"status,omitempty"`
+	// Error is the failure message for a snapshot in [SnapshotStatusError].
+	// Empty otherwise.
+	Error string `json:"error,omitempty"`
+	// StartingTurnIndex is the zero-based index of the first turn this
+	// snapshot covers within its invocation. For sync snapshots it is the
+	// index of the single turn that ended. For pending snapshots it is the
+	// index of the first input in [PendingInputs]; subsequent inputs map to
+	// StartingTurnIndex+1, +2, etc. Pair with [TurnEnd.TurnIndex] on
+	// chunks to correlate durable-stream chunks back to inputs.
+	StartingTurnIndex int `json:"startingTurnIndex"`
+	// PendingInputs is the inputs captured at detach time, in FIFO order.
+	// The first entry may be the input that was in flight when detach
+	// landed (its turn was suppressed because snapshots were suspended in
+	// the same atomic step that captured it); the rest were queued behind
+	// it. Set only on snapshots in [SnapshotStatusPending]; cleared when
+	// the snapshot is finalized.
+	PendingInputs []*SessionFlowInput `json:"pendingInputs,omitempty"`
+	// State is the actual conversation state. Empty on a pending snapshot
+	// (the queued inputs are in [PendingInputs] and the live state is not
+	// yet committed); populated on terminal snapshots.
 	State SessionState[State] `json:"state"`
 }
 
@@ -59,14 +115,64 @@ type SnapshotContext[State any] struct {
 // If not provided and a store is configured, snapshots are always created.
 type SnapshotCallback[State any] = func(ctx context.Context, sc *SnapshotContext[State]) bool
 
+// applyTransform returns the result of applying t to *state, or state
+// unchanged if t is nil. A nil state is returned as-is.
+func applyTransform[State any](t SnapshotTransform[State], state *SessionState[State]) *SessionState[State] {
+	if t == nil || state == nil {
+		return state
+	}
+	transformed := t(*state)
+	return &transformed
+}
+
 // --- Session store ---
+
+// SnapshotMetadata is the metadata-only projection of a [SessionSnapshot]:
+// identifying fields, lifecycle timestamps, and status. It exists so callers
+// (notably the detached-invocation heartbeat poller) can check status
+// without paying for a full state read.
+type SnapshotMetadata struct {
+	// SnapshotID is the unique identifier for this snapshot.
+	SnapshotID string `json:"snapshotId"`
+	// ParentID is the ID of the previous snapshot in this timeline.
+	ParentID string `json:"parentId,omitempty"`
+	// CreatedAt is when the snapshot was first written.
+	CreatedAt time.Time `json:"createdAt"`
+	// UpdatedAt is when the snapshot was last written.
+	UpdatedAt time.Time `json:"updatedAt,omitempty"`
+	// Event is what triggered this snapshot.
+	Event SnapshotEvent `json:"event"`
+	// Status is the lifecycle state of this snapshot.
+	Status SnapshotStatus `json:"status,omitempty"`
+	// Error is the failure message for a snapshot in [SnapshotStatusError].
+	Error string `json:"error,omitempty"`
+	// StartingTurnIndex is the zero-based index of the first turn this
+	// snapshot covers within its invocation. See [SessionSnapshot.StartingTurnIndex].
+	StartingTurnIndex int `json:"startingTurnIndex"`
+}
 
 // SessionStore persists and retrieves snapshots.
 type SessionStore[State any] interface {
 	// GetSnapshot retrieves a snapshot by ID. Returns nil if not found.
 	GetSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[State], error)
+	// GetSnapshotMetadata retrieves only the metadata for a snapshot.
+	// Returns nil if not found. Implementations should avoid loading the
+	// full session state — this is called by the heartbeat poller on a
+	// configured cadence while a detached invocation is in flight.
+	GetSnapshotMetadata(ctx context.Context, snapshotID string) (*SnapshotMetadata, error)
 	// SaveSnapshot persists a snapshot.
 	SaveSnapshot(ctx context.Context, snapshot *SessionSnapshot[State]) error
+	// CancelSnapshot atomically transitions a snapshot from
+	// [SnapshotStatusPending] to [SnapshotStatusCanceled] and returns the
+	// resulting metadata. If the snapshot is in any other status the
+	// operation is a no-op and the existing metadata is returned. Returns
+	// nil if the snapshot is not found.
+	//
+	// Implementations must perform the read-and-write atomically (e.g., a
+	// transaction or the equivalent of a compare-and-swap). The session
+	// flow's cancelSnapshot action and finalizer rely on this to avoid a
+	// pending row being clobbered by a racing terminal write.
+	CancelSnapshot(ctx context.Context, snapshotID string) (*SnapshotMetadata, error)
 }
 
 // InMemorySessionStore provides a thread-safe in-memory snapshot store.
@@ -86,30 +192,66 @@ func NewInMemorySessionStore[State any]() *InMemorySessionStore[State] {
 func (s *InMemorySessionStore[State]) GetSnapshot(_ context.Context, snapshotID string) (*SessionSnapshot[State], error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
-	snap, exists := s.snapshots[snapshotID]
-	if !exists {
+	snap, ok := s.snapshots[snapshotID]
+	if !ok {
 		return nil, nil
 	}
+	return copySnapshot(snap)
+}
 
-	copied, err := copySnapshot(snap)
-	if err != nil {
-		return nil, err
+// GetSnapshotMetadata retrieves only the metadata for a snapshot. Returns
+// nil if not found.
+func (s *InMemorySessionStore[State]) GetSnapshotMetadata(_ context.Context, snapshotID string) (*SnapshotMetadata, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	snap, ok := s.snapshots[snapshotID]
+	if !ok {
+		return nil, nil
 	}
-	return copied, nil
+	return snapshotMetadata(snap), nil
+}
+
+// CancelSnapshot atomically flips a pending snapshot to canceled. If the
+// snapshot is already terminal the existing metadata is returned unchanged.
+// Returns nil if the snapshot is not found.
+func (s *InMemorySessionStore[State]) CancelSnapshot(_ context.Context, snapshotID string) (*SnapshotMetadata, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snap, ok := s.snapshots[snapshotID]
+	if !ok {
+		return nil, nil
+	}
+	if snap.Status == SnapshotStatusPending {
+		snap.Status = SnapshotStatusCanceled
+		snap.UpdatedAt = time.Now()
+	}
+	return snapshotMetadata(snap), nil
 }
 
 // SaveSnapshot persists a snapshot.
 func (s *InMemorySessionStore[State]) SaveSnapshot(_ context.Context, snapshot *SessionSnapshot[State]) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
 	copied, err := copySnapshot(snapshot)
 	if err != nil {
 		return err
 	}
 	s.snapshots[copied.SnapshotID] = copied
 	return nil
+}
+
+// snapshotMetadata projects the metadata fields of a snapshot.
+func snapshotMetadata[State any](snap *SessionSnapshot[State]) *SnapshotMetadata {
+	return &SnapshotMetadata{
+		SnapshotID:        snap.SnapshotID,
+		ParentID:          snap.ParentID,
+		CreatedAt:         snap.CreatedAt,
+		UpdatedAt:         snap.UpdatedAt,
+		Event:             snap.Event,
+		Status:            snap.Status,
+		Error:             snap.Error,
+		StartingTurnIndex: snap.StartingTurnIndex,
+	}
 }
 
 // copySnapshot creates a deep copy of a snapshot using JSON marshaling.
@@ -126,6 +268,139 @@ func copySnapshot[State any](snap *SessionSnapshot[State]) (*SessionSnapshot[Sta
 		return nil, fmt.Errorf("copy snapshot: unmarshal: %w", err)
 	}
 	return &copied, nil
+}
+
+// --- Snapshot companion actions ---
+
+// GetSnapshotRequest is the input for a session flow's getSnapshot companion
+// action. The action is registered at `{flowName}/getSnapshot` when the flow
+// is defined and is intended for Dev UI and client-side reconnect flows.
+type GetSnapshotRequest struct {
+	// SnapshotID identifies the snapshot to fetch.
+	SnapshotID string `json:"snapshotId"`
+}
+
+// GetSnapshotResponse is the output of the getSnapshot companion action. It
+// is a client-facing view of the stored snapshot: identifying metadata plus
+// the session state, with [WithSnapshotTransform] applied if configured.
+//
+// Unlike the raw [SessionSnapshot], this response intentionally omits
+// internal fields (parent ID, event) and does not leak the snapshot
+// envelope beyond what callers need to repopulate a UI.
+type GetSnapshotResponse[State any] struct {
+	// SnapshotID echoes the requested snapshot ID.
+	SnapshotID string `json:"snapshotId"`
+	// CreatedAt is when the snapshot record was first written.
+	CreatedAt time.Time `json:"createdAt,omitempty"`
+	// UpdatedAt is when the snapshot record was last written. Equals
+	// CreatedAt for snapshots that have not been rewritten.
+	UpdatedAt time.Time `json:"updatedAt,omitempty"`
+	// Status is the lifecycle state of the snapshot. See [SnapshotStatus].
+	Status SnapshotStatus `json:"status,omitempty"`
+	// Error is populated when Status is [SnapshotStatusError].
+	Error string `json:"error,omitempty"`
+	// StartingTurnIndex is the zero-based index of the first turn this
+	// snapshot covers within its invocation. See
+	// [SessionSnapshot.StartingTurnIndex].
+	StartingTurnIndex int `json:"startingTurnIndex"`
+	// PendingInputs is the queued inputs captured at detach time. Populated
+	// only when Status is [SnapshotStatusPending].
+	PendingInputs []*SessionFlowInput `json:"pendingInputs,omitempty"`
+	// State is the session state captured by the snapshot, after any
+	// configured transform. Empty when Status is pending or error.
+	State *SessionState[State] `json:"state,omitempty"`
+}
+
+// CancelSnapshotRequest is the input for the cancelSnapshot companion action.
+type CancelSnapshotRequest struct {
+	// SnapshotID identifies the snapshot whose invocation should be cancelled.
+	SnapshotID string `json:"snapshotId"`
+}
+
+// CancelSnapshotResponse is the output of the cancelSnapshot companion action.
+type CancelSnapshotResponse struct {
+	// SnapshotID echoes the requested snapshot ID.
+	SnapshotID string `json:"snapshotId"`
+	// Status is the snapshot's status after the cancel attempt. For a
+	// pending snapshot this is [SnapshotStatusCanceled]. For an
+	// already-terminal snapshot this is the existing terminal status (the
+	// cancel is a no-op).
+	Status SnapshotStatus `json:"status,omitempty"`
+}
+
+// registerSnapshotActions registers the getSnapshot and cancelSnapshot
+// companion actions for a session flow, both keyed under the flow's name.
+func registerSnapshotActions[State any](
+	r api.Registry,
+	flowName string,
+	store SessionStore[State],
+	transform SnapshotTransform[State],
+) {
+	core.DefineAction(r, flowName+"/getSnapshot", api.ActionTypeUtil, nil, nil,
+		func(ctx context.Context, req *GetSnapshotRequest) (*GetSnapshotResponse[State], error) {
+			if store == nil {
+				return nil, core.NewError(core.FAILED_PRECONDITION,
+					"getSnapshot: session flow %q has no session store configured", flowName)
+			}
+			if req == nil || req.SnapshotID == "" {
+				return nil, core.NewError(core.INVALID_ARGUMENT, "getSnapshot: snapshotId is required")
+			}
+			snap, err := store.GetSnapshot(ctx, req.SnapshotID)
+			if err != nil {
+				return nil, core.NewError(core.INTERNAL, "getSnapshot: %v", err)
+			}
+			if snap == nil {
+				return nil, core.NewError(core.NOT_FOUND, "getSnapshot: snapshot %q not found", req.SnapshotID)
+			}
+
+			status := snap.Status
+			if status == "" {
+				status = SnapshotStatusComplete
+			}
+			updatedAt := snap.UpdatedAt
+			if updatedAt.IsZero() {
+				updatedAt = snap.CreatedAt
+			}
+
+			resp := &GetSnapshotResponse[State]{
+				SnapshotID:        snap.SnapshotID,
+				CreatedAt:         snap.CreatedAt,
+				UpdatedAt:         updatedAt,
+				Status:            status,
+				Error:             snap.Error,
+				StartingTurnIndex: snap.StartingTurnIndex,
+				PendingInputs:     snap.PendingInputs,
+			}
+			if status != SnapshotStatusError && status != SnapshotStatusPending {
+				resp.State = applyTransform(transform, &snap.State)
+			}
+			return resp, nil
+		})
+
+	core.DefineAction(r, flowName+"/cancelSnapshot", api.ActionTypeUtil, nil, nil,
+		func(ctx context.Context, req *CancelSnapshotRequest) (*CancelSnapshotResponse, error) {
+			if store == nil {
+				return nil, core.NewError(core.FAILED_PRECONDITION,
+					"cancelSnapshot: session flow %q has no session store configured", flowName)
+			}
+			if req == nil || req.SnapshotID == "" {
+				return nil, core.NewError(core.INVALID_ARGUMENT, "cancelSnapshot: snapshotId is required")
+			}
+			meta, err := store.CancelSnapshot(ctx, req.SnapshotID)
+			if err != nil {
+				return nil, core.NewError(core.INTERNAL, "cancelSnapshot: %v", err)
+			}
+			if meta == nil {
+				return nil, core.NewError(core.NOT_FOUND, "cancelSnapshot: snapshot %q not found", req.SnapshotID)
+			}
+			// Re-read so the response reflects the snapshot's current truth,
+			// not just what the CAS returned. If a finalizer raced and won
+			// after the CAS landed, surface the resulting terminal status.
+			if verify, vErr := store.GetSnapshotMetadata(ctx, req.SnapshotID); vErr == nil && verify != nil {
+				meta = verify
+			}
+			return &CancelSnapshotResponse{SnapshotID: meta.SnapshotID, Status: meta.Status}, nil
+		})
 }
 
 // --- Session ---

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -329,20 +329,17 @@ type CancelSnapshotResponse struct {
 }
 
 // registerSnapshotActions registers the getSnapshot and cancelSnapshot
-// companion actions for a session flow, both keyed under the flow's name,
-// and returns references to them so the SessionFlow can expose typed
-// methods that delegate to the actions without callers having to call
-// ResolveActionFor.
+// companion actions for a session flow, both keyed under the flow's name.
+// They exist so non-Go callers (Dev UI, other languages) can observe and
+// cancel snapshots over the reflection API. Local Go callers use the
+// store reference passed to WithSessionStore directly.
 func registerSnapshotActions[State any](
 	r api.Registry,
 	flowName string,
 	store SessionStore[State],
 	transform SnapshotTransform[State],
-) (
-	*core.Action[*GetSnapshotRequest, *GetSnapshotResponse[State], struct{}, struct{}],
-	*core.Action[*CancelSnapshotRequest, *CancelSnapshotResponse, struct{}, struct{}],
 ) {
-	getAction := core.DefineAction(r, flowName+"/getSnapshot", api.ActionTypeUtil, nil, nil,
+	core.DefineAction(r, flowName+"/getSnapshot", api.ActionTypeUtil, nil, nil,
 		func(ctx context.Context, req *GetSnapshotRequest) (*GetSnapshotResponse[State], error) {
 			if store == nil {
 				return nil, core.NewError(core.FAILED_PRECONDITION,
@@ -383,7 +380,7 @@ func registerSnapshotActions[State any](
 			return resp, nil
 		})
 
-	cancelAction := core.DefineAction(r, flowName+"/cancelSnapshot", api.ActionTypeUtil, nil, nil,
+	core.DefineAction(r, flowName+"/cancelSnapshot", api.ActionTypeUtil, nil, nil,
 		func(ctx context.Context, req *CancelSnapshotRequest) (*CancelSnapshotResponse, error) {
 			if store == nil {
 				return nil, core.NewError(core.FAILED_PRECONDITION,
@@ -407,8 +404,6 @@ func registerSnapshotActions[State any](
 			}
 			return &CancelSnapshotResponse{SnapshotID: meta.SnapshotID, Status: meta.Status}, nil
 		})
-
-	return getAction, cancelAction
 }
 
 // --- Session ---

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -329,14 +329,20 @@ type CancelSnapshotResponse struct {
 }
 
 // registerSnapshotActions registers the getSnapshot and cancelSnapshot
-// companion actions for a session flow, both keyed under the flow's name.
+// companion actions for a session flow, both keyed under the flow's name,
+// and returns references to them so the SessionFlow can expose typed
+// methods that delegate to the actions without callers having to call
+// ResolveActionFor.
 func registerSnapshotActions[State any](
 	r api.Registry,
 	flowName string,
 	store SessionStore[State],
 	transform SnapshotTransform[State],
+) (
+	*core.Action[*GetSnapshotRequest, *GetSnapshotResponse[State], struct{}, struct{}],
+	*core.Action[*CancelSnapshotRequest, *CancelSnapshotResponse, struct{}, struct{}],
 ) {
-	core.DefineAction(r, flowName+"/getSnapshot", api.ActionTypeUtil, nil, nil,
+	getAction := core.DefineAction(r, flowName+"/getSnapshot", api.ActionTypeUtil, nil, nil,
 		func(ctx context.Context, req *GetSnapshotRequest) (*GetSnapshotResponse[State], error) {
 			if store == nil {
 				return nil, core.NewError(core.FAILED_PRECONDITION,
@@ -377,7 +383,7 @@ func registerSnapshotActions[State any](
 			return resp, nil
 		})
 
-	core.DefineAction(r, flowName+"/cancelSnapshot", api.ActionTypeUtil, nil, nil,
+	cancelAction := core.DefineAction(r, flowName+"/cancelSnapshot", api.ActionTypeUtil, nil, nil,
 		func(ctx context.Context, req *CancelSnapshotRequest) (*CancelSnapshotResponse, error) {
 			if store == nil {
 				return nil, core.NewError(core.FAILED_PRECONDITION,
@@ -401,6 +407,8 @@ func registerSnapshotActions[State any](
 			}
 			return &CancelSnapshotResponse{SnapshotID: meta.SnapshotID, Status: meta.Status}, nil
 		})
+
+	return getAction, cancelAction
 }
 
 // --- Session ---

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -37,11 +37,12 @@ import (
 // (an empty value is also treated as complete for backwards compatibility).
 //
 // When a client sets [SessionFlowInput.Detach], the server writes a single
-// snapshot with [SnapshotStatusPending] capturing the queued inputs and
-// returns its ID immediately. Background processing then either updates that
-// snapshot to [SnapshotStatusComplete] / [SnapshotStatusError] when the flow
-// finishes, or to [SnapshotStatusCanceled] if the client called
-// abortSnapshot in the meantime.
+// snapshot with [SnapshotStatusPending] (and empty state) and returns its
+// ID immediately. Background processing then either rewrites that snapshot
+// with the cumulative final state and [SnapshotStatusComplete] /
+// [SnapshotStatusError] when the flow finishes, or with
+// [SnapshotStatusCanceled] if the client called abortSnapshot in the
+// meantime.
 type SnapshotStatus string
 
 const (
@@ -80,16 +81,10 @@ type SessionSnapshot[State any] struct {
 	// Error is the failure message for a snapshot in [SnapshotStatusError].
 	// Empty otherwise.
 	Error string `json:"error,omitempty"`
-	// PendingInputs is the inputs captured at detach time, in FIFO order.
-	// The first entry may be the input that was in flight when detach
-	// landed (its turn was suppressed because snapshots were suspended in
-	// the same atomic step that captured it); the rest were queued behind
-	// it. Set only on snapshots in [SnapshotStatusPending]; cleared when
-	// the snapshot is finalized.
-	PendingInputs []*SessionFlowInput `json:"pendingInputs,omitempty"`
 	// State is the actual conversation state. Empty on a pending snapshot
-	// (the queued inputs are in [PendingInputs] and the live state is not
-	// yet committed); populated on terminal snapshots.
+	// (the live state is not yet committed; the background invocation is
+	// still processing queued inputs); populated on terminal snapshots
+	// with the cumulative final state.
 	State SessionState[State] `json:"state"`
 }
 
@@ -384,9 +379,6 @@ type GetSnapshotResponse[State any] struct {
 	Status SnapshotStatus `json:"status,omitempty"`
 	// Error is populated when Status is [SnapshotStatusError].
 	Error string `json:"error,omitempty"`
-	// PendingInputs is the queued inputs captured at detach time. Populated
-	// only when Status is [SnapshotStatusPending].
-	PendingInputs []*SessionFlowInput `json:"pendingInputs,omitempty"`
 	// State is the session state captured by the snapshot, after any
 	// configured transform. Empty when Status is pending or error.
 	State *SessionState[State] `json:"state,omitempty"`
@@ -455,12 +447,11 @@ func registerSnapshotActions[State any](
 			}
 
 			resp := &GetSnapshotResponse[State]{
-				SnapshotID:    snap.SnapshotID,
-				CreatedAt:     snap.CreatedAt,
-				UpdatedAt:     updatedAt,
-				Status:        status,
-				Error:         snap.Error,
-				PendingInputs: snap.PendingInputs,
+				SnapshotID: snap.SnapshotID,
+				CreatedAt:  snap.CreatedAt,
+				UpdatedAt:  updatedAt,
+				Status:     status,
+				Error:      snap.Error,
 			}
 			if status != SnapshotStatusError && status != SnapshotStatusPending {
 				resp.State = applyTransform(transform, &snap.State)

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -203,7 +203,10 @@ type SessionStore[State any] interface {
 // implements the full set of optional store interfaces (reader, writer,
 // aborter, status subscriber).
 type InMemorySessionStore[State any] struct {
-	mu        sync.Mutex
+	// mu is RWMutex so GetSnapshot (which JSON-marshals while holding the
+	// lock) can run concurrently with other readers. All writers (Save,
+	// Abort, OnSnapshotStatusChange, removeSub) take the full Lock().
+	mu        sync.RWMutex
 	snapshots map[string]*SessionSnapshot[State]
 	subs      map[string][]chan SnapshotStatus
 }
@@ -218,8 +221,8 @@ func NewInMemorySessionStore[State any]() *InMemorySessionStore[State] {
 
 // GetSnapshot retrieves a snapshot by ID. Returns nil if not found.
 func (s *InMemorySessionStore[State]) GetSnapshot(_ context.Context, snapshotID string) (*SessionSnapshot[State], error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	snap, ok := s.snapshots[snapshotID]
 	if !ok {
 		return nil, nil

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -399,20 +399,27 @@ type AbortSnapshotResponse struct {
 	Status SnapshotStatus `json:"status,omitempty"`
 }
 
-// registerSnapshotActions registers the getSnapshot and abortSnapshot
-// companion actions for a session flow, both keyed under the flow's name.
-// They exist so non-Go callers (Dev UI, other languages) can observe and
-// abort snapshots over the reflection API. Local Go callers use the store
-// reference passed to WithSessionStore directly. The abortSnapshot action
-// is only registered if the store implements [SnapshotAborter], so the
-// reflected action surface matches the store's actual capabilities.
+// registerSnapshotActions registers the session flow's companion actions:
+//
+//   - The flow's name under [api.ActionTypeAgentSnapshot] — getSnapshot,
+//     registered whenever a [SessionStore] is configured. The action is
+//     the remote counterpart to [SessionStore.GetSnapshot] for Dev UI and
+//     non-Go clients; local Go callers use the store reference directly.
+//
+//   - The flow's name under [api.ActionTypeAgentAbort] — abortSnapshot,
+//     registered only when the store implements both [SnapshotAborter]
+//     and [SnapshotStatusSubscriber]. Aborting needs both capabilities:
+//     the aborter to flip the row, and the subscriber so the session
+//     flow runtime can react to the flip without polling. Surfacing the
+//     action only when both are present keeps the reflected API aligned
+//     with what the store can actually do.
 func registerSnapshotActions[State any](
 	r api.Registry,
 	flowName string,
 	store SessionStore[State],
 	transform SnapshotTransform[State],
 ) {
-	core.DefineAction(r, flowName+"/getSnapshot", api.ActionTypeUtil, nil, nil,
+	core.DefineAction(r, flowName, api.ActionTypeAgentSnapshot, nil, nil,
 		func(ctx context.Context, req *GetSnapshotRequest) (*GetSnapshotResponse[State], error) {
 			if store == nil {
 				return nil, core.NewError(core.FAILED_PRECONDITION,
@@ -452,11 +459,15 @@ func registerSnapshotActions[State any](
 			return resp, nil
 		})
 
-	aborter, _ := store.(SnapshotAborter)
-	if aborter == nil {
+	aborter, hasAborter := store.(SnapshotAborter)
+	_, hasSubscriber := store.(SnapshotStatusSubscriber)
+	if !hasAborter || !hasSubscriber {
+		// Without both capabilities, abort cannot be observed by the
+		// session flow runtime in a meaningful way. Don't surface the
+		// action.
 		return
 	}
-	core.DefineAction(r, flowName+"/abortSnapshot", api.ActionTypeUtil, nil, nil,
+	core.DefineAction(r, flowName, api.ActionTypeAgentAbort, nil, nil,
 		func(ctx context.Context, req *AbortSnapshotRequest) (*AbortSnapshotResponse, error) {
 			if req == nil || req.SnapshotID == "" {
 				return nil, core.NewError(core.INVALID_ARGUMENT, "abortSnapshot: snapshotId is required")

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -156,9 +156,24 @@ type SnapshotWriter[State any] interface {
 	SaveSnapshot(ctx context.Context, snapshot *SessionSnapshot[State]) error
 }
 
-// SnapshotAborter atomically transitions a pending snapshot to canceled.
-// Required for detach-capable session flows so [SessionFlowInput.Detach]
-// invocations can be aborted via the abortSnapshot companion action.
+// SnapshotAborter is the optional capability layered on [SessionStore]
+// that lets a session flow's invocations be aborted. It bundles the two
+// methods that must be implemented together for the abort lifecycle to
+// function:
+//
+//   - [SnapshotAborter.AbortSnapshot] flips a pending snapshot's status
+//     to canceled (typically called by the abortSnapshot companion
+//     action or directly by a Go caller holding the store).
+//
+//   - [SnapshotAborter.OnSnapshotStatusChange] lets the session flow
+//     runtime observe the flip without polling, so it can promptly
+//     cancel the work context.
+//
+// They are bundled because neither is useful alone: flipping status
+// with no observer means the running fn never learns it was aborted;
+// observing without a way to trigger the flip means no abort can
+// happen. Splitting them into separate interfaces made the
+// "implemented one, not the other" footgun too easy to hit.
 type SnapshotAborter interface {
 	// AbortSnapshot atomically transitions a snapshot from
 	// [SnapshotStatusPending] to [SnapshotStatusCanceled] and returns the
@@ -171,29 +186,24 @@ type SnapshotAborter interface {
 	// action and finalizer rely on this to avoid a pending row being
 	// clobbered by a racing terminal write.
 	AbortSnapshot(ctx context.Context, snapshotID string) (*SnapshotMetadata, error)
-}
 
-// SnapshotStatusSubscriber notifies subscribers when a snapshot's lifecycle
-// status changes. Required for detach-capable session flows: the runtime
-// uses it to react to abortSnapshot without polling the store on a fixed
-// cadence. Implementations may push changes from a transaction log, a CDC
-// feed, or fall back to polling internally; the contract just spares
-// callers the choice.
-type SnapshotStatusSubscriber interface {
 	// OnSnapshotStatusChange returns a channel that yields the snapshot's
 	// status whenever it changes. The first value (if any) reflects the
 	// status at subscription time. The channel is closed when ctx is
 	// cancelled. If the snapshot does not exist when the subscription is
 	// established, the channel is closed without yielding a value.
+	//
+	// Implementations may push changes from a transaction log, a CDC
+	// feed, or fall back to polling internally; the contract just spares
+	// callers the choice.
 	OnSnapshotStatusChange(ctx context.Context, snapshotID string) <-chan SnapshotStatus
 }
 
 // SessionStore is the minimum store interface required by
-// [WithSessionStore]. Detach-related operations (abort, status
-// subscription) are layered as separate optional interfaces and checked at
-// runtime: a store wired into a flow that intends to support detach must
-// also implement [SnapshotAborter] and [SnapshotStatusSubscriber], or the
-// runtime will reject detach attempts.
+// [WithSessionStore]. The abort lifecycle is layered as the optional
+// [SnapshotAborter] capability and checked at runtime: a store wired
+// into a flow that intends to support detach must also implement
+// [SnapshotAborter], or the runtime will reject detach attempts.
 type SessionStore[State any] interface {
 	SnapshotReader[State]
 	SnapshotWriter[State]
@@ -407,12 +417,11 @@ type AbortSnapshotResponse struct {
 //     non-Go clients; local Go callers use the store reference directly.
 //
 //   - The flow's name under [api.ActionTypeAgentAbort] — abortSnapshot,
-//     registered only when the store implements both [SnapshotAborter]
-//     and [SnapshotStatusSubscriber]. Aborting needs both capabilities:
-//     the aborter to flip the row, and the subscriber so the session
-//     flow runtime can react to the flip without polling. Surfacing the
-//     action only when both are present keeps the reflected API aligned
-//     with what the store can actually do.
+//     registered only when the store implements [SnapshotAborter]
+//     (which bundles both the abort trigger and the status-change
+//     subscription needed for the runtime to react). Surfacing the
+//     action only when the capability is present keeps the reflected
+//     API aligned with what the store can actually do.
 func registerSnapshotActions[State any](
 	r api.Registry,
 	flowName string,
@@ -459,11 +468,9 @@ func registerSnapshotActions[State any](
 			return resp, nil
 		})
 
-	aborter, hasAborter := store.(SnapshotAborter)
-	_, hasSubscriber := store.(SnapshotStatusSubscriber)
-	if !hasAborter || !hasSubscriber {
-		// Without both capabilities, abort cannot be observed by the
-		// session flow runtime in a meaningful way. Don't surface the
+	aborter, ok := store.(SnapshotAborter)
+	if !ok {
+		// Store doesn't support the abort lifecycle. Don't surface the
 		// action.
 		return
 	}

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -40,7 +41,7 @@ import (
 // returns its ID immediately. Background processing then either updates that
 // snapshot to [SnapshotStatusComplete] / [SnapshotStatusError] when the flow
 // finishes, or to [SnapshotStatusCanceled] if the client called
-// cancelSnapshot in the meantime.
+// abortSnapshot in the meantime.
 type SnapshotStatus string
 
 const (
@@ -51,7 +52,7 @@ const (
 	// SnapshotStatusComplete indicates the snapshot captures a settled state.
 	SnapshotStatusComplete SnapshotStatus = "complete"
 	// SnapshotStatusCanceled indicates the snapshot's invocation was
-	// cancelled via the cancelSnapshot companion action while detached.
+	// aborted via the abortSnapshot companion action while detached.
 	SnapshotStatusCanceled SnapshotStatus = "canceled"
 	// SnapshotStatusError indicates the invocation terminated with an error.
 	// The snapshot's Error field describes the failure and resume is
@@ -79,13 +80,6 @@ type SessionSnapshot[State any] struct {
 	// Error is the failure message for a snapshot in [SnapshotStatusError].
 	// Empty otherwise.
 	Error string `json:"error,omitempty"`
-	// StartingTurnIndex is the zero-based index of the first turn this
-	// snapshot covers within its invocation. For sync snapshots it is the
-	// index of the single turn that ended. For pending snapshots it is the
-	// index of the first input in [PendingInputs]; subsequent inputs map to
-	// StartingTurnIndex+1, +2, etc. Pair with [TurnEnd.TurnIndex] on
-	// chunks to correlate durable-stream chunks back to inputs.
-	StartingTurnIndex int `json:"startingTurnIndex"`
 	// PendingInputs is the inputs captured at detach time, in FIFO order.
 	// The first entry may be the input that was in flight when detach
 	// landed (its turn was suppressed because snapshots were suspended in
@@ -128,9 +122,9 @@ func applyTransform[State any](t SnapshotTransform[State], state *SessionState[S
 // --- Session store ---
 
 // SnapshotMetadata is the metadata-only projection of a [SessionSnapshot]:
-// identifying fields, lifecycle timestamps, and status. It exists so callers
-// (notably the detached-invocation heartbeat poller) can check status
-// without paying for a full state read.
+// identifying fields, lifecycle timestamps, and status. Returned by store
+// operations that surface a snapshot's lifecycle state without paying for
+// a full state read.
 type SnapshotMetadata struct {
 	// SnapshotID is the unique identifier for this snapshot.
 	SnapshotID string `json:"snapshotId"`
@@ -146,52 +140,86 @@ type SnapshotMetadata struct {
 	Status SnapshotStatus `json:"status,omitempty"`
 	// Error is the failure message for a snapshot in [SnapshotStatusError].
 	Error string `json:"error,omitempty"`
-	// StartingTurnIndex is the zero-based index of the first turn this
-	// snapshot covers within its invocation. See [SessionSnapshot.StartingTurnIndex].
-	StartingTurnIndex int `json:"startingTurnIndex"`
 }
 
-// SessionStore persists and retrieves snapshots.
-type SessionStore[State any] interface {
+// SnapshotReader retrieves snapshots. The minimum any session store must
+// implement to be used with [WithSessionStore].
+type SnapshotReader[State any] interface {
 	// GetSnapshot retrieves a snapshot by ID. Returns nil if not found.
 	GetSnapshot(ctx context.Context, snapshotID string) (*SessionSnapshot[State], error)
-	// GetSnapshotMetadata retrieves only the metadata for a snapshot.
-	// Returns nil if not found. Implementations should avoid loading the
-	// full session state — this is called by the heartbeat poller on a
-	// configured cadence while a detached invocation is in flight.
-	GetSnapshotMetadata(ctx context.Context, snapshotID string) (*SnapshotMetadata, error)
+}
+
+// SnapshotWriter persists snapshots. The minimum any session store must
+// implement to be used with [WithSessionStore].
+type SnapshotWriter[State any] interface {
 	// SaveSnapshot persists a snapshot.
 	SaveSnapshot(ctx context.Context, snapshot *SessionSnapshot[State]) error
-	// CancelSnapshot atomically transitions a snapshot from
+}
+
+// SnapshotAborter atomically transitions a pending snapshot to canceled.
+// Required for detach-capable session flows so [SessionFlowInput.Detach]
+// invocations can be aborted via the abortSnapshot companion action.
+type SnapshotAborter interface {
+	// AbortSnapshot atomically transitions a snapshot from
 	// [SnapshotStatusPending] to [SnapshotStatusCanceled] and returns the
 	// resulting metadata. If the snapshot is in any other status the
 	// operation is a no-op and the existing metadata is returned. Returns
 	// nil if the snapshot is not found.
 	//
 	// Implementations must perform the read-and-write atomically (e.g., a
-	// transaction or the equivalent of a compare-and-swap). The session
-	// flow's cancelSnapshot action and finalizer rely on this to avoid a
-	// pending row being clobbered by a racing terminal write.
-	CancelSnapshot(ctx context.Context, snapshotID string) (*SnapshotMetadata, error)
+	// transaction or a compare-and-swap). The session flow's abortSnapshot
+	// action and finalizer rely on this to avoid a pending row being
+	// clobbered by a racing terminal write.
+	AbortSnapshot(ctx context.Context, snapshotID string) (*SnapshotMetadata, error)
 }
 
-// InMemorySessionStore provides a thread-safe in-memory snapshot store.
+// SnapshotStatusSubscriber notifies subscribers when a snapshot's lifecycle
+// status changes. Required for detach-capable session flows: the runtime
+// uses it to react to abortSnapshot without polling the store on a fixed
+// cadence. Implementations may push changes from a transaction log, a CDC
+// feed, or fall back to polling internally; the contract just spares
+// callers the choice.
+type SnapshotStatusSubscriber interface {
+	// OnSnapshotStatusChange returns a channel that yields the snapshot's
+	// status whenever it changes. The first value (if any) reflects the
+	// status at subscription time. The channel is closed when ctx is
+	// cancelled. If the snapshot does not exist when the subscription is
+	// established, the channel is closed without yielding a value.
+	OnSnapshotStatusChange(ctx context.Context, snapshotID string) <-chan SnapshotStatus
+}
+
+// SessionStore is the minimum store interface required by
+// [WithSessionStore]. Detach-related operations (abort, status
+// subscription) are layered as separate optional interfaces and checked at
+// runtime: a store wired into a flow that intends to support detach must
+// also implement [SnapshotAborter] and [SnapshotStatusSubscriber], or the
+// runtime will reject detach attempts.
+type SessionStore[State any] interface {
+	SnapshotReader[State]
+	SnapshotWriter[State]
+}
+
+// InMemorySessionStore provides a thread-safe in-memory snapshot store. It
+// implements the full set of optional store interfaces (reader, writer,
+// aborter, status subscriber).
 type InMemorySessionStore[State any] struct {
+	mu        sync.Mutex
 	snapshots map[string]*SessionSnapshot[State]
-	mu        sync.RWMutex
+	subs      map[string][]chan SnapshotStatus
 }
 
 // NewInMemorySessionStore creates a new in-memory snapshot store.
 func NewInMemorySessionStore[State any]() *InMemorySessionStore[State] {
 	return &InMemorySessionStore[State]{
 		snapshots: make(map[string]*SessionSnapshot[State]),
+		subs:      make(map[string][]chan SnapshotStatus),
 	}
 }
 
 // GetSnapshot retrieves a snapshot by ID. Returns nil if not found.
 func (s *InMemorySessionStore[State]) GetSnapshot(_ context.Context, snapshotID string) (*SessionSnapshot[State], error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	snap, ok := s.snapshots[snapshotID]
 	if !ok {
 		return nil, nil
@@ -199,22 +227,10 @@ func (s *InMemorySessionStore[State]) GetSnapshot(_ context.Context, snapshotID 
 	return copySnapshot(snap)
 }
 
-// GetSnapshotMetadata retrieves only the metadata for a snapshot. Returns
-// nil if not found.
-func (s *InMemorySessionStore[State]) GetSnapshotMetadata(_ context.Context, snapshotID string) (*SnapshotMetadata, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	snap, ok := s.snapshots[snapshotID]
-	if !ok {
-		return nil, nil
-	}
-	return snapshotMetadata(snap), nil
-}
-
-// CancelSnapshot atomically flips a pending snapshot to canceled. If the
+// AbortSnapshot atomically flips a pending snapshot to canceled. If the
 // snapshot is already terminal the existing metadata is returned unchanged.
 // Returns nil if the snapshot is not found.
-func (s *InMemorySessionStore[State]) CancelSnapshot(_ context.Context, snapshotID string) (*SnapshotMetadata, error) {
+func (s *InMemorySessionStore[State]) AbortSnapshot(_ context.Context, snapshotID string) (*SnapshotMetadata, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	snap, ok := s.snapshots[snapshotID]
@@ -224,6 +240,7 @@ func (s *InMemorySessionStore[State]) CancelSnapshot(_ context.Context, snapshot
 	if snap.Status == SnapshotStatusPending {
 		snap.Status = SnapshotStatusCanceled
 		snap.UpdatedAt = time.Now()
+		s.notifyLocked(snapshotID, snap.Status)
 	}
 	return snapshotMetadata(snap), nil
 }
@@ -236,21 +253,76 @@ func (s *InMemorySessionStore[State]) SaveSnapshot(_ context.Context, snapshot *
 	if err != nil {
 		return err
 	}
+	prev, existed := s.snapshots[copied.SnapshotID]
 	s.snapshots[copied.SnapshotID] = copied
+	if !existed || prev.Status != copied.Status {
+		s.notifyLocked(copied.SnapshotID, copied.Status)
+	}
 	return nil
+}
+
+// OnSnapshotStatusChange subscribes to status changes for a snapshot. The
+// returned channel yields the current status (if any) and any subsequent
+// changes, until ctx is cancelled.
+func (s *InMemorySessionStore[State]) OnSnapshotStatusChange(ctx context.Context, snapshotID string) <-chan SnapshotStatus {
+	ch := make(chan SnapshotStatus, 1)
+
+	s.mu.Lock()
+	snap, ok := s.snapshots[snapshotID]
+	if !ok {
+		s.mu.Unlock()
+		close(ch)
+		return ch
+	}
+	ch <- snap.Status
+	s.subs[snapshotID] = append(s.subs[snapshotID], ch)
+	s.mu.Unlock()
+
+	context.AfterFunc(ctx, func() { s.removeSub(snapshotID, ch) })
+	return ch
+}
+
+// removeSub detaches a subscriber and closes its channel.
+func (s *InMemorySessionStore[State]) removeSub(snapshotID string, ch chan SnapshotStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	subs := s.subs[snapshotID]
+	i := slices.Index(subs, ch)
+	if i < 0 {
+		return
+	}
+	subs = slices.Delete(subs, i, i+1)
+	if len(subs) == 0 {
+		delete(s.subs, snapshotID)
+	} else {
+		s.subs[snapshotID] = subs
+	}
+	close(ch)
+}
+
+// notifyLocked publishes status to all live subscribers of snapshotID.
+// Caller must hold s.mu. Sends are best-effort: a slow subscriber may miss
+// intermediate values, but the store guarantees the latest value visible
+// to the subscription is the one persisted at notify time.
+func (s *InMemorySessionStore[State]) notifyLocked(snapshotID string, status SnapshotStatus) {
+	for _, ch := range s.subs[snapshotID] {
+		select {
+		case ch <- status:
+		default:
+		}
+	}
 }
 
 // snapshotMetadata projects the metadata fields of a snapshot.
 func snapshotMetadata[State any](snap *SessionSnapshot[State]) *SnapshotMetadata {
 	return &SnapshotMetadata{
-		SnapshotID:        snap.SnapshotID,
-		ParentID:          snap.ParentID,
-		CreatedAt:         snap.CreatedAt,
-		UpdatedAt:         snap.UpdatedAt,
-		Event:             snap.Event,
-		Status:            snap.Status,
-		Error:             snap.Error,
-		StartingTurnIndex: snap.StartingTurnIndex,
+		SnapshotID: snap.SnapshotID,
+		ParentID:   snap.ParentID,
+		CreatedAt:  snap.CreatedAt,
+		UpdatedAt:  snap.UpdatedAt,
+		Event:      snap.Event,
+		Status:     snap.Status,
+		Error:      snap.Error,
 	}
 }
 
@@ -299,10 +371,6 @@ type GetSnapshotResponse[State any] struct {
 	Status SnapshotStatus `json:"status,omitempty"`
 	// Error is populated when Status is [SnapshotStatusError].
 	Error string `json:"error,omitempty"`
-	// StartingTurnIndex is the zero-based index of the first turn this
-	// snapshot covers within its invocation. See
-	// [SessionSnapshot.StartingTurnIndex].
-	StartingTurnIndex int `json:"startingTurnIndex"`
 	// PendingInputs is the queued inputs captured at detach time. Populated
 	// only when Status is [SnapshotStatusPending].
 	PendingInputs []*SessionFlowInput `json:"pendingInputs,omitempty"`
@@ -311,28 +379,30 @@ type GetSnapshotResponse[State any] struct {
 	State *SessionState[State] `json:"state,omitempty"`
 }
 
-// CancelSnapshotRequest is the input for the cancelSnapshot companion action.
-type CancelSnapshotRequest struct {
-	// SnapshotID identifies the snapshot whose invocation should be cancelled.
+// AbortSnapshotRequest is the input for the abortSnapshot companion action.
+type AbortSnapshotRequest struct {
+	// SnapshotID identifies the snapshot whose invocation should be aborted.
 	SnapshotID string `json:"snapshotId"`
 }
 
-// CancelSnapshotResponse is the output of the cancelSnapshot companion action.
-type CancelSnapshotResponse struct {
+// AbortSnapshotResponse is the output of the abortSnapshot companion action.
+type AbortSnapshotResponse struct {
 	// SnapshotID echoes the requested snapshot ID.
 	SnapshotID string `json:"snapshotId"`
-	// Status is the snapshot's status after the cancel attempt. For a
+	// Status is the snapshot's status after the abort attempt. For a
 	// pending snapshot this is [SnapshotStatusCanceled]. For an
 	// already-terminal snapshot this is the existing terminal status (the
-	// cancel is a no-op).
+	// abort is a no-op).
 	Status SnapshotStatus `json:"status,omitempty"`
 }
 
-// registerSnapshotActions registers the getSnapshot and cancelSnapshot
+// registerSnapshotActions registers the getSnapshot and abortSnapshot
 // companion actions for a session flow, both keyed under the flow's name.
 // They exist so non-Go callers (Dev UI, other languages) can observe and
-// cancel snapshots over the reflection API. Local Go callers use the
-// store reference passed to WithSessionStore directly.
+// abort snapshots over the reflection API. Local Go callers use the store
+// reference passed to WithSessionStore directly. The abortSnapshot action
+// is only registered if the store implements [SnapshotAborter], so the
+// reflected action surface matches the store's actual capabilities.
 func registerSnapshotActions[State any](
 	r api.Registry,
 	flowName string,
@@ -366,13 +436,12 @@ func registerSnapshotActions[State any](
 			}
 
 			resp := &GetSnapshotResponse[State]{
-				SnapshotID:        snap.SnapshotID,
-				CreatedAt:         snap.CreatedAt,
-				UpdatedAt:         updatedAt,
-				Status:            status,
-				Error:             snap.Error,
-				StartingTurnIndex: snap.StartingTurnIndex,
-				PendingInputs:     snap.PendingInputs,
+				SnapshotID:    snap.SnapshotID,
+				CreatedAt:     snap.CreatedAt,
+				UpdatedAt:     updatedAt,
+				Status:        status,
+				Error:         snap.Error,
+				PendingInputs: snap.PendingInputs,
 			}
 			if status != SnapshotStatusError && status != SnapshotStatusPending {
 				resp.State = applyTransform(transform, &snap.State)
@@ -380,29 +449,23 @@ func registerSnapshotActions[State any](
 			return resp, nil
 		})
 
-	core.DefineAction(r, flowName+"/cancelSnapshot", api.ActionTypeUtil, nil, nil,
-		func(ctx context.Context, req *CancelSnapshotRequest) (*CancelSnapshotResponse, error) {
-			if store == nil {
-				return nil, core.NewError(core.FAILED_PRECONDITION,
-					"cancelSnapshot: session flow %q has no session store configured", flowName)
-			}
+	aborter, _ := store.(SnapshotAborter)
+	if aborter == nil {
+		return
+	}
+	core.DefineAction(r, flowName+"/abortSnapshot", api.ActionTypeUtil, nil, nil,
+		func(ctx context.Context, req *AbortSnapshotRequest) (*AbortSnapshotResponse, error) {
 			if req == nil || req.SnapshotID == "" {
-				return nil, core.NewError(core.INVALID_ARGUMENT, "cancelSnapshot: snapshotId is required")
+				return nil, core.NewError(core.INVALID_ARGUMENT, "abortSnapshot: snapshotId is required")
 			}
-			meta, err := store.CancelSnapshot(ctx, req.SnapshotID)
+			meta, err := aborter.AbortSnapshot(ctx, req.SnapshotID)
 			if err != nil {
-				return nil, core.NewError(core.INTERNAL, "cancelSnapshot: %v", err)
+				return nil, core.NewError(core.INTERNAL, "abortSnapshot: %v", err)
 			}
 			if meta == nil {
-				return nil, core.NewError(core.NOT_FOUND, "cancelSnapshot: snapshot %q not found", req.SnapshotID)
+				return nil, core.NewError(core.NOT_FOUND, "abortSnapshot: snapshot %q not found", req.SnapshotID)
 			}
-			// Re-read so the response reflects the snapshot's current truth,
-			// not just what the CAS returned. If a finalizer raced and won
-			// after the CAS landed, surface the resulting terminal status.
-			if verify, vErr := store.GetSnapshotMetadata(ctx, req.SnapshotID); vErr == nil && verify != nil {
-				meta = verify
-			}
-			return &CancelSnapshotResponse{SnapshotID: meta.SnapshotID, Status: meta.Status}, nil
+			return &AbortSnapshotResponse{SnapshotID: meta.SnapshotID, Status: meta.Status}, nil
 		})
 }
 

--- a/go/ai/exp/session.go
+++ b/go/ai/exp/session.go
@@ -28,6 +28,7 @@ import (
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/base"
+	"github.com/google/uuid"
 )
 
 // --- Snapshot ---
@@ -106,11 +107,11 @@ type SnapshotCallback[State any] = func(ctx context.Context, sc *SnapshotContext
 
 // applyTransform returns the result of applying t to *state, or state
 // unchanged if t is nil. A nil state is returned as-is.
-func applyTransform[State any](t SnapshotTransform[State], state *SessionState[State]) *SessionState[State] {
+func applyTransform[State any](ctx context.Context, t StateTransform[State], state *SessionState[State]) *SessionState[State] {
 	if t == nil || state == nil {
 		return state
 	}
-	transformed := t(*state)
+	transformed := t(ctx, *state)
 	return &transformed
 }
 
@@ -147,8 +148,37 @@ type SnapshotReader[State any] interface {
 // SnapshotWriter persists snapshots. The minimum any session store must
 // implement to be used with [WithSessionStore].
 type SnapshotWriter[State any] interface {
-	// SaveSnapshot persists a snapshot.
-	SaveSnapshot(ctx context.Context, snapshot *SessionSnapshot[State]) error
+	// SaveSnapshot atomically reads the snapshot at id (if any), applies
+	// fn, and persists the result. The store owns identity and
+	// lifecycle-timestamp fields:
+	//
+	//   - SnapshotID: if id is empty, the store generates a fresh ID;
+	//     otherwise the store uses id (any SnapshotID populated by fn is
+	//     overridden).
+	//   - CreatedAt: stamped to the wall clock on first write; preserved
+	//     from the existing row on update.
+	//   - UpdatedAt: stamped to the wall clock on every commit.
+	//   - Status: if the snapshot returned by fn has Status="", it is
+	//     defaulted to [SnapshotStatusComplete] (the common case for
+	//     synchronous turn-end and invocation-end writes). Callers
+	//     writing a pending row must set Status explicitly.
+	//
+	// fn receives the existing snapshot (or nil if id is empty or the
+	// row does not exist) and returns the snapshot to commit, or
+	// (nil, nil) to skip the write without changing the row.
+	//
+	// Under contention, stores that use optimistic concurrency or
+	// transaction retries may call fn multiple times. fn must therefore
+	// be a pure function of its input: no side effects (channel sends,
+	// logging, external I/O) inside fn.
+	//
+	// Returns the snapshot as persisted (with the store-owned fields
+	// populated), or nil if fn declined to write.
+	SaveSnapshot(
+		ctx context.Context,
+		id string,
+		fn func(existing *SessionSnapshot[State]) (*SessionSnapshot[State], error),
+	) (*SessionSnapshot[State], error)
 }
 
 // SnapshotAborter is the optional capability layered on [SessionStore]
@@ -253,20 +283,65 @@ func (s *InMemorySessionStore[State]) AbortSnapshot(_ context.Context, snapshotI
 	return snapshotMetadata(snap), nil
 }
 
-// SaveSnapshot persists a snapshot.
-func (s *InMemorySessionStore[State]) SaveSnapshot(_ context.Context, snapshot *SessionSnapshot[State]) error {
+// SaveSnapshot atomically reads, applies fn, and persists. See the
+// [SnapshotWriter] interface for the full contract; this implementation
+// satisfies it by holding s.mu for the entire read-modify-write so fn
+// is called exactly once per SaveSnapshot call.
+func (s *InMemorySessionStore[State]) SaveSnapshot(
+	_ context.Context,
+	id string,
+	fn func(existing *SessionSnapshot[State]) (*SessionSnapshot[State], error),
+) (*SessionSnapshot[State], error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	copied, err := copySnapshot(snapshot)
+
+	if id == "" {
+		id = uuid.New().String()
+	}
+
+	var existing *SessionSnapshot[State]
+	if stored, ok := s.snapshots[id]; ok {
+		copied, err := copySnapshot(stored)
+		if err != nil {
+			return nil, err
+		}
+		existing = copied
+	}
+
+	next, err := fn(existing)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	prev, existed := s.snapshots[copied.SnapshotID]
-	s.snapshots[copied.SnapshotID] = copied
-	if !existed || prev.Status != copied.Status {
-		s.notifyLocked(copied.SnapshotID, copied.Status)
+	if next == nil {
+		return nil, nil
 	}
-	return nil
+
+	next.SnapshotID = id
+	now := time.Now()
+	if existing != nil {
+		next.CreatedAt = existing.CreatedAt
+	} else {
+		next.CreatedAt = now
+	}
+	next.UpdatedAt = now
+	if next.Status == "" {
+		next.Status = SnapshotStatusComplete
+	}
+
+	copied, err := copySnapshot(next)
+	if err != nil {
+		return nil, err
+	}
+	s.snapshots[id] = copied
+	if existing == nil || existing.Status != next.Status {
+		s.notifyLocked(id, next.Status)
+	}
+	// Return next (the freshly-allocated struct from fn) rather than
+	// copied: copied is the pointer the store retains, so returning it
+	// would alias the caller's view with the stored row and let future
+	// in-place mutations (e.g. AbortSnapshot updating UpdatedAt) leak
+	// through.
+	return next, nil
 }
 
 // OnSnapshotStatusChange subscribes to status changes for a snapshot. The
@@ -362,7 +437,7 @@ type GetSnapshotRequest struct {
 
 // GetSnapshotResponse is the output of the getSnapshot companion action. It
 // is a client-facing view of the stored snapshot: identifying metadata plus
-// the session state, with [WithSnapshotTransform] applied if configured.
+// the session state, with [WithStateTransform] applied if configured.
 //
 // Unlike the raw [SessionSnapshot], this response intentionally omits
 // internal fields (parent ID, event) and does not leak the snapshot
@@ -418,7 +493,7 @@ func registerSnapshotActions[State any](
 	r api.Registry,
 	flowName string,
 	store SessionStore[State],
-	transform SnapshotTransform[State],
+	transform StateTransform[State],
 ) {
 	core.DefineAction(r, flowName, api.ActionTypeAgentSnapshot, nil, nil,
 		func(ctx context.Context, req *GetSnapshotRequest) (*GetSnapshotResponse[State], error) {
@@ -454,7 +529,7 @@ func registerSnapshotActions[State any](
 				Error:      snap.Error,
 			}
 			if status != SnapshotStatusError && status != SnapshotStatusPending {
-				resp.State = applyTransform(transform, &snap.State)
+				resp.State = applyTransform(ctx, transform, &snap.State)
 			}
 			return resp, nil
 		})

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -47,9 +47,7 @@ type SessionFlowFunc[Stream, State any] = func(ctx context.Context, resp Respond
 
 // SessionFlow is a bidirectional streaming flow with automatic snapshot management.
 type SessionFlow[Stream, State any] struct {
-	flow           *core.Flow[*SessionFlowInit[State], *SessionFlowOutput[State], *SessionFlowStreamChunk[Stream], *SessionFlowInput]
-	getSnapshot    *core.Action[*GetSnapshotRequest, *GetSnapshotResponse[State], struct{}, struct{}]
-	cancelSnapshot *core.Action[*CancelSnapshotRequest, *CancelSnapshotResponse, struct{}, struct{}]
+	flow *core.Flow[*SessionFlowInit[State], *SessionFlowOutput[State], *SessionFlowStreamChunk[Stream], *SessionFlowInput]
 }
 
 // DefineSessionFlow creates an SessionFlow with automatic snapshot management and registers it.
@@ -82,13 +80,9 @@ func DefineSessionFlow[Stream, State any](
 		return rt.run(ctx, fn)
 	})
 
-	getAction, cancelAction := registerSnapshotActions(r, name, cfg.store, cfg.transform)
+	registerSnapshotActions(r, name, cfg.store, cfg.transform)
 
-	return &SessionFlow[Stream, State]{
-		flow:           flow,
-		getSnapshot:    getAction,
-		cancelSnapshot: cancelAction,
-	}
+	return &SessionFlow[Stream, State]{flow: flow}
 }
 
 // --- sessionFlowRuntime ---
@@ -1141,27 +1135,6 @@ func (af *SessionFlow[Stream, State]) RunText(
 	return af.Run(ctx, &SessionFlowInput{
 		Messages: []*ai.Message{ai.NewUserTextMessage(text)},
 	}, opts...)
-}
-
-// GetSnapshot returns the metadata and (when settled) the state for a
-// snapshot. State is omitted for snapshots in pending or error status;
-// PendingInputs is populated for pending snapshots. If
-// WithSnapshotTransform is configured, it is applied to the returned state.
-//
-// This is a typed wrapper over the {flowName}/getSnapshot companion action
-// and produces the same observable behavior.
-func (af *SessionFlow[Stream, State]) GetSnapshot(ctx context.Context, snapshotID string) (*GetSnapshotResponse[State], error) {
-	return af.getSnapshot.Run(ctx, &GetSnapshotRequest{SnapshotID: snapshotID}, nil)
-}
-
-// CancelSnapshot atomically transitions a pending snapshot to canceled.
-// On a non-pending snapshot it is a no-op and the existing terminal status
-// is returned.
-//
-// This is a typed wrapper over the {flowName}/cancelSnapshot companion
-// action and produces the same observable behavior.
-func (af *SessionFlow[Stream, State]) CancelSnapshot(ctx context.Context, snapshotID string) (*CancelSnapshotResponse, error) {
-	return af.cancelSnapshot.Run(ctx, &CancelSnapshotRequest{SnapshotID: snapshotID}, nil)
 }
 
 // resolveOptions applies invocation options and returns the init struct.

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -47,7 +47,9 @@ type SessionFlowFunc[Stream, State any] = func(ctx context.Context, resp Respond
 
 // SessionFlow is a bidirectional streaming flow with automatic snapshot management.
 type SessionFlow[Stream, State any] struct {
-	flow *core.Flow[*SessionFlowInit[State], *SessionFlowOutput[State], *SessionFlowStreamChunk[Stream], *SessionFlowInput]
+	flow           *core.Flow[*SessionFlowInit[State], *SessionFlowOutput[State], *SessionFlowStreamChunk[Stream], *SessionFlowInput]
+	getSnapshot    *core.Action[*GetSnapshotRequest, *GetSnapshotResponse[State], struct{}, struct{}]
+	cancelSnapshot *core.Action[*CancelSnapshotRequest, *CancelSnapshotResponse, struct{}, struct{}]
 }
 
 // DefineSessionFlow creates an SessionFlow with automatic snapshot management and registers it.
@@ -80,9 +82,13 @@ func DefineSessionFlow[Stream, State any](
 		return rt.run(ctx, fn)
 	})
 
-	registerSnapshotActions(r, name, cfg.store, cfg.transform)
+	getAction, cancelAction := registerSnapshotActions(r, name, cfg.store, cfg.transform)
 
-	return &SessionFlow[Stream, State]{flow: flow}
+	return &SessionFlow[Stream, State]{
+		flow:           flow,
+		getSnapshot:    getAction,
+		cancelSnapshot: cancelAction,
+	}
 }
 
 // --- sessionFlowRuntime ---
@@ -908,8 +914,17 @@ func (i *detachIntake) enqueue(input *SessionFlowInput) {
 // handleDetach drains any buffered src inputs into the queue and signals
 // the detach handler. The detach handler then calls suspendAndCapture for
 // the atomic read of the full state.
+//
+// A pure detach signal (no Messages, no ToolRestarts) is dropped rather
+// than enqueued: it carries no payload to process, so adding it to
+// PendingInputs would just leave a stray empty input there. Callers that
+// want to ride a final input on the detach signal can do so by calling
+// Send(&SessionFlowInput{Detach: true, Messages: ...}) explicitly.
 func (i *detachIntake) handleDetach(first *SessionFlowInput) {
-	drained := []*SessionFlowInput{first}
+	var drained []*SessionFlowInput
+	if hasInputPayload(first) {
+		drained = append(drained, first)
+	}
 drainLoop:
 	for {
 		select {
@@ -923,15 +938,24 @@ drainLoop:
 		}
 	}
 
-	i.mu.Lock()
-	i.queue = append(i.queue, drained...)
-	i.mu.Unlock()
-	i.signal()
+	if len(drained) > 0 {
+		i.mu.Lock()
+		i.queue = append(i.queue, drained...)
+		i.mu.Unlock()
+		i.signal()
+	}
 
 	select {
 	case i.detachCh <- struct{}{}:
 	case <-i.stop:
 	}
+}
+
+// hasInputPayload reports whether the input carries data the runner would
+// otherwise process. Used to filter pure detach signals out of
+// PendingInputs.
+func hasInputPayload(in *SessionFlowInput) bool {
+	return in != nil && (len(in.Messages) > 0 || len(in.ToolRestarts) > 0)
 }
 
 // forward pops the queue and writes to dst at the runner's pace. The
@@ -1119,6 +1143,59 @@ func (af *SessionFlow[Stream, State]) RunText(
 	}, opts...)
 }
 
+// RunBackground starts a single-turn session flow invocation that runs in
+// the background: the input is sent with Detach=true so the server writes
+// a pending snapshot and continues processing after the connection closes.
+// The returned output carries the pending snapshot ID; use GetSnapshot to
+// observe its progression and CancelSnapshot to stop it.
+//
+// Requires a session store to be configured via WithSessionStore.
+func (af *SessionFlow[Stream, State]) RunBackground(
+	ctx context.Context,
+	input *SessionFlowInput,
+	opts ...InvocationOption[State],
+) (*SessionFlowOutput[State], error) {
+	conn, err := af.StreamBidi(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	bg := SessionFlowInput{Detach: true}
+	if input != nil {
+		bg = *input
+		bg.Detach = true
+	}
+	if err := conn.Send(&bg); err != nil {
+		return nil, err
+	}
+	for _, err := range conn.Receive() {
+		if err != nil {
+			return nil, err
+		}
+	}
+	return conn.Output()
+}
+
+// GetSnapshot returns the metadata and (when settled) the state for a
+// snapshot. State is omitted for snapshots in pending or error status;
+// PendingInputs is populated for pending snapshots. If
+// WithSnapshotTransform is configured, it is applied to the returned state.
+//
+// This is a typed wrapper over the {flowName}/getSnapshot companion action
+// and produces the same observable behavior.
+func (af *SessionFlow[Stream, State]) GetSnapshot(ctx context.Context, snapshotID string) (*GetSnapshotResponse[State], error) {
+	return af.getSnapshot.Run(ctx, &GetSnapshotRequest{SnapshotID: snapshotID}, nil)
+}
+
+// CancelSnapshot atomically transitions a pending snapshot to canceled.
+// On a non-pending snapshot it is a no-op and the existing terminal status
+// is returned.
+//
+// This is a typed wrapper over the {flowName}/cancelSnapshot companion
+// action and produces the same observable behavior.
+func (af *SessionFlow[Stream, State]) CancelSnapshot(ctx context.Context, snapshotID string) (*CancelSnapshotResponse, error) {
+	return af.cancelSnapshot.Run(ctx, &CancelSnapshotRequest{SnapshotID: snapshotID}, nil)
+}
+
 // resolveOptions applies invocation options and returns the init struct.
 func (af *SessionFlow[Stream, State]) resolveOptions(opts []InvocationOption[State]) (*SessionFlowInit[State], error) {
 	cfg := &invocationOptions[State]{}
@@ -1197,20 +1274,16 @@ func (c *SessionFlowConnection[Stream, State]) SendToolRestarts(parts ...*ai.Par
 	return c.conn.Send(&SessionFlowInput{ToolRestarts: parts})
 }
 
-// Detach asks the server to write a pending snapshot capturing this input
-// (and any others already buffered), close the connection, and continue
-// processing in the background. Output() returns the pending snapshot ID;
-// the client can later call cancelSnapshot to stop the background work or
-// poll getSnapshot/getSnapshotMetadata to observe its progression.
+// Detach asks the server to write a pending snapshot capturing any inputs
+// already buffered, close the connection, and continue processing in the
+// background. Output() returns the pending snapshot ID; the client can
+// later call CancelSnapshot to stop the background work or GetSnapshot to
+// observe its progression.
 //
-// The caller's input is not mutated.
-func (c *SessionFlowConnection[Stream, State]) Detach(input *SessionFlowInput) error {
-	var detach SessionFlowInput
-	if input != nil {
-		detach = *input
-	}
-	detach.Detach = true
-	return c.conn.Send(&detach)
+// To send a final input as part of the same wire message, use
+// Send(&SessionFlowInput{Detach: true, Messages: ...}) directly.
+func (c *SessionFlowConnection[Stream, State]) Detach() error {
+	return c.conn.Send(&SessionFlowInput{Detach: true})
 }
 
 // Close signals that no more inputs will be sent.

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"iter"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
@@ -35,6 +36,437 @@ import (
 	"github.com/firebase/genkit/go/internal/base"
 	"github.com/google/uuid"
 )
+
+// --- SessionFlow ---
+
+// SessionFlowFunc is the function signature for session flows.
+// Type parameters:
+//   - Stream: Type for status updates sent via the responder
+//   - State: Type for user-defined state in snapshots
+type SessionFlowFunc[Stream, State any] = func(ctx context.Context, resp Responder[Stream], sess *SessionRunner[State]) (*SessionFlowResult, error)
+
+// SessionFlow is a bidirectional streaming flow with automatic snapshot management.
+type SessionFlow[Stream, State any] struct {
+	flow *core.Flow[*SessionFlowInit[State], *SessionFlowOutput[State], *SessionFlowStreamChunk[Stream], *SessionFlowInput]
+}
+
+// DefineSessionFlow creates an SessionFlow with automatic snapshot management and registers it.
+func DefineSessionFlow[Stream, State any](
+	r api.Registry,
+	name string,
+	fn SessionFlowFunc[Stream, State],
+	opts ...SessionFlowOption[State],
+) *SessionFlow[Stream, State] {
+	cfg := &sessionFlowOptions[State]{}
+	for _, opt := range opts {
+		if err := opt.applySessionFlow(cfg); err != nil {
+			panic(fmt.Errorf("DefineSessionFlow %q: %w", name, err))
+		}
+	}
+	if cfg.heartbeatInterval <= 0 {
+		cfg.heartbeatInterval = DefaultHeartbeatInterval
+	}
+
+	flow := core.DefineBidiFlow(r, name, func(
+		ctx context.Context,
+		in *SessionFlowInit[State],
+		inCh <-chan *SessionFlowInput,
+		outCh chan<- *SessionFlowStreamChunk[Stream],
+	) (*SessionFlowOutput[State], error) {
+		rt, err := newSessionFlowRuntime(ctx, name, cfg, in, inCh, outCh)
+		if err != nil {
+			return nil, err
+		}
+		return rt.run(ctx, fn)
+	})
+
+	registerSnapshotActions(r, name, cfg.store, cfg.transform)
+
+	return &SessionFlow[Stream, State]{flow: flow}
+}
+
+// --- sessionFlowRuntime ---
+
+// sessionFlowRuntime owns the per-invocation wiring of a session flow:
+// session, runner, output router, input intake, and the goroutine that runs
+// the user fn. Its methods implement the three terminal paths the flow can
+// take: detach, fn-completion, and client-cancel. Centralizing this state
+// lets each method take just the context-specific arguments instead of the
+// dozen-plus parameters that were previously threaded through.
+type sessionFlowRuntime[Stream, State any] struct {
+	name string
+	cfg  *sessionFlowOptions[State]
+
+	session        *Session[State]
+	parentSnapshot *SessionSnapshot[State]
+	runner         *SessionRunner[State]
+	router         *chunkRouter[Stream, State]
+	intake         *detachIntake
+
+	fnDone chan fnDoneResult[State]
+}
+
+// fnDoneResult carries the user fn's return values across the goroutine
+// boundary that runs it. A named type keeps the channel signatures readable.
+type fnDoneResult[State any] struct {
+	result *SessionFlowResult
+	err    error
+}
+
+func newSessionFlowRuntime[Stream, State any](
+	ctx context.Context,
+	name string,
+	cfg *sessionFlowOptions[State],
+	in *SessionFlowInit[State],
+	inCh <-chan *SessionFlowInput,
+	outCh chan<- *SessionFlowStreamChunk[Stream],
+) (*sessionFlowRuntime[Stream, State], error) {
+	session, parent, err := loadSession(ctx, in, cfg.store)
+	if err != nil {
+		return nil, err
+	}
+
+	rt := &sessionFlowRuntime[Stream, State]{
+		name:           name,
+		cfg:            cfg,
+		session:        session,
+		parentSnapshot: parent,
+		router:         startChunkRouter(session, outCh),
+		intake:         startDetachIntake(inCh),
+		fnDone:         make(chan fnDoneResult[State], 1),
+	}
+
+	rt.runner = &SessionRunner[State]{
+		Session:          session,
+		InputCh:          rt.intake.out(),
+		snapshotCallback: cfg.callback,
+		lastSnapshot:     parent,
+		intake:           rt.intake,
+	}
+	rt.runner.collectTurnOutput = func() any { return rt.router.collectTurnChunks() }
+	rt.runner.onEndTurn = rt.emitTurnEnd
+
+	return rt, nil
+}
+
+// emitTurnEnd is called by the runner after each successful turn. It writes
+// a turn-end snapshot (if applicable) and forwards the resulting [TurnEnd]
+// chunk through the router so clients see it on the output stream.
+func (rt *sessionFlowRuntime[Stream, State]) emitTurnEnd(ctx context.Context) {
+	turnIndex := rt.runner.TurnIndex
+	snapshotID := rt.runner.maybeSnapshot(ctx, SnapshotEventTurnEnd)
+	rt.router.send() <- &SessionFlowStreamChunk[Stream]{TurnEnd: &TurnEnd{
+		SnapshotID: snapshotID,
+		TurnIndex:  turnIndex,
+	}}
+}
+
+// run drives the user fn to completion and returns the flow output.
+//
+// workCtx carries the session and is decoupled from clientCtx: pre-detach a
+// watcher mirrors clientCtx so a disconnect cancels the work; on detach the
+// watcher exits and the finalizer goroutine owns workCtx until fn returns.
+func (rt *sessionFlowRuntime[Stream, State]) run(
+	clientCtx context.Context,
+	fn SessionFlowFunc[Stream, State],
+) (*SessionFlowOutput[State], error) {
+	workCtx, cancelWork := context.WithCancel(context.WithoutCancel(clientCtx))
+	workCtx = NewSessionContext(workCtx, rt.session)
+
+	var detachOnce sync.Once
+	detached := make(chan struct{})
+	markDetached := func() { detachOnce.Do(func() { close(detached) }) }
+	defer markDetached() // ensure the watcher exits on every return path
+
+	go func() {
+		select {
+		case <-clientCtx.Done():
+			cancelWork()
+		case <-detached:
+		}
+	}()
+
+	go func() {
+		result, err := fn(workCtx, rt.router.responder(), rt.runner)
+		rt.fnDone <- fnDoneResult[State]{result: result, err: err}
+	}()
+
+	select {
+	case <-rt.intake.detachSignal():
+		if rt.cfg.store == nil {
+			rt.drainAndWait(cancelWork)
+			return nil, core.NewError(core.FAILED_PRECONDITION,
+				"session flow %q: detach requires a session store", rt.name)
+		}
+		return rt.handleDetach(clientCtx, workCtx, cancelWork, markDetached)
+
+	case res := <-rt.fnDone:
+		return rt.handleFnDone(clientCtx, cancelWork, res)
+
+	case <-clientCtx.Done():
+		res := rt.drainAndWait(cancelWork)
+		if res.err != nil {
+			return nil, res.err
+		}
+		return nil, clientCtx.Err()
+	}
+}
+
+// drainAndWait performs a synchronous shutdown: cancel work, wait for the
+// intake reader/forwarder to finish, drain fnDone, and close the router.
+// Returns the fn's result for callers that need to surface its error.
+func (rt *sessionFlowRuntime[Stream, State]) drainAndWait(cancelWork context.CancelFunc) fnDoneResult[State] {
+	cancelWork()
+	rt.intake.stopAndWait()
+	res := <-rt.fnDone
+	rt.router.close()
+	return res
+}
+
+// handleFnDone is the synchronous-completion path: fn returned before any
+// detach signal. Capture an invocation-end snapshot if state advanced past
+// the last turn-end snapshot, then assemble the output.
+func (rt *sessionFlowRuntime[Stream, State]) handleFnDone(
+	ctx context.Context,
+	cancelWork context.CancelFunc,
+	res fnDoneResult[State],
+) (*SessionFlowOutput[State], error) {
+	cancelWork()
+	rt.intake.stopAndWait()
+	rt.router.close()
+
+	if res.err != nil {
+		return nil, res.err
+	}
+
+	snapshotID := rt.runner.maybeSnapshot(ctx, SnapshotEventInvocationEnd)
+	if snapshotID == "" && rt.runner.lastSnapshot != nil {
+		// State unchanged since the last turn-end snapshot — reuse it so
+		// the response always carries an ID when a store is configured.
+		snapshotID = rt.runner.lastSnapshot.SnapshotID
+	}
+
+	out := &SessionFlowOutput[State]{SnapshotID: snapshotID}
+	if res.result != nil {
+		out.Message = res.result.Message
+		out.Artifacts = res.result.Artifacts
+	}
+	if rt.cfg.store == nil {
+		out.State = applyTransform(rt.cfg.transform, rt.session.State())
+	}
+	return out, nil
+}
+
+// handleDetach commits the pending snapshot, returns its ID, and spawns the
+// heartbeat poller and finalizer goroutines that own the rest of the
+// invocation. Per-turn snapshots are suspended for the remainder.
+//
+// PendingInputs is FIFO: in-flight input (atomically captured with the
+// suspend flag, so it's never both turn-end-snapshotted and listed here),
+// followed by the intake's queue, followed by anything the reader drains
+// from src after detach. StartingTurnIndex is the index of the FIRST entry.
+func (rt *sessionFlowRuntime[Stream, State]) handleDetach(
+	clientCtx, workCtx context.Context,
+	cancelWork context.CancelFunc,
+	markDetached func(),
+) (*SessionFlowOutput[State], error) {
+	// Stop mirroring clientCtx. From here, only the heartbeat or fn
+	// completion can cancel workCtx.
+	markDetached()
+
+	combined, startTurnIndex := rt.intake.suspendAndCapture()
+
+	parentID := ""
+	if rt.runner.lastSnapshot != nil {
+		parentID = rt.runner.lastSnapshot.SnapshotID
+	} else if rt.parentSnapshot != nil {
+		parentID = rt.parentSnapshot.SnapshotID
+	}
+
+	now := time.Now()
+	pending := &SessionSnapshot[State]{
+		SnapshotID:        uuid.New().String(),
+		ParentID:          parentID,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		Event:             SnapshotEventDetach,
+		Status:            SnapshotStatusPending,
+		StartingTurnIndex: startTurnIndex,
+		PendingInputs:     combined,
+	}
+	if err := rt.cfg.store.SaveSnapshot(clientCtx, pending); err != nil {
+		rt.drainAndWait(cancelWork)
+		return nil, core.NewError(core.INTERNAL,
+			"session flow %q: failed to write pending snapshot: %v", rt.name, err)
+	}
+
+	// The router can no longer write to outCh once we return; the bidi
+	// framework closes it shortly after. The router keeps draining its
+	// input channel so fn never blocks on send.
+	rt.router.stopAndWait()
+
+	canceledByUser := &atomic.Bool{}
+	pollerCtx, stopPolling := context.WithCancel(workCtx)
+	go runHeartbeatPoller(pollerCtx, rt.cfg.heartbeatInterval, rt.cfg.store, pending.SnapshotID, func() {
+		canceledByUser.Store(true)
+		cancelWork()
+	})
+
+	finalizeCtx := context.WithoutCancel(clientCtx)
+	go func() {
+		res := <-rt.fnDone
+		stopPolling()
+		rt.intake.stopAndWait()
+		rt.router.close()
+		rt.finalizePendingSnapshot(finalizeCtx, pending, res.err, canceledByUser.Load())
+		cancelWork()
+	}()
+
+	return &SessionFlowOutput[State]{SnapshotID: pending.SnapshotID}, nil
+}
+
+// finalizePendingSnapshot rewrites the pending snapshot row with the
+// terminal state and status. canceledByUser distinguishes a context
+// cancellation from cancelSnapshot polling (status=canceled) from an
+// internal failure (status=error). Re-checks the store before writing so a
+// cancel that lands between fn-return and this write is honored rather
+// than clobbered with status=complete.
+func (rt *sessionFlowRuntime[Stream, State]) finalizePendingSnapshot(
+	ctx context.Context,
+	pending *SessionSnapshot[State],
+	fnErr error,
+	canceledByUser bool,
+) {
+	if !canceledByUser {
+		if meta, err := rt.cfg.store.GetSnapshotMetadata(ctx, pending.SnapshotID); err == nil && meta != nil && meta.Status == SnapshotStatusCanceled {
+			canceledByUser = true
+		}
+	}
+
+	status := SnapshotStatusComplete
+	errMsg := ""
+	switch {
+	case canceledByUser:
+		status = SnapshotStatusCanceled
+		if fnErr != nil {
+			errMsg = fnErr.Error() // canceled status takes precedence; preserve text
+		}
+	case fnErr != nil:
+		status = SnapshotStatusError
+		errMsg = fnErr.Error()
+	}
+
+	final := &SessionSnapshot[State]{
+		SnapshotID:        pending.SnapshotID,
+		ParentID:          pending.ParentID,
+		CreatedAt:         pending.CreatedAt,
+		UpdatedAt:         time.Now(),
+		Event:             SnapshotEventDetach,
+		Status:            status,
+		Error:             errMsg,
+		StartingTurnIndex: pending.StartingTurnIndex,
+		State:             *rt.session.State(),
+	}
+	if err := rt.cfg.store.SaveSnapshot(ctx, final); err != nil {
+		logger.FromContext(ctx).Error("session flow: failed to finalize pending snapshot",
+			"snapshotId", pending.SnapshotID, "err", err)
+	}
+}
+
+// runHeartbeatPoller polls the store's metadata projection at the given
+// interval and invokes onCancel exactly once if it observes
+// [SnapshotStatusCanceled]. It exits when ctx is done or when the snapshot
+// reaches any terminal status.
+func runHeartbeatPoller[State any](
+	ctx context.Context,
+	interval time.Duration,
+	store SessionStore[State],
+	snapshotID string,
+	onCancel func(),
+) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			meta, err := store.GetSnapshotMetadata(ctx, snapshotID)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				logger.FromContext(ctx).Warn("session flow heartbeat: GetSnapshotMetadata failed",
+					"snapshotId", snapshotID, "err", err)
+				continue
+			}
+			if meta == nil {
+				return // snapshot vanished; nothing more to observe
+			}
+			switch meta.Status {
+			case SnapshotStatusCanceled:
+				onCancel()
+				return
+			case SnapshotStatusComplete, SnapshotStatusError:
+				return // terminal but not by us; stop polling
+			}
+		}
+	}
+}
+
+// loadSession constructs a Session from the invocation's init payload,
+// loading from the store when a snapshot ID is provided. Returns the
+// snapshot too so the runtime can chain ParentID off it.
+func loadSession[State any](
+	ctx context.Context,
+	init *SessionFlowInit[State],
+	store SessionStore[State],
+) (*Session[State], *SessionSnapshot[State], error) {
+	s := &Session[State]{store: store}
+	if init == nil {
+		return s, nil, nil
+	}
+
+	if init.SnapshotID != "" && init.State != nil {
+		return nil, nil, core.NewError(core.INVALID_ARGUMENT, "snapshot ID and state are mutually exclusive")
+	}
+
+	if init.SnapshotID == "" {
+		if init.State != nil {
+			s.state = *init.State
+		}
+		return s, nil, nil
+	}
+
+	if store == nil {
+		return nil, nil, core.NewError(core.FAILED_PRECONDITION,
+			"snapshot ID %q provided but no session store configured", init.SnapshotID)
+	}
+	snap, err := store.GetSnapshot(ctx, init.SnapshotID)
+	if err != nil {
+		return nil, nil, core.NewError(core.INTERNAL, "failed to load snapshot %q: %v", init.SnapshotID, err)
+	}
+	if snap == nil {
+		return nil, nil, core.NewError(core.NOT_FOUND, "snapshot %q not found", init.SnapshotID)
+	}
+	switch snap.Status {
+	case SnapshotStatusError:
+		msg := snap.Error
+		if msg == "" {
+			msg = "snapshot recorded an error"
+		}
+		return nil, nil, core.NewError(core.FAILED_PRECONDITION,
+			"snapshot %q terminated with error: %s", init.SnapshotID, msg)
+	case SnapshotStatusPending:
+		return nil, nil, core.NewError(core.FAILED_PRECONDITION,
+			"snapshot %q is still pending; wait for it to finalize before resuming", init.SnapshotID)
+	case SnapshotStatusCanceled:
+		return nil, nil, core.NewError(core.FAILED_PRECONDITION,
+			"snapshot %q was canceled", init.SnapshotID)
+	}
+	s.state = snap.State
+	return s, snap, nil
+}
 
 // --- SessionRunner ---
 
@@ -59,6 +491,12 @@ type SessionRunner[State any] struct {
 	lastSnapshot        *SessionSnapshot[State]
 	lastSnapshotVersion uint64
 	collectTurnOutput   func() any
+
+	// intake is the source of truth for in-flight, queued, suspended, and
+	// the turn-index counter. The runner consults it via beginTurnEnd (in
+	// maybeSnapshot) so per-turn snapshot writes and detach captures
+	// cannot race over the same input.
+	intake *detachIntake
 }
 
 // Run loops over the input channel, calling fn for each turn. Each turn is
@@ -72,18 +510,14 @@ func (s *SessionRunner[State]) Run(ctx context.Context, fn func(ctx context.Cont
 			Type:    "flowStep",
 			Subtype: "flowStep",
 		}
-
 		_, err := tracing.RunInNewSpan(ctx, spanMeta, input,
 			func(ctx context.Context, input *SessionFlowInput) (any, error) {
 				s.AddMessages(input.Messages...)
-
 				if err := fn(ctx, input); err != nil {
 					return nil, err
 				}
-
 				s.onEndTurn(ctx)
 				s.TurnIndex++
-
 				if s.collectTurnOutput != nil {
 					return s.collectTurnOutput(), nil
 				}
@@ -118,8 +552,26 @@ func (s *SessionRunner[State]) Result() *SessionFlowResult {
 }
 
 // maybeSnapshot creates a snapshot if conditions are met (store configured,
-// callback approves, state changed). Returns the snapshot ID or empty string.
+// callback approves, state changed, detach has not suspended snapshots).
+// Returns the snapshot ID or empty string.
+//
+// For turn-end events, the runner consults the intake atomically: if
+// detach has suspended snapshots, intake.beginTurnEnd reports that and
+// the runner skips. Otherwise intake.beginTurnEnd clears the in-flight
+// input and reports its turn index, which becomes the snapshot's
+// StartingTurnIndex. This is what guarantees the in-flight input is
+// never both turn-end-snapshotted AND included in the pending snapshot's
+// PendingInputs.
 func (s *SessionRunner[State]) maybeSnapshot(ctx context.Context, event SnapshotEvent) string {
+	startingTurnIndex := s.TurnIndex
+	if event == SnapshotEventTurnEnd && s.intake != nil {
+		suspended, idx := s.intake.beginTurnEnd()
+		if suspended {
+			return ""
+		}
+		startingTurnIndex = idx
+	}
+
 	if s.store == nil {
 		return ""
 	}
@@ -152,11 +604,15 @@ func (s *SessionRunner[State]) maybeSnapshot(ctx context.Context, event Snapshot
 		}
 	}
 
+	now := time.Now()
 	snapshot := &SessionSnapshot[State]{
-		SnapshotID: uuid.New().String(),
-		CreatedAt:  time.Now(),
-		Event:      event,
-		State:      currentState,
+		SnapshotID:        uuid.New().String(),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		Event:             event,
+		Status:            SnapshotStatusComplete,
+		StartingTurnIndex: startingTurnIndex,
+		State:             currentState,
 	}
 	if s.lastSnapshot != nil {
 		snapshot.ParentID = s.lastSnapshot.SnapshotID
@@ -167,21 +623,27 @@ func (s *SessionRunner[State]) maybeSnapshot(ctx context.Context, event Snapshot
 		return ""
 	}
 
-	// Set snapshotId in last message metadata.
-	s.mu.Lock()
-	if msgs := s.state.Messages; len(msgs) > 0 {
-		lastMsg := msgs[len(msgs)-1]
-		if lastMsg.Metadata == nil {
-			lastMsg.Metadata = make(map[string]any)
-		}
-		lastMsg.Metadata["snapshotId"] = snapshot.SnapshotID
-	}
-	s.mu.Unlock()
-
+	s.tagLastMessage(snapshot.SnapshotID)
 	s.lastSnapshot = snapshot
 	s.lastSnapshotVersion = currentVersion
-
 	return snapshot.SnapshotID
+}
+
+// tagLastMessage records snapshotID in the metadata of the last message in
+// session history, so clients can correlate messages with the snapshot that
+// captured them.
+func (s *SessionRunner[State]) tagLastMessage(snapshotID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	msgs := s.state.Messages
+	if len(msgs) == 0 {
+		return
+	}
+	last := msgs[len(msgs)-1]
+	if last.Metadata == nil {
+		last.Metadata = make(map[string]any)
+	}
+	last.Metadata["snapshotId"] = snapshotID
 }
 
 // --- Responder ---
@@ -207,245 +669,398 @@ func (r Responder[Stream]) SendArtifact(artifact *Artifact) {
 	r <- &SessionFlowStreamChunk[Stream]{Artifact: artifact}
 }
 
-// --- SessionFlow ---
-
-// SessionFlowFunc is the function signature for session flows.
-// Type parameters:
-//   - Stream: Type for status updates sent via the responder
-//   - State: Type for user-defined state in snapshots
-type SessionFlowFunc[Stream, State any] = func(ctx context.Context, resp Responder[Stream], sess *SessionRunner[State]) (*SessionFlowResult, error)
-
-// SessionFlow is a bidirectional streaming flow with automatic snapshot management.
-type SessionFlow[Stream, State any] struct {
-	flow *core.Flow[*SessionFlowInit[State], *SessionFlowOutput[State], *SessionFlowStreamChunk[Stream], *SessionFlowInput]
-}
-
-// DefineSessionFlow creates an SessionFlow with automatic snapshot management and registers it.
-func DefineSessionFlow[Stream, State any](
-	r api.Registry,
-	name string,
-	fn SessionFlowFunc[Stream, State],
-	opts ...SessionFlowOption[State],
-) *SessionFlow[Stream, State] {
-	afOpts := &sessionFlowOptions[State]{}
-	for _, opt := range opts {
-		if err := opt.applySessionFlow(afOpts); err != nil {
-			panic(fmt.Errorf("DefineSessionFlow %q: %w", name, err))
-		}
-	}
-
-	store := afOpts.store
-	snapshotCallback := afOpts.callback
-
-	flow := core.DefineBidiFlow(r, name, func(
-		ctx context.Context,
-		in *SessionFlowInit[State],
-		inCh <-chan *SessionFlowInput,
-		outCh chan<- *SessionFlowStreamChunk[Stream],
-	) (*SessionFlowOutput[State], error) {
-		session, snapshot, err := newSessionFromInit(ctx, in, store)
-		if err != nil {
-			return nil, err
-		}
-		ctx = NewSessionContext(ctx, session)
-
-		agentSess := &SessionRunner[State]{
-			Session:          session,
-			snapshotCallback: snapshotCallback,
-			InputCh:          inCh,
-			lastSnapshot:     snapshot,
-		}
-
-		// Turn output accumulator: collects content chunks per turn for span output.
-		var (
-			turnMu     sync.Mutex
-			turnChunks []*SessionFlowStreamChunk[Stream]
-		)
-
-		agentSess.collectTurnOutput = func() any {
-			turnMu.Lock()
-			defer turnMu.Unlock()
-			result := turnChunks
-			turnChunks = nil
-			return result
-		}
-
-		// Intermediary channel: intercepts artifacts, accumulates turn output,
-		// and forwards to outCh.
-		respCh := make(chan *SessionFlowStreamChunk[Stream])
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for chunk := range respCh {
-				if chunk.Artifact != nil {
-					session.AddArtifacts(chunk.Artifact)
-				}
-				// Accumulate content chunks (exclude the TurnEnd control signal).
-				if chunk.TurnEnd == nil {
-					turnMu.Lock()
-					turnChunks = append(turnChunks, chunk)
-					turnMu.Unlock()
-				}
-				outCh <- chunk
-			}
-		}()
-
-		// Wire up onEndTurn: triggers snapshot + sends TurnEnd chunk.
-		// Writes through respCh to preserve ordering with user chunks.
-		agentSess.onEndTurn = func(turnCtx context.Context) {
-			snapshotID := agentSess.maybeSnapshot(turnCtx, SnapshotEventTurnEnd)
-			respCh <- &SessionFlowStreamChunk[Stream]{
-				TurnEnd: &TurnEnd{SnapshotID: snapshotID},
-			}
-		}
-
-		result, fnErr := fn(ctx, Responder[Stream](respCh), agentSess)
-		close(respCh)
-		wg.Wait()
-
-		if fnErr != nil {
-			return nil, fnErr
-		}
-
-		// Final snapshot at invocation end. If skipped (state unchanged
-		// since last turn-end snapshot), use the last snapshot's ID so
-		// the output always reflects the latest snapshot.
-		snapshotID := agentSess.maybeSnapshot(ctx, SnapshotEventInvocationEnd)
-		if snapshotID == "" && agentSess.lastSnapshot != nil {
-			snapshotID = agentSess.lastSnapshot.SnapshotID
-		}
-
-		out := &SessionFlowOutput[State]{
-			SnapshotID: snapshotID,
-		}
-		if result != nil {
-			out.Message = result.Message
-			out.Artifacts = result.Artifacts
-		}
-
-		// Only include full state when client-managed (no store).
-		if store == nil {
-			out.State = session.State()
-		}
-
-		return out, nil
-	})
-
-	return &SessionFlow[Stream, State]{flow: flow}
-}
-
-// promptMessageKey is the metadata key used to tag prompt-rendered messages
-// so they can be excluded from session history after generation.
-const promptMessageKey = "_genkit_prompt"
-
-// DefineSessionFlowFromPrompt creates a prompt-backed SessionFlow with an
-// automatic conversation loop. Each turn renders the prompt, appends
-// conversation history, calls GenerateWithRequest, streams chunks to the
-// client, and adds the model response to the session.
+// --- chunkRouter ---
 //
-// The prompt is looked up by name from the registry using
-// [ai.LookupDataPrompt]. The defaultInput is used for prompt rendering
-// unless overridden per invocation via WithInputVariables.
-func DefineSessionFlowFromPrompt[State, PromptIn any](
-	r api.Registry,
-	promptName string,
-	defaultInput PromptIn,
-	opts ...SessionFlowOption[State],
-) *SessionFlow[any, State] {
-	p := ai.LookupDataPrompt[PromptIn, string](r, promptName)
-	if p == nil {
-		panic(fmt.Sprintf("DefineSessionFlowFromPrompt: prompt %q not found", promptName))
-	}
+// chunkRouter owns the intermediate stream channel that all chunks flow
+// through on their way to outCh. It captures side effects (adding artifacts
+// to the session, accumulating turn chunks for span output) regardless of
+// whether the chunk is delivered to the client.
+//
+// The "stop-writing" mode exists for detached flows: on detach, the bidi
+// framework closes outCh shortly after bidiFn returns, so the router must
+// commit to not writing to outCh before we return. It keeps draining in (so
+// the fn goroutine never blocks on send) until in is closed.
 
-	fn := func(ctx context.Context, resp Responder[any], sess *SessionRunner[State]) (*SessionFlowResult, error) {
-		if err := sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
-			// Resolve prompt input: session state override > default.
-			promptInput := defaultInput
-			if stored := sess.InputVariables(); stored != nil {
-				typed, ok := base.ConvertTo[PromptIn](stored)
-				if !ok {
-					return core.NewError(core.INVALID_ARGUMENT, "input variables type mismatch: got %T, want %T", stored, promptInput)
-				}
-				promptInput = typed
-			}
+type chunkRouter[Stream, State any] struct {
+	in      chan *SessionFlowStreamChunk[Stream]
+	out     chan<- *SessionFlowStreamChunk[Stream]
+	session *Session[State]
 
-			// Render the prompt template.
-			genOpts, err := p.Render(ctx, promptInput)
-			if err != nil {
-				return fmt.Errorf("prompt render: %w", err)
-			}
+	turnMu     sync.Mutex
+	turnChunks []*SessionFlowStreamChunk[Stream]
 
-			// Tag prompt-rendered messages so we can exclude them from
-			// session history after generation.
-			for _, m := range genOpts.Messages {
-				if m.Metadata == nil {
-					m.Metadata = make(map[string]any)
-				}
-				m.Metadata[promptMessageKey] = true
-			}
-
-			// Append conversation history after the prompt-rendered messages.
-			genOpts.Messages = append(genOpts.Messages, sess.Messages()...)
-
-			// If tool restarts were provided, set the resume option so
-			// handleResumeOption re-executes the interrupted tools.
-			if len(input.ToolRestarts) > 0 {
-				for _, p := range input.ToolRestarts {
-					if !p.IsToolRequest() {
-						return core.NewError(core.INVALID_ARGUMENT, "ToolRestarts: part is not a tool request")
-					}
-				}
-				genOpts.Resume = ai.NewResume(input.ToolRestarts, nil)
-			}
-
-			// Call the model with streaming.
-			modelResp, err := ai.GenerateWithRequest(ctx, r, genOpts, nil,
-				func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
-					resp.SendModelChunk(chunk)
-					return nil
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("generate: %w", err)
-			}
-
-			// Replace session messages with the full history minus prompt
-			// messages. This captures intermediate tool call/response
-			// messages from the tool loop, not just the final response.
-			if modelResp.Request != nil {
-				var msgs []*ai.Message
-				for _, m := range modelResp.History() {
-					if m.Metadata != nil && m.Metadata[promptMessageKey] == true {
-						continue
-					}
-					msgs = append(msgs, m)
-				}
-				sess.SetMessages(msgs)
-			} else if modelResp.Message != nil {
-				sess.AddMessages(modelResp.Message)
-			}
-
-			// Stream interrupt parts so the client can detect and
-			// handle them (e.g. prompt the user for confirmation).
-			if modelResp.FinishReason == ai.FinishReasonInterrupted {
-				if parts := modelResp.Interrupts(); len(parts) > 0 {
-					resp.SendModelChunk(&ai.ModelResponseChunk{
-						Role:    ai.RoleTool,
-						Content: parts,
-					})
-				}
-			}
-
-			return nil
-		}); err != nil {
-			return nil, err
-		}
-		return sess.Result(), nil
-	}
-
-	return DefineSessionFlow(r, promptName, fn, opts...)
+	done          chan struct{}
+	stopWriting   chan struct{}
+	writerStopped chan struct{}
 }
+
+func startChunkRouter[Stream, State any](
+	session *Session[State],
+	out chan<- *SessionFlowStreamChunk[Stream],
+) *chunkRouter[Stream, State] {
+	r := &chunkRouter[Stream, State]{
+		in:            make(chan *SessionFlowStreamChunk[Stream]),
+		out:           out,
+		session:       session,
+		done:          make(chan struct{}),
+		stopWriting:   make(chan struct{}),
+		writerStopped: make(chan struct{}),
+	}
+	go r.run()
+	return r
+}
+
+func (r *chunkRouter[Stream, State]) run() {
+	defer close(r.done)
+	stopCh := r.stopWriting
+	disable := func() {
+		if stopCh != nil {
+			close(r.writerStopped)
+			stopCh = nil
+		}
+	}
+	for {
+		select {
+		case chunk, ok := <-r.in:
+			if !ok {
+				return
+			}
+			if chunk.Artifact != nil {
+				r.session.AddArtifacts(chunk.Artifact)
+			}
+			if chunk.TurnEnd == nil {
+				r.turnMu.Lock()
+				r.turnChunks = append(r.turnChunks, chunk)
+				r.turnMu.Unlock()
+			}
+			if stopCh == nil {
+				continue
+			}
+			select {
+			case r.out <- chunk:
+			case <-stopCh:
+				disable()
+			}
+		case <-stopCh:
+			disable()
+		}
+	}
+}
+
+// responder returns a [Responder] that sends chunks into the router.
+func (r *chunkRouter[Stream, State]) responder() Responder[Stream] {
+	return Responder[Stream](r.in)
+}
+
+// send returns the internal chunk channel for producers other than the user
+// flow function (e.g. the runtime's emitTurnEnd).
+func (r *chunkRouter[Stream, State]) send() chan<- *SessionFlowStreamChunk[Stream] {
+	return r.in
+}
+
+// collectTurnChunks returns and resets accumulated turn chunks.
+func (r *chunkRouter[Stream, State]) collectTurnChunks() []*SessionFlowStreamChunk[Stream] {
+	r.turnMu.Lock()
+	defer r.turnMu.Unlock()
+	result := r.turnChunks
+	r.turnChunks = nil
+	return result
+}
+
+// stopAndWait tells the router to stop writing to out and blocks until it
+// has committed. After it returns, it is safe for the framework to close
+// out without risking a write-to-closed-channel panic.
+func (r *chunkRouter[Stream, State]) stopAndWait() {
+	close(r.stopWriting)
+	<-r.writerStopped
+}
+
+// close signals end-of-input and waits for the router to drain.
+func (r *chunkRouter[Stream, State]) close() {
+	close(r.in)
+	<-r.done
+}
+
+// --- detachIntake ---
+//
+// detachIntake separates eager src reading from runner-paced forwarding,
+// and is the single source of truth for in-flight tracking, queue state,
+// suspend state, and turn-index counting.
+//
+// The reader goroutine pulls from the bidi framework's inCh as soon as
+// inputs arrive and appends them to an internal queue. This is what makes
+// detach detection immediate: the moment an input with
+// [SessionFlowInput.Detach] lands in src, the reader sees it without
+// waiting for the runner to finish whatever it's processing.
+//
+// The forwarder goroutine pops the queue and writes to dst, blocking on
+// the runner. Crucially, it sets in-flight (under the same mutex it pops
+// under) BEFORE the dst send, so an input is never "in transit" without
+// being tracked — closing the gap that would otherwise let detach miss it.
+//
+// The runner asks beginTurnEnd at the end of each turn: if not suspended,
+// in-flight is cleared and the turn's index is returned to be used as the
+// snapshot's StartingTurnIndex. If suspended, the runner skips its
+// snapshot and the input rolls into the pending snapshot instead.
+//
+// suspendAndCapture is the detach handler's atomic read: flips suspended,
+// reads in-flight, reads queue, and reports the turn index of the first
+// pending input — all under one lock so there's no race with maybeSnapshot
+// or the forwarder.
+
+type detachIntake struct {
+	src    <-chan *SessionFlowInput
+	dst    chan *SessionFlowInput
+	notify chan struct{} // buffered size 1; wakes forwarder when queue grows
+
+	// turnDone is signaled by beginTurnEnd to release the forwarder so it
+	// may pop the next input. Initialized with one token so the very
+	// first turn can start without a preceding turn end.
+	turnDone chan struct{}
+
+	mu                sync.Mutex
+	suspended         bool
+	inFlight          *SessionFlowInput
+	inFlightTurnIndex int
+	queue             []*SessionFlowInput
+	nextTurnIndex     int
+
+	readDone atomic.Bool
+	detachCh chan struct{} // signaled by reader when detach observed
+
+	stop     chan struct{}
+	stopOnce sync.Once
+	done     chan struct{}
+}
+
+func startDetachIntake(src <-chan *SessionFlowInput) *detachIntake {
+	i := &detachIntake{
+		src:      src,
+		dst:      make(chan *SessionFlowInput),
+		notify:   make(chan struct{}, 1),
+		turnDone: make(chan struct{}, 1),
+		detachCh: make(chan struct{}, 1),
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	i.turnDone <- struct{}{} // initial credit for the first turn
+	go i.run()
+	return i
+}
+
+func (i *detachIntake) run() {
+	defer close(i.done)
+
+	forwarderDone := make(chan struct{})
+	go func() {
+		defer close(forwarderDone)
+		defer close(i.dst)
+		i.forward()
+	}()
+
+	i.read()
+	<-forwarderDone
+}
+
+// signal wakes the forwarder. Non-blocking: the channel is buffered size
+// 1, so a pending signal is enough.
+func (i *detachIntake) signal() {
+	select {
+	case i.notify <- struct{}{}:
+	default:
+	}
+}
+
+// read pulls eagerly from src into the internal queue and detects detach
+// the moment it lands. When detach is observed, it drains any remaining
+// buffered src non-blockingly (so all pre-detach inputs are accounted
+// for), signals the detach handler, and exits.
+func (i *detachIntake) read() {
+	defer func() {
+		i.readDone.Store(true)
+		i.signal()
+	}()
+
+	for {
+		select {
+		case input, ok := <-i.src:
+			if !ok {
+				return
+			}
+			if input.Detach {
+				i.handleDetach(input)
+				return
+			}
+			i.enqueue(input)
+		case <-i.stop:
+			return
+		}
+	}
+}
+
+func (i *detachIntake) enqueue(input *SessionFlowInput) {
+	i.mu.Lock()
+	i.queue = append(i.queue, input)
+	i.mu.Unlock()
+	i.signal()
+}
+
+// handleDetach drains any buffered src inputs into the queue and signals
+// the detach handler. The detach handler then calls suspendAndCapture for
+// the atomic read of the full state.
+func (i *detachIntake) handleDetach(first *SessionFlowInput) {
+	drained := []*SessionFlowInput{first}
+drainLoop:
+	for {
+		select {
+		case more, ok := <-i.src:
+			if !ok {
+				break drainLoop
+			}
+			drained = append(drained, more)
+		default:
+			break drainLoop
+		}
+	}
+
+	i.mu.Lock()
+	i.queue = append(i.queue, drained...)
+	i.mu.Unlock()
+	i.signal()
+
+	select {
+	case i.detachCh <- struct{}{}:
+	case <-i.stop:
+	}
+}
+
+// forward pops the queue and writes to dst at the runner's pace. The
+// runner signals turnDone via beginTurnEnd when it's ready for the next
+// input; until then the forwarder waits, so inFlight always reflects the
+// input actually being processed (or in transit to the runner) rather
+// than running ahead. The forwarder atomically pops the queue and sets
+// inFlight under mu, closing the gap between "removed from queue" and
+// "in flight".
+func (i *detachIntake) forward() {
+	for {
+		// Wait for the previous turn to release us (initial credit lets
+		// the first turn through immediately).
+		select {
+		case <-i.turnDone:
+		case <-i.stop:
+			return
+		}
+
+		// Wait for at least one queued input.
+		for {
+			i.mu.Lock()
+			if len(i.queue) > 0 {
+				input := i.queue[0]
+				i.queue = i.queue[1:]
+				i.inFlight = input
+				i.inFlightTurnIndex = i.nextTurnIndex
+				i.mu.Unlock()
+
+				forwarded := *input
+				forwarded.Detach = false
+				select {
+				case i.dst <- &forwarded:
+				case <-i.stop:
+					return
+				}
+				break
+			}
+			done := i.readDone.Load()
+			i.mu.Unlock()
+			if done {
+				return
+			}
+			select {
+			case <-i.notify:
+			case <-i.stop:
+				return
+			}
+		}
+	}
+}
+
+// releaseForward releases the forwarder so it can pop the next input.
+// Must be called from beginTurnEnd (and only there) so the forwarder
+// stays in step with the runner's turn pacing.
+func (i *detachIntake) releaseForward() {
+	select {
+	case i.turnDone <- struct{}{}:
+	default:
+	}
+}
+
+func (i *detachIntake) out() <-chan *SessionFlowInput {
+	return i.dst
+}
+
+func (i *detachIntake) detachSignal() <-chan struct{} {
+	return i.detachCh
+}
+
+// beginTurnEnd is called by [SessionRunner.maybeSnapshot] before writing
+// a turn-end snapshot. If the intake has been suspended (detach landed),
+// it returns suspended=true and the runner skips the snapshot. Otherwise
+// it clears in-flight, advances the turn-index counter, and returns the
+// just-ended turn's index for the snapshot's StartingTurnIndex.
+//
+// In all cases (including suspended) the forwarder is released so it can
+// pop the next queued input — suspension stops snapshot writing, not
+// processing.
+func (i *detachIntake) beginTurnEnd() (suspended bool, turnIndex int) {
+	i.mu.Lock()
+	if i.suspended {
+		i.mu.Unlock()
+		i.releaseForward()
+		return true, 0
+	}
+	turnIndex = i.inFlightTurnIndex
+	i.inFlight = nil
+	i.nextTurnIndex++
+	i.mu.Unlock()
+	i.releaseForward()
+	return false, turnIndex
+}
+
+// suspendAndCapture is called once by the detach handler. It flips
+// suspended=true, reads the in-flight input (if any) and the queue
+// snapshot, and returns the StartingTurnIndex for the pending snapshot:
+// the in-flight input's index if any, otherwise the index that the next
+// queued input will occupy. Inputs are returned in FIFO order with
+// Detach cleared.
+func (i *detachIntake) suspendAndCapture() (combined []*SessionFlowInput, startTurnIndex int) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.suspended = true
+
+	if i.inFlight != nil {
+		startTurnIndex = i.inFlightTurnIndex
+		c := *i.inFlight
+		c.Detach = false
+		combined = append(combined, &c)
+	} else {
+		startTurnIndex = i.nextTurnIndex
+	}
+	for _, q := range i.queue {
+		c := *q
+		c.Detach = false
+		combined = append(combined, &c)
+	}
+	return
+}
+
+// stopAndWait forces the intake to exit and waits for both reader and
+// forwarder goroutines.
+func (i *detachIntake) stopAndWait() {
+	i.stopOnce.Do(func() { close(i.stop) })
+	<-i.done
+}
+
+// --- SessionFlow client API ---
 
 // StreamBidi starts a new session flow invocation with bidirectional streaming.
 // Use this for multi-turn interactions where you need to send multiple inputs
@@ -454,16 +1069,14 @@ func (af *SessionFlow[Stream, State]) StreamBidi(
 	ctx context.Context,
 	opts ...InvocationOption[State],
 ) (*SessionFlowConnection[Stream, State], error) {
-	invOpts, err := af.resolveOptions(opts)
+	init, err := af.resolveOptions(opts)
 	if err != nil {
 		return nil, err
 	}
-
-	conn, err := af.flow.StreamBidi(ctx, invOpts)
+	conn, err := af.flow.StreamBidi(ctx, init)
 	if err != nil {
 		return nil, err
 	}
-
 	return &SessionFlowConnection[Stream, State]{conn: conn}, nil
 }
 
@@ -479,21 +1092,17 @@ func (af *SessionFlow[Stream, State]) Run(
 	if err != nil {
 		return nil, err
 	}
-
 	if err := conn.Send(input); err != nil {
 		return nil, err
 	}
 	if err := conn.Close(); err != nil {
 		return nil, err
 	}
-
-	// Drain stream chunks.
 	for _, err := range conn.Receive() {
 		if err != nil {
 			return nil, err
 		}
 	}
-
 	return conn.Output()
 }
 
@@ -512,60 +1121,23 @@ func (af *SessionFlow[Stream, State]) RunText(
 
 // resolveOptions applies invocation options and returns the init struct.
 func (af *SessionFlow[Stream, State]) resolveOptions(opts []InvocationOption[State]) (*SessionFlowInit[State], error) {
-	invOpts := &invocationOptions[State]{}
+	cfg := &invocationOptions[State]{}
 	for _, opt := range opts {
-		if err := opt.applyInvocation(invOpts); err != nil {
+		if err := opt.applyInvocation(cfg); err != nil {
 			return nil, fmt.Errorf("SessionFlow %q: %w", af.flow.Name(), err)
 		}
 	}
-
 	init := &SessionFlowInit[State]{
-		SnapshotID: invOpts.snapshotID,
-		State:      invOpts.state,
+		SnapshotID: cfg.snapshotID,
+		State:      cfg.state,
 	}
-	if invOpts.promptInput != nil {
+	if cfg.promptInput != nil {
 		if init.State == nil {
 			init.State = &SessionState[State]{}
 		}
-		init.State.InputVariables = invOpts.promptInput
+		init.State.InputVariables = cfg.promptInput
 	}
-
 	return init, nil
-}
-
-// newSessionFromInit creates a Session from initialization data.
-// If resuming from a snapshot, the loaded snapshot is also returned.
-func newSessionFromInit[State any](
-	ctx context.Context,
-	init *SessionFlowInit[State],
-	store SessionStore[State],
-) (*Session[State], *SessionSnapshot[State], error) {
-	s := &Session[State]{store: store}
-
-	var snapshot *SessionSnapshot[State]
-	if init != nil {
-		if init.SnapshotID != "" && init.State != nil {
-			return nil, nil, core.NewError(core.INVALID_ARGUMENT, "snapshot ID and state are mutually exclusive")
-		}
-		if init.SnapshotID != "" && store == nil {
-			return nil, nil, core.NewError(core.FAILED_PRECONDITION, "snapshot ID %q provided but no session store configured", init.SnapshotID)
-		}
-		if init.SnapshotID != "" && store != nil {
-			var err error
-			snapshot, err = store.GetSnapshot(ctx, init.SnapshotID)
-			if err != nil {
-				return nil, nil, core.NewError(core.INTERNAL, "failed to load snapshot %q: %v", init.SnapshotID, err)
-			}
-			if snapshot == nil {
-				return nil, nil, core.NewError(core.NOT_FOUND, "snapshot %q not found", init.SnapshotID)
-			}
-			s.state = snapshot.State
-		} else if init.State != nil {
-			s.state = *init.State
-		}
-	}
-
-	return s, snapshot, nil
 }
 
 // --- SessionFlowConnection ---
@@ -625,6 +1197,22 @@ func (c *SessionFlowConnection[Stream, State]) SendToolRestarts(parts ...*ai.Par
 	return c.conn.Send(&SessionFlowInput{ToolRestarts: parts})
 }
 
+// Detach asks the server to write a pending snapshot capturing this input
+// (and any others already buffered), close the connection, and continue
+// processing in the background. Output() returns the pending snapshot ID;
+// the client can later call cancelSnapshot to stop the background work or
+// poll getSnapshot/getSnapshotMetadata to observe its progression.
+//
+// The caller's input is not mutated.
+func (c *SessionFlowConnection[Stream, State]) Detach(input *SessionFlowInput) error {
+	var detach SessionFlowInput
+	if input != nil {
+		detach = *input
+	}
+	detach.Detach = true
+	return c.conn.Send(&detach)
+}
+
 // Close signals that no more inputs will be sent.
 func (c *SessionFlowConnection[Stream, State]) Close() error {
 	return c.conn.Close()
@@ -637,27 +1225,159 @@ func (c *SessionFlowConnection[Stream, State]) Close() error {
 func (c *SessionFlowConnection[Stream, State]) Receive() iter.Seq2[*SessionFlowStreamChunk[Stream], error] {
 	c.initReceiver()
 	return func(yield func(*SessionFlowStreamChunk[Stream], error) bool) {
-		for {
-			chunk, ok := <-c.chunks
-			if !ok {
-				if err := c.chunkErr; err != nil {
-					yield(nil, err)
-				}
-				return
-			}
+		for chunk := range c.chunks {
 			if !yield(chunk, nil) {
 				return
 			}
+		}
+		if err := c.chunkErr; err != nil {
+			yield(nil, err)
 		}
 	}
 }
 
 // Output returns the final response after the session flow completes.
+//
+// Unlike the underlying BidiConnection, Output waits for the flow to
+// finalize before returning. This is important for detached invocations:
+// when the client sends Detach, the flow function returns promptly with a
+// pending snapshot ID, and callers need to observe that output rather than
+// the context cancellation error.
 func (c *SessionFlowConnection[Stream, State]) Output() (*SessionFlowOutput[State], error) {
+	<-c.conn.Done()
 	return c.conn.Output()
 }
 
 // Done returns a channel closed when the connection completes.
 func (c *SessionFlowConnection[Stream, State]) Done() <-chan struct{} {
 	return c.conn.Done()
+}
+
+// --- DefineSessionFlowFromPrompt ---
+
+// promptMessageKey tags prompt-rendered messages so they can be excluded
+// from session history after generation. They're rendered fresh each turn
+// from the registered prompt, so persisting them in history would cause
+// duplication on resume.
+const promptMessageKey = "_genkit_prompt"
+
+// DefineSessionFlowFromPrompt creates a prompt-backed SessionFlow with an
+// automatic conversation loop. Each turn renders the prompt, appends
+// conversation history, calls GenerateWithRequest, streams chunks to the
+// client, and adds the model response to the session.
+//
+// The prompt is looked up by name from the registry using
+// [ai.LookupDataPrompt]. The defaultInput is used for prompt rendering
+// unless overridden per invocation via WithInputVariables.
+func DefineSessionFlowFromPrompt[State, PromptIn any](
+	r api.Registry,
+	promptName string,
+	defaultInput PromptIn,
+	opts ...SessionFlowOption[State],
+) *SessionFlow[any, State] {
+	p := ai.LookupDataPrompt[PromptIn, string](r, promptName)
+	if p == nil {
+		panic(fmt.Sprintf("DefineSessionFlowFromPrompt: prompt %q not found", promptName))
+	}
+
+	turn := func(ctx context.Context, resp Responder[any], sess *SessionRunner[State], input *SessionFlowInput) error {
+		genOpts, err := renderPromptForTurn(ctx, p, sess, defaultInput)
+		if err != nil {
+			return err
+		}
+
+		if len(input.ToolRestarts) > 0 {
+			for _, part := range input.ToolRestarts {
+				if !part.IsToolRequest() {
+					return core.NewError(core.INVALID_ARGUMENT, "ToolRestarts: part is not a tool request")
+				}
+			}
+			genOpts.Resume = ai.NewResume(input.ToolRestarts, nil)
+		}
+
+		modelResp, err := ai.GenerateWithRequest(ctx, r, genOpts, nil,
+			func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
+				resp.SendModelChunk(chunk)
+				return nil
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("generate: %w", err)
+		}
+
+		// Replace session messages with the full history minus prompt
+		// messages. This captures intermediate tool call/response messages
+		// from the tool loop, not just the final response.
+		if modelResp.Request != nil {
+			var msgs []*ai.Message
+			for _, m := range modelResp.History() {
+				if m.Metadata[promptMessageKey] == true {
+					continue
+				}
+				msgs = append(msgs, m)
+			}
+			sess.SetMessages(msgs)
+		} else if modelResp.Message != nil {
+			sess.AddMessages(modelResp.Message)
+		}
+
+		// Stream interrupt parts so the client can detect and handle them
+		// (e.g. prompt the user for confirmation).
+		if modelResp.FinishReason == ai.FinishReasonInterrupted {
+			if parts := modelResp.Interrupts(); len(parts) > 0 {
+				resp.SendModelChunk(&ai.ModelResponseChunk{
+					Role:    ai.RoleTool,
+					Content: parts,
+				})
+			}
+		}
+		return nil
+	}
+
+	fn := func(ctx context.Context, resp Responder[any], sess *SessionRunner[State]) (*SessionFlowResult, error) {
+		err := sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+			return turn(ctx, resp, sess, input)
+		})
+		if err != nil {
+			return nil, err
+		}
+		return sess.Result(), nil
+	}
+
+	return DefineSessionFlow(r, promptName, fn, opts...)
+}
+
+// renderPromptForTurn renders the prompt with the active input variables
+// (session override > default), tags the prompt-rendered messages so they
+// can be excluded from history, and appends conversation history.
+func renderPromptForTurn[State, PromptIn any](
+	ctx context.Context,
+	p *ai.DataPrompt[PromptIn, string],
+	sess *SessionRunner[State],
+	defaultInput PromptIn,
+) (*ai.GenerateActionOptions, error) {
+	promptInput := defaultInput
+	if stored := sess.InputVariables(); stored != nil {
+		typed, ok := base.ConvertTo[PromptIn](stored)
+		if !ok {
+			return nil, core.NewError(core.INVALID_ARGUMENT,
+				"input variables type mismatch: got %T, want %T", stored, promptInput)
+		}
+		promptInput = typed
+	}
+
+	genOpts, err := p.Render(ctx, promptInput)
+	if err != nil {
+		return nil, fmt.Errorf("prompt render: %w", err)
+	}
+
+	for _, m := range genOpts.Messages {
+		if m.Metadata == nil {
+			m.Metadata = make(map[string]any)
+		}
+		m.Metadata[promptMessageKey] = true
+	}
+
+	genOpts.Messages = append(genOpts.Messages, sess.Messages()...)
+	return genOpts, nil
 }

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -1143,38 +1143,6 @@ func (af *SessionFlow[Stream, State]) RunText(
 	}, opts...)
 }
 
-// RunBackground starts a single-turn session flow invocation that runs in
-// the background: the input is sent with Detach=true so the server writes
-// a pending snapshot and continues processing after the connection closes.
-// The returned output carries the pending snapshot ID; use GetSnapshot to
-// observe its progression and CancelSnapshot to stop it.
-//
-// Requires a session store to be configured via WithSessionStore.
-func (af *SessionFlow[Stream, State]) RunBackground(
-	ctx context.Context,
-	input *SessionFlowInput,
-	opts ...InvocationOption[State],
-) (*SessionFlowOutput[State], error) {
-	conn, err := af.StreamBidi(ctx, opts...)
-	if err != nil {
-		return nil, err
-	}
-	bg := SessionFlowInput{Detach: true}
-	if input != nil {
-		bg = *input
-		bg.Detach = true
-	}
-	if err := conn.Send(&bg); err != nil {
-		return nil, err
-	}
-	for _, err := range conn.Receive() {
-		if err != nil {
-			return nil, err
-		}
-	}
-	return conn.Output()
-}
-
 // GetSnapshot returns the metadata and (when settled) the state for a
 // snapshot. State is omitted for snapshots in pending or error status;
 // PendingInputs is populated for pending snapshots. If

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -93,37 +93,10 @@ func DefineSessionFlow[Stream, State any](
 	return &SessionFlow[Stream, State]{action: action}
 }
 
-// AgentMetadataStateManagement enumerates who owns session state for an
-// agent: "server" (a [SessionStore] is configured and snapshots are
-// persisted server-side) or "client" (no store; state flows through
-// invocation init / output).
-type AgentMetadataStateManagement string
-
-const (
-	// AgentMetadataStateManagementServer indicates the agent is wired
-	// with a [SessionStore] and persists snapshots server-side.
-	AgentMetadataStateManagementServer AgentMetadataStateManagement = "server"
-	// AgentMetadataStateManagementClient indicates the agent has no
-	// store; session state is client-managed and round-trips through
-	// invocation init and output.
-	AgentMetadataStateManagementClient AgentMetadataStateManagement = "client"
-)
-
-// AgentMetadata is the value placed under metadata["agent"] on a session
-// flow's action descriptor. It exposes capability information so the Dev
-// UI and other reflective callers can render the right surface (e.g.,
-// hide the Abort button when the configured store doesn't support it)
-// without round-tripping through the reflection API.
-type AgentMetadata struct {
-	// StateManagement reports who owns session state.
-	StateManagement AgentMetadataStateManagement `json:"stateManagement"`
-	// Abortable reports whether the agent's invocations can be aborted
-	// (true when the store implements [SnapshotAborter]).
-	Abortable bool `json:"abortable"`
-}
-
 // agentMetadataFor derives the [AgentMetadata] value attached to the
-// session flow's action descriptor under the "agent" key.
+// session flow's action descriptor under the "agent" key. [AgentMetadata]
+// itself is generated from agent.ts; this constructor is hand-written
+// because it inspects the configured store's optional capabilities.
 func agentMetadataFor[State any](store SessionStore[State]) AgentMetadata {
 	mgmt := AgentMetadataStateManagementClient
 	abortable := false

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -118,8 +118,7 @@ type AgentMetadata struct {
 	// StateManagement reports who owns session state.
 	StateManagement AgentMetadataStateManagement `json:"stateManagement"`
 	// Abortable reports whether the agent's invocations can be aborted
-	// (true when the store implements both [SnapshotAborter] and
-	// [SnapshotStatusSubscriber]).
+	// (true when the store implements [SnapshotAborter]).
 	Abortable bool `json:"abortable"`
 }
 
@@ -130,9 +129,7 @@ func agentMetadataFor[State any](store SessionStore[State]) AgentMetadata {
 	abortable := false
 	if store != nil {
 		mgmt = AgentMetadataStateManagementServer
-		_, hasAborter := store.(SnapshotAborter)
-		_, hasSubscriber := store.(SnapshotStatusSubscriber)
-		abortable = hasAborter && hasSubscriber
+		_, abortable = store.(SnapshotAborter)
 	}
 	return AgentMetadata{
 		StateManagement: mgmt,
@@ -262,8 +259,9 @@ func (rt *sessionFlowRuntime[Stream, State]) run(
 
 // checkDetachCapabilities reports whether the configured store is capable
 // of supporting detach. Detach requires a writable store (to persist the
-// pending snapshot), an aborter (to cancel mid-flight), and a status
-// subscriber (so the runtime can react to the abort without polling).
+// pending snapshot) and a [SnapshotAborter] (which bundles both abort
+// triggering and status-change subscription so the runtime can react to
+// the abort without polling).
 func (rt *sessionFlowRuntime[Stream, State]) checkDetachCapabilities() error {
 	if rt.cfg.store == nil {
 		return core.NewError(core.FAILED_PRECONDITION,
@@ -272,10 +270,6 @@ func (rt *sessionFlowRuntime[Stream, State]) checkDetachCapabilities() error {
 	if _, ok := rt.cfg.store.(SnapshotAborter); !ok {
 		return core.NewError(core.FAILED_PRECONDITION,
 			"session flow %q: detach requires a session store implementing SnapshotAborter", rt.name)
-	}
-	if _, ok := rt.cfg.store.(SnapshotStatusSubscriber); !ok {
-		return core.NewError(core.FAILED_PRECONDITION,
-			"session flow %q: detach requires a session store implementing SnapshotStatusSubscriber", rt.name)
 	}
 	return nil
 }
@@ -376,8 +370,8 @@ func (rt *sessionFlowRuntime[Stream, State]) handleDetach(
 
 	canceledByUser := &atomic.Bool{}
 	subCtx, stopSub := context.WithCancel(workCtx)
-	subscriber := rt.cfg.store.(SnapshotStatusSubscriber)
-	statusCh := subscriber.OnSnapshotStatusChange(subCtx, pending.SnapshotID)
+	aborter := rt.cfg.store.(SnapshotAborter) // safe: checkDetachCapabilities ran already
+	statusCh := aborter.OnSnapshotStatusChange(subCtx, pending.SnapshotID)
 	go func() {
 		for status := range statusCh {
 			if status == SnapshotStatusCanceled {

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -1085,14 +1085,28 @@ func (af *SessionFlow[Stream, State]) Run(
 	if err != nil {
 		return nil, err
 	}
+	// If the bidi function fails fast (e.g. resuming from an errored
+	// snapshot rejects in newSessionFlowRuntime), Send / Close / Receive
+	// see a closed connection and return generic "action has completed"
+	// errors. The real fn error is on Output(). Prefer it whenever it's
+	// non-nil so callers get the meaningful failure.
 	if err := conn.Send(input); err != nil {
+		if _, outErr := conn.Output(); outErr != nil {
+			return nil, outErr
+		}
 		return nil, err
 	}
 	if err := conn.Close(); err != nil {
+		if _, outErr := conn.Output(); outErr != nil {
+			return nil, outErr
+		}
 		return nil, err
 	}
 	for _, err := range conn.Receive() {
 		if err != nil {
+			if _, outErr := conn.Output(); outErr != nil {
+				return nil, outErr
+			}
 			return nil, err
 		}
 	}

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -26,7 +26,6 @@ import (
 	"iter"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
@@ -34,7 +33,6 @@ import (
 	"github.com/firebase/genkit/go/core/logger"
 	"github.com/firebase/genkit/go/core/tracing"
 	"github.com/firebase/genkit/go/internal/base"
-	"github.com/google/uuid"
 )
 
 // --- SessionFlow ---
@@ -287,7 +285,7 @@ func (rt *sessionFlowRuntime[Stream, State]) handleFnDone(
 		out.Artifacts = res.result.Artifacts
 	}
 	if rt.cfg.store == nil {
-		out.State = applyTransform(rt.cfg.transform, rt.session.State())
+		out.State = applyTransform(ctx, rt.cfg.transform, rt.session.State())
 	}
 	return out, nil
 }
@@ -310,27 +308,23 @@ func (rt *sessionFlowRuntime[Stream, State]) handleDetach(
 
 	rt.intake.suspend()
 
-	parentID := ""
-	if rt.runner.lastSnapshot != nil {
-		parentID = rt.runner.lastSnapshot.SnapshotID
-	}
+	parentID := rt.runner.parentSnapshotID()
 
-	now := time.Now()
-	pending := &SessionSnapshot[State]{
-		SnapshotID: uuid.New().String(),
-		ParentID:   parentID,
-		CreatedAt:  now,
-		UpdatedAt:  now,
-		Event:      SnapshotEventDetach,
-		Status:     SnapshotStatusPending,
-	}
 	// Detach intends to outlive the client connection. If clientCtx was
 	// already cancelled (or cancels mid-write), we still want the pending
 	// row durable so observers can find it later. Decouple this write.
-	if err := rt.cfg.store.SaveSnapshot(context.WithoutCancel(clientCtx), pending); err != nil {
+	pending, err := rt.cfg.store.SaveSnapshot(context.WithoutCancel(clientCtx), "",
+		func(_ *SessionSnapshot[State]) (*SessionSnapshot[State], error) {
+			return &SessionSnapshot[State]{
+				ParentID: parentID,
+				Event:    SnapshotEventDetach,
+				Status:   SnapshotStatusPending,
+			}, nil
+		})
+	if err != nil {
 		rt.drainAndWait(cancelWork)
 		return nil, core.NewError(core.INTERNAL,
-			"session flow %q: detach: save pending snapshot %q: %v", rt.name, pending.SnapshotID, err)
+			"session flow %q: detach: save pending snapshot: %v", rt.name, err)
 	}
 
 	// The router can no longer write to outCh once we return; the bidi
@@ -368,45 +362,47 @@ func (rt *sessionFlowRuntime[Stream, State]) handleDetach(
 // finalizePendingSnapshot rewrites the pending snapshot row with the
 // terminal state and status. canceledByUser distinguishes a context
 // cancellation from abortSnapshot (status=canceled) from an internal
-// failure (status=error). Re-checks the store's current status before
-// writing so an abort that lands between fn-return and this write is
-// honored rather than clobbered with status=complete.
+// failure (status=error). The write is funneled through SaveSnapshot
+// so the read-and-rewrite is one atomic step: if the row has already
+// transitioned to canceled (a late abort racing this finalize),
+// SaveSnapshot sees it inside fn and we leave the row untouched.
 func (rt *sessionFlowRuntime[Stream, State]) finalizePendingSnapshot(
 	ctx context.Context,
 	pending *SessionSnapshot[State],
 	fnErr error,
 	canceledByUser bool,
 ) {
-	if !canceledByUser {
-		if snap, err := rt.cfg.store.GetSnapshot(ctx, pending.SnapshotID); err == nil && snap != nil && snap.Status == SnapshotStatusCanceled {
-			canceledByUser = true
-		}
-	}
+	finalState := *rt.session.State()
 
-	status := SnapshotStatusComplete
-	errMsg := ""
-	switch {
-	case canceledByUser:
-		status = SnapshotStatusCanceled
-		if fnErr != nil {
-			errMsg = fnErr.Error() // canceled status takes precedence; preserve text
-		}
-	case fnErr != nil:
-		status = SnapshotStatusError
-		errMsg = fnErr.Error()
-	}
+	_, err := rt.cfg.store.SaveSnapshot(ctx, pending.SnapshotID,
+		func(existing *SessionSnapshot[State]) (*SessionSnapshot[State], error) {
+			// Late abort wins over the terminal we were about to land.
+			if existing != nil && existing.Status == SnapshotStatusCanceled {
+				return nil, nil
+			}
 
-	final := &SessionSnapshot[State]{
-		SnapshotID: pending.SnapshotID,
-		ParentID:   pending.ParentID,
-		CreatedAt:  pending.CreatedAt,
-		UpdatedAt:  time.Now(),
-		Event:      SnapshotEventDetach,
-		Status:     status,
-		Error:      errMsg,
-		State:      *rt.session.State(),
-	}
-	if err := rt.cfg.store.SaveSnapshot(ctx, final); err != nil {
+			status := SnapshotStatusComplete
+			errMsg := ""
+			switch {
+			case canceledByUser:
+				status = SnapshotStatusCanceled
+				if fnErr != nil {
+					errMsg = fnErr.Error() // canceled wins, preserve text
+				}
+			case fnErr != nil:
+				status = SnapshotStatusError
+				errMsg = fnErr.Error()
+			}
+
+			return &SessionSnapshot[State]{
+				ParentID: pending.ParentID,
+				Event:    SnapshotEventDetach,
+				Status:   status,
+				Error:    errMsg,
+				State:    finalState,
+			}, nil
+		})
+	if err != nil {
 		logger.FromContext(ctx).Error("session flow: failed to finalize pending snapshot",
 			"snapshotId", pending.SnapshotID, "err", err)
 	}
@@ -495,6 +491,16 @@ type SessionRunner[State any] struct {
 	// maybeSnapshot) so per-turn snapshot writes and detach captures
 	// cannot race over the same input.
 	intake *detachIntake
+}
+
+// parentSnapshotID returns the ID of the most recent snapshot in this
+// invocation (used to chain new snapshots via ParentID), or "" if no
+// snapshot has been written yet.
+func (s *SessionRunner[State]) parentSnapshotID() string {
+	if s.lastSnapshot == nil {
+		return ""
+	}
+	return s.lastSnapshot.SnapshotID
 }
 
 // Run loops over the input channel, calling fn for each turn. Each turn is
@@ -597,27 +603,25 @@ func (s *SessionRunner[State]) maybeSnapshot(ctx context.Context, event Snapshot
 		}
 	}
 
-	now := time.Now()
-	snapshot := &SessionSnapshot[State]{
-		SnapshotID: uuid.New().String(),
-		CreatedAt:  now,
-		UpdatedAt:  now,
-		Event:      event,
-		Status:     SnapshotStatusComplete,
-		State:      currentState,
-	}
-	if s.lastSnapshot != nil {
-		snapshot.ParentID = s.lastSnapshot.SnapshotID
-	}
+	parentID := s.parentSnapshotID()
 
-	if err := s.store.SaveSnapshot(ctx, snapshot); err != nil {
+	saved, err := s.store.SaveSnapshot(ctx, "",
+		func(_ *SessionSnapshot[State]) (*SessionSnapshot[State], error) {
+			return &SessionSnapshot[State]{
+				ParentID: parentID,
+				Event:    event,
+				Status:   SnapshotStatusComplete,
+				State:    currentState,
+			}, nil
+		})
+	if err != nil {
 		logger.FromContext(ctx).Error("session flow: failed to save snapshot", "err", err)
 		return ""
 	}
 
-	s.lastSnapshot = snapshot
+	s.lastSnapshot = saved
 	s.lastSnapshotVersion = currentVersion
-	return snapshot.SnapshotID
+	return saved.SnapshotID
 }
 
 // --- Responder ---

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -63,9 +63,6 @@ func DefineSessionFlow[Stream, State any](
 			panic(fmt.Errorf("DefineSessionFlow %q: %w", name, err))
 		}
 	}
-	if cfg.heartbeatInterval <= 0 {
-		cfg.heartbeatInterval = DefaultHeartbeatInterval
-	}
 
 	flow := core.DefineBidiFlow(r, name, func(
 		ctx context.Context,
@@ -90,18 +87,15 @@ func DefineSessionFlow[Stream, State any](
 // sessionFlowRuntime owns the per-invocation wiring of a session flow:
 // session, runner, output router, input intake, and the goroutine that runs
 // the user fn. Its methods implement the three terminal paths the flow can
-// take: detach, fn-completion, and client-cancel. Centralizing this state
-// lets each method take just the context-specific arguments instead of the
-// dozen-plus parameters that were previously threaded through.
+// take: detach, fn-completion, and client-cancel.
 type sessionFlowRuntime[Stream, State any] struct {
 	name string
 	cfg  *sessionFlowOptions[State]
 
-	session        *Session[State]
-	parentSnapshot *SessionSnapshot[State]
-	runner         *SessionRunner[State]
-	router         *chunkRouter[Stream, State]
-	intake         *detachIntake
+	session *Session[State]
+	runner  *SessionRunner[State]
+	router  *chunkRouter[Stream, State]
+	intake  *detachIntake
 
 	fnDone chan fnDoneResult[State]
 }
@@ -127,13 +121,12 @@ func newSessionFlowRuntime[Stream, State any](
 	}
 
 	rt := &sessionFlowRuntime[Stream, State]{
-		name:           name,
-		cfg:            cfg,
-		session:        session,
-		parentSnapshot: parent,
-		router:         startChunkRouter(session, outCh),
-		intake:         startDetachIntake(inCh),
-		fnDone:         make(chan fnDoneResult[State], 1),
+		name:    name,
+		cfg:     cfg,
+		session: session,
+		router:  startChunkRouter(session, outCh),
+		intake:  startDetachIntake(inCh),
+		fnDone:  make(chan fnDoneResult[State], 1),
 	}
 
 	rt.runner = &SessionRunner[State]{
@@ -153,11 +146,9 @@ func newSessionFlowRuntime[Stream, State any](
 // a turn-end snapshot (if applicable) and forwards the resulting [TurnEnd]
 // chunk through the router so clients see it on the output stream.
 func (rt *sessionFlowRuntime[Stream, State]) emitTurnEnd(ctx context.Context) {
-	turnIndex := rt.runner.TurnIndex
 	snapshotID := rt.runner.maybeSnapshot(ctx, SnapshotEventTurnEnd)
 	rt.router.send() <- &SessionFlowStreamChunk[Stream]{TurnEnd: &TurnEnd{
 		SnapshotID: snapshotID,
-		TurnIndex:  turnIndex,
 	}}
 }
 
@@ -193,10 +184,9 @@ func (rt *sessionFlowRuntime[Stream, State]) run(
 
 	select {
 	case <-rt.intake.detachSignal():
-		if rt.cfg.store == nil {
+		if err := rt.checkDetachCapabilities(); err != nil {
 			rt.drainAndWait(cancelWork)
-			return nil, core.NewError(core.FAILED_PRECONDITION,
-				"session flow %q: detach requires a session store", rt.name)
+			return nil, err
 		}
 		return rt.handleDetach(clientCtx, workCtx, cancelWork, markDetached)
 
@@ -210,6 +200,26 @@ func (rt *sessionFlowRuntime[Stream, State]) run(
 		}
 		return nil, clientCtx.Err()
 	}
+}
+
+// checkDetachCapabilities reports whether the configured store is capable
+// of supporting detach. Detach requires a writable store (to persist the
+// pending snapshot), an aborter (to cancel mid-flight), and a status
+// subscriber (so the runtime can react to the abort without polling).
+func (rt *sessionFlowRuntime[Stream, State]) checkDetachCapabilities() error {
+	if rt.cfg.store == nil {
+		return core.NewError(core.FAILED_PRECONDITION,
+			"session flow %q: detach requires a session store", rt.name)
+	}
+	if _, ok := rt.cfg.store.(SnapshotAborter); !ok {
+		return core.NewError(core.FAILED_PRECONDITION,
+			"session flow %q: detach requires a session store implementing SnapshotAborter", rt.name)
+	}
+	if _, ok := rt.cfg.store.(SnapshotStatusSubscriber); !ok {
+		return core.NewError(core.FAILED_PRECONDITION,
+			"session flow %q: detach requires a session store implementing SnapshotStatusSubscriber", rt.name)
+	}
+	return nil
 }
 
 // drainAndWait performs a synchronous shutdown: cancel work, wait for the
@@ -258,41 +268,39 @@ func (rt *sessionFlowRuntime[Stream, State]) handleFnDone(
 }
 
 // handleDetach commits the pending snapshot, returns its ID, and spawns the
-// heartbeat poller and finalizer goroutines that own the rest of the
-// invocation. Per-turn snapshots are suspended for the remainder.
+// status-subscriber and finalizer goroutines that own the rest of the
+// invocation. Per-turn snapshots are suspended for the remainder, and the
+// chunk router enters trash mode (no further outCh writes, no side effects).
 //
 // PendingInputs is FIFO: in-flight input (atomically captured with the
 // suspend flag, so it's never both turn-end-snapshotted and listed here),
 // followed by the intake's queue, followed by anything the reader drains
-// from src after detach. StartingTurnIndex is the index of the FIRST entry.
+// from src after detach.
 func (rt *sessionFlowRuntime[Stream, State]) handleDetach(
 	clientCtx, workCtx context.Context,
 	cancelWork context.CancelFunc,
 	markDetached func(),
 ) (*SessionFlowOutput[State], error) {
-	// Stop mirroring clientCtx. From here, only the heartbeat or fn
-	// completion can cancel workCtx.
+	// Stop mirroring clientCtx. From here, only the abort subscription or
+	// fn completion can cancel workCtx.
 	markDetached()
 
-	combined, startTurnIndex := rt.intake.suspendAndCapture()
+	combined := rt.intake.suspendAndCapture()
 
 	parentID := ""
 	if rt.runner.lastSnapshot != nil {
 		parentID = rt.runner.lastSnapshot.SnapshotID
-	} else if rt.parentSnapshot != nil {
-		parentID = rt.parentSnapshot.SnapshotID
 	}
 
 	now := time.Now()
 	pending := &SessionSnapshot[State]{
-		SnapshotID:        uuid.New().String(),
-		ParentID:          parentID,
-		CreatedAt:         now,
-		UpdatedAt:         now,
-		Event:             SnapshotEventDetach,
-		Status:            SnapshotStatusPending,
-		StartingTurnIndex: startTurnIndex,
-		PendingInputs:     combined,
+		SnapshotID:    uuid.New().String(),
+		ParentID:      parentID,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+		Event:         SnapshotEventDetach,
+		Status:        SnapshotStatusPending,
+		PendingInputs: combined,
 	}
 	if err := rt.cfg.store.SaveSnapshot(clientCtx, pending); err != nil {
 		rt.drainAndWait(cancelWork)
@@ -301,21 +309,28 @@ func (rt *sessionFlowRuntime[Stream, State]) handleDetach(
 	}
 
 	// The router can no longer write to outCh once we return; the bidi
-	// framework closes it shortly after. The router keeps draining its
-	// input channel so fn never blocks on send.
+	// framework closes it shortly after. The router stops writing and
+	// trashes any further chunks.
 	rt.router.stopAndWait()
 
 	canceledByUser := &atomic.Bool{}
-	pollerCtx, stopPolling := context.WithCancel(workCtx)
-	go runHeartbeatPoller(pollerCtx, rt.cfg.heartbeatInterval, rt.cfg.store, pending.SnapshotID, func() {
-		canceledByUser.Store(true)
-		cancelWork()
-	})
+	subCtx, stopSub := context.WithCancel(workCtx)
+	subscriber := rt.cfg.store.(SnapshotStatusSubscriber)
+	statusCh := subscriber.OnSnapshotStatusChange(subCtx, pending.SnapshotID)
+	go func() {
+		for status := range statusCh {
+			if status == SnapshotStatusCanceled {
+				canceledByUser.Store(true)
+				cancelWork()
+				return
+			}
+		}
+	}()
 
 	finalizeCtx := context.WithoutCancel(clientCtx)
 	go func() {
 		res := <-rt.fnDone
-		stopPolling()
+		stopSub()
 		rt.intake.stopAndWait()
 		rt.router.close()
 		rt.finalizePendingSnapshot(finalizeCtx, pending, res.err, canceledByUser.Load())
@@ -327,10 +342,10 @@ func (rt *sessionFlowRuntime[Stream, State]) handleDetach(
 
 // finalizePendingSnapshot rewrites the pending snapshot row with the
 // terminal state and status. canceledByUser distinguishes a context
-// cancellation from cancelSnapshot polling (status=canceled) from an
-// internal failure (status=error). Re-checks the store before writing so a
-// cancel that lands between fn-return and this write is honored rather
-// than clobbered with status=complete.
+// cancellation from abortSnapshot (status=canceled) from an internal
+// failure (status=error). Re-checks the store's current status before
+// writing so an abort that lands between fn-return and this write is
+// honored rather than clobbered with status=complete.
 func (rt *sessionFlowRuntime[Stream, State]) finalizePendingSnapshot(
 	ctx context.Context,
 	pending *SessionSnapshot[State],
@@ -338,7 +353,7 @@ func (rt *sessionFlowRuntime[Stream, State]) finalizePendingSnapshot(
 	canceledByUser bool,
 ) {
 	if !canceledByUser {
-		if meta, err := rt.cfg.store.GetSnapshotMetadata(ctx, pending.SnapshotID); err == nil && meta != nil && meta.Status == SnapshotStatusCanceled {
+		if snap, err := rt.cfg.store.GetSnapshot(ctx, pending.SnapshotID); err == nil && snap != nil && snap.Status == SnapshotStatusCanceled {
 			canceledByUser = true
 		}
 	}
@@ -357,60 +372,18 @@ func (rt *sessionFlowRuntime[Stream, State]) finalizePendingSnapshot(
 	}
 
 	final := &SessionSnapshot[State]{
-		SnapshotID:        pending.SnapshotID,
-		ParentID:          pending.ParentID,
-		CreatedAt:         pending.CreatedAt,
-		UpdatedAt:         time.Now(),
-		Event:             SnapshotEventDetach,
-		Status:            status,
-		Error:             errMsg,
-		StartingTurnIndex: pending.StartingTurnIndex,
-		State:             *rt.session.State(),
+		SnapshotID: pending.SnapshotID,
+		ParentID:   pending.ParentID,
+		CreatedAt:  pending.CreatedAt,
+		UpdatedAt:  time.Now(),
+		Event:      SnapshotEventDetach,
+		Status:     status,
+		Error:      errMsg,
+		State:      *rt.session.State(),
 	}
 	if err := rt.cfg.store.SaveSnapshot(ctx, final); err != nil {
 		logger.FromContext(ctx).Error("session flow: failed to finalize pending snapshot",
 			"snapshotId", pending.SnapshotID, "err", err)
-	}
-}
-
-// runHeartbeatPoller polls the store's metadata projection at the given
-// interval and invokes onCancel exactly once if it observes
-// [SnapshotStatusCanceled]. It exits when ctx is done or when the snapshot
-// reaches any terminal status.
-func runHeartbeatPoller[State any](
-	ctx context.Context,
-	interval time.Duration,
-	store SessionStore[State],
-	snapshotID string,
-	onCancel func(),
-) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			meta, err := store.GetSnapshotMetadata(ctx, snapshotID)
-			if err != nil {
-				if ctx.Err() != nil {
-					return
-				}
-				logger.FromContext(ctx).Warn("session flow heartbeat: GetSnapshotMetadata failed",
-					"snapshotId", snapshotID, "err", err)
-				continue
-			}
-			if meta == nil {
-				return // snapshot vanished; nothing more to observe
-			}
-			switch meta.Status {
-			case SnapshotStatusCanceled:
-				onCancel()
-				return
-			case SnapshotStatusComplete, SnapshotStatusError:
-				return // terminal but not by us; stop polling
-			}
-		}
 	}
 }
 
@@ -492,8 +465,8 @@ type SessionRunner[State any] struct {
 	lastSnapshotVersion uint64
 	collectTurnOutput   func() any
 
-	// intake is the source of truth for in-flight, queued, suspended, and
-	// the turn-index counter. The runner consults it via beginTurnEnd (in
+	// intake is the source of truth for in-flight tracking, queue state,
+	// and suspended state. The runner consults it via beginTurnEnd (in
 	// maybeSnapshot) so per-turn snapshot writes and detach captures
 	// cannot race over the same input.
 	intake *detachIntake
@@ -558,18 +531,14 @@ func (s *SessionRunner[State]) Result() *SessionFlowResult {
 // For turn-end events, the runner consults the intake atomically: if
 // detach has suspended snapshots, intake.beginTurnEnd reports that and
 // the runner skips. Otherwise intake.beginTurnEnd clears the in-flight
-// input and reports its turn index, which becomes the snapshot's
-// StartingTurnIndex. This is what guarantees the in-flight input is
-// never both turn-end-snapshotted AND included in the pending snapshot's
+// input. This is what guarantees the in-flight input is never both
+// turn-end-snapshotted AND included in the pending snapshot's
 // PendingInputs.
 func (s *SessionRunner[State]) maybeSnapshot(ctx context.Context, event SnapshotEvent) string {
-	startingTurnIndex := s.TurnIndex
 	if event == SnapshotEventTurnEnd && s.intake != nil {
-		suspended, idx := s.intake.beginTurnEnd()
-		if suspended {
+		if suspended := s.intake.beginTurnEnd(); suspended {
 			return ""
 		}
-		startingTurnIndex = idx
 	}
 
 	if s.store == nil {
@@ -606,13 +575,12 @@ func (s *SessionRunner[State]) maybeSnapshot(ctx context.Context, event Snapshot
 
 	now := time.Now()
 	snapshot := &SessionSnapshot[State]{
-		SnapshotID:        uuid.New().String(),
-		CreatedAt:         now,
-		UpdatedAt:         now,
-		Event:             event,
-		Status:            SnapshotStatusComplete,
-		StartingTurnIndex: startingTurnIndex,
-		State:             currentState,
+		SnapshotID: uuid.New().String(),
+		CreatedAt:  now,
+		UpdatedAt:  now,
+		Event:      event,
+		Status:     SnapshotStatusComplete,
+		State:      currentState,
 	}
 	if s.lastSnapshot != nil {
 		snapshot.ParentID = s.lastSnapshot.SnapshotID
@@ -664,7 +632,10 @@ func (r Responder[Stream]) SendStatus(status Stream) {
 }
 
 // SendArtifact sends an artifact to the stream and adds it to the session.
-// If an artifact with the same name already exists in the session, it is replaced.
+// If an artifact with the same name already exists in the session, it is
+// replaced. The session-level side effect happens whether or not detach
+// has landed; only the wire forward to the client is suppressed
+// post-detach, when there is no longer a client to receive it.
 func (r Responder[Stream]) SendArtifact(artifact *Artifact) {
 	r <- &SessionFlowStreamChunk[Stream]{Artifact: artifact}
 }
@@ -672,14 +643,14 @@ func (r Responder[Stream]) SendArtifact(artifact *Artifact) {
 // --- chunkRouter ---
 //
 // chunkRouter owns the intermediate stream channel that all chunks flow
-// through on their way to outCh. It captures side effects (adding artifacts
-// to the session, accumulating turn chunks for span output) regardless of
-// whether the chunk is delivered to the client.
-//
-// The "stop-writing" mode exists for detached flows: on detach, the bidi
-// framework closes outCh shortly after bidiFn returns, so the router must
-// commit to not writing to outCh before we return. It keeps draining in (so
-// the fn goroutine never blocks on send) until in is closed.
+// through on their way to outCh. Every chunk gets the same in-process
+// side effects (adding artifacts to the session, accumulating turn
+// chunks for span output) regardless of whether detach has landed; the
+// wire forward to outCh is the only thing detach suppresses, since the
+// bidi framework closes outCh shortly after bidiFn returns. The router
+// commits to not writing before we return so that close is safe, and
+// keeps draining its input so the user fn never blocks on a responder
+// send.
 
 type chunkRouter[Stream, State any] struct {
 	in      chan *SessionFlowStreamChunk[Stream]
@@ -712,37 +683,50 @@ func startChunkRouter[Stream, State any](
 
 func (r *chunkRouter[Stream, State]) run() {
 	defer close(r.done)
-	stopCh := r.stopWriting
-	disable := func() {
-		if stopCh != nil {
-			close(r.writerStopped)
-			stopCh = nil
-		}
+	if !r.forward() {
+		// r.in closed before detach; nothing left to do.
+		return
 	}
+	close(r.writerStopped)
+	// Detached: keep applying side effects so the user fn's
+	// SendArtifact/SendModelChunk calls behave the same way they did
+	// pre-detach. Only the wire forward to outCh is suppressed.
+	for chunk := range r.in {
+		r.applySideEffects(chunk)
+	}
+}
+
+// applySideEffects records the chunk's effect on session state and turn
+// span output. Invoked from both forward (pre-detach) and the post-detach
+// drain so a Send call is observably the same in either mode.
+func (r *chunkRouter[Stream, State]) applySideEffects(chunk *SessionFlowStreamChunk[Stream]) {
+	if chunk.Artifact != nil {
+		r.session.AddArtifacts(chunk.Artifact)
+	}
+	if chunk.TurnEnd == nil {
+		r.turnMu.Lock()
+		r.turnChunks = append(r.turnChunks, chunk)
+		r.turnMu.Unlock()
+	}
+}
+
+// forward delivers chunks to outCh and applies side effects until detach
+// or r.in closes. Returns true if it stopped because of detach.
+func (r *chunkRouter[Stream, State]) forward() bool {
 	for {
 		select {
 		case chunk, ok := <-r.in:
 			if !ok {
-				return
+				return false
 			}
-			if chunk.Artifact != nil {
-				r.session.AddArtifacts(chunk.Artifact)
-			}
-			if chunk.TurnEnd == nil {
-				r.turnMu.Lock()
-				r.turnChunks = append(r.turnChunks, chunk)
-				r.turnMu.Unlock()
-			}
-			if stopCh == nil {
-				continue
-			}
+			r.applySideEffects(chunk)
 			select {
 			case r.out <- chunk:
-			case <-stopCh:
-				disable()
+			case <-r.stopWriting:
+				return true
 			}
-		case <-stopCh:
-			disable()
+		case <-r.stopWriting:
+			return true
 		}
 	}
 }
@@ -785,7 +769,7 @@ func (r *chunkRouter[Stream, State]) close() {
 //
 // detachIntake separates eager src reading from runner-paced forwarding,
 // and is the single source of truth for in-flight tracking, queue state,
-// suspend state, and turn-index counting.
+// and suspend state.
 //
 // The reader goroutine pulls from the bidi framework's inCh as soon as
 // inputs arrive and appends them to an internal queue. This is what makes
@@ -799,14 +783,12 @@ func (r *chunkRouter[Stream, State]) close() {
 // being tracked — closing the gap that would otherwise let detach miss it.
 //
 // The runner asks beginTurnEnd at the end of each turn: if not suspended,
-// in-flight is cleared and the turn's index is returned to be used as the
-// snapshot's StartingTurnIndex. If suspended, the runner skips its
-// snapshot and the input rolls into the pending snapshot instead.
+// in-flight is cleared. If suspended, the runner skips its snapshot and
+// the input rolls into the pending snapshot instead.
 //
 // suspendAndCapture is the detach handler's atomic read: flips suspended,
-// reads in-flight, reads queue, and reports the turn index of the first
-// pending input — all under one lock so there's no race with maybeSnapshot
-// or the forwarder.
+// reads in-flight, reads queue, all under one lock so there's no race
+// with maybeSnapshot or the forwarder.
 
 type detachIntake struct {
 	src    <-chan *SessionFlowInput
@@ -818,12 +800,10 @@ type detachIntake struct {
 	// first turn can start without a preceding turn end.
 	turnDone chan struct{}
 
-	mu                sync.Mutex
-	suspended         bool
-	inFlight          *SessionFlowInput
-	inFlightTurnIndex int
-	queue             []*SessionFlowInput
-	nextTurnIndex     int
+	mu        sync.Mutex
+	suspended bool
+	inFlight  *SessionFlowInput
+	queue     []*SessionFlowInput
 
 	readDone atomic.Bool
 	detachCh chan struct{} // signaled by reader when detach observed
@@ -956,9 +936,7 @@ func hasInputPayload(in *SessionFlowInput) bool {
 // runner signals turnDone via beginTurnEnd when it's ready for the next
 // input; until then the forwarder waits, so inFlight always reflects the
 // input actually being processed (or in transit to the runner) rather
-// than running ahead. The forwarder atomically pops the queue and sets
-// inFlight under mu, closing the gap between "removed from queue" and
-// "in flight".
+// than running ahead.
 func (i *detachIntake) forward() {
 	for {
 		// Wait for the previous turn to release us (initial credit lets
@@ -968,36 +946,42 @@ func (i *detachIntake) forward() {
 		case <-i.stop:
 			return
 		}
+		input := i.awaitInput()
+		if input == nil {
+			return // reader done with empty queue, or stop signaled
+		}
+		forwarded := *input
+		forwarded.Detach = false
+		select {
+		case i.dst <- &forwarded:
+		case <-i.stop:
+			return
+		}
+	}
+}
 
-		// Wait for at least one queued input.
-		for {
-			i.mu.Lock()
-			if len(i.queue) > 0 {
-				input := i.queue[0]
-				i.queue = i.queue[1:]
-				i.inFlight = input
-				i.inFlightTurnIndex = i.nextTurnIndex
-				i.mu.Unlock()
-
-				forwarded := *input
-				forwarded.Detach = false
-				select {
-				case i.dst <- &forwarded:
-				case <-i.stop:
-					return
-				}
-				break
-			}
-			done := i.readDone.Load()
+// awaitInput blocks until the queue has an input, the reader is done, or
+// stop is signaled. Returns the popped input (with inFlight set under mu)
+// or nil if no further inputs will arrive.
+func (i *detachIntake) awaitInput() *SessionFlowInput {
+	for {
+		i.mu.Lock()
+		if len(i.queue) > 0 {
+			input := i.queue[0]
+			i.queue = i.queue[1:]
+			i.inFlight = input
 			i.mu.Unlock()
-			if done {
-				return
-			}
-			select {
-			case <-i.notify:
-			case <-i.stop:
-				return
-			}
+			return input
+		}
+		done := i.readDone.Load()
+		i.mu.Unlock()
+		if done {
+			return nil
+		}
+		select {
+		case <-i.notify:
+		case <-i.stop:
+			return nil
 		}
 	}
 }
@@ -1023,45 +1007,36 @@ func (i *detachIntake) detachSignal() <-chan struct{} {
 // beginTurnEnd is called by [SessionRunner.maybeSnapshot] before writing
 // a turn-end snapshot. If the intake has been suspended (detach landed),
 // it returns suspended=true and the runner skips the snapshot. Otherwise
-// it clears in-flight, advances the turn-index counter, and returns the
-// just-ended turn's index for the snapshot's StartingTurnIndex.
+// it clears in-flight.
 //
 // In all cases (including suspended) the forwarder is released so it can
 // pop the next queued input — suspension stops snapshot writing, not
 // processing.
-func (i *detachIntake) beginTurnEnd() (suspended bool, turnIndex int) {
+func (i *detachIntake) beginTurnEnd() (suspended bool) {
 	i.mu.Lock()
 	if i.suspended {
 		i.mu.Unlock()
 		i.releaseForward()
-		return true, 0
+		return true
 	}
-	turnIndex = i.inFlightTurnIndex
 	i.inFlight = nil
-	i.nextTurnIndex++
 	i.mu.Unlock()
 	i.releaseForward()
-	return false, turnIndex
+	return false
 }
 
 // suspendAndCapture is called once by the detach handler. It flips
-// suspended=true, reads the in-flight input (if any) and the queue
-// snapshot, and returns the StartingTurnIndex for the pending snapshot:
-// the in-flight input's index if any, otherwise the index that the next
-// queued input will occupy. Inputs are returned in FIFO order with
-// Detach cleared.
-func (i *detachIntake) suspendAndCapture() (combined []*SessionFlowInput, startTurnIndex int) {
+// suspended=true and reads the in-flight input (if any) and the queue
+// snapshot. Inputs are returned in FIFO order with Detach cleared.
+func (i *detachIntake) suspendAndCapture() (combined []*SessionFlowInput) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.suspended = true
 
 	if i.inFlight != nil {
-		startTurnIndex = i.inFlightTurnIndex
 		c := *i.inFlight
 		c.Detach = false
 		combined = append(combined, &c)
-	} else {
-		startTurnIndex = i.nextTurnIndex
 	}
 	for _, q := range i.queue {
 		c := *q
@@ -1218,8 +1193,11 @@ func (c *SessionFlowConnection[Stream, State]) SendToolRestarts(parts ...*ai.Par
 // Detach asks the server to write a pending snapshot capturing any inputs
 // already buffered, close the connection, and continue processing in the
 // background. Output() returns the pending snapshot ID; the client can
-// later call CancelSnapshot to stop the background work or GetSnapshot to
-// observe its progression.
+// later call AbortSnapshot to stop the background work or GetSnapshot to
+// observe its progression. Streamed chunks emitted after detach are not
+// forwarded over the wire (the connection is gone), but their session-
+// level side effects still apply: artifacts sent via [Responder.SendArtifact]
+// land in the session and end up in the final snapshot's state.
 //
 // To send a final input as part of the same wire message, use
 // Send(&SessionFlowInput{Detach: true, Messages: ...}) directly.

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -302,10 +302,13 @@ func (rt *sessionFlowRuntime[Stream, State]) handleDetach(
 		Status:        SnapshotStatusPending,
 		PendingInputs: combined,
 	}
-	if err := rt.cfg.store.SaveSnapshot(clientCtx, pending); err != nil {
+	// Detach intends to outlive the client connection. If clientCtx was
+	// already cancelled (or cancels mid-write), we still want the pending
+	// row durable so observers can find it later. Decouple this write.
+	if err := rt.cfg.store.SaveSnapshot(context.WithoutCancel(clientCtx), pending); err != nil {
 		rt.drainAndWait(cancelWork)
 		return nil, core.NewError(core.INTERNAL,
-			"session flow %q: failed to write pending snapshot: %v", rt.name, err)
+			"session flow %q: detach: save pending snapshot %q: %v", rt.name, pending.SnapshotID, err)
 	}
 
 	// The router can no longer write to outCh once we return; the bidi

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -294,13 +294,11 @@ func (rt *sessionFlowRuntime[Stream, State]) handleFnDone(
 
 // handleDetach commits the pending snapshot, returns its ID, and spawns the
 // status-subscriber and finalizer goroutines that own the rest of the
-// invocation. Per-turn snapshots are suspended for the remainder, and the
-// chunk router enters trash mode (no further outCh writes, no side effects).
-//
-// PendingInputs is FIFO: in-flight input (atomically captured with the
-// suspend flag, so it's never both turn-end-snapshotted and listed here),
-// followed by the intake's queue, followed by anything the reader drains
-// from src after detach.
+// invocation. Per-turn snapshots are suspended for the remainder so the
+// queued inputs roll into a single finalize rewrite; the chunk router
+// stops writing to outCh but keeps applying in-process side effects
+// (e.g. artifacts added via Responder.SendArtifact) so user code does
+// not have to branch on detach.
 func (rt *sessionFlowRuntime[Stream, State]) handleDetach(
 	clientCtx, workCtx context.Context,
 	cancelWork context.CancelFunc,
@@ -310,7 +308,7 @@ func (rt *sessionFlowRuntime[Stream, State]) handleDetach(
 	// fn completion can cancel workCtx.
 	markDetached()
 
-	combined := rt.intake.suspendAndCapture()
+	rt.intake.suspend()
 
 	parentID := ""
 	if rt.runner.lastSnapshot != nil {
@@ -319,13 +317,12 @@ func (rt *sessionFlowRuntime[Stream, State]) handleDetach(
 
 	now := time.Now()
 	pending := &SessionSnapshot[State]{
-		SnapshotID:    uuid.New().String(),
-		ParentID:      parentID,
-		CreatedAt:     now,
-		UpdatedAt:     now,
-		Event:         SnapshotEventDetach,
-		Status:        SnapshotStatusPending,
-		PendingInputs: combined,
+		SnapshotID: uuid.New().String(),
+		ParentID:   parentID,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+		Event:      SnapshotEventDetach,
+		Status:     SnapshotStatusPending,
 	}
 	// Detach intends to outlive the client connection. If clientCtx was
 	// already cancelled (or cancels mid-write), we still want the pending
@@ -556,12 +553,11 @@ func (s *SessionRunner[State]) Result() *SessionFlowResult {
 // callback approves, state changed, detach has not suspended snapshots).
 // Returns the snapshot ID or empty string.
 //
-// For turn-end events, the runner consults the intake atomically: if
-// detach has suspended snapshots, intake.beginTurnEnd reports that and
-// the runner skips. Otherwise intake.beginTurnEnd clears the in-flight
-// input. This is what guarantees the in-flight input is never both
-// turn-end-snapshotted AND included in the pending snapshot's
-// PendingInputs.
+// For turn-end events, the runner asks the intake whether snapshots
+// have been suspended (i.e. detach has landed). If so, the runner skips
+// the turn-end snapshot — the pending row already captures the
+// invocation and a single finalize rewrite will record the cumulative
+// state once the queued inputs drain.
 func (s *SessionRunner[State]) maybeSnapshot(ctx context.Context, event SnapshotEvent) string {
 	if event == SnapshotEventTurnEnd && s.intake != nil {
 		if suspended := s.intake.beginTurnEnd(); suspended {
@@ -619,27 +615,9 @@ func (s *SessionRunner[State]) maybeSnapshot(ctx context.Context, event Snapshot
 		return ""
 	}
 
-	s.tagLastMessage(snapshot.SnapshotID)
 	s.lastSnapshot = snapshot
 	s.lastSnapshotVersion = currentVersion
 	return snapshot.SnapshotID
-}
-
-// tagLastMessage records snapshotID in the metadata of the last message in
-// session history, so clients can correlate messages with the snapshot that
-// captured them.
-func (s *SessionRunner[State]) tagLastMessage(snapshotID string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	msgs := s.state.Messages
-	if len(msgs) == 0 {
-		return
-	}
-	last := msgs[len(msgs)-1]
-	if last.Metadata == nil {
-		last.Metadata = make(map[string]any)
-	}
-	last.Metadata["snapshotId"] = snapshotID
 }
 
 // --- Responder ---
@@ -796,8 +774,7 @@ func (r *chunkRouter[Stream, State]) close() {
 // --- detachIntake ---
 //
 // detachIntake separates eager src reading from runner-paced forwarding,
-// and is the single source of truth for in-flight tracking, queue state,
-// and suspend state.
+// and owns the queue and suspend state.
 //
 // The reader goroutine pulls from the bidi framework's inCh as soon as
 // inputs arrive and appends them to an internal queue. This is what makes
@@ -806,17 +783,17 @@ func (r *chunkRouter[Stream, State]) close() {
 // waiting for the runner to finish whatever it's processing.
 //
 // The forwarder goroutine pops the queue and writes to dst, blocking on
-// the runner. Crucially, it sets in-flight (under the same mutex it pops
-// under) BEFORE the dst send, so an input is never "in transit" without
-// being tracked — closing the gap that would otherwise let detach miss it.
+// the runner via turnDone so it stays in step with turn pacing.
 //
-// The runner asks beginTurnEnd at the end of each turn: if not suspended,
-// in-flight is cleared. If suspended, the runner skips its snapshot and
-// the input rolls into the pending snapshot instead.
+// The runner asks beginTurnEnd at the end of each turn: if suspended
+// (detach has landed), the runner skips its turn-end snapshot — the
+// pending row already captures the invocation and a single finalize
+// will rewrite it with the cumulative state once the queued inputs
+// drain. If not suspended, a normal turn-end snapshot is written.
 //
-// suspendAndCapture is the detach handler's atomic read: flips suspended,
-// reads in-flight, reads queue, all under one lock so there's no race
-// with maybeSnapshot or the forwarder.
+// suspend is called once by the detach handler under the same mutex
+// that beginTurnEnd reads from, ensuring memory ordering: any
+// beginTurnEnd that returns after suspend completes sees suspended=true.
 
 type detachIntake struct {
 	src    <-chan *SessionFlowInput
@@ -830,7 +807,6 @@ type detachIntake struct {
 
 	mu        sync.Mutex
 	suspended bool
-	inFlight  *SessionFlowInput
 	queue     []*SessionFlowInput
 
 	readDone atomic.Bool
@@ -914,13 +890,13 @@ func (i *detachIntake) enqueue(input *SessionFlowInput) {
 }
 
 // handleDetach drains any buffered src inputs into the queue and signals
-// the detach handler. The detach handler then calls suspendAndCapture for
-// the atomic read of the full state.
+// the detach handler. The detach handler then calls suspend to halt
+// turn-end snapshots while the queued inputs finish processing.
 //
 // A pure detach signal (no Messages, no ToolRestarts) is dropped rather
-// than enqueued: it carries no payload to process, so adding it to
-// PendingInputs would just leave a stray empty input there. Callers that
-// want to ride a final input on the detach signal can do so by calling
+// than enqueued: it carries no payload to process, so it would just
+// trigger a no-op turn. Callers that want to ride a final input on the
+// detach signal can do so by calling
 // Send(&SessionFlowInput{Detach: true, Messages: ...}) explicitly.
 func (i *detachIntake) handleDetach(first *SessionFlowInput) {
 	var drained []*SessionFlowInput
@@ -954,17 +930,16 @@ drainLoop:
 }
 
 // hasInputPayload reports whether the input carries data the runner would
-// otherwise process. Used to filter pure detach signals out of
-// PendingInputs.
+// otherwise process. Used to filter pure detach signals out of the
+// queue so they don't trigger no-op turns.
 func hasInputPayload(in *SessionFlowInput) bool {
 	return in != nil && (len(in.Messages) > 0 || len(in.ToolRestarts) > 0)
 }
 
 // forward pops the queue and writes to dst at the runner's pace. The
 // runner signals turnDone via beginTurnEnd when it's ready for the next
-// input; until then the forwarder waits, so inFlight always reflects the
-// input actually being processed (or in transit to the runner) rather
-// than running ahead.
+// input; until then the forwarder waits, so it never gets ahead of the
+// runner.
 func (i *detachIntake) forward() {
 	for {
 		// Wait for the previous turn to release us (initial credit lets
@@ -989,15 +964,14 @@ func (i *detachIntake) forward() {
 }
 
 // awaitInput blocks until the queue has an input, the reader is done, or
-// stop is signaled. Returns the popped input (with inFlight set under mu)
-// or nil if no further inputs will arrive.
+// stop is signaled. Returns the popped input or nil if no further inputs
+// will arrive.
 func (i *detachIntake) awaitInput() *SessionFlowInput {
 	for {
 		i.mu.Lock()
 		if len(i.queue) > 0 {
 			input := i.queue[0]
 			i.queue = i.queue[1:]
-			i.inFlight = input
 			i.mu.Unlock()
 			return input
 		}
@@ -1034,44 +1008,27 @@ func (i *detachIntake) detachSignal() <-chan struct{} {
 
 // beginTurnEnd is called by [SessionRunner.maybeSnapshot] before writing
 // a turn-end snapshot. If the intake has been suspended (detach landed),
-// it returns suspended=true and the runner skips the snapshot. Otherwise
-// it clears in-flight.
+// it returns suspended=true and the runner skips the snapshot.
 //
 // In all cases (including suspended) the forwarder is released so it can
 // pop the next queued input — suspension stops snapshot writing, not
 // processing.
 func (i *detachIntake) beginTurnEnd() (suspended bool) {
 	i.mu.Lock()
-	if i.suspended {
-		i.mu.Unlock()
-		i.releaseForward()
-		return true
-	}
-	i.inFlight = nil
+	suspended = i.suspended
 	i.mu.Unlock()
 	i.releaseForward()
-	return false
+	return suspended
 }
 
-// suspendAndCapture is called once by the detach handler. It flips
-// suspended=true and reads the in-flight input (if any) and the queue
-// snapshot. Inputs are returned in FIFO order with Detach cleared.
-func (i *detachIntake) suspendAndCapture() (combined []*SessionFlowInput) {
+// suspend is called once by the detach handler. It flips suspended=true
+// under the mutex so subsequent beginTurnEnd calls observe the change
+// and skip their turn-end snapshot writes; the queued inputs roll into
+// a single finalize rewrite of the pending row instead.
+func (i *detachIntake) suspend() {
 	i.mu.Lock()
-	defer i.mu.Unlock()
 	i.suspended = true
-
-	if i.inFlight != nil {
-		c := *i.inFlight
-		c.Detach = false
-		combined = append(combined, &c)
-	}
-	for _, q := range i.queue {
-		c := *q
-		c.Detach = false
-		combined = append(combined, &c)
-	}
-	return
+	i.mu.Unlock()
 }
 
 // stopAndWait forces the intake to exit and waits for both reader and
@@ -1232,14 +1189,18 @@ func (c *SessionFlowConnection[Stream, State]) SendToolRestarts(parts ...*ai.Par
 	return c.conn.Send(&SessionFlowInput{ToolRestarts: parts})
 }
 
-// Detach asks the server to write a pending snapshot capturing any inputs
-// already buffered, close the connection, and continue processing in the
-// background. Output() returns the pending snapshot ID; the client can
-// later call AbortSnapshot to stop the background work or GetSnapshot to
-// observe its progression. Streamed chunks emitted after detach are not
-// forwarded over the wire (the connection is gone), but their session-
-// level side effects still apply: artifacts sent via [Responder.SendArtifact]
-// land in the session and end up in the final snapshot's state.
+// Detach asks the server to write a pending snapshot, close the
+// connection, and continue processing any already-buffered inputs in
+// the background. Output() returns the pending snapshot ID; the client
+// can later call AbortSnapshot to stop the background work or
+// GetSnapshot to observe its progression. The pending snapshot is
+// finalized with the cumulative final state once the queued inputs
+// are processed.
+//
+// Streamed chunks emitted after detach are not forwarded over the wire
+// (the connection is gone), but their session-level side effects still
+// apply: artifacts sent via [Responder.SendArtifact] land in the
+// session and end up in the final snapshot's state.
 //
 // To send a final input as part of the same wire message, use
 // Send(&SessionFlowInput{Detach: true, Messages: ...}) directly.

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -75,11 +75,61 @@ func DefineSessionFlow[Stream, State any](
 			return nil, err
 		}
 		return rt.run(ctx, fn)
-	})
+	}, &core.ActionOptions{Metadata: agentMetadata(cfg.store)})
 
 	registerSnapshotActions(r, name, cfg.store, cfg.transform)
 
 	return &SessionFlow[Stream, State]{flow: flow}
+}
+
+// AgentMetadataStateManagement enumerates who owns session state for an
+// agent: "server" (a [SessionStore] is configured and snapshots are
+// persisted server-side) or "client" (no store; state flows through
+// invocation init / output).
+type AgentMetadataStateManagement string
+
+const (
+	// AgentMetadataStateManagementServer indicates the agent is wired
+	// with a [SessionStore] and persists snapshots server-side.
+	AgentMetadataStateManagementServer AgentMetadataStateManagement = "server"
+	// AgentMetadataStateManagementClient indicates the agent has no
+	// store; session state is client-managed and round-trips through
+	// invocation init and output.
+	AgentMetadataStateManagementClient AgentMetadataStateManagement = "client"
+)
+
+// AgentMetadata is the value placed under metadata["agent"] on a session
+// flow's action descriptor. It exposes capability information so the Dev
+// UI and other reflective callers can render the right surface (e.g.,
+// hide the Abort button when the configured store doesn't support it)
+// without round-tripping through the reflection API.
+type AgentMetadata struct {
+	// StateManagement reports who owns session state.
+	StateManagement AgentMetadataStateManagement `json:"stateManagement"`
+	// Abortable reports whether the agent's invocations can be aborted
+	// (true when the store implements both [SnapshotAborter] and
+	// [SnapshotStatusSubscriber]).
+	Abortable bool `json:"abortable"`
+}
+
+// agentMetadata derives the metadata map placed on the session flow's
+// action descriptor under the "agent" key. The value matches
+// [AgentMetadata].
+func agentMetadata[State any](store SessionStore[State]) map[string]any {
+	mgmt := AgentMetadataStateManagementClient
+	abortable := false
+	if store != nil {
+		mgmt = AgentMetadataStateManagementServer
+		_, hasAborter := store.(SnapshotAborter)
+		_, hasSubscriber := store.(SnapshotStatusSubscriber)
+		abortable = hasAborter && hasSubscriber
+	}
+	return map[string]any{
+		"agent": AgentMetadata{
+			StateManagement: mgmt,
+			Abortable:       abortable,
+		},
+	}
 }
 
 // --- sessionFlowRuntime ---

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -47,10 +47,16 @@ type SessionFlowFunc[Stream, State any] = func(ctx context.Context, resp Respond
 
 // SessionFlow is a bidirectional streaming flow with automatic snapshot management.
 type SessionFlow[Stream, State any] struct {
-	flow *core.Flow[*SessionFlowInit[State], *SessionFlowOutput[State], *SessionFlowStreamChunk[Stream], *SessionFlowInput]
+	action *core.Action[*SessionFlowInit[State], *SessionFlowOutput[State], *SessionFlowStreamChunk[Stream], *SessionFlowInput]
 }
 
-// DefineSessionFlow creates an SessionFlow with automatic snapshot management and registers it.
+// DefineSessionFlow creates an SessionFlow with automatic snapshot
+// management and registers it. The underlying action is created via
+// [core.DefineBidiAction] (rather than [core.DefineBidiFlow]) so the
+// agent capability metadata can be set at construction time — actions
+// must be immutable once registered. The flow-context wrapping that
+// makes [core.Run] work inside fn is preserved via
+// [core.WithFlowContext].
 func DefineSessionFlow[Stream, State any](
 	r api.Registry,
 	name string,
@@ -64,23 +70,27 @@ func DefineSessionFlow[Stream, State any](
 		}
 	}
 
-	flow := core.DefineBidiFlow(r, name, func(
-		ctx context.Context,
-		in *SessionFlowInit[State],
-		inCh <-chan *SessionFlowInput,
-		outCh chan<- *SessionFlowStreamChunk[Stream],
-	) (*SessionFlowOutput[State], error) {
-		rt, err := newSessionFlowRuntime(ctx, name, cfg, in, inCh, outCh)
-		if err != nil {
-			return nil, err
-		}
-		return rt.run(ctx, fn)
-	})
-	flow.SetMetadataValue("agent", agentMetadataFor(cfg.store))
+	action := core.DefineBidiAction(r, name, api.ActionTypeFlow,
+		&core.ActionOptions{
+			Metadata: map[string]any{"agent": agentMetadataFor(cfg.store)},
+		},
+		func(
+			ctx context.Context,
+			in *SessionFlowInit[State],
+			inCh <-chan *SessionFlowInput,
+			outCh chan<- *SessionFlowStreamChunk[Stream],
+		) (*SessionFlowOutput[State], error) {
+			ctx = core.WithFlowContext(ctx, name)
+			rt, err := newSessionFlowRuntime(ctx, name, cfg, in, inCh, outCh)
+			if err != nil {
+				return nil, err
+			}
+			return rt.run(ctx, fn)
+		})
 
 	registerSnapshotActions(r, name, cfg.store, cfg.transform)
 
-	return &SessionFlow[Stream, State]{flow: flow}
+	return &SessionFlow[Stream, State]{action: action}
 }
 
 // AgentMetadataStateManagement enumerates who owns session state for an
@@ -1117,7 +1127,7 @@ func (af *SessionFlow[Stream, State]) StreamBidi(
 	if err != nil {
 		return nil, err
 	}
-	conn, err := af.flow.StreamBidi(ctx, init)
+	conn, err := af.action.StreamBidi(ctx, init)
 	if err != nil {
 		return nil, err
 	}
@@ -1182,7 +1192,7 @@ func (af *SessionFlow[Stream, State]) resolveOptions(opts []InvocationOption[Sta
 	cfg := &invocationOptions[State]{}
 	for _, opt := range opts {
 		if err := opt.applyInvocation(cfg); err != nil {
-			return nil, fmt.Errorf("SessionFlow %q: %w", af.flow.Name(), err)
+			return nil, fmt.Errorf("SessionFlow %q: %w", af.action.Name(), err)
 		}
 	}
 	init := &SessionFlowInit[State]{

--- a/go/ai/exp/session_flow.go
+++ b/go/ai/exp/session_flow.go
@@ -75,7 +75,8 @@ func DefineSessionFlow[Stream, State any](
 			return nil, err
 		}
 		return rt.run(ctx, fn)
-	}, &core.ActionOptions{Metadata: agentMetadata(cfg.store)})
+	})
+	flow.SetMetadataValue("agent", agentMetadataFor(cfg.store))
 
 	registerSnapshotActions(r, name, cfg.store, cfg.transform)
 
@@ -112,10 +113,9 @@ type AgentMetadata struct {
 	Abortable bool `json:"abortable"`
 }
 
-// agentMetadata derives the metadata map placed on the session flow's
-// action descriptor under the "agent" key. The value matches
-// [AgentMetadata].
-func agentMetadata[State any](store SessionStore[State]) map[string]any {
+// agentMetadataFor derives the [AgentMetadata] value attached to the
+// session flow's action descriptor under the "agent" key.
+func agentMetadataFor[State any](store SessionStore[State]) AgentMetadata {
 	mgmt := AgentMetadataStateManagementClient
 	abortable := false
 	if store != nil {
@@ -124,11 +124,9 @@ func agentMetadata[State any](store SessionStore[State]) map[string]any {
 		_, hasSubscriber := store.(SnapshotStatusSubscriber)
 		abortable = hasAborter && hasSubscriber
 	}
-	return map[string]any{
-		"agent": AgentMetadata{
-			StateManagement: mgmt,
-			Abortable:       abortable,
-		},
+	return AgentMetadata{
+		StateManagement: mgmt,
+		Abortable:       abortable,
 	}
 }
 

--- a/go/ai/exp/session_flow_test.go
+++ b/go/ai/exp/session_flow_test.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
@@ -2281,13 +2283,14 @@ func TestSessionFlow_Detach_CancelSnapshotStopsFlow(t *testing.T) {
 		t.Fatal("expected pending snapshot ID")
 	}
 
-	// Cancel via the typed wrapper on the flow.
-	resp, err := af.CancelSnapshot(context.Background(), out.SnapshotID)
+	// Cancel via the store. The local caller already has the store
+	// reference from WithSessionStore.
+	meta, err := store.CancelSnapshot(context.Background(), out.SnapshotID)
 	if err != nil {
 		t.Fatalf("CancelSnapshot: %v", err)
 	}
-	if resp.Status != SnapshotStatusCanceled {
-		t.Errorf("CancelSnapshot status = %q, want canceled", resp.Status)
+	if meta.Status != SnapshotStatusCanceled {
+		t.Errorf("CancelSnapshot status = %q, want canceled", meta.Status)
 	}
 
 	// The heartbeat poller picks this up within ~20ms, cancels work, and
@@ -2442,7 +2445,7 @@ func TestSessionFlow_ResumeFromErrorSnapshot_Rejected(t *testing.T) {
 	}
 }
 
-func TestSessionFlow_GetSnapshot_ReturnsTransformedState(t *testing.T) {
+func TestSessionFlow_GetSnapshotAction_ReturnsTransformedState(t *testing.T) {
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
 
@@ -2475,9 +2478,16 @@ func TestSessionFlow_GetSnapshot_ReturnsTransformedState(t *testing.T) {
 		t.Fatalf("RunText: %v", err)
 	}
 
-	resp, err := af.GetSnapshot(ctx, out.SnapshotID)
+	// Transform is action-layer behavior: invoke the registered action
+	// directly the way a non-Go client would.
+	action := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
+		reg, api.ActionTypeUtil, "transformedFlow/getSnapshot")
+	if action == nil {
+		t.Fatal("getSnapshot action not registered")
+	}
+	resp, err := action.Run(ctx, &GetSnapshotRequest{SnapshotID: out.SnapshotID}, nil)
 	if err != nil {
-		t.Fatalf("GetSnapshot: %v", err)
+		t.Fatalf("getSnapshot action: %v", err)
 	}
 	if resp.SnapshotID != out.SnapshotID {
 		t.Errorf("SnapshotID mismatch: got %q want %q", resp.SnapshotID, out.SnapshotID)
@@ -2516,38 +2526,35 @@ func TestSessionFlow_GetSnapshot_ReturnsTransformedState(t *testing.T) {
 	}
 }
 
-func TestSessionFlow_GetSnapshot_NotFound(t *testing.T) {
-	reg := newTestRegistry(t)
+func TestInMemorySessionStore_GetSnapshot_NotFound(t *testing.T) {
 	store := NewInMemorySessionStore[testState]()
 
-	af := DefineSessionFlow(reg, "nfFlow",
-		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
-			return nil, nil
-		},
-		WithSessionStore(store),
-	)
-
-	_, err := af.GetSnapshot(context.Background(), "nope")
-	if err == nil {
-		t.Fatal("expected NOT_FOUND error")
+	snap, err := store.GetSnapshot(context.Background(), "nope")
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
 	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("unexpected error: %v", err)
+	if snap != nil {
+		t.Errorf("expected nil for missing snapshot, got %+v", snap)
 	}
 }
 
-func TestSessionFlow_GetSnapshot_NoStore(t *testing.T) {
+func TestSessionFlow_GetSnapshotAction_NoStore(t *testing.T) {
 	reg := newTestRegistry(t)
 
-	af := DefineSessionFlow(reg, "noStoreFlow",
+	DefineSessionFlow(reg, "noStoreFlow",
 		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
 			return nil, nil
 		},
 	)
 
-	// Action remains registered even without a store, so the typed wrapper
-	// still dispatches; the action returns FAILED_PRECONDITION.
-	_, err := af.GetSnapshot(context.Background(), "any")
+	// Action remains registered even without a store; it returns
+	// FAILED_PRECONDITION when invoked.
+	action := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
+		reg, api.ActionTypeUtil, "noStoreFlow/getSnapshot")
+	if action == nil {
+		t.Fatal("getSnapshot action should be registered even without a store")
+	}
+	_, err := action.Run(context.Background(), &GetSnapshotRequest{SnapshotID: "any"}, nil)
 	if err == nil {
 		t.Fatal("expected error when store is not configured")
 	}
@@ -2863,7 +2870,7 @@ func TestSessionFlow_CancelSnapshot_NoOpOnTerminal(t *testing.T) {
 		t.Fatalf("RunText: %v", err)
 	}
 
-	resp, err := af.CancelSnapshot(ctx, out.SnapshotID)
+	resp, err := store.CancelSnapshot(ctx, out.SnapshotID)
 	if err != nil {
 		t.Fatalf("CancelSnapshot: %v", err)
 	}

--- a/go/ai/exp/session_flow_test.go
+++ b/go/ai/exp/session_flow_test.go
@@ -18,11 +18,15 @@ package exp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
@@ -1708,5 +1712,1192 @@ func TestSessionFlow_InvocationEndSnapshotWhenStateChangesAfterRun(t *testing.T)
 	// Should have a parent (the turn-end snapshot).
 	if snap.ParentID == "" {
 		t.Error("expected parent ID (turn-end snapshot)")
+	}
+}
+
+// --- Detach, transform, and getSnapshot tests ---
+
+// waitForSnapshot polls the store for a snapshot matching the predicate,
+// failing the test if it doesn't show up within the timeout.
+func waitForSnapshot[State any](
+	t *testing.T,
+	store SessionStore[State],
+	id string,
+	timeout time.Duration,
+	predicate func(*SessionSnapshot[State]) bool,
+) *SessionSnapshot[State] {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		snap, err := store.GetSnapshot(context.Background(), id)
+		if err != nil {
+			t.Fatalf("GetSnapshot(%q): %v", id, err)
+		}
+		if snap != nil && predicate(snap) {
+			return snap
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("snapshot %q did not satisfy predicate within %s", id, timeout)
+	return nil
+}
+
+func TestSessionFlow_TurnEnd_CarriesTurnIndex(t *testing.T) {
+	// Sanity: each TurnEnd chunk carries its zero-based TurnIndex,
+	// monotonically increasing within an invocation, and corresponding
+	// sync snapshots have a matching StartingTurnIndex.
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	af := DefineSessionFlow(reg, "turnIndexFlow",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				sess.AddMessages(ai.NewModelTextMessage("ok"))
+				return nil
+			})
+		},
+		WithSessionStore(store),
+	)
+
+	conn, err := af.StreamBidi(context.Background())
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+
+	var observed []TurnEnd
+	for turn := 0; turn < 3; turn++ {
+		if err := conn.SendText(fmt.Sprintf("turn %d", turn)); err != nil {
+			t.Fatalf("SendText: %v", err)
+		}
+		for chunk, err := range conn.Receive() {
+			if err != nil {
+				t.Fatalf("Receive: %v", err)
+			}
+			if chunk.TurnEnd != nil {
+				observed = append(observed, *chunk.TurnEnd)
+				break
+			}
+		}
+	}
+	conn.Close()
+	if _, err := conn.Output(); err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+
+	if got := len(observed); got != 3 {
+		t.Fatalf("observed %d TurnEnd chunks, want 3", got)
+	}
+	for i, te := range observed {
+		if te.TurnIndex != i {
+			t.Errorf("TurnEnd[%d].TurnIndex = %d, want %d", i, te.TurnIndex, i)
+		}
+		if te.SnapshotID == "" {
+			t.Errorf("TurnEnd[%d].SnapshotID is empty", i)
+			continue
+		}
+		snap, err := store.GetSnapshot(context.Background(), te.SnapshotID)
+		if err != nil {
+			t.Fatalf("GetSnapshot: %v", err)
+		}
+		if snap.StartingTurnIndex != i {
+			t.Errorf("snapshot for turn %d StartingTurnIndex = %d, want %d", i, snap.StartingTurnIndex, i)
+		}
+	}
+}
+
+func TestSessionFlow_Detach_CapturesInFlightAndQueued(t *testing.T) {
+	// Detach lands while turn 0 (input A) is mid-fn and an extra turn
+	// (the detach input D itself) is waiting. The pending snapshot must:
+	//   - Include A AND D in PendingInputs (in FIFO order)
+	//   - Set StartingTurnIndex to A's turn index (0 here)
+	//   - NOT write a separate turn-end snapshot for A (suspended)
+	// After release, the finalized snapshot has both A's and D's effects.
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	entered := make(chan struct{}, 4)
+	release := make(chan struct{})
+
+	af := DefineSessionFlow(reg, "detachInFlight",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				entered <- struct{}{}
+				<-release
+				sess.AddMessages(ai.NewModelTextMessage("reply-" + input.Messages[0].Text()))
+				sess.UpdateCustom(func(s testState) testState {
+					s.Counter++
+					return s
+				})
+				return nil
+			})
+		},
+		WithSessionStore(store),
+	)
+
+	conn, err := af.StreamBidi(context.Background())
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+
+	// Drain stream chunks in the background.
+	go func() {
+		for _, err := range conn.Receive() {
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// Send A and wait for it to enter fn (so it's in-flight when detach
+	// arrives).
+	if err := conn.SendText("A"); err != nil {
+		t.Fatalf("SendText A: %v", err)
+	}
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("A did not enter fn")
+	}
+
+	// Send D with detach=true. The eager intake reader should observe
+	// this immediately even though the runner is blocked on A.
+	if err := conn.Detach(&SessionFlowInput{
+		Messages: []*ai.Message{ai.NewUserTextMessage("D")},
+	}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+
+	out, err := conn.Output()
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if out.SnapshotID == "" {
+		t.Fatal("expected pending snapshot ID")
+	}
+
+	pending, err := store.GetSnapshot(context.Background(), out.SnapshotID)
+	if err != nil {
+		t.Fatalf("GetSnapshot pending: %v", err)
+	}
+	if pending.Status != SnapshotStatusPending {
+		t.Errorf("pending snapshot status = %q, want pending", pending.Status)
+	}
+	if pending.StartingTurnIndex != 0 {
+		t.Errorf("pending StartingTurnIndex = %d, want 0", pending.StartingTurnIndex)
+	}
+	if got := len(pending.PendingInputs); got != 2 {
+		t.Fatalf("pending PendingInputs len = %d, want 2 (in-flight A + queued D)", got)
+	}
+	if msg := pending.PendingInputs[0].Messages[0].Text(); msg != "A" {
+		t.Errorf("PendingInputs[0] = %q, want A", msg)
+	}
+	if msg := pending.PendingInputs[1].Messages[0].Text(); msg != "D" {
+		t.Errorf("PendingInputs[1] = %q, want D", msg)
+	}
+	for i, p := range pending.PendingInputs {
+		if p.Detach {
+			t.Errorf("PendingInputs[%d] retained Detach=true", i)
+		}
+	}
+
+	// No separate turn-end snapshot for A should have been written.
+	// (Walk the parent chain — pending should have no parent in this
+	// invocation since A was the first turn and got suspended.)
+	if pending.ParentID != "" {
+		t.Errorf("pending ParentID = %q, want empty (A was suspended)", pending.ParentID)
+	}
+
+	close(release)
+
+	final := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+		return s.Status == SnapshotStatusComplete
+	})
+	if final.State.Custom.Counter != 2 {
+		t.Errorf("final counter = %d, want 2 (A + D both processed)", final.State.Custom.Counter)
+	}
+	if got := len(final.State.Messages); got != 4 {
+		// 2 user (A, D) + 2 model replies = 4.
+		t.Errorf("final messages = %d, want 4", got)
+	}
+	if final.PendingInputs != nil {
+		t.Errorf("final PendingInputs not cleared: %d entries", len(final.PendingInputs))
+	}
+	if final.StartingTurnIndex != 0 {
+		t.Errorf("final StartingTurnIndex = %d, want 0 (preserved from pending)", final.StartingTurnIndex)
+	}
+}
+
+func TestSessionFlow_Detach_AfterPriorTurns_StartingTurnIndex(t *testing.T) {
+	// Run two normal turns first, then detach during a third (in-flight)
+	// turn. The pending snapshot's StartingTurnIndex must be 2 (= the
+	// in-flight turn's index), and PendingInputs[0] is the in-flight one.
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	enter := make(chan struct{}, 4)
+	release := make(chan struct{}, 4)
+
+	af := DefineSessionFlow(reg, "detachStartIdx",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				enter <- struct{}{}
+				<-release
+				sess.AddMessages(ai.NewModelTextMessage("ok"))
+				return nil
+			})
+		},
+		WithSessionStore(store),
+	)
+
+	conn, err := af.StreamBidi(context.Background())
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+
+	// Background drainer.
+	go func() {
+		for _, err := range conn.Receive() {
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// Run two normal turns.
+	for i := 0; i < 2; i++ {
+		release <- struct{}{} // pre-load release so this turn's fn doesn't block
+		if err := conn.SendText(fmt.Sprintf("sync-%d", i)); err != nil {
+			t.Fatalf("SendText: %v", err)
+		}
+		<-enter
+	}
+
+	// Wait for both to actually finish (no easy hook; poll snapshots).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		// Two turn-end snapshots should exist.
+		// We don't have IDs; use a different signal: check Custom doesn't matter,
+		// just check that no in-flight is left by sleeping briefly.
+		time.Sleep(20 * time.Millisecond)
+		break
+	}
+	// Drain enter signal if buffered.
+	for len(enter) > 0 {
+		<-enter
+	}
+
+	// Now start a third turn but DON'T release it — the third turn is
+	// in-flight when detach lands.
+	if err := conn.SendText("inflight"); err != nil {
+		t.Fatalf("SendText inflight: %v", err)
+	}
+	<-enter // third turn entered fn
+
+	// Detach.
+	if err := conn.Detach(&SessionFlowInput{
+		Messages: []*ai.Message{ai.NewUserTextMessage("detach-msg")},
+	}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+
+	out, err := conn.Output()
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	pending, err := store.GetSnapshot(context.Background(), out.SnapshotID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if pending.StartingTurnIndex != 2 {
+		t.Errorf("pending StartingTurnIndex = %d, want 2 (after 2 sync turns)", pending.StartingTurnIndex)
+	}
+	if got := len(pending.PendingInputs); got != 2 {
+		t.Fatalf("PendingInputs len = %d, want 2 (in-flight + detach)", got)
+	}
+	if msg := pending.PendingInputs[0].Messages[0].Text(); msg != "inflight" {
+		t.Errorf("PendingInputs[0] = %q, want inflight", msg)
+	}
+	if pending.ParentID == "" {
+		t.Error("pending ParentID empty; expected parent = last sync turn snapshot")
+	}
+
+	// Release remaining turns and let finalize run.
+	close(release)
+	waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+		return s.Status == SnapshotStatusComplete
+	})
+}
+
+func TestSessionFlow_Detach_RequiresStore(t *testing.T) {
+	reg := newTestRegistry(t)
+
+	af := DefineSessionFlow(reg, "detachNoStore",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				return nil
+			})
+		},
+	)
+
+	conn, err := af.StreamBidi(context.Background())
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+	if err := conn.Detach(&SessionFlowInput{Messages: []*ai.Message{ai.NewUserTextMessage("hi")}}); err != nil {
+		t.Fatalf("Detach send: %v", err)
+	}
+	conn.Close()
+
+	_, err = conn.Output()
+	if err == nil {
+		t.Fatal("expected error when detaching without a session store")
+	}
+	if !strings.Contains(err.Error(), "detach requires a session store") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSessionFlow_Detach_PendingThenComplete(t *testing.T) {
+	// Client detaches mid-flow; flow finishes naturally; pending snapshot
+	// flips to status=complete with the full session state.
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	release := make(chan struct{})
+	entered := make(chan struct{})
+
+	af := DefineSessionFlow(reg, "detachComplete",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				select {
+				case entered <- struct{}{}:
+				case <-ctx.Done():
+				}
+				<-release
+				sess.AddMessages(ai.NewModelTextMessage("finished"))
+				sess.UpdateCustom(func(s testState) testState {
+					s.Counter = 42
+					return s
+				})
+				return nil
+			})
+		},
+		WithSessionStore(store),
+	)
+
+	conn, err := af.StreamBidi(context.Background())
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+
+	// Drain chunks so the responder isn't blocked.
+	go func() {
+		for _, err := range conn.Receive() {
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	if err := conn.Detach(&SessionFlowInput{
+		Messages: []*ai.Message{ai.NewUserTextMessage("go")},
+	}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("flow did not enter work phase")
+	}
+
+	// Output returns the pending snapshot ID immediately; the snapshot
+	// itself should be in the store with status=pending.
+	out, err := conn.Output()
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if out.SnapshotID == "" {
+		t.Fatal("expected snapshot ID after detach")
+	}
+
+	pending, err := store.GetSnapshot(context.Background(), out.SnapshotID)
+	if err != nil {
+		t.Fatalf("GetSnapshot pending: %v", err)
+	}
+	if pending == nil {
+		t.Fatal("pending snapshot not written")
+	}
+	if pending.Status != SnapshotStatusPending {
+		t.Errorf("expected status=%q, got %q", SnapshotStatusPending, pending.Status)
+	}
+	if got := len(pending.PendingInputs); got != 1 {
+		t.Errorf("expected 1 pending input, got %d", got)
+	} else if pending.PendingInputs[0].Detach {
+		t.Error("pending input retained Detach=true; expected it cleared")
+	} else if got := pending.PendingInputs[0].Messages[0].Text(); got != "go" {
+		t.Errorf("pending input message = %q, want %q", got, "go")
+	}
+	if got := len(pending.State.Messages); got != 0 {
+		t.Errorf("pending snapshot should not carry message history, got %d messages", got)
+	}
+
+	// Release; finalizer rewrites the snapshot with the terminal state.
+	close(release)
+
+	finalSnap := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+		return s.Status == SnapshotStatusComplete
+	})
+	if finalSnap.State.Custom.Counter != 42 {
+		t.Errorf("expected counter=42 in final snapshot, got %d", finalSnap.State.Custom.Counter)
+	}
+	if got := len(finalSnap.State.Messages); got < 2 {
+		t.Errorf("expected at least 2 messages in final snapshot, got %d", got)
+	}
+	if finalSnap.PendingInputs != nil {
+		t.Errorf("expected PendingInputs cleared on finalize, got %d", len(finalSnap.PendingInputs))
+	}
+}
+
+func TestSessionFlow_Detach_FlowErrorsBecomesError(t *testing.T) {
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	release := make(chan struct{})
+	entered := make(chan struct{})
+	boom := errors.New("kaboom")
+
+	af := DefineSessionFlow(reg, "detachErr",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				select {
+				case entered <- struct{}{}:
+				case <-time.After(time.Second):
+				}
+				<-release
+				return boom
+			})
+		},
+		WithSessionStore(store),
+	)
+
+	conn, err := af.StreamBidi(context.Background())
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+	go func() {
+		for _, err := range conn.Receive() {
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	if err := conn.Detach(&SessionFlowInput{
+		Messages: []*ai.Message{ai.NewUserTextMessage("go")},
+	}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	<-entered
+
+	out, err := conn.Output()
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if out.SnapshotID == "" {
+		t.Fatal("expected pending snapshot ID")
+	}
+
+	close(release)
+
+	snap := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+		return s.Status == SnapshotStatusError
+	})
+	if !strings.Contains(snap.Error, "kaboom") {
+		t.Errorf("expected snapshot.Error to contain %q, got %q", "kaboom", snap.Error)
+	}
+
+	// Resuming from an errored detached snapshot is rejected.
+	_, err = af.RunText(context.Background(), "retry", WithSnapshotID[testState](out.SnapshotID))
+	if err == nil {
+		t.Fatal("expected error when resuming from errored snapshot")
+	}
+	if !strings.Contains(err.Error(), "kaboom") {
+		t.Errorf("unexpected resume error: %v", err)
+	}
+}
+
+func TestSessionFlow_Detach_CancelSnapshotStopsFlow(t *testing.T) {
+	// Client detaches, then calls cancelSnapshot. The heartbeat poller
+	// observes status=canceled, cancels the work context, and the
+	// snapshot is finalized with status=canceled.
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	entered := make(chan struct{})
+
+	af := DefineSessionFlow(reg, "detachCancel",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				select {
+				case entered <- struct{}{}:
+				case <-time.After(time.Second):
+				}
+				<-ctx.Done()
+				return ctx.Err()
+			})
+		},
+		WithSessionStore(store),
+		WithHeartbeatInterval[testState](20*time.Millisecond),
+	)
+
+	conn, err := af.StreamBidi(context.Background())
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+	go func() {
+		for _, err := range conn.Receive() {
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	if err := conn.Detach(&SessionFlowInput{
+		Messages: []*ai.Message{ai.NewUserTextMessage("go")},
+	}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	<-entered
+
+	out, err := conn.Output()
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if out.SnapshotID == "" {
+		t.Fatal("expected pending snapshot ID")
+	}
+
+	// Issue cancel via the cancelSnapshot action.
+	cancelAction := core.ResolveActionFor[*CancelSnapshotRequest, *CancelSnapshotResponse, struct{}, struct{}](
+		reg, api.ActionTypeUtil, "detachCancel/cancelSnapshot")
+	if cancelAction == nil {
+		t.Fatal("cancelSnapshot action not registered")
+	}
+	resp, err := cancelAction.Run(context.Background(), &CancelSnapshotRequest{SnapshotID: out.SnapshotID}, nil)
+	if err != nil {
+		t.Fatalf("cancelSnapshot: %v", err)
+	}
+	if resp.Status != SnapshotStatusCanceled {
+		t.Errorf("cancelSnapshot status = %q, want canceled", resp.Status)
+	}
+
+	// The heartbeat poller picks this up within ~20ms, cancels work, and
+	// the finalizer rewrites the snapshot with the canceled status.
+	finalSnap := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+		return s.Status == SnapshotStatusCanceled && s.UpdatedAt.After(s.CreatedAt)
+	})
+	if finalSnap.State.Custom.Counter != 0 {
+		// The flow only blocked on ctx — no state mutation expected.
+		t.Errorf("unexpected counter value in canceled snapshot: %d", finalSnap.State.Custom.Counter)
+	}
+}
+
+func TestSessionFlow_Detach_NormalCompletionStillEmitsTurnEnd(t *testing.T) {
+	// Sanity: a non-detached invocation against a store-backed flow still
+	// behaves like a synchronous flow (turn-end snapshots, no pending row).
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	af := DefineSessionFlow(reg, "syncStillWorks",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				sess.AddMessages(ai.NewModelTextMessage("ok"))
+				return nil
+			})
+		},
+		WithSessionStore(store),
+	)
+
+	conn, err := af.StreamBidi(context.Background())
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+	if err := conn.SendText("hi"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+
+	var turnEndID string
+	for chunk, err := range conn.Receive() {
+		if err != nil {
+			t.Fatalf("Receive: %v", err)
+		}
+		if chunk.TurnEnd != nil {
+			turnEndID = chunk.TurnEnd.SnapshotID
+			break
+		}
+	}
+	if turnEndID == "" {
+		t.Fatal("expected snapshot ID on TurnEnd chunk")
+	}
+	conn.Close()
+	if _, err := conn.Output(); err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+
+	snap, err := store.GetSnapshot(context.Background(), turnEndID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if snap.Status != SnapshotStatusComplete {
+		t.Errorf("turn-end snapshot status = %q, want complete", snap.Status)
+	}
+	if snap.Event != SnapshotEventTurnEnd {
+		t.Errorf("turn-end snapshot event = %q, want %q", snap.Event, SnapshotEventTurnEnd)
+	}
+}
+
+func TestSessionFlow_Detach_ClientDisconnectBeforeDetachCancels(t *testing.T) {
+	// Without detach, a client cancel still cancels the work — this is
+	// the regression guard for "until detach=true is called, this is a
+	// normal HTTP/WS connection that cancels on close."
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	entered := make(chan struct{})
+	exited := make(chan error, 1)
+
+	af := DefineSessionFlow(reg, "syncCancel",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			err := sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				select {
+				case entered <- struct{}{}:
+				case <-ctx.Done():
+				}
+				<-ctx.Done()
+				return ctx.Err()
+			})
+			exited <- err
+			return nil, err
+		},
+		WithSessionStore(store),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, err := af.StreamBidi(ctx)
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+	go func() {
+		for _, err := range conn.Receive() {
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	if err := conn.SendText("go"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	<-entered
+	cancel()
+
+	select {
+	case fnErr := <-exited:
+		if fnErr == nil {
+			t.Error("expected fn to exit with ctx error after client cancel")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("fn did not exit after client cancel")
+	}
+}
+
+func TestSessionFlow_ResumeFromErrorSnapshot_Rejected(t *testing.T) {
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	erroredID := "errored-456"
+	if err := store.SaveSnapshot(context.Background(), &SessionSnapshot[testState]{
+		SnapshotID: erroredID,
+		CreatedAt:  time.Now(),
+		Event:      SnapshotEventInvocationEnd,
+		Status:     SnapshotStatusError,
+		Error:      "underlying failure",
+		State:      SessionState[testState]{},
+	}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	af := DefineSessionFlow(reg, "resumeErrored",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, nil
+		},
+		WithSessionStore(store),
+	)
+
+	_, err := af.RunText(context.Background(), "hi", WithSnapshotID[testState](erroredID))
+	if err == nil {
+		t.Fatal("expected error when resuming from errored snapshot")
+	}
+	if !strings.Contains(err.Error(), "underlying failure") {
+		t.Errorf("expected error to surface underlying failure, got: %v", err)
+	}
+}
+
+func TestSessionFlow_GetSnapshotAction_ReturnsTransformedState(t *testing.T) {
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	// Transform that scrubs a specific word from all messages.
+	transform := func(s SessionState[testState]) SessionState[testState] {
+		for _, msg := range s.Messages {
+			for _, p := range msg.Content {
+				if p.Text != "" {
+					p.Text = strings.ReplaceAll(p.Text, "secret", "[REDACTED]")
+				}
+			}
+		}
+		return s
+	}
+
+	af := DefineSessionFlow(reg, "transformedFlow",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				sess.AddMessages(ai.NewModelTextMessage("the secret is out"))
+				return nil
+			})
+		},
+		WithSessionStore(store),
+		WithSnapshotTransform[testState](transform),
+	)
+
+	ctx := context.Background()
+	out, err := af.RunText(ctx, "tell me the secret")
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+
+	action := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
+		reg, api.ActionTypeUtil, "transformedFlow/getSnapshot")
+	if action == nil {
+		t.Fatal("getSnapshot action not registered")
+	}
+
+	resp, err := action.Run(ctx, &GetSnapshotRequest{SnapshotID: out.SnapshotID}, nil)
+	if err != nil {
+		t.Fatalf("getSnapshot action: %v", err)
+	}
+	if resp.SnapshotID != out.SnapshotID {
+		t.Errorf("SnapshotID mismatch: got %q want %q", resp.SnapshotID, out.SnapshotID)
+	}
+	if resp.Status != SnapshotStatusComplete {
+		t.Errorf("expected status=complete, got %q", resp.Status)
+	}
+	if resp.State == nil {
+		t.Fatal("expected state in response")
+	}
+	// Both messages should be redacted: user message (from input) and model reply.
+	for i, msg := range resp.State.Messages {
+		for _, p := range msg.Content {
+			if strings.Contains(p.Text, "secret") {
+				t.Errorf("message %d still contains 'secret': %q", i, p.Text)
+			}
+		}
+	}
+
+	// The stored snapshot must remain untransformed so the flow can be
+	// resumed faithfully.
+	stored, err := store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("GetSnapshot direct: %v", err)
+	}
+	foundRaw := false
+	for _, msg := range stored.State.Messages {
+		for _, p := range msg.Content {
+			if strings.Contains(p.Text, "secret") {
+				foundRaw = true
+			}
+		}
+	}
+	if !foundRaw {
+		t.Error("expected stored snapshot to retain the original 'secret' text")
+	}
+}
+
+func TestSessionFlow_GetSnapshotAction_NotFound(t *testing.T) {
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	DefineSessionFlow(reg, "nfFlow",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, nil
+		},
+		WithSessionStore(store),
+	)
+
+	action := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
+		reg, api.ActionTypeUtil, "nfFlow/getSnapshot")
+	if action == nil {
+		t.Fatal("getSnapshot action not registered")
+	}
+
+	_, err := action.Run(context.Background(), &GetSnapshotRequest{SnapshotID: "nope"}, nil)
+	if err == nil {
+		t.Fatal("expected NOT_FOUND error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSessionFlow_GetSnapshotAction_NoStore(t *testing.T) {
+	reg := newTestRegistry(t)
+
+	DefineSessionFlow(reg, "noStoreFlow",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, nil
+		},
+	)
+
+	action := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
+		reg, api.ActionTypeUtil, "noStoreFlow/getSnapshot")
+	if action == nil {
+		t.Fatal("getSnapshot action should still be registered even without a store")
+	}
+
+	_, err := action.Run(context.Background(), &GetSnapshotRequest{SnapshotID: "any"}, nil)
+	if err == nil {
+		t.Fatal("expected error when store is not configured")
+	}
+	if !strings.Contains(err.Error(), "no session store configured") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSessionFlow_SnapshotTransform_ClientManagedState(t *testing.T) {
+	reg := newTestRegistry(t)
+
+	// Client-managed state: transform should be applied to SessionFlowOutput.State.
+	transform := func(s SessionState[testState]) SessionState[testState] {
+		// Zero out the counter to demonstrate the transform is applied.
+		s.Custom.Counter = -1
+		return s
+	}
+
+	af := DefineSessionFlow(reg, "clientXformFlow",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				sess.UpdateCustom(func(s testState) testState {
+					s.Counter = 7
+					return s
+				})
+				return nil
+			})
+		},
+		WithSnapshotTransform[testState](transform),
+	)
+
+	out, err := af.RunText(context.Background(), "go")
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+	if out.State == nil {
+		t.Fatal("expected client-managed state in output")
+	}
+	if out.State.Custom.Counter != -1 {
+		t.Errorf("expected transformed counter=-1, got %d", out.State.Custom.Counter)
+	}
+}
+
+func TestSessionFlow_ResumeFromFinalizedDetachedSnapshot(t *testing.T) {
+	// End-to-end: run a flow that the client detaches from, let it
+	// finalize, then resume from its snapshot as if reconnecting later.
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	af := DefineSessionFlow(reg, "resumeDetachedFlow",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				sess.AddMessages(ai.NewModelTextMessage("reply"))
+				sess.UpdateCustom(func(s testState) testState {
+					s.Counter++
+					return s
+				})
+				return nil
+			})
+		},
+		WithSessionStore(store),
+	)
+
+	ctx := context.Background()
+
+	// First invocation: detach to write a pending snapshot, then wait
+	// for finalize.
+	conn, err := af.StreamBidi(ctx)
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+	go func() {
+		for _, err := range conn.Receive() {
+			if err != nil {
+				return
+			}
+		}
+	}()
+	if err := conn.Detach(&SessionFlowInput{
+		Messages: []*ai.Message{ai.NewUserTextMessage("turn 1")},
+	}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	first, err := conn.Output()
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	finalSnap := waitForSnapshot(t, store, first.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+		return s.Status == SnapshotStatusComplete
+	})
+	if finalSnap.State.Custom.Counter != 1 {
+		t.Fatalf("expected counter=1 in finalized snapshot, got %d", finalSnap.State.Custom.Counter)
+	}
+
+	// Resume from the finalized snapshot.
+	second, err := af.RunText(ctx, "turn 2", WithSnapshotID[testState](first.SnapshotID))
+	if err != nil {
+		t.Fatalf("resume RunText: %v", err)
+	}
+
+	snap, err := store.GetSnapshot(ctx, second.SnapshotID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if snap.State.Custom.Counter != 2 {
+		t.Errorf("expected counter=2 after resume, got %d", snap.State.Custom.Counter)
+	}
+}
+
+func TestInMemorySessionStore_CancelSnapshot_AtomicAndIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemorySessionStore[testState]()
+
+	// Cancel on missing snapshot returns nil metadata, no error.
+	if meta, err := store.CancelSnapshot(ctx, "nope"); err != nil || meta != nil {
+		t.Fatalf("CancelSnapshot(missing) = %+v, %v; want nil, nil", meta, err)
+	}
+
+	// Pending → canceled, UpdatedAt advances.
+	created := time.Now().Add(-time.Hour)
+	pending := &SessionSnapshot[testState]{
+		SnapshotID: "snap-cas",
+		CreatedAt:  created,
+		UpdatedAt:  created,
+		Event:      SnapshotEventDetach,
+		Status:     SnapshotStatusPending,
+	}
+	if err := store.SaveSnapshot(ctx, pending); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+	meta, err := store.CancelSnapshot(ctx, "snap-cas")
+	if err != nil {
+		t.Fatalf("CancelSnapshot: %v", err)
+	}
+	if meta.Status != SnapshotStatusCanceled {
+		t.Errorf("status after first cancel = %q, want canceled", meta.Status)
+	}
+	if !meta.UpdatedAt.After(created) {
+		t.Errorf("UpdatedAt did not advance: %v vs %v", meta.UpdatedAt, created)
+	}
+
+	// Idempotent: second cancel returns canceled, no error, no further mutation.
+	firstUpdate := meta.UpdatedAt
+	meta2, err := store.CancelSnapshot(ctx, "snap-cas")
+	if err != nil {
+		t.Fatalf("CancelSnapshot (second): %v", err)
+	}
+	if meta2.Status != SnapshotStatusCanceled {
+		t.Errorf("status after second cancel = %q, want canceled", meta2.Status)
+	}
+	if !meta2.UpdatedAt.Equal(firstUpdate) {
+		t.Errorf("UpdatedAt advanced on idempotent cancel: %v vs %v", meta2.UpdatedAt, firstUpdate)
+	}
+
+	// Cancel on terminal status is a no-op that returns the existing status.
+	complete := &SessionSnapshot[testState]{
+		SnapshotID: "snap-complete",
+		CreatedAt:  created,
+		UpdatedAt:  created,
+		Event:      SnapshotEventTurnEnd,
+		Status:     SnapshotStatusComplete,
+	}
+	if err := store.SaveSnapshot(ctx, complete); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+	meta3, err := store.CancelSnapshot(ctx, "snap-complete")
+	if err != nil {
+		t.Fatalf("CancelSnapshot on complete: %v", err)
+	}
+	if meta3.Status != SnapshotStatusComplete {
+		t.Errorf("cancel on complete returned status=%q, want complete", meta3.Status)
+	}
+}
+
+func TestSessionFlow_Detach_FinalizeRespectsConcurrentCancel(t *testing.T) {
+	// Simulate the race where a cancel lands between fn-return and the
+	// finalizer's write: the finalizer must read the current status and
+	// preserve cancel rather than overwrite it with complete.
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	// Block fn until we manually pre-cancel the pending snapshot, so the
+	// flow's own heartbeat has no chance to be the one that cancels.
+	fnRelease := make(chan struct{})
+	entered := make(chan struct{})
+
+	af := DefineSessionFlow(reg, "raceFinalize",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				select {
+				case entered <- struct{}{}:
+				case <-time.After(time.Second):
+				}
+				<-fnRelease
+				// Return cleanly — without the finalizer's recheck, this
+				// would land status=complete and clobber the cancel.
+				return nil
+			})
+		},
+		WithSessionStore(store),
+		// Long heartbeat so the in-process poller does NOT observe the
+		// cancel before the finalizer runs.
+		WithHeartbeatInterval[testState](time.Hour),
+	)
+
+	conn, err := af.StreamBidi(context.Background())
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+	go func() {
+		for _, err := range conn.Receive() {
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	if err := conn.Detach(&SessionFlowInput{
+		Messages: []*ai.Message{ai.NewUserTextMessage("go")},
+	}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	<-entered
+
+	out, err := conn.Output()
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+
+	// Externally cancel before releasing fn. The flow's heartbeat is
+	// hourly, so only the finalizer's recheck can pick this up.
+	if _, err := store.CancelSnapshot(context.Background(), out.SnapshotID); err != nil {
+		t.Fatalf("CancelSnapshot: %v", err)
+	}
+
+	close(fnRelease)
+
+	finalSnap := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+		return s.Status == SnapshotStatusCanceled || s.Status == SnapshotStatusComplete
+	})
+	if finalSnap.Status != SnapshotStatusCanceled {
+		t.Errorf("finalize clobbered canceled with %q", finalSnap.Status)
+	}
+}
+
+func TestInMemorySessionStore_GetSnapshotMetadata(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemorySessionStore[testState]()
+
+	now := time.Now()
+	full := &SessionSnapshot[testState]{
+		SnapshotID: "snap-meta",
+		ParentID:   "parent-meta",
+		CreatedAt:  now,
+		UpdatedAt:  now.Add(time.Second),
+		Event:      SnapshotEventDetach,
+		Status:     SnapshotStatusPending,
+		PendingInputs: []*SessionFlowInput{
+			{Messages: []*ai.Message{ai.NewUserTextMessage("hi")}},
+		},
+		State: SessionState[testState]{
+			Custom:   testState{Counter: 7},
+			Messages: []*ai.Message{ai.NewModelTextMessage("reply")},
+		},
+	}
+	if err := store.SaveSnapshot(ctx, full); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	meta, err := store.GetSnapshotMetadata(ctx, "snap-meta")
+	if err != nil {
+		t.Fatalf("GetSnapshotMetadata: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("expected metadata, got nil")
+	}
+	if meta.SnapshotID != full.SnapshotID || meta.ParentID != full.ParentID ||
+		meta.Status != full.Status || meta.Event != full.Event ||
+		!meta.CreatedAt.Equal(full.CreatedAt) || !meta.UpdatedAt.Equal(full.UpdatedAt) {
+		t.Errorf("metadata mismatch: %+v vs %+v", meta, full)
+	}
+
+	missing, err := store.GetSnapshotMetadata(ctx, "nope")
+	if err != nil {
+		t.Fatalf("GetSnapshotMetadata(missing): %v", err)
+	}
+	if missing != nil {
+		t.Errorf("expected nil for missing snapshot, got %+v", missing)
+	}
+}
+
+func TestSessionFlow_CancelSnapshotAction_NoOpOnTerminal(t *testing.T) {
+	// Calling cancelSnapshot on an already-terminal snapshot is a no-op
+	// that returns the existing status.
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	af := DefineSessionFlow(reg, "cancelNoop",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				sess.AddMessages(ai.NewModelTextMessage("reply"))
+				return nil
+			})
+		},
+		WithSessionStore(store),
+	)
+
+	ctx := context.Background()
+	out, err := af.RunText(ctx, "hi")
+	if err != nil {
+		t.Fatalf("RunText: %v", err)
+	}
+
+	action := core.ResolveActionFor[*CancelSnapshotRequest, *CancelSnapshotResponse, struct{}, struct{}](
+		reg, api.ActionTypeUtil, "cancelNoop/cancelSnapshot")
+	if action == nil {
+		t.Fatal("cancelSnapshot action not registered")
+	}
+	resp, err := action.Run(ctx, &CancelSnapshotRequest{SnapshotID: out.SnapshotID}, nil)
+	if err != nil {
+		t.Fatalf("cancelSnapshot: %v", err)
+	}
+	if resp.Status != SnapshotStatusComplete {
+		t.Errorf("expected status=%q (existing terminal), got %q", SnapshotStatusComplete, resp.Status)
+	}
+
+	// Confirm the store snapshot was not flipped.
+	snap, err := store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if snap.Status != SnapshotStatusComplete {
+		t.Errorf("snapshot status = %q after cancel-on-terminal, want complete", snap.Status)
 	}
 }

--- a/go/ai/exp/session_flow_test.go
+++ b/go/ai/exp/session_flow_test.go
@@ -25,8 +25,6 @@ import (
 	"time"
 
 	"github.com/firebase/genkit/go/ai"
-	"github.com/firebase/genkit/go/core"
-	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
@@ -1859,11 +1857,12 @@ func TestSessionFlow_Detach_CapturesInFlightAndQueued(t *testing.T) {
 		t.Fatal("A did not enter fn")
 	}
 
-	// Send D with detach=true. The eager intake reader should observe
-	// this immediately even though the runner is blocked on A.
-	if err := conn.Detach(&SessionFlowInput{
-		Messages: []*ai.Message{ai.NewUserTextMessage("D")},
-	}); err != nil {
+	// Send D, then Detach. The eager intake reader sees D queued and the
+	// detach signal immediately, even though the runner is blocked on A.
+	if err := conn.SendText("D"); err != nil {
+		t.Fatalf("SendText D: %v", err)
+	}
+	if err := conn.Detach(); err != nil {
 		t.Fatalf("Detach: %v", err)
 	}
 
@@ -1993,10 +1992,11 @@ func TestSessionFlow_Detach_AfterPriorTurns_StartingTurnIndex(t *testing.T) {
 	}
 	<-enter // third turn entered fn
 
-	// Detach.
-	if err := conn.Detach(&SessionFlowInput{
-		Messages: []*ai.Message{ai.NewUserTextMessage("detach-msg")},
-	}); err != nil {
+	// Send the queued input and detach.
+	if err := conn.SendText("detach-msg"); err != nil {
+		t.Fatalf("SendText detach-msg: %v", err)
+	}
+	if err := conn.Detach(); err != nil {
 		t.Fatalf("Detach: %v", err)
 	}
 
@@ -2043,7 +2043,7 @@ func TestSessionFlow_Detach_RequiresStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StreamBidi: %v", err)
 	}
-	if err := conn.Detach(&SessionFlowInput{Messages: []*ai.Message{ai.NewUserTextMessage("hi")}}); err != nil {
+	if err := conn.Detach(); err != nil {
 		t.Fatalf("Detach send: %v", err)
 	}
 	conn.Close()
@@ -2099,9 +2099,10 @@ func TestSessionFlow_Detach_PendingThenComplete(t *testing.T) {
 		}
 	}()
 
-	if err := conn.Detach(&SessionFlowInput{
-		Messages: []*ai.Message{ai.NewUserTextMessage("go")},
-	}); err != nil {
+	if err := conn.SendText("go"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	if err := conn.Detach(); err != nil {
 		t.Fatalf("Detach: %v", err)
 	}
 
@@ -2193,9 +2194,10 @@ func TestSessionFlow_Detach_FlowErrorsBecomesError(t *testing.T) {
 		}
 	}()
 
-	if err := conn.Detach(&SessionFlowInput{
-		Messages: []*ai.Message{ai.NewUserTextMessage("go")},
-	}); err != nil {
+	if err := conn.SendText("go"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	if err := conn.Detach(); err != nil {
 		t.Fatalf("Detach: %v", err)
 	}
 	<-entered
@@ -2263,9 +2265,10 @@ func TestSessionFlow_Detach_CancelSnapshotStopsFlow(t *testing.T) {
 		}
 	}()
 
-	if err := conn.Detach(&SessionFlowInput{
-		Messages: []*ai.Message{ai.NewUserTextMessage("go")},
-	}); err != nil {
+	if err := conn.SendText("go"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	if err := conn.Detach(); err != nil {
 		t.Fatalf("Detach: %v", err)
 	}
 	<-entered
@@ -2278,18 +2281,13 @@ func TestSessionFlow_Detach_CancelSnapshotStopsFlow(t *testing.T) {
 		t.Fatal("expected pending snapshot ID")
 	}
 
-	// Issue cancel via the cancelSnapshot action.
-	cancelAction := core.ResolveActionFor[*CancelSnapshotRequest, *CancelSnapshotResponse, struct{}, struct{}](
-		reg, api.ActionTypeUtil, "detachCancel/cancelSnapshot")
-	if cancelAction == nil {
-		t.Fatal("cancelSnapshot action not registered")
-	}
-	resp, err := cancelAction.Run(context.Background(), &CancelSnapshotRequest{SnapshotID: out.SnapshotID}, nil)
+	// Cancel via the typed wrapper on the flow.
+	resp, err := af.CancelSnapshot(context.Background(), out.SnapshotID)
 	if err != nil {
-		t.Fatalf("cancelSnapshot: %v", err)
+		t.Fatalf("CancelSnapshot: %v", err)
 	}
 	if resp.Status != SnapshotStatusCanceled {
-		t.Errorf("cancelSnapshot status = %q, want canceled", resp.Status)
+		t.Errorf("CancelSnapshot status = %q, want canceled", resp.Status)
 	}
 
 	// The heartbeat poller picks this up within ~20ms, cancels work, and
@@ -2444,7 +2442,7 @@ func TestSessionFlow_ResumeFromErrorSnapshot_Rejected(t *testing.T) {
 	}
 }
 
-func TestSessionFlow_GetSnapshotAction_ReturnsTransformedState(t *testing.T) {
+func TestSessionFlow_GetSnapshot_ReturnsTransformedState(t *testing.T) {
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
 
@@ -2477,15 +2475,9 @@ func TestSessionFlow_GetSnapshotAction_ReturnsTransformedState(t *testing.T) {
 		t.Fatalf("RunText: %v", err)
 	}
 
-	action := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
-		reg, api.ActionTypeUtil, "transformedFlow/getSnapshot")
-	if action == nil {
-		t.Fatal("getSnapshot action not registered")
-	}
-
-	resp, err := action.Run(ctx, &GetSnapshotRequest{SnapshotID: out.SnapshotID}, nil)
+	resp, err := af.GetSnapshot(ctx, out.SnapshotID)
 	if err != nil {
-		t.Fatalf("getSnapshot action: %v", err)
+		t.Fatalf("GetSnapshot: %v", err)
 	}
 	if resp.SnapshotID != out.SnapshotID {
 		t.Errorf("SnapshotID mismatch: got %q want %q", resp.SnapshotID, out.SnapshotID)
@@ -2524,24 +2516,18 @@ func TestSessionFlow_GetSnapshotAction_ReturnsTransformedState(t *testing.T) {
 	}
 }
 
-func TestSessionFlow_GetSnapshotAction_NotFound(t *testing.T) {
+func TestSessionFlow_GetSnapshot_NotFound(t *testing.T) {
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
 
-	DefineSessionFlow(reg, "nfFlow",
+	af := DefineSessionFlow(reg, "nfFlow",
 		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
 			return nil, nil
 		},
 		WithSessionStore(store),
 	)
 
-	action := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
-		reg, api.ActionTypeUtil, "nfFlow/getSnapshot")
-	if action == nil {
-		t.Fatal("getSnapshot action not registered")
-	}
-
-	_, err := action.Run(context.Background(), &GetSnapshotRequest{SnapshotID: "nope"}, nil)
+	_, err := af.GetSnapshot(context.Background(), "nope")
 	if err == nil {
 		t.Fatal("expected NOT_FOUND error")
 	}
@@ -2550,22 +2536,18 @@ func TestSessionFlow_GetSnapshotAction_NotFound(t *testing.T) {
 	}
 }
 
-func TestSessionFlow_GetSnapshotAction_NoStore(t *testing.T) {
+func TestSessionFlow_GetSnapshot_NoStore(t *testing.T) {
 	reg := newTestRegistry(t)
 
-	DefineSessionFlow(reg, "noStoreFlow",
+	af := DefineSessionFlow(reg, "noStoreFlow",
 		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
 			return nil, nil
 		},
 	)
 
-	action := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
-		reg, api.ActionTypeUtil, "noStoreFlow/getSnapshot")
-	if action == nil {
-		t.Fatal("getSnapshot action should still be registered even without a store")
-	}
-
-	_, err := action.Run(context.Background(), &GetSnapshotRequest{SnapshotID: "any"}, nil)
+	// Action remains registered even without a store, so the typed wrapper
+	// still dispatches; the action returns FAILED_PRECONDITION.
+	_, err := af.GetSnapshot(context.Background(), "any")
 	if err == nil {
 		t.Fatal("expected error when store is not configured")
 	}
@@ -2644,9 +2626,10 @@ func TestSessionFlow_ResumeFromFinalizedDetachedSnapshot(t *testing.T) {
 			}
 		}
 	}()
-	if err := conn.Detach(&SessionFlowInput{
-		Messages: []*ai.Message{ai.NewUserTextMessage("turn 1")},
-	}); err != nil {
+	if err := conn.SendText("turn 1"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	if err := conn.Detach(); err != nil {
 		t.Fatalf("Detach: %v", err)
 	}
 	first, err := conn.Output()
@@ -2783,9 +2766,10 @@ func TestSessionFlow_Detach_FinalizeRespectsConcurrentCancel(t *testing.T) {
 		}
 	}()
 
-	if err := conn.Detach(&SessionFlowInput{
-		Messages: []*ai.Message{ai.NewUserTextMessage("go")},
-	}); err != nil {
+	if err := conn.SendText("go"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	if err := conn.Detach(); err != nil {
 		t.Fatalf("Detach: %v", err)
 	}
 	<-entered
@@ -2857,8 +2841,8 @@ func TestInMemorySessionStore_GetSnapshotMetadata(t *testing.T) {
 	}
 }
 
-func TestSessionFlow_CancelSnapshotAction_NoOpOnTerminal(t *testing.T) {
-	// Calling cancelSnapshot on an already-terminal snapshot is a no-op
+func TestSessionFlow_CancelSnapshot_NoOpOnTerminal(t *testing.T) {
+	// Calling CancelSnapshot on an already-terminal snapshot is a no-op
 	// that returns the existing status.
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
@@ -2879,14 +2863,9 @@ func TestSessionFlow_CancelSnapshotAction_NoOpOnTerminal(t *testing.T) {
 		t.Fatalf("RunText: %v", err)
 	}
 
-	action := core.ResolveActionFor[*CancelSnapshotRequest, *CancelSnapshotResponse, struct{}, struct{}](
-		reg, api.ActionTypeUtil, "cancelNoop/cancelSnapshot")
-	if action == nil {
-		t.Fatal("cancelSnapshot action not registered")
-	}
-	resp, err := action.Run(ctx, &CancelSnapshotRequest{SnapshotID: out.SnapshotID}, nil)
+	resp, err := af.CancelSnapshot(ctx, out.SnapshotID)
 	if err != nil {
-		t.Fatalf("cancelSnapshot: %v", err)
+		t.Fatalf("CancelSnapshot: %v", err)
 	}
 	if resp.Status != SnapshotStatusComplete {
 		t.Errorf("expected status=%q (existing terminal), got %q", SnapshotStatusComplete, resp.Status)

--- a/go/ai/exp/session_flow_test.go
+++ b/go/ai/exp/session_flow_test.go
@@ -2620,9 +2620,9 @@ func TestSessionFlow_GetSnapshotAction_NoStore(t *testing.T) {
 	}
 }
 
-// minimalStore is a SessionStore that does NOT implement SnapshotAborter or
-// SnapshotStatusSubscriber. Used to verify the abort action stays
-// unregistered for stores that lack the capabilities.
+// minimalStore is a SessionStore that does NOT implement SnapshotAborter.
+// Used to verify the abort action stays unregistered for stores that
+// lack the capability.
 type minimalStore[State any] struct{}
 
 func (minimalStore[State]) GetSnapshot(context.Context, string) (*SessionSnapshot[State], error) {
@@ -2705,12 +2705,12 @@ func TestSessionFlow_AgentMetadata(t *testing.T) {
 }
 
 func TestSessionFlow_AbortAction_GatedOnCapabilities(t *testing.T) {
-	// Verify the abort companion action is only registered when the store
-	// implements both SnapshotAborter and SnapshotStatusSubscriber. The
-	// getSnapshot action is registered regardless.
-	t.Run("full capabilities → both registered", func(t *testing.T) {
+	// Verify the abort companion action is only registered when the
+	// store implements SnapshotAborter. The getSnapshot action is
+	// registered regardless.
+	t.Run("aborter capability → both registered", func(t *testing.T) {
 		reg := newTestRegistry(t)
-		store := NewInMemorySessionStore[testState]() // implements both
+		store := NewInMemorySessionStore[testState]() // implements SnapshotAborter
 		DefineSessionFlow(reg, "fullCaps",
 			func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
 				return nil, nil
@@ -2725,11 +2725,11 @@ func TestSessionFlow_AbortAction_GatedOnCapabilities(t *testing.T) {
 		abortAction := core.ResolveActionFor[*AbortSnapshotRequest, *AbortSnapshotResponse, struct{}, struct{}](
 			reg, api.ActionTypeAgentAbort, "fullCaps")
 		if abortAction == nil {
-			t.Error("abortSnapshot action should be registered when store implements both interfaces")
+			t.Error("abortSnapshot action should be registered when store implements SnapshotAborter")
 		}
 	})
 
-	t.Run("missing capabilities → abort not registered", func(t *testing.T) {
+	t.Run("no aborter capability → abort not registered", func(t *testing.T) {
 		reg := newTestRegistry(t)
 		DefineSessionFlow(reg, "minCaps",
 			func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
@@ -2740,12 +2740,12 @@ func TestSessionFlow_AbortAction_GatedOnCapabilities(t *testing.T) {
 		getAction := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
 			reg, api.ActionTypeAgentSnapshot, "minCaps")
 		if getAction == nil {
-			t.Error("getSnapshot action should be registered even when store lacks abort/subscribe")
+			t.Error("getSnapshot action should be registered even when store lacks SnapshotAborter")
 		}
 		abortAction := core.ResolveActionFor[*AbortSnapshotRequest, *AbortSnapshotResponse, struct{}, struct{}](
 			reg, api.ActionTypeAgentAbort, "minCaps")
 		if abortAction != nil {
-			t.Error("abortSnapshot action should NOT be registered when store lacks SnapshotAborter+SnapshotStatusSubscriber")
+			t.Error("abortSnapshot action should NOT be registered when store lacks SnapshotAborter")
 		}
 	})
 }

--- a/go/ai/exp/session_flow_test.go
+++ b/go/ai/exp/session_flow_test.go
@@ -2538,7 +2538,7 @@ func TestSessionFlow_GetSnapshotAction_ReturnsTransformedState(t *testing.T) {
 	// Transform is action-layer behavior: invoke the registered action
 	// directly the way a non-Go client would.
 	action := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
-		reg, api.ActionTypeUtil, "transformedFlow/getSnapshot")
+		reg, api.ActionTypeAgentSnapshot, "transformedFlow")
 	if action == nil {
 		t.Fatal("getSnapshot action not registered")
 	}
@@ -2607,7 +2607,7 @@ func TestSessionFlow_GetSnapshotAction_NoStore(t *testing.T) {
 	// Action remains registered even without a store; it returns
 	// FAILED_PRECONDITION when invoked.
 	action := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
-		reg, api.ActionTypeUtil, "noStoreFlow/getSnapshot")
+		reg, api.ActionTypeAgentSnapshot, "noStoreFlow")
 	if action == nil {
 		t.Fatal("getSnapshot action should be registered even without a store")
 	}
@@ -2618,6 +2618,64 @@ func TestSessionFlow_GetSnapshotAction_NoStore(t *testing.T) {
 	if !strings.Contains(err.Error(), "no session store configured") {
 		t.Errorf("unexpected error: %v", err)
 	}
+}
+
+// minimalStore is a SessionStore that does NOT implement SnapshotAborter or
+// SnapshotStatusSubscriber. Used to verify the abort action stays
+// unregistered for stores that lack the capabilities.
+type minimalStore[State any] struct{}
+
+func (minimalStore[State]) GetSnapshot(context.Context, string) (*SessionSnapshot[State], error) {
+	return nil, nil
+}
+func (minimalStore[State]) SaveSnapshot(context.Context, *SessionSnapshot[State]) error {
+	return nil
+}
+
+func TestSessionFlow_AbortAction_GatedOnCapabilities(t *testing.T) {
+	// Verify the abort companion action is only registered when the store
+	// implements both SnapshotAborter and SnapshotStatusSubscriber. The
+	// getSnapshot action is registered regardless.
+	t.Run("full capabilities → both registered", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		store := NewInMemorySessionStore[testState]() // implements both
+		DefineSessionFlow(reg, "fullCaps",
+			func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+				return nil, nil
+			},
+			WithSessionStore(store),
+		)
+		getAction := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
+			reg, api.ActionTypeAgentSnapshot, "fullCaps")
+		if getAction == nil {
+			t.Error("getSnapshot action should be registered")
+		}
+		abortAction := core.ResolveActionFor[*AbortSnapshotRequest, *AbortSnapshotResponse, struct{}, struct{}](
+			reg, api.ActionTypeAgentAbort, "fullCaps")
+		if abortAction == nil {
+			t.Error("abortSnapshot action should be registered when store implements both interfaces")
+		}
+	})
+
+	t.Run("missing capabilities → abort not registered", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		DefineSessionFlow(reg, "minCaps",
+			func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+				return nil, nil
+			},
+			WithSessionStore[testState](minimalStore[testState]{}),
+		)
+		getAction := core.ResolveActionFor[*GetSnapshotRequest, *GetSnapshotResponse[testState], struct{}, struct{}](
+			reg, api.ActionTypeAgentSnapshot, "minCaps")
+		if getAction == nil {
+			t.Error("getSnapshot action should be registered even when store lacks abort/subscribe")
+		}
+		abortAction := core.ResolveActionFor[*AbortSnapshotRequest, *AbortSnapshotResponse, struct{}, struct{}](
+			reg, api.ActionTypeAgentAbort, "minCaps")
+		if abortAction != nil {
+			t.Error("abortSnapshot action should NOT be registered when store lacks SnapshotAborter+SnapshotStatusSubscriber")
+		}
+	})
 }
 
 func TestSessionFlow_SnapshotTransform_ClientManagedState(t *testing.T) {

--- a/go/ai/exp/session_flow_test.go
+++ b/go/ai/exp/session_flow_test.go
@@ -1742,14 +1742,13 @@ func waitForSnapshot[State any](
 	return nil
 }
 
-func TestSessionFlow_TurnEnd_CarriesTurnIndex(t *testing.T) {
-	// Sanity: each TurnEnd chunk carries its zero-based TurnIndex,
-	// monotonically increasing within an invocation, and corresponding
-	// sync snapshots have a matching StartingTurnIndex.
+func TestSessionFlow_TurnEnd_CarriesSnapshotID(t *testing.T) {
+	// Sanity: each TurnEnd chunk carries the snapshot ID of the turn-end
+	// snapshot, and the snapshots themselves are persisted.
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
 
-	af := DefineSessionFlow(reg, "turnIndexFlow",
+	af := DefineSessionFlow(reg, "turnEndSnapshotFlow",
 		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
 			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
 				sess.AddMessages(ai.NewModelTextMessage("ok"))
@@ -1788,9 +1787,6 @@ func TestSessionFlow_TurnEnd_CarriesTurnIndex(t *testing.T) {
 		t.Fatalf("observed %d TurnEnd chunks, want 3", got)
 	}
 	for i, te := range observed {
-		if te.TurnIndex != i {
-			t.Errorf("TurnEnd[%d].TurnIndex = %d, want %d", i, te.TurnIndex, i)
-		}
 		if te.SnapshotID == "" {
 			t.Errorf("TurnEnd[%d].SnapshotID is empty", i)
 			continue
@@ -1799,8 +1795,8 @@ func TestSessionFlow_TurnEnd_CarriesTurnIndex(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetSnapshot: %v", err)
 		}
-		if snap.StartingTurnIndex != i {
-			t.Errorf("snapshot for turn %d StartingTurnIndex = %d, want %d", i, snap.StartingTurnIndex, i)
+		if snap == nil {
+			t.Errorf("turn %d: snapshot %q not in store", i, te.SnapshotID)
 		}
 	}
 }
@@ -1809,7 +1805,6 @@ func TestSessionFlow_Detach_CapturesInFlightAndQueued(t *testing.T) {
 	// Detach lands while turn 0 (input A) is mid-fn and an extra turn
 	// (the detach input D itself) is waiting. The pending snapshot must:
 	//   - Include A AND D in PendingInputs (in FIFO order)
-	//   - Set StartingTurnIndex to A's turn index (0 here)
 	//   - NOT write a separate turn-end snapshot for A (suspended)
 	// After release, the finalized snapshot has both A's and D's effects.
 	reg := newTestRegistry(t)
@@ -1883,9 +1878,6 @@ func TestSessionFlow_Detach_CapturesInFlightAndQueued(t *testing.T) {
 	if pending.Status != SnapshotStatusPending {
 		t.Errorf("pending snapshot status = %q, want pending", pending.Status)
 	}
-	if pending.StartingTurnIndex != 0 {
-		t.Errorf("pending StartingTurnIndex = %d, want 0", pending.StartingTurnIndex)
-	}
 	if got := len(pending.PendingInputs); got != 2 {
 		t.Fatalf("pending PendingInputs len = %d, want 2 (in-flight A + queued D)", got)
 	}
@@ -1923,22 +1915,19 @@ func TestSessionFlow_Detach_CapturesInFlightAndQueued(t *testing.T) {
 	if final.PendingInputs != nil {
 		t.Errorf("final PendingInputs not cleared: %d entries", len(final.PendingInputs))
 	}
-	if final.StartingTurnIndex != 0 {
-		t.Errorf("final StartingTurnIndex = %d, want 0 (preserved from pending)", final.StartingTurnIndex)
-	}
 }
 
-func TestSessionFlow_Detach_AfterPriorTurns_StartingTurnIndex(t *testing.T) {
+func TestSessionFlow_Detach_AfterPriorTurns_ChainsParent(t *testing.T) {
 	// Run two normal turns first, then detach during a third (in-flight)
-	// turn. The pending snapshot's StartingTurnIndex must be 2 (= the
-	// in-flight turn's index), and PendingInputs[0] is the in-flight one.
+	// turn. The pending snapshot must chain off the second turn's snapshot
+	// and capture the in-flight + queued inputs in FIFO order.
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
 
 	enter := make(chan struct{}, 4)
 	release := make(chan struct{}, 4)
 
-	af := DefineSessionFlow(reg, "detachStartIdx",
+	af := DefineSessionFlow(reg, "detachChainParent",
 		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
 			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
 				enter <- struct{}{}
@@ -1972,16 +1961,8 @@ func TestSessionFlow_Detach_AfterPriorTurns_StartingTurnIndex(t *testing.T) {
 		}
 		<-enter
 	}
-
-	// Wait for both to actually finish (no easy hook; poll snapshots).
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		// Two turn-end snapshots should exist.
-		// We don't have IDs; use a different signal: check Custom doesn't matter,
-		// just check that no in-flight is left by sleeping briefly.
-		time.Sleep(20 * time.Millisecond)
-		break
-	}
+	// Brief settle so the second turn-end snapshot lands before detach.
+	time.Sleep(20 * time.Millisecond)
 	// Drain enter signal if buffered.
 	for len(enter) > 0 {
 		<-enter
@@ -2009,9 +1990,6 @@ func TestSessionFlow_Detach_AfterPriorTurns_StartingTurnIndex(t *testing.T) {
 	pending, err := store.GetSnapshot(context.Background(), out.SnapshotID)
 	if err != nil {
 		t.Fatalf("GetSnapshot: %v", err)
-	}
-	if pending.StartingTurnIndex != 2 {
-		t.Errorf("pending StartingTurnIndex = %d, want 2 (after 2 sync turns)", pending.StartingTurnIndex)
 	}
 	if got := len(pending.PendingInputs); got != 2 {
 		t.Fatalf("PendingInputs len = %d, want 2 (in-flight + detach)", got)
@@ -2162,6 +2140,86 @@ func TestSessionFlow_Detach_PendingThenComplete(t *testing.T) {
 	}
 }
 
+func TestSessionFlow_Detach_SendArtifactPostDetachLandsInSnapshot(t *testing.T) {
+	// SendArtifact must behave the same way regardless of whether detach
+	// has landed: the artifact is added to the session and shows up in
+	// the finalized snapshot's state. The wire forward is the only thing
+	// detach suppresses, so flow authors don't need to branch on detach.
+	reg := newTestRegistry(t)
+	store := NewInMemorySessionStore[testState]()
+
+	detached := make(chan struct{})
+	release := make(chan struct{})
+
+	af := DefineSessionFlow(reg, "detachArtifact",
+		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
+				resp.SendArtifact(&Artifact{
+					Name:  "before.txt",
+					Parts: []*ai.Part{ai.NewTextPart("pre-detach")},
+				})
+				select {
+				case <-detached:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+				resp.SendArtifact(&Artifact{
+					Name:  "after.txt",
+					Parts: []*ai.Part{ai.NewTextPart("post-detach")},
+				})
+				<-release
+				return nil
+			})
+		},
+		WithSessionStore(store),
+	)
+
+	conn, err := af.StreamBidi(context.Background())
+	if err != nil {
+		t.Fatalf("StreamBidi: %v", err)
+	}
+	go func() {
+		for _, err := range conn.Receive() {
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	if err := conn.SendText("go"); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	if err := conn.Detach(); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+
+	out, err := conn.Output()
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if out.SnapshotID == "" {
+		t.Fatal("expected pending snapshot ID")
+	}
+
+	close(detached)
+	close(release)
+
+	final := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
+		return s.Status == SnapshotStatusComplete
+	})
+
+	names := make(map[string]bool, len(final.State.Artifacts))
+	for _, a := range final.State.Artifacts {
+		names[a.Name] = true
+	}
+	if !names["before.txt"] {
+		t.Errorf("pre-detach artifact missing from final snapshot: %v", final.State.Artifacts)
+	}
+	if !names["after.txt"] {
+		t.Errorf("post-detach artifact missing from final snapshot: %v", final.State.Artifacts)
+	}
+}
+
 func TestSessionFlow_Detach_FlowErrorsBecomesError(t *testing.T) {
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
@@ -2231,16 +2289,16 @@ func TestSessionFlow_Detach_FlowErrorsBecomesError(t *testing.T) {
 	}
 }
 
-func TestSessionFlow_Detach_CancelSnapshotStopsFlow(t *testing.T) {
-	// Client detaches, then calls cancelSnapshot. The heartbeat poller
-	// observes status=canceled, cancels the work context, and the
-	// snapshot is finalized with status=canceled.
+func TestSessionFlow_Detach_AbortSnapshotStopsFlow(t *testing.T) {
+	// Client detaches, then calls AbortSnapshot. The store's status
+	// subscriber notifies the runtime, which cancels the work context, and
+	// the finalizer rewrites the snapshot with status=canceled.
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
 
 	entered := make(chan struct{})
 
-	af := DefineSessionFlow(reg, "detachCancel",
+	af := DefineSessionFlow(reg, "detachAbort",
 		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
 			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
 				select {
@@ -2252,7 +2310,6 @@ func TestSessionFlow_Detach_CancelSnapshotStopsFlow(t *testing.T) {
 			})
 		},
 		WithSessionStore(store),
-		WithHeartbeatInterval[testState](20*time.Millisecond),
 	)
 
 	conn, err := af.StreamBidi(context.Background())
@@ -2283,18 +2340,18 @@ func TestSessionFlow_Detach_CancelSnapshotStopsFlow(t *testing.T) {
 		t.Fatal("expected pending snapshot ID")
 	}
 
-	// Cancel via the store. The local caller already has the store
+	// Abort via the store. The local caller already has the store
 	// reference from WithSessionStore.
-	meta, err := store.CancelSnapshot(context.Background(), out.SnapshotID)
+	meta, err := store.AbortSnapshot(context.Background(), out.SnapshotID)
 	if err != nil {
-		t.Fatalf("CancelSnapshot: %v", err)
+		t.Fatalf("AbortSnapshot: %v", err)
 	}
 	if meta.Status != SnapshotStatusCanceled {
-		t.Errorf("CancelSnapshot status = %q, want canceled", meta.Status)
+		t.Errorf("AbortSnapshot status = %q, want canceled", meta.Status)
 	}
 
-	// The heartbeat poller picks this up within ~20ms, cancels work, and
-	// the finalizer rewrites the snapshot with the canceled status.
+	// The subscriber wakes the runtime, cancels work, and the finalizer
+	// rewrites the snapshot with the canceled status.
 	finalSnap := waitForSnapshot(t, store, out.SnapshotID, 2*time.Second, func(s *SessionSnapshot[testState]) bool {
 		return s.Status == SnapshotStatusCanceled && s.UpdatedAt.After(s.CreatedAt)
 	})
@@ -2665,13 +2722,13 @@ func TestSessionFlow_ResumeFromFinalizedDetachedSnapshot(t *testing.T) {
 	}
 }
 
-func TestInMemorySessionStore_CancelSnapshot_AtomicAndIdempotent(t *testing.T) {
+func TestInMemorySessionStore_AbortSnapshot_AtomicAndIdempotent(t *testing.T) {
 	ctx := context.Background()
 	store := NewInMemorySessionStore[testState]()
 
-	// Cancel on missing snapshot returns nil metadata, no error.
-	if meta, err := store.CancelSnapshot(ctx, "nope"); err != nil || meta != nil {
-		t.Fatalf("CancelSnapshot(missing) = %+v, %v; want nil, nil", meta, err)
+	// Abort on missing snapshot returns nil metadata, no error.
+	if meta, err := store.AbortSnapshot(ctx, "nope"); err != nil || meta != nil {
+		t.Fatalf("AbortSnapshot(missing) = %+v, %v; want nil, nil", meta, err)
 	}
 
 	// Pending → canceled, UpdatedAt advances.
@@ -2686,31 +2743,31 @@ func TestInMemorySessionStore_CancelSnapshot_AtomicAndIdempotent(t *testing.T) {
 	if err := store.SaveSnapshot(ctx, pending); err != nil {
 		t.Fatalf("SaveSnapshot: %v", err)
 	}
-	meta, err := store.CancelSnapshot(ctx, "snap-cas")
+	meta, err := store.AbortSnapshot(ctx, "snap-cas")
 	if err != nil {
-		t.Fatalf("CancelSnapshot: %v", err)
+		t.Fatalf("AbortSnapshot: %v", err)
 	}
 	if meta.Status != SnapshotStatusCanceled {
-		t.Errorf("status after first cancel = %q, want canceled", meta.Status)
+		t.Errorf("status after first abort = %q, want canceled", meta.Status)
 	}
 	if !meta.UpdatedAt.After(created) {
 		t.Errorf("UpdatedAt did not advance: %v vs %v", meta.UpdatedAt, created)
 	}
 
-	// Idempotent: second cancel returns canceled, no error, no further mutation.
+	// Idempotent: second abort returns canceled, no error, no further mutation.
 	firstUpdate := meta.UpdatedAt
-	meta2, err := store.CancelSnapshot(ctx, "snap-cas")
+	meta2, err := store.AbortSnapshot(ctx, "snap-cas")
 	if err != nil {
-		t.Fatalf("CancelSnapshot (second): %v", err)
+		t.Fatalf("AbortSnapshot (second): %v", err)
 	}
 	if meta2.Status != SnapshotStatusCanceled {
-		t.Errorf("status after second cancel = %q, want canceled", meta2.Status)
+		t.Errorf("status after second abort = %q, want canceled", meta2.Status)
 	}
 	if !meta2.UpdatedAt.Equal(firstUpdate) {
-		t.Errorf("UpdatedAt advanced on idempotent cancel: %v vs %v", meta2.UpdatedAt, firstUpdate)
+		t.Errorf("UpdatedAt advanced on idempotent abort: %v vs %v", meta2.UpdatedAt, firstUpdate)
 	}
 
-	// Cancel on terminal status is a no-op that returns the existing status.
+	// Abort on terminal status is a no-op that returns the existing status.
 	complete := &SessionSnapshot[testState]{
 		SnapshotID: "snap-complete",
 		CreatedAt:  created,
@@ -2721,24 +2778,24 @@ func TestInMemorySessionStore_CancelSnapshot_AtomicAndIdempotent(t *testing.T) {
 	if err := store.SaveSnapshot(ctx, complete); err != nil {
 		t.Fatalf("SaveSnapshot: %v", err)
 	}
-	meta3, err := store.CancelSnapshot(ctx, "snap-complete")
+	meta3, err := store.AbortSnapshot(ctx, "snap-complete")
 	if err != nil {
-		t.Fatalf("CancelSnapshot on complete: %v", err)
+		t.Fatalf("AbortSnapshot on complete: %v", err)
 	}
 	if meta3.Status != SnapshotStatusComplete {
-		t.Errorf("cancel on complete returned status=%q, want complete", meta3.Status)
+		t.Errorf("abort on complete returned status=%q, want complete", meta3.Status)
 	}
 }
 
-func TestSessionFlow_Detach_FinalizeRespectsConcurrentCancel(t *testing.T) {
-	// Simulate the race where a cancel lands between fn-return and the
-	// finalizer's write: the finalizer must read the current status and
-	// preserve cancel rather than overwrite it with complete.
+func TestSessionFlow_Detach_FinalizeRespectsConcurrentAbort(t *testing.T) {
+	// An abort that lands while fn is still running but does not actually
+	// stop fn (because fn does not observe ctx) must still result in
+	// status=canceled — the finalizer must not clobber canceled with
+	// complete. The subscriber observes the status flip and the finalizer
+	// reads the resulting flag.
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
 
-	// Block fn until we manually pre-cancel the pending snapshot, so the
-	// flow's own heartbeat has no chance to be the one that cancels.
 	fnRelease := make(chan struct{})
 	entered := make(chan struct{})
 
@@ -2750,15 +2807,13 @@ func TestSessionFlow_Detach_FinalizeRespectsConcurrentCancel(t *testing.T) {
 				case <-time.After(time.Second):
 				}
 				<-fnRelease
-				// Return cleanly — without the finalizer's recheck, this
-				// would land status=complete and clobber the cancel.
+				// Return cleanly without observing ctx. Without the
+				// subscriber/recheck, this would land status=complete and
+				// clobber the abort.
 				return nil
 			})
 		},
 		WithSessionStore(store),
-		// Long heartbeat so the in-process poller does NOT observe the
-		// cancel before the finalizer runs.
-		WithHeartbeatInterval[testState](time.Hour),
 	)
 
 	conn, err := af.StreamBidi(context.Background())
@@ -2786,10 +2841,9 @@ func TestSessionFlow_Detach_FinalizeRespectsConcurrentCancel(t *testing.T) {
 		t.Fatalf("Output: %v", err)
 	}
 
-	// Externally cancel before releasing fn. The flow's heartbeat is
-	// hourly, so only the finalizer's recheck can pick this up.
-	if _, err := store.CancelSnapshot(context.Background(), out.SnapshotID); err != nil {
-		t.Fatalf("CancelSnapshot: %v", err)
+	// Externally abort before releasing fn.
+	if _, err := store.AbortSnapshot(context.Background(), out.SnapshotID); err != nil {
+		t.Fatalf("AbortSnapshot: %v", err)
 	}
 
 	close(fnRelease)
@@ -2802,59 +2856,82 @@ func TestSessionFlow_Detach_FinalizeRespectsConcurrentCancel(t *testing.T) {
 	}
 }
 
-func TestInMemorySessionStore_GetSnapshotMetadata(t *testing.T) {
-	ctx := context.Background()
+func TestInMemorySessionStore_OnSnapshotStatusChange(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	store := NewInMemorySessionStore[testState]()
 
-	now := time.Now()
-	full := &SessionSnapshot[testState]{
-		SnapshotID: "snap-meta",
-		ParentID:   "parent-meta",
-		CreatedAt:  now,
-		UpdatedAt:  now.Add(time.Second),
+	// Subscribe to a missing snapshot: channel returns immediately closed
+	// without yielding a value.
+	missing := store.OnSnapshotStatusChange(ctx, "nope")
+	if _, ok := <-missing; ok {
+		t.Errorf("expected channel for missing snapshot to be closed without a value")
+	}
+
+	// Persist a pending snapshot so subsequent subscribers get an initial
+	// value plus updates on each status flip.
+	pending := &SessionSnapshot[testState]{
+		SnapshotID: "snap-sub",
+		CreatedAt:  time.Now(),
 		Event:      SnapshotEventDetach,
 		Status:     SnapshotStatusPending,
-		PendingInputs: []*SessionFlowInput{
-			{Messages: []*ai.Message{ai.NewUserTextMessage("hi")}},
-		},
-		State: SessionState[testState]{
-			Custom:   testState{Counter: 7},
-			Messages: []*ai.Message{ai.NewModelTextMessage("reply")},
-		},
 	}
-	if err := store.SaveSnapshot(ctx, full); err != nil {
+	if err := store.SaveSnapshot(ctx, pending); err != nil {
 		t.Fatalf("SaveSnapshot: %v", err)
 	}
 
-	meta, err := store.GetSnapshotMetadata(ctx, "snap-meta")
-	if err != nil {
-		t.Fatalf("GetSnapshotMetadata: %v", err)
-	}
-	if meta == nil {
-		t.Fatal("expected metadata, got nil")
-	}
-	if meta.SnapshotID != full.SnapshotID || meta.ParentID != full.ParentID ||
-		meta.Status != full.Status || meta.Event != full.Event ||
-		!meta.CreatedAt.Equal(full.CreatedAt) || !meta.UpdatedAt.Equal(full.UpdatedAt) {
-		t.Errorf("metadata mismatch: %+v vs %+v", meta, full)
+	subCtx, subCancel := context.WithCancel(ctx)
+	defer subCancel()
+	statusCh := store.OnSnapshotStatusChange(subCtx, "snap-sub")
+
+	// Initial value reflects current status.
+	select {
+	case status, ok := <-statusCh:
+		if !ok {
+			t.Fatal("channel closed before initial status")
+		}
+		if status != SnapshotStatusPending {
+			t.Errorf("initial status = %q, want pending", status)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive initial status")
 	}
 
-	missing, err := store.GetSnapshotMetadata(ctx, "nope")
-	if err != nil {
-		t.Fatalf("GetSnapshotMetadata(missing): %v", err)
+	// Abort flips status; subscriber observes canceled.
+	if _, err := store.AbortSnapshot(ctx, "snap-sub"); err != nil {
+		t.Fatalf("AbortSnapshot: %v", err)
 	}
-	if missing != nil {
-		t.Errorf("expected nil for missing snapshot, got %+v", missing)
+	select {
+	case status, ok := <-statusCh:
+		if !ok {
+			t.Fatal("channel closed before abort notification")
+		}
+		if status != SnapshotStatusCanceled {
+			t.Errorf("status notification = %q, want canceled", status)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive abort notification")
 	}
+
+	// Cancelling the subscription closes the channel.
+	subCancel()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		_, ok := <-statusCh
+		if !ok {
+			return
+		}
+	}
+	t.Fatal("channel did not close after subscription ctx cancel")
 }
 
-func TestSessionFlow_CancelSnapshot_NoOpOnTerminal(t *testing.T) {
-	// Calling CancelSnapshot on an already-terminal snapshot is a no-op
+func TestSessionFlow_AbortSnapshot_NoOpOnTerminal(t *testing.T) {
+	// Calling AbortSnapshot on an already-terminal snapshot is a no-op
 	// that returns the existing status.
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
 
-	af := DefineSessionFlow(reg, "cancelNoop",
+	af := DefineSessionFlow(reg, "abortNoop",
 		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
 			return nil, sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
 				sess.AddMessages(ai.NewModelTextMessage("reply"))
@@ -2870,9 +2947,9 @@ func TestSessionFlow_CancelSnapshot_NoOpOnTerminal(t *testing.T) {
 		t.Fatalf("RunText: %v", err)
 	}
 
-	resp, err := store.CancelSnapshot(ctx, out.SnapshotID)
+	resp, err := store.AbortSnapshot(ctx, out.SnapshotID)
 	if err != nil {
-		t.Fatalf("CancelSnapshot: %v", err)
+		t.Fatalf("AbortSnapshot: %v", err)
 	}
 	if resp.Status != SnapshotStatusComplete {
 		t.Errorf("expected status=%q (existing terminal), got %q", SnapshotStatusComplete, resp.Status)
@@ -2884,6 +2961,6 @@ func TestSessionFlow_CancelSnapshot_NoOpOnTerminal(t *testing.T) {
 		t.Fatalf("GetSnapshot: %v", err)
 	}
 	if snap.Status != SnapshotStatusComplete {
-		t.Errorf("snapshot status = %q after cancel-on-terminal, want complete", snap.Status)
+		t.Errorf("snapshot status = %q after abort-on-terminal, want complete", snap.Status)
 	}
 }

--- a/go/ai/exp/session_flow_test.go
+++ b/go/ai/exp/session_flow_test.go
@@ -2632,6 +2632,78 @@ func (minimalStore[State]) SaveSnapshot(context.Context, *SessionSnapshot[State]
 	return nil
 }
 
+func TestSessionFlow_AgentMetadata(t *testing.T) {
+	// Verify the metadata["agent"] payload on the flow's action descriptor
+	// correctly reports stateManagement and abortable for each combination
+	// of store capabilities.
+	noopFn := func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
+		return nil, nil
+	}
+
+	cases := []struct {
+		name        string
+		define      func(reg api.Registry, flowName string)
+		wantMgmt    AgentMetadataStateManagement
+		wantAbortab bool
+	}{
+		{
+			name: "no store → client-managed, not abortable",
+			define: func(reg api.Registry, flowName string) {
+				DefineSessionFlow(reg, flowName, noopFn)
+			},
+			wantMgmt:    AgentMetadataStateManagementClient,
+			wantAbortab: false,
+		},
+		{
+			name: "store missing abort capabilities → server-managed, not abortable",
+			define: func(reg api.Registry, flowName string) {
+				DefineSessionFlow(reg, flowName, noopFn,
+					WithSessionStore[testState](minimalStore[testState]{}))
+			},
+			wantMgmt:    AgentMetadataStateManagementServer,
+			wantAbortab: false,
+		},
+		{
+			name: "store with full capabilities → server-managed, abortable",
+			define: func(reg api.Registry, flowName string) {
+				DefineSessionFlow(reg, flowName, noopFn,
+					WithSessionStore(NewInMemorySessionStore[testState]()))
+			},
+			wantMgmt:    AgentMetadataStateManagementServer,
+			wantAbortab: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := newTestRegistry(t)
+			flowName := "metaFlow"
+			tc.define(reg, flowName)
+
+			act := core.ResolveActionFor[*SessionFlowInit[testState], *SessionFlowOutput[testState], *SessionFlowStreamChunk[testStatus], *SessionFlowInput](
+				reg, api.ActionTypeFlow, flowName)
+			if act == nil {
+				t.Fatal("flow action not registered")
+			}
+			desc := act.Desc()
+			raw, ok := desc.Metadata["agent"]
+			if !ok {
+				t.Fatalf("metadata[\"agent\"] missing; got metadata = %+v", desc.Metadata)
+			}
+			meta, ok := raw.(AgentMetadata)
+			if !ok {
+				t.Fatalf("metadata[\"agent\"] type = %T, want AgentMetadata", raw)
+			}
+			if meta.StateManagement != tc.wantMgmt {
+				t.Errorf("stateManagement = %q, want %q", meta.StateManagement, tc.wantMgmt)
+			}
+			if meta.Abortable != tc.wantAbortab {
+				t.Errorf("abortable = %v, want %v", meta.Abortable, tc.wantAbortab)
+			}
+		})
+	}
+}
+
 func TestSessionFlow_AbortAction_GatedOnCapabilities(t *testing.T) {
 	// Verify the abort companion action is only registered when the store
 	// implements both SnapshotAborter and SnapshotStatusSubscriber. The

--- a/go/ai/exp/session_flow_test.go
+++ b/go/ai/exp/session_flow_test.go
@@ -631,46 +631,132 @@ func TestSessionFlow_SetMessages(t *testing.T) {
 }
 
 func TestInMemorySessionStore(t *testing.T) {
-	ctx := context.Background()
-	store := NewInMemorySessionStore[testState]()
+	t.Run("GetMissing", func(t *testing.T) {
+		store := NewInMemorySessionStore[testState]()
+		snap, err := store.GetSnapshot(context.Background(), "nonexistent")
+		if err != nil {
+			t.Fatalf("GetSnapshot failed: %v", err)
+		}
+		if snap != nil {
+			t.Errorf("expected nil, got %v", snap)
+		}
+	})
 
-	// Get non-existent.
-	snap, err := store.GetSnapshot(ctx, "nonexistent")
-	if err != nil {
-		t.Fatalf("GetSnapshot failed: %v", err)
-	}
-	if snap != nil {
-		t.Errorf("expected nil, got %v", snap)
-	}
+	t.Run("SaveWithFixedID", func(t *testing.T) {
+		store := NewInMemorySessionStore[testState]()
+		saved, err := store.SaveSnapshot(context.Background(), "snap-1",
+			func(existing *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+				if existing != nil {
+					t.Errorf("expected nil existing on first save, got %+v", existing)
+				}
+				return &SessionSnapshot[testState]{
+					Status: SnapshotStatusComplete,
+					State:  SessionState[testState]{Custom: testState{Counter: 1}},
+				}, nil
+			})
+		if err != nil {
+			t.Fatalf("SaveSnapshot failed: %v", err)
+		}
+		if saved.SnapshotID != "snap-1" {
+			t.Errorf("saved SnapshotID = %q, want %q", saved.SnapshotID, "snap-1")
+		}
+		if saved.CreatedAt.IsZero() || saved.UpdatedAt.IsZero() {
+			t.Errorf("expected CreatedAt/UpdatedAt stamped, got created=%v updated=%v",
+				saved.CreatedAt, saved.UpdatedAt)
+		}
+	})
 
-	// Save and retrieve.
-	snapshot := &SessionSnapshot[testState]{
-		SnapshotID: "snap-1",
-		State: SessionState[testState]{
-			Custom: testState{Counter: 1},
-		},
-	}
-	if err := store.SaveSnapshot(ctx, snapshot); err != nil {
-		t.Fatalf("SaveSnapshot failed: %v", err)
-	}
+	t.Run("GetReturnsCopy", func(t *testing.T) {
+		store := NewInMemorySessionStore[testState]()
+		if _, err := store.SaveSnapshot(context.Background(), "snap-1",
+			func(_ *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+				return &SessionSnapshot[testState]{
+					Status: SnapshotStatusComplete,
+					State:  SessionState[testState]{Custom: testState{Counter: 1}},
+				}, nil
+			}); err != nil {
+			t.Fatalf("SaveSnapshot: %v", err)
+		}
+		retrieved, _ := store.GetSnapshot(context.Background(), "snap-1")
+		retrieved.State.Custom.Counter = 999
+		retrieved2, _ := store.GetSnapshot(context.Background(), "snap-1")
+		if retrieved2.State.Custom.Counter != 1 {
+			t.Errorf("expected counter=1 (isolation), got %d", retrieved2.State.Custom.Counter)
+		}
+	})
 
-	retrieved, err := store.GetSnapshot(ctx, "snap-1")
-	if err != nil {
-		t.Fatalf("GetSnapshot failed: %v", err)
-	}
-	if retrieved == nil {
-		t.Fatal("expected snapshot")
-	}
-	if retrieved.State.Custom.Counter != 1 {
-		t.Errorf("expected counter=1, got %d", retrieved.State.Custom.Counter)
-	}
+	t.Run("DefaultsEmptyStatusToComplete", func(t *testing.T) {
+		store := NewInMemorySessionStore[testState]()
+		saved, err := store.SaveSnapshot(context.Background(), "",
+			func(_ *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+				return &SessionSnapshot[testState]{}, nil
+			})
+		if err != nil {
+			t.Fatalf("SaveSnapshot: %v", err)
+		}
+		if saved.SnapshotID == "" {
+			t.Error("expected store to generate SnapshotID")
+		}
+		if saved.Status != SnapshotStatusComplete {
+			t.Errorf("expected Status=complete by default, got %q", saved.Status)
+		}
+	})
 
-	// Verify isolation.
-	snapshot.State.Custom.Counter = 999
-	retrieved2, _ := store.GetSnapshot(ctx, "snap-1")
-	if retrieved2.State.Custom.Counter != 1 {
-		t.Errorf("expected counter=1 (isolation), got %d", retrieved2.State.Custom.Counter)
-	}
+	t.Run("NoopFnSkipsWrite", func(t *testing.T) {
+		store := NewInMemorySessionStore[testState]()
+		if _, err := store.SaveSnapshot(context.Background(), "snap-1",
+			func(_ *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+				return &SessionSnapshot[testState]{Status: SnapshotStatusComplete}, nil
+			}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		before, _ := store.GetSnapshot(context.Background(), "snap-1")
+		noop, err := store.SaveSnapshot(context.Background(), "snap-1",
+			func(_ *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+				return nil, nil
+			})
+		if err != nil {
+			t.Fatalf("noop SaveSnapshot: %v", err)
+		}
+		if noop != nil {
+			t.Errorf("expected nil return on noop, got %+v", noop)
+		}
+		after, _ := store.GetSnapshot(context.Background(), "snap-1")
+		if before.UpdatedAt != after.UpdatedAt {
+			t.Errorf("noop should not bump UpdatedAt: before=%v after=%v", before.UpdatedAt, after.UpdatedAt)
+		}
+	})
+
+	t.Run("PreservesCreatedAtOnUpdate", func(t *testing.T) {
+		store := NewInMemorySessionStore[testState]()
+		saved, err := store.SaveSnapshot(context.Background(), "snap-1",
+			func(_ *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+				return &SessionSnapshot[testState]{Status: SnapshotStatusComplete}, nil
+			})
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		time.Sleep(time.Millisecond) // ensure measurable UpdatedAt delta
+		updated, err := store.SaveSnapshot(context.Background(), "snap-1",
+			func(existing *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+				if existing == nil {
+					t.Fatal("expected non-nil existing on update")
+				}
+				return &SessionSnapshot[testState]{
+					Status: SnapshotStatusComplete,
+					State:  SessionState[testState]{Custom: testState{Counter: 2}},
+				}, nil
+			})
+		if err != nil {
+			t.Fatalf("update: %v", err)
+		}
+		if !updated.CreatedAt.Equal(saved.CreatedAt) {
+			t.Errorf("CreatedAt not preserved: before=%v after=%v", saved.CreatedAt, updated.CreatedAt)
+		}
+		if !updated.UpdatedAt.After(saved.UpdatedAt) {
+			t.Errorf("UpdatedAt did not advance: before=%v after=%v", saved.UpdatedAt, updated.UpdatedAt)
+		}
+	})
 }
 
 func TestSessionFlow_TurnSpanOutput(t *testing.T) {
@@ -2392,14 +2478,15 @@ func TestSessionFlow_ResumeFromErrorSnapshot_Rejected(t *testing.T) {
 	store := NewInMemorySessionStore[testState]()
 
 	erroredID := "errored-456"
-	if err := store.SaveSnapshot(context.Background(), &SessionSnapshot[testState]{
-		SnapshotID: erroredID,
-		CreatedAt:  time.Now(),
-		Event:      SnapshotEventInvocationEnd,
-		Status:     SnapshotStatusError,
-		Error:      "underlying failure",
-		State:      SessionState[testState]{},
-	}); err != nil {
+	if _, err := store.SaveSnapshot(context.Background(), erroredID,
+		func(_ *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+			return &SessionSnapshot[testState]{
+				Event:  SnapshotEventInvocationEnd,
+				Status: SnapshotStatusError,
+				Error:  "underlying failure",
+				State:  SessionState[testState]{},
+			}, nil
+		}); err != nil {
 		t.Fatalf("SaveSnapshot: %v", err)
 	}
 
@@ -2424,7 +2511,7 @@ func TestSessionFlow_GetSnapshotAction_ReturnsTransformedState(t *testing.T) {
 	store := NewInMemorySessionStore[testState]()
 
 	// Transform that scrubs a specific word from all messages.
-	transform := func(s SessionState[testState]) SessionState[testState] {
+	transform := func(_ context.Context, s SessionState[testState]) SessionState[testState] {
 		for _, msg := range s.Messages {
 			for _, p := range msg.Content {
 				if p.Text != "" {
@@ -2443,7 +2530,7 @@ func TestSessionFlow_GetSnapshotAction_ReturnsTransformedState(t *testing.T) {
 			})
 		},
 		WithSessionStore(store),
-		WithSnapshotTransform[testState](transform),
+		WithStateTransform[testState](transform),
 	)
 
 	ctx := context.Background()
@@ -2545,8 +2632,11 @@ type minimalStore[State any] struct{}
 func (minimalStore[State]) GetSnapshot(context.Context, string) (*SessionSnapshot[State], error) {
 	return nil, nil
 }
-func (minimalStore[State]) SaveSnapshot(context.Context, *SessionSnapshot[State]) error {
-	return nil
+func (minimalStore[State]) SaveSnapshot(
+	context.Context, string,
+	func(*SessionSnapshot[State]) (*SessionSnapshot[State], error),
+) (*SessionSnapshot[State], error) {
+	return nil, nil
 }
 
 func TestSessionFlow_AgentMetadata(t *testing.T) {
@@ -2667,11 +2757,11 @@ func TestSessionFlow_AbortAction_GatedOnCapabilities(t *testing.T) {
 	})
 }
 
-func TestSessionFlow_SnapshotTransform_ClientManagedState(t *testing.T) {
+func TestSessionFlow_StateTransform_ClientManagedState(t *testing.T) {
 	reg := newTestRegistry(t)
 
 	// Client-managed state: transform should be applied to SessionFlowOutput.State.
-	transform := func(s SessionState[testState]) SessionState[testState] {
+	transform := func(_ context.Context, s SessionState[testState]) SessionState[testState] {
 		// Zero out the counter to demonstrate the transform is applied.
 		s.Custom.Counter = -1
 		return s
@@ -2687,7 +2777,7 @@ func TestSessionFlow_SnapshotTransform_ClientManagedState(t *testing.T) {
 				return nil
 			})
 		},
-		WithSnapshotTransform[testState](transform),
+		WithStateTransform[testState](transform),
 	)
 
 	out, err := af.RunText(context.Background(), "go")
@@ -2779,17 +2869,17 @@ func TestInMemorySessionStore_AbortSnapshot_AtomicAndIdempotent(t *testing.T) {
 	}
 
 	// Pending → canceled, UpdatedAt advances.
-	created := time.Now().Add(-time.Hour)
-	pending := &SessionSnapshot[testState]{
-		SnapshotID: "snap-cas",
-		CreatedAt:  created,
-		UpdatedAt:  created,
-		Event:      SnapshotEventDetach,
-		Status:     SnapshotStatusPending,
-	}
-	if err := store.SaveSnapshot(ctx, pending); err != nil {
+	pending, err := store.SaveSnapshot(ctx, "snap-cas",
+		func(_ *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+			return &SessionSnapshot[testState]{
+				Event:  SnapshotEventDetach,
+				Status: SnapshotStatusPending,
+			}, nil
+		})
+	if err != nil {
 		t.Fatalf("SaveSnapshot: %v", err)
 	}
+	time.Sleep(time.Millisecond) // ensure measurable UpdatedAt delta
 	meta, err := store.AbortSnapshot(ctx, "snap-cas")
 	if err != nil {
 		t.Fatalf("AbortSnapshot: %v", err)
@@ -2797,8 +2887,8 @@ func TestInMemorySessionStore_AbortSnapshot_AtomicAndIdempotent(t *testing.T) {
 	if meta.Status != SnapshotStatusCanceled {
 		t.Errorf("status after first abort = %q, want canceled", meta.Status)
 	}
-	if !meta.UpdatedAt.After(created) {
-		t.Errorf("UpdatedAt did not advance: %v vs %v", meta.UpdatedAt, created)
+	if !meta.UpdatedAt.After(pending.UpdatedAt) {
+		t.Errorf("UpdatedAt did not advance: %v vs %v", meta.UpdatedAt, pending.UpdatedAt)
 	}
 
 	// Idempotent: second abort returns canceled, no error, no further mutation.
@@ -2815,14 +2905,13 @@ func TestInMemorySessionStore_AbortSnapshot_AtomicAndIdempotent(t *testing.T) {
 	}
 
 	// Abort on terminal status is a no-op that returns the existing status.
-	complete := &SessionSnapshot[testState]{
-		SnapshotID: "snap-complete",
-		CreatedAt:  created,
-		UpdatedAt:  created,
-		Event:      SnapshotEventTurnEnd,
-		Status:     SnapshotStatusComplete,
-	}
-	if err := store.SaveSnapshot(ctx, complete); err != nil {
+	if _, err := store.SaveSnapshot(ctx, "snap-complete",
+		func(_ *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+			return &SessionSnapshot[testState]{
+				Event:  SnapshotEventTurnEnd,
+				Status: SnapshotStatusComplete,
+			}, nil
+		}); err != nil {
 		t.Fatalf("SaveSnapshot: %v", err)
 	}
 	meta3, err := store.AbortSnapshot(ctx, "snap-complete")
@@ -2917,13 +3006,13 @@ func TestInMemorySessionStore_OnSnapshotStatusChange(t *testing.T) {
 
 	// Persist a pending snapshot so subsequent subscribers get an initial
 	// value plus updates on each status flip.
-	pending := &SessionSnapshot[testState]{
-		SnapshotID: "snap-sub",
-		CreatedAt:  time.Now(),
-		Event:      SnapshotEventDetach,
-		Status:     SnapshotStatusPending,
-	}
-	if err := store.SaveSnapshot(ctx, pending); err != nil {
+	if _, err := store.SaveSnapshot(ctx, "snap-sub",
+		func(_ *SessionSnapshot[testState]) (*SessionSnapshot[testState], error) {
+			return &SessionSnapshot[testState]{
+				Event:  SnapshotEventDetach,
+				Status: SnapshotStatusPending,
+			}, nil
+		}); err != nil {
 		t.Fatalf("SaveSnapshot: %v", err)
 	}
 

--- a/go/ai/exp/session_flow_test.go
+++ b/go/ai/exp/session_flow_test.go
@@ -630,59 +630,6 @@ func TestSessionFlow_SetMessages(t *testing.T) {
 	}
 }
 
-func TestSessionFlow_SnapshotIDInMessageMetadata(t *testing.T) {
-	ctx := context.Background()
-	reg := newTestRegistry(t)
-	store := NewInMemorySessionStore[testState]()
-
-	af := DefineSessionFlow(reg, "metadataFlow",
-		func(ctx context.Context, resp Responder[testStatus], sess *SessionRunner[testState]) (*SessionFlowResult, error) {
-			err := sess.Run(ctx, func(ctx context.Context, input *SessionFlowInput) error {
-				sess.AddMessages(ai.NewModelTextMessage("reply"))
-				return nil
-			})
-			if err != nil {
-				return nil, err
-			}
-			msgs := sess.Messages()
-			return &SessionFlowResult{Message: msgs[len(msgs)-1]}, nil
-		},
-		WithSessionStore(store),
-	)
-
-	conn, err := af.StreamBidi(ctx)
-	if err != nil {
-		t.Fatalf("StreamBidi failed: %v", err)
-	}
-
-	conn.SendText("hello")
-	for chunk, err := range conn.Receive() {
-		if err != nil {
-			t.Fatalf("Receive error: %v", err)
-		}
-		if chunk.TurnEnd != nil {
-			break
-		}
-	}
-	conn.Close()
-
-	response, err := conn.Output()
-	if err != nil {
-		t.Fatalf("Output failed: %v", err)
-	}
-
-	// The last model message should have snapshotId in its metadata.
-	if response.Message == nil {
-		t.Fatal("expected Message in response")
-	}
-	if response.Message.Metadata == nil {
-		t.Fatal("expected metadata on last message")
-	}
-	if _, ok := response.Message.Metadata["snapshotId"]; !ok {
-		t.Error("expected snapshotId in last message metadata")
-	}
-}
-
 func TestInMemorySessionStore(t *testing.T) {
 	ctx := context.Background()
 	store := NewInMemorySessionStore[testState]()
@@ -1801,11 +1748,12 @@ func TestSessionFlow_TurnEnd_CarriesSnapshotID(t *testing.T) {
 	}
 }
 
-func TestSessionFlow_Detach_CapturesInFlightAndQueued(t *testing.T) {
+func TestSessionFlow_Detach_SuspendsTurnSnapshotsAndProcessesQueue(t *testing.T) {
 	// Detach lands while turn 0 (input A) is mid-fn and an extra turn
 	// (the detach input D itself) is waiting. The pending snapshot must:
-	//   - Include A AND D in PendingInputs (in FIFO order)
-	//   - NOT write a separate turn-end snapshot for A (suspended)
+	//   - Be written with empty state and no parent (A was suspended, so
+	//     no turn-end snapshot landed before pending).
+	//   - NOT write a separate turn-end snapshot for A or D (suspended).
 	// After release, the finalized snapshot has both A's and D's effects.
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
@@ -1878,19 +1826,8 @@ func TestSessionFlow_Detach_CapturesInFlightAndQueued(t *testing.T) {
 	if pending.Status != SnapshotStatusPending {
 		t.Errorf("pending snapshot status = %q, want pending", pending.Status)
 	}
-	if got := len(pending.PendingInputs); got != 2 {
-		t.Fatalf("pending PendingInputs len = %d, want 2 (in-flight A + queued D)", got)
-	}
-	if msg := pending.PendingInputs[0].Messages[0].Text(); msg != "A" {
-		t.Errorf("PendingInputs[0] = %q, want A", msg)
-	}
-	if msg := pending.PendingInputs[1].Messages[0].Text(); msg != "D" {
-		t.Errorf("PendingInputs[1] = %q, want D", msg)
-	}
-	for i, p := range pending.PendingInputs {
-		if p.Detach {
-			t.Errorf("PendingInputs[%d] retained Detach=true", i)
-		}
+	if got := len(pending.State.Messages); got != 0 {
+		t.Errorf("pending state messages = %d, want 0 (live state not yet committed)", got)
 	}
 
 	// No separate turn-end snapshot for A should have been written.
@@ -1912,15 +1849,11 @@ func TestSessionFlow_Detach_CapturesInFlightAndQueued(t *testing.T) {
 		// 2 user (A, D) + 2 model replies = 4.
 		t.Errorf("final messages = %d, want 4", got)
 	}
-	if final.PendingInputs != nil {
-		t.Errorf("final PendingInputs not cleared: %d entries", len(final.PendingInputs))
-	}
 }
 
 func TestSessionFlow_Detach_AfterPriorTurns_ChainsParent(t *testing.T) {
 	// Run two normal turns first, then detach during a third (in-flight)
-	// turn. The pending snapshot must chain off the second turn's snapshot
-	// and capture the in-flight + queued inputs in FIFO order.
+	// turn. The pending snapshot must chain off the second turn's snapshot.
 	reg := newTestRegistry(t)
 	store := NewInMemorySessionStore[testState]()
 
@@ -1990,12 +1923,6 @@ func TestSessionFlow_Detach_AfterPriorTurns_ChainsParent(t *testing.T) {
 	pending, err := store.GetSnapshot(context.Background(), out.SnapshotID)
 	if err != nil {
 		t.Fatalf("GetSnapshot: %v", err)
-	}
-	if got := len(pending.PendingInputs); got != 2 {
-		t.Fatalf("PendingInputs len = %d, want 2 (in-flight + detach)", got)
-	}
-	if msg := pending.PendingInputs[0].Messages[0].Text(); msg != "inflight" {
-		t.Errorf("PendingInputs[0] = %q, want inflight", msg)
 	}
 	if pending.ParentID == "" {
 		t.Error("pending ParentID empty; expected parent = last sync turn snapshot")
@@ -2112,13 +2039,6 @@ func TestSessionFlow_Detach_PendingThenComplete(t *testing.T) {
 	if pending.Status != SnapshotStatusPending {
 		t.Errorf("expected status=%q, got %q", SnapshotStatusPending, pending.Status)
 	}
-	if got := len(pending.PendingInputs); got != 1 {
-		t.Errorf("expected 1 pending input, got %d", got)
-	} else if pending.PendingInputs[0].Detach {
-		t.Error("pending input retained Detach=true; expected it cleared")
-	} else if got := pending.PendingInputs[0].Messages[0].Text(); got != "go" {
-		t.Errorf("pending input message = %q, want %q", got, "go")
-	}
 	if got := len(pending.State.Messages); got != 0 {
 		t.Errorf("pending snapshot should not carry message history, got %d messages", got)
 	}
@@ -2134,9 +2054,6 @@ func TestSessionFlow_Detach_PendingThenComplete(t *testing.T) {
 	}
 	if got := len(finalSnap.State.Messages); got < 2 {
 		t.Errorf("expected at least 2 messages in final snapshot, got %d", got)
-	}
-	if finalSnap.PendingInputs != nil {
-		t.Errorf("expected PendingInputs cleared on finalize, got %d", len(finalSnap.PendingInputs))
 	}
 }
 

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -582,8 +582,21 @@ func (c *BidiConnection[StreamIn, StreamOut, Out]) Receive() iter.Seq2[StreamOut
 }
 
 // Output returns the final output after the action completes.
-// Blocks until done or context cancelled.
+// Blocks until done or context cancelled. If the action has finished, its
+// actual output is returned even when the context was cancelled concurrently.
 func (c *BidiConnection[StreamIn, StreamOut, Out]) Output() (Out, error) {
+	// Fast path: if the action has already finished, return its output
+	// rather than racing with ctx.Done. This matters for callers that
+	// observe a completed action just after cancelling ctx (e.g., session
+	// flows backgrounded on client disconnect).
+	select {
+	case <-c.doneCh:
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.output, c.err
+	default:
+	}
+
 	select {
 	case <-c.doneCh:
 		c.mu.Lock()

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -388,6 +388,21 @@ func (a *Action[In, Out, StreamOut, StreamIn]) Desc() api.ActionDesc {
 	return *a.desc
 }
 
+// SetMetadataValue sets a single key/value pair on the action's metadata
+// map, creating the map if necessary. Intended for callers that build
+// higher-level abstractions on top of the action and need to attach
+// reflective hints (e.g. capability flags) after construction.
+//
+// Must be called during setup, before the action is invoked or its
+// descriptor is observed concurrently — there is no synchronization
+// against [Desc] or [Run].
+func (a *Action[In, Out, StreamOut, StreamIn]) SetMetadataValue(key string, value any) {
+	if a.desc.Metadata == nil {
+		a.desc.Metadata = map[string]any{}
+	}
+	a.desc.Metadata[key] = value
+}
+
 // Register registers the action with the given registry.
 func (a *Action[In, Out, StreamOut, StreamIn]) Register(r api.Registry) {
 	a.registry = r

--- a/go/core/action.go
+++ b/go/core/action.go
@@ -388,21 +388,6 @@ func (a *Action[In, Out, StreamOut, StreamIn]) Desc() api.ActionDesc {
 	return *a.desc
 }
 
-// SetMetadataValue sets a single key/value pair on the action's metadata
-// map, creating the map if necessary. Intended for callers that build
-// higher-level abstractions on top of the action and need to attach
-// reflective hints (e.g. capability flags) after construction.
-//
-// Must be called during setup, before the action is invoked or its
-// descriptor is observed concurrently — there is no synchronization
-// against [Desc] or [Run].
-func (a *Action[In, Out, StreamOut, StreamIn]) SetMetadataValue(key string, value any) {
-	if a.desc.Metadata == nil {
-		a.desc.Metadata = map[string]any{}
-	}
-	a.desc.Metadata[key] = value
-}
-
 // Register registers the action with the given registry.
 func (a *Action[In, Out, StreamOut, StreamIn]) Register(r api.Registry) {
 	a.registry = r

--- a/go/core/api/action.go
+++ b/go/core/api/action.go
@@ -62,6 +62,8 @@ const (
 	ActionTypeToolV2           ActionType = "tool.v2"
 	ActionTypeUtil             ActionType = "util"
 	ActionTypeCustom           ActionType = "custom"
+	ActionTypeAgentSnapshot    ActionType = "agent-snapshot"
+	ActionTypeAgentAbort       ActionType = "agent-abort"
 	ActionTypeCheckOperation   ActionType = "check-operation"
 	ActionTypeCancelOperation  ActionType = "cancel-operation"
 	ActionTypeSessionFlow      ActionType = "session-flow"

--- a/go/core/flow.go
+++ b/go/core/flow.go
@@ -189,3 +189,17 @@ func FlowNameFromContext(ctx context.Context) string {
 	}
 	return ""
 }
+
+// WithFlowContext attaches flow-context metadata to ctx so that [Run] and
+// [FlowNameFromContext] work from within. Use it when wiring a custom
+// flow-like action (e.g. via [NewBidiAction] / [DefineBidiAction]) that
+// should behave like a flow from the user's perspective — letting them
+// call [Run] for sub-step tracking and see the flow name in spans —
+// without going through [NewBidiFlow] / [DefineBidiFlow].
+//
+// The Define*Flow constructors call this internally; direct callers
+// only need it when bypassing those constructors to set custom
+// [ActionOptions].
+func WithFlowContext(ctx context.Context, flowName string) context.Context {
+	return flowContextKey.NewContext(ctx, &flowContext{flowName: flowName})
+}

--- a/go/core/flow.go
+++ b/go/core/flow.go
@@ -73,20 +73,13 @@ func NewStreamingFlow[In, Out, StreamOut any](name string, fn StreamingFunc[In, 
 }
 
 // NewBidiFlow creates a bidirectional streaming Flow without registering it.
-// Flow context is injected so that [Run] works inside the bidi function. An
-// optional [ActionOptions] (variadic for source compatibility — at most one
-// value is consumed) lets callers attach metadata or override schemas on the
-// underlying action descriptor.
-func NewBidiFlow[In, Out, StreamOut, StreamIn any](name string, fn BidiFunc[In, Out, StreamOut, StreamIn], opts ...*ActionOptions) *Flow[In, Out, StreamOut, StreamIn] {
+// Flow context is injected so that [Run] works inside the bidi function.
+func NewBidiFlow[In, Out, StreamOut, StreamIn any](name string, fn BidiFunc[In, Out, StreamOut, StreamIn]) *Flow[In, Out, StreamOut, StreamIn] {
 	wrapped := func(ctx context.Context, in In, inCh <-chan StreamIn, outCh chan<- StreamOut) (Out, error) {
 		ctx = flowContextKey.NewContext(ctx, &flowContext{flowName: name})
 		return fn(ctx, in, inCh, outCh)
 	}
-	var ao *ActionOptions
-	if len(opts) > 0 {
-		ao = opts[0]
-	}
-	return &Flow[In, Out, StreamOut, StreamIn]{NewBidiAction(name, api.ActionTypeFlow, ao, wrapped)}
+	return &Flow[In, Out, StreamOut, StreamIn]{NewBidiAction(name, api.ActionTypeFlow, nil, wrapped)}
 }
 
 // DefineFlow creates a Flow that runs fn, and registers it as an action. fn takes an input of type In and returns an output of type Out.
@@ -111,13 +104,10 @@ func DefineStreamingFlow[In, Out, StreamOut any](r api.Registry, name string, fn
 	return f
 }
 
-// DefineBidiFlow creates a bidirectional streaming Flow that runs fn, and
-// registers it as an action. Flow context is injected so that [Run] works
-// inside the bidi function. Variadic [ActionOptions] (at most one) lets
-// callers attach metadata or override schemas on the underlying action
-// descriptor.
-func DefineBidiFlow[In, Out, StreamOut, StreamIn any](r api.Registry, name string, fn BidiFunc[In, Out, StreamOut, StreamIn], opts ...*ActionOptions) *Flow[In, Out, StreamOut, StreamIn] {
-	f := NewBidiFlow(name, fn, opts...)
+// DefineBidiFlow creates a bidirectional streaming Flow that runs fn, and registers it as an action.
+// Flow context is injected so that [Run] works inside the bidi function.
+func DefineBidiFlow[In, Out, StreamOut, StreamIn any](r api.Registry, name string, fn BidiFunc[In, Out, StreamOut, StreamIn]) *Flow[In, Out, StreamOut, StreamIn] {
+	f := NewBidiFlow(name, fn)
 	f.Register(r)
 	return f
 }

--- a/go/core/flow.go
+++ b/go/core/flow.go
@@ -73,13 +73,20 @@ func NewStreamingFlow[In, Out, StreamOut any](name string, fn StreamingFunc[In, 
 }
 
 // NewBidiFlow creates a bidirectional streaming Flow without registering it.
-// Flow context is injected so that [Run] works inside the bidi function.
-func NewBidiFlow[In, Out, StreamOut, StreamIn any](name string, fn BidiFunc[In, Out, StreamOut, StreamIn]) *Flow[In, Out, StreamOut, StreamIn] {
+// Flow context is injected so that [Run] works inside the bidi function. An
+// optional [ActionOptions] (variadic for source compatibility — at most one
+// value is consumed) lets callers attach metadata or override schemas on the
+// underlying action descriptor.
+func NewBidiFlow[In, Out, StreamOut, StreamIn any](name string, fn BidiFunc[In, Out, StreamOut, StreamIn], opts ...*ActionOptions) *Flow[In, Out, StreamOut, StreamIn] {
 	wrapped := func(ctx context.Context, in In, inCh <-chan StreamIn, outCh chan<- StreamOut) (Out, error) {
 		ctx = flowContextKey.NewContext(ctx, &flowContext{flowName: name})
 		return fn(ctx, in, inCh, outCh)
 	}
-	return &Flow[In, Out, StreamOut, StreamIn]{NewBidiAction(name, api.ActionTypeFlow, nil, wrapped)}
+	var ao *ActionOptions
+	if len(opts) > 0 {
+		ao = opts[0]
+	}
+	return &Flow[In, Out, StreamOut, StreamIn]{NewBidiAction(name, api.ActionTypeFlow, ao, wrapped)}
 }
 
 // DefineFlow creates a Flow that runs fn, and registers it as an action. fn takes an input of type In and returns an output of type Out.
@@ -104,10 +111,13 @@ func DefineStreamingFlow[In, Out, StreamOut any](r api.Registry, name string, fn
 	return f
 }
 
-// DefineBidiFlow creates a bidirectional streaming Flow that runs fn, and registers it as an action.
-// Flow context is injected so that [Run] works inside the bidi function.
-func DefineBidiFlow[In, Out, StreamOut, StreamIn any](r api.Registry, name string, fn BidiFunc[In, Out, StreamOut, StreamIn]) *Flow[In, Out, StreamOut, StreamIn] {
-	f := NewBidiFlow(name, fn)
+// DefineBidiFlow creates a bidirectional streaming Flow that runs fn, and
+// registers it as an action. Flow context is injected so that [Run] works
+// inside the bidi function. Variadic [ActionOptions] (at most one) lets
+// callers attach metadata or override schemas on the underlying action
+// descriptor.
+func DefineBidiFlow[In, Out, StreamOut, StreamIn any](r api.Registry, name string, fn BidiFunc[In, Out, StreamOut, StreamIn], opts ...*ActionOptions) *Flow[In, Out, StreamOut, StreamIn] {
+	f := NewBidiFlow(name, fn, opts...)
 	f.Register(r)
 	return f
 }

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -1203,6 +1203,15 @@ SessionFlowInput doc
 SessionFlowInput is the input sent to an session flow during a conversation turn.
 .
 
+SessionFlowInput.detach doc
+Detach signals that the client wishes to disconnect after this input is
+accepted. The server writes a single pending snapshot capturing the
+queued inputs (this one and any others already buffered), returns
+[SessionFlowOutput] with that snapshot ID, and continues processing in
+a background context. The pending snapshot is finalized once all queued
+inputs are processed (or the snapshot is cancelled via cancelSnapshot).
+.
+
 SessionFlowInput.messages type []*ai.Message
 SessionFlowInput.messages doc
 Messages contains the user's input for this turn.
@@ -1341,7 +1350,18 @@ snapshot was persisted.
 TurnEnd.snapshotId doc
 SnapshotID is the ID of the snapshot persisted at the end of this turn.
 Empty if no snapshot was created (callback returned false or no store
-configured).
+configured, or snapshots were suspended after detach).
+.
+
+TurnEnd.turnIndex type int
+TurnEnd.turnIndex doc
+TurnIndex is the zero-based index of the turn that just ended within
+this invocation. It restarts at 0 for each new invocation (resume,
+reconnect). Clients consuming a durable chunk stream use this field
+to anchor chunks to inputs: chunks emitted between TurnEnd{turnIndex:N-1}
+and TurnEnd{turnIndex:N} belong to the input at turn N. After detach,
+pair with [SessionSnapshot.StartingTurnIndex] and
+[SessionSnapshot.PendingInputs] to recover input correspondence.
 .
 
 # ----------------------------------------------------------------------------
@@ -1393,6 +1413,29 @@ TurnEnd indicates the snapshot was triggered at the end of a turn.
 SnapshotEventInvocationEnd doc
 InvocationEnd indicates the snapshot was triggered at the end of the invocation.
 .
+
+SnapshotEventDetach doc
+Detach indicates the snapshot was created when the client detached the
+invocation and the flow continues in the background. The snapshot is
+initially written with [SnapshotStatusPending] and rewritten with a
+terminal status once the background work finishes.
+.
+
+# ----------------------------------------------------------------------------
+# Snapshot lifecycle types (hand-written in go/ai/exp/session.go)
+# ----------------------------------------------------------------------------
+
+# SnapshotStatus enum and the persisted snapshot envelope are hand-written
+# alongside the Session type. The companion-action request/response types
+# are also hand-written because they reference SessionState[State] with a
+# Go type parameter, which the generator does not support.
+SnapshotStatus            omit
+SessionSnapshot           omit
+SnapshotMetadata          omit
+GetSnapshotRequest        omit
+GetSnapshotResponse       omit
+CancelSnapshotRequest     omit
+CancelSnapshotResponse    omit
 
 # ============================================================================
 # REFLECTION V2 TYPES (generated into genkit package)

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -1353,17 +1353,6 @@ Empty if no snapshot was created (callback returned false or no store
 configured, or snapshots were suspended after detach).
 .
 
-TurnEnd.turnIndex type int
-TurnEnd.turnIndex doc
-TurnIndex is the zero-based index of the turn that just ended within
-this invocation. It restarts at 0 for each new invocation (resume,
-reconnect). Clients consuming a durable chunk stream use this field
-to anchor chunks to inputs: chunks emitted between TurnEnd{turnIndex:N-1}
-and TurnEnd{turnIndex:N} belong to the input at turn N. After detach,
-pair with [SessionSnapshot.StartingTurnIndex] and
-[SessionSnapshot.PendingInputs] to recover input correspondence.
-.
-
 # ----------------------------------------------------------------------------
 # SessionState
 # ----------------------------------------------------------------------------
@@ -1434,8 +1423,8 @@ SessionSnapshot           omit
 SnapshotMetadata          omit
 GetSnapshotRequest        omit
 GetSnapshotResponse       omit
-CancelSnapshotRequest     omit
-CancelSnapshotResponse    omit
+AbortSnapshotRequest      omit
+AbortSnapshotResponse     omit
 
 # ============================================================================
 # REFLECTION V2 TYPES (generated into genkit package)

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -1205,11 +1205,12 @@ SessionFlowInput is the input sent to an session flow during a conversation turn
 
 SessionFlowInput.detach doc
 Detach signals that the client wishes to disconnect after this input is
-accepted. The server writes a single pending snapshot capturing the
-queued inputs (this one and any others already buffered), returns
-[SessionFlowOutput] with that snapshot ID, and continues processing in
-a background context. The pending snapshot is finalized once all queued
-inputs are processed (or the snapshot is cancelled via cancelSnapshot).
+accepted. The server writes a single pending snapshot (with empty
+state), returns [SessionFlowOutput] with that snapshot ID, and
+continues processing any already-buffered inputs in a background
+context. The pending snapshot is finalized with the cumulative final
+state once all queued inputs are processed (or the snapshot is
+cancelled via cancelSnapshot).
 .
 
 SessionFlowInput.messages type []*ai.Message

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -1426,6 +1426,49 @@ GetSnapshotResponse       omit
 AbortSnapshotRequest      omit
 AbortSnapshotResponse     omit
 
+# ----------------------------------------------------------------------------
+# AgentMetadata
+# ----------------------------------------------------------------------------
+
+AgentMetadata pkg ai/exp
+
+AgentMetadata doc
+AgentMetadata is the value placed under metadata["agent"] on a session
+flow's action descriptor. It exposes capability information so the Dev
+UI and other reflective callers can render the right surface (e.g.
+hide the Abort button when the configured store doesn't support it)
+without round-tripping through the reflection API.
+.
+
+AgentMetadata.stateManagement doc
+StateManagement reports who owns session state.
+.
+
+AgentMetadata.abortable doc
+Abortable reports whether the agent's invocations can be aborted
+(true when the store implements [SnapshotAborter]).
+.
+
+AgentMetadataStateManagement pkg ai/exp
+
+AgentMetadataStateManagement doc
+AgentMetadataStateManagement enumerates who owns session state for an
+agent: "server" (a [SessionStore] is configured and snapshots are
+persisted server-side) or "client" (no store; state flows through
+invocation init / output).
+.
+
+AgentMetadataStateManagementServer doc
+AgentMetadataStateManagementServer indicates the agent is wired with
+a [SessionStore] and persists snapshots server-side.
+.
+
+AgentMetadataStateManagementClient doc
+AgentMetadataStateManagementClient indicates the agent has no store;
+session state is client-managed and round-trips through invocation
+init and output.
+.
+
 # ============================================================================
 # REFLECTION V2 TYPES (generated into genkit package)
 # ============================================================================

--- a/go/genkit/gen.go
+++ b/go/genkit/gen.go
@@ -18,7 +18,9 @@
 
 package genkit
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 // ReflectionCancelActionParams is the payload for the "cancelAction" request
 // sent by the CLI manager to cancel a running action.

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -414,8 +414,8 @@ func DefineStreamingFlow[In, Out, Stream any](g *Genkit, name string, fn core.St
 //	// Get the final output:
 //	output, err := conn.Output()
 //	fmt.Println(output) // Output: "processed 2 messages"
-func DefineBidiFlow[In, Out, StreamOut, StreamIn any](g *Genkit, name string, fn core.BidiFunc[In, Out, StreamOut, StreamIn]) *core.Flow[In, Out, StreamOut, StreamIn] {
-	return core.DefineBidiFlow(g.reg, name, fn)
+func DefineBidiFlow[In, Out, StreamOut, StreamIn any](g *Genkit, name string, fn core.BidiFunc[In, Out, StreamOut, StreamIn], opts ...*core.ActionOptions) *core.Flow[In, Out, StreamOut, StreamIn] {
+	return core.DefineBidiFlow(g.reg, name, fn, opts...)
 }
 
 // DefineSessionFlow defines a custom session flow with full control over the

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -414,8 +414,8 @@ func DefineStreamingFlow[In, Out, Stream any](g *Genkit, name string, fn core.St
 //	// Get the final output:
 //	output, err := conn.Output()
 //	fmt.Println(output) // Output: "processed 2 messages"
-func DefineBidiFlow[In, Out, StreamOut, StreamIn any](g *Genkit, name string, fn core.BidiFunc[In, Out, StreamOut, StreamIn], opts ...*core.ActionOptions) *core.Flow[In, Out, StreamOut, StreamIn] {
-	return core.DefineBidiFlow(g.reg, name, fn, opts...)
+func DefineBidiFlow[In, Out, StreamOut, StreamIn any](g *Genkit, name string, fn core.BidiFunc[In, Out, StreamOut, StreamIn]) *core.Flow[In, Out, StreamOut, StreamIn] {
+	return core.DefineBidiFlow(g.reg, name, fn)
 }
 
 // DefineSessionFlow defines a custom session flow with full control over the

--- a/go/genkit/reflection_test.go
+++ b/go/genkit/reflection_test.go
@@ -302,22 +302,24 @@ func TestEarlyTraceIDTransmission(t *testing.T) {
 	tc := tracing.NewTestOnlyTelemetryClient()
 	tracing.WriteTelemetryImmediate(tc)
 
-	actionStarted := make(chan struct{})
-	actionCanProceed := make(chan struct{})
-
-	// Action that waits for permission to complete - this lets us check headers while it's running
-	core.DefineAction(g.reg, "test/slow", api.ActionTypeCustom, nil, nil,
-		func(ctx context.Context, input any) (any, error) {
-			close(actionStarted) // Signal we've started
-			<-actionCanProceed   // Wait for test to say we can finish
-			return "completed", nil
-		})
-
 	s := &reflectionServer{Server: &http.Server{}, activeActions: newActiveActionsMap()}
 	ts := httptest.NewServer(serveMux(g, s))
 	defer ts.Close()
 
 	t.Run("headers arrive before body completes", func(t *testing.T) {
+		// Subtest-local channels and action so the server goroutine for
+		// this subtest doesn't read variables that the next subtest is
+		// about to reassign. The previous shared-state setup raced under
+		// -race because t.Run only synchronizes with the subtest
+		// goroutine, not with the httptest server's request goroutine.
+		actionStarted := make(chan struct{})
+		actionCanProceed := make(chan struct{})
+		core.DefineAction(g.reg, "test/slow", api.ActionTypeCustom, nil, nil,
+			func(ctx context.Context, input any) (any, error) {
+				close(actionStarted)
+				<-actionCanProceed
+				return "completed", nil
+			})
 		// Channel to receive headers as soon as they arrive
 		type headerResult struct {
 			traceID string
@@ -375,11 +377,10 @@ func TestEarlyTraceIDTransmission(t *testing.T) {
 
 	// Backwards compatability
 	t.Run("trace ID in headers matches body", func(t *testing.T) {
-		// Reset channels for this subtest
-		actionStarted = make(chan struct{})
-		actionCanProceed = make(chan struct{})
-
-		// Re-register action for this subtest
+		// Subtest-local channels and action; see the comment on the
+		// previous subtest.
+		actionStarted := make(chan struct{})
+		actionCanProceed := make(chan struct{})
 		core.DefineAction(g.reg, "test/slow2", api.ActionTypeCustom, nil, nil,
 			func(ctx context.Context, input any) (any, error) {
 				close(actionStarted)


### PR DESCRIPTION
Builds on top of #4462. Adds `SessionFlowConnection.Detach` so a client can disconnect from a session flow and have it continue processing in the background, plus the snapshot lifecycle (`pending` / `complete` / `canceled` / `error`) and companion actions needed to observe and abort that work.

## Examples

### Detaching a connection

`Detach` ends the input stream and asks the server to take ownership of the rest of the work. The connection closes promptly with a snapshot ID the client can use later. Send any final inputs first.

```go
chatFlow := genkit.DefineSessionFlow(g, "chat", myFn,
    aix.WithSessionStore(store),
)

conn, _ := chatFlow.StreamBidi(ctx)
conn.SendText("draft a long report on Go's runtime")
conn.SendText("...and email it to me when done")

// Client wants to walk away. The server keeps working.
conn.Detach()

out, _ := conn.Output() // returns immediately with the pending snapshot ID
fmt.Println(out.SnapshotID)
```

For single-turn use, `Run` already takes a `SessionFlowInput` whose `Detach` field is the same wire bit, so detached single-turn with a final payload is just:

```go
out, _ := chatFlow.Run(ctx, &aix.SessionFlowInput{
    Detach:   true,
    Messages: []*ai.Message{ai.NewUserTextMessage("...")},
})
```

### Polling status, fetching results, aborting

Local Go callers use the `store` reference they already have from `WithSessionStore`. No indirection through the flow.

```go
snap, _ := store.GetSnapshot(ctx, id)

switch snap.Status {
case aix.SnapshotStatusPending:   // still working; snap.State is empty until finalize
case aix.SnapshotStatusComplete:  // snap.State has the cumulative final state
case aix.SnapshotStatusError:     // snap.Error has the failure message
case aix.SnapshotStatusCanceled:  // someone (or some thing) aborted it
}

store.AbortSnapshot(ctx, id) // atomic pending → canceled; no-op otherwise
```

For Dev UI and non-Go clients, every session flow registers a `getSnapshot` companion action under the `agent-snapshot` action type (action name = flow name) whenever a store is configured, and an `abortSnapshot` companion action under the `agent-abort` action type — registered only when the store implements `SnapshotAborter`, so the reflected surface matches actual capabilities. The action responses are a client-facing view (`WithStateTransform` applied; raw snapshot envelope hidden) that the local store calls bypass.

Each session flow's action descriptor also carries `metadata["agent"] = {stateManagement, abortable}` so reflective callers (Dev UI etc.) can shape the surface — e.g. hide the Abort button when the store can't support it — without round-tripping through the reflection API. `AgentMetadata` is defined as a shared schema type in `agent.ts` and generated into `go/ai/exp/gen.go`.

### Resuming after the background run finishes

Once the snapshot has finalized to `complete`, resume it like any other snapshot. Pending, canceled, and error snapshots are rejected.

```go
out, _ := chatFlow.RunText(ctx, "next question",
    aix.WithSnapshotID[MyState](id),
)
```

### Transform for redaction

```go
chatFlow := genkit.DefineSessionFlow(g, "chat", myFn,
    aix.WithSessionStore(store),
    aix.WithStateTransform[MyState](func(ctx context.Context, s aix.SessionState[MyState]) aix.SessionState[MyState] {
        return redactPII(ctx, s) // ctx carries the caller identity for RBAC-aware redaction
    }),
)
```

---

## Lifecycle

A session flow runs in two modes: **sync** (default) and **detached** (opt-in).

```
sync     ── turn ── turn ── fn returns ──→ output on the wire

detach   ── turn ── Detach ──→ pending snapshot ID; client disconnects
                                  │
                                  └─→ pending ──→ complete | error | canceled
                                                    ↑
                                          AbortSnapshot can flip
```

**Sync.** Each turn writes a turn-end snapshot; `fn`-return writes an invocation-end snapshot; output is returned over the connection. Same as #4462. Pre-detach a client disconnect cancels the work like any normal HTTP/WS connection.

**Detach is immediate.** When `Detach=true` lands, an eager intake reader sees it the moment it arrives in the input channel, regardless of what the runner is processing. The server suspends future turn-end snapshots, writes a single pending snapshot (empty state placeholder, chained off the most recent prior snapshot), returns that ID over the wire, and closes the connection. The `fn` keeps running on a context decoupled from the client's; any inputs queued behind the in-flight one continue draining through the runner. A pure detach signal (no payload) is consumed as the trigger only and does not enter the queue.

**Background terminal.** When `fn` returns, the same snapshot row is rewritten in place with one of three statuses (`complete`, `error` with `Error` set, or `canceled`) and the cumulative final session state. The snapshot ID never changes, so callers keep polling the same ID. Side effects on session state (`sess.AddMessages`, `resp.SendArtifact`, etc.) keep applying through the queued turns so user code does not have to branch on detach.

**Abort.** `store.AbortSnapshot(id)` (or the `abortSnapshot` action) atomically flips pending → canceled. The runtime subscribes to status changes via `SnapshotAborter.OnSnapshotStatusChange`, so the abort is observed by push rather than polling — `fn`'s context is cancelled as soon as the store publishes the status change. The finalizer rechecks status before writing terminal state, so a late abort wins over a `complete` that was about to land.

**Resume.** Pass any `complete` snapshot ID via `WithSnapshotID`. Pending, canceled, and error snapshots are rejected with `FAILED_PRECONDITION`.

**Detach pre-conditions.** Detach requires a store that implements `SnapshotAborter`. Stores missing it are rejected at detach time with `FAILED_PRECONDITION` — the flow can still run synchronously against a minimal `SessionStore`.

---

## API additions

### Connection

```go
// Detach asks the server to write a pending snapshot, close the
// connection, and continue processing any already-buffered inputs in
// the background. To ride a final input on the same wire message, send
// Send(&SessionFlowInput{Detach: true, Messages: ...}) directly.
func (*SessionFlowConnection) Detach() error
```

### Snapshot lifecycle

```go
type SnapshotStatus string
const (
    SnapshotStatusPending  SnapshotStatus = "pending"  // detached invocation still running
    SnapshotStatusComplete SnapshotStatus = "complete" // settled state
    SnapshotStatusCanceled SnapshotStatus = "canceled" // aborted via AbortSnapshot
    SnapshotStatusError    SnapshotStatus = "error"    // invocation failed; Error is populated
)

const SnapshotEventDetach SnapshotEvent = "detach"
```

`SessionSnapshot` gains: `UpdatedAt`, `Status`, `Error`. Pending rows carry an empty `State`; the finalizer rewrites in place with the cumulative final state once `fn` returns.

### Companion action wire types (auto-registered per flow)

```go
// Registered under action type "agent-snapshot", action name = flow name.
// Always registered when a store is configured.
type GetSnapshotRequest  struct { SnapshotID string }
type GetSnapshotResponse[State any] struct {
    SnapshotID           string
    CreatedAt, UpdatedAt time.Time
    Status               SnapshotStatus
    Error                string
    State                *SessionState[State] // omitted when status=pending or error
}

// Registered under action type "agent-abort", action name = flow name.
// Registered only when the store implements SnapshotAborter.
type AbortSnapshotRequest  struct { SnapshotID string }
type AbortSnapshotResponse struct { SnapshotID string; Status SnapshotStatus }
```

### Agent capability metadata

```go
// Shared schema (agent.ts → go/ai/exp/gen.go), attached at registration
// time via metadata["agent"] on the flow's action descriptor.
type AgentMetadata struct {
    StateManagement AgentMetadataStateManagement // "server" | "client"
    Abortable       bool                         // true iff store implements SnapshotAborter
}
```

### Store interfaces

The minimum to use `WithSessionStore`:

```go
type SnapshotReader[State any] interface {
    GetSnapshot(ctx, id) (*SessionSnapshot[State], error)
}
type SnapshotWriter[State any] interface {
    // Atomic read-modify-write. The store owns identity (SnapshotID,
    // generated if id is empty) and lifecycle timestamps (CreatedAt on
    // first write, UpdatedAt on every commit). Status defaults to
    // SnapshotStatusComplete if fn leaves it empty — callers writing a
    // pending row set it explicitly.
    //
    // fn receives the existing row (or nil) and returns the snapshot to
    // commit, or (nil, nil) to skip without changing the row. fn must
    // be a pure function of its input: stores using optimistic
    // concurrency or transaction retries may invoke fn multiple times.
    SaveSnapshot(
        ctx context.Context,
        id string,
        fn func(existing *SessionSnapshot[State]) (*SessionSnapshot[State], error),
    ) (*SessionSnapshot[State], error)
}
type SessionStore[State any] interface {
    SnapshotReader[State]
    SnapshotWriter[State]
}
```

The atomic shape composes cleanly with SQL (`SELECT FOR UPDATE` in a txn), Firestore (`RunTransaction(fn)`), DynamoDB (optimistic concurrency on a `version` attribute), or any K/V store with a CAS primitive. It also folds the finalize path's read-then-rewrite into one step so a late abort can't be clobbered by the terminal write.

Detach support layers on a single optional interface. Abort triggering and status-change subscription live together because neither is useful alone — splitting them just exposed the "implemented one, not the other" footgun:

```go
type SnapshotAborter interface {
    // Atomic pending → canceled; no-op otherwise. Must be transactional
    // (or CAS-equivalent) so a racing finalizer cannot clobber an abort.
    AbortSnapshot(ctx, id) (*SnapshotMetadata, error)

    // Push notifications for status changes. Replaces what would
    // otherwise be a periodic store poll. The first value (if any)
    // reflects status at subscription time; the channel closes when ctx
    // is cancelled or the snapshot does not exist.
    OnSnapshotStatusChange(ctx, id) <-chan SnapshotStatus
}
```

`InMemorySessionStore` implements both. External stores must implement at least reader+writer; for detach support also implement `SnapshotAborter`. Implementations may push from a transaction log, a CDC feed, or fall back to polling internally — the contract just spares callers the choice.

### State transform

```go
// Applied to SessionState on the way out to a client (getSnapshot
// response, client-managed SessionFlowOutput.State). Not applied to
// state persisted in the store or passed to the user fn. ctx carries
// the caller's identity (for RBAC-aware redaction), trace, and any
// cancellation signal.
type StateTransform[State any] = func(ctx context.Context, state SessionState[State]) SessionState[State]
```

### Wire input

```go
type SessionFlowInput struct {
    Detach       bool          `json:"detach,omitempty"` // new
    Messages     []*ai.Message
    ToolRestarts []*ai.Part
}
```


### Supporting core additions

Two `go/core` changes that the design relies on:

```go
// WithFlowContext attaches flow-context metadata so core.Run and
// core.FlowNameFromContext resolve from inside a custom flow-like
// action wired via core.NewBidiAction / core.DefineBidiAction.
// Session flows take that path so the agent metadata can be set on
// the action descriptor at construction time (actions are immutable
// once registered); the Define*Flow constructors call it internally.
func WithFlowContext(ctx context.Context, flowName string) context.Context
```

`BidiConnection.Output()` gains a fast path that returns the already-settled output even when the connection context was cancelled concurrently. This is what makes `conn.Output()` after `Detach()` return the pending snapshot ID instead of `ctx.Err()` on the client side when the server closes the wire first.
