### PR TITLE
feat(go/plugins): sort tools by name for stable provider output

### DIFF
--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/internal/base"
+	plugininternal "github.com/firebase/genkit/go/plugins/internal"
 	pluginjsonschema "github.com/firebase/genkit/go/plugins/internal/jsonschema"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/packages/param"
@@ -184,7 +185,7 @@ func (g *ModelGenerator) WithTools(tools []*ai.ToolDefinition) *ModelGenerator {
 	}
 
 	toolParams := make([]openai.ChatCompletionToolParam, 0, len(tools))
-	for _, tool := range tools {
+	for _, tool := range plugininternal.SortToolDefinitions(tools) {
 		if tool == nil || tool.Name == "" {
 			continue
 		}

--- a/go/plugins/googlegenai/tools.go
+++ b/go/plugins/googlegenai/tools.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/firebase/genkit/go/ai"
+	plugininternal "github.com/firebase/genkit/go/plugins/internal"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
 	"google.golang.org/genai"
 )
@@ -24,7 +25,7 @@ func toGeminiTools(inTools []*ai.ToolDefinition) ([]*genai.Tool, error) {
 	var outTools []*genai.Tool
 	functions := []*genai.FunctionDeclaration{}
 
-	for _, t := range inTools {
+	for _, t := range plugininternal.SortToolDefinitions(inTools) {
 		if !validToolName(t.Name) {
 			return nil, fmt.Errorf(`invalid tool name: %q, must start with a letter or an underscore, must be alphanumeric, underscores, dots or dashes with a max length of 64 chars`, t.Name)
 		}

--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -28,6 +28,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/base"
+	plugininternal "github.com/firebase/genkit/go/plugins/internal"
 	pluginjsonschema "github.com/firebase/genkit/go/plugins/internal/jsonschema"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
 	"github.com/invopop/jsonschema"
@@ -302,7 +303,7 @@ func toAnthropicTools(provider string, tools []*ai.ToolDefinition) ([]anthropic.
 	resp := make([]anthropic.ToolUnionParam, 0)
 	regex := regexp.MustCompile(ToolNameRegex)
 
-	for _, t := range tools {
+	for _, t := range plugininternal.SortToolDefinitions(tools) {
 		if t.Name == "" {
 			return nil, fmt.Errorf("tool name is required")
 		}

--- a/go/plugins/internal/tools.go
+++ b/go/plugins/internal/tools.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+)
+
+// SortToolDefinitions returns a new slice of tool definitions sorted by Name.
+//
+// Genkit's tool registry is a Go map, so iteration order is randomized —
+// without sorting, two requests with identical tool sets produce different
+// wire bytes. Stable order makes the provider payload bytewise identical
+// across turns, which is a precondition for provider-side prompt caching
+// (e.g. Anthropic's cache_control) to match.
+//
+// Nil entries are sorted to the end so callers can keep their existing
+// nil-handling logic without an index panic.
+func SortToolDefinitions(tools []*ai.ToolDefinition) []*ai.ToolDefinition {
+	if len(tools) == 0 {
+		return tools
+	}
+	sorted := make([]*ai.ToolDefinition, len(tools))
+	copy(sorted, tools)
+	slices.SortStableFunc(sorted, func(a, b *ai.ToolDefinition) int {
+		if a == nil || b == nil {
+			if a == b {
+				return 0
+			}
+			if a == nil {
+				return 1
+			}
+			return -1
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+	return sorted
+}

--- a/go/plugins/internal/tools.go
+++ b/go/plugins/internal/tools.go
@@ -29,24 +29,23 @@ import (
 // across turns, which is a precondition for provider-side prompt caching
 // (e.g. Anthropic's cache_control) to match.
 //
-// Nil entries are sorted to the end so callers can keep their existing
-// nil-handling logic without an index panic.
+// Nil entries are filtered out so callers can iterate the result without
+// guarding against a nil-pointer dereference on field access.
 func SortToolDefinitions(tools []*ai.ToolDefinition) []*ai.ToolDefinition {
-	if len(tools) == 0 {
+	if len(tools) <= 1 {
+		if len(tools) == 1 && tools[0] == nil {
+			return tools[:0]
+		}
 		return tools
 	}
-	sorted := make([]*ai.ToolDefinition, len(tools))
-	copy(sorted, tools)
-	slices.SortStableFunc(sorted, func(a, b *ai.ToolDefinition) int {
-		if a == nil || b == nil {
-			if a == b {
-				return 0
-			}
-			if a == nil {
-				return 1
-			}
-			return -1
+	sorted := make([]*ai.ToolDefinition, 0, len(tools))
+	for _, t := range tools {
+		if t == nil {
+			continue
 		}
+		sorted = append(sorted, t)
+	}
+	slices.SortStableFunc(sorted, func(a, b *ai.ToolDefinition) int {
 		return strings.Compare(a.Name, b.Name)
 	})
 	return sorted

--- a/go/plugins/internal/tools.go
+++ b/go/plugins/internal/tools.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+)
+
+// SortToolDefinitions returns a new slice of tool definitions sorted by Name.
+//
+// Genkit's tool registry is a Go map, so iteration order is randomized —
+// without sorting, two requests with identical tool sets produce different
+// wire bytes. Stable order makes the provider payload bytewise identical
+// across turns, which is a precondition for provider-side prompt caching
+// (e.g. Anthropic's cache_control) to match.
+//
+// Nil entries are filtered out so callers can iterate the result without
+// guarding against a nil-pointer dereference on field access.
+func SortToolDefinitions(tools []*ai.ToolDefinition) []*ai.ToolDefinition {
+	if len(tools) <= 1 {
+		if len(tools) == 1 && tools[0] == nil {
+			return tools[:0]
+		}
+		return tools
+	}
+	sorted := make([]*ai.ToolDefinition, 0, len(tools))
+	for _, t := range tools {
+		if t == nil {
+			continue
+		}
+		sorted = append(sorted, t)
+	}
+	slices.SortStableFunc(sorted, func(a, b *ai.ToolDefinition) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return sorted
+}

--- a/go/plugins/internal/tools_test.go
+++ b/go/plugins/internal/tools_test.go
@@ -1,0 +1,110 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSortToolDefinitions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []*ai.ToolDefinition
+		expected []*ai.ToolDefinition
+	}{
+		{
+			name:     "nil slice",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty slice",
+			input:    []*ai.ToolDefinition{},
+			expected: []*ai.ToolDefinition{},
+		},
+		{
+			name: "already sorted",
+			input: []*ai.ToolDefinition{
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "c"},
+			},
+			expected: []*ai.ToolDefinition{
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "c"},
+			},
+		},
+		{
+			name: "unsorted",
+			input: []*ai.ToolDefinition{
+				{Name: "c"},
+				{Name: "a"},
+				{Name: "b"},
+			},
+			expected: []*ai.ToolDefinition{
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "c"},
+			},
+		},
+		{
+			name: "with nil entries",
+			input: []*ai.ToolDefinition{
+				{Name: "b"},
+				nil,
+				{Name: "a"},
+			},
+			expected: []*ai.ToolDefinition{
+				{Name: "a"},
+				{Name: "b"},
+			},
+		},
+		{
+			name: "stable sort",
+			input: []*ai.ToolDefinition{
+				{Name: "a", Description: "1"},
+				{Name: "a", Description: "2"},
+				{Name: "b"},
+			},
+			expected: []*ai.ToolDefinition{
+				{Name: "a", Description: "1"},
+				{Name: "a", Description: "2"},
+				{Name: "b"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SortToolDefinitions(tt.input)
+			if diff := cmp.Diff(tt.expected, got); diff != "" {
+				t.Errorf("SortToolDefinitions() mismatch (-want +got):\n%s", diff)
+			}
+
+			// Ensure original slice is not modified
+			if len(tt.input) > 0 {
+				// We can't easily check for nil input without it being a bit messy,
+				// but for non-empty we should ensure the reference is different if sorted.
+				// Actually, SortToolDefinitions always makes a copy if len > 0.
+			}
+		})
+	}
+}

--- a/go/plugins/ollama/ollama.go
+++ b/go/plugins/ollama/ollama.go
@@ -36,6 +36,7 @@ import (
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/genkit"
+	plugininternal "github.com/firebase/genkit/go/plugins/internal"
 	"github.com/firebase/genkit/go/plugins/internal/uri"
 	"github.com/invopop/jsonschema"
 )
@@ -546,7 +547,7 @@ func (g *generator) generate(ctx context.Context, input *ai.ModelRequest, cb fun
 // convertTools converts Genkit tool definitions to Ollama tool format
 func convertTools(tools []*ai.ToolDefinition) ([]ollamaTool, error) {
 	ollamaTools := make([]ollamaTool, 0, len(tools))
-	for _, tool := range tools {
+	for _, tool := range plugininternal.SortToolDefinitions(tools) {
 		ollamaTools = append(ollamaTools, ollamaTool{
 			Type: "function",
 			Function: ollamaFunction{


### PR DESCRIPTION
Genkit's tool registry is a Go map, so iteration order is randomized. Without sorting, two requests with identical tool sets produce different wire bytes — which breaks[ Anthropic's prompt cache](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#cache-limitations:~:text=Verify%20that%20the%20keys%20in%20your%20tool%5Fuse%20content%20blocks%20have%20stable%20ordering%20as%20some%20languages%20%28for%20example%2C%20Swift%2C%20Go%29%20randomize%20key%20order%20during%20JSON%20conversion%2C%20breaking%20caches) (and prevents stable output more generally) and from what I can tell it affects other providers like openai and gemini since that's how prompt caching works. I understand we currently don't have caching in the Go SDK and it's [being worked on ](https://github.com/genkit-ai/genkit/pull/5103). But I did enable caching in a local fork to verify that sorted tools for at least Anthropic does help with caching, without sorting prompt caching is basically non-existent

 I haven't actually tested this with OpenAI or Gemini, but I'd expect the same problem, their caches also depend on the request looking the same byte-for-byte each turn, and random tool order would break that too. Sorting in the shared helper is cheap, so I included them. Happy to drop those call sites if you'd rather land them separately once someone verifies.


Adds a shared SortToolDefinitions helper in go/plugins/internal and wires it into toAnthropicTools plus the compat_oai, googlegenai, and ollama providers.

