### PR TITLE
docs(py): sync api reference index with latest package exports

### DIFF
--- a/py/docs/index.md
+++ b/py/docs/index.md
@@ -21,11 +21,15 @@
 
 ::: genkit.PromptGenerateOptions
 
-::: genkit.ResumeOptions
+::: genkit.Tool
+
+::: genkit.tool
+
+::: genkit.respond_to_interrupt
+
+::: genkit.restart_tool
 
 ::: genkit.ToolRunContext
-
-::: genkit.tool_response
 
 ::: genkit.StreamResponse
 

--- a/py/samples/context/src/main.py
+++ b/py/samples/context/src/main.py
@@ -18,8 +18,7 @@
 
 from pydantic import BaseModel, Field
 
-from genkit import Genkit
-from genkit._core._action import ActionRunContext
+from genkit import Genkit, ActionRunContext
 from genkit.plugins.google_genai import GoogleAI
 
 ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')

--- a/py/samples/context/src/main.py
+++ b/py/samples/context/src/main.py
@@ -18,7 +18,7 @@
 
 from pydantic import BaseModel, Field
 
-from genkit import Genkit, ActionRunContext
+from genkit import ActionRunContext, Genkit
 from genkit.plugins.google_genai import GoogleAI
 
 ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')


### PR DESCRIPTION
This PR updates the Python API reference index (`py/docs/index.md`) to align perfectly with the latest `__all__` exports of the `genkit` veneer and sub-namespaces.

Specifically:
- Removes stale / deleted exports: `ResumeOptions`, `tool_response`
- Adds new veneer API exports: `Tool`, `tool`, `respond_to_interrupt`, `restart_tool`

(Verified programmatically by comparing index.md directives against imported package symbols.)