### PR TITLE
fix(tools): restrict CORS origin in Dev UI server

### DIFF
--- a/genkit-tools/common/src/server/server.ts
+++ b/genkit-tools/common/src/server/server.ts
@@ -90,7 +90,6 @@ export function startServer(manager: BaseRuntimeManager, port: number) {
   let server: Server;
   const app = express();
 
-  // Only allow localhost origins (matching telemetry server pattern)
   app.use(
     cors({
       origin: /^http:\/\/localhost:\d+$/,

--- a/genkit-tools/common/src/server/server.ts
+++ b/genkit-tools/common/src/server/server.ts
@@ -90,10 +90,10 @@ export function startServer(manager: BaseRuntimeManager, port: number) {
   let server: Server;
   const app = express();
 
-  // Allow all origins and expose trace ID header
+  // Only allow localhost origins (matching telemetry server pattern)
   app.use(
     cors({
-      origin: '*',
+      origin: /^http:\/\/localhost:\d+$/,
       allowedHeaders: ['Content-Type'],
       exposedHeaders: ['X-Genkit-Trace-Id'],
     })


### PR DESCRIPTION
## Summary

The Dev UI server has two security issues:

1. **CORS wildcard** (`server.ts`): `Access-Control-Allow-Origin: *` is hardcoded, allowing any website to make cross-origin requests and read responses.

2. **Environment variable disclosure** (`router.ts`): `getGenkitEnvironment` returns every environment variable without filtering, including `GOOGLE_API_KEY`, `GEMINI_API_KEY`, and other secrets.

Combined, any website a developer visits while running `genkit start` can silently read all their API keys via cross-origin fetch.

## Fix

- Restrict CORS origin to `http://localhost:{port}` (the Dev UI itself)
- Filter environment variables matching sensitive patterns (KEY, SECRET, PASSWORD, TOKEN, CREDENTIAL, PRIVATE) from the response

## Reproduction

```bash
genkit start
# From any webpage:
# fetch('http://localhost:4000/api/getGenkitEnvironment').then(r=>r.json()).then(console.log)
# Returns all env vars including GOOGLE_API_KEY
```