### PR TITLE
fix(py): Make plugin init state loop-local to fix cross-loop Task error

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -332,7 +332,9 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         Args:
             input: Template variables for rendering.
         """
-        return await self._call_impl(input, opts)  # ty: ignore[invalid-argument-type]  # ty doesn't infer Unpack[TD] as TD in function body (PEP 692 gap)
+        return await self._call_impl(
+            input, opts
+        )  # ty: ignore[invalid-argument-type]  # ty doesn't infer Unpack[TD] as TD in function body (PEP 692 gap)
 
     async def _call_impl(
         self,
@@ -521,7 +523,9 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         Same keyword options as ``__call__`` (see PromptGenerateOptions).
         """
         await self._ensure_resolved()
-        return await self._render_impl(input, opts)  # ty: ignore[invalid-argument-type]  # ty doesn't infer Unpack[TD] as TD in function body (PEP 692 gap)
+        return await self._render_impl(
+            input, opts
+        )  # ty: ignore[invalid-argument-type]  # ty doesn't infer Unpack[TD] as TD in function body (PEP 692 gap)
 
 
 def register_prompt_actions(

--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -332,9 +332,7 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         Args:
             input: Template variables for rendering.
         """
-        return await self._call_impl(
-            input, opts
-        )  # ty: ignore[invalid-argument-type]  # ty doesn't infer Unpack[TD] as TD in function body (PEP 692 gap)
+        return await self._call_impl(input, opts)  # ty: ignore[invalid-argument-type]  # ty doesn't infer Unpack[TD] as TD in function body (PEP 692 gap)
 
     async def _call_impl(
         self,
@@ -523,9 +521,7 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         Same keyword options as ``__call__`` (see PromptGenerateOptions).
         """
         await self._ensure_resolved()
-        return await self._render_impl(
-            input, opts
-        )  # ty: ignore[invalid-argument-type]  # ty doesn't infer Unpack[TD] as TD in function body (PEP 692 gap)
+        return await self._render_impl(input, opts)  # ty: ignore[invalid-argument-type]  # ty doesn't infer Unpack[TD] as TD in function body (PEP 692 gap)
 
 
 def register_prompt_actions(

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -423,12 +423,12 @@ class Registry:
 
     async def initialize_all_plugins(self) -> None:
         """Run ``init()`` for every plugin on this registry exactly once per event loop.
+
         Skip setting _all_plugins_initialized if a new plugin was registered
         during initialization.
 
         Used before enumerating registered actions so plugin-registered entries exist in ``_entries``.
         """
-
         loop = asyncio.get_running_loop()
         if self._all_plugins_initialized.get(loop):
             return

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -422,13 +422,13 @@ class Registry:
             self._all_plugins_initialized.clear()
 
     async def initialize_all_plugins(self) -> None:
-        """
-        Run ``init()`` for every plugin on this registry exactly once per event loop.
+        """Run ``init()`` for every plugin on this registry exactly once per event loop.
         Skip setting _all_plugins_initialized if a new plugin was registered
         during initialization.
 
         Used before enumerating registered actions so plugin-registered entries exist in ``_entries``.
         """
+        
         loop = asyncio.get_running_loop()
         if self._all_plugins_initialized.get(loop):
             return

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -164,12 +164,12 @@ class Registry:
         #   we key both the in-flight task cache and the "all done" flag by the
         #   running loop.
         self._plugins: dict[str, Plugin] = {}
-        self._plugin_init_tasks: weakref.WeakKeyDictionary[
-            asyncio.AbstractEventLoop, dict[str, asyncio.Task[None]]
-        ] = weakref.WeakKeyDictionary()
-        self._all_plugins_initialized: weakref.WeakKeyDictionary[
-            asyncio.AbstractEventLoop, bool
-        ] = weakref.WeakKeyDictionary()
+        self._plugin_init_tasks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Task[None]]] = (
+            weakref.WeakKeyDictionary()
+        )
+        self._all_plugins_initialized: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, bool] = (
+            weakref.WeakKeyDictionary()
+        )
 
     # -------------------------------------------------------------------------
     # Child registry support

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -422,7 +422,8 @@ class Registry:
             self._all_plugins_initialized.clear()
 
     async def initialize_all_plugins(self) -> None:
-        """Run ``init()`` for every plugin on this registry exactly once per event loop.
+        """
+        Run ``init()`` for every plugin on this registry exactly once per event loop.
         Skip setting _all_plugins_initialized if a new plugin was registered
         during initialization.
 

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import weakref
 from collections.abc import Awaitable, Callable
 from typing import cast
 
@@ -163,12 +164,12 @@ class Registry:
         #   we key both the in-flight task cache and the "all done" flag by the
         #   running loop.
         self._plugins: dict[str, Plugin] = {}
-        self._plugin_init_tasks: dict[
+        self._plugin_init_tasks: weakref.WeakKeyDictionary[
             asyncio.AbstractEventLoop, dict[str, asyncio.Task[None]]
-        ] = {}
-        self._all_plugins_initialized: dict[
+        ] = weakref.WeakKeyDictionary()
+        self._all_plugins_initialized: weakref.WeakKeyDictionary[
             asyncio.AbstractEventLoop, bool
-        ] = {}
+        ] = weakref.WeakKeyDictionary()
 
     # -------------------------------------------------------------------------
     # Child registry support
@@ -432,7 +433,9 @@ class Registry:
             plugin_names = list(self._plugins.keys())
         for name in plugin_names:
             await self._ensure_plugin_initialized(name)
-        self._all_plugins_initialized[loop] = True
+        with self._lock:
+            if len(self._plugins) == len(plugin_names):
+                self._all_plugins_initialized[loop] = True
 
     async def _ensure_plugin_initialized(self, plugin_name: str) -> None:
         """Ensure a plugin is initialized exactly once.

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -422,7 +422,9 @@ class Registry:
             self._all_plugins_initialized.clear()
 
     async def initialize_all_plugins(self) -> None:
-        """Run ``init()`` for every plugin on this registry exactly once per event loop (until a new plugin is registered).
+        """Run ``init()`` for every plugin on this registry exactly once per event loop.
+        Skip setting _all_plugins_initialized if a new plugin was registered
+        during initialization.
 
         Used before enumerating registered actions so plugin-registered entries exist in ``_entries``.
         """

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -157,13 +157,18 @@ class Registry:
         # - Registry state is protected by the thread lock (`_lock`) because the dev
         #   reflection server runs in a separate OS thread and inspects the same
         #   registry instance.
-        # - Plugin initialization is lazy and "init-once" via an in-flight task
-        #   cache (`_plugin_init_tasks`). This assumes a single asyncio event loop
-        #   drives plugin initialization for a given registry instance. (The dev
-        #   reflection server schedules coroutines onto that loop.)
+        # - Plugin initialization is lazy and "init-once" per event loop.  The dev
+        #   reflection server runs asyncio.run() in its own daemon thread, which
+        #   creates a second event loop.  asyncio.Task objects are loop-bound, so
+        #   we key both the in-flight task cache and the "all done" flag by the
+        #   running loop.
         self._plugins: dict[str, Plugin] = {}
-        self._plugin_init_tasks: dict[str, asyncio.Task[None]] = {}
-        self._all_plugins_initialized: bool = False
+        self._plugin_init_tasks: dict[
+            asyncio.AbstractEventLoop, dict[str, asyncio.Task[None]]
+        ] = {}
+        self._all_plugins_initialized: dict[
+            asyncio.AbstractEventLoop, bool
+        ] = {}
 
     # -------------------------------------------------------------------------
     # Child registry support
@@ -413,20 +418,21 @@ class Registry:
             if plugin.name in self._plugins:
                 raise ValueError(f'Plugin {plugin.name} already registered')
             self._plugins[plugin.name] = plugin
-            self._all_plugins_initialized = False
+            self._all_plugins_initialized.clear()
 
     async def initialize_all_plugins(self) -> None:
-        """Run ``init()`` for every plugin on this registry exactly once (until a new plugin is registered).
+        """Run ``init()`` for every plugin on this registry exactly once per event loop.
 
         Used before enumerating registered actions so plugin-registered entries exist in ``_entries``.
         """
-        if self._all_plugins_initialized:
+        loop = asyncio.get_running_loop()
+        if self._all_plugins_initialized.get(loop):
             return
         with self._lock:
             plugin_names = list(self._plugins.keys())
         for name in plugin_names:
             await self._ensure_plugin_initialized(name)
-        self._all_plugins_initialized = True
+        self._all_plugins_initialized[loop] = True
 
     async def _ensure_plugin_initialized(self, plugin_name: str) -> None:
         """Ensure a plugin is initialized exactly once.
@@ -443,8 +449,14 @@ class Registry:
         # IMPORTANT: Do not hold `_lock` across any `await`. The critical section
         # below is sync-only (dict access + task creation), so it is safe to use
         # `_lock` to make the init-once behavior atomic across threads/tasks.
+        #
+        # Tasks are loop-bound: key the cache by the running loop so that the
+        # reflection server thread (which calls asyncio.run() and gets its own
+        # loop) never awaits a Task created on the main application loop.
+        loop = asyncio.get_running_loop()
         with self._lock:
-            task = self._plugin_init_tasks.get(plugin_name)
+            loop_tasks = self._plugin_init_tasks.setdefault(loop, {})
+            task = loop_tasks.get(plugin_name)
             if task is None:
                 plugin = self._plugins.get(plugin_name)
                 if plugin is None:
@@ -458,7 +470,7 @@ class Registry:
                         self.register_action_instance(action, namespace=plugin_name)
 
                 task = asyncio.create_task(run_init())
-                self._plugin_init_tasks[plugin_name] = task
+                loop_tasks[plugin_name] = task
 
         await task
 

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -428,7 +428,7 @@ class Registry:
 
         Used before enumerating registered actions so plugin-registered entries exist in ``_entries``.
         """
-        
+
         loop = asyncio.get_running_loop()
         if self._all_plugins_initialized.get(loop):
             return

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -422,7 +422,7 @@ class Registry:
             self._all_plugins_initialized.clear()
 
     async def initialize_all_plugins(self) -> None:
-        """Run ``init()`` for every plugin on this registry exactly once per event loop.
+        """Run ``init()`` for every plugin on this registry exactly once per event loop (until a new plugin is registered).
 
         Used before enumerating registered actions so plugin-registered entries exist in ``_entries``.
         """


### PR DESCRIPTION
This fixes a bug around cross-event-loop contamination by ensuring that `_ensure_plugin_initialized()` is loop-local. This function happens to be called in multiple event loops at the same time, causing a `RuntimeError: Task <...> got Future <...> attached to a different loop` bug when starting samples with `genkit start`. Bug was introduced in https://github.com/genkit-ai/genkit/pull/5073

Context:
When running with samples with Dev UI via `genkit start`, ai.run_main() launches the reflection server in a background thread using asyncio.run(), which creates a second event loop (Loop B) alongside the main app's loop (Loop A).

We refactored the reflection server to initialize plugins during the startup hook so that we pre-fetch models before user ever tries to load the Dev UI.

As a result, both loops call `_ensure_plugin_initialized()` at startup — Loop B via the startup lifecycle hook, Loop A from the first generate() / prompt() call. 

The old implementation stored plugin init Tasks in a plain dict[str, asyncio.Task]. Whichever loop ran first would store its Task there; the other loop would find it and await it — but asyncio.Task objects are permanently bound to the loop that created them. Awaiting a Task across loops raises:

```RuntimeError: Task <...> got Future <...> attached to a different loop```

Fix: change _plugin_init_tasks and _all_plugins_initialized from flat dicts to dict[asyncio.AbstractEventLoop, ...], keyed by the running loop. Each loop now gets its own Task and its own initialized flag, so no loop ever sees or awaits a Task it didn't create.