### PR TITLE
fix(js/plugins/google-genai): use native constrained generation with tools

### DIFF
--- a/js/plugins/google-genai/src/googleai/gemini.ts
+++ b/js/plugins/google-genai/src/googleai/gemini.ts
@@ -829,11 +829,9 @@ export function defineModel(
         };
       }
 
-      // Cannot use tools with JSON mode
       const jsonMode =
         request.output?.format === 'json' ||
-        (request.output?.contentType === 'application/json' &&
-          tools.length === 0);
+        request.output?.contentType === 'application/json';
 
       const generationConfig: GenerationConfig = {
         ...removeClientOptionOverrides(restOfConfigOptions),

--- a/js/plugins/google-genai/src/googleai/gemini.ts
+++ b/js/plugins/google-genai/src/googleai/gemini.ts
@@ -424,7 +424,7 @@ function commonRef(
         tools: true,
         toolChoice: true,
         systemRole: true,
-        constrained: 'no-tools',
+        constrained: 'all',
         output: ['text', 'json'],
       },
     },
@@ -441,7 +441,7 @@ const GENERIC_TTS_MODEL = commonRef(
       tools: false,
       toolChoice: false,
       systemRole: false,
-      constrained: 'no-tools',
+      constrained: 'all',
     },
   },
   GeminiTtsConfigSchema
@@ -455,7 +455,7 @@ const GENERIC_IMAGE_MODEL = commonRef(
       tools: true,
       toolChoice: true,
       systemRole: true,
-      constrained: 'no-tools',
+      constrained: 'all',
     },
   },
   GeminiImageConfigSchema

--- a/js/plugins/google-genai/src/vertexai/gemini.ts
+++ b/js/plugins/google-genai/src/vertexai/gemini.ts
@@ -411,7 +411,7 @@ function commonRef(
         tools: true,
         toolChoice: true,
         systemRole: true,
-        constrained: 'no-tools',
+        constrained: 'all',
       },
     },
   });

--- a/js/plugins/google-genai/src/vertexai/gemini.ts
+++ b/js/plugins/google-genai/src/vertexai/gemini.ts
@@ -665,10 +665,8 @@ export function defineModel(
         toolConfig.retrievalConfig = structuredClone(retrievalConfig);
       }
 
-      // Cannot use tools and function calling at the same time
       const jsonMode =
-        (request.output?.format === 'json' || !!request.output?.schema) &&
-        tools.length === 0;
+        request.output?.format === 'json' || !!request.output?.schema;
 
       if (toolsFromConfig) {
         tools.push(...(toolsFromConfig as any[]));


### PR DESCRIPTION
## Summary

Fixes #5392. Both `googleai` and `vertexai` Gemini providers declared every model as `supports.constrained: 'no-tools'`, which forced `simulateConstrainedGeneration` to run whenever a call combined `tools` with `output: { schema }`. The simulator serialized the JSON schema as text, injected it into the user message, and stripped `responseJsonSchema` / `responseMimeType` from the Gemini API request.

A second layer of the same staleness lived in each provider's `jsonMode` definition: both gated JSON mode on `tools.length === 0`, which meant even after the metadata flip the Vertex path would skip the simulator without setting `responseJsonSchema` either, leaving the model fully unconstrained on tool-using calls.

The Gemini API has supported tools + native constrained generation since Gemini 2.0. Every model in `KNOWN_GEMINI_MODELS` and the image model set is Gemini 2.5+. After this PR, tool-using calls go through the native path: `generationConfig.responseJsonSchema` is set on the Gemini request directly.

## Changes

**Metadata defaults flipped from `'no-tools'` to `'all'`** (four occurrences):

- `js/plugins/google-genai/src/googleai/gemini.ts` — default `commonRef` info, plus the explicit overrides for `GENERIC_TTS_MODEL` and `GENERIC_IMAGE_MODEL`.
- `js/plugins/google-genai/src/vertexai/gemini.ts` — default `commonRef` info (the image model on Vertex inherits via `info: undefined`).

**`jsonMode` no longer gated on `tools.length === 0`** in either provider, with the stale `// Cannot use tools…` comments removed:

- `googleai/gemini.ts` previously only gated the `contentType === 'application/json'` branch; the `format === 'json'` branch happened to work because `applyFormat` upstream sets `format: 'json'` whenever a schema is present.
- `vertexai/gemini.ts` gated the entire `jsonMode` on `tools.length === 0`, which would have made the metadata fix incomplete on Vertex.

## Not a breaking change

All Gemini 1.x models are deprecated and absent from `KNOWN_GEMINI_MODELS`. The current entries (`gemini-flash-latest`, `gemini-pro-latest`, `gemini-2.5-*`, `gemini-3.x-*`) all support combined tools + constrained generation at the API level. A future model that lacks this support can still opt out by declaring `'no-tools'` explicitly in its model-specific `info`.

## Migration note for users with strict production schemas

The native Gemini structured-output validator is stricter than the prompt-based simulator. Some schemas that worked under the simulator (heavy use of `oneOf`, complex `$ref` chains, certain regex `pattern` constraints, recursive types) may now produce `INVALID_ARGUMENT` from the API.

Users who hit this can opt back into the simulator on a per-call basis using the existing exported middleware:

```ts
import { simulateConstrainedGeneration } from 'genkit/model';

await ai.generate({
  prompt: '...',
  tools: [...],
  output: { schema: yourSchema },
  use: [simulateConstrainedGeneration()],
});
```

The user-supplied simulator runs first in the middleware chain, injects the schema into the user message, and strips `output.constrained` so neither the auto-attached middleware nor the native path fires for that call.

To force this behavior for every call against a specific custom-registered model, attach the same middleware at model-definition time. A plugin-level flag to force it globally for an entire plugin is not part of this PR; users who want one are encouraged to file a follow-up issue.

## Test plan

- [x] Built `google-genai` from this branch and linked into a working Genkit + Angular reproduction.
- [x] Ran a flow that combines a `defineTool` call with `output: { schema }` against `gemini-flash-latest`.
- [x] Before the fix: streamed structured chunks included `"$schema": "http://json-schema.org/draft-07/schema#"` echoed back from the prompt-injected schema. After the fix: chunks contain only the declared schema fields.
- [x] Tool was still called and the model still produced valid structured output through the native path.
- [x] Verified again after the second commit (`jsonMode` cleanup): no regression on the GoogleAI path, same end-to-end behavior.
- [ ] CI on this branch.