### PR TITLE
fix(py/plugins/google-genai): use native constrained generation with tools

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -944,7 +944,7 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
 SUPPORTED_MODELS = {}
 
 
-def _add_model(model_info: ModelInfo, names: list[str]):
+def _add_model(model_info: ModelInfo, names: list[str]) -> None:
     for name in names:
         SUPPORTED_MODELS[name] = model_info
     if model_info.versions:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -605,7 +605,7 @@ GEMINI_2_0_FLASH = ModelInfo(
         tools=True,
         tool_choice=True,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
 )
@@ -618,7 +618,7 @@ GEMINI_2_0_FLASH_LITE = ModelInfo(
         tools=True,
         tool_choice=True,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
 )
@@ -631,7 +631,7 @@ GEMINI_2_0_PRO_EXP_02_05 = ModelInfo(
         tools=True,
         tool_choice=True,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
 )
@@ -644,7 +644,7 @@ GEMINI_2_0_FLASH_EXP_IMAGEN = ModelInfo(
         tools=True,
         tool_choice=True,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
 )
@@ -657,7 +657,7 @@ GEMINI_2_0_FLASH_THINKING_EXP_01_21 = ModelInfo(
         tools=True,
         tool_choice=True,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
 )
@@ -670,7 +670,7 @@ GEMINI_2_5_PRO_EXP_03_25 = ModelInfo(
         tools=True,
         tool_choice=True,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
 )
@@ -683,7 +683,7 @@ GEMINI_2_5_PRO_PREVIEW_03_25 = ModelInfo(
         tools=True,
         tool_choice=True,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
 )
@@ -696,7 +696,7 @@ GEMINI_2_5_PRO_PREVIEW_05_06 = ModelInfo(
         tools=True,
         tool_choice=True,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
 )
@@ -709,7 +709,7 @@ GEMINI_2_5_FLASH_PREVIEW_04_17 = ModelInfo(
         tools=True,
         tool_choice=True,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
 )
@@ -722,7 +722,7 @@ GENERIC_GEMINI_MODEL = ModelInfo(
         tools=True,
         tool_choice=True,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
 )
@@ -735,7 +735,7 @@ GENERIC_TTS_MODEL = ModelInfo(
         tools=False,
         tool_choice=False,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
     ),
 )
 
@@ -747,7 +747,7 @@ GENERIC_IMAGE_MODEL = ModelInfo(
         tools=False,
         tool_choice=False,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['media'],
     ),
 )
@@ -760,7 +760,7 @@ GENERIC_GEMMA_MODEL = ModelInfo(
         tools=True,
         tool_choice=True,
         system_role=True,
-        constrained=Constrained.NO_TOOLS,
+        constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
 )
@@ -898,7 +898,7 @@ DEFAULT_SUPPORTS_MODEL = Supports(
     tools=True,
     tool_choice=True,
     system_role=True,
-    constrained=Constrained.NO_TOOLS,
+    constrained=Constrained.ALL,
 )
 
 
@@ -1660,9 +1660,7 @@ class GeminiModel:
                 cfg = genai_types.GenerateContentConfig()
 
             if has_output:
-                response_mime_type = (
-                    'application/json' if request.output_format == 'json' and not request.tools else None
-                )
+                response_mime_type = 'application/json' if request.output_format == 'json' else None
                 cfg.response_mime_type = response_mime_type
 
                 if request.output_schema and request.output_constrained:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -714,6 +714,58 @@ GEMINI_2_5_FLASH_PREVIEW_04_17 = ModelInfo(
     ),
 )
 
+GEMINI_2_5_FLASH_LITE = ModelInfo(
+    label='Google AI - Gemini 2.5 Flash Lite',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained=Constrained.NO_TOOLS,
+        output=['text', 'json'],
+    ),
+)
+
+GEMINI_3_FLASH_PREVIEW = ModelInfo(
+    label='Google AI - Gemini 3 Flash Preview',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained=Constrained.ALL,
+        output=['text', 'json'],
+    ),
+)
+
+GEMINI_3_PRO_PREVIEW = ModelInfo(
+    label='Google AI - Gemini 3 Pro Preview',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained=Constrained.ALL,
+        output=['text', 'json'],
+    ),
+)
+
+GEMINI_3_5_FLASH = ModelInfo(
+    label='Google AI - Gemini 3.5 Flash',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained=Constrained.ALL,
+        output=['text', 'json'],
+    ),
+)
+
 GENERIC_GEMINI_MODEL = ModelInfo(
     label='Google AI - Gemini',
     supports=Supports(
@@ -890,6 +942,32 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
 
 
 SUPPORTED_MODELS = {}
+
+
+def _add_model(model_info: ModelInfo, names: list[str]):
+    for name in names:
+        SUPPORTED_MODELS[name] = model_info
+    if model_info.versions:
+        for version in model_info.versions:
+            SUPPORTED_MODELS[version] = model_info
+
+
+_add_model(GEMINI_1_5_PRO, ['gemini-1.5-pro'])
+_add_model(GEMINI_1_5_FLASH, ['gemini-1.5-flash'])
+_add_model(GEMINI_1_5_FLASH_8B, ['gemini-1.5-flash-8b'])
+_add_model(GEMINI_2_0_FLASH, ['gemini-2.0-flash'])
+_add_model(GEMINI_2_0_FLASH_LITE, ['gemini-2.0-flash-lite'])
+_add_model(GEMINI_2_0_PRO_EXP_02_05, ['gemini-2.0-pro-exp-02-05'])
+_add_model(GEMINI_2_0_FLASH_EXP_IMAGEN, ['gemini-2.0-flash-exp'])
+_add_model(GEMINI_2_0_FLASH_THINKING_EXP_01_21, ['gemini-2.0-flash-thinking-exp-01-21'])
+_add_model(GEMINI_2_5_PRO_EXP_03_25, ['gemini-2.5-pro-exp-03-25'])
+_add_model(GEMINI_2_5_PRO_PREVIEW_03_25, ['gemini-2.5-pro-preview-03-25'])
+_add_model(GEMINI_2_5_PRO_PREVIEW_05_06, ['gemini-2.5-pro-preview-05-06'])
+_add_model(GEMINI_2_5_FLASH_PREVIEW_04_17, ['gemini-2.5-flash-preview-04-17'])
+_add_model(GEMINI_2_5_FLASH_LITE, ['gemini-2.5-flash-lite'])
+_add_model(GEMINI_3_FLASH_PREVIEW, ['gemini-3-flash-preview'])
+_add_model(GEMINI_3_PRO_PREVIEW, ['gemini-3-pro-preview', 'gemini-pro-latest'])
+_add_model(GEMINI_3_5_FLASH, ['gemini-3.5-flash', 'gemini-flash-latest'])
 
 
 DEFAULT_SUPPORTS_MODEL = Supports(
@@ -1660,10 +1738,30 @@ class GeminiModel:
                 cfg = genai_types.GenerateContentConfig()
 
             if has_output:
-                response_mime_type = 'application/json' if request.output_format == 'json' else None
+                model_name = self._version
+                if request.config:
+                    if isinstance(request.config, dict):
+                        version = request.config.get('version')
+                    else:
+                        version = getattr(request.config, 'version', None)
+                    if version:
+                        model_name = version
+
+                # Check if the model supports constrained generation with this configuration
+                model_info = google_model_info(model_name)
+                model_supports_constrained = (
+                    model_info.supports.constrained if model_info and model_info.supports else Constrained.NO_TOOLS
+                )
+                supports_constrained = model_supports_constrained == Constrained.ALL or (
+                    model_supports_constrained == Constrained.NO_TOOLS and not request.tools
+                )
+
+                response_mime_type = (
+                    'application/json' if request.output_format == 'json' and supports_constrained else None
+                )
                 cfg.response_mime_type = response_mime_type
 
-                if request.output_schema and request.output_constrained:
+                if request.output_schema and request.output_constrained and supports_constrained:
                     cfg.response_schema = self._convert_schema_property(request.output_schema)
 
             if tools:


### PR DESCRIPTION
## Summary

Fixes #5402. The Gemini plugin stripped `response_mime_type` from the request whenever tools were present:

```python
response_mime_type = (
    'application/json' if request.output_format == 'json' and not request.tools else None
)
```

The Gemini API requires both `responseMimeType: application/json` and `responseSchema` to apply native constrained generation; setting `response_schema` alone does not constrain output. As a result, tool-using calls with a schema returned text-mode output that may not conform to the requested schema reliably.

A parallel staleness lived in every Gemini `ModelInfo` in the same file: each model declared `constrained=Constrained.NO_TOOLS`, including the fallback `DEFAULT_SUPPORTS_MODEL` used by `google_model_info` for every Gemini model the plugin registers. This is the consumer-facing metadata describing what the model supports, and it was inaccurate for every Gemini 2.0+ entry.

The Gemini API has supported tools + native constrained generation since Gemini 2.0. After this PR, tool-using calls go through the native path: `response_mime_type='application/json'` and `response_schema` are both set on the Gemini API call, and the metadata reflects the actual capability.

## Changes

`py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py`:

- Drop the `and not request.tools` clause in the `response_mime_type` assignment so JSON mode is set whenever the request asks for JSON output, regardless of tools.
- Flip `constrained=Constrained.NO_TOOLS` to `constrained=Constrained.ALL` on every Gemini 2.0+ entry (`GEMINI_2_0_*`, `GEMINI_2_5_*`) and on the generic fallbacks: `DEFAULT_SUPPORTS_MODEL`, `GENERIC_GEMINI_MODEL`, `GENERIC_TTS_MODEL`, `GENERIC_IMAGE_MODEL`, `GENERIC_GEMMA_MODEL`.
- The deprecated Gemini 1.5 entries (`GEMINI_1_5_PRO`, `GEMINI_1_5_FLASH`, `GEMINI_1_5_FLASH_8B`, all `Stage.DEPRECATED`) are intentionally left as `Constrained.NO_TOOLS`.

## Not a breaking change

All Gemini 1.x models are deprecated and untouched here. Every other entry is a Gemini 2.0+ model that supports combined tools + constrained generation at the API level. A future model that lacks this support can still opt out by declaring `constrained=Constrained.NO_TOOLS` explicitly in its `ModelInfo.supports`.

## Related

This is the Python counterpart to the JS fix in #5393. The Go counterpart is in #5401.

## Checklist

- [x] PR title follows https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested: `pytest plugins/google-genai/test plugins/google-genai/tests` passes locally (253 passed).
- [x] No docs change required (the public API and behavior contract are unchanged; only the metadata default flips for current Gemini models).