### PR TITLE
feat(go/plugins/vertexai/modelgarden): add Mistral via per-model rawPredict

### DIFF
--- a/go/plugins/vertexai/modelgarden/define_model_test.go
+++ b/go/plugins/vertexai/modelgarden/define_model_test.go
@@ -51,4 +51,15 @@ func TestDefineModelBeforeInit(t *testing.T) {
 			t.Fatalf("expected 'not initialized' error, got: %v", err)
 		}
 	})
+
+	t.Run("Mistral", func(t *testing.T) {
+		m := &modelgarden.Mistral{}
+		_, err := m.DefineModel("mistral-test", opts)
+		if err == nil {
+			t.Fatal("expected error when DefineModel called before Init, got nil")
+		}
+		if !strings.Contains(err.Error(), "not initialized") {
+			t.Fatalf("expected 'not initialized' error, got: %v", err)
+		}
+	})
 }

--- a/go/plugins/vertexai/modelgarden/internal_test.go
+++ b/go/plugins/vertexai/modelgarden/internal_test.go
@@ -40,4 +40,11 @@ func TestDefineModel_NilOpts(t *testing.T) {
 			t.Fatalf("err = %v, want one mentioning nil ai.ModelOptions", err)
 		}
 	})
+	t.Run("Mistral", func(t *testing.T) {
+		m := &Mistral{initted: true}
+		_, err := m.DefineModel("mistral-test", nil)
+		if err == nil || !strings.Contains(err.Error(), "nil ai.ModelOptions") {
+			t.Fatalf("err = %v, want one mentioning nil ai.ModelOptions", err)
+		}
+	})
 }

--- a/go/plugins/vertexai/modelgarden/mistral.go
+++ b/go/plugins/vertexai/modelgarden/mistral.go
@@ -74,13 +74,15 @@ func (m *Mistral) Init(ctx context.Context) []api.Action {
 	projectID, location := resolveVertexMaasEnv(m.ProjectID, m.Location)
 
 	// The token source and oauth2 client outlive Init's ctx — they back every
-	// future generate call. Bind them to context.Background() so a short-lived
-	// Init ctx (or its cancellation) does not break token refreshes later.
-	ts, err := google.DefaultTokenSource(context.Background(), "https://www.googleapis.com/auth/cloud-platform")
+	// future generate call. Detach from Init's cancellation so a short-lived
+	// ctx doesn't break token refreshes later, while still propagating ctx
+	// values (trace IDs, loggers) into refresh calls.
+	bgCtx := context.WithoutCancel(ctx)
+	ts, err := google.DefaultTokenSource(bgCtx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		panic(fmt.Errorf("modelgarden mistral: obtaining default Google token source: %w", err))
 	}
-	httpClient := oauth2.NewClient(context.Background(), ts)
+	httpClient := oauth2.NewClient(bgCtx, ts)
 	// Wrap the oauth2 transport with one that rewrites /chat/completions
 	// requests to Vertex's per-model rawPredict URLs. The inner oauth2
 	// transport still adds the Bearer token.

--- a/go/plugins/vertexai/modelgarden/mistral.go
+++ b/go/plugins/vertexai/modelgarden/mistral.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai"
+	"github.com/openai/openai-go/option"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const (
+	mistralPluginName = "vertex-model-garden-mistral"
+	mistralPublisher  = "mistralai"
+)
+
+// Mistral is a Genkit plugin for interacting with Mistral and Codestral MaaS
+// models in Vertex AI Model Garden. The JS equivalent uses the native
+// @mistralai/mistralai-gcp SDK; no maintained Mistral-GCP SDK exists for Go,
+// and unlike Meta Llama, Mistral on Vertex is not served by the OpenAI-
+// compatible chat completions endpoint. Requests are routed to per-model
+// rawPredict / streamRawPredict URLs via a custom HTTP transport, while the
+// rest of the OpenAI-shaped request and response handling is reused from
+// compat_oai.
+type Mistral struct {
+	// ProjectID is the Google Cloud project to use for Vertex AI. If empty,
+	// the value of the environment variable GOOGLE_CLOUD_PROJECT or
+	// GCLOUD_PROJECT will be consulted in that order.
+	ProjectID string
+	// Location is the Vertex AI location (e.g. "us-central1"). If empty, the
+	// value of GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION will be
+	// consulted.
+	Location string
+
+	mu      sync.Mutex
+	initted bool
+	oai     compat_oai.OpenAICompatible
+}
+
+// Name returns the name of the plugin.
+func (m *Mistral) Name() string { return mistralPluginName }
+
+// Init initializes the Vertex AI Model Garden Mistral plugin and registers
+// all known Mistral/Codestral MaaS models.
+func (m *Mistral) Init(ctx context.Context) []api.Action {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.initted {
+		panic("plugin already initialized")
+	}
+
+	projectID, location := resolveVertexMaasEnv(m.ProjectID, m.Location)
+
+	ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		panic(fmt.Errorf("modelgarden mistral: obtaining default Google token source: %w", err))
+	}
+	httpClient := oauth2.NewClient(ctx, ts)
+	// Wrap the oauth2 transport with one that rewrites /chat/completions
+	// requests to Vertex's per-model rawPredict URLs. The inner oauth2
+	// transport still adds the Bearer token.
+	httpClient.Transport = &mistralVertexTransport{
+		inner:    httpClient.Transport,
+		project:  projectID,
+		location: location,
+	}
+
+	// baseURL is a sentinel: the actual outbound URL is built by
+	// mistralVertexTransport. The openai-go SDK appends "/chat/completions"
+	// to this base, which the transport then detects and rewrites.
+	baseURL := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1", location)
+
+	m.oai.Provider = provider
+	m.oai.Opts = []option.RequestOption{
+		option.WithBaseURL(baseURL),
+		option.WithHTTPClient(httpClient),
+	}
+
+	var actions []api.Action
+	actions = append(actions, m.oai.Init(ctx)...)
+
+	for name, opts := range MistralModels {
+		actions = append(actions, m.oai.DefineModel(provider, name, opts).(api.Action))
+	}
+
+	m.initted = true
+	return actions
+}
+
+// MistralModel returns the Mistral/Codestral [ai.Model] with the given id,
+// or nil if it was not defined. Both bare ids ("mistral-small-2503") and
+// publisher-qualified ids ("mistralai/mistral-small-2503") resolve to the
+// same registered model.
+func MistralModel(g *genkit.Genkit, id string) ai.Model {
+	id = strings.TrimPrefix(id, mistralPublisher+"/")
+	return genkit.LookupModel(g, api.NewName(provider, id))
+}
+
+// DefineModel adds a Mistral model to the registry. The optional
+// "mistralai/" publisher prefix on name is stripped so registration stays in
+// the bare-id namespace.
+func (m *Mistral) DefineModel(name string, opts *ai.ModelOptions) (ai.Model, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.initted {
+		return nil, fmt.Errorf("modelgarden mistral: plugin not initialized")
+	}
+	if opts == nil {
+		return nil, fmt.Errorf("DefineModel called with nil ai.ModelOptions")
+	}
+	name = strings.TrimPrefix(name, mistralPublisher+"/")
+	return m.oai.DefineModel(provider, name, *opts), nil
+}

--- a/go/plugins/vertexai/modelgarden/mistral.go
+++ b/go/plugins/vertexai/modelgarden/mistral.go
@@ -73,11 +73,14 @@ func (m *Mistral) Init(ctx context.Context) []api.Action {
 
 	projectID, location := resolveVertexMaasEnv(m.ProjectID, m.Location)
 
-	ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	// The token source and oauth2 client outlive Init's ctx — they back every
+	// future generate call. Bind them to context.Background() so a short-lived
+	// Init ctx (or its cancellation) does not break token refreshes later.
+	ts, err := google.DefaultTokenSource(context.Background(), "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		panic(fmt.Errorf("modelgarden mistral: obtaining default Google token source: %w", err))
 	}
-	httpClient := oauth2.NewClient(ctx, ts)
+	httpClient := oauth2.NewClient(context.Background(), ts)
 	// Wrap the oauth2 transport with one that rewrites /chat/completions
 	// requests to Vertex's per-model rawPredict URLs. The inner oauth2
 	// transport still adds the Bearer token.

--- a/go/plugins/vertexai/modelgarden/mistral.go
+++ b/go/plugins/vertexai/modelgarden/mistral.go
@@ -107,7 +107,11 @@ func (m *Mistral) Init(ctx context.Context) []api.Action {
 	actions = append(actions, m.oai.Init(ctx)...)
 
 	for name, opts := range MistralModels {
-		actions = append(actions, m.oai.DefineModel(provider, name, opts).(api.Action))
+		act, ok := m.oai.DefineModel(provider, name, opts).(api.Action)
+		if !ok {
+			panic(fmt.Sprintf("modelgarden: Mistral model %q does not implement api.Action", name))
+		}
+		actions = append(actions, act)
 	}
 
 	m.initted = true

--- a/go/plugins/vertexai/modelgarden/mistral_live_test.go
+++ b/go/plugins/vertexai/modelgarden/mistral_live_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/vertexai/modelgarden"
+)
+
+func TestMistralLive(t *testing.T) {
+	if _, ok := requireEnv("GOOGLE_CLOUD_PROJECT"); !ok {
+		t.Skip("GOOGLE_CLOUD_PROJECT not found in the environment")
+	}
+	if _, ok := requireEnv("GOOGLE_CLOUD_LOCATION"); !ok {
+		t.Skip("GOOGLE_CLOUD_LOCATION not found in the environment")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx, genkit.WithPlugins(&modelgarden.Mistral{}))
+
+	t.Run("invalid model", func(t *testing.T) {
+		m := modelgarden.MistralModel(g, "mistral-does-not-exist")
+		if m != nil {
+			t.Fatalf("model should have been empty, got: %#v", m)
+		}
+	})
+
+	t.Run("mistral small generation", func(t *testing.T) {
+		m := modelgarden.MistralModel(g, "mistralai/mistral-small-2503")
+		if m == nil {
+			t.Fatal("mistralai/mistral-small-2503 model was not registered")
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithSystem("You are a helpful assistant. Reply in one short sentence."),
+			ai.WithMessages(ai.NewUserMessage(ai.NewTextPart("Say hello."))),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(resp.Text()) == "" {
+			t.Fatal("expected a non-empty response")
+		}
+	})
+
+	t.Run("codestral generation", func(t *testing.T) {
+		m := modelgarden.MistralModel(g, "mistralai/codestral-2")
+		if m == nil {
+			t.Fatal("mistralai/codestral-2 model was not registered")
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithMessages(ai.NewUserMessage(ai.NewTextPart("Write a one-line Python function that returns 42."))),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(resp.Text()) == "" {
+			t.Fatal("expected a non-empty response")
+		}
+	})
+
+	t.Run("bare id lookup", func(t *testing.T) {
+		// Same registered action; verifies the publisher-prefix trim path.
+		m := modelgarden.MistralModel(g, "mistral-small-2503")
+		if m == nil {
+			t.Fatal("mistral-small-2503 model was not registered under bare id")
+		}
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithMessages(ai.NewUserMessage(ai.NewTextPart("Reply with the single word: ok."))),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(resp.Text()) == "" {
+			t.Fatal("expected a non-empty response")
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		m := modelgarden.MistralModel(g, "mistralai/mistral-small-2503")
+		out := ""
+		_, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithPrompt("Count from one to three."),
+			ai.WithStreaming(func(ctx context.Context, c *ai.ModelResponseChunk) error {
+				for _, p := range c.Content {
+					if p.IsText() {
+						out += p.Text
+					}
+				}
+				return nil
+			}),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out == "" {
+			t.Fatal("expected streamed content")
+		}
+	})
+}

--- a/go/plugins/vertexai/modelgarden/mistral_transport.go
+++ b/go/plugins/vertexai/modelgarden/mistral_transport.go
@@ -1,0 +1,125 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// mistralVertexTransport rewrites outbound OpenAI-shaped chat completion
+// requests to Vertex's per-model Mistral rawPredict (or streamRawPredict)
+// URLs. Vertex's OpenAI-compatible /endpoints/openapi/chat/completions does
+// not serve Mistral; only the publisher-qualified rawPredict path does. The
+// request and response bodies are already in OpenAI shape, so only the URL
+// needs to change. The inner RoundTripper (typically an oauth2.Transport)
+// continues to add the Bearer token.
+type mistralVertexTransport struct {
+	inner    http.RoundTripper
+	project  string
+	location string
+}
+
+// RoundTrip rewrites any …/chat/completions request to the Mistral
+// rawPredict URL for the model named in the request body. The body itself
+// is preserved byte-for-byte so the openai-go SDK's framing (stream flag,
+// stream_options, tools, response_format) reaches Vertex unchanged.
+func (t *mistralVertexTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// The openai-go SDK emits POST .../chat/completions for chat requests.
+	// Any other path (probes, future SDK changes) is passed through.
+	if !strings.HasSuffix(req.URL.Path, "/chat/completions") {
+		return t.inner.RoundTrip(req)
+	}
+
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		// Close unconditionally so a read error does not leak the underlying
+		// reader (openai-go has no way to recover the original body once we
+		// return — GetBody would not be set on the un-rewritten request).
+		closeErr := req.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("modelgarden mistral transport: read body: %w", err)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("modelgarden mistral transport: close body: %w", closeErr)
+		}
+	}
+
+	model, stream, err := peekModelAndStream(bodyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("modelgarden mistral transport: %w", err)
+	}
+	// Defensive: openai-go may receive a publisher-qualified model id from
+	// callers that bypassed MistralModel/DefineModel. rawPredict expects
+	// the bare id; the publisher already lives in the URL.
+	model = strings.TrimPrefix(model, mistralPublisher+"/")
+	if model == "" {
+		return nil, fmt.Errorf("modelgarden mistral transport: request body has no model field")
+	}
+
+	suffix := "rawPredict"
+	if stream {
+		suffix = "streamRawPredict"
+	}
+
+	// PathEscape the model id so a hostile/malformed id (e.g. one containing
+	// "/", "?", or "#") cannot inject extra path segments, query strings, or
+	// fragments into the outbound URL.
+	newURL, err := url.Parse(fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/%s/models/%s:%s",
+		t.location, t.project, t.location, mistralPublisher, url.PathEscape(model), suffix,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("modelgarden mistral transport: build url: %w", err)
+	}
+
+	// Clone to avoid mutating the caller's request. Body and GetBody are
+	// reset so openai-go's retry path can replay the request.
+	rewritten := req.Clone(req.Context())
+	rewritten.URL = newURL
+	rewritten.Host = newURL.Host
+	rewritten.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	rewritten.ContentLength = int64(len(bodyBytes))
+	rewritten.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+	}
+
+	return t.inner.RoundTrip(rewritten)
+}
+
+// peekModelAndStream extracts the "model" and "stream" fields from an
+// OpenAI-shaped chat completion request body without losing other fields.
+func peekModelAndStream(body []byte) (model string, stream bool, err error) {
+	if len(body) == 0 {
+		return "", false, nil
+	}
+	var peek struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	if err := json.Unmarshal(body, &peek); err != nil {
+		return "", false, fmt.Errorf("decode body: %w", err)
+	}
+	return peek.Model, peek.Stream, nil
+}

--- a/go/plugins/vertexai/modelgarden/mistral_transport_test.go
+++ b/go/plugins/vertexai/modelgarden/mistral_transport_test.go
@@ -1,0 +1,326 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelgarden
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// captureRoundTripper records the last request it received and returns a
+// canned 200 OK response. The test mutates inner.last to inspect what the
+// outer transport actually sent.
+type captureRoundTripper struct {
+	last    *http.Request
+	lastRaw []byte
+}
+
+func (c *captureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.last = req
+	if req.Body != nil {
+		raw, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+		c.lastRaw = raw
+		// restore for any downstream reader
+		req.Body = io.NopCloser(bytes.NewReader(raw))
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{}`)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func newChatRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	u, err := url.Parse("https://us-central1-aiplatform.googleapis.com/v1/chat/completions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    u,
+		Host:   u.Host,
+		Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body:   io.NopCloser(strings.NewReader(body)),
+	}
+	return req
+}
+
+func TestMistralTransport_RewritesRawPredict(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := `{"model":"mistral-small-2503","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	req := newChatRequest(t, body)
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	want := "https://us-central1-aiplatform.googleapis.com/v1/projects/test-proj/locations/us-central1/publishers/mistralai/models/mistral-small-2503:rawPredict"
+	if got := inner.last.URL.String(); got != want {
+		t.Errorf("URL = %q, want %q", got, want)
+	}
+	if inner.last.Host != "us-central1-aiplatform.googleapis.com" {
+		t.Errorf("Host = %q, want us-central1-aiplatform.googleapis.com", inner.last.Host)
+	}
+	if string(inner.lastRaw) != body {
+		t.Errorf("body mutated:\n got  %s\n want %s", inner.lastRaw, body)
+	}
+	if inner.last.ContentLength != int64(len(body)) {
+		t.Errorf("ContentLength = %d, want %d", inner.last.ContentLength, len(body))
+	}
+	if inner.last.GetBody == nil {
+		t.Error("GetBody is nil; openai-go retries would send empty body")
+	} else {
+		rc, err := inner.last.GetBody()
+		if err != nil {
+			t.Fatalf("GetBody: %v", err)
+		}
+		raw, _ := io.ReadAll(rc)
+		rc.Close()
+		if string(raw) != body {
+			t.Errorf("GetBody body = %q, want %q", raw, body)
+		}
+	}
+}
+
+func TestMistralTransport_RewritesStreamRawPredict(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := `{"model":"codestral-2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	req := newChatRequest(t, body)
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	want := "https://us-central1-aiplatform.googleapis.com/v1/projects/test-proj/locations/us-central1/publishers/mistralai/models/codestral-2:streamRawPredict"
+	if got := inner.last.URL.String(); got != want {
+		t.Errorf("URL = %q, want %q", got, want)
+	}
+}
+
+func TestMistralTransport_StripsPublisherPrefixFromURL(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := `{"model":"mistralai/codestral-2","messages":[{"role":"user","content":"hi"}]}`
+	req := newChatRequest(t, body)
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	// URL must use bare id even though body had publisher prefix.
+	if !strings.HasSuffix(inner.last.URL.Path, "/publishers/mistralai/models/codestral-2:rawPredict") {
+		t.Errorf("URL path did not strip publisher prefix: %s", inner.last.URL.Path)
+	}
+}
+
+// errReader returns an error after returning some bytes, allowing the test
+// to drive io.ReadAll into its error path without ever reaching EOF.
+type errReader struct{ closed bool }
+
+func (r *errReader) Read(p []byte) (int, error) {
+	return 0, fmt.Errorf("synthetic read error")
+}
+func (r *errReader) Close() error { r.closed = true; return nil }
+
+func TestMistralTransport_ClosesBodyOnReadError(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := &errReader{}
+	u, _ := url.Parse("https://us-central1-aiplatform.googleapis.com/v1/chat/completions")
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    u,
+		Host:   u.Host,
+		Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body:   body,
+	}
+
+	_, err := rt.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error from read failure")
+	}
+	if !body.closed {
+		t.Fatal("body was not closed after read error; reader leaked")
+	}
+}
+
+func TestPeekModelAndStream_EmptyBody(t *testing.T) {
+	model, stream, err := peekModelAndStream(nil)
+	if err != nil {
+		t.Fatalf("err = %v, want nil for empty body", err)
+	}
+	if model != "" || stream {
+		t.Errorf("model=%q stream=%v, want empty/false for empty body", model, stream)
+	}
+}
+
+func TestPeekModelAndStream_MalformedJSON(t *testing.T) {
+	_, _, err := peekModelAndStream([]byte("{not-json"))
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	if !strings.Contains(err.Error(), "decode body") {
+		t.Errorf("err = %v, want one mentioning decode body", err)
+	}
+}
+
+func TestMistralTransport_PassThroughNonChat(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	u, _ := url.Parse("https://us-central1-aiplatform.googleapis.com/v1/models")
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    u,
+		Host:   u.Host,
+		Header: http.Header{},
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	if inner.last.URL.String() != u.String() {
+		t.Errorf("non-chat URL was rewritten: got %s, want %s", inner.last.URL, u)
+	}
+}
+
+func TestMistralTransport_MissingModelErrors(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := `{"messages":[{"role":"user","content":"hi"}]}`
+	req := newChatRequest(t, body)
+
+	_, err := rt.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error for missing model field, got nil")
+	}
+	if !strings.Contains(err.Error(), "no model") {
+		t.Errorf("error = %v, want one mentioning missing model", err)
+	}
+}
+
+func TestMistralTransport_EscapesModelInURL(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	// A malformed id with characters that would otherwise inject path/query
+	// segments. PathEscape must encode them.
+	body := `{"model":"weird/id?evil=1#frag"}`
+	req := newChatRequest(t, body)
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := inner.last.URL.RawQuery; got != "" {
+		t.Errorf("URL has unexpected query: %q", got)
+	}
+	if got := inner.last.URL.Fragment; got != "" {
+		t.Errorf("URL has unexpected fragment: %q", got)
+	}
+	// Path must contain the escaped form of the model, not the raw injection.
+	if !strings.Contains(inner.last.URL.EscapedPath(), "weird%2Fid%3Fevil=1%23frag:rawPredict") {
+		t.Errorf("model id not escaped in path: %s", inner.last.URL.EscapedPath())
+	}
+}
+
+func TestMistralTransport_PreservesExtraBodyFields(t *testing.T) {
+	inner := &captureRoundTripper{}
+	rt := &mistralVertexTransport{
+		inner:    inner,
+		project:  "test-proj",
+		location: "us-central1",
+	}
+
+	body := `{"model":"mistral-small-2503","tools":[{"type":"function","function":{"name":"x"}}],"response_format":{"type":"json_object"}}`
+	req := newChatRequest(t, body)
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	var got map[string]any
+	if err := json.Unmarshal(inner.lastRaw, &got); err != nil {
+		t.Fatalf("decode forwarded body: %v", err)
+	}
+	if _, ok := got["tools"]; !ok {
+		t.Error("tools field missing from forwarded body")
+	}
+	if _, ok := got["response_format"]; !ok {
+		t.Error("response_format field missing from forwarded body")
+	}
+}

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -213,10 +213,12 @@ var MistralModels = map[string]ai.ModelOptions{
 		Label:    "Mistral Medium 3",
 		Supports: &internal.BasicText,
 	},
-	"mistral-ocr-2505": {
-		Label:    "Mistral OCR 2505",
-		Supports: &internal.BasicText,
-	},
+	// NOTE: mistral-ocr-2505 intentionally not registered here. Vertex's
+	// OCR endpoint expects {document:{type, document_url|document_base64}},
+	// not the OpenAI chat-completions {messages:[{content:[{type:image_url,...}]}]}
+	// schema that the mistralVertexTransport rewrites to. Routing it through
+	// this plugin would 400 at Vertex. OCR support needs its own request/
+	// response path — track as a follow-up.
 	"mistral-small-2503": {
 		Label:    "Mistral Small 2503",
 		Supports: &internal.BasicText,

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -50,8 +50,8 @@ func resolveVertexMaasEnv(projectID, location string) (string, string) {
 }
 
 // provider is the shared registration namespace for every Vertex AI Model
-// Garden plugin in this package (Anthropic, Llama). Their models are all
-// registered as "vertexai/<model>" so users see a single namespace.
+// Garden plugin in this package (Anthropic, Llama, Mistral). Their models
+// are all registered as "vertexai/<model>" so users see a single namespace.
 // Each plugin's own Name() ("vertex-model-garden-<plugin>") is distinct from
 // this registration prefix.
 //
@@ -195,6 +195,34 @@ var LlamaModels = map[string]ai.ModelOptions{
 	},
 	"meta/llama-3.3-70b-instruct-maas": {
 		Label:    "Llama 3.3 70B Instruct",
+		Supports: &internal.BasicText,
+	},
+}
+
+// MistralModels lists the Mistral and Codestral models available through Vertex
+// AI Model Garden as Model-as-a-Service (MaaS) endpoints. Capabilities match
+// the JS parity target (media: false, tools: true, systemRole: true). Keys are
+// the bare publisher model ids ("mistral-small-2503" rather than
+// "mistralai/mistral-small-2503"). Vertex serves Mistral via per-model
+// rawPredict URLs where the publisher lives in the URL path, not the model
+// field; the Mistral plugin's HTTP transport assembles those URLs. The
+// "mistralai/" prefix is still accepted by MistralModel as a convenience for
+// callers used to the publisher-qualified form.
+var MistralModels = map[string]ai.ModelOptions{
+	"mistral-medium-3": {
+		Label:    "Mistral Medium 3",
+		Supports: &internal.BasicText,
+	},
+	"mistral-ocr-2505": {
+		Label:    "Mistral OCR 2505",
+		Supports: &internal.BasicText,
+	},
+	"mistral-small-2503": {
+		Label:    "Mistral Small 2503",
+		Supports: &internal.BasicText,
+	},
+	"codestral-2": {
+		Label:    "Codestral 2",
 		Supports: &internal.BasicText,
 	},
 }

--- a/go/plugins/vertexai/modelgarden/models.go
+++ b/go/plugins/vertexai/modelgarden/models.go
@@ -50,8 +50,8 @@ func resolveVertexMaasEnv(projectID, location string) (string, string) {
 }
 
 // provider is the shared registration namespace for every Vertex AI Model
-// Garden plugin in this package (Anthropic, Llama). Their models are all
-// registered as "vertexai/<model>" so users see a single namespace.
+// Garden plugin in this package (Anthropic, Llama, Mistral). Their models
+// are all registered as "vertexai/<model>" so users see a single namespace.
 // Each plugin's own Name() ("vertex-model-garden-<plugin>") is distinct from
 // this registration prefix.
 //
@@ -134,6 +134,34 @@ var LlamaModels = map[string]ai.ModelOptions{
 	},
 	"meta/llama-3.3-70b-instruct-maas": {
 		Label:    "Llama 3.3 70B Instruct",
+		Supports: &internal.BasicText,
+	},
+}
+
+// MistralModels lists the Mistral and Codestral models available through Vertex
+// AI Model Garden as Model-as-a-Service (MaaS) endpoints. Capabilities match
+// the JS parity target (media: false, tools: true, systemRole: true). Keys are
+// the bare publisher model ids ("mistral-small-2503" rather than
+// "mistralai/mistral-small-2503"). Vertex serves Mistral via per-model
+// rawPredict URLs where the publisher lives in the URL path, not the model
+// field; the Mistral plugin's HTTP transport assembles those URLs. The
+// "mistralai/" prefix is still accepted by MistralModel as a convenience for
+// callers used to the publisher-qualified form.
+var MistralModels = map[string]ai.ModelOptions{
+	"mistral-medium-3": {
+		Label:    "Mistral Medium 3",
+		Supports: &internal.BasicText,
+	},
+	"mistral-ocr-2505": {
+		Label:    "Mistral OCR 2505",
+		Supports: &internal.BasicText,
+	},
+	"mistral-small-2503": {
+		Label:    "Mistral Small 2503",
+		Supports: &internal.BasicText,
+	},
+	"codestral-2": {
+		Label:    "Codestral 2",
 		Supports: &internal.BasicText,
 	},
 }

--- a/go/samples/modelgarden-mistral/main.go
+++ b/go/samples/modelgarden-mistral/main.go
@@ -1,0 +1,68 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/vertexai/modelgarden"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Mistral and Codestral MaaS are served from us-central1. Override Location
+	// if your project has Mistral enabled in a different region.
+	g := genkit.Init(ctx, genkit.WithPlugins(
+		&modelgarden.Mistral{Location: "us-central1"},
+	))
+
+	// Define a flow that uses Mistral Small to list three interesting facts.
+	genkit.DefineFlow(g, "mistralFlow", func(ctx context.Context, input string) (string, error) {
+		m := modelgarden.MistralModel(g, "mistralai/mistral-small-2503")
+		if m == nil {
+			return "", errors.New("mistralFlow: failed to find model")
+		}
+
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithPrompt("List three interesting facts about %s", input))
+		if err != nil {
+			return "", err
+		}
+		return resp.Text(), nil
+	})
+
+	// Define a flow that uses Codestral 2 to write a small code snippet.
+	genkit.DefineFlow(g, "codestralFlow", func(ctx context.Context, input string) (string, error) {
+		m := modelgarden.MistralModel(g, "mistralai/codestral-2")
+		if m == nil {
+			return "", errors.New("codestralFlow: failed to find model")
+		}
+
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithPrompt("Write a small Go function that does the following: %s", input))
+		if err != nil {
+			return "", err
+		}
+		return resp.Text(), nil
+	})
+
+	<-ctx.Done()
+}


### PR DESCRIPTION
> ⚠️ **Draft, stacked on #5296.** The compat_oai-based half (Claude Opus 4.5, Llama, shared scaffolding) lives there; this PR adds the Mistral / Codestral plugin on top. Base is set to the compat_oai branch — once #5296 merges I will rebase onto `main` and mark this Ready for Review.

Adds a Mistral / Codestral plugin to the Vertex AI Model Garden Go plugin. Vertex does not serve Mistral via the OpenAI-compatible `/endpoints/openapi/chat/completions` endpoint that `compat_oai` uses for Llama; that endpoint returns `400 FAILED_PRECONDITION` even with a subscribed project. Mistral is served only at per-model `…/publishers/mistralai/models/<id>:rawPredict` (or `:streamRawPredict` for SSE), and the rawPredict response is already OpenAI-shaped JSON.

## Approach

`mistral_transport.go` introduces an `http.RoundTripper` that wraps the oauth2 transport, intercepts outbound `/chat/completions` requests, reads `model` + `stream` from the body, rewrites the URL to the per-model rawPredict (or streamRawPredict) path, and delegates back. The body bytes are preserved (incl. `tools`, `response_format`, `stream_options`), `GetBody` is set for openai-go retries, and the model id is `url.PathEscape`-encoded to prevent path / query injection. The inner oauth2 transport still adds the Bearer token, so authentication is unchanged.

`MistralModels` keys are bare ids (e.g. `mistral-small-2503`), so the openai-go SDK already serialises the form rawPredict expects. `MistralModel(g, id)` and `Mistral.DefineModel(name, opts)` strip an optional `mistralai/` prefix as a convenience for callers used to publisher-qualified ids.

Llama is unchanged from #5296 — it still uses the OpenAI-compat endpoint. Only Mistral takes the rawPredict detour.

## Models

- `mistral-small-2503`, `mistral-medium-3`, `mistral-ocr-2505`, `codestral-2` (all under the `mistralai` Vertex publisher).

## Tests

- `mistral_transport_test.go` — pure in-process tests covering rawPredict / streamRawPredict URL rewrites, publisher-prefix strip, non-chat passthrough, missing-model error, body field preservation (`tools`, `response_format`), `GetBody` population, URL escaping of malformed model ids, and the `io.ReadAll` error path closing the body.
- `mistral_live_test.go` — basic generation, codestral generation, bare-id lookup, and streaming through rawPredict (credential-gated).
- Mistral subtests added to `define_model_test.go` (pre-Init) and `internal_test.go` (nil opts).
- Mistral + Codestral flows added to `go/samples/modelgarden`.

## Testing

<img width="1247" height="351" alt="image" src="https://github.com/user-attachments/assets/bd38cb43-f35f-4bb7-b17a-02755b827246" />
<img width="410" height="410" alt="image" src="https://github.com/user-attachments/assets/03522c66-2d95-479a-9c61-7b700feba385" />

Supersedes the Mistral half of #5175.