### PR TITLE
feat(go/plugins/vertexai/modelgarden): add Claude Opus 4.5, Llama, shared scaffolding

### DIFF
--- a/go/plugins/vertexai/modelgarden/anthropic.go
+++ b/go/plugins/vertexai/modelgarden/anthropic.go
@@ -19,7 +19,6 @@ package modelgarden
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -31,11 +30,7 @@ import (
 	ant "github.com/firebase/genkit/go/plugins/internal/anthropic"
 )
 
-const (
-	// TODO: The provider value should be updated in the next major version to avoid collisions with the main vertexai plugin.
-	provider   = "vertexai"
-	pluginName = "vertex-model-garden-anthropic"
-)
+const pluginName = "vertex-model-garden-anthropic"
 
 // Anthropic is a Genkit plugin for interacting with Anthropic models in Vertex AI Model Garden
 type Anthropic struct {
@@ -65,27 +60,7 @@ func (a *Anthropic) Init(ctx context.Context) []api.Action {
 		panic("plugin already initialized")
 	}
 
-	projectID := a.ProjectID
-	if projectID == "" {
-		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
-		if projectID == "" {
-			projectID = os.Getenv("GCLOUD_PROJECT")
-			if projectID == "" {
-				panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_PROJECT or GCLOUD_PROJECT in the environment. You can get a project ID at https://console.cloud.google.com/home/dashboard")
-			}
-		}
-	}
-
-	location := a.Location
-	if location == "" {
-		location = os.Getenv("GOOGLE_CLOUD_LOCATION")
-		if location == "" {
-			location = os.Getenv("GOOGLE_CLOUD_REGION")
-		}
-		if location == "" {
-			panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION in the environment. You can get a location at https://cloud.google.com/vertex-ai/docs/general/locations")
-		}
-	}
+	projectID, location := resolveVertexMaasEnv(a.ProjectID, a.Location)
 
 	c := anthropic.NewClient(
 		vertex.WithGoogleAuth(ctx, location, projectID, "https://www.googleapis.com/auth/cloud-platform"),
@@ -112,6 +87,11 @@ func AnthropicModel(g *genkit.Genkit, id string) ai.Model {
 
 // DefineModel adds the model to the registry
 func (a *Anthropic) DefineModel(name string, opts *ai.ModelOptions) (ai.Model, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.initted {
+		return nil, fmt.Errorf("modelgarden anthropic: plugin not initialized")
+	}
 	if opts == nil {
 		return nil, fmt.Errorf("DefineModel called with nil ai.ModelOptions")
 	}

--- a/go/plugins/vertexai/modelgarden/anthropic_live_test.go
+++ b/go/plugins/vertexai/modelgarden/anthropic_live_test.go
@@ -83,6 +83,29 @@ func TestAnthropicLive(t *testing.T) {
 		}
 	})
 
+	t.Run("opus 4.5", func(t *testing.T) {
+		m := modelgarden.AnthropicModel(g, "claude-opus-4-5@20251101")
+		if m == nil {
+			t.Fatal("claude-opus-4-5@20251101 model was not registered")
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithConfig(&anthropic.MessageNewParams{
+				Temperature: anthropic.Float(1),
+				MaxTokens:   1024,
+			}),
+			ai.WithModel(m),
+			ai.WithSystem("talk to me like an evil pirate and say ARR several times but be very short"),
+			ai.WithMessages(ai.NewUserMessage(ai.NewTextPart("I'm a fish"))),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(resp.Text(), "ARR") {
+			t.Fatalf("not a pirate :( :%s", resp.Text())
+		}
+	})
+
 	t.Run("media content", func(t *testing.T) {
 		i, err := fetchImgAsBase64()
 		if err != nil {

--- a/go/plugins/vertexai/modelgarden/anthropic_live_test.go
+++ b/go/plugins/vertexai/modelgarden/anthropic_live_test.go
@@ -49,8 +49,8 @@ func TestAnthropicLive(t *testing.T) {
 		}
 	})
 
-	t.Run("model version ok", func(t *testing.T) {
-		m := modelgarden.AnthropicModel(g, "claude-opus-4@20250514")
+	t.Run("model ok", func(t *testing.T) {
+		m := modelgarden.AnthropicModel(g, "claude-opus-4")
 		resp, err := genkit.Generate(ctx, g,
 			ai.WithConfig(&anthropic.MessageNewParams{
 				Temperature: anthropic.Float(1),
@@ -69,8 +69,8 @@ func TestAnthropicLive(t *testing.T) {
 		}
 	})
 
-	t.Run("model version nok", func(t *testing.T) {
-		m := modelgarden.AnthropicModel(g, "claude-opus-4@20250514")
+	t.Run("model without messages fails", func(t *testing.T) {
+		m := modelgarden.AnthropicModel(g, "claude-opus-4")
 		_, err := genkit.Generate(ctx, g,
 			ai.WithConfig(&anthropic.MessageNewParams{
 				Temperature: anthropic.Float(1),
@@ -79,14 +79,14 @@ func TestAnthropicLive(t *testing.T) {
 			ai.WithModel(m),
 		)
 		if err == nil {
-			t.Fatal("should have failed due wrong model version")
+			t.Fatal("should have failed due missing messages")
 		}
 	})
 
 	t.Run("opus 4.5", func(t *testing.T) {
-		m := modelgarden.AnthropicModel(g, "claude-opus-4-5@20251101")
+		m := modelgarden.AnthropicModel(g, "claude-opus-4-5")
 		if m == nil {
-			t.Fatal("claude-opus-4-5@20251101 model was not registered")
+			t.Fatal("claude-opus-4-5 model was not registered")
 		}
 		resp, err := genkit.Generate(ctx, g,
 			ai.WithConfig(&anthropic.MessageNewParams{
@@ -111,7 +111,7 @@ func TestAnthropicLive(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		m := modelgarden.AnthropicModel(g, "claude-opus-4@20250514")
+		m := modelgarden.AnthropicModel(g, "claude-opus-4")
 		resp, err := genkit.Generate(ctx, g,
 			ai.WithSystem("You are a professional image detective that talks like an evil pirate that loves animals, your task is to tell the name of the animal in the image but be very short"),
 			ai.WithModel(m),
@@ -132,7 +132,7 @@ func TestAnthropicLive(t *testing.T) {
 	})
 
 	t.Run("tools", func(t *testing.T) {
-		m := modelgarden.AnthropicModel(g, "claude-opus-4@20250514")
+		m := modelgarden.AnthropicModel(g, "claude-opus-4")
 		myJokeTool := genkit.DefineTool(
 			g,
 			"myJoke",
@@ -159,7 +159,7 @@ func TestAnthropicLive(t *testing.T) {
 	})
 
 	t.Run("streaming", func(t *testing.T) {
-		m := modelgarden.AnthropicModel(g, "claude-opus-4@20250514")
+		m := modelgarden.AnthropicModel(g, "claude-opus-4")
 		out := ""
 
 		final, err := genkit.Generate(ctx, g,
@@ -191,7 +191,7 @@ func TestAnthropicLive(t *testing.T) {
 		}
 	})
 	t.Run("streaming with thinking", func(t *testing.T) {
-		m := modelgarden.AnthropicModel(g, "claude-opus-4@20250514")
+		m := modelgarden.AnthropicModel(g, "claude-opus-4")
 		out := ""
 
 		final, err := genkit.Generate(ctx, g,
@@ -237,7 +237,7 @@ func TestAnthropicLive(t *testing.T) {
 	})
 
 	t.Run("tools streaming", func(t *testing.T) {
-		m := modelgarden.AnthropicModel(g, "claude-opus-4@20250514")
+		m := modelgarden.AnthropicModel(g, "claude-opus-4")
 		out := ""
 
 		myStoryTool := genkit.DefineTool(

--- a/go/plugins/vertexai/modelgarden/define_model_test.go
+++ b/go/plugins/vertexai/modelgarden/define_model_test.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/plugins/vertexai/modelgarden"
+)
+
+// TestDefineModelBeforeInit verifies that calling DefineModel on a
+// modelgarden plugin before Init returns an error rather than panicking on a
+// nil/uninitialized client.
+func TestDefineModelBeforeInit(t *testing.T) {
+	opts := &ai.ModelOptions{Label: "test"}
+
+	t.Run("Anthropic", func(t *testing.T) {
+		a := &modelgarden.Anthropic{}
+		_, err := a.DefineModel("claude-test", opts)
+		if err == nil {
+			t.Fatal("expected error when DefineModel called before Init, got nil")
+		}
+		if !strings.Contains(err.Error(), "not initialized") {
+			t.Fatalf("expected 'not initialized' error, got: %v", err)
+		}
+	})
+
+	t.Run("Llama", func(t *testing.T) {
+		l := &modelgarden.Llama{}
+		_, err := l.DefineModel("llama-test", opts)
+		if err == nil {
+			t.Fatal("expected error when DefineModel called before Init, got nil")
+		}
+		if !strings.Contains(err.Error(), "not initialized") {
+			t.Fatalf("expected 'not initialized' error, got: %v", err)
+		}
+	})
+}

--- a/go/plugins/vertexai/modelgarden/internal_test.go
+++ b/go/plugins/vertexai/modelgarden/internal_test.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDefineModel_NilOpts verifies that each plugin's DefineModel returns the
+// nil-opts error after Init, without touching the underlying client. This is
+// a white-box test so it can flip `initted` without running Init (which would
+// require GCP credentials).
+func TestDefineModel_NilOpts(t *testing.T) {
+	t.Run("Anthropic", func(t *testing.T) {
+		a := &Anthropic{initted: true}
+		_, err := a.DefineModel("claude-test", nil)
+		if err == nil || !strings.Contains(err.Error(), "nil ai.ModelOptions") {
+			t.Fatalf("err = %v, want one mentioning nil ai.ModelOptions", err)
+		}
+	})
+	t.Run("Llama", func(t *testing.T) {
+		l := &Llama{initted: true}
+		_, err := l.DefineModel("llama-test", nil)
+		if err == nil || !strings.Contains(err.Error(), "nil ai.ModelOptions") {
+			t.Fatalf("err = %v, want one mentioning nil ai.ModelOptions", err)
+		}
+	})
+}

--- a/go/plugins/vertexai/modelgarden/llama.go
+++ b/go/plugins/vertexai/modelgarden/llama.go
@@ -69,13 +69,15 @@ func (l *Llama) Init(ctx context.Context) []api.Action {
 	projectID, location := resolveVertexMaasEnv(l.ProjectID, l.Location)
 
 	// The token source and oauth2 client outlive Init's ctx — they back every
-	// future generate call. Bind them to context.Background() so a short-lived
-	// Init ctx (or its cancellation) does not break token refreshes later.
-	ts, err := google.DefaultTokenSource(context.Background(), "https://www.googleapis.com/auth/cloud-platform")
+	// future generate call. Detach from Init's cancellation so a short-lived
+	// ctx doesn't break token refreshes later, while still propagating ctx
+	// values (trace IDs, loggers) into refresh calls.
+	bgCtx := context.WithoutCancel(ctx)
+	ts, err := google.DefaultTokenSource(bgCtx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		panic(fmt.Errorf("modelgarden llama: obtaining default Google token source: %w", err))
 	}
-	httpClient := oauth2.NewClient(context.Background(), ts)
+	httpClient := oauth2.NewClient(bgCtx, ts)
 
 	baseURL := fmt.Sprintf(
 		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi",

--- a/go/plugins/vertexai/modelgarden/llama.go
+++ b/go/plugins/vertexai/modelgarden/llama.go
@@ -68,11 +68,14 @@ func (l *Llama) Init(ctx context.Context) []api.Action {
 
 	projectID, location := resolveVertexMaasEnv(l.ProjectID, l.Location)
 
-	ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	// The token source and oauth2 client outlive Init's ctx — they back every
+	// future generate call. Bind them to context.Background() so a short-lived
+	// Init ctx (or its cancellation) does not break token refreshes later.
+	ts, err := google.DefaultTokenSource(context.Background(), "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		panic(fmt.Errorf("modelgarden llama: obtaining default Google token source: %w", err))
 	}
-	httpClient := oauth2.NewClient(ctx, ts)
+	httpClient := oauth2.NewClient(context.Background(), ts)
 
 	baseURL := fmt.Sprintf(
 		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi",

--- a/go/plugins/vertexai/modelgarden/llama.go
+++ b/go/plugins/vertexai/modelgarden/llama.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go/option"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const (
+	llamaPluginName = "vertex-model-garden-llama"
+)
+
+// Llama is a Genkit plugin for interacting with Meta Llama MaaS models in
+// Vertex AI Model Garden. Llama models on Vertex are served via an
+// OpenAI-compatible endpoint (`.../endpoints/openapi`) and authenticated with
+// a Google OAuth2 access token.
+type Llama struct {
+	// ProjectID is the Google Cloud project to use for Vertex AI. If empty,
+	// the value of the environment variable GOOGLE_CLOUD_PROJECT or
+	// GCLOUD_PROJECT will be consulted in that order.
+	ProjectID string
+	// Location is the Vertex AI location (e.g. "us-central1"). If empty, the
+	// value of GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION will be
+	// consulted.
+	Location string
+
+	mu      sync.Mutex
+	initted bool
+	oai     compat_oai.OpenAICompatible
+}
+
+// Name returns the name of the plugin.
+func (l *Llama) Name() string { return llamaPluginName }
+
+// Init initializes the Vertex AI Model Garden Llama plugin and registers all
+// known Llama MaaS models. After calling Init you may call DefineModel to
+// register additional Llama models.
+func (l *Llama) Init(ctx context.Context) []api.Action {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.initted {
+		panic("plugin already initialized")
+	}
+
+	projectID, location := resolveVertexMaasEnv(l.ProjectID, l.Location)
+
+	ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		panic(fmt.Errorf("modelgarden llama: obtaining default Google token source: %w", err))
+	}
+	httpClient := oauth2.NewClient(ctx, ts)
+
+	baseURL := fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi",
+		location, projectID, location,
+	)
+
+	l.oai.Provider = provider
+	l.oai.Opts = []option.RequestOption{
+		option.WithBaseURL(baseURL),
+		option.WithHTTPClient(httpClient),
+	}
+
+	var actions []api.Action
+	actions = append(actions, l.oai.Init(ctx)...)
+
+	for name, opts := range LlamaModels {
+		actions = append(actions, l.oai.DefineModel(provider, name, opts).(api.Action))
+	}
+
+	l.initted = true
+	return actions
+}
+
+// LlamaModel returns the Llama [ai.Model] with the given id, or nil if it was
+// not defined.
+func LlamaModel(g *genkit.Genkit, id string) ai.Model {
+	return genkit.LookupModel(g, api.NewName(provider, id))
+}
+
+// DefineModel adds a Llama model to the registry.
+func (l *Llama) DefineModel(name string, opts *ai.ModelOptions) (ai.Model, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.initted {
+		return nil, fmt.Errorf("modelgarden llama: plugin not initialized")
+	}
+	if opts == nil {
+		return nil, fmt.Errorf("DefineModel called with nil ai.ModelOptions")
+	}
+	return l.oai.DefineModel(provider, name, *opts), nil
+}

--- a/go/plugins/vertexai/modelgarden/llama_live_test.go
+++ b/go/plugins/vertexai/modelgarden/llama_live_test.go
@@ -1,0 +1,90 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/vertexai/modelgarden"
+)
+
+func TestLlamaLive(t *testing.T) {
+	if _, ok := requireEnv("GOOGLE_CLOUD_PROJECT"); !ok {
+		t.Skip("GOOGLE_CLOUD_PROJECT not found in the environment")
+	}
+	if _, ok := requireEnv("GOOGLE_CLOUD_LOCATION"); !ok {
+		t.Skip("GOOGLE_CLOUD_LOCATION not found in the environment")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx, genkit.WithPlugins(&modelgarden.Llama{}))
+
+	t.Run("invalid model", func(t *testing.T) {
+		m := modelgarden.LlamaModel(g, "meta/llama-does-not-exist")
+		if m != nil {
+			t.Fatalf("model should have been empty, got: %#v", m)
+		}
+	})
+
+	t.Run("basic generation", func(t *testing.T) {
+		m := modelgarden.LlamaModel(g, "meta/llama-3.3-70b-instruct-maas")
+		if m == nil {
+			t.Fatal("meta/llama-3.3-70b-instruct-maas model was not registered")
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithSystem("You are a helpful assistant. Reply in one short sentence."),
+			ai.WithMessages(ai.NewUserMessage(ai.NewTextPart("Say hello."))),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(resp.Text()) == "" {
+			t.Fatal("expected a non-empty response")
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		m := modelgarden.LlamaModel(g, "meta/llama-3.3-70b-instruct-maas")
+		out := ""
+		final, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithPrompt("Count from one to three."),
+			ai.WithStreaming(func(ctx context.Context, c *ai.ModelResponseChunk) error {
+				for _, p := range c.Content {
+					if p.IsText() {
+						out += p.Text
+					}
+				}
+				return nil
+			}),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out == "" {
+			t.Fatal("expected streamed content")
+		}
+		if final.Usage.InputTokens == 0 || final.Usage.OutputTokens == 0 {
+			t.Fatalf("empty usage stats: %#v", *final.Usage)
+		}
+	})
+}

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -65,57 +65,74 @@ func resolveVertexMaasEnv(projectID, location string) (string, string) {
 // matches the plugin that owns it.
 const provider = "vertexai"
 
-// AnthropicModels is a list of models supported in VertexAI
-// Keep this list updated since models cannot be dynamically listed
-// if we are authenticating with Google Credentials
+// AnthropicModels is a list of models supported in VertexAI.
+// Keep this list updated since models cannot be dynamically listed if we are
+// authenticating with Google Credentials. Keys must be Vertex AI publisher
+// model IDs, not Anthropic API date-versioned IDs.
 var AnthropicModels = map[string]ai.ModelOptions{
-	"claude-3-5-sonnet-v2@20241022": {
+	"claude-opus-4-7": {
+		Label:    "Claude Opus 4.7",
+		Supports: &internal.Multimodal,
+	},
+	"claude-opus-4-6": {
+		Label:    "Claude Opus 4.6",
+		Supports: &internal.Multimodal,
+	},
+	"claude-sonnet-4-6": {
+		Label:    "Claude Sonnet 4.6",
+		Supports: &internal.Multimodal,
+	},
+	"claude-opus-4-5": {
+		Label:    "Claude Opus 4.5",
+		Supports: &internal.Multimodal,
+	},
+	"claude-opus-4-1": {
+		Label:    "Claude Opus 4.1",
+		Supports: &internal.Multimodal,
+	},
+	"claude-opus-4": {
+		Label:    "Claude Opus 4",
+		Supports: &internal.Multimodal,
+	},
+	"claude-sonnet-4-5": {
+		Label:    "Claude Sonnet 4.5",
+		Supports: &internal.Multimodal,
+	},
+	"claude-sonnet-4": {
+		Label:    "Claude Sonnet 4",
+		Supports: &internal.Multimodal,
+	},
+	"claude-3-7-sonnet": {
+		Label:    "Claude 3.7 Sonnet",
+		Supports: &internal.Multimodal,
+	},
+	"claude-3-5-sonnet-v2": {
 		Label:    "Claude 3.5 Sonnet",
 		Supports: &internal.Multimodal,
 	},
-	"claude-3-5-sonnet@20240620": {
+	"claude-haiku-4-5": {
+		Label:    "Claude Haiku 4.5",
+		Supports: &internal.Multimodal,
+	},
+	"claude-3-5-haiku": {
+		Label:    "Claude 3.5 Haiku",
+		Supports: &internal.Multimodal,
+	},
+	"claude-3-5-sonnet": {
 		Label:    "Claude 3.5 Sonnet",
 		Supports: &internal.Multimodal,
 	},
-	"claude-3-sonnet@20240229": {
+	"claude-3-sonnet": {
 		Label:    "Claude 3 Sonnet",
 		Supports: &internal.Multimodal,
 	},
-	"claude-3-haiku@20240307": {
+	"claude-3-haiku": {
 		Label:    "Claude 3 Haiku",
 		Supports: &internal.Multimodal,
 		Stage:    ai.ModelStageDeprecated,
 	},
-	"claude-3-opus@20240229": {
+	"claude-3-opus": {
 		Label:    "Claude 3 Opus",
-		Supports: &internal.Multimodal,
-	},
-	"claude-3-7-sonnet@20250219": {
-		Label:    "Claude 3.7 Sonnet",
-		Supports: &internal.Multimodal,
-	},
-	"claude-opus-4@20250514": {
-		Label:    "Claude Opus 4",
-		Supports: &internal.Multimodal,
-	},
-	"claude-sonnet-4@20250514": {
-		Label:    "Claude Sonnet 4",
-		Supports: &internal.Multimodal,
-	},
-	"claude-opus-4-1-20250805": {
-		Label:    "Claude 4.1 Opus",
-		Supports: &internal.Multimodal,
-	},
-	"claude-sonnet-4-5-20250929": {
-		Label:    "Claude 4.5 Sonnet",
-		Supports: &internal.Multimodal,
-	},
-	"claude-haiku-4-5-20251001": {
-		Label:    "Claude 4.5 Haiku",
-		Supports: &internal.Multimodal,
-	},
-	"claude-opus-4-5@20251101": {
-		Label:    "Claude Opus 4.5",
 		Supports: &internal.Multimodal,
 	},
 }

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -135,6 +135,50 @@ var AnthropicModels = map[string]ai.ModelOptions{
 		Label:    "Claude 3 Opus",
 		Supports: &internal.Multimodal,
 	},
+
+	// Date-versioned aliases kept for backwards compatibility with callers
+	// pinned to the IDs that shipped before the undated rename. Vertex AI
+	// accepts both forms for the same underlying model.
+	"claude-opus-4@20250514": {
+		Label:    "Claude Opus 4",
+		Supports: &internal.Multimodal,
+		Stage:    ai.ModelStageDeprecated,
+	},
+	"claude-sonnet-4@20250514": {
+		Label:    "Claude Sonnet 4",
+		Supports: &internal.Multimodal,
+		Stage:    ai.ModelStageDeprecated,
+	},
+	"claude-3-7-sonnet@20250219": {
+		Label:    "Claude 3.7 Sonnet",
+		Supports: &internal.Multimodal,
+		Stage:    ai.ModelStageDeprecated,
+	},
+	"claude-3-5-sonnet-v2@20241022": {
+		Label:    "Claude 3.5 Sonnet",
+		Supports: &internal.Multimodal,
+		Stage:    ai.ModelStageDeprecated,
+	},
+	"claude-3-5-sonnet@20240620": {
+		Label:    "Claude 3.5 Sonnet",
+		Supports: &internal.Multimodal,
+		Stage:    ai.ModelStageDeprecated,
+	},
+	"claude-3-sonnet@20240229": {
+		Label:    "Claude 3 Sonnet",
+		Supports: &internal.Multimodal,
+		Stage:    ai.ModelStageDeprecated,
+	},
+	"claude-3-haiku@20240307": {
+		Label:    "Claude 3 Haiku",
+		Supports: &internal.Multimodal,
+		Stage:    ai.ModelStageDeprecated,
+	},
+	"claude-3-opus@20240229": {
+		Label:    "Claude 3 Opus",
+		Supports: &internal.Multimodal,
+		Stage:    ai.ModelStageDeprecated,
+	},
 }
 
 // LlamaModels lists the Meta Llama models available through Vertex AI Model Garden

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -17,9 +17,53 @@
 package modelgarden
 
 import (
+	"os"
+
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/plugins/internal"
 )
+
+// resolveVertexMaasEnv resolves project and location from explicit arguments
+// with fallback to the conventional environment variables. Panics if neither a
+// value nor a fallback env var is set. Shared by all Vertex AI Model Garden
+// plugins in this package.
+func resolveVertexMaasEnv(projectID, location string) (string, string) {
+	if projectID == "" {
+		projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
+		if projectID == "" {
+			projectID = os.Getenv("GCLOUD_PROJECT")
+		}
+		if projectID == "" {
+			panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_PROJECT or GCLOUD_PROJECT in the environment. You can get a project ID at https://console.cloud.google.com/home/dashboard")
+		}
+	}
+	if location == "" {
+		location = os.Getenv("GOOGLE_CLOUD_LOCATION")
+		if location == "" {
+			location = os.Getenv("GOOGLE_CLOUD_REGION")
+		}
+		if location == "" {
+			panic("Vertex AI Modelgarden requires setting GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION in the environment. You can get a location at https://cloud.google.com/vertex-ai/docs/general/locations")
+		}
+	}
+	return projectID, location
+}
+
+// provider is the shared registration namespace for every Vertex AI Model
+// Garden plugin in this package (Anthropic, Llama). Their models are all
+// registered as "vertexai/<model>" so users see a single namespace.
+// Each plugin's own Name() ("vertex-model-garden-<plugin>") is distinct from
+// this registration prefix.
+//
+// Note that this collides with the main googlegenai.VertexAI plugin, whose
+// Name() is also "vertexai" — model-name prefixes overlap, but plugin names
+// do not. Consequence: dynamic resolution of an unknown "vertexai/<name>" is
+// routed to googlegenai.VertexAI, not to the modelgarden plugins.
+//
+// TODO: in the next major version, switch to per-plugin prefixes
+// (e.g. "vertex-model-garden-anthropic/<model>") so the model namespace
+// matches the plugin that owns it.
+const provider = "vertexai"
 
 // AnthropicModels is a list of models supported in VertexAI
 // Keep this list updated since models cannot be dynamically listed
@@ -40,6 +84,7 @@ var AnthropicModels = map[string]ai.ModelOptions{
 	"claude-3-haiku@20240307": {
 		Label:    "Claude 3 Haiku",
 		Supports: &internal.Multimodal,
+		Stage:    ai.ModelStageDeprecated,
 	},
 	"claude-3-opus@20240229": {
 		Label:    "Claude 3 Opus",
@@ -68,5 +113,27 @@ var AnthropicModels = map[string]ai.ModelOptions{
 	"claude-haiku-4-5-20251001": {
 		Label:    "Claude 4.5 Haiku",
 		Supports: &internal.Multimodal,
+	},
+	"claude-opus-4-5@20251101": {
+		Label:    "Claude Opus 4.5",
+		Supports: &internal.Multimodal,
+	},
+}
+
+// LlamaModels lists the Meta Llama models available through Vertex AI Model Garden
+// as Model-as-a-Service (MaaS) endpoints. These models are served via an
+// OpenAI-compatible API.
+var LlamaModels = map[string]ai.ModelOptions{
+	"meta/llama-4-maverick-17b-128e-instruct-maas": {
+		Label:    "Llama 4 Maverick 17B 128E Instruct",
+		Supports: &internal.Multimodal,
+	},
+	"meta/llama-4-scout-17b-16e-instruct-maas": {
+		Label:    "Llama 4 Scout 17B 16E Instruct",
+		Supports: &internal.Multimodal,
+	},
+	"meta/llama-3.3-70b-instruct-maas": {
+		Label:    "Llama 3.3 70B Instruct",
+		Supports: &internal.BasicText,
 	},
 }

--- a/go/plugins/vertexai/modelgarden/models_test.go
+++ b/go/plugins/vertexai/modelgarden/models_test.go
@@ -19,6 +19,8 @@ package modelgarden
 import (
 	"strings"
 	"testing"
+
+	"github.com/firebase/genkit/go/ai"
 )
 
 func TestResolveVertexMaasEnv_ExplicitArgsWin(t *testing.T) {
@@ -80,6 +82,33 @@ func TestResolveVertexMaasEnv_PanicsWithoutProject(t *testing.T) {
 		}
 	}()
 	resolveVertexMaasEnv("", "")
+}
+
+// TestAnthropicModels_DeprecatedAliases pins the backwards-compat surface:
+// the date-suffixed IDs that shipped before the undated rename must remain
+// in AnthropicModels and must be marked deprecated, so callers pinned to
+// those keys keep resolving and get a warning via model_middleware.
+func TestAnthropicModels_DeprecatedAliases(t *testing.T) {
+	aliases := []string{
+		"claude-opus-4@20250514",
+		"claude-sonnet-4@20250514",
+		"claude-3-7-sonnet@20250219",
+		"claude-3-5-sonnet-v2@20241022",
+		"claude-3-5-sonnet@20240620",
+		"claude-3-sonnet@20240229",
+		"claude-3-haiku@20240307",
+		"claude-3-opus@20240229",
+	}
+	for _, id := range aliases {
+		opts, ok := AnthropicModels[id]
+		if !ok {
+			t.Errorf("alias %q missing from AnthropicModels", id)
+			continue
+		}
+		if opts.Stage != ai.ModelStageDeprecated {
+			t.Errorf("alias %q stage = %q, want %q", id, opts.Stage, ai.ModelStageDeprecated)
+		}
+	}
 }
 
 func TestResolveVertexMaasEnv_PanicsWithoutLocation(t *testing.T) {

--- a/go/plugins/vertexai/modelgarden/models_test.go
+++ b/go/plugins/vertexai/modelgarden/models_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveVertexMaasEnv_ExplicitArgsWin(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "from-env")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "from-env")
+
+	p, l := resolveVertexMaasEnv("explicit-proj", "explicit-loc")
+	if p != "explicit-proj" {
+		t.Errorf("project = %q, want explicit-proj", p)
+	}
+	if l != "explicit-loc" {
+		t.Errorf("location = %q, want explicit-loc", l)
+	}
+}
+
+func TestResolveVertexMaasEnv_FallsBackToPrimaryEnv(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "primary-proj")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "primary-loc")
+	t.Setenv("GCLOUD_PROJECT", "secondary-proj")
+	t.Setenv("GOOGLE_CLOUD_REGION", "secondary-loc")
+
+	p, l := resolveVertexMaasEnv("", "")
+	if p != "primary-proj" {
+		t.Errorf("project = %q, want primary-proj", p)
+	}
+	if l != "primary-loc" {
+		t.Errorf("location = %q, want primary-loc", l)
+	}
+}
+
+func TestResolveVertexMaasEnv_FallsBackToSecondaryEnv(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "")
+	t.Setenv("GCLOUD_PROJECT", "secondary-proj")
+	t.Setenv("GOOGLE_CLOUD_REGION", "secondary-loc")
+
+	p, l := resolveVertexMaasEnv("", "")
+	if p != "secondary-proj" {
+		t.Errorf("project = %q, want secondary-proj", p)
+	}
+	if l != "secondary-loc" {
+		t.Errorf("location = %q, want secondary-loc", l)
+	}
+}
+
+func TestResolveVertexMaasEnv_PanicsWithoutProject(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+	t.Setenv("GCLOUD_PROJECT", "")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when no project env is set")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "GOOGLE_CLOUD_PROJECT") {
+			t.Fatalf("panic = %v, want message mentioning GOOGLE_CLOUD_PROJECT", r)
+		}
+	}()
+	resolveVertexMaasEnv("", "")
+}
+
+func TestResolveVertexMaasEnv_PanicsWithoutLocation(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "some-proj")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "")
+	t.Setenv("GOOGLE_CLOUD_REGION", "")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when no location env is set")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "GOOGLE_CLOUD_LOCATION") {
+			t.Fatalf("panic = %v, want message mentioning GOOGLE_CLOUD_LOCATION", r)
+		}
+	}()
+	resolveVertexMaasEnv("", "")
+}

--- a/go/samples/modelgarden-llama/main.go
+++ b/go/samples/modelgarden-llama/main.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/vertexai/modelgarden"
@@ -27,27 +26,26 @@ import (
 func main() {
 	ctx := context.Background()
 
-	g := genkit.Init(ctx, genkit.WithPlugins(&modelgarden.Anthropic{}))
+	// Llama MaaS is served from us-central1. Override Location if your project
+	// has Llama enabled in a different region.
+	g := genkit.Init(ctx, genkit.WithPlugins(
+		&modelgarden.Llama{Location: "us-central1"},
+	))
 
-	// Define a simple flow that generates jokes about a given topic
-	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, input string) (string, error) {
-		m := modelgarden.AnthropicModel(g, "claude-3-5-sonnet-v2")
+	// Define a flow that uses Llama 3.3 70B to describe a topic.
+	genkit.DefineFlow(g, "llamaFlow", func(ctx context.Context, input string) (string, error) {
+		m := modelgarden.LlamaModel(g, "meta/llama-3.3-70b-instruct-maas")
 		if m == nil {
-			return "", errors.New("jokesFlow: failed to find model")
+			return "", errors.New("llamaFlow: failed to find model")
 		}
 
 		resp, err := genkit.Generate(ctx, g,
 			ai.WithModel(m),
-			ai.WithConfig(&anthropic.MessageNewParams{
-				Temperature: anthropic.Float(1.0),
-			}),
-			ai.WithPrompt(`Tell a short joke about %s`, input))
+			ai.WithPrompt("In one short sentence, describe %s", input))
 		if err != nil {
 			return "", err
 		}
-
-		text := resp.Text()
-		return text, nil
+		return resp.Text(), nil
 	})
 
 	<-ctx.Done()

--- a/go/samples/modelgarden/main.go
+++ b/go/samples/modelgarden/main.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/firebase/genkit/go/ai"
@@ -27,28 +27,58 @@ import (
 func main() {
 	ctx := context.Background()
 
-	g := genkit.Init(ctx, genkit.WithPlugins(&modelgarden.Anthropic{}))
+	// Vertex AI MaaS regional availability differs per publisher: Anthropic
+	// Claude models live in us-east5 / europe-west4, while Meta Llama lives
+	// in us-central1. Each plugin takes its own Location to avoid forcing one
+	// global region.
+	g := genkit.Init(ctx, genkit.WithPlugins(
+		&modelgarden.Anthropic{Location: "us-east5"},
+		&modelgarden.Llama{Location: "us-central1"},
+	))
 
-	// Define a simple flow that generates jokes about a given topic
-	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, input string) (string, error) {
-		m := modelgarden.AnthropicModel(g, "claude-3-5-sonnet-v2")
+	// Anthropic flow. Add additional flows pointing at other Claude variants
+	// (e.g. claude-sonnet-4-5-20250929, claude-haiku-4-5-20251001) once they
+	// are enabled in the Vertex Model Garden for your project.
+	defineFlow(g, "opus45Flow",
+		modelgarden.AnthropicModel(g, "claude-opus-4-5@20251101"),
+		"Write a haiku about %s",
+		ai.WithConfig(&anthropic.MessageNewParams{
+			MaxTokens:   256,
+			Temperature: anthropic.Float(1.0),
+		}),
+	)
+
+	// Llama flow.
+	defineFlow(g, "llamaFlow",
+		modelgarden.LlamaModel(g, "meta/llama-3.3-70b-instruct-maas"),
+		"In one short sentence, describe %s",
+	)
+
+	<-ctx.Done()
+}
+
+// defineFlow registers a Dev UI flow that generates from the given model using
+// a prompt template. Extra GenerateOption values (e.g. provider-specific
+// config) are appended to the base options.
+func defineFlow(
+	g *genkit.Genkit,
+	name string,
+	m ai.Model,
+	promptTemplate string,
+	extra ...ai.GenerateOption,
+) {
+	genkit.DefineFlow(g, name, func(ctx context.Context, input string) (string, error) {
 		if m == nil {
-			return "", errors.New("jokesFlow: failed to find model")
+			return "", fmt.Errorf("%s: model not registered", name)
 		}
-
-		resp, err := genkit.Generate(ctx, g,
+		opts := append([]ai.GenerateOption{
 			ai.WithModel(m),
-			ai.WithConfig(&anthropic.MessageNewParams{
-				Temperature: anthropic.Float(1.0),
-			}),
-			ai.WithPrompt(`Tell a short joke about %s`, input))
+			ai.WithPrompt(promptTemplate, input),
+		}, extra...)
+		resp, err := genkit.Generate(ctx, g, opts...)
 		if err != nil {
 			return "", err
 		}
-
-		text := resp.Text()
-		return text, nil
+		return resp.Text(), nil
 	})
-
-	<-ctx.Done()
 }


### PR DESCRIPTION
Extends the Vertex AI Model Garden Go plugin with new Anthropic Claude models, a new Meta Llama plugin, and shared scaffolding used by all modelgarden plugins.

This PR is the first half of the work originally proposed in #5175. The Mistral plugin (which requires a different transport approach because Vertex does not serve Mistral via the OpenAI-compatible endpoint) is stacked on top of this PR in a follow-up.

## Models

- **Anthropic** (existing plugin, more models): `claude-opus-4-5@20251101`, `claude-opus-4-1-20250805`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`, plus the previously supported Claude 3.5 / 3.7 / Opus 4 / Sonnet 4 entries.
- **Meta Llama (MaaS, new plugin)**: `meta/llama-4-maverick-17b-128e-instruct-maas`, `meta/llama-4-scout-17b-16e-instruct-maas`, `meta/llama-3.3-70b-instruct-maas`. Llama 4 variants register as `Multimodal`; Llama 3.3 70B is text-only. Routed through `compat_oai` against the Vertex MaaS OpenAI-compatible endpoint.

## Plugin scaffolding

- New `Llama` plugin type alongside the existing `Anthropic`, with `Init`, `Name`, `DefineModel(name, opts)`, and a top-level `LlamaModel(g, id)` lookup mirroring the Anthropic shape.
- Shared `resolveVertexMaasEnv` helper for `GOOGLE_CLOUD_PROJECT` / `GCLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` / `GOOGLE_CLOUD_REGION` resolution.
- Shared `provider = "vertexai"` constant so every modelgarden plugin registers models under the same `vertexai/<model>` namespace.
- `Anthropic.DefineModel` now takes the same mutex and `initted` guard as `Llama.DefineModel`, so calling it before `Init` returns an explicit `"not initialized"` error instead of using a zero-value client.

## Sample

`go/samples/modelgarden` registers two flows for Dev UI smoke testing:

- `opus45Flow` — `claude-opus-4-5@20251101`
- `llamaFlow` — `meta/llama-3.3-70b-instruct-maas`

Each plugin is constructed with an explicit `Location` because Vertex MaaS regional availability differs per publisher (Anthropic in `us-east5`, Llama in `us-central1`).

## Tests

- `define_model_test.go` — pre-Init error path for both plugins.
- `internal_test.go` — nil `ai.ModelOptions` branch of `DefineModel` for both plugins.
- `models_test.go` — `resolveVertexMaasEnv` covered for explicit args, primary / secondary env fallback, and panic paths.
- `llama_live_test.go` — basic + streaming generation against Llama 3.3 70B (credential-gated).
- `anthropic_live_test.go` — Opus 4.5 subtest (credential-gated).

## Testing
<img width="1247" height="351" alt="image" src="https://github.com/user-attachments/assets/37a80532-ca8f-46da-80ed-b6c1a9c78d11" />
<img width="1247" height="841" alt="image" src="https://github.com/user-attachments/assets/3c7c1d89-3cbb-43fc-8d5e-cf56015ef48f" />