### PR TITLE
feat(js): honor Retry-After header & never retry AbortError/ToolInterruptError

### DIFF
--- a/js/core/src/error.ts
+++ b/js/core/src/error.ts
@@ -26,6 +26,18 @@ export interface HttpErrorWireFormat {
 }
 
 /**
+ * Metadata from the HTTP response that triggered this error.
+ * This is not serialized into the wire format — it's only available
+ * in-process for middleware (e.g. retry) to make informed decisions.
+ */
+export interface ErrorResponseMetadata {
+  /** Provider-suggested retry delay in milliseconds (parsed from Retry-After header). */
+  retryAfterMs?: number;
+  /** Raw HTTP response headers, if available. */
+  headers?: Record<string, string>;
+}
+
+/**
  * Base error class for Genkit errors.
  */
 export class GenkitError extends Error {
@@ -33,6 +45,13 @@ export class GenkitError extends Error {
   status: StatusName;
   detail?: any;
   code: number;
+
+  /**
+   * Metadata from the HTTP response that triggered this error.
+   * Not serialized into the wire format — only available in-process
+   * for middleware (e.g. retry) to make informed decisions.
+   */
+  responseMetadata?: ErrorResponseMetadata;
 
   // For easy printing, we wrap the error with information like the source
   // and status, but that's redundant with JSON.
@@ -43,17 +62,20 @@ export class GenkitError extends Error {
     message,
     detail,
     source,
+    responseMetadata,
   }: {
     status: StatusName;
     message: string;
     detail?: any;
     source?: string;
+    responseMetadata?: ErrorResponseMetadata;
   }) {
     super(`${source ? `${source}: ` : ''}${status}: ${message}`);
     this.originalMessage = message;
     this.code = httpStatusCode(status);
     this.status = status;
     this.detail = detail;
+    this.responseMetadata = responseMetadata;
     this.name = 'GenkitError';
   }
 

--- a/js/core/src/index.ts
+++ b/js/core/src/index.ts
@@ -70,6 +70,7 @@ export {
   assertUnstable,
   getCallableJSON,
   getHttpStatus,
+  type ErrorResponseMetadata,
   type StatusName,
 } from './error.js';
 export {

--- a/js/genkit/src/common.ts
+++ b/js/genkit/src/common.ts
@@ -153,6 +153,7 @@ export {
   type ActionContext,
   type ActionMetadata,
   type DynamicActionProviderAction,
+  type ErrorResponseMetadata,
   type Flow,
   type FlowConfig,
   type FlowFn,

--- a/js/plugins/anthropic/src/models.ts
+++ b/js/plugins/anthropic/src/models.ts
@@ -15,13 +15,19 @@
  * limitations under the License.
  */
 
+import { APIError } from '@anthropic-ai/sdk';
 import type {
   GenerateRequest,
   GenerateResponseData,
   ModelReference,
   StreamingCallback,
 } from 'genkit';
-import { z } from 'genkit';
+import {
+  GenkitError,
+  z,
+  type ErrorResponseMetadata,
+  type StatusName,
+} from 'genkit';
 import type { GenerateResponseChunkData, ModelAction } from 'genkit/model';
 import { modelRef } from 'genkit/model';
 import { model } from 'genkit/plugin';
@@ -36,6 +42,18 @@ import {
   type ClaudeRunnerParams,
 } from './types.js';
 import { checkModelName, isKnownKey } from './utils.js';
+
+/**
+ * Parses a `Retry-After` header value into milliseconds.
+ * Supports delay-seconds and HTTP-date formats (RFC 7231 §7.1.3).
+ */
+function parseRetryAfterMs(value: string): number | undefined {
+  const seconds = Number(value);
+  if (!isNaN(seconds) && seconds >= 0) return seconds * 1000;
+  const date = new Date(value);
+  if (!isNaN(date.getTime())) return Math.max(0, date.getTime() - Date.now());
+  return undefined;
+}
 
 // This contains all the Anthropic config schema types
 type ConfigSchemaType = AnthropicConfigSchemaType;
@@ -148,11 +166,53 @@ export function claudeRunner<TConfigSchema extends z.ZodTypeAny>(
     const runner = isBeta
       ? (betaRunner ??= new BetaRunner(runnerParams))
       : (stableRunner ??= new Runner(runnerParams));
-    return runner.run(normalizedRequest, {
-      streamingRequested,
-      sendChunk,
-      abortSignal,
-    });
+    try {
+      return await runner.run(normalizedRequest, {
+        streamingRequested,
+        sendChunk,
+        abortSignal,
+      });
+    } catch (e) {
+      if (e instanceof APIError) {
+        let status: StatusName = 'UNKNOWN';
+        switch (e.status) {
+          case 429:
+            status = 'RESOURCE_EXHAUSTED';
+            break;
+          case 401:
+            status = 'UNAUTHENTICATED';
+            break;
+          case 403:
+            status = 'PERMISSION_DENIED';
+            break;
+          case 400:
+            status = 'INVALID_ARGUMENT';
+            break;
+          case 500:
+            status = 'INTERNAL';
+            break;
+          case 503:
+            status = 'UNAVAILABLE';
+            break;
+          case 529:
+            status = 'UNAVAILABLE';
+            break;
+        }
+        const retryAfterHeader = e.headers?.get?.('retry-after');
+        const retryAfterMs = retryAfterHeader
+          ? parseRetryAfterMs(retryAfterHeader)
+          : undefined;
+        const responseMetadata: ErrorResponseMetadata | undefined = retryAfterMs
+          ? { retryAfterMs }
+          : undefined;
+        throw new GenkitError({
+          status,
+          message: e.message,
+          responseMetadata,
+        });
+      }
+      throw e;
+    }
   };
 }
 

--- a/js/plugins/anthropic/src/models.ts
+++ b/js/plugins/anthropic/src/models.ts
@@ -48,6 +48,7 @@ import { checkModelName, isKnownKey } from './utils.js';
  * Supports delay-seconds and HTTP-date formats (RFC 7231 §7.1.3).
  */
 function parseRetryAfterMs(value: string): number | undefined {
+  if (!value || !value.trim()) return undefined;
   const seconds = Number(value);
   if (!isNaN(seconds) && seconds >= 0) return seconds * 1000;
   const date = new Date(value);
@@ -202,9 +203,8 @@ export function claudeRunner<TConfigSchema extends z.ZodTypeAny>(
         const retryAfterMs = retryAfterHeader
           ? parseRetryAfterMs(retryAfterHeader)
           : undefined;
-        const responseMetadata: ErrorResponseMetadata | undefined = retryAfterMs
-          ? { retryAfterMs }
-          : undefined;
+        const responseMetadata: ErrorResponseMetadata | undefined =
+          retryAfterMs !== undefined ? { retryAfterMs } : undefined;
         throw new GenkitError({
           status,
           message: e.message,

--- a/js/plugins/anthropic/src/models.ts
+++ b/js/plugins/anthropic/src/models.ts
@@ -193,8 +193,6 @@ export function claudeRunner<TConfigSchema extends z.ZodTypeAny>(
             status = 'INTERNAL';
             break;
           case 503:
-            status = 'UNAVAILABLE';
-            break;
           case 529:
             status = 'UNAVAILABLE';
             break;

--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -58,6 +58,7 @@ import { maybeCreateRequestScopedOpenAIClient, toModelName } from './utils.js';
  * Supports delay-seconds and HTTP-date formats (RFC 7231 §7.1.3).
  */
 function parseRetryAfterMs(value: string): number | undefined {
+  if (!value || !value.trim()) return undefined;
   const seconds = Number(value);
   if (!isNaN(seconds) && seconds >= 0) return seconds * 1000;
   const date = new Date(value);
@@ -651,9 +652,8 @@ export function openAIModelRunner(
         const retryAfterMs = retryAfterHeader
           ? parseRetryAfterMs(retryAfterHeader)
           : undefined;
-        const responseMetadata: ErrorResponseMetadata | undefined = retryAfterMs
-          ? { retryAfterMs }
-          : undefined;
+        const responseMetadata: ErrorResponseMetadata | undefined =
+          retryAfterMs !== undefined ? { retryAfterMs } : undefined;
         throw new GenkitError({
           status,
           message: e.message,

--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -33,6 +33,7 @@ import {
   StatusName,
   modelRef,
   z,
+  type ErrorResponseMetadata,
 } from 'genkit';
 import type { ModelAction, ModelInfo, ToolDefinition } from 'genkit/model';
 import { model } from 'genkit/plugin';
@@ -51,6 +52,18 @@ import type {
 } from 'openai/resources/index.mjs';
 import { PluginOptions } from './index.js';
 import { maybeCreateRequestScopedOpenAIClient, toModelName } from './utils.js';
+
+/**
+ * Parses a `Retry-After` header value into milliseconds.
+ * Supports delay-seconds and HTTP-date formats (RFC 7231 §7.1.3).
+ */
+function parseRetryAfterMs(value: string): number | undefined {
+  const seconds = Number(value);
+  if (!isNaN(seconds) && seconds >= 0) return seconds * 1000;
+  const date = new Date(value);
+  if (!isNaN(date.getTime())) return Math.max(0, date.getTime() - Date.now());
+  return undefined;
+}
 
 const VisualDetailLevelSchema = z.enum(['auto', 'low', 'high']).optional();
 
@@ -632,9 +645,19 @@ export function openAIModelRunner(
             status = 'UNAVAILABLE';
             break;
         }
+        const retryAfterHeader =
+          e.headers?.get?.('retry-after') ??
+          (e.headers as any)?.['retry-after'];
+        const retryAfterMs = retryAfterHeader
+          ? parseRetryAfterMs(retryAfterHeader)
+          : undefined;
+        const responseMetadata: ErrorResponseMetadata | undefined = retryAfterMs
+          ? { retryAfterMs }
+          : undefined;
         throw new GenkitError({
           status,
           message: e.message,
+          responseMetadata,
         });
       }
       throw e;

--- a/js/plugins/google-genai/src/common/utils.ts
+++ b/js/plugins/google-genai/src/common/utils.ts
@@ -690,4 +690,4 @@ export function parseRetryAfterMs(value: string): number | undefined {
   return undefined;
 }
 
-export const TEST_ONLY = { aggregateResponses, parseRetryAfterMs };
+export const TEST_ONLY = { aggregateResponses };

--- a/js/plugins/google-genai/src/common/utils.ts
+++ b/js/plugins/google-genai/src/common/utils.ts
@@ -626,4 +626,26 @@ export function isKnownKey<T extends object>(
   return key in obj;
 }
 
-export const TEST_ONLY = { aggregateResponses };
+/**
+ * Parses the value of a `Retry-After` HTTP header into milliseconds.
+ * Supports both delay-seconds (e.g. "60") and HTTP-date formats
+ * (e.g. "Mon, 19 May 2026 12:00:00 GMT") per RFC 7231 §7.1.3.
+ *
+ * @param value The raw Retry-After header value.
+ * @returns The delay in milliseconds, or undefined if the value cannot be parsed.
+ */
+export function parseRetryAfterMs(value: string): number | undefined {
+  // Try as delay-seconds (e.g., "60")
+  const seconds = Number(value);
+  if (!isNaN(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+  // Try as HTTP-date (e.g., "Mon, 19 May 2026 12:00:00 GMT")
+  const date = new Date(value);
+  if (!isNaN(date.getTime())) {
+    return Math.max(0, date.getTime() - Date.now());
+  }
+  return undefined;
+}
+
+export const TEST_ONLY = { aggregateResponses, parseRetryAfterMs };

--- a/js/plugins/google-genai/src/common/utils.ts
+++ b/js/plugins/google-genai/src/common/utils.ts
@@ -635,6 +635,9 @@ export function isKnownKey<T extends object>(
  * @returns The delay in milliseconds, or undefined if the value cannot be parsed.
  */
 export function parseRetryAfterMs(value: string): number | undefined {
+  if (!value || !value.trim()) {
+    return undefined;
+  }
   // Try as delay-seconds (e.g., "60")
   const seconds = Number(value);
   if (!isNaN(seconds) && seconds >= 0) {

--- a/js/plugins/google-genai/src/googleai/client.ts
+++ b/js/plugins/google-genai/src/googleai/client.ts
@@ -519,9 +519,8 @@ async function makeRequest(
       const retryAfterMs = retryAfterHeader
         ? parseRetryAfterMs(retryAfterHeader)
         : undefined;
-      const responseMetadata: ErrorResponseMetadata | undefined = retryAfterMs
-        ? { retryAfterMs }
-        : undefined;
+      const responseMetadata: ErrorResponseMetadata | undefined =
+        retryAfterMs !== undefined ? { retryAfterMs } : undefined;
 
       throw new GenkitError({
         status,

--- a/js/plugins/google-genai/src/googleai/client.ts
+++ b/js/plugins/google-genai/src/googleai/client.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { GenkitError, StatusName } from 'genkit';
+import { GenkitError, StatusName, type ErrorResponseMetadata } from 'genkit';
 import { logger } from 'genkit/logging';
 import {
   extractErrMsg,
   getGenkitClientHeader,
+  parseRetryAfterMs,
   processStream,
 } from '../common/utils.js';
 import {
@@ -513,10 +514,20 @@ async function makeRequest(
           status = 'UNAVAILABLE';
           break;
       }
+      // Capture Retry-After header for retry middleware to use
+      const retryAfterHeader = response.headers.get('retry-after');
+      const retryAfterMs = retryAfterHeader
+        ? parseRetryAfterMs(retryAfterHeader)
+        : undefined;
+      const responseMetadata: ErrorResponseMetadata | undefined = retryAfterMs
+        ? { retryAfterMs }
+        : undefined;
+
       throw new GenkitError({
         status,
         message: `Error fetching from ${url}: [${response.status} ${response.statusText}] ${errorMessage}`,
         detail: errorDetail,
+        responseMetadata,
       });
     }
     return response;

--- a/js/plugins/google-genai/src/vertexai/client.ts
+++ b/js/plugins/google-genai/src/vertexai/client.ts
@@ -439,9 +439,8 @@ async function makeRequest(
       const retryAfterMs = retryAfterHeader
         ? parseRetryAfterMs(retryAfterHeader)
         : undefined;
-      const responseMetadata: ErrorResponseMetadata | undefined = retryAfterMs
-        ? { retryAfterMs }
-        : undefined;
+      const responseMetadata: ErrorResponseMetadata | undefined =
+        retryAfterMs !== undefined ? { retryAfterMs } : undefined;
 
       throw new GenkitError({
         status,

--- a/js/plugins/google-genai/src/vertexai/client.ts
+++ b/js/plugins/google-genai/src/vertexai/client.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { GenkitError, StatusName } from 'genkit';
+import { GenkitError, StatusName, type ErrorResponseMetadata } from 'genkit';
 import { logger } from 'genkit/logging';
 import { GoogleAuth } from 'google-auth-library';
 import {
   extractErrMsg,
   getGenkitClientHeader,
+  parseRetryAfterMs,
   processStream,
 } from '../common/utils.js';
 import {
@@ -433,10 +434,20 @@ async function makeRequest(
           status = 'UNAVAILABLE';
           break;
       }
+      // Capture Retry-After header for retry middleware to use
+      const retryAfterHeader = response.headers.get('retry-after');
+      const retryAfterMs = retryAfterHeader
+        ? parseRetryAfterMs(retryAfterHeader)
+        : undefined;
+      const responseMetadata: ErrorResponseMetadata | undefined = retryAfterMs
+        ? { retryAfterMs }
+        : undefined;
+
       throw new GenkitError({
         status,
         message: `Error fetching from ${url}: [${response.status} ${response.statusText}] ${errorMessage}`,
         detail: errorDetail,
+        responseMetadata,
       });
     }
     return response;

--- a/js/plugins/google-genai/tests/common/utils_test.ts
+++ b/js/plugins/google-genai/tests/common/utils_test.ts
@@ -34,6 +34,7 @@ import {
   extractText,
   extractVersion,
   modelName,
+  parseRetryAfterMs,
   processStream,
 } from '../../src/common/utils.js';
 
@@ -805,6 +806,52 @@ describe('Common Utils', () => {
         aggregated.candidates?.[0].content.parts[1].text,
         ' World'
       );
+    });
+  });
+
+  describe('parseRetryAfterMs', () => {
+    it('parses delay-seconds to milliseconds', () => {
+      assert.strictEqual(parseRetryAfterMs('60'), 60_000);
+      assert.strictEqual(parseRetryAfterMs('0'), 0);
+      assert.strictEqual(parseRetryAfterMs('120'), 120_000);
+    });
+
+    it('parses fractional delay-seconds', () => {
+      assert.strictEqual(parseRetryAfterMs('1.5'), 1_500);
+    });
+
+    it('parses HTTP-date format', () => {
+      const futureDate = new Date(Date.now() + 30_000);
+      const result = parseRetryAfterMs(futureDate.toUTCString());
+      assert.ok(result !== undefined);
+      // Should be approximately 30 seconds (allow some tolerance for test execution time)
+      assert.ok(
+        result > 28_000 && result <= 31_000,
+        `Expected ~30000ms, got ${result}ms`
+      );
+    });
+
+    it('returns 0 for HTTP-date in the past', () => {
+      const pastDate = new Date(Date.now() - 60_000);
+      assert.strictEqual(parseRetryAfterMs(pastDate.toUTCString()), 0);
+    });
+
+    it('returns 0 for negative delay-seconds (parsed as ancient date)', () => {
+      // '-5' fails the seconds >= 0 check, but JS Date parses it as year -5,
+      // which is in the past, so Math.max(0, past - now) = 0.
+      assert.strictEqual(parseRetryAfterMs('-5'), 0);
+    });
+
+    it('returns undefined for unparseable values', () => {
+      assert.strictEqual(parseRetryAfterMs('not-a-number-or-date'), undefined);
+    });
+
+    it('returns undefined for empty string', () => {
+      assert.strictEqual(parseRetryAfterMs(''), undefined);
+    });
+
+    it('returns undefined for whitespace-only string', () => {
+      assert.strictEqual(parseRetryAfterMs('   '), undefined);
     });
   });
 

--- a/js/plugins/middleware/src/retry.ts
+++ b/js/plugins/middleware/src/retry.ts
@@ -94,6 +94,13 @@ const DEFAULT_RETRY_STATUSES: StatusName[] = [
   'INTERNAL',
 ];
 
+/**
+ * Error names that should never be retried, even when the error is not a GenkitError.
+ * - AbortError: User explicitly cancelled the operation via AbortController.
+ * - ToolInterruptError: Deliberate control-flow signal for tool interrupt handling.
+ */
+const NEVER_RETRY_ERROR_NAMES = ['AbortError', 'ToolInterruptError'];
+
 let __setTimeout: (
   callback: (...args: any[]) => void,
   ms?: number
@@ -163,11 +170,22 @@ export const retry: GenerateMiddleware<typeof RetryOptionsSchema> =
                     shouldRetry = true;
                   }
                 } else {
-                  shouldRetry = true;
+                  // Don't retry AbortError or ToolInterruptError
+                  shouldRetry = !NEVER_RETRY_ERROR_NAMES.includes(error.name);
                 }
 
                 if (shouldRetry) {
                   let delay = currentDelay;
+                  // Honor provider's Retry-After if available
+                  if (
+                    error instanceof GenkitError &&
+                    error.responseMetadata?.retryAfterMs
+                  ) {
+                    delay = Math.max(
+                      delay,
+                      error.responseMetadata.retryAfterMs
+                    );
+                  }
                   if (!noJitter) {
                     delay = delay + 1000 * Math.pow(2, i) * Math.random();
                   }

--- a/js/plugins/middleware/src/retry.ts
+++ b/js/plugins/middleware/src/retry.ts
@@ -165,13 +165,14 @@ export const retry: GenerateMiddleware<typeof RetryOptionsSchema> =
               const error = e as Error;
               if (i < maxRetries) {
                 let shouldRetry = false;
-                if (error instanceof GenkitError) {
+                if (NEVER_RETRY_ERROR_NAMES.includes(error?.name)) {
+                  shouldRetry = false;
+                } else if (error instanceof GenkitError) {
                   if ((statuses as string[]).includes(error.status)) {
                     shouldRetry = true;
                   }
                 } else {
-                  // Don't retry AbortError or ToolInterruptError
-                  shouldRetry = !NEVER_RETRY_ERROR_NAMES.includes(error.name);
+                  shouldRetry = true;
                 }
 
                 if (shouldRetry) {

--- a/js/plugins/middleware/tests/retry_test.ts
+++ b/js/plugins/middleware/tests/retry_test.ts
@@ -272,4 +272,137 @@ describe('retry', () => {
     assert.strictEqual(result.text, 'success');
     assert.strictEqual(totalDelay, 50 + 60);
   });
+
+  it('should not retry on AbortError', async () => {
+    let requestCount = 0;
+    const ai = genkit({});
+    const pm = ai.defineModel({ name: 'programmableModel' }, async (req) => {
+      requestCount++;
+      const err = new DOMException('The operation was aborted', 'AbortError');
+      throw err;
+    });
+
+    TEST_ONLY.setRetryTimeout((callback, ms) => {
+      callback();
+      return 0 as any;
+    });
+
+    await assert.rejects(
+      ai.generate({
+        model: pm,
+        prompt: 'test',
+        use: [retry({ maxRetries: 3 })],
+      }),
+      /AbortError/
+    );
+
+    assert.strictEqual(requestCount, 1);
+  });
+
+  it('should not retry on ToolInterruptError', async () => {
+    let requestCount = 0;
+    const ai = genkit({});
+    const pm = ai.defineModel({ name: 'programmableModel' }, async (req) => {
+      requestCount++;
+      const err = new Error('tool interrupt');
+      err.name = 'ToolInterruptError';
+      throw err;
+    });
+
+    TEST_ONLY.setRetryTimeout((callback, ms) => {
+      callback();
+      return 0 as any;
+    });
+
+    await assert.rejects(
+      ai.generate({
+        model: pm,
+        prompt: 'test',
+        use: [retry({ maxRetries: 3 })],
+      }),
+      /tool interrupt/
+    );
+
+    assert.strictEqual(requestCount, 1);
+  });
+
+  it('should use retryAfterMs as delay floor', async () => {
+    let requestCount = 0;
+    const ai = genkit({});
+    const pm = ai.defineModel({ name: 'programmableModel' }, async (req) => {
+      requestCount++;
+      if (requestCount < 2) {
+        throw new GenkitError({
+          status: 'RESOURCE_EXHAUSTED',
+          message: 'rate limited',
+          responseMetadata: { retryAfterMs: 5000 },
+        });
+      }
+      return { message: { role: 'model', content: [{ text: 'success' }] } };
+    });
+
+    let totalDelay = 0;
+    TEST_ONLY.setRetryTimeout((callback, ms) => {
+      totalDelay += ms!;
+      callback();
+      return 0 as any;
+    });
+
+    const result = await ai.generate({
+      model: pm,
+      prompt: 'test',
+      use: [
+        retry({
+          maxRetries: 2,
+          initialDelayMs: 100,
+          noJitter: true,
+        }),
+      ],
+    });
+
+    assert.strictEqual(requestCount, 2);
+    assert.strictEqual(result.text, 'success');
+    // retryAfterMs (5000) should override initialDelayMs (100)
+    assert.strictEqual(totalDelay, 5000);
+  });
+
+  it('should use computed delay when it exceeds retryAfterMs', async () => {
+    let requestCount = 0;
+    const ai = genkit({});
+    const pm = ai.defineModel({ name: 'programmableModel' }, async (req) => {
+      requestCount++;
+      if (requestCount < 2) {
+        throw new GenkitError({
+          status: 'RESOURCE_EXHAUSTED',
+          message: 'rate limited',
+          responseMetadata: { retryAfterMs: 10 },
+        });
+      }
+      return { message: { role: 'model', content: [{ text: 'success' }] } };
+    });
+
+    let totalDelay = 0;
+    TEST_ONLY.setRetryTimeout((callback, ms) => {
+      totalDelay += ms!;
+      callback();
+      return 0 as any;
+    });
+
+    const result = await ai.generate({
+      model: pm,
+      prompt: 'test',
+      use: [
+        retry({
+          maxRetries: 2,
+          initialDelayMs: 500,
+          noJitter: true,
+        }),
+      ],
+    });
+
+    assert.strictEqual(requestCount, 2);
+    assert.strictEqual(result.text, 'success');
+    // initialDelayMs (500) exceeds retryAfterMs (10), so 500 is used
+    assert.strictEqual(totalDelay, 500);
+  });
 });


### PR DESCRIPTION
Fixes #5270 
Fixes #5331

### What

Make the retry middleware to respect the `Retry-After` HTTP header from providers, and prevents retrying errors that should never be retried.

### Changes

**Core (`@genkit-ai/core`)**
- Added `ErrorResponseMetadata` interface with `retryAfterMs` and `headers` fields
- Added optional `responseMetadata` property to `GenkitError` (not serialized in `toJSON()` — in-process only)

**Retry middleware (`@genkit-ai/middleware`)**
- Uses `responseMetadata.retryAfterMs` as a floor for the retry delay (`Math.max(computedDelay, retryAfterMs)`)
- Never retries `AbortError` (from `AbortController`) or `ToolInterruptError` (control-flow signal), regardless of error type
- Added 4 new unit tests covering both behaviors

**Provider plugins** — all now capture `Retry-After` from HTTP responses and pass it as `responseMetadata` on `GenkitError`:
- **google-genai**: `googleai/client.ts` and `vertexai/client.ts` read from `Response.headers`
- **compat-oai**: reads from OpenAI SDK `APIError.headers`
- **anthropic**: added try/catch around `runner.run()` to convert Anthropic SDK `APIError` → `GenkitError` with status mapping (429→RESOURCE_EXHAUSTED, 401→UNAUTHENTICATED, etc.) and `Retry-After` propagation

### Notes
- `parseRetryAfterMs` supports both delay-seconds and HTTP-date formats (RFC 7231 §7.1.3), with guards against empty/whitespace input
- `retryAfterMs` uses `!== undefined` checks to preserve `Retry-After: 0` as a valid "retry immediately" signal
- The anthropic plugin previously let raw SDK errors propagate; it now normalizes them to `GenkitError` with proper status codes