### PR TITLE
fix(py): surface action context on span metadata so Dev UI can render it

### DIFF
--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -58,40 +58,45 @@ def _record_latency(output: object, start_time: float) -> object:
     return output
 
 
-def _sanitize_context(context: dict[str, Any]) -> dict[str, Any]:
+def _sanitize_value(val: object, seen: set[int] | None = None) -> object:
     """Recursively filter out dictionary keys or list items that cannot be serialized to JSON."""
-    sanitized = {}
-    for k, v in context.items():
-        if not isinstance(k, str):
-            k = str(k)
-        if isinstance(v, dict):
-            sanitized[k] = _sanitize_context(v)
-        elif isinstance(v, list):
-            sanitized[k] = _sanitize_list(v)
-        else:
-            try:
-                json.dumps(v)
-                sanitized[k] = v
-            except (TypeError, ValueError):
-                continue
-    return sanitized
+    if seen is None:
+        seen = set()
 
+    ref_id = id(val)
+    if ref_id in seen:
+        return '[Circular]'
 
-def _sanitize_list(items: list[Any]) -> list[Any]:
-    """Recursively filter list items for serializability."""
-    sanitized = []
-    for item in items:
-        if isinstance(item, dict):
-            sanitized.append(_sanitize_context(item))
-        elif isinstance(item, list):
-            sanitized.append(_sanitize_list(item))
-        else:
+    if isinstance(val, dict):
+        seen.add(ref_id)
+        sanitized = {}
+        for k, v in val.items():
+            if not isinstance(k, str):
+                k = str(k)
             try:
-                json.dumps(item)
-                sanitized.append(item)
+                sanitized[k] = _sanitize_value(v, seen)
             except (TypeError, ValueError):
-                continue
-    return sanitized
+                sanitized[k] = repr(v)
+        seen.remove(ref_id)
+        return sanitized
+    elif isinstance(val, (list, set, tuple)):
+        seen.add(ref_id)
+        sanitized_list = []
+        for item in val:
+            try:
+                sanitized_list.append(_sanitize_value(item, seen))
+            except (TypeError, ValueError):
+                sanitized_list.append(repr(item))
+        seen.remove(ref_id)
+        return sanitized_list
+    else:
+        if isinstance(val, (str, int, float, bool, type(None))):
+            return val
+        try:
+            json.dumps(val)
+            return val
+        except (TypeError, ValueError):
+            return repr(val)
 
 
 # =============================================================================
@@ -570,7 +575,7 @@ class Action(Generic[InputT, OutputT, ChunkT]):
                 extra_metadata['context'] = json.dumps(ctx.context)
             except Exception:
                 try:
-                    cleaned_context = _sanitize_context(ctx.context)
+                    cleaned_context = _sanitize_value(ctx.context)
                     extra_metadata['context'] = json.dumps(cleaned_context)
                 except Exception:
                     extra_metadata['context'] = str(ctx.context)

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -567,10 +567,13 @@ class Action(Generic[InputT, OutputT, ChunkT]):
         # trace inspector can render the "Context" panel for a flow run.
         if ctx.context:
             try:
-                cleaned_context = _sanitize_context(ctx.context)
-                extra_metadata['context'] = json.dumps(cleaned_context)
-            except (TypeError, ValueError):
-                extra_metadata['context'] = str(ctx.context)
+                extra_metadata['context'] = json.dumps(ctx.context)
+            except Exception:
+                try:
+                    cleaned_context = _sanitize_context(ctx.context)
+                    extra_metadata['context'] = json.dumps(cleaned_context)
+                except Exception:
+                    extra_metadata['context'] = str(ctx.context)
         span_meta = SpanMetadata(
             name=self._name,
             type='action',

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -18,6 +18,7 @@
 
 import asyncio
 import inspect
+import json
 import re
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
@@ -55,6 +56,42 @@ def _record_latency(output: object, start_time: float) -> object:
             if hasattr(output, 'model_copy'):
                 output = cast(Any, output).model_copy(update={'latency_ms': latency_ms})
     return output
+
+
+def _sanitize_context(context: dict[str, Any]) -> dict[str, Any]:
+    """Recursively filter out dictionary keys or list items that cannot be serialized to JSON."""
+    sanitized = {}
+    for k, v in context.items():
+        if not isinstance(k, str):
+            k = str(k)
+        if isinstance(v, dict):
+            sanitized[k] = _sanitize_context(v)
+        elif isinstance(v, list):
+            sanitized[k] = _sanitize_list(v)
+        else:
+            try:
+                json.dumps(v)
+                sanitized[k] = v
+            except (TypeError, ValueError):
+                continue
+    return sanitized
+
+
+def _sanitize_list(items: list[Any]) -> list[Any]:
+    """Recursively filter list items for serializability."""
+    sanitized = []
+    for item in items:
+        if isinstance(item, dict):
+            sanitized.append(_sanitize_context(item))
+        elif isinstance(item, list):
+            sanitized.append(_sanitize_list(item))
+        else:
+            try:
+                json.dumps(item)
+                sanitized.append(item)
+            except (TypeError, ValueError):
+                continue
+    return sanitized
 
 
 # =============================================================================
@@ -525,12 +562,21 @@ class Action(Generic[InputT, OutputT, ChunkT]):
         # ``type``/``subtype`` set canonical genkit:type / genkit:metadata:subtype attrs.
         # ``self._span_metadata`` uses short keys; run_in_new_span auto-prefixes them with
         # ``genkit:metadata:``. ``telemetry_labels`` are caller-controlled passthrough attrs.
+        extra_metadata: dict[str, str] = {k: str(v) for k, v in self._span_metadata.items()}
+        # Surface action context (auth, headers, etc.) on the span so the Dev UI
+        # trace inspector can render the "Context" panel for a flow run.
+        if ctx.context:
+            try:
+                cleaned_context = _sanitize_context(ctx.context)
+                extra_metadata['context'] = json.dumps(cleaned_context)
+            except (TypeError, ValueError):
+                extra_metadata['context'] = str(ctx.context)
         span_meta = SpanMetadata(
             name=self._name,
             type='action',
             subtype=str(self._kind),
             input=input,
-            metadata={k: str(v) for k, v in self._span_metadata.items()} or None,
+            metadata=extra_metadata or None,
             telemetry_labels={k: str(v) for k, v in (telemetry_labels or {}).items()} or None,
         )
 

--- a/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
+++ b/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
@@ -187,3 +187,56 @@ async def test_action_error_attribute_keeps_original_text(exporter: InMemorySpan
     assert attrs['genkit:type'] == 'action'
     assert attrs['genkit:metadata:subtype'] == 'custom'
     assert attrs['genkit:state'] == 'error'
+
+
+@pytest.mark.asyncio
+async def test_action_context_telemetry_sanitizes_unserializable(exporter: InMemorySpanExporter) -> None:
+    """Verify that unserializable values in action context are dropped from tracing metadata.
+
+    Also verify that JSON-serializable values are kept.
+    """
+    import json
+
+    class UnserializableObject:
+        def __repr__(self) -> str:
+            return 'Unserializable'
+
+    async def noop() -> str:
+        return 'ok'
+
+    action = Action(
+        name='sanitizedFlow',
+        kind=ActionKind.FLOW,
+        fn=noop,
+    )
+
+    # We pass a context dictionary with both serializable and unserializable values,
+    # including nested dictionaries and lists.
+    complex_context = {
+        'auth': {
+            'user_id': 123,
+            'token': 'secret_token',
+            'raw_connection': UnserializableObject(),  # should be dropped
+        },
+        'serializable_list': [1, 'two', {'nested_key': 'nested_val'}],
+        'unserializable_list': [1, UnserializableObject(), 3],  # UnserializableObject should be dropped, keeping [1, 3]
+        'top_level_unserializable': UnserializableObject(),  # should be dropped entirely
+    }
+
+    await action.run(context=complex_context)
+
+    span = _by_name(exporter.get_finished_spans(), 'sanitizedFlow')
+    attrs = dict(span.attributes or {})
+
+    # The context key is mapped under genkit:metadata:context
+    assert 'genkit:metadata:context' in attrs
+    context_json = json.loads(attrs['genkit:metadata:context'])
+
+    # Assertions
+    assert context_json['auth']['user_id'] == 123
+    assert context_json['auth']['token'] == 'secret_token'
+    assert 'raw_connection' not in context_json['auth']
+
+    assert context_json['serializable_list'] == [1, 'two', {'nested_key': 'nested_val'}]
+    assert context_json['unserializable_list'] == [1, 3]
+    assert 'top_level_unserializable' not in context_json

--- a/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
+++ b/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
@@ -212,7 +212,7 @@ async def test_action_context_telemetry_sanitizes_unserializable(exporter: InMem
 
     # We pass a context dictionary with both serializable and unserializable values,
     # including nested dictionaries and lists.
-    complex_context = {
+    complex_context: dict[str, object] = {
         'auth': {
             'user_id': 123,
             'token': 'secret_token',
@@ -230,7 +230,9 @@ async def test_action_context_telemetry_sanitizes_unserializable(exporter: InMem
 
     # The context key is mapped under genkit:metadata:context
     assert 'genkit:metadata:context' in attrs
-    context_json = json.loads(attrs['genkit:metadata:context'])
+    context_attr = attrs['genkit:metadata:context']
+    assert isinstance(context_attr, str)
+    context_json = json.loads(context_attr)
 
     # Assertions
     assert context_json['auth']['user_id'] == 123
@@ -257,7 +259,7 @@ async def test_action_context_telemetry_circular_references(exporter: InMemorySp
     )
 
     # Setup a context dictionary with circular references
-    circular_context = {
+    circular_context: dict[str, object] = {
         'key': 'val',
     }
     circular_context['self'] = circular_context
@@ -268,7 +270,9 @@ async def test_action_context_telemetry_circular_references(exporter: InMemorySp
     attrs = dict(span.attributes or {})
 
     assert 'genkit:metadata:context' in attrs
-    context_json = json.loads(attrs['genkit:metadata:context'])
+    context_attr = attrs['genkit:metadata:context']
+    assert isinstance(context_attr, str)
+    context_json = json.loads(context_attr)
 
     # 'key' is serializable, and 'self' circular reference should be safely cut off with '[Circular]'
     assert context_json == {'key': 'val', 'self': '[Circular]'}

--- a/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
+++ b/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
@@ -235,8 +235,40 @@ async def test_action_context_telemetry_sanitizes_unserializable(exporter: InMem
     # Assertions
     assert context_json['auth']['user_id'] == 123
     assert context_json['auth']['token'] == 'secret_token'
-    assert 'raw_connection' not in context_json['auth']
+    assert context_json['auth']['raw_connection'] == 'Unserializable'
 
     assert context_json['serializable_list'] == [1, 'two', {'nested_key': 'nested_val'}]
-    assert context_json['unserializable_list'] == [1, 3]
-    assert 'top_level_unserializable' not in context_json
+    assert context_json['unserializable_list'] == [1, 'Unserializable', 3]
+    assert context_json['top_level_unserializable'] == 'Unserializable'
+
+
+@pytest.mark.asyncio
+async def test_action_context_telemetry_circular_references(exporter: InMemorySpanExporter) -> None:
+    """Verify that circular references inside the context are proactively detected and dropped."""
+    import json
+
+    async def noop() -> str:
+        return 'ok'
+
+    action = Action(
+        name='circularFlow',
+        kind=ActionKind.FLOW,
+        fn=noop,
+    )
+
+    # Setup a context dictionary with circular references
+    circular_context = {
+        'key': 'val',
+    }
+    circular_context['self'] = circular_context
+
+    await action.run(context=circular_context)
+
+    span = _by_name(exporter.get_finished_spans(), 'circularFlow')
+    attrs = dict(span.attributes or {})
+
+    assert 'genkit:metadata:context' in attrs
+    context_json = json.loads(attrs['genkit:metadata:context'])
+
+    # 'key' is serializable, and 'self' circular reference should be safely cut off with '[Circular]'
+    assert context_json == {'key': 'val', 'self': '[Circular]'}


### PR DESCRIPTION
## Context

Discovered a bug while testing the `basic-flows` sample.

Run any Python flow with a context — say `withContext` from `py/samples/basic-flows` — and pass `{"auth": {"username": "pavel", "email": "[pavel@example.com](mailto:pavel@example.com)"}, "role": "admin"}`. The flow itself sees the context correctly (`ctx.context` works inside the function), but the Dev UI trace inspector's **Context** panel is empty.

## Root cause

The trace consumer (Dev UI, downstream tools) reads action context off the span attribute `genkit:metadata:context`. The JS SDK writes this in `js/core/src/action.ts`:

```ts
if (options?.context) {
  setCustomMetadataAttributes({
    context: JSON.stringify(options.context),
  });
}
```

Python's `Action._run_with_telemetry` was constructing `SpanMetadata` from `self._span_metadata` only — `ctx.context` was never serialized onto the span. So the attribute simply did not exist on Python-emitted spans, and the Dev UI had nothing to render.

## Fix

In `py/packages/genkit/src/genkit/_core/_action.py`, copy the relevant span-metadata entries into a local dict, and if `ctx.context` is non-empty, add a `context` key whose value is the JSON-encoded context. The existing tracing layer (`_tracing.run_in_new_span`) already prefixes metadata keys with `genkit:metadata:` and stores them as strings, so this lands on the wire as `genkit:metadata:context` — exactly the attribute the Dev UI already knows how to read.

JSON-encoded over `str(...)` so the Dev UI can parse it back into a real object for the tree view (matches JS). Falls back to `str(...)` if the context happens to contain something non-JSON-serializable, rather than failing the whole span.

## Testing
Verified manually in Dev UI.

<img width="1306" height="1588" alt="bug1-context-in-devui" src="https://github.com/user-attachments/assets/4fe359d6-0aad-48bd-8408-480397e96927" />
