### PR TITLE
fix(js/plugins/middleware): propagate ToolInterruptError through filesystem handler

### DIFF
--- a/js/plugins/middleware/src/filesystem.ts
+++ b/js/plugins/middleware/src/filesystem.ts
@@ -110,6 +110,10 @@ export const filesystem: GenerateMiddleware<typeof FilesystemOptionsSchema> =
           try {
             return await next(req, ctx);
           } catch (e: any) {
+            // Don't catch ToolInterruptError — let it propagate for interrupt handling
+            // (e.g. from toolApproval middleware further down the chain).
+            if (e.name === 'ToolInterruptError') throw e;
+
             if (filesystemToolNames.includes(req.toolRequest.name)) {
               const errorPart = {
                 text: `Tool '${req.toolRequest.name}' failed: ${

--- a/js/plugins/middleware/tests/filesystem_test.ts
+++ b/js/plugins/middleware/tests/filesystem_test.ts
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import * as os from 'os';
 import * as path from 'path';
 import { filesystem } from '../src/filesystem.js';
+import { toolApproval } from '../src/tool-approval.js';
 
 describe('filesystem middleware', () => {
   let tempDir: string;
@@ -617,6 +618,58 @@ D
         toolMsg,
         undefined,
         'Tool message should not be present'
+      );
+    });
+
+    it('should let ToolInterruptError propagate when toolApproval is after filesystem', async () => {
+      const ai = genkit({});
+      // Model requests write_file which is a filesystem tool but NOT in the approved list
+      const pm = createToolModel(ai, 'write_file', {
+        filePath: 'test.txt',
+        content: 'hello',
+      });
+
+      const result = (await ai.generate({
+        model: pm,
+        prompt: 'write a file',
+        use: [
+          // filesystem is FIRST — its tool hook wraps toolApproval's tool hook.
+          // Without the fix, filesystem's catch block would swallow the ToolInterruptError.
+          filesystem({ rootDirectory: tempDir, allowWriteAccess: true }),
+          toolApproval({ approved: ['read_file', 'list_files'] }),
+        ],
+      })) as any;
+
+      // The ToolInterruptError should propagate through filesystem's error handler
+      // and result in an interrupted finish reason, NOT a swallowed error message.
+      assert.strictEqual(
+        result.finishReason,
+        'interrupted',
+        'Should be interrupted, not swallowed by filesystem error handler'
+      );
+
+      // Verify there's no user message with a swallowed error
+      const swallowedErrorMsg = result.messages.find(
+        (m: any) =>
+          m.role === 'user' &&
+          m.content.some(
+            (c: any) => c.text && c.text.includes("Tool 'write_file' failed")
+          )
+      );
+      assert.strictEqual(
+        swallowedErrorMsg,
+        undefined,
+        'ToolInterruptError should not be swallowed into a user error message'
+      );
+
+      // Verify the interrupt metadata is present
+      const interruptPart = result.message?.content.find(
+        (p: any) => p.metadata?.interrupt
+      );
+      assert.ok(interruptPart, 'Should have interrupt metadata');
+      assert.match(
+        interruptPart.metadata.interrupt.message,
+        /Tool not in approved list/
       );
     });
   });


### PR DESCRIPTION
The Problem:
When the `use` array is ordered as `[toolApproval(...), filesystem(...)]` (like in the current `coding_agent.ts` example), things work correctly because toolApproval's tool hook runs first — if a tool is unapproved, `ToolInterruptError` is thrown and propagates cleanly.

But when the order is reversed to `[filesystem(...), toolApproval(...)]`, the middleware wrapping means:

1. filesystem's `tool` hook wraps toolApproval's `tool` hook
2. toolApproval throws `ToolInterruptError` for unapproved tools
3. filesystem's `catch(e)` block catches it and treats it as a regular tool error — swallowing it and injecting a user message like `"Tool 'write_file' failed: ..."` instead of properly interrupting

Solution:
Re-throw ToolInterruptError in the filesystem middleware's catch block instead of swallowing it into a user error message. This ensures that when toolApproval middleware is composed after filesystem, interrupt signals propagate correctly and result in an "interrupted" finish reason rather than being silently converted to tool failure messages.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
