### PR TITLE
fix(go): skip zero-value struct chunks in GenerateDataStream / ExecuteStream

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -816,8 +816,10 @@ func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...Ge
 				yield(nil, err)
 				return err
 			}
-			// Skip yielding if there's no parseable output yet (e.g., incomplete JSON during streaming).
-			if base.IsNil(streamValue) {
+			// Skip yielding if the chunk's parsed output is still the zero value
+			// for Out (e.g. incomplete JSON during streaming, or a struct whose
+			// fields haven't been populated yet by the partial parser).
+			if base.IsZero(streamValue) {
 				return nil
 			}
 			if !yield(&StreamValue[Out, Out]{Chunk: streamValue}, nil) {

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -2226,6 +2226,66 @@ func TestGenerateDataStream(t *testing.T) {
 			t.Error("expected parsing error to be propagated")
 		}
 	})
+
+	t.Run("skips zero-value struct chunks during incremental streaming", func(t *testing.T) {
+		// Simulate a model emitting JSON token by token. The first chunk is a
+		// lone opening brace; the partial parser completes it to `{}`, which
+		// unmarshals into a zero-value streamingTestData{}. Subsequent chunks
+		// build up populated objects. GenerateDataStream must skip the zero-
+		// value chunk to avoid the production bug where the client briefly
+		// sees an empty struct between meaningful chunks.
+		streamModel := DefineModel(r, "test/streamSkipZeroModel", &ModelOptions{
+			Supports: &ModelSupports{
+				Multiturn:   true,
+				Constrained: ConstrainedSupportAll,
+			},
+		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			if cb != nil {
+				cb(ctx, &ModelResponseChunk{Content: []*Part{NewJSONPart(`{`)}})
+				cb(ctx, &ModelResponseChunk{Content: []*Part{NewJSONPart(`"name":"populated"`)}})
+				cb(ctx, &ModelResponseChunk{Content: []*Part{NewJSONPart(`,"value":42}`)}})
+			}
+			return &ModelResponse{
+				Request: req,
+				Message: &Message{
+					Role:    RoleModel,
+					Content: []*Part{NewJSONPart(`{"name":"populated","value":42}`)},
+				},
+			}, nil
+		})
+
+		var chunks []streamingTestData
+		var finalOutput streamingTestData
+
+		for val, err := range GenerateDataStream[streamingTestData](context.Background(), r,
+			WithModel(streamModel),
+			WithPrompt("test zero-value chunk skip"),
+		) {
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if val.Done {
+				finalOutput = val.Output
+			} else {
+				chunks = append(chunks, val.Chunk)
+			}
+		}
+
+		// The first chunk parses to streamingTestData{} (zero value) and must
+		// be suppressed. The two remaining chunks build a populated object and
+		// should both surface.
+		if len(chunks) != 2 {
+			t.Fatalf("expected 2 non-empty chunks (zero-value chunks should be skipped); got %d: %#v", len(chunks), chunks)
+		}
+		for i, c := range chunks {
+			if c == (streamingTestData{}) {
+				t.Errorf("chunk[%d] is zero-value; zero-value chunks should be skipped", i)
+			}
+		}
+		if finalOutput.Name != "populated" || finalOutput.Value != 42 {
+			t.Errorf("finalOutput = %#v, want {Name: \"populated\", Value: 42}", finalOutput)
+		}
+	})
 }
 
 func TestGenerateText(t *testing.T) {

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -2286,6 +2286,63 @@ func TestGenerateDataStream(t *testing.T) {
 			t.Errorf("finalOutput = %#v, want {Name: \"populated\", Value: 42}", finalOutput)
 		}
 	})
+
+	t.Run("skips zero-value pointer-to-struct chunks during incremental streaming", func(t *testing.T) {
+		// Same scenario as the previous subtest, but with a pointer output type.
+		// When chunk.Output unmarshals into **streamingTestData, the JSON unmarshaler
+		// allocates a non-nil pointer to a zero-value struct (&streamingTestData{}).
+		// IsZero must transitively unwrap the pointer and treat the pointee's zero
+		// value as zero, otherwise the same flicker bug recurs for callers that use
+		// GenerateDataStream[*T].
+		streamModel := DefineModel(r, "test/streamSkipZeroPtrModel", &ModelOptions{
+			Supports: &ModelSupports{
+				Multiturn:   true,
+				Constrained: ConstrainedSupportAll,
+			},
+		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			if cb != nil {
+				cb(ctx, &ModelResponseChunk{Content: []*Part{NewJSONPart(`{`)}})
+				cb(ctx, &ModelResponseChunk{Content: []*Part{NewJSONPart(`"name":"populated"`)}})
+				cb(ctx, &ModelResponseChunk{Content: []*Part{NewJSONPart(`,"value":42}`)}})
+			}
+			return &ModelResponse{
+				Request: req,
+				Message: &Message{
+					Role:    RoleModel,
+					Content: []*Part{NewJSONPart(`{"name":"populated","value":42}`)},
+				},
+			}, nil
+		})
+
+		var chunks []*streamingTestData
+		var finalOutput *streamingTestData
+
+		for val, err := range GenerateDataStream[*streamingTestData](context.Background(), r,
+			WithModel(streamModel),
+			WithPrompt("test zero-value pointer chunk skip"),
+		) {
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if val.Done {
+				finalOutput = val.Output
+			} else {
+				chunks = append(chunks, val.Chunk)
+			}
+		}
+
+		if len(chunks) != 2 {
+			t.Fatalf("expected 2 non-empty chunks (nil and &zero pointer chunks should be skipped); got %d: %#v", len(chunks), chunks)
+		}
+		for i, c := range chunks {
+			if c == nil || *c == (streamingTestData{}) {
+				t.Errorf("chunk[%d] is nil or points to zero value; should be skipped", i)
+			}
+		}
+		if finalOutput == nil || finalOutput.Name != "populated" || finalOutput.Value != 42 {
+			t.Errorf("finalOutput = %#v, want non-nil *{Name: \"populated\", Value: 42}", finalOutput)
+		}
+	})
 }
 
 func TestGenerateText(t *testing.T) {

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -1034,8 +1034,10 @@ func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts
 				yield(nil, err)
 				return err
 			}
-			// Skip yielding if there's no parseable output yet (e.g., incomplete JSON during streaming).
-			if base.IsNil(streamValue) {
+			// Skip yielding if the chunk's parsed output is still the zero value
+			// for Out (e.g. incomplete JSON during streaming, or a struct whose
+			// fields haven't been populated yet by the partial parser).
+			if base.IsZero(streamValue) {
 				return nil
 			}
 			if !yield(&StreamValue[Out, Out]{Chunk: streamValue}, nil) {

--- a/go/internal/base/misc.go
+++ b/go/internal/base/misc.go
@@ -52,3 +52,17 @@ func IsNil[T any](v T) bool {
 		return false
 	}
 }
+
+// IsZero returns true if v is the zero value for its type.
+//
+// Unlike [IsNil], it returns true for zero-value structs and primitives (e.g.
+// Recipe{}, "", 0) in addition to nil pointers/interfaces/maps/slices/channels/funcs.
+// Empty-but-non-nil slices and maps (e.g. []int{}) are still considered non-zero,
+// matching reflect.Value.IsZero semantics.
+func IsZero[T any](v T) bool {
+	rv := reflect.ValueOf(v)
+	if !rv.IsValid() {
+		return true
+	}
+	return rv.IsZero()
+}

--- a/go/internal/base/misc.go
+++ b/go/internal/base/misc.go
@@ -57,10 +57,21 @@ func IsNil[T any](v T) bool {
 //
 // Unlike [IsNil], it returns true for zero-value structs and primitives (e.g.
 // Recipe{}, "", 0) in addition to nil pointers/interfaces/maps/slices/channels/funcs.
-// Empty-but-non-nil slices and maps (e.g. []int{}) are still considered non-zero,
-// matching reflect.Value.IsZero semantics.
+// Pointers and interfaces are followed transitively, so a non-nil pointer that
+// points to a zero-value struct (&Recipe{}) is also considered zero. This is
+// useful for "is there meaningful content here?" checks regardless of whether
+// the value is held by reference or by value.
+//
+// Empty-but-non-nil slices and maps (e.g. []int{}) are still considered
+// non-zero, matching reflect.Value.IsZero semantics.
 func IsZero[T any](v T) bool {
 	rv := reflect.ValueOf(v)
+	for rv.IsValid() && (rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface) {
+		if rv.IsNil() {
+			return true
+		}
+		rv = rv.Elem()
+	}
 	if !rv.IsValid() {
 		return true
 	}

--- a/go/internal/base/misc_test.go
+++ b/go/internal/base/misc_test.go
@@ -70,6 +70,13 @@ func TestIsZero(t *testing.T) {
 		{"struct with n", IsZero(sample{N: 1}), false},
 		{"populated struct", IsZero(sample{Name: "x", N: 1}), false},
 
+		// Pointers: nil and non-nil pointing to a zero-value pointee are both
+		// considered zero (transitive unwrap).
+		{"non-nil pointer to zero struct", IsZero(&sample{}), true},
+		{"non-nil pointer to populated struct", IsZero(&sample{Name: "x"}), false},
+		{"pointer to zero int", IsZero(new(int)), true},
+		{"pointer to nonzero int", func() bool { n := 7; return IsZero(&n) }(), false},
+
 		// Primitives.
 		{"empty string", IsZero(""), true},
 		{"non-empty string", IsZero("x"), false},

--- a/go/internal/base/misc_test.go
+++ b/go/internal/base/misc_test.go
@@ -1,0 +1,86 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package base
+
+import "testing"
+
+type sample struct {
+	Name string
+	N    int
+}
+
+func TestIsNil(t *testing.T) {
+	tests := []struct {
+		name string
+		got  bool
+		want bool
+	}{
+		{"nil interface", IsNil[any](nil), true},
+		{"nil pointer", IsNil[*sample](nil), true},
+		{"nil slice", IsNil[[]int](nil), true},
+		{"nil map", IsNil[map[string]int](nil), true},
+
+		{"empty slice", IsNil[[]int]([]int{}), false},
+		{"empty map", IsNil[map[string]int](map[string]int{}), false},
+		{"zero struct", IsNil(sample{}), false},
+		{"populated struct", IsNil(sample{Name: "x", N: 1}), false},
+		{"empty string", IsNil(""), false},
+		{"zero int", IsNil(0), false},
+	}
+	for _, tt := range tests {
+		if tt.got != tt.want {
+			t.Errorf("%s: got %v, want %v", tt.name, tt.got, tt.want)
+		}
+	}
+}
+
+func TestIsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		got  bool
+		want bool
+	}{
+		// Nil-like values: zero matches the IsNil behavior.
+		{"nil interface", IsZero[any](nil), true},
+		{"nil pointer", IsZero[*sample](nil), true},
+		{"nil slice", IsZero[[]int](nil), true},
+		{"nil map", IsZero[map[string]int](nil), true},
+
+		// Empty-but-non-nil collections are not zero.
+		{"empty slice", IsZero[[]int]([]int{}), false},
+		{"empty map", IsZero[map[string]int](map[string]int{}), false},
+
+		// Structs: zero-value vs populated. This is the case IsNil misses.
+		{"zero struct", IsZero(sample{}), true},
+		{"struct with name", IsZero(sample{Name: "x"}), false},
+		{"struct with n", IsZero(sample{N: 1}), false},
+		{"populated struct", IsZero(sample{Name: "x", N: 1}), false},
+
+		// Primitives.
+		{"empty string", IsZero(""), true},
+		{"non-empty string", IsZero("x"), false},
+		{"zero int", IsZero(0), true},
+		{"nonzero int", IsZero(7), false},
+		{"false bool", IsZero(false), true},
+		{"true bool", IsZero(true), false},
+	}
+	for _, tt := range tests {
+		if tt.got != tt.want {
+			t.Errorf("%s: got %v, want %v", tt.name, tt.got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5398.

## Summary

The skip guard in the streaming callback for `GenerateDataStream[Out]` and `DataPrompt[In, Out].ExecuteStream` used `base.IsNil`, which only treats nil pointers/interfaces/maps/slices/channels/funcs as "no parseable output yet." For non-pointer **struct** output types — the common case for typed structured-output flows — `IsNil` returns `false`, so a zero-value `Out{}` from the partial-JSON parser is yielded as a real chunk to the consumer.

In production this surfaces as alternating populated and empty chunks during incremental streaming. With Gemini structured output and a tool-using flow, the second model message's early chunks parse to `Recipe{}` and overwrite the client's UI state, causing visible flicker. Raw `curl` output from a reproducing flow:

```
data: {"message":{"title":"","description":"","servings":0,"ingredients":null,"steps":null}}
data: {"message":{"title":"Simple Garlic Chicken Stir-Fry",...}}
data: {"message":{"title":"","description":"","servings":0,...}}   ← reset
data: {"message":{"title":"Simple Garlic Chicken Stir-Fry","description":"A quick...","servings":4,"ingredients":[...]}}
...
```

## Fix

- New `base.IsZero[T]` helper (in `go/internal/base/misc.go`) using `reflect.Value.IsZero()`, which is `true` for nil pointers/interfaces/maps/slices/channels/funcs *and* for zero-value structs and primitives. Empty-but-non-nil slices and maps stay non-zero, matching reflect's semantics.
- Use `IsZero` at the two streaming skip-guard sites:
  - `go/ai/generate.go` in `GenerateDataStream[Out]`
  - `go/ai/prompt.go` in `DataPrompt[In, Out].ExecuteStream`

`base.IsNil` is left in place for the unrelated caller in `ai/generate.go` (config-presence check around `modelRef.Config()`) where the existing nil-only semantics are correct.

## Tests

- `go/internal/base/misc_test.go` (new): tabular tests for `IsNil` (preserves existing behavior) and `IsZero` (covers nil, empty non-nil slice/map, zero struct, populated struct, primitives).
- `go/ai/generate_test.go` (new subtest of `TestGenerateDataStream`): "skips zero-value struct chunks during incremental streaming" emits JSON token by token (`{`, then `"name":"populated"`, then `,"value":42}`); the first chunk parses to `streamingTestData{}` via the partial parser and must be suppressed. Asserts exactly two populated chunks and a populated final output.
- Existing `TestGenerateDataStream` subtests all continue to pass.

## Verification

End-to-end check using a [reproducing sample](https://github.com/genkit-ai/genkit/issues/5398) (Chi + Genkit Go backend + Angular SPA frontend with structured-output streaming):

- **Before the fix**, raw `curl` output alternated between populated and zero-value chunks; the Angular client rendered the recipe card with visible flicker as fields toggled on and off.
- **After the fix** (sample's `go.mod` `replace`'d to point at this branch), the first chunk that reaches the wire already has its title populated, every subsequent chunk is a superset of the previous, and the client renders smoothly with fields accumulating monotonically.

## Test plan

- [x] `go test ./internal/base/...` — all pass
- [x] `go test ./ai/...` — all pass including the new subtest
- [x] `go test ./genkit/...` — all pass
- [x] Verified end-to-end against a real Gemini-backed streaming flow with structured `Recipe` output
- [ ] CI test matrix (will run on PR open)