### PR TITLE
feat(tools): consolidate OTLP routes to prioritize standard v1 endpoints

### DIFF
--- a/genkit-tools/telemetry-server/src/index.ts
+++ b/genkit-tools/telemetry-server/src/index.ts
@@ -241,11 +241,14 @@ export async function startTelemetryServer(params: {
   );
 
   api.post(
-    '/api/otlp/:parentTraceId/:parentSpanId',
+    [
+      '/api/otlp',
+      '/api/otlp/v1/traces',
+      '/api/otlp/v1/logs',
+      '/api/otlp/v1/metrics',
+    ],
     async (request, response) => {
       try {
-        const { parentTraceId, parentSpanId } = request.params;
-
         if (
           !request.body.resourceSpans?.length &&
           !request.body.resourceLogs?.length
@@ -255,27 +258,29 @@ export async function startTelemetryServer(params: {
           return;
         }
         const traces = traceDataFromOtlp(request.body);
-        for (const traceData of traces) {
-          traceData.traceId = parentTraceId;
-          for (const span of Object.values(traceData.spans)) {
-            span.attributes['genkit:otlp-traceId'] = span.traceId;
-            span.traceId = parentTraceId;
-            if (!span.parentSpanId) {
-              span.parentSpanId = parentSpanId;
-            }
+        for (const trace of traces) {
+          const traceData = TraceDataSchema.parse(trace);
+          await params.traceStore.save(traceData.traceId, traceData);
+
+          // Convert each span to an event and broadcast individually
+          for (const [_, span] of Object.entries(traceData.spans)) {
+            const event: {
+              type: 'span_start' | 'span_end';
+              traceId: string;
+              span: SpanData;
+            } = {
+              type: span.endTime > 0 ? 'span_end' : 'span_start',
+              traceId: traceData.traceId,
+              span,
+            };
+            broadcastManager.broadcast(traceData.traceId, event);
           }
-          await params.traceStore.save(parentTraceId, traceData);
         }
 
+        // TODO: Add real time support and broadcast log events
         if (request.body.resourceLogs?.length) {
           const logs = logDataFromOtlp(request.body);
           if (logs.length > 0) {
-            for (const log of logs) {
-              log.traceId = parentTraceId;
-              if (!log.spanId) {
-                log.spanId = parentSpanId;
-              }
-            }
             await params.logStore.save(logs);
           }
         }
@@ -291,55 +296,6 @@ export async function startTelemetryServer(params: {
       }
     }
   );
-
-  api.post('/api/otlp', async (request, response) => {
-    try {
-      if (
-        !request.body.resourceSpans?.length &&
-        !request.body.resourceLogs?.length
-      ) {
-        // Acknowledge and ignore empty payloads.
-        response.status(200).json({});
-        return;
-      }
-      const traces = traceDataFromOtlp(request.body);
-      for (const trace of traces) {
-        const traceData = TraceDataSchema.parse(trace);
-        await params.traceStore.save(traceData.traceId, traceData);
-
-        // Convert each span to an event and broadcast individually
-        for (const [_, span] of Object.entries(traceData.spans)) {
-          const event: {
-            type: 'span_start' | 'span_end';
-            traceId: string;
-            span: SpanData;
-          } = {
-            type: span.endTime > 0 ? 'span_end' : 'span_start',
-            traceId: traceData.traceId,
-            span,
-          };
-          broadcastManager.broadcast(traceData.traceId, event);
-        }
-      }
-
-      // TODO: Add real time support and broadcast log events
-      if (request.body.resourceLogs?.length) {
-        const logs = logDataFromOtlp(request.body);
-        if (logs.length > 0) {
-          await params.logStore.save(logs);
-        }
-      }
-
-      response.status(200).json({});
-    } catch (err) {
-      logger.error(`Error processing OTLP payload: ${err}`);
-      response.status(500).json({
-        code: 13, // INTERNAL
-        message:
-          'An internal error occurred while processing the OTLP payload.',
-      });
-    }
-  });
 
   api.use((err: any, req: any, res: any, next: any) => {
     logger.error(err.stack);


### PR DESCRIPTION
I tried to hook up gemini-cli (which has migrated to Otel) to our telemetry server and it immediately blew up due to allocation of "large" strings. The culprit was that the `/api/otlp/:parentTraceId/:parentSpanId` endpoint matched all of the standard Otlp endpoints by accident, creating one giant trace with the traceId `v1`. 

Speaking with SamB, we don't actually need this endpoint.

- Remove experimental `/api/otlp/:parentTraceId/:parentSpanId` endpoint, because:
  - It conflicts with the standard OTel endpoints
  - It results in very very large traces that break
 
- Support the standard  OTel endpoints. We must add these, or we'll not be able to accept standard Otel traffic.
  - `v1/traces`
  - `v1/logs`
  - `v1/metrics`

For now, the same route handles everything, just as before. But ideally, we'd want to break it out in the very near future.
 
Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)

**Screenshot**

<img width="1491" height="1280" alt="image" src="https://github.com/user-attachments/assets/2d5366d6-452f-4c6f-9f1f-356421667377" />

**See also**

- Gemini CLI Otel - https://github.com/google-gemini/gemini-cli/pull/20237/changes
- Standard Otel endpoints: https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_endpoint