### PR TITLE
feat(cli): Add trace:get CLI command

### DIFF
--- a/genkit-tools/cli/src/cli.ts
+++ b/genkit-tools/cli/src/cli.ts
@@ -40,6 +40,7 @@ import {
 import { start } from './commands/start';
 import { startFlutter } from './commands/start-flutter';
 import { traceGet } from './commands/trace-get';
+import { traceList } from './commands/trace-list';
 import { uiStart } from './commands/ui-start';
 import { uiStop } from './commands/ui-stop';
 import { detectCLIRuntime } from './utils/runtime-detector.js';
@@ -70,6 +71,7 @@ const commands: Command[] = [
   docsRead,
   docsSearch,
   traceGet,
+  traceList,
 ];
 
 /** Main entry point for CLI. */

--- a/genkit-tools/cli/src/cli.ts
+++ b/genkit-tools/cli/src/cli.ts
@@ -39,6 +39,7 @@ import {
 } from './commands/server-harness';
 import { start } from './commands/start';
 import { startFlutter } from './commands/start-flutter';
+import { traceGet } from './commands/trace-get';
 import { uiStart } from './commands/ui-start';
 import { uiStop } from './commands/ui-stop';
 import { detectCLIRuntime } from './utils/runtime-detector.js';
@@ -68,6 +69,7 @@ const commands: Command[] = [
   docsList,
   docsRead,
   docsSearch,
+  traceGet,
 ];
 
 /** Main entry point for CLI. */

--- a/genkit-tools/cli/src/commands/trace-get.ts
+++ b/genkit-tools/cli/src/commands/trace-get.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { BaseRuntimeManager } from '@genkit-ai/tools-common/manager';
+import { findProjectRoot, logger } from '@genkit-ai/tools-common/utils';
+import { Command } from 'commander';
+import { runWithManager } from '../utils/manager-utils';
+
+/** Command to get a trace. */
+export const traceGet = new Command('trace:get')
+  .description('get a trace by id')
+  .argument('<traceId>', 'id of the trace to get')
+  .action(async (traceId: string) => {
+    const projectRoot = await findProjectRoot();
+
+    const runAction = async (manager: BaseRuntimeManager) => {
+      try {
+        const response = await manager.getTrace({ traceId });
+        if (!response) {
+          logger.error(`Trace with ID '${traceId}' not found.`);
+          return;
+        }
+        console.log(JSON.stringify(response, undefined, 2));
+      } catch (e) {
+        logger.error(`Error retrieving trace: ${e}`);
+      }
+    };
+
+    await runWithManager(projectRoot, runAction);
+  });

--- a/genkit-tools/cli/src/commands/trace-list.ts
+++ b/genkit-tools/cli/src/commands/trace-list.ts
@@ -47,9 +47,9 @@ export interface TraceListOptions {
 export const traceList = new Command('trace:list')
   .description('list traces')
   .option('-l, --limit <number>', 'limit the number of returned traces', '15')
-  .option('--status <status>', 'filter by trace status')
-  .option('--type <type>', 'filter by trace type')
-  .option('--name <name>', 'filter by trace name')
+  .option('--status <status>', 'filter by root span status')
+  .option('--type <type>', 'filter by root span type')
+  .option('--name <name>', 'filter by root span name')
   .option('--continuation-token <token>', 'continuation token for pagination')
   .action(async (options: TraceListOptions) => {
     const projectRoot = await findProjectRoot();

--- a/genkit-tools/cli/src/commands/trace-list.ts
+++ b/genkit-tools/cli/src/commands/trace-list.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TraceQueryFilter } from '@genkit-ai/tools-common';
+import type { BaseRuntimeManager } from '@genkit-ai/tools-common/manager';
+import {
+  findProjectRoot,
+  logger,
+  stackTraceSpans,
+} from '@genkit-ai/tools-common/utils';
+import { Command } from 'commander';
+import { runWithManager } from '../utils/manager-utils';
+
+function formatTruncated(val: any, maxLen = 100): string {
+  if (val === undefined) return '';
+  const parsed = typeof val === 'string' ? val : JSON.stringify(val);
+  return parsed.length > maxLen
+    ? parsed.substring(0, maxLen - 3) + '...'
+    : parsed;
+}
+
+export interface TraceListOptions {
+  limit: string;
+  status?: string;
+  type?: string;
+  name?: string;
+  continuationToken?: string;
+}
+
+/** Command to list traces. */
+export const traceList = new Command('trace:list')
+  .description('list traces')
+  .option('-l, --limit <number>', 'limit the number of returned traces', '15')
+  .option('--status <status>', 'filter by trace status')
+  .option('--type <type>', 'filter by trace type')
+  .option('--name <name>', 'filter by trace name')
+  .option('--continuation-token <token>', 'continuation token for pagination')
+  .action(async (options: TraceListOptions) => {
+    const projectRoot = await findProjectRoot();
+
+    const runAction = async (manager: BaseRuntimeManager) => {
+      try {
+        const eqFilter: Record<string, any[]> = {};
+        if (options.status) {
+          // Status mapped exactly as dev UI enum (Success: 0, Error: 2)
+          const statusVal =
+            options.status.toLowerCase() === 'error'
+              ? 2
+              : options.status.toLowerCase() === 'success'
+                ? 0
+                : Number(options.status);
+          eqFilter['status'] = [statusVal];
+        }
+        if (options.type) {
+          eqFilter['type'] = [options.type];
+        }
+        if (options.name) {
+          eqFilter['name'] = [options.name];
+        }
+
+        const filter: TraceQueryFilter = {
+          eq: Object.keys(eqFilter).length > 0 ? eqFilter : undefined,
+          neq: { 'genkitx:ignore-trace': ['true'] },
+        };
+
+        const listRequest = {
+          limit: Number.parseInt(options.limit, 10),
+          continuationToken: options.continuationToken,
+          filter,
+        };
+
+        const response = await manager.listTraces(listRequest);
+
+        if (!response || !response.traces || response.traces.length === 0) {
+          logger.info('No traces found.');
+          return;
+        }
+
+        console.log(`Found ${response.traces.length} traces:\n`);
+
+        response.traces.forEach((trace) => {
+          let duration = 'unknown';
+          let time = 'unknown';
+          if (trace.startTime) {
+            time = new Date(trace.startTime).toLocaleString();
+            if (trace.endTime) {
+              duration = `${trace.endTime - trace.startTime}ms`;
+            }
+          }
+
+          let status = 'unknown';
+          let type = 'unknown';
+          let inputStr = '';
+          let outputStr = '';
+
+          const rootSpan = stackTraceSpans(trace);
+          if (rootSpan) {
+            const attrs = rootSpan.attributes || {};
+            status =
+              (attrs['genkit:state'] as string) ||
+              (rootSpan.status?.code !== undefined
+                ? String(rootSpan.status.code)
+                : 'unknown');
+            type =
+              (attrs['genkit:metadata:subtype'] as string) ||
+              (attrs['genkit:type'] as string) ||
+              'unknown';
+
+            inputStr = formatTruncated(attrs['genkit:input']);
+            outputStr = formatTruncated(attrs['genkit:output']);
+          }
+
+          console.log(`ID:       ${trace.traceId}`);
+          console.log(`Type:     ${type}`);
+          console.log(`Name:     ${trace.displayName || 'unknown'}`);
+          console.log(`Status:   ${status}`);
+          console.log(`Time:     ${time}`);
+          console.log(`Duration: ${duration}`);
+          if (inputStr) console.log(`Input:    ${inputStr}`);
+          if (outputStr) console.log(`Output:   ${outputStr}`);
+
+          console.log('---');
+        });
+
+        if (response.continuationToken) {
+          console.log(
+            `\nTo get the next page, use: --continuation-token ${response.continuationToken}`
+          );
+        }
+      } catch (e) {
+        logger.error(`Error listing traces: ${e}`);
+      }
+    };
+
+    await runWithManager(projectRoot, runAction);
+  });

--- a/genkit-tools/cli/src/commands/trace-list.ts
+++ b/genkit-tools/cli/src/commands/trace-list.ts
@@ -40,7 +40,10 @@ export interface TraceListOptions {
   continuationToken?: string;
 }
 
-/** Command to list traces. */
+/**
+ * Command to list traces. By default, traces are returned in reverse
+ * chronological order.
+ */
 export const traceList = new Command('trace:list')
   .description('list traces')
   .option('-l, --limit <number>', 'limit the number of returned traces', '15')

--- a/genkit-tools/cli/tests/commands/trace-get_test.ts
+++ b/genkit-tools/cli/tests/commands/trace-get_test.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { findProjectRoot, logger } from '@genkit-ai/tools-common/utils';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { traceGet } from '../../src/commands/trace-get';
+import { runWithManager } from '../../src/utils/manager-utils';
+
+jest.mock('@genkit-ai/tools-common/utils');
+jest.mock('../../src/utils/manager-utils');
+
+const mockedFindProjectRoot = findProjectRoot as jest.MockedFunction<
+  typeof findProjectRoot
+>;
+const mockedLogger = logger as jest.Mocked<typeof logger>;
+const mockedRunWithManager = runWithManager as jest.MockedFunction<
+  typeof runWithManager
+>;
+
+describe('trace:get', () => {
+  const createCommand = () =>
+    traceGet.exitOverride().configureOutput({
+      writeOut: () => {},
+      writeErr: () => {},
+    });
+
+  const mockProjectRoot = '/mock/project/root';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFindProjectRoot.mockResolvedValue(mockProjectRoot);
+
+    // Mock console.log to avoid spamming test output
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    // Provide a default implementation for runWithManager
+    mockedRunWithManager.mockImplementation(async (projectRoot, fn) => {
+      // Simulate calling the action with a mocked manager
+      const mockManager = {
+        getTrace: jest
+          .fn<any>()
+          .mockResolvedValue({ traceId: 'test-id', details: 'mock-trace' }),
+      };
+      await fn(mockManager as any);
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should get and print trace details', async () => {
+    await createCommand().parseAsync(['node', 'trace:get', 'test-trace-id']);
+
+    expect(mockedFindProjectRoot).toHaveBeenCalled();
+    expect(mockedRunWithManager).toHaveBeenCalled();
+
+    // Verify console.log was called with stringified trace
+    expect(console.log).toHaveBeenCalledWith(
+      JSON.stringify(
+        { traceId: 'test-id', details: 'mock-trace' },
+        undefined,
+        2
+      )
+    );
+  });
+
+  it('should handle trace not found', async () => {
+    mockedRunWithManager.mockImplementation(async (projectRoot, fn) => {
+      const mockManager = {
+        getTrace: jest.fn<any>().mockResolvedValue(undefined), // Simulate trace not found
+      };
+      await fn(mockManager as any);
+    });
+
+    await createCommand().parseAsync(['node', 'trace:get', 'missing-trace-id']);
+
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      "Trace with ID 'missing-trace-id' not found."
+    );
+  });
+
+  it('should handle errors thrown by getTrace', async () => {
+    const errorMsg = 'Failed to connect to telemetry server';
+    mockedRunWithManager.mockImplementation(async (projectRoot, fn) => {
+      const mockManager = {
+        getTrace: jest.fn<any>().mockRejectedValue(new Error(errorMsg)),
+      };
+      await fn(mockManager as any);
+    });
+
+    await createCommand().parseAsync(['node', 'trace:get', 'error-trace-id']);
+
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      `Error retrieving trace: Error: ${errorMsg}`
+    );
+  });
+});

--- a/genkit-tools/cli/tests/commands/trace-list_test.ts
+++ b/genkit-tools/cli/tests/commands/trace-list_test.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  findProjectRoot,
+  logger,
+  stackTraceSpans,
+} from '@genkit-ai/tools-common/utils';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { traceList } from '../../src/commands/trace-list';
+import { runWithManager } from '../../src/utils/manager-utils';
+
+jest.mock('@genkit-ai/tools-common/utils');
+jest.mock('../../src/utils/manager-utils');
+
+describe('trace:list command', () => {
+  let mockManager: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockManager = {
+      listTraces: jest.fn(),
+    };
+
+    (findProjectRoot as jest.Mock<any>).mockResolvedValue('/mock/project/root');
+
+    (runWithManager as jest.Mock<any>).mockImplementation(
+      async (projectRoot: any, action: any) => {
+        await action(mockManager);
+      }
+    );
+
+    jest.spyOn(logger, 'info').mockImplementation((() => {}) as any);
+    jest.spyOn(logger, 'error').mockImplementation((() => {}) as any);
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('should list traces with default limit', async () => {
+    mockManager.listTraces.mockResolvedValue({
+      traces: [
+        {
+          traceId: 'trace-1',
+          displayName: 'Test Trace 1',
+          startTime: 1000,
+          endTime: 2000,
+        },
+      ],
+    });
+
+    (stackTraceSpans as jest.Mock<any>).mockReturnValue({
+      attributes: {
+        'genkit:state': 'success',
+        'genkit:input': 'my input string',
+        'genkit:output': 'my output string',
+      },
+    });
+
+    await traceList.parseAsync(['node', 'trace:list']);
+
+    expect(findProjectRoot).toHaveBeenCalled();
+    expect(runWithManager).toHaveBeenCalled();
+    expect(mockManager.listTraces).toHaveBeenCalledWith({
+      limit: 15,
+      continuationToken: undefined,
+      filter: {
+        eq: undefined,
+        neq: { 'genkitx:ignore-trace': ['true'] },
+      },
+    });
+    expect(console.log).toHaveBeenCalledWith('Found 1 traces:\n');
+    expect(console.log).toHaveBeenCalledWith('ID:       trace-1');
+    expect(console.log).toHaveBeenCalledWith('Status:   success');
+    expect(console.log).toHaveBeenCalledWith('Input:    my input string');
+    expect(console.log).toHaveBeenCalledWith('Output:   my output string');
+  });
+
+  it('should list traces with filters and custom limit', async () => {
+    mockManager.listTraces.mockResolvedValue({
+      traces: [
+        {
+          traceId: 'trace-2',
+          displayName: 'Error Trace',
+          startTime: 1000,
+        },
+      ],
+    });
+
+    await traceList.parseAsync([
+      'node',
+      'trace:list',
+      '--limit',
+      '5',
+      '--status',
+      'error',
+      '--type',
+      'Flow',
+      '--name',
+      'myFlow',
+    ]);
+
+    expect(mockManager.listTraces).toHaveBeenCalledWith({
+      limit: 5,
+      continuationToken: undefined,
+      filter: {
+        eq: {
+          status: [2],
+          type: ['Flow'],
+          name: ['myFlow'],
+        },
+        neq: { 'genkitx:ignore-trace': ['true'] },
+      },
+    });
+  });
+
+  it('should handle pagination with continuation token', async () => {
+    mockManager.listTraces.mockResolvedValue({
+      traces: [
+        {
+          traceId: 'trace-3',
+        },
+      ],
+      continuationToken: 'next-page-token',
+    });
+
+    // Reset commander's options cache or create a fresh parse to avoid inheriting state from previous test
+    const cmd = require('../../src/commands/trace-list').traceList;
+
+    // Create a fresh command instance to isolate state
+    jest.isolateModules(() => {
+      const freshTraceList = require('../../src/commands/trace-list').traceList;
+
+      return freshTraceList.parseAsync([
+        'node',
+        'trace:list',
+        '--continuation-token',
+        'some-token',
+      ]);
+    });
+
+    // Wait a tick for promises if needed, but since we are mocking anyway...
+    // Actually, commander mutates process.argv state sometimes, the issue was traceList
+    // holding onto previous options. Let's just parse the options properly.
+    await traceList.parseAsync([
+      'node',
+      'trace:list',
+      // override previous args if commander caches them
+      '--limit',
+      '15',
+      '--status',
+      '',
+      '--type',
+      '',
+      '--name',
+      '',
+      '--continuation-token',
+      'some-token',
+    ]);
+
+    expect(mockManager.listTraces).toHaveBeenCalledWith({
+      limit: 15,
+      continuationToken: 'some-token',
+      filter: {
+        eq: undefined,
+        neq: { 'genkitx:ignore-trace': ['true'] },
+      },
+    });
+    expect(console.log).toHaveBeenCalledWith(
+      '\nTo get the next page, use: --continuation-token next-page-token'
+    );
+  });
+
+  it('should log info when no traces are found', async () => {
+    mockManager.listTraces.mockResolvedValue({
+      traces: [],
+    });
+
+    await traceList.parseAsync(['node', 'trace:list']);
+
+    expect(logger.info).toHaveBeenCalledWith('No traces found.');
+  });
+
+  it('should handle and log errors', async () => {
+    mockManager.listTraces.mockRejectedValue(new Error('API failure'));
+
+    await traceList.parseAsync(['node', 'trace:list']);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error listing traces: Error: API failure')
+    );
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/genkit-ai/genkit/issues/5379

Usage: 

```
$ genkit trace:get 5aa367e7d3895db78339f6148aab29b4
Telemetry API running on http://localhost:4033
{
  "traceId": "5aa367e7d3895db78339f6148aab29b4",
  "displayName": "generate",
  "startTime": 1778700071212,
  "endTime": 1778700072191.0662,
....
```

```
$ genkit trace:list -l 2 --name generate
Telemetry API running on http://localhost:4033
Found 2 traces:

ID:       34aeabf91dc21a1c8d43a9482d45657b
Type:     util
Name:     generate
Status:   error
Time:     5/26/2026, 4:17:15 PM
Duration: 328.314453125ms
Input:    {"model":"googleai/gemini-2.0-flash-lite","messages":[{"role":"user","content":[{"text":"asdasd"}...
---
ID:       558dbdc4477acbe9c91db5b73dde2b67
Type:     util
Name:     generate
Status:   success
Time:     5/26/2026, 4:16:57 PM
Duration: 2094.606689453125ms
Input:    {"model":"googleai/gemini-2.0-flash","messages":[{"role":"user","content":[{"text":"asdasd"}]}],"...
Output:   {"message":{"role":"model","content":[{"text":"I am an AI language model, and I don't have access...
---
```

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)