### PR TITLE
feat(js): mark interrupt tools as non-restartable and preserve tool metadata

### DIFF
--- a/js/ai/src/tool.ts
+++ b/js/ai/src/tool.ts
@@ -489,7 +489,13 @@ export function interrupt<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
   const { requestMetadata, ...toolConfig } = config;
 
   return tool<I, O>(
-    { ...toolConfig, metadata: { tool: { restartable: false } } },
+    {
+      ...toolConfig,
+      metadata: {
+        ...(toolConfig.metadata || {}),
+        tool: { ...toolConfig.metadata?.tool, restartable: false },
+      },
+    },
     async (input, { interrupt }) => {
       if (!config.requestMetadata) interrupt();
       else if (typeof config.requestMetadata === 'object')

--- a/js/ai/src/tool.ts
+++ b/js/ai/src/tool.ts
@@ -488,12 +488,15 @@ export function interrupt<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
 ): ToolAction<I, O> {
   const { requestMetadata, ...toolConfig } = config;
 
-  return tool<I, O>(toolConfig, async (input, { interrupt }) => {
-    if (!config.requestMetadata) interrupt();
-    else if (typeof config.requestMetadata === 'object')
-      interrupt(config.requestMetadata);
-    else interrupt(await Promise.resolve(config.requestMetadata(input)));
-  });
+  return tool<I, O>(
+    { ...toolConfig, metadata: { tool: { restartable: false } } },
+    async (input, { interrupt }) => {
+      if (!config.requestMetadata) interrupt();
+      else if (typeof config.requestMetadata === 'object')
+        interrupt(config.requestMetadata);
+      else interrupt(await Promise.resolve(config.requestMetadata(input)));
+    }
+  );
 }
 
 export function defineInterrupt<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
@@ -617,7 +620,7 @@ function multipartTool<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
       metadata: {
         ...(config.metadata || {}),
         type: 'tool.v2',
-        tool: { multipart: true },
+        tool: { ...config.metadata?.tool, multipart: true },
         dynamic: true,
       },
     },

--- a/js/ai/tests/tool_test.ts
+++ b/js/ai/tests/tool_test.ts
@@ -99,18 +99,24 @@ describe('defineInterrupt', () => {
     );
   });
 
-  it('should set restartable to false in metadata for interrupts', () => {
+  it('should set restartable to false in metadata for interrupts and preserve other metadata', () => {
     const registered = defineInterrupt(registry, {
       name: 'registered',
       description: 'registered interrupt',
+      metadata: { custom: 'value', tool: { existing: 'prop' } },
     });
     assert.strictEqual(registered.__action.metadata.tool?.restartable, false);
+    assert.strictEqual(registered.__action.metadata.tool?.existing, 'prop');
+    assert.strictEqual(registered.__action.metadata.custom, 'value');
 
     const dynamic = interrupt({
       name: 'dynamic',
       description: 'dynamic interrupt',
+      metadata: { custom: 'value', tool: { existing: 'prop' } },
     });
     assert.strictEqual(dynamic.__action.metadata.tool?.restartable, false);
+    assert.strictEqual(dynamic.__action.metadata.tool?.existing, 'prop');
+    assert.strictEqual(dynamic.__action.metadata.custom, 'value');
   });
 
   it('should register the reply schema / json schema as the output schema of the tool', () => {

--- a/js/ai/tests/tool_test.ts
+++ b/js/ai/tests/tool_test.ts
@@ -22,6 +22,7 @@ import { afterEach, describe, it } from 'node:test';
 import {
   defineInterrupt,
   defineTool,
+  interrupt,
   isDynamicTool,
   isMultipartTool,
   respondTool,
@@ -96,6 +97,20 @@ describe('defineInterrupt', () => {
       },
       { foo: 'bar' }
     );
+  });
+
+  it('should set restartable to false in metadata for interrupts', () => {
+    const registered = defineInterrupt(registry, {
+      name: 'registered',
+      description: 'registered interrupt',
+    });
+    assert.strictEqual(registered.__action.metadata.tool?.restartable, false);
+
+    const dynamic = interrupt({
+      name: 'dynamic',
+      description: 'dynamic interrupt',
+    });
+    assert.strictEqual(dynamic.__action.metadata.tool?.restartable, false);
   });
 
   it('should register the reply schema / json schema as the output schema of the tool', () => {
@@ -173,6 +188,43 @@ describe('defineInterrupt', () => {
       assert.deepStrictEqual(result, {
         content: [{ text: 'part 1' }],
       });
+    });
+
+    it('should preserve existing metadata.tool properties on multipart tools', () => {
+      // registered multipart with prior tool metadata
+      const registered = defineTool(
+        registry,
+        {
+          name: 'test_preserve',
+          description: 'test',
+          multipart: true,
+          metadata: { tool: { restartable: false } },
+        },
+        async () => ({})
+      );
+      assert.strictEqual(registered.__action.metadata.tool.multipart, true);
+      assert.strictEqual(registered.__action.metadata.tool.restartable, false);
+
+      // registered multipart without prior tool metadata
+      const noMeta = defineTool(
+        registry,
+        { name: 'test_no_meta', description: 'test', multipart: true },
+        async () => ({})
+      );
+      assert.deepStrictEqual(noMeta.__action.metadata.tool, {
+        multipart: true,
+      });
+
+      // dynamic multipart with prior tool metadata
+      const dynamic = tool({
+        name: 'dynamic_preserve',
+        description: 'test',
+        multipart: true,
+        metadata: { tool: { restartable: false, custom: 'value' } },
+      });
+      assert.strictEqual(dynamic.__action.metadata.tool.multipart, true);
+      assert.strictEqual(dynamic.__action.metadata.tool.restartable, false);
+      assert.strictEqual(dynamic.__action.metadata.tool.custom, 'value');
     });
   });
 });
@@ -438,6 +490,29 @@ describe('defineTool', () => {
         }
       );
     });
+  });
+
+  it('should preserve metadata.tool properties on non-multipart tools', () => {
+    const registered = defineTool(
+      registry,
+      {
+        name: 'test_restartable',
+        description: 'test',
+        metadata: { tool: { restartable: false } },
+      },
+      async () => {}
+    );
+    assert.strictEqual(registered.__action.metadata.tool.restartable, false);
+    assert.strictEqual(registered.__action.metadata.type, 'tool');
+
+    const dynamic = tool({
+      name: 'dynamic_restartable',
+      description: 'test',
+      metadata: { tool: { restartable: false, custom: 'val' } },
+    });
+    assert.strictEqual(dynamic.__action.metadata.tool.restartable, false);
+    assert.strictEqual(dynamic.__action.metadata.tool.custom, 'val');
+    assert.strictEqual(dynamic.__action.metadata.type, 'tool');
   });
 
   it('should register a v1 tool as v2 as well', async () => {


### PR DESCRIPTION
- Set `restartable: false` in interrupt tool metadata so consumers can distinguish interrupts from regular tools
- Spread existing `config.metadata.tool` in multipart tools to avoid overwriting prior tool metadata properties (e.g. `restartable`)
- Add tests covering metadata preservation for interrupts, multipart, and non-multipart tools
