### PR TITLE
chore(go): purge retired models, default samples to gemini-flash-latest

### DIFF
--- a/go/GEMINI.md
+++ b/go/GEMINI.md
@@ -84,7 +84,7 @@ type Recipe struct {
 }
 
 recipe, _, err := genkit.GenerateData[Recipe](ctx, g,
-	ai.WithModelName("googleai/gemini-2.0-flash"),
+	ai.WithModelName("googleai/gemini-flash-latest"),
 	ai.WithPrompt("Suggest a pancake recipe"),
 )
 ```

--- a/go/README.md
+++ b/go/README.md
@@ -658,7 +658,7 @@ response, _ := genkit.Generate(ctx, g,
     ai.WithUse(
         &middleware.Retry{MaxRetries: 3},
         &middleware.Fallback{Models: []ai.ModelRef{
-            googlegenai.ModelRef("googleai/gemini-2.5-flash", nil),
+            googlegenai.ModelRef("googleai/gemini-3.5-flash", nil),
         }},
     ),
 )

--- a/go/ai/example_test.go
+++ b/go/ai/example_test.go
@@ -136,12 +136,12 @@ func ExampleNewMediaPart() {
 func ExampleNewModelRef() {
 	// Create a reference to a model with custom configuration
 	// The config type depends on the model provider
-	modelRef := ai.NewModelRef("googleai/gemini-2.5-flash", map[string]any{
+	modelRef := ai.NewModelRef("googleai/gemini-flash-latest", map[string]any{
 		"temperature": 0.7,
 	})
 
 	fmt.Println("Model name:", modelRef.Name())
-	// Output: Model name: googleai/gemini-2.5-flash
+	// Output: Model name: googleai/gemini-flash-latest
 }
 
 // This example demonstrates building a multi-turn conversation.

--- a/go/ai/gen.go
+++ b/go/ai/gen.go
@@ -94,7 +94,7 @@ type GenerateActionOptions struct {
 	MaxTurns int `json:"maxTurns,omitempty"`
 	// Messages contains the conversation history for multi-turn prompting when supported.
 	Messages []*Message `json:"messages,omitempty"`
-	// Model is a model name (e.g., "vertexai/gemini-1.0-pro").
+	// Model is a model name (e.g., "vertexai/gemini-flash-latest").
 	Model string `json:"model,omitempty"`
 	// Output specifies the desired output format. Defaults to the model's default if unspecified.
 	Output    *GenerateActionOutputConfig `json:"output,omitempty"`
@@ -165,7 +165,7 @@ type GenerationCommonConfig struct {
 	// TopP (nucleus sampling) limits sampling to tokens whose cumulative probability exceeds P.
 	TopP float64 `json:"topP,omitempty"`
 	// Version specifies a particular version of a model family,
-	// e.g., "gemini-1.0-pro-001" for the "gemini-1.0-pro" family.
+	// e.g., "gemini-3.5-flash-001" for the "gemini-3.5-flash" family.
 	Version string `json:"version,omitempty"`
 }
 

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -1458,7 +1458,7 @@ func (ModelRef) JSONSchema() *jsonschema.Schema {
 	props := jsonschema.NewProperties()
 	props.Set("name", &jsonschema.Schema{
 		Type:        "string",
-		Description: "Model name (e.g. \"googleai/gemini-2.5-flash\")",
+		Description: "Model name (e.g. \"googleai/gemini-flash-latest\")",
 	})
 	props.Set("config", &jsonschema.Schema{
 		Description: "Optional model configuration",

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -223,7 +223,7 @@ GenerationCommonConfig holds configuration parameters for model generation reque
 
 GenerationCommonConfig.version doc
 Version specifies a particular version of a model family,
-e.g., "gemini-1.0-pro-001" for the "gemini-1.0-pro" family.
+e.g., "gemini-3.5-flash-001" for the "gemini-3.5-flash" family.
 .
 
 GenerationCommonConfig.temperature doc
@@ -685,7 +685,7 @@ GenerateActionOptions holds configuration for a generate action request.
 .
 
 GenerateActionOptions.model doc
-Model is a model name (e.g., "vertexai/gemini-1.0-pro").
+Model is a model name (e.g., "vertexai/gemini-flash-latest").
 .
 
 GenerateActionOptions.docs doc

--- a/go/genkit/doc.go
+++ b/go/genkit/doc.go
@@ -36,7 +36,7 @@ Initialize Genkit with a plugin to connect to an AI provider:
 Generate text with a simple prompt:
 
 	text, err := genkit.GenerateText(ctx, g,
-		ai.WithModelName("googleai/gemini-2.5-flash"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithPrompt("Tell me a joke"),
 	)
 	if err != nil {
@@ -51,7 +51,7 @@ models from providers like Google AI, Vertex AI, Anthropic, or Ollama. Models ar
 referenced by name and can include provider-specific configuration:
 
 	resp, err := genkit.Generate(ctx, g,
-		ai.WithModelName("googleai/gemini-2.5-flash"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithPrompt("Explain quantum computing in simple terms"),
 	)
 
@@ -59,7 +59,7 @@ You can set a default model during initialization:
 
 	g := genkit.Init(ctx,
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
-		genkit.WithDefaultModel("googleai/gemini-2.5-flash"),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
 	)
 
 # Flows
@@ -114,7 +114,7 @@ They encapsulate model configuration, input schemas, and template logic for reus
 Define a prompt in code:
 
 	jokePrompt := genkit.DefinePrompt(g, "joke",
-		ai.WithModelName("googleai/gemini-2.5-flash"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithInputType(JokeRequest{Topic: "default topic"}),
 		ai.WithPrompt("Share a joke about {{topic}}."),
 	)
@@ -354,7 +354,7 @@ accept options from the [ai] package to control behavior. The most common option
 Model and Configuration:
 
   - [ai.WithModel]: Specify the model (accepts [ai.ModelRef] or plugin model refs)
-  - [ai.WithModelName]: Specify model by name string (e.g., "googleai/gemini-2.5-flash")
+  - [ai.WithModelName]: Specify model by name string (e.g., "googleai/gemini-flash-latest")
   - [ai.WithConfig]: Set generation parameters (temperature, max tokens, etc.)
 
 Prompting:
@@ -376,7 +376,7 @@ Streaming:
 Example combining multiple options:
 
 	resp, err := genkit.Generate(ctx, g,
-		ai.WithModelName("googleai/gemini-2.5-flash"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithSystem("You are a helpful coding assistant."),
 		ai.WithMessages(conversationHistory...),
 		ai.WithPrompt("Explain this code: %s", code),

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -1159,7 +1159,7 @@ func GenerateStream(ctx context.Context, g *Genkit, opts ...ai.GenerateOption) i
 // Example:
 //
 //	op, err := genkit.GenerateOperation(ctx, g,
-//		ai.WithModelName("googleai/veo-2.0-generate-001"),
+//		ai.WithModelName("googleai/veo-3.1-generate-preview"),
 //		ai.WithPrompt("A banana riding a bicycle."),
 //	)
 //	if err != nil {

--- a/go/plugins/googlegenai/README.md
+++ b/go/plugins/googlegenai/README.md
@@ -85,8 +85,8 @@ Genkit automatically discovers available models supported by the [Go GenAI SDK](
 Commonly used models include:
 
 - **Gemini Series**: `gemini-flash-latest`, `gemini-3.5-flash`, `gemini-3.1-flash-lite`
-- **Imagen Series**: `imagen-3.0-generate-001`
-- **Veo Series**: `veo-3.0-generate-001`
+- **Imagen Series**: `imagen-4.0-generate-001`
+- **Veo Series**: `veo-3.1-generate-preview`
 
 > **Note:** You can use any model ID supported by the underlying SDK. For a complete and up-to-date list of models and their specific capabilities, refer to the [Google Generative AI models documentation](https://ai.google.dev/gemini-api/docs/models).
 
@@ -392,10 +392,11 @@ fmt.Printf("Embedding: %v\n", res.Embeddings[0].Embedding)
 
 ### Available Models
 
-**Imagen 3 Series**:
+**Imagen 4 Series**:
 
-- `imagen-3.0-generate-001`
-- `imagen-3.0-fast-generate-001`
+- `imagen-4.0-generate-001`
+- `imagen-4.0-fast-generate-001`
+- `imagen-4.0-ultra-generate-001`
 
 ### Usage
 
@@ -403,7 +404,7 @@ fmt.Printf("Embedding: %v\n", res.Embeddings[0].Embedding)
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/imagen-3.0-generate-001"),
+ ai.WithModelName("googleai/imagen-4.0-generate-001"),
  ai.WithPrompt("A serene Japanese garden with cherry blossoms"),
  ai.WithConfig(&genai.GenerateImagesConfig{
   NumberOfImages: 4,
@@ -424,15 +425,7 @@ The Google AI plugin provides access to video generation capabilities through th
 **Veo 3.1 Series**:
 
 - `veo-3.1-generate-preview`
-
-**Veo 3.0 Series**:
-
-- `veo-3.0-generate-001`
-- `veo-3.0-fast-generate-001`
-
-**Veo 2.0 Series**:
-
-- `veo-2.0-generate-001`
+- `veo-3.1-fast-generate-preview`
 
 ### Usage
 

--- a/go/plugins/googlegenai/README.md
+++ b/go/plugins/googlegenai/README.md
@@ -84,7 +84,7 @@ Genkit automatically discovers available models supported by the [Go GenAI SDK](
 
 Commonly used models include:
 
-- **Gemini Series**: `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-flash`, `gemini-2.5-pro`
+- **Gemini Series**: `gemini-flash-latest`, `gemini-3.5-flash`, `gemini-3.1-flash-lite`
 - **Imagen Series**: `imagen-3.0-generate-001`
 - **Veo Series**: `veo-3.0-generate-001`
 
@@ -106,7 +106,7 @@ func main() {
  // ... Init genkit with googlegenai plugin ...
 
  resp, err := genkit.Generate(ctx, g,
-  ai.WithModelName("googleai/gemini-2.5-flash"),
+  ai.WithModelName("googleai/gemini-flash-latest"),
   ai.WithPrompt("Explain how neural networks learn in simple terms."),
  )
  if err != nil {
@@ -132,7 +132,7 @@ type Character struct {
 
 // Automatically infers schema from the struct and unmarshals the result
 char, resp, err := genkit.GenerateData[Character](ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
+ ai.WithModelName("googleai/gemini-flash-latest"),
  ai.WithPrompt("Generate a profile for a fictional character"),
 )
 if err != nil {
@@ -148,7 +148,7 @@ You can also use the standard `Generate` function and unmarshal manually:
 
 ```go
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
+ ai.WithModelName("googleai/gemini-flash-latest"),
  ai.WithPrompt("Generate a profile for a fictional character"),
  ai.WithOutputType(Character{}),
 )
@@ -180,7 +180,7 @@ Gemini 2.5 and newer models use an internal thinking process that improves reaso
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
+ ai.WithModelName("googleai/gemini-flash-latest"),
  ai.WithPrompt("what is heavier, one kilo of steel or one kilo of feathers"),
  ai.WithConfig(&genai.GenerateContentConfig{
   ThinkingConfig: &genai.ThinkingConfig{
@@ -201,14 +201,14 @@ cachedMsg := ai.NewUserTextMessage(largeContent).WithCacheTTL(300)
 
 // First request - content will be cached
 resp1, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
+ ai.WithModelName("googleai/gemini-flash-latest"),
  ai.WithMessages(cachedMsg),
  ai.WithPrompt("Task 1..."),
 )
 
 // Second request with same prefix - eligible for cache hit
 resp2, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
+ ai.WithModelName("googleai/gemini-flash-latest"),
  // Reuse the history from previous response or construct messages with same prefix
  ai.WithMessages(resp1.History()...),
  ai.WithPrompt("Task 2..."),
@@ -223,7 +223,7 @@ You can configure safety settings to control content filtering:
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
+ ai.WithModelName("googleai/gemini-flash-latest"),
  ai.WithPrompt("Your prompt here"),
  ai.WithConfig(&genai.GenerateContentConfig{
   SafetySettings: []*genai.SafetySetting{
@@ -248,7 +248,7 @@ Enable Google Search to provide answers with current information and verifiable 
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
+ ai.WithModelName("googleai/gemini-flash-latest"),
  ai.WithPrompt("What are the top tech news stories this week?"),
  ai.WithConfig(&genai.GenerateContentConfig{
   Tools: []*genai.Tool{
@@ -268,7 +268,7 @@ Enable Google Maps to provide location-aware responses.
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
+ ai.WithModelName("googleai/gemini-flash-latest"),
  ai.WithPrompt("Find coffee shops near Times Square"),
  ai.WithConfig(&genai.GenerateContentConfig{
   Tools: []*genai.Tool{
@@ -307,7 +307,7 @@ Enable the model to write and execute Python code for calculations and logic.
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-pro"),
+ ai.WithModelName("googleai/gemini-flash-latest"),
  ai.WithPrompt("Calculate the 20th Fibonacci number"),
  ai.WithConfig(&genai.GenerateContentConfig{
   Tools: []*genai.Tool{
@@ -321,13 +321,13 @@ resp, err := genkit.Generate(ctx, g,
 
 ### Generating Text and Images
 
-Some Gemini models (like `gemini-2.5-flash-image`) can output images natively alongside text.
+Some Gemini models (like `gemini-3.1-flash-image`) can output images natively alongside text.
 
 ```go
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash-image"),
+ ai.WithModelName("googleai/gemini-3.1-flash-image"),
  ai.WithPrompt("Create a picture of a futuristic city and describe it"),
  ai.WithConfig(&genai.GenerateContentConfig{
   ResponseModalities: []string{"IMAGE", "TEXT"},
@@ -356,7 +356,7 @@ videoPart := ai.NewMediaPart("video/mp4", "https://example.com/video.mp4")
 imagePart := ai.NewMediaPart("image/jpeg", "data:image/jpeg;base64,...")
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
+ ai.WithModelName("googleai/gemini-flash-latest"),
  ai.WithMessages(
   ai.NewUserMessage(
    ai.NewTextPart("Describe this content"),
@@ -549,7 +549,7 @@ op, err := genkit.GenerateOperation(ctx, g,
 ## Speech Models
 
 Use Gemini TTS models to generate speech. Dedicated TTS models include
-`gemini-2.5-flash-preview-tts` and `gemini-2.5-pro-preview-tts`.
+`gemini-3.1-flash-tts-preview`.
 
 Gemini TTS responses are returned as media parts. The media data may be raw PCM
 audio, commonly `audio/L16;codec=pcm;rate=24000`, rather than a WAV or MP3 file.
@@ -565,7 +565,7 @@ the JavaScript Gemini TTS samples, which convert the returned PCM bytes with a
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash-preview-tts"),
+ ai.WithModelName("googleai/gemini-3.1-flash-tts-preview"),
  ai.WithPrompt("Say that Genkit is an amazing AI framework"),
  ai.WithConfig(&genai.GenerateContentConfig{
   SpeechConfig: &genai.SpeechConfig{

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -95,17 +95,10 @@ var (
 )
 
 const (
-	gemini20Flash     = "gemini-2.0-flash"
-	gemini20FlashExp  = "gemini-2.0-flash-exp"
-	gemini20FlashLite = "gemini-2.0-flash-lite"
-
 	gemini25Flash     = "gemini-2.5-flash"
 	gemini25FlashLite = "gemini-2.5-flash-lite"
 
 	gemini25Pro = "gemini-2.5-pro"
-
-	gemini31FlashLitePreview  = "gemini-3.1-flash-lite-preview"
-	gemini31FlashImagePreview = "gemini-3.1-flash-image-preview"
 
 	gemini35Flash      = "gemini-3.5-flash"
 	gemini31FlashLite  = "gemini-3.1-flash-lite"
@@ -116,21 +109,15 @@ const (
 	gemini25ProPreviewTTS   = "gemini-2.5-pro-preview-tts"
 	gemini31FlashTTSPreview = "gemini-3.1-flash-tts-preview"
 
-	imagen3Generate001       = "imagen-3.0-generate-001"
-	imagen3FastGenerate001   = "imagen-3.0-fast-generate-001"
 	imagen40FastGenerate001  = "imagen-4.0-fast-generate-001"
 	imagen40Generate001      = "imagen-4.0-generate-001"
 	imagen40UltraGenerate001 = "imagen-4.0-ultra-generate-001"
 
-	veo20Generate001         = "veo-2.0-generate-001"
-	veo30Generate001         = "veo-3.0-generate-001"
-	veo30FastGenerate001     = "veo-3.0-fast-generate-001"
 	veo31Generate001         = "veo-3.1-generate-001"
 	veo31FastGenerate001     = "veo-3.1-fast-generate-001"
 	veo31GeneratePreview     = "veo-3.1-generate-preview"
 	veo31FastGeneratePreview = "veo-3.1-fast-generate-preview"
 
-	embedding001                      = "embedding-001"
 	textembeddinggecko003             = "textembedding-gecko@003"
 	textembeddinggecko002             = "textembedding-gecko@002"
 	textembeddinggecko001             = "textembedding-gecko@001"
@@ -144,36 +131,26 @@ var (
 	// eventually, Vertex AI and Google AI models will match, in the meantime,
 	// keep them sepparated
 	vertexAIModels = []string{
-		gemini20Flash,
-		gemini20FlashLite,
 		gemini25Flash,
 		gemini25FlashLite,
 		gemini25Pro,
-		gemini31FlashLitePreview,
-		gemini31FlashImagePreview,
 		gemini35Flash,
 		gemini31FlashLite,
 		gemini31FlashImage,
 		gemini3ProImage,
 
-		imagen3Generate001,
-		imagen3FastGenerate001,
+		imagen40FastGenerate001,
+		imagen40Generate001,
+		imagen40UltraGenerate001,
 
-		veo20Generate001,
-		veo30Generate001,
-		veo30FastGenerate001,
 		veo31Generate001,
 		veo31FastGenerate001,
 	}
 
 	googleAIModels = []string{
-		gemini20Flash,
-		gemini20FlashExp,
 		gemini25Flash,
 		gemini25FlashLite,
 		gemini25Pro,
-		gemini31FlashLitePreview,
-		gemini31FlashImagePreview,
 		gemini35Flash,
 		gemini31FlashImage,
 		gemini3ProImage,
@@ -186,30 +163,11 @@ var (
 		gemini25ProPreviewTTS,
 		gemini31FlashTTSPreview,
 
-		veo20Generate001,
-		veo30Generate001,
-		veo30FastGenerate001,
 		veo31GeneratePreview,
 		veo31FastGeneratePreview,
 	}
 
 	supportedGeminiModels = map[string]ai.ModelOptions{
-		gemini20Flash: {
-			Label: "Gemini 2.0 Flash",
-			Versions: []string{
-				"gemini-2.0-flash-001",
-			},
-			Supports: &Multimodal,
-			Stage:    ai.ModelStageStable,
-		},
-		gemini20FlashLite: {
-			Label: "Gemini 2.0 Flash Lite",
-			Versions: []string{
-				"gemini-2.0-flash-lite-001",
-			},
-			Supports: &Multimodal,
-			Stage:    ai.ModelStageStable,
-		},
 		gemini25Flash: {
 			Label:    "Gemini 2.5 Flash",
 			Versions: []string{},
@@ -227,18 +185,6 @@ var (
 			Versions: []string{},
 			Supports: &Multimodal,
 			Stage:    ai.ModelStageStable,
-		},
-		gemini31FlashLitePreview: {
-			Label:    "Gemini 3.1 Flash Lite Preview",
-			Versions: []string{},
-			Supports: &Multimodal,
-			Stage:    ai.ModelStageUnstable,
-		},
-		gemini31FlashImagePreview: {
-			Label:    "Gemini 3.1 Flash Image Preview",
-			Versions: []string{},
-			Supports: &Multimodal,
-			Stage:    ai.ModelStageUnstable,
 		},
 		gemini35Flash: {
 			Label:    "Gemini 3.5 Flash",
@@ -285,18 +231,6 @@ var (
 	}
 
 	supportedImagenModels = map[string]ai.ModelOptions{
-		imagen3Generate001: {
-			Label:    "Imagen 3 Generate 001",
-			Versions: []string{},
-			Supports: &Media,
-			Stage:    ai.ModelStageStable,
-		},
-		imagen3FastGenerate001: {
-			Label:    "Imagen 3 Fast Generate 001",
-			Versions: []string{},
-			Supports: &Media,
-			Stage:    ai.ModelStageStable,
-		},
 		imagen40FastGenerate001: {
 			Label:    "Imagen 4 Fast Generate 001",
 			Versions: []string{},
@@ -318,24 +252,6 @@ var (
 	}
 
 	supportedVideoModels = map[string]ai.ModelOptions{
-		veo20Generate001: {
-			Label:    "Veo 2.0 Generate 001",
-			Versions: []string{},
-			Supports: &VeoSupports,
-			Stage:    ai.ModelStageStable,
-		},
-		veo30Generate001: {
-			Label:    "Veo 3.0 Generate 001",
-			Versions: []string{},
-			Supports: &VeoSupports,
-			Stage:    ai.ModelStageStable,
-		},
-		veo30FastGenerate001: {
-			Label:    "Veo 3.0 Fast Generate 001",
-			Versions: []string{},
-			Supports: &VeoSupports,
-			Stage:    ai.ModelStageStable,
-		},
 		veo31Generate001: {
 			Label:    "Veo 3.1 Generate 001",
 			Versions: []string{},
@@ -363,13 +279,6 @@ var (
 	}
 
 	embedderConfig = map[string]ai.EmbedderOptions{
-		embedding001: {
-			Dimensions: 768,
-			Label:      "Google Gen AI - Text Embedding Gecko (Legacy)",
-			Supports: &ai.EmbedderSupports{
-				Input: []string{"text"},
-			},
-		},
 		textembeddinggecko003: {
 			Dimensions: 768,
 			Label:      "Google Gen AI - Text Embedding Gecko 003",

--- a/go/plugins/googlegenai/refs.go
+++ b/go/plugins/googlegenai/refs.go
@@ -33,7 +33,7 @@ func VertexAIModelRef(id string, config *genai.GenerateContentConfig) ai.ModelRe
 // --- Image generation (Imagen) ---
 
 // ImageModelRef creates a ModelRef for an image generation model.
-// The name should include provider prefix (e.g., "googleai/imagen-3.0-generate-001").
+// The name should include provider prefix (e.g., "googleai/imagen-4.0-generate-001").
 func ImageModelRef(name string, config *genai.GenerateImagesConfig) ai.ModelRef {
 	return ai.NewModelRef(name, config)
 }
@@ -41,7 +41,7 @@ func ImageModelRef(name string, config *genai.GenerateImagesConfig) ai.ModelRef 
 // --- Video generation (Veo) ---
 
 // VideoModelRef creates a ModelRef for a video generation model.
-// The name should include provider prefix (e.g., "googleai/veo-2.0-generate-001").
+// The name should include provider prefix (e.g., "googleai/veo-3.1-generate-preview").
 func VideoModelRef(name string, config *genai.GenerateVideosConfig) ai.ModelRef {
 	return ai.NewModelRef(name, config)
 }

--- a/go/plugins/googlegenai/refs.go
+++ b/go/plugins/googlegenai/refs.go
@@ -11,7 +11,7 @@ import (
 // --- Gemini (text generation) ---
 
 // ModelRef creates a ModelRef for a Gemini model.
-// The name should include provider prefix (e.g., "googleai/gemini-2.0-flash").
+// The name should include provider prefix (e.g., "googleai/gemini-flash-latest").
 func ModelRef(name string, config *genai.GenerateContentConfig) ai.ModelRef {
 	return ai.NewModelRef(name, config)
 }

--- a/go/plugins/middleware/fallback.go
+++ b/go/plugins/middleware/fallback.go
@@ -51,8 +51,8 @@ var defaultFallbackStatuses = []status.Name{
 //	    ai.WithModel(primary),
 //	    ai.WithPrompt("hello"),
 //	    ai.WithUse(&middleware.Fallback{Models: []ai.ModelRef{
-//	        googlegenai.ModelRef("googleai/gemini-2.5-flash", ...),
-//	        googlegenai.ModelRef("vertexai/gemini-2.5-flash", ...),
+//	        googlegenai.ModelRef("googleai/gemini-flash-latest", ...),
+//	        googlegenai.ModelRef("vertexai/gemini-flash-latest", ...),
 //	    }}),
 //	)
 type Fallback struct {

--- a/go/samples/basic-prompts/main.go
+++ b/go/samples/basic-prompts/main.go
@@ -142,7 +142,7 @@ func main() {
 func DefineSimpleJokeWithInlinePrompt(g *genkit.Genkit) {
 	jokePrompt := genkit.DefinePrompt(
 		g, "joke.code",
-		ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+		ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 			ThinkingConfig: &genai.ThinkingConfig{
 				ThinkingBudget: genai.Ptr[int32](0),
 			},
@@ -201,7 +201,7 @@ func DefineSimpleJokeWithDotprompt(g *genkit.Genkit) {
 func DefineStructuredJokeWithInlinePrompt(g *genkit.Genkit) {
 	jokePrompt := genkit.DefineDataPrompt[JokeRequest, *Joke](
 		g, "structured-joke.code",
-		ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+		ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 			ThinkingConfig: &genai.ThinkingConfig{
 				ThinkingBudget: genai.Ptr[int32](0),
 			},
@@ -254,7 +254,7 @@ func DefineStructuredJokeWithDotprompt(g *genkit.Genkit) {
 func DefineRecipeWithInlinePrompt(g *genkit.Genkit) {
 	recipePrompt := genkit.DefineDataPrompt[RecipeRequest, *Recipe](
 		g, "recipe.code",
-		ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+		ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 			ThinkingConfig: &genai.ThinkingConfig{
 				ThinkingBudget: genai.Ptr[int32](0),
 			},

--- a/go/samples/basic-prompts/main.go
+++ b/go/samples/basic-prompts/main.go
@@ -138,7 +138,7 @@ func main() {
 func DefineSimpleJokeWithInlinePrompt(g *genkit.Genkit) {
 	jokePrompt := genkit.DefinePrompt(
 		g, "joke.code",
-		ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+		ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 			ThinkingConfig: &genai.ThinkingConfig{
 				ThinkingBudget: genai.Ptr[int32](0),
 			},
@@ -197,7 +197,7 @@ func DefineSimpleJokeWithDotprompt(g *genkit.Genkit) {
 func DefineStructuredJokeWithInlinePrompt(g *genkit.Genkit) {
 	jokePrompt := genkit.DefineDataPrompt[JokeRequest, *Joke](
 		g, "structured-joke.code",
-		ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+		ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 			ThinkingConfig: &genai.ThinkingConfig{
 				ThinkingBudget: genai.Ptr[int32](0),
 			},
@@ -250,7 +250,7 @@ func DefineStructuredJokeWithDotprompt(g *genkit.Genkit) {
 func DefineRecipeWithInlinePrompt(g *genkit.Genkit) {
 	recipePrompt := genkit.DefineDataPrompt[RecipeRequest, *Recipe](
 		g, "recipe.code",
-		ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+		ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 			ThinkingConfig: &genai.ThinkingConfig{
 				ThinkingBudget: genai.Ptr[int32](0),
 			},

--- a/go/samples/basic-prompts/prompts/joke.prompt
+++ b/go/samples/basic-prompts/prompts/joke.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 config:
   thinkingConfig:
     thinkingBudget: 0

--- a/go/samples/basic-prompts/prompts/recipe.prompt
+++ b/go/samples/basic-prompts/prompts/recipe.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 config:
   thinkingConfig:
     thinkingBudget: 0

--- a/go/samples/basic-prompts/prompts/structured-joke.prompt
+++ b/go/samples/basic-prompts/prompts/structured-joke.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 config:
   thinkingConfig:
     thinkingBudget: 0

--- a/go/samples/basic-structured/main.go
+++ b/go/samples/basic-structured/main.go
@@ -114,7 +114,7 @@ func DefineSimpleJoke(g *genkit.Genkit) {
 	genkit.DefineStreamingFlow(g, "simpleJokesFlow",
 		func(ctx context.Context, input string, sendChunk core.StreamCallback[string]) (string, error) {
 			stream := genkit.GenerateStream(ctx, g,
-				ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+				ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 					ThinkingConfig: &genai.ThinkingConfig{
 						ThinkingBudget: genai.Ptr[int32](0),
 					},
@@ -143,7 +143,7 @@ func DefineStructuredJoke(g *genkit.Genkit) {
 	genkit.DefineStreamingFlow(g, "structuredJokesFlow",
 		func(ctx context.Context, input JokeRequest, sendChunk core.StreamCallback[*Joke]) (*Joke, error) {
 			stream := genkit.GenerateDataStream[*Joke](ctx, g,
-				ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+				ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 					ThinkingConfig: &genai.ThinkingConfig{
 						ThinkingBudget: genai.Ptr[int32](0),
 					},
@@ -171,7 +171,7 @@ func DefineRecipe(g *genkit.Genkit) {
 	genkit.DefineStreamingFlow(g, "recipeFlow",
 		func(ctx context.Context, input RecipeRequest, sendChunk core.StreamCallback[[]*Ingredient]) (*Recipe, error) {
 			stream := genkit.GenerateDataStream[*Recipe](ctx, g,
-				ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+				ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 					ThinkingConfig: &genai.ThinkingConfig{
 						ThinkingBudget: genai.Ptr[int32](0),
 					},

--- a/go/samples/basic/main.go
+++ b/go/samples/basic/main.go
@@ -61,7 +61,7 @@ func main() {
 		}
 
 		return genkit.GenerateText(ctx, g,
-			ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+			ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 				ThinkingConfig: &genai.ThinkingConfig{
 					ThinkingBudget: genai.Ptr[int32](0),
 				},
@@ -78,7 +78,7 @@ func main() {
 			}
 
 			resp, err := genkit.Generate(ctx, g,
-				ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+				ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 					ThinkingConfig: &genai.ThinkingConfig{
 						ThinkingBudget: genai.Ptr[int32](0),
 					},

--- a/go/samples/cache-gemini/main.go
+++ b/go/samples/cache-gemini/main.go
@@ -36,7 +36,7 @@ type duneQuestionInput struct {
 func main() {
 	ctx := context.Background()
 	g := genkit.Init(ctx,
-		genkit.WithDefaultModel("googleai/gemini-2.5-flash"),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
 	)
 

--- a/go/samples/code-execution-gemini/main.go
+++ b/go/samples/code-execution-gemini/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	// Define a flow to demonstrate code execution
 	genkit.DefineFlow(g, "codeExecutionFlow", func(ctx context.Context, _ any) (string, error) {
-		m := googlegenai.GoogleAIModel(g, "gemini-2.5-flash")
+		m := googlegenai.GoogleAIModel(g, "gemini-flash-latest")
 		if m == nil {
 			return "", errors.New("failed to find model")
 		}

--- a/go/samples/coffee-shop/main.go
+++ b/go/samples/coffee-shop/main.go
@@ -99,11 +99,11 @@ type testAllCoffeeFlowsOutput struct {
 func main() {
 	ctx := context.Background()
 	g := genkit.Init(ctx,
-		genkit.WithDefaultModel("googleai/gemini-2.5-flash"),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
 	)
 
-	m := googlegenai.GoogleAIModel(g, "gemini-2.5-flash")
+	m := googlegenai.GoogleAIModel(g, "gemini-flash-latest")
 	simpleGreetingPrompt := genkit.DefinePrompt(g, "simpleGreeting2",
 		ai.WithPrompt(simpleGreetingPromptTemplate),
 		ai.WithModel(m),

--- a/go/samples/files-api-vision/main.go
+++ b/go/samples/files-api-vision/main.go
@@ -63,7 +63,7 @@ func main() {
 	// Use Files API URI directly with Genkit (now supported!)
 	fmt.Println("Analyzing image with Genkit using Files API URI...")
 	resp, err := genkit.Generate(ctx, g,
-		ai.WithModelName("googleai/gemini-2.5-flash"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithMessages(
 			ai.NewUserMessage(
 				ai.NewTextPart("What do you see in this image?"),

--- a/go/samples/formats/main.go
+++ b/go/samples/formats/main.go
@@ -38,7 +38,7 @@ func main() {
 	ctx := context.Background()
 	g := genkit.Init(ctx,
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
-		genkit.WithDefaultModel("googleai/gemini-2.5-flash"),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
 	)
 
 	var callback func(context.Context, *ai.ModelResponseChunk) error

--- a/go/samples/imagen-gemini/main.go
+++ b/go/samples/imagen-gemini/main.go
@@ -101,8 +101,8 @@ func main() {
 	// GEMINI_API_KEY or GOOGLE_API_KEY environment variable, which is the recommended
 	// practice. The Vertex AI plugin is added conditionally when GOOGLE_CLOUD_PROJECT
 	// and a location are set, so the gemini-3.1 Vertex flows only register when
-	// that config is present. Vertex's gemini-3.1-flash-*-preview models are
-	// Global-only — set GOOGLE_CLOUD_LOCATION=global.
+	// that config is present. Vertex's gemini-3.1-flash-* models are
+	// Global-only, so set GOOGLE_CLOUD_LOCATION=global.
 	plugins := []api.Plugin{&googlegenai.GoogleAI{}}
 	hasVertex := hasVertexAIConfig()
 	if hasVertex {
@@ -145,20 +145,20 @@ func main() {
 	})
 
 	genkit.DefineFlow(g, "gemini31LiteGoogleAIFlow", func(ctx context.Context, input string) (string, error) {
-		return generateGemini31Lite(ctx, g, "googleai/gemini-3.1-flash-lite-preview", input)
+		return generateGemini31Lite(ctx, g, "googleai/gemini-3.1-flash-lite", input)
 	})
 
 	genkit.DefineFlow(g, "gemini31ImageGoogleAIFlow", func(ctx context.Context, input string) (*imageFlowResult, error) {
-		return generateGemini31Image(ctx, g, "googleai/gemini-3.1-flash-image-preview", input)
+		return generateGemini31Image(ctx, g, "googleai/gemini-3.1-flash-image", input)
 	})
 
 	if hasVertex {
 		genkit.DefineFlow(g, "gemini31LiteVertexAIFlow", func(ctx context.Context, input string) (string, error) {
-			return generateGemini31Lite(ctx, g, "vertexai/gemini-3.1-flash-lite-preview", input)
+			return generateGemini31Lite(ctx, g, "vertexai/gemini-3.1-flash-lite", input)
 		})
 
 		genkit.DefineFlow(g, "gemini31ImageVertexAIFlow", func(ctx context.Context, input string) (*imageFlowResult, error) {
-			return generateGemini31Image(ctx, g, "vertexai/gemini-3.1-flash-image-preview", input)
+			return generateGemini31Image(ctx, g, "vertexai/gemini-3.1-flash-image", input)
 		})
 	}
 

--- a/go/samples/imagen-gemini/main.go
+++ b/go/samples/imagen-gemini/main.go
@@ -112,7 +112,7 @@ func main() {
 
 	// Define a simple flow that generates an image of a given topic
 	genkit.DefineFlow(g, "imageFlow", func(ctx context.Context, input string) ([]string, error) {
-		m := googlegenai.GoogleAIModel(g, "gemini-2.5-flash-image")
+		m := googlegenai.GoogleAIModel(g, "gemini-3.1-flash-image")
 		if m == nil {
 			return nil, errors.New("imageFlow: failed to find model")
 		}

--- a/go/samples/imagen/main.go
+++ b/go/samples/imagen/main.go
@@ -30,7 +30,7 @@ func main() {
 
 	genkit.DefineFlow(g, "image-generation", func(ctx context.Context, input string) ([]string, error) {
 		r, err := genkit.Generate(ctx, g,
-			ai.WithModelName("vertexai/imagen-3.0-generate-001"),
+			ai.WithModelName("vertexai/imagen-4.0-generate-001"),
 			ai.WithPrompt("Generate an image of %s", input),
 			ai.WithConfig(&genai.GenerateImagesConfig{
 				NumberOfImages:    2,

--- a/go/samples/intermediate-interrupts/main.go
+++ b/go/samples/intermediate-interrupts/main.go
@@ -90,7 +90,7 @@ func main() {
 	// Define the payment agent flow
 	paymentAgent := genkit.DefineFlow(g, "paymentAgent", func(ctx context.Context, request string) (string, error) {
 		resp, err := genkit.Generate(ctx, g,
-			ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+			ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 				ThinkingConfig: &genai.ThinkingConfig{ThinkingBudget: genai.Ptr[int32](0)},
 			})),
 			ai.WithSystem("You are a helpful payment assistant. When the user wants to transfer money, use the transferMoney tool. Always confirm the result with the user."),
@@ -157,7 +157,7 @@ func main() {
 			}
 
 			resp, err = genkit.Generate(ctx, g,
-				ai.WithModel(googlegenai.ModelRef("googleai/gemini-2.5-flash", &genai.GenerateContentConfig{
+				ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", &genai.GenerateContentConfig{
 					ThinkingConfig: &genai.ThinkingConfig{ThinkingBudget: genai.Ptr[int32](0)},
 				})),
 				ai.WithMessages(resp.History()...),

--- a/go/samples/mcp-ception/mcp_ception.go
+++ b/go/samples/mcp-ception/mcp_ception.go
@@ -137,7 +137,7 @@ func mcpSelfConnection() {
 	// Initialize Genkit with Google AI for the client
 	g := genkit.Init(ctx,
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
-		genkit.WithDefaultModel("googleai/gemini-2.5-flash"),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
 	)
 
 	// Server process is spawned automatically via stdio

--- a/go/samples/mcp-client/main.go
+++ b/go/samples/mcp-client/main.go
@@ -57,7 +57,7 @@ func clientExample() {
 	}
 
 	response, err := genkit.Generate(ctx, g,
-		ai.WithModelName("googleai/gemini-2.5-pro"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithPrompt("Convert the current time from New York to London timezone."),
 		ai.WithTools(toolRefs...),
 		ai.WithToolChoice(ai.ToolChoiceAuto),
@@ -109,7 +109,7 @@ func managerExample() {
 	}
 
 	response, err := genkit.Generate(ctx, g,
-		ai.WithModelName("googleai/gemini-2.5-pro"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithPrompt("What time is it in New York and Tokyo?"),
 		ai.WithTools(toolRefs...),
 		ai.WithToolChoice(ai.ToolChoiceAuto),

--- a/go/samples/mcp-git-pr-explainer/main.go
+++ b/go/samples/mcp-git-pr-explainer/main.go
@@ -106,7 +106,7 @@ Always pass owner='%s' repo='%s' pull_number='%d'.`,
 		pr, repo, owner, name, pr,
 	)
 
-	m := googlegenai.GoogleAIModel(g, "gemini-2.5-flash")
+	m := googlegenai.GoogleAIModel(g, "gemini-flash-latest")
 	resp, err := genkit.Generate(ctx, g,
 		ai.WithModel(m),
 		ai.WithPrompt(prompt),

--- a/go/samples/mcp-server/client.go
+++ b/go/samples/mcp-server/client.go
@@ -66,7 +66,7 @@ func client() {
 	logger.FromContext(ctx).Info("Starting demo: Fetch and summarize content")
 
 	response, err := genkit.Generate(ctx, g,
-		ai.WithModelName("googleai/gemini-2.5-pro"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithPrompt("Fetch content from https://httpbin.org/json and give me a summary of what you find"),
 		ai.WithTools(toolRefs...),
 		ai.WithToolChoice(ai.ToolChoiceAuto),

--- a/go/samples/menu/main.go
+++ b/go/samples/menu/main.go
@@ -62,7 +62,7 @@ func main() {
 	ctx := context.Background()
 	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.VertexAI{}))
 
-	model := googlegenai.VertexAIModel(g, "gemini-2.5-flash")
+	model := googlegenai.VertexAIModel(g, "gemini-flash-latest")
 	embedder := googlegenai.VertexAIEmbedder(g, "text-embedding-004")
 
 	if err := setup01(g, model); err != nil {

--- a/go/samples/multipart-tools/main.go
+++ b/go/samples/multipart-tools/main.go
@@ -46,7 +46,7 @@ func main() {
 	// Define a simple flow that uses the multipart tool
 	genkit.DefineStreamingFlow(g, "cardFlow", func(ctx context.Context, input any, cb ai.ModelStreamCallback) (string, error) {
 		resp, err := genkit.Generate(ctx, g,
-			ai.WithModelName("googleai/gemini-3-pro-preview"),
+			ai.WithModelName("googleai/gemini-flash-latest"),
 			ai.WithConfig(&genai.GenerateContentConfig{
 				Temperature: genai.Ptr[float32](1.0),
 				ThinkingConfig: &genai.ThinkingConfig{

--- a/go/samples/partials-and-helpers/main.go
+++ b/go/samples/partials-and-helpers/main.go
@@ -35,7 +35,7 @@ func main() {
 	})
 
 	g := genkit.Init(ctx,
-		genkit.WithDefaultModel("googleai/gemini-2.5-flash"),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
 	)
 

--- a/go/samples/pgvector/main.go
+++ b/go/samples/pgvector/main.go
@@ -67,7 +67,7 @@ func run(g *genkit.Genkit) error {
 		return errors.New("need -apikey")
 	}
 	ctx := context.Background()
-	const embedderName = "embedding-001"
+	const embedderName = "gemini-embedding-001"
 	embedder := googlegenai.GoogleAIEmbedder(g, embedderName)
 	if embedder == nil {
 		return fmt.Errorf("embedder %s is not known to the googlegenai plugin", embedderName)

--- a/go/samples/prompts-embed/prompts/example.prompt
+++ b/go/samples/prompts-embed/prompts/example.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 ---
 
 Say hello!.

--- a/go/samples/prompts/main.go
+++ b/go/samples/prompts/main.go
@@ -34,7 +34,7 @@ import (
 func main() {
 	ctx := context.Background()
 	g := genkit.Init(ctx,
-		genkit.WithDefaultModel("googleai/gemini-2.5-flash"),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
 		genkit.WithPromptDir("prompts"),
 	)
@@ -208,7 +208,7 @@ func PromptWithMultiMessage(ctx context.Context, g *genkit.Genkit) {
 		log.Fatal("empty prompt")
 	}
 	resp, err := prompt.Execute(ctx,
-		ai.WithModelName("googleai/gemini-2.5-pro"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithInput(map[string]any{
 			"videoUrl":    "https://www.youtube.com/watch?v=K-hY0E6cGfo",
 			"contentType": "video/mp4",
@@ -265,7 +265,7 @@ func PromptWithMessageHistory(ctx context.Context, g *genkit.Genkit) {
 	helloPrompt := genkit.DefinePrompt(
 		g, "PromptWithMessageHistory",
 		ai.WithSystem("You are a helpful AI assistant named Walt"),
-		ai.WithModelName("googleai/gemini-2.5-flash-lite"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithMessages(
 			ai.NewUserTextMessage("Hi, my name is Bob"),
 			ai.NewModelTextMessage("Hi, my name is Walt, what can I help you with?"),
@@ -291,7 +291,7 @@ func PromptWithExecuteOverrides(ctx context.Context, g *genkit.Genkit) {
 
 	// Call the model and add additional messages from the user.
 	resp, err := helloPrompt.Execute(ctx,
-		ai.WithModel(googlegenai.GoogleAIModel(g, "gemini-2.5-flash-lite")),
+		ai.WithModel(googlegenai.GoogleAIModel(g, "gemini-flash-latest")),
 		ai.WithMessages(ai.NewUserTextMessage("And I like turtles.")),
 	)
 	if err != nil {
@@ -338,7 +338,7 @@ func PromptWithMediaType(ctx context.Context, g *genkit.Genkit) {
 		log.Fatal("empty prompt")
 	}
 	resp, err := prompt.Execute(ctx,
-		ai.WithModelName("googleai/gemini-2.5-flash"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithInput(map[string]any{"imageUrl": "data:image/jpeg;base64," + img}),
 	)
 	if err != nil {
@@ -380,7 +380,7 @@ func PromptWithOutputSchemaName(ctx context.Context, g *genkit.Genkit) {
 	})
 
 	resp, err := prompt.Execute(ctx,
-		ai.WithModelName("googleai/gemini-2.5-pro"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithInput(map[string]any{"food": "tacos", "ingredients": []string{"octopus", "shrimp"}}),
 	)
 	if err != nil {

--- a/go/samples/prompts/main.go
+++ b/go/samples/prompts/main.go
@@ -34,7 +34,7 @@ import (
 func main() {
 	ctx := context.Background()
 	g := genkit.Init(ctx,
-		genkit.WithDefaultModel("googleai/gemini-2.5-flash"),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
 		genkit.WithPromptDir("prompts"),
 	)
@@ -63,7 +63,7 @@ func SimplePrompt(ctx context.Context, g *genkit.Genkit) {
 	// Define prompt with default model and system text.
 	helloPrompt := genkit.DefinePrompt(
 		g, "SimplePrompt",
-		ai.WithModelName("googleai/gemini-2.5-pro"), // Override the default model.
+		ai.WithModelName("googleai/gemini-3.5-flash"), // Override the default model.
 		ai.WithSystem("You are a helpful AI assistant named Walt. Greet the user."),
 		ai.WithPrompt("Hello, who are you?"),
 	)
@@ -208,7 +208,7 @@ func PromptWithMultiMessage(ctx context.Context, g *genkit.Genkit) {
 		log.Fatal("empty prompt")
 	}
 	resp, err := prompt.Execute(ctx,
-		ai.WithModelName("googleai/gemini-2.5-pro"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithInput(map[string]any{
 			"videoUrl":    "https://www.youtube.com/watch?v=K-hY0E6cGfo",
 			"contentType": "video/mp4",
@@ -265,7 +265,7 @@ func PromptWithMessageHistory(ctx context.Context, g *genkit.Genkit) {
 	helloPrompt := genkit.DefinePrompt(
 		g, "PromptWithMessageHistory",
 		ai.WithSystem("You are a helpful AI assistant named Walt"),
-		ai.WithModelName("googleai/gemini-2.5-flash-lite"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithMessages(
 			ai.NewUserTextMessage("Hi, my name is Bob"),
 			ai.NewModelTextMessage("Hi, my name is Walt, what can I help you with?"),
@@ -291,7 +291,7 @@ func PromptWithExecuteOverrides(ctx context.Context, g *genkit.Genkit) {
 
 	// Call the model and add additional messages from the user.
 	resp, err := helloPrompt.Execute(ctx,
-		ai.WithModel(googlegenai.GoogleAIModel(g, "gemini-2.5-flash-lite")),
+		ai.WithModel(googlegenai.GoogleAIModel(g, "gemini-3.5-flash")),
 		ai.WithMessages(ai.NewUserTextMessage("And I like turtles.")),
 	)
 	if err != nil {
@@ -338,7 +338,7 @@ func PromptWithMediaType(ctx context.Context, g *genkit.Genkit) {
 		log.Fatal("empty prompt")
 	}
 	resp, err := prompt.Execute(ctx,
-		ai.WithModelName("googleai/gemini-2.5-flash"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithInput(map[string]any{"imageUrl": "data:image/jpeg;base64," + img}),
 	)
 	if err != nil {
@@ -380,7 +380,7 @@ func PromptWithOutputSchemaName(ctx context.Context, g *genkit.Genkit) {
 	})
 
 	resp, err := prompt.Execute(ctx,
-		ai.WithModelName("googleai/gemini-2.5-pro"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithInput(map[string]any{"food": "tacos", "ingredients": []string{"octopus", "shrimp"}}),
 	)
 	if err != nil {

--- a/go/samples/prompts/prompts/countries.prompt
+++ b/go/samples/prompts/prompts/countries.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 config:
   temperature: 0.5
 output:

--- a/go/samples/prompts/prompts/media.prompt
+++ b/go/samples/prompts/prompts/media.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 config:
   temperature: 0.1
 input:

--- a/go/samples/prompts/prompts/multi-msg.prompt
+++ b/go/samples/prompts/prompts/multi-msg.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 input:
   schema:
     videoUrl: string

--- a/go/samples/prompts/prompts/recipe.prompt
+++ b/go/samples/prompts/prompts/recipe.prompt
@@ -1,5 +1,5 @@
 ---
-model: googleai/gemini-2.5-pro
+model: googleai/gemini-flash-latest
 input:
   schema:
     food: string

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -106,7 +106,7 @@ func main() {
 	}
 
 	simpleQaPrompt := genkit.DefinePrompt(g, "simpleQaPrompt",
-		ai.WithModelName("googleai/gemini-2.5-flash"),
+		ai.WithModelName("googleai/gemini-flash-latest"),
 		ai.WithPrompt(simpleQaPromptTemplate),
 		ai.WithInputType(simpleQaPromptInput{}),
 		ai.WithOutputFormat(ai.OutputFormatText),

--- a/go/samples/rag/main.go
+++ b/go/samples/rag/main.go
@@ -85,7 +85,7 @@ func main() {
 	}
 	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}, &evaluators.GenkitEval{Metrics: metrics}))
 
-	embedder := googlegenai.GoogleAIEmbedder(g, "embedding-001")
+	embedder := googlegenai.GoogleAIEmbedder(g, "gemini-embedding-001")
 	if embedder == nil {
 		log.Fatal("embedder is not defined")
 	}

--- a/go/samples/session/main.go
+++ b/go/samples/session/main.go
@@ -109,7 +109,7 @@ func main() {
 		ctx = session.NewContext(ctx, sess)
 
 		return genkit.GenerateText(ctx, g,
-			ai.WithModel(googlegenai.ModelRef("gemini-2.5-flash", &genai.GenerateContentConfig{
+			ai.WithModel(googlegenai.ModelRef("gemini-flash-latest", &genai.GenerateContentConfig{
 				ThinkingConfig: &genai.ThinkingConfig{
 					ThinkingBudget: genai.Ptr[int32](0),
 				},

--- a/go/samples/telemetry-test/kitchen_sink/kitchen_sink.go
+++ b/go/samples/telemetry-test/kitchen_sink/kitchen_sink.go
@@ -69,7 +69,7 @@ func main() {
 		}
 
 		searchResp, err := genkit.Generate(ctx, g,
-			ai.WithModelName("googleai/gemini-2.5-flash"),
+			ai.WithModelName("googleai/gemini-flash-latest"),
 			ai.WithTools(searchTool),
 			ai.WithConfig(&genai.GenerateContentConfig{
 				Temperature: genai.Ptr[float32](0.7),
@@ -94,7 +94,7 @@ func main() {
 		}
 
 		resp, err := genkit.Generate(ctx, g,
-			ai.WithModelName("googleai/gemini-2.5-flash"),
+			ai.WithModelName("googleai/gemini-flash-latest"),
 			ai.WithMessages(
 				ai.NewUserMessage(
 					ai.NewTextPart(prompt),
@@ -116,7 +116,7 @@ func main() {
 
 		for _, topic := range topics {
 			resp, err := genkit.Generate(ctx, g,
-				ai.WithModelName("googleai/gemini-2.5-flash"),
+				ai.WithModelName("googleai/gemini-flash-latest"),
 				ai.WithConfig(&genai.GenerateContentConfig{
 					Temperature: genai.Ptr[float32](0.8),
 				}),

--- a/go/samples/telemetry-test/simple/simple_joke.go
+++ b/go/samples/telemetry-test/simple/simple_joke.go
@@ -45,7 +45,7 @@ func main() {
 	genkit.DefineFlow(g, "jokeFlow", func(ctx context.Context, topic string) (string, error) {
 		// Generate a joke using Gemini
 		resp, err := genkit.Generate(ctx, g,
-			ai.WithModelName("googleai/gemini-2.5-flash"),
+			ai.WithModelName("googleai/gemini-flash-latest"),
 			ai.WithConfig(&genai.GenerateContentConfig{
 				Temperature: genai.Ptr[float32](1.0),
 			}),

--- a/go/samples/text-to-speech/gemini/README.md
+++ b/go/samples/text-to-speech/gemini/README.md
@@ -23,7 +23,7 @@ go run ./samples/text-to-speech/gemini
 ```
 
 Invoke the `text-to-speech-flow` from Dev UI. The default model is
-`googleai/gemini-2.5-flash-preview-tts`, and the generated WAV path defaults to
+`googleai/gemini-3.1-flash-tts-preview`, and the generated WAV path defaults to
 `./generated-tts.wav`.
 
 The dedicated `*-tts` models produce audio by default, so this sample configures

--- a/go/samples/text-to-speech/gemini/main.go
+++ b/go/samples/text-to-speech/gemini/main.go
@@ -61,7 +61,7 @@ func main() {
 		}
 		model := input.Model
 		if model == "" {
-			model = "googleai/gemini-2.5-flash-preview-tts"
+			model = "googleai/gemini-3.1-flash-tts-preview"
 		}
 		voiceName := input.VoiceName
 		if voiceName == "" {
@@ -111,7 +111,7 @@ func main() {
 			return "", err
 		}
 		resp, err := genkit.Generate(ctx, g,
-			ai.WithModelName("googleai/gemini-2.5-flash"),
+			ai.WithModelName("googleai/gemini-flash-latest"),
 			ai.WithMessages(ai.NewUserMessage(
 				ai.NewTextPart("Can you transcribe the next audio?"),
 				ai.NewMediaPart("audio/wav", "data:audio/wav;base64,"+base64.StdEncoding.EncodeToString(audioBytes)))),

--- a/go/samples/text-to-speech/main.go
+++ b/go/samples/text-to-speech/main.go
@@ -75,7 +75,7 @@ func main() {
 			return "", err
 		}
 		resp, err := genkit.Generate(ctx, g,
-			ai.WithModelName("googleai/gemini-2.5-flash"),
+			ai.WithModelName("googleai/gemini-flash-latest"),
 			ai.WithMessages(ai.NewUserMessage(
 				ai.NewTextPart("Can you transcribe the next audio?"),
 				ai.NewMediaPart("audio/wav", "data:audio/wav;base64,"+base64.StdEncoding.EncodeToString(audioBytes)))),

--- a/go/samples/vectorsearch-biqguery/main.go
+++ b/go/samples/vectorsearch-biqguery/main.go
@@ -84,7 +84,7 @@ func main() {
 			Location:  vectorsearchPlugin.Location,
 		}, vectorsearchPlugin))
 
-	model := googlegenai.VertexAIModel(g, "gemini-2.5-flash")
+	model := googlegenai.VertexAIModel(g, "gemini-flash-latest")
 
 	// Create a BigQuery client.
 	bqClient, err := bigquery.NewClient(ctx, vectorsearchPlugin.ProjectID)

--- a/go/samples/vectorsearch-firestore/main.go
+++ b/go/samples/vectorsearch-firestore/main.go
@@ -84,7 +84,7 @@ func main() {
 			Location:  vectorsearchPlugin.Location,
 		}, vectorsearchPlugin))
 
-	model := googlegenai.VertexAIModel(g, "gemini-2.5-flash")
+	model := googlegenai.VertexAIModel(g, "gemini-flash-latest")
 
 	databaseId := "${FIRESTORE_DATABASE_ID}"         // Replace with your Firestore database ID
 	collectionName := "${FIRESTORE_COLLECTION_NAME}" // Replace with your Firestore collection name


### PR DESCRIPTION
Two problems, both about model ids going stale. Samples were pinned to specific ids across three generations, so every turndown rots another batch of them. And the plugin's static model lists still advertised models whose shutdown dates have already passed, so the Dev UI listed them and `DefineModel(name, nil)` accepted them, only for the request to 404 at generation time.

## Samples follow the catalog instead of trailing it

General text flows now use `googleai/gemini-flash-latest`, an alias that tracks the current Flash release and is valid on both Google AI and Vertex AI.

The 2.5 models replaced here are not dead: they are superseded but have no announced shutdown. The alias is about not re-pinning, not about repairing broken samples.

The alias only covers Flash text, so capability-specific models move to their current-generation equivalent instead. `gemini-2.5-flash-image` becomes `gemini-3.1-flash-image` in `imagen-gemini`; it has a published shutdown on October 2, 2026. `gemini-2.5-flash-preview-tts` becomes `gemini-3.1-flash-tts-preview` in `text-to-speech/gemini`, the replacement named on the deprecations page.

Two call sites in `samples/prompts` keep an explicitly different model, because contrasting with the default is the point of the demo: the `SimplePrompt` "Override the default model" case and the execute-time override in `PromptWithExecuteOverrides`, both now `gemini-3.5-flash`.

## Models past their shutdown date are unregistered

Each of these has a published shutdown date that has already passed:

| Model | Shutdown |
| --- | --- |
| `gemini-2.0-flash` | June 1, 2026 (Google AI and Vertex AI) |
| `gemini-2.0-flash-lite` | June 1, 2026 (Google AI and Vertex AI) |
| `gemini-3.1-flash-lite-preview` | May 25, 2026 |
| `gemini-3.1-flash-image-preview` | June 25, 2026 |
| `imagen-3.0-generate-001` | November 10, 2025 |
| `veo-2.0-generate-001` | June 30, 2026 |
| `veo-3.0-generate-001` | June 30, 2026 |
| `veo-3.0-fast-generate-001` | June 30, 2026 |
| `embedding-001` | October 30, 2025 |

`gemini-2.0-flash-exp` and `imagen-3.0-fast-generate-001` have no published date but are absent from the current catalog, so they go with their families.

The `imagen-gemini` sample was still naming both retired 3.1 previews, so its flows move to the GA successors. `googleai/gemini-3.1-flash-lite` is registered for Vertex AI only (a split `TestNewGeminiModelsProviderSplit` pins to a ticket), so it reaches that sample through the dynamic resolver rather than the static list. Worth a second look: the Gemini API deprecations page directs `gemini-3.1-flash-lite-preview` users to the GA model on Google AI, which suggests the Vertex-only split may have outlived its ticket. Left alone here.

Vertex AI gains the GA Imagen 4 models, which it has always served but which were only ever listed for Google AI. Dropping Imagen 3 without them would have left the Vertex image samples with nothing to name.

**The 2.5 family stays registered.** It is superseded but has no announced shutdown, so removing it would break working code.

## Not a breaking change in practice

`DefineModel(name, nil)` now errors for the unregistered names instead of handing back a model that 404s on first use, and they stop appearing in the Dev UI. Nothing else moves: `LookupModel` resolves any name dynamically through the plugin's `ResolveAction`, so code naming one of these models explicitly behaves exactly as it did, down to the API error it gets back.

## Verification

Go 1.26.3, `go build ./...`, `go vet ./...`, and `go test ./...` in `go/`: 41 packages pass, 0 failures. Every date above was checked against the Gemini API deprecations page, and the 2.0 retirement was confirmed independently against Vertex AI's own documentation.
