### PR TITLE
fix(prompt): prompt metadata for middleware and tools

### DIFF
--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -18,6 +18,7 @@ import {
   GenkitError,
   defineActionAsync,
   getContext,
+  isAction,
   stripUndefinedProps,
   type Action,
   type ActionAsyncParams,
@@ -440,6 +441,12 @@ function promptMetadata(options: PromptConfig<any, any, any>) {
         ? options.name.split('.')[0]
         : options.name,
       model: modelName(options.model),
+      tools: (options.tools ?? []).map(toolName).filter(Boolean) as string[],
+      toolChoice: options.toolChoice,
+      use: (options.use ?? []).map(toMiddlewareMetadata).filter(Boolean) as {
+        name: string;
+        config?: any;
+      }[],
     },
     type: 'prompt',
   };
@@ -680,6 +687,35 @@ function modelName(
   return (modelArg as ModelAction).__action.name;
 }
 
+function toolName(tool: ToolArgument): string | undefined {
+  if (typeof tool === 'string') {
+    return tool;
+  }
+  if (isAction(tool)) {
+    return tool.__action.name;
+  }
+  if (isExecutablePrompt(tool)) {
+    return tool.ref.name;
+  }
+  return undefined;
+}
+
+function toMiddlewareMetadata(
+  middleware: any
+): { name: string; config?: any } | undefined {
+  if (typeof middleware === 'string') {
+    return { name: middleware };
+  }
+  if (
+    typeof middleware === 'object' &&
+    middleware !== null &&
+    middleware.name
+  ) {
+    return { name: middleware.name, config: middleware.config };
+  }
+  return undefined;
+}
+
 function normalizeParts(parts: string | Part | Part[]): Part[] {
   if (Array.isArray(parts)) return parts;
   if (typeof parts === 'string') {
@@ -839,6 +875,13 @@ function loadPrompt(
         type: 'prompt',
         prompt: {
           ...promptMetadata,
+          use: (Array.isArray(promptMetadata.raw?.['use'])
+            ? promptMetadata.raw?.['use']
+            : []
+          )
+            .map(toMiddlewareMetadata)
+            .filter(Boolean),
+          toolChoice: promptMetadata.raw?.['toolChoice'],
           template: parsedPrompt.template,
         },
       };

--- a/js/ai/tests/prompt/prompt_test.ts
+++ b/js/ai/tests/prompt/prompt_test.ts
@@ -815,6 +815,23 @@ describe('prompt', () => {
     });
   }
 
+  it('metadata is correctly populated', async () => {
+    definePrompt(registry, {
+      name: 'metadataTest',
+      model: 'echoModel',
+      tools: ['toolA'],
+      toolChoice: 'auto',
+      use: ['myMiddleware'],
+      prompt: 'hello',
+    });
+
+    const action = await registry.lookupAction('/prompt/metadataTest');
+    const metadata = (action as any).__action.metadata.prompt;
+    assert.deepStrictEqual(metadata.tools, ['toolA']);
+    assert.strictEqual(metadata.toolChoice, 'auto');
+    assert.deepStrictEqual(metadata.use, [{ name: 'myMiddleware' }]);
+  });
+
   it('respects output schema in the definition', async () => {
     const schema1 = z.object({
       puppyName: z.string({ description: 'A cute name for a puppy' }),

--- a/js/genkit/tests/prompts/test.variant.prompt
+++ b/js/genkit/tests/prompts/test.variant.prompt
@@ -2,5 +2,7 @@
 description: a prompt variant in a file
 config: 
   temperature: 13
+tools: [toolA]
+use: [myMiddleware]
 ---
 Hello from a variant of the hello prompt

--- a/js/genkit/tests/prompts_test.ts
+++ b/js/genkit/tests/prompts_test.ts
@@ -1033,6 +1033,13 @@ describe('prompt', () => {
     });
     defineEchoModel(ai);
     pm = defineProgrammableModel(ai);
+    ai.defineTool(
+      {
+        name: 'toolA',
+        description: 'toolA it is',
+      },
+      async () => {}
+    );
     ai.defineSchema('myInputSchema', z.object({ foo: z.string() }));
     ai.defineSchema('myOutputSchema', z.object({ output: z.string() }));
   });
@@ -1307,11 +1314,17 @@ describe('prompt', () => {
         name: 'test',
         variant: 'variant',
         template: 'Hello from a variant of the hello prompt',
+        tools: ['toolA'],
+        toolChoice: undefined,
+        toolDefs: [],
+        use: [{ name: 'myMiddleware' }],
         raw: {
           config: {
             temperature: 13,
           },
           description: 'a prompt variant in a file',
+          tools: ['toolA'],
+          use: ['myMiddleware'],
         },
       },
       type: 'prompt',
@@ -1352,6 +1365,9 @@ describe('prompt', () => {
       config: {
         temperature: 0.13,
       },
+      tools: ['toolA'],
+      toolChoice: 'auto',
+      use: ['myMiddleware'],
       messages: async (input) => [],
     });
     const testPrompt: PromptAction =
@@ -1365,6 +1381,9 @@ describe('prompt', () => {
         config: {
           temperature: 0.13,
         },
+        tools: ['toolA'],
+        toolChoice: 'auto',
+        use: [{ name: 'myMiddleware' }],
         input: {
           schema: {
             type: 'object',

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -193,7 +193,7 @@ importers:
         version: 4.1.1
       '@genkit-ai/firebase':
         specifier: ^1.16.1
-        version: 1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
+        version: 1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
 
   doc-snippets:
     dependencies:
@@ -1193,6 +1193,9 @@ importers:
       '@genkit-ai/google-genai':
         specifier: workspace:*
         version: link:../../plugins/google-genai
+      '@genkit-ai/middleware':
+        specifier: workspace:*
+        version: link:../../plugins/middleware
       '@genkit-ai/vertexai':
         specifier: workspace:*
         version: link:../../plugins/vertexai
@@ -2923,11 +2926,11 @@ packages:
     resolution: {integrity: sha512-Lm/ZLhDZcBECta3TmCQSngiQykFdfw+QtI1/GYMsZd4l3nG+P8WLB16XuS7WaBGLQ+9E+cOcWQsth9cayuGt8g==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@genkit-ai/ai@1.33.0-rc.1':
-    resolution: {integrity: sha512-IARfQs+XvLqkEF5EyqYj1CaQEZeUvb1fxNTlolmMm8yzoRoNJ1Sh5CXi4IcyblGf0YvaPiwUMEc85K2A6Aac2w==}
+  '@genkit-ai/ai@1.33.0':
+    resolution: {integrity: sha512-d58ByMSIHy8cwKoq6CXdpIk7BMq3VIFi+5lfP4TlZiDxC+HQX1P+jTNjgGdCCjqIwhiF5qjqqX0/PbdX/YP1rg==}
 
-  '@genkit-ai/core@1.33.0-rc.1':
-    resolution: {integrity: sha512-Hk4KqmZXud1qU/G2FETD02y0y6jTJ6ZJy1Fm3cEFmjXe8OsSXBiZKOJr5s4K+QW9QD40sB021rhis+q8LrW3Xw==}
+  '@genkit-ai/core@1.33.0':
+    resolution: {integrity: sha512-0adFPBl/nsxuV+B94nyzwRkRHKkW5eCxQbv/80f0OdkcNpQS6CwamAK+kttjplHdUvq9Yu70PzRQz7Sx9tj5NQ==}
 
   '@genkit-ai/express@1.29.0':
     resolution: {integrity: sha512-+Mf8e45RbAlvns3a3hvIDpUAjNyWTIu1cy7vV86+6NvpPqPhkEaPkptgIX7KIXsPBEwiwsEM4SXx80M/TRbmTg==}
@@ -5927,8 +5930,8 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
-  genkit@1.33.0-rc.1:
-    resolution: {integrity: sha512-YmwJbXqx9luEeHbgmJ9+qVyukxZRRIB3Vf2vdzQfl/mXMMIEJJa4AG0nI2lA64WFKGHDnv0kyCkx5VHymi4CcQ==}
+  genkit@1.33.0:
+    resolution: {integrity: sha512-46cS8uUE+Et/glO0zt4JxR/2RjJ2b9OCOYfIgmJKaOk9vdjLBVBIBcJPNQZ7ToGnr6TJE3ZfM6jyCRfxd7NFQA==}
 
   genkitx-openai@0.30.0:
     resolution: {integrity: sha512-6Dt3o6f+cKrZ1njSzYj2rm0U8SE5nQDwpz5VbFuLjaloE5BBj2c9OSlPGegdcz4PN5wBocGKiNsaKn0t5PpJdA==}
@@ -9700,9 +9703,9 @@ snapshots:
       retry: 0.13.1
     optional: true
 
-  '@genkit-ai/ai@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/ai@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/core': 1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/core': 1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
       '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.37
       colorette: 2.0.20
@@ -9724,11 +9727,13 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@genkit-ai/core@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/core@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
       '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.52.1
       '@opentelemetry/context-async-hooks': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.52.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-node': 0.52.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.25.1(@opentelemetry/api@1.9.0)
@@ -9746,7 +9751,7 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
-      '@genkit-ai/firebase': 1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/firebase': 1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
     transitivePeerDependencies:
       - '@google-cloud/firestore'
       - bufferutil
@@ -9767,12 +9772,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@genkit-ai/firebase@1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/firebase@1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
       '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
       firebase-admin: 13.7.0(encoding@0.1.13)
-      genkit: 1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)
     optionalDependencies:
       firebase: 11.10.0
     transitivePeerDependencies:
@@ -9780,12 +9785,12 @@ snapshots:
       - supports-color
     optional: true
 
-  '@genkit-ai/firebase@1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/firebase@1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
       '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
       firebase-admin: 13.7.0(encoding@0.1.13)
-      genkit: 1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)
     optionalDependencies:
       firebase: 11.10.0
     transitivePeerDependencies:
@@ -9793,7 +9798,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@genkit-ai/google-cloud@1.30.1(encoding@0.1.13)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/google-cloud@1.30.1(encoding@0.1.13)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
       '@google-cloud/logging-winston': 6.0.1(encoding@0.1.13)(winston@3.19.0)
       '@google-cloud/modelarmor': 0.4.1
@@ -9810,7 +9815,7 @@ snapshots:
       '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-node': 0.52.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.25.1(@opentelemetry/api@1.9.0)
-      genkit: 1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)
       google-auth-library: 9.15.1(encoding@0.1.13)
       node-fetch: 3.3.2
       winston: 3.19.0
@@ -13258,10 +13263,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0):
+  genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0):
     dependencies:
-      '@genkit-ai/ai': 1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
-      '@genkit-ai/core': 1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0-rc.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/ai': 1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/core': 1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.33.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.7.0(encoding@0.1.13))(firebase@11.10.0))
       uuid: 10.0.0
     transitivePeerDependencies:
       - '@google-cloud/firestore'

--- a/js/testapps/dev-ui-gallery/package.json
+++ b/js/testapps/dev-ui-gallery/package.json
@@ -28,6 +28,7 @@
     "@genkit-ai/firebase": "workspace:*",
     "@genkit-ai/google-cloud": "workspace:*",
     "@genkit-ai/google-genai": "workspace:*",
+    "@genkit-ai/middleware": "workspace:*",
     "@genkit-ai/vertexai": "workspace:*",
     "firebase-admin": ">=12.2",
     "firebase-functions": "^6.3.1",

--- a/js/testapps/dev-ui-gallery/prompts/agent.prompt
+++ b/js/testapps/dev-ui-gallery/prompts/agent.prompt
@@ -1,0 +1,21 @@
+---
+model: googleai/gemini-3-flash-preview
+config:
+  maxOutputTokens: 2048
+  temperature: 1.0
+  topK: 16
+  topP: 0.95
+tools:
+  - getWeather
+  - getTime
+use:
+  - name: retry
+    config: 
+      maxRetries: 3
+  - name: filesystem
+    config:
+      rootDirectory: ./
+---
+
+{{role "system"}}
+You are a helpful AI assistant.

--- a/js/testapps/dev-ui-gallery/src/genkit.ts
+++ b/js/testapps/dev-ui-gallery/src/genkit.ts
@@ -19,6 +19,13 @@ import { GenkitMetric, genkitEval } from '@genkit-ai/evaluator';
 import { enableFirebaseTelemetry } from '@genkit-ai/firebase';
 import { googleAI, vertexAI } from '@genkit-ai/google-genai';
 import {
+  fallback,
+  filesystem,
+  retry,
+  skills,
+  toolApproval,
+} from '@genkit-ai/middleware';
+import {
   VertexAIEvaluationMetricType,
   vertexAIEvaluation,
 } from '@genkit-ai/vertexai/evaluation';
@@ -172,5 +179,12 @@ export const ai = genkit({
         GenkitMetric.MALICIOUSNESS,
       ],
     }),
+
+    //middleware
+    fallback.plugin(),
+    filesystem.plugin(),
+    retry.plugin(),
+    skills.plugin(),
+    toolApproval.plugin(),
   ],
 });


### PR DESCRIPTION
Added middleware to prompt metadata in the `ModelRef` format for the Dev UI.

While I was in here, it was discovered that `definePrompt` was also failing to populate tool names.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)
