### PR TITLE
feat(go/plugins/middleware): rework filesystem middleware

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -274,33 +274,41 @@ response, _ := genkit.Generate(ctx, g,
 )
 ```
 
-The `middleware` plugin also ships with [`ToolApproval`](plugins/middleware/tool_approval.go) for human-in-the-loop gating, [`Filesystem`](samples/basic-middleware/filesystem) for sandboxed file access, and [`Skills`](samples/basic-middleware/skills) for loadable `SKILL.md` skills. [See the retry + fallback sample](samples/basic-middleware/retry-fallback) for the full composition.
+The `middleware` plugin also ships with:
+
+- [`ToolApproval`](plugins/middleware/tool_approval.go) — interrupts any tool not on an allow list and resumes once the call is explicitly approved on restart.
+- [`Filesystem`](samples/basic-middleware/filesystem) — gives the model `list_files` and `read_file` tools (plus `write_file` and `edit_file` when `AllowWriteAccess` is set), all confined to a single `RootDir` via `os.Root` (Go 1.25+) so paths cannot escape via `..`, absolute paths, or symlinks.
+- [`Skills`](samples/basic-middleware/skills) — exposes a library of `SKILL.md` files through a `use_skill` tool so the model can pull in specialised instructions on demand.
+
+[See the retry + fallback sample](samples/basic-middleware/retry-fallback) for a full composition.
 
 ### Custom Middleware
 
-Implement the `ai.Middleware` interface to build your own. Embed `ai.BaseMiddleware` to inherit pass-through defaults for the hooks you don't need, then override `WrapGenerate`, `WrapModel`, or `WrapTool`:
+Implement the `ai.Middleware` interface — `Name()` plus `New(ctx)` — to build your own. `New` returns a `Hooks` bundle whose four fields (`Tools`, `WrapGenerate`, `WrapModel`, `WrapTool`) are all optional; nil hooks pass through:
 
 ```go
 type Logger struct {
-    ai.BaseMiddleware
     Prefix string `json:"prefix,omitempty"`
 }
 
-func (l *Logger) Name() string      { return "mine/logger" }
-func (l *Logger) New() ai.Middleware { return &Logger{Prefix: l.Prefix} }
+func (l *Logger) Name() string { return "mine/logger" }
 
-func (l *Logger) WrapModel(ctx context.Context, params *ai.ModelParams, next ai.ModelNext) (*ai.ModelResponse, error) {
-    start := time.Now()
-    resp, err := next(ctx, params)
-    log.Printf("%s model call took %s", l.Prefix, time.Since(start))
-    return resp, err
+func (l *Logger) New(ctx context.Context) (*ai.Hooks, error) {
+    return &ai.Hooks{
+        WrapModel: func(ctx context.Context, params *ai.ModelParams, next ai.ModelNext) (*ai.ModelResponse, error) {
+            start := time.Now()
+            resp, err := next(ctx, params)
+            log.Printf("%s model call took %s", l.Prefix, time.Since(start))
+            return resp, err
+        },
+    }, nil
 }
 
 // Use it like any built-in middleware.
 ai.WithUse(&Logger{Prefix: "[trace]"})
 ```
 
-`New()` is called once per `Generate` invocation, so middleware can hold per-call state without worrying about concurrent use across calls. `Name()` must be unique and stable since it's the key used to register and reference the middleware from the Dev UI and across runtimes.
+`Name()` must be unique and stable since it's the key used to register the middleware and reference it from the Dev UI and across runtimes. `New()` is called once per `Generate` invocation, so per-call state (counters, caches, message queues) can be allocated inside it and closed over by the hooks — just guard anything mutable, since `WrapTool` may run concurrently when tools execute in parallel. For ad-hoc, inline middleware that doesn't need to surface in the Dev UI, wrap a factory closure with `ai.MiddlewareFunc`.
 
 ### Define Flows
 

--- a/go/plugins/middleware/filesystem.go
+++ b/go/plugins/middleware/filesystem.go
@@ -52,14 +52,25 @@ const fileStateCacheMaxEntries = 200
 // is still current. The earlier tool result is still in conversation history.
 const fileUnchangedStub = "File unchanged since last read. The content from the earlier read_file result in this conversation is still current — refer to that instead of re-reading."
 
-// fileState records what the model has been shown for a given absolute path,
-// plus the on-disk mtime at the time of read. Used to gate edits against
-// external modifications and to dedup re-reads.
+// fileState records the on-disk state observed at the last read or write of
+// a given absolute path: mtime and byte size. Used to gate edits against
+// external modifications and to dedup re-reads. Comparing both mtime and
+// size narrows the window where a same-mtime overwrite slips through;
+// filesystem mtime resolution can be as coarse as 1 s.
 type fileState struct {
-	Content []byte
 	ModTime time.Time
+	Size    int64
 	Offset  int // 0 when the read covered the whole file
 	Limit   int // 0 when the read covered the whole file
+}
+
+func newFileState(info os.FileInfo, offset, limit int) *fileState {
+	return &fileState{
+		ModTime: info.ModTime(),
+		Size:    info.Size(),
+		Offset:  offset,
+		Limit:   limit,
+	}
 }
 
 // fileStateCache is a per-call, bounded path→state map. The middleware's New()
@@ -94,25 +105,30 @@ func (c *fileStateCache) set(p string, s *fileState) {
 	c.entries[p] = s
 }
 
-// pathLocks serializes read-modify-write on a per-path basis so two concurrent
-// edits on the same file can't interleave their staleness check and write.
+// pathLockBuckets caps the lock memory footprint at compile time. A fixed
+// array of mutexes is sized once at construction; no map growth.
+const pathLockBuckets = 256
+
+// pathLocks serializes read-modify-write on the same path by hashing into a
+// fixed bucket of mutexes. Two different paths that hash to the same bucket
+// will spuriously serialize against each other — that's harmless because
+// file ops are short and 256 buckets keep the collision rate low for any
+// realistic per-call working set.
 type pathLocks struct {
-	mu    sync.Mutex
-	locks map[string]*sync.Mutex
+	buckets [pathLockBuckets]sync.Mutex
 }
 
-func newPathLocks() *pathLocks {
-	return &pathLocks{locks: make(map[string]*sync.Mutex)}
-}
+func newPathLocks() *pathLocks { return &pathLocks{} }
 
 func (p *pathLocks) lock(path string) func() {
-	p.mu.Lock()
-	m, ok := p.locks[path]
-	if !ok {
-		m = &sync.Mutex{}
-		p.locks[path] = m
+	// FNV-style multiplicative hash. Distribution is good for filesystem
+	// paths (which differ most in their tail) and avoids pulling in
+	// hash/fnv for one call site.
+	var h uint32
+	for i := 0; i < len(path); i++ {
+		h = h*31 + uint32(path[i])
 	}
-	p.mu.Unlock()
+	m := &p.buckets[h%pathLockBuckets]
 	m.Lock()
 	return m.Unlock
 }
@@ -279,7 +295,7 @@ func normalizeRel(p string) string {
 }
 
 // requireFilePath validates the shared filePath argument used by read_file,
-// write_file, and search_and_replace.
+// write_file, and edit_file.
 func requireFilePath(s string) error {
 	if strings.TrimSpace(s) == "" {
 		return errors.New("filePath is required")
@@ -398,10 +414,12 @@ func (f *Filesystem) newReadFileTool(
 			}
 
 			// Dedup: text re-reads of an unchanged file at the same range get a stub
-			// instead of a fresh inject.
+			// instead of a fresh inject. Size is compared alongside mtime because
+			// mtime resolution is coarse on some filesystems.
 			if !isImage {
 				if prev := cache.get(key); prev != nil &&
 					prev.ModTime.Equal(info.ModTime()) &&
+					prev.Size == info.Size() &&
 					prev.Offset == in.Offset && prev.Limit == in.Limit {
 					return fileUnchangedStub, nil
 				}
@@ -474,12 +492,7 @@ func (f *Filesystem) newReadFileTool(
 			// when content doesn't, we shouldn't fabricate one — the model could
 			// pick it up and pass it into edit_file.oldString and miss the match.
 			enqueueParts(ai.NewTextPart(header + "\n" + string(content) + "</read_file>"))
-			cache.set(key, &fileState{
-				Content: append([]byte(nil), data...),
-				ModTime: info.ModTime(),
-				Offset:  in.Offset,
-				Limit:   in.Limit,
-			})
+			cache.set(key, newFileState(info, in.Offset, in.Limit))
 			return summary, nil
 		},
 	)
@@ -568,7 +581,7 @@ func (f *Filesystem) newWriteFileTool(
 				if prev == nil {
 					return "", fmt.Errorf("file %s exists but has not been read yet; read_file it first before overwriting", in.FilePath)
 				}
-				if !info.ModTime().Equal(prev.ModTime) {
+				if !info.ModTime().Equal(prev.ModTime) || info.Size() != prev.Size {
 					return "", fmt.Errorf("file %s has been modified since last read; re-read it before overwriting", in.FilePath)
 				}
 			}
@@ -582,10 +595,7 @@ func (f *Filesystem) newWriteFileTool(
 				return "", err
 			}
 			if newInfo, err := root.Stat(osPath); err == nil {
-				cache.set(key, &fileState{
-					Content: []byte(in.Content),
-					ModTime: newInfo.ModTime(),
-				})
+				cache.set(key, newFileState(newInfo, 0, 0))
 			}
 			return fmt.Sprintf("File %s written successfully.", in.FilePath), nil
 		},
@@ -635,7 +645,7 @@ func (f *Filesystem) newEditFileTool(
 			if err != nil {
 				return "", err
 			}
-			if !info.ModTime().Equal(prev.ModTime) {
+			if !info.ModTime().Equal(prev.ModTime) || info.Size() != prev.Size {
 				return "", fmt.Errorf("file %s has been modified since last read; re-read it before editing", in.FilePath)
 			}
 
@@ -657,10 +667,7 @@ func (f *Filesystem) newEditFileTool(
 				return "", err
 			}
 			if newInfo, err := root.Stat(osPath); err == nil {
-				cache.set(key, &fileState{
-					Content: []byte(content),
-					ModTime: newInfo.ModTime(),
-				})
+				cache.set(key, newFileState(newInfo, 0, 0))
 			}
 			return fmt.Sprintf("Successfully applied %d edit(s) to %s.", len(in.Edits), in.FilePath), nil
 		},

--- a/go/plugins/middleware/filesystem.go
+++ b/go/plugins/middleware/filesystem.go
@@ -17,6 +17,7 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -28,21 +29,90 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
 )
 
-// SEARCH/REPLACE block markers used by the search_and_replace tool.
-const (
-	searchReplaceStart     = "<<<<<<< SEARCH\n"
-	searchReplaceEnd       = "\n>>>>>>> REPLACE"
-	searchReplaceSeparator = "\n=======\n"
-)
+// readMaxBytes caps a single full read. Models can step past it via offset/limit.
+const readMaxBytes = 256 * 1024
+
+// fileStateCacheMaxEntries bounds the per-call cache. Eviction is FIFO on insert.
+const fileStateCacheMaxEntries = 200
+
+// fileUnchangedStub is returned by read_file when a prior read at the same range
+// is still current. The earlier tool result is still in conversation history.
+const fileUnchangedStub = "File unchanged since last read. The content from the earlier read_file result in this conversation is still current — refer to that instead of re-reading."
+
+// fileState records what the model has been shown for a given absolute path,
+// plus the on-disk mtime at the time of read. Used to gate edits against
+// external modifications and to dedup re-reads.
+type fileState struct {
+	Content []byte
+	ModTime time.Time
+	Offset  int // 0 when the read covered the whole file
+	Limit   int // 0 when the read covered the whole file
+}
+
+// fileStateCache is a per-call, bounded path→state map. The middleware's New()
+// allocates one per Hooks instance so cache lifetime equals call lifetime.
+type fileStateCache struct {
+	mu      sync.Mutex
+	max     int
+	entries map[string]*fileState
+	order   []string
+}
+
+func newFileStateCache(max int) *fileStateCache {
+	return &fileStateCache{max: max, entries: make(map[string]*fileState)}
+}
+
+func (c *fileStateCache) get(p string) *fileState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.entries[p]
+}
+
+func (c *fileStateCache) set(p string, s *fileState) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.entries[p]; !ok {
+		if len(c.entries) >= c.max && len(c.order) > 0 {
+			delete(c.entries, c.order[0])
+			c.order = c.order[1:]
+		}
+		c.order = append(c.order, p)
+	}
+	c.entries[p] = s
+}
+
+// pathLocks serializes read-modify-write on a per-path basis so two concurrent
+// edits on the same file can't interleave their staleness check and write.
+type pathLocks struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newPathLocks() *pathLocks {
+	return &pathLocks{locks: make(map[string]*sync.Mutex)}
+}
+
+func (p *pathLocks) lock(path string) func() {
+	p.mu.Lock()
+	m, ok := p.locks[path]
+	if !ok {
+		m = &sync.Mutex{}
+		p.locks[path] = m
+	}
+	p.mu.Unlock()
+	m.Lock()
+	return m.Unlock
+}
 
 // Filesystem is a middleware that grants the LLM scoped file access under a
 // single root directory. It registers list_files and read_file, plus
-// write_file and search_and_replace when AllowWriteAccess is true.
+// write_file and edit_file when AllowWriteAccess is true.
 //
 // Path safety is enforced by [os.Root] (Go 1.25+), which rejects any path
 // that resolves outside the root, including via "..", absolute paths, or
@@ -61,7 +131,7 @@ const (
 type Filesystem struct {
 	// RootDir is the directory that all operations are confined to.
 	RootDir string `json:"rootDirectory,omitempty"`
-	// AllowWriteAccess adds write_file and search_and_replace.
+	// AllowWriteAccess adds write_file and edit_file.
 	AllowWriteAccess bool `json:"allowWriteAccess,omitempty"`
 	// ToolNamePrefix is prepended to each tool name. Use distinct prefixes
 	// when attaching multiple Filesystem middlewares to one call so their
@@ -101,7 +171,9 @@ func (f *Filesystem) New(ctx context.Context) (*ai.Hooks, error) {
 		queue = append(queue, ai.NewUserMessage(parts...))
 	}
 
-	tools := f.buildTools(root, enqueueParts)
+	cache := newFileStateCache(fileStateCacheMaxEntries)
+	locks := newPathLocks()
+	tools := f.buildTools(root, abs, cache, locks, enqueueParts)
 	toolSet := make(map[string]struct{}, len(tools))
 	for _, t := range tools {
 		toolSet[t.Name()] = struct{}{}
@@ -161,15 +233,29 @@ func (f *Filesystem) New(ctx context.Context) (*ai.Hooks, error) {
 // toolName returns suffix prefixed with f.ToolNamePrefix.
 func (f *Filesystem) toolName(suffix string) string { return f.ToolNamePrefix + suffix }
 
-func (f *Filesystem) buildTools(root *os.Root, enqueueParts func(parts ...*ai.Part)) []ai.Tool {
+func (f *Filesystem) buildTools(
+	root *os.Root,
+	rootAbs string,
+	cache *fileStateCache,
+	locks *pathLocks,
+	enqueueParts func(parts ...*ai.Part),
+) []ai.Tool {
 	tools := []ai.Tool{
 		f.newListFilesTool(root),
-		f.newReadFileTool(root, enqueueParts),
+		f.newReadFileTool(root, rootAbs, cache, enqueueParts),
 	}
 	if f.AllowWriteAccess {
-		tools = append(tools, f.newWriteFileTool(root), f.newSearchReplaceTool(root))
+		tools = append(tools,
+			f.newWriteFileTool(root, rootAbs, cache, locks),
+			f.newEditFileTool(root, rootAbs, cache, locks),
+		)
 	}
 	return tools
+}
+
+// cacheKey returns the absolute path used as the fileStateCache key.
+func cacheKey(rootAbs, rel string) string {
+	return filepath.Join(rootAbs, filepath.FromSlash(rel))
 }
 
 // normalizeRel canonicalises an LLM-supplied path into a slash-separated
@@ -202,6 +288,7 @@ type listFilesInput struct {
 type fileEntry struct {
 	Path        string `json:"path"`
 	IsDirectory bool   `json:"isDirectory"`
+	SizeBytes   int64  `json:"sizeBytes,omitempty"`
 }
 
 func (f *Filesystem) newListFilesTool(root *os.Root) ai.Tool {
@@ -219,7 +306,13 @@ func (f *Filesystem) newListFilesTool(root *os.Root) ai.Tool {
 				}
 				out := make([]fileEntry, 0, len(entries))
 				for _, e := range entries {
-					out = append(out, fileEntry{Path: e.Name(), IsDirectory: e.IsDir()})
+					fe := fileEntry{Path: e.Name(), IsDirectory: e.IsDir()}
+					if !e.IsDir() {
+						if info, err := e.Info(); err == nil {
+							fe.SizeBytes = info.Size()
+						}
+					}
+					out = append(out, fe)
 				}
 				return out, nil
 			}
@@ -236,10 +329,16 @@ func (f *Filesystem) newListFilesTool(root *os.Root) ai.Tool {
 				if relErr != nil {
 					rel = p
 				}
-				out = append(out, fileEntry{
+				fe := fileEntry{
 					Path:        filepath.ToSlash(rel),
 					IsDirectory: d.IsDir(),
-				})
+				}
+				if !d.IsDir() {
+					if info, err := d.Info(); err == nil {
+						fe.SizeBytes = info.Size()
+					}
+				}
+				out = append(out, fe)
 				return nil
 			})
 			if err != nil {
@@ -252,36 +351,145 @@ func (f *Filesystem) newListFilesTool(root *os.Root) ai.Tool {
 
 type readFileInput struct {
 	FilePath string `json:"filePath" jsonschema:"description=File path relative to root."`
+	Offset   int    `json:"offset,omitempty" jsonschema:"description=1-indexed line to start reading from. 0 or 1 means start at the beginning."`
+	Limit    int    `json:"limit,omitempty" jsonschema:"description=Maximum number of lines to read. 0 means read to end of file."`
 }
 
-func (f *Filesystem) newReadFileTool(root *os.Root, enqueueParts func(parts ...*ai.Part)) ai.Tool {
+func (f *Filesystem) newReadFileTool(
+	root *os.Root,
+	rootAbs string,
+	cache *fileStateCache,
+	enqueueParts func(parts ...*ai.Part),
+) ai.Tool {
 	return ai.NewTool(
 		f.toolName("read_file"),
-		"Reads the contents of a file. The actual contents are delivered as a user message on the next turn.",
+		"Reads the contents of a file. The actual contents are delivered as a user message on the next turn. Use offset and limit (1-indexed lines) for large files.",
 		func(_ *ai.ToolContext, in readFileInput) (string, error) {
 			if err := requireFilePath(in.FilePath); err != nil {
 				return "", err
 			}
 			rel := normalizeRel(in.FilePath)
 			mimeType := mime.TypeByExtension(strings.ToLower(path.Ext(rel)))
-			data, err := root.ReadFile(filepath.FromSlash(rel))
+			osPath := filepath.FromSlash(rel)
+			isImage := strings.HasPrefix(mimeType, "image/")
+			key := cacheKey(rootAbs, rel)
+
+			info, err := root.Stat(osPath)
+			if err != nil {
+				return "", err
+			}
+			if info.IsDir() {
+				return "", fmt.Errorf("path %s is a directory; use list_files", in.FilePath)
+			}
+
+			// Dedup: text re-reads of an unchanged file at the same range get a stub
+			// instead of a fresh inject.
+			if !isImage {
+				if prev := cache.get(key); prev != nil &&
+					prev.ModTime.Equal(info.ModTime()) &&
+					prev.Offset == in.Offset && prev.Limit == in.Limit {
+					return fileUnchangedStub, nil
+				}
+			}
+
+			fullSize := info.Size()
+			if !isImage && in.Offset == 0 && in.Limit == 0 && fullSize > readMaxBytes {
+				return "", fmt.Errorf(
+					"file %s is %d bytes (>%d); use offset/limit to read a slice",
+					in.FilePath, fullSize, readMaxBytes,
+				)
+			}
+
+			data, err := root.ReadFile(osPath)
 			if err != nil {
 				return "", err
 			}
 
-			if strings.HasPrefix(mimeType, "image/") {
-				encoded := "data:" + mimeType + ";base64," + base64.StdEncoding.EncodeToString(data)
+			content := data
+			if !isImage && (in.Offset > 0 || in.Limit > 0) {
+				content = sliceLines(data, in.Offset, in.Limit)
+				if len(content) > readMaxBytes {
+					return "", fmt.Errorf(
+						"requested slice of %s is %d bytes (>%d); narrow the range",
+						in.FilePath, len(content), readMaxBytes,
+					)
+				}
+			}
+
+			if isImage {
+				encoded := "data:" + mimeType + ";base64," + base64.StdEncoding.EncodeToString(content)
 				enqueueParts(
 					ai.NewTextPart(fmt.Sprintf("\n\nread_file result %s %s", mimeType, in.FilePath)),
 					ai.NewMediaPart(mimeType, encoded),
 				)
-			} else {
-				enqueueParts(ai.NewTextPart(fmt.Sprintf(
-					"<read_file path=%q>\n%s\n</read_file>", in.FilePath, string(data))))
+				return fmt.Sprintf("File %s read successfully, see contents below.", in.FilePath), nil
 			}
-			return fmt.Sprintf("File %s read successfully, see contents below.", in.FilePath), nil
+
+			totalLines := countLines(data)
+			shownLines := countLines(content)
+			sliced := in.Offset > 0 || in.Limit > 0
+
+			var header, summary string
+			if sliced {
+				startLine := in.Offset
+				if startLine < 1 {
+					startLine = 1
+				}
+				endLine := startLine + shownLines - 1
+				if endLine < startLine {
+					endLine = startLine
+				}
+				header = fmt.Sprintf(`<read_file path=%q lines="%d-%d" totalLines="%d">`,
+					in.FilePath, startLine, endLine, totalLines)
+				summary = fmt.Sprintf("File %s read successfully (lines %d-%d of %d total). See contents below.",
+					in.FilePath, startLine, endLine, totalLines)
+			} else {
+				header = fmt.Sprintf(`<read_file path=%q totalLines="%d">`, in.FilePath, totalLines)
+				summary = fmt.Sprintf("File %s read successfully (%d lines). See contents below.",
+					in.FilePath, totalLines)
+			}
+			enqueueParts(ai.NewTextPart(header + "\n" + string(content) + "\n</read_file>"))
+			cache.set(key, &fileState{
+				Content: append([]byte(nil), data...),
+				ModTime: info.ModTime(),
+				Offset:  in.Offset,
+				Limit:   in.Limit,
+			})
+			return summary, nil
 		},
 	)
+}
+
+// countLines returns the number of lines in data. A trailing newline does not
+// add a phantom empty line; an unterminated final line still counts.
+func countLines(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	n := bytes.Count(data, []byte{'\n'})
+	if data[len(data)-1] != '\n' {
+		n++
+	}
+	return n
+}
+
+// sliceLines returns the [offset, offset+limit) line window of data, 1-indexed.
+// offset <= 1 starts at the beginning; limit == 0 reads to end. The result
+// preserves the trailing newline when the original window did.
+func sliceLines(data []byte, offset, limit int) []byte {
+	if offset < 1 {
+		offset = 1
+	}
+	lines := strings.Split(string(data), "\n")
+	start := offset - 1
+	if start >= len(lines) {
+		return nil
+	}
+	end := len(lines)
+	if limit > 0 && start+limit < end {
+		end = start + limit
+	}
+	return []byte(strings.Join(lines[start:end], "\n"))
 }
 
 type writeFileInput struct {
@@ -289,15 +497,41 @@ type writeFileInput struct {
 	Content  string `json:"content" jsonschema:"description=Content to write to the file."`
 }
 
-func (f *Filesystem) newWriteFileTool(root *os.Root) ai.Tool {
+func (f *Filesystem) newWriteFileTool(
+	root *os.Root,
+	rootAbs string,
+	cache *fileStateCache,
+	locks *pathLocks,
+) ai.Tool {
 	return ai.NewTool(
 		f.toolName("write_file"),
-		"Writes content to a file, creating it (and any missing parent directories) or overwriting it if it exists.",
+		"Writes content to a file, creating it (and any missing parent directories) or overwriting it if it exists. Overwriting an existing file requires a prior read_file in this session.",
 		func(_ *ai.ToolContext, in writeFileInput) (string, error) {
 			if err := requireFilePath(in.FilePath); err != nil {
 				return "", err
 			}
-			osPath := filepath.FromSlash(normalizeRel(in.FilePath))
+			rel := normalizeRel(in.FilePath)
+			osPath := filepath.FromSlash(rel)
+			key := cacheKey(rootAbs, rel)
+
+			unlock := locks.lock(key)
+			defer unlock()
+
+			info, statErr := root.Stat(osPath)
+			exists := statErr == nil
+			if exists && info.IsDir() {
+				return "", fmt.Errorf("path %s is a directory", in.FilePath)
+			}
+			if exists {
+				prev := cache.get(key)
+				if prev == nil {
+					return "", fmt.Errorf("file %s exists but has not been read yet; read_file it first before overwriting", in.FilePath)
+				}
+				if !info.ModTime().Equal(prev.ModTime) {
+					return "", fmt.Errorf("file %s has been modified since last read; re-read it before overwriting", in.FilePath)
+				}
+			}
+
 			if parent := filepath.Dir(osPath); parent != "." {
 				if err := root.MkdirAll(parent, 0o755); err != nil {
 					return "", fmt.Errorf("create parent dirs: %w", err)
@@ -306,25 +540,63 @@ func (f *Filesystem) newWriteFileTool(root *os.Root) ai.Tool {
 			if err := root.WriteFile(osPath, []byte(in.Content), 0o644); err != nil {
 				return "", err
 			}
+			if newInfo, err := root.Stat(osPath); err == nil {
+				cache.set(key, &fileState{
+					Content: []byte(in.Content),
+					ModTime: newInfo.ModTime(),
+				})
+			}
 			return fmt.Sprintf("File %s written successfully.", in.FilePath), nil
 		},
 	)
 }
 
-type searchReplaceInput struct {
-	FilePath string   `json:"filePath" jsonschema:"description=File path relative to root."`
-	Edits    []string `json:"edits" jsonschema:"description=SEARCH/REPLACE blocks in the format '<<<<<<< SEARCH\\n[search]\\n=======\\n[replace]\\n>>>>>>> REPLACE'."`
+type editSpec struct {
+	OldString  string `json:"oldString" jsonschema:"description=The exact text to find. Match is byte-for-byte including whitespace and indentation."`
+	NewString  string `json:"newString" jsonschema:"description=The replacement text. Use an empty string to delete oldString."`
+	ReplaceAll bool   `json:"replaceAll,omitempty" jsonschema:"description=If true, replace every occurrence of oldString. If false (default), oldString must match exactly once in the file."`
 }
 
-func (f *Filesystem) newSearchReplaceTool(root *os.Root) ai.Tool {
+type editFileInput struct {
+	FilePath string     `json:"filePath" jsonschema:"description=File path relative to root."`
+	Edits    []editSpec `json:"edits" jsonschema:"description=One or more edits to apply in order. Each edit is applied to the result of the previous edit."`
+}
+
+func (f *Filesystem) newEditFileTool(
+	root *os.Root,
+	rootAbs string,
+	cache *fileStateCache,
+	locks *pathLocks,
+) ai.Tool {
 	return ai.NewTool(
-		f.toolName("search_and_replace"),
-		"Replaces text in a file using one or more SEARCH/REPLACE blocks. Use this to edit existing files.",
-		func(_ *ai.ToolContext, in searchReplaceInput) (string, error) {
+		f.toolName("edit_file"),
+		"Applies one or more structured edits to a file. Requires a prior read_file in this session. Edits are applied sequentially; later edits see the changes from earlier ones. Each edit's oldString must match the file byte-for-byte (including whitespace), and by default must be unique — set replaceAll on the edit to rename across all occurrences.",
+		func(_ *ai.ToolContext, in editFileInput) (string, error) {
 			if err := requireFilePath(in.FilePath); err != nil {
 				return "", err
 			}
-			osPath := filepath.FromSlash(normalizeRel(in.FilePath))
+			if len(in.Edits) == 0 {
+				return "", errors.New("edits is required")
+			}
+			rel := normalizeRel(in.FilePath)
+			osPath := filepath.FromSlash(rel)
+			key := cacheKey(rootAbs, rel)
+
+			unlock := locks.lock(key)
+			defer unlock()
+
+			prev := cache.get(key)
+			if prev == nil {
+				return "", fmt.Errorf("file %s has not been read yet; read_file it first before editing", in.FilePath)
+			}
+
+			info, err := root.Stat(osPath)
+			if err != nil {
+				return "", err
+			}
+			if !info.ModTime().Equal(prev.ModTime) {
+				return "", fmt.Errorf("file %s has been modified since last read; re-read it before editing", in.FilePath)
+			}
 
 			data, err := root.ReadFile(osPath)
 			if err != nil {
@@ -332,8 +604,8 @@ func (f *Filesystem) newSearchReplaceTool(root *os.Root) ai.Tool {
 			}
 			content := string(data)
 
-			for i, block := range in.Edits {
-				next, err := applySearchReplace(content, block, in.FilePath)
+			for i, e := range in.Edits {
+				next, err := applyEdit(content, e, in.FilePath)
 				if err != nil {
 					return "", fmt.Errorf("edit %d: %w", i, err)
 				}
@@ -343,48 +615,35 @@ func (f *Filesystem) newSearchReplaceTool(root *os.Root) ai.Tool {
 			if err := root.WriteFile(osPath, []byte(content), 0o644); err != nil {
 				return "", err
 			}
+			if newInfo, err := root.Stat(osPath); err == nil {
+				cache.set(key, &fileState{
+					Content: []byte(content),
+					ModTime: newInfo.ModTime(),
+				})
+			}
 			return fmt.Sprintf("Successfully applied %d edit(s) to %s.", len(in.Edits), in.FilePath), nil
 		},
 	)
 }
 
-// applySearchReplace applies one SEARCH/REPLACE block to content. The separator
-// may legitimately appear in either half of the block, so every candidate
-// split is tried and the longest (most specific) matching search wins.
-func applySearchReplace(content, block, filePath string) (string, error) {
-	if !strings.HasPrefix(block, searchReplaceStart) || !strings.HasSuffix(block, searchReplaceEnd) {
-		return "", errors.New(`invalid edit block: must start with "<<<<<<< SEARCH\n" and end with "\n>>>>>>> REPLACE"`)
+// applyEdit replaces oldString with newString in content. With replaceAll,
+// every occurrence is replaced; without it, oldString must match exactly once.
+func applyEdit(content string, e editSpec, filePath string) (string, error) {
+	if e.OldString == "" {
+		return "", errors.New("oldString is required")
 	}
-	inner := block[len(searchReplaceStart) : len(block)-len(searchReplaceEnd)]
-
-	var splits []int
-	for i := 0; i < len(inner); {
-		off := strings.Index(inner[i:], searchReplaceSeparator)
-		if off < 0 {
-			break
-		}
-		splits = append(splits, i+off)
-		i = i + off + 1 // +1 so the same match isn't re-found next iteration
+	if e.OldString == e.NewString {
+		return "", errors.New("oldString and newString are identical")
 	}
-	if len(splits) == 0 {
-		return "", errors.New(`invalid edit block: missing separator "\n=======\n"`)
+	count := strings.Count(content, e.OldString)
+	if count == 0 {
+		return "", fmt.Errorf("oldString not found in %s; the match must be byte-for-byte, including whitespace and indentation", filePath)
 	}
-
-	var bestSearch, bestReplace string
-	matched := false
-	for _, idx := range splits {
-		search := inner[:idx]
-		replace := inner[idx+len(searchReplaceSeparator):]
-		if strings.Contains(content, search) {
-			if !matched || len(search) > len(bestSearch) {
-				bestSearch, bestReplace = search, replace
-			}
-			matched = true
-		}
+	if count > 1 && !e.ReplaceAll {
+		return "", fmt.Errorf("oldString matches %d locations in %s; add more surrounding context to make it unique, or set replaceAll=true", count, filePath)
 	}
-
-	if !matched {
-		return "", fmt.Errorf("search content not found in file %s; the search block must match byte-for-byte, including whitespace and indentation", filePath)
+	if e.ReplaceAll {
+		return strings.ReplaceAll(content, e.OldString, e.NewString), nil
 	}
-	return strings.Replace(content, bestSearch, bestReplace, 1), nil
+	return strings.Replace(content, e.OldString, e.NewString, 1), nil
 }

--- a/go/plugins/middleware/filesystem.go
+++ b/go/plugins/middleware/filesystem.go
@@ -35,8 +35,15 @@ import (
 	"github.com/firebase/genkit/go/core"
 )
 
-// readMaxBytes caps a single full read. Models can step past it via offset/limit.
-const readMaxBytes = 256 * 1024
+// readMaxBytes caps a single full read or returned slice. Models can step
+// past it on the read side via offset/limit, but the resulting slice still
+// has to fit. fileMaxBytes is the absolute on-disk file-size ceiling: even
+// a sliced read materializes the whole file via root.ReadFile, so without
+// this cap a 1 GB log could OOM the process before sliceLines runs.
+const (
+	readMaxBytes = 256 * 1024
+	fileMaxBytes = 10 * 1024 * 1024
+)
 
 // fileStateCacheMaxEntries bounds the per-call cache. Eviction is FIFO on insert.
 const fileStateCacheMaxEntries = 200
@@ -242,7 +249,7 @@ func (f *Filesystem) buildTools(
 ) []ai.Tool {
 	tools := []ai.Tool{
 		f.newListFilesTool(root),
-		f.newReadFileTool(root, rootAbs, cache, enqueueParts),
+		f.newReadFileTool(root, rootAbs, cache, locks, enqueueParts),
 	}
 	if f.AllowWriteAccess {
 		tools = append(tools,
@@ -359,6 +366,7 @@ func (f *Filesystem) newReadFileTool(
 	root *os.Root,
 	rootAbs string,
 	cache *fileStateCache,
+	locks *pathLocks,
 	enqueueParts func(parts ...*ai.Part),
 ) ai.Tool {
 	return ai.NewTool(
@@ -373,6 +381,13 @@ func (f *Filesystem) newReadFileTool(
 			osPath := filepath.FromSlash(rel)
 			isImage := strings.HasPrefix(mimeType, "image/")
 			key := cacheKey(rootAbs, rel)
+
+			// Serialize the stat → dedup-check → read → cache-set sequence
+			// against concurrent edit_file/write_file on the same path. genkit
+			// runs tool calls in parallel goroutines, so an interleaved write
+			// could otherwise let the read clobber the cache with stale state.
+			unlock := locks.lock(key)
+			defer unlock()
 
 			info, err := root.Stat(osPath)
 			if err != nil {
@@ -393,6 +408,12 @@ func (f *Filesystem) newReadFileTool(
 			}
 
 			fullSize := info.Size()
+			if fullSize > fileMaxBytes {
+				return "", fmt.Errorf(
+					"file %s is %d bytes (>%d); too large to read until streaming line-slicing is supported",
+					in.FilePath, fullSize, fileMaxBytes,
+				)
+			}
 			if !isImage && in.Offset == 0 && in.Limit == 0 && fullSize > readMaxBytes {
 				return "", fmt.Errorf(
 					"file %s is %d bytes (>%d); use offset/limit to read a slice",
@@ -448,7 +469,11 @@ func (f *Filesystem) newReadFileTool(
 				summary = fmt.Sprintf("File %s read successfully (%d lines). See contents below.",
 					in.FilePath, totalLines)
 			}
-			enqueueParts(ai.NewTextPart(header + "\n" + string(content) + "\n</read_file>"))
+			// No "\n" before the closing tag: when content already ends with a
+			// newline, the file's own terminator separates it from </read_file>;
+			// when content doesn't, we shouldn't fabricate one — the model could
+			// pick it up and pass it into edit_file.oldString and miss the match.
+			enqueueParts(ai.NewTextPart(header + "\n" + string(content) + "</read_file>"))
 			cache.set(key, &fileState{
 				Content: append([]byte(nil), data...),
 				ModTime: info.ModTime(),
@@ -473,23 +498,39 @@ func countLines(data []byte) int {
 	return n
 }
 
-// sliceLines returns the [offset, offset+limit) line window of data, 1-indexed.
-// offset <= 1 starts at the beginning; limit == 0 reads to end. The result
-// preserves the trailing newline when the original window did.
+// sliceLines returns the byte-range covering lines [offset, offset+limit)
+// of data, 1-indexed. offset <= 1 starts at the beginning; limit <= 0 reads
+// to end. Returns nil when offset is past EOF. The window is sliced directly
+// out of data, so any line terminators present in the original are preserved
+// — preserving byte-for-byte fidelity for downstream edit_file calls.
 func sliceLines(data []byte, offset, limit int) []byte {
 	if offset < 1 {
 		offset = 1
 	}
-	lines := strings.Split(string(data), "\n")
-	start := offset - 1
-	if start >= len(lines) {
+	start := 0
+	for i := 1; i < offset; i++ {
+		idx := bytes.IndexByte(data[start:], '\n')
+		if idx == -1 {
+			return nil
+		}
+		start += idx + 1
+	}
+	if start >= len(data) {
 		return nil
 	}
-	end := len(lines)
-	if limit > 0 && start+limit < end {
-		end = start + limit
+	if limit <= 0 {
+		return data[start:]
 	}
-	return []byte(strings.Join(lines[start:end], "\n"))
+	end := start
+	for i := 0; i < limit && end < len(data); i++ {
+		idx := bytes.IndexByte(data[end:], '\n')
+		if idx == -1 {
+			end = len(data)
+			break
+		}
+		end += idx + 1
+	}
+	return data[start:end]
 }
 
 type writeFileInput struct {

--- a/go/plugins/middleware/filesystem_test.go
+++ b/go/plugins/middleware/filesystem_test.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/internal/registry"
@@ -398,7 +399,7 @@ func TestFilesystemWriteFileRequiresAllowWriteAccess(t *testing.T) {
 	if !names["list_files"] || !names["read_file"] {
 		t.Errorf("read-only config missing expected tools; got %v", names)
 	}
-	if names["write_file"] || names["search_and_replace"] {
+	if names["write_file"] || names["edit_file"] {
 		t.Errorf("read-only config exposed write tools; got %v", names)
 	}
 }
@@ -434,17 +435,25 @@ func TestFilesystemWriteFileCreatesAndOverwrites(t *testing.T) {
 	}
 }
 
-func TestFilesystemSearchAndReplace(t *testing.T) {
+func TestFilesystemEditFile(t *testing.T) {
 	r := newTestRegistry(t)
 	root := makeFS(t)
 
-	edit := "<<<<<<< SEARCH\nhello world\n=======\nhello there\n>>>>>>> REPLACE"
-	m, _ := scriptedModel(t, r, "test/fs-sr", []modelTurn{
+	m, _ := scriptedModel(t, r, "test/fs-edit", []modelTurn{
 		{Tools: []*ai.ToolRequest{{
-			Name: "search_and_replace",
+			Name:  "read_file",
+			Input: map[string]any{"filePath": "hello.txt"},
+		}}},
+		{Tools: []*ai.ToolRequest{{
+			Name: "edit_file",
 			Input: map[string]any{
 				"filePath": "hello.txt",
-				"edits":    []any{edit},
+				"edits": []any{
+					map[string]any{
+						"oldString": "hello world",
+						"newString": "hello there",
+					},
+				},
 			},
 		}}},
 		{Text: "done"},
@@ -466,20 +475,28 @@ func TestFilesystemSearchAndReplace(t *testing.T) {
 	}
 }
 
-func TestFilesystemSearchAndReplaceNotFound(t *testing.T) {
-	// When the search content can't be located, the tool call should fail,
-	// and the failure should surface to the model as a placeholder tool
-	// response plus a user message, rather than crashing the generation.
+func TestFilesystemEditFileNotFound(t *testing.T) {
+	// When oldString can't be located, the tool call should fail, and the
+	// failure should surface to the model as a placeholder tool response
+	// plus a user message, rather than crashing the generation.
 	r := newTestRegistry(t)
 	root := makeFS(t)
 
-	edit := "<<<<<<< SEARCH\nNOT THERE\n=======\nREPLACED\n>>>>>>> REPLACE"
-	m, seen := scriptedModel(t, r, "test/fs-sr-miss", []modelTurn{
+	m, seen := scriptedModel(t, r, "test/fs-edit-miss", []modelTurn{
 		{Tools: []*ai.ToolRequest{{
-			Name: "search_and_replace",
+			Name:  "read_file",
+			Input: map[string]any{"filePath": "hello.txt"},
+		}}},
+		{Tools: []*ai.ToolRequest{{
+			Name: "edit_file",
 			Input: map[string]any{
 				"filePath": "hello.txt",
-				"edits":    []any{edit},
+				"edits": []any{
+					map[string]any{
+						"oldString": "NOT THERE",
+						"newString": "REPLACED",
+					},
+				},
 			},
 		}}},
 		{Text: "recovered"},
@@ -496,7 +513,6 @@ func TestFilesystemSearchAndReplaceNotFound(t *testing.T) {
 		t.Errorf("final text = %q, want %q", resp.Text(), "recovered")
 	}
 
-	// File must be untouched.
 	got, err := os.ReadFile(filepath.Join(root, "hello.txt"))
 	if err != nil {
 		t.Fatal(err)
@@ -505,18 +521,16 @@ func TestFilesystemSearchAndReplaceNotFound(t *testing.T) {
 		t.Errorf("file modified despite failed edit: %q", got)
 	}
 
-	// The second turn should have received an injected user message carrying
-	// the tool failure.
-	if len(*seen) < 2 {
-		t.Fatalf("expected 2 model calls, got %d", len(*seen))
+	if len(*seen) < 3 {
+		t.Fatalf("expected 3 model calls, got %d", len(*seen))
 	}
 	found := false
-	for _, msg := range (*seen)[1].Messages {
+	for _, msg := range (*seen)[2].Messages {
 		if msg.Role != ai.RoleUser {
 			continue
 		}
 		for _, p := range msg.Content {
-			if p.IsText() && strings.Contains(p.Text, `Tool "search_and_replace" failed`) {
+			if p.IsText() && strings.Contains(p.Text, `Tool "edit_file" failed`) {
 				found = true
 			}
 		}
@@ -592,7 +606,7 @@ func TestFilesystemToolNamePrefix(t *testing.T) {
 	for _, tool := range hooks.Tools {
 		names[tool.Name()] = true
 	}
-	for _, want := range []string{"fs_list_files", "fs_read_file", "fs_write_file", "fs_search_and_replace"} {
+	for _, want := range []string{"fs_list_files", "fs_read_file", "fs_write_file", "fs_edit_file"} {
 		if !names[want] {
 			t.Errorf("expected prefixed tool %q; got %v", want, names)
 		}
@@ -676,34 +690,419 @@ func TestFilesystemMissingRootDirIsAnError(t *testing.T) {
 	}
 }
 
-func TestApplySearchReplaceAmbiguousSeparators(t *testing.T) {
-	// When the same "=======" string appears in the SEARCH half (e.g. because
-	// the file contains it), both split positions parse as valid blocks. The
-	// longer matching search must win.
-	content := "line1\n=======\nline2"
+// TestFilesystemListFilesIncludesSize verifies list_files reports byte size
+// for files (and omits it for directories).
+func TestFilesystemListFilesIncludesSize(t *testing.T) {
+	r := newTestRegistry(t)
+	root := makeFS(t)
 
-	block := "<<<<<<< SEARCH\nline1\n=======\nline2\n=======\nREPLACED\n>>>>>>> REPLACE"
+	m, _ := scriptedModel(t, r, "test/fs-list-size", []modelTurn{
+		{Tools: []*ai.ToolRequest{{
+			Name:  "list_files",
+			Input: map[string]any{"dirPath": ""},
+		}}},
+		{Text: "done"},
+	})
 
-	got, err := applySearchReplace(content, block, "x.txt")
+	fs := &Filesystem{RootDir: root}
+	ai.DefineMiddleware(r, "filesystem", fs)
+	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != "REPLACED" {
-		t.Errorf("got %q, want %q", got, "REPLACED")
+
+	var helloSize float64
+	var sawDir bool
+	for _, msg := range resp.History() {
+		for _, p := range msg.Content {
+			if p.IsToolResponse() && p.ToolResponse.Name == "list_files" {
+				list, _ := p.ToolResponse.Output.([]any)
+				for _, e := range list {
+					em, _ := e.(map[string]any)
+					name, _ := em["path"].(string)
+					isDir, _ := em["isDirectory"].(bool)
+					sz, _ := em["sizeBytes"].(float64)
+					if name == "hello.txt" && !isDir {
+						helloSize = sz
+					}
+					if name == "docs" && isDir {
+						sawDir = true
+						if _, has := em["sizeBytes"]; has {
+							t.Errorf("directory entry should not include sizeBytes")
+						}
+					}
+				}
+			}
+		}
+	}
+	if helloSize != float64(len("hello world")) {
+		t.Errorf("hello.txt size = %v, want %d", helloSize, len("hello world"))
+	}
+	if !sawDir {
+		t.Errorf("expected docs directory entry")
 	}
 }
 
-func TestApplySearchReplaceInvalidBlock(t *testing.T) {
-	cases := []string{
-		"no markers at all",
-		"<<<<<<< SEARCH\nonly search\n>>>>>>> REPLACE",
-		"<<<<<<< SEARCH\na\n=======\n",   // missing end
-		"a\n=======\nb\n>>>>>>> REPLACE", // missing start
+// TestFilesystemReadFileIncludesLineMetadata verifies read_file emits
+// totalLines and a lines window for sliced reads.
+func TestFilesystemReadFileIncludesLineMetadata(t *testing.T) {
+	r := newTestRegistry(t)
+	root := t.TempDir()
+	body := "a\nb\nc\nd\ne\n"
+	if err := os.WriteFile(filepath.Join(root, "lines.txt"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	for _, b := range cases {
-		if _, err := applySearchReplace("anything", b, "x"); err == nil {
-			t.Errorf("expected error for block %q", b)
+
+	m, seen := scriptedModel(t, r, "test/fs-read-meta", []modelTurn{
+		{Tools: []*ai.ToolRequest{{
+			Name:  "read_file",
+			Input: map[string]any{"filePath": "lines.txt"},
+		}}},
+		{Tools: []*ai.ToolRequest{{
+			Name:  "read_file",
+			Input: map[string]any{"filePath": "lines.txt", "offset": 2, "limit": 2},
+		}}},
+		{Text: "done"},
+	})
+
+	fs := &Filesystem{RootDir: root}
+	ai.DefineMiddleware(r, "filesystem", fs)
+	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(*seen) < 3 {
+		t.Fatalf("expected 3 model calls, got %d", len(*seen))
+	}
+
+	fullOK := false
+	for _, msg := range (*seen)[1].Messages {
+		for _, p := range msg.Content {
+			if p.IsText() && strings.Contains(p.Text, `totalLines="5"`) &&
+				strings.Contains(p.Text, `path="lines.txt"`) {
+				fullOK = true
+			}
 		}
+	}
+	if !fullOK {
+		t.Errorf("full-read body missing totalLines metadata")
+	}
+
+	sliceOK := false
+	for _, msg := range (*seen)[2].Messages {
+		for _, p := range msg.Content {
+			if p.IsText() && strings.Contains(p.Text, `lines="2-3"`) &&
+				strings.Contains(p.Text, `totalLines="5"`) {
+				sliceOK = true
+			}
+		}
+	}
+	if !sliceOK {
+		t.Errorf("sliced-read body missing line-window metadata")
+	}
+}
+
+// TestFilesystemEditFileRequiresPriorRead verifies the read-first guard:
+// editing a file the model never read must fail before any bytes are touched.
+func TestFilesystemEditFileRequiresPriorRead(t *testing.T) {
+	r := newTestRegistry(t)
+	root := makeFS(t)
+
+	m, _ := scriptedModel(t, r, "test/fs-edit-noread", []modelTurn{
+		{Tools: []*ai.ToolRequest{{
+			Name: "edit_file",
+			Input: map[string]any{
+				"filePath": "hello.txt",
+				"edits": []any{
+					map[string]any{
+						"oldString": "hello world",
+						"newString": "hello there",
+					},
+				},
+			},
+		}}},
+		{Text: "ok"},
+	})
+
+	fs := &Filesystem{RootDir: root, AllowWriteAccess: true}
+	ai.DefineMiddleware(r, "filesystem", fs)
+	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, "hello.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello world" {
+		t.Errorf("file modified despite no prior read: %q", got)
+	}
+}
+
+// TestFilesystemEditFileDetectsExternalModification verifies the staleness
+// check: if a file changes on disk between read and edit, the edit must fail
+// rather than overwrite the external change.
+func TestFilesystemEditFileDetectsExternalModification(t *testing.T) {
+	r := newTestRegistry(t)
+	root := makeFS(t)
+
+	helloPath := filepath.Join(root, "hello.txt")
+	scripted := []modelTurn{
+		{Tools: []*ai.ToolRequest{{
+			Name:  "read_file",
+			Input: map[string]any{"filePath": "hello.txt"},
+		}}},
+		{Tools: []*ai.ToolRequest{{
+			Name: "edit_file",
+			Input: map[string]any{
+				"filePath": "hello.txt",
+				"edits": []any{
+					map[string]any{
+						"oldString": "hello world",
+						"newString": "hello there",
+					},
+				},
+			},
+		}}},
+		{Text: "done"},
+	}
+
+	turn := 0
+	m := ai.DefineModel(r, "test/fs-edit-stale", &ai.ModelOptions{
+		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true},
+	}, func(ctx context.Context, req *ai.ModelRequest, _ ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		// Between the read and the edit, simulate the user editing the file.
+		if turn == 1 {
+			// Make sure the new mtime is strictly after the cached one.
+			time.Sleep(10 * time.Millisecond)
+			if err := os.WriteFile(helloPath, []byte("user changed it"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		t := scripted[turn]
+		turn++
+		if len(t.Tools) > 0 {
+			content := make([]*ai.Part, 0, len(t.Tools))
+			for _, tr := range t.Tools {
+				content = append(content, ai.NewToolRequestPart(tr))
+			}
+			return &ai.ModelResponse{Request: req, Message: &ai.Message{Role: ai.RoleModel, Content: content}}, nil
+		}
+		return &ai.ModelResponse{Request: req, Message: ai.NewModelTextMessage(t.Text)}, nil
+	})
+
+	fs := &Filesystem{RootDir: root, AllowWriteAccess: true}
+	ai.DefineMiddleware(r, "filesystem", fs)
+	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(helloPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "user changed it" {
+		t.Errorf("user's external change was clobbered: got %q", got)
+	}
+}
+
+// TestFilesystemReadFileDedupsUnchanged verifies that re-reading the same file
+// at the same range without any disk change returns the unchanged-stub instead
+// of injecting the bytes a second time.
+func TestFilesystemReadFileDedupsUnchanged(t *testing.T) {
+	r := newTestRegistry(t)
+	root := makeFS(t)
+
+	m, seen := scriptedModel(t, r, "test/fs-read-dedup", []modelTurn{
+		{Tools: []*ai.ToolRequest{{
+			Name:  "read_file",
+			Input: map[string]any{"filePath": "hello.txt"},
+		}}},
+		{Tools: []*ai.ToolRequest{{
+			Name:  "read_file",
+			Input: map[string]any{"filePath": "hello.txt"},
+		}}},
+		{Text: "done"},
+	})
+
+	fs := &Filesystem{RootDir: root}
+	ai.DefineMiddleware(r, "filesystem", fs)
+	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
+		t.Fatal(err)
+	}
+
+	// The second read's tool_response output must be the unchanged stub, and
+	// turn 3 must NOT receive a second injected user message with the bytes.
+	if len(*seen) < 3 {
+		t.Fatalf("expected 3 model calls, got %d", len(*seen))
+	}
+
+	stubFound := false
+	for _, msg := range (*seen)[2].Messages {
+		for _, p := range msg.Content {
+			if p.IsToolResponse() && p.ToolResponse.Name == "read_file" {
+				if s, ok := p.ToolResponse.Output.(string); ok && strings.Contains(s, "File unchanged since last read") {
+					stubFound = true
+				}
+			}
+		}
+	}
+	if !stubFound {
+		t.Errorf("expected dedup stub in second read tool response")
+	}
+
+	bodyCount := 0
+	for _, msg := range (*seen)[2].Messages {
+		if msg.Role != ai.RoleUser {
+			continue
+		}
+		for _, p := range msg.Content {
+			if p.IsText() && strings.Contains(p.Text, "hello world") &&
+				strings.Contains(p.Text, `path="hello.txt"`) {
+				bodyCount++
+			}
+		}
+	}
+	if bodyCount != 1 {
+		t.Errorf("expected exactly one injected file-content body across history, got %d", bodyCount)
+	}
+}
+
+// TestFilesystemWriteFileRequiresReadOnOverwrite verifies that overwriting an
+// existing file requires a prior read, while creating a new file does not.
+func TestFilesystemWriteFileRequiresReadOnOverwrite(t *testing.T) {
+	r := newTestRegistry(t)
+	root := makeFS(t)
+
+	m, _ := scriptedModel(t, r, "test/fs-write-noread", []modelTurn{
+		{Tools: []*ai.ToolRequest{{
+			Name: "write_file",
+			Input: map[string]any{
+				"filePath": "hello.txt",
+				"content":  "clobbered",
+			},
+		}}},
+		{Text: "ok"},
+	})
+
+	fs := &Filesystem{RootDir: root, AllowWriteAccess: true}
+	ai.DefineMiddleware(r, "filesystem", fs)
+	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, "hello.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello world" {
+		t.Errorf("existing file overwritten without prior read: %q", got)
+	}
+}
+
+// TestFilesystemReadFileOffsetLimit verifies that line-windowed reads return
+// only the requested slice.
+func TestFilesystemReadFileOffsetLimit(t *testing.T) {
+	r := newTestRegistry(t)
+	root := t.TempDir()
+	body := "a\nb\nc\nd\ne\n"
+	if err := os.WriteFile(filepath.Join(root, "lines.txt"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, seen := scriptedModel(t, r, "test/fs-offset", []modelTurn{
+		{Tools: []*ai.ToolRequest{{
+			Name:  "read_file",
+			Input: map[string]any{"filePath": "lines.txt", "offset": 2, "limit": 2},
+		}}},
+		{Text: "done"},
+	})
+
+	fs := &Filesystem{RootDir: root}
+	ai.DefineMiddleware(r, "filesystem", fs)
+	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(*seen) < 2 {
+		t.Fatalf("expected 2 model calls, got %d", len(*seen))
+	}
+	found := false
+	for _, msg := range (*seen)[1].Messages {
+		for _, p := range msg.Content {
+			if p.IsText() && strings.Contains(p.Text, "b\nc") &&
+				!strings.Contains(p.Text, "a\nb") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("offset/limit did not produce the expected line window")
+	}
+}
+
+func TestApplyEditDeletesWithEmptyNewString(t *testing.T) {
+	content := "keep\n- [ ] Write a smoke test for /health.\nkeep\n"
+	got, err := applyEdit(content, editSpec{
+		OldString: "- [ ] Write a smoke test for /health.\n",
+		NewString: "",
+	}, "todo.txt")
+	if err != nil {
+		t.Fatalf("delete via empty newString rejected: %v", err)
+	}
+	want := "keep\nkeep\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestApplyEditMultiMatchRequiresReplaceAll(t *testing.T) {
+	content := "foo\nfoo\nbar"
+
+	if _, err := applyEdit(content, editSpec{
+		OldString: "foo",
+		NewString: "baz",
+	}, "x.txt"); err == nil {
+		t.Error("expected error when oldString matches multiple times without replaceAll")
+	}
+
+	got, err := applyEdit(content, editSpec{
+		OldString:  "foo",
+		NewString:  "baz",
+		ReplaceAll: true,
+	}, "x.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "baz\nbaz\nbar" {
+		t.Errorf("got %q, want %q", got, "baz\nbaz\nbar")
+	}
+}
+
+func TestApplyEditEqualOldAndNew(t *testing.T) {
+	if _, err := applyEdit("hello", editSpec{
+		OldString: "hello",
+		NewString: "hello",
+	}, "x.txt"); err == nil {
+		t.Error("expected error when oldString and newString are identical")
+	}
+}
+
+func TestApplyEditNotFound(t *testing.T) {
+	if _, err := applyEdit("hello", editSpec{
+		OldString: "missing",
+		NewString: "x",
+	}, "x.txt"); err == nil {
+		t.Error("expected error when oldString does not appear in content")
+	}
+}
+
+func TestApplyEditEmptyOldString(t *testing.T) {
+	if _, err := applyEdit("hello", editSpec{
+		OldString: "",
+		NewString: "x",
+	}, "x.txt"); err == nil {
+		t.Error("expected error when oldString is empty")
 	}
 }
 

--- a/go/samples/basic-middleware/filesystem/main.go
+++ b/go/samples/basic-middleware/filesystem/main.go
@@ -130,7 +130,7 @@ func DefineEditFlow(g *genkit.Genkit) {
 					"Keep unrelated content unchanged.",
 			),
 			ai.WithPrompt("Apply the following change to the workspace and report what you did:\n\n%s", instruction),
-			ai.WithMaxTurns(12),
+			ai.WithMaxTurns(20),
 			ai.WithUse(&middleware.Filesystem{
 				RootDir:          workspaceDir,
 				AllowWriteAccess: true,


### PR DESCRIPTION
Rebuilds the filesystem middleware around the patterns established by tool-calling code agents: structured edits, a per-call file-state cache, and explicit safety guards. The previous SEARCH/REPLACE text-block parser is replaced with an `edit_file` tool that takes JSON-shaped edits — no markers, no whitespace edge cases. Read/write/edit are now coordinated through a shared cache that enforces read-before-edit, detects external modifications, and dedups unchanged re-reads.

## Tool surface

### `list_files`

Entries now report byte size for files (omitted for directories):

```go
{Path: "todo.txt", IsDirectory: false, SizeBytes: 412}
{Path: "docs",     IsDirectory: true}
```

### `read_file`

Returns the file via the deferred user-message channel with a `<read_file>` envelope that carries metadata. New optional `offset` (1-indexed line) and `limit` parameters select a window. The header includes `totalLines` and (for sliced reads) `lines="X-Y"` so the model can reason about scope. A 256 KiB byte cap on full reads bails large files with a hint to use `offset`/`limit`.

```
<read_file path="todo.txt" totalLines="42">
...
</read_file>

<read_file path="big.log" lines="100-120" totalLines="50000">
...
</read_file>
```

Re-reading the same file at the same range with no on-disk modification returns a stub instead of re-injecting the bytes:

> File unchanged since last read. The content from the earlier read_file result in this conversation is still current — refer to that instead of re-reading.

### `write_file`

Creating a new file works as before. **Overwriting an existing file now requires a prior `read_file` in this session** — the cache must contain an entry whose mtime matches disk. This catches the lost-update class of bug where the model writes over an external change it never saw. The cache is updated after a successful write.

### `edit_file` (replaces `search_and_replace`)

Takes structured edits — no markers, no parsing:

```json
{
  "filePath": "todo.txt",
  "edits": [
    {"oldString": "- [ ] Write a smoke test for /health.\n", "newString": ""},
    {"oldString": "TODO\n====", "newString": "TODO\n====\nLast updated: 2026-04-28"}
  ]
}
```

Per-edit `replaceAll` handles renames. Edits apply sequentially — each sees the result of the previous. Same require-read-first and mtime-staleness guards as `write_file`.

`applyEdit` rules:
- empty `oldString` → error
- `oldString == newString` → error
- no match → error with byte-for-byte hint
- multi-match without `replaceAll` → error citing match count
- otherwise `strings.Replace` (one) or `strings.ReplaceAll` (all)

## Safety guarantees

| Failure mode | Guard |
|---|---|
| Edit a file the model never read | `edit_file` and overwrite-`write_file` refuse without a cache entry |
| User edits the file in their editor between read and edit | mtime check refuses; model re-reads |
| Two concurrent edits race on the same path | per-path mutex around stat → write → cache-update |
| Re-reading an unchanged file | stub response; the original tool result already lives in history |
| `oldString` matches multiple locations silently | error citing the exact count, suggesting `replaceAll` or more context |
| `oldString == newString` | error |
| Reading a 50 MB file in full | 256 KiB cap; hint to use `offset`/`limit` |

All guards return actionable error messages so the model can self-correct on the next turn.

## Internal additions

- `fileStateCache`: per-call, FIFO-bounded (200 entries) `path → {content, mtime, offset, limit}` map. Allocated in `New()`, scoped to one `Hooks` instance.
- `pathLocks`: `path → *sync.Mutex` for serializing read-modify-write.
- `countLines`, `sliceLines`: helpers for `read_file` metadata and windowing.

## What was deliberately deferred

- **File content in the `tool_result` instead of a deferred user message.** `read_file` still injects content as a separate user message on the next turn (via `enqueueParts`). Putting it directly in `MultipartToolResponse` is structurally cleaner — single block per read, no protocol-awkward consecutive user messages — but works today and is non-breaking to defer.
- **Line numbers in `read_file` output.** Useful for reasoning about line positions, but pairs with a footgun (the model can copy line-number prefixes into edit blocks where they don't match disk bytes). Structured edits don't need them.
- **Partial-view tracking on edits.** The cache records `offset`/`limit`, but `edit_file` doesn't yet refuse edits whose `oldString` falls outside a partial-read window. Mtime check is sufficient for the common case.

## Sample

`samples/basic-middleware/filesystem` exercises the full surface (read_file → edit_file with `oldString` → `""` to delete) against a tiny workspace. `MaxTurns` bumped from 12 to 20 to give the model room to recover from any first-attempt format errors during interactive testing.

## Test coverage

24 tests, all passing. New coverage:

- Structured edit semantics: not-found, multi-match + `replaceAll`, equal old/new, empty old, deletion via empty new
- Integration: `edit_file` happy path, `edit_file` failure surfacing, require-read-first on edit, require-read-first on overwrite, external-modification detection, dedup stub, `read_file` offset/limit, `list_files` size metadata, `read_file` line metadata