### PR TITLE
chore(dependabot): add project config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Maintain dependencies for the root JS (pnpm)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-dependencies:
+        patterns:
+          - "*"
+
+  # Maintain dependencies for the core JS workspace
+  - package-ecosystem: "npm"
+    directory: "/js"
+    schedule:
+      interval: "weekly"
+    groups:
+      js-dependencies:
+        patterns:
+          - "*"
+
+  # Maintain dependencies for genkit-tools
+  - package-ecosystem: "npm"
+    directory: "/genkit-tools"
+    schedule:
+      interval: "weekly"
+    groups:
+      tools-dependencies:
+        patterns:
+          - "*"
+
+  # Maintain dependencies for Go
+  - package-ecosystem: "gomod"
+    directory: "/go"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  # Maintain dependencies for Python (uv workspace)
+  - package-ecosystem: "uv"
+    directory: "/py"
+    schedule:
+      interval: "weekly"
+    groups:
+      py-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Reduce noise by grouping PRs into high leve groups on a weekly schedule.

We talked about trying to do something like this a while back. I'm on "rotation" this week -- so finally getting around to it.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
