### PR TITLE
fix(py): [reflection v2] drain stream chunks in exception blocks

### DIFF
--- a/py/packages/genkit/src/genkit/_core/_reflection_v2.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection_v2.py
@@ -517,8 +517,8 @@ class ReflectionServerV2:
             await self._send_error(sid, JSON_RPC_SERVER_ERROR, 'Action was cancelled', err_data)
             return
         except Exception as e:
-            await _drain_chunks()
             logger.exception('reflection V2: runAction error')
+            await _drain_chunks()
             # Wire contract requires ``details`` to carry only ``stack`` and ``traceId``
             # (see ``GenkitErrorSchema.data.genkitErrorDetails`` in genkit-tools); anything
             # else in ``GenkitError.details`` is runtime-internal and gets dropped.

--- a/py/packages/genkit/src/genkit/_core/_reflection_v2.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection_v2.py
@@ -478,6 +478,10 @@ class ReflectionServerV2:
         if p.telemetry_labels is not None:
             labels = {str(k): v for k, v in p.telemetry_labels.items()}
 
+        async def _drain_chunks() -> None:
+            if stream_chunk_tasks:
+                await asyncio.gather(*stream_chunk_tasks, return_exceptions=True)
+
         try:
             output = await action.run(
                 input=p.input,
@@ -486,8 +490,7 @@ class ReflectionServerV2:
                 on_trace_start=on_trace_start,
                 telemetry_labels=labels,
             )
-            if stream_chunk_tasks:
-                await asyncio.gather(*stream_chunk_tasks)
+            await _drain_chunks()
             await self._flush_tracing()
             result_body: object
             if isinstance(output.response, BaseModel):
@@ -501,6 +504,7 @@ class ReflectionServerV2:
                 success_body['telemetry'] = {'traceId': output.trace_id}
             await self._send_response(sid, success_body)
         except asyncio.CancelledError:
+            await _drain_chunks()
             err_details: dict[str, Any] = {}
             if trace_holder[0]:
                 err_details['traceId'] = trace_holder[0]
@@ -513,6 +517,7 @@ class ReflectionServerV2:
             await self._send_error(sid, JSON_RPC_SERVER_ERROR, 'Action was cancelled', err_data)
             return
         except Exception as e:
+            await _drain_chunks()
             logger.exception('reflection V2: runAction error')
             # Wire contract requires ``details`` to carry only ``stack`` and ``traceId``
             # (see ``GenkitErrorSchema.data.genkitErrorDetails`` in genkit-tools); anything


### PR DESCRIPTION
## Context

Noticed a bug while testing the `basic-flows` sample.

`streamyThrowy` (in `py/samples/basic-flows`) is supposed to emit chunks 0, 1, 2 and then `raise RuntimeError("whoops")`. Streaming the action against reflection server v2 gave you chunks 0, 1, error — one chunk short. Every `streamy*` flow with a tail error or cancellation had the same off-by-one.

```
$ curl -N -X POST localhost:4000/api/streamAction \
    -d '{"key":"/flow/streamyThrowy","input":5}'
{"count":0}
{"count":1}
{"error":{... RuntimeError('whoops') ...}}    ← chunk 2 was lost
```

## Root cause

`ReflectionServerV2._handle_run_action` wires each `ctx.send_chunk(...)` to a callback that schedules the outbound notification with `asyncio.create_task(self._send_notification("streamChunk", ...))`. The original code only `await`ed those tasks in the success path; on error / cancel it went straight to `_send_error`.

The subtler half: even moving the `gather` into a `finally` block doesn't fix it. All websocket writes serialize through `self._write_lock`, so the order of operations on the wire is:

1. action raises → control returns to `_handle_run_action` `except` block
2. `await self._send_error(...)` — acquires the write lock (it's free), starts the WS send
3. event loop yields, the still-pending chunk task wakes up, queues on the *same* lock behind the error
4. error WS frame finishes → Dev UI sees the JSON-RPC error and closes the HTTP stream
5. lock releases, chunk task acquires it and sends — into a closed stream

So the last chunk arrives at the server but is never forwarded to the HTTP client.

## Fix

Extract a small `_drain_chunks()` helper and call it in *every* terminal branch (success, `CancelledError`, `Exception`) before the final `_send_response` / `_send_error`. Pending chunk tasks always get to acquire the write lock before the terminal frame goes out.

`asyncio.gather(..., return_exceptions=True)` so a single bad chunk task can't mask the real error we're about to report.

## Testing

Side-by-side curl runs of the exact same flow, same input, against `/api/streamAction` (the same wire path Dev UI uses):

- **before:** `{"count":0}` → `{"count":1}` → error  (2 chunks)
- **after:**  `{"count":0}` → `{"count":1}` → `{"count":2}` → error  (3 chunks)

Was able to reproduce the off-by-one error predictably without this fix.