### PR TITLE
fix(go): preserve schema for shared struct types in InferJSONSchema

### DIFF
--- a/go/internal/base/json.go
+++ b/go/internal/base/json.go
@@ -75,55 +75,82 @@ func ReadJSONFile(filename string, pvalue any) error {
 	return json.NewDecoder(f).Decode(pvalue)
 }
 
+var jsonMarshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+
 // InferJSONSchema infers a JSON schema from a Go value.
-func InferJSONSchema(x any) (s *jsonschema.Schema) {
-	seen := make(map[reflect.Type]bool)
+//
+// Recursion is detected by stack: while a struct type T is being reflected, T
+// is marked in-progress. Any nested encounter of T (a self-reference) returns
+// an "any" schema; T is unmarked when its reflection completes. Each top-level
+// occurrence of T (siblings, repeats) gets its own full reflection — so a
+// struct used in multiple fields produces the correct schema each time.
+//
+// We can't observe reflection completion through the library's Mapper hook
+// alone, so each struct type is reflected via a sub-Reflector. The Mapper's
+// defer fires when the sub-Reflector returns, which is the exit point.
+func InferJSONSchema(x any) *jsonschema.Schema {
+	inProgress := make(map[reflect.Type]bool)
+	var mapper func(reflect.Type) *jsonschema.Schema
+	mapper = func(t reflect.Type) *jsonschema.Schema {
+		// []any reflects to `{ type: "array", items: true }` which is not valid JSON schema.
+		if t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Interface {
+			return &jsonschema.Schema{
+				Type:  "array",
+				Items: &jsonschema.Schema{AdditionalProperties: jsonschema.TrueSchema},
+			}
+		}
+		baseType := t
+		if t.Kind() == reflect.Ptr {
+			baseType = t.Elem()
+		}
+		if baseType.Kind() != reflect.Struct {
+			return nil
+		}
+		if inProgress[baseType] {
+			return anyStructSchema(baseType)
+		}
 
-	r := jsonschema.Reflector{
-		DoNotReference: true,
-		Mapper: func(t reflect.Type) *jsonschema.Schema {
-			// []any generates `{ type: "array", items: true }` which is not valid JSON schema.
-			if t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Interface {
-				return &jsonschema.Schema{
-					Type: "array",
-					Items: &jsonschema.Schema{
-						// This field is not necessary but it's the most benign way for the object to not be empty.
-						AdditionalProperties: jsonschema.TrueSchema,
-					},
+		inProgress[baseType] = true
+		defer delete(inProgress, baseType)
+
+		// The sub-Reflector's first Mapper call is for baseType itself: return
+		// nil so the library reflects it. All nested calls (fields, including
+		// recursive self-references) delegate back to the outer mapper, where
+		// inProgress[baseType] is set and recursion is broken.
+		firstCall := true
+		sub := jsonschema.Reflector{
+			DoNotReference: true,
+			Anonymous:      true, // suppress $id on this nested schema
+			Mapper: func(st reflect.Type) *jsonschema.Schema {
+				if firstCall && st == baseType {
+					firstCall = false
+					return nil
 				}
-			}
-
-			// Handle recursive types: track struct types we've seen.
-			// The first encounter is reflected normally; subsequent encounters
-			// (including self-references) return an "any" schema to break recursion.
-			baseType := t
-			if t.Kind() == reflect.Ptr {
-				baseType = t.Elem()
-			}
-			if baseType.Kind() == reflect.Struct {
-				if seen[baseType] {
-					// check if the type implements json.Marshaler since it might serialize to a non-object
-					marshalerType := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
-					if baseType.Implements(marshalerType) || reflect.PointerTo(baseType).Implements(marshalerType) {
-						return &jsonschema.Schema{
-							AdditionalProperties: jsonschema.TrueSchema,
-						}
-					}
-					return &jsonschema.Schema{
-						Type:                 "object",
-						AdditionalProperties: jsonschema.TrueSchema,
-					}
-				}
-				seen[baseType] = true
-			}
-
-			return nil // Return nil to use default schema generation for other types
-		},
+				return mapper(st)
+			},
+		}
+		s := sub.ReflectFromType(baseType)
+		s.Version = "" // suppress $schema on this nested schema
+		return s
 	}
-	s = r.Reflect(x)
+
+	r := jsonschema.Reflector{DoNotReference: true, Anonymous: true, Mapper: mapper}
+	s := r.Reflect(x)
 	s.Version = ""
-	s.ID = ""
 	return s
+}
+
+// anyStructSchema returns the "any" schema used to break recursion. Types
+// that implement json.Marshaler may serialize to a non-object, so we omit
+// `type: object` for them.
+func anyStructSchema(t reflect.Type) *jsonschema.Schema {
+	if t.Implements(jsonMarshalerType) || reflect.PointerTo(t).Implements(jsonMarshalerType) {
+		return &jsonschema.Schema{AdditionalProperties: jsonschema.TrueSchema}
+	}
+	return &jsonschema.Schema{
+		Type:                 "object",
+		AdditionalProperties: jsonschema.TrueSchema,
+	}
 }
 
 // MapToStruct converts a map[string]any to a struct of type T via JSON round-trip.

--- a/go/internal/base/json_test.go
+++ b/go/internal/base/json_test.go
@@ -19,6 +19,7 @@ package base
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -236,16 +237,24 @@ func TestInferJSONSchema_SharedType(t *testing.T) {
 		t.Fatal("expected properties in schema")
 	}
 
-	second, ok := properties["second"].(map[string]any)
-	if !ok {
-		t.Fatal("expected 'second' property in schema")
+	// A non-recursive shared struct type should produce the same full schema
+	// for every occurrence rather than collapsing to {additionalProperties: true}.
+	want := map[string]any{
+		"additionalProperties": false,
+		"type":                 "object",
+		"required":             []any{"amount"},
+		"properties": map[string]any{
+			"amount": map[string]any{"type": "number"},
+		},
 	}
-
-	if second["type"] != "object" {
-		t.Errorf("expected type: object for shared type occurrence, got %v", second["type"])
-	}
-	if second["additionalProperties"] != true {
-		t.Errorf("expected additionalProperties: true for shared type occurrence, got %v", second["additionalProperties"])
+	for _, name := range []string{"first", "second"} {
+		got, ok := properties[name].(map[string]any)
+		if !ok {
+			t.Fatalf("expected %q property in schema", name)
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("%q schema mismatch (-want +got):\n%s", name, diff)
+		}
 	}
 }
 
@@ -268,19 +277,88 @@ func TestInferJSONSchema_SharedTypeWithMarshaler(t *testing.T) {
 		t.Fatal("expected properties in schema")
 	}
 
-	second, ok := properties["B"].(map[string]any)
+	a, ok := properties["A"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'A' property in schema")
+	}
+	b, ok := properties["B"].(map[string]any)
 	if !ok {
 		t.Fatal("expected 'B' property in schema")
 	}
+	if diff := cmp.Diff(a, b); diff != "" {
+		t.Errorf("expected A and B to have identical schemas, diff:\n%s", diff)
+	}
+}
 
-	// type should be non-object because it implements json.Marshaler
-	if typ, hasType := second["type"]; hasType {
-		if typ == "object" {
-			t.Errorf("expected type to NOT be object for shared type with marshaler, got %v", typ)
-		}
+// TestInferJSONSchema_SharedTimeFields is a regression test for issue #5200:
+// `time.Time` used in two fields of the same struct must produce the correct
+// `{type: string, format: date-time}` schema for both fields.
+func TestInferJSONSchema_SharedTimeFields(t *testing.T) {
+	type Input struct {
+		StartsAfter  *time.Time `json:"starts_after,omitempty"`
+		StartsBefore *time.Time `json:"starts_before,omitempty"`
 	}
 
-	if val, ok := second["additionalProperties"]; !ok || val != true {
-		t.Errorf("expected additionalProperties: true, got %v", val)
+	schema := SchemaAsMap(InferJSONSchema(Input{}))
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("expected properties in schema")
+	}
+
+	want := map[string]any{
+		"type":   "string",
+		"format": "date-time",
+	}
+	for _, name := range []string{"starts_after", "starts_before"} {
+		got, ok := properties[name].(map[string]any)
+		if !ok {
+			t.Fatalf("expected %q property in schema", name)
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("%q schema mismatch (-want +got):\n%s", name, diff)
+		}
+	}
+}
+
+// TestInferJSONSchema_RecursiveSharedType verifies that a recursive type
+// used in multiple fields of the same struct still produces a usable schema
+// for every occurrence. Both fields should expand the same way; recursion is
+// only broken at the self-reference inside the type, not across siblings.
+func TestInferJSONSchema_RecursiveSharedType(t *testing.T) {
+	type Node struct {
+		Value    string  `json:"value,omitempty"`
+		Children []*Node `json:"children,omitempty"`
+	}
+	type Pair struct {
+		Left  Node `json:"left"`
+		Right Node `json:"right"`
+	}
+
+	schema := SchemaAsMap(InferJSONSchema(Pair{}))
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("expected properties in schema")
+	}
+
+	left, ok := properties["left"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'left' property in schema")
+	}
+	right, ok := properties["right"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'right' property in schema")
+	}
+	if diff := cmp.Diff(left, right); diff != "" {
+		t.Errorf("expected 'left' and 'right' schemas to match, diff:\n%s", diff)
+	}
+	if left["type"] != "object" {
+		t.Errorf("expected left.type=object, got %v", left["type"])
+	}
+	leftProps, ok := left["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'left' to have properties")
+	}
+	if _, ok := leftProps["value"]; !ok {
+		t.Errorf("expected 'left' schema to expose 'value' field, got %v", leftProps)
 	}
 }


### PR DESCRIPTION
Fixes #5200.

`InferJSONSchema` tracked struct types in a flat `seen` map and returned an "any" schema on every repeat encounter, so a non-recursive type used in two sibling fields collapsed to `{additionalProperties: true}` after the first occurrence:

```go
type Input struct {
    StartsAfter  *time.Time `json:"starts_after,omitempty"`
    StartsBefore *time.Time `json:"starts_before,omitempty"`
}
```

`starts_after` was reflected as `{type: string, format: date-time}` (correct), but `starts_before` came out as `{additionalProperties: true}`. Strict tool input APIs (e.g. Anthropic's) reject this with `Schema type is missing for schema: {'additionalProperties': True}`.

## Fix

Replace the flat seen-set with a true stack. While a struct type T is being reflected, T is marked in-progress; nested encounters of T return the "any" schema; T is unmarked when reflection completes. Each sibling/repeat occurrence then gets its own full reflection.

`jsonschema.Reflector.Mapper` only fires on entry, not exit, so the exit hook is synthesized by routing each struct type through a sub-Reflector. The Mapper closure's `defer delete(inProgress, baseType)` runs when `sub.ReflectFromType` returns, which is the exit point.

## Tests

- `TestInferJSONSchema_SharedTimeFields`: regression test for the issue's exact case.
- `TestInferJSONSchema_SharedType`, `TestInferJSONSchema_SharedTypeWithMarshaler`: updated to assert the fixed behavior (both occurrences full schema, identical to each other). The previous assertions accidentally locked in the buggy output.
- `TestInferJSONSchema_RecursiveSharedType`: new test confirming a recursive type used in two sibling fields still expands the same way in each location, with recursion broken only at self-references inside the type.
- Existing `TestSchemaAsMapRecursive` (true self-recursion via `[]*Node`) passes unchanged.

Full `go test ./...` passes.

Checklist:
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (unit tests added, full Go test suite passes)
- [ ] Docs updated (n/a, internal package)