### PR TITLE
fix(ai): retry middleware honors abortSignal and skips AbortError

### DIFF
--- a/js/ai/src/model/middleware.ts
+++ b/js/ai/src/model/middleware.ts
@@ -24,6 +24,7 @@ import type {
   MessageData,
   ModelInfo,
   ModelMiddleware,
+  ModelMiddlewareWithOptions,
   Part,
 } from '../model.js';
 import { resolveModel } from '../model.js';
@@ -334,7 +335,9 @@ const DEFAULT_FALLBACK_STATUSES: StatusName[] = [
  * });
  * ```
  */
-export function retry(options: RetryOptions = {}): ModelMiddleware {
+export function retry(
+  options: RetryOptions = {}
+): ModelMiddlewareWithOptions {
   const {
     maxRetries = 3,
     statuses = DEFAULT_RETRY_STATUSES,
@@ -345,18 +348,24 @@ export function retry(options: RetryOptions = {}): ModelMiddleware {
     onError,
   } = options;
 
-  return async (req, next) => {
+  return async (req, opts, next) => {
+    const abortSignal = opts?.abortSignal;
     let lastError: any;
     let currentDelay = initialDelayMs;
     for (let i = 0; i <= maxRetries; i++) {
+      if (abortSignal?.aborted) {
+        throw abortSignal.reason ?? new Error('Aborted');
+      }
       try {
-        return await next(req);
+        return await next(req, opts);
       } catch (e) {
         lastError = e;
         const error = e as Error;
         if (i < maxRetries) {
           let shouldRetry = false;
-          if (error instanceof GenkitError) {
+          if (isAbortError(error) || abortSignal?.aborted) {
+            shouldRetry = false;
+          } else if (error instanceof GenkitError) {
             if (statuses.includes(error.status)) {
               shouldRetry = true;
             }
@@ -370,7 +379,7 @@ export function retry(options: RetryOptions = {}): ModelMiddleware {
             if (!noJitter) {
               delay = delay + 1000 * Math.pow(2, i) * Math.random();
             }
-            await new Promise((resolve) => __setTimeout(resolve, delay));
+            await abortableDelay(delay, abortSignal);
             currentDelay = Math.min(currentDelay * backoffFactor, maxDelayMs);
             continue;
           }
@@ -380,6 +389,37 @@ export function retry(options: RetryOptions = {}): ModelMiddleware {
     }
     throw lastError;
   };
+}
+
+function isAbortError(error: Error): boolean {
+  return (
+    error?.name === 'AbortError' ||
+    (error as { code?: string })?.code === 'ABORT_ERR'
+  );
+}
+
+function abortableDelay(
+  ms: number,
+  signal?: AbortSignal
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = __setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error('Aborted'));
+    };
+    if (signal) {
+      if (signal.aborted) {
+        clearTimeout(timer);
+        reject(signal.reason ?? new Error('Aborted'));
+        return;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
 }
 
 /**

--- a/js/ai/tests/model/middleware_test.ts
+++ b/js/ai/tests/model/middleware_test.ts
@@ -477,6 +477,104 @@ describe('retry', () => {
     assert.strictEqual(result.text, 'success');
     assert.strictEqual(totalDelay, 20 + 30);
   });
+
+  it('should not retry on AbortError', async () => {
+    const pm = defineProgrammableModel(registry);
+    let requestCount = 0;
+    pm.handleResponse = async (req, sc) => {
+      requestCount++;
+      const err = new Error('aborted by caller');
+      err.name = 'AbortError';
+      throw err;
+    };
+
+    let delayCalls = 0;
+    setRetryTimeout((callback, ms) => {
+      delayCalls++;
+      callback();
+      return 0 as any;
+    });
+
+    await assert.rejects(
+      generate(registry, {
+        model: 'programmableModel',
+        prompt: 'test',
+        use: [retry({ maxRetries: 3, noJitter: true })],
+      }),
+      /aborted by caller/
+    );
+
+    assert.strictEqual(requestCount, 1);
+    assert.strictEqual(delayCalls, 0);
+  });
+
+  it('should not retry once abortSignal is already aborted', async () => {
+    const pm = defineProgrammableModel(registry);
+    let requestCount = 0;
+    pm.handleResponse = async (req, sc) => {
+      requestCount++;
+      throw new Error('generic error');
+    };
+
+    let delayCalls = 0;
+    setRetryTimeout((callback, ms) => {
+      delayCalls++;
+      callback();
+      return 0 as any;
+    });
+
+    const controller = new AbortController();
+    controller.abort(new Error('cancelled'));
+
+    await assert.rejects(
+      generate(registry, {
+        model: 'programmableModel',
+        prompt: 'test',
+        abortSignal: controller.signal,
+        use: [retry({ maxRetries: 3, noJitter: true })],
+      })
+    );
+
+    assert.ok(requestCount <= 1);
+    assert.strictEqual(delayCalls, 0);
+  });
+
+  it('should abort the backoff sleep when signal fires mid-retry', async () => {
+    const pm = defineProgrammableModel(registry);
+    let requestCount = 0;
+    const controller = new AbortController();
+    pm.handleResponse = async (req, sc) => {
+      requestCount++;
+      throw new Error('generic error');
+    };
+
+    // Use the real setTimeout so the abort listener wired up inside the
+    // middleware can interrupt the sleep.
+    setRetryTimeout(setTimeout);
+
+    // Fire the abort shortly after the first failure starts the backoff.
+    setTimeout(() => controller.abort(new Error('cancelled')), 10);
+
+    await assert.rejects(
+      generate(registry, {
+        model: 'programmableModel',
+        prompt: 'test',
+        abortSignal: controller.signal,
+        use: [
+          retry({
+            maxRetries: 5,
+            initialDelayMs: 10_000,
+            noJitter: true,
+          }),
+        ],
+      }),
+      /cancelled/
+    );
+
+    // First call always runs; subsequent calls should be skipped because the
+    // sleep was interrupted by the abort.
+    assert.strictEqual(requestCount, 1);
+  });
 });
 
 describe('fallback', () => {


### PR DESCRIPTION
## Problem

The \`retry\` model middleware retries **any** non-\`GenkitError\`, including \`AbortError\`. When a caller passes \`abortSignal\` to \`generateStream\`/\`generate\` and aborts mid-stream, the middleware intercepts the resulting \`AbortError\` and sleeps through exponential backoff before retrying the model call — completely defeating the abort. The backoff sleep itself is also not signal-aware, so even if a later attempt detects the abort, the user still waits out the full delay.

Fixes #5331.

## Solution

- Convert \`retry\` to a \`ModelMiddlewareWithOptions\` so it can read \`opts.abortSignal\`.
- Short-circuit at three points:
  - Before every attempt if the signal is already aborted.
  - On any caught \`AbortError\` (matched by \`error.name === 'AbortError'\` or \`error.code === 'ABORT_ERR'\`).
  - During the backoff sleep — \`abortableDelay\` clears the timer and rejects with \`signal.reason\` when the signal fires.
- Existing \`__setTimeout\` hook is preserved so the test helper (\`TEST_ONLY.setRetryTimeout\`) still works.

The retry function's public return type changes from \`ModelMiddleware\` to \`ModelMiddlewareWithOptions\`. Both are valid \`ModelMiddlewareArgument\` entries, so usage via \`use: [retry()]\` is unaffected.

## Testing

Three new cases in \`tests/model/middleware_test.ts\`:

- \`should not retry on AbortError\` — model throws an \`AbortError\`; verifies the model is called exactly once and no backoff sleep runs.
- \`should not retry once abortSignal is already aborted\` — pre-aborted signal; verifies retry bails before sleeping.
- \`should abort the backoff sleep when signal fires mid-retry\` — uses the real \`setTimeout\` so the abort listener fires; verifies the 10s sleep is interrupted and the second attempt is skipped.

All 38 retry/fallback/system-prompt/context tests in the suite pass:

\`\`\`
pnpm test:single tests/model/middleware_test.ts
# tests 38 / pass 38 / fail 0
\`\`\`

\`pnpm check\` (tsc) is clean.