### PR TITLE
fix(py): change middleware hook argument signature and pass ctx into next_fn

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -185,13 +185,13 @@ def _prepare_middleware(
     )
 
 
-async def _chain_tool_middleware(
+async def dispatch_tool(
     middleware: list[MiddlewareDef],
     params: ToolHookParams,
     next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
     ctx: GenerateMiddlewareContext,
 ) -> MultipartToolResponse:
-    """Run the tool middleware chain and return the tool response."""
+    """Chain wrap_tool middleware and call next_fn."""
     runner: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]] = next_fn
     for mw in reversed(middleware):
         _mw = mw
@@ -1113,7 +1113,7 @@ async def resolve_tool_requests(
 
         try:
             if mw_list and mw_pipeline is not None:
-                multipart = await _chain_tool_middleware(mw_list, params, base, mw_pipeline.ctx)
+                multipart = await dispatch_tool(mw_list, params, base, mw_pipeline.ctx)
             else:
                 multipart = await base(
                     params, mw_pipeline.ctx if mw_pipeline else GenerateMiddlewareContext(registry=registry)
@@ -1417,7 +1417,7 @@ async def _run_restart_through_middleware(
         )
 
     try:
-        multipart = await _chain_tool_middleware(mw_list, params, next_fn, mw_pipeline.ctx)
+        multipart = await dispatch_tool(mw_list, params, next_fn, mw_pipeline.ctx)
     except Exception as e:
         if _interrupt_from_tool_exc(e) is not None:
             # Re-interrupting during restart is a hard error — same as the legacy

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -188,8 +188,8 @@ def _prepare_middleware(
 async def dispatch_tool(
     middleware: list[MiddlewareDef],
     params: ToolHookParams,
-    next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
     ctx: GenerateMiddlewareContext,
+    next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
 ) -> MultipartToolResponse:
     """Chain wrap_tool middleware and call next_fn."""
     runner: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]] = next_fn
@@ -1113,7 +1113,7 @@ async def resolve_tool_requests(
 
         try:
             if mw_list and mw_pipeline is not None:
-                multipart = await dispatch_tool(mw_list, params, base, mw_pipeline.ctx)
+                multipart = await dispatch_tool(mw_list, params, mw_pipeline.ctx, base)
             else:
                 multipart = await base(
                     params, mw_pipeline.ctx if mw_pipeline else GenerateMiddlewareContext(registry=registry)
@@ -1417,7 +1417,7 @@ async def _run_restart_through_middleware(
         )
 
     try:
-        multipart = await dispatch_tool(mw_list, params, next_fn, mw_pipeline.ctx)
+        multipart = await dispatch_tool(mw_list, params, mw_pipeline.ctx, next_fn)
     except Exception as e:
         if _interrupt_from_tool_exc(e) is not None:
             # Re-interrupting during restart is a hard error — same as the legacy

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -515,7 +515,6 @@ async def _generate_action_turn(
     """Run one model call plus tool resolution, then recurse for the next turn."""
     middleware = mw_pipeline.middleware
     run_ctx = mw_pipeline.ctx
-    on_chunk = run_ctx.on_chunk
 
     model, tools, format_def = await resolve_parameters(registry, raw_request)
 
@@ -1119,7 +1118,9 @@ async def resolve_tool_requests(
             if mw_list and mw_pipeline is not None:
                 multipart = await _chain_tool_middleware(mw_list, params, base, mw_pipeline.ctx)
             else:
-                multipart = await base(params, mw_pipeline.ctx if mw_pipeline else GenerateMiddlewareContext(registry=registry))
+                multipart = await base(
+                    params, mw_pipeline.ctx if mw_pipeline else GenerateMiddlewareContext(registry=registry)
+                )
             return (multipart, None)
         except Exception as e:
             # Interrupts (raised by the tool body or by middleware) become a

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -200,7 +200,6 @@ async def _chain_tool_middleware(
         async def run_next(
             p: ToolHookParams,
             c: GenerateMiddlewareContext,
-            *,
             _m: MiddlewareDef = _mw,
             _i: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]] = _inner,
         ) -> MultipartToolResponse:
@@ -612,7 +611,6 @@ async def _generate_action_turn(
             async def run_next(
                 p: GenerateHookParams,
                 c: GenerateMiddlewareContext,
-                *,
                 _m: MiddlewareDef = _mw,
                 _i: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = _inner,
             ) -> ModelResponse:
@@ -643,7 +641,6 @@ async def _generate_action_turn(
             async def run_next(
                 params: ModelHookParams,
                 c: GenerateMiddlewareContext,
-                *,
                 _mw: MiddlewareDef = _mw,
                 _inner: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = _inner,
             ) -> ModelResponse:

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1108,14 +1108,14 @@ async def resolve_tool_requests(
     ) -> tuple[MultipartToolResponse | None, ToolRequestPart | None]:
         params = ToolHookParams(tool_request_part=trp, tool=tool)
 
-        async def base(p: ToolHookParams, c: GenerateMiddlewareContext) -> MultipartToolResponse:
+        async def next_fn(p: ToolHookParams, c: GenerateMiddlewareContext) -> MultipartToolResponse:
             return await _resolve_tool_request(p.tool, p.tool_request_part)
 
         try:
             if mw_list and mw_pipeline is not None:
-                multipart = await dispatch_tool(mw_list, params, mw_pipeline.ctx, base)
+                multipart = await dispatch_tool(mw_list, params, mw_pipeline.ctx, next_fn)
             else:
-                multipart = await base(
+                multipart = await next_fn(
                     params, mw_pipeline.ctx if mw_pipeline else GenerateMiddlewareContext(registry=registry)
                 )
             return (multipart, None)

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -188,27 +188,26 @@ def _prepare_middleware(
 async def _chain_tool_middleware(
     middleware: list[MiddlewareDef],
     params: ToolHookParams,
-    next_fn: Callable[[ToolHookParams], Awaitable[MultipartToolResponse]],
+    next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
     ctx: GenerateMiddlewareContext,
 ) -> MultipartToolResponse:
     """Run the tool middleware chain and return the tool response."""
-    runner: Callable[[ToolHookParams], Awaitable[MultipartToolResponse]] = next_fn
+    runner: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]] = next_fn
     for mw in reversed(middleware):
         _mw = mw
         _inner = runner
-        _ctx = ctx
 
         async def run_next(
             p: ToolHookParams,
+            c: GenerateMiddlewareContext,
             *,
             _m: MiddlewareDef = _mw,
-            _i: Callable[[ToolHookParams], Awaitable[MultipartToolResponse]] = _inner,
-            _c: GenerateMiddlewareContext = _ctx,
+            _i: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]] = _inner,
         ) -> MultipartToolResponse:
-            return await _m.wrap_tool(p, _i, _c)
+            return await _m.wrap_tool(p, c, _i)
 
         runner = run_next
-    return await runner(params)
+    return await runner(params, ctx)
 
 
 async def expand_wildcard_tools(registry: Registry, tool_names: list[str]) -> list[str]:
@@ -580,14 +579,19 @@ async def _generate_action_turn(
             chunk_parser=chunk_parser if formatter else None,
         )
 
-    def wrap_chunks(role: Role | None = None) -> Callable[[ModelResponseChunk], None]:
+    def wrap_chunks(
+        ctx: GenerateMiddlewareContext,
+        role: Role | None = None,
+    ) -> Callable[[ModelResponseChunk], None]:
         """Return a callback that wraps chunks with the given role for streaming."""
         if role is None:
             role = Role.MODEL
 
+        downstream_on_chunk = ctx.on_chunk
+
         def wrapper(chunk: ModelResponseChunk) -> None:
-            if on_chunk is not None:
-                on_chunk(make_chunk(role, chunk))
+            if downstream_on_chunk is not None:
+                downstream_on_chunk(make_chunk(role, chunk))
 
         return wrapper
 
@@ -597,73 +601,77 @@ async def _generate_action_turn(
 
     async def dispatch_generate(
         params: GenerateHookParams,
-        next_fn: Callable[[GenerateHookParams], Awaitable[ModelResponse]],
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         """Chain wrap_generate middleware and call next_fn."""
-        runner: Callable[[GenerateHookParams], Awaitable[ModelResponse]] = next_fn
+        runner: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = next_fn
         for mw in reversed(middleware):
             _mw = mw
             _inner = runner
-            _ctx = run_ctx
 
             async def run_next(
                 p: GenerateHookParams,
+                c: GenerateMiddlewareContext,
                 *,
                 _m: MiddlewareDef = _mw,
-                _i: Callable[[GenerateHookParams], Awaitable[ModelResponse]] = _inner,
-                _c: GenerateMiddlewareContext = _ctx,
+                _i: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = _inner,
             ) -> ModelResponse:
-                return await _m.wrap_generate(p, _i, _c)
+                return await _m.wrap_generate(p, c, _i)
 
             runner = run_next
-        return await runner(params)
+        return await runner(params, ctx)
 
     async def dispatch_model(
         req: ModelRequest,
         chunk_callback: Callable[[ModelResponseChunk], None] | None,
+        ctx: GenerateMiddlewareContext,
     ) -> ModelResponse:
-        async def run_model(params: ModelHookParams) -> ModelResponse:
+        async def run_model(params: ModelHookParams, c: GenerateMiddlewareContext) -> ModelResponse:
             return (
                 await model.run(
                     input=params.request,
-                    context=run_ctx.custom_context,
-                    on_chunk=run_ctx.on_chunk,
+                    context=c.custom_context,
+                    on_chunk=c.on_chunk,
                 )
             ).response
 
-        runner: Callable[[ModelHookParams], Awaitable[ModelResponse]] = run_model
+        runner: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = run_model
         for mw in reversed(middleware):
             _mw = mw
             _inner = runner
 
             async def run_next(
                 params: ModelHookParams,
+                c: GenerateMiddlewareContext,
                 *,
                 _mw: MiddlewareDef = _mw,
-                _inner: Callable[[ModelHookParams], Awaitable[ModelResponse]] = _inner,
-                _c: GenerateMiddlewareContext = run_ctx,
+                _inner: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = _inner,
             ) -> ModelResponse:
-                return await _mw.wrap_model(params, _inner, _c)
+                return await _mw.wrap_model(params, c, _inner)
 
-            runner = cast(Callable[[ModelHookParams], Awaitable[ModelResponse]], run_next)
+            runner = cast(Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]], run_next)
 
-        previous_on_chunk = run_ctx.replace_on_chunk(chunk_callback) if chunk_callback else None
+        previous_on_chunk = ctx.replace_on_chunk(chunk_callback) if chunk_callback else None
         try:
-            return await runner(ModelHookParams(request=req))
+            return await runner(ModelHookParams(request=req), ctx)
         finally:
             if chunk_callback is not None:
-                run_ctx.replace_on_chunk(previous_on_chunk)
+                ctx.replace_on_chunk(previous_on_chunk)
 
     # if resolving the 'resume' option above generated a tool message, stream it.
-    if resumed_tool_message and on_chunk:
-        wrap_chunks(Role.TOOL)(
+    if resumed_tool_message and run_ctx.on_chunk:
+        wrap_chunks(run_ctx, Role.TOOL)(
             ModelResponseChunk(
                 role=resumed_tool_message.role,
                 content=resumed_tool_message.content,
             )
         )
 
-    async def run_one_iteration(_params: GenerateHookParams) -> ModelResponse:
+    async def run_one_iteration(
+        _params: GenerateHookParams,
+        _ctx: GenerateMiddlewareContext,
+    ) -> ModelResponse:
         """Execute one turn of the generate loop (model call + optional tool resolution)."""
         nonlocal request, message_index, chunk_role
         # Pick up whatever wrap_generate middleware put on params.request — replacement
@@ -672,7 +680,8 @@ async def _generate_action_turn(
 
         model_response = await dispatch_model(
             request,
-            wrap_chunks() if on_chunk else None,
+            wrap_chunks(_ctx) if _ctx.on_chunk else None,
+            _ctx,
         )
 
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
@@ -758,8 +767,8 @@ async def _generate_action_turn(
             return interrupted_resp
 
         # If the loop will continue, stream out the tool response message...
-        if on_chunk and tool_msg:
-            on_chunk(
+        if _ctx.on_chunk and tool_msg:
+            _ctx.on_chunk(
                 make_chunk(
                     Role.TOOL,
                     ModelResponseChunk(
@@ -792,7 +801,7 @@ async def _generate_action_turn(
         iteration=current_turn,
         message_index=message_index,
     )
-    return await dispatch_generate(generate_params, run_one_iteration)
+    return await dispatch_generate(generate_params, run_ctx, run_one_iteration)
 
 
 def apply_format(
@@ -1103,14 +1112,14 @@ async def resolve_tool_requests(
     ) -> tuple[MultipartToolResponse | None, ToolRequestPart | None]:
         params = ToolHookParams(tool_request_part=trp, tool=tool)
 
-        async def base(p: ToolHookParams) -> MultipartToolResponse:
+        async def base(p: ToolHookParams, c: GenerateMiddlewareContext) -> MultipartToolResponse:
             return await _resolve_tool_request(p.tool, p.tool_request_part)
 
         try:
             if mw_list and mw_pipeline is not None:
                 multipart = await _chain_tool_middleware(mw_list, params, base, mw_pipeline.ctx)
             else:
-                multipart = await base(params)
+                multipart = await base(params, mw_pipeline.ctx if mw_pipeline else GenerateMiddlewareContext(registry=registry))
             return (multipart, None)
         except Exception as e:
             # Interrupts (raised by the tool body or by middleware) become a
@@ -1402,7 +1411,7 @@ async def _run_restart_through_middleware(
         tool=tool,
     )
 
-    async def next_fn(p: ToolHookParams) -> MultipartToolResponse:
+    async def next_fn(p: ToolHookParams, c: GenerateMiddlewareContext) -> MultipartToolResponse:
         executed = await run_tool_after_restart(p.tool, restart_trp)
         return MultipartToolResponse(
             output=executed.tool_response.output,

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -620,20 +620,12 @@ async def _generate_action_turn(
         return await runner(params, ctx)
 
     async def dispatch_model(
-        req: ModelRequest,
-        chunk_callback: Callable[[ModelResponseChunk], None] | None,
+        params: ModelHookParams,
         ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        async def run_model(params: ModelHookParams, c: GenerateMiddlewareContext) -> ModelResponse:
-            return (
-                await model.run(
-                    input=params.request,
-                    context=c.custom_context,
-                    on_chunk=c.on_chunk,
-                )
-            ).response
-
-        runner: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = run_model
+        """Chain wrap_model middleware and call next_fn."""
+        runner: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = next_fn
         for mw in reversed(middleware):
             _mw = mw
             _inner = runner
@@ -647,13 +639,7 @@ async def _generate_action_turn(
                 return await _mw.wrap_model(params, c, _inner)
 
             runner = cast(Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]], run_next)
-
-        previous_on_chunk = ctx.replace_on_chunk(chunk_callback) if chunk_callback else None
-        try:
-            return await runner(ModelHookParams(request=req), ctx)
-        finally:
-            if chunk_callback is not None:
-                ctx.replace_on_chunk(previous_on_chunk)
+        return await runner(params, ctx)
 
     # if resolving the 'resume' option above generated a tool message, stream it.
     if resumed_tool_message and run_ctx.on_chunk:
@@ -674,11 +660,26 @@ async def _generate_action_turn(
         # or in-place mutation. Without this re-sync, those changes get silently dropped.
         request = _params.request
 
-        model_response = await dispatch_model(
-            request,
-            wrap_chunks(_ctx) if _ctx.on_chunk else None,
-            _ctx,
-        )
+        async def next_fn(params: ModelHookParams, c: GenerateMiddlewareContext) -> ModelResponse:
+            return (
+                await model.run(
+                    input=params.request,
+                    context=c.custom_context,
+                    on_chunk=c.on_chunk,
+                )
+            ).response
+
+        chunk_callback = wrap_chunks(_ctx) if _ctx.on_chunk else None
+        previous_on_chunk = _ctx.replace_on_chunk(chunk_callback) if chunk_callback else None
+        try:
+            model_response = await dispatch_model(
+                ModelHookParams(request=request),
+                _ctx,
+                next_fn,
+            )
+        finally:
+            if chunk_callback is not None:
+                _ctx.replace_on_chunk(previous_on_chunk)
 
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
             if formatter is None:

--- a/py/packages/genkit/src/genkit/_ai/_testing.py
+++ b/py/packages/genkit/src/genkit/_ai/_testing.py
@@ -17,6 +17,7 @@
 """Internal testing utilities for Genkit AI (mock models, test_models)."""
 
 import json
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Any, TypedDict
 
@@ -46,6 +47,7 @@ class ProgrammableModel:
         self.responses: list[ModelResponse] = []
         self.chunks: list[list[ModelResponseChunk]] | None = None
         self.last_request: ModelRequest | None = None
+        self.response_cb: Callable[[ModelRequest], ModelResponse] | None = None
 
     def reset(self) -> None:
         self._request_idx = 0
@@ -53,6 +55,7 @@ class ProgrammableModel:
         self.responses = []
         self.chunks = None
         self.last_request = None
+        self.response_cb = None
 
     async def model_fn(
         self,
@@ -62,7 +65,10 @@ class ProgrammableModel:
         self.last_request = deepcopy(request)
         self.request_count += 1
 
-        response = self.responses[self._request_idx]
+        if self.response_cb is not None:
+            response = self.response_cb(request)
+        else:
+            response = self.responses[self._request_idx]
         if self.chunks and self._request_idx < len(self.chunks):
             for chunk in self.chunks[self._request_idx]:
                 ctx.send_chunk(chunk)

--- a/py/packages/genkit/src/genkit/_core/_middleware.py
+++ b/py/packages/genkit/src/genkit/_core/_middleware.py
@@ -267,26 +267,26 @@ class BaseMiddleware(Generic[TConfig]):
     async def wrap_generate(
         self,
         params: GenerateHookParams,
-        next_fn: Callable[[GenerateHookParams], Awaitable[ModelResponse]],
         ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         """Wrap each iteration of the tool loop (model call + optional tool resolution)."""
-        return await next_fn(params)
+        return await next_fn(params, ctx)
 
     async def wrap_model(
         self,
         params: ModelHookParams,
-        next_fn: Callable[[ModelHookParams], Awaitable[ModelResponse]],
         ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         """Wrap each model API call."""
-        return await next_fn(params)
+        return await next_fn(params, ctx)
 
     async def wrap_tool(
         self,
         params: ToolHookParams,
-        next_fn: Callable[[ToolHookParams], Awaitable[MultipartToolResponse]],
         ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
     ) -> MultipartToolResponse:
         """Wrap each tool execution.
 
@@ -294,7 +294,7 @@ class BaseMiddleware(Generic[TConfig]):
         tool's result.  Raise `Interrupt(metadata)` to halt this tool call
         and surface an interrupt to the caller.
         """
-        return await next_fn(params)
+        return await next_fn(params, ctx)
 
 
 def _copy_middleware_instance(impl: BaseMiddleware[Any]) -> BaseMiddleware[Any]:
@@ -316,8 +316,8 @@ class MiddlewareDef(Protocol):
     async def wrap_generate(
         self,
         params: GenerateHookParams,
-        next_fn: Callable[[GenerateHookParams], Awaitable[ModelResponse]],
         ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         """Wrap each iteration of the tool loop (model call + optional tool resolution)."""
         ...
@@ -325,8 +325,8 @@ class MiddlewareDef(Protocol):
     async def wrap_model(
         self,
         params: ModelHookParams,
-        next_fn: Callable[[ModelHookParams], Awaitable[ModelResponse]],
         ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         """Wrap each model API call."""
         ...
@@ -334,8 +334,8 @@ class MiddlewareDef(Protocol):
     async def wrap_tool(
         self,
         params: ToolHookParams,
-        next_fn: Callable[[ToolHookParams], Awaitable[MultipartToolResponse]],
         ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
     ) -> MultipartToolResponse:
         """Wrap each tool execution."""
         ...

--- a/py/packages/genkit/tests/genkit/ai/generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_test.py
@@ -8,7 +8,7 @@
 import json
 import pathlib
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import pytest
 import yaml
@@ -331,7 +331,10 @@ define_echo_model(ai)
 @ai.middleware(name='pre_mw')
 class PreMiddleware(BaseMiddleware):
     async def wrap_model(
-        self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+        self,
+        params: ModelHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         txt = ''.join(text_from_message(m) for m in params.request.messages)
         return await next_fn(
@@ -341,16 +344,20 @@ class PreMiddleware(BaseMiddleware):
                         Message(role=Role.USER, content=[Part(TextPart(text=f'PRE {txt}'))]),
                     ],
                 ),
-            )
+            ),
+            ctx,
         )
 
 
 @ai.middleware(name='post_mw')
 class PostMiddleware(BaseMiddleware):
     async def wrap_model(
-        self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+        self,
+        params: ModelHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        resp: ModelResponse = await next_fn(params)
+        resp: ModelResponse = await next_fn(params, ctx)
         assert resp.message is not None
         txt = text_from_message(resp.message)
         return ModelResponse(
@@ -398,7 +405,10 @@ class ConfiguredPrefixMiddleware(BaseMiddleware[_PrefixConfig]):
     """Inline middleware driven purely by a pydantic config field."""
 
     async def wrap_model(
-        self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+        self,
+        params: ModelHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         txt = ''.join(text_from_message(m) for m in params.request.messages)
         return await next_fn(
@@ -408,7 +418,8 @@ class ConfiguredPrefixMiddleware(BaseMiddleware[_PrefixConfig]):
                         Message(role=Role.USER, content=[Part(TextPart(text=f'{self.config.prefix} {txt}'))]),
                     ],
                 ),
-            )
+            ),
+            ctx,
         )
 
 
@@ -466,7 +477,10 @@ async def test_ai_middleware_decorator_registers_on_the_app() -> None:
     @local_ai.middleware(name='live_prefix_mw')
     class LivePrefixMiddleware(BaseMiddleware[_PrefixConfig]):
         async def wrap_model(
-            self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             txt = ''.join(text_from_message(m) for m in params.request.messages)
             return await next_fn(
@@ -476,7 +490,8 @@ async def test_ai_middleware_decorator_registers_on_the_app() -> None:
                             Message(role=Role.USER, content=[Part(TextPart(text=f'{self.config.prefix} {txt}'))]),
                         ],
                     ),
-                )
+                ),
+                ctx,
             )
 
     response = await local_ai.generate(
@@ -713,16 +728,22 @@ async def test_generate_middleware_next_fn_args_optional() -> None:
 @ai.middleware(name='add_ctx')
 class AddContextMiddleware(BaseMiddleware):
     async def wrap_model(
-        self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+        self,
+        params: ModelHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         ctx.custom_context['banana'] = True
-        return await next_fn(params)
+        return await next_fn(params, ctx)
 
 
 @ai.middleware(name='inject_ctx')
 class InjectContextMiddleware(BaseMiddleware):
     async def wrap_model(
-        self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+        self,
+        params: ModelHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         txt = ''.join(text_from_message(m) for m in params.request.messages)
         return await next_fn(
@@ -735,7 +756,8 @@ class InjectContextMiddleware(BaseMiddleware):
                         ),
                     ],
                 ),
-            )
+            ),
+            ctx,
         )
 
 
@@ -778,7 +800,10 @@ async def test_generate_middleware_can_modify_stream() -> None:
     @ai.middleware(name='mod_stream_mw')
     class ModifyStreamMiddleware(BaseMiddleware):
         async def wrap_model(
-            self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             if ctx.on_chunk:
                 ctx.send_chunk(
@@ -800,7 +825,7 @@ async def test_generate_middleware_can_modify_stream() -> None:
                     )
 
             previous = ctx.replace_on_chunk(chunk_handler)
-            resp = await next_fn(params)
+            resp = await next_fn(params, ctx)
             ctx.replace_on_chunk(previous)
             if ctx.on_chunk:
                 ctx.send_chunk(
@@ -858,6 +883,127 @@ async def test_generate_middleware_can_modify_stream() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_interception_chains_across_model_and_generate_hooks() -> None:
+    """wrap_model can intercept streaming; wrap_generate can modify the response.
+
+    Matches JS behaviour ('can intercept and modify the stream from model and
+    generate interceptors'):
+    - wrap_generate installs gen_chunk_handler on ctx.on_chunk
+    - wrap_model installs model_chunk_handler on ctx.on_chunk (wrapping gen_chunk_handler)
+    - wrap_chunks() captures ctx.on_chunk *at call time* so it picks up the full chain
+    - Raw chunks flow: model → wrap_chunks → model_chunk_handler → gen_chunk_handler → caller
+    """
+    ai = Genkit()
+    chunk_intercepts: list[str] = []
+
+    @ai.middleware(name='chain_stream_mw')
+    class ChainStreamMiddleware(BaseMiddleware):
+        async def wrap_model(
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            downstream = ctx.on_chunk
+
+            def model_chunk_handler(chunk: ModelResponseChunk) -> None:
+                text = text_from_content(chunk.content)
+                chunk_intercepts.append(f'model_mw: {text}')
+                if downstream:
+                    downstream(
+                        ModelResponseChunk(
+                            role=Role.MODEL,
+                            content=[Part(TextPart(text=text.upper()))],
+                        )
+                    )
+
+            previous = ctx.replace_on_chunk(model_chunk_handler)
+            resp = await next_fn(params, ctx)
+            ctx.replace_on_chunk(previous)
+            return resp
+
+        async def wrap_generate(
+            self,
+            params: GenerateHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            downstream = ctx.on_chunk
+
+            def gen_chunk_handler(chunk: ModelResponseChunk) -> None:
+                text = text_from_content(chunk.content)
+                chunk_intercepts.append(f'gen_mw: {text}')
+                if downstream:
+                    downstream(
+                        ModelResponseChunk(
+                            role=Role.MODEL,
+                            content=[Part(TextPart(text=f'[{text}]'))],
+                        )
+                    )
+
+            previous = ctx.replace_on_chunk(gen_chunk_handler)
+            resp = await next_fn(params, ctx)
+            ctx.replace_on_chunk(previous)
+
+            # Also modify the final response text.
+            original_text = text_from_message(resp.message)
+            return ModelResponse(
+                finish_reason=resp.finish_reason,
+                message=Message(
+                    role=Role.MODEL,
+                    content=[Part(TextPart(text=f'modified_result: {original_text}'))],
+                ),
+            )
+
+    pm, _ = define_programmable_model(ai)
+
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(TextPart(text='chunk1chunk2'))]),
+        )
+    )
+    pm.chunks = [
+        [
+            ModelResponseChunk(role=Role.MODEL, content=[Part(TextPart(text='chunk1'))]),
+            ModelResponseChunk(role=Role.MODEL, content=[Part(TextPart(text='chunk2'))]),
+        ]
+    ]
+
+    final_chunks: list[str] = []
+
+    def collect(c: ModelResponseChunk) -> None:
+        final_chunks.append(text_from_content(c.content))
+
+    response = await generate_action(
+        ai.registry,
+        GenerateActionOptions(
+            model='programmableModel',
+            messages=[
+                Message(role=Role.USER, content=[Part(TextPart(text='test streaming mw'))]),
+            ],
+            use=[MiddlewareRef(name='chain_stream_mw')],
+        ),
+        on_chunk=collect,
+    )
+
+    # Both wrap_model AND wrap_generate chunk handlers are called in order.
+    assert chunk_intercepts == [
+        'model_mw: chunk1',
+        'gen_mw: CHUNK1',
+        'model_mw: chunk2',
+        'gen_mw: CHUNK2',
+    ]
+
+    # Chunks arrive at the caller with both transformations applied:
+    # wrap_model uppercases, then wrap_generate bracket-wraps.
+    assert final_chunks == ['[CHUNK1]', '[CHUNK2]']
+
+    # wrap_generate CAN still modify the final response — this works.
+    assert response.text == 'modified_result: chunk1chunk2'
+
+
+@pytest.mark.asyncio
 async def test_wrap_generate_called_per_turn() -> None:
     """wrap_generate is invoked for each turn of the generate loop.
 
@@ -874,21 +1020,21 @@ async def test_wrap_generate_called_per_turn() -> None:
         async def wrap_generate(
             self,
             params: GenerateHookParams,
-            next_fn: Callable[[GenerateHookParams], Awaitable[ModelResponse]],
             ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             iters_a.append(params.iteration)
-            return await next_fn(params)
+            return await next_fn(params, ctx)
 
     class TrackerB(BaseMiddleware):
         async def wrap_generate(
             self,
             params: GenerateHookParams,
-            next_fn: Callable[[GenerateHookParams], Awaitable[ModelResponse]],
             ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             iters_b.append(params.iteration)
-            return await next_fn(params)
+            return await next_fn(params, ctx)
 
     ai = Genkit(
         plugins=[
@@ -959,11 +1105,11 @@ async def test_wrap_tool_called_on_tool_execution() -> None:
         async def wrap_tool(
             self,
             params: ToolHookParams,
-            next_fn: Callable[[ToolHookParams], Awaitable[MultipartToolResponse]],
             ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
         ) -> MultipartToolResponse:
             tool_names.append(params.tool_request_part.tool_request.name)
-            return await next_fn(params)
+            return await next_fn(params, ctx)
 
     ai = Genkit(
         plugins=[
@@ -1023,8 +1169,8 @@ async def test_middleware_wrap_tool_interrupt_handled_as_interrupt_not_crash() -
         async def wrap_tool(
             self,
             params: ToolHookParams,
-            next_fn: Callable[[ToolHookParams], Awaitable[MultipartToolResponse]],
             ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
         ) -> MultipartToolResponse:
             raise Interrupt({'blocked': True})
 
@@ -1158,8 +1304,8 @@ async def test_middleware_in_one_call_share_an_isolated_registry() -> None:
         async def wrap_generate(
             self,
             params: GenerateHookParams,
-            next_fn: Callable[[GenerateHookParams], Awaitable[ModelResponse]],
             ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             # Resolve the tool ProviderMW just contributed — only works if
             # both middleware share the same per-call registry scope.
@@ -1176,7 +1322,7 @@ async def test_middleware_in_one_call_share_an_isolated_registry() -> None:
 
             leak = define_tool(scratch, leaky_tool, name='leaky_tool').action()
             ctx.registry.register_action_from_instance(leak)
-            return await next_fn(params)
+            return await next_fn(params, ctx)
 
     pm, _ = define_programmable_model(ai)
     pm.responses.append(
@@ -1228,8 +1374,8 @@ async def test_queue_drain_streams_each_message_at_one_index() -> None:
         async def wrap_generate(
             self,
             params: GenerateHookParams,
-            next_fn: Callable[[GenerateHookParams], Awaitable[ModelResponse]],
             ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             if self._queued:
                 queued = list(self._queued)
@@ -1246,15 +1392,15 @@ async def test_queue_drain_streams_each_message_at_one_index() -> None:
                 request = params.request.model_copy()
                 request.messages = [*request.messages, *queued]
                 params = params.model_copy(update={'request': request})
-            return await next_fn(params)
+            return await next_fn(params, ctx)
 
         async def wrap_tool(
             self,
             params: ToolHookParams,
-            next_fn: Callable[[ToolHookParams], Awaitable[MultipartToolResponse]],
             ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
         ) -> MultipartToolResponse:
-            result = await next_fn(params)
+            result = await next_fn(params, ctx)
             self._queued.append(Message(role=Role.USER, content=[Part(TextPart(text='extra-context'))]))
             return result
 
@@ -1317,11 +1463,11 @@ async def test_restart_path_routes_through_wrap_tool_middleware() -> None:
         async def wrap_tool(
             self,
             params: ToolHookParams,
-            next_fn: Callable[[ToolHookParams], Awaitable[MultipartToolResponse]],
             ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
         ) -> MultipartToolResponse:
             invocations.append(params.tool.name)
-            return await next_fn(params)
+            return await next_fn(params, ctx)
 
     pm, _ = define_programmable_model(ai)
 

--- a/py/packages/genkit/tests/genkit/ai/generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_test.py
@@ -8,7 +8,7 @@
 import json
 import pathlib
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, ClassVar, cast
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -946,6 +946,7 @@ async def test_stream_interception_chains_across_model_and_generate_hooks() -> N
             ctx.replace_on_chunk(previous)
 
             # Also modify the final response text.
+            assert resp.message is not None
             original_text = text_from_message(resp.message)
             return ModelResponse(
                 finish_reason=resp.finish_reason,
@@ -1740,7 +1741,7 @@ async def test_generate_and_model_middleware_execution_order() -> None:
             return resp
 
     # The programmable model appends to execution_order when called.
-    original_run = pm.responses.copy()
+    pm.responses.copy()
     pm.responses.clear()
 
     def model_side_effect(request: ModelRequest) -> ModelResponse:

--- a/py/packages/genkit/tests/genkit/ai/generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_test.py
@@ -1697,6 +1697,246 @@ async def test_parallel_tool_requests_one_interrupt_keeps_pending_output_for_oth
     assert c_root.metadata and c_root.metadata.get('pendingOutput') == 'c_ok'
 
 
+@pytest.mark.asyncio
+async def test_generate_and_model_middleware_execution_order() -> None:
+    """wrap_generate and wrap_model run in the correct nested order.
+
+    Matches JS: 'runs generate and model middleware in the correct order'.
+    Expected: generateBefore → modelBefore → modelExecution → modelAfter → generateAfter
+    """
+    execution_order: list[str] = []
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(TextPart(text='response'))]),
+        )
+    )
+
+    @ai.middleware(name='order_mw')
+    class OrderMiddleware(BaseMiddleware):
+        async def wrap_generate(
+            self,
+            params: GenerateHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            execution_order.append('generateBefore')
+            resp = await next_fn(params, ctx)
+            execution_order.append('generateAfter')
+            return resp
+
+        async def wrap_model(
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            execution_order.append('modelBefore')
+            resp = await next_fn(params, ctx)
+            execution_order.append('modelAfter')
+            return resp
+
+    # The programmable model appends to execution_order when called.
+    original_run = pm.responses.copy()
+    pm.responses.clear()
+
+    def model_side_effect(request: ModelRequest) -> ModelResponse:
+        execution_order.append('modelExecution')
+        return ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(TextPart(text='response'))]),
+        )
+
+    pm.response_cb = model_side_effect
+    response = await generate_action(
+        ai.registry,
+        GenerateActionOptions(
+            model='programmableModel',
+            messages=[Message(role=Role.USER, content=[Part(TextPart(text='hi'))])],
+            use=[MiddlewareRef(name='order_mw')],
+        ),
+    )
+
+    assert response.text == 'response'
+    assert execution_order == [
+        'generateBefore',
+        'modelBefore',
+        'modelExecution',
+        'modelAfter',
+        'generateAfter',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generate_model_tool_middleware_ordering_across_turns() -> None:
+    """All three hooks (generate, model, tool) fire in correct order across a two-turn tool flow.
+
+    Matches JS: 'runs tool middleware correctly'.
+    Turn 1: model returns a tool request → tool executes
+    Turn 2: model returns final text response
+    Expected order mirrors the JS assertion.
+    """
+    execution_order: list[str] = []
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+
+    @ai.tool(name='orderTool')
+    async def order_tool() -> str:
+        execution_order.append('toolExecution')
+        return 'tool result'
+
+    turn = 0
+
+    def model_side_effect(request: ModelRequest) -> ModelResponse:
+        nonlocal turn
+        turn += 1
+        execution_order.append('modelExecution')
+        if turn == 1:
+            return ModelResponse(
+                message=Message(
+                    role=Role.MODEL,
+                    content=[
+                        Part(root=ToolRequestPart(tool_request=ToolRequest(name='orderTool', input={}, ref='r1')))
+                    ],
+                ),
+            )
+        return ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(TextPart(text='final response'))]),
+        )
+
+    pm.response_cb = model_side_effect
+
+    # The middleware tracks a turn counter internally, matching JS's `turnCount`.
+    turn_counter: list[int] = [0]
+
+    @ai.middleware(name='full_order_mw')
+    class FullOrderMiddleware(BaseMiddleware):
+        async def wrap_generate(
+            self,
+            params: GenerateHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[GenerateHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            turn_counter[0] += 1
+            t = turn_counter[0]
+            execution_order.append(f'generateBefore-{t}')
+            resp = await next_fn(params, ctx)
+            execution_order.append(f'generateAfter-{t}')
+            return resp
+
+        async def wrap_model(
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            execution_order.append(f'modelBefore-{turn_counter[0]}')
+            resp = await next_fn(params, ctx)
+            execution_order.append(f'modelAfter-{turn_counter[0]}')
+            return resp
+
+        async def wrap_tool(
+            self,
+            params: ToolHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ToolHookParams, GenerateMiddlewareContext], Awaitable[MultipartToolResponse]],
+        ) -> MultipartToolResponse:
+            execution_order.append(f'toolBefore-{turn_counter[0]}')
+            resp = await next_fn(params, ctx)
+            execution_order.append(f'toolAfter-{turn_counter[0]}')
+            return resp
+
+    response = await generate_action(
+        ai.registry,
+        GenerateActionOptions(
+            model='programmableModel',
+            messages=[Message(role=Role.USER, content=[Part(TextPart(text='hi'))])],
+            tools=['orderTool'],
+            use=[MiddlewareRef(name='full_order_mw')],
+        ),
+    )
+
+    assert response.text == 'final response'
+    assert execution_order == [
+        'generateBefore-1',
+        'modelBefore-1',
+        'modelExecution',
+        'modelAfter-1',
+        'toolBefore-1',
+        'toolExecution',
+        'toolAfter-1',
+        'generateBefore-2',
+        'modelBefore-2',
+        'modelExecution',
+        'modelAfter-2',
+        'generateAfter-2',
+        'generateAfter-1',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_middleware_contributed_tool_resolvable_during_restart() -> None:
+    """Tools injected by middleware.tools() are resolvable during a resume/restart flow.
+
+    Matches JS: 'should resolve tools injected by middleware during restarts'.
+    Scenario: middleware contributes a tool, that tool gets interrupted, then
+    resume.restart can still find and execute it through the middleware pipeline.
+    """
+    ai = Genkit()
+
+    @ai.middleware(name='tool_injector_mw')
+    class ToolInjectorMiddleware(BaseMiddleware):
+        def tools(self, ctx: GenerateMiddlewareContext) -> list:
+            scratch = Registry()
+
+            async def injected_tool() -> str:
+                """A tool contributed by middleware."""
+                return 'injected_success'
+
+            return [define_tool(scratch, injected_tool, name='injectedTool').action()]
+
+    pm, _ = define_programmable_model(ai)
+
+    # The model will be called after restart — return a final response.
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(TextPart(text='done after restart'))]),
+        )
+    )
+
+    # Simulate: model previously called injectedTool, it was interrupted,
+    # now we resume with restart.
+    interrupt_part = ToolRequestPart(
+        tool_request=ToolRequest(name='injectedTool', input={}, ref='r1'),
+        metadata={'interrupt': True},
+    )
+
+    response = await generate_action(
+        ai.registry,
+        GenerateActionOptions(
+            model='programmableModel',
+            messages=[
+                Message(role=Role.USER, content=[Part(TextPart(text='do it'))]),
+                Message(role=Role.MODEL, content=[Part(root=interrupt_part)]),
+            ],
+            use=[MiddlewareRef(name='tool_injector_mw')],
+            resume=Resume(
+                restart=[
+                    ToolRequestPart(
+                        tool_request=ToolRequest(name='injectedTool', input={}, ref='r1'),
+                    )
+                ],
+            ),
+        ),
+    )
+    assert response.text == 'done after restart'
+
+
 ##########################################################################
 # run tests from /tests/specs/generate.yaml
 ##########################################################################

--- a/py/packages/genkit/tests/genkit/ai/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/ai/prompt_test.py
@@ -18,7 +18,7 @@
 """Tests for the action module."""
 
 import tempfile
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
@@ -45,7 +45,10 @@ from genkit.plugin_api import new_middleware
 
 class _PreMiddleware(BaseMiddleware):
     async def wrap_model(
-        self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+        self,
+        params: ModelHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         txt = ''.join(text_from_message(m) for m in params.request.messages)
         return await next_fn(
@@ -53,15 +56,19 @@ class _PreMiddleware(BaseMiddleware):
                 request=ModelRequest(
                     messages=[Message(role=Role.USER, content=[Part(TextPart(text=f'PRE {txt}'))])],
                 ),
-            )
+            ),
+            ctx,
         )
 
 
 class _PostMiddleware(BaseMiddleware):
     async def wrap_model(
-        self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+        self,
+        params: ModelHookParams,
+        ctx: GenerateMiddlewareContext,
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        resp: ModelResponse = await next_fn(params)
+        resp: ModelResponse = await next_fn(params, ctx)
         assert resp.message is not None
         txt = text_from_message(resp.message)
         return ModelResponse(

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -6,7 +6,7 @@
 """Tests for the action module."""
 
 import json
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import pytest
@@ -1012,7 +1012,10 @@ async def test_generate_with_middleware() -> None:
     @ai.middleware(name='pre_mw')
     class PreMiddleware(BaseMiddleware):
         async def wrap_model(
-            self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             txt = ''.join(text_from_message(m) for m in params.request.messages)
             return await next_fn(
@@ -1022,15 +1025,19 @@ async def test_generate_with_middleware() -> None:
                             Message(role=Role.USER, content=[Part(root=TextPart(text=f'PRE {txt}'))]),
                         ],
                     ),
-                )
+                ),
+                ctx,
             )
 
     @ai.middleware(name='post_mw')
     class PostMiddleware(BaseMiddleware):
         async def wrap_model(
-            self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
         ) -> ModelResponse:
-            resp: ModelResponse = await next_fn(params)
+            resp: ModelResponse = await next_fn(params, ctx)
             assert resp.message is not None
             txt = text_from_message(resp.message)
             return ModelResponse(
@@ -1067,7 +1074,10 @@ async def test_generate_passes_through_current_action_context() -> None:
     @ai.middleware(name='inject_ctx')
     class InjectContextMiddleware(BaseMiddleware):
         async def wrap_model(
-            self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             txt = ''.join(text_from_message(m) for m in params.request.messages)
             return await next_fn(
@@ -1080,7 +1090,8 @@ async def test_generate_passes_through_current_action_context() -> None:
                             ),
                         ],
                     ),
-                )
+                ),
+                ctx,
             )
 
     async def action_fn() -> ModelResponse:
@@ -1106,7 +1117,10 @@ async def test_generate_uses_explicitly_passed_in_context() -> None:
     @ai.middleware(name='inject_ctx')
     class InjectContextMiddleware(BaseMiddleware):
         async def wrap_model(
-            self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             txt = ''.join(text_from_message(m) for m in params.request.messages)
             return await next_fn(
@@ -1119,7 +1133,8 @@ async def test_generate_uses_explicitly_passed_in_context() -> None:
                             ),
                         ],
                     ),
-                )
+                ),
+                ctx,
             )
 
     async def action_fn() -> ModelResponse:
@@ -1145,7 +1160,10 @@ async def test_generate_uses_inline_middleware_instance_with_context() -> None:
 
     class InjectContextMiddleware(BaseMiddleware):
         async def wrap_model(
-            self, params: ModelHookParams, next_fn: Callable, ctx: GenerateMiddlewareContext
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             txt = ''.join(text_from_message(m) for m in params.request.messages)
             return await next_fn(
@@ -1158,7 +1176,8 @@ async def test_generate_uses_inline_middleware_instance_with_context() -> None:
                             ),
                         ],
                     ),
-                )
+                ),
+                ctx,
             )
 
     async def action_fn() -> ModelResponse:


### PR DESCRIPTION
Address comments from Pavel's review:

-> 1. Update the hook signatures such that `next_fn` is the last argument: `params, ctx, next_fn`  
-> 2. Update `next_fn` signature to pass in ctx. That enables middleware to mutate or pass in a different ctx.

