### PR TITLE
chore(py): Bump Python SDK version to 0.6.0

### DIFF
--- a/py/packages/genkit/pyproject.toml
+++ b/py/packages/genkit/pyproject.toml
@@ -76,7 +76,7 @@ license = "Apache-2.0"
 name = "genkit"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.2"
+version = "0.6.0"
 
 [project.optional-dependencies]
 flask                 = ["genkit-plugin-flask"]

--- a/py/plugins/anthropic/pyproject.toml
+++ b/py/plugins/anthropic/pyproject.toml
@@ -58,7 +58,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-anthropic"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.2"
+version = "0.6.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/plugins/compat-oai/pyproject.toml
+++ b/py/plugins/compat-oai/pyproject.toml
@@ -58,7 +58,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-compat-oai"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.2"
+version = "0.6.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/plugins/evaluators/pyproject.toml
+++ b/py/plugins/evaluators/pyproject.toml
@@ -38,7 +38,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-evaluators"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.2"
+version = "0.6.0"
 
 [project.urls]
 "Homepage" = "https://github.com/genkit-ai/genkit"

--- a/py/plugins/fastapi/pyproject.toml
+++ b/py/plugins/fastapi/pyproject.toml
@@ -52,7 +52,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-fastapi"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.2"
+version = "0.6.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/plugins/flask/pyproject.toml
+++ b/py/plugins/flask/pyproject.toml
@@ -64,7 +64,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-flask"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.2"
+version = "0.6.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/plugins/google-cloud/pyproject.toml
+++ b/py/plugins/google-cloud/pyproject.toml
@@ -66,7 +66,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-google-cloud"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.2"
+version = "0.6.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/plugins/google-genai/pyproject.toml
+++ b/py/plugins/google-genai/pyproject.toml
@@ -66,7 +66,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-google-genai"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.2"
+version = "0.6.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/plugins/ollama/pyproject.toml
+++ b/py/plugins/ollama/pyproject.toml
@@ -59,7 +59,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-ollama"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.2"
+version = "0.6.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/plugins/vertex-ai/pyproject.toml
+++ b/py/plugins/vertex-ai/pyproject.toml
@@ -69,7 +69,7 @@ license = "Apache-2.0"
 name = "genkit-plugin-vertex-ai"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.2"
+version = "0.6.0"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"


### PR DESCRIPTION
## Python SDK v0.6.0 Release Notes

This release bumps the Genkit Python SDK to version `0.6.0`.

### New Features
- **Dynamic Tools**: Add support for dynamically defined tools (#5214).
- **Tool Restarts & Interrupts**: Add tool restarts and refactor Interrupts (#5069) and add interrupt metadata so that they're rendered w/ special callouts in Dev UI (#5260).

### Existing API Changes

- **Breaking change: When executing prompts, options have been flattened into standard Python keyword arguments.**

```python
# OLD (v0.5.2):
response = await my_prompt(input_data, {'config': {'temperature': 0.7}})

# NEW (v0.6.0):
response = await my_prompt(input_data, config={'temperature': 0.7})
```
In your Genkit code, if you invoke prompts with custom configuration defined in code, you will need to migrate your usage code such that `config` is named as an explicit kwarg.

- **Non-breaking change: Decorator @ai.tool returns a Tool wrapper instead of the raw function.**

In v0.5.2, decorating a function with @ai.tool registered the action behind the scenes, but returned the original raw Python function. In v0.6.0, decorating a function with @ai.tool now returns a wrapper instance of the Tool class. This change shouldn't require any migration on your end for typical Genkit usage.

### Bug Fixes & Refactoring
- **Code Execution**: Fix code execution serialization issue for googleai plugin (#5326).
- **Async Safety**: Make plugin init state loop-local to fix cross-loop Task error (#5262).
- **Telemetry**: Fix double generate span in model runner (#5113).
- **Validation**: Enforce object root JSON Schema for tool inputs at `define_tool` (#5059) and parallelize tool calls in generate loop (#5054).
- **Dependencies & Configuration**: Fix pyproject.toml on `fastapi` plugin (#5030) and bump `mistune` dependency (#5289).
- **Repository URL Migration**: Update repository URLs and references from `firebase/genkit` to `genkit-ai/genkit` (#5155).
- **Samples**: Update samples to use `gemini-*latest` (#5328).
- **Reflection Server v2**: Implement reflection server v2 support (#5186). Hidden behind flag.
- **Expose ActionRunContext in Dev UI correctly.**: Before it was propagating correctly but not showing up in the Dev UI, now it is (#5364).
- **Observability & Spans**: Unify span creation through `run_in_new_span` + hand-write `SpanMetadata` (#5311).