### PR TITLE
fix(client): make space after "data:" optional in SSE parser

### DIFF
--- a/js/genkit/src/client/client.ts
+++ b/js/genkit/src/client/client.ts
@@ -138,11 +138,17 @@ async function __flowRunEnvelope({
     }
     // If buffer includes the delimiter that means we are still receiving chunks.
     while (buffer.includes(__flowStreamDelimiter)) {
-      const chunk = JSON.parse(
-        buffer
-          .substring(0, buffer.indexOf(__flowStreamDelimiter))
-          .substring('data: '.length)
-      );
+      const event = buffer.substring(0, buffer.indexOf(__flowStreamDelimiter));
+      // Per the SSE spec, the space after `data:` is optional, so strip the
+      // prefix and then at most one leading space.
+      // https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+      let payload = event.startsWith('data:')
+        ? event.substring('data:'.length)
+        : event;
+      if (payload.startsWith(' ')) {
+        payload = payload.substring(1);
+      }
+      const chunk = JSON.parse(payload);
       if (chunk.hasOwnProperty('message')) {
         sendChunk(chunk.message);
       } else if (chunk.hasOwnProperty('result')) {

--- a/js/genkit/src/client/client.ts
+++ b/js/genkit/src/client/client.ts
@@ -149,6 +149,9 @@ async function __flowRunEnvelope({
         payload = payload.substring(1);
       }
       const chunk = JSON.parse(payload);
+      if (!chunk || typeof chunk !== 'object') {
+        throw new Error('unknown chunk format: ' + JSON.stringify(chunk));
+      }
       if (chunk.hasOwnProperty('message')) {
         sendChunk(chunk.message);
       } else if (chunk.hasOwnProperty('result')) {

--- a/js/genkit/tests/client_test.ts
+++ b/js/genkit/tests/client_test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { streamFlow } from '../src/client/client.js';
+
+function mockSseFetch(body: string) {
+  return async (_url: string, _init?: RequestInit): Promise<Response> => {
+    return new Response(body, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+  };
+}
+
+describe('streamFlow SSE parser', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('parses spec-compliant events without a space after "data:"', async () => {
+    const body =
+      `data:${JSON.stringify({ message: 'a' })}\n\n` +
+      `data:${JSON.stringify({ message: 'b' })}\n\n` +
+      `data:${JSON.stringify({ result: 'done' })}\n\n`;
+    globalThis.fetch = mockSseFetch(body) as typeof fetch;
+
+    const response = streamFlow({ url: 'http://example.com/flow' });
+    const chunks: string[] = [];
+    for await (const chunk of response.stream) {
+      chunks.push(chunk);
+    }
+    assert.deepStrictEqual(chunks, ['a', 'b']);
+    assert.strictEqual(await response.output, 'done');
+  });
+
+  it('parses events with the conventional "data: " prefix', async () => {
+    const body =
+      `data: ${JSON.stringify({ message: 'a' })}\n\n` +
+      `data: ${JSON.stringify({ result: 'done' })}\n\n`;
+    globalThis.fetch = mockSseFetch(body) as typeof fetch;
+
+    const response = streamFlow({ url: 'http://example.com/flow' });
+    const chunks: string[] = [];
+    for await (const chunk of response.stream) {
+      chunks.push(chunk);
+    }
+    assert.deepStrictEqual(chunks, ['a']);
+    assert.strictEqual(await response.output, 'done');
+  });
+});

--- a/js/genkit/tests/client_test.ts
+++ b/js/genkit/tests/client_test.ts
@@ -50,6 +50,21 @@ describe('streamFlow SSE parser', () => {
     assert.strictEqual(await response.output, 'done');
   });
 
+  it('throws on null or primitive JSON payload', async () => {
+    const body = `data:null\n\n`;
+    globalThis.fetch = mockSseFetch(body) as typeof fetch;
+
+    const response = streamFlow({ url: 'http://example.com/flow' });
+    await assert.rejects(
+      async () => {
+        for await (const _ of response.stream) {
+          // drain
+        }
+      },
+      /unknown chunk format/
+    );
+  });
+
   it('parses events with the conventional "data: " prefix', async () => {
     const body =
       `data: ${JSON.stringify({ message: 'a' })}\n\n` +


### PR DESCRIPTION
## Problem

`streamFlow` (`js/genkit/src/client/client.ts`) strips a hardcoded `"data: "` (6 characters) from each SSE event before passing the rest to `JSON.parse`. Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), the single space after `data:` is optional — sources are allowed to emit `data:foo`. When they do (e.g. Spring WebFlux's built-in `ServerSentEventHttpMessageWriter`), the current parser consumes the first character of the payload and `JSON.parse` throws:

```
SyntaxError: Unexpected non-whitespace character after JSON at position 9
```

Fixes #3728.

## Solution

Strip the `data:` prefix first, then strip at most one optional leading space — matching the SSE spec's "if value starts with a U+0020 SPACE character, remove it from value" rule.

## Testing

Added `tests/client_test.ts` covering both `data:{...}` (no space) and `data: {...}` (conventional) event forms. Local run:

```
$ pnpm test
# tests 127
# pass 127
# fail 0
```