### PR TITLE
fix(go): use *Part for GenerateActionResume.Respond and Restart

### DIFF
--- a/go/ai/gen.go
+++ b/go/ai/gen.go
@@ -121,9 +121,9 @@ type GenerateActionResume struct {
 	// Metadata contains additional context for resuming the generation.
 	Metadata map[string]any `json:"metadata,omitempty"`
 	// Respond contains tool response parts to send to the model when resuming.
-	Respond []*toolResponsePart `json:"respond,omitempty"`
+	Respond []*Part `json:"respond,omitempty"`
 	// Restart contains tool request parts to restart when resuming.
-	Restart []*toolRequestPart `json:"restart,omitempty"`
+	Restart []*Part `json:"restart,omitempty"`
 }
 
 // ToolChoice controls how the model uses tools.

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -661,30 +661,6 @@ func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*Mod
 		}
 	}
 
-	respondParts := []*toolResponsePart{}
-	for _, part := range genOpts.RespondParts {
-		if !part.IsToolResponse() {
-			return nil, core.NewError(core.INVALID_ARGUMENT, "ai.Generate: respond part is not a tool response")
-		}
-
-		respondParts = append(respondParts, &toolResponsePart{
-			ToolResponse: part.ToolResponse,
-			Metadata:     part.Metadata,
-		})
-	}
-
-	restartParts := []*toolRequestPart{}
-	for _, part := range genOpts.RestartParts {
-		if !part.IsToolRequest() {
-			return nil, core.NewError(core.INVALID_ARGUMENT, "ai.Generate: restart part is not a tool request")
-		}
-
-		restartParts = append(restartParts, &toolRequestPart{
-			ToolRequest: part.ToolRequest,
-			Metadata:    part.Metadata,
-		})
-	}
-
 	actionOpts := &GenerateActionOptions{
 		Model:              modelName,
 		Messages:           messages,
@@ -702,10 +678,10 @@ func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*Mod
 		},
 	}
 
-	if len(respondParts) > 0 || len(restartParts) > 0 {
+	if len(genOpts.RespondParts) > 0 || len(genOpts.RestartParts) > 0 {
 		actionOpts.Resume = &GenerateActionResume{
-			Respond: respondParts,
-			Restart: restartParts,
+			Respond: genOpts.RespondParts,
+			Restart: genOpts.RestartParts,
 		}
 	}
 
@@ -1509,6 +1485,17 @@ func handleResumedToolRequest(ctx context.Context, r api.Registry, genOpts *Gene
 func handleResumeOption(ctx context.Context, r api.Registry, genOpts *GenerateActionOptions, runTool toolRunnerFunc) (*resumeOptionOutput, error) {
 	if genOpts.Resume == nil || (len(genOpts.Resume.Respond) == 0 && len(genOpts.Resume.Restart) == 0) {
 		return &resumeOptionOutput{revisedRequest: genOpts}, nil
+	}
+
+	for _, part := range genOpts.Resume.Respond {
+		if !part.IsToolResponse() {
+			return nil, core.NewError(core.INVALID_ARGUMENT, "handleResumeOption: respond part is not a tool response")
+		}
+	}
+	for _, part := range genOpts.Resume.Restart {
+		if !part.IsToolRequest() {
+			return nil, core.NewError(core.INVALID_ARGUMENT, "handleResumeOption: restart part is not a tool request")
+		}
 	}
 
 	toolDefMap := make(map[string]*ToolDefinition)

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -1103,6 +1103,8 @@ GenerateActionOptions.returnToolRequests        type bool
 GenerateActionOptions.maxTurns                  type int
 GenerateActionOptions.use                       type []*MiddlewareRef
 GenerateActionOptionsResume                     name GenerateActionResume
+GenerateActionOptionsResume.respond             type []*Part
+GenerateActionOptionsResume.restart             type []*Part
 
 # GenerateActionOutputConfig
 GenerateActionOutputConfig.instructions         type *string


### PR DESCRIPTION
The `Respond` and `Restart` fields on `GenerateActionResume` used the unexported `toolResponsePart` and `toolRequestPart` types, which are intended only for JSON marshaling. The rest of the codebase uses `*Part` with the appropriate `Kind` set, and the unexported types made these fields impossible for external callers to construct.

This change:

- Adds type overrides in `schemas.config` so codegen produces `[]*Part` for both fields, and regenerates `gen.go`.
- Drops the conversion loops in `Generate()` that copied `*Part` into the private types — `genOpts.RespondParts` / `RestartParts` now flow through directly.
- Moves part-kind validation into `handleResumeOption`, the single consumer, so all entry points (including direct `GenerateWithRequest` calls with hand-built `GenerateActionOptions`) are covered.

The private `toolRequestPart` / `toolResponsePart` types remain in `gen.go` and are still used by `Part.MarshalJSON` for the wire format, so JSON output is unchanged.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes