### PR TITLE
fix(js/compat-oai): omit visualDetailLevel from requests

### DIFF
--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -484,6 +484,7 @@ export function toOpenAIRequestBody(
     version: modelVersion,
     tools: toolsFromConfig,
     apiKey,
+    visualDetailLevel,
     ...restOfConfig
   } = request.config ?? {};
 

--- a/js/plugins/compat-oai/tests/compat_oai_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_test.ts
@@ -1149,6 +1149,45 @@ describe('toOpenAiRequestBody', () => {
     });
   }
 
+  it('uses visualDetailLevel without passing it through to the request body', () => {
+    const actualOutput = toOpenAIRequestBody('gpt-4o', {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              media: {
+                contentType: 'image/png',
+                url: 'https://example.com/image.png',
+              },
+            },
+          ],
+        },
+      ],
+      config: {
+        seed: 42,
+        visualDetailLevel: 'high',
+      },
+    } as GenerateRequest) as any;
+
+    expect(actualOutput.visualDetailLevel).toBeUndefined();
+    expect(actualOutput.seed).toBe(42);
+    expect(actualOutput.messages).toStrictEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'https://example.com/image.png',
+              detail: 'high',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('(gpt4) does NOT set response_format in openai request body', () => {
     // In either case - output.format='json' or output.format='text' - do NOT set response_format in the OpenAI request body explicitly.
     const modelName = 'gpt-4';


### PR DESCRIPTION
Fixes #4592.

Summary:
- keep `visualDetailLevel` for image detail conversion
- avoid passing it through to the OpenAI request body
- add regression coverage

Checks:
- `pnpm --filter @genkit-ai/compat-oai check`
- `pnpm --filter @genkit-ai/compat-oai exec jest tests/compat_oai_test.ts --runInBand`
- `prettier --check` on the changed files
- `git diff --check`