### PR TITLE
chore(py): remove `tool` argument from `restart_tool` helper

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_tools.py
+++ b/py/packages/genkit/src/genkit/_ai/_tools.py
@@ -201,8 +201,7 @@ def restart_tool(
     """
     tool_req = interrupt.tool_request
 
-    existing_meta = interrupt.metadata or {}
-    new_meta: dict[str, Any] = dict(existing_meta) if existing_meta else {}
+    new_meta: dict[str, Any] = dict(interrupt.metadata or {})
 
     new_meta['resumed'] = resumed_metadata if resumed_metadata is not None else True
 

--- a/py/packages/genkit/src/genkit/_ai/_tools.py
+++ b/py/packages/genkit/src/genkit/_ai/_tools.py
@@ -78,51 +78,6 @@ class Tool:
         """Run the tool and return the unwrapped response value."""
         return (await self._action.run(*args, **kwargs)).response
 
-    def restart(
-        self,
-        replace_input: Any | None = None,  # noqa: ANN401
-        *,
-        interrupt: ToolRequestPart,
-        resumed_metadata: dict[str, Any] | None = None,
-    ) -> ToolRequestPart:
-        """Create a restart request for an interrupted tool call.
-
-        Args:
-            replace_input: Optional new ``tool_request.input`` for this run (previous input is
-                stored in ``metadata.replacedInput`` when this is set).
-            interrupt: The interrupted ``ToolRequestPart`` (e.g. from ``response.interrupts``).
-            resumed_metadata: Passed to the tool as ``ToolRunContext.resumed_metadata``.
-
-        Returns:
-            A ``ToolRequestPart`` for ``resume_restart`` / message history.
-
-        Example:
-            ``pay_invoice.restart({**trp.tool_request.input, "confirmed": True}, interrupt=trp,``
-            ``resumed_metadata={"by": "bob"})``
-        """
-        tool_req = interrupt.tool_request
-        if tool_req.name != self.name:
-            raise ValueError(f"Interrupt is for tool '{tool_req.name}', not '{self.name}'")
-
-        existing_meta = interrupt.metadata or {}
-        new_meta: dict[str, Any] = dict(existing_meta) if existing_meta else {}
-
-        new_meta['resumed'] = resumed_metadata if resumed_metadata is not None else True
-
-        new_input = tool_req.input
-        if replace_input is not None:
-            new_meta['replacedInput'] = tool_req.input
-            new_input = replace_input
-
-        return ToolRequestPart(
-            tool_request=ToolRequest(
-                name=tool_req.name,
-                ref=tool_req.ref,
-                input=new_input,
-            ),
-            metadata=new_meta,
-        )
-
 
 # Context variables for propagating resumed metadata to tools
 _tool_resumed_metadata: ContextVar[dict[str, Any] | None] = ContextVar('tool_resumed_metadata', default=None)
@@ -221,33 +176,49 @@ def respond_to_interrupt(
 
 
 def restart_tool(
-    replace_input: Any | None = None,  # noqa: ANN401 - new tool input; shape is per tool
-    *,
-    tool: Tool,
     interrupt: ToolRequestPart,
+    *,
     resumed_metadata: dict[str, Any] | None = None,
+    replace_input: Any | None = None,  # noqa: ANN401 - new tool input; shape is per tool
 ) -> ToolRequestPart:
     """Build a restart ``ToolRequestPart`` for a pending tool interrupt.
 
-    Thin wrapper around :meth:`Tool.restart` for symmetry with
-    :func:`respond_to_interrupt`. Pass the return value to
-    ``generate(..., resume_restart=...)``.
+    Pass the return value to ``generate(..., resume_restart=...)``.
 
     Args:
-        replace_input: Optional new ``tool_request.input`` for this run (previous input is
-            stored in ``metadata.replacedInput`` when this is set).
-        tool: The registered :class:`Tool` that was interrupted.
         interrupt: The interrupted ``ToolRequestPart`` (e.g. from ``response.interrupts``).
-        resumed_metadata: Passed to the tool as ``ToolRunContext.resumed_metadata``.
+        resumed_metadata: Passed to the tool as ``ToolRunContext.resumed_metadata``. The
+            common case is a small dict the tool / middleware checks
+            (e.g. ``{'toolApproved': True}`` for ``ToolApproval``).
+        replace_input: Optional new ``tool_request.input`` for this run; the previous input
+            is stashed in ``metadata.replacedInput`` so the tool can see what changed.
 
     Returns:
         A ``ToolRequestPart`` for ``resume_restart`` / message history.
 
     Example:
-        ``restart_tool({**trp.tool_request.input, "confirmed": True}, tool=pay_invoice,``
-        ``interrupt=trp, resumed_metadata={"by": "bob"})``
+        ``restart_tool(trp, resumed_metadata={'toolApproved': True})``
     """
-    return tool.restart(replace_input, interrupt=interrupt, resumed_metadata=resumed_metadata)
+    tool_req = interrupt.tool_request
+
+    existing_meta = interrupt.metadata or {}
+    new_meta: dict[str, Any] = dict(existing_meta) if existing_meta else {}
+
+    new_meta['resumed'] = resumed_metadata if resumed_metadata is not None else True
+
+    new_input = tool_req.input
+    if replace_input is not None:
+        new_meta['replacedInput'] = tool_req.input
+        new_input = replace_input
+
+    return ToolRequestPart(
+        tool_request=ToolRequest(
+            name=tool_req.name,
+            ref=tool_req.ref,
+            input=new_input,
+        ),
+        metadata=new_meta,
+    )
 
 
 async def run_tool_after_restart(tool: Action[Any, Any, Any], restart_trp: ToolRequestPart) -> ToolResponsePart:

--- a/py/packages/genkit/tests/genkit/ai/_tools_test.py
+++ b/py/packages/genkit/tests/genkit/ai/_tools_test.py
@@ -19,20 +19,13 @@ from genkit._core._error import GenkitError
 from genkit._core._typing import ToolRequest, ToolRequestPart, ToolResponsePart
 
 
-@pytest.mark.asyncio
-async def test_restart_sets_resumed_metadata_and_preserves_interrupt() -> None:
-    """``tool.restart``: copy interrupt metadata, set ``resumed``; ``interrupt`` stays on the restart TRP."""
-    ai = Genkit()
-
-    @ai.tool(name='pay')
-    async def pay(inp: dict) -> str:  # noqa: ARG001
-        return 'ok'
-
+def test_restart_sets_resumed_metadata_and_preserves_interrupt() -> None:
+    """``restart_tool``: copy interrupt metadata, set ``resumed``; ``interrupt`` stays on the restart TRP."""
     interrupt_trp = ToolRequestPart(
         tool_request=ToolRequest(name='pay', ref='r1', input={'amount': 10}),
         metadata={'interrupt': {'reason': 'hold'}},
     )
-    out = pay.restart(None, interrupt=interrupt_trp, resumed_metadata={'k': 'v'})
+    out = restart_tool(interrupt_trp, resumed_metadata={'k': 'v'})
     assert isinstance(out, ToolRequestPart)
     assert out.metadata is not None
     assert out.metadata.get('resumed') == {'k': 'v'}
@@ -40,20 +33,13 @@ async def test_restart_sets_resumed_metadata_and_preserves_interrupt() -> None:
     assert out.tool_request.input == {'amount': 10}
 
 
-@pytest.mark.asyncio
-async def test_restart_replace_input_sets_replaced_input() -> None:
+def test_restart_replace_input_sets_replaced_input() -> None:
     """Restart with new input sets ``replacedInput`` to prior input and updates ``tool_request.input``."""
-    ai = Genkit()
-
-    @ai.tool(name='pay')
-    async def pay(inp: dict) -> str:  # noqa: ARG001
-        return 'ok'
-
     interrupt_trp = ToolRequestPart(
         tool_request=ToolRequest(name='pay', ref='r1', input={'amount': 10}),
         metadata={'interrupt': True},
     )
-    out = pay.restart({'amount': 99}, interrupt=interrupt_trp, resumed_metadata={'by': 'u'})
+    out = restart_tool(interrupt_trp, resumed_metadata={'by': 'u'}, replace_input={'amount': 99})
     assert isinstance(out, ToolRequestPart)
     assert out.metadata is not None
     assert out.metadata.get('replacedInput') == {'amount': 10}
@@ -62,20 +48,13 @@ async def test_restart_replace_input_sets_replaced_input() -> None:
     assert out.metadata.get('interrupt') is True
 
 
-@pytest.mark.asyncio
-async def test_restart_resumed_defaults_to_true() -> None:
+def test_restart_resumed_defaults_to_true() -> None:
     """When ``resumed_metadata=None``, restart TRP sets ``metadata.resumed`` to True."""
-    ai = Genkit()
-
-    @ai.tool(name='pay')
-    async def pay(inp: dict) -> str:  # noqa: ARG001
-        return 'ok'
-
     interrupt_trp = ToolRequestPart(
         tool_request=ToolRequest(name='pay', ref='r1', input={}),
         metadata={'interrupt': True},
     )
-    out = pay.restart(None, interrupt=interrupt_trp, resumed_metadata=None)
+    out = restart_tool(interrupt_trp, resumed_metadata=None)
     assert isinstance(out, ToolRequestPart)
     assert out.metadata is not None
     assert out.metadata.get('resumed') is True
@@ -227,103 +206,34 @@ def test_respond_to_interrupt_wire_format_with_metadata() -> None:
     assert result.metadata.get('interruptResponse') == {'by': 'admin'}
 
 
-@pytest.mark.asyncio
-async def test_restart_tool_matches_method_no_replace_input() -> None:
-    """``restart_tool`` is equivalent to calling ``tool.restart`` (no replace_input)."""
-    ai = Genkit()
+def test_restart_tool_does_not_require_tool_reference() -> None:
+    """``restart_tool`` works from an interrupt alone — no ``Tool`` needed.
 
-    @ai.tool(name='pay')
-    async def pay(inp: dict) -> str:  # noqa: ARG001
-        return 'ok'
-
+    Middleware-contributed tools (``read_file`` from a filesystem middleware,
+    anything gated by a ``ToolApproval`` middleware) never give the caller
+    a ``Tool`` reference; they just appear in ``response.interrupts``. The
+    helper has to be callable from the interrupt by itself.
+    """
     interrupt_trp = ToolRequestPart(
-        tool_request=ToolRequest(name='pay', ref='r1', input={'amount': 10}),
-        metadata={'interrupt': {'reason': 'hold'}},
-    )
-
-    via_helper = restart_tool(tool=pay, interrupt=interrupt_trp, resumed_metadata={'k': 'v'})
-    via_method = pay.restart(None, interrupt=interrupt_trp, resumed_metadata={'k': 'v'})
-
-    assert via_helper.model_dump() == via_method.model_dump()
-
-
-@pytest.mark.asyncio
-async def test_restart_tool_with_replace_input() -> None:
-    """``restart_tool`` forwards ``replace_input`` and matches ``tool.restart``."""
-    ai = Genkit()
-
-    @ai.tool(name='pay')
-    async def pay(inp: dict) -> str:  # noqa: ARG001
-        return 'ok'
-
-    interrupt_trp = ToolRequestPart(
-        tool_request=ToolRequest(name='pay', ref='r1', input={'amount': 10}),
+        tool_request=ToolRequest(name='middleware_tool', ref='r1', input={'p': 1}),
         metadata={'interrupt': True},
     )
 
-    out = restart_tool({'amount': 99}, tool=pay, interrupt=interrupt_trp, resumed_metadata={'by': 'u'})
+    out = restart_tool(interrupt_trp, resumed_metadata={'toolApproved': True})
 
-    assert isinstance(out, ToolRequestPart)
+    assert out.tool_request.name == 'middleware_tool'
+    assert out.tool_request.input == {'p': 1}
     assert out.metadata is not None
-    assert out.metadata.get('replacedInput') == {'amount': 10}
-    assert out.tool_request.input == {'amount': 99}
-    assert out.metadata.get('resumed') == {'by': 'u'}
-    assert out.metadata.get('interrupt') is True
-
-
-@pytest.mark.asyncio
-async def test_restart_tool_resumed_defaults_to_true() -> None:
-    """``restart_tool`` with ``resumed_metadata=None`` sets ``metadata.resumed`` to True."""
-    ai = Genkit()
-
-    @ai.tool(name='pay')
-    async def pay(inp: dict) -> str:  # noqa: ARG001
-        return 'ok'
-
-    interrupt_trp = ToolRequestPart(
-        tool_request=ToolRequest(name='pay', ref='r1', input={}),
-        metadata={'interrupt': True},
-    )
-
-    out = restart_tool(tool=pay, interrupt=interrupt_trp)
-
-    assert isinstance(out, ToolRequestPart)
-    assert out.metadata is not None
-    assert out.metadata.get('resumed') is True
-    assert out.tool_request.ref == 'r1'
-
-
-@pytest.mark.asyncio
-async def test_restart_tool_rejects_mismatched_tool() -> None:
-    """``restart_tool`` propagates the ``Tool.restart`` name-mismatch guard."""
-    ai = Genkit()
-
-    @ai.tool(name='pay')
-    async def pay(inp: dict) -> str:  # noqa: ARG001
-        return 'ok'
-
-    interrupt_trp = ToolRequestPart(
-        tool_request=ToolRequest(name='other', ref='r1', input={}),
-        metadata={'interrupt': True},
-    )
-
-    with pytest.raises(ValueError, match="Interrupt is for tool 'other', not 'pay'"):
-        restart_tool(tool=pay, interrupt=interrupt_trp)
+    assert out.metadata.get('resumed') == {'toolApproved': True}
 
 
 def test_restart_preserves_ref_on_wire() -> None:
-    """restart() preserves the original tool_request.ref so the resumed TRP can be correlated."""
-    ai = Genkit()
-
-    @ai.tool(name='pay')
-    async def pay(inp: dict) -> str:  # noqa: ARG001
-        return 'ok'
-
+    """``restart_tool`` preserves the original tool_request.ref so the resumed TRP can be correlated."""
     interrupt_trp = ToolRequestPart(
         tool_request=ToolRequest(name='pay', ref='corr-id-1', input={'amount': 50}),
         metadata={'interrupt': True},
     )
-    out = pay.restart(None, interrupt=interrupt_trp)
+    out = restart_tool(interrupt_trp)
 
     assert out.tool_request.ref == 'corr-id-1'
 

--- a/py/packages/genkit/tests/genkit/ai/generate_interrupt_resume_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_interrupt_resume_test.py
@@ -12,7 +12,7 @@ import pytest
 from genkit import Genkit, Message, ModelResponse
 from genkit._ai._generate import generate_action
 from genkit._ai._testing import define_programmable_model
-from genkit._ai._tools import Interrupt, ToolRunContext, respond_to_interrupt
+from genkit._ai._tools import Interrupt, ToolRunContext, respond_to_interrupt, restart_tool
 from genkit._core._error import GenkitError
 from genkit._core._model import GenerateActionOptions
 from genkit._core._typing import FinishReason, Resume
@@ -439,7 +439,7 @@ async def test_resume_restart_runs_tool_second_time_and_resolved_interrupt_on_mo
         },
     ]
 
-    restart_trp = pay.restart({'ok': True}, interrupt=first.interrupts[0], resumed_metadata={'by': 'test'})
+    restart_trp = restart_tool(first.interrupts[0], resumed_metadata={'by': 'test'}, replace_input={'ok': True})
 
     second = await generate_action(
         ai.registry,
@@ -555,7 +555,7 @@ async def test_mixed_resume_one_respond_one_restart() -> None:
             messages=list(first.messages),
             resume=Resume(
                 respond=[respond_to_interrupt({'done': True}, interrupt=ia)],
-                restart=[b_tool.restart({'ok': True}, interrupt=ib, resumed_metadata=None)],
+                restart=[restart_tool(ib, replace_input={'ok': True})],
             ),
         ),
     )

--- a/py/samples/tool-interrupts/src/approval_example.py
+++ b/py/samples/tool-interrupts/src/approval_example.py
@@ -157,11 +157,7 @@ async def interactive_restart_cli() -> None:
         ans = input('Approve transfer? [y/N]: ').strip().lower()
 
         if ans in ('y', 'yes'):
-            restart = restart_tool(
-                tool=request_transfer,
-                interrupt=interrupt,
-                resumed_metadata={'via': 'cli', 'path': 'restart'},
-            )
+            restart = restart_tool(interrupt, resumed_metadata={'via': 'cli', 'path': 'restart'})
             response = await ai.generate(
                 messages=messages,
                 resume_restart=restart,


### PR DESCRIPTION
## Summary
- `restart_tool` new signature: `restart_tool(interrupt, *, resumed_metadata=None, replace_input=None) -> ToolRequestPart`. 
- You don't need to pass the tool in anymore. The updated part can be constructed with the above information only.
- Also converted to `resumed_metadata` and `replace_input` to explicit kwargs rather than positional to prevent ambiguity. The interrupt ToolRequestPart is the only positional argument now.

## Why
Originally` restart_tool `required a `Tool` reference, which app developers don't hold for tools registered by middleware. Those tools surface in `response.interrupts` but never as a `Tool` handle to the caller, so passing the tool explicitly was tricky. 

Imagine this use case: middleware `tools()` function provides some additional tools that require approval. The app developer's code never has a reference to those tools since they are injected to the registry automatically via the framework. When resuming, the app developer doesn't have an easy way to retrieve the middleware tool to pass it in to the `restart_tool` helper.

Note: Not a breaking change because we didn't release the `restart_tool` helper yet. This will be bundled with the initial release of the restart feature. 

Example:

```python
 restart_tool(interrupt, resumed_metadata={'toolApproved': True})
```

works for any interrupt from any source.
