### PR TITLE
feat(go): trace GenerateActionOptions as input for generate calls

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -372,16 +372,20 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 	var runGenerate func(context.Context, *GenerateParams) (*ModelResponse, error)
 
 	runGenerate = func(ctx context.Context, params *GenerateParams) (*ModelResponse, error) {
-		req := params.Request
-		currentTurn := params.Iteration
-		messageIndex := params.MessageIndex
+		name := params.Options.StepName
+		if name == "" {
+			name = "generate"
+		}
 		spanMetadata := &tracing.SpanMetadata{
-			Name:    "generate",
+			Name:    name,
 			Type:    "util",
 			Subtype: "util",
 		}
 
-		return tracing.RunInNewSpan(ctx, spanMetadata, req, func(ctx context.Context, req *ModelRequest) (*ModelResponse, error) {
+		return tracing.RunInNewSpan(ctx, spanMetadata, params.Options, func(ctx context.Context, _ *GenerateActionOptions) (*ModelResponse, error) {
+			req := params.Request
+			currentTurn := params.Iteration
+			messageIndex := params.MessageIndex
 			var wrappedCb ModelStreamCallback
 			currentRole := RoleModel
 			currentIndex := messageIndex
@@ -694,6 +698,7 @@ func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*Mod
 		ToolChoice:         genOpts.ToolChoice,
 		Docs:               genOpts.Documents,
 		ReturnToolRequests: genOpts.ReturnToolRequests != nil && *genOpts.ReturnToolRequests,
+		StepName:           genOpts.StepName,
 		Output: &GenerateActionOutputConfig{
 			JsonSchema:   genOpts.OutputSchema,
 			Format:       genOpts.OutputFormat,

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -257,6 +257,11 @@ func WithUse(middleware ...Middleware) CommonGenOption {
 	return &commonGenOptions{Use: middleware}
 }
 
+// WithStepName sets a custom name for the generation step in traces.
+func WithStepName(name string) GenerateOption {
+	return &generateOptions{StepName: name}
+}
+
 // WithMaxTurns sets the maximum number of tool call iterations before erroring.
 // A tool call happens when tools are provided in the request and a model decides to call one or more as a response.
 // Each round trip, including multiple tools in parallel, counts as one turn.
@@ -889,6 +894,7 @@ type generateOptions struct {
 	documentOptions
 	RespondParts []*Part // Tool responses to return from interrupted tool calls.
 	RestartParts []*Part // Tool requests to restart interrupted tools with.
+	StepName     string  // Custom name for the generation step in traces.
 }
 
 // GenerateOption is an option for generating a model response. It applies only to Generate().
@@ -930,6 +936,13 @@ func (o *generateOptions) applyGenerate(genOpts *generateOptions) error {
 			return errors.New("cannot set restart parts more than once (WithToolRestarts)")
 		}
 		genOpts.RestartParts = o.RestartParts
+	}
+
+	if o.StepName != "" {
+		if genOpts.StepName != "" {
+			return errors.New("cannot set step name more than once (WithStepName)")
+		}
+		genOpts.StepName = o.StepName
 	}
 
 	return nil


### PR DESCRIPTION
Currently all of the generate options (such as use/middleware, model, etc) are missing from the trace because `Request` is set as the input. Switching to `Options` is the most idiomatic thing for Go at this time (IMO). 

This PR:

- Updates the trace span for generate to populate `Options` as the input
- Allow custom stepName for generate spans

**Note: This is a bit different from Typescript, because in Go, recursive generate calls do not accumulate message history in the `GenerateActionOptions`, which Typescript does.** For recursive calls, each generate will have the same exact `Options`, even though the underlying request is growing.

We _could_ set the full `GenerateParams` as the input, but there are two problems (a) it "leaks" internal details and (b) it's confusing to have 2 message arrays.

In any case, the full message history will accumulate in the model spans beneath each generate call.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e3e3ddae-93c3-409f-a70a-21f5a6bd66fd" />
