### PR TITLE
feat(go/ai): per-tool strict schema control via WithStrict option

### DIFF
--- a/go/ai/gen.go
+++ b/go/ai/gen.go
@@ -529,6 +529,9 @@ type ToolDefinition struct {
 	Name string `json:"name,omitempty"`
 	// OutputSchema is a valid JSON Schema describing the output of the tool.
 	OutputSchema map[string]any `json:"outputSchema,omitempty"`
+	// Strict controls whether strict schema validation is enforced for this tool.
+	// When nil, the provider's default is used.
+	Strict *bool `json:"strict,omitempty"`
 }
 
 // A ToolRequest is a message from the model to the client that it should run a

--- a/go/ai/gen.go
+++ b/go/ai/gen.go
@@ -529,9 +529,6 @@ type ToolDefinition struct {
 	Name string `json:"name,omitempty"`
 	// OutputSchema is a valid JSON Schema describing the output of the tool.
 	OutputSchema map[string]any `json:"outputSchema,omitempty"`
-	// Strict controls whether strict schema validation is enforced for this tool.
-	// When nil, the provider's default is used.
-	Strict *bool `json:"strict,omitempty"`
 }
 
 // A ToolRequest is a message from the model to the client that it should run a

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -964,6 +964,7 @@ func WithToolRestarts(parts ...*Part) GenerateOption {
 // toolOptions holds configuration options for defining tools.
 type toolOptions struct {
 	inputOptions
+	Strict *bool
 }
 
 // ToolOption is an option for defining a tool.
@@ -973,7 +974,16 @@ type ToolOption interface {
 
 // applyTool applies the option to the tool options.
 func (o *toolOptions) applyTool(opts *toolOptions) error {
+	if o.Strict != nil {
+		opts.Strict = o.Strict
+	}
 	return o.inputOptions.applyTool(opts)
+}
+
+// WithStrict controls whether strict schema validation is enforced for this tool.
+// When not set, the provider's default is used.
+func WithStrict(strict bool) ToolOption {
+	return &toolOptions{Strict: &strict}
 }
 
 // promptExecutionOptions are options for generating a model response by executing a prompt.

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -964,7 +964,7 @@ func WithToolRestarts(parts ...*Part) GenerateOption {
 // toolOptions holds configuration options for defining tools.
 type toolOptions struct {
 	inputOptions
-	Strict *bool
+	StrictSchema *bool
 }
 
 // ToolOption is an option for defining a tool.
@@ -974,16 +974,24 @@ type ToolOption interface {
 
 // applyTool applies the option to the tool options.
 func (o *toolOptions) applyTool(opts *toolOptions) error {
-	if o.Strict != nil {
-		opts.Strict = o.Strict
+	if o.StrictSchema != nil {
+		if opts.StrictSchema != nil {
+			return errors.New("cannot set strict schema more than once (WithStrictSchema)")
+		}
+		opts.StrictSchema = o.StrictSchema
 	}
 	return o.inputOptions.applyTool(opts)
 }
 
-// WithStrict controls whether strict schema validation is enforced for this tool.
-// When not set, the provider's default is used.
-func WithStrict(strict bool) ToolOption {
-	return &toolOptions{Strict: &strict}
+// WithStrictSchema controls whether the provider enforces strict JSON schema
+// validation on this tool's input. Strict mode requires recursive
+// additionalProperties: false and may reject some JSON Schema keywords
+// (e.g. minItems/maxItems on Anthropic).
+//
+// When unset, the provider's default applies. Providers without strict-tool
+// support ignore this option.
+func WithStrictSchema(strict bool) ToolOption {
+	return &toolOptions{StrictSchema: &strict}
 }
 
 // promptExecutionOptions are options for generating a model response by executing a prompt.

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -63,7 +63,6 @@ type ToolDef[In, Out any] struct {
 	action    api.Action   // The underlying action.
 	multipart bool         // Whether this is a multipart-only tool.
 	registry  api.Registry // Registry for schema resolution. Set when registered.
-	strict    *bool        // Per-tool strict schema enforcement; nil means provider default.
 }
 
 // Tool represents a tool that can be called by a model.
@@ -294,10 +293,13 @@ func OriginalInputAs[T any](tc *ToolContext) (T, bool) {
 	return zero, false
 }
 
-// applyStrictMetadata persists the per-tool strict flag on the action metadata
-// under metadata["tool"]["strict"] so providers reading the action (rather than
-// the [ToolDef] wrapper) observe the same setting for both registered and
-// dynamic tools.
+// toolStrictKey is the metadata key under metadata["tool"] used to carry the
+// per-tool strict-schema flag through the action metadata and onto
+// [ToolDefinition.Metadata]. Plugins consume this key directly.
+const toolStrictKey = "strict"
+
+// applyStrictMetadata sets metadata["tool"][toolStrictKey] = *strict when
+// strict is non-nil. A nil value leaves the metadata untouched.
 func applyStrictMetadata(metadata map[string]any, strict *bool) {
 	if strict == nil {
 		return
@@ -307,7 +309,7 @@ func applyStrictMetadata(metadata map[string]any, strict *bool) {
 		toolMeta = map[string]any{}
 		metadata["tool"] = toolMeta
 	}
-	toolMeta["strict"] = *strict
+	toolMeta[toolStrictKey] = *strict
 }
 
 // DefineTool creates a new [ToolDef] and registers it.
@@ -334,14 +336,14 @@ func DefineTool[In, Out any](
 	}
 
 	metadata, wrappedFn := wrapToolFunc(name, description, fn)
-	applyStrictMetadata(metadata, toolOpts.Strict)
+	applyStrictMetadata(metadata, toolOpts.StrictSchema)
 	action := core.DefineAction(r, name, api.ActionTypeToolV2, metadata, toolOpts.InputSchema, wrappedFn)
 
 	// Also register under the "tool" action type for backward compatibility.
 	provider, id := api.ParseName(name)
 	r.RegisterAction(api.NewKey(api.ActionTypeTool, provider, id), action)
 
-	return &ToolDef[In, Out]{action: action, multipart: false, registry: r, strict: toolOpts.Strict}
+	return &ToolDef[In, Out]{action: action, multipart: false, registry: r}
 }
 
 // DefineToolWithInputSchema creates a new [ToolDef] with a custom input schema and registers it.
@@ -377,9 +379,9 @@ func NewTool[In, Out any](name, description string, fn ToolFunc[In, Out], opts .
 
 	metadata, wrappedFn := wrapToolFunc(name, description, fn)
 	metadata["dynamic"] = true
-	applyStrictMetadata(metadata, toolOpts.Strict)
+	applyStrictMetadata(metadata, toolOpts.StrictSchema)
 	action := core.NewAction(name, api.ActionTypeToolV2, metadata, toolOpts.InputSchema, wrappedFn)
-	return &ToolDef[In, Out]{action: action, multipart: false, strict: toolOpts.Strict}
+	return &ToolDef[In, Out]{action: action, multipart: false}
 }
 
 // NewToolWithInputSchema creates a new [ToolDef] with a custom input schema. It can be passed directly to [Generate].
@@ -406,9 +408,9 @@ func DefineMultipartTool[In any](
 	}
 
 	metadata, wrappedFn := wrapMultipartToolFunc(name, description, fn)
-	applyStrictMetadata(metadata, toolOpts.Strict)
+	applyStrictMetadata(metadata, toolOpts.StrictSchema)
 	action := core.DefineAction(r, name, api.ActionTypeToolV2, metadata, toolOpts.InputSchema, wrappedFn)
-	return &ToolDef[In, *MultipartToolResponse]{action: action, multipart: true, registry: r, strict: toolOpts.Strict}
+	return &ToolDef[In, *MultipartToolResponse]{action: action, multipart: true, registry: r}
 }
 
 // NewMultipartTool creates a new multipart [ToolDef]. It can be passed directly to [Generate].
@@ -424,9 +426,9 @@ func NewMultipartTool[In any](name, description string, fn MultipartToolFunc[In]
 
 	metadata, wrappedFn := wrapMultipartToolFunc(name, description, fn)
 	metadata["dynamic"] = true
-	applyStrictMetadata(metadata, toolOpts.Strict)
+	applyStrictMetadata(metadata, toolOpts.StrictSchema)
 	action := core.NewAction(name, api.ActionTypeToolV2, metadata, toolOpts.InputSchema, wrappedFn)
-	return &ToolDef[In, *MultipartToolResponse]{action: action, multipart: true, strict: toolOpts.Strict}
+	return &ToolDef[In, *MultipartToolResponse]{action: action, multipart: true}
 }
 
 // wrapToolFunc wraps a regular tool function to return MultipartToolResponse.
@@ -511,15 +513,21 @@ func (t *ToolDef[In, Out]) Definition() *ToolDefinition {
 		}
 	}
 
+	metadata := map[string]any{
+		"multipart": t.multipart,
+	}
+	if toolMeta, ok := desc.Metadata["tool"].(map[string]any); ok {
+		if s, ok := toolMeta[toolStrictKey].(bool); ok {
+			metadata[toolStrictKey] = s
+		}
+	}
+
 	return &ToolDefinition{
 		Name:         desc.Name,
 		Description:  desc.Description,
 		InputSchema:  inputSchema,
 		OutputSchema: outputSchema,
-		Strict:       t.strict,
-		Metadata: map[string]any{
-			"multipart": t.multipart,
-		},
+		Metadata:     metadata,
 	}
 }
 
@@ -589,20 +597,15 @@ func LookupTool(r api.Registry, name string) Tool {
 		return nil
 	}
 
-	// Check if it's a multipart-only tool
 	desc := action.Desc()
 	multipart := false
-	var strict *bool
 	if toolMeta, ok := desc.Metadata["tool"].(map[string]any); ok {
 		if mp, ok := toolMeta["multipart"].(bool); ok {
 			multipart = mp
 		}
-		if s, ok := toolMeta["strict"].(bool); ok {
-			strict = &s
-		}
 	}
 
-	return &ToolDef[any, any]{action: action, multipart: multipart, registry: r, strict: strict}
+	return &ToolDef[any, any]{action: action, multipart: multipart, registry: r}
 }
 
 // IsMultipart returns true if the tool is a multipart tool (tool.v2 only).

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -29,8 +29,10 @@ import (
 	"github.com/firebase/genkit/go/internal/base"
 )
 
-var resumedCtxKey = base.NewContextKey[map[string]any]()
-var origInputCtxKey = base.NewContextKey[any]()
+var (
+	resumedCtxKey   = base.NewContextKey[map[string]any]()
+	origInputCtxKey = base.NewContextKey[any]()
+)
 
 // ToolFunc is the function type for tool implementations.
 type ToolFunc[In, Out any] = func(ctx *ToolContext, input In) (Out, error)
@@ -61,6 +63,7 @@ type ToolDef[In, Out any] struct {
 	action    api.Action   // The underlying action.
 	multipart bool         // Whether this is a multipart-only tool.
 	registry  api.Registry // Registry for schema resolution. Set when registered.
+	strict    *bool        // Per-tool strict schema enforcement; nil means provider default.
 }
 
 // Tool represents a tool that can be called by a model.
@@ -291,6 +294,22 @@ func OriginalInputAs[T any](tc *ToolContext) (T, bool) {
 	return zero, false
 }
 
+// applyStrictMetadata persists the per-tool strict flag on the action metadata
+// under metadata["tool"]["strict"] so providers reading the action (rather than
+// the [ToolDef] wrapper) observe the same setting for both registered and
+// dynamic tools.
+func applyStrictMetadata(metadata map[string]any, strict *bool) {
+	if strict == nil {
+		return
+	}
+	toolMeta, _ := metadata["tool"].(map[string]any)
+	if toolMeta == nil {
+		toolMeta = map[string]any{}
+		metadata["tool"] = toolMeta
+	}
+	toolMeta["strict"] = *strict
+}
+
 // DefineTool creates a new [ToolDef] and registers it.
 // Use [WithInputSchema] to provide a custom JSON schema instead of inferring from the type parameter.
 func DefineTool[In, Out any](
@@ -315,13 +334,14 @@ func DefineTool[In, Out any](
 	}
 
 	metadata, wrappedFn := wrapToolFunc(name, description, fn)
+	applyStrictMetadata(metadata, toolOpts.Strict)
 	action := core.DefineAction(r, name, api.ActionTypeToolV2, metadata, toolOpts.InputSchema, wrappedFn)
 
 	// Also register under the "tool" action type for backward compatibility.
 	provider, id := api.ParseName(name)
 	r.RegisterAction(api.NewKey(api.ActionTypeTool, provider, id), action)
 
-	return &ToolDef[In, Out]{action: action, multipart: false, registry: r}
+	return &ToolDef[In, Out]{action: action, multipart: false, registry: r, strict: toolOpts.Strict}
 }
 
 // DefineToolWithInputSchema creates a new [ToolDef] with a custom input schema and registers it.
@@ -357,8 +377,9 @@ func NewTool[In, Out any](name, description string, fn ToolFunc[In, Out], opts .
 
 	metadata, wrappedFn := wrapToolFunc(name, description, fn)
 	metadata["dynamic"] = true
+	applyStrictMetadata(metadata, toolOpts.Strict)
 	action := core.NewAction(name, api.ActionTypeToolV2, metadata, toolOpts.InputSchema, wrappedFn)
-	return &ToolDef[In, Out]{action: action, multipart: false}
+	return &ToolDef[In, Out]{action: action, multipart: false, strict: toolOpts.Strict}
 }
 
 // NewToolWithInputSchema creates a new [ToolDef] with a custom input schema. It can be passed directly to [Generate].
@@ -385,8 +406,9 @@ func DefineMultipartTool[In any](
 	}
 
 	metadata, wrappedFn := wrapMultipartToolFunc(name, description, fn)
+	applyStrictMetadata(metadata, toolOpts.Strict)
 	action := core.DefineAction(r, name, api.ActionTypeToolV2, metadata, toolOpts.InputSchema, wrappedFn)
-	return &ToolDef[In, *MultipartToolResponse]{action: action, multipart: true, registry: r}
+	return &ToolDef[In, *MultipartToolResponse]{action: action, multipart: true, registry: r, strict: toolOpts.Strict}
 }
 
 // NewMultipartTool creates a new multipart [ToolDef]. It can be passed directly to [Generate].
@@ -402,8 +424,9 @@ func NewMultipartTool[In any](name, description string, fn MultipartToolFunc[In]
 
 	metadata, wrappedFn := wrapMultipartToolFunc(name, description, fn)
 	metadata["dynamic"] = true
+	applyStrictMetadata(metadata, toolOpts.Strict)
 	action := core.NewAction(name, api.ActionTypeToolV2, metadata, toolOpts.InputSchema, wrappedFn)
-	return &ToolDef[In, *MultipartToolResponse]{action: action, multipart: true}
+	return &ToolDef[In, *MultipartToolResponse]{action: action, multipart: true, strict: toolOpts.Strict}
 }
 
 // wrapToolFunc wraps a regular tool function to return MultipartToolResponse.
@@ -493,6 +516,7 @@ func (t *ToolDef[In, Out]) Definition() *ToolDefinition {
 		Description:  desc.Description,
 		InputSchema:  inputSchema,
 		OutputSchema: outputSchema,
+		Strict:       t.strict,
 		Metadata: map[string]any{
 			"multipart": t.multipart,
 		},
@@ -568,13 +592,17 @@ func LookupTool(r api.Registry, name string) Tool {
 	// Check if it's a multipart-only tool
 	desc := action.Desc()
 	multipart := false
+	var strict *bool
 	if toolMeta, ok := desc.Metadata["tool"].(map[string]any); ok {
 		if mp, ok := toolMeta["multipart"].(bool); ok {
 			multipart = mp
 		}
+		if s, ok := toolMeta["strict"].(bool); ok {
+			strict = &s
+		}
 	}
 
-	return &ToolDef[any, any]{action: action, multipart: multipart, registry: r}
+	return &ToolDef[any, any]{action: action, multipart: multipart, registry: r, strict: strict}
 }
 
 // IsMultipart returns true if the tool is a multipart tool (tool.v2 only).

--- a/go/ai/tools_test.go
+++ b/go/ai/tools_test.go
@@ -19,6 +19,7 @@ package ai
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -438,6 +439,119 @@ func TestLookupTool(t *testing.T) {
 		if got == nil {
 			t.Error("LookupTool returned nil for registered tool")
 		}
+	})
+}
+
+// TestWithStrictSchema verifies the strict-schema flag round-trips through
+// Definition().Metadata["strict"] and LookupTool, for both registered and
+// dynamic tools.
+func TestWithStrictSchema(t *testing.T) {
+	type runOnTool func(*testing.T, Tool)
+
+	t.Run("absent by default", func(t *testing.T) {
+		r := newTestRegistry(t)
+		tl := DefineTool(r, "strict/default", "no strict opt", func(ctx *ToolContext, input struct{}) (string, error) {
+			return "", nil
+		})
+		def := tl.Definition()
+		if _, ok := def.Metadata["strict"]; ok {
+			t.Errorf("expected strict metadata to be absent by default, got %v", def.Metadata["strict"])
+		}
+	})
+
+	check := func(want bool) runOnTool {
+		return func(t *testing.T, tl Tool) {
+			t.Helper()
+			def := tl.Definition()
+			got, ok := def.Metadata["strict"]
+			if !ok {
+				t.Fatalf("expected strict metadata to be present, got nothing")
+			}
+			if got != want {
+				t.Errorf("strict metadata = %v, want %v", got, want)
+			}
+		}
+	}
+
+	t.Run("DefineTool with WithStrictSchema(true) is surfaced on Definition", func(t *testing.T) {
+		r := newTestRegistry(t)
+		tl := DefineTool(r, "strict/registered-true", "registered strict",
+			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
+			WithStrictSchema(true),
+		)
+		check(true)(t, tl)
+	})
+
+	t.Run("DefineTool with WithStrictSchema(false) is surfaced on Definition", func(t *testing.T) {
+		r := newTestRegistry(t)
+		tl := DefineTool(r, "strict/registered-false", "registered loose",
+			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
+			WithStrictSchema(false),
+		)
+		check(false)(t, tl)
+	})
+
+	t.Run("LookupTool round-trips the strict flag for registered tools", func(t *testing.T) {
+		r := newTestRegistry(t)
+		DefineTool(r, "strict/lookup-true", "registered strict",
+			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
+			WithStrictSchema(true),
+		)
+		found := LookupTool(r, "strict/lookup-true")
+		if found == nil {
+			t.Fatal("LookupTool returned nil")
+		}
+		check(true)(t, found)
+	})
+
+	t.Run("LookupTool round-trips the strict flag for dynamic tools after Register", func(t *testing.T) {
+		r := newTestRegistry(t)
+		tl := NewTool("strict/dynamic-false", "dynamic loose",
+			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
+			WithStrictSchema(false),
+		)
+		check(false)(t, tl)
+
+		tl.Register(r)
+		found := LookupTool(r, "strict/dynamic-false")
+		if found == nil {
+			t.Fatal("LookupTool returned nil")
+		}
+		check(false)(t, found)
+	})
+
+	t.Run("DefineMultipartTool plumbs strict the same way", func(t *testing.T) {
+		r := newTestRegistry(t)
+		tl := DefineMultipartTool(r, "strict/multipart", "multipart strict",
+			func(ctx *ToolContext, input struct{}) (*MultipartToolResponse, error) {
+				return &MultipartToolResponse{}, nil
+			},
+			WithStrictSchema(true),
+		)
+		check(true)(t, tl)
+	})
+
+	t.Run("setting strict twice returns an error via panic", func(t *testing.T) {
+		// DefineTool surfaces applyTool errors as a panic.
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected panic from setting WithStrictSchema twice, got none")
+			}
+			msg, ok := r.(error)
+			if !ok {
+				t.Fatalf("expected error from panic, got %T: %v", r, r)
+			}
+			if got := msg.Error(); !strings.Contains(got, "strict schema") {
+				t.Errorf("expected panic to mention strict schema, got %q", got)
+			}
+		}()
+		r := newTestRegistry(t)
+		DefineTool(r, "strict/double-set", "double set",
+			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
+			WithStrictSchema(true),
+			WithStrictSchema(false),
+		)
 	})
 }
 

--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/internal/base"
+	pluginjsonschema "github.com/firebase/genkit/go/plugins/internal/jsonschema"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/packages/param"
 	"github.com/openai/openai-go/shared"
@@ -188,12 +189,27 @@ func (g *ModelGenerator) WithTools(tools []*ai.ToolDefinition) *ModelGenerator {
 			continue
 		}
 
+		// Strict mode is opt-in. When enabled, recursively set
+		// additionalProperties: false on every object subschema; the caller
+		// is responsible for OpenAI's other strict requirements (e.g. every
+		// property must be listed in "required").
+		strict := false
+		if v, ok := tool.Metadata["strict"].(bool); ok {
+			strict = v
+		}
+		var params openai.FunctionParameters
+		if strict {
+			params = openai.FunctionParameters(pluginjsonschema.EnforceStrict(tool.InputSchema))
+		} else {
+			params = openai.FunctionParameters(tool.InputSchema)
+		}
+
 		toolParams = append(toolParams, openai.ChatCompletionToolParam{
 			Function: (shared.FunctionDefinitionParam{
 				Name:        tool.Name,
 				Description: openai.String(tool.Description),
-				Parameters:  openai.FunctionParameters(tool.InputSchema),
-				Strict:      openai.Bool(false), // TODO: implement strict mode
+				Parameters:  params,
+				Strict:      openai.Bool(strict),
 			}),
 		})
 	}

--- a/go/plugins/compat_oai/generate_test.go
+++ b/go/plugins/compat_oai/generate_test.go
@@ -1,0 +1,133 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compat_oai
+
+import (
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/openai/openai-go"
+)
+
+// newGen returns a ModelGenerator with a nil client; only local tool-shaping
+// logic is exercised, so no network call is made.
+func newGen() *ModelGenerator {
+	return NewModelGenerator((*openai.Client)(nil), "test-model")
+}
+
+// TestWithTools_StrictDefaultsOff verifies the default behavior of sending
+// strict: false to OpenAI when the tool has no strict metadata.
+func TestWithTools_StrictDefaultsOff(t *testing.T) {
+	g := newGen().WithTools([]*ai.ToolDefinition{
+		{
+			Name:        "ping",
+			Description: "ping",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"msg": map[string]any{"type": "string"}},
+			},
+		},
+	})
+	if len(g.tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(g.tools))
+	}
+	fn := g.tools[0].Function
+	if !fn.Strict.Valid() || fn.Strict.Value {
+		t.Errorf("expected Strict=false by default, got valid=%v value=%v", fn.Strict.Valid(), fn.Strict.Value)
+	}
+	if _, present := fn.Parameters["additionalProperties"]; present {
+		t.Errorf("expected no additionalProperties when strict is off, got %v", fn.Parameters["additionalProperties"])
+	}
+}
+
+// TestWithTools_StrictOptIn verifies a tool with Metadata["strict"]=true is
+// sent with Strict=true and additionalProperties: false applied recursively.
+func TestWithTools_StrictOptIn(t *testing.T) {
+	g := newGen().WithTools([]*ai.ToolDefinition{
+		{
+			Name:        "weather",
+			Description: "get weather",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"location": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"city": map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+			Metadata: map[string]any{"strict": true},
+		},
+	})
+	if len(g.tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(g.tools))
+	}
+	fn := g.tools[0].Function
+	if !fn.Strict.Valid() || !fn.Strict.Value {
+		t.Errorf("expected Strict=true, got valid=%v value=%v", fn.Strict.Valid(), fn.Strict.Value)
+	}
+	if fn.Parameters["additionalProperties"] != false {
+		t.Errorf("expected top-level additionalProperties: false, got %v", fn.Parameters["additionalProperties"])
+	}
+	props, _ := fn.Parameters["properties"].(map[string]any)
+	loc, _ := props["location"].(map[string]any)
+	if loc["additionalProperties"] != false {
+		t.Errorf("expected nested additionalProperties: false on location, got %v", loc["additionalProperties"])
+	}
+}
+
+// TestWithTools_StrictExplicitFalse verifies an explicit opt-out matches the
+// default: Strict=false and the schema is not enforced.
+func TestWithTools_StrictExplicitFalse(t *testing.T) {
+	g := newGen().WithTools([]*ai.ToolDefinition{
+		{
+			Name:        "ping",
+			Description: "ping",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"msg": map[string]any{"type": "string"}},
+			},
+			Metadata: map[string]any{"strict": false},
+		},
+	})
+	fn := g.tools[0].Function
+	if !fn.Strict.Valid() || fn.Strict.Value {
+		t.Errorf("expected Strict=false, got valid=%v value=%v", fn.Strict.Valid(), fn.Strict.Value)
+	}
+	if _, present := fn.Parameters["additionalProperties"]; present {
+		t.Errorf("expected no additionalProperties when strict is off, got %v", fn.Parameters["additionalProperties"])
+	}
+}
+
+// TestWithTools_StrictDoesNotMutateCallerSchema guards against the caller's
+// input schema being mutated in place by strict-mode enforcement.
+func TestWithTools_StrictDoesNotMutateCallerSchema(t *testing.T) {
+	original := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"msg": map[string]any{"type": "string"}},
+	}
+	def := &ai.ToolDefinition{
+		Name:        "ping",
+		Description: "ping",
+		InputSchema: original,
+		Metadata:    map[string]any{"strict": true},
+	}
+	newGen().WithTools([]*ai.ToolDefinition{def})
+	if _, present := original["additionalProperties"]; present {
+		t.Errorf("caller schema was mutated: additionalProperties leaked into original input schema")
+	}
+}

--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -317,35 +317,40 @@ func toAnthropicTools(provider string, tools []*ai.ToolDefinition) ([]anthropic.
 			return nil, fmt.Errorf("tool name must match regex: %s", ToolNameRegex)
 		}
 
-		var schema anthropic.ToolInputSchemaParam
 		inputSchema := t.InputSchema
 		if len(inputSchema) == 0 {
 			inputSchema = map[string]any{"type": "object", "properties": map[string]any{}}
 		}
 
-		// Strict tools require additionalProperties: false recursively
-		var strictInputSchema map[string]any
-		if b, err := json.Marshal(inputSchema); err != nil {
-			return nil, fmt.Errorf("failed to clone tool input schema: %w", err)
-		} else if err := json.Unmarshal(b, &strictInputSchema); err != nil {
-			return nil, fmt.Errorf("failed to clone tool input schema: %w", err)
-		}
-		enforceStrictSchema(strictInputSchema)
-		inputSchema = strictInputSchema
+		// Strict is the provider default (true) unless the tool explicitly opts out.
+		strict := provider != "vertexai" && (t.Strict == nil || *t.Strict)
 
-		var err error
-		schema, err = base.MapToStruct[anthropic.ToolInputSchemaParam](inputSchema)
+		// Strict mode requires additionalProperties: false recursively throughout the schema.
+		if strict {
+			var strictInputSchema map[string]any
+			if b, err := json.Marshal(inputSchema); err != nil {
+				return nil, fmt.Errorf("failed to clone tool input schema: %w", err)
+			} else if err := json.Unmarshal(b, &strictInputSchema); err != nil {
+				return nil, fmt.Errorf("failed to clone tool input schema: %w", err)
+			}
+			enforceStrictSchema(strictInputSchema)
+			inputSchema = strictInputSchema
+		}
+
+		schema, err := base.MapToStruct[anthropic.ToolInputSchemaParam](inputSchema)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse tool input schema: %w", err)
 		}
 
 		// ToolInputSchemaParam struct doesn't have AdditionalProperties field,
 		// so we must add it to ExtraFields manually for the top-level schema.
-		if schema.ExtraFields == nil {
-			schema.ExtraFields = make(map[string]any)
-		}
-		if t, ok := inputSchema["type"].(string); ok && t == "object" {
-			schema.ExtraFields["additionalProperties"] = false
+		if strict {
+			if schema.ExtraFields == nil {
+				schema.ExtraFields = make(map[string]any)
+			}
+			if typ, ok := inputSchema["type"].(string); ok && typ == "object" {
+				schema.ExtraFields["additionalProperties"] = false
+			}
 		}
 
 		tool := &anthropic.ToolParam{
@@ -353,8 +358,10 @@ func toAnthropicTools(provider string, tools []*ai.ToolDefinition) ([]anthropic.
 			Description: anthropic.String(t.Description),
 			InputSchema: schema,
 		}
-		// Vertex AI's Anthropic endpoint does not support the strict field.
-		if provider != "vertexai" {
+		// Only set strict when true. Sending strict: false still triggers
+		// Anthropic's supported-keywords validator (which rejects e.g.
+		// maxItems/minItems); omitting the field skips validation entirely.
+		if strict {
 			tool.Strict = anthropic.Bool(true)
 		}
 		resp = append(resp, anthropic.ToolUnionParam{OfTool: tool})

--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -28,6 +28,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/base"
+	pluginjsonschema "github.com/firebase/genkit/go/plugins/internal/jsonschema"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
 	"github.com/invopop/jsonschema"
 
@@ -261,18 +262,10 @@ func toAnthropicRequest(provider string, i *ai.ModelRequest) (*anthropic.Message
 	req.Tools = tools
 
 	if i.Output != nil && i.Output.Format == "json" && i.Output.Schema != nil && i.Output.Constrained {
-		// Native structured output via OutputConfig
-		var outputSchema map[string]any
-		if b, err := json.Marshal(i.Output.Schema); err != nil {
-			return nil, fmt.Errorf("failed to clone output schema: %w", err)
-		} else if err := json.Unmarshal(b, &outputSchema); err != nil {
-			return nil, fmt.Errorf("failed to clone output schema: %w", err)
-		}
-		enforceStrictSchema(outputSchema)
-
+		// Native structured output via OutputConfig.
 		req.OutputConfig = anthropic.OutputConfigParam{
 			Format: anthropic.JSONOutputFormatParam{
-				Schema: outputSchema,
+				Schema: pluginjsonschema.EnforceStrict(i.Output.Schema),
 				// Type is elided, defaults to "json_schema"
 			},
 		}
@@ -322,19 +315,17 @@ func toAnthropicTools(provider string, tools []*ai.ToolDefinition) ([]anthropic.
 			inputSchema = map[string]any{"type": "object", "properties": map[string]any{}}
 		}
 
-		// Strict is the provider default (true) unless the tool explicitly opts out.
-		strict := provider != "vertexai" && (t.Strict == nil || *t.Strict)
+		// Vertex AI's Anthropic endpoint does not support the strict field;
+		// elsewhere, strict is the default unless the tool opts out.
+		strictSupported := provider != "vertexai"
+		strictRequested := true
+		if v, ok := t.Metadata["strict"].(bool); ok {
+			strictRequested = v
+		}
+		strict := strictSupported && strictRequested
 
-		// Strict mode requires additionalProperties: false recursively throughout the schema.
 		if strict {
-			var strictInputSchema map[string]any
-			if b, err := json.Marshal(inputSchema); err != nil {
-				return nil, fmt.Errorf("failed to clone tool input schema: %w", err)
-			} else if err := json.Unmarshal(b, &strictInputSchema); err != nil {
-				return nil, fmt.Errorf("failed to clone tool input schema: %w", err)
-			}
-			enforceStrictSchema(strictInputSchema)
-			inputSchema = strictInputSchema
+			inputSchema = pluginjsonschema.EnforceStrict(inputSchema)
 		}
 
 		schema, err := base.MapToStruct[anthropic.ToolInputSchemaParam](inputSchema)
@@ -368,27 +359,6 @@ func toAnthropicTools(provider string, tools []*ai.ToolDefinition) ([]anthropic.
 	}
 
 	return resp, nil
-}
-
-// enforceStrictSchema is a helper function that sets additionalProperties to false
-// for every object in a schema
-func enforceStrictSchema(schema map[string]any) {
-	if t, ok := schema["type"].(string); ok && t == "object" {
-		schema["additionalProperties"] = false
-		if props, ok := schema["properties"].(map[string]any); ok {
-			for _, v := range props {
-				if subSchema, ok := v.(map[string]any); ok {
-					enforceStrictSchema(subSchema)
-				}
-			}
-		}
-	}
-	// recursively enforce additionalProperties to false
-	if t, ok := schema["type"].(string); ok && t == "array" {
-		if items, ok := schema["items"].(map[string]any); ok {
-			enforceStrictSchema(items)
-		}
-	}
 }
 
 // toAnthropicParts translates [ai.Part] to an anthropic.ContentBlockParamUnion type

--- a/go/plugins/internal/anthropic/anthropic_test.go
+++ b/go/plugins/internal/anthropic/anthropic_test.go
@@ -204,6 +204,37 @@ func TestToAnthropicTools(t *testing.T) {
 			},
 		},
 		{
+			name: "tool with strict opt-out omits the strict field",
+			tools: []*ai.ToolDefinition{
+				{
+					Name:        "loose-tool",
+					Description: "tool that opts out of strict",
+					InputSchema: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"items": map[string]any{
+								"type":     "array",
+								"maxItems": 5,
+							},
+						},
+					},
+					Strict: func() *bool { b := false; return &b }(),
+				},
+			},
+			check: func(t *testing.T, got []anthropic.ToolUnionParam) {
+				if len(got) != 1 {
+					t.Fatalf("expected 1 tool, got %d", len(got))
+				}
+				tool := got[0].OfTool
+				if tool.Strict.Valid() {
+					t.Errorf("expected Strict to be omitted, got value=%v", tool.Strict.Value)
+				}
+				if _, ok := tool.InputSchema.ExtraFields["additionalProperties"]; ok {
+					t.Errorf("expected additionalProperties to be absent, got %v", tool.InputSchema.ExtraFields["additionalProperties"])
+				}
+			},
+		},
+		{
 			name: "empty tool name",
 			tools: []*ai.ToolDefinition{
 				{

--- a/go/plugins/internal/anthropic/anthropic_test.go
+++ b/go/plugins/internal/anthropic/anthropic_test.go
@@ -218,7 +218,7 @@ func TestToAnthropicTools(t *testing.T) {
 							},
 						},
 					},
-					Strict: func() *bool { b := false; return &b }(),
+					Metadata: map[string]any{"strict": false},
 				},
 			},
 			check: func(t *testing.T, got []anthropic.ToolUnionParam) {
@@ -231,6 +231,50 @@ func TestToAnthropicTools(t *testing.T) {
 				}
 				if _, ok := tool.InputSchema.ExtraFields["additionalProperties"]; ok {
 					t.Errorf("expected additionalProperties to be absent, got %v", tool.InputSchema.ExtraFields["additionalProperties"])
+				}
+				// maxItems must be preserved when strict is off.
+				items, _ := tool.InputSchema.Properties.(map[string]any)["items"].(map[string]any)
+				if items["maxItems"] != float64(5) {
+					t.Errorf("expected maxItems to be preserved, got %v", items["maxItems"])
+				}
+			},
+		},
+		{
+			name: "tool with explicit strict=true still enforces additionalProperties",
+			tools: []*ai.ToolDefinition{
+				{
+					Name:        "explicit-strict",
+					Description: "tool that opts in to strict explicitly",
+					InputSchema: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"nested": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"x": map[string]any{"type": "string"},
+								},
+							},
+						},
+					},
+					Metadata: map[string]any{"strict": true},
+				},
+			},
+			check: func(t *testing.T, got []anthropic.ToolUnionParam) {
+				if len(got) != 1 {
+					t.Fatalf("expected 1 tool, got %d", len(got))
+				}
+				tool := got[0].OfTool
+				if !tool.Strict.Valid() || !tool.Strict.Value {
+					t.Errorf("expected Strict=true, got valid=%v value=%v", tool.Strict.Valid(), tool.Strict.Value)
+				}
+				if tool.InputSchema.ExtraFields["additionalProperties"] != false {
+					t.Errorf("expected top-level additionalProperties: false, got %v", tool.InputSchema.ExtraFields["additionalProperties"])
+				}
+				// Nested object must also have additionalProperties: false.
+				props, _ := tool.InputSchema.Properties.(map[string]any)
+				nested, _ := props["nested"].(map[string]any)
+				if nested["additionalProperties"] != false {
+					t.Errorf("expected nested additionalProperties: false, got %v", nested["additionalProperties"])
 				}
 			},
 		},
@@ -264,6 +308,61 @@ func TestToAnthropicTools(t *testing.T) {
 			}
 			if tt.check != nil {
 				tt.check(t, got)
+			}
+		})
+	}
+}
+
+// TestToAnthropicToolsVertex verifies the strict field is never set when the
+// provider is "vertexai", regardless of the tool's strict metadata.
+func TestToAnthropicToolsVertex(t *testing.T) {
+	tests := []struct {
+		name string
+		tool *ai.ToolDefinition
+	}{
+		{
+			name: "default strict is downgraded on vertex",
+			tool: &ai.ToolDefinition{
+				Name:        "default-tool",
+				Description: "default strict behavior",
+				InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+			},
+		},
+		{
+			name: "explicit strict=true is downgraded on vertex",
+			tool: &ai.ToolDefinition{
+				Name:        "explicit-strict-vertex",
+				Description: "user explicitly opted into strict but vertex does not support it",
+				InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+				Metadata:    map[string]any{"strict": true},
+			},
+		},
+		{
+			name: "explicit strict=false is also downgraded on vertex",
+			tool: &ai.ToolDefinition{
+				Name:        "explicit-loose-vertex",
+				Description: "user opted out and vertex doesn't support strict anyway",
+				InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+				Metadata:    map[string]any{"strict": false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toAnthropicTools("vertexai", []*ai.ToolDefinition{tt.tool})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("expected 1 tool, got %d", len(got))
+			}
+			tool := got[0].OfTool
+			if tool.Strict.Valid() {
+				t.Errorf("expected Strict to be unset on vertex, got value=%v", tool.Strict.Value)
+			}
+			if _, ok := tool.InputSchema.ExtraFields["additionalProperties"]; ok {
+				t.Errorf("expected additionalProperties to be absent on vertex, got %v", tool.InputSchema.ExtraFields["additionalProperties"])
 			}
 		})
 	}

--- a/go/plugins/internal/jsonschema/strict.go
+++ b/go/plugins/internal/jsonschema/strict.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package jsonschema contains JSON Schema helpers shared by Genkit provider plugins.
+package jsonschema
+
+import "encoding/json"
+
+// EnforceStrict returns a deep copy of schema with additionalProperties: false
+// set on every object subschema, recursing through "properties" and "items".
+// This is the shape OpenAI and Anthropic require for strict tool schemas.
+//
+// The input is not mutated. If the schema is not JSON-marshalable, the
+// original map is returned unchanged.
+func EnforceStrict(schema map[string]any) map[string]any {
+	if schema == nil {
+		return nil
+	}
+	var cloned map[string]any
+	b, err := json.Marshal(schema)
+	if err != nil {
+		return schema
+	}
+	if err := json.Unmarshal(b, &cloned); err != nil {
+		return schema
+	}
+	enforceStrict(cloned)
+	return cloned
+}
+
+// enforceStrict mutates schema in place. Callers must clone first.
+func enforceStrict(schema map[string]any) {
+	if t, ok := schema["type"].(string); ok && t == "object" {
+		schema["additionalProperties"] = false
+		if props, ok := schema["properties"].(map[string]any); ok {
+			for _, v := range props {
+				if subSchema, ok := v.(map[string]any); ok {
+					enforceStrict(subSchema)
+				}
+			}
+		}
+	}
+	if t, ok := schema["type"].(string); ok && t == "array" {
+		if items, ok := schema["items"].(map[string]any); ok {
+			enforceStrict(items)
+		}
+	}
+}

--- a/go/plugins/internal/jsonschema/strict_test.go
+++ b/go/plugins/internal/jsonschema/strict_test.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonschema
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEnforceStrict_NilReturnsNil(t *testing.T) {
+	if got := EnforceStrict(nil); got != nil {
+		t.Errorf("EnforceStrict(nil) = %v, want nil", got)
+	}
+}
+
+func TestEnforceStrict_TopLevelObject(t *testing.T) {
+	got := EnforceStrict(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+	})
+	if got["additionalProperties"] != false {
+		t.Errorf("missing additionalProperties on top-level object: %v", got)
+	}
+}
+
+func TestEnforceStrict_RecursesIntoNestedObjects(t *testing.T) {
+	got := EnforceStrict(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"outer": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"inner": map[string]any{
+						"type":       "object",
+						"properties": map[string]any{},
+					},
+				},
+			},
+		},
+	})
+
+	outer := got["properties"].(map[string]any)["outer"].(map[string]any)
+	if outer["additionalProperties"] != false {
+		t.Errorf("missing additionalProperties on nested object: %v", outer)
+	}
+	inner := outer["properties"].(map[string]any)["inner"].(map[string]any)
+	if inner["additionalProperties"] != false {
+		t.Errorf("missing additionalProperties on doubly-nested object: %v", inner)
+	}
+}
+
+func TestEnforceStrict_RecursesIntoArrayItems(t *testing.T) {
+	got := EnforceStrict(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"list": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{},
+				},
+			},
+		},
+	})
+	list := got["properties"].(map[string]any)["list"].(map[string]any)
+	items := list["items"].(map[string]any)
+	if items["additionalProperties"] != false {
+		t.Errorf("missing additionalProperties on array items: %v", items)
+	}
+}
+
+func TestEnforceStrict_DoesNotMutateInput(t *testing.T) {
+	input := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+	}
+	// Snapshot a deep-ish copy for comparison.
+	snapshot := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+	}
+	_ = EnforceStrict(input)
+	if !reflect.DeepEqual(input, snapshot) {
+		t.Errorf("input was mutated: got %v, want %v", input, snapshot)
+	}
+}
+
+func TestEnforceStrict_LeavesNonObjectsAlone(t *testing.T) {
+	got := EnforceStrict(map[string]any{
+		"type": "string",
+	})
+	if _, present := got["additionalProperties"]; present {
+		t.Errorf("did not expect additionalProperties on non-object schema, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #5230 

This is backwards compatible so users who don't define strict will be automatically marked as strict (previous behavior). Right now we define a strict parameter in `go/ai/gen.go`, but it's only used for the anthropic plugin however I believe it sets the foundation to use `strict` in other providers (I noticed there was a todo for the openai plugin). I've tested locally and it properly sets tools as strict that are marked as strict, tools that are marked as not strict are not strict and tools with no strict field set are still strict





