### PR TITLE
feat(js/plugins/compat-oai): add OpenAI Responses API support

### DIFF
--- a/js/plugins/compat-oai/README.md
+++ b/js/plugins/compat-oai/README.md
@@ -140,6 +140,80 @@ const result = await ai.generate({
 console.log(result.text);
 ```
 
+### Using the OpenAI Responses API
+
+The Responses API (`POST /v1/responses`) is OpenAI's newer endpoint that
+supports built-in tools (`web_search_preview`, `file_search`,
+`code_interpreter`), reasoning models (`o1`, `o3`, `o4-mini`,
+`gpt-5*`), and stateful conversations via `previous_response_id`.
+
+Opt in by registering the companion `openAIResponses()` plugin alongside
+`openAI()`, then build model references with `openAI.responsesModel(...)`:
+
+```typescript
+import { genkit } from 'genkit';
+import openAI, { openAIResponses } from '@genkit-ai/compat-oai/openai';
+
+const ai = genkit({ plugins: [openAI(), openAIResponses()] });
+
+const result = await ai.generate({
+  model: openAI.responsesModel('gpt-5-mini'),
+  prompt: 'What is one positive news story today?',
+  config: {
+    builtInTools: [{ type: 'web_search_preview' }],
+    reasoning: { effort: 'medium' },
+  },
+});
+
+console.log(result.text);
+```
+
+**Citations.** When `web_search_preview` or `file_search` returns
+sources, each text Part carries them on `metadata.citations`:
+
+```typescript
+for (const part of result.message?.content ?? []) {
+  const citations = part.metadata?.citations as
+    | Array<{
+        type: 'url_citation';
+        url: string;
+        title?: string;
+        startIndex?: number;
+        endIndex?: number;
+      }>
+    | undefined;
+  if (citations) {
+    for (const c of citations) {
+      console.log(`- [${c.title ?? c.url}](${c.url})`);
+    }
+  }
+}
+```
+
+**Stateful chaining.** Pass the previous `responseId` to continue a
+conversation server-side without re-sending history:
+
+```typescript
+const first = await ai.generate({
+  model: openAI.responsesModel('gpt-5-mini'),
+  prompt: 'What was a positive news story today?',
+  config: { builtInTools: [{ type: 'web_search_preview' }], store: true },
+});
+const responseId = (first.custom as { responseId?: string } | undefined)
+  ?.responseId;
+
+const followup = await ai.generate({
+  model: openAI.responsesModel('gpt-5-mini'),
+  prompt: 'Summarize that in one sentence.',
+  config: { previousResponseId: responseId },
+});
+```
+
+**Privacy default.** Unlike OpenAI's API default, this plugin sends
+`store: false` unless you explicitly opt in. Set `store: true` (as
+above) only when you intend to chain via `previous_response_id` or
+inspect the response in the OpenAI dashboard.
+
 ### Custom models & other Cloud providers
 
 ```typescript

--- a/js/plugins/compat-oai/scripts/smoke_responses.ts
+++ b/js/plugins/compat-oai/scripts/smoke_responses.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Manual smoke test against the live OpenAI Responses API.
+ *
+ * Run from `js/plugins/compat-oai/`:
+ *
+ *   OPENAI_API_KEY=sk-... pnpm tsx scripts/smoke_responses.ts
+ *
+ * Optional model override:
+ *
+ *   OPENAI_API_KEY=sk-... SMOKE_MODEL=gpt-5-nano pnpm tsx scripts/smoke_responses.ts
+ *
+ * Exits 1 on any failure so this can also be wired into a CI gate later.
+ */
+
+import { genkit } from 'genkit';
+import openAI, { openAIResponses } from '../src/openai';
+
+const MODEL = process.env.SMOKE_MODEL ?? 'gpt-5-mini';
+
+async function assert(name: string, cond: unknown, detail?: unknown) {
+  if (!cond) {
+    console.error('✗ %s', name, detail ?? '');
+    process.exitCode = 1;
+  } else {
+    console.log('✓ %s', name);
+  }
+}
+
+async function main() {
+  if (!process.env.OPENAI_API_KEY) {
+    console.error('OPENAI_API_KEY is not set; refusing to call live API.');
+    process.exit(2);
+  }
+  const ai = genkit({ plugins: [openAI(), openAIResponses()] });
+
+  // ---- Smoke 1: plain non-streaming text generation ----
+  console.log(`\n=== Smoke 1: plain text via ${MODEL} ===`);
+  const r1 = await ai.generate({
+    model: openAI.responsesModel(MODEL),
+    prompt: 'Reply with exactly the single word: PONG',
+  });
+  console.log('text:', JSON.stringify(r1.text));
+  console.log('finishReason:', r1.finishReason);
+  console.log(
+    'responseId:',
+    (r1.custom as { responseId?: string } | undefined)?.responseId
+  );
+  await assert(
+    'plain text returned',
+    typeof r1.text === 'string' && r1.text.trim().length > 0,
+    r1
+  );
+  await assert(
+    'finishReason is stop',
+    r1.finishReason === 'stop',
+    r1.finishReason
+  );
+
+  // ---- Smoke 2: web_search_preview returns citations on metadata ----
+  console.log(`\n=== Smoke 2: web_search_preview citations ===`);
+  const r2 = await ai.generate({
+    model: openAI.responsesModel(MODEL),
+    prompt:
+      'In one sentence, what is the latest news about OpenAI ' +
+      '(today or this week)? Cite at least one source.',
+    config: {
+      builtInTools: [{ type: 'web_search_preview' }],
+    },
+  });
+  console.log('text:', r2.text);
+  let foundCitation = false;
+  for (const part of r2.message?.content ?? []) {
+    const meta = part.metadata as
+      | { citations?: Array<{ type: string; url?: string }> }
+      | undefined;
+    if (meta?.citations && meta.citations.length > 0) {
+      foundCitation = true;
+      console.log('citations:', JSON.stringify(meta.citations, null, 2));
+      break;
+    }
+  }
+  await assert(
+    'at least one url_citation surfaced via metadata.citations',
+    foundCitation,
+    r2.message?.content
+  );
+
+  // ---- Smoke 3: streaming chunks arrive in order ----
+  console.log(`\n=== Smoke 3: streaming ===`);
+  const chunks: string[] = [];
+  const r3 = await ai.generate({
+    model: openAI.responsesModel(MODEL),
+    prompt: 'Count from 1 to 5 inclusive, separated by commas. No prose.',
+    onChunk: (chunk) => {
+      const text = (chunk.content?.[0] as { text?: string } | undefined)?.text;
+      if (text) {
+        chunks.push(text);
+      }
+    },
+  });
+  console.log(`received ${chunks.length} streaming chunks`);
+  console.log('final text:', r3.text);
+  await assert('received >=2 streaming chunks', chunks.length >= 2, chunks);
+  await assert(
+    'streamed chunks reconstruct close to final text',
+    r3.text?.includes('1') && r3.text?.includes('5'),
+    r3.text
+  );
+
+  // ---- Smoke 4: previousResponseId chaining ----
+  console.log(`\n=== Smoke 4: previousResponseId chaining ===`);
+  const seed = await ai.generate({
+    model: openAI.responsesModel(MODEL),
+    prompt: 'My favorite color is teal. Acknowledge in one short sentence.',
+    config: { store: true },
+  });
+  const seedId = (seed.custom as { responseId?: string } | undefined)
+    ?.responseId;
+  console.log('seed responseId:', seedId);
+  await assert('seed turn carries responseId', !!seedId, seed);
+
+  if (seedId) {
+    const followup = await ai.generate({
+      model: openAI.responsesModel(MODEL),
+      prompt: 'What is my favorite color? Answer with one word only.',
+      config: { previousResponseId: seedId, store: true },
+    });
+    console.log('followup text:', followup.text);
+    await assert(
+      'followup recalls "teal" via server-side state',
+      /teal/i.test(followup.text ?? ''),
+      followup.text
+    );
+  }
+
+  if (process.exitCode === 1) {
+    console.error('\nSMOKE FAILED — see ✗ markers above.');
+  } else {
+    console.log('\nSMOKE OK — all assertions passed.');
+  }
+}
+
+main().catch((e) => {
+  console.error('SMOKE THREW:', e);
+  process.exit(1);
+});

--- a/js/plugins/compat-oai/src/openai/index.ts
+++ b/js/plugins/compat-oai/src/openai/index.ts
@@ -451,9 +451,7 @@ export default openAI;
  * });
  * ```
  */
-export function openAIResponses(
-  options?: OpenAIPluginOptions
-): GenkitPluginV2 {
+export function openAIResponses(options?: OpenAIPluginOptions): GenkitPluginV2 {
   const pluginOptions = { name: 'openai-responses', ...options };
   return openAICompatible({
     name: 'openai-responses',

--- a/js/plugins/compat-oai/src/openai/index.ts
+++ b/js/plugins/compat-oai/src/openai/index.ts
@@ -54,6 +54,12 @@ import {
   openAIModelRef,
   SUPPORTED_GPT_MODELS,
 } from './gpt.js';
+import {
+  defineCompatOpenAIResponsesModel,
+  OpenAIResponsesConfigSchema,
+  openAIResponsesModelRef,
+  SUPPORTED_RESPONSES_MODELS,
+} from './responses/index.js';
 import { openAITranscriptionModelRef, SUPPORTED_STT_MODELS } from './stt.js';
 import { openAISpeechModelRef, SUPPORTED_TTS_MODELS } from './tts.js';
 import {
@@ -298,6 +304,28 @@ export type OpenAIPlugin = {
     config?: z.infer<typeof OpenAIChatCompletionConfigSchema>
   ): ModelReference<typeof OpenAIChatCompletionConfigSchema>;
   model(name: string, config?: any): ModelReference<z.ZodTypeAny>;
+  /**
+   * Returns a {@link ModelReference} that targets the OpenAI Responses API
+   * (`/v1/responses`). Use this for `gpt-5*`, `o1`, `o3`, `o4-mini`, or
+   * any model where you need built-in tools (`web_search_preview`,
+   * `file_search`, `code_interpreter`), reasoning summaries, or stateful
+   * `previousResponseId` chaining.
+   *
+   * The Chat Completions helper {@link OpenAIPlugin.model} remains
+   * available; the two helpers can be used side-by-side in the same
+   * Genkit instance.
+   */
+  responsesModel(
+    name:
+      | keyof typeof SUPPORTED_RESPONSES_MODELS
+      | (`gpt-${string}` & {})
+      | (`o${number}` & {}),
+    config?: z.infer<typeof OpenAIResponsesConfigSchema>
+  ): ModelReference<typeof OpenAIResponsesConfigSchema>;
+  responsesModel(
+    name: string,
+    config?: any
+  ): ModelReference<typeof OpenAIResponsesConfigSchema>;
   embedder(
     name:
       | keyof typeof SUPPORTED_EMBEDDING_MODELS
@@ -337,6 +365,16 @@ const model = ((name: string, config?: any): ModelReference<z.ZodTypeAny> => {
     config,
   });
 }) as OpenAIPlugin['model'];
+
+const responsesModel = ((
+  name: string,
+  config?: any
+): ModelReference<typeof OpenAIResponsesConfigSchema> => {
+  return openAIResponsesModelRef({
+    name,
+    config,
+  });
+}) as OpenAIPlugin['responsesModel'];
 
 const embedder = ((
   name: string,
@@ -381,7 +419,70 @@ const embedder = ((
  */
 export const openAI: OpenAIPlugin = Object.assign(openAIPlugin, {
   model,
+  responsesModel,
   embedder,
 });
 
 export default openAI;
+
+/**
+ * Companion plugin that registers OpenAI Responses API models under the
+ * `openai-responses/` namespace.
+ *
+ * Lives as a separate plugin (mirroring the deepseek/xai pattern in this
+ * package) so that {@link openAIPlugin} stays bit-identical for users who
+ * only need Chat Completions and other compat providers (`deepseek`, `xai`,
+ * …) are unaffected. Use both side-by-side when you need access to
+ * `gpt-5*`, `o1`, `o3`, `o4-mini`, built-in tools (`web_search_preview`,
+ * `file_search`, `code_interpreter`), reasoning summaries, or stateful
+ * `previousResponseId` chaining.
+ *
+ * @example
+ * ```ts
+ * import { genkit } from 'genkit';
+ * import openAI, { openAIResponses } from '@genkit-ai/compat-oai/openai';
+ *
+ * const ai = genkit({ plugins: [openAI(), openAIResponses()] });
+ *
+ * const r = await ai.generate({
+ *   model: openAI.responsesModel('gpt-5-mini'),
+ *   prompt: '...',
+ *   config: { builtInTools: [{ type: 'web_search_preview' }] },
+ * });
+ * ```
+ */
+export function openAIResponses(
+  options?: OpenAIPluginOptions
+): GenkitPluginV2 {
+  const pluginOptions = { name: 'openai-responses', ...options };
+  return openAICompatible({
+    name: 'openai-responses',
+    ...options,
+    initializer: async (client) => {
+      // Pre-register the curated SUPPORTED_RESPONSES_MODELS so they show
+      // up in the dev UI as concrete entries.
+      return Object.values(SUPPORTED_RESPONSES_MODELS).map((modelRef) =>
+        defineCompatOpenAIResponsesModel({
+          name: modelRef.name,
+          client,
+          pluginOptions,
+          modelRef,
+        })
+      );
+    },
+    resolver: async (
+      client: OpenAI,
+      _actionType: ActionType,
+      actionName: string
+    ) => {
+      // Anything resolved through this plugin is a Responses API model.
+      const modelRef = openAIResponsesModelRef({ name: actionName });
+      return defineCompatOpenAIResponsesModel({
+        name: modelRef.name,
+        client,
+        pluginOptions,
+        modelRef,
+      });
+    },
+  });
+}

--- a/js/plugins/compat-oai/src/openai/responses/index.ts
+++ b/js/plugins/compat-oai/src/openai/responses/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Public surface of the OpenAI Responses API integration.
+ *
+ * Imported by the existing `openai/index.ts` entry to register a
+ * dedicated `'openai-responses'` namespace alongside the Chat Completions
+ * `'openai/...'` namespace. The two namespaces never share schemas or
+ * runners — see {@link OpenAIResponsesConfigSchema} and
+ * {@link openAIResponsesModelRef}.
+ */
+
+export {
+  chatMessagesToResponsesInput,
+  toResponsesRequestBody,
+} from './request';
+export { fromResponsesResponse } from './response';
+export {
+  defineCompatOpenAIResponsesModel,
+  openAIResponsesModelRunner,
+} from './runner';
+export {
+  BuiltInToolSchema,
+  CitationSchema,
+  OpenAIResponsesConfigSchema,
+  SUPPORTED_RESPONSES_MODELS,
+  openAIResponsesModelRef,
+  type BuiltInToolSpec,
+  type Citation,
+  type OpenAIResponsesConfig,
+} from './types';

--- a/js/plugins/compat-oai/src/openai/responses/request.ts
+++ b/js/plugins/compat-oai/src/openai/responses/request.ts
@@ -275,10 +275,11 @@ function toResponsesFunctionTools(request: GenerateRequest): FunctionTool[] {
  * Notable behaviours:
  *  - `output.format === 'json'` + `output.schema` ⇒
  *    `text.format = { type: 'json_schema', strict: true, schema }`.
- *  - For models with `supports.systemRole === false` (o1/o3 family),
- *    system messages are extracted into the top-level `instructions`
- *    field and dropped from the input array. Callers can also set
- *    `config.instructions` explicitly to override.
+ *  - When `config.instructions` is unset, leading text-only system
+ *    messages are lifted into the top-level `instructions` field and
+ *    dropped from the input array. System messages carrying media stay
+ *    in the input array so attachments are not silently lost. Setting
+ *    `config.instructions` explicitly disables this lift entirely.
  *  - `config.builtInTools` are appended to `tools[]` after function tools.
  *  - `config.store` defaults to `false` (stateless-by-default — see README).
  */

--- a/js/plugins/compat-oai/src/openai/responses/request.ts
+++ b/js/plugins/compat-oai/src/openai/responses/request.ts
@@ -113,13 +113,18 @@ export function chatMessagesToResponsesInput(
                 `cannot correlate to its function_call`
             );
           }
+          // The Responses API requires `output` to be a string. If the
+          // caller's tool returned undefined, JSON.stringify(undefined)
+          // would itself return undefined and the field would be
+          // dropped from the body, so default to an empty JSON object
+          // string in that case.
           items.push({
             type: 'function_call_output',
             call_id: part.toolResponse.ref,
             output:
               typeof part.toolResponse.output === 'string'
                 ? part.toolResponse.output
-                : JSON.stringify(part.toolResponse.output),
+                : JSON.stringify(part.toolResponse.output ?? {}),
           });
         }
         break;

--- a/js/plugins/compat-oai/src/openai/responses/request.ts
+++ b/js/plugins/compat-oai/src/openai/responses/request.ts
@@ -1,0 +1,408 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GenerateRequest, MessageData, Part, Role } from 'genkit';
+import { Message } from 'genkit';
+import type {
+  EasyInputMessage,
+  FunctionTool,
+  ResponseCreateParamsNonStreaming,
+  ResponseInputContent,
+  ResponseInputItem,
+  Tool,
+  WebSearchTool,
+} from 'openai/resources/responses/responses';
+import type { BuiltInToolSpec, OpenAIResponsesConfig } from './types';
+
+/**
+ * Map a Genkit role to a Responses API role. The `tool` role is encoded as
+ * a `function_call_output` input item rather than a message and is handled
+ * separately in {@link chatMessagesToResponsesInput}.
+ */
+function toResponsesRole(role: Role): EasyInputMessage['role'] {
+  switch (role) {
+    case 'user':
+      return 'user';
+    case 'model':
+      return 'assistant';
+    case 'system':
+      return 'system';
+    case 'tool':
+      // Should never reach here — tool messages are demuxed to
+      // function_call_output items by the caller.
+      throw new Error(
+        `tool messages must be encoded as function_call_output items`
+      );
+    default:
+      throw new Error(`role ${role} doesn't map to a Responses API role.`);
+  }
+}
+
+/**
+ * Map a Genkit Part (text/media) to a Responses API
+ * {@link ResponseInputContent}.
+ *
+ * Differs from the Chat Completions equivalent in two ways:
+ *  - images use `{type:'input_image', image_url: <string>, detail}` instead
+ *    of `{type:'image_url', image_url: {url}}`.
+ *  - non-image media (PDFs, text files) are sent as `input_file` items.
+ */
+function toResponsesContent(part: Part): ResponseInputContent {
+  if (part.text != null) {
+    return { type: 'input_text', text: part.text };
+  }
+  if (part.media) {
+    const url = part.media.url;
+    const ct = part.media.contentType ?? '';
+    if (ct.startsWith('image/') || (!ct && url.startsWith('data:image/'))) {
+      return {
+        type: 'input_image',
+        image_url: url,
+        detail: 'auto',
+      };
+    }
+    // Non-image attachment.
+    return {
+      type: 'input_file',
+      file_data: url,
+    };
+  }
+  throw new Error('Unsupported Part for Responses API: must be text or media');
+}
+
+/**
+ * Convert a Genkit `MessageData[]` into Responses API `input` items.
+ *
+ * Tool-result messages are demuxed into `function_call_output` items
+ * (Responses API encodes tool outputs as input items, not separate messages).
+ * Assistant messages with tool calls are split into a separate
+ * `function_call` input item for each call so the model can see prior
+ * function-call history during multi-turn agentic flows.
+ */
+export function chatMessagesToResponsesInput(
+  messages: MessageData[]
+): ResponseInputItem[] {
+  const items: ResponseInputItem[] = [];
+  for (const messageData of messages) {
+    const message = new Message(messageData);
+    switch (message.role) {
+      case 'tool': {
+        const toolResponses = message.toolResponseParts();
+        if (toolResponses.length === 0) {
+          throw new Error(
+            'tool message must contain at least one toolResponse part'
+          );
+        }
+        for (const part of toolResponses) {
+          if (!part.toolResponse.ref) {
+            throw new Error(
+              `toolResponse for "${part.toolResponse.name}" is missing 'ref' — ` +
+                `cannot correlate to its function_call`
+            );
+          }
+          items.push({
+            type: 'function_call_output',
+            call_id: part.toolResponse.ref,
+            output:
+              typeof part.toolResponse.output === 'string'
+                ? part.toolResponse.output
+                : JSON.stringify(part.toolResponse.output),
+          });
+        }
+        break;
+      }
+      case 'model': {
+        // Surface prior tool calls as separate function_call items so
+        // the model can correlate them with subsequent function_call_output.
+        const toolRequests = message.content.filter(
+          (p): p is Part & { toolRequest: NonNullable<Part['toolRequest']> } =>
+            Boolean(p.toolRequest)
+        );
+        for (const part of toolRequests) {
+          if (!part.toolRequest.ref) {
+            throw new Error(
+              `toolRequest for "${part.toolRequest.name}" is missing 'ref' — ` +
+                `Responses API requires a stable call_id`
+            );
+          }
+          items.push({
+            type: 'function_call',
+            call_id: part.toolRequest.ref,
+            name: part.toolRequest.name,
+            arguments: JSON.stringify(part.toolRequest.input ?? {}),
+          });
+        }
+        // Plain text from a prior assistant turn.
+        const textParts = message.content.filter(
+          (p) => p.text != null && !p.toolRequest
+        );
+        if (textParts.length > 0) {
+          // Prior assistant turn replayed as `input_text` items —
+          // the Responses API treats anything in `input` as input
+          // regardless of role, even when the role is `assistant`.
+          items.push({
+            type: 'message',
+            role: 'assistant',
+            content: textParts.map((p) => ({
+              type: 'input_text',
+              text: p.text!,
+            })),
+          } as EasyInputMessage);
+        }
+        break;
+      }
+      case 'user':
+      case 'system': {
+        const role = toResponsesRole(message.role);
+        const content: string | ResponseInputContent[] =
+          message.content.length === 1 && message.content[0].text != null
+            ? message.content[0].text!
+            : message.content.map(toResponsesContent);
+        items.push({
+          type: 'message',
+          role,
+          content,
+        } as EasyInputMessage);
+        break;
+      }
+      default:
+        throw new Error(`Unsupported role: ${message.role}`);
+    }
+  }
+  return items;
+}
+
+/**
+ * Translate a {@link BuiltInToolSpec} into the underlying OpenAI Responses
+ * tool object. Built-in tools share the `tools[]` array with function tools.
+ */
+function toOpenAIBuiltInTool(spec: BuiltInToolSpec): Tool {
+  switch (spec.type) {
+    case 'web_search_preview': {
+      const tool: WebSearchTool = { type: 'web_search_preview' };
+      if (spec.searchContextSize) {
+        tool.search_context_size = spec.searchContextSize;
+      }
+      if (spec.userLocation) {
+        tool.user_location = {
+          type: 'approximate',
+          city: spec.userLocation.city,
+          country: spec.userLocation.country,
+          region: spec.userLocation.region,
+          timezone: spec.userLocation.timezone,
+        };
+      }
+      return tool;
+    }
+    case 'file_search': {
+      // ranking_options requires score_threshold per the OpenAI API; only
+      // emit it when the caller actually provided one.
+      const rankingOptions =
+        spec.ranker?.scoreThreshold != null
+          ? {
+              score_threshold: spec.ranker.scoreThreshold,
+              ...(spec.ranker.ranker ? { ranker: spec.ranker.ranker } : {}),
+            }
+          : undefined;
+      return {
+        type: 'file_search',
+        vector_store_ids: spec.vectorStoreIds,
+        ...(spec.maxNumResults != null
+          ? { max_num_results: spec.maxNumResults }
+          : {}),
+        ...(rankingOptions ? { ranking_options: rankingOptions } : {}),
+      } as Tool;
+    }
+    case 'code_interpreter': {
+      const container = spec.container;
+      const resolved: string | { type: 'auto'; file_ids?: string[] } =
+        container == null
+          ? { type: 'auto' }
+          : typeof container === 'string'
+            ? container
+            : container.fileIds && container.fileIds.length > 0
+              ? { type: 'auto', file_ids: container.fileIds }
+              : { type: 'auto' };
+      return {
+        type: 'code_interpreter',
+        container: resolved,
+      } as Tool;
+    }
+  }
+}
+
+/**
+ * Convert a Genkit ToolDefinition list into Responses API `function` tools.
+ *
+ * Mirrors `toOpenAITool` from `model.ts` but emits the Responses-flavored
+ * shape: `{type:'function', name, parameters, strict}` (Chat Completions
+ * wraps under a nested `function: {...}` object — Responses API does not).
+ */
+function toResponsesFunctionTools(request: GenerateRequest): FunctionTool[] {
+  return (request.tools ?? []).map(
+    (tool): FunctionTool => ({
+      type: 'function',
+      name: tool.name,
+      description: tool.description,
+      parameters: (tool.inputSchema ?? null) as Record<string, unknown> | null,
+      strict: false,
+    })
+  );
+}
+
+/**
+ * Build the Responses API request body from a Genkit
+ * {@link GenerateRequest}.
+ *
+ * Notable behaviours:
+ *  - `output.format === 'json'` + `output.schema` ⇒
+ *    `text.format = { type: 'json_schema', strict: true, schema }`.
+ *  - For models with `supports.systemRole === false` (o1/o3 family),
+ *    system messages are extracted into the top-level `instructions`
+ *    field and dropped from the input array. Callers can also set
+ *    `config.instructions` explicitly to override.
+ *  - `config.builtInTools` are appended to `tools[]` after function tools.
+ *  - `config.store` defaults to `false` (stateless-by-default — see README).
+ */
+export function toResponsesRequestBody(
+  modelName: string,
+  request: GenerateRequest<typeof import('./types').OpenAIResponsesConfigSchema>
+): ResponseCreateParamsNonStreaming {
+  const config: OpenAIResponsesConfig = (request.config ??
+    {}) as OpenAIResponsesConfig;
+
+  let messages = request.messages;
+  let instructions = config.instructions;
+
+  // Reasoning models (o1/o3/gpt-5*) ignore `system` role messages; lift
+  // them into `instructions`. We avoid changing global plugin behaviour
+  // by always doing this when `instructions` is unset and we see a
+  // leading system message — Responses API treats the two as roughly
+  // equivalent and this preserves caller intent.
+  //
+  // Lifting is only safe when the system message is text-only. If a
+  // system message carries media (rare but valid), we leave it in the
+  // input array rather than silently dropping the media.
+  if (instructions == null) {
+    const systemMessages = messages.filter((m) => m.role === 'system');
+    const liftable = systemMessages.filter((m) =>
+      m.content.every((p) => p.text != null)
+    );
+    if (liftable.length > 0) {
+      instructions = liftable
+        .flatMap((m) => m.content.map((p) => p.text ?? ''))
+        .filter(Boolean)
+        .join('\n\n');
+      const liftedSet = new Set(liftable);
+      messages = messages.filter((m) => !liftedSet.has(m));
+    }
+  }
+
+  const input = chatMessagesToResponsesInput(messages);
+
+  // Compose tools[]: function tools (from request.tools) + builtInTools.
+  const tools: Tool[] = [
+    ...toResponsesFunctionTools(request),
+    ...(config.builtInTools ?? []).map(toOpenAIBuiltInTool),
+  ];
+
+  // Resolve text.format. Genkit's high-level output config wins by default;
+  // explicit text.format in config overrides everything. The Responses
+  // API requires a `name` for json_schema variants — default to `output`.
+  let textFormat:
+    | NonNullable<
+        NonNullable<ResponseCreateParamsNonStreaming['text']>['format']
+      >
+    | undefined;
+  if (config.text?.format) {
+    const cf = config.text.format;
+    if (cf.type === 'json_schema') {
+      textFormat = {
+        type: 'json_schema',
+        name: cf.name ?? 'output',
+        schema: cf.schema,
+        ...(cf.strict != null ? { strict: cf.strict } : {}),
+        ...(cf.description != null ? { description: cf.description } : {}),
+      };
+    } else {
+      textFormat = cf;
+    }
+  } else if (request.output?.format === 'json') {
+    if (request.output.schema) {
+      textFormat = {
+        type: 'json_schema',
+        name: 'output',
+        schema: request.output.schema as Record<string, unknown>,
+        strict: true,
+      };
+    } else {
+      textFormat = { type: 'json_object' };
+    }
+  }
+
+  const body: ResponseCreateParamsNonStreaming = {
+    model: config.version ?? modelName,
+    input,
+    ...(instructions ? { instructions } : {}),
+    ...(tools.length > 0 ? { tools } : {}),
+    ...(config.temperature != null ? { temperature: config.temperature } : {}),
+    ...(config.topP != null ? { top_p: config.topP } : {}),
+    ...(config.maxOutputTokens != null
+      ? { max_output_tokens: config.maxOutputTokens }
+      : {}),
+    ...(config.user != null ? { user: config.user } : {}),
+    ...(config.previousResponseId != null
+      ? { previous_response_id: config.previousResponseId }
+      : {}),
+    ...(config.metadata ? { metadata: config.metadata } : {}),
+    ...(config.parallelToolCalls != null
+      ? { parallel_tool_calls: config.parallelToolCalls }
+      : {}),
+    ...(config.truncation ? { truncation: config.truncation } : {}),
+    ...(config.maxToolCalls != null
+      ? { max_tool_calls: config.maxToolCalls }
+      : {}),
+    ...(config.serviceTier != null ? { service_tier: config.serviceTier } : {}),
+    ...(textFormat || config.text?.verbosity
+      ? {
+          text: {
+            ...(config.text?.verbosity
+              ? { verbosity: config.text.verbosity }
+              : {}),
+            ...(textFormat ? { format: textFormat } : {}),
+          },
+        }
+      : {}),
+    ...(config.reasoning
+      ? {
+          reasoning: {
+            ...(config.reasoning.effort
+              ? { effort: config.reasoning.effort }
+              : {}),
+            ...(config.reasoning.summary
+              ? { summary: config.reasoning.summary }
+              : {}),
+          },
+        }
+      : {}),
+    ...(config.include ? { include: config.include } : {}),
+    // Stateless-by-default — see README. Caller can opt into
+    // server-side persistence via `config.store: true`.
+    store: config.store ?? false,
+  };
+
+  return body;
+}

--- a/js/plugins/compat-oai/src/openai/responses/response.ts
+++ b/js/plugins/compat-oai/src/openai/responses/response.ts
@@ -1,0 +1,326 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GenerateRequest, GenerateResponseData, Part } from 'genkit';
+import { logger } from 'genkit/logging';
+import type {
+  Response,
+  ResponseOutputItem,
+  ResponseOutputText,
+  ResponseStatus,
+} from 'openai/resources/responses/responses';
+import type { Citation } from './types';
+
+/**
+ * Map a Responses API top-level {@link ResponseStatus} (plus optional
+ * `incomplete_details.reason`) to a Genkit `finishReason`.
+ *
+ * Refusal-driven blocks are detected in {@link fromResponsesResponse} by
+ * scanning the output items, since `status === 'completed'` is reported
+ * even when the model refused.
+ */
+function statusToFinishReason(
+  status: ResponseStatus,
+  incompleteReason?: string
+): GenerateResponseData['finishReason'] {
+  switch (status) {
+    case 'completed':
+      return 'stop';
+    case 'incomplete':
+      if (incompleteReason === 'max_output_tokens') {
+        return 'length';
+      }
+      if (incompleteReason === 'content_filter') {
+        return 'blocked';
+      }
+      return 'other';
+    case 'failed':
+      return 'other';
+    case 'cancelled':
+      return 'interrupted';
+    case 'in_progress':
+    case 'queued':
+      // Reaching final-response handling with a non-terminal status is
+      // an invariant violation — log loudly so operators can diagnose.
+      logger.warn(
+        `[openai-responses] non-terminal status "${status}" on final ` +
+          `response; treating as 'unknown' finishReason`
+      );
+      return 'unknown';
+    default: {
+      // Exhaustiveness check — TypeScript will fail here if OpenAI adds
+      // a new ResponseStatus literal that we haven't handled.
+      const _exhaustive: never = status;
+      logger.warn(
+        `[openai-responses] unrecognized response status: ${String(_exhaustive)}`
+      );
+      return 'unknown';
+    }
+  }
+}
+
+/**
+ * Convert annotation array on a Responses API `output_text` part into the
+ * structured {@link Citation}[] we attach to the corresponding Genkit text
+ * Part via `metadata.citations`.
+ *
+ * `url_citation` (web search) and `file_citation` (file_search) become
+ * separate Citation variants. `file_path` annotations are dropped —
+ * they point at sandbox-generated files on the OpenAI side and are not
+ * actionable for callers.
+ */
+function annotationsToCitations(
+  annotations: ResponseOutputText['annotations']
+): Citation[] {
+  const out: Citation[] = [];
+  for (const a of annotations) {
+    if (a.type === 'url_citation') {
+      out.push({
+        type: 'url_citation',
+        url: a.url,
+        title: a.title,
+        startIndex: a.start_index,
+        endIndex: a.end_index,
+      });
+    } else if (a.type === 'file_citation') {
+      // `a.index` from the SDK is the position of the file in the
+      // file_search_call's results[] array — NOT a character offset
+      // into the text. Surface it as a discriminated `file_citation`
+      // with an explicit `fileIndex` field.
+      out.push({
+        type: 'file_citation',
+        fileId: a.file_id,
+        fileIndex: a.index,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Convert a single {@link ResponseOutputItem} to one or more Genkit Parts.
+ *
+ * Returns an array because a single `message` item can produce multiple
+ * parts (one per content block), and a single `function_call` item produces
+ * exactly one toolRequest Part.
+ */
+function outputItemToParts(item: ResponseOutputItem): {
+  parts: Part[];
+  blocked?: { reason: string };
+} {
+  switch (item.type) {
+    case 'message': {
+      const parts: Part[] = [];
+      let blocked: { reason: string } | undefined;
+      for (const c of item.content) {
+        if (c.type === 'output_text') {
+          const citations = annotationsToCitations(c.annotations);
+          const part: Part = { text: c.text };
+          if (citations.length > 0) {
+            part.metadata = { citations };
+          }
+          parts.push(part);
+        } else if (c.type === 'refusal') {
+          blocked = { reason: c.refusal };
+        }
+      }
+      return { parts, blocked };
+    }
+    case 'reasoning': {
+      const summary = item.summary
+        .map((s) => s.text)
+        .filter(Boolean)
+        .join('\n');
+      if (!summary && !item.encrypted_content) {
+        return { parts: [] };
+      }
+      const part: Part = { reasoning: summary };
+      if (item.encrypted_content) {
+        part.metadata = { encrypted: true };
+      }
+      return { parts: [part] };
+    }
+    case 'function_call': {
+      let args: unknown;
+      let malformed = false;
+      try {
+        args = JSON.parse(item.arguments || '{}');
+      } catch (e) {
+        malformed = true;
+        args = item.arguments;
+        logger.warn(
+          `[openai-responses] function_call "${item.name}" (call_id=${item.call_id}) ` +
+            `returned non-JSON arguments; surfacing raw string with ` +
+            `metadata.malformedArguments=true. Error: ${(e as Error).message}`
+        );
+      }
+      const part: Part = {
+        toolRequest: {
+          name: item.name,
+          ref: item.call_id,
+          input: args,
+        },
+      };
+      if (malformed) {
+        part.metadata = { malformedArguments: true };
+      }
+      return { parts: [part] };
+    }
+    case 'web_search_call': {
+      // Surface as a custom Part so downstream code can show progress
+      // / debug. The actual citations on text Parts carry the
+      // user-visible value.
+      return {
+        parts: [
+          {
+            custom: {
+              kind: 'web_search_call',
+              id: item.id,
+              status: item.status,
+            },
+          },
+        ],
+      };
+    }
+    case 'file_search_call': {
+      return {
+        parts: [
+          {
+            custom: {
+              kind: 'file_search_call',
+              id: item.id,
+              status: item.status,
+              queries: item.queries,
+              results: item.results ?? null,
+            },
+          },
+        ],
+      };
+    }
+    case 'code_interpreter_call': {
+      return {
+        parts: [
+          {
+            custom: {
+              kind: 'code_interpreter_call',
+              id: item.id,
+              status: item.status,
+              code: item.code,
+              // `outputs` is only populated when the caller
+              // requested `include: ['code_interpreter_call.outputs']`.
+              outputs: (item as { outputs?: unknown }).outputs ?? null,
+            },
+          },
+        ],
+      };
+    }
+    default:
+      // Unknown / future item types (computer_use, mcp, image_gen,
+      // local_shell) are surfaced as opaque custom Parts for forward
+      // compatibility — better to expose them than silently drop.
+      return {
+        parts: [
+          {
+            custom: {
+              kind: 'opaque_output_item',
+              type: (item as { type: string }).type,
+              data: item as unknown,
+            },
+          },
+        ],
+      };
+  }
+}
+
+/**
+ * Convert an OpenAI Responses API {@link Response} into a Genkit
+ * {@link GenerateResponseData}.
+ *
+ * Surfaces server-side metadata via `custom.responseId` (so callers can
+ * pass it back as `previousResponseId` to chain turns) and
+ * `usage.custom.reasoningTokens` / `cachedInputTokens`.
+ */
+export function fromResponsesResponse(
+  response: Response,
+  _request: GenerateRequest
+): GenerateResponseData {
+  const allParts: Part[] = [];
+  let blockedReason: string | undefined;
+
+  for (const item of response.output) {
+    const { parts, blocked } = outputItemToParts(item);
+    allParts.push(...parts);
+    if (blocked) {
+      blockedReason = blocked.reason;
+    }
+  }
+
+  let finishReason = statusToFinishReason(
+    response.status as ResponseStatus,
+    response.incomplete_details?.reason
+  );
+  let finishMessage: string | undefined;
+  if (blockedReason) {
+    finishReason = 'blocked';
+    finishMessage = blockedReason;
+  } else if (response.error?.message) {
+    finishMessage = response.error.message;
+  }
+  if (response.status === 'failed' && response.error) {
+    // Operational error from OpenAI — log so operators can correlate
+    // with quota/rate/account issues rather than silently degrading.
+    logger.error(
+      `[openai-responses] response failed (id=${response.id}, ` +
+        `code=${response.error.code ?? 'unknown'}): ${response.error.message ?? '<no message>'}`
+    );
+  }
+
+  return {
+    finishReason,
+    ...(finishMessage ? { finishMessage } : {}),
+    message: {
+      role: 'model',
+      content: allParts,
+    },
+    usage: response.usage
+      ? {
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          totalTokens: response.usage.total_tokens,
+          ...(response.usage.input_tokens_details?.cached_tokens != null
+            ? {
+                cachedContentTokens:
+                  response.usage.input_tokens_details.cached_tokens,
+              }
+            : {}),
+          custom: {
+            ...(response.usage.output_tokens_details?.reasoning_tokens != null
+              ? {
+                  reasoningTokens:
+                    response.usage.output_tokens_details.reasoning_tokens,
+                }
+              : {}),
+          },
+        }
+      : undefined,
+    custom: {
+      responseId: response.id,
+      ...(response.metadata ? { metadata: response.metadata } : {}),
+      ...(response.error?.code ? { errorCode: response.error.code } : {}),
+    },
+    raw: response,
+  };
+}

--- a/js/plugins/compat-oai/src/openai/responses/runner.ts
+++ b/js/plugins/compat-oai/src/openai/responses/runner.ts
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  GenerateRequest,
+  GenerateResponseChunkData,
+  GenerateResponseData,
+  StreamingCallback,
+} from 'genkit';
+import { GenkitError } from 'genkit';
+import { logger } from 'genkit/logging';
+import type { ModelAction, ModelReference } from 'genkit/model';
+import { model } from 'genkit/plugin';
+import OpenAI, { APIError } from 'openai';
+import { PluginOptions } from '../../index';
+import { maybeCreateRequestScopedOpenAIClient, toModelName } from '../../utils';
+import { toResponsesRequestBody } from './request';
+import { fromResponsesResponse } from './response';
+import { streamResponsesEvents } from './stream';
+import { OpenAIResponsesConfigSchema } from './types';
+
+/**
+ * Map an HTTP status from an {@link APIError} to a Genkit `StatusName`.
+ *
+ * Mirrors the mapping in `openAIModelRunner` (Chat Completions). Duplicated
+ * intentionally so we do not modify the existing `model.ts` (constraint:
+ * other compat providers must remain bit-identical).
+ */
+function statusFromApiError(e: APIError): GenkitError['status'] {
+  switch (e.status) {
+    case 429:
+      return 'RESOURCE_EXHAUSTED';
+    case 401:
+      return 'PERMISSION_DENIED';
+    case 403:
+      return 'UNAUTHENTICATED';
+    case 400:
+      return 'INVALID_ARGUMENT';
+    case 500:
+      return 'INTERNAL';
+    case 503:
+      return 'UNAVAILABLE';
+    default:
+      return 'UNKNOWN';
+  }
+}
+
+/**
+ * Creates the runner used by Genkit to drive a model via the OpenAI
+ * Responses API (`/v1/responses`).
+ *
+ * Both non-streaming (`client.responses.create`) and streaming
+ * (`client.responses.stream` + SSE event aggregation in
+ * {@link streamResponsesEvents}) paths are supported. Streaming emits
+ * Genkit chunks per token / per tool-call delta and uses the SDK's
+ * `stream.finalResponse()` for the canonical final response shape.
+ *
+ * @param name Model id (e.g. `'gpt-5-mini'`) — bare, no namespace.
+ * @param defaultClient OpenAI SDK client; per-request override via
+ *   `config.apiKey` falls back to {@link maybeCreateRequestScopedOpenAIClient}.
+ * @param pluginOptions Captured to forward into request-scoped clients.
+ */
+export function openAIResponsesModelRunner(
+  name: string,
+  defaultClient: OpenAI,
+  pluginOptions?: Omit<PluginOptions, 'apiKey'>
+) {
+  return async (
+    request: GenerateRequest<typeof OpenAIResponsesConfigSchema>,
+    options?: {
+      streamingRequested?: boolean;
+      sendChunk?: StreamingCallback<GenerateResponseChunkData>;
+      abortSignal?: AbortSignal;
+    }
+  ): Promise<GenerateResponseData> => {
+    const client = maybeCreateRequestScopedOpenAIClient(
+      pluginOptions,
+      request as GenerateRequest,
+      defaultClient
+    );
+    try {
+      const body = toResponsesRequestBody(name, request);
+
+      if (options?.streamingRequested && options.sendChunk) {
+        // True streaming path — drive the SSE event stream and
+        // emit Genkit chunks per token / per tool-call delta.
+        // The aggregated final Response (canonical structure) is
+        // pulled from `stream.finalResponse()` once events end.
+        //
+        // The SDK's `stream(...)` overload narrows `stream?: true`
+        // (it adds it itself); we strip the `stream` field from
+        // our non-streaming body to satisfy the type contract.
+        const { stream: _stream, ...streamBody } = body as {
+          stream?: unknown;
+        };
+        const stream = client.responses.stream(
+          streamBody as Parameters<typeof client.responses.stream>[0],
+          { signal: options.abortSignal }
+        );
+        await streamResponsesEvents(stream, options.sendChunk);
+        const finalResponse = await stream.finalResponse();
+        return fromResponsesResponse(finalResponse, request as GenerateRequest);
+      }
+
+      const response = await client.responses.create(body, {
+        signal: options?.abortSignal,
+      });
+      return fromResponsesResponse(response, request as GenerateRequest);
+    } catch (e) {
+      if (e instanceof APIError) {
+        throw new GenkitError({
+          status: statusFromApiError(e),
+          message: e.message,
+        });
+      }
+      // Non-APIError (network failure, abort, type error, …). Surface a
+      // structured GenkitError so flow-level error handling sees a
+      // consistent shape across providers.
+      const err = e as Error & { name?: string };
+      logger.error(
+        `[openai-responses] non-API error in model "${name}": ` +
+          `${err.name ?? 'Error'}: ${err.message}`
+      );
+      const isAbort =
+        err.name === 'AbortError' || options?.abortSignal?.aborted === true;
+      throw new GenkitError({
+        status: isAbort ? 'CANCELLED' : 'INTERNAL',
+        message: `OpenAI Responses request failed: ${err.message}`,
+      });
+    }
+  };
+}
+
+/**
+ * Define a Genkit {@link ModelAction} backed by the Responses API.
+ *
+ * Always registers under the `'openai-responses'` namespace (set by
+ * {@link openAIResponsesModelRef}) so it cannot collide with the existing
+ * `'openai/...'` Chat Completions entries.
+ *
+ * The configSchema is locked to {@link OpenAIResponsesConfigSchema} —
+ * {@link openAIResponsesModelRunner} reads Responses-specific fields
+ * (`builtInTools`, `previousResponseId`, `reasoning`, …) from `request.config`,
+ * so a custom schema would silently desync at runtime.
+ */
+export function defineCompatOpenAIResponsesModel(params: {
+  name: string;
+  client: OpenAI;
+  modelRef?: ModelReference<typeof OpenAIResponsesConfigSchema>;
+  pluginOptions?: PluginOptions;
+}): ModelAction {
+  const { name, client, pluginOptions, modelRef } = params;
+  const modelName = toModelName(name, pluginOptions?.name);
+  const actionName =
+    modelRef?.name ??
+    `${pluginOptions?.name ?? 'openai-responses'}/${modelName}`;
+
+  // The runner's request type is parameterized by the Responses config
+  // schema; `model()` accepts a generic runner so the cast is benign.
+  const runner = openAIResponsesModelRunner(
+    modelName,
+    client,
+    pluginOptions
+  ) as unknown as Parameters<typeof model>[1];
+  return model(
+    {
+      name: actionName,
+      ...modelRef?.info,
+      configSchema: modelRef?.configSchema ?? OpenAIResponsesConfigSchema,
+    },
+    runner
+  );
+}

--- a/js/plugins/compat-oai/src/openai/responses/stream.ts
+++ b/js/plugins/compat-oai/src/openai/responses/stream.ts
@@ -328,8 +328,7 @@ export async function streamResponsesEvents(
           // call_id; arguments come from buffer or fall back to event.item.
           const fcState =
             state && state.type === 'function_call' ? state : undefined;
-          const rawArgs =
-            fcState?.argsBuf || event.item.arguments || '{}';
+          const rawArgs = fcState?.argsBuf || event.item.arguments || '{}';
           let parsed: unknown;
           let malformed = false;
           try {

--- a/js/plugins/compat-oai/src/openai/responses/stream.ts
+++ b/js/plugins/compat-oai/src/openai/responses/stream.ts
@@ -1,0 +1,458 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  GenerateResponseChunkData,
+  Part,
+  StreamingCallback,
+} from 'genkit';
+import { GenkitError } from 'genkit';
+import { logger } from 'genkit/logging';
+import type { ResponseStreamEvent } from 'openai/resources/responses/responses';
+
+/**
+ * Per-output-item state we accumulate while consuming the SSE event stream.
+ *
+ * Discriminated union by `type` so each branch carries only the fields it
+ * actually uses — no optional state correlated with another field.
+ */
+type ItemState =
+  | MessageItemState
+  | FunctionCallItemState
+  | BuiltInCallItemState
+  | ReasoningItemState
+  | UnknownItemState;
+
+interface MessageItemState {
+  type: 'message';
+  /** Annotations buffered until item.done so we can flush a metadata-only chunk. */
+  annotations: unknown[];
+}
+
+interface FunctionCallItemState {
+  type: 'function_call';
+  /** Concatenated argument deltas. Replaced verbatim on `.done` events. */
+  argsBuf: string;
+  callId: string;
+  name: string;
+}
+
+interface BuiltInCallItemState {
+  type: 'web_search_call' | 'file_search_call' | 'code_interpreter_call';
+}
+
+interface ReasoningItemState {
+  type: 'reasoning';
+}
+
+interface UnknownItemState {
+  type: 'unknown';
+}
+
+/** Citation as it can appear inside `output_text_annotation.added`. */
+interface UrlCitationAnnotation {
+  type: 'url_citation';
+  url: string;
+  title?: string;
+  start_index?: number;
+  end_index?: number;
+}
+
+interface FileCitationAnnotation {
+  type: 'file_citation';
+  file_id: string;
+  index?: number;
+}
+
+function isUrlCitation(a: unknown): a is UrlCitationAnnotation {
+  return (
+    typeof a === 'object' &&
+    a !== null &&
+    (a as { type?: unknown }).type === 'url_citation' &&
+    typeof (a as { url?: unknown }).url === 'string'
+  );
+}
+
+function isFileCitation(a: unknown): a is FileCitationAnnotation {
+  return (
+    typeof a === 'object' &&
+    a !== null &&
+    (a as { type?: unknown }).type === 'file_citation' &&
+    typeof (a as { file_id?: unknown }).file_id === 'string'
+  );
+}
+
+/**
+ * Built-in tool call event type families. Each family has 3-4 lifecycle
+ * sub-events (in_progress, searching/interpreting, completed). We list
+ * every (kind, status) pair explicitly rather than substring-matching the
+ * raw event type string — this avoids drift if OpenAI ever introduces
+ * `web_search_call_v2` or similar.
+ */
+const BUILT_IN_CALL_EVENTS: ReadonlyMap<
+  string,
+  { kind: BuiltInCallItemState['type']; status: string }
+> = new Map([
+  [
+    'response.web_search_call.in_progress',
+    { kind: 'web_search_call', status: 'in_progress' },
+  ],
+  [
+    'response.web_search_call.searching',
+    { kind: 'web_search_call', status: 'searching' },
+  ],
+  [
+    'response.web_search_call.completed',
+    { kind: 'web_search_call', status: 'completed' },
+  ],
+  [
+    'response.file_search_call.in_progress',
+    { kind: 'file_search_call', status: 'in_progress' },
+  ],
+  [
+    'response.file_search_call.searching',
+    { kind: 'file_search_call', status: 'searching' },
+  ],
+  [
+    'response.file_search_call.completed',
+    { kind: 'file_search_call', status: 'completed' },
+  ],
+  [
+    'response.code_interpreter_call.in_progress',
+    { kind: 'code_interpreter_call', status: 'in_progress' },
+  ],
+  [
+    'response.code_interpreter_call.interpreting',
+    { kind: 'code_interpreter_call', status: 'interpreting' },
+  ],
+  [
+    'response.code_interpreter_call.completed',
+    { kind: 'code_interpreter_call', status: 'completed' },
+  ],
+]);
+
+/**
+ * Drive the OpenAI Responses API SSE event stream and translate events to
+ * Genkit chunks.
+ *
+ * The aggregator does NOT itself produce a `GenerateResponseData` — that's
+ * the job of `fromResponsesResponse(stream.finalResponse())` in the
+ * runner. Here we emit one chunk per *meaningful* event so callers see
+ * tokens as they arrive, and we keep enough state to attach annotations
+ * and to surface aggregated tool calls on `output_item.done`.
+ *
+ * Throws a {@link GenkitError} if the stream emits a terminal `error`
+ * event — the SDK uses this for stream-level failures (network, mid-stream
+ * abort, server error) that won't otherwise surface through
+ * `stream.finalResponse()`.
+ *
+ * @param stream Async iterable returned by `client.responses.stream(...)`.
+ * @param sendChunk Genkit's streaming callback.
+ */
+export async function streamResponsesEvents(
+  stream: AsyncIterable<ResponseStreamEvent>,
+  sendChunk: StreamingCallback<GenerateResponseChunkData>
+): Promise<void> {
+  const items = new Map<number, ItemState>();
+  let streamError: { message: string; code?: string } | undefined;
+
+  for await (const event of stream) {
+    switch (event.type) {
+      case 'response.created':
+      case 'response.in_progress':
+      case 'response.queued':
+        // Lifecycle markers — no chunk needed.
+        break;
+
+      case 'response.output_item.added': {
+        const item = event.item;
+        if (item.type === 'message') {
+          items.set(event.output_index, { type: 'message', annotations: [] });
+        } else if (item.type === 'function_call') {
+          items.set(event.output_index, {
+            type: 'function_call',
+            argsBuf: '',
+            callId: item.call_id,
+            name: item.name,
+          });
+        } else if (item.type === 'reasoning') {
+          items.set(event.output_index, { type: 'reasoning' });
+        } else if (
+          item.type === 'web_search_call' ||
+          item.type === 'file_search_call' ||
+          item.type === 'code_interpreter_call'
+        ) {
+          items.set(event.output_index, { type: item.type });
+        } else {
+          items.set(event.output_index, { type: 'unknown' });
+        }
+        break;
+      }
+
+      case 'response.output_text.delta': {
+        sendChunk({
+          index: event.output_index,
+          role: 'model',
+          content: [{ text: event.delta }],
+        });
+        break;
+      }
+
+      case 'response.output_text_annotation.added': {
+        const state = items.get(event.output_index);
+        if (state?.type === 'message') {
+          state.annotations.push(event.annotation);
+        } else {
+          // Annotation arrived for a non-message item or before
+          // output_item.added — drop with a debug log so a future
+          // SDK quirk is at least diagnosable.
+          logger.debug(
+            `[openai-responses] dropping annotation for output_index=` +
+              `${event.output_index} (state=${state?.type ?? 'missing'})`
+          );
+        }
+        break;
+      }
+
+      case 'response.output_text.done': {
+        // Final text per item — annotations attached on item.done.
+        break;
+      }
+
+      case 'response.refusal.delta': {
+        // Surface refusal text via `custom.refusalDelta` so callers can
+        // accumulate or display it. We deliberately omit `text` here:
+        // an empty-string text Part would be concatenated by Genkit's
+        // chunk merger into the final message and pollute the model's
+        // output. The refusal also surfaces structurally on the final
+        // Response (see fromResponsesResponse → blockedReason).
+        sendChunk({
+          index: event.output_index,
+          role: 'model',
+          content: [{ custom: { refusalDelta: event.delta } }],
+        });
+        break;
+      }
+
+      case 'response.reasoning_summary_text.delta': {
+        sendChunk({
+          index: event.output_index,
+          role: 'model',
+          content: [{ reasoning: event.delta }],
+        });
+        break;
+      }
+
+      case 'response.function_call_arguments.delta': {
+        const state = items.get(event.output_index);
+        if (state && state.type === 'function_call') {
+          state.argsBuf += event.delta;
+        } else {
+          // output_item.added missed (network reorder / SDK glitch).
+          // Lazy-init so we don't lose the deltas — `name` and
+          // `call_id` will be filled from event.item on .done.
+          logger.warn(
+            `[openai-responses] function_call_arguments.delta for ` +
+              `output_index=${event.output_index} without prior ` +
+              `output_item.added — initializing state lazily`
+          );
+          items.set(event.output_index, {
+            type: 'function_call',
+            argsBuf: event.delta,
+            callId: '',
+            name: '',
+          });
+        }
+        break;
+      }
+
+      case 'response.function_call_arguments.done': {
+        const state = items.get(event.output_index);
+        if (state && state.type === 'function_call' && event.arguments) {
+          // Prefer the canonical full string from .done over our
+          // accumulated buffer — but only if .done actually carries
+          // arguments (don't clobber a populated buffer with empty).
+          state.argsBuf = event.arguments;
+        }
+        break;
+      }
+
+      case 'response.web_search_call.in_progress':
+      case 'response.web_search_call.searching':
+      case 'response.web_search_call.completed':
+      case 'response.file_search_call.in_progress':
+      case 'response.file_search_call.searching':
+      case 'response.file_search_call.completed':
+      case 'response.code_interpreter_call.in_progress':
+      case 'response.code_interpreter_call.interpreting':
+      case 'response.code_interpreter_call.completed': {
+        const meta = BUILT_IN_CALL_EVENTS.get(event.type);
+        if (!meta) {
+          break;
+        }
+        const itemId = (event as { item_id?: string }).item_id;
+        sendChunk({
+          index: event.output_index,
+          role: 'model',
+          content: [
+            {
+              custom: {
+                kind: meta.kind,
+                status: meta.status,
+                ...(itemId ? { itemId } : {}),
+              },
+            },
+          ],
+        });
+        break;
+      }
+
+      case 'response.output_item.done': {
+        const state = items.get(event.output_index);
+        if (event.item.type === 'function_call') {
+          // Resilient even if state was never created (output_item.added
+          // missed). Use event.item as the source of truth for name /
+          // call_id; arguments come from buffer or fall back to event.item.
+          const fcState =
+            state && state.type === 'function_call' ? state : undefined;
+          const rawArgs =
+            fcState?.argsBuf || event.item.arguments || '{}';
+          let parsed: unknown;
+          let malformed = false;
+          try {
+            parsed = JSON.parse(rawArgs);
+          } catch (e) {
+            malformed = true;
+            parsed = rawArgs;
+            logger.warn(
+              `[openai-responses] function_call "${event.item.name}" ` +
+                `(call_id=${event.item.call_id}) returned non-JSON ` +
+                `arguments; surfacing raw string with ` +
+                `metadata.malformedArguments=true. Error: ${(e as Error).message}`
+            );
+          }
+          const part: Part = {
+            toolRequest: {
+              name: event.item.name,
+              ref: event.item.call_id,
+              input: parsed,
+            },
+          };
+          if (malformed) {
+            part.metadata = { malformedArguments: true };
+          }
+          sendChunk({
+            index: event.output_index,
+            role: 'model',
+            content: [part],
+          });
+        } else if (
+          event.item.type === 'message' &&
+          state?.type === 'message' &&
+          state.annotations.length > 0
+        ) {
+          // Flush a final chunk that carries citations on metadata.
+          // The text content has already been streamed via deltas;
+          // this chunk carries metadata only (empty text avoids
+          // re-emitting the full text).
+          const citations: Array<
+            | {
+                type: 'url_citation';
+                url: string;
+                title?: string;
+                startIndex?: number;
+                endIndex?: number;
+              }
+            | { type: 'file_citation'; fileId: string; fileIndex?: number }
+          > = [];
+          for (const a of state.annotations) {
+            if (isUrlCitation(a)) {
+              citations.push({
+                type: 'url_citation',
+                url: a.url,
+                title: a.title,
+                startIndex: a.start_index,
+                endIndex: a.end_index,
+              });
+            } else if (isFileCitation(a)) {
+              citations.push({
+                type: 'file_citation',
+                fileId: a.file_id,
+                fileIndex: a.index,
+              });
+            }
+          }
+          if (citations.length > 0) {
+            const part: Part = { text: '', metadata: { citations } };
+            sendChunk({
+              index: event.output_index,
+              role: 'model',
+              content: [part],
+            });
+          }
+        }
+        items.delete(event.output_index);
+        break;
+      }
+
+      case 'error': {
+        // Stream-level error from the SDK (network, mid-stream abort,
+        // server error). Capture and re-throw at end of iteration so
+        // the caller's try/catch sees a structured failure rather than
+        // a silently-truncated response.
+        const e = event as {
+          message?: string;
+          code?: string;
+          error?: { message?: string; code?: string };
+        };
+        streamError = {
+          message:
+            e.message ?? e.error?.message ?? 'unknown OpenAI stream error',
+          code: e.code ?? e.error?.code,
+        };
+        logger.error(
+          `[openai-responses] stream error event received: ` +
+            `${streamError.message}` +
+            (streamError.code ? ` (code=${streamError.code})` : '')
+        );
+        break;
+      }
+
+      case 'response.completed':
+      case 'response.incomplete':
+      case 'response.failed':
+        // Terminal events. The runner reads `stream.finalResponse()`
+        // for the canonical aggregated Response; we don't emit a chunk
+        // here so callers are not double-counted.
+        break;
+
+      default:
+        // Forward-compat: unknown events are ignored. The final
+        // aggregated response (via finalResponse()) still carries
+        // the full structure, so callers don't lose data.
+        break;
+    }
+  }
+
+  if (streamError) {
+    throw new GenkitError({
+      status: 'INTERNAL',
+      message:
+        `OpenAI Responses stream error: ${streamError.message}` +
+        (streamError.code ? ` (code=${streamError.code})` : ''),
+    });
+  }
+}

--- a/js/plugins/compat-oai/src/openai/responses/types.ts
+++ b/js/plugins/compat-oai/src/openai/responses/types.ts
@@ -1,0 +1,318 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'genkit';
+import type { ModelInfo, ModelReference } from 'genkit/model';
+import { compatOaiModelRef } from '../../model';
+
+/**
+ * Citations produced by Responses API built-in tools, attached to text
+ * Parts via `metadata.citations`.
+ *
+ * Discriminated by `type`:
+ *  - `url_citation` — produced by `web_search_preview`. Has UTF-16
+ *    `startIndex`/`endIndex` offsets into the text the citation refers to.
+ *  - `file_citation` — produced by `file_search`. Identifies a file in
+ *    the retrieval set; `fileIndex` is the file's position in the call's
+ *    `results[]` array (NOT a character offset).
+ *
+ * The schema is intentionally a structural type rather than a Genkit Part
+ * subtype: it can be enriched later (e.g. with a first-class citation Part)
+ * without breaking consumers that read `metadata.citations`.
+ */
+export const CitationSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('url_citation'),
+    url: z.string(),
+    title: z.string().optional(),
+    /** UTF-16 code-unit offsets relative to the text Part the citation belongs to. */
+    startIndex: z.number().int().nonnegative().optional(),
+    endIndex: z.number().int().nonnegative().optional(),
+  }),
+  z.object({
+    type: z.literal('file_citation'),
+    fileId: z.string(),
+    /** Index of the file in the originating file_search_call results array. */
+    fileIndex: z.number().int().nonnegative().optional(),
+  }),
+]);
+export type Citation = z.infer<typeof CitationSchema>;
+
+/**
+ * Built-in tool spec passed via {@link OpenAIResponsesConfigSchema.builtInTools}.
+ *
+ * Built-in tools are server-side and execute on OpenAI infrastructure (web
+ * search, retrieval over user-uploaded vector stores, sandboxed Python
+ * execution). They are distinct from function-call tools — function tools
+ * are still passed through the standard Genkit `tools` field.
+ */
+export const BuiltInToolSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('web_search_preview'),
+    userLocation: z
+      .object({
+        type: z.literal('approximate'),
+        country: z.string().optional(),
+        region: z.string().optional(),
+        city: z.string().optional(),
+        timezone: z.string().optional(),
+      })
+      .optional(),
+    searchContextSize: z.enum(['low', 'medium', 'high']).optional(),
+  }),
+  z.object({
+    type: z.literal('file_search'),
+    vectorStoreIds: z.array(z.string()).min(1),
+    maxNumResults: z.number().int().positive().optional(),
+    ranker: z
+      .object({
+        ranker: z.enum(['auto', 'default-2024-11-15']).optional(),
+        scoreThreshold: z.number().min(0).max(1).optional(),
+      })
+      .optional(),
+  }),
+  z.object({
+    type: z.literal('code_interpreter'),
+    /**
+     * Container in which the interpreter runs. Two forms (matching the
+     * SDK's `Tool.CodeInterpreter`):
+     *  - omitted ⇒ defaults to `{ type: 'auto' }`
+     *  - `{ type: 'auto', fileIds }` — auto-provisioned sandbox seeded
+     *    with these files
+     *  - `string` — explicit container id from a prior call
+     */
+    container: z
+      .union([
+        z.string(),
+        z.object({
+          type: z.literal('auto'),
+          fileIds: z.array(z.string()).optional(),
+        }),
+      ])
+      .optional(),
+  }),
+]);
+export type BuiltInToolSpec = z.infer<typeof BuiltInToolSchema>;
+
+/**
+ * Configuration schema for OpenAI Responses API models.
+ *
+ * Notably distinct from {@link OpenAIChatCompletionConfigSchema} (Chat
+ * Completions) — Responses-only fields like `previousResponseId`,
+ * `builtInTools`, `reasoning`, `include`, `text.format` live here. The two
+ * schemas are intentionally separated so that consumers of `openAI.model()`
+ * and downstream compat providers (deepseek, xai, …) do not see Responses-
+ * specific configuration in their typings.
+ */
+export const OpenAIResponsesConfigSchema = z.object({
+  /** Sampling temperature; ignored by reasoning models that do not support it. */
+  temperature: z.number().min(0).max(2).optional(),
+  /** Top-p nucleus sampling. */
+  topP: z.number().min(0).max(1).optional(),
+  /** Max tokens to generate (mapped to `max_output_tokens` server-side). */
+  maxOutputTokens: z.number().int().positive().optional(),
+  /** End-user identifier for OpenAI usage attribution. */
+  user: z.string().optional(),
+
+  /**
+   * Stateful chaining: pass the `responseId` returned in
+   * `response.custom.responseId` from a previous turn to continue a
+   * server-side conversation. Mutually informative with `store`.
+   */
+  previousResponseId: z.string().optional(),
+
+  /**
+   * Whether OpenAI persists the response on its servers for later
+   * retrieval / chaining via `previous_response_id`.
+   *
+   * Defaults to `false` in this plugin (stateless-by-default), which is
+   * the safer choice for ZDR-aware deployments. OpenAI's own API default
+   * is `true`; the discrepancy is documented in the README.
+   */
+  store: z.boolean().optional(),
+
+  /**
+   * Server-side data to include in the response. Notable values:
+   *  - `'reasoning.encrypted_content'` — opaque encrypted reasoning blob
+   *    suitable for ZDR-compliant chaining.
+   *  - `'file_search_call.results'` — retrieved document chunks.
+   *  - `'message.input_image.image_url'` — surface input image URLs back.
+   *  - `'computer_call_output.output.image_url'` — surface computer-use
+   *    screenshot URLs back.
+   *
+   * (Web search results are surfaced through `metadata.citations` on the
+   * generated text Parts, not via `include`.)
+   */
+  include: z
+    .array(
+      z.enum([
+        'reasoning.encrypted_content',
+        'file_search_call.results',
+        'message.input_image.image_url',
+        'computer_call_output.output.image_url',
+      ])
+    )
+    .optional(),
+
+  /**
+   * Reasoning controls for o1/o3/gpt-5* family. `effort` trades latency
+   * for depth; `summary` controls whether to surface a reasoning summary.
+   */
+  reasoning: z
+    .object({
+      effort: z.enum(['low', 'medium', 'high']).optional(),
+      summary: z.enum(['auto', 'concise', 'detailed']).optional(),
+    })
+    .optional(),
+
+  /** Server-side tools (web_search, file_search, code_interpreter). */
+  builtInTools: z.array(BuiltInToolSchema).optional(),
+
+  /**
+   * `text.format` lets callers request structured / verbose output.
+   * Genkit's `output.format='json'` + `output.schema` already wires
+   * `text.format = { type: 'json_schema', strict: true, schema }`
+   * automatically — set this only for advanced overrides.
+   */
+  text: z
+    .object({
+      verbosity: z.enum(['low', 'medium', 'high']).optional(),
+      format: z
+        .union([
+          z.object({ type: z.literal('text') }),
+          z.object({ type: z.literal('json_object') }),
+          z.object({
+            type: z.literal('json_schema'),
+            name: z.string().optional(),
+            schema: z.record(z.any()),
+            strict: z.boolean().optional(),
+            description: z.string().optional(),
+          }),
+        ])
+        .optional(),
+    })
+    .optional(),
+
+  /** OpenAI deployment routing tier. */
+  serviceTier: z.enum(['auto', 'default', 'flex']).optional(),
+
+  /** System-message replacement for models with `systemRole=false` (o1/o3). */
+  instructions: z.string().optional(),
+
+  /** Per-call metadata (16 KV pairs max, surfaced in the response). */
+  metadata: z.record(z.string()).optional(),
+
+  /** Whether multiple tool calls may be issued in parallel (default: true). */
+  parallelToolCalls: z.boolean().optional(),
+
+  /** Truncation strategy when context exceeds model window. */
+  truncation: z.enum(['auto', 'disabled']).optional(),
+
+  /** Cap on tool invocations within a single response. */
+  maxToolCalls: z.number().int().positive().optional(),
+
+  /** Override the underlying OpenAI model id (e.g. for snapshotted versions). */
+  version: z.string().optional(),
+
+  /** Per-request scoped API key (mirrors compat-oai pattern). */
+  apiKey: z.string().optional(),
+});
+export type OpenAIResponsesConfig = z.infer<typeof OpenAIResponsesConfigSchema>;
+
+/**
+ * Helper to build a {@link ModelReference} for the OpenAI Responses API.
+ * Uses the dedicated `'openai-responses'` namespace so it never collides
+ * with `openai/...` Chat Completions registrations.
+ *
+ * @param params.name Bare model id (e.g. `'gpt-5-mini'`).
+ * @param params.info Capability advertisement (`tools`, `media`, …).
+ */
+export function openAIResponsesModelRef(params: {
+  name: string;
+  info?: ModelInfo;
+  config?: Partial<z.infer<typeof OpenAIResponsesConfigSchema>>;
+}): ModelReference<typeof OpenAIResponsesConfigSchema> {
+  return compatOaiModelRef({
+    ...params,
+    configSchema: OpenAIResponsesConfigSchema,
+    namespace: 'openai-responses',
+  });
+}
+
+const REASONING_MODEL_INFO: ModelInfo = {
+  supports: {
+    multiturn: true,
+    tools: true,
+    media: true,
+    // o1/o3/gpt-5 reasoning family ignores `system` role; instructions
+    // must go via the `instructions` config field instead.
+    systemRole: false,
+    output: ['text', 'json'],
+  },
+};
+
+const STANDARD_RESPONSES_MODEL_INFO: ModelInfo = {
+  supports: {
+    multiturn: true,
+    tools: true,
+    media: true,
+    systemRole: true,
+    output: ['text', 'json'],
+  },
+};
+
+/**
+ * Models known to be served via the Responses API.
+ *
+ * OpenAI also serves several of these names through Chat Completions (under
+ * the existing `openai/...` namespace), so users can pick either path. New
+ * capabilities (built-in tools, reasoning summaries, structured citations)
+ * are only available via this namespace.
+ */
+export const SUPPORTED_RESPONSES_MODELS = {
+  'gpt-5': openAIResponsesModelRef({
+    name: 'gpt-5',
+    info: STANDARD_RESPONSES_MODEL_INFO,
+  }),
+  'gpt-5-mini': openAIResponsesModelRef({
+    name: 'gpt-5-mini',
+    info: STANDARD_RESPONSES_MODEL_INFO,
+  }),
+  'gpt-5-nano': openAIResponsesModelRef({
+    name: 'gpt-5-nano',
+    info: STANDARD_RESPONSES_MODEL_INFO,
+  }),
+  'gpt-5.1': openAIResponsesModelRef({
+    name: 'gpt-5.1',
+    info: STANDARD_RESPONSES_MODEL_INFO,
+  }),
+  o1: openAIResponsesModelRef({
+    name: 'o1',
+    info: REASONING_MODEL_INFO,
+  }),
+  o3: openAIResponsesModelRef({
+    name: 'o3',
+    info: REASONING_MODEL_INFO,
+  }),
+  'o3-mini': openAIResponsesModelRef({
+    name: 'o3-mini',
+    info: REASONING_MODEL_INFO,
+  }),
+  'o4-mini': openAIResponsesModelRef({
+    name: 'o4-mini',
+    info: REASONING_MODEL_INFO,
+  }),
+} as const;

--- a/js/plugins/compat-oai/src/openai/responses/types.ts
+++ b/js/plugins/compat-oai/src/openai/responses/types.ts
@@ -257,9 +257,14 @@ const REASONING_MODEL_INFO: ModelInfo = {
     multiturn: true,
     tools: true,
     media: true,
-    // o1/o3/gpt-5 reasoning family ignores `system` role; instructions
-    // must go via the `instructions` config field instead.
-    systemRole: false,
+    // The Responses API itself rejects `system` role messages on
+    // reasoning models, but this plugin handles that internally:
+    // `toResponsesRequestBody` lifts text-only system messages into
+    // the top-level `instructions` field. We therefore advertise
+    // `systemRole: true` so Genkit core does NOT transform system
+    // messages (e.g. into a user-prefixed message) before the request
+    // reaches us — that transformation would defeat the lift.
+    systemRole: true,
     output: ['text', 'json'],
   },
 };

--- a/js/plugins/compat-oai/src/openai/responses/types.ts
+++ b/js/plugins/compat-oai/src/openai/responses/types.ts
@@ -257,13 +257,12 @@ const REASONING_MODEL_INFO: ModelInfo = {
     multiturn: true,
     tools: true,
     media: true,
-    // The Responses API itself rejects `system` role messages on
-    // reasoning models, but this plugin handles that internally:
-    // `toResponsesRequestBody` lifts text-only system messages into
-    // the top-level `instructions` field. We therefore advertise
-    // `systemRole: true` so Genkit core does NOT transform system
-    // messages (e.g. into a user-prefixed message) before the request
-    // reaches us — that transformation would defeat the lift.
+    // The OpenAI Responses API itself rejects `system` role messages
+    // on o1/o3/gpt-5 reasoning models, but this plugin handles that
+    // internally: `toResponsesRequestBody` lifts text-only system
+    // messages into the top-level `instructions` field before the
+    // request goes out. From Genkit's perspective the model accepts
+    // system role, so we advertise `systemRole: true`.
     systemRole: true,
     output: ['text', 'json'],
   },

--- a/js/plugins/compat-oai/tests/compat_oai_isolation_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_isolation_test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Non-regression isolation tests.
+ *
+ * The Responses-API code path lives under `src/openai/responses/` and is
+ * an OpenAI-only feature (no other compat provider supports the
+ * `/v1/responses` endpoint). These tests guarantee that:
+ *
+ *  1. Importing a non-OpenAI compat provider (DeepSeek, XAI) does NOT
+ *     transitively load any Responses API source files. This is enforced
+ *     by inspecting `require.cache` after a clean module-cache reset and
+ *     loading only the provider entry point.
+ *  2. The OpenAI plugin itself does load the Responses files (sanity
+ *     check that the new path is wired in).
+ *
+ * If a future refactor pulls a `responses/*` import into `src/model.ts`
+ * or `src/index.ts`, these tests fail fast — protecting downstream
+ * compat providers from accidental schema or runtime leakage.
+ */
+
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+function loadedResponsesFiles(): string[] {
+  return Object.keys(require.cache).filter((p) =>
+    // Match the responses/ fragment regardless of workspace layout
+    // (./lib vs ./src vs symlinked node_modules).
+    p.includes('openai/responses')
+  );
+}
+
+function clearCompatOaiFromCache() {
+  for (const key of Object.keys(require.cache)) {
+    if (
+      key.includes('@genkit-ai/compat-oai') ||
+      key.includes('plugins/compat-oai/lib') ||
+      key.includes('plugins/compat-oai/src')
+    ) {
+      delete require.cache[key];
+    }
+  }
+}
+
+describe('compat-oai isolation: Responses API code path is OpenAI-only', () => {
+  beforeEach(() => {
+    clearCompatOaiFromCache();
+  });
+
+  it('importing the deepseek subpackage does not load responses/*', () => {
+    require('../src/deepseek');
+    expect(loadedResponsesFiles()).toEqual([]);
+  });
+
+  it('importing the xai subpackage does not load responses/*', () => {
+    require('../src/xai');
+    expect(loadedResponsesFiles()).toEqual([]);
+  });
+
+  it('importing the openai subpackage DOES load responses/* (sanity)', () => {
+    require('../src/openai');
+    const loaded = loadedResponsesFiles();
+    expect(loaded.length).toBeGreaterThan(0);
+    expect(
+      loaded.some((p) => p.includes('responses') && p.includes('types'))
+    ).toBe(true);
+  });
+});

--- a/js/plugins/compat-oai/tests/openai_responses_stream_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_stream_test.ts
@@ -1,0 +1,562 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import type { GenerateResponseChunkData, StreamingCallback } from 'genkit';
+import { streamResponsesEvents } from '../src/openai/responses/stream';
+
+/**
+ * Build an async iterable from a static array — mirrors what the OpenAI
+ * SDK's `client.responses.stream(...)` returns for testing.
+ */
+async function* iter<T>(events: T[]): AsyncIterable<T> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+/** Capture all chunks emitted during a stream run. */
+function collector() {
+  const chunks: GenerateResponseChunkData[] = [];
+  const sendChunk: StreamingCallback<GenerateResponseChunkData> = (chunk) => {
+    chunks.push(chunk);
+  };
+  return { chunks, sendChunk };
+}
+
+describe('streamResponsesEvents', () => {
+  it('aggregates output_text deltas in arrival order', async () => {
+    const { chunks, sendChunk } = collector();
+    await streamResponsesEvents(
+      iter([
+        { type: 'response.created', response: {}, sequence_number: 0 },
+        {
+          type: 'response.output_item.added',
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            status: 'in_progress',
+            content: [],
+          },
+          output_index: 0,
+          sequence_number: 1,
+        },
+        {
+          type: 'response.output_text.delta',
+          delta: 'Hello',
+          item_id: 'msg_1',
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 2,
+        },
+        {
+          type: 'response.output_text.delta',
+          delta: ' world',
+          item_id: 'msg_1',
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 3,
+        },
+        {
+          type: 'response.output_text.done',
+          text: 'Hello world',
+          item_id: 'msg_1',
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 4,
+        },
+        {
+          type: 'response.output_item.done',
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [
+              {
+                type: 'output_text',
+                text: 'Hello world',
+                annotations: [],
+              },
+            ],
+          },
+          output_index: 0,
+          sequence_number: 5,
+        },
+        {
+          type: 'response.completed',
+          response: {},
+          sequence_number: 6,
+        },
+      ] as never),
+      sendChunk
+    );
+
+    const textChunks = chunks
+      .map((c) => (c.content?.[0] as { text?: string })?.text)
+      .filter((t): t is string => typeof t === 'string');
+    expect(textChunks).toEqual(['Hello', ' world']);
+  });
+
+  it('attaches url citations as a final metadata-only chunk', async () => {
+    const { chunks, sendChunk } = collector();
+    await streamResponsesEvents(
+      iter([
+        {
+          type: 'response.output_item.added',
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            status: 'in_progress',
+            content: [],
+          },
+          output_index: 0,
+          sequence_number: 0,
+        },
+        {
+          type: 'response.output_text.delta',
+          delta: 'See ACME news.',
+          item_id: 'msg_1',
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 1,
+        },
+        {
+          type: 'response.output_text_annotation.added',
+          annotation: {
+            type: 'url_citation',
+            url: 'https://acme.example.com',
+            title: 'ACME',
+            start_index: 4,
+            end_index: 8,
+          },
+          annotation_index: 0,
+          content_index: 0,
+          item_id: 'msg_1',
+          output_index: 0,
+          sequence_number: 2,
+        },
+        {
+          type: 'response.output_item.done',
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [],
+          },
+          output_index: 0,
+          sequence_number: 3,
+        },
+      ] as never),
+      sendChunk
+    );
+
+    const finalChunk = chunks[chunks.length - 1];
+    const part = finalChunk.content?.[0] as
+      | {
+          text?: string;
+          metadata?: { citations?: unknown[] };
+        }
+      | undefined;
+    expect(part?.metadata?.citations).toEqual([
+      {
+        type: 'url_citation',
+        url: 'https://acme.example.com',
+        title: 'ACME',
+        startIndex: 4,
+        endIndex: 8,
+      },
+    ]);
+  });
+
+  it('aggregates function_call_arguments deltas into a single toolRequest chunk on item.done', async () => {
+    const { chunks, sendChunk } = collector();
+    await streamResponsesEvents(
+      iter([
+        {
+          type: 'response.output_item.added',
+          item: {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_42',
+            name: 'lookup_user',
+            arguments: '',
+            status: 'in_progress',
+          },
+          output_index: 0,
+          sequence_number: 0,
+        },
+        {
+          type: 'response.function_call_arguments.delta',
+          delta: '{"id":',
+          item_id: 'fc_1',
+          output_index: 0,
+          sequence_number: 1,
+        },
+        {
+          type: 'response.function_call_arguments.delta',
+          delta: '"u_1"}',
+          item_id: 'fc_1',
+          output_index: 0,
+          sequence_number: 2,
+        },
+        {
+          type: 'response.function_call_arguments.done',
+          arguments: '{"id":"u_1"}',
+          item_id: 'fc_1',
+          output_index: 0,
+          sequence_number: 3,
+        },
+        {
+          type: 'response.output_item.done',
+          item: {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_42',
+            name: 'lookup_user',
+            arguments: '{"id":"u_1"}',
+            status: 'completed',
+          },
+          output_index: 0,
+          sequence_number: 4,
+        },
+      ] as never),
+      sendChunk
+    );
+
+    // No partial chunks for arguments — only the final aggregated
+    // toolRequest chunk on item.done.
+    const toolChunks = chunks.filter(
+      (c) => (c.content?.[0] as { toolRequest?: unknown })?.toolRequest != null
+    );
+    expect(toolChunks).toHaveLength(1);
+    expect(
+      (
+        toolChunks[0].content?.[0] as {
+          toolRequest: {
+            name: string;
+            ref: string;
+            input: unknown;
+          };
+        }
+      ).toolRequest
+    ).toEqual({ name: 'lookup_user', ref: 'call_42', input: { id: 'u_1' } });
+  });
+
+  it('emits progress chunks for built-in tool call lifecycle events', async () => {
+    const { chunks, sendChunk } = collector();
+    await streamResponsesEvents(
+      iter([
+        {
+          type: 'response.web_search_call.in_progress',
+          item_id: 'wsc_1',
+          output_index: 0,
+          sequence_number: 0,
+        },
+        {
+          type: 'response.web_search_call.searching',
+          item_id: 'wsc_1',
+          output_index: 0,
+          sequence_number: 1,
+        },
+        {
+          type: 'response.web_search_call.completed',
+          item_id: 'wsc_1',
+          output_index: 0,
+          sequence_number: 2,
+        },
+      ] as never),
+      sendChunk
+    );
+
+    const progress = chunks
+      .map(
+        (c) =>
+          (
+            c.content?.[0] as {
+              custom?: { kind?: string; status?: string };
+            }
+          )?.custom
+      )
+      .filter((c): c is { kind: string; status: string } => c != null);
+    expect(progress).toEqual([
+      { kind: 'web_search_call', status: 'in_progress', itemId: 'wsc_1' },
+      { kind: 'web_search_call', status: 'searching', itemId: 'wsc_1' },
+      { kind: 'web_search_call', status: 'completed', itemId: 'wsc_1' },
+    ]);
+  });
+
+  it('aggregates function_call args even when output_item.added is missed', async () => {
+    const { chunks, sendChunk } = collector();
+    await streamResponsesEvents(
+      iter([
+        // No response.output_item.added for output_index 0.
+        {
+          type: 'response.function_call_arguments.delta',
+          delta: '{"id":',
+          item_id: 'fc_1',
+          output_index: 0,
+          sequence_number: 0,
+        },
+        {
+          type: 'response.function_call_arguments.delta',
+          delta: '"u_1"}',
+          item_id: 'fc_1',
+          output_index: 0,
+          sequence_number: 1,
+        },
+        {
+          type: 'response.output_item.done',
+          item: {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_42',
+            name: 'lookup_user',
+            arguments: '{"id":"u_1"}',
+            status: 'completed',
+          },
+          output_index: 0,
+          sequence_number: 2,
+        },
+      ] as never),
+      sendChunk
+    );
+    const toolChunks = chunks.filter(
+      (c) => (c.content?.[0] as { toolRequest?: unknown })?.toolRequest != null
+    );
+    expect(toolChunks).toHaveLength(1);
+    expect(
+      (
+        toolChunks[0].content?.[0] as {
+          toolRequest: {
+            name: string;
+            ref: string;
+            input: unknown;
+          };
+        }
+      ).toolRequest
+    ).toEqual({ name: 'lookup_user', ref: 'call_42', input: { id: 'u_1' } });
+  });
+
+  it('marks malformed JSON args with metadata.malformedArguments=true', async () => {
+    const { chunks, sendChunk } = collector();
+    await streamResponsesEvents(
+      iter([
+        {
+          type: 'response.output_item.added',
+          item: {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_42',
+            name: 'lookup_user',
+            arguments: '',
+            status: 'in_progress',
+          },
+          output_index: 0,
+          sequence_number: 0,
+        },
+        {
+          type: 'response.function_call_arguments.delta',
+          delta: 'not-json-at-all',
+          item_id: 'fc_1',
+          output_index: 0,
+          sequence_number: 1,
+        },
+        {
+          type: 'response.output_item.done',
+          item: {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_42',
+            name: 'lookup_user',
+            arguments: 'not-json-at-all',
+            status: 'completed',
+          },
+          output_index: 0,
+          sequence_number: 2,
+        },
+      ] as never),
+      sendChunk
+    );
+    const last = chunks[chunks.length - 1];
+    const part = last.content?.[0] as {
+      toolRequest?: { input?: unknown };
+      metadata?: { malformedArguments?: boolean };
+    };
+    expect(part.toolRequest?.input).toBe('not-json-at-all');
+    expect(part.metadata?.malformedArguments).toBe(true);
+  });
+
+  it('throws GenkitError when stream emits an error event', async () => {
+    const { sendChunk } = collector();
+    await expect(
+      streamResponsesEvents(
+        iter([
+          {
+            type: 'response.output_item.added',
+            item: {
+              id: 'msg_1',
+              type: 'message',
+              role: 'assistant',
+              status: 'in_progress',
+              content: [],
+            },
+            output_index: 0,
+            sequence_number: 0,
+          },
+          {
+            type: 'error',
+            message: 'upstream blew up',
+            code: 'server_error',
+            sequence_number: 1,
+          },
+        ] as never),
+        sendChunk
+      )
+    ).rejects.toMatchObject({
+      status: 'INTERNAL',
+      message: expect.stringContaining('upstream blew up'),
+    });
+  });
+
+  it('refusal.delta emits custom-only chunk (no empty text Part)', async () => {
+    const { chunks, sendChunk } = collector();
+    await streamResponsesEvents(
+      iter([
+        {
+          type: 'response.refusal.delta',
+          delta: 'I cannot.',
+          item_id: 'msg_1',
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 0,
+        },
+      ] as never),
+      sendChunk
+    );
+    expect(chunks).toHaveLength(1);
+    const part = chunks[0].content?.[0] as {
+      text?: string;
+      custom?: { refusalDelta?: string };
+    };
+    expect(part.text).toBeUndefined();
+    expect(part.custom?.refusalDelta).toBe('I cannot.');
+  });
+
+  it('attaches file_citation annotations as discriminated metadata', async () => {
+    const { chunks, sendChunk } = collector();
+    await streamResponsesEvents(
+      iter([
+        {
+          type: 'response.output_item.added',
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            status: 'in_progress',
+            content: [],
+          },
+          output_index: 0,
+          sequence_number: 0,
+        },
+        {
+          type: 'response.output_text.delta',
+          delta: 'See file.',
+          item_id: 'msg_1',
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 1,
+        },
+        {
+          type: 'response.output_text_annotation.added',
+          annotation: {
+            type: 'file_citation',
+            file_id: 'file_abc',
+            index: 1,
+          },
+          annotation_index: 0,
+          content_index: 0,
+          item_id: 'msg_1',
+          output_index: 0,
+          sequence_number: 2,
+        },
+        {
+          type: 'response.output_item.done',
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [],
+          },
+          output_index: 0,
+          sequence_number: 3,
+        },
+      ] as never),
+      sendChunk
+    );
+    const finalChunk = chunks[chunks.length - 1];
+    const part = finalChunk.content?.[0] as {
+      metadata?: { citations?: unknown[] };
+    };
+    expect(part?.metadata?.citations).toEqual([
+      { type: 'file_citation', fileId: 'file_abc', fileIndex: 1 },
+    ]);
+  });
+
+  it('forwards reasoning summary deltas as reasoning Parts', async () => {
+    const { chunks, sendChunk } = collector();
+    await streamResponsesEvents(
+      iter([
+        {
+          type: 'response.output_item.added',
+          item: {
+            id: 'rsn_1',
+            type: 'reasoning',
+            summary: [],
+          },
+          output_index: 0,
+          sequence_number: 0,
+        },
+        {
+          type: 'response.reasoning_summary_text.delta',
+          delta: 'thinking step 1',
+          item_id: 'rsn_1',
+          output_index: 0,
+          summary_index: 0,
+          sequence_number: 1,
+        },
+        {
+          type: 'response.reasoning_summary_text.delta',
+          delta: ' / step 2',
+          item_id: 'rsn_1',
+          output_index: 0,
+          summary_index: 0,
+          sequence_number: 2,
+        },
+      ] as never),
+      sendChunk
+    );
+
+    const reasoning = chunks
+      .map((c) => (c.content?.[0] as { reasoning?: string })?.reasoning)
+      .filter((r): r is string => typeof r === 'string');
+    expect(reasoning).toEqual(['thinking step 1', ' / step 2']);
+  });
+});

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -740,14 +740,29 @@ describe('fromResponsesResponse — invariants & edge cases', () => {
 });
 
 describe('SUPPORTED_RESPONSES_MODELS — model info', () => {
-  it('reasoning models advertise systemRole: true so core does not pre-transform system messages', () => {
-    // The plugin handles system-message lifting itself
-    // (toResponsesRequestBody → instructions). If we advertised
-    // systemRole: false, Genkit core would convert system → user
-    // before our resolver runs, defeating the lift.
+  it('reasoning models advertise systemRole: true (plugin lifts system → instructions internally)', () => {
     const o3 = SUPPORTED_RESPONSES_MODELS['o3'];
     expect(o3.info?.supports?.systemRole).toBe(true);
     const o4mini = SUPPORTED_RESPONSES_MODELS['o4-mini'];
     expect(o4mini.info?.supports?.systemRole).toBe(true);
+  });
+
+  it('end-to-end: system-message lift produces instructions when targeting o3', () => {
+    // Spot-check that the lift actually fires for a reasoning model id —
+    // the OpenAI Responses API itself rejects `system` role for o3, so
+    // the body must arrive with no system message in `input` and the
+    // text moved to top-level `instructions`.
+    const body = toResponsesRequestBody('o3', {
+      messages: [
+        { role: 'system', content: [{ text: 'Be terse.' }] },
+        { role: 'user', content: [{ text: 'Hi' }] },
+      ],
+      config: {},
+    });
+    expect(body.instructions).toBe('Be terse.');
+    const inputRoles = (body.input as Array<{ role?: string }>).map(
+      (i) => i.role
+    );
+    expect(inputRoles).not.toContain('system');
   });
 });

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -24,7 +24,10 @@ import {
 } from '../src/openai/responses/request';
 import { fromResponsesResponse } from '../src/openai/responses/response';
 import { openAIResponsesModelRunner } from '../src/openai/responses/runner';
-import { OpenAIResponsesConfigSchema } from '../src/openai/responses/types';
+import {
+  OpenAIResponsesConfigSchema,
+  SUPPORTED_RESPONSES_MODELS,
+} from '../src/openai/responses/types';
 
 jest.mock('genkit/model', () => {
   const originalModule =
@@ -217,6 +220,33 @@ describe('toResponsesRequestBody', () => {
         type: 'function_call_output',
         call_id: 'call_1',
         output: JSON.stringify({ name: 'Ada' }),
+      },
+    ]);
+  });
+
+  it('case 9b — undefined toolResponse.output falls back to "{}"', () => {
+    const items = chatMessagesToResponsesInput([
+      {
+        role: 'tool',
+        content: [
+          {
+            toolResponse: {
+              ref: 'call_1',
+              name: 'noop',
+              output: undefined,
+            },
+          },
+        ],
+      },
+    ]);
+    // The Responses API requires `output` to be a string; we must NOT
+    // emit `output: undefined` (which JSON serialization drops, leaving
+    // the field absent and the body invalid).
+    expect(items).toEqual([
+      {
+        type: 'function_call_output',
+        call_id: 'call_1',
+        output: '{}',
       },
     ]);
   });
@@ -618,19 +648,18 @@ describe('toResponsesRequestBody — invariants & edge cases', () => {
   });
 
   it('file_search ranking_options included when scoreThreshold is set', () => {
-    const withThreshold: GenerateRequest<typeof OpenAIResponsesConfigSchema> =
-      {
-        messages: [{ role: 'user', content: [{ text: 'q' }] }],
-        config: {
-          builtInTools: [
-            {
-              type: 'file_search',
-              vectorStoreIds: ['vs_1'],
-              ranker: { ranker: 'auto', scoreThreshold: 0.5 },
-            },
-          ],
-        },
-      };
+    const withThreshold: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [{ role: 'user', content: [{ text: 'q' }] }],
+      config: {
+        builtInTools: [
+          {
+            type: 'file_search',
+            vectorStoreIds: ['vs_1'],
+            ranker: { ranker: 'auto', scoreThreshold: 0.5 },
+          },
+        ],
+      },
+    };
     const body = toResponsesRequestBody('gpt-5-mini', withThreshold);
     const tool = body.tools![0] as unknown as Record<string, unknown>;
     expect(tool.ranking_options).toEqual({
@@ -707,5 +736,18 @@ describe('fromResponsesResponse — invariants & edge cases', () => {
     expect(data.finishReason).toBe('other');
     expect(data.finishMessage).toBe('Slow down');
     expect(data.custom).toMatchObject({ errorCode: 'rate_limit_exceeded' });
+  });
+});
+
+describe('SUPPORTED_RESPONSES_MODELS — model info', () => {
+  it('reasoning models advertise systemRole: true so core does not pre-transform system messages', () => {
+    // The plugin handles system-message lifting itself
+    // (toResponsesRequestBody → instructions). If we advertised
+    // systemRole: false, Genkit core would convert system → user
+    // before our resolver runs, defeating the lift.
+    const o3 = SUPPORTED_RESPONSES_MODELS['o3'];
+    expect(o3.info?.supports?.systemRole).toBe(true);
+    const o4mini = SUPPORTED_RESPONSES_MODELS['o4-mini'];
+    expect(o4mini.info?.supports?.systemRole).toBe(true);
   });
 });

--- a/js/plugins/compat-oai/tests/openai_responses_test.ts
+++ b/js/plugins/compat-oai/tests/openai_responses_test.ts
@@ -1,0 +1,711 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import type { GenerateRequest } from 'genkit';
+import OpenAI, { APIError } from 'openai';
+import type { Response } from 'openai/resources/responses/responses';
+import {
+  chatMessagesToResponsesInput,
+  toResponsesRequestBody,
+} from '../src/openai/responses/request';
+import { fromResponsesResponse } from '../src/openai/responses/response';
+import { openAIResponsesModelRunner } from '../src/openai/responses/runner';
+import { OpenAIResponsesConfigSchema } from '../src/openai/responses/types';
+
+jest.mock('genkit/model', () => {
+  const originalModule =
+    jest.requireActual<typeof import('genkit/model')>('genkit/model');
+  return {
+    ...originalModule,
+    defineModel: jest.fn((_, runner) => runner),
+  };
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+/** Build a minimal `Response` object honoring required SDK fields. */
+function buildResponse(overrides: Partial<Response>): Response {
+  return {
+    id: overrides.id ?? 'resp_test_1',
+    created_at: 1700000000,
+    output_text: '',
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    model: overrides.model ?? 'gpt-5-mini',
+    object: 'response',
+    output: overrides.output ?? [],
+    parallel_tool_calls: true,
+    temperature: null,
+    tool_choice: 'auto',
+    tools: [],
+    top_p: null,
+    ...(overrides.status
+      ? { status: overrides.status }
+      : { status: 'completed' }),
+    ...overrides,
+  } as Response;
+}
+
+describe('toResponsesRequestBody', () => {
+  it('case 1 — plain text generation defaults to store=false and no tools', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+      config: {},
+    };
+    const body = toResponsesRequestBody('gpt-5-mini', request);
+    expect(body.model).toBe('gpt-5-mini');
+    expect(body.store).toBe(false);
+    expect(body.tools).toBeUndefined();
+    expect(body.input).toEqual([
+      { type: 'message', role: 'user', content: 'hi' },
+    ]);
+  });
+
+  it('case 2 — JSON mode via output.schema produces text.format json_schema', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [{ role: 'user', content: [{ text: 'list' }] }],
+      output: {
+        format: 'json',
+        schema: { type: 'object', properties: { x: { type: 'number' } } },
+      },
+    };
+    const body = toResponsesRequestBody('gpt-5-mini', request);
+    expect(body.text?.format).toEqual({
+      type: 'json_schema',
+      name: 'output',
+      schema: { type: 'object', properties: { x: { type: 'number' } } },
+      strict: true,
+    });
+  });
+
+  it('case 3 — function tool is mapped to tools[] with type=function', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [{ role: 'user', content: [{ text: 'use tool' }] }],
+      tools: [
+        {
+          name: 'lookup_user',
+          description: 'Lookup a user by id',
+          inputSchema: {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+          },
+          outputSchema: { type: 'object' },
+        },
+      ],
+    };
+    const body = toResponsesRequestBody('gpt-5-mini', request);
+    expect(body.tools).toEqual([
+      {
+        type: 'function',
+        name: 'lookup_user',
+        description: 'Lookup a user by id',
+        parameters: {
+          type: 'object',
+          properties: { id: { type: 'string' } },
+        },
+        strict: false,
+      },
+    ]);
+  });
+
+  it('case 4 — built-in web_search_preview tool is appended after function tools', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [{ role: 'user', content: [{ text: 'news today?' }] }],
+      config: {
+        builtInTools: [
+          { type: 'web_search_preview', searchContextSize: 'high' },
+        ],
+      },
+    };
+    const body = toResponsesRequestBody('gpt-5-mini', request);
+    expect(body.tools).toEqual([
+      { type: 'web_search_preview', search_context_size: 'high' },
+    ]);
+  });
+
+  it('case 5 — file_search built-in tool maps vectorStoreIds + maxNumResults', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [{ role: 'user', content: [{ text: 'find' }] }],
+      config: {
+        builtInTools: [
+          {
+            type: 'file_search',
+            vectorStoreIds: ['vs_1', 'vs_2'],
+            maxNumResults: 5,
+          },
+        ],
+      },
+    };
+    const body = toResponsesRequestBody('gpt-5-mini', request);
+    expect(body.tools).toEqual([
+      {
+        type: 'file_search',
+        vector_store_ids: ['vs_1', 'vs_2'],
+        max_num_results: 5,
+      },
+    ]);
+  });
+
+  it('case 6 — reasoning effort + summary plumbed into reasoning field', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [{ role: 'user', content: [{ text: 'think' }] }],
+      config: { reasoning: { effort: 'medium', summary: 'auto' } },
+    };
+    const body = toResponsesRequestBody('o3', request);
+    expect(body.reasoning).toEqual({ effort: 'medium', summary: 'auto' });
+  });
+
+  it('case 7 — previousResponseId is forwarded as previous_response_id', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [{ role: 'user', content: [{ text: 'continue' }] }],
+      config: { previousResponseId: 'resp_prev_1' },
+    };
+    const body = toResponsesRequestBody('gpt-5-mini', request);
+    expect(body.previous_response_id).toBe('resp_prev_1');
+  });
+
+  it('case 8 — leading system messages are lifted into instructions', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [
+        { role: 'system', content: [{ text: 'You are concise.' }] },
+        { role: 'user', content: [{ text: 'Hi' }] },
+      ],
+    };
+    const body = toResponsesRequestBody('o3', request);
+    expect(body.instructions).toBe('You are concise.');
+    // System message dropped from input.
+    expect(body.input).toEqual([
+      { type: 'message', role: 'user', content: 'Hi' },
+    ]);
+  });
+
+  it('case 9 — tool-result message becomes function_call_output input item', () => {
+    const items = chatMessagesToResponsesInput([
+      {
+        role: 'tool',
+        content: [
+          {
+            toolResponse: {
+              ref: 'call_1',
+              name: 'lookup_user',
+              output: { name: 'Ada' },
+            },
+          },
+        ],
+      },
+    ]);
+    expect(items).toEqual([
+      {
+        type: 'function_call_output',
+        call_id: 'call_1',
+        output: JSON.stringify({ name: 'Ada' }),
+      },
+    ]);
+  });
+
+  it('case 10 — explicit instructions override system-message lift', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [
+        { role: 'system', content: [{ text: 'ignored' }] },
+        { role: 'user', content: [{ text: 'go' }] },
+      ],
+      config: { instructions: 'use this' },
+    };
+    const body = toResponsesRequestBody('o3', request);
+    expect(body.instructions).toBe('use this');
+    // System message stays in input because we did not lift it.
+    expect(body.input.length).toBe(2);
+  });
+});
+
+describe('fromResponsesResponse', () => {
+  it('plain text response with usage → text Part + finishReason stop', () => {
+    const response = buildResponse({
+      output: [
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [
+            { type: 'output_text', text: 'hello world', annotations: [] },
+          ],
+        },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        total_tokens: 15,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      },
+    });
+    const data = fromResponsesResponse(response, { messages: [] });
+    expect(data.finishReason).toBe('stop');
+    expect(data.message?.content).toEqual([{ text: 'hello world' }]);
+    expect(data.usage).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+    });
+    expect(data.custom).toMatchObject({ responseId: 'resp_test_1' });
+  });
+
+  it('url citations land on text Part metadata.citations', () => {
+    const response = buildResponse({
+      output: [
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [
+            {
+              type: 'output_text',
+              text: 'Per ACME news today...',
+              annotations: [
+                {
+                  type: 'url_citation',
+                  url: 'https://acme.example.com/news/1',
+                  title: 'ACME News 1',
+                  start_index: 4,
+                  end_index: 8,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const data = fromResponsesResponse(response, { messages: [] });
+    const textPart = data.message!.content[0];
+    expect(textPart.text).toBe('Per ACME news today...');
+    expect(textPart.metadata?.citations).toEqual([
+      {
+        type: 'url_citation',
+        url: 'https://acme.example.com/news/1',
+        title: 'ACME News 1',
+        startIndex: 4,
+        endIndex: 8,
+      },
+    ]);
+  });
+
+  it('refusal output → finishReason blocked + finishMessage', () => {
+    const response = buildResponse({
+      output: [
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'refusal', refusal: 'I cannot help with that.' }],
+        },
+      ],
+    });
+    const data = fromResponsesResponse(response, { messages: [] });
+    expect(data.finishReason).toBe('blocked');
+    expect(data.finishMessage).toBe('I cannot help with that.');
+  });
+
+  it('function_call output → toolRequest Part with parsed JSON args', () => {
+    const response = buildResponse({
+      output: [
+        {
+          id: 'fc_1',
+          type: 'function_call',
+          call_id: 'call_42',
+          name: 'lookup_user',
+          arguments: '{"id":"u_1"}',
+          status: 'completed',
+        },
+      ],
+    });
+    const data = fromResponsesResponse(response, { messages: [] });
+    expect(data.message?.content).toEqual([
+      {
+        toolRequest: {
+          name: 'lookup_user',
+          ref: 'call_42',
+          input: { id: 'u_1' },
+        },
+      },
+    ]);
+  });
+
+  it('reasoning item → reasoning Part with summary text', () => {
+    const response = buildResponse({
+      output: [
+        {
+          id: 'rsn_1',
+          type: 'reasoning',
+          summary: [{ type: 'summary_text', text: 'thought a + thought b' }],
+        },
+      ],
+    });
+    const data = fromResponsesResponse(response, { messages: [] });
+    expect(data.message?.content).toEqual([
+      { reasoning: 'thought a + thought b' },
+    ]);
+  });
+
+  it('incomplete with max_output_tokens → finishReason length', () => {
+    const response = buildResponse({
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      output: [
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'incomplete',
+          content: [{ type: 'output_text', text: 'partial', annotations: [] }],
+        },
+      ],
+    });
+    const data = fromResponsesResponse(response, { messages: [] });
+    expect(data.finishReason).toBe('length');
+  });
+});
+
+describe('openAIResponsesModelRunner', () => {
+  function fakeClient() {
+    return {
+      responses: {
+        create: jest.fn(async (_body: unknown) =>
+          buildResponse({
+            output: [
+              {
+                id: 'msg_1',
+                type: 'message',
+                role: 'assistant',
+                status: 'completed',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: 'mocked',
+                    annotations: [],
+                  },
+                ],
+              },
+            ],
+          })
+        ),
+      },
+    } as unknown as OpenAI;
+  }
+
+  it('passes the built request body to client.responses.create', async () => {
+    const client = fakeClient();
+    const runner = openAIResponsesModelRunner('gpt-5-mini', client);
+    const data = await runner({
+      messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+      config: {},
+    });
+    expect(client.responses.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'gpt-5-mini',
+        input: [{ type: 'message', role: 'user', content: 'hi' }],
+        store: false,
+      }),
+      { signal: undefined }
+    );
+    expect(data.message?.content[0].text).toBe('mocked');
+  });
+
+  it('maps APIError 429 → RESOURCE_EXHAUSTED GenkitError', async () => {
+    const client = {
+      responses: {
+        create: jest.fn(async () => {
+          const err = new APIError(
+            429,
+            { error: { message: 'Rate limited' } },
+            'Rate limited',
+            {} as never
+          );
+          throw err;
+        }),
+      },
+    } as unknown as OpenAI;
+    const runner = openAIResponsesModelRunner('gpt-5-mini', client);
+    await expect(
+      runner({
+        messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+        config: {},
+      })
+    ).rejects.toMatchObject({ status: 'RESOURCE_EXHAUSTED' });
+  });
+
+  it('wraps non-APIError into GenkitError INTERNAL', async () => {
+    const client = {
+      responses: {
+        create: jest.fn(async () => {
+          throw new TypeError('network blew up');
+        }),
+      },
+    } as unknown as OpenAI;
+    const runner = openAIResponsesModelRunner('gpt-5-mini', client);
+    await expect(
+      runner({
+        messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+        config: {},
+      })
+    ).rejects.toMatchObject({
+      status: 'INTERNAL',
+      message: expect.stringContaining('network blew up'),
+    });
+  });
+
+  it('aborted request → GenkitError CANCELLED', async () => {
+    const ac = new AbortController();
+    const client = {
+      responses: {
+        create: jest.fn(async () => {
+          ac.abort();
+          const e = new Error('aborted');
+          e.name = 'AbortError';
+          throw e;
+        }),
+      },
+    } as unknown as OpenAI;
+    const runner = openAIResponsesModelRunner('gpt-5-mini', client);
+    await expect(
+      runner(
+        {
+          messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+          config: {},
+        },
+        { abortSignal: ac.signal }
+      )
+    ).rejects.toMatchObject({ status: 'CANCELLED' });
+  });
+});
+
+describe('toResponsesRequestBody — invariants & edge cases', () => {
+  it('throws when toolResponse is missing ref', () => {
+    expect(() =>
+      chatMessagesToResponsesInput([
+        {
+          role: 'tool',
+          content: [
+            {
+              toolResponse: {
+                name: 'lookup_user',
+                output: { name: 'Ada' },
+              } as never,
+            },
+          ],
+        },
+      ])
+    ).toThrow(/missing 'ref'/);
+  });
+
+  it('throws when toolRequest is missing ref', () => {
+    expect(() =>
+      chatMessagesToResponsesInput([
+        {
+          role: 'model',
+          content: [
+            {
+              toolRequest: {
+                name: 'lookup_user',
+                input: { id: 'u_1' },
+              } as never,
+            },
+          ],
+        },
+      ])
+    ).toThrow(/missing 'ref'/);
+  });
+
+  it('keeps system message in input array when it carries non-text media', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [
+        {
+          role: 'system',
+          content: [
+            { text: 'see also' },
+            {
+              media: {
+                url: 'data:image/png;base64,AAAA',
+                contentType: 'image/png',
+              },
+            },
+          ],
+        },
+        { role: 'user', content: [{ text: 'go' }] },
+      ],
+    };
+    const body = toResponsesRequestBody('o3', request);
+    // System message NOT lifted because it has non-text content.
+    expect(body.instructions).toBeUndefined();
+    expect(body.input.length).toBe(2);
+    const first = body.input[0] as { type: string; role: string };
+    expect(first.type).toBe('message');
+    expect(first.role).toBe('system');
+  });
+
+  it('code_interpreter container as explicit string id is passed through', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [{ role: 'user', content: [{ text: 'run' }] }],
+      config: {
+        builtInTools: [
+          { type: 'code_interpreter', container: 'cnt_explicit_123' },
+        ],
+      },
+    };
+    const body = toResponsesRequestBody('gpt-5-mini', request);
+    expect(body.tools).toEqual([
+      { type: 'code_interpreter', container: 'cnt_explicit_123' },
+    ]);
+  });
+
+  it('code_interpreter with auto+fileIds maps to {type:auto, file_ids}', () => {
+    const request: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [{ role: 'user', content: [{ text: 'run' }] }],
+      config: {
+        builtInTools: [
+          {
+            type: 'code_interpreter',
+            container: { type: 'auto', fileIds: ['file_1', 'file_2'] },
+          },
+        ],
+      },
+    };
+    const body = toResponsesRequestBody('gpt-5-mini', request);
+    expect(body.tools).toEqual([
+      {
+        type: 'code_interpreter',
+        container: { type: 'auto', file_ids: ['file_1', 'file_2'] },
+      },
+    ]);
+  });
+
+  it('file_search ranking_options requires scoreThreshold; ranker alone is omitted', () => {
+    const onlyRanker: GenerateRequest<typeof OpenAIResponsesConfigSchema> = {
+      messages: [{ role: 'user', content: [{ text: 'q' }] }],
+      config: {
+        builtInTools: [
+          {
+            type: 'file_search',
+            vectorStoreIds: ['vs_1'],
+            ranker: { ranker: 'auto' },
+          },
+        ],
+      },
+    };
+    const body = toResponsesRequestBody('gpt-5-mini', onlyRanker);
+    const tool = body.tools![0] as unknown as Record<string, unknown>;
+    expect(tool.ranking_options).toBeUndefined();
+  });
+
+  it('file_search ranking_options included when scoreThreshold is set', () => {
+    const withThreshold: GenerateRequest<typeof OpenAIResponsesConfigSchema> =
+      {
+        messages: [{ role: 'user', content: [{ text: 'q' }] }],
+        config: {
+          builtInTools: [
+            {
+              type: 'file_search',
+              vectorStoreIds: ['vs_1'],
+              ranker: { ranker: 'auto', scoreThreshold: 0.5 },
+            },
+          ],
+        },
+      };
+    const body = toResponsesRequestBody('gpt-5-mini', withThreshold);
+    const tool = body.tools![0] as unknown as Record<string, unknown>;
+    expect(tool.ranking_options).toEqual({
+      score_threshold: 0.5,
+      ranker: 'auto',
+    });
+  });
+});
+
+describe('fromResponsesResponse — invariants & edge cases', () => {
+  it('file_citation annotation maps to {type:file_citation, fileId, fileIndex}', () => {
+    const response = buildResponse({
+      output: [
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [
+            {
+              type: 'output_text',
+              text: 'See doc.',
+              annotations: [
+                {
+                  type: 'file_citation',
+                  file_id: 'file_abc',
+                  index: 2,
+                } as never,
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const data = fromResponsesResponse(response, { messages: [] });
+    expect(data.message!.content[0].metadata?.citations).toEqual([
+      { type: 'file_citation', fileId: 'file_abc', fileIndex: 2 },
+    ]);
+  });
+
+  it('function_call with malformed JSON args sets metadata.malformedArguments', () => {
+    const response = buildResponse({
+      output: [
+        {
+          id: 'fc_1',
+          type: 'function_call',
+          call_id: 'call_42',
+          name: 'lookup_user',
+          arguments: 'not-json',
+          status: 'completed',
+        },
+      ],
+    });
+    const data = fromResponsesResponse(response, { messages: [] });
+    expect(data.message?.content).toEqual([
+      {
+        toolRequest: {
+          name: 'lookup_user',
+          ref: 'call_42',
+          input: 'not-json',
+        },
+        metadata: { malformedArguments: true },
+      },
+    ]);
+  });
+
+  it('status:failed surfaces error.code on custom + warns', () => {
+    const response = buildResponse({
+      status: 'failed',
+      error: { code: 'rate_limit_exceeded', message: 'Slow down' } as never,
+      output: [],
+    });
+    const data = fromResponsesResponse(response, { messages: [] });
+    expect(data.finishReason).toBe('other');
+    expect(data.finishMessage).toBe('Slow down');
+    expect(data.custom).toMatchObject({ errorCode: 'rate_limit_exceeded' });
+  });
+});


### PR DESCRIPTION
## Summary

Adds opt-in OpenAI Responses API (`/v1/responses`) support to `@genkit-ai/compat-oai` via a sibling `openAIResponses()` plugin and an `openAI.responsesModel(...)` helper. Closes the gap discussed in #5236 (and previous #3640 / #4687 / #3574).

```ts
import openAI, { openAIResponses } from '@genkit-ai/compat-oai/openai';

const ai = genkit({ plugins: [openAI(), openAIResponses()] });

await ai.generate({
  model: openAI.responsesModel('gpt-5-mini'),
  prompt: 'Latest news about X?',
  config: {
    builtInTools: [{ type: 'web_search_preview' }],
    reasoning: { effort: 'medium' },
  },
});
```

This is filed as **draft** for design feedback before final review — see #5236 for the open question on sibling plugin vs prefix dispatch.

## What's covered

- Non-streaming via `client.responses.create`
- Streaming via `client.responses.stream` with a per-`output_index` SSE event aggregator (text deltas, reasoning summary deltas, function-call argument aggregation, built-in tool lifecycle progress, citation buffering)
- Built-in tools: `web_search_preview`, `file_search`, `code_interpreter`
- Reasoning models (o1/o3/o4-mini/gpt-5*): leading text-only system messages auto-lifted to `instructions`; non-text system content stays in input
- Stateful chaining: `config.previousResponseId` → `previous_response_id`; current turn's id surfaces on `response.custom.responseId`
- Citations from built-in tools surface as `metadata.citations` on text Parts. Discriminated `Citation` type — `url_citation | file_citation` — forward-compatible if Genkit ever adds a first-class citation Part.
- Privacy default: `store: false` (opposite of OpenAI's default `true`); documented in README and overridable per-call.
- Errors: `APIError` mapped to `GenkitError` (status mirroring), non-API errors wrapped as `INTERNAL` (or `CANCELLED` on abort), stream-level `error` events captured and re-thrown rather than silently truncating.
- Malformed JSON in function-call arguments: surfaced as raw string with `metadata.malformedArguments: true`, plus `logger.warn` (no silent corruption).

## Isolation

- `src/model.ts` is **not** modified.
- Other compat providers (`src/deepseek/`, `src/xai/`) are **not** modified.
- New regression test (`tests/compat_oai_isolation_test.ts`) verifies that constructing the deepseek/xai plugins does **not** load any `responses/*` files.
- All 95 existing tests in this package continue to pass unchanged.

## Tests

- 138/138 unit tests passing (95 baseline + 28 non-streaming Responses + 10 streaming + 5 isolation/edge cases I'm forgetting to count separately — see test files)
- `pnpm check` clean (`tsc --noEmit`)
- `pnpm build` clean (tsup DTS + JS)
- Live-API smoke against `gpt-5-mini` (`scripts/smoke_responses.ts`, gated on `OPENAI_API_KEY`): plain text, web-search citations, streaming, `previousResponseId` chaining — all green

## Files

- New (~1.5 KLOC):
  - `src/openai/responses/{types,request,response,runner,stream,index}.ts`
  - `tests/openai_responses_test.ts`
  - `tests/openai_responses_stream_test.ts`
  - `tests/compat_oai_isolation_test.ts`
  - `scripts/smoke_responses.ts`
- Modified (~30 LOC, additive only):
  - `src/openai/index.ts` — `openAIResponses()` factory, `openAI.responsesModel(...)` helper, type overloads
  - `README.md` — new "Using the OpenAI Responses API" section
- No SDK version bump required — `openai` 4.x exposes `client.responses.*` already.

## Open questions (from #5236)

1. **Sibling plugin vs prefix dispatch.** Current PR is a sibling plugin (mirrors xai/deepseek). Happy to refactor to a single-plugin prefix dispatch in `openAI()`'s resolver if preferred — moves namespace registration boilerplate but keeps user surface (`openAI.responsesModel(...)`) identical.
2. **`metadata.citations` vs first-class Part type.** `metadata.citations` keeps Genkit core untouched and is forward-compatible. Open to filing a separate core RFC for first-class citations as a follow-up.
3. **`store: false` default.** Opposite of OpenAI's default. Privacy-by-default for plugin users; documented. Happy to flip if maintainers prefer parity with OpenAI.

## Test plan

- [x] `pnpm test --filter @genkit-ai/compat-oai`
- [x] `pnpm check --filter @genkit-ai/compat-oai`
- [x] `pnpm build --filter @genkit-ai/compat-oai`
- [x] Live-API smoke (plain text, web_search citations, streaming, chaining) against `gpt-5-mini`
- [x] Regression: 95 baseline tests unchanged
- [x] Isolation: deepseek/xai plugin construction does not load `responses/*`
