### PR TITLE
feat(js/plugins/compat-oai): add gpt-5.x supported models

### DIFF
--- a/js/plugins/compat-oai/src/openai/gpt.ts
+++ b/js/plugins/compat-oai/src/openai/gpt.ts
@@ -252,6 +252,26 @@ const gpt5_1 = openAIModelRef({
   name: 'gpt-5.1',
   info: GPT_5_MODEL_INFO,
 });
+const gpt5_2 = openAIModelRef({
+  name: 'gpt-5.2',
+  info: GPT_5_MODEL_INFO,
+});
+const gpt5_4 = openAIModelRef({
+  name: 'gpt-5.4',
+  info: GPT_5_MODEL_INFO,
+});
+const gpt5_4Mini = openAIModelRef({
+  name: 'gpt-5.4-mini',
+  info: GPT_5_MODEL_INFO,
+});
+const gpt5_4Nano = openAIModelRef({
+  name: 'gpt-5.4-nano',
+  info: GPT_5_MODEL_INFO,
+});
+const gpt5_5 = openAIModelRef({
+  name: 'gpt-5.5',
+  info: GPT_5_MODEL_INFO,
+});
 
 export const SUPPORTED_GPT_MODELS = {
   'gpt-4.5': gpt45,
@@ -284,4 +304,9 @@ export const SUPPORTED_GPT_MODELS = {
   'gpt-5-nano': gpt5Nano,
   'gpt-5-chat-latest': gpt5ChatLatest,
   'gpt-5.1': gpt5_1,
+  'gpt-5.2': gpt5_2,
+  'gpt-5.4': gpt5_4,
+  'gpt-5.4-mini': gpt5_4Mini,
+  'gpt-5.4-nano': gpt5_4Nano,
+  'gpt-5.5': gpt5_5,
 } as const;


### PR DESCRIPTION
Description here... Help the reviewer by:
 - added the latest GPT models available.
 - list: `gpt-5.2`, `gpt-5.4`, `gpt-5.4-nano`, `gpt-5.4-mini`, `gpt-5.4`, `gpt-5.5`

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
