### PR TITLE
fix(ai): namespace dotprompt partials by subdirectory

### DIFF
--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -670,6 +670,10 @@ func convertToPartPointers(parts []dotprompt.Part) ([]*Part, error) {
 // The fsys parameter should be an fs.FS implementation (e.g., embed.FS or os.DirFS).
 // The dir parameter specifies the directory within the filesystem where prompts are located.
 func LoadPromptDirFromFS(r api.Registry, fsys fs.FS, dir, namespace string) {
+	loadPromptDirFromFS(r, fsys, dir, namespace, "")
+}
+
+func loadPromptDirFromFS(r api.Registry, fsys fs.FS, dir, namespace, subPath string) {
 	if fsys == nil {
 		panic(errors.New("no prompt filesystem provided"))
 	}
@@ -687,10 +691,18 @@ func LoadPromptDirFromFS(r api.Registry, fsys fs.FS, dir, namespace string) {
 		filename := entry.Name()
 		filePath := path.Join(dir, filename)
 		if entry.IsDir() {
-			LoadPromptDirFromFS(r, fsys, filePath, namespace)
+			childSubPath := filename
+			if subPath != "" {
+				childSubPath = path.Join(subPath, filename)
+			}
+			loadPromptDirFromFS(r, fsys, filePath, namespace, childSubPath)
 		} else if strings.HasSuffix(filename, ".prompt") {
 			if strings.HasPrefix(filename, "_") {
-				partialName := strings.TrimSuffix(filename[1:], ".prompt")
+				partialBaseName := strings.TrimSuffix(filename[1:], ".prompt")
+				partialName := partialBaseName
+				if subPath != "" {
+					partialName = path.Join(subPath, partialBaseName)
+				}
 				source, err := fs.ReadFile(fsys, filePath)
 				if err != nil {
 					slog.Error("Failed to read partial file", "error", err)

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -1232,6 +1232,29 @@ Hello, {{name}}!
 	}
 }
 
+func TestLoadPromptDirFromFS_NamespacedPartials(t *testing.T) {
+	fsys := fstest.MapFS{
+		"prompts/flowA/_system.prompt": &fstest.MapFile{Data: []byte("system A")},
+		"prompts/flowB/_system.prompt": &fstest.MapFile{Data: []byte("system B")},
+		"prompts/_greeting.prompt":     &fstest.MapFile{Data: []byte("hello")},
+	}
+
+	reg := registry.New()
+
+	LoadPromptDirFromFS(reg, fsys, "prompts", "")
+
+	partials := reg.Dotprompt().Partials
+	if partials["flowA/system"] != "system A" {
+		t.Errorf("flowA/system partial = %q, want %q", partials["flowA/system"], "system A")
+	}
+	if partials["flowB/system"] != "system B" {
+		t.Errorf("flowB/system partial = %q, want %q", partials["flowB/system"], "system B")
+	}
+	if partials["greeting"] != "hello" {
+		t.Errorf("greeting partial = %q, want %q", partials["greeting"], "hello")
+	}
+}
+
 func TestLoadPromptFS_WithVariant(t *testing.T) {
 	mockPromptContent := `---
 model: test/chat

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -34,7 +34,7 @@ import { SPAN_TYPE_ATTR, runInNewSpan } from '@genkit-ai/core/tracing';
 import { Message as DpMessage, PromptFunction } from 'dotprompt';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import type Handlebars from 'handlebars';
-import { basename, join, resolve } from 'path';
+import { basename, join, resolve, sep } from 'path';
 import type { DocumentData } from './document.js';
 import {
   generate,
@@ -793,7 +793,7 @@ export function loadPromptFolderRecursively(
         // Include subdirectory in the partial name to prevent naming conflicts,
         // matching how executable prompts are namespaced.
         const partialName = subDir
-          ? `${subDir.replace(/\\/g, '/')}/${partialBaseName}`
+          ? `${subDir.split(sep).join('/')}/${partialBaseName}`
           : partialBaseName;
         definePartial(
           registry,

--- a/js/ai/src/prompt.ts
+++ b/js/ai/src/prompt.ts
@@ -789,7 +789,12 @@ export function loadPromptFolderRecursively(
     const fileName = dirEnt.name;
     if (dirEnt.isFile() && fileName.endsWith('.prompt')) {
       if (fileName.startsWith('_')) {
-        const partialName = fileName.substring(1, fileName.length - 7);
+        const partialBaseName = fileName.substring(1, fileName.length - 7);
+        // Include subdirectory in the partial name to prevent naming conflicts,
+        // matching how executable prompts are namespaced.
+        const partialName = subDir
+          ? `${subDir.replace(/\\/g, '/')}/${partialBaseName}`
+          : partialBaseName;
         definePartial(
           registry,
           partialName,

--- a/js/ai/tests/prompt/loadPromptFolder_test.ts
+++ b/js/ai/tests/prompt/loadPromptFolder_test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { initNodeFeatures } from '@genkit-ai/core/node';
+import { Registry } from '@genkit-ai/core/registry';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'fs';
+import assert from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadPromptFolder, prompt } from '../../src/prompt.js';
+import { defineEchoModel } from '../helpers.js';
+
+initNodeFeatures();
+
+describe('loadPromptFolder', () => {
+  let registry: Registry;
+  let promptDir: string;
+
+  beforeEach(() => {
+    registry = new Registry();
+    defineEchoModel(registry);
+    promptDir = mkdtempSync(join(tmpdir(), 'genkit-prompts-'));
+  });
+
+  it('registers nested partials with subdirectory namespace', async () => {
+    mkdirSync(join(promptDir, 'flowA'), { recursive: true });
+    mkdirSync(join(promptDir, 'flowB'), { recursive: true });
+    writeFileSync(join(promptDir, 'flowA', '_system.prompt'), 'system A');
+    writeFileSync(join(promptDir, 'flowB', '_system.prompt'), 'system B');
+    writeFileSync(
+      join(promptDir, 'flowA', 'main.prompt'),
+      `---
+model: echoModel
+---
+{{> flowA/system}}`
+    );
+    writeFileSync(
+      join(promptDir, 'flowB', 'main.prompt'),
+      `---
+model: echoModel
+---
+{{> flowB/system}}`
+    );
+
+    loadPromptFolder(registry, promptDir, '');
+
+    const flowA = await prompt(registry, 'flowA/main');
+    const flowB = await prompt(registry, 'flowB/main');
+
+    const renderedA = await flowA.render({});
+    const renderedB = await flowB.render({});
+
+    assert.strictEqual(renderedA.messages[0].content[0].text, 'system A');
+    assert.strictEqual(renderedB.messages[0].content[0].text, 'system B');
+  });
+
+  it('registers root-level partials without subdirectory prefix', async () => {
+    writeFileSync(join(promptDir, '_greeting.prompt'), 'hello');
+    writeFileSync(
+      join(promptDir, 'test.prompt'),
+      `---
+model: echoModel
+---
+{{> greeting}}`
+    );
+
+    loadPromptFolder(registry, promptDir, '');
+
+    const testPrompt = await prompt(registry, 'test');
+    const rendered = await testPrompt.render({});
+    assert.strictEqual(rendered.messages[0].content[0].text, 'hello');
+  });
+});


### PR DESCRIPTION
## Summary

- Namespace dotprompt partials loaded from subdirectories as `{subdir}/{name}`, matching how executable prompts are already namespaced
- Root-level `_*.prompt` partials keep their base name (e.g. `_greeting.prompt` → `{{> greeting}}`)
- Add JS and Go tests for namespaced partial registration

## Breaking change

Nested partial references must use the namespaced form (e.g. `{{> foo/bar/system}}` instead of `{{> system}}`). This fixes global partial name collisions when multiple flows define partials with the same filename.

## Test plan

- [x] `pnpm test:single tests/prompt/loadPromptFolder_test.ts` (JS)
- [x] `go test ./go/ai -run TestLoadPromptDirFromFS_NamespacedPartials` (Go)