### PR TITLE
feat(js): introduce annotateschema for ui-specific metadata

### DIFF
--- a/js/core/src/index.ts
+++ b/js/core/src/index.ts
@@ -84,7 +84,13 @@ export {
 } from './flow.js';
 export * from './plugin.js';
 export * from './reflection.js';
-export { defineJsonSchema, defineSchema, type JSONSchema } from './schema.js';
+export {
+  annotateSchema,
+  defineJsonSchema,
+  defineSchema,
+  toJsonSchema,
+  type JSONSchema,
+} from './schema.js';
 export * from './telemetryTypes.js';
 export * from './utils.js';
 

--- a/js/core/src/schema.ts
+++ b/js/core/src/schema.ts
@@ -40,6 +40,8 @@ const schemaAnnotations = new WeakMap<z.ZodTypeAny, Record<string, any>>();
 
 /**
  * Annotates a Zod schema with UI-specific metadata.
+ *
+ * NOTE: It's typically recommended to use x-genkit-* (or similar) as the prefix.
  */
 export function annotateSchema<T extends z.ZodTypeAny>(
   schema: T,
@@ -146,6 +148,15 @@ function applyAnnotations(schema: z.ZodTypeAny, json: any): any {
     }
   } else if (inner instanceof z.ZodArray && json.items) {
     applyAnnotations(inner.element, json.items);
+  } else if (inner instanceof z.ZodUnion && json.anyOf) {
+    for (let i = 0; i < inner.options.length; i++) {
+      applyAnnotations(inner.options[i], json.anyOf[i]);
+    }
+  } else if (inner instanceof z.ZodIntersection && json.allOf) {
+    applyAnnotations(inner._def.left, json.allOf[0]);
+    applyAnnotations(inner._def.right, json.allOf[1]);
+  } else if (inner instanceof z.ZodRecord && json.additionalProperties) {
+    applyAnnotations(inner.valueSchema, json.additionalProperties);
   }
 
   return json;

--- a/js/core/src/schema.ts
+++ b/js/core/src/schema.ts
@@ -36,6 +36,19 @@ export type JSONSchema = JSONSchemaType<any> | any;
 const jsonSchemas = new WeakMap<z.ZodTypeAny, JSONSchema>();
 const ajvValidators = new WeakMap<JSONSchema, ReturnType<typeof ajv.compile>>();
 const cfWorkerValidators = new WeakMap<JSONSchema, Validator>();
+const schemaAnnotations = new WeakMap<z.ZodTypeAny, Record<string, any>>();
+
+/**
+ * Annotates a Zod schema with UI-specific metadata.
+ */
+export function annotateSchema<T extends z.ZodTypeAny>(
+  schema: T,
+  annotations: Record<string, any>
+): T {
+  const current = schemaAnnotations.get(schema) || {};
+  schemaAnnotations.set(schema, { ...current, ...annotations });
+  return schema;
+}
 
 /**
  * Wrapper object for various ways schema can be provided.
@@ -82,8 +95,43 @@ export function toJsonSchema({
   const outSchema = zodToJsonSchema(schema!, {
     removeAdditionalStrategy: 'strict',
   });
-  jsonSchemas.set(schema!, outSchema as JSONSchema);
-  return outSchema as JSONSchema;
+  const annotatedSchema = applyAnnotations(schema!, outSchema as JSONSchema);
+  jsonSchemas.set(schema!, annotatedSchema);
+  return annotatedSchema;
+}
+
+function applyAnnotations(schema: z.ZodTypeAny, json: any): any {
+  if (!json || typeof json !== 'object') return json;
+
+  const annotations = schemaAnnotations.get(schema);
+  if (annotations) {
+    Object.assign(json, annotations);
+  }
+
+  let inner = schema;
+  // Handle common Zod wrappers
+  while (
+    inner instanceof z.ZodOptional ||
+    inner instanceof z.ZodNullable ||
+    inner instanceof z.ZodDefault ||
+    inner instanceof z.ZodEffects
+  ) {
+    inner = (inner as any)._def.innerType || (inner as any)._def.schema;
+    const innerAnn = schemaAnnotations.get(inner);
+    if (innerAnn) Object.assign(json, innerAnn);
+  }
+
+  if (inner instanceof z.ZodObject && json.properties) {
+    for (const key in inner.shape) {
+      if (json.properties[key]) {
+        applyAnnotations(inner.shape[key], json.properties[key]);
+      }
+    }
+  } else if (inner instanceof z.ZodArray && json.items) {
+    applyAnnotations(inner.element, json.items);
+  }
+
+  return json;
 }
 
 /**

--- a/js/core/src/schema.ts
+++ b/js/core/src/schema.ts
@@ -167,6 +167,10 @@ function applyAnnotations(schema: z.ZodTypeAny, json: any): any {
     applyAnnotations(inner._def.right, json.allOf[1]);
   } else if (inner instanceof z.ZodRecord && json.additionalProperties) {
     applyAnnotations(inner.valueSchema, json.additionalProperties);
+  } else if (inner instanceof z.ZodTuple && Array.isArray(json.items)) {
+    for (let i = 0; i < inner.items.length; i++) {
+      applyAnnotations(inner.items[i], json.items[i]);
+    }
   }
 
   return json;

--- a/js/core/src/schema.ts
+++ b/js/core/src/schema.ts
@@ -103,6 +103,10 @@ export function toJsonSchema({
 /**
  * Recursively applies annotations to a JSON schema by walking the Zod tree
  * and matching it against the JSON schema structure.
+ *
+ * Note: This currently does not resolve JSON schema `$ref` nodes. Annotations
+ * on recursive schemas (using `z.lazy`) may not be correctly applied to the
+ * referenced definitions.
  */
 function applyAnnotations(schema: z.ZodTypeAny, json: any): any {
   if (!json || typeof json !== 'object') return json;

--- a/js/core/src/schema.ts
+++ b/js/core/src/schema.ts
@@ -163,8 +163,21 @@ function applyAnnotations(schema: z.ZodTypeAny, json: any): any {
       applyAnnotations(inner.options[i], json.anyOf[i]);
     }
   } else if (inner instanceof z.ZodIntersection && json.allOf) {
-    applyAnnotations(inner._def.left, json.allOf[0]);
-    applyAnnotations(inner._def.right, json.allOf[1]);
+    const schemas: z.ZodTypeAny[] = [];
+    const collect = (s: z.ZodTypeAny) => {
+      if (s instanceof z.ZodIntersection) {
+        collect(s._def.left);
+        collect(s._def.right);
+      } else {
+        schemas.push(s);
+      }
+    };
+    collect(inner);
+    if (schemas.length === json.allOf.length) {
+      for (let i = 0; i < schemas.length; i++) {
+        applyAnnotations(schemas[i], json.allOf[i]);
+      }
+    }
   } else if (inner instanceof z.ZodRecord && json.additionalProperties) {
     applyAnnotations(inner.valueSchema, json.additionalProperties);
   } else if (inner instanceof z.ZodTuple && Array.isArray(json.items)) {

--- a/js/core/src/schema.ts
+++ b/js/core/src/schema.ts
@@ -133,10 +133,20 @@ function applyAnnotations(schema: z.ZodTypeAny, json: any): any {
     }
   }
 
-  // Apply annotations in reverse order (inner-most first, outer-most last)
-  // so that outer annotations correctly overwrite inner ones.
+  // Resolve annotations (outer-most last so it wins)
+  const resolvedAnnotations: Record<string, any> = {};
   for (let i = annotationsToApply.length - 1; i >= 0; i--) {
-    Object.assign(json, annotationsToApply[i]);
+    Object.assign(resolvedAnnotations, annotationsToApply[i]);
+  }
+
+  for (const key in resolvedAnnotations) {
+    if (Object.prototype.hasOwnProperty.call(json, key)) {
+      console.warn(
+        `Annotation key "${key}" conflicts with existing JSON schema property and will be ignored.`
+      );
+      continue;
+    }
+    json[key] = resolvedAnnotations[key];
   }
 
   const inner = current;

--- a/js/core/src/schema.ts
+++ b/js/core/src/schema.ts
@@ -107,24 +107,33 @@ export function toJsonSchema({
 function applyAnnotations(schema: z.ZodTypeAny, json: any): any {
   if (!json || typeof json !== 'object') return json;
 
-  const annotations = schemaAnnotations.get(schema);
-  if (annotations) {
-    Object.assign(json, annotations);
+  const annotationsToApply: Record<string, any>[] = [];
+  let current = schema;
+
+  // Collect all annotations in the hierarchy (outer to inner)
+  while (current) {
+    const ann = schemaAnnotations.get(current);
+    if (ann) annotationsToApply.push(ann);
+
+    if (
+      current instanceof z.ZodOptional ||
+      current instanceof z.ZodNullable ||
+      current instanceof z.ZodDefault ||
+      current instanceof z.ZodEffects
+    ) {
+      current = (current as any)._def.innerType || (current as any)._def.schema;
+    } else {
+      break;
+    }
   }
 
-  let inner = schema;
-  // Handle common Zod wrappers
-  while (
-    inner instanceof z.ZodOptional ||
-    inner instanceof z.ZodNullable ||
-    inner instanceof z.ZodDefault ||
-    inner instanceof z.ZodEffects
-  ) {
-    inner = (inner as any)._def.innerType || (inner as any)._def.schema;
-    const innerAnn = schemaAnnotations.get(inner);
-    if (innerAnn) Object.assign(json, innerAnn);
+  // Apply annotations in reverse order (inner-most first, outer-most last)
+  // so that outer annotations correctly overwrite inner ones.
+  for (let i = annotationsToApply.length - 1; i >= 0; i--) {
+    Object.assign(json, annotationsToApply[i]);
   }
 
+  const inner = current;
   if (inner instanceof z.ZodObject && json.properties) {
     for (const key in inner.shape) {
       if (json.properties[key]) {

--- a/js/core/src/schema.ts
+++ b/js/core/src/schema.ts
@@ -171,6 +171,10 @@ function applyAnnotations(schema: z.ZodTypeAny, json: any): any {
     for (let i = 0; i < inner.items.length; i++) {
       applyAnnotations(inner.items[i], json.items[i]);
     }
+  } else if (inner instanceof z.ZodDiscriminatedUnion && json.anyOf) {
+    for (let i = 0; i < inner.options.length; i++) {
+      applyAnnotations(inner.options[i], json.anyOf[i]);
+    }
   }
 
   return json;

--- a/js/core/src/schema.ts
+++ b/js/core/src/schema.ts
@@ -100,6 +100,10 @@ export function toJsonSchema({
   return annotatedSchema;
 }
 
+/**
+ * Recursively applies annotations to a JSON schema by walking the Zod tree
+ * and matching it against the JSON schema structure.
+ */
 function applyAnnotations(schema: z.ZodTypeAny, json: any): any {
   if (!json || typeof json !== 'object') return json;
 

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -251,16 +251,31 @@ describe('annotateSchema()', () => {
   });
 
   it('should merge annotations for ZodRecord (additionalProperties)', () => {
-    const schema = z.record(annotateSchema(z.string(), { 'x-hint': 'value' }));
+    const schema = z.record(
+      annotateSchema(z.string(), { 'x-hint': 'value' })
+    );
 
     const json = toJsonSchema({ schema });
-    assert.ok(
-      json.additionalProperties,
-      'JSON schema should have additionalProperties'
-    );
+    assert.ok(json.additionalProperties, 'JSON schema should have additionalProperties');
     assert.strictEqual(json.additionalProperties['x-hint'], 'value');
   });
-});
+
+  it('should not overwrite existing JSON schema fields and log a warning', () => {
+    const warnSpy = mock.method(console, 'warn', () => {});
+    const schema = annotateSchema(z.string(), { type: 'number', 'x-ok': true });
+
+    const json = toJsonSchema({ schema });
+
+    assert.strictEqual(json.type, 'string');
+    assert.strictEqual(json['x-ok'], true);
+    assert.strictEqual(warnSpy.mock.callCount(), 1);
+    assert.ok(
+      warnSpy.mock.calls[0].arguments[0].includes('Annotation key "type" conflicts')
+    );
+    warnSpy.mock.restore();
+  });
+  });
+
 
 describe('disableSchemaCodeGeneration()', () => {
   let compileMock: any;

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -260,6 +260,18 @@ describe('annotateSchema()', () => {
     assert.strictEqual(json.additionalProperties['x-hint'], 'value');
   });
 
+  it('should merge annotations for ZodTuple (items array)', () => {
+    const schema = z.tuple([
+      annotateSchema(z.string(), { 'x-hint': 'first' }),
+      annotateSchema(z.number(), { 'x-hint': 'second' }),
+    ]);
+
+    const json = toJsonSchema({ schema });
+    assert.ok(Array.isArray(json.items), 'JSON schema items should be an array');
+    assert.strictEqual(json.items[0]['x-hint'], 'first');
+    assert.strictEqual(json.items[1]['x-hint'], 'second');
+  });
+
   it('should not overwrite existing JSON schema fields and log a warning', () => {
     const warnSpy = mock.method(console, 'warn', () => {});
     const schema = annotateSchema(z.string(), { type: 'number', 'x-ok': true });

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -250,13 +250,31 @@ describe('annotateSchema()', () => {
     assert.strictEqual(json.allOf[1]['x-hint'], 'b');
   });
 
-  it('should merge annotations for ZodRecord (additionalProperties)', () => {
-    const schema = z.record(
-      annotateSchema(z.string(), { 'x-hint': 'value' })
+  it('should merge annotations for nested ZodIntersection (flattened allOf)', () => {
+    const schema = z.intersection(
+      z.intersection(
+        annotateSchema(z.object({ a: z.string() }), { 'x-hint': 'a' }),
+        annotateSchema(z.object({ b: z.number() }), { 'x-hint': 'b' })
+      ),
+      annotateSchema(z.object({ c: z.boolean() }), { 'x-hint': 'c' })
     );
 
     const json = toJsonSchema({ schema });
-    assert.ok(json.additionalProperties, 'JSON schema should have additionalProperties');
+    assert.ok(json.allOf, 'JSON schema should have allOf');
+    assert.strictEqual(json.allOf.length, 3, 'Should have 3 elements in allOf');
+    assert.strictEqual(json.allOf[0]['x-hint'], 'a');
+    assert.strictEqual(json.allOf[1]['x-hint'], 'b');
+    assert.strictEqual(json.allOf[2]['x-hint'], 'c');
+  });
+
+  it('should merge annotations for ZodRecord (additionalProperties)', () => {
+    const schema = z.record(annotateSchema(z.string(), { 'x-hint': 'value' }));
+
+    const json = toJsonSchema({ schema });
+    assert.ok(
+      json.additionalProperties,
+      'JSON schema should have additionalProperties'
+    );
     assert.strictEqual(json.additionalProperties['x-hint'], 'value');
   });
 
@@ -267,7 +285,10 @@ describe('annotateSchema()', () => {
     ]);
 
     const json = toJsonSchema({ schema });
-    assert.ok(Array.isArray(json.items), 'JSON schema items should be an array');
+    assert.ok(
+      Array.isArray(json.items),
+      'JSON schema items should be an array'
+    );
     assert.strictEqual(json.items[0]['x-hint'], 'first');
     assert.strictEqual(json.items[1]['x-hint'], 'second');
   });
@@ -298,12 +319,13 @@ describe('annotateSchema()', () => {
     assert.strictEqual(json['x-ok'], true);
     assert.strictEqual(warnSpy.mock.callCount(), 1);
     assert.ok(
-      warnSpy.mock.calls[0].arguments[0].includes('Annotation key "type" conflicts')
+      warnSpy.mock.calls[0].arguments[0].includes(
+        'Annotation key "type" conflicts'
+      )
     );
     warnSpy.mock.restore();
   });
-  });
-
+});
 
 describe('disableSchemaCodeGeneration()', () => {
   let compileMock: any;

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -21,6 +21,7 @@ import { afterEach, describe, it, mock } from 'node:test';
 import { setGenkitRuntimeConfig } from '../src/config.js';
 import {
   ValidationError,
+  annotateSchema,
   parseSchema,
   toJsonSchema,
   validateSchema,
@@ -161,6 +162,56 @@ describe('toJsonSchema', () => {
         required: ['output'],
         type: 'object',
       }
+    );
+  });
+});
+
+describe('annotateSchema()', () => {
+  it('should merge annotations into the JSON schema', () => {
+    const schema = annotateSchema(z.string(), {
+      'x-genkit-data-source': 'my-action',
+    });
+
+    const json = toJsonSchema({ schema });
+    assert.strictEqual(json['x-genkit-data-source'], 'my-action');
+  });
+
+  it('should merge annotations for nested fields', () => {
+    const schema = z.object({
+      field: annotateSchema(z.string(), {
+        'x-genkit-data-source': 'nested-action',
+      }),
+    });
+
+    const json = toJsonSchema({ schema });
+    assert.strictEqual(
+      json.properties.field['x-genkit-data-source'],
+      'nested-action'
+    );
+  });
+
+  it('should merge annotations for array items', () => {
+    const schema = z.array(
+      annotateSchema(z.string(), {
+        'x-genkit-data-source': 'array-action',
+      })
+    );
+
+    const json = toJsonSchema({ schema });
+    assert.strictEqual(json.items['x-genkit-data-source'], 'array-action');
+  });
+
+  it('should merge annotations for optional fields', () => {
+    const schema = z.object({
+      field: annotateSchema(z.string(), {
+        'x-genkit-data-source': 'optional-action',
+      }).optional(),
+    });
+
+    const json = toJsonSchema({ schema });
+    assert.strictEqual(
+      json.properties.field['x-genkit-data-source'],
+      'optional-action'
     );
   });
 });

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -214,6 +214,16 @@ describe('annotateSchema()', () => {
       'optional-action'
     );
   });
+
+  it('should favor outer annotations over inner ones', () => {
+    const schema = annotateSchema(
+      annotateSchema(z.string(), { title: 'Inner' }).optional(),
+      { title: 'Outer' }
+    );
+
+    const json = toJsonSchema({ schema });
+    assert.strictEqual(json.title, 'Outer');
+  });
 });
 
 describe('disableSchemaCodeGeneration()', () => {

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -272,6 +272,22 @@ describe('annotateSchema()', () => {
     assert.strictEqual(json.items[1]['x-hint'], 'second');
   });
 
+  it('should merge annotations for ZodDiscriminatedUnion (anyOf)', () => {
+    const schema = z.discriminatedUnion('type', [
+      annotateSchema(z.object({ type: z.literal('a'), a: z.string() }), {
+        'x-hint': 'a',
+      }),
+      annotateSchema(z.object({ type: z.literal('b'), b: z.number() }), {
+        'x-hint': 'b',
+      }),
+    ]);
+
+    const json = toJsonSchema({ schema });
+    assert.ok(json.anyOf, 'JSON schema should have anyOf');
+    assert.strictEqual(json.anyOf[0]['x-hint'], 'a');
+    assert.strictEqual(json.anyOf[1]['x-hint'], 'b');
+  });
+
   it('should not overwrite existing JSON schema fields and log a warning', () => {
     const warnSpy = mock.method(console, 'warn', () => {});
     const schema = annotateSchema(z.string(), { type: 'number', 'x-ok': true });

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -224,6 +224,42 @@ describe('annotateSchema()', () => {
     const json = toJsonSchema({ schema });
     assert.strictEqual(json.title, 'Outer');
   });
+
+  it('should merge annotations for ZodUnion (anyOf)', () => {
+    // Use objects to force anyOf instead of simple type array optimization
+    const schema = z.union([
+      annotateSchema(z.object({ a: z.string() }), { 'x-hint': 'a' }),
+      annotateSchema(z.object({ b: z.number() }), { 'x-hint': 'b' }),
+    ]);
+
+    const json = toJsonSchema({ schema });
+    assert.ok(json.anyOf, 'JSON schema should have anyOf');
+    assert.strictEqual(json.anyOf[0]['x-hint'], 'a');
+    assert.strictEqual(json.anyOf[1]['x-hint'], 'b');
+  });
+
+  it('should merge annotations for ZodIntersection (allOf)', () => {
+    const schema = z.intersection(
+      annotateSchema(z.object({ a: z.string() }), { 'x-hint': 'a' }),
+      annotateSchema(z.object({ b: z.number() }), { 'x-hint': 'b' })
+    );
+
+    const json = toJsonSchema({ schema });
+    assert.ok(json.allOf, 'JSON schema should have allOf');
+    assert.strictEqual(json.allOf[0]['x-hint'], 'a');
+    assert.strictEqual(json.allOf[1]['x-hint'], 'b');
+  });
+
+  it('should merge annotations for ZodRecord (additionalProperties)', () => {
+    const schema = z.record(annotateSchema(z.string(), { 'x-hint': 'value' }));
+
+    const json = toJsonSchema({ schema });
+    assert.ok(
+      json.additionalProperties,
+      'JSON schema should have additionalProperties'
+    );
+    assert.strictEqual(json.additionalProperties['x-hint'], 'value');
+  });
 });
 
 describe('disableSchemaCodeGeneration()', () => {

--- a/js/genkit/src/common.ts
+++ b/js/genkit/src/common.ts
@@ -138,6 +138,7 @@ export {
   StatusCodes,
   StatusSchema,
   UserFacingError,
+  annotateSchema,
   defineJsonSchema,
   defineSchema,
   getClientHeader,

--- a/js/genkit/src/schema.ts
+++ b/js/genkit/src/schema.ts
@@ -29,6 +29,7 @@
 
 export {
   ValidationError,
+  annotateSchema,
   parseSchema,
   toJsonSchema,
   validateSchema,


### PR DESCRIPTION
Adds `annotateSchema`, a utility that allows attaching arbitrary metadata to Zod schemas. This metadata is automatically merged into the resulting JSON schema when calling `toJsonSchema`.

This enables workflows like specifying data sources or custom UI hints directly on the schema definition without modifying Zod objects directly.

- Implements `annotateSchema` using WeakMaps for memory efficiency.
- Updates `toJsonSchema` to recursively apply annotations to nested objects and arrays.
- Exports `annotateSchema` from genkit and genkit/schema.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)
