### PR TITLE
fix(go/plugins/googlegenai): handle multi-field response parts

### DIFF
--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -409,73 +409,57 @@ func translateCandidate(cand *genai.Candidate) (*ai.ModelResponse, error) {
 	}
 	msg := &ai.Message{}
 	msg.Role = ai.Role(cand.Content.Role)
-	// iterate over the candidate parts, only one struct member
-	// must be populated, more than one is considered an error
+	// A single genai.Part may have several fields populated at once (e.g.
+	// image-generation models can return text alongside InlineData). Emit a
+	// separate ai.Part for each populated field rather than failing.
 	for _, part := range cand.Content.Parts {
-		var p *ai.Part
-		partFound := 0
+		var emitted []*ai.Part
 
 		if part.Thought {
-			p = ai.NewReasoningPart(part.Text, part.ThoughtSignature)
-			partFound++
-		}
-		if part.Text != "" && !part.Thought {
-			p = ai.NewTextPart(part.Text)
-			partFound++
+			emitted = append(emitted, ai.NewReasoningPart(part.Text, part.ThoughtSignature))
+		} else if part.Text != "" {
+			emitted = append(emitted, ai.NewTextPart(part.Text))
 		}
 		if part.InlineData != nil {
-			partFound++
-			p = ai.NewMediaPart(part.InlineData.MIMEType, "data:"+part.InlineData.MIMEType+";base64,"+base64.StdEncoding.EncodeToString((part.InlineData.Data)))
+			emitted = append(emitted, ai.NewMediaPart(part.InlineData.MIMEType, "data:"+part.InlineData.MIMEType+";base64,"+base64.StdEncoding.EncodeToString(part.InlineData.Data)))
 		}
 		if part.FileData != nil {
-			partFound++
-			p = ai.NewMediaPart(part.FileData.MIMEType, part.FileData.FileURI)
-
+			emitted = append(emitted, ai.NewMediaPart(part.FileData.MIMEType, part.FileData.FileURI))
 		}
 		if part.FunctionCall != nil {
-			partFound++
-			p = ai.NewToolRequestPart(&ai.ToolRequest{
+			emitted = append(emitted, ai.NewToolRequestPart(&ai.ToolRequest{
 				Name:  part.FunctionCall.Name,
 				Input: part.FunctionCall.Args,
-			})
-			// FunctionCall parts may contain a ThoughtSignature that must be preserved
-			// and returned in subsequent requests for the tool call to be valid.
-			if len(part.ThoughtSignature) > 0 {
-				if p.Metadata == nil {
-					p.Metadata = make(map[string]any)
-				}
-				p.Metadata["signature"] = part.ThoughtSignature
-			}
+			}))
 		}
 		if part.CodeExecutionResult != nil {
-			partFound++
-			p = newCodeExecutionResultPart(
+			emitted = append(emitted, newCodeExecutionResultPart(
 				string(part.CodeExecutionResult.Outcome),
 				part.CodeExecutionResult.Output,
-			)
+			))
 		}
 		if part.ExecutableCode != nil {
-			partFound++
-			p = newExecutableCodePart(
+			emitted = append(emitted, newExecutableCodePart(
 				string(part.ExecutableCode.Language),
 				part.ExecutableCode.Code,
-			)
+			))
 		}
-		if partFound > 1 {
-			panic(fmt.Sprintf("expected only 1 content part in response, got %d, part: %#v", partFound, part))
-		}
-		if p == nil {
+
+		if len(emitted) == 0 {
 			continue
 		}
 
+		// Attach the thought signature to the first emitted part so that a
+		// subsequent request round-trips a single signature per genai.Part.
 		if len(part.ThoughtSignature) > 0 {
-			if p.Metadata == nil {
-				p.Metadata = make(map[string]any)
+			first := emitted[0]
+			if first.Metadata == nil {
+				first.Metadata = make(map[string]any)
 			}
-			p.Metadata["signature"] = part.ThoughtSignature
+			first.Metadata["signature"] = part.ThoughtSignature
 		}
 
-		msg.Content = append(msg.Content, p)
+		msg.Content = append(msg.Content, emitted...)
 	}
 	m.Message = msg
 	return m, nil

--- a/go/plugins/googlegenai/gemini_test.go
+++ b/go/plugins/googlegenai/gemini_test.go
@@ -1072,6 +1072,82 @@ func TestTranslateCandidateThoughtSignature(t *testing.T) {
 	})
 }
 
+// TestTranslateCandidateMultiFieldPart verifies that a single genai.Part with
+// multiple populated fields (e.g. text alongside InlineData, as returned by
+// image-generation models like Nano Banana 2) is split into separate ai.Parts
+// instead of panicking. Regression test for issue #5195.
+func TestTranslateCandidateMultiFieldPart(t *testing.T) {
+	t.Run("text and inline data in the same part", func(t *testing.T) {
+		imageBytes := []byte{0x89, 0x50, 0x4e, 0x47}
+		candidate := &genai.Candidate{
+			FinishReason: genai.FinishReasonStop,
+			Content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{
+						Text: "Here is the restored photo.",
+						InlineData: &genai.Blob{
+							MIMEType: "image/png",
+							Data:     imageBytes,
+						},
+					},
+				},
+			},
+		}
+
+		resp, err := translateCandidate(candidate)
+		if err != nil {
+			t.Fatalf("translateCandidate failed: %v", err)
+		}
+
+		if got, want := len(resp.Message.Content), 2; got != want {
+			t.Fatalf("expected %d parts, got %d", want, got)
+		}
+		if !resp.Message.Content[0].IsText() || resp.Message.Content[0].Text != "Here is the restored photo." {
+			t.Errorf("expected first part to be the text, got %#v", resp.Message.Content[0])
+		}
+		if !resp.Message.Content[1].IsMedia() {
+			t.Errorf("expected second part to be media, got %#v", resp.Message.Content[1])
+		}
+	})
+
+	t.Run("signature attaches to the first emitted part only", func(t *testing.T) {
+		testSignature := []byte("multi-part-signature")
+		candidate := &genai.Candidate{
+			FinishReason: genai.FinishReasonStop,
+			Content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{
+						Text: "caption",
+						InlineData: &genai.Blob{
+							MIMEType: "image/png",
+							Data:     []byte{0x00},
+						},
+						ThoughtSignature: testSignature,
+					},
+				},
+			},
+		}
+
+		resp, err := translateCandidate(candidate)
+		if err != nil {
+			t.Fatalf("translateCandidate failed: %v", err)
+		}
+
+		if got, want := len(resp.Message.Content), 2; got != want {
+			t.Fatalf("expected %d parts, got %d", want, got)
+		}
+		sig, ok := resp.Message.Content[0].Metadata["signature"].([]byte)
+		if !ok || string(sig) != string(testSignature) {
+			t.Errorf("expected signature on first part, got metadata %#v", resp.Message.Content[0].Metadata)
+		}
+		if _, ok := resp.Message.Content[1].Metadata["signature"]; ok {
+			t.Errorf("did not expect signature on second part, got metadata %#v", resp.Message.Content[1].Metadata)
+		}
+	})
+}
+
 // TestFinishReasonMapping tests the mapping of Gemini finish reasons to Genkit finish reasons.
 func TestFinishReasonMapping(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
## Summary

- Nano Banana 2 (`vertexai/gemini-3.1-flash-image-preview`) returns response parts that populate both `Text` (a caption) and `InlineData` (the image bytes) in a single `genai.Part`. The current code in `translateCandidate` asserts at most one populated field per part and panics with `expected only 1 content part in response, got 2, part: ...`.
- Replace the panic with logic that emits one `ai.Part` per populated field. The `ThoughtSignature`, when present, is attached to the first emitted part so a single signature still round-trips back to the API rather than being duplicated.
- Add a regression test `TestTranslateCandidateMultiFieldPart` covering the text + inline-data case and signature placement.

`resp.Media()` from the issue's reproducer iterates all parts and returns the first `IsMedia()`, so the image is recovered correctly even when a text part precedes it.

Fixes #5195

## Test plan

- [x] `go test ./plugins/googlegenai/...` (existing + new tests pass)
- [x] `go vet ./plugins/googlegenai/...`
- [ ] Manually verify against `vertexai/gemini-3.1-flash-image-preview` using the reproducer from the issue