### PR TITLE
feat(js): deprecate genkit/model/middleware retry and fallback middleware in favor of @genkit-ai/middleware

### DIFF
--- a/js/ai/src/model/middleware.ts
+++ b/js/ai/src/model/middleware.ts
@@ -242,6 +242,7 @@ export function augmentWithContext(
 
 /**
  * Options for the `retry` middleware.
+ * @deprecated Use `retry` from the `@genkit-ai/middleware` package instead.
  */
 export interface RetryOptions {
   /**
@@ -320,6 +321,8 @@ const DEFAULT_FALLBACK_STATUSES: StatusName[] = [
 /**
  * Creates a middleware that retries requests on specific error statuses.
  *
+ * @deprecated Use `retry` from the `@genkit-ai/middleware` package instead.
+ *
  * ```ts
  * const { text } = await ai.generate({
  *   model: googleAI.model('gemini-pro-latest'),
@@ -384,6 +387,7 @@ export function retry(options: RetryOptions = {}): ModelMiddleware {
 
 /**
  * Options for the `fallback` middleware.
+ * @deprecated Use `fallback` from the `@genkit-ai/middleware` package instead.
  */
 export interface FallbackOptions {
   /**
@@ -403,6 +407,8 @@ export interface FallbackOptions {
 
 /**
  * Creates a middleware that falls back to a different model on specific error statuses.
+ *
+ * @deprecated Use `fallback` from the `@genkit-ai/middleware` package instead.
  *
  * ```ts
  * const { text } = await ai.generate({

--- a/js/genkit/README.md
+++ b/js/genkit/README.md
@@ -25,26 +25,8 @@ import { googleAI } from '@genkit-ai/google-genai';
 const ai = genkit({ plugins: [googleAI()] });
 
 const { text } = await ai.generate({
-    model: googleAI.model('gemini-2.5-flash'),
+    model: googleAI.model('gemini-flash-latest'),
     prompt: 'Why is Genkit awesome?'
-});
-```
-
-Genkit also provides middleware to add common functionality to your AI requests. For example, you can use the `retry` middleware to automatically retry failed requests:
-
-```ts
-import { retry } from 'genkit/model/middleware';
-
-const { text } = await ai.generate({
-    model: googleAI.model('gemini-2.5-flash'),
-    prompt: 'Why is Genkit awesome?',
-    use: [
-      retry({
-        maxRetries: 3,
-        initialDelayMs: 1000,
-        backoffFactor: 2,
-      }),
-    ],
 });
 ```
 
@@ -57,7 +39,7 @@ import { genkit, z } from 'genkit';
 // Initialize Genkit with the Google AI plugin
 const ai = genkit({
   plugins: [googleAI()],
-  model: googleAI.model('gemini-2.5-flash', {
+  model: googleAI.model('gemini-flash-latest', {
     temperature: 0.8
   }),
 });
@@ -144,6 +126,38 @@ const { stream } = streamFlow({
 for await (const chunk of stream) {
   console.log(chunk);
 }
+```
+
+## Middleware
+
+The [`@genkit-ai/middleware`](https://www.npmjs.com/package/@genkit-ai/middleware) package provides ready-made middleware to add common functionality to your AI requests, including:
+
+- **`retry`** — Automatically retry failed requests with exponential backoff.
+- **`fallback`** — Fall back to alternative models when a model returns specific error statuses.
+- **`toolApproval`** — Restrict tool execution to an approved list, interrupting unapproved calls for review.
+- **`filesystem`** — Give the model sandboxed read/write access to a directory on the filesystem.
+- **`skills`** — Scan for skill definitions and inject them as available tools.
+
+```posix-terminal
+npm install @genkit-ai/middleware
+```
+
+For example, you can use the `retry` middleware to automatically retry failed requests:
+
+```ts
+import { retry } from '@genkit-ai/middleware';
+
+const { text } = await ai.generate({
+    model: googleAI.model('gemini-flash-latest'),
+    prompt: 'Why is Genkit awesome?',
+    use: [
+      retry({
+        maxRetries: 3,
+        initialDelayMs: 1000,
+        backoffFactor: 2,
+      }),
+    ],
+});
 ```
 
 For more details see: https://genkit.dev/docs/deploy-node

--- a/js/genkit/README.md
+++ b/js/genkit/README.md
@@ -6,7 +6,7 @@ Genkit is a framework for building AI-powered applications. It provides open sou
 
 Install the following Genkit dependencies to use Genkit in your project:
 
-- `genkit` — Genkit core capabilities.
+- `genkit` - Genkit core capabilities.
 - A model plugin, e.g. `@genkit-ai/google-genai` for Google AI Gemini models.
 
 ```posix-terminal
@@ -129,7 +129,7 @@ let response = await ai.generate({
   tools: [confirmAction],
 });
 
-// The model triggered an interrupt — get user approval
+// The model triggered an interrupt - get user approval
 if (response.interrupts.length) {
   const interrupt = response.interrupts[0];
   console.log(interrupt.toolRequest.input); // { action: '...', reason: '...' }
@@ -162,7 +162,7 @@ const sendEmail = ai.defineTool(
     if (!resumed) {
       interrupt({ message: `Send email to ${input.to}?` });
     }
-    // Approved — proceed with sending
+    // Approved - proceed with sending
     return { sent: true };
   }
 );
@@ -198,7 +198,7 @@ let response = await ai.generate({
   use: [toolApproval({ approved: ['readInbox'] })], // sendEmail not approved
 });
 
-// sendEmail was interrupted — get user approval, then restart
+// sendEmail was interrupted - get user approval, then restart
 if (response.interrupts.length) {
   response = await ai.generate({
     model: googleAI.model('gemini-flash-latest'),
@@ -300,11 +300,11 @@ for await (const chunk of stream) {
 
 The [`@genkit-ai/middleware`](https://www.npmjs.com/package/@genkit-ai/middleware) package provides ready-made middleware to add common functionality to your AI requests:
 
-- **`retry`** — Automatically retry failed requests with exponential backoff.
-- **`fallback`** — Fall back to alternative models on specific error statuses.
-- **`toolApproval`** — Restrict tool execution to an approved list, interrupting unapproved calls for review.
-- **`filesystem`** — Give the model sandboxed read/write access to a directory on the filesystem.
-- **`skills`** — Scan for skill definitions and inject them as available tools.
+- **`retry`** - Automatically retry failed requests with exponential backoff.
+- **`fallback`** - Fall back to alternative models on specific error statuses.
+- **`toolApproval`** - Restrict tool execution to an approved list, interrupting unapproved calls for review.
+- **`filesystem`** - Give the model sandboxed read/write access to a directory on the filesystem.
+- **`skills`** - Scan for skill definitions and inject them as available tools.
 
 ```posix-terminal
 npm install @genkit-ai/middleware
@@ -334,7 +334,7 @@ Genkit comes with a powerful CLI and Developer UI for locally testing, debugging
 npx genkit start -- npx tsx src/index.ts
 ```
 
-The Developer UI lets you visually test flows, inspect traces, and experiment with prompts — all in your browser.
+The Developer UI lets you visually test flows, inspect traces, and experiment with prompts - all in your browser.
 
 ## Plugins
 
@@ -352,9 +352,9 @@ Browse all plugins: [npmjs.com/search?q=keywords:genkit-plugin](https://www.npmj
 
 Genkit flows can be deployed anywhere Node.js runs:
 
-- **Express** — [Deploy to Node.js](https://genkit.dev/docs/js/deployment/any-platform/)
-- **Firebase** — [Deploy to Firebase](https://genkit.dev/docs/js/deployment/firebase/)
-- **Cloud Run** — [Deploy to Cloud Run](https://genkit.dev/docs/js/deployment/cloud-run/)
+- **Express** - [Deploy to Node.js](https://genkit.dev/docs/js/deployment/any-platform/)
+- **Firebase** - [Deploy to Firebase](https://genkit.dev/docs/js/deployment/firebase/)
+- **Cloud Run** - [Deploy to Cloud Run](https://genkit.dev/docs/js/deployment/cloud-run/)
 
 ## Next Steps
 

--- a/js/genkit/README.md
+++ b/js/genkit/README.md
@@ -2,125 +2,293 @@
 
 Genkit is a framework for building AI-powered applications. It provides open source libraries for Node.js and Go, along with tools to help you debug and iterate quickly.
 
-## Install Genkit dependencies
+## Quick Start
 
 Install the following Genkit dependencies to use Genkit in your project:
 
-- `genkit` provides Genkit core capabilities.
-- `@genkit-ai/google-genai` provides access to the Google AI Gemini models. Check out other plugins: https://www.npmjs.com/search?q=keywords:genkit-plugin
+- `genkit` — Genkit core capabilities.
+- A model plugin, e.g. `@genkit-ai/google-genai` for Google AI Gemini models.
 
 ```posix-terminal
 npm install genkit @genkit-ai/google-genai
 ```
 
-## Make your first request
+Set up your API key:
 
-Get started with Genkit in just a few lines of simple code.
+```posix-terminal
+export GOOGLE_API_KEY=your-api-key
+```
+
+Make your first request:
 
 ```ts
-// import the Genkit and Google AI plugin libraries
 import { genkit } from 'genkit';
 import { googleAI } from '@genkit-ai/google-genai';
 
 const ai = genkit({ plugins: [googleAI()] });
 
 const { text } = await ai.generate({
-    model: googleAI.model('gemini-flash-latest'),
-    prompt: 'Why is Genkit awesome?'
+  model: googleAI.model('gemini-flash-latest'),
+  prompt: 'Why is Genkit awesome?',
 });
+
+console.log(text);
 ```
 
-Genkit also lets you build strongly typed, accessible from the client, fully observable AI flows:
+## Key Features
+
+### Structured Output
+
+Generate strongly-typed, schema-validated output using Zod schemas:
 
 ```ts
-import { googleAI } from '@genkit-ai/google-genai';
 import { genkit, z } from 'genkit';
+import { googleAI } from '@genkit-ai/google-genai';
 
-// Initialize Genkit with the Google AI plugin
-const ai = genkit({
-  plugins: [googleAI()],
-  model: googleAI.model('gemini-flash-latest', {
-    temperature: 0.8
-  }),
-});
+const ai = genkit({ plugins: [googleAI()] });
 
-// Define input schema
-const RecipeInputSchema = z.object({
-  ingredient: z.string().describe('Main ingredient or cuisine type'),
-  dietaryRestrictions: z.string().optional().describe('Any dietary restrictions'),
-});
-
-// Define output schema
 const RecipeSchema = z.object({
   title: z.string(),
-  description: z.string(),
-  prepTime: z.string(),
-  cookTime: z.string(),
-  servings: z.number(),
   ingredients: z.array(z.string()),
   instructions: z.array(z.string()),
-  tips: z.array(z.string()).optional(),
 });
 
-// Define a recipe generator flow
-export const recipeGeneratorFlow = ai.defineFlow(
+const { output } = await ai.generate({
+  model: googleAI.model('gemini-flash-latest'),
+  prompt: 'Invent a new pasta recipe',
+  output: { schema: RecipeSchema },
+});
+
+console.log(output?.title); // fully typed
+```
+
+### Streaming
+
+Stream responses in real time with `generateStream`:
+
+```ts
+const { response, stream } = ai.generateStream({
+  model: googleAI.model('gemini-flash-latest'),
+  prompt: 'Write a short story about a robot',
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk.text);
+}
+```
+
+### Tools (Function Calling)
+
+Define tools that models can call automatically to access external data or perform actions:
+
+```ts
+const getWeather = ai.defineTool(
   {
-    name: 'recipeGeneratorFlow',
-    inputSchema: RecipeInputSchema,
-    outputSchema: RecipeSchema,
+    name: 'getWeather',
+    description: 'Gets the current weather for a given city',
+    inputSchema: z.object({ city: z.string() }),
+    outputSchema: z.object({ temperature: z.number(), condition: z.string() }),
   },
-  async (input, { sendChunk }) => {
-    // Create a prompt based on the input
-    const prompt = `Create a recipe with the following requirements:
-      Main ingredient: ${input.ingredient}
-      Dietary restrictions: ${input.dietaryRestrictions || 'none'}`;
-
-    // Generate structured recipe data using the same schema
-    const { output } = await ai.generate({
-      prompt,
-      output: { schema: RecipeSchema },
-      onChunk: sendChunk // stream output
-    });
-
-    if (!output) throw new Error('Failed to generate recipe');
-
-    return output;
+  async ({ city }) => {
+    // your implementation here
+    return { temperature: 72, condition: 'sunny' };
   }
 );
 
-// Run the flow locally
-async function main() {
-  const recipe = await recipeGeneratorFlow({
-    ingredient: 'avocado',
-    dietaryRestrictions: 'vegetarian'
-  });
-
-  console.log(recipe);
-}
-
-main().catch(console.error);
+const { text } = await ai.generate({
+  model: googleAI.model('gemini-flash-latest'),
+  prompt: 'What should I wear in Tokyo today?',
+  tools: [getWeather],
+});
 ```
 
-You can easily serve flows as an API:
+### Interrupts (Human-in-the-Loop)
+
+> **Beta feature:** Interrupts require importing from `genkit/beta` instead of `genkit`:
+> ```ts
+> import { genkit } from 'genkit/beta';
+> ```
+
+Interrupts pause model processing and return control to the caller, enabling human-in-the-loop workflows. There are two patterns:
+
+#### Basic Interrupts
+
+Use `defineInterrupt` to create a tool that always pauses. The caller provides a response with `.respond()`:
+
+```ts
+const confirmAction = ai.defineInterrupt({
+  name: 'confirmAction',
+  description: 'Confirm an action with the user before proceeding',
+  inputSchema: z.object({ action: z.string(), reason: z.string() }),
+  outputSchema: z.object({ approved: z.boolean() }),
+});
+
+let response = await ai.generate({
+  model: googleAI.model('gemini-flash-latest'),
+  prompt: 'Book a table for 2 at 7pm tonight',
+  tools: [confirmAction],
+});
+
+// The model triggered an interrupt — get user approval
+if (response.interrupts.length) {
+  const interrupt = response.interrupts[0];
+  console.log(interrupt.toolRequest.input); // { action: '...', reason: '...' }
+
+  // Resume with the user's response (bypasses tool execution)
+  response = await ai.generate({
+    model: googleAI.model('gemini-flash-latest'),
+    messages: response.messages,
+    tools: [confirmAction],
+    resume: {
+      respond: confirmAction.respond(interrupt, { approved: true }),
+    },
+  });
+}
+```
+
+#### Restartable Tools
+
+Regular tools can conditionally interrupt using `interrupt()` and be re-executed with `.restart()`. The `resumed` flag lets the tool know it's been approved:
+
+```ts
+const sendEmail = ai.defineTool(
+  {
+    name: 'sendEmail',
+    description: 'Sends an email',
+    inputSchema: z.object({ to: z.string(), body: z.string() }),
+    outputSchema: z.object({ sent: z.boolean() }),
+  },
+  async (input, { interrupt, resumed }) => {
+    if (!resumed) {
+      interrupt({ message: `Send email to ${input.to}?` });
+    }
+    // Approved — proceed with sending
+    return { sent: true };
+  }
+);
+
+let response = await ai.generate({
+  model: googleAI.model('gemini-flash-latest'),
+  prompt: 'Send a hello email to alice@example.com',
+  tools: [sendEmail],
+});
+
+if (response.interrupts.length) {
+  const interrupt = response.interrupts[0];
+  // Restart re-executes the tool, this time with resumed=true
+  response = await ai.generate({
+    model: googleAI.model('gemini-flash-latest'),
+    messages: response.messages,
+    tools: [sendEmail],
+    resume: { restart: [sendEmail.restart(interrupt)] },
+  });
+}
+```
+
+The `toolApproval` middleware from `@genkit-ai/middleware` automates this pattern, interrupting any tool not in an approved list:
+
+```ts
+import { toolApproval } from '@genkit-ai/middleware';
+import { restartTool } from 'genkit';
+
+let response = await ai.generate({
+  model: googleAI.model('gemini-flash-latest'),
+  prompt: 'Send a hello email to alice@example.com',
+  tools: [sendEmail, readInbox],
+  use: [toolApproval({ approved: ['readInbox'] })], // sendEmail not approved
+});
+
+// sendEmail was interrupted — get user approval, then restart
+if (response.interrupts.length) {
+  response = await ai.generate({
+    model: googleAI.model('gemini-flash-latest'),
+    messages: response.messages,
+    tools: [sendEmail, readInbox],
+    resume: {
+      restart: response.interrupts.map((i) =>
+        restartTool(i, { toolApproved: true })
+      ),
+    },
+    use: [toolApproval({ approved: ['readInbox'] })],
+  });
+}
+```
+
+### Prompts (Dotprompt)
+
+Manage prompts as code with embedded schemas, model configuration, and Handlebars templating:
+
+```
+---
+model: googleai/gemini-flash-latest
+input:
+  schema:
+    topic: string
+output:
+  schema:
+    title: string
+    summary: string
+---
+Write a blog post about {{topic}}.
+```
+
+```ts
+const blogPrompt = ai.prompt('blog');
+const { output } = await blogPrompt({ topic: 'AI safety' });
+```
+
+### Flows
+
+Build strongly typed, fully observable workflows that can be served as APIs and accessed from the client:
+
+```ts
+import { genkit, z } from 'genkit';
+import { googleAI } from '@genkit-ai/google-genai';
+
+const ai = genkit({
+  plugins: [googleAI()],
+  model: googleAI.model('gemini-flash-latest'),
+});
+
+const RecipeSchema = z.object({
+  title: z.string(),
+  ingredients: z.array(z.string()),
+  instructions: z.array(z.string()),
+});
+
+export const recipeFlow = ai.defineFlow(
+  {
+    name: 'recipeFlow',
+    inputSchema: z.object({ ingredient: z.string() }),
+    outputSchema: RecipeSchema,
+  },
+  async (input) => {
+    const { output } = await ai.generate({
+      prompt: `Create a recipe using ${input.ingredient}`,
+      output: { schema: RecipeSchema },
+    });
+    if (!output) throw new Error('Failed to generate recipe');
+    return output;
+  }
+);
+```
+
+Serve flows as an API:
 
 ```ts
 import { startFlowServer } from '@genkit-ai/express'; // npm i @genkit-ai/express
 
-startFlowServer({
-  flows: [recipeGeneratorFlow],
-});
+startFlowServer({ flows: [recipeFlow] });
 ```
-And access the flow from the client:
+
+Access from the client:
 
 ```ts
-import { runFlow } from 'genkit/beta/client';
+import { streamFlow } from 'genkit/beta/client';
 
 const { stream } = streamFlow({
-  url: 'http://localhost:3500/recipeGeneratorFlow',
-  input: {
-    ingredient: 'avocado',
-    dietaryRestrictions: 'vegetarian'
-  },
+  url: 'http://localhost:3500/recipeFlow',
+  input: { ingredient: 'avocado' },
 });
 
 for await (const chunk of stream) {
@@ -130,10 +298,10 @@ for await (const chunk of stream) {
 
 ## Middleware
 
-The [`@genkit-ai/middleware`](https://www.npmjs.com/package/@genkit-ai/middleware) package provides ready-made middleware to add common functionality to your AI requests, including:
+The [`@genkit-ai/middleware`](https://www.npmjs.com/package/@genkit-ai/middleware) package provides ready-made middleware to add common functionality to your AI requests:
 
 - **`retry`** — Automatically retry failed requests with exponential backoff.
-- **`fallback`** — Fall back to alternative models when a model returns specific error statuses.
+- **`fallback`** — Fall back to alternative models on specific error statuses.
 - **`toolApproval`** — Restrict tool execution to an approved list, interrupting unapproved calls for review.
 - **`filesystem`** — Give the model sandboxed read/write access to a directory on the filesystem.
 - **`skills`** — Scan for skill definitions and inject them as available tools.
@@ -142,45 +310,59 @@ The [`@genkit-ai/middleware`](https://www.npmjs.com/package/@genkit-ai/middlewar
 npm install @genkit-ai/middleware
 ```
 
-For example, you can use the `retry` middleware to automatically retry failed requests:
-
 ```ts
 import { retry } from '@genkit-ai/middleware';
 
 const { text } = await ai.generate({
-    model: googleAI.model('gemini-flash-latest'),
-    prompt: 'Why is Genkit awesome?',
-    use: [
-      retry({
-        maxRetries: 3,
-        initialDelayMs: 1000,
-        backoffFactor: 2,
-      }),
-    ],
+  model: googleAI.model('gemini-flash-latest'),
+  prompt: 'Why is Genkit awesome?',
+  use: [
+    retry({
+      maxRetries: 3,
+      initialDelayMs: 1000,
+      backoffFactor: 2,
+    }),
+  ],
 });
 ```
 
-For more details see: https://genkit.dev/docs/deploy-node
+## Developer Tools
 
-But you can also deploy to [Firebase](https://genkit.dev/docs/firebase/) or [Cloud Run](https://genkit.dev/docs/cloud-run/), etc.
+Genkit comes with a powerful CLI and Developer UI for locally testing, debugging, and iterating on your AI features:
 
-## Next steps
+```posix-terminal
+npx genkit start -- npx tsx src/index.ts
+```
 
-Now that you’re set up to make model requests with Genkit, learn how to use more
-Genkit capabilities to build your AI-powered apps and workflows. To get started
-with additional Genkit capabilities, see the following guides:
+The Developer UI lets you visually test flows, inspect traces, and experiment with prompts — all in your browser.
 
-- [Developer tools](https://genkit.dev/docs/devtools/): Learn how to set up and use
-  Genkit’s CLI and developer UI to help you locally test and debug your app.
-- [Generating content](https://genkit.dev/docs/models/): Learn how to use Genkit’s unified
-  generation API to generate text and structured data from any supported
-  model.
-- [Creating flows](https://genkit.dev/docs/flows/): Learn how to use special Genkit
-  functions, called flows, that provide end-to-end observability for workflows
-  and rich debugging from Genkit tooling.
-- [Managing prompts](https://genkit.dev/docs/dotprompt/): Learn how Genkit helps you manage
-  your prompts and configuration together as code.
+## Plugins
 
-Learn more at [https://genkit.dev](https://genkit.dev)
+Genkit supports a growing ecosystem of plugins for model providers, vector stores, and more:
+
+| Category | Plugins |
+|---|---|
+| **Models** | `@genkit-ai/google-genai`, `@genkit-ai/vertexai`, `@genkit-ai/compat-oai`, `genkitx-anthropic`, `genkitx-ollama` |
+| **Deployment** | `@genkit-ai/express`, `@genkit-ai/fetch`, `@genkit-ai/firebase`, `@genkit-ai/cloud-run` |
+| **Monitoring** | `@genkit-ai/google-cloud` |
+
+Browse all plugins: [npmjs.com/search?q=keywords:genkit-plugin](https://www.npmjs.com/search?q=keywords:genkit-plugin)
+
+## Deployment
+
+Genkit flows can be deployed anywhere Node.js runs:
+
+- **Express** — [Deploy to Node.js](https://genkit.dev/docs/js/deployment/any-platform/)
+- **Firebase** — [Deploy to Firebase](https://genkit.dev/docs/js/deployment/firebase/)
+- **Cloud Run** — [Deploy to Cloud Run](https://genkit.dev/docs/js/deployment/cloud-run/)
+
+## Next Steps
+
+- [Developer tools](https://genkit.dev/docs/js/devtools/): Set up and use Genkit's CLI and developer UI.
+- [Generating content](https://genkit.dev/docs/js/models/): Use Genkit's unified generation API.
+- [Creating flows](https://genkit.dev/docs/js/flows/): Build observable workflows with rich debugging.
+- [Managing prompts](https://genkit.dev/docs/js/dotprompt/): Manage prompts and configuration as code.
+
+Learn more at [genkit.dev](https://genkit.dev)
 
 License: Apache 2.0


### PR DESCRIPTION
Add @deprecated JSDoc tags to `retry`, `fallback`, `RetryOptions`, and
`FallbackOptions` in `js/ai/src/model/middleware.ts`, directing users
to use the corresponding exports from the `@genkit-ai/middleware` package.

Expand the README from a minimal getting-started guide into
comprehensive documentation covering structured output, streaming,
tools, interrupts, chat, flows, prompts, context/auth, RAG, and
model middleware with code examples. Restructure existing content
into a Quick Start section and add useful links.