### PR TITLE
feat(valkey): add Valkey integration

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/valkey-io/valkey-glide/go/v2 v2.4.0
 	go.opencensus.io v0.24.0 // indirect
 )
 

--- a/go/go.sum
+++ b/go/go.sum
@@ -375,6 +375,8 @@ github.com/uptrace/bun/dialect/pgdialect v1.1.12 h1:m/CM1UfOkoBTglGO5CUTKnIKKOAp
 github.com/uptrace/bun/dialect/pgdialect v1.1.12/go.mod h1:Ij6WIxQILxLlL2frUBxUBOZJtLElD2QQNDcu/PWDHTc=
 github.com/uptrace/bun/driver/pgdriver v1.1.12 h1:3rRWB1GK0psTJrHwxzNfEij2MLibggiLdTqjTtfHc1w=
 github.com/uptrace/bun/driver/pgdriver v1.1.12/go.mod h1:ssYUP+qwSEgeDDS1xm2XBip9el1y9Mi5mTAvLoiADLM=
+github.com/valkey-io/valkey-glide/go/v2 v2.4.0 h1:tgpNMkTnX9AYyLU/4s7lqZ5mil2F4l8MNIh7YBRgnfs=
+github.com/valkey-io/valkey-glide/go/v2 v2.4.0/go.mod h1:LK5zmODJa5xnxZndarh1trntExb3GVGJXz4GwDCagho=
 github.com/vmihailenco/bufpool v0.1.11 h1:gOq2WmBrq0i2yW5QJ16ykccQ4wH9UyEsgLm6czKAd94=
 github.com/vmihailenco/bufpool v0.1.11/go.mod h1:AFf/MOy3l2CFTKbxwt0mp2MwnqjNEs5H/UxrkA5jxTQ=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=

--- a/go/plugins/valkey/valkey.go
+++ b/go/plugins/valkey/valkey.go
@@ -1,0 +1,585 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package valkey provides a Genkit plugin for Valkey vector store using
+// valkey-glide. It supports indexing documents as Hashes with HNSW vector
+// fields and retrieving them via FT.SEARCH KNN queries.
+package valkey
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"strings"
+	"sync"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	glide "github.com/valkey-io/valkey-glide/go/v2"
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+	"github.com/valkey-io/valkey-glide/go/v2/constants"
+	glideopts "github.com/valkey-io/valkey-glide/go/v2/options"
+	"github.com/valkey-io/valkey-glide/go/v2/pipeline"
+	"github.com/valkey-io/valkey-glide/go/v2/servermodules/glideft"
+)
+
+const provider = "valkey"
+
+// MetadataFieldType describes how a metadata field is indexed in the FT schema.
+type MetadataFieldType string
+
+const (
+	// MetadataFieldTypeTag indexes the field as a TAG (exact-match filter).
+	MetadataFieldTypeTag MetadataFieldType = "TAG"
+	// MetadataFieldTypeNumeric indexes the field as a NUMERIC (range filter).
+	MetadataFieldTypeNumeric MetadataFieldType = "NUMERIC"
+)
+
+// MetadataFieldConfig declares a metadata key to be indexed for query-time filtering.
+type MetadataFieldConfig struct {
+	// Name is the metadata key (must match a key in the document's Metadata map).
+	Name string
+	// Type determines whether the field is indexed as TAG or NUMERIC.
+	Type MetadataFieldType
+}
+
+// Valkey implements the Genkit plugin interface for Valkey vector store.
+type Valkey struct {
+	// Addresses is the list of Valkey server addresses.
+	Addresses []config.NodeAddress
+
+	mu      sync.Mutex
+	client  *glide.Client
+	initted bool
+	initErr error
+}
+
+// Close closes the underlying Glide client connection.
+func (v *Valkey) Close() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.client != nil {
+		v.client.Close()
+		v.client = nil
+	}
+}
+
+// Client returns the underlying Glide client. Useful for administrative
+// operations such as dropping indexes in tests.
+func (v *Valkey) Client() *glide.Client {
+	return v.client
+}
+
+// Name returns the plugin name.
+func (v *Valkey) Name() string {
+	return provider
+}
+
+// Init initializes the Valkey plugin by creating a Glide client connection.
+// If initialization fails, the error is stored and surfaced on first use via
+// newDocstore. This avoids panicking on recoverable errors like transient
+// network failures.
+func (v *Valkey) Init(ctx context.Context) []api.Action {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.initted {
+		v.initErr = errors.New("valkey.Init already called")
+		return []api.Action{}
+	}
+
+	clientConfig := config.NewClientConfiguration()
+	for i := range v.Addresses {
+		clientConfig.WithAddress(&v.Addresses[i])
+	}
+	clientConfig.WithClientName("genkit_vector_store_client")
+
+	client, err := glide.NewClient(clientConfig)
+	if err != nil {
+		v.initErr = fmt.Errorf("valkey.Init: failed to create client: %w", err)
+		v.initted = true
+		return []api.Action{}
+	}
+	v.client = client
+	v.initted = true
+	return []api.Action{}
+}
+
+// Config provides configuration options for DefineRetriever.
+type Config struct {
+	// IndexName is the name of the FT index in Valkey.
+	IndexName string
+	// Embedder to use for embedding documents and queries.
+	Embedder ai.Embedder
+	// EmbedderOptions are options passed to the embedder.
+	EmbedderOptions any
+	// Dimension is the vector dimension for the HNSW index.
+	Dimension int
+	// Prefix is the key prefix for stored documents. Defaults to IndexName.
+	Prefix string
+	// DistanceMetric is the distance metric for the HNSW index.
+	// Defaults to constants.DistanceMetricCosine.
+	DistanceMetric constants.DistanceMetric
+	// MetadataFields declares which document metadata keys to index for filtering.
+	MetadataFields []MetadataFieldConfig
+}
+
+// RetrieverOptions may be passed in the Options field of ai.RetrieverRequest.
+type RetrieverOptions struct {
+	K int `json:"k,omitempty"` // Number of results to return; defaults to 10.
+	// Filter is a raw FT.SEARCH pre-filter expression interpolated directly
+	// into the query. Callers must ensure it does not contain untrusted user
+	// input — a malformed value can alter query semantics.
+	Filter string `json:"filter,omitempty"`
+}
+
+// Docstore holds the Valkey client and configuration for indexing and retrieval.
+type Docstore struct {
+	Client          *glide.Client
+	IndexName       string
+	Prefix          string
+	Dimension       int
+	Embedder        ai.Embedder
+	EmbedderOptions any
+	MetadataFields  []MetadataFieldConfig
+}
+
+// IndexerRequest is the input type for the indexer action.
+type IndexerRequest struct {
+	Documents []*ai.Document `json:"documents"`
+}
+
+// IndexerResponse is the output type for the indexer action (empty on success).
+type IndexerResponse struct{}
+
+// DefineRetriever defines a Retriever and Indexer backed by Valkey vector search.
+// It ensures the FT index exists and registers both actions with the Genkit registry.
+func DefineRetriever(ctx context.Context, g *genkit.Genkit, cfg Config, opts *ai.RetrieverOptions) (*Docstore, ai.Retriever, error) {
+	plugin := genkit.LookupPlugin(g, provider)
+	if plugin == nil {
+		return nil, nil, errors.New("valkey plugin not found; did you call genkit.Init with the valkey plugin")
+	}
+	p := plugin.(*Valkey)
+
+	ds, err := p.newDocstore(ctx, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Register the indexer action so it appears in the Genkit Dev UI and can
+	// be invoked via the reflection API, matching JS and Python behaviour.
+	indexerAction := core.NewAction(
+		api.NewName(provider, cfg.IndexName),
+		api.ActionTypeIndexer,
+		map[string]any{
+			"type": api.ActionTypeIndexer,
+			"indexer": map[string]any{
+				"label": fmt.Sprintf("Valkey - %s", cfg.IndexName),
+			},
+		},
+		nil,
+		func(ctx context.Context, req *IndexerRequest) (*IndexerResponse, error) {
+			if err := ds.Index(ctx, req.Documents); err != nil {
+				return nil, err
+			}
+			return &IndexerResponse{}, nil
+		},
+	)
+	genkit.RegisterAction(g, indexerAction)
+
+	return ds, genkit.DefineRetriever(g, api.NewName(provider, cfg.IndexName), opts, ds.Retrieve), nil
+}
+
+// Retriever returns the retriever with the given index name.
+func Retriever(g *genkit.Genkit, name string) ai.Retriever {
+	return genkit.LookupRetriever(g, api.NewName(provider, name))
+}
+
+// IsDefinedRetriever reports whether the named Retriever is defined by this plugin.
+func IsDefinedRetriever(g *genkit.Genkit, name string) bool {
+	return genkit.LookupRetriever(g, api.NewName(provider, name)) != nil
+}
+
+func (v *Valkey) newDocstore(ctx context.Context, cfg Config) (*Docstore, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if !v.initted {
+		return nil, errors.New("valkey.Init not called")
+	}
+	if v.initErr != nil {
+		return nil, v.initErr
+	}
+	if cfg.IndexName == "" {
+		return nil, errors.New("valkey: IndexName required")
+	}
+	if cfg.Embedder == nil {
+		return nil, errors.New("valkey: Embedder required")
+	}
+	if cfg.Dimension <= 0 {
+		return nil, errors.New("valkey: Dimension must be positive")
+	}
+
+	prefix := cfg.Prefix
+	if prefix == "" {
+		prefix = cfg.IndexName
+	}
+
+	metric := cfg.DistanceMetric
+	if metric == "" {
+		metric = constants.DistanceMetricCosine
+	}
+
+	if err := ensureIndex(ctx, v.client, cfg.IndexName, cfg.Dimension, prefix, metric, cfg.MetadataFields); err != nil {
+		return nil, fmt.Errorf("valkey: failed to ensure index: %w", err)
+	}
+
+	return &Docstore{
+		Client:          v.client,
+		IndexName:       cfg.IndexName,
+		Prefix:          prefix,
+		Dimension:       cfg.Dimension,
+		Embedder:        cfg.Embedder,
+		EmbedderOptions: cfg.EmbedderOptions,
+		MetadataFields:  cfg.MetadataFields,
+	}, nil
+}
+
+// ensureIndex creates the FT index if it does not already exist.
+func ensureIndex(
+	ctx context.Context,
+	client *glide.Client,
+	indexName string,
+	dimension int,
+	prefix string,
+	metric constants.DistanceMetric,
+	metadataFields []MetadataFieldConfig,
+) error {
+	schema := []glideopts.Field{
+		glideopts.NewVectorFieldHNSW("embedding", metric, dimension),
+		glideopts.NewTextField("_content"),
+		glideopts.NewTextField("_metadata"),
+		glideopts.NewTextField("_dataType"),
+	}
+
+	for _, mf := range metadataFields {
+		switch mf.Type {
+		case MetadataFieldTypeNumeric:
+			schema = append(schema, glideopts.NewNumericField(mf.Name))
+		default:
+			schema = append(schema, glideopts.NewTagField(mf.Name))
+		}
+	}
+
+	ftOpts := &glideopts.FtCreateOptions{
+		DataType: constants.IndexDataTypeHash,
+		Prefixes: []string{prefix + ":"},
+	}
+
+	_, err := glideft.FtCreate(ctx, client, indexName, schema, ftOpts)
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// Index stores documents in Valkey as Hashes with vector embeddings.
+func (ds *Docstore) Index(ctx context.Context, docs []*ai.Document) error {
+	if len(docs) == 0 {
+		return nil
+	}
+
+	ereq := &ai.EmbedRequest{
+		Input:   docs,
+		Options: ds.EmbedderOptions,
+	}
+	eres, err := ds.Embedder.Embed(ctx, ereq)
+	if err != nil {
+		return fmt.Errorf("valkey index embedding failed: %w", err)
+	}
+
+	if len(eres.Embeddings) != len(docs) {
+		return fmt.Errorf("valkey: embedder returned %d embeddings for %d docs", len(eres.Embeddings), len(docs))
+	}
+
+	// Pre-validate all embeddings before writing anything.
+	for i, de := range eres.Embeddings {
+		if len(de.Embedding) != ds.Dimension {
+			return fmt.Errorf("valkey: embedder returned %d-dim vector for doc %d, expected %d", len(de.Embedding), i, ds.Dimension)
+		}
+	}
+
+	// Build all HSet commands into a non-atomic batch (pipeline) and execute
+	// in a single round-trip.
+	// Note: NewStandaloneBatch works only with glide.Client (standalone mode).
+	// Cluster deployments require GlideClusterClient + pipeline.NewClusterBatch,
+	// which is planned for a future release.
+	//
+	// Large document sets are chunked into batches of indexBatchSize to avoid
+	// unbounded pipeline sizes that could cause OOM or timeouts.
+	const indexBatchSize = 1000
+
+	type docEntry struct {
+		key    string
+		fields map[string]string
+	}
+	entries := make([]docEntry, 0, len(docs))
+
+	for i, de := range eres.Embeddings {
+		doc := docs[i]
+		id, err := docID(doc)
+		if err != nil {
+			return err
+		}
+
+		var sb strings.Builder
+		for _, p := range doc.Content {
+			sb.WriteString(p.Text)
+		}
+
+		metadataJSON, err := json.Marshal(doc.Metadata)
+		if err != nil {
+			return fmt.Errorf("valkey: error marshaling metadata: %w", err)
+		}
+
+		embeddingBytes := float32SliceToBytes(de.Embedding)
+
+		key := fmt.Sprintf("%s:%s", ds.Prefix, id)
+		fields := map[string]string{
+			"embedding": string(embeddingBytes),
+			"_content":  sb.String(),
+			"_metadata": string(metadataJSON),
+			"_dataType": "text", // Go SDK Document lacks DataType field; always "text" for now
+		}
+
+		// Store declared metadata keys as top-level HASH fields for filtering.
+		if doc.Metadata != nil {
+			for _, mf := range ds.MetadataFields {
+				if val, ok := doc.Metadata[mf.Name]; ok {
+					fields[mf.Name] = metadataValueToString(val, mf.Type)
+				}
+			}
+		}
+
+		entries = append(entries, docEntry{key: key, fields: fields})
+	}
+
+	for start := 0; start < len(entries); start += indexBatchSize {
+		end := min(start+indexBatchSize, len(entries))
+		chunk := entries[start:end]
+
+		batch := pipeline.NewStandaloneBatch(false)
+		for _, e := range chunk {
+			batch.HSet(e.key, e.fields)
+		}
+
+		results, err := ds.Client.Exec(ctx, *batch, true)
+		if err != nil {
+			return fmt.Errorf("valkey: batch index failed (%d/%d commands executed, chunk offset %d): %w", len(results), len(chunk), start, err)
+		}
+	}
+
+	return nil
+}
+
+// Retrieve performs a KNN vector search against the Valkey FT index.
+func (ds *Docstore) Retrieve(ctx context.Context, req *ai.RetrieverRequest) (*ai.RetrieverResponse, error) {
+	k := 10
+	var filter string
+	if req.Options != nil {
+		ropt, ok := req.Options.(*RetrieverOptions)
+		if !ok {
+			return nil, fmt.Errorf("valkey.Retrieve options have type %T, want %T", req.Options, &RetrieverOptions{})
+		}
+		if ropt.K > 0 {
+			k = ropt.K
+		}
+		if k > 1000 {
+			return nil, errors.New("valkey: K must not exceed 1000")
+		}
+		filter = ropt.Filter
+	}
+
+	if filter != "" {
+		if err := validateFilter(filter); err != nil {
+			return nil, err
+		}
+	}
+
+	ereq := &ai.EmbedRequest{
+		Input:   []*ai.Document{req.Query},
+		Options: ds.EmbedderOptions,
+	}
+	eres, err := ds.Embedder.Embed(ctx, ereq)
+	if err != nil {
+		return nil, fmt.Errorf("valkey retrieve embedding failed: %w", err)
+	}
+
+	if len(eres.Embeddings) == 0 {
+		return nil, errors.New("valkey: embedder returned no embeddings")
+	}
+	queryVec := float32SliceToBytes(eres.Embeddings[0].Embedding)
+
+	searchOpts := &glideopts.FtSearchOptions{
+		Params: []glideopts.FtSearchParam{
+			{Key: "k", Value: fmt.Sprintf("%d", k)},
+			{Key: "query_vec", Value: string(queryVec)},
+		},
+		ReturnFields: []glideopts.FtSearchReturnField{
+			{FieldIdentifier: "_content"},
+			{FieldIdentifier: "_metadata"},
+			{FieldIdentifier: "_dataType"},
+		},
+	}
+
+	// Build KNN query with optional pre-filter expression.
+	var query string
+	if filter != "" {
+		query = fmt.Sprintf("(%s)=>[KNN $k @embedding $query_vec]", filter)
+	} else {
+		query = "*=>[KNN $k @embedding $query_vec]"
+	}
+
+	result, err := glideft.FtSearch(ctx, ds.Client, ds.IndexName, query, searchOpts)
+	if err != nil {
+		return nil, fmt.Errorf("valkey retrieve search failed: %w", err)
+	}
+
+	docs := make([]*ai.Document, 0, len(result.Documents))
+	for _, doc := range result.Documents {
+		content := fieldToString(doc.Fields["_content"])
+		if content == "" {
+			continue
+		}
+		metadataStr := fieldToString(doc.Fields["_metadata"])
+		// Read _dataType for cross-language consistency. The Go SDK Document
+		// struct does not expose a DataType field, so we cannot reconstruct
+		// non-text documents yet. The value is preserved in storage for
+		// interop with JS/Python retrievers.
+		_ = fieldToString(doc.Fields["_dataType"])
+
+		var meta map[string]any
+		if metadataStr != "" && metadataStr != "{}" {
+			if err := json.Unmarshal([]byte(metadataStr), &meta); err != nil {
+				slog.Warn("valkey: failed to parse document metadata", "key", doc.Key, "error", err)
+				meta = map[string]any{"_metadata_parse_error": true}
+			}
+		}
+
+		d := ai.DocumentFromText(content, meta)
+		docs = append(docs, d)
+	}
+
+	return &ai.RetrieverResponse{
+		Documents: docs,
+	}, nil
+}
+
+// float32SliceToBytes converts a float32 slice to a little-endian byte slice,
+// matching the JS Buffer.from(new Float32Array(...).buffer) encoding.
+func float32SliceToBytes(v []float32) []byte {
+	buf := make([]byte, len(v)*4)
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(f))
+	}
+	return buf
+}
+
+// docID returns the ID to use for a Document.
+// Uses a canonical serialization format (sorted JSON of {content, metadata, dataType})
+// that matches the JS and Python implementations for cross-language interop.
+func docID(doc *ai.Document) (string, error) {
+	var sb strings.Builder
+	for _, p := range doc.Content {
+		sb.WriteString(p.Text)
+	}
+
+	canonical := map[string]any{
+		"data":     sb.String(),
+		"metadata": doc.Metadata,
+		"dataType": "text",
+	}
+	b, err := json.Marshal(canonical)
+	if err != nil {
+		return "", fmt.Errorf("valkey: error marshaling document: %w", err)
+	}
+	return fmt.Sprintf("%02x", md5.Sum(b)), nil
+}
+
+// fieldToString extracts a string from a field value that may be returned as
+// string or []byte depending on the Valkey client version.
+func fieldToString(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case []byte:
+		return string(val)
+	default:
+		return ""
+	}
+}
+
+// filterDisallowedChars contains characters that could alter FT.SEARCH query
+// semantics if injected into a filter expression.
+const filterDisallowedChars = ";|`$\\"
+
+// maxFilterLength is the maximum allowed length for a filter expression to
+// prevent DoS via query amplification.
+const maxFilterLength = 2048
+
+// validateFilter checks that a filter expression does not contain characters
+// or sequences that could break out of the filter context.
+func validateFilter(filter string) error {
+	if len(filter) > maxFilterLength {
+		return errors.New("valkey: filter expression too long")
+	}
+	if strings.ContainsAny(filter, filterDisallowedChars) {
+		return errors.New("valkey: filter expression contains disallowed characters; do not pass untrusted user input as a filter")
+	}
+	if strings.Contains(filter, "=>") {
+		return errors.New("valkey: filter expression contains disallowed sequence '=>'; do not pass untrusted user input as a filter")
+	}
+	return nil
+}
+
+// metadataValueToString converts a metadata value to a string suitable for
+// storage in a Valkey HASH field. Numeric fields are formatted to preserve
+// parseability as 64-bit floats.
+func metadataValueToString(val any, fieldType MetadataFieldType) string {
+	if fieldType == MetadataFieldTypeNumeric {
+		switch v := val.(type) {
+		case float64:
+			return fmt.Sprintf("%g", v)
+		case float32:
+			return fmt.Sprintf("%g", v)
+		case int:
+			return fmt.Sprintf("%d", v)
+		case int64:
+			return fmt.Sprintf("%d", v)
+		case json.Number:
+			return v.String()
+		}
+	}
+	return fmt.Sprintf("%v", val)
+}

--- a/go/plugins/valkey/valkey.go
+++ b/go/plugins/valkey/valkey.go
@@ -221,13 +221,17 @@ func IsDefinedRetriever(g *genkit.Genkit, name string) bool {
 
 func (v *Valkey) newDocstore(ctx context.Context, cfg Config) (*Docstore, error) {
 	v.mu.Lock()
-	defer v.mu.Unlock()
 	if !v.initted {
+		v.mu.Unlock()
 		return nil, errors.New("valkey.Init not called")
 	}
 	if v.initErr != nil {
-		return nil, v.initErr
+		err := v.initErr
+		v.mu.Unlock()
+		return nil, err
 	}
+	client := v.client
+	v.mu.Unlock()
 	if cfg.IndexName == "" {
 		return nil, errors.New("valkey: IndexName required")
 	}
@@ -248,12 +252,12 @@ func (v *Valkey) newDocstore(ctx context.Context, cfg Config) (*Docstore, error)
 		metric = constants.DistanceMetricCosine
 	}
 
-	if err := ensureIndex(ctx, v.client, cfg.IndexName, cfg.Dimension, prefix, metric, cfg.MetadataFields); err != nil {
+	if err := ensureIndex(ctx, client, cfg.IndexName, cfg.Dimension, prefix, metric, cfg.MetadataFields); err != nil {
 		return nil, fmt.Errorf("valkey: failed to ensure index: %w", err)
 	}
 
 	return &Docstore{
-		Client:          v.client,
+		Client:          client,
 		IndexName:       cfg.IndexName,
 		Prefix:          prefix,
 		Dimension:       cfg.Dimension,
@@ -377,7 +381,11 @@ func (ds *Docstore) Index(ctx context.Context, docs []*ai.Document) error {
 		if doc.Metadata != nil {
 			for _, mf := range ds.MetadataFields {
 				if val, ok := doc.Metadata[mf.Name]; ok {
-					fields[mf.Name] = metadataValueToString(val, mf.Type)
+					strVal, err := metadataValueToString(val, mf.Type)
+					if err != nil {
+						return err
+					}
+					fields[mf.Name] = strVal
 				}
 			}
 		}
@@ -566,20 +574,22 @@ func validateFilter(filter string) error {
 // metadataValueToString converts a metadata value to a string suitable for
 // storage in a Valkey HASH field. Numeric fields are formatted to preserve
 // parseability as 64-bit floats.
-func metadataValueToString(val any, fieldType MetadataFieldType) string {
+func metadataValueToString(val any, fieldType MetadataFieldType) (string, error) {
 	if fieldType == MetadataFieldTypeNumeric {
 		switch v := val.(type) {
 		case float64:
-			return fmt.Sprintf("%g", v)
+			return fmt.Sprintf("%g", v), nil
 		case float32:
-			return fmt.Sprintf("%g", v)
+			return fmt.Sprintf("%g", v), nil
 		case int:
-			return fmt.Sprintf("%d", v)
+			return fmt.Sprintf("%d", v), nil
 		case int64:
-			return fmt.Sprintf("%d", v)
+			return fmt.Sprintf("%d", v), nil
 		case json.Number:
-			return v.String()
+			return v.String(), nil
+		default:
+			return "", fmt.Errorf("valkey: NUMERIC field received non-numeric value: %T", val)
 		}
 	}
-	return fmt.Sprintf("%v", val)
+	return fmt.Sprintf("%v", val), nil
 }

--- a/go/plugins/valkey/valkey_test.go
+++ b/go/plugins/valkey/valkey_test.go
@@ -1,0 +1,447 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package valkey
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/internal/fakeembedder"
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+	"github.com/valkey-io/valkey-glide/go/v2/servermodules/glideft"
+)
+
+var testValkeyAddr = flag.String("test-valkey-addr", "", "Valkey address (host:port) to use for integration tests")
+
+func TestPluginName(t *testing.T) {
+	v := &Valkey{}
+	if got := v.Name(); got != "valkey" {
+		t.Errorf("Name() = %q, want %q", got, "valkey")
+	}
+}
+
+func TestDocID(t *testing.T) {
+	d1 := ai.DocumentFromText("hello", nil)
+	d2 := ai.DocumentFromText("hello", nil)
+	d3 := ai.DocumentFromText("world", nil)
+
+	id1, err := docID(d1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, err := docID(d2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id3, err := docID(d3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if id1 != id2 {
+		t.Errorf("same document produced different IDs: %q vs %q", id1, id2)
+	}
+	if id1 == id3 {
+		t.Errorf("different documents produced same ID: %q", id1)
+	}
+	// MD5 hex is 32 characters.
+	if len(id1) != 32 {
+		t.Errorf("docID length = %d, want 32", len(id1))
+	}
+}
+
+func TestDocIDWithMetadata(t *testing.T) {
+	meta := map[string]any{"b": 1, "a": 2, "c": "three"}
+	d1 := ai.DocumentFromText("hello", meta)
+	d2 := ai.DocumentFromText("hello", meta)
+
+	// Verify determinism across multiple calls (Go map iteration is random).
+	for i := 0; i < 10; i++ {
+		id1, err := docID(d1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		id2, err := docID(d2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if id1 != id2 {
+			t.Fatalf("iteration %d: same document with metadata produced different IDs: %q vs %q", i, id1, id2)
+		}
+	}
+}
+
+func TestFloat32SliceToBytes(t *testing.T) {
+	input := []float32{1.0, 2.0, 3.0}
+	result := float32SliceToBytes(input)
+
+	if len(result) != 12 {
+		t.Fatalf("expected 12 bytes, got %d", len(result))
+	}
+
+	// Verify round-trip.
+	for i, expected := range input {
+		bits := binary.LittleEndian.Uint32(result[i*4:])
+		got := math.Float32frombits(bits)
+		if got != expected {
+			t.Errorf("index %d: got %f, want %f", i, got, expected)
+		}
+	}
+}
+
+func TestFloat32SliceToBytesEmpty(t *testing.T) {
+	result := float32SliceToBytes(nil)
+	if len(result) != 0 {
+		t.Errorf("expected empty slice, got %d bytes", len(result))
+	}
+}
+
+func TestValidateFilter(t *testing.T) {
+	for _, tc := range []struct {
+		filter  string
+		wantErr bool
+	}{
+		{"@price:[100 200]", false},
+		{"@tag:{foo}", false},
+		{"*", false},
+		{"", false},
+		{"@field:[0 10];DROP", true},
+		{"@a|@b", true},
+		{"val`cmd", true},
+		{"$var", true},
+		{`back\slash`, true},
+		{"@tag:{x})=>[KNN 99999 @embedding $query_vec]", true},
+		{"foo=>bar", true},
+	} {
+		err := validateFilter(tc.filter)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("validateFilter(%q): got err=%v, wantErr=%v", tc.filter, err, tc.wantErr)
+		}
+	}
+}
+
+func TestFieldToString(t *testing.T) {
+	if got := fieldToString("hello"); got != "hello" {
+		t.Errorf("string: got %q", got)
+	}
+	if got := fieldToString([]byte("world")); got != "world" {
+		t.Errorf("[]byte: got %q", got)
+	}
+	if got := fieldToString(42); got != "" {
+		t.Errorf("unknown type: want empty, got %q", got)
+	}
+}
+
+func TestMetadataValueToString(t *testing.T) {
+	for _, tc := range []struct {
+		val       any
+		fieldType MetadataFieldType
+		want      string
+	}{
+		{float64(3.14), MetadataFieldTypeNumeric, "3.14"},
+		{float32(1.5), MetadataFieldTypeNumeric, "1.5"},
+		{int(42), MetadataFieldTypeNumeric, "42"},
+		{int64(99), MetadataFieldTypeNumeric, "99"},
+		{json.Number("2.718"), MetadataFieldTypeNumeric, "2.718"},
+		{"label", MetadataFieldTypeTag, "label"},
+		{float64(7.0), MetadataFieldTypeTag, "7"},
+	} {
+		got := metadataValueToString(tc.val, tc.fieldType)
+		if got != tc.want {
+			t.Errorf("metadataValueToString(%v, %v): got %q, want %q", tc.val, tc.fieldType, got, tc.want)
+		}
+	}
+}
+
+// errorEmbedder is a mock embedder that always returns an error.
+type errorEmbedder struct {
+	err error
+}
+
+func (e *errorEmbedder) Name() string { return "error/embedder" }
+func (e *errorEmbedder) Embed(_ context.Context, _ *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+	return nil, e.err
+}
+func (e *errorEmbedder) Register(_ api.Registry) {}
+
+// mismatchEmbedder returns a fixed number of embeddings regardless of input count.
+type mismatchEmbedder struct {
+	count int
+	dim   int
+}
+
+func (m *mismatchEmbedder) Name() string { return "mismatch/embedder" }
+func (m *mismatchEmbedder) Embed(_ context.Context, _ *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+	resp := &ai.EmbedResponse{}
+	for i := 0; i < m.count; i++ {
+		resp.Embeddings = append(resp.Embeddings, &ai.Embedding{Embedding: make([]float32, m.dim)})
+	}
+	return resp, nil
+}
+func (m *mismatchEmbedder) Register(_ api.Registry) {}
+
+func TestIndexEmbedderError(t *testing.T) {
+	ds := &Docstore{
+		Embedder:  &errorEmbedder{err: fmt.Errorf("connection timeout")},
+		Prefix:    "test",
+		Dimension: 3,
+	}
+	docs := []*ai.Document{ai.DocumentFromText("hello", nil)}
+	err := ds.Index(context.Background(), docs)
+	if err == nil {
+		t.Fatal("expected error from embedder, got nil")
+	}
+	if !strings.Contains(err.Error(), "connection timeout") {
+		t.Errorf("expected error to contain 'connection timeout', got: %v", err)
+	}
+}
+
+func TestIndexEmbeddingCountMismatch(t *testing.T) {
+	ds := &Docstore{
+		Embedder:  &mismatchEmbedder{count: 1, dim: 3},
+		Prefix:    "test",
+		Dimension: 3,
+	}
+	docs := []*ai.Document{
+		ai.DocumentFromText("doc1", nil),
+		ai.DocumentFromText("doc2", nil),
+	}
+	err := ds.Index(context.Background(), docs)
+	if err == nil {
+		t.Fatal("expected embedding count mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "1 embeddings for 2 docs") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestIndexEmptyDocs(t *testing.T) {
+	ds := &Docstore{
+		Embedder:  &errorEmbedder{err: fmt.Errorf("should not be called")},
+		Prefix:    "test",
+		Dimension: 3,
+	}
+	err := ds.Index(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("expected nil error for empty docs, got: %v", err)
+	}
+}
+
+func TestRetrieveEmbedderError(t *testing.T) {
+	ds := &Docstore{
+		Embedder:  &errorEmbedder{err: fmt.Errorf("rate limited")},
+		IndexName: "test-index",
+		Prefix:    "test",
+		Dimension: 3,
+	}
+	req := &ai.RetrieverRequest{
+		Query: ai.DocumentFromText("query", nil),
+	}
+	_, err := ds.Retrieve(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error from embedder, got nil")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("expected error to contain 'rate limited', got: %v", err)
+	}
+}
+
+func TestRetrieveInvalidOptions(t *testing.T) {
+	ds := &Docstore{
+		Embedder:  &errorEmbedder{err: fmt.Errorf("should not be called")},
+		IndexName: "test-index",
+		Prefix:    "test",
+		Dimension: 3,
+	}
+	req := &ai.RetrieverRequest{
+		Query:   ai.DocumentFromText("query", nil),
+		Options: "invalid-type", // wrong type
+	}
+	_, err := ds.Retrieve(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected type error for invalid options, got nil")
+	}
+	if !strings.Contains(err.Error(), "RetrieverOptions") {
+		t.Errorf("expected error about RetrieverOptions type, got: %v", err)
+	}
+}
+
+func TestRetrieveWithFilter(t *testing.T) {
+	ds := &Docstore{
+		Embedder:  &errorEmbedder{err: fmt.Errorf("should not reach embedder")},
+		IndexName: "test-index",
+		Prefix:    "test",
+		Dimension: 3,
+	}
+
+	for _, tc := range []struct {
+		filter  string
+		wantErr string
+	}{
+		// Valid filter expressions should not fail validation (error comes from embedder).
+		{"@price:[100 200]", "should not reach embedder"},
+		{"@tag:{foo}", "should not reach embedder"},
+		// Injected KNN separator must be rejected before reaching the embedder.
+		{"@tag:{x})=>[KNN 99999 @embedding $query_vec]", "disallowed"},
+		{"@a;@b", "disallowed"},
+	} {
+		req := &ai.RetrieverRequest{
+			Query:   ai.DocumentFromText("query", nil),
+			Options: &RetrieverOptions{Filter: tc.filter},
+		}
+		_, err := ds.Retrieve(context.Background(), req)
+		if err == nil {
+			t.Errorf("filter=%q: expected error, got nil", tc.filter)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.wantErr) {
+			t.Errorf("filter=%q: got %q, want substring %q", tc.filter, err.Error(), tc.wantErr)
+		}
+	}
+}
+
+func TestRetrieveEmptyEmbeddings(t *testing.T) {
+	ds := &Docstore{
+		Embedder:  &mismatchEmbedder{count: 0, dim: 3},
+		IndexName: "test-index",
+		Prefix:    "test",
+		Dimension: 3,
+	}
+	req := &ai.RetrieverRequest{
+		Query: ai.DocumentFromText("query", nil),
+	}
+	_, err := ds.Retrieve(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for empty embeddings, got nil")
+	}
+	if !strings.Contains(err.Error(), "no embeddings") {
+		t.Errorf("expected 'no embeddings' error, got: %v", err)
+	}
+}
+
+func TestIntegration(t *testing.T) {
+	if *testValkeyAddr == "" {
+		t.Skip("skipping integration test: -test-valkey-addr flag not set")
+	}
+
+	parts := strings.SplitN(*testValkeyAddr, ":", 2)
+	host := parts[0]
+	port := 6379
+	if len(parts) == 2 {
+		fmt.Sscanf(parts[1], "%d", &port)
+	}
+
+	ctx := context.Background()
+
+	addresses := []config.NodeAddress{
+		{Host: host, Port: port},
+	}
+
+	g := genkit.Init(ctx, genkit.WithPlugins(&Valkey{Addresses: addresses}))
+
+	const dim = 3
+	indexName := "test-genkit-valkey"
+
+	// Clean up the test index before and after the test.
+	plugin := genkit.LookupPlugin(g, provider).(*Valkey)
+	t.Cleanup(func() {
+		glideft.FtDropIndex(ctx, plugin.Client(), indexName)
+	})
+	// Drop any leftover index from a previous run.
+	glideft.FtDropIndex(ctx, plugin.Client(), indexName)
+
+	// Create fake embedder with known vectors.
+	d1 := ai.DocumentFromText("espresso is strong coffee", nil)
+	d2 := ai.DocumentFromText("latte has steamed milk", nil)
+	d3 := ai.DocumentFromText("croissant is a pastry", nil)
+
+	v1 := []float32{1.0, 0.0, 0.0}
+	v2 := []float32{0.9, 0.1, 0.0}
+	v3 := []float32{0.0, 0.0, 1.0}
+
+	embedder := fakeembedder.New()
+	embedder.Register(d1, v1)
+	embedder.Register(d2, v2)
+	embedder.Register(d3, v3)
+
+	emdOpts := &ai.EmbedderOptions{
+		Dimensions: dim,
+		Label:      "fake-embedder",
+		Supports: &ai.EmbedderSupports{
+			Input: []string{"text"},
+		},
+	}
+
+	cfg := Config{
+		IndexName: indexName,
+		Embedder:  genkit.DefineEmbedder(g, "fake/embedder", emdOpts, embedder.Embed),
+		Dimension: dim,
+	}
+
+	retOpts := &ai.RetrieverOptions{
+		ConfigSchema: core.InferSchemaMap(RetrieverOptions{}),
+		Label:        "valkey-test",
+		Supports: &ai.RetrieverSupports{
+			Media: false,
+		},
+	}
+
+	ds, retriever, err := DefineRetriever(ctx, g, cfg, retOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Index documents.
+	if err := ds.Index(ctx, []*ai.Document{d1, d2, d3}); err != nil {
+		t.Fatalf("Index failed: %v", err)
+	}
+
+	// Retrieve documents similar to d1 (should return d1 and d2).
+	retrieverOptions := &RetrieverOptions{K: 2}
+	resp, err := genkit.Retrieve(ctx, g,
+		ai.WithRetriever(retriever),
+		ai.WithDocs(d1),
+		ai.WithConfig(retrieverOptions))
+	if err != nil {
+		t.Fatalf("Retrieve failed: %v", err)
+	}
+
+	if len(resp.Documents) != 2 {
+		t.Errorf("got %d results, want 2", len(resp.Documents))
+	}
+
+	// Both results should be coffee-related, not the pastry.
+	for _, d := range resp.Documents {
+		text := d.Content[0].Text
+		if strings.Contains(text, "croissant") {
+			t.Errorf("unexpected result: %q (should not contain pastry)", text)
+		}
+		if !strings.Contains(text, "espresso") && !strings.Contains(text, "latte") {
+			t.Errorf("unexpected result: %q (expected espresso or latte)", text)
+		}
+	}
+}

--- a/go/plugins/valkey/valkey_test.go
+++ b/go/plugins/valkey/valkey_test.go
@@ -170,10 +170,20 @@ func TestMetadataValueToString(t *testing.T) {
 		{"label", MetadataFieldTypeTag, "label"},
 		{float64(7.0), MetadataFieldTypeTag, "7"},
 	} {
-		got := metadataValueToString(tc.val, tc.fieldType)
+		got, err := metadataValueToString(tc.val, tc.fieldType)
+		if err != nil {
+			t.Errorf("metadataValueToString(%v, %v): unexpected error: %v", tc.val, tc.fieldType, err)
+			continue
+		}
 		if got != tc.want {
 			t.Errorf("metadataValueToString(%v, %v): got %q, want %q", tc.val, tc.fieldType, got, tc.want)
 		}
+	}
+
+	// Verify that non-numeric types return an error for NUMERIC fields.
+	_, err := metadataValueToString("not-a-number", MetadataFieldTypeNumeric)
+	if err == nil {
+		t.Error("metadataValueToString(string, NUMERIC): expected error, got nil")
 	}
 }
 

--- a/go/samples/valkey/main.go
+++ b/go/samples/valkey/main.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Full RAG demo: Valkey vector search via the Genkit Go plugin.
+// Indexes 4 documents into Valkey, retrieves the top-2 matches for a query,
+// then prints the retrieved documents.
+//
+// Prerequisites:
+//  1. Valkey 8+ with valkey-search module:
+//     docker run -d --name valkey -p 6379:6379 valkey/valkey:8-alpine
+//  2. Ollama running locally with nomic-embed-text pulled:
+//     ollama pull nomic-embed-text
+//  3. From the go/ directory: go mod tidy
+//
+// Run (from go/ directory):
+//
+//	go run ./samples/valkey/main.go -valkey-addr localhost:6379
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/ollama"
+	valkeyplugin "github.com/firebase/genkit/go/plugins/valkey"
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+)
+
+var (
+	valkeyAddr = flag.String("valkey-addr", "localhost:6379", "Valkey address host:port")
+	ollamaAddr = flag.String("ollama-addr", "http://localhost:11434", "Ollama server address")
+)
+
+const (
+	indexName = "coffee-menu-go"
+	dimension = 768 // nomic-embed-text output dimension
+)
+
+func main() {
+	flag.Parse()
+
+	ctx := context.Background()
+
+	// --- Parse Valkey address ---
+	parts := strings.SplitN(*valkeyAddr, ":", 2)
+	host := parts[0]
+	port := 6379
+	if len(parts) == 2 {
+		if _, err := fmt.Sscanf(parts[1], "%d", &port); err != nil {
+			log.Fatalf("invalid port in address %q: %v", *valkeyAddr, err)
+		}
+	}
+
+	// --- Bootstrap: init Genkit with Ollama + Valkey plugins ---
+	ollamaPlugin := &ollama.Ollama{ServerAddress: *ollamaAddr}
+
+	g := genkit.Init(ctx, genkit.WithPlugins(
+		ollamaPlugin,
+		&valkeyplugin.Valkey{
+			Addresses: []config.NodeAddress{{Host: host, Port: port}},
+		},
+	))
+
+	// --- Define embedder using Ollama nomic-embed-text ---
+	embedder := ollamaPlugin.DefineEmbedder(g, *ollamaAddr, "nomic-embed-text", &ai.EmbedderOptions{
+		Dimensions: dimension,
+		Label:      "nomic-embed-text",
+		Supports:   &ai.EmbedderSupports{Input: []string{"text"}},
+	})
+
+	// --- Define retriever (creates FT index if absent) ---
+	cfg := valkeyplugin.Config{
+		IndexName: indexName,
+		Embedder:  embedder,
+		Dimension: dimension,
+	}
+	retOpts := &ai.RetrieverOptions{
+		ConfigSchema: core.InferSchemaMap(valkeyplugin.RetrieverOptions{}),
+		Label:        "valkey-coffee-menu",
+		Supports:     &ai.RetrieverSupports{Media: false},
+	}
+	ds, retriever, err := valkeyplugin.DefineRetriever(ctx, g, cfg, retOpts)
+	if err != nil {
+		log.Fatalf("DefineRetriever: %v", err)
+	}
+
+	// --- Index documents ---
+	docs := []*ai.Document{
+		ai.DocumentFromText("Espresso: a concentrated coffee brewed by forcing hot water through finely-ground beans. $3.50", nil),
+		ai.DocumentFromText("Latte: espresso with steamed milk and a thin layer of foam. $4.75", nil),
+		ai.DocumentFromText("Cold Brew: coffee steeped in cold water for 12-24 hours, served chilled. $4.25", nil),
+		ai.DocumentFromText("Croissant: a buttery, flaky pastry of French origin. $3.00", nil),
+	}
+
+	if err := ds.Index(ctx, docs); err != nil {
+		log.Fatalf("Index: %v", err)
+	}
+	fmt.Printf("Indexed %d documents into %q.\n", len(docs), indexName)
+
+	// --- Retrieve ---
+	query := ai.DocumentFromText("What cold coffee drinks do you have?", nil)
+
+	resp, err := genkit.Retrieve(ctx, g,
+		ai.WithRetriever(retriever),
+		ai.WithDocs(query),
+		ai.WithConfig(&valkeyplugin.RetrieverOptions{K: 2}),
+	)
+	if err != nil {
+		log.Fatalf("Retrieve: %v", err)
+	}
+
+	fmt.Printf("\nRetrieved %d documents for: %q\n", len(resp.Documents), query.Content[0].Text)
+	for i, d := range resp.Documents {
+		fmt.Printf("  [%d] %s\n", i+1, d.Content[0].Text)
+	}
+}

--- a/js/plugins/valkey/.npmignore
+++ b/js/plugins/valkey/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+tsconfig.json
+tsup.config.ts

--- a/js/plugins/valkey/LICENSE
+++ b/js/plugins/valkey/LICENSE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+  Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   

--- a/js/plugins/valkey/README.md
+++ b/js/plugins/valkey/README.md
@@ -1,0 +1,85 @@
+# genkitx-valkey
+
+Genkit AI framework plugin for Valkey vector database.
+
+This plugin provides `Indexer` and `Retriever` implementations backed by
+[Valkey](https://valkey.io/) with the
+[valkey-search](https://github.com/valkey-io/valkey-search) module loaded.
+
+## Prerequisites
+
+Your Valkey instance must have the `valkey-search` module loaded. This enables
+the `FT.CREATE` and `FT.SEARCH` commands used for vector indexing and KNN
+retrieval.
+
+- **Docker**: use `valkey/valkey-bundle` which bundles the module.
+- **ElastiCache**: engine versions that include `valkey-search` work
+  out-of-the-box.
+- **Manual**: pass `--loadmodule /path/to/libsearch.so` at startup.
+
+## Installation
+
+```bash
+pnpm add genkitx-valkey
+```
+
+## Usage
+
+```typescript
+import { genkit } from 'genkit';
+import { valkeyPlugin, valkeyIndexer, valkeyRetriever } from 'genkitx-valkey';
+
+const ai = genkit({
+  plugins: [
+    valkeyPlugin([
+      {
+        indexName: 'docs',
+        embedder: 'googleai/gemini-embedding-001',
+        dimension: 768,
+        clientConfig: {
+          addresses: [{ host: 'localhost', port: 6379 }],
+        },
+      },
+    ]),
+  ],
+});
+
+// Index documents
+await ai.index({
+  indexer: valkeyIndexer({ indexName: 'docs' }),
+  documents: [
+    { content: [{ text: 'Valkey is an open-source key-value store.' }] },
+  ],
+});
+
+// Retrieve documents
+const docs = await ai.retrieve({
+  retriever: valkeyRetriever({ indexName: 'docs' }),
+  query: 'What is Valkey?',
+  options: { k: 3 },
+});
+```
+
+## Configuration
+
+Each entry in the plugin params array accepts:
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `indexName` | `string` | Yes | Name of the FT index in Valkey |
+| `embedder` | `EmbedderArgument` | Yes | Genkit embedder reference |
+| `dimension` | `number` | Yes | Embedding vector dimension |
+| `clientConfig` | `GlideClientConfiguration` | Yes | Connection config for `@valkey/valkey-glide` |
+| `embedderOptions` | `object` | No | Options passed to the embedder |
+| `prefix` | `string` | No | Hash key prefix (defaults to `indexName`) |
+| `distanceMetric` | `'COSINE' \| 'L2' \| 'IP'` | No | HNSW distance metric (defaults to `COSINE`) |
+| `metadataFields` | `ValkeyMetadataField[]` | No | Metadata fields to index for query-time filtering |
+
+## Limitations
+
+- **Standalone mode only**: This plugin uses `GlideClient` (standalone). Cluster
+  deployments (`GlideClusterClient`) are not yet supported.
+
+## License
+
+Apache-2.0

--- a/js/plugins/valkey/jest.config.ts
+++ b/js/plugins/valkey/jest.config.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Config } from 'jest';
+
+const config: Config = {
+  clearMocks: true,
+  preset: 'ts-jest',
+  testMatch: ['**/test/**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  transformIgnorePatterns: ['/node_modules/'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};
+
+export default config;

--- a/js/plugins/valkey/package.json
+++ b/js/plugins/valkey/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "genkitx-valkey",
+  "description": "Genkit AI framework plugin for Valkey vector database.",
+  "keywords": [
+    "genkit",
+    "genkit-retriever",
+    "genkit-plugin",
+    "genkit-indexer",
+    "valkey",
+    "vector",
+    "embedding",
+    "ai",
+    "genai",
+    "generative-ai"
+  ],
+  "version": "1.34.0",
+  "type": "commonjs",
+  "scripts": {
+    "check": "tsc",
+    "compile": "tsup-node",
+    "build:clean": "rimraf ./lib",
+    "build": "npm-run-all build:clean check compile",
+    "build:watch": "tsup-node --watch",
+    "test": "jest --verbose"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/genkit-ai/genkit.git",
+    "directory": "js/plugins/valkey"
+  },
+  "author": "genkit",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@valkey/valkey-glide": "2.4.0"
+  },
+  "peerDependencies": {
+    "genkit": "workspace:^"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.16",
+    "genkitx-ollama": "workspace:*",
+    "jest": "^29.7.0",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "tsup": "^8.3.5",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3"
+  },
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "require": "./lib/index.js",
+      "import": "./lib/index.mjs",
+      "default": "./lib/index.js"
+    }
+  }
+}

--- a/js/plugins/valkey/sample.ts
+++ b/js/plugins/valkey/sample.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * sample.ts — Full RAG demo: Valkey vector search + Ollama generation via Genkit.
+ *
+ * Prerequisites:
+ *   1. Valkey 8+ with valkey-search module:
+ *      docker run -d --name valkey -p 6379:6379 valkey/valkey:8-alpine
+ *   2. Ollama running locally with models pulled:
+ *      ollama pull nomic-embed-text
+ *      ollama pull gemma4:e2b
+ *   3. From this directory: pnpm install
+ *
+ * Run:
+ *   npx tsx sample.ts
+ */
+
+import { Document, genkit } from 'genkit';
+import { ollama } from 'genkitx-ollama';
+import { valkeyIndexerRef, valkeyPlugin, valkeyRetrieverRef } from './src';
+
+const INDEX_NAME = 'coffee-menu';
+const DIMENSION = 768; // nomic-embed-text output dimension
+
+const valkey = valkeyPlugin([
+  {
+    indexName: INDEX_NAME,
+    embedder: ollama.embedder('nomic-embed-text'),
+    dimension: DIMENSION,
+    clientConfig: {
+      addresses: [{ host: process.env.VALKEY_HOST ?? 'localhost', port: 6379 }],
+    },
+  },
+]);
+
+const ai = genkit({
+  plugins: [
+    ollama({
+      serverAddress: process.env.OLLAMA_HOST ?? 'http://localhost:11434',
+      models: [{ name: 'gemma4:e2b' }],
+      embedders: [{ name: 'nomic-embed-text', dimensions: DIMENSION }],
+    }),
+    valkey.plugin,
+  ],
+});
+
+async function main() {
+  // --- Indexing flow ---
+  const indexer = valkeyIndexerRef({ indexName: INDEX_NAME });
+
+  const documents = [
+    Document.fromText(
+      'Espresso: a concentrated coffee brewed by forcing hot water through finely-ground beans. $3.50',
+      { category: 'drinks' }
+    ),
+    Document.fromText(
+      'Latte: espresso with steamed milk and a thin layer of foam. $4.75',
+      { category: 'drinks' }
+    ),
+    Document.fromText(
+      'Cold Brew: coffee steeped in cold water for 12-24 hours, served chilled. $4.25',
+      { category: 'drinks' }
+    ),
+    Document.fromText(
+      'Croissant: a buttery, flaky pastry of French origin. $3.00',
+      { category: 'food' }
+    ),
+  ];
+
+  await ai.index({ indexer, documents });
+  console.log(`Indexed ${documents.length} documents into "${INDEX_NAME}".`);
+
+  // --- Retrieval flow ---
+  const retriever = valkeyRetrieverRef({ indexName: INDEX_NAME });
+  const query = 'What cold coffee drinks do you have?';
+
+  const results = await ai.retrieve({
+    retriever,
+    query,
+    options: { k: 2 },
+  });
+
+  console.log(`\nRetrieved ${results.length} documents for: "${query}"\n`);
+  for (const doc of results) {
+    console.log(`  - ${doc.text}`);
+  }
+
+  // --- RAG generation with gemma4:e2b ---
+  const { text } = await ai.generate({
+    model: ollama.model('gemma4:e2b'),
+    prompt: `Answer the customer's question concisely: ${query}`,
+    docs: results,
+  });
+
+  console.log(`\n--- Generated answer ---\n${text}\n`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => valkey.close());

--- a/js/plugins/valkey/src/index.ts
+++ b/js/plugins/valkey/src/index.ts
@@ -1,0 +1,520 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Batch,
+  GlideClient,
+  GlideFt,
+  type Field,
+  type GlideClientConfiguration,
+  type NumericField,
+  type TagField,
+  type TextField,
+  type VectorField,
+} from '@valkey/valkey-glide';
+import { createHash } from 'crypto';
+import {
+  Document,
+  indexerRef,
+  retrieverRef,
+  z,
+  type EmbedderAction,
+  type EmbedderArgument,
+  type EmbedderReference,
+  type Genkit,
+} from 'genkit';
+import { genkitPlugin, type GenkitPlugin } from 'genkit/plugin';
+import { CommonRetrieverOptionsSchema } from 'genkit/retriever';
+
+/** Distance metric for the HNSW index. */
+export type ValkeyDistanceMetric = 'COSINE' | 'L2' | 'IP';
+
+/** Declares a metadata field to index for query-time filtering. */
+export type ValkeyMetadataField = {
+  name: string;
+  type: 'TAG' | 'NUMERIC';
+};
+
+const ValkeyRetrieverOptionsSchema = CommonRetrieverOptionsSchema.extend({
+  k: z.number().max(1000).default(10),
+  /** Raw FT.SEARCH pre-filter expression. Do not pass untrusted user input. */
+  filter: z.string().optional(),
+});
+
+const ValkeyIndexerOptionsSchema = z.null().optional();
+
+type ValkeyPluginParams<
+  EmbedderCustomOptions extends z.ZodTypeAny = z.ZodTypeAny,
+> = {
+  indexName: string;
+  embedder: EmbedderArgument<EmbedderCustomOptions>;
+  embedderOptions?: z.infer<EmbedderCustomOptions>;
+  clientConfig: GlideClientConfiguration;
+  dimension: number;
+  prefix?: string;
+  distanceMetric?: ValkeyDistanceMetric;
+  metadataFields?: ValkeyMetadataField[];
+}[];
+
+/**
+ * Handle returned by valkeyPlugin for managing plugin lifecycle.
+ * Call close() during application shutdown to release connections.
+ */
+export interface ValkeyPluginHandle {
+  /** Close all GlideClient connections owned by this plugin instance. */
+  close(): Promise<void>;
+  /** The GenkitPlugin to pass to Genkit's plugins array. */
+  plugin: GenkitPlugin;
+}
+
+/**
+ * Valkey plugin that provides a Valkey vector store retriever and indexer.
+ * Requires a Valkey instance with the valkey-search module loaded.
+ *
+ * Returns a handle with a `plugin` property (pass to Genkit) and a `close()`
+ * method for connection cleanup. Each call creates an isolated set of clients
+ * scoped to the returned handle.
+ */
+export function valkeyPlugin<EmbedderCustomOptions extends z.ZodTypeAny>(
+  params: ValkeyPluginParams<EmbedderCustomOptions>
+): ValkeyPluginHandle {
+  const clients: GlideClient[] = [];
+
+  const plugin = genkitPlugin('valkey', async (ai: Genkit) => {
+    for (const config of params) {
+      const clientConfig = { ...config.clientConfig };
+      if (!clientConfig.clientName) {
+        clientConfig.clientName = 'genkit_vector_store_client';
+      }
+      const client = await GlideClient.createClient(clientConfig);
+      clients.push(client);
+      const prefix = config.prefix ?? config.indexName;
+      const distanceMetric = config.distanceMetric ?? 'COSINE';
+      const metadataFields = config.metadataFields ?? [];
+
+      await ensureIndex(
+        client,
+        config.indexName,
+        config.dimension,
+        prefix,
+        distanceMetric,
+        metadataFields
+      );
+
+      configureValkeyIndexer(ai, { ...config, prefix, client, metadataFields });
+      configureValkeyRetriever(ai, { ...config, prefix, client });
+    }
+  });
+
+  return {
+    plugin,
+    async close() {
+      const toClose = clients.splice(0);
+      await Promise.all(toClose.map((c) => c.close()));
+    },
+  };
+}
+
+/**
+ * Creates a reference to a Valkey retriever.
+ */
+export const valkeyRetrieverRef = (params: {
+  indexName: string;
+  displayName?: string;
+}) => {
+  return retrieverRef({
+    name: `valkey/${params.indexName}`,
+    info: {
+      label: params.displayName ?? `Valkey - ${params.indexName}`,
+    },
+    configSchema: ValkeyRetrieverOptionsSchema.optional(),
+  });
+};
+
+/**
+ * Creates a reference to a Valkey indexer.
+ */
+export const valkeyIndexerRef = (params: {
+  indexName: string;
+  displayName?: string;
+}) => {
+  return indexerRef({
+    name: `valkey/${params.indexName}`,
+    info: {
+      label: params.displayName ?? `Valkey - ${params.indexName}`,
+    },
+    configSchema: ValkeyIndexerOptionsSchema,
+  });
+};
+
+export default valkeyPlugin;
+
+/** Alias exports matching the naming convention from the narrative. */
+export const valkeyIndexer = valkeyIndexerRef;
+export const valkeyRetriever = valkeyRetrieverRef;
+
+/**
+ * Ensures the FT index exists. If it already exists, the duplicate error is
+ * swallowed silently.
+ */
+async function ensureIndex(
+  client: GlideClient,
+  indexName: string,
+  dimension: number,
+  prefix: string,
+  distanceMetric: ValkeyDistanceMetric,
+  metadataFields: ValkeyMetadataField[]
+): Promise<void> {
+  const vectorField: VectorField = {
+    type: 'VECTOR',
+    name: 'embedding',
+    attributes: {
+      algorithm: 'HNSW',
+      dimensions: dimension,
+      distanceMetric,
+      type: 'FLOAT32',
+    },
+  };
+  const contentField: TextField = { type: 'TEXT', name: '_content' };
+  const metaField: TextField = { type: 'TEXT', name: '_metadata' };
+  const dataTypeField: TextField = { type: 'TEXT', name: '_dataType' };
+
+  const schema: Field[] = [vectorField, contentField, metaField, dataTypeField];
+
+  for (const mf of metadataFields) {
+    if (mf.type === 'NUMERIC') {
+      const f: NumericField = { type: 'NUMERIC', name: mf.name };
+      schema.push(f);
+    } else {
+      const f: TagField = { type: 'TAG', name: mf.name };
+      schema.push(f);
+    }
+  }
+
+  try {
+    await GlideFt.create(client, indexName, schema, {
+      dataType: 'HASH',
+      prefixes: [`${prefix}:`],
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!message.includes('already exists')) {
+      throw err;
+    }
+  }
+}
+
+/**
+ * Configures a Valkey indexer that embeds documents and stores them as Hashes.
+ */
+function configureValkeyIndexer<EmbedderCustomOptions extends z.ZodTypeAny>(
+  ai: Genkit,
+  params: {
+    indexName: string;
+    embedder: EmbedderArgument<EmbedderCustomOptions>;
+    embedderOptions?: z.infer<EmbedderCustomOptions>;
+    prefix: string;
+    client: GlideClient;
+    metadataFields: ValkeyMetadataField[];
+  }
+) {
+  const {
+    indexName,
+    embedder,
+    embedderOptions,
+    prefix,
+    client,
+    metadataFields,
+  } = params;
+
+  return ai.defineIndexer(
+    {
+      name: `valkey/${indexName}`,
+      configSchema: ValkeyIndexerOptionsSchema,
+    },
+    async (docs) => {
+      // Resolve the embedder action once, then batch all documents in a single
+      // call. This avoids N round-trips to the embedder service.
+      const embedderAction = await resolveEmbedderAction(ai, embedder);
+      const response = await embedderAction({
+        input: docs.map((doc) => doc.toJSON()),
+        options: embedderOptions,
+      });
+      const allEmbeddings = response.embeddings;
+
+      // Collect all hset entries, then chunk into batches of INDEX_BATCH_SIZE
+      // to avoid unbounded pipeline sizes that could cause OOM or timeouts.
+      const INDEX_BATCH_SIZE = 1000;
+
+      type HSetEntry = { key: string; fields: Record<string, string | Buffer> };
+      const entries: HSetEntry[] = [];
+
+      for (let i = 0; i < docs.length; i++) {
+        const doc = docs[i];
+        const docEmbeddings = [allEmbeddings[i]];
+        const embeddingDocs = doc.getEmbeddingDocuments(docEmbeddings);
+
+        for (let j = 0; j < docEmbeddings.length; j++) {
+          const embedding = docEmbeddings[j].embedding;
+          const embeddingDoc = embeddingDocs[j];
+          const id = stableDocId(embeddingDoc);
+          const embeddingBuffer = Buffer.from(
+            new Float32Array(embedding).buffer
+          );
+
+          const fields: Record<string, string | Buffer> = {
+            embedding: embeddingBuffer,
+            _content: embeddingDoc.data,
+            _metadata: JSON.stringify(embeddingDoc.metadata ?? {}),
+            _dataType: embeddingDoc.dataType ?? '',
+          };
+
+          // Store declared metadata keys as top-level HASH fields for filtering.
+          // Numeric fields are stored as-is to preserve Valkey numeric indexing;
+          // TAG fields are converted to strings.
+          if (embeddingDoc.metadata) {
+            for (const mf of metadataFields) {
+              const val = (embeddingDoc.metadata as Record<string, unknown>)[
+                mf.name
+              ];
+              if (val !== undefined && val !== null) {
+                if (mf.type === 'NUMERIC') {
+                  if (typeof val !== 'number') {
+                    throw new Error(
+                      `valkey: NUMERIC metadata field '${mf.name}' received non-number value: ${typeof val}`
+                    );
+                  }
+                  fields[mf.name] = val.toString();
+                } else {
+                  fields[mf.name] = String(val);
+                }
+              }
+            }
+          }
+
+          entries.push({ key: `${prefix}:${id}`, fields });
+        }
+      }
+
+      for (let start = 0; start < entries.length; start += INDEX_BATCH_SIZE) {
+        const chunk = entries.slice(start, start + INDEX_BATCH_SIZE);
+        const batch = new Batch(false);
+        for (const entry of chunk) {
+          batch.hset(entry.key, entry.fields);
+        }
+        await client.exec(batch, true);
+      }
+    }
+  );
+}
+
+/**
+ * Configures a Valkey retriever that performs KNN vector search.
+ */
+function configureValkeyRetriever<EmbedderCustomOptions extends z.ZodTypeAny>(
+  ai: Genkit,
+  params: {
+    indexName: string;
+    embedder: EmbedderArgument<EmbedderCustomOptions>;
+    embedderOptions?: z.infer<EmbedderCustomOptions>;
+    prefix: string;
+    client: GlideClient;
+  }
+) {
+  const { indexName, embedder, embedderOptions, client } = params;
+
+  return ai.defineRetriever(
+    {
+      name: `valkey/${indexName}`,
+      configSchema: ValkeyRetrieverOptionsSchema.optional(),
+    },
+    async (content, options) => {
+      const queryEmbeddings = await ai.embed({
+        embedder,
+        content,
+        options: embedderOptions,
+      });
+
+      if (!queryEmbeddings.length) {
+        throw new Error('valkey: embedder returned no embeddings for query');
+      }
+      const queryVector = queryEmbeddings[0].embedding;
+      const queryBuffer = Buffer.from(new Float32Array(queryVector).buffer);
+      const k = options?.k ?? 10;
+      const filter = options?.filter;
+
+      if (filter !== undefined) {
+        validateFilterExpression(filter);
+      }
+
+      // Build KNN query with optional pre-filter expression.
+      const knnQuery = filter
+        ? `(${filter})=>[KNN $k @embedding $query_vec]`
+        : '*=>[KNN $k @embedding $query_vec]';
+
+      const result = await GlideFt.search(client, indexName, knnQuery, {
+        params: [
+          { key: 'k', value: k.toString() },
+          { key: 'query_vec', value: queryBuffer },
+        ],
+        returnFields: [
+          { fieldIdentifier: '_content' },
+          { fieldIdentifier: '_metadata' },
+          { fieldIdentifier: '_dataType' },
+          { fieldIdentifier: '__embedding_score' },
+        ],
+      });
+
+      const [, records] = result;
+
+      const documents = records.map((record) => {
+        const fields = record.value;
+        let contentValue = '';
+        let metadataValue = '{}';
+        let dataTypeValue = '';
+
+        for (const field of fields) {
+          const fieldKey =
+            field.key instanceof Buffer
+              ? field.key.toString()
+              : String(field.key);
+          const fieldVal =
+            field.value instanceof Buffer
+              ? field.value.toString()
+              : String(field.value);
+
+          switch (fieldKey) {
+            case '_content':
+              contentValue = fieldVal;
+              break;
+            case '_metadata':
+              metadataValue = fieldVal;
+              break;
+            case '_dataType':
+              dataTypeValue = fieldVal;
+              break;
+          }
+        }
+
+        const metadata = safeJsonParse(metadataValue);
+        const effectiveDataType = dataTypeValue || 'text';
+        return Document.fromData(contentValue, effectiveDataType, metadata);
+      });
+
+      return { documents };
+    }
+  );
+}
+
+function safeJsonParse(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, unknown>;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Produces a deterministic document ID using a canonical serialization format
+ * ({data, dataType, metadata} with sorted keys) that matches the Go and Python
+ * implementations for cross-language interop.
+ */
+/** @internal */
+export function stableDocId(doc: {
+  data: string;
+  metadata?: unknown;
+  dataType?: string;
+}): string {
+  const canonical = {
+    data: doc.data,
+    dataType: doc.dataType ?? 'text',
+    metadata: doc.metadata ?? null,
+  };
+  const sortedStringify = (v: unknown): string => {
+    if (typeof v !== 'object' || v === null) return JSON.stringify(v);
+    if (Array.isArray(v)) return '[' + v.map(sortedStringify).join(',') + ']';
+    return (
+      '{' +
+      Object.keys(v as object)
+        .sort()
+        .map(
+          (k) =>
+            JSON.stringify(k) +
+            ':' +
+            sortedStringify((v as Record<string, unknown>)[k])
+        )
+        .join(',') +
+      '}'
+    );
+  };
+  return createHash('md5').update(sortedStringify(canonical)).digest('hex');
+}
+
+/**
+ * Characters or sequences that could alter FT.SEARCH query semantics if injected.
+ * This is a conservative allowlist approach: reject expressions containing
+ * unbalanced brackets, pipes, semicolons, or the KNN separator '=>' that could
+ * break out of the filter context.
+ */
+const FILTER_DISALLOWED_PATTERN = /[;|`$\\]|=>/;
+
+/** Maximum allowed filter expression length to prevent DoS via query amplification. */
+const MAX_FILTER_LENGTH = 2048;
+
+/**
+ * Validates a filter expression to prevent query injection.
+ * Throws if the expression contains characters that could alter query semantics.
+ */
+/** @internal */
+export function validateFilterExpression(filter: string): void {
+  if (filter.length > MAX_FILTER_LENGTH) {
+    throw new Error('valkey: filter expression too long');
+  }
+  if (FILTER_DISALLOWED_PATTERN.test(filter)) {
+    throw new Error(
+      'valkey: filter expression contains disallowed characters. ' +
+        'Do not pass untrusted user input as a filter.'
+    );
+  }
+}
+
+/**
+ * Resolves an EmbedderArgument to an EmbedderAction. Handles all reference
+ * variants: string name, EmbedderAction (has __action), and EmbedderReference
+ * (has name but may lack info).
+ */
+async function resolveEmbedderAction<CustomOptions extends z.ZodTypeAny>(
+  ai: Genkit,
+  embedder: EmbedderArgument<CustomOptions>
+): Promise<EmbedderAction<CustomOptions>> {
+  if (typeof embedder === 'string') {
+    return (await ai.registry.lookupAction(
+      `/embedder/${embedder}`
+    )) as EmbedderAction<CustomOptions>;
+  } else if (Object.hasOwnProperty.call(embedder, '__action')) {
+    return embedder as EmbedderAction<CustomOptions>;
+  } else if (Object.hasOwnProperty.call(embedder, 'name')) {
+    const ref = embedder as EmbedderReference<CustomOptions>;
+    return (await ai.registry.lookupAction(
+      `/embedder/${ref.name}`
+    )) as EmbedderAction<CustomOptions>;
+  }
+  throw new Error(`valkey: failed to resolve embedder`);
+}

--- a/js/plugins/valkey/src/index.ts
+++ b/js/plugins/valkey/src/index.ts
@@ -228,6 +228,7 @@ function configureValkeyIndexer<EmbedderCustomOptions extends z.ZodTypeAny>(
     embedderOptions?: z.infer<EmbedderCustomOptions>;
     prefix: string;
     client: GlideClient;
+    dimension: number;
     metadataFields: ValkeyMetadataField[];
   }
 ) {
@@ -237,6 +238,7 @@ function configureValkeyIndexer<EmbedderCustomOptions extends z.ZodTypeAny>(
     embedderOptions,
     prefix,
     client,
+    dimension,
     metadataFields,
   } = params;
 
@@ -246,6 +248,9 @@ function configureValkeyIndexer<EmbedderCustomOptions extends z.ZodTypeAny>(
       configSchema: ValkeyIndexerOptionsSchema,
     },
     async (docs) => {
+      if (docs.length === 0) {
+        return;
+      }
       // Resolve the embedder action once, then batch all documents in a single
       // call. This avoids N round-trips to the embedder service.
       const embedderAction = await resolveEmbedderAction(ai, embedder);
@@ -254,6 +259,19 @@ function configureValkeyIndexer<EmbedderCustomOptions extends z.ZodTypeAny>(
         options: embedderOptions,
       });
       const allEmbeddings = response.embeddings;
+      if (allEmbeddings.length !== docs.length) {
+        throw new Error(
+          `valkey: embedder returned ${allEmbeddings.length} embeddings for ${docs.length} docs`
+        );
+      }
+
+      for (let i = 0; i < allEmbeddings.length; i++) {
+        if (allEmbeddings[i].embedding.length !== dimension) {
+          throw new Error(
+            `valkey: embedder returned ${allEmbeddings[i].embedding.length}-dim vector, expected ${dimension}`
+          );
+        }
+      }
 
       // Collect all hset entries, then chunk into batches of INDEX_BATCH_SIZE
       // to avoid unbounded pipeline sizes that could cause OOM or timeouts.

--- a/js/plugins/valkey/test/index.test.ts
+++ b/js/plugins/valkey/test/index.test.ts
@@ -1,0 +1,596 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import type { EmbedderArgument, Genkit } from 'genkit';
+import { z } from 'genkit';
+import { Document } from 'genkit/retriever';
+
+// Mock @valkey/valkey-glide
+const mockHset = jest.fn<any>().mockResolvedValue(1);
+const mockBatchHset = jest.fn<any>().mockReturnValue(undefined);
+const mockExec = jest.fn<any>().mockResolvedValue([]);
+const mockClient = { hset: mockHset, exec: mockExec };
+
+const mockGlideFtCreate = jest.fn<any>().mockResolvedValue('OK');
+const mockGlideFtSearch = jest.fn<any>();
+
+jest.mock('@valkey/valkey-glide', () => ({
+  GlideClient: {
+    createClient: jest.fn<any>().mockResolvedValue(mockClient),
+  },
+  GlideFt: {
+    create: (...args: unknown[]) => mockGlideFtCreate(...args),
+    search: (...args: unknown[]) => mockGlideFtSearch(...args),
+  },
+  Batch: jest.fn<any>().mockImplementation(() => {
+    const instance = {
+      hset: (...args: unknown[]) => {
+        mockBatchHset(...args);
+        return instance;
+      },
+    };
+    return instance;
+  }),
+}));
+
+// Import after mocks are set up
+import {
+  stableDocId,
+  validateFilterExpression,
+  valkeyIndexerRef,
+  valkeyPlugin,
+  valkeyRetrieverRef,
+} from '../src';
+
+// Mock Genkit instance
+const mockEmbed = jest.fn<any>();
+const mockEmbedderAction = jest.fn<any>();
+const mockLookupAction = jest.fn<any>().mockResolvedValue(mockEmbedderAction);
+const mockDefineRetriever = jest.fn<any>((config: any, handler: any) => ({
+  config,
+  retrieve: handler,
+}));
+const mockDefineIndexer = jest.fn<any>((config: any, handler: any) => ({
+  config,
+  index: handler,
+}));
+
+const mockGenkit: Genkit = {
+  embed: mockEmbed,
+  defineRetriever: mockDefineRetriever,
+  defineIndexer: mockDefineIndexer,
+  registry: {
+    lookupAction: mockLookupAction,
+  },
+} as unknown as Genkit;
+
+const mockEmbedder: EmbedderArgument<z.ZodTypeAny> = {
+  name: 'mock-embedder',
+  type: 'embedder',
+  configSchema: z.object({}),
+} as any;
+
+describe('valkeyPlugin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGlideFtCreate.mockResolvedValue('OK');
+  });
+
+  test('should create index on initialization', async () => {
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'test-index',
+        embedder: mockEmbedder,
+        dimension: 768,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    // genkitPlugin returns a function that takes Genkit and returns {initializer}
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await pluginInstance.initializer();
+
+    expect(mockGlideFtCreate).toHaveBeenCalledWith(
+      mockClient,
+      'test-index',
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'VECTOR',
+          name: 'embedding',
+          attributes: expect.objectContaining({
+            algorithm: 'HNSW',
+            dimensions: 768,
+            distanceMetric: 'COSINE',
+            type: 'FLOAT32',
+          }),
+        }),
+        expect.objectContaining({ type: 'TEXT', name: '_content' }),
+        expect.objectContaining({ type: 'TEXT', name: '_metadata' }),
+        expect.objectContaining({ type: 'TEXT', name: '_dataType' }),
+      ]),
+      expect.objectContaining({
+        dataType: 'HASH',
+        prefixes: ['test-index:'],
+      })
+    );
+  });
+
+  test('should handle duplicate index error gracefully', async () => {
+    mockGlideFtCreate.mockRejectedValue(new Error('Index already exists'));
+
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'existing-index',
+        embedder: mockEmbedder,
+        dimension: 768,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await expect(pluginInstance.initializer()).resolves.not.toThrow();
+  });
+
+  test('should propagate non-duplicate-index errors', async () => {
+    mockGlideFtCreate.mockRejectedValue(new Error('Connection refused'));
+
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'fail-index',
+        embedder: mockEmbedder,
+        dimension: 768,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await expect(pluginInstance.initializer()).rejects.toThrow(
+      'Connection refused'
+    );
+  });
+
+  test('should register both indexer and retriever', async () => {
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'test-index',
+        embedder: mockEmbedder,
+        dimension: 768,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await pluginInstance.initializer();
+
+    expect(mockDefineIndexer).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'valkey/test-index' }),
+      expect.any(Function)
+    );
+    expect(mockDefineRetriever).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'valkey/test-index' }),
+      expect.any(Function)
+    );
+  });
+
+  test('should use custom prefix when provided', async () => {
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'test-index',
+        embedder: mockEmbedder,
+        dimension: 768,
+        prefix: 'custom',
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await pluginInstance.initializer();
+
+    expect(mockGlideFtCreate).toHaveBeenCalledWith(
+      mockClient,
+      'test-index',
+      expect.any(Array),
+      expect.objectContaining({
+        prefixes: ['custom:'],
+      })
+    );
+  });
+});
+
+describe('valkeyIndexer', () => {
+  let indexerHandler: (docs: Document[]) => Promise<void>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockGlideFtCreate.mockResolvedValue('OK');
+
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'test-index',
+        embedder: mockEmbedder,
+        dimension: 3,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await pluginInstance.initializer();
+
+    indexerHandler = mockDefineIndexer.mock.calls[0][1] as any;
+  });
+
+  test('should embed documents and store as hashes', async () => {
+    mockEmbedderAction.mockResolvedValue({
+      embeddings: [{ embedding: [0.1, 0.2, 0.3] }],
+    });
+
+    const doc = new Document({
+      content: [{ text: 'Hello world' }],
+      metadata: { source: 'test' },
+    });
+
+    await indexerHandler([doc]);
+
+    expect(mockEmbedderAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.any(Array),
+      })
+    );
+    expect(mockBatchHset).toHaveBeenCalledWith(
+      expect.stringMatching(/^test-index:/),
+      expect.objectContaining({
+        embedding: expect.anything(),
+        _content: expect.any(String),
+        _metadata: expect.any(String),
+        _dataType: expect.any(String),
+      })
+    );
+    expect(mockExec).toHaveBeenCalledTimes(1);
+  });
+
+  test('should convert embedding to Float32 buffer', async () => {
+    const embedding = [1.0, 2.0, 3.0];
+    mockEmbedderAction.mockResolvedValue({
+      embeddings: [{ embedding }],
+    });
+
+    const doc = new Document({ content: [{ text: 'test' }] });
+    await indexerHandler([doc]);
+
+    const hsetCall = mockBatchHset.mock.calls[0] as unknown[];
+    const fields = hsetCall[1] as Record<string, any>;
+    const embeddingValue = fields['embedding'];
+
+    expect(embeddingValue).toBeDefined();
+    expect(embeddingValue).toBeInstanceOf(Buffer);
+
+    const expected = Buffer.from(new Float32Array(embedding).buffer);
+    expect(embeddingValue).toEqual(expected);
+  });
+
+  test('should serialize metadata as JSON', async () => {
+    mockEmbedderAction.mockResolvedValue({
+      embeddings: [{ embedding: [0.1, 0.2, 0.3] }],
+    });
+
+    const metadata = { page: 1, source: 'docs', nested: { key: 'value' } };
+    const doc = new Document({
+      content: [{ text: 'test' }],
+      metadata,
+    });
+
+    await indexerHandler([doc]);
+
+    const hsetCall = mockBatchHset.mock.calls[0] as unknown[];
+    const fields = hsetCall[1] as Record<string, any>;
+    const metadataValue = fields['_metadata'];
+
+    expect(metadataValue).toBeDefined();
+    expect(JSON.parse(metadataValue)).toEqual(metadata);
+  });
+
+  test('should handle multiple documents', async () => {
+    mockEmbedderAction.mockResolvedValue({
+      embeddings: [
+        { embedding: [0.1, 0.2, 0.3] },
+        { embedding: [0.4, 0.5, 0.6] },
+        { embedding: [0.7, 0.8, 0.9] },
+      ],
+    });
+
+    const docs = [
+      new Document({ content: [{ text: 'doc1' }] }),
+      new Document({ content: [{ text: 'doc2' }] }),
+      new Document({ content: [{ text: 'doc3' }] }),
+    ];
+
+    await indexerHandler(docs);
+
+    // Batched: single call to embedder with all docs
+    expect(mockEmbedderAction).toHaveBeenCalledTimes(1);
+    expect(mockBatchHset).toHaveBeenCalledTimes(3);
+    expect(mockExec).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('valkeyRetriever', () => {
+  let retrieverHandler: (content: any, options: any) => Promise<any>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockGlideFtCreate.mockResolvedValue('OK');
+
+    const plugin = valkeyPlugin([
+      {
+        indexName: 'test-index',
+        embedder: mockEmbedder,
+        dimension: 3,
+        clientConfig: { addresses: [{ host: 'localhost', port: 6379 }] },
+      },
+    ]);
+
+    const pluginInstance = (plugin.plugin as any)(mockGenkit);
+    await pluginInstance.initializer();
+
+    retrieverHandler = mockDefineRetriever.mock.calls[0][1] as any;
+  });
+
+  test('should embed query and call GlideFt.search with KNN', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([0, []]);
+
+    await retrieverHandler('What is Valkey?', { k: 5 });
+
+    expect(mockEmbed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embedder: mockEmbedder,
+        content: 'What is Valkey?',
+      })
+    );
+    expect(mockGlideFtSearch).toHaveBeenCalledWith(
+      mockClient,
+      'test-index',
+      '*=>[KNN $k @embedding $query_vec]',
+      expect.objectContaining({
+        params: expect.arrayContaining([
+          expect.objectContaining({ key: 'k', value: '5' }),
+          expect.objectContaining({ key: 'query_vec' }),
+        ]),
+        returnFields: expect.arrayContaining([
+          expect.objectContaining({ fieldIdentifier: '_content' }),
+          expect.objectContaining({ fieldIdentifier: '_metadata' }),
+          expect.objectContaining({ fieldIdentifier: '_dataType' }),
+        ]),
+      })
+    );
+  });
+
+  test('should parse search results into Document objects', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([
+      2,
+      [
+        {
+          key: 'test-index:abc123',
+          value: [
+            { key: '_content', value: 'Valkey is a key-value store.' },
+            { key: '_metadata', value: '{"source":"docs"}' },
+            { key: '_dataType', value: 'text' },
+            { key: '__embedding_score', value: '0.95' },
+          ],
+        },
+        {
+          key: 'test-index:def456',
+          value: [
+            { key: '_content', value: 'ElastiCache supports Valkey.' },
+            { key: '_metadata', value: '{}' },
+            { key: '_dataType', value: '' },
+            { key: '__embedding_score', value: '0.85' },
+          ],
+        },
+      ],
+    ]);
+
+    const result = await retrieverHandler('What is Valkey?', { k: 2 });
+
+    expect(result.documents).toHaveLength(2);
+    expect(result.documents[0]).toBeInstanceOf(Document);
+    expect(result.documents[1]).toBeInstanceOf(Document);
+  });
+
+  test('should handle Buffer values in search results', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([
+      1,
+      [
+        {
+          key: Buffer.from('test-index:abc123'),
+          value: [
+            { key: Buffer.from('_content'), value: Buffer.from('Hello') },
+            { key: Buffer.from('_metadata'), value: Buffer.from('{}') },
+            { key: Buffer.from('_dataType'), value: Buffer.from('text') },
+          ],
+        },
+      ],
+    ]);
+
+    const result = await retrieverHandler('query', { k: 1 });
+
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0]).toBeInstanceOf(Document);
+  });
+
+  test('should default k to 10 when not specified', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([0, []]);
+
+    await retrieverHandler('query', {});
+
+    expect(mockGlideFtSearch).toHaveBeenCalledWith(
+      mockClient,
+      'test-index',
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.arrayContaining([
+          expect.objectContaining({ key: 'k', value: '10' }),
+        ]),
+      })
+    );
+  });
+
+  test('should handle empty search results', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([0, []]);
+
+    const result = await retrieverHandler('no results query', { k: 5 });
+
+    expect(result.documents).toHaveLength(0);
+  });
+
+  test('should handle invalid metadata JSON gracefully', async () => {
+    mockEmbed.mockResolvedValue([{ embedding: [0.1, 0.2, 0.3] }]);
+    mockGlideFtSearch.mockResolvedValue([
+      1,
+      [
+        {
+          key: 'test-index:abc',
+          value: [
+            { key: '_content', value: 'content' },
+            { key: '_metadata', value: 'not-valid-json' },
+            { key: '_dataType', value: '' },
+          ],
+        },
+      ],
+    ]);
+
+    const result = await retrieverHandler('query', { k: 1 });
+
+    expect(result.documents).toHaveLength(1);
+    // Should not throw, metadata should be undefined
+    expect(result.documents[0]).toBeInstanceOf(Document);
+  });
+});
+
+describe('valkeyRetrieverRef', () => {
+  test('should create a retriever reference with correct name', () => {
+    const ref = valkeyRetrieverRef({ indexName: 'my-docs' });
+    expect(ref.name).toBe('valkey/my-docs');
+  });
+
+  test('should use custom display name', () => {
+    const ref = valkeyRetrieverRef({
+      indexName: 'my-docs',
+      displayName: 'My Docs Retriever',
+    });
+    expect(ref.info?.label).toBe('My Docs Retriever');
+  });
+
+  test('should use default display name', () => {
+    const ref = valkeyRetrieverRef({ indexName: 'my-docs' });
+    expect(ref.info?.label).toBe('Valkey - my-docs');
+  });
+});
+
+describe('valkeyIndexerRef', () => {
+  test('should create an indexer reference with correct name', () => {
+    const ref = valkeyIndexerRef({ indexName: 'my-docs' });
+    expect(ref.name).toBe('valkey/my-docs');
+  });
+
+  test('should use custom display name', () => {
+    const ref = valkeyIndexerRef({
+      indexName: 'my-docs',
+      displayName: 'My Docs Indexer',
+    });
+    expect(ref.info?.label).toBe('My Docs Indexer');
+  });
+});
+
+describe('stableDocId', () => {
+  test('same doc with nested metadata in different key orders produces same ID', () => {
+    const id1 = stableDocId({
+      data: 'hello',
+      metadata: { a: 1, b: 2 },
+      dataType: 'text',
+    });
+    const id2 = stableDocId({
+      data: 'hello',
+      metadata: { b: 2, a: 1 },
+      dataType: 'text',
+    });
+    expect(id1).toBe(id2);
+  });
+
+  test('docs with different metadata produce different IDs', () => {
+    const id1 = stableDocId({
+      data: 'hello',
+      metadata: { a: 1 },
+      dataType: 'text',
+    });
+    const id2 = stableDocId({
+      data: 'hello',
+      metadata: { a: 2 },
+      dataType: 'text',
+    });
+    expect(id1).not.toBe(id2);
+  });
+
+  test('metadata content is included in hash (not dropped)', () => {
+    const idWithMeta = stableDocId({
+      data: 'hello',
+      metadata: { key: 'value' },
+      dataType: 'text',
+    });
+    const idNoMeta = stableDocId({
+      data: 'hello',
+      metadata: {},
+      dataType: 'text',
+    });
+    expect(idWithMeta).not.toBe(idNoMeta);
+  });
+
+  test('cross-language test vector matches Go and Python', () => {
+    // Canonical JSON: {"data":"hello","dataType":"text","metadata":null}
+    // MD5: 3c04c6b9f04e5e522404b4c567ad09b0
+    const id = stableDocId({ data: 'hello', dataType: 'text' });
+    expect(id).toBe('3c04c6b9f04e5e522404b4c567ad09b0');
+  });
+});
+
+describe('validateFilterExpression', () => {
+  test('valid filter expressions do not throw', () => {
+    expect(() => validateFilterExpression('@price:[100 200]')).not.toThrow();
+    expect(() => validateFilterExpression('@tag:{foo}')).not.toThrow();
+    expect(() => validateFilterExpression('*')).not.toThrow();
+    expect(() => validateFilterExpression('')).not.toThrow();
+  });
+
+  test.each([';', '|', '`', '$', '\\'])('blocks disallowed char %s', (char) => {
+    expect(() =>
+      validateFilterExpression(`@field:[0 10]${char}inject`)
+    ).toThrow('disallowed characters');
+  });
+
+  test('blocks => KNN query injection sequence', () => {
+    expect(() =>
+      validateFilterExpression('@tag:{x})=>[KNN 99999 @embedding $query_vec]')
+    ).toThrow('disallowed characters');
+    expect(() => validateFilterExpression('foo=>bar')).toThrow(
+      'disallowed characters'
+    );
+  });
+});

--- a/js/plugins/valkey/tsconfig.json
+++ b/js/plugins/valkey/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/js/plugins/valkey/tsup.config.ts
+++ b/js/plugins/valkey/tsup.config.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig, type Options } from 'tsup';
+import { defaultOptions } from '../../tsup.common';
+
+export default defineConfig({
+  ...(defaultOptions as Options),
+});

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -193,7 +193,7 @@ importers:
         version: 4.1.1
       '@genkit-ai/firebase':
         specifier: ^1.16.1
-        version: 1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+        version: 1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
 
   doc-snippets:
     dependencies:
@@ -338,7 +338,7 @@ importers:
     dependencies:
       chromadb:
         specifier: 1.8.1
-        version: 1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
+        version: 1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
       genkit:
         specifier: workspace:^
         version: link:../../genkit
@@ -400,7 +400,7 @@ importers:
         version: 16.6.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.37)
+        version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -409,7 +409,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(postcss@8.5.15)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
@@ -427,7 +427,7 @@ importers:
         version: link:../../genkit
       openai:
         specifier: ^4.95.0
-        version: 4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
     devDependencies:
       '@jest/globals':
         specifier: ^29.7.0
@@ -437,7 +437,7 @@ importers:
         version: 20.19.37
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.37)
+        version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -446,7 +446,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.2
         version: 8.5.1(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -627,7 +627,7 @@ importers:
         version: link:../../genkit
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.37)
+        version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -636,7 +636,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(postcss@8.5.15)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
@@ -715,7 +715,7 @@ importers:
         version: 20.19.37
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.37)
+        version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -724,7 +724,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(postcss@8.5.15)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
@@ -779,10 +779,10 @@ importers:
     dependencies:
       '@langchain/community':
         specifier: ^0.0.53
-        version: 0.0.53(@pinecone-database/pinecone@2.2.2)(chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)))(encoding@0.1.13)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))(pg@8.20.0)(ws@8.20.1)
+        version: 0.0.53(@pinecone-database/pinecone@2.2.2)(chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)))(encoding@0.1.13)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(pg@8.20.0)(ws@8.19.0)
       '@langchain/core':
         specifier: ^0.1.61
-        version: 0.1.63(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
+        version: 0.1.63(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -791,7 +791,7 @@ importers:
         version: link:../../genkit
       langchain:
         specifier: ^0.1.36
-        version: 0.1.37(@google-cloud/storage@7.19.0(encoding@0.1.13))(@pinecone-database/pinecone@2.2.2)(chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)))(encoding@0.1.13)(fast-xml-parser@5.5.3)(handlebars@4.7.8)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))(pg@8.20.0)(ws@8.20.1)
+        version: 0.1.37(@google-cloud/storage@7.19.0(encoding@0.1.13))(@pinecone-database/pinecone@2.2.2)(chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)))(encoding@0.1.13)(fast-xml-parser@5.5.3)(handlebars@4.7.8)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(pg@8.20.0)(ws@8.19.0)
     devDependencies:
       '@types/node':
         specifier: ^20.11.16
@@ -835,7 +835,7 @@ importers:
         version: 5.1.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.37)
+        version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -844,7 +844,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(postcss@8.5.15)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
@@ -905,7 +905,7 @@ importers:
         version: link:../../genkit
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.37)
+        version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       next:
         specifier: ^15.5.14
         version: 15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.90.0)
@@ -917,7 +917,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.2
         version: 8.5.1(postcss@8.5.15)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
@@ -990,6 +990,52 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  plugins/valkey:
+    dependencies:
+      '@valkey/valkey-glide':
+        specifier: 2.4.0
+        version: 2.4.0
+      genkit:
+        specifier: workspace:^
+        version: link:../../genkit
+    devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.16
+        version: 20.19.37
+      genkitx-ollama:
+        specifier: workspace:*
+        version: link:../ollama
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.19.37)(typescript@5.9.3)
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   plugins/vertexai:
     dependencies:
       '@anthropic-ai/sdk':
@@ -1021,7 +1067,7 @@ importers:
         version: 3.3.2
       openai:
         specifier: ^4.52.7
-        version: 4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)
+        version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: ^20.11.16
@@ -1065,28 +1111,28 @@ importers:
     dependencies:
       '@angular/common':
         specifier: ^20.3.0
-        version: 20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+        version: 20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
       '@angular/compiler':
         specifier: ^20.3.0
-        version: 20.3.21
+        version: 20.3.23
       '@angular/core':
         specifier: ^20.3.0
-        version: 20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)
+        version: 20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/forms':
         specifier: ^20.3.0
-        version: 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+        version: 20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
       '@angular/platform-browser':
         specifier: ^20.3.0
-        version: 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))
+        version: 20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))
       '@angular/platform-server':
         specifier: ^20.3.0
-        version: 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+        version: 20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.23)(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
       '@angular/router':
         specifier: ^20.3.0
-        version: 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+        version: 20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
       '@angular/ssr':
         specifier: ^20.3.1
-        version: 20.3.26(2723f3610bf9645aa8083ef05f9c0439)
+        version: 20.3.26(fc5d35fafdc45e8c53a7a1ec82451a3e)
       '@genkit-ai/express':
         specifier: workspace:*
         version: link:../../plugins/express
@@ -1111,13 +1157,13 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: ^20.3.1
-        version: 20.3.26(e09c72c626068a1906187110fb2b0bc4)
+        version: 20.3.26(3f76474723b1833fe10fac46bced2db9)
       '@angular/cli':
         specifier: ^20.3.1
         version: 20.3.26(@cfworker/json-schema@4.1.1)(@types/node@20.19.37)(chokidar@4.0.3)
       '@angular/compiler-cli':
         specifier: ^20.3.0
-        version: 20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3)
+        version: 20.3.23(@angular/compiler@20.3.23)(typescript@5.9.3)
       '@types/express':
         specifier: ^5.0.1
         version: 5.0.6
@@ -1798,7 +1844,7 @@ importers:
         version: link:../../plugins/ollama
       genkitx-openai:
         specifier: ^0.30.0
-        version: 0.30.0(genkit@genkit)(ws@8.20.1)(zod@3.25.76)
+        version: 0.30.0(genkit@genkit)(ws@8.19.0)(zod@3.25.76)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -2356,33 +2402,33 @@ packages:
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     hasBin: true
 
-  '@angular/common@20.3.21':
-    resolution: {integrity: sha512-BjVpJYaC0T73nIT4BCOR5jcFUcXAFe2kKPlSDfD8mjBl8+Ug3Uy/Xs3Blx/6IKDLwNkbCUAxo/IwT+zzpTYNpw==}
+  '@angular/common@20.3.23':
+    resolution: {integrity: sha512-g6Y5cWs1B11DbKInPMTqFMZyqa2oo3h9vs3v2szLXG/kp61Ks7F6XQboKjYyzl4n0vMuOjsHHuDxObPMf1Nsuw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
-      '@angular/core': 20.3.21
+      '@angular/core': 20.3.23
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/compiler-cli@20.3.21':
-    resolution: {integrity: sha512-Bo0lCIm1YZ18b4abP7InqP9q3uxcOzbVxYwdZYTiht4mrV5HUTBjsI5Yn8GL7eXXpjmY4e1CrdDe81+nNDn+0A==}
+  '@angular/compiler-cli@20.3.23':
+    resolution: {integrity: sha512-xVLENeFDLpgdkDCcoCSx8x6+dbbs4SHaqG5bj2B3AKSHE3zWlgcc55wIRL2XNs2NUFUrgwh+OquJSuBaaYukww==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
-      '@angular/compiler': 20.3.21
+      '@angular/compiler': 20.3.23
       typescript: '>=5.8 <6.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@angular/compiler@20.3.21':
-    resolution: {integrity: sha512-XufWMAUS0gNKE29LkDFf21eTxdBN2WIcN/3ownqfYqKwDzMMpUAm5EEjPYfn0b/2/b5OYGNJrU4yeTHoz0Bt7g==}
+  '@angular/compiler@20.3.23':
+    resolution: {integrity: sha512-/a6x7QX+g8FA2skrCRMU+YlAos7NK0X4TxNqfxvU566E8jgkiRRqOTnmidtmT84Frw1Z+ntMso4byZ6GLq4HLw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  '@angular/core@20.3.21':
-    resolution: {integrity: sha512-sZMWyxh6dkuT6F90epkM1F7E2WJeduHoA9PRHYChIIVFnBd0VKITxpfrwRQS44IPJAtR456/5twtrcCNBALweQ==}
+  '@angular/core@20.3.23':
+    resolution: {integrity: sha512-OACWRsy1en9VVEHJxuZ6axLRObV2KLOMzWVsW0GbFcIOXY8bug6BrdUxEzSdBUtl9uVvN9uTtz9shd/5UMHgdw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
-      '@angular/compiler': 20.3.21
+      '@angular/compiler': 20.3.23
       rxjs: ^6.5.3 || ^7.4.0
       zone.js: ~0.15.0
     peerDependenciesMeta:
@@ -2391,43 +2437,43 @@ packages:
       zone.js:
         optional: true
 
-  '@angular/forms@20.3.21':
-    resolution: {integrity: sha512-2T2K+32pSCjLH0SmM6ORrQrtyZKOk70APDl3wLUu33aExnrtzI98A32TdJ+G8+FTtZKTUDT22b6aQj+xvSewpA==}
+  '@angular/forms@20.3.23':
+    resolution: {integrity: sha512-SpCs219zNx6ef57VDn3wsDNLpmO5NH8MclXTh6gGskg10QyM/9Tb0leA35PzSYiSNVBxtMRdxZQnqNj3Gpi4KA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
-      '@angular/common': 20.3.21
-      '@angular/core': 20.3.21
-      '@angular/platform-browser': 20.3.21
+      '@angular/common': 20.3.23
+      '@angular/core': 20.3.23
+      '@angular/platform-browser': 20.3.23
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/platform-browser@20.3.21':
-    resolution: {integrity: sha512-hhsB2dv4Iq8SMmh50fYkMA2IOQ7JGXfQSBS4pPC3zj5njVQZtSNEJ/il8QNjYyw/KsMSFffhA/if6vSAumYvUg==}
+  '@angular/platform-browser@20.3.23':
+    resolution: {integrity: sha512-CUHvfrF6hjznjQ6aAHj/pR0/SAHgSSymlWvyG6rORV3WQSaAvQF648v6Be8exJxBM1MnNMB1aw4jTQDroFsU8w==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
-      '@angular/animations': 20.3.21
-      '@angular/common': 20.3.21
-      '@angular/core': 20.3.21
+      '@angular/animations': 20.3.23
+      '@angular/common': 20.3.23
+      '@angular/core': 20.3.23
     peerDependenciesMeta:
       '@angular/animations':
         optional: true
 
-  '@angular/platform-server@20.3.21':
-    resolution: {integrity: sha512-+Pbjs4zHBRLt6EG+s5vXxQWuVIn+N7jIQuiTf2VIM5MhgcIQxY2r0iIx+wgcLvqtnjwPRK7Be+ITsRnNFgKs1A==}
+  '@angular/platform-server@20.3.23':
+    resolution: {integrity: sha512-o9IyliBY24AxoC89cIlXlGA43mFVOiSr36fuPQUQZyuGGIM2EH8bcz+LxHnWdvGXqe1lF5mcUrtDM9K6RbWA/w==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
-      '@angular/common': 20.3.21
-      '@angular/compiler': 20.3.21
-      '@angular/core': 20.3.21
-      '@angular/platform-browser': 20.3.21
+      '@angular/common': 20.3.23
+      '@angular/compiler': 20.3.23
+      '@angular/core': 20.3.23
+      '@angular/platform-browser': 20.3.23
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/router@20.3.21':
-    resolution: {integrity: sha512-8MLfjHVnVs7CLd6ZY9dbwtJfqFqKx9thr0dKzHdlPc/lorGckQ6aco6yOQnPuIeUVIp/zqxokFba27q7Z1aGxw==}
+  '@angular/router@20.3.23':
+    resolution: {integrity: sha512-Kxo0mm+6o5pJ4jobmS465Sud6G6l6BjV4gtQXBYzF2WoABdDzp7AMD+/nGOBIqHm966GQPTD9+ktAypW2ZngdA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
-      '@angular/common': 20.3.21
-      '@angular/core': 20.3.21
-      '@angular/platform-browser': 20.3.21
+      '@angular/common': 20.3.23
+      '@angular/core': 20.3.23
+      '@angular/platform-browser': 20.3.23
       rxjs: ^6.5.3 || ^7.4.0
 
   '@angular/ssr@20.3.26':
@@ -2668,6 +2714,10 @@ packages:
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
@@ -3383,11 +3433,11 @@ packages:
     resolution: {integrity: sha512-Lm/ZLhDZcBECta3TmCQSngiQykFdfw+QtI1/GYMsZd4l3nG+P8WLB16XuS7WaBGLQ+9E+cOcWQsth9cayuGt8g==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@genkit-ai/ai@1.35.0':
-    resolution: {integrity: sha512-P66XQgX4//2JhyoUwTGpEWzdH07ss/vKEeEpTlj0DkyUE+LvCYTxn6etBl6XITOp6LsmOKM2bqWgD/Xh5XsBQg==}
+  '@genkit-ai/ai@1.36.0':
+    resolution: {integrity: sha512-xMDfclS4sMLEl4YQP92XlxnPxuehz+90iuysg2gRGfHXXz6iRSGjWVq7QycBWqMmZ7OYHfgTgYz4CgL63Ezl0A==}
 
-  '@genkit-ai/core@1.35.0':
-    resolution: {integrity: sha512-Yfq4XUGTkM6wgBwqhpxHVU/TruscwWKbv5TT9FYzCk2N66rK8PgQGmTSiFDuPDwZ1YG26pQcq31jISZ93c+kZQ==}
+  '@genkit-ai/core@1.36.0':
+    resolution: {integrity: sha512-kkWzROCNPz8Ol2OtBDjsNk2zaS32axIomuR3wm0iHjkR8NdFYPk9Ab4J80EKiUEGdhXiIwvO+4RhqOgy7zYm1A==}
 
   '@genkit-ai/express@1.29.0':
     resolution: {integrity: sha512-+Mf8e45RbAlvns3a3hvIDpUAjNyWTIu1cy7vV86+6NvpPqPhkEaPkptgIX7KIXsPBEwiwsEM4SXx80M/TRbmTg==}
@@ -3933,6 +3983,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -5378,9 +5431,6 @@ packages:
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
-  '@socket.io/component-emitter@3.1.2':
-    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
-
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -5393,6 +5443,18 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@tsconfig/node10@1.0.12':
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
   '@tufjs/canonical-json@2.0.0':
     resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
@@ -5603,6 +5665,40 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
+  '@valkey/valkey-glide-darwin-arm64@2.4.0':
+    resolution: {integrity: sha512-ET1diKJc84APH5P4kisiVr8Ys2lmNV3rezMa2fLwZ1vP6pdB9KQZxbdnib3cdrqXsG2q0QAFnF39l+k56QSgeA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@valkey/valkey-glide-darwin-x64@2.4.0':
+    resolution: {integrity: sha512-hMnQTYqOugiSUH26KwVII20Pj8vacSyKqt52XIFn5y0XPwEHuHCeTdorch4dLeLT+/2h0hS0wrJBuOYGmdxRuw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@valkey/valkey-glide-linux-arm64-gnu@2.4.0':
+    resolution: {integrity: sha512-8yXVEYRh1pbpWaoVWh096JrvtSjdPNVexjpAdmbyMzOuGMGnNVyjrnH8+l1iA2qBqglj+4KQPD3FMpxAGDZXXA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@valkey/valkey-glide-linux-arm64-musl@2.4.0':
+    resolution: {integrity: sha512-is8IvM2AZ2bhDXHMktOez/6owGWsdM8BsHrUT46unqCXwRWSOMUhdNG8lNxmcajhgHkM8EYCUqwQCKvhzvLW/w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@valkey/valkey-glide-linux-x64-gnu@2.4.0':
+    resolution: {integrity: sha512-2CtNW0qkYLkbMULrPBCj2xb0AzBANZ0INTkXhO5HG0RhOCtXepwJQfs+PZsxJUDgODjWt6TYfsQsrkWKN9vQ2g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@valkey/valkey-glide-linux-x64-musl@2.4.0':
+    resolution: {integrity: sha512-Or4z46RwjkjIwEoZGL84dvErKfbNFFT+GDsIhQ3E3pAtMLVM8s6y/eP168y13v8Z4lXNkMddFL0z3xYJDGofSg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@valkey/valkey-glide@2.4.0':
+    resolution: {integrity: sha512-kSD0X/TCIBoUdSrXI9HbO6ZEtAdbC5FNWNPRcJQSbIfhKpqUQkdoF+7VHhJM4u9c3OhOgrDry436KE/VAnwP2w==}
+    engines: {node: '>=16'}
+
   '@vitejs/plugin-basic-ssl@2.1.0':
     resolution: {integrity: sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -5632,6 +5728,10 @@ packages:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
       acorn: ^8
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -5722,6 +5822,9 @@ packages:
   archiver@7.0.1:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
     engines: {node: '>= 14'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -5858,10 +5961,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  base64id@2.0.0:
-    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
-    engines: {node: ^4.5.0 || >= 5.9}
-
   baseline-browser-mapping@2.10.7:
     resolution: {integrity: sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==}
     engines: {node: '>=6.0.0'}
@@ -5877,6 +5976,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   beasties@0.3.5:
     resolution: {integrity: sha512-NaWu+f4YrJxEttJSm16AzMIFtVldCvaJ68b1L098KpqXmxt9xOLtKoLkKxb8ekhOrLqEJAbvT6n6SEvB/sac7A==}
@@ -6300,6 +6400,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
 
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
     engines: {node: '>=20'}
@@ -6337,9 +6440,6 @@ packages:
   csv-parse@5.6.0:
     resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
 
-  custom-event@1.0.1:
-    resolution: {integrity: sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==}
-
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -6363,10 +6463,6 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
-
-  date-format@4.0.14:
-    resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
-    engines: {node: '>=4.0'}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -6467,12 +6563,13 @@ packages:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
 
-  di@0.0.1:
-    resolution: {integrity: sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==}
-
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
 
   diff@5.2.2:
     resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
@@ -6487,9 +6584,6 @@ packages:
 
   discontinuous-range@1.0.0:
     resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
-
-  dom-serialize@2.2.1:
-    resolution: {integrity: sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -6579,18 +6673,6 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
-  engine.io-parser@5.2.3:
-    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
-    engines: {node: '>=10.0.0'}
-
-  engine.io@6.6.8:
-    resolution: {integrity: sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==}
-    engines: {node: '>=10.2.0'}
-
-  ent@2.2.2:
-    resolution: {integrity: sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==}
-    engines: {node: '>= 0.4'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -6914,20 +6996,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  flatted@3.4.2:
-    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
-
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
-
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -6971,10 +7041,6 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
-
-  fs-extra@8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
 
   fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
@@ -7025,8 +7091,8 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
-  genkit@1.35.0:
-    resolution: {integrity: sha512-n98e5j+0PYyRE52gkApCadXufUjJBi8UGYlTX7Uc0Bbpws0G05w5PoCkLOoFwaHZmUmOHfcV2erqTSmEOCbSGQ==}
+  genkit@1.36.0:
+    resolution: {integrity: sha512-5kwpWAOiIusWKOrYlUpuU60SSjxuyzcAqJTwM8c89NHWj0AsUqJKcgHAmm2JTbfJRAMXlPfgOLxNi1qGyqI+yQ==}
 
   genkitx-openai@0.30.0:
     resolution: {integrity: sha512-6Dt3o6f+cKrZ1njSzYj2rm0U8SE5nQDwpz5VbFuLjaloE5BBj2c9OSlPGegdcz4PN5wBocGKiNsaKn0t5PpJdA==}
@@ -7252,10 +7318,6 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
-
-  http-proxy@1.18.1:
-    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
-    engines: {node: '>=8.0.0'}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -7588,10 +7650,6 @@ packages:
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
-  isbinaryfile@4.0.10:
-    resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
-    engines: {node: '>= 8.0.0'}
-
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -7847,9 +7905,6 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
-  jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
-
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
@@ -7882,11 +7937,6 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
-
-  karma@6.4.4:
-    resolution: {integrity: sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==}
-    engines: {node: '>= 10'}
-    hasBin: true
 
   kind-of@3.2.2:
     resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
@@ -8216,10 +8266,6 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
-  log4js@6.9.1:
-    resolution: {integrity: sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==}
-    engines: {node: '>=8.0'}
-
   logform@2.7.0:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
@@ -8443,10 +8489,6 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
-
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -9147,9 +9189,6 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
-  punycode@1.4.1:
-    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -9160,10 +9199,6 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
-
-  qjobs@1.2.0:
-    resolution: {integrity: sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==}
-    engines: {node: '>=0.9'}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -9278,9 +9313,6 @@ packages:
     resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
     engines: {node: '>=8.6.0'}
 
-  requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -9331,11 +9363,6 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
 
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
@@ -9526,17 +9553,6 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  socket.io-adapter@2.5.7:
-    resolution: {integrity: sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==}
-
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
-    engines: {node: '>=10.0.0'}
-
-  socket.io@4.8.3:
-    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
-    engines: {node: '>=10.2.0'}
-
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
@@ -9637,10 +9653,6 @@ packages:
 
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
-
-  streamroller@3.1.5:
-    resolution: {integrity: sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==}
-    engines: {node: '>=8.0'}
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
@@ -9901,6 +9913,20 @@ packages:
     resolution: {integrity: sha512-DiwiXfwvcTeZ5wCE0z+2A9EseZsztaiZtGrtSaY5JOD7ekPnR/GoIVD5gXZAlK9Na9Kvpo9Waz5rW64WKAWApg==}
     engines: {node: '>=12'}
 
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -10025,10 +10051,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ua-parser-js@0.7.41:
-    resolution: {integrity: sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==}
-    hasBin: true
-
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
@@ -10069,10 +10091,6 @@ packages:
   universal-analytics@0.5.3:
     resolution: {integrity: sha512-HXSMyIcf2XTvwZ6ZZQLfxfViRm/yTGoRgDeTbojtq6rezeyKB0sTBcKH2fhddnteAHRcHiKgr/ACpbgjGOC6RQ==}
     engines: {node: '>=12.18.2'}
-
-  universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -10129,6 +10147,9 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
@@ -10193,10 +10214,6 @@ packages:
         optional: true
       yaml:
         optional: true
-
-  void-elements@2.0.1:
-    resolution: {integrity: sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==}
-    engines: {node: '>=0.10.0'}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -10349,18 +10366,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   xdg-basedir@4.0.0:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
     engines: {node: '>=8'}
@@ -10420,6 +10425,10 @@ packages:
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -10569,12 +10578,12 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/build@20.3.26(e09c72c626068a1906187110fb2b0bc4)':
+  '@angular/build@20.3.26(3f76474723b1833fe10fac46bced2db9)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.26(chokidar@4.0.3)
-      '@angular/compiler': 20.3.21
-      '@angular/compiler-cli': 20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3)
+      '@angular/compiler': 20.3.23
+      '@angular/compiler-cli': 20.3.23(@angular/compiler@20.3.23)(typescript@5.9.3)
       '@babel/core': 7.28.3
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
@@ -10602,11 +10611,10 @@ snapshots:
       vite: 7.3.2(@types/node@20.19.37)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
       watchpack: 2.4.4
     optionalDependencies:
-      '@angular/core': 20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/platform-browser': 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))
-      '@angular/platform-server': 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
-      '@angular/ssr': 20.3.26(2723f3610bf9645aa8083ef05f9c0439)
-      karma: 6.4.4
+      '@angular/core': 20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser': 20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))
+      '@angular/platform-server': 20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.23)(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+      '@angular/ssr': 20.3.26(fc5d35fafdc45e8c53a7a1ec82451a3e)
       lmdb: 3.4.2
       postcss: 8.5.15
     transitivePeerDependencies:
@@ -10648,15 +10656,15 @@ snapshots:
       - chokidar
       - supports-color
 
-  '@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)':
+  '@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)':
     dependencies:
-      '@angular/core': 20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/core': 20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3)':
+  '@angular/compiler-cli@20.3.23(@angular/compiler@20.3.23)(typescript@5.9.3)':
     dependencies:
-      '@angular/compiler': 20.3.21
+      '@angular/compiler': 20.3.23
       '@babel/core': 7.28.3
       '@jridgewell/sourcemap-codec': 1.5.5
       chokidar: 4.0.3
@@ -10670,58 +10678,58 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@angular/compiler@20.3.21':
+  '@angular/compiler@20.3.23':
     dependencies:
       tslib: 2.8.1
 
-  '@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)':
+  '@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)':
     dependencies:
       rxjs: 7.8.2
       tslib: 2.8.1
     optionalDependencies:
-      '@angular/compiler': 20.3.21
+      '@angular/compiler': 20.3.23
       zone.js: 0.15.1
 
-  '@angular/forms@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
+  '@angular/forms@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
     dependencies:
-      '@angular/common': 20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
-      '@angular/core': 20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/platform-browser': 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))
+      '@angular/common': 20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core': 20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser': 20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/platform-browser@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))':
+  '@angular/platform-browser@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))':
     dependencies:
-      '@angular/common': 20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
-      '@angular/core': 20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/common': 20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core': 20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)
       tslib: 2.8.1
 
-  '@angular/platform-server@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
+  '@angular/platform-server@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.23)(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
     dependencies:
-      '@angular/common': 20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
-      '@angular/compiler': 20.3.21
-      '@angular/core': 20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/platform-browser': 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))
+      '@angular/common': 20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/compiler': 20.3.23
+      '@angular/core': 20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser': 20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))
       rxjs: 7.8.2
       tslib: 2.8.1
       xhr2: 0.2.1
 
-  '@angular/router@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
+  '@angular/router@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)':
     dependencies:
-      '@angular/common': 20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
-      '@angular/core': 20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/platform-browser': 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))
+      '@angular/common': 20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core': 20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser': 20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/ssr@20.3.26(2723f3610bf9645aa8083ef05f9c0439)':
+  '@angular/ssr@20.3.26(fc5d35fafdc45e8c53a7a1ec82451a3e)':
     dependencies:
-      '@angular/common': 20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
-      '@angular/core': 20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)
-      '@angular/router': 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+      '@angular/common': 20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core': 20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/router': 20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
       tslib: 2.8.1
     optionalDependencies:
-      '@angular/platform-server': 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+      '@angular/platform-server': 20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.23)(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.23(@angular/common@20.3.23(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.23(@angular/compiler@20.3.23)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
 
   '@anthropic-ai/sdk@0.71.2(zod@4.1.13)':
     dependencies:
@@ -11007,6 +11015,10 @@ snapshots:
     optional: true
 
   '@colors/colors@1.6.0': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@dabh/diagnostics@2.0.8':
     dependencies:
@@ -11615,9 +11627,9 @@ snapshots:
     dependencies:
       retry: 0.13.1
 
-  '@genkit-ai/ai@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/ai@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/core': 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/core': 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.37
       colorette: 2.0.20
@@ -11639,7 +11651,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@genkit-ai/core@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/core@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.52.1
@@ -11658,12 +11670,12 @@ snapshots:
       express: 4.22.1
       get-port: 5.1.1
       json-schema: 0.4.0
-      ws: 8.20.1
+      ws: 8.19.0
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
-      '@genkit-ai/firebase': 1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/firebase': 1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
     transitivePeerDependencies:
       - '@google-cloud/firestore'
       - bufferutil
@@ -11684,12 +11696,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@genkit-ai/firebase@1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/firebase@1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
       firebase-admin: 13.8.0(encoding@0.1.13)
-      genkit: 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
     optionalDependencies:
       firebase: 11.10.0
     transitivePeerDependencies:
@@ -11697,12 +11709,12 @@ snapshots:
       - supports-color
     optional: true
 
-  '@genkit-ai/firebase@1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/firebase@1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
       firebase-admin: 13.8.0(encoding@0.1.13)
-      genkit: 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
     optionalDependencies:
       firebase: 11.10.0
     transitivePeerDependencies:
@@ -11710,7 +11722,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@genkit-ai/google-cloud@1.30.1(encoding@0.1.13)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/google-cloud@1.30.1(encoding@0.1.13)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
       '@google-cloud/logging-winston': 6.0.1(encoding@0.1.13)(winston@3.19.0)
       '@google-cloud/modelarmor': 0.4.1
@@ -11727,7 +11739,7 @@ snapshots:
       '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-node': 0.52.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.25.1(@opentelemetry/api@1.9.0)
-      genkit: 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
       google-auth-library: 9.15.1(encoding@0.1.13)
       node-fetch: 3.3.2
       winston: 3.19.0
@@ -12259,7 +12271,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -12273,7 +12285,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.37)
+      jest-config: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -12431,6 +12443,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@js-sdsl/ordered-map@4.4.2': {}
 
   '@jsdevtools/ono@7.1.3': {}
@@ -12443,34 +12460,34 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@langchain/community@0.0.53(@pinecone-database/pinecone@2.2.2)(chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)))(encoding@0.1.13)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))(pg@8.20.0)(ws@8.20.1)':
+  '@langchain/community@0.0.53(@pinecone-database/pinecone@2.2.2)(chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)))(encoding@0.1.13)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(pg@8.20.0)(ws@8.19.0)':
     dependencies:
-      '@langchain/core': 0.1.63(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
-      '@langchain/openai': 0.0.34(encoding@0.1.13)(ws@8.20.1)
+      '@langchain/core': 0.1.63(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
+      '@langchain/openai': 0.0.34(encoding@0.1.13)(ws@8.19.0)
       expr-eval: 2.0.2
       flat: 5.0.2
-      langsmith: 0.1.68(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
+      langsmith: 0.1.68(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
       uuid: 9.0.1
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     optionalDependencies:
       '@pinecone-database/pinecone': 2.2.2
-      chromadb: 1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
+      chromadb: 1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
       jsonwebtoken: 9.0.3
       lodash: 4.17.23
       pg: 8.20.0
-      ws: 8.20.1
+      ws: 8.19.0
     transitivePeerDependencies:
       - encoding
       - openai
 
-  '@langchain/core@0.1.63(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))':
+  '@langchain/core@0.1.63(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.1.68(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
+      langsmith: 0.1.68(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
       ml-distance: 4.0.1
       mustache: 4.2.0
       p-queue: 6.6.2
@@ -12481,13 +12498,13 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/core@0.2.36(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))':
+  '@langchain/core@0.2.36(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.1.68(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
+      langsmith: 0.1.68(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -12497,20 +12514,20 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/openai@0.0.34(encoding@0.1.13)(ws@8.20.1)':
+  '@langchain/openai@0.0.34(encoding@0.1.13)(ws@8.19.0)':
     dependencies:
-      '@langchain/core': 0.1.63(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
+      '@langchain/core': 0.1.63(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
       js-tiktoken: 1.0.21
-      openai: 4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)
+      openai: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - encoding
       - ws
 
-  '@langchain/textsplitters@0.0.3(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))':
+  '@langchain/textsplitters@0.0.3(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))':
     dependencies:
-      '@langchain/core': 0.2.36(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
+      '@langchain/core': 0.2.36(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
       js-tiktoken: 1.0.21
     transitivePeerDependencies:
       - openai
@@ -13759,9 +13776,6 @@ snapshots:
       color: 5.0.3
       text-hex: 1.0.0
 
-  '@socket.io/component-emitter@3.1.2':
-    optional: true
-
   '@stablelib/base64@1.0.1': {}
 
   '@swc/helpers@0.5.15':
@@ -13771,6 +13785,14 @@ snapshots:
   '@tootallnate/once@2.0.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@tsconfig/node10@1.0.12': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
 
   '@tufjs/canonical-json@2.0.0': {}
 
@@ -14025,6 +14047,36 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@valkey/valkey-glide-darwin-arm64@2.4.0':
+    optional: true
+
+  '@valkey/valkey-glide-darwin-x64@2.4.0':
+    optional: true
+
+  '@valkey/valkey-glide-linux-arm64-gnu@2.4.0':
+    optional: true
+
+  '@valkey/valkey-glide-linux-arm64-musl@2.4.0':
+    optional: true
+
+  '@valkey/valkey-glide-linux-x64-gnu@2.4.0':
+    optional: true
+
+  '@valkey/valkey-glide-linux-x64-musl@2.4.0':
+    optional: true
+
+  '@valkey/valkey-glide@2.4.0':
+    dependencies:
+      long: 5.3.2
+      protobufjs: 7.5.4
+    optionalDependencies:
+      '@valkey/valkey-glide-darwin-arm64': 2.4.0
+      '@valkey/valkey-glide-darwin-x64': 2.4.0
+      '@valkey/valkey-glide-linux-arm64-gnu': 2.4.0
+      '@valkey/valkey-glide-linux-arm64-musl': 2.4.0
+      '@valkey/valkey-glide-linux-x64-gnu': 2.4.0
+      '@valkey/valkey-glide-linux-x64-musl': 2.4.0
+
   '@vitejs/plugin-basic-ssl@2.1.0(vite@7.3.2(@types/node@20.19.37)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       vite: 7.3.2(@types/node@20.19.37)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -14048,6 +14100,10 @@ snapshots:
       negotiator: 1.0.0
 
   acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
 
@@ -14155,6 +14211,8 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  arg@4.1.3: {}
 
   argparse@1.0.10:
     dependencies:
@@ -14305,9 +14363,6 @@ snapshots:
   base-64@0.1.0: {}
 
   base64-js@1.5.1: {}
-
-  base64id@2.0.0:
-    optional: true
 
   baseline-browser-mapping@2.10.7: {}
 
@@ -14551,12 +14606,12 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)):
+  chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)):
     dependencies:
       cliui: 8.0.1
       isomorphic-fetch: 3.0.0(encoding@0.1.13)
     optionalDependencies:
-      openai: 4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)
+      openai: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
     transitivePeerDependencies:
       - encoding
 
@@ -14779,13 +14834,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.7.0
 
-  create-jest@29.7.0(@types/node@20.19.37):
+  create-jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.37)
+      jest-config: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -14793,6 +14848,8 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  create-require@1.1.1: {}
 
   cross-env@10.1.0:
     dependencies:
@@ -14833,9 +14890,6 @@ snapshots:
 
   csv-parse@5.6.0: {}
 
-  custom-event@1.0.1:
-    optional: true
-
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@6.0.2: {}
@@ -14862,9 +14916,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
-
-  date-format@4.0.14:
-    optional: true
 
   debug@2.6.9:
     dependencies:
@@ -14931,10 +14982,9 @@ snapshots:
 
   detect-newline@3.1.0: {}
 
-  di@0.0.1:
-    optional: true
-
   diff-sequences@29.6.3: {}
+
+  diff@4.0.4: {}
 
   diff@5.2.2: {}
 
@@ -14946,14 +14996,6 @@ snapshots:
       md5: 2.3.0
 
   discontinuous-range@1.0.0: {}
-
-  dom-serialize@2.2.1:
-    dependencies:
-      custom-event: 1.0.1
-      ent: 2.2.2
-      extend: 3.0.2
-      void-elements: 2.0.1
-    optional: true
 
   dom-serializer@2.0.0:
     dependencies:
@@ -15040,35 +15082,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-
-  engine.io-parser@5.2.3:
-    optional: true
-
-  engine.io@6.6.8:
-    dependencies:
-      '@types/cors': 2.8.19
-      '@types/node': 20.19.37
-      '@types/ws': 8.18.1
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cookie: 0.7.2
-      cors: 2.8.6
-      debug: 4.4.3
-      engine.io-parser: 5.2.3
-      ws: 8.20.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
-
-  ent@2.2.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      punycode: 1.4.1
-      safe-regex-test: 1.1.0
-    optional: true
 
   entities@4.5.0: {}
 
@@ -15724,13 +15737,7 @@ snapshots:
 
   flat@5.0.2: {}
 
-  flatted@3.4.2:
-    optional: true
-
   fn.name@1.1.0: {}
-
-  follow-redirects@1.16.0:
-    optional: true
 
   for-each@0.3.5:
     dependencies:
@@ -15780,13 +15787,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
-
-  fs-extra@8.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-    optional: true
 
   fs-minipass@2.1.0:
     dependencies:
@@ -15855,10 +15855,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0):
+  genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0):
     dependencies:
-      '@genkit-ai/ai': 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
-      '@genkit-ai/core': 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/ai': 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/core': 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       uuid: 10.0.0
     transitivePeerDependencies:
       - '@google-cloud/firestore'
@@ -15870,10 +15870,10 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  genkitx-openai@0.30.0(genkit@genkit)(ws@8.20.1)(zod@3.25.76):
+  genkitx-openai@0.30.0(genkit@genkit)(ws@8.19.0)(zod@3.25.76):
     dependencies:
       genkit: link:genkit
-      openai: 4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)
+      openai: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
     transitivePeerDependencies:
       - encoding
       - ws
@@ -16169,15 +16169,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  http-proxy@1.18.1:
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.16.0
-      requires-port: 1.0.0
-    transitivePeerDependencies:
-      - debug
-    optional: true
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -16486,9 +16477,6 @@ snapshots:
 
   isarray@2.0.5: {}
 
-  isbinaryfile@4.0.10:
-    optional: true
-
   isexe@2.0.0: {}
 
   isexe@4.0.0: {}
@@ -16585,16 +16573,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.37):
+  jest-cli@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.37)
+      create-jest: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.37)
+      jest-config: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -16604,7 +16592,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.37):
+  jest-config@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -16630,6 +16618,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.37
+      ts-node: 10.9.2(@types/node@20.19.37)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -16849,12 +16838,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.37):
+  jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.37)
+      jest-cli: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -16927,11 +16916,6 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
-  jsonfile@4.0.0:
-    optionalDependencies:
-      graceful-fs: 4.2.11
-    optional: true
-
   jsonfile@6.2.0:
     dependencies:
       universalify: 2.0.1
@@ -16989,39 +16973,6 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  karma@6.4.4:
-    dependencies:
-      '@colors/colors': 1.5.0
-      body-parser: 1.20.4
-      braces: 3.0.3
-      chokidar: 3.6.0
-      connect: 3.7.0
-      di: 0.0.1
-      dom-serialize: 2.2.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      http-proxy: 1.18.1
-      isbinaryfile: 4.0.10
-      lodash: 4.17.23
-      log4js: 6.9.1
-      mime: 2.6.0
-      minimatch: 3.1.5
-      mkdirp: 0.5.6
-      qjobs: 1.2.0
-      range-parser: 1.2.1
-      rimraf: 3.0.2
-      socket.io: 4.8.3
-      source-map: 0.6.1
-      tmp: 0.2.5
-      ua-parser-js: 0.7.41
-      yargs: 16.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   kind-of@3.2.2:
     dependencies:
       is-buffer: 1.1.6
@@ -17051,19 +17002,19 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  langchain@0.1.37(@google-cloud/storage@7.19.0(encoding@0.1.13))(@pinecone-database/pinecone@2.2.2)(chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)))(encoding@0.1.13)(fast-xml-parser@5.5.3)(handlebars@4.7.8)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))(pg@8.20.0)(ws@8.20.1):
+  langchain@0.1.37(@google-cloud/storage@7.19.0(encoding@0.1.13))(@pinecone-database/pinecone@2.2.2)(chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)))(encoding@0.1.13)(fast-xml-parser@5.5.3)(handlebars@4.7.8)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(pg@8.20.0)(ws@8.19.0):
     dependencies:
       '@anthropic-ai/sdk': 0.9.1(encoding@0.1.13)
-      '@langchain/community': 0.0.53(@pinecone-database/pinecone@2.2.2)(chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)))(encoding@0.1.13)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))(pg@8.20.0)(ws@8.20.1)
-      '@langchain/core': 0.1.63(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
-      '@langchain/openai': 0.0.34(encoding@0.1.13)(ws@8.20.1)
-      '@langchain/textsplitters': 0.0.3(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
+      '@langchain/community': 0.0.53(@pinecone-database/pinecone@2.2.2)(chromadb@1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)))(encoding@0.1.13)(jsonwebtoken@9.0.3)(lodash@4.17.23)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(pg@8.20.0)(ws@8.19.0)
+      '@langchain/core': 0.1.63(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
+      '@langchain/openai': 0.0.34(encoding@0.1.13)(ws@8.19.0)
+      '@langchain/textsplitters': 0.0.3(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
       binary-extensions: 2.3.0
       js-tiktoken: 1.0.21
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
       langchainhub: 0.0.11
-      langsmith: 0.1.68(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
+      langsmith: 0.1.68(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
       ml-distance: 4.0.1
       openapi-types: 12.1.3
       p-retry: 4.6.2
@@ -17074,10 +17025,10 @@ snapshots:
     optionalDependencies:
       '@google-cloud/storage': 7.19.0(encoding@0.1.13)
       '@pinecone-database/pinecone': 2.2.2
-      chromadb: 1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76))
+      chromadb: 1.8.1(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))
       fast-xml-parser: 5.5.3
       handlebars: 4.7.8
-      ws: 8.20.1
+      ws: 8.19.0
     transitivePeerDependencies:
       - '@aws-crypto/sha256-js'
       - '@aws-sdk/client-bedrock-agent-runtime'
@@ -17151,7 +17102,7 @@ snapshots:
 
   langchainhub@0.0.11: {}
 
-  langsmith@0.1.68(openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)):
+  langsmith@0.1.68(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       commander: 10.0.1
@@ -17160,7 +17111,7 @@ snapshots:
       semver: 7.7.4
       uuid: 10.0.0
     optionalDependencies:
-      openai: 4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76)
+      openai: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
 
   lazystream@1.0.1:
     dependencies:
@@ -17280,17 +17231,6 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
-
-  log4js@6.9.1:
-    dependencies:
-      date-format: 4.0.14
-      debug: 4.4.3
-      flatted: 3.4.2
-      rfdc: 1.4.1
-      streamroller: 3.1.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   logform@2.7.0:
     dependencies:
@@ -17511,11 +17451,6 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
-
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
-    optional: true
 
   mkdirp@1.0.4: {}
 
@@ -17767,7 +17702,7 @@ snapshots:
       chalk: 2.4.2
       cross-spawn: 7.0.6
       memorystream: 0.3.1
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
       shell-quote: 1.8.3
@@ -17840,7 +17775,7 @@ snapshots:
     dependencies:
       is-wsl: 1.1.0
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.20.1)(zod@3.25.76):
+  openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -17850,7 +17785,7 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
-      ws: 8.20.1
+      ws: 8.19.0
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
@@ -18292,9 +18227,6 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  punycode@1.4.1:
-    optional: true
-
   punycode@2.3.1: {}
 
   pupa@2.1.1:
@@ -18302,9 +18234,6 @@ snapshots:
       escape-goat: 2.1.1
 
   pure-rand@6.1.0: {}
-
-  qjobs@1.2.0:
-    optional: true
 
   qs@6.14.2:
     dependencies:
@@ -18457,9 +18386,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  requires-port@1.0.0:
-    optional: true
-
   resolve-cwd@3.0.0:
     dependencies:
       resolve-from: 5.0.0
@@ -18509,11 +18435,6 @@ snapshots:
   retry@0.13.1: {}
 
   rfdc@1.4.1: {}
-
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
-    optional: true
 
   rimraf@5.0.10:
     dependencies:
@@ -18815,39 +18736,6 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socket.io-adapter@2.5.7:
-    dependencies:
-      debug: 4.4.3
-      ws: 8.20.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
-
-  socket.io-parser@4.2.6:
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  socket.io@4.8.3:
-    dependencies:
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cors: 2.8.6
-      debug: 4.4.3
-      engine.io: 6.6.8
-      socket.io-adapter: 2.5.7
-      socket.io-parser: 4.2.6
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
@@ -18950,15 +18838,6 @@ snapshots:
       - supports-color
 
   stream-shift@1.0.3: {}
-
-  streamroller@3.1.5:
-    dependencies:
-      date-format: 4.0.14
-      debug: 4.4.3
-      fs-extra: 8.1.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   streamx@2.23.0:
     dependencies:
@@ -19251,12 +19130,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@20.19.37)
+      jest: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -19272,6 +19151,24 @@ snapshots:
       jest-util: 29.7.0
 
   ts-md5@1.3.1: {}
+
+  ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.37
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
 
   tslib@1.14.1: {}
 
@@ -19468,9 +19365,6 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  ua-parser-js@0.7.41:
-    optional: true
-
   uc.micro@2.1.0: {}
 
   ufo@1.6.3: {}
@@ -19509,9 +19403,6 @@ snapshots:
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
-
-  universalify@0.1.2:
-    optional: true
 
   universalify@2.0.1: {}
 
@@ -19566,6 +19457,8 @@ snapshots:
 
   uuid@9.0.1: {}
 
+  v8-compile-cache-lib@3.0.1: {}
+
   v8-to-istanbul@9.3.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -19601,9 +19494,6 @@ snapshots:
       sass: 1.90.0
       tsx: 4.21.0
       yaml: 2.8.2
-
-  void-elements@2.0.1:
-    optional: true
 
   walker@1.0.8:
     dependencies:
@@ -19782,9 +19672,6 @@ snapshots:
 
   ws@8.19.0: {}
 
-  ws@8.20.1:
-    optional: true
-
   xdg-basedir@4.0.0: {}
 
   xhr2@0.2.1: {}
@@ -19837,6 +19724,8 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/py/packages/genkit/src/genkit/__init__.py
+++ b/py/packages/genkit/src/genkit/__init__.py
@@ -61,6 +61,17 @@ from genkit.embedder import (
     EmbedResponse,
 )
 
+# Import retriever/indexer types
+from genkit._ai._retriever import (
+    IndexerOptions,
+    IndexerRef,
+    IndexerRequest,
+    RetrieverOptions,
+    RetrieverRef,
+    RetrieverRequest,
+    RetrieverResponse,
+)
+
 # Import model-related types from the model namespace.
 from genkit.model import (
     Constrained,
@@ -140,4 +151,12 @@ __all__ = [
     'ModelRequest',
     'ModelResponse',
     'ModelResponseChunk',
+    # Retriever/Indexer
+    'IndexerOptions',
+    'IndexerRef',
+    'IndexerRequest',
+    'RetrieverOptions',
+    'RetrieverRef',
+    'RetrieverRequest',
+    'RetrieverResponse',
 ]

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -35,6 +35,19 @@ import uvicorn
 from pydantic import BaseModel
 
 from genkit._ai._embedding import EmbedderFn, EmbedderOptions, EmbedderRef, define_embedder
+from genkit._ai._retriever import (
+    IndexerFn,
+    IndexerOptions,
+    IndexerRef,
+    IndexerRequest,
+    RetrieverFn,
+    RetrieverOptions,
+    RetrieverRef,
+    RetrieverRequest,
+    RetrieverResponse,
+    define_indexer,
+    define_retriever,
+)
 from genkit._ai._evaluator import (
     BatchEvaluatorFn,
     EvaluatorFn,
@@ -398,6 +411,28 @@ class Genkit:
     ) -> Action:
         """Register a custom embedder action."""
         return define_embedder(self.registry, name, fn, options, metadata, description)
+
+    def define_retriever(
+        self,
+        name: str,
+        fn: RetrieverFn,
+        options: RetrieverOptions | None = None,
+        metadata: dict[str, object] | None = None,
+        description: str | None = None,
+    ) -> Action:
+        """Register a retriever action."""
+        return define_retriever(self.registry, name, fn, options, metadata, description)
+
+    def define_indexer(
+        self,
+        name: str,
+        fn: IndexerFn,
+        options: IndexerOptions | None = None,
+        metadata: dict[str, object] | None = None,
+        description: str | None = None,
+    ) -> Action:
+        """Register an indexer action."""
+        return define_indexer(self.registry, name, fn, options, metadata, description)
 
     def define_format(self, format: FormatDef) -> None:
         """Register a custom output format."""
@@ -1076,6 +1111,67 @@ class Genkit:
         response = (await embed_action.run(EmbedRequest(input=documents, options=options))).response  # type: ignore[arg-type]
         return response.embeddings
 
+    async def retrieve(
+        self,
+        *,
+        retriever: str | RetrieverRef,
+        query: str | Document,
+        options: dict[str, object] | None = None,
+    ) -> RetrieverResponse:
+        """Retrieve documents from a vector store.
+
+        Args:
+            retriever: Name or reference to the retriever.
+            query: The query document or text string.
+            options: Optional retriever-specific options (e.g., k).
+
+        Returns:
+            RetrieverResponse containing matched documents.
+        """
+        if isinstance(retriever, RetrieverRef):
+            name = retriever.name
+            merged_options = {**(retriever.config or {}), **(options or {})} if retriever.config or options else options
+        else:
+            name = retriever
+            merged_options = options
+
+        retriever_action = await self.registry.resolve_retriever(name)
+        if retriever_action is None:
+            raise ValueError(f'Retriever "{name}" not found')
+
+        query_doc = Document.from_text(query) if isinstance(query, str) else query
+        request = RetrieverRequest(query=query_doc, options=merged_options)
+        result = await retriever_action.run(request)
+        return result.response
+
+    async def index(
+        self,
+        *,
+        indexer: str | IndexerRef,
+        documents: list[Document],
+        options: dict[str, object] | None = None,
+    ) -> None:
+        """Index documents into a vector store.
+
+        Args:
+            indexer: Name or reference to the indexer.
+            documents: Documents to index.
+            options: Optional indexer-specific options.
+        """
+        if isinstance(indexer, IndexerRef):
+            name = indexer.name
+            merged_options = {**(indexer.config or {}), **(options or {})} if indexer.config or options else options
+        else:
+            name = indexer
+            merged_options = options
+
+        indexer_action = await self.registry.resolve_indexer(name)
+        if indexer_action is None:
+            raise ValueError(f'Indexer "{name}" not found')
+
+        request = IndexerRequest(documents=documents, options=merged_options)
+        await indexer_action.run(request)
+
     async def evaluate(
         self,
         evaluator: str | EvaluatorRef | None = None,
@@ -1165,6 +1261,15 @@ class Genkit:
             raise ValueError(f'Failed to resolve background action from original request: {operation.action}')
 
         return await background_action.cancel(operation)
+
+    async def close(self) -> None:
+        """Shut down the Genkit instance, releasing plugin resources.
+
+        Iterates all registered plugins and calls their ``close()`` method.
+        Safe to call multiple times.
+        """
+        for plugin in self.registry._plugins.values():
+            await plugin.close()
 
     async def generate_operation(
         self,

--- a/py/packages/genkit/src/genkit/_ai/_retriever.py
+++ b/py/packages/genkit/src/genkit/_ai/_retriever.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Retriever and indexer types and utilities for Genkit."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+from genkit._core._action import Action, ActionKind, get_func_description
+from genkit._core._base import GenkitModel
+from genkit._core._model import Document
+from genkit._core._registry import Registry
+from genkit._core._schema import to_json_schema
+
+
+class RetrieverRequest(GenkitModel):
+    """Request payload for a retriever action."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        alias_generator=to_camel, extra='forbid', populate_by_name=True
+    )
+    query: Document
+    options: Any | None = None
+
+
+class RetrieverResponse(GenkitModel):
+    """Response payload from a retriever action."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        alias_generator=to_camel, extra='forbid', populate_by_name=True
+    )
+    documents: list[Document]
+
+
+class IndexerRequest(GenkitModel):
+    """Request payload for an indexer action."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        alias_generator=to_camel, extra='forbid', populate_by_name=True
+    )
+    documents: list[Document]
+    options: Any | None = None
+
+
+class IndexerResponse(GenkitModel):
+    """Response payload from an indexer action (empty — indexing is side-effect only)."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        alias_generator=to_camel, extra='forbid', populate_by_name=True
+    )
+
+
+class RetrieverOptions(BaseModel):
+    """Configuration options for a retriever."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
+
+    config_schema: dict[str, Any] | None = None
+    label: str | None = None
+
+
+class IndexerOptions(BaseModel):
+    """Configuration options for an indexer."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra='forbid', populate_by_name=True, alias_generator=to_camel)
+
+    config_schema: dict[str, Any] | None = None
+    label: str | None = None
+
+
+class RetrieverRef(BaseModel):
+    """Reference to a retriever with optional configuration."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra='forbid', populate_by_name=True)
+
+    name: str
+    config: Any | None = None
+
+
+class IndexerRef(BaseModel):
+    """Reference to an indexer with optional configuration."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra='forbid', populate_by_name=True)
+
+    name: str
+    config: Any | None = None
+
+
+RetrieverFn = Callable[[RetrieverRequest], Awaitable[RetrieverResponse]]
+IndexerFn = Callable[[IndexerRequest], Awaitable[IndexerResponse]]
+
+
+def define_retriever(
+    registry: Registry,
+    name: str,
+    fn: RetrieverFn,
+    options: RetrieverOptions | None = None,
+    metadata: dict[str, object] | None = None,
+    description: str | None = None,
+) -> Action:
+    """Register a retriever action."""
+    retriever_meta: dict[str, object] = dict(metadata) if metadata else {}
+    retriever_info: dict[str, object]
+    existing = retriever_meta.get('retriever')
+    if isinstance(existing, dict):
+        retriever_info = {str(k): v for k, v in existing.items()}
+    else:
+        retriever_info = {}
+    retriever_meta['retriever'] = retriever_info
+
+    if options:
+        if options.label:
+            retriever_info['label'] = options.label
+        if options.config_schema:
+            retriever_info['customOptions'] = to_json_schema(options.config_schema)
+
+    retriever_description = get_func_description(fn, description)
+    return registry.register_action(
+        name=name,
+        kind=ActionKind.RETRIEVER,
+        fn=fn,
+        metadata=retriever_meta,
+        description=retriever_description,
+    )
+
+
+def define_indexer(
+    registry: Registry,
+    name: str,
+    fn: IndexerFn,
+    options: IndexerOptions | None = None,
+    metadata: dict[str, object] | None = None,
+    description: str | None = None,
+) -> Action:
+    """Register an indexer action."""
+    indexer_meta: dict[str, object] = dict(metadata) if metadata else {}
+    indexer_info: dict[str, object]
+    existing = indexer_meta.get('indexer')
+    if isinstance(existing, dict):
+        indexer_info = {str(k): v for k, v in existing.items()}
+    else:
+        indexer_info = {}
+    indexer_meta['indexer'] = indexer_info
+
+    if options:
+        if options.label:
+            indexer_info['label'] = options.label
+        if options.config_schema:
+            indexer_info['customOptions'] = to_json_schema(options.config_schema)
+
+    indexer_description = get_func_description(fn, description)
+    return registry.register_action(
+        name=name,
+        kind=ActionKind.INDEXER,
+        fn=fn,
+        metadata=indexer_meta,
+        description=indexer_description,
+    )

--- a/py/packages/genkit/src/genkit/_core/_plugin.py
+++ b/py/packages/genkit/src/genkit/_core/_plugin.py
@@ -17,15 +17,20 @@
 """Abstract base class for Genkit plugins."""
 
 import abc
+from typing import TYPE_CHECKING
 
 from genkit._core._action import Action, ActionKind
 from genkit._core._typing import ActionMetadata
+
+if TYPE_CHECKING:
+    from genkit._core._registry import Registry
 
 
 class Plugin(abc.ABC):
     """Abstract base class for Genkit plugins."""
 
     name: str  # plugin namespace
+    _registry: 'Registry | None' = None
 
     @abc.abstractmethod
     async def init(self) -> list[Action]:
@@ -56,3 +61,10 @@ class Plugin(abc.ABC):
         """Resolve an embedder action by name (local or namespaced)."""
         target = name if '/' in name else f'{self.name}/{name}'
         return await self.resolve(ActionKind.EMBEDDER, target)
+
+    async def close(self) -> None:
+        """Release resources held by the plugin (connections, file handles, etc.).
+
+        Override this in plugins that hold open connections. The default is a no-op.
+        Called by ``Genkit.close()`` during shutdown.
+        """

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -419,6 +419,8 @@ class Registry:
             if plugin.name in self._plugins:
                 raise ValueError(f'Plugin {plugin.name} already registered')
             self._plugins[plugin.name] = plugin
+            # Allow plugins to resolve other actions at runtime (e.g., embedders).
+            plugin._registry = self
             self._all_plugins_initialized.clear()
 
     async def initialize_all_plugins(self) -> None:
@@ -785,3 +787,25 @@ class Registry:
         if action is None:
             return None
         return cast(Action[EvalRequest, EvalResponse, Never], action)
+
+    async def resolve_retriever(self, name: str) -> Action | None:
+        """Resolve a retriever action by name.
+
+        Args:
+            name: The retriever name (e.g., "my-retriever" or "plugin/retriever").
+
+        Returns:
+            A retriever action, or None if not found.
+        """
+        return await self.resolve_action(ActionKind.RETRIEVER, name)
+
+    async def resolve_indexer(self, name: str) -> Action | None:
+        """Resolve an indexer action by name.
+
+        Args:
+            name: The indexer name (e.g., "my-indexer" or "plugin/indexer").
+
+        Returns:
+            An indexer action, or None if not found.
+        """
+        return await self.resolve_action(ActionKind.INDEXER, name)

--- a/py/plugins/valkey/README.md
+++ b/py/plugins/valkey/README.md
@@ -1,0 +1,43 @@
+# Genkit Valkey Plugin
+
+Valkey vector store plugin for [Genkit](https://github.com/firebase/genkit).
+
+Provides indexing and retrieval backed by Valkey with the valkey-search module
+using HNSW vector similarity search.
+
+## Installation
+
+```bash
+pip install genkit-plugin-valkey
+```
+
+## Requirements
+
+- Valkey 8+ with the valkey-search module
+- Python 3.11+
+
+## Limitations
+
+- **Standalone mode only**: This plugin uses `GlideClient` (standalone). Cluster
+  deployments (`GlideClusterClient`) are not yet supported.
+
+## Usage
+
+```python
+from genkit import Genkit, Document
+from genkit.plugins.valkey import Valkey, ValkeyConfig
+
+cfg = ValkeyConfig(
+    index_name="my-index",
+    embedder="ollama/nomic-embed-text",
+    dimension=768,
+)
+
+ai = Genkit(plugins=[Valkey(configs=[cfg])])
+
+# Index documents
+await ai.index(indexer="valkey/my-index", documents=[...])
+
+# Retrieve
+resp = await ai.retrieve(retriever="valkey/my-index", query="search text", options={"k": 5})
+```

--- a/py/plugins/valkey/pyproject.toml
+++ b/py/plugins/valkey/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "genkit-plugin-valkey"
+version = "0.1.0"
+description = "Valkey vector store plugin for Genkit"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.11"
+dependencies = [
+    "genkit>=0.1.0,<1.0.0",
+    "valkey-glide>=2.0.0,<3.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/genkit"]

--- a/py/plugins/valkey/src/genkit/plugins/valkey/__init__.py
+++ b/py/plugins/valkey/src/genkit/plugins/valkey/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Valkey vector store plugin for Genkit."""
+
+from genkit.plugins.valkey.plugin import (
+    MetadataField,
+    MetadataFieldType,
+    Valkey,
+    ValkeyConfig,
+    ValkeyRetrieverOptions,
+    valkey_indexer_ref,
+    valkey_retriever_ref,
+)
+
+__all__ = [
+    'MetadataField',
+    'MetadataFieldType',
+    'Valkey',
+    'ValkeyConfig',
+    'ValkeyRetrieverOptions',
+    'valkey_indexer_ref',
+    'valkey_retriever_ref',
+]

--- a/py/plugins/valkey/src/genkit/plugins/valkey/plugin.py
+++ b/py/plugins/valkey/src/genkit/plugins/valkey/plugin.py
@@ -1,0 +1,467 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Valkey vector store plugin for Genkit.
+
+Provides indexing (HSET with HNSW vector fields) and retrieval (FT.SEARCH KNN)
+backed by Valkey with the valkey-search module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import struct
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from glide import (
+    Batch,
+    DataType,
+    DistanceMetricType,
+    FtCreateOptions,
+    FtSearchOptions,
+    GlideClient,
+    GlideClientConfiguration,
+    NodeAddress,
+    NumericField,
+    RequestError,
+    ReturnField,
+    TagField,
+    TextField,
+    VectorAlgorithm,
+    VectorField,
+    VectorFieldAttributesHnsw,
+    VectorType,
+)
+from glide import ft as glide_ft
+
+from genkit._ai._retriever import (
+    IndexerRef,
+    IndexerRequest,
+    IndexerResponse,
+    RetrieverRef,
+    RetrieverRequest,
+    RetrieverResponse,
+)
+from genkit._core._action import Action, ActionKind
+from genkit._core._model import Document
+from genkit._core._plugin import Plugin
+from genkit._core._typing import ActionMetadata, EmbedRequest
+
+
+VALKEY_PLUGIN_NAME = 'valkey'
+
+
+class MetadataFieldType(Enum):
+    """Type of a metadata field for FT.CREATE schema."""
+
+    TAG = 'TAG'
+    NUMERIC = 'NUMERIC'
+
+
+@dataclass
+class MetadataField:
+    """Declaration of a metadata field to index for filtering."""
+
+    name: str
+    field_type: MetadataFieldType = MetadataFieldType.TAG
+
+
+@dataclass
+class ValkeyRetrieverOptions:
+    """Options passed at retrieval time."""
+
+    k: int = 10
+    # Raw FT.SEARCH pre-filter expression interpolated directly into the query.
+    # Callers must ensure it does not contain untrusted user input.
+    filter: str | None = None
+
+
+@dataclass
+class ValkeyConfig:
+    """Configuration for a single Valkey index."""
+
+    index_name: str
+    embedder: str
+    dimension: int
+    host: str = 'localhost'
+    port: int = 6379
+    prefix: str | None = None
+    embedder_options: dict[str, Any] | None = None
+    distance_metric: DistanceMetricType = DistanceMetricType.COSINE
+    metadata_fields: list[MetadataField] = field(default_factory=list)
+
+
+def valkey_retriever_ref(index_name: str) -> RetrieverRef:
+    """Return a typed retriever reference for a Valkey index."""
+    return RetrieverRef(name=f'{VALKEY_PLUGIN_NAME}/{index_name}')
+
+
+def valkey_indexer_ref(index_name: str) -> IndexerRef:
+    """Return a typed indexer reference for a Valkey index."""
+    return IndexerRef(name=f'{VALKEY_PLUGIN_NAME}/{index_name}')
+
+
+def _float32_to_bytes(vec: list[float]) -> bytes:
+    """Convert a list of floats to little-endian bytes (matches Go/JS encoding)."""
+    return struct.pack(f'<{len(vec)}f', *vec)
+
+
+def _doc_id(doc: Document) -> str:
+    """Compute a deterministic document ID (MD5 of canonical JSON).
+
+    Uses a canonical serialization format {data, dataType, metadata} with
+    sorted keys that matches the Go and JS implementations for cross-language
+    interop.
+    """
+    canonical = {
+        'data': doc.data,
+        'dataType': doc.data_type or 'text',
+        'metadata': doc.metadata,
+    }
+    serialized = json.dumps(canonical, sort_keys=True, separators=(',', ':'))
+    return hashlib.md5(serialized.encode()).hexdigest()
+
+
+class Valkey(Plugin):
+    """Valkey vector store plugin for Genkit.
+
+    Registers an indexer and retriever for each configured index.
+    Requires a Valkey instance with the valkey-search module loaded.
+    """
+
+    name = VALKEY_PLUGIN_NAME
+
+    def __init__(self, configs: list[ValkeyConfig]) -> None:
+        """Initialize with one or more index configurations."""
+        self.configs = configs
+        self._clients: dict[str, GlideClient] = {}
+
+    async def init(self) -> list[Action]:
+        """Connect to Valkey and ensure indexes exist."""
+        actions: list[Action] = []
+
+        # Reuse clients for configs sharing the same host:port.
+        client_cache: dict[tuple[str, int], GlideClient] = {}
+
+        for cfg in self.configs:
+            prefix = cfg.prefix or cfg.index_name
+            cache_key = (cfg.host, cfg.port)
+            if cache_key in client_cache:
+                client = client_cache[cache_key]
+            else:
+                client = await GlideClient.create(
+                    GlideClientConfiguration(
+                        addresses=[NodeAddress(cfg.host, cfg.port)],
+                        client_name="genkit_vector_store_client",
+                    )
+                )
+                client_cache[cache_key] = client
+            self._clients[cfg.index_name] = client
+
+            await _ensure_index(
+                client, cfg.index_name, cfg.dimension, prefix,
+                cfg.distance_metric, cfg.metadata_fields,
+            )
+
+            indexer_action = Action(
+                kind=ActionKind.INDEXER,
+                name=f'{VALKEY_PLUGIN_NAME}/{cfg.index_name}',
+                fn=self._make_index_fn(client, cfg, prefix),
+                metadata={'indexer': {'label': f'Valkey - {cfg.index_name}'}},
+            )
+            actions.append(indexer_action)
+
+            retriever_action = Action(
+                kind=ActionKind.RETRIEVER,
+                name=f'{VALKEY_PLUGIN_NAME}/{cfg.index_name}',
+                fn=self._make_retrieve_fn(client, cfg, prefix),
+                metadata={'retriever': {'label': f'Valkey - {cfg.index_name}'}},
+            )
+            actions.append(retriever_action)
+
+        return actions
+
+    async def close(self) -> None:
+        """Close all Valkey client connections."""
+        seen: set[int] = set()
+        for client in self._clients.values():
+            if id(client) not in seen:
+                seen.add(id(client))
+                await client.close()
+        self._clients.clear()
+
+    async def _resolve_embedder(self, cfg: ValkeyConfig) -> Action:
+        """Resolve the embedder action from the registry.
+
+        Raises RuntimeError if the plugin is not registered, or ValueError
+        if the embedder cannot be found.
+        """
+        if self._registry is None:
+            raise RuntimeError(
+                'Valkey plugin not registered with a Genkit registry; '
+                'pass it to Genkit(plugins=[...]) before use'
+            )
+        action = await self._registry.resolve_embedder(cfg.embedder)
+        if action is None:
+            raise ValueError(f'Embedder "{cfg.embedder}" not found')
+        return action
+
+    async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
+        """Resolve is not needed — all actions are pre-registered in init."""
+        return None
+
+    async def list_actions(self) -> list[ActionMetadata]:
+        """List available indexer and retriever actions."""
+        actions: list[ActionMetadata] = []
+        for cfg in self.configs:
+            actions.append(
+                ActionMetadata(
+                    action_type=ActionKind.INDEXER,
+                    name=f'{VALKEY_PLUGIN_NAME}/{cfg.index_name}',
+                )
+            )
+            actions.append(
+                ActionMetadata(
+                    action_type=ActionKind.RETRIEVER,
+                    name=f'{VALKEY_PLUGIN_NAME}/{cfg.index_name}',
+                )
+            )
+        return actions
+
+    def _make_index_fn(self, client: GlideClient, cfg: ValkeyConfig, prefix: str):
+        """Create the indexer function for a given config."""
+        plugin = self
+
+        async def index_fn(req: IndexerRequest) -> IndexerResponse:
+            embedder_action = await plugin._resolve_embedder(cfg)
+
+            embed_response = (
+                await embedder_action.run(
+                    EmbedRequest(input=req.documents, options=cfg.embedder_options)  # type: ignore[arg-type]
+                )
+            ).response
+
+            if len(embed_response.embeddings) != len(req.documents):
+                raise ValueError(
+                    f'valkey: embedder returned {len(embed_response.embeddings)} embeddings for {len(req.documents)} docs'
+                )
+
+            for i, doc in enumerate(req.documents):
+                embedding = embed_response.embeddings[i].embedding
+                if len(embedding) != cfg.dimension:
+                    raise ValueError(
+                        f'valkey: embedder returned {len(embedding)}-dim vector, expected {cfg.dimension}'
+                    )
+
+            # Chunk documents into batches to avoid unbounded pipeline sizes
+            # that could cause OOM or timeouts with very large inputs.
+            _INDEX_BATCH_SIZE = 1000
+
+            entries: list[tuple[str, dict[str, bytes | str]]] = []
+            for i, doc in enumerate(req.documents):
+                embedding = embed_response.embeddings[i].embedding
+                vec_bytes = _float32_to_bytes(embedding)
+                doc_key = _doc_id(doc)
+                content = doc.data
+                data_type = doc.data_type or 'text'
+                metadata_json = json.dumps(doc.metadata or {})
+
+                key = f'{prefix}:{doc_key}'
+                fields: dict[str, bytes | str] = {
+                    'embedding': vec_bytes,
+                    '_content': content,
+                    '_metadata': metadata_json,
+                    '_dataType': data_type,
+                }
+
+                # Store declared metadata fields as top-level HASH fields for filtering.
+                # Numeric fields preserve numeric formatting for Valkey indexing.
+                if doc.metadata and cfg.metadata_fields:
+                    for mf in cfg.metadata_fields:
+                        val = doc.metadata.get(mf.name)
+                        if val is not None:
+                            if mf.field_type == MetadataFieldType.NUMERIC and isinstance(val, (int, float)):
+                                if isinstance(val, float) and (val != val or val == float('inf') or val == float('-inf')):
+                                    raise ValueError(
+                                        f'valkey: NUMERIC field {mf.name!r} received non-finite float {val!r}'
+                                    )
+                                fields[mf.name] = str(val)
+                            else:
+                                fields[mf.name] = str(val)
+
+                entries.append((key, fields))
+
+            for start in range(0, len(entries), _INDEX_BATCH_SIZE):
+                chunk = entries[start:start + _INDEX_BATCH_SIZE]
+                batch = Batch(is_atomic=False)
+                for key, fields in chunk:
+                    batch.hset(key, fields)
+                await client.exec(batch, raise_on_error=True)
+
+            return IndexerResponse()
+
+        return index_fn
+
+    def _make_retrieve_fn(self, client: GlideClient, cfg: ValkeyConfig, prefix: str):
+        """Create the retriever function for a given config."""
+        plugin = self
+
+        async def retrieve_fn(req: RetrieverRequest) -> RetrieverResponse:
+            k = 10
+            filter_expr: str | None = None
+            if req.options and isinstance(req.options, dict):
+                k = req.options.get('k', 10)
+                filter_expr = req.options.get('filter', None)
+
+            if k > 1000:
+                raise ValueError('valkey: k must not exceed 1000')
+
+            if filter_expr is not None:
+                _validate_filter(filter_expr)
+
+            embedder_action = await plugin._resolve_embedder(cfg)
+
+            embed_response = (
+                await embedder_action.run(
+                    EmbedRequest(input=[req.query], options=cfg.embedder_options)  # type: ignore[arg-type]
+                )
+            ).response
+
+            if not embed_response.embeddings:
+                raise ValueError('valkey: embedder returned no embeddings')
+            query_vec = embed_response.embeddings[0].embedding
+            query_bytes = _float32_to_bytes(query_vec)
+
+            # Build KNN query, optionally with a pre-filter expression.
+            if filter_expr:
+                query_str = f'({filter_expr})=>[KNN $k @embedding $query_vec]'
+            else:
+                query_str = '*=>[KNN $k @embedding $query_vec]'
+
+            search_options = FtSearchOptions(
+                params={
+                    'k': str(k),
+                    'query_vec': query_bytes,
+                },
+                return_fields=[
+                    ReturnField(field_identifier='_content'),
+                    ReturnField(field_identifier='_metadata'),
+                    ReturnField(field_identifier='_dataType'),
+                ],
+            )
+
+            result = await glide_ft.search(client, cfg.index_name, query_str, search_options)
+
+            documents: list[Document] = []
+            if isinstance(result, list) and len(result) > 1:
+                for entry in result[1:]:
+                    if not isinstance(entry, dict):
+                        continue
+                    for _doc_key, fields in entry.items():
+                        if not isinstance(fields, dict):
+                            continue
+                        content = ''
+                        metadata_str = '{}'
+                        data_type = 'text'
+                        for field_name, field_val in fields.items():
+                            fname = bytes(field_name).decode() if isinstance(field_name, (bytes, bytearray, memoryview)) else str(field_name)
+                            fval = bytes(field_val).decode() if isinstance(field_val, (bytes, bytearray, memoryview)) else str(field_val)
+                            if fname == '_content':
+                                content = fval
+                            elif fname == '_metadata':
+                                metadata_str = fval
+                            elif fname == '_dataType':
+                                data_type = fval or 'text'
+
+                        if not content:
+                            continue
+
+                        metadata = None
+                        if metadata_str and metadata_str != '{}':
+                            try:
+                                metadata = json.loads(metadata_str)
+                            except (json.JSONDecodeError, TypeError):
+                                metadata = None
+
+                        documents.append(Document.from_data(content, data_type, metadata))
+
+            return RetrieverResponse(documents=documents)
+
+        return retrieve_fn
+
+
+async def _ensure_index(
+    client: GlideClient,
+    index_name: str,
+    dimension: int,
+    prefix: str,
+    distance_metric: DistanceMetricType = DistanceMetricType.COSINE,
+    metadata_fields: list[MetadataField] | None = None,
+) -> None:
+    """Create the FT index if it does not already exist."""
+    schema = [
+        VectorField(
+            name='embedding',
+            algorithm=VectorAlgorithm.HNSW,
+            attributes=VectorFieldAttributesHnsw(
+                dimensions=dimension,
+                distance_metric=distance_metric,
+                type=VectorType.FLOAT32,
+            ),
+        ),
+        TextField(name='_content'),
+        TextField(name='_metadata'),
+        TextField(name='_dataType'),
+    ]
+
+    for mf in (metadata_fields or []):
+        if mf.field_type == MetadataFieldType.NUMERIC:
+            schema.append(NumericField(name=mf.name))
+        else:
+            schema.append(TagField(name=mf.name))
+
+    options = FtCreateOptions(data_type=DataType.HASH, prefixes=[f'{prefix}:'])
+
+    try:
+        await glide_ft.create(client, index_name, schema, options)
+    except RequestError as e:
+        if 'already exists' in str(e).lower():
+            return
+        raise
+
+
+_FILTER_DISALLOWED_PATTERN = re.compile(r'[;|`$\\]|=>')
+
+_MAX_FILTER_LENGTH = 2048
+
+
+def _validate_filter(filter_expr: str) -> None:
+    """Validate a filter expression to prevent query injection.
+
+    Raises ValueError if the expression contains characters or sequences that
+    could alter FT.SEARCH query semantics.
+    """
+    if len(filter_expr) > _MAX_FILTER_LENGTH:
+        raise ValueError('valkey: filter expression too long')
+    if _FILTER_DISALLOWED_PATTERN.search(filter_expr):
+        raise ValueError(
+            'valkey: filter expression contains disallowed characters. '
+            'Do not pass untrusted user input as a filter.'
+        )

--- a/py/plugins/valkey/src/genkit/plugins/valkey/plugin.py
+++ b/py/plugins/valkey/src/genkit/plugins/valkey/plugin.py
@@ -250,6 +250,8 @@ class Valkey(Plugin):
         plugin = self
 
         async def index_fn(req: IndexerRequest) -> IndexerResponse:
+            if not req.documents:
+                return IndexerResponse()
             embedder_action = await plugin._resolve_embedder(cfg)
 
             embed_response = (
@@ -297,7 +299,11 @@ class Valkey(Plugin):
                     for mf in cfg.metadata_fields:
                         val = doc.metadata.get(mf.name)
                         if val is not None:
-                            if mf.field_type == MetadataFieldType.NUMERIC and isinstance(val, (int, float)):
+                            if mf.field_type == MetadataFieldType.NUMERIC:
+                                if not isinstance(val, (int, float)):
+                                    raise ValueError(
+                                        f'valkey: NUMERIC field {mf.name!r} received non-numeric value: {type(val).__name__}'
+                                    )
                                 if isinstance(val, float) and (val != val or val == float('inf') or val == float('-inf')):
                                     raise ValueError(
                                         f'valkey: NUMERIC field {mf.name!r} received non-finite float {val!r}'

--- a/py/plugins/valkey/tests/test_plugin_unit.py
+++ b/py/plugins/valkey/tests/test_plugin_unit.py
@@ -1,0 +1,214 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the Valkey plugin error paths.
+
+These tests use mocked GlideClient and embedder to verify error propagation
+without requiring a running Valkey instance.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genkit._ai._retriever import IndexerRequest, RetrieverRequest
+from genkit._core._model import Document
+from genkit._core._typing import EmbedResponse, Embedding
+from genkit.plugins.valkey.plugin import (
+    Valkey,
+    ValkeyConfig,
+    _doc_id,
+    _float32_to_bytes,
+)
+
+
+# --- Helper utilities ---
+
+
+class FakeRegistry:
+    """Minimal registry mock for plugin tests."""
+
+    def __init__(self, embedder_fn=None, embedder_error=None):
+        self._embedder_fn = embedder_fn
+        self._embedder_error = embedder_error
+
+    async def resolve_embedder(self, name: str):
+        if self._embedder_error:
+            raise self._embedder_error
+        action = AsyncMock()
+        action.run = self._embedder_fn
+        return action
+
+
+def make_embed_fn(embeddings: list[list[float]] | None = None, error: Exception | None = None):
+    """Create a mock embedder function that returns given embeddings or raises an error."""
+    async def embed_fn(req):
+        if error:
+            raise error
+        vecs = embeddings or []
+        resp = MagicMock()
+        resp.response = EmbedResponse(
+            embeddings=[Embedding(embedding=v) for v in vecs]
+        )
+        return resp
+    return embed_fn
+
+
+# --- Unit tests for utility functions ---
+
+
+class TestDocId:
+    def test_deterministic(self):
+        d1 = Document.from_text('hello')
+        d2 = Document.from_text('hello')
+        assert _doc_id(d1) == _doc_id(d2)
+
+    def test_different_content(self):
+        d1 = Document.from_text('hello')
+        d2 = Document.from_text('world')
+        assert _doc_id(d1) != _doc_id(d2)
+
+    def test_md5_hex_length(self):
+        d = Document.from_text('test')
+        assert len(_doc_id(d)) == 32
+
+
+class TestFloat32ToBytes:
+    def test_basic_conversion(self):
+        result = _float32_to_bytes([1.0, 2.0, 3.0])
+        assert len(result) == 12  # 3 floats * 4 bytes
+
+    def test_empty_list(self):
+        result = _float32_to_bytes([])
+        assert result == b''
+
+    def test_round_trip(self):
+        import struct
+        values = [1.5, -2.5, 0.0]
+        result = _float32_to_bytes(values)
+        unpacked = struct.unpack(f'<{len(values)}f', result)
+        for expected, actual in zip(values, unpacked):
+            assert abs(expected - actual) < 1e-6
+
+
+# --- Unit tests for indexer error paths ---
+
+
+@pytest.mark.asyncio
+class TestIndexerErrors:
+    async def _make_index_fn(self, embed_fn, dimension=3):
+        """Create an indexer function with a mocked client and embedder."""
+        cfg = ValkeyConfig(
+            index_name='test-index',
+            embedder='mock/embedder',
+            dimension=dimension,
+            host='localhost',
+            port=6379,
+        )
+        plugin = Valkey(configs=[cfg])
+        mock_client = AsyncMock()
+        mock_client.hset = AsyncMock(return_value=1)
+
+        registry = MagicMock()
+        registry.resolve_embedder = AsyncMock(return_value=MagicMock(run=embed_fn))
+        plugin._registry = registry
+
+        prefix = cfg.prefix or cfg.index_name
+        index_fn = plugin._make_index_fn(mock_client, cfg, prefix)
+        return index_fn, mock_client
+
+    async def test_embedder_error_propagates(self):
+        """Embedder errors should propagate to the caller."""
+        embed_fn = make_embed_fn(error=RuntimeError('connection timeout'))
+        index_fn, _ = await self._make_index_fn(embed_fn)
+
+        docs = [Document.from_text('hello')]
+        with pytest.raises(RuntimeError, match='connection timeout'):
+            await index_fn(IndexerRequest(documents=docs))
+
+    async def test_embedding_count_mismatch(self):
+        """Should raise when embedder returns wrong number of embeddings."""
+        # Return 1 embedding for 2 documents
+        embed_fn = make_embed_fn(embeddings=[[0.1, 0.2, 0.3]])
+        index_fn, _ = await self._make_index_fn(embed_fn)
+
+        docs = [Document.from_text('doc1'), Document.from_text('doc2')]
+        with pytest.raises(ValueError, match='1 embeddings for 2 docs'):
+            await index_fn(IndexerRequest(documents=docs))
+
+    async def test_dimension_mismatch(self):
+        """Should raise when embedding dimension doesn't match config."""
+        # Config expects dim=3, embedder returns dim=2
+        embed_fn = make_embed_fn(embeddings=[[0.1, 0.2]])
+        index_fn, _ = await self._make_index_fn(embed_fn, dimension=3)
+
+        docs = [Document.from_text('hello')]
+        with pytest.raises(ValueError, match='2-dim vector, expected 3'):
+            await index_fn(IndexerRequest(documents=docs))
+
+    async def test_empty_documents_succeeds(self):
+        """Indexing empty list should succeed (embedder returns 0 embeddings, loop is no-op)."""
+        embed_fn = make_embed_fn(embeddings=[])
+        index_fn, _ = await self._make_index_fn(embed_fn)
+
+        result = await index_fn(IndexerRequest(documents=[]))
+        assert result is not None
+
+
+# --- Unit tests for retriever error paths ---
+
+
+@pytest.mark.asyncio
+class TestRetrieverErrors:
+    async def _make_retrieve_fn(self, embed_fn):
+        """Create a retriever function with a mocked client and embedder."""
+        cfg = ValkeyConfig(
+            index_name='test-index',
+            embedder='mock/embedder',
+            dimension=3,
+            host='localhost',
+            port=6379,
+        )
+        plugin = Valkey(configs=[cfg])
+        mock_client = AsyncMock()
+
+        registry = MagicMock()
+        registry.resolve_embedder = AsyncMock(return_value=MagicMock(run=embed_fn))
+        plugin._registry = registry
+
+        prefix = cfg.prefix or cfg.index_name
+        retrieve_fn = plugin._make_retrieve_fn(mock_client, cfg, prefix)
+        return retrieve_fn, mock_client
+
+    async def test_embedder_error_propagates(self):
+        """Embedder errors should propagate to the caller."""
+        embed_fn = make_embed_fn(error=RuntimeError('rate limited'))
+        retrieve_fn, _ = await self._make_retrieve_fn(embed_fn)
+
+        req = RetrieverRequest(query=Document.from_text('query'))
+        with pytest.raises(RuntimeError, match='rate limited'):
+            await retrieve_fn(req)
+
+    async def test_empty_embeddings_raises(self):
+        """Should raise when embedder returns no embeddings."""
+        embed_fn = make_embed_fn(embeddings=[])
+        retrieve_fn, _ = await self._make_retrieve_fn(embed_fn)
+
+        req = RetrieverRequest(query=Document.from_text('query'))
+        with pytest.raises(ValueError, match='no embeddings'):
+            await retrieve_fn(req)

--- a/py/plugins/valkey/tests/test_utils.py
+++ b/py/plugins/valkey/tests/test_utils.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure unit tests for valkey plugin utilities (no Valkey instance required)."""
+
+import struct
+
+import pytest
+
+from genkit import Document
+from genkit.plugins.valkey.plugin import (
+    _doc_id,
+    _float32_to_bytes,
+    _validate_filter,
+)
+
+
+def test_float32_to_bytes():
+    """Test float32 encoding matches expected little-endian format."""
+    vec = [1.0, 2.0, 3.0]
+    result = _float32_to_bytes(vec)
+    assert len(result) == 12  # 3 floats * 4 bytes
+
+    # Verify round-trip
+    unpacked = struct.unpack('<3f', result)
+    assert unpacked == (1.0, 2.0, 3.0)
+
+
+def test_doc_id_deterministic():
+    """Test that doc IDs are deterministic."""
+    d1 = Document.from_text('hello')
+    d2 = Document.from_text('hello')
+    d3 = Document.from_text('world')
+
+    assert _doc_id(d1) == _doc_id(d2)
+    assert _doc_id(d1) != _doc_id(d3)
+    assert len(_doc_id(d1)) == 32  # MD5 hex
+
+
+def test_validate_filter_allows_valid_expressions():
+    _validate_filter('@price:[100 200]')
+    _validate_filter('@tag:{foo}')
+    _validate_filter('*')
+    _validate_filter('')
+
+
+@pytest.mark.parametrize('char', [';', '|', '`', '$', '\\'])
+def test_validate_filter_blocks_disallowed_chars(char):
+    with pytest.raises(ValueError, match='disallowed characters'):
+        _validate_filter(f'@field:[0 10]{char}inject')
+
+
+def test_validate_filter_blocks_knn_injection_sequence():
+    """The => token separates filter from KNN clause and must be blocked."""
+    with pytest.raises(ValueError, match='disallowed characters'):
+        _validate_filter('@tag:{x})=>[KNN 99999 @embedding $query_vec]')
+    with pytest.raises(ValueError, match='disallowed characters'):
+        _validate_filter('foo=>bar')

--- a/py/plugins/valkey/tests/test_valkey.py
+++ b/py/plugins/valkey/tests/test_valkey.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for the Valkey plugin.
+
+Requires a running Valkey instance with valkey-search module:
+    docker run -d --name valkey -p 6379:6379 valkey/valkey:8-alpine
+
+Run:
+    VALKEY_TEST=1 pytest tests/test_valkey.py -v
+
+Note: These tests use asyncio.run() directly (sync test functions) because
+the valkey-glide client's Rust-backed tokio runtime deadlocks under
+pytest-asyncio's managed event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from genkit import Document, Genkit
+from genkit._ai._retriever import RetrieverResponse
+from genkit._core._typing import EmbedRequest, EmbedResponse, Embedding
+from genkit.plugins.valkey import Valkey, ValkeyConfig
+
+
+VALKEY_HOST = os.environ.get('VALKEY_HOST', 'localhost')
+VALKEY_PORT = int(os.environ.get('VALKEY_PORT', '6379'))
+
+# Skip all tests if VALKEY_TEST env var is not set
+pytestmark = pytest.mark.skipif(
+    os.environ.get('VALKEY_TEST') != '1',
+    reason='Set VALKEY_TEST=1 to run Valkey integration tests',
+)
+
+
+# --- Fake embedder that returns known vectors ---
+
+FAKE_VECTORS: dict[str, list[float]] = {
+    'espresso is strong coffee': [1.0, 0.0, 0.0],
+    'latte has steamed milk': [0.9, 0.1, 0.0],
+    'croissant is a pastry': [0.0, 0.0, 1.0],
+}
+
+
+async def fake_embed(req: EmbedRequest) -> EmbedResponse:
+    """Fake embedder that returns pre-registered vectors."""
+    embeddings = []
+    for doc in req.input:
+        text = ''
+        for part in doc.content:
+            part_data = part.root if hasattr(part, 'root') else part
+            text_val = getattr(part_data, 'text', None)
+            if isinstance(text_val, str):
+                text += text_val
+        vec = FAKE_VECTORS.get(text, [0.5, 0.5, 0.0])
+        embeddings.append(Embedding(embedding=vec))
+    return EmbedResponse(embeddings=embeddings)
+
+
+async def _run_index_and_retrieve() -> None:
+    """Index documents and retrieve them via KNN search."""
+    # Ensure the reflection server does not start.
+    os.environ.pop('GENKIT_ENV', None)
+
+    cfg = ValkeyConfig(
+        index_name='test-genkit-valkey-py',
+        embedder='fake/embedder',
+        dimension=3,
+        host=VALKEY_HOST,
+        port=VALKEY_PORT,
+    )
+
+    ai = Genkit(plugins=[Valkey(configs=[cfg])])
+    ai.define_embedder('fake/embedder', fake_embed)
+    await ai.registry.initialize_all_plugins()
+
+    try:
+        docs = [
+            Document.from_text('espresso is strong coffee'),
+            Document.from_text('latte has steamed milk'),
+            Document.from_text('croissant is a pastry'),
+        ]
+
+        await ai.index(indexer='valkey/test-genkit-valkey-py', documents=docs)
+
+        resp = await ai.retrieve(
+            retriever='valkey/test-genkit-valkey-py',
+            query=Document.from_text('espresso is strong coffee'),
+            options={'k': 2},
+        )
+
+        assert isinstance(resp, RetrieverResponse)
+        assert len(resp.documents) == 2
+
+        texts = [d.text for d in resp.documents]
+        for text in texts:
+            assert 'croissant' not in text, f'Unexpected pastry in results: {text}'
+    finally:
+        # Cleanup: drop the test index and close connections.
+        for plugin in ai.registry._plugins.values():
+            if hasattr(plugin, '_clients'):
+                client = plugin._clients.get(cfg.index_name)
+                if client:
+                    from glide import ft as glide_ft
+                    try:
+                        await glide_ft.dropindex(client, cfg.index_name)
+                    except Exception:
+                        pass
+                await plugin.close()
+
+
+def test_index_and_retrieve():
+    """Test indexing documents and retrieving them via KNN search."""
+    asyncio.run(_run_index_and_retrieve())
+
+
+def test_doc_id_cross_language_vector():
+    """Cross-language test vector: must match Go and JS implementations.
+
+    Canonical JSON: {"data":"hello","dataType":"text","metadata":null}
+    MD5: 3c04c6b9f04e5e522404b4c567ad09b0
+    """
+    from genkit.plugins.valkey.plugin import _doc_id
+
+    doc = Document.from_text('hello')
+    assert _doc_id(doc) == '3c04c6b9f04e5e522404b4c567ad09b0'

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "genkit-plugin-google-genai",
   "genkit-plugin-ollama",
   "genkit-plugin-evaluators",
+  "genkit-plugin-valkey",
   "genkit-plugin-vertex-ai",
   # Internal tools (private, not published)
   "liccheck>=0.9.2",
@@ -176,6 +177,7 @@ genkit-plugin-google-cloud          = { workspace = true }
 genkit-plugin-google-genai          = { workspace = true }
 genkit-plugin-ollama                = { workspace = true }
 genkit-plugin-evaluators            = { workspace = true }
+genkit-plugin-valkey                = { workspace = true }
 genkit-plugin-vertex-ai             = { workspace = true }
 [tool.uv.workspace]
 exclude = ["*/shared", "testapps/*"]

--- a/py/samples/valkey/README.md
+++ b/py/samples/valkey/README.md
@@ -1,0 +1,27 @@
+# Valkey RAG Sample
+
+Indexes documents into Valkey, retrieves the top matches for a query via KNN
+vector search, then uses an Ollama LLM to generate an answer grounded in the
+retrieved context.
+
+## Prerequisites
+
+1. Valkey with the valkey-search module:
+
+   ```bash
+   docker run -d --name valkey-search -p 6379:6379 valkey/valkey-search:latest
+   ```
+
+2. Ollama with the required models:
+
+   ```bash
+   ollama pull nomic-embed-text
+   ollama pull gemma4:e2b
+   ```
+
+## Run
+
+```bash
+uv sync
+uv run src/main.py
+```

--- a/py/samples/valkey/pyproject.toml
+++ b/py/samples/valkey/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "valkey-sample"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "genkit",
+    "genkit-plugin-valkey",
+    "genkit-plugin-ollama",
+]
+
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/py/samples/valkey/src/main.py
+++ b/py/samples/valkey/src/main.py
@@ -1,0 +1,107 @@
+# Genkit (Python) + Valkey RAG sample
+# Indexes 5 documents into Valkey, retrieves the top-3 matches for a query,
+# then uses an Ollama LLM to answer a question grounded in those results.
+#
+# Prerequisites:
+#   Valkey:  docker run -d --name valkey-search -p 6379:6379 valkey/valkey-search:latest
+#   Ollama:  ollama pull nomic-embed-text && ollama pull gemma4:e2b
+#   Install: cd py && uv sync
+#
+# How to run:
+#   uv run src/main.py
+
+from __future__ import annotations
+
+import asyncio
+
+from genkit import Document, Genkit
+from genkit.plugins.ollama import Ollama
+from genkit.plugins.ollama.embedders import EmbeddingDefinition
+from genkit.plugins.ollama.models import ModelDefinition
+from genkit.plugins.valkey import Valkey, ValkeyConfig
+
+EMBEDDER = 'ollama/nomic-embed-text'
+MODEL = 'ollama/gemma4:e2b'
+INDEX_NAME = 'genkit-sample-py'
+DIMENSION = 768  # nomic-embed-text output dimension
+
+
+async def main() -> None:
+    # --- Bootstrap ---
+    cfg = ValkeyConfig(
+        index_name=INDEX_NAME,
+        embedder=EMBEDDER,
+        dimension=DIMENSION,
+        host='localhost',
+        port=6379,
+    )
+
+    ai = Genkit(
+        plugins=[
+            Ollama(
+                models=[ModelDefinition(name='gemma4:e2b')],
+                embedders=[EmbeddingDefinition(name='nomic-embed-text', dimensions=DIMENSION)],
+            ),
+            Valkey(configs=[cfg]),
+        ],
+        model=MODEL,
+    )
+    await ai.registry.initialize_all_plugins()
+
+    # --- Index documents ---
+    docs = [
+        Document.from_text(
+            'Valkey is an open-source, high-performance in-memory data store '
+            'forked from Redis after the license change in 2024.',
+            metadata={'source': 'valkey-overview'},
+        ),
+        Document.from_text(
+            'The valkey-search module adds vector similarity search, full-text '
+            'search, and secondary indexing capabilities to Valkey.',
+            metadata={'source': 'valkey-search-docs'},
+        ),
+        Document.from_text(
+            'Genkit is a framework for building AI-powered applications that '
+            'supports flows, tools, retrievers, and indexers.',
+            metadata={'source': 'genkit-overview'},
+        ),
+        Document.from_text(
+            'HNSW (Hierarchical Navigable Small World) is an approximate nearest '
+            'neighbour algorithm used for fast vector similarity search.',
+            metadata={'source': 'hnsw-paper'},
+        ),
+        Document.from_text(
+            'Ollama lets you run large language models like Llama 3 and Mistral '
+            'locally on your own hardware without cloud dependencies.',
+            metadata={'source': 'ollama-docs'},
+        ),
+    ]
+
+    print('Indexing documents...')
+    await ai.index(indexer=f'valkey/{INDEX_NAME}', documents=docs)
+    print(f'Indexed {len(docs)} documents.\n')
+
+    # --- Retrieve ---
+    query = 'How does Valkey support vector search?'
+    print(f'Query: {query}')
+    response = await ai.retrieve(
+        retriever=f'valkey/{INDEX_NAME}',
+        query=query,
+        options={'k': 3},
+    )
+    print(f'Retrieved {len(response.documents)} documents:')
+    for i, doc in enumerate(response.documents, 1):
+        src = (doc.metadata or {}).get('source', 'unknown')
+        print(f'  [{i}] ({src}) {doc.text[:80]}...')
+    print()
+
+    # --- Generate answer grounded in retrieved context ---
+    answer = await ai.generate(
+        prompt=f'Answer the question concisely: {query}',
+        docs=response.documents,
+    )
+    print('Answer:', answer.text)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1,12 +1,11 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
+    "python_full_version < '3.12'",
 ]
 
 [manifest]
@@ -29,6 +28,7 @@ members = [
     "genkit-plugin-google-cloud",
     "genkit-plugin-google-genai",
     "genkit-plugin-ollama",
+    "genkit-plugin-valkey",
     "genkit-plugin-vertex-ai",
     "genkit-workspace",
     "google-genai-media",
@@ -37,6 +37,7 @@ members = [
     "prompts",
     "tool-interrupts",
     "tracing",
+    "valkey-sample",
     "vertexai-imagen",
 ]
 overrides = [{ name = "werkzeug", specifier = ">=3.1.6" }]
@@ -117,7 +118,6 @@ name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -185,11 +185,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
     { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
     { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
-    { url = "https://files.pythonhosted.org/packages/11/2d/ba4e4ca8d149f8dcc0d952ac0967089e1d759c7e5fcf0865a317eb680fbb/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6dca33a9859abf613e22733131fc9194091c1fa7cb3e131c143056b4856aa47e", size = 24549, upload-time = "2025-07-30T10:02:00.101Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/82/9b2386cc75ac0bd3210e12a44bfc7fd1632065ed8b80d573036eecb10442/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:21378b40e1b8d1655dd5310c84a40fc19a9aa5e6366e835ceb8576bf0fea716d", size = 25539, upload-time = "2025-07-30T10:02:00.929Z" },
-    { url = "https://files.pythonhosted.org/packages/31/db/740de99a37aa727623730c90d92c22c9e12585b3c98c54b7960f7810289f/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d588dec224e2a83edbdc785a5e6f3c6cd736f46bfd4b441bbb5aa1f5085e584", size = 28467, upload-time = "2025-07-30T10:02:02.08Z" },
-    { url = "https://files.pythonhosted.org/packages/71/7a/47c4509ea18d755f44e2b92b7178914f0c113946d11e16e626df8eaa2b0b/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5acb4e41090d53f17ca1110c3427f0a130f944b896fc8c83973219c97f57b690", size = 27355, upload-time = "2025-07-30T10:02:02.867Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/82/82745642d3c46e7cea25e1885b014b033f4693346ce46b7f47483cf5d448/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:da0c79c23a63723aa5d782250fbf51b768abca630285262fb5144ba5ae01e520", size = 29187, upload-time = "2025-07-30T10:02:03.674Z" },
 ]
 
 [[package]]
@@ -209,9 +204,6 @@ wheels = [
 name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
@@ -230,9 +222,6 @@ wheels = [
 name = "async-lru"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/c3/bbf34f15ea88dfb649ab2c40f9d75081784a50573a9ea431563cab64adb8/async_lru-2.1.0.tar.gz", hash = "sha256:9eeb2fecd3fe42cc8a787fc32ead53a3a7158cc43d039c3c55ab3e4e5b2a80ed", size = 12041, upload-time = "2026-01-17T22:52:18.931Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/e9/eb6a5db5ac505d5d45715388e92bced7a5bb556facc4d0865d192823f2d2/async_lru-2.1.0-py3-none-any.whl", hash = "sha256:fa12dcf99a42ac1280bc16c634bbaf06883809790f6304d85cdab3f666f33a7e", size = 6933, upload-time = "2026-01-17T22:52:17.389Z" },
@@ -254,15 +243,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
-]
-
-[[package]]
-name = "backports-asyncio-runner"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
 ]
 
 [[package]]
@@ -324,16 +304,9 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/a8/11170031095655d36ebc6664fe0897866f6023892396900eec0e8fdc4299/black-26.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:86a8b5035fce64f5dcd1b794cf8ec4d31fe458cf6ce3986a30deb434df82a1d2", size = 1866562, upload-time = "2026-03-12T03:39:58.639Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ce/9e7548d719c3248c6c2abfd555d11169457cbd584d98d179111338423790/black-26.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5602bdb96d52d2d0672f24f6ffe5218795736dd34807fd0fd55ccd6bf206168b", size = 1703623, upload-time = "2026-03-12T03:40:00.347Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/0a/8d17d1a9c06f88d3d030d0b1d4373c1551146e252afe4547ed601c0e697f/black-26.3.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c54a4a82e291a1fee5137371ab488866b7c86a3305af4026bdd4dc78642e1ac", size = 1768388, upload-time = "2026-03-12T03:40:01.765Z" },
-    { url = "https://files.pythonhosted.org/packages/52/79/c1ee726e221c863cde5164f925bacf183dfdf0397d4e3f94889439b947b4/black-26.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:6e131579c243c98f35bce64a7e08e87fb2d610544754675d4a0e73a070a5aa3a", size = 1412969, upload-time = "2026-03-12T03:40:03.252Z" },
-    { url = "https://files.pythonhosted.org/packages/73/a5/15c01d613f5756f68ed8f6d4ec0a1e24b82b18889fa71affd3d1f7fad058/black-26.3.1-cp310-cp310-win_arm64.whl", hash = "sha256:5ed0ca58586c8d9a487352a96b15272b7fa55d139fc8496b519e78023a8dab0a", size = 1220345, upload-time = "2026-03-12T03:40:04.892Z" },
     { url = "https://files.pythonhosted.org/packages/17/57/5f11c92861f9c92eb9dddf515530bc2d06db843e44bdcf1c83c1427824bc/black-26.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff", size = 1851987, upload-time = "2026-03-12T03:40:06.248Z" },
     { url = "https://files.pythonhosted.org/packages/54/aa/340a1463660bf6831f9e39646bf774086dbd8ca7fc3cded9d59bbdf4ad0a/black-26.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c", size = 1689499, upload-time = "2026-03-12T03:40:07.642Z" },
     { url = "https://files.pythonhosted.org/packages/f3/01/b726c93d717d72733da031d2de10b92c9fa4c8d0c67e8a8a372076579279/black-26.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5", size = 1754369, upload-time = "2026-03-12T03:40:09.279Z" },
@@ -411,13 +384,11 @@ version = "0.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "curtsies" },
-    { name = "cwcwidth", version = "0.1.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cwcwidth", version = "0.1.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cwcwidth" },
     { name = "greenlet" },
     { name = "pygments" },
     { name = "pyxdg" },
     { name = "requests" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/29/cd80e9108a6fc6a925ffb915f8f69198a2bb2388e39167a41d743ac2a8f4/bpython-0.26.tar.gz", hash = "sha256:f79083e1e3723be9b49c9994ad1dd3a19ccb4d0d4f9a6f5b3a73bef8bc327433", size = 207564, upload-time = "2025-10-28T07:19:41.97Z" }
 wheels = [
@@ -469,18 +440,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
-    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
-    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
-    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
-    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
-    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
-    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
     { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
     { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
     { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
@@ -557,22 +516,6 @@ version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/b8/6d51fc1d52cbd52cd4ccedd5b5b2f0f6a11bbf6765c782298b0f3e808541/charset_normalizer-3.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d", size = 209709, upload-time = "2025-10-14T04:40:11.385Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/af/1f9d7f7faafe2ddfb6f72a2e07a548a629c61ad510fe60f9630309908fef/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8", size = 148814, upload-time = "2025-10-14T04:40:13.135Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3d/f2e3ac2bbc056ca0c204298ea4e3d9db9b4afe437812638759db2c976b5f/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad", size = 144467, upload-time = "2025-10-14T04:40:14.728Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/85/1bf997003815e60d57de7bd972c57dc6950446a3e4ccac43bc3070721856/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8", size = 162280, upload-time = "2025-10-14T04:40:16.14Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/8e/6aa1952f56b192f54921c436b87f2aaf7c7a7c3d0d1a765547d64fd83c13/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d", size = 159454, upload-time = "2025-10-14T04:40:17.567Z" },
-    { url = "https://files.pythonhosted.org/packages/36/3b/60cbd1f8e93aa25d1c669c649b7a655b0b5fb4c571858910ea9332678558/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313", size = 153609, upload-time = "2025-10-14T04:40:19.08Z" },
-    { url = "https://files.pythonhosted.org/packages/64/91/6a13396948b8fd3c4b4fd5bc74d045f5637d78c9675585e8e9fbe5636554/charset_normalizer-3.4.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e", size = 151849, upload-time = "2025-10-14T04:40:20.607Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/7a/59482e28b9981d105691e968c544cc0df3b7d6133152fb3dcdc8f135da7a/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93", size = 151586, upload-time = "2025-10-14T04:40:21.719Z" },
-    { url = "https://files.pythonhosted.org/packages/92/59/f64ef6a1c4bdd2baf892b04cd78792ed8684fbc48d4c2afe467d96b4df57/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0", size = 145290, upload-time = "2025-10-14T04:40:23.069Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/63/3bf9f279ddfa641ffa1962b0db6a57a9c294361cc2f5fcac997049a00e9c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84", size = 163663, upload-time = "2025-10-14T04:40:24.17Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/09/c9e38fc8fa9e0849b172b581fd9803bdf6e694041127933934184e19f8c3/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e", size = 151964, upload-time = "2025-10-14T04:40:25.368Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/d1/d28b747e512d0da79d8b6a1ac18b7ab2ecfd81b2944c4c710e166d8dd09c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db", size = 161064, upload-time = "2025-10-14T04:40:26.806Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/9a/31d62b611d901c3b9e5500c36aab0ff5eb442043fb3a1c254200d3d397d9/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6", size = 155015, upload-time = "2025-10-14T04:40:28.284Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f3/107e008fa2bff0c8b9319584174418e5e5285fef32f79d8ee6a430d0039c/charset_normalizer-3.4.4-cp310-cp310-win32.whl", hash = "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f", size = 99792, upload-time = "2025-10-14T04:40:29.613Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/66/e396e8a408843337d7315bab30dbf106c38966f1819f123257f5520f8a96/charset_normalizer-3.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d", size = 107198, upload-time = "2025-10-14T04:40:30.644Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/58/01b4f815bf0312704c267f2ccb6e5d42bcc7752340cd487bc9f8c3710597/charset_normalizer-3.4.4-cp310-cp310-win_arm64.whl", hash = "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69", size = 100262, upload-time = "2025-10-14T04:40:32.108Z" },
     { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", size = 206988, upload-time = "2025-10-14T04:40:33.79Z" },
     { url = "https://files.pythonhosted.org/packages/94/59/2e87300fe67ab820b5428580a53cad894272dbb97f38a7a814a2a1ac1011/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0", size = 147324, upload-time = "2025-10-14T04:40:34.961Z" },
     { url = "https://files.pythonhosted.org/packages/07/fb/0cf61dc84b2b088391830f6274cb57c82e4da8bbc2efeac8c025edb88772/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3", size = 142742, upload-time = "2025-10-14T04:40:36.105Z" },
@@ -709,20 +652,6 @@ version = "7.13.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/56/95b7e30fa389756cb56630faa728da46a27b8c6eb46f9d557c68fff12b65/coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91", size = 827239, upload-time = "2026-02-09T12:59:03.86Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/d4/7827d9ffa34d5d4d752eec907022aa417120936282fc488306f5da08c292/coverage-7.13.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0fc31c787a84f8cd6027eba44010517020e0d18487064cd3d8968941856d1415", size = 219152, upload-time = "2026-02-09T12:56:11.974Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b0/d69df26607c64043292644dbb9dc54b0856fabaa2cbb1eeee3331cc9e280/coverage-7.13.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a32ebc02a1805adf637fc8dec324b5cdacd2e493515424f70ee33799573d661b", size = 219667, upload-time = "2026-02-09T12:56:13.33Z" },
-    { url = "https://files.pythonhosted.org/packages/82/a4/c1523f7c9e47b2271dbf8c2a097e7a1f89ef0d66f5840bb59b7e8814157b/coverage-7.13.4-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e24f9156097ff9dc286f2f913df3a7f63c0e333dcafa3c196f2c18b4175ca09a", size = 246425, upload-time = "2026-02-09T12:56:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/02/aa7ec01d1a5023c4b680ab7257f9bfde9defe8fdddfe40be096ac19e8177/coverage-7.13.4-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8041b6c5bfdc03257666e9881d33b1abc88daccaf73f7b6340fb7946655cd10f", size = 248229, upload-time = "2026-02-09T12:56:16.31Z" },
-    { url = "https://files.pythonhosted.org/packages/35/98/85aba0aed5126d896162087ef3f0e789a225697245256fc6181b95f47207/coverage-7.13.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a09cfa6a5862bc2fc6ca7c3def5b2926194a56b8ab78ffcf617d28911123012", size = 250106, upload-time = "2026-02-09T12:56:18.024Z" },
-    { url = "https://files.pythonhosted.org/packages/96/72/1db59bd67494bc162e3e4cd5fbc7edba2c7026b22f7c8ef1496d58c2b94c/coverage-7.13.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:296f8b0af861d3970c2a4d8c91d48eb4dd4771bcef9baedec6a9b515d7de3def", size = 252021, upload-time = "2026-02-09T12:56:19.272Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/97/72899c59c7066961de6e3daa142d459d47d104956db43e057e034f015c8a/coverage-7.13.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e101609bcbbfb04605ea1027b10dc3735c094d12d40826a60f897b98b1c30256", size = 247114, upload-time = "2026-02-09T12:56:21.051Z" },
-    { url = "https://files.pythonhosted.org/packages/39/1f/f1885573b5970235e908da4389176936c8933e86cb316b9620aab1585fa2/coverage-7.13.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa3feb8db2e87ff5e6d00d7e1480ae241876286691265657b500886c98f38bda", size = 248143, upload-time = "2026-02-09T12:56:22.585Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/cf/e80390c5b7480b722fa3e994f8202807799b85bc562aa4f1dde209fbb7be/coverage-7.13.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4fc7fa81bbaf5a02801b65346c8b3e657f1d93763e58c0abdf7c992addd81a92", size = 246152, upload-time = "2026-02-09T12:56:23.748Z" },
-    { url = "https://files.pythonhosted.org/packages/44/bf/f89a8350d85572f95412debb0fb9bb4795b1d5b5232bd652923c759e787b/coverage-7.13.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:33901f604424145c6e9c2398684b92e176c0b12df77d52db81c20abd48c3794c", size = 249959, upload-time = "2026-02-09T12:56:25.209Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/6e/612a02aece8178c818df273e8d1642190c4875402ca2ba74514394b27aba/coverage-7.13.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:bb28c0f2cf2782508a40cec377935829d5fcc3ad9a3681375af4e84eb34b6b58", size = 246416, upload-time = "2026-02-09T12:56:26.475Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/98/b5afc39af67c2fa6786b03c3a7091fc300947387ce8914b096db8a73d67a/coverage-7.13.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d107aff57a83222ddbd8d9ee705ede2af2cc926608b57abed8ef96b50b7e8f9", size = 247025, upload-time = "2026-02-09T12:56:27.727Z" },
-    { url = "https://files.pythonhosted.org/packages/51/30/2bba8ef0682d5bd210c38fe497e12a06c9f8d663f7025e9f5c2c31ce847d/coverage-7.13.4-cp310-cp310-win32.whl", hash = "sha256:a6f94a7d00eb18f1b6d403c91a88fd58cfc92d4b16080dfdb774afc8294469bf", size = 221758, upload-time = "2026-02-09T12:56:29.051Z" },
-    { url = "https://files.pythonhosted.org/packages/78/13/331f94934cf6c092b8ea59ff868eb587bc8fe0893f02c55bc6c0183a192e/coverage-7.13.4-cp310-cp310-win_amd64.whl", hash = "sha256:2cb0f1e000ebc419632bbe04366a8990b6e32c4e0b51543a6484ffe15eaeda95", size = 222693, upload-time = "2026-02-09T12:56:30.366Z" },
     { url = "https://files.pythonhosted.org/packages/b4/ad/b59e5b451cf7172b8d1043dc0fa718f23aab379bc1521ee13d4bd9bfa960/coverage-7.13.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d490ba50c3f35dd7c17953c68f3270e7ccd1c6642e2d2afe2d8e720b98f5a053", size = 219278, upload-time = "2026-02-09T12:56:31.673Z" },
     { url = "https://files.pythonhosted.org/packages/f1/17/0cb7ca3de72e5f4ef2ec2fa0089beafbcaaaead1844e8b8a63d35173d77d/coverage-7.13.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:19bc3c88078789f8ef36acb014d7241961dbf883fd2533d18cb1e7a5b4e28b11", size = 219783, upload-time = "2026-02-09T12:56:33.104Z" },
     { url = "https://files.pythonhosted.org/packages/ab/63/325d8e5b11e0eaf6d0f6a44fad444ae58820929a9b0de943fa377fe73e85/coverage-7.13.4-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3998e5a32e62fdf410c0dbd3115df86297995d6e3429af80b8798aad894ca7aa", size = 250200, upload-time = "2026-02-09T12:56:34.474Z" },
@@ -827,7 +756,6 @@ version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
 wheels = [
@@ -887,8 +815,7 @@ version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blessed" },
-    { name = "cwcwidth", version = "0.1.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cwcwidth", version = "0.1.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cwcwidth" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/18/5741cb42624089a815520d5b65c39c3e59673a77fd1fab6ad65bdebf2f91/curtsies-0.4.3.tar.gz", hash = "sha256:102a0ffbf952124f1be222fd6989da4ec7cce04e49f613009e5f54ad37618825", size = 53401, upload-time = "2025-06-05T06:33:20.099Z" }
 wheels = [
@@ -897,60 +824,8 @@ wheels = [
 
 [[package]]
 name = "cwcwidth"
-version = "0.1.11"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/bc/1746c7650e8c676e7799d40fc31d37d88882c18d92fbcdd1d014c8c8786c/cwcwidth-0.1.11.tar.gz", hash = "sha256:594d8855a6319cc3ef36e0b6374fae02e4f4fe17cd87d0debe8b6e00eb186c17", size = 71727, upload-time = "2025-10-28T08:22:08.186Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/ee/8073e18f9ec39195b7d44d153eea900f409324b973626c571ccc61b0b7f3/cwcwidth-0.1.11-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7bf37420fc4894ff21eedb069cd75f38a8f330a5c79501160a7bb21c79163ad9", size = 25105, upload-time = "2025-10-28T08:21:31.577Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/32/22d951c240200129e4b47849dcc6dd25f8222e5cf3812f08ad19dd1f0072/cwcwidth-0.1.11-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fd61620714344d529250a6d7b5896f51261b65526c84299691cf062cbf4666ce", size = 93135, upload-time = "2025-10-28T08:21:33.009Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/d3/ef90bdf90a572dcad2eca0007752f452cd912ccec1a07b3bda3b95498d9e/cwcwidth-0.1.11-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ea4a44ce6101a9f47491dae881cb97a31930e9d7ebd77854a2b7ee79674b3859", size = 96992, upload-time = "2025-10-28T08:21:34.168Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/f8/efa7c8ee215617ca5ec8ddf469e4d7578e9aecbe819e877c830ab1a847af/cwcwidth-0.1.11-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d72185b2c20d85b90ef22eeec650c9e48a0652f8787811b806f2d54f1b2bbe39", size = 95306, upload-time = "2025-10-28T08:21:35.44Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/b2/72263ab2f036398d1babc1b4ab8a6f1c84ed2c630eb1fbf3c48e7b44d68f/cwcwidth-0.1.11-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e8e32df4db4a6c15770b885795f8e1bb709fc272337d4c0567691130f66ab83a", size = 94791, upload-time = "2025-10-28T08:21:36.436Z" },
-    { url = "https://files.pythonhosted.org/packages/89/e5/47790bea7f0a7abd6f50eb844caed668058819bd3edff2464b1b09755494/cwcwidth-0.1.11-cp310-cp310-win32.whl", hash = "sha256:0be3ab3e9b0b7691dce2c7099b038319cb5bc1384f53ec4c7e84371a92670db4", size = 23608, upload-time = "2025-10-28T08:21:37.691Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/3d/4ea6783ac7e3807204d589a167c57c5d18571c3f4723b322f139175f44e1/cwcwidth-0.1.11-cp310-cp310-win_amd64.whl", hash = "sha256:bdc00d41885d9ec4ef201e7f1c09225f895b63dde2b913bb5a62e9ce805ecf31", size = 25819, upload-time = "2025-10-28T08:21:38.458Z" },
-    { url = "https://files.pythonhosted.org/packages/98/62/06a0b0ca86072e73e5a517772b0a4c7f293207b8662d9dbe33101922c611/cwcwidth-0.1.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a920e4a8734ee3da9088c9ef57ba38070c51d06131d23650fd02278b2229d72b", size = 25382, upload-time = "2025-10-28T08:21:39.227Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/2e/14c02a88854c169113db2e5543e5c07903bab52a7af7db0d3060f5040d18/cwcwidth-0.1.11-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0cf261cbf7cbb80f5b9382872bcab2d601c9c0ef3781933945f18d717635f67f", size = 99377, upload-time = "2025-10-28T08:21:40.136Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/22/1194998e82ee394dc0d489ed501b37e73a824825823cc6338cb30233e370/cwcwidth-0.1.11-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95cb5d3035601a2224149081d9e42e86e1740aef78ad7d82e6c7eb84e4ac6273", size = 103198, upload-time = "2025-10-28T08:21:41.041Z" },
-    { url = "https://files.pythonhosted.org/packages/64/4b/a381e93922da1df7833d00068221b63ecc3f3934d360a6e1516321431385/cwcwidth-0.1.11-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:57a11d509afeac7f3b565948e9c760caf81d2c158d8fa8d3863b0a344871cd20", size = 101598, upload-time = "2025-10-28T08:21:42.376Z" },
-    { url = "https://files.pythonhosted.org/packages/71/4c/4c4f2066f4a014a7f00735ade8aedcfc2c9c642a24aba25f990b6ca953a6/cwcwidth-0.1.11-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:47827c8d13b24102c3616fb920828330a732e6b3e80dc9d67f3cc2148a7b7e72", size = 101160, upload-time = "2025-10-28T08:21:43.402Z" },
-    { url = "https://files.pythonhosted.org/packages/15/48/459518aa52378fd4e880030869922ab6a6a4cd1f789b8612110945bab7ec/cwcwidth-0.1.11-cp311-cp311-win32.whl", hash = "sha256:11ad90f3d75b99836aae45d509f0ae788379ef0c95c934f6d1941c59c93d9fbf", size = 23670, upload-time = "2025-10-28T08:21:44.601Z" },
-    { url = "https://files.pythonhosted.org/packages/50/6c/5c2502ca2b9bfcb719e5aafb398fa6308648f207c0fb8ae64db01b0a145b/cwcwidth-0.1.11-cp311-cp311-win_amd64.whl", hash = "sha256:6c2c7d1d02b6a5d77f049a5e0ebba7917471f74c05c482e8f484194ce3c327b7", size = 25996, upload-time = "2025-10-28T08:21:45.381Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/14/b515b65df350fe36ab2ae446d254bc37ef08db1a3d5b9b8e1f8596232e49/cwcwidth-0.1.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:31684dacd89476ebcc19e3b7317626fd9c5c04511a77d4a03df5f95f39a1daee", size = 25579, upload-time = "2025-10-28T08:21:46.497Z" },
-    { url = "https://files.pythonhosted.org/packages/66/e1/5e9e8b2cd8b04669996f027e4f5d9e66e20e3ec3c6e0870c521c11b84bfe/cwcwidth-0.1.11-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0677707bd62906808e1d0a28c53eeeedaf9402d207c8f52688d2be001021c492", size = 104721, upload-time = "2025-10-28T08:21:47.756Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ff/0789b77c461ed903443c6239025240ec7272071a44aa4340af8a55ea2d4d/cwcwidth-0.1.11-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39acf51e7295e76e2397bc36f005e0fbbcca7c6863fd1d3b83f6730265e93a42", size = 107261, upload-time = "2025-10-28T08:21:48.764Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/49/d09f6e459cac8479b96405e0000073d59738eeae6a477a3ed70c3dc3d25d/cwcwidth-0.1.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4367d307debcebf5253e64953675d66aa2086cf4eb579b29d72608fa99d63460", size = 104272, upload-time = "2025-10-28T08:21:49.72Z" },
-    { url = "https://files.pythonhosted.org/packages/61/89/1cc2522abfe6c83adfa09b4b876541aaba14c6a09ef93eca981e9a3f7860/cwcwidth-0.1.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ac3a61d915edd746a2052554c42e3d8a4b3089622b1c0bf15dc7ecbf42594d3c", size = 105353, upload-time = "2025-10-28T08:21:50.678Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/86/da21524ca60ddef67a17f64dc29481bf333570d61ed6bcdec81fd2309d6a/cwcwidth-0.1.11-cp312-cp312-win32.whl", hash = "sha256:e2ee1b8345522430ddb9c5a854610f99cfe53760aa22cefb85a9ddc4fecd3640", size = 23861, upload-time = "2025-10-28T08:21:51.598Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/37/572682341342824076ed307ffb5f0d4ab2aca057a8586d73fe28fd483d44/cwcwidth-0.1.11-cp312-cp312-win_amd64.whl", hash = "sha256:16d26ca8da308edc0683d09e85b134b3753baad14052dd147b31c63bca379118", size = 26080, upload-time = "2025-10-28T08:21:52.358Z" },
-    { url = "https://files.pythonhosted.org/packages/de/b9/7528208e30820a0b718fa4f0a094a1dd5429ecf06a2b8d673ed3977c3777/cwcwidth-0.1.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cb220310460009a6f5655bb311be9cfe44762a5f7e9a6ea7fe423bd4e3763406", size = 24883, upload-time = "2025-10-28T08:21:53.157Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/1a/7e372c5e5479af46b84809c1875bc981c1dafd3d91abf3284a619cdfa842/cwcwidth-0.1.11-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6002380693fd55c0ba6d8f6dca4af9f270aa9dc8f8f00041e015099e80100f8a", size = 101609, upload-time = "2025-10-28T08:21:54.056Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/bd/868798b28e9321bc11d38905e0a840946e3a2d2c072564c7ef081df0954a/cwcwidth-0.1.11-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40b77971fe7471d84ebce8c393efb456435091ba6a5f9e2a381a9c169bd13a51", size = 103902, upload-time = "2025-10-28T08:21:55.878Z" },
-    { url = "https://files.pythonhosted.org/packages/37/bd/5c54addc8cc8367b9edbf23820bfd11d598c6e66e929dc51ba39851c7ec4/cwcwidth-0.1.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b14b4f9d947f2ac6f1993c1ac447962d8e8c54d7479ba2d149cbc54ba45f17cb", size = 101881, upload-time = "2025-10-28T08:21:57.031Z" },
-    { url = "https://files.pythonhosted.org/packages/40/cb/b285b614a36af9f50275b43a435e27041c01385e450ee13a3d5a26c5e08b/cwcwidth-0.1.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f898e6f3b07be5862185a40bd75a3eadaefa4bfd4e12f583b975cd4552b86435", size = 101613, upload-time = "2025-10-28T08:21:58.356Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/90/46397fba692d5ecb8dc9bddc87a2a44a4ef54cd5d2f34fc491ecfd02640f/cwcwidth-0.1.11-cp313-cp313-win32.whl", hash = "sha256:9d30cf5b19e00198dc060d989b8295ece94b67df6719045361f8c8ef93cdd60e", size = 23348, upload-time = "2025-10-28T08:21:59.239Z" },
-    { url = "https://files.pythonhosted.org/packages/43/8b/f45db33a1ed0fae2d21d2ee5d992e4aec4d6a401e534fd8ede5cebe5a5c5/cwcwidth-0.1.11-cp313-cp313-win_amd64.whl", hash = "sha256:6b448e65ba72c755a258db08b6424ea58f2593fd8046240e0270d37a41f8137a", size = 25364, upload-time = "2025-10-28T08:22:00.012Z" },
-    { url = "https://files.pythonhosted.org/packages/65/d6/ec3e4990f3f60461697359b6e65b67130f9303a7460c9b6c10b7d358cb68/cwcwidth-0.1.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c65d5c1799e9fa68f6a5e1b164d597cdaf9c00e31230728e1ec07e44565a2ed5", size = 25046, upload-time = "2025-10-28T08:22:00.826Z" },
-    { url = "https://files.pythonhosted.org/packages/18/77/5e9763e522df91ec9b2dc40d481b4f76f73b5721fb41f31012c295a966d8/cwcwidth-0.1.11-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4c5bfcf94647861bae11902b54c6114fa07e4a503252866fd1f4d00411469d71", size = 100349, upload-time = "2025-10-28T08:22:01.745Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/2e/3fe196e78bbe5c722c8a7ae2f11980eaddbdbdb92df2027156b6cce5d4a4/cwcwidth-0.1.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a06f859c3716ced0572b869adc40c04c2c42326f00cda5e21237c7597f33bdda", size = 103560, upload-time = "2025-10-28T08:22:02.727Z" },
-    { url = "https://files.pythonhosted.org/packages/30/28/ae5b9e1743901835c9d5ed064f0aebc0af2f23421bffcc10160b0f2bdd66/cwcwidth-0.1.11-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cec169c878817869d1d9b32a0db42771bd5234c177582dfb2bf0632fcb6d140", size = 101375, upload-time = "2025-10-28T08:22:04.072Z" },
-    { url = "https://files.pythonhosted.org/packages/17/69/f2eb6be437b81a6a80d75f9d85c85ad38ccb5debd107ff95c8719ef29968/cwcwidth-0.1.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:01398db710dadece862038f1327bea01a28647e9f4695dbc10423e8ce125c9b9", size = 100651, upload-time = "2025-10-28T08:22:05.067Z" },
-    { url = "https://files.pythonhosted.org/packages/06/74/e8b8976be02773f86cd0321da8fab9b49d9954049299af989fae7d95020b/cwcwidth-0.1.11-cp314-cp314-win32.whl", hash = "sha256:cbfa87a03a419cf672f2d942b8d4d2d7ad938709d928ad07be9d8bb4f5922034", size = 24645, upload-time = "2025-10-28T08:22:06.193Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/2c/b951ec7f8cbbad087265341273f861aca06509a6cc8eadedbdee24b4a5da/cwcwidth-0.1.11-cp314-cp314-win_amd64.whl", hash = "sha256:e8f301dc12e950d27ae66f0753aa01eeb222172bd463f38860c9aa669f0a5467", size = 26574, upload-time = "2025-10-28T08:22:07.019Z" },
-]
-
-[[package]]
-name = "cwcwidth"
 version = "0.1.12"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/86/5f/f5c3d1b4e9c8c541406ca0654efa1bfaa05414f8e7d1c14bc6e3fd0752f8/cwcwidth-0.1.12.tar.gz", hash = "sha256:bfc16531d1246dd2558eb9b3a63aa37a9978672b956860dc5426da2343ebf366", size = 72009, upload-time = "2025-11-01T17:48:53.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/48/42998c088895974ee2a5ce58d3e9bec504ffb4e063dbadc9e325499220d1/cwcwidth-0.1.12-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:a2c7ab3b9eb0abab9bb326fec751b36aca52e0cfe3987c0909f188b9f681042c", size = 24206, upload-time = "2025-11-01T17:48:17.749Z" },
@@ -1040,10 +915,6 @@ version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/be/8bd693a0b9d53d48c8978fa5d889e06f3b5b03e45fd1ea1e78267b4887cb/debugpy-1.8.20-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:157e96ffb7f80b3ad36d808646198c90acb46fdcfd8bb1999838f0b6f2b59c64", size = 2099192, upload-time = "2026-01-29T23:03:29.707Z" },
-    { url = "https://files.pythonhosted.org/packages/77/1b/85326d07432086a06361d493d2743edd0c4fc2ef62162be7f8618441ac37/debugpy-1.8.20-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:c1178ae571aff42e61801a38b007af504ec8e05fde1c5c12e5a7efef21009642", size = 3088568, upload-time = "2026-01-29T23:03:31.467Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/60/3e08462ee3eccd10998853eb35947c416e446bfe2bc37dbb886b9044586c/debugpy-1.8.20-cp310-cp310-win32.whl", hash = "sha256:c29dd9d656c0fbd77906a6e6a82ae4881514aa3294b94c903ff99303e789b4a2", size = 5284399, upload-time = "2026-01-29T23:03:33.678Z" },
-    { url = "https://files.pythonhosted.org/packages/72/43/09d49106e770fe558ced5e80df2e3c2ebee10e576eda155dcc5670473663/debugpy-1.8.20-cp310-cp310-win_amd64.whl", hash = "sha256:3ca85463f63b5dd0aa7aaa933d97cbc47c174896dcae8431695872969f981893", size = 5316388, upload-time = "2026-01-29T23:03:35.095Z" },
     { url = "https://files.pythonhosted.org/packages/51/56/c3baf5cbe4dd77427fd9aef99fcdade259ad128feeb8a786c246adb838e5/debugpy-1.8.20-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:eada6042ad88fa1571b74bd5402ee8b86eded7a8f7b827849761700aff171f1b", size = 2208318, upload-time = "2026-01-29T23:03:36.481Z" },
     { url = "https://files.pythonhosted.org/packages/9a/7d/4fa79a57a8e69fe0d9763e98d1110320f9ecd7f1f362572e3aafd7417c9d/debugpy-1.8.20-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:7de0b7dfeedc504421032afba845ae2a7bcc32ddfb07dae2c3ca5442f821c344", size = 3171493, upload-time = "2026-01-29T23:03:37.775Z" },
     { url = "https://files.pythonhosted.org/packages/7d/f2/1e8f8affe51e12a26f3a8a8a4277d6e60aa89d0a66512f63b1e799d424a4/debugpy-1.8.20-cp311-cp311-win32.whl", hash = "sha256:773e839380cf459caf73cc533ea45ec2737a5cc184cf1b3b796cd4fd98504fec", size = 5209240, upload-time = "2026-01-29T23:03:39.109Z" },
@@ -1087,7 +958,6 @@ version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/62/55/f054de99871e7beb81935dea8a10b90cd5ce42122b1c3081d5282fdb3621/dependency_groups-1.3.1.tar.gz", hash = "sha256:78078301090517fd938c19f64a53ce98c32834dfe0dee6b88004a569a6adfefd", size = 10093, upload-time = "2025-05-02T00:34:29.452Z" }
 wheels = [
@@ -1103,7 +973,6 @@ dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "packaging" },
     { name = "requirements-parser" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/aa/5cae0f25a2ac5334d5bd2782a6bcd80eecf184f433ff74b2fb0387cfbbb6/deptry-0.24.0.tar.gz", hash = "sha256:852e88af2087e03cdf9ece6916f3f58b74191ab51cc8074897951bd496ee7dbb", size = 440158, upload-time = "2025-11-09T00:31:44.637Z" }
 wheels = [
@@ -1330,18 +1199,6 @@ requires-dist = [
 ]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
-]
-
-[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1529,7 +1386,6 @@ dependencies = [
     { name = "rich" },
     { name = "sse-starlette" },
     { name = "starlette" },
-    { name = "strenum", marker = "python_full_version < '3.11'" },
     { name = "structlog" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
@@ -1610,7 +1466,6 @@ source = { editable = "plugins/compat-oai" }
 dependencies = [
     { name = "genkit" },
     { name = "openai" },
-    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
@@ -1698,7 +1553,6 @@ dependencies = [
     { name = "google-cloud-logging" },
     { name = "opentelemetry-exporter-gcp-monitoring" },
     { name = "opentelemetry-exporter-gcp-trace" },
-    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
@@ -1718,7 +1572,6 @@ dependencies = [
     { name = "genkit" },
     { name = "google-cloud-aiplatform" },
     { name = "google-genai" },
-    { name = "strenum", marker = "python_full_version < '3.11'" },
     { name = "structlog" },
 ]
 
@@ -1749,6 +1602,30 @@ requires-dist = [
 ]
 
 [[package]]
+name = "genkit-plugin-valkey"
+version = "0.1.0"
+source = { editable = "plugins/valkey" }
+dependencies = [
+    { name = "genkit" },
+    { name = "valkey-glide" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "valkey-glide", specifier = ">=2.0.0,<3.0.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
 name = "genkit-plugin-vertex-ai"
 version = "0.6.0"
 source = { editable = "plugins/vertex-ai" }
@@ -1760,7 +1637,6 @@ dependencies = [
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-firestore" },
     { name = "google-genai" },
-    { name = "strenum", marker = "python_full_version < '3.11'" },
     { name = "structlog" },
 ]
 
@@ -1793,20 +1669,19 @@ dependencies = [
     { name = "genkit-plugin-google-cloud" },
     { name = "genkit-plugin-google-genai" },
     { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-valkey" },
     { name = "genkit-plugin-vertex-ai" },
     { name = "liccheck" },
     { name = "mcp" },
     { name = "python-multipart" },
     { name = "setuptools" },
-    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "bpython" },
     { name = "datamodel-code-generator" },
-    { name = "ipython", version = "8.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython" },
     { name = "jupyter" },
     { name = "nox" },
     { name = "nox-uv" },
@@ -1864,6 +1739,7 @@ requires-dist = [
     { name = "genkit-plugin-google-cloud", editable = "plugins/google-cloud" },
     { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
     { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-valkey", editable = "plugins/valkey" },
     { name = "genkit-plugin-vertex-ai", editable = "plugins/vertex-ai" },
     { name = "liccheck", specifier = ">=0.9.2" },
     { name = "mcp", specifier = ">=1.25.0" },
@@ -2187,11 +2063,6 @@ version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/ac/6f7bc93886a823ab545948c2dd48143027b2355ad1944c7cf852b338dc91/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0470b8c3d73b5f4e3300165498e4cf25221c7eb37f1159e221d1825b6df8a7ff", size = 31296, upload-time = "2025-12-16T00:19:07.261Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/97/a5accde175dee985311d949cfcb1249dcbb290f5ec83c994ea733311948f/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:119fcd90c57c89f30040b47c211acee231b25a45d225e3225294386f5d258288", size = 30870, upload-time = "2025-12-16T00:29:17.669Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/63/bec827e70b7a0d4094e7476f863c0dbd6b5f0f1f91d9c9b32b76dcdfeb4e/google_crc32c-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6f35aaffc8ccd81ba3162443fabb920e65b1f20ab1952a31b13173a67811467d", size = 33214, upload-time = "2025-12-16T00:40:19.618Z" },
-    { url = "https://files.pythonhosted.org/packages/63/bc/11b70614df04c289128d782efc084b9035ef8466b3d0a8757c1b6f5cf7ac/google_crc32c-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:864abafe7d6e2c4c66395c1eb0fe12dc891879769b52a3d56499612ca93b6092", size = 33589, upload-time = "2025-12-16T00:40:20.7Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/00/a08a4bc24f1261cc5b0f47312d8aebfbe4b53c2e6307f1b595605eed246b/google_crc32c-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:db3fe8eaf0612fc8b20fa21a5f25bd785bc3cd5be69f8f3412b0ac2ffd49e733", size = 34437, upload-time = "2025-12-16T00:35:19.437Z" },
     { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
     { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
     { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
@@ -2289,14 +2160,6 @@ version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8a/99/1cd3411c56a410994669062bd73dd58270c00cc074cac15f385a1fd91f8a/greenlet-3.3.1.tar.gz", hash = "sha256:41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98", size = 184690, upload-time = "2026-01-23T15:31:02.076Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/65/5b235b40581ad75ab97dcd8b4218022ae8e3ab77c13c919f1a1dfe9171fd/greenlet-3.3.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:04bee4775f40ecefcdaa9d115ab44736cd4b9c5fba733575bfe9379419582e13", size = 273723, upload-time = "2026-01-23T15:30:37.521Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ad/eb4729b85cba2d29499e0a04ca6fbdd8f540afd7be142fd571eea43d712f/greenlet-3.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e1457f4fed12a50e427988a07f0f9df53cf0ee8da23fab16e6732c2ec909d4", size = 574874, upload-time = "2026-01-23T16:00:54.551Z" },
-    { url = "https://files.pythonhosted.org/packages/87/32/57cad7fe4c8b82fdaa098c89498ef85ad92dfbb09d5eb713adedfc2ae1f5/greenlet-3.3.1-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:070472cd156f0656f86f92e954591644e158fd65aa415ffbe2d44ca77656a8f5", size = 586309, upload-time = "2026-01-23T16:05:25.18Z" },
-    { url = "https://files.pythonhosted.org/packages/66/66/f041005cb87055e62b0d68680e88ec1a57f4688523d5e2fb305841bc8307/greenlet-3.3.1-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1108b61b06b5224656121c3c8ee8876161c491cbe74e5c519e0634c837cf93d5", size = 597461, upload-time = "2026-01-23T16:15:51.943Z" },
-    { url = "https://files.pythonhosted.org/packages/87/eb/8a1ec2da4d55824f160594a75a9d8354a5fe0a300fb1c48e7944265217e1/greenlet-3.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a300354f27dd86bae5fbf7002e6dd2b3255cd372e9242c933faf5e859b703fe", size = 586985, upload-time = "2026-01-23T15:32:47.968Z" },
-    { url = "https://files.pythonhosted.org/packages/15/1c/0621dd4321dd8c351372ee8f9308136acb628600658a49be1b7504208738/greenlet-3.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e84b51cbebf9ae573b5fbd15df88887815e3253fc000a7d0ff95170e8f7e9729", size = 1547271, upload-time = "2026-01-23T16:04:18.977Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/53/24047f8924c83bea7a59c8678d9571209c6bfe5f4c17c94a78c06024e9f2/greenlet-3.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0093bd1a06d899892427217f0ff2a3c8f306182b8c754336d32e2d587c131b4", size = 1613427, upload-time = "2026-01-23T15:33:44.428Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/07/ac9bf1ec008916d1a3373cae212884c1dcff4a4ba0d41127ce81a8deb4e9/greenlet-3.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:7932f5f57609b6a3b82cc11877709aa7a98e3308983ed93552a1c377069b20c8", size = 226100, upload-time = "2026-01-23T15:30:56.957Z" },
     { url = "https://files.pythonhosted.org/packages/ec/e8/2e1462c8fdbe0f210feb5ac7ad2d9029af8be3bf45bd9fa39765f821642f/greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c", size = 274974, upload-time = "2026-01-23T15:31:02.891Z" },
     { url = "https://files.pythonhosted.org/packages/7e/a8/530a401419a6b302af59f67aaf0b9ba1015855ea7e56c036b5928793c5bd/greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd", size = 577175, upload-time = "2026-01-23T16:00:56.213Z" },
     { url = "https://files.pythonhosted.org/packages/8e/89/7e812bb9c05e1aaef9b597ac1d0962b9021d2c6269354966451e885c4e6b/greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5", size = 590401, upload-time = "2026-01-23T16:05:26.365Z" },
@@ -2366,16 +2229,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/a8/690a085b4d1fe066130de97a87de32c45062cf2ecd218df9675add895550/grpcio-1.78.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:7cc47943d524ee0096f973e1081cb8f4f17a4615f2116882a5f1416e4cfe92b5", size = 5946986, upload-time = "2026-02-06T09:54:34.043Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/1b/e5213c5c0ced9d2d92778d30529ad5bb2dcfb6c48c4e2d01b1f302d33d64/grpcio-1.78.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c3f293fdc675ccba4db5a561048cca627b5e7bd1c8a6973ffedabe7d116e22e2", size = 11816533, upload-time = "2026-02-06T09:54:37.04Z" },
-    { url = "https://files.pythonhosted.org/packages/18/37/1ba32dccf0a324cc5ace744c44331e300b000a924bf14840f948c559ede7/grpcio-1.78.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10a9a644b5dd5aec3b82b5b0b90d41c0fa94c85ef42cb42cf78a23291ddb5e7d", size = 6519964, upload-time = "2026-02-06T09:54:40.268Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/f5/c0e178721b818072f2e8b6fde13faaba942406c634009caf065121ce246b/grpcio-1.78.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4c5533d03a6cbd7f56acfc9cfb44ea64f63d29091e40e44010d34178d392d7eb", size = 7198058, upload-time = "2026-02-06T09:54:42.389Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/b2/40d43c91ae9cd667edc960135f9f08e58faa1576dc95af29f66ec912985f/grpcio-1.78.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff870aebe9a93a85283837801d35cd5f8814fe2ad01e606861a7fb47c762a2b7", size = 6727212, upload-time = "2026-02-06T09:54:44.91Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/88/9da42eed498f0efcfcd9156e48ae63c0cde3bea398a16c99fb5198c885b6/grpcio-1.78.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:391e93548644e6b2726f1bb84ed60048d4bcc424ce5e4af0843d28ca0b754fec", size = 7300845, upload-time = "2026-02-06T09:54:47.562Z" },
-    { url = "https://files.pythonhosted.org/packages/23/3f/1c66b7b1b19a8828890e37868411a6e6925df5a9030bfa87ab318f34095d/grpcio-1.78.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:df2c8f3141f7cbd112a6ebbd760290b5849cda01884554f7c67acc14e7b1758a", size = 8284605, upload-time = "2026-02-06T09:54:50.475Z" },
-    { url = "https://files.pythonhosted.org/packages/94/c4/ca1bd87394f7b033e88525384b4d1e269e8424ab441ea2fba1a0c5b50986/grpcio-1.78.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bd8cb8026e5f5b50498a3c4f196f57f9db344dad829ffae16b82e4fdbaea2813", size = 7726672, upload-time = "2026-02-06T09:54:53.11Z" },
-    { url = "https://files.pythonhosted.org/packages/41/09/f16e487d4cc65ccaf670f6ebdd1a17566b965c74fc3d93999d3b2821e052/grpcio-1.78.0-cp310-cp310-win32.whl", hash = "sha256:f8dff3d9777e5d2703a962ee5c286c239bf0ba173877cc68dc02c17d042e29de", size = 4076715, upload-time = "2026-02-06T09:54:55.549Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/32/4ce60d94e242725fd3bcc5673c04502c82a8e87b21ea411a63992dc39f8f/grpcio-1.78.0-cp310-cp310-win_amd64.whl", hash = "sha256:94f95cf5d532d0e717eed4fc1810e8e6eded04621342ec54c89a7c2f14b581bf", size = 4799157, upload-time = "2026-02-06T09:54:59.838Z" },
     { url = "https://files.pythonhosted.org/packages/86/c7/d0b780a29b0837bf4ca9580904dfb275c1fc321ded7897d620af7047ec57/grpcio-1.78.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2777b783f6c13b92bd7b716667452c329eefd646bfb3f2e9dabea2e05dbd34f6", size = 5951525, upload-time = "2026-02-06T09:55:01.989Z" },
     { url = "https://files.pythonhosted.org/packages/c5/b1/96920bf2ee61df85a9503cb6f733fe711c0ff321a5a697d791b075673281/grpcio-1.78.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9dca934f24c732750389ce49d638069c3892ad065df86cb465b3fa3012b70c9e", size = 11830418, upload-time = "2026-02-06T09:55:04.462Z" },
     { url = "https://files.pythonhosted.org/packages/83/0c/7c1528f098aeb75a97de2bae18c530f56959fb7ad6c882db45d9884d6edc/grpcio-1.78.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:459ab414b35f4496138d0ecd735fed26f1318af5e52cb1efbc82a09f0d5aa911", size = 6524477, upload-time = "2026-02-06T09:55:07.111Z" },
@@ -2507,13 +2360,6 @@ version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/e5/c07e0bcf4ec8db8164e9f6738c048b2e66aabf30e7506f440c4cc6953f60/httptools-0.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:11d01b0ff1fe02c4c32d60af61a4d613b74fad069e47e06e9067758c01e9ac78", size = 204531, upload-time = "2025-10-10T03:54:20.887Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/4f/35e3a63f863a659f92ffd92bef131f3e81cf849af26e6435b49bd9f6f751/httptools-0.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:84d86c1e5afdc479a6fdabf570be0d3eb791df0ae727e8dbc0259ed1249998d4", size = 109408, upload-time = "2025-10-10T03:54:22.455Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/71/b0a9193641d9e2471ac541d3b1b869538a5fb6419d52fd2669fa9c79e4b8/httptools-0.7.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c8c751014e13d88d2be5f5f14fc8b89612fcfa92a9cc480f2bc1598357a23a05", size = 440889, upload-time = "2025-10-10T03:54:23.753Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d9/2e34811397b76718750fea44658cb0205b84566e895192115252e008b152/httptools-0.7.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:654968cb6b6c77e37b832a9be3d3ecabb243bbe7a0b8f65fbc5b6b04c8fcabed", size = 440460, upload-time = "2025-10-10T03:54:25.313Z" },
-    { url = "https://files.pythonhosted.org/packages/01/3f/a04626ebeacc489866bb4d82362c0657b2262bef381d68310134be7f40bb/httptools-0.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b580968316348b474b020edf3988eecd5d6eec4634ee6561e72ae3a2a0e00a8a", size = 425267, upload-time = "2025-10-10T03:54:26.81Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/99/adcd4f66614db627b587627c8ad6f4c55f18881549bab10ecf180562e7b9/httptools-0.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d496e2f5245319da9d764296e86c5bb6fcf0cf7a8806d3d000717a889c8c0b7b", size = 424429, upload-time = "2025-10-10T03:54:28.174Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/72/ec8fc904a8fd30ba022dfa85f3bbc64c3c7cd75b669e24242c0658e22f3c/httptools-0.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:cbf8317bfccf0fed3b5680c559d3459cccf1abe9039bfa159e62e391c7270568", size = 86173, upload-time = "2025-10-10T03:54:29.5Z" },
     { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521, upload-time = "2025-10-10T03:54:31.002Z" },
     { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", size = 110375, upload-time = "2025-10-10T03:54:31.941Z" },
     { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", size = 456621, upload-time = "2025-10-10T03:54:33.176Z" },
@@ -2582,13 +2428,9 @@ name = "hypercorn"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "h11" },
     { name = "h2" },
     { name = "priority" },
-    { name = "taskgroup", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "wsproto" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/01/39f41a014b83dd5c795217362f2ca9071cf243e6a75bdcd6cd5b944658cc/hypercorn-0.18.0.tar.gz", hash = "sha256:d63267548939c46b0247dc8e5b45a9947590e35e64ee73a23c074aa3cf88e9da", size = 68420, upload-time = "2025-11-08T13:54:04.78Z" }
@@ -2668,8 +2510,7 @@ dependencies = [
     { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
-    { name = "ipython", version = "8.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython" },
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "matplotlib-inline" },
@@ -2687,51 +2528,20 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "8.38.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/61/1810830e8b93c72dcd3c0f150c80a00c3deb229562d9423807ec92c3a539/ipython-8.38.0.tar.gz", hash = "sha256:9cfea8c903ce0867cc2f23199ed8545eb741f3a69420bfcf3743ad1cec856d39", size = 5513996, upload-time = "2026-01-05T10:59:06.901Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/df/db59624f4c71b39717c423409950ac3f2c8b2ce4b0aac843112c7fb3f721/ipython-8.38.0-py3-none-any.whl", hash = "sha256:750162629d800ac65bb3b543a14e7a74b0e88063eac9b92124d4b2aa3f6d8e86", size = 831813, upload-time = "2026-01-05T10:59:04.239Z" },
-]
-
-[[package]]
-name = "ipython"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/ce/012a0f40ca58a966f87a6e894d6828e2817657cbdf522b02a5d3a87d92ce/ipython-9.0.2.tar.gz", hash = "sha256:ec7b479e3e5656bf4f58c652c120494df1820f4f28f522fb7ca09e213c2aab52", size = 4366102, upload-time = "2025-03-08T15:04:52.885Z" }
 wheels = [
@@ -2743,7 +2553,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -2756,8 +2566,7 @@ version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "comm" },
-    { name = "ipython", version = "8.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython" },
     { name = "jupyterlab-widgets" },
     { name = "traitlets" },
     { name = "widgetsnbextension" },
@@ -2884,18 +2693,6 @@ version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/5a/41da76c5ea07bec1b0472b6b2fdb1b651074d504b19374d7e130e0cdfb25/jiter-0.13.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2ffc63785fd6c7977defe49b9824ae6ce2b2e2b77ce539bdaf006c26da06342e", size = 311164, upload-time = "2026-02-02T12:35:17.688Z" },
-    { url = "https://files.pythonhosted.org/packages/40/cb/4a1bf994a3e869f0d39d10e11efb471b76d0ad70ecbfb591427a46c880c2/jiter-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4a638816427006c1e3f0013eb66d391d7a3acda99a7b0cf091eff4497ccea33a", size = 320296, upload-time = "2026-02-02T12:35:19.828Z" },
-    { url = "https://files.pythonhosted.org/packages/09/82/acd71ca9b50ecebadc3979c541cd717cce2fe2bc86236f4fa597565d8f1a/jiter-0.13.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19928b5d1ce0ff8c1ee1b9bdef3b5bfc19e8304f1b904e436caf30bc15dc6cf5", size = 352742, upload-time = "2026-02-02T12:35:21.258Z" },
-    { url = "https://files.pythonhosted.org/packages/71/03/d1fc996f3aecfd42eb70922edecfb6dd26421c874503e241153ad41df94f/jiter-0.13.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:309549b778b949d731a2f0e1594a3f805716be704a73bf3ad9a807eed5eb5721", size = 363145, upload-time = "2026-02-02T12:35:24.653Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/61/a30492366378cc7a93088858f8991acd7d959759fe6138c12a4644e58e81/jiter-0.13.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcdabaea26cb04e25df3103ce47f97466627999260290349a88c8136ecae0060", size = 487683, upload-time = "2026-02-02T12:35:26.162Z" },
-    { url = "https://files.pythonhosted.org/packages/20/4e/4223cffa9dbbbc96ed821c5aeb6bca510848c72c02086d1ed3f1da3d58a7/jiter-0.13.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a377af27b236abbf665a69b2bdd680e3b5a0bd2af825cd3b81245279a7606c", size = 373579, upload-time = "2026-02-02T12:35:27.582Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/c9/b0489a01329ab07a83812d9ebcffe7820a38163c6d9e7da644f926ff877c/jiter-0.13.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe49d3ff6db74321f144dff9addd4a5874d3105ac5ba7c5b77fac099cfae31ae", size = 362904, upload-time = "2026-02-02T12:35:28.925Z" },
-    { url = "https://files.pythonhosted.org/packages/05/af/53e561352a44afcba9a9bc67ee1d320b05a370aed8df54eafe714c4e454d/jiter-0.13.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2113c17c9a67071b0f820733c0893ed1d467b5fcf4414068169e5c2cabddb1e2", size = 392380, upload-time = "2026-02-02T12:35:30.385Z" },
-    { url = "https://files.pythonhosted.org/packages/76/2a/dd805c3afb8ed5b326c5ae49e725d1b1255b9754b1b77dbecdc621b20773/jiter-0.13.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ab1185ca5c8b9491b55ebf6c1e8866b8f68258612899693e24a92c5fdb9455d5", size = 517939, upload-time = "2026-02-02T12:35:31.865Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2a/7b67d76f55b8fe14c937e7640389612f05f9a4145fc28ae128aaa5e62257/jiter-0.13.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9621ca242547edc16400981ca3231e0c91c0c4c1ab8573a596cd9bb3575d5c2b", size = 551696, upload-time = "2026-02-02T12:35:33.306Z" },
-    { url = "https://files.pythonhosted.org/packages/85/9c/57cdd64dac8f4c6ab8f994fe0eb04dc9fd1db102856a4458fcf8a99dfa62/jiter-0.13.0-cp310-cp310-win32.whl", hash = "sha256:a7637d92b1c9d7a771e8c56f445c7f84396d48f2e756e5978840ecba2fac0894", size = 204592, upload-time = "2026-02-02T12:35:34.58Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/38/f4f3ea5788b8a5bae7510a678cdc747eda0c45ffe534f9878ff37e7cf3b3/jiter-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:c1b609e5cbd2f52bb74fb721515745b407df26d7b800458bd97cb3b972c29e7d", size = 206016, upload-time = "2026-02-02T12:35:36.435Z" },
     { url = "https://files.pythonhosted.org/packages/71/29/499f8c9eaa8a16751b1c0e45e6f5f1761d180da873d417996cc7bddc8eef/jiter-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ea026e70a9a28ebbdddcbcf0f1323128a8db66898a06eaad3a4e62d2f554d096", size = 311157, upload-time = "2026-02-02T12:35:37.758Z" },
     { url = "https://files.pythonhosted.org/packages/50/f6/566364c777d2ab450b92100bea11333c64c38d32caf8dc378b48e5b20c46/jiter-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66aa3e663840152d18cc8ff1e4faad3dd181373491b9cfdc6004b92198d67911", size = 319729, upload-time = "2026-02-02T12:35:39.246Z" },
     { url = "https://files.pythonhosted.org/packages/73/dd/560f13ec5e4f116d8ad2658781646cca91b617ae3b8758d4a5076b278f70/jiter-0.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3524798e70655ff19aec58c7d05adb1f074fecff62da857ea9be2b908b6d701", size = 354766, upload-time = "2026-02-02T12:35:40.662Z" },
@@ -3081,8 +2878,7 @@ version = "6.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ipykernel" },
-    { name = "ipython", version = "8.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython" },
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "prompt-toolkit" },
@@ -3198,7 +2994,6 @@ dependencies = [
     { name = "notebook-shim" },
     { name = "packaging" },
     { name = "setuptools" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tornado" },
     { name = "traitlets" },
 ]
@@ -3276,18 +3071,6 @@ version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8a/3f/4ca7dd7819bf8ff303aca39c3c60e5320e46e766ab7f7dd627d3b9c11bdf/librt-0.8.0.tar.gz", hash = "sha256:cb74cdcbc0103fc988e04e5c58b0b31e8e5dd2babb9182b6f9490488eb36324b", size = 177306, upload-time = "2026-02-12T14:53:54.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/e9/018cfd60629e0404e6917943789800aa2231defbea540a17b90cc4547b97/librt-0.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:db63cf3586a24241e89ca1ce0b56baaec9d371a328bd186c529b27c914c9a1ef", size = 65690, upload-time = "2026-02-12T14:51:57.761Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/80/8d39980860e4d1c9497ee50e5cd7c4766d8cfd90d105578eae418e8ffcbc/librt-0.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ba9d9e60651615bc614be5e21a82cdb7b1769a029369cf4b4d861e4f19686fb6", size = 68373, upload-time = "2026-02-12T14:51:59.013Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/76/6e6f7a443af63977e421bd542551fec4072d9eaba02e671b05b238fe73bc/librt-0.8.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb4b3ad543084ed79f186741470b251b9d269cd8b03556f15a8d1a99a64b7de5", size = 197091, upload-time = "2026-02-12T14:52:00.642Z" },
-    { url = "https://files.pythonhosted.org/packages/14/40/fa064181c231334c9f4cb69eb338132d39510c8928e84beba34b861d0a71/librt-0.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d2720335020219197380ccfa5c895f079ac364b4c429e96952cd6509934d8eb", size = 207350, upload-time = "2026-02-12T14:52:02.32Z" },
-    { url = "https://files.pythonhosted.org/packages/50/49/e7f8438dd226305e3e5955d495114ad01448e6a6ffc0303289b4153b5fc5/librt-0.8.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726305d3e53419d27fc8cdfcd3f9571f0ceae22fa6b5ea1b3662c2e538f833e", size = 219962, upload-time = "2026-02-12T14:52:03.884Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/2c/74086fc5d52e77107a3cc80a9a3209be6ad1c9b6bc99969d8d9bbf9fdfe4/librt-0.8.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc3d107f603b5ee7a79b6aa6f166551b99b32fb4a5303c4dfcb4222fc6a0335e", size = 212939, upload-time = "2026-02-12T14:52:05.537Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/ae/d6917c0ebec9bc2e0293903d6a5ccc7cdb64c228e529e96520b277318f25/librt-0.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:41064a0c07b4cc7a81355ccc305cb097d6027002209ffca51306e65ee8293630", size = 221393, upload-time = "2026-02-12T14:52:07.164Z" },
-    { url = "https://files.pythonhosted.org/packages/04/97/15df8270f524ce09ad5c19cbbe0e8f95067582507149a6c90594e7795370/librt-0.8.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c6e4c10761ddbc0d67d2f6e2753daf99908db85d8b901729bf2bf5eaa60e0567", size = 216721, upload-time = "2026-02-12T14:52:08.857Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/52/17cbcf9b7a1bae5016d9d3561bc7169b32c3bd216c47d934d3f270602c0c/librt-0.8.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ba581acad5ac8f33e2ff1746e8a57e001b47c6721873121bf8bbcf7ba8bd3aa4", size = 214790, upload-time = "2026-02-12T14:52:10.033Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/2d/010a236e8dc4d717dd545c46fd036dcced2c7ede71ef85cf55325809ff92/librt-0.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bdab762e2c0b48bab76f1a08acb3f4c77afd2123bedac59446aeaaeed3d086cf", size = 237384, upload-time = "2026-02-12T14:52:11.244Z" },
-    { url = "https://files.pythonhosted.org/packages/38/14/f1c0eff3df8760dee761029efb72991c554d9f3282f1048e8c3d0eb60997/librt-0.8.0-cp310-cp310-win32.whl", hash = "sha256:6a3146c63220d814c4a2c7d6a1eacc8d5c14aed0ff85115c1dfea868080cd18f", size = 54289, upload-time = "2026-02-12T14:52:12.798Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/0b/2684d473e64890882729f91866ed97ccc0a751a0afc3b4bf1a7b57094dbb/librt-0.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:bbebd2bba5c6ae02907df49150e55870fdd7440d727b6192c46b6f754723dde9", size = 61347, upload-time = "2026-02-12T14:52:13.793Z" },
     { url = "https://files.pythonhosted.org/packages/51/e9/42af181c89b65abfd557c1b017cba5b82098eef7bf26d1649d82ce93ccc7/librt-0.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0ce33a9778e294507f3a0e3468eccb6a698b5166df7db85661543eca1cfc5369", size = 65314, upload-time = "2026-02-12T14:52:14.778Z" },
     { url = "https://files.pythonhosted.org/packages/9d/4a/15a847fca119dc0334a4b8012b1e15fdc5fc19d505b71e227eaf1bcdba09/librt-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8070aa3368559de81061ef752770d03ca1f5fc9467d4d512d405bd0483bfffe6", size = 68015, upload-time = "2026-02-12T14:52:15.797Z" },
     { url = "https://files.pythonhosted.org/packages/e1/87/ffc8dbd6ab68dd91b736c88529411a6729649d2b74b887f91f3aaff8d992/librt-0.8.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:20f73d4fecba969efc15cdefd030e382502d56bb6f1fc66b580cce582836c9fa", size = 194508, upload-time = "2026-02-12T14:52:16.835Z" },
@@ -3387,7 +3170,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "click" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "httpx" },
     { name = "litestar-htmx" },
     { name = "msgspec" },
@@ -3432,17 +3214,6 @@ version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
-    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
-    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
-    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
-    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
-    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
     { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
     { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
     { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
@@ -3582,9 +3353,6 @@ requires-dist = [
 name = "mistune"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
@@ -3605,14 +3373,6 @@ version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/a2/3b68a9e769db68668b25c6108444a35f9bd163bb848c0650d516761a59c0/msgpack-1.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0051fffef5a37ca2cd16978ae4f0aef92f164df86823871b5162812bebecd8e2", size = 81318, upload-time = "2025-10-08T09:14:38.722Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e1/2b720cc341325c00be44e1ed59e7cfeae2678329fbf5aa68f5bda57fe728/msgpack-1.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a605409040f2da88676e9c9e5853b3449ba8011973616189ea5ee55ddbc5bc87", size = 83786, upload-time = "2025-10-08T09:14:40.082Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e5/c2241de64bfceac456b140737812a2ab310b10538a7b34a1d393b748e095/msgpack-1.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b696e83c9f1532b4af884045ba7f3aa741a63b2bc22617293a2c6a7c645f251", size = 398240, upload-time = "2025-10-08T09:14:41.151Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/09/2a06956383c0fdebaef5aa9246e2356776f12ea6f2a44bd1368abf0e46c4/msgpack-1.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:365c0bbe981a27d8932da71af63ef86acc59ed5c01ad929e09a0b88c6294e28a", size = 406070, upload-time = "2025-10-08T09:14:42.821Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/74/2957703f0e1ef20637d6aead4fbb314330c26f39aa046b348c7edcf6ca6b/msgpack-1.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:41d1a5d875680166d3ac5c38573896453bbbea7092936d2e107214daf43b1d4f", size = 393403, upload-time = "2025-10-08T09:14:44.38Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/09/3bfc12aa90f77b37322fc33e7a8a7c29ba7c8edeadfa27664451801b9860/msgpack-1.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:354e81bcdebaab427c3df4281187edc765d5d76bfb3a7c125af9da7a27e8458f", size = 398947, upload-time = "2025-10-08T09:14:45.56Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/4f/05fcebd3b4977cb3d840f7ef6b77c51f8582086de5e642f3fefee35c86fc/msgpack-1.1.2-cp310-cp310-win32.whl", hash = "sha256:e64c8d2f5e5d5fda7b842f55dec6133260ea8f53c4257d64494c534f306bf7a9", size = 64769, upload-time = "2025-10-08T09:14:47.334Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/3e/b4547e3a34210956382eed1c85935fff7e0f9b98be3106b3745d7dec9c5e/msgpack-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:db6192777d943bdaaafb6ba66d44bf65aa0e9c5616fa1d2da9bb08828c6b39aa", size = 71293, upload-time = "2025-10-08T09:14:48.665Z" },
     { url = "https://files.pythonhosted.org/packages/2c/97/560d11202bcd537abca693fd85d81cebe2107ba17301de42b01ac1677b69/msgpack-1.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2e86a607e558d22985d856948c12a3fa7b42efad264dca8a3ebbcfa2735d786c", size = 82271, upload-time = "2025-10-08T09:14:49.967Z" },
     { url = "https://files.pythonhosted.org/packages/83/04/28a41024ccbd67467380b6fb440ae916c1e4f25e2cd4c63abe6835ac566e/msgpack-1.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:283ae72fc89da59aa004ba147e8fc2f766647b1251500182fac0350d8af299c0", size = 84914, upload-time = "2025-10-08T09:14:50.958Z" },
     { url = "https://files.pythonhosted.org/packages/71/46/b817349db6886d79e57a966346cf0902a426375aadc1e8e7a86a75e22f19/msgpack-1.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61c8aa3bd513d87c72ed0b37b53dd5c5a0f58f2ff9f26e1555d3bd7948fb7296", size = 416962, upload-time = "2025-10-08T09:14:51.997Z" },
@@ -3666,14 +3426,6 @@ version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/9c/bfbd12955a49180cbd234c5d29ec6f74fe641698f0cd9df154a854fc8a15/msgspec-0.20.0.tar.gz", hash = "sha256:692349e588fde322875f8d3025ac01689fead5901e7fb18d6870a44519d62a29", size = 317862, upload-time = "2025-11-24T03:56:28.934Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/5e/151883ba2047cca9db8ed2f86186b054ad200bc231352df15b0c1dd75b1f/msgspec-0.20.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:23a6ec2a3b5038c233b04740a545856a068bc5cb8db184ff493a58e08c994fbf", size = 195191, upload-time = "2025-11-24T03:55:08.549Z" },
-    { url = "https://files.pythonhosted.org/packages/50/88/a795647672f547c983eff0823b82aaa35db922c767e1b3693e2dcf96678d/msgspec-0.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cde2c41ed3eaaef6146365cb0d69580078a19f974c6cb8165cc5dcd5734f573e", size = 188513, upload-time = "2025-11-24T03:55:10.008Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/91/eb0abb0e0de142066cebfe546dc9140c5972ea824aa6ff507ad0b6a126ac/msgspec-0.20.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5da0daa782f95d364f0d95962faed01e218732aa1aa6cad56b25a5d2092e75a4", size = 216370, upload-time = "2025-11-24T03:55:11.566Z" },
-    { url = "https://files.pythonhosted.org/packages/15/2a/48e41d9ef0a24b1c6e67cbd94a676799e0561bfbc163be1aaaff5ca853f5/msgspec-0.20.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9369d5266144bef91be2940a3821e03e51a93c9080fde3ef72728c3f0a3a8bb7", size = 222653, upload-time = "2025-11-24T03:55:13.159Z" },
-    { url = "https://files.pythonhosted.org/packages/90/c9/14b825df203d980f82a623450d5f39e7f7a09e6e256c52b498ea8f29d923/msgspec-0.20.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:90fb865b306ca92c03964a5f3d0cd9eb1adda14f7e5ac7943efd159719ea9f10", size = 222337, upload-time = "2025-11-24T03:55:14.777Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/d7/39a5c3ddd294f587d6fb8efccc8361b6aa5089974015054071e665c9d24b/msgspec-0.20.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e8112cd48b67dfc0cfa49fc812b6ce7eb37499e1d95b9575061683f3428975d3", size = 225565, upload-time = "2025-11-24T03:55:16.4Z" },
-    { url = "https://files.pythonhosted.org/packages/98/bd/5db3c14d675ee12842afb9b70c94c64f2c873f31198c46cbfcd7dffafab0/msgspec-0.20.0-cp310-cp310-win_amd64.whl", hash = "sha256:666b966d503df5dc27287675f525a56b6e66a2b8e8ccd2877b0c01328f19ae6c", size = 188412, upload-time = "2025-11-24T03:55:17.747Z" },
-    { url = "https://files.pythonhosted.org/packages/76/c7/06cc218bc0c86f0c6c6f34f7eeea6cfb8b835070e8031e3b0ef00f6c7c69/msgspec-0.20.0-cp310-cp310-win_arm64.whl", hash = "sha256:099e3e85cd5b238f2669621be65f0728169b8c7cb7ab07f6137b02dc7feea781", size = 173951, upload-time = "2025-11-24T03:55:19.335Z" },
     { url = "https://files.pythonhosted.org/packages/03/59/fdcb3af72f750a8de2bcf39d62ada70b5eb17b06d7f63860e0a679cb656b/msgspec-0.20.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:09e0efbf1ac641fedb1d5496c59507c2f0dc62a052189ee62c763e0aae217520", size = 193345, upload-time = "2025-11-24T03:55:20.613Z" },
     { url = "https://files.pythonhosted.org/packages/5a/15/3c225610da9f02505d37d69a77f4a2e7daae2a125f99d638df211ba84e59/msgspec-0.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23ee3787142e48f5ee746b2909ce1b76e2949fbe0f97f9f6e70879f06c218b54", size = 186867, upload-time = "2025-11-24T03:55:22.4Z" },
     { url = "https://files.pythonhosted.org/packages/81/36/13ab0c547e283bf172f45491edfdea0e2cecb26ae61e3a7b1ae6058b326d/msgspec-0.20.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:81f4ac6f0363407ac0465eff5c7d4d18f26870e00674f8fcb336d898a1e36854", size = 215351, upload-time = "2025-11-24T03:55:23.958Z" },
@@ -3720,29 +3472,8 @@ wheels = [
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/0b/19348d4c98980c4851d2f943f8ebafdece2ae7ef737adcfa5994ce8e5f10/multidict-6.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c93c3db7ea657dd4637d57e74ab73de31bccefe144d3d4ce370052035bc85fb5", size = 77176, upload-time = "2026-01-26T02:42:59.784Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/04/9de3f8077852e3d438215c81e9b691244532d2e05b4270e89ce67b7d103c/multidict-6.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:974e72a2474600827abaeda71af0c53d9ebbc3c2eb7da37b37d7829ae31232d8", size = 44996, upload-time = "2026-01-26T02:43:01.674Z" },
-    { url = "https://files.pythonhosted.org/packages/31/5c/08c7f7fe311f32e83f7621cd3f99d805f45519cd06fafb247628b861da7d/multidict-6.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdea2e7b2456cfb6694fb113066fd0ec7ea4d67e3a35e1f4cbeea0b448bf5872", size = 44631, upload-time = "2026-01-26T02:43:03.169Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/7f/0e3b1390ae772f27501199996b94b52ceeb64fe6f9120a32c6c3f6b781be/multidict-6.7.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17207077e29342fdc2c9a82e4b306f1127bf1ea91f8b71e02d4798a70bb99991", size = 242561, upload-time = "2026-01-26T02:43:04.733Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/f4/8719f4f167586af317b69dd3e90f913416c91ca610cac79a45c53f590312/multidict-6.7.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4f49cb5661344764e4c7c7973e92a47a59b8fc19b6523649ec9dc4960e58a03", size = 242223, upload-time = "2026-01-26T02:43:06.695Z" },
-    { url = "https://files.pythonhosted.org/packages/47/ab/7c36164cce64a6ad19c6d9a85377b7178ecf3b89f8fd589c73381a5eedfd/multidict-6.7.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a9fc4caa29e2e6ae408d1c450ac8bf19892c5fca83ee634ecd88a53332c59981", size = 222322, upload-time = "2026-01-26T02:43:08.472Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/79/a25add6fb38035b5337bc5734f296d9afc99163403bbcf56d4170f97eb62/multidict-6.7.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c5f0c21549ab432b57dcc82130f388d84ad8179824cc3f223d5e7cfbfd4143f6", size = 254005, upload-time = "2026-01-26T02:43:10.127Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/7b/64a87cf98e12f756fc8bd444b001232ffff2be37288f018ad0d3f0aae931/multidict-6.7.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7dfb78d966b2c906ae1d28ccf6e6712a3cd04407ee5088cd276fe8cb42186190", size = 251173, upload-time = "2026-01-26T02:43:11.731Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/ac/b605473de2bb404e742f2cc3583d12aedb2352a70e49ae8fce455b50c5aa/multidict-6.7.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b0d9b91d1aa44db9c1f1ecd0d9d2ae610b2f4f856448664e01a3b35899f3f92", size = 243273, upload-time = "2026-01-26T02:43:13.063Z" },
-    { url = "https://files.pythonhosted.org/packages/03/65/11492d6a0e259783720f3bc1d9ea55579a76f1407e31ed44045c99542004/multidict-6.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dd96c01a9dcd4889dcfcf9eb5544ca0c77603f239e3ffab0524ec17aea9a93ee", size = 238956, upload-time = "2026-01-26T02:43:14.843Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/a7/7ee591302af64e7c196fb63fe856c788993c1372df765102bd0448e7e165/multidict-6.7.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:067343c68cd6612d375710f895337b3a98a033c94f14b9a99eff902f205424e2", size = 233477, upload-time = "2026-01-26T02:43:16.025Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/99/c109962d58756c35fd9992fed7f2355303846ea2ff054bb5f5e9d6b888de/multidict-6.7.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5884a04f4ff56c6120f6ccf703bdeb8b5079d808ba604d4d53aec0d55dc33568", size = 243615, upload-time = "2026-01-26T02:43:17.84Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5f/1973e7c771c86e93dcfe1c9cc55a5481b610f6614acfc28c0d326fe6bfad/multidict-6.7.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8affcf1c98b82bc901702eb73b6947a1bfa170823c153fe8a47b5f5f02e48e40", size = 249930, upload-time = "2026-01-26T02:43:19.06Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/a5/f170fc2268c3243853580203378cd522446b2df632061e0a5409817854c7/multidict-6.7.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:0d17522c37d03e85c8098ec8431636309b2682cf12e58f4dbc76121fb50e4962", size = 243807, upload-time = "2026-01-26T02:43:20.286Z" },
-    { url = "https://files.pythonhosted.org/packages/de/01/73856fab6d125e5bc652c3986b90e8699a95e84b48d72f39ade6c0e74a8c/multidict-6.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:24c0cf81544ca5e17cfcb6e482e7a82cd475925242b308b890c9452a074d4505", size = 239103, upload-time = "2026-01-26T02:43:21.508Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/46/f1220bd9944d8aa40d8ccff100eeeee19b505b857b6f603d6078cb5315b0/multidict-6.7.1-cp310-cp310-win32.whl", hash = "sha256:d82dd730a95e6643802f4454b8fdecdf08667881a9c5670db85bc5a56693f122", size = 41416, upload-time = "2026-01-26T02:43:22.703Z" },
-    { url = "https://files.pythonhosted.org/packages/68/00/9b38e272a770303692fc406c36e1a4c740f401522d5787691eb38a8925a8/multidict-6.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:cf37cbe5ced48d417ba045aca1b21bafca67489452debcde94778a576666a1df", size = 46022, upload-time = "2026-01-26T02:43:23.77Z" },
-    { url = "https://files.pythonhosted.org/packages/64/65/d8d42490c02ee07b6bbe00f7190d70bb4738b3cce7629aaf9f213ef730dd/multidict-6.7.1-cp310-cp310-win_arm64.whl", hash = "sha256:59bc83d3f66b41dac1e7460aac1d196edc70c9ba3094965c467715a70ecb46db", size = 43238, upload-time = "2026-01-26T02:43:24.882Z" },
     { url = "https://files.pythonhosted.org/packages/ce/f1/a90635c4f88fb913fbf4ce660b83b7445b7a02615bda034b2f8eb38fd597/multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d", size = 76626, upload-time = "2026-01-26T02:43:26.485Z" },
     { url = "https://files.pythonhosted.org/packages/a6/9b/267e64eaf6fc637a15b35f5de31a566634a2740f97d8d094a69d34f524a4/multidict-6.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:844c5bca0b5444adb44a623fb0a1310c2f4cd41f402126bb269cd44c9b3f3e1e", size = 44706, upload-time = "2026-01-26T02:43:27.607Z" },
     { url = "https://files.pythonhosted.org/packages/dd/a4/d45caf2b97b035c57267791ecfaafbd59c68212004b3842830954bb4b02e/multidict-6.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2a0a924d4c2e9afcd7ec64f9de35fcd96915149b2216e1cb2c10a56df483855", size = 44356, upload-time = "2026-01-26T02:43:28.661Z" },
@@ -3871,17 +3602,10 @@ dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/63/e499890d8e39b1ff2df4c0c6ce5d371b6844ee22b8250687a99fd2f657a8/mypy-1.19.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5f05aa3d375b385734388e844bc01733bd33c644ab48e9684faa54e5389775ec", size = 13101333, upload-time = "2025-12-15T05:03:03.28Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4b/095626fc136fba96effc4fd4a82b41d688ab92124f8c4f7564bffe5cf1b0/mypy-1.19.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:022ea7279374af1a5d78dfcab853fe6a536eebfda4b59deab53cd21f6cd9f00b", size = 12164102, upload-time = "2025-12-15T05:02:33.611Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/5b/952928dd081bf88a83a5ccd49aaecfcd18fd0d2710c7ff07b8fb6f7032b9/mypy-1.19.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee4c11e460685c3e0c64a4c5de82ae143622410950d6be863303a1c4ba0e36d6", size = 12765799, upload-time = "2025-12-15T05:03:28.44Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/0d/93c2e4a287f74ef11a66fb6d49c7a9f05e47b0a4399040e6719b57f500d2/mypy-1.19.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de759aafbae8763283b2ee5869c7255391fbc4de3ff171f8f030b5ec48381b74", size = 13522149, upload-time = "2025-12-15T05:02:36.011Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/0e/33a294b56aaad2b338d203e3a1d8b453637ac36cb278b45005e0901cf148/mypy-1.19.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ab43590f9cd5108f41aacf9fca31841142c786827a74ab7cc8a2eacb634e09a1", size = 13810105, upload-time = "2025-12-15T05:02:40.327Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/fd/3e82603a0cb66b67c5e7abababce6bf1a929ddf67bf445e652684af5c5a0/mypy-1.19.1-cp310-cp310-win_amd64.whl", hash = "sha256:2899753e2f61e571b3971747e302d5f420c3fd09650e1951e99f823bc3089dac", size = 10057200, upload-time = "2025-12-15T05:02:51.012Z" },
     { url = "https://files.pythonhosted.org/packages/ef/47/6b3ebabd5474d9cdc170d1342fbf9dddc1b0ec13ec90bf9004ee6f391c31/mypy-1.19.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d8dfc6ab58ca7dda47d9237349157500468e404b17213d44fc1cb77bce532288", size = 13028539, upload-time = "2025-12-15T05:03:44.129Z" },
     { url = "https://files.pythonhosted.org/packages/5c/a6/ac7c7a88a3c9c54334f53a941b765e6ec6c4ebd65d3fe8cdcfbe0d0fd7db/mypy-1.19.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e3f276d8493c3c97930e354b2595a44a21348b320d859fb4a2b9f66da9ed27ab", size = 12083163, upload-time = "2025-12-15T05:03:37.679Z" },
     { url = "https://files.pythonhosted.org/packages/67/af/3afa9cf880aa4a2c803798ac24f1d11ef72a0c8079689fac5cfd815e2830/mypy-1.19.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2abb24cf3f17864770d18d673c85235ba52456b36a06b6afc1e07c1fdcd3d0e6", size = 12687629, upload-time = "2025-12-15T05:02:31.526Z" },
@@ -4073,7 +3797,6 @@ dependencies = [
     { name = "dependency-groups" },
     { name = "humanize" },
     { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "virtualenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/8e/55a9679b31f1efc48facedd2448eb53c7f1e647fb592aa1403c9dd7a4590/nox-2026.2.9.tar.gz", hash = "sha256:1bc8a202ee8cd69be7aaada63b2a7019126899a06fc930a7aee75585bf8ee41b", size = 4031165, upload-time = "2026-02-10T04:38:58.878Z" }
@@ -4095,79 +3818,8 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.2.6"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb", size = 21165245, upload-time = "2025-05-17T21:27:58.555Z" },
-    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90", size = 14360048, upload-time = "2025-05-17T21:28:21.406Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163", size = 5340542, upload-time = "2025-05-17T21:28:30.931Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf", size = 6878301, upload-time = "2025-05-17T21:28:41.613Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83", size = 14297320, upload-time = "2025-05-17T21:29:02.78Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915", size = 16801050, upload-time = "2025-05-17T21:29:27.675Z" },
-    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680", size = 15807034, upload-time = "2025-05-17T21:29:51.102Z" },
-    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289", size = 18614185, upload-time = "2025-05-17T21:30:18.703Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d", size = 6527149, upload-time = "2025-05-17T21:30:29.788Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3", size = 12904620, upload-time = "2025-05-17T21:30:48.994Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae", size = 21176963, upload-time = "2025-05-17T21:31:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/2b/64e1affc7972decb74c9e29e5649fac940514910960ba25cd9af4488b66c/numpy-2.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c820a93b0255bc360f53eca31a0e676fd1101f673dda8da93454a12e23fc5f7a", size = 14406743, upload-time = "2025-05-17T21:31:41.087Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9f/0121e375000b5e50ffdd8b25bf78d8e1a5aa4cca3f185d41265198c7b834/numpy-2.2.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42", size = 5352616, upload-time = "2025-05-17T21:31:50.072Z" },
-    { url = "https://files.pythonhosted.org/packages/31/0d/b48c405c91693635fbe2dcd7bc84a33a602add5f63286e024d3b6741411c/numpy-2.2.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:481b49095335f8eed42e39e8041327c05b0f6f4780488f61286ed3c01368d491", size = 6889579, upload-time = "2025-05-17T21:32:01.712Z" },
-    { url = "https://files.pythonhosted.org/packages/52/b8/7f0554d49b565d0171eab6e99001846882000883998e7b7d9f0d98b1f934/numpy-2.2.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b64d8d4d17135e00c8e346e0a738deb17e754230d7e0810ac5012750bbd85a5a", size = 14312005, upload-time = "2025-05-17T21:32:23.332Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/dd/2238b898e51bd6d389b7389ffb20d7f4c10066d80351187ec8e303a5a475/numpy-2.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba10f8411898fc418a521833e014a77d3ca01c15b0c6cdcce6a0d2897e6dbbdf", size = 16821570, upload-time = "2025-05-17T21:32:47.991Z" },
-    { url = "https://files.pythonhosted.org/packages/83/6c/44d0325722cf644f191042bf47eedad61c1e6df2432ed65cbe28509d404e/numpy-2.2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd48227a919f1bafbdda0583705e547892342c26fb127219d60a5c36882609d1", size = 15818548, upload-time = "2025-05-17T21:33:11.728Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/9d/81e8216030ce66be25279098789b665d49ff19eef08bfa8cb96d4957f422/numpy-2.2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9551a499bf125c1d4f9e250377c1ee2eddd02e01eac6644c080162c0c51778ab", size = 18620521, upload-time = "2025-05-17T21:33:39.139Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/fd/e19617b9530b031db51b0926eed5345ce8ddc669bb3bc0044b23e275ebe8/numpy-2.2.6-cp311-cp311-win32.whl", hash = "sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47", size = 6525866, upload-time = "2025-05-17T21:33:50.273Z" },
-    { url = "https://files.pythonhosted.org/packages/31/0a/f354fb7176b81747d870f7991dc763e157a934c717b67b58456bc63da3df/numpy-2.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:e8213002e427c69c45a52bbd94163084025f533a55a59d6f9c5b820774ef3303", size = 12907455, upload-time = "2025-05-17T21:34:09.135Z" },
-    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
-    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
-    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828, upload-time = "2025-05-17T21:37:56.699Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006, upload-time = "2025-05-17T21:38:18.291Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765, upload-time = "2025-05-17T21:38:27.319Z" },
-    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736, upload-time = "2025-05-17T21:38:38.141Z" },
-    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719, upload-time = "2025-05-17T21:38:58.433Z" },
-    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072, upload-time = "2025-05-17T21:39:22.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213, upload-time = "2025-05-17T21:39:45.865Z" },
-    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632, upload-time = "2025-05-17T21:40:13.331Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532, upload-time = "2025-05-17T21:43:46.099Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885, upload-time = "2025-05-17T21:44:05.145Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467, upload-time = "2025-05-17T21:40:44Z" },
-    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144, upload-time = "2025-05-17T21:41:05.695Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217, upload-time = "2025-05-17T21:41:15.903Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014, upload-time = "2025-05-17T21:41:27.321Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935, upload-time = "2025-05-17T21:41:49.738Z" },
-    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122, upload-time = "2025-05-17T21:42:14.046Z" },
-    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143, upload-time = "2025-05-17T21:42:37.464Z" },
-    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
-    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
-    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d", size = 21040391, upload-time = "2025-05-17T21:44:35.948Z" },
-    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
-    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
-    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
-]
-
-[[package]]
-name = "numpy"
 version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", size = 20723651, upload-time = "2026-01-31T23:13:10.135Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/44/71852273146957899753e69986246d6a176061ea183407e95418c2aa4d9a/numpy-2.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7e88598032542bd49af7c4747541422884219056c268823ef6e5e89851c8825", size = 16955478, upload-time = "2026-01-31T23:10:25.623Z" },
@@ -4539,21 +4191,13 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/f7/f425a00df4fcc22b292c6895c6831c0c8ae1d9fac1e024d16f98a9ce8749/pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c", size = 11555763, upload-time = "2025-09-29T23:16:53.287Z" },
-    { url = "https://files.pythonhosted.org/packages/13/4f/66d99628ff8ce7857aca52fed8f0066ce209f96be2fede6cef9f84e8d04f/pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a", size = 10801217, upload-time = "2025-09-29T23:17:04.522Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/03/3fc4a529a7710f890a239cc496fc6d50ad4a0995657dccc1d64695adb9f4/pandas-2.3.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf26f64126b6c7aec964f74266f435afef1c1b13da3b0636c7518a1fa3e2b1", size = 12148791, upload-time = "2025-09-29T23:17:18.444Z" },
-    { url = "https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd7478f1463441ae4ca7308a70e90b33470fa593429f9d4c578dd00d1fa78838", size = 12769373, upload-time = "2025-09-29T23:17:35.846Z" },
-    { url = "https://files.pythonhosted.org/packages/df/91/82cc5169b6b25440a7fc0ef3a694582418d875c8e3ebf796a6d6470aa578/pandas-2.3.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4793891684806ae50d1288c9bae9330293ab4e083ccd1c5e383c34549c6e4250", size = 13200444, upload-time = "2025-09-29T23:17:49.341Z" },
-    { url = "https://files.pythonhosted.org/packages/10/ae/89b3283800ab58f7af2952704078555fa60c807fff764395bb57ea0b0dbd/pandas-2.3.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28083c648d9a99a5dd035ec125d42439c6c1c525098c58af0fc38dd1a7a1b3d4", size = 13858459, upload-time = "2025-09-29T23:18:03.722Z" },
-    { url = "https://files.pythonhosted.org/packages/85/72/530900610650f54a35a19476eca5104f38555afccda1aa11a92ee14cb21d/pandas-2.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:503cf027cf9940d2ceaa1a93cfb5f8c8c7e6e90720a2850378f0b3f3b1e06826", size = 11346086, upload-time = "2025-09-29T23:18:18.505Z" },
     { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
     { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
     { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
@@ -4659,17 +4303,6 @@ version = "12.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/42/5c74462b4fd957fcd7b13b04fb3205ff8349236ea74c7c375766d6c82288/pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4", size = 46980264, upload-time = "2026-02-11T04:23:07.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/30/5bd3d794762481f8c8ae9c80e7b76ecea73b916959eb587521358ef0b2f9/pillow-12.1.1-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1f1625b72740fdda5d77b4def688eb8fd6490975d06b909fd19f13f391e077e0", size = 5304099, upload-time = "2026-02-11T04:20:06.13Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c1/aab9e8f3eeb4490180e357955e15c2ef74b31f64790ff356c06fb6cf6d84/pillow-12.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:178aa072084bd88ec759052feca8e56cbb14a60b39322b99a049e58090479713", size = 4657880, upload-time = "2026-02-11T04:20:09.291Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/0a/9879e30d56815ad529d3985aeff5af4964202425c27261a6ada10f7cbf53/pillow-12.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b66e95d05ba806247aaa1561f080abc7975daf715c30780ff92a20e4ec546e1b", size = 6222587, upload-time = "2026-02-11T04:20:10.82Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/5f/a1b72ff7139e4f89014e8d451442c74a774d5c43cd938fb0a9f878576b37/pillow-12.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:89c7e895002bbe49cdc5426150377cbbc04767d7547ed145473f496dfa40408b", size = 8027678, upload-time = "2026-02-11T04:20:12.455Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c2/c7cb187dac79a3d22c3ebeae727abee01e077c8c7d930791dc592f335153/pillow-12.1.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a5cbdcddad0af3da87cb16b60d23648bc3b51967eb07223e9fed77a82b457c4", size = 6335777, upload-time = "2026-02-11T04:20:14.441Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/7b/f9b09a7804ec7336effb96c26d37c29d27225783dc1501b7d62dcef6ae25/pillow-12.1.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f51079765661884a486727f0729d29054242f74b46186026582b4e4769918e4", size = 7027140, upload-time = "2026-02-11T04:20:16.387Z" },
-    { url = "https://files.pythonhosted.org/packages/98/b2/2fa3c391550bd421b10849d1a2144c44abcd966daadd2f7c12e19ea988c4/pillow-12.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:99c1506ea77c11531d75e3a412832a13a71c7ebc8192ab9e4b2e355555920e3e", size = 6449855, upload-time = "2026-02-11T04:20:18.554Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ff/9caf4b5b950c669263c39e96c78c0d74a342c71c4f43fd031bb5cb7ceac9/pillow-12.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:36341d06738a9f66c8287cf8b876d24b18db9bd8740fa0672c74e259ad408cff", size = 7151329, upload-time = "2026-02-11T04:20:20.646Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/f8/4b24841f582704da675ca535935bccb32b00a6da1226820845fac4a71136/pillow-12.1.1-cp310-cp310-win32.whl", hash = "sha256:6c52f062424c523d6c4db85518774cc3d50f5539dd6eed32b8f6229b26f24d40", size = 6325574, upload-time = "2026-02-11T04:20:22.43Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/f9/9f6b01c0881d7036063aa6612ef04c0e2cad96be21325a1e92d0203f8e91/pillow-12.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:c6008de247150668a705a6338156efb92334113421ceecf7438a12c9a12dab23", size = 7032347, upload-time = "2026-02-11T04:20:23.932Z" },
-    { url = "https://files.pythonhosted.org/packages/79/13/c7922edded3dcdaf10c59297540b72785620abc0538872c819915746757d/pillow-12.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:1a9b0ee305220b392e1124a764ee4265bd063e54a751a6b62eff69992f457fa9", size = 2453457, upload-time = "2026-02-11T04:20:25.392Z" },
     { url = "https://files.pythonhosted.org/packages/2b/46/5da1ec4a5171ee7bf1a0efa064aba70ba3d6e0788ce3f5acd1375d23c8c0/pillow-12.1.1-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:e879bb6cd5c73848ef3b2b48b8af9ff08c5b71ecda8048b7dd22d8a33f60be32", size = 5304084, upload-time = "2026-02-11T04:20:27.501Z" },
     { url = "https://files.pythonhosted.org/packages/78/93/a29e9bc02d1cf557a834da780ceccd54e02421627200696fcf805ebdc3fb/pillow-12.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:365b10bb9417dd4498c0e3b128018c4a624dc11c7b97d8cc54effe3b096f4c38", size = 4657866, upload-time = "2026-02-11T04:20:29.827Z" },
     { url = "https://files.pythonhosted.org/packages/13/84/583a4558d492a179d31e4aae32eadce94b9acf49c0337c4ce0b70e0a01f2/pillow-12.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d4ce8e329c93845720cd2014659ca67eac35f6433fd3050393d85f3ecef0dad5", size = 6232148, upload-time = "2026-02-11T04:20:31.329Z" },
@@ -4831,7 +4464,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pastel" },
     { name = "pyyaml" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/b9/fa92286560f70eaa40d473ea48376d20c6c21f63627d33c6bb1c5e385175/poethepoet-0.41.0.tar.gz", hash = "sha256:dcaad621dc061f6a90b17d091bebb9ca043d67bfe9bd6aa4185aea3ebf7ff3e6", size = 87780, upload-time = "2026-02-08T20:45:36.061Z" }
 wheels = [
@@ -4993,13 +4625,6 @@ version = "23.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/33/ffd9c3eb087fa41dd79c3cf20c4c0ae3cdb877c4f8e1107a446006344924/pyarrow-23.0.0.tar.gz", hash = "sha256:180e3150e7edfcd182d3d9afba72f7cf19839a497cc76555a8dce998a8f67615", size = 1167185, upload-time = "2026-01-18T16:19:42.218Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/2f/23e042a5aa99bcb15e794e14030e8d065e00827e846e53a66faec73c7cd6/pyarrow-23.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:cbdc2bf5947aa4d462adcf8453cf04aee2f7932653cb67a27acd96e5e8528a67", size = 34281861, upload-time = "2026-01-18T16:13:34.332Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/65/1651933f504b335ec9cd8f99463718421eb08d883ed84f0abd2835a16cad/pyarrow-23.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:4d38c836930ce15cd31dce20114b21ba082da231c884bdc0a7b53e1477fe7f07", size = 35825067, upload-time = "2026-01-18T16:13:42.549Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ec/d6fceaec050c893f4e35c0556b77d4cc9973fcc24b0a358a5781b1234582/pyarrow-23.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4222ff8f76919ecf6c716175a0e5fddb5599faeed4c56d9ea41a2c42be4998b2", size = 44458539, upload-time = "2026-01-18T16:13:52.975Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/d9/369f134d652b21db62fe3ec1c5c2357e695f79eb67394b8a93f3a2b2cffa/pyarrow-23.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:87f06159cbe38125852657716889296c83c37b4d09a5e58f3d10245fd1f69795", size = 47535889, upload-time = "2026-01-18T16:14:03.693Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/95/f37b6a252fdbf247a67a78fb3f61a529fe0600e304c4d07741763d3522b1/pyarrow-23.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1675c374570d8b91ea6d4edd4608fa55951acd44e0c31bd146e091b4005de24f", size = 48157777, upload-time = "2026-01-18T16:14:12.483Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/ab/fb94923108c9c6415dab677cf1f066d3307798eafc03f9a65ab4abc61056/pyarrow-23.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:247374428fde4f668f138b04031a7e7077ba5fa0b5b1722fdf89a017bf0b7ee0", size = 50580441, upload-time = "2026-01-18T16:14:20.187Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/78/897ba6337b517fc8e914891e1bd918da1c4eb8e936a553e95862e67b80f6/pyarrow-23.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:de53b1bd3b88a2ee93c9af412c903e57e738c083be4f6392288294513cd8b2c1", size = 27530028, upload-time = "2026-01-18T16:14:27.353Z" },
     { url = "https://files.pythonhosted.org/packages/aa/c0/57fe251102ca834fee0ef69a84ad33cc0ff9d5dfc50f50b466846356ecd7/pyarrow-23.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:5574d541923efcbfdf1294a2746ae3b8c2498a2dc6cd477882f6f4e7b1ac08d3", size = 34276762, upload-time = "2026-01-18T16:14:34.128Z" },
     { url = "https://files.pythonhosted.org/packages/f8/4e/24130286548a5bc250cbed0b6bbf289a2775378a6e0e6f086ae8c68fc098/pyarrow-23.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:2ef0075c2488932e9d3c2eb3482f9459c4be629aa673b725d5e3cf18f777f8e4", size = 35821420, upload-time = "2026-01-18T16:14:40.699Z" },
     { url = "https://files.pythonhosted.org/packages/ee/55/a869e8529d487aa2e842d6c8865eb1e2c9ec33ce2786eb91104d2c3e3f10/pyarrow-23.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:65666fc269669af1ef1c14478c52222a2aa5c907f28b68fb50a203c777e4f60c", size = 44457412, upload-time = "2026-01-18T16:14:49.051Z" },
@@ -5103,19 +4728,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
-    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
-    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
-    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
-    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
     { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
     { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
     { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
@@ -5194,14 +4806,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
     { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
     { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
-    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
-    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
     { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
     { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
     { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
@@ -5232,8 +4836,7 @@ version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/ca/40e14e196864a0f61a92abb14d09b3d3da98f94ccb03b49cf51688140dab/pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605", size = 3832240, upload-time = "2024-05-10T15:36:21.153Z" }
 wheels = [
@@ -5253,9 +4856,6 @@ wheels = [
 name = "pyjwt"
 version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
@@ -5279,9 +4879,6 @@ wheels = [
 name = "pypdf"
 version = "6.8.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/a3/e705b0805212b663a4c27b861c8a603dba0f8b4bb281f96f8e746576a50d/pypdf-6.8.0.tar.gz", hash = "sha256:cb7eaeaa4133ce76f762184069a854e03f4d9a08568f0e0623f7ea810407833b", size = 5307831, upload-time = "2026-03-09T13:37:40.591Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/ec/4ccf3bb86b1afe5d7176e1c8abcdbf22b53dd682ec2eda50e1caadcf6846/pypdf-6.8.0-py3-none-any.whl", hash = "sha256:2a025080a8dd73f48123c89c57174a5ff3806c71763ee4e49572dc90454943c7", size = 332177, upload-time = "2026-03-09T13:37:38.774Z" },
@@ -5293,7 +4890,6 @@ version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/45/7b/c0e1333b61d41c69e59e5366e727b18c4992688caf0de1be10b3e5265f6b/pyproject_api-1.10.0.tar.gz", hash = "sha256:40c6f2d82eebdc4afee61c773ed208c04c19db4c4a60d97f8d7be3ebc0bbb330", size = 22785, upload-time = "2025-10-09T19:12:27.21Z" }
 wheels = [
@@ -5335,11 +4931,6 @@ version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b1/4a/10df9ff9a7b37a4aecee0d65997521e504a4d101a98ce831fb12486ef28f/pysentry_rs-0.4.1.tar.gz", hash = "sha256:d5b6e0dcfc8e7c817e5f6b7362609c908e39421ed9582a8e0ba4a3c01fde7736", size = 594972, upload-time = "2026-02-06T10:47:53.226Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/30/0d6417a83e72889beaec76c9c48cf0b13ccbe7cee1f3a17afedd05a896bf/pysentry_rs-0.4.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:7981eddd09ea6dd9ffae6316551381e05523fe8463b849a476d99e858dd52e46", size = 4485615, upload-time = "2026-02-06T10:46:41.095Z" },
-    { url = "https://files.pythonhosted.org/packages/29/06/f5b642453f33a515d482acfe3c46992e40db5f69814517a9868ca4679498/pysentry_rs-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9d3b68cf5dc011f6c20b8be26b555777e73c952c8ec1a3ec1e1ffbc487b4dab3", size = 4288451, upload-time = "2026-02-06T10:46:43.19Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/72/c4ec56889358ae0b183ded61b0c2c096df99eaf0d8b86684d466418d1b58/pysentry_rs-0.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71c9c0544bae93d66ce2f4b91c004040c93929541a769675631272f5e7a585a9", size = 4762072, upload-time = "2026-02-06T10:46:45.063Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/7f/e74c4ae97eb8133abac7e95044a26ac0eb16a3c729f4abc431b5ca3316b7/pysentry_rs-0.4.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:7ac7ffeb9ef9c8ba714fc5e2ab439cf53d9807607d228d4e2b19d748409bae1b", size = 4717303, upload-time = "2026-02-06T10:46:46.968Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/aa/cc3b91a847637c21d9a81e8ed9eaf4e9f791cfb9d897ca843363a3aaabe6/pysentry_rs-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:29b9815edebad86b37d97fa7d71d1c07ca9535831890b4bddbb2319e65c2b298", size = 4075016, upload-time = "2026-02-06T10:46:49.217Z" },
     { url = "https://files.pythonhosted.org/packages/e1/f3/b47d9fa8bf00f24944552bbc19a784d50df18e9775cce5fb70cd0c46e5a6/pysentry_rs-0.4.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b99b784776a5f18ac9a5880722a14439a397d8c33deddc9e34e8c6ffb43e84a2", size = 4485366, upload-time = "2026-02-06T10:46:51.079Z" },
     { url = "https://files.pythonhosted.org/packages/1c/fb/fe044aa5a5fa7be36b42db39744cdf25f24ceb4ee857b7ed339e645fa646/pysentry_rs-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b7741a7eecf82ca3f329fee459d701aad2f7c76b77948e4de9d10678c6b314b2", size = 4288007, upload-time = "2026-02-06T10:46:52.613Z" },
     { url = "https://files.pythonhosted.org/packages/23/d6/b5564e6a95c7f51257cd6256ad0b89fb672728acdb13ca794ef92b5c727c/pysentry_rs-0.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc8270618b00da2c0e5e42f3df659f688824d4b1a69e4c805b56358d89e66d29", size = 4762003, upload-time = "2026-02-06T10:46:54.492Z" },
@@ -5378,12 +4969,10 @@ version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
@@ -5395,7 +4984,6 @@ name = "pytest-asyncio"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -5435,7 +5023,6 @@ name = "pytest-watcher"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "watchdog" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e6/d2/80606077b7fa8784417687f494ff801d7ab817d9a17fc94305811d5919bb/pytest_watcher-0.6.3.tar.gz", hash = "sha256:842dc904264df0ad2d5264153a66bb452fccfa46598cd6e0a5ef1d19afed9b13", size = 601878, upload-time = "2026-01-10T23:28:18.805Z" }
@@ -5488,11 +5075,6 @@ version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
-    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
-    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
     { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
     { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
     { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
@@ -5535,9 +5117,6 @@ name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
-    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
     { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
     { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
     { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
@@ -5567,8 +5146,6 @@ version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f7/54/37c7370ba91f579235049dc26cd2c5e657d2a943e01820844ffc81f32176/pywinpty-3.0.3.tar.gz", hash = "sha256:523441dc34d231fb361b4b00f8c99d3f16de02f5005fd544a0183112bcc22412", size = 31309, upload-time = "2026-02-04T21:51:09.524Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/28/a652709bd76ca7533cd1c443b03add9f5051fdf71bc6bdb8801dddd4e7a3/pywinpty-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:ff05f12d775b142b11c6fe085129bdd759b61cf7d41da6c745e78e3a1ef5bf40", size = 2114320, upload-time = "2026-02-04T21:53:50.972Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/13/a0181cc5c2d5635d3dbc3802b97bc8e3ad4fa7502ccef576651a5e08e54c/pywinpty-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:340ccacb4d74278a631923794ccd758471cfc8eeeeee4610b280420a17ad1e82", size = 235670, upload-time = "2026-02-04T21:50:20.324Z" },
     { url = "https://files.pythonhosted.org/packages/79/c3/3e75075c7f71735f22b66fab0481f2c98e3a4d58cba55cb50ba29114bcf6/pywinpty-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:dff25a9a6435f527d7c65608a7e62783fc12076e7d44487a4911ee91be5a8ac8", size = 2114430, upload-time = "2026-02-04T21:54:19.485Z" },
     { url = "https://files.pythonhosted.org/packages/8d/1e/8a54166a8c5e4f5cb516514bdf4090be4d51a71e8d9f6d98c0aa00fe45d4/pywinpty-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:fbc1e230e5b193eef4431cba3f39996a288f9958f9c9f092c8a961d930ee8f68", size = 236191, upload-time = "2026-02-04T21:50:36.239Z" },
     { url = "https://files.pythonhosted.org/packages/7c/d4/aeb5e1784d2c5bff6e189138a9ca91a090117459cea0c30378e1f2db3d54/pywinpty-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c9081df0e49ffa86d15db4a6ba61530630e48707f987df42c9d3313537e81fc0", size = 2113098, upload-time = "2026-02-04T21:54:37.711Z" },
@@ -5598,15 +5175,6 @@ version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
-    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
     { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
     { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
     { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
@@ -5665,16 +5233,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/b9/52aa9ec2867528b54f1e60846728d8b4d84726630874fee3a91e66c7df81/pyzmq-27.1.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:508e23ec9bc44c0005c4946ea013d9317ae00ac67778bd47519fdf5a0e930ff4", size = 1329850, upload-time = "2025-09-08T23:07:26.274Z" },
-    { url = "https://files.pythonhosted.org/packages/99/64/5653e7b7425b169f994835a2b2abf9486264401fdef18df91ddae47ce2cc/pyzmq-27.1.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:507b6f430bdcf0ee48c0d30e734ea89ce5567fd7b8a0f0044a369c176aa44556", size = 906380, upload-time = "2025-09-08T23:07:29.78Z" },
-    { url = "https://files.pythonhosted.org/packages/73/78/7d713284dbe022f6440e391bd1f3c48d9185673878034cfb3939cdf333b2/pyzmq-27.1.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf7b38f9fd7b81cb6d9391b2946382c8237fd814075c6aa9c3b746d53076023b", size = 666421, upload-time = "2025-09-08T23:07:31.263Z" },
-    { url = "https://files.pythonhosted.org/packages/30/76/8f099f9d6482450428b17c4d6b241281af7ce6a9de8149ca8c1c649f6792/pyzmq-27.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03ff0b279b40d687691a6217c12242ee71f0fba28bf8626ff50e3ef0f4410e1e", size = 854149, upload-time = "2025-09-08T23:07:33.17Z" },
-    { url = "https://files.pythonhosted.org/packages/59/f0/37fbfff06c68016019043897e4c969ceab18bde46cd2aca89821fcf4fb2e/pyzmq-27.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:677e744fee605753eac48198b15a2124016c009a11056f93807000ab11ce6526", size = 1655070, upload-time = "2025-09-08T23:07:35.205Z" },
-    { url = "https://files.pythonhosted.org/packages/47/14/7254be73f7a8edc3587609554fcaa7bfd30649bf89cd260e4487ca70fdaa/pyzmq-27.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:dd2fec2b13137416a1c5648b7009499bcc8fea78154cd888855fa32514f3dad1", size = 2033441, upload-time = "2025-09-08T23:07:37.432Z" },
-    { url = "https://files.pythonhosted.org/packages/22/dc/49f2be26c6f86f347e796a4d99b19167fc94503f0af3fd010ad262158822/pyzmq-27.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:08e90bb4b57603b84eab1d0ca05b3bbb10f60c1839dc471fc1c9e1507bef3386", size = 1891529, upload-time = "2025-09-08T23:07:39.047Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/3e/154fb963ae25be70c0064ce97776c937ecc7d8b0259f22858154a9999769/pyzmq-27.1.0-cp310-cp310-win32.whl", hash = "sha256:a5b42d7a0658b515319148875fcb782bbf118dd41c671b62dae33666c2213bda", size = 567276, upload-time = "2025-09-08T23:07:40.695Z" },
-    { url = "https://files.pythonhosted.org/packages/62/b2/f4ab56c8c595abcb26b2be5fd9fa9e6899c1e5ad54964e93ae8bb35482be/pyzmq-27.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:c0bb87227430ee3aefcc0ade2088100e528d5d3298a0a715a64f3d04c60ba02f", size = 632208, upload-time = "2025-09-08T23:07:42.298Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/e3/be2cc7ab8332bdac0522fdb64c17b1b6241a795bee02e0196636ec5beb79/pyzmq-27.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:9a916f76c2ab8d045b19f2286851a38e9ac94ea91faf65bd64735924522a8b32", size = 559766, upload-time = "2025-09-08T23:07:43.869Z" },
     { url = "https://files.pythonhosted.org/packages/06/5d/305323ba86b284e6fcb0d842d6adaa2999035f70f8c38a9b6d21ad28c3d4/pyzmq-27.1.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:226b091818d461a3bef763805e75685e478ac17e9008f49fce2d3e52b3d58b86", size = 1333328, upload-time = "2025-09-08T23:07:45.946Z" },
     { url = "https://files.pythonhosted.org/packages/bd/a0/fc7e78a23748ad5443ac3275943457e8452da67fda347e05260261108cbc/pyzmq-27.1.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0790a0161c281ca9723f804871b4027f2e8b5a528d357c8952d08cd1a9c15581", size = 908803, upload-time = "2025-09-08T23:07:47.551Z" },
     { url = "https://files.pythonhosted.org/packages/7e/22/37d15eb05f3bdfa4abea6f6d96eb3bb58585fbd3e4e0ded4e743bc650c97/pyzmq-27.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c895a6f35476b0c3a54e3eb6ccf41bf3018de937016e6e18748317f25d4e925f", size = 668836, upload-time = "2025-09-08T23:07:49.436Z" },
@@ -5717,11 +5275,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
     { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
     { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/81/a65e71c1552f74dec9dff91d95bafb6e0d33338a8dfefbc88aa562a20c92/pyzmq-27.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c17e03cbc9312bee223864f1a2b13a99522e0dc9f7c5df0177cd45210ac286e6", size = 836266, upload-time = "2025-09-08T23:09:40.048Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ed/0202ca350f4f2b69faa95c6d931e3c05c3a397c184cacb84cb4f8f42f287/pyzmq-27.1.0-pp310-pypy310_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f328d01128373cb6763823b2b4e7f73bdf767834268c565151eacb3b7a392f90", size = 800206, upload-time = "2025-09-08T23:09:41.902Z" },
-    { url = "https://files.pythonhosted.org/packages/47/42/1ff831fa87fe8f0a840ddb399054ca0009605d820e2b44ea43114f5459f4/pyzmq-27.1.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c1790386614232e1b3a40a958454bdd42c6d1811837b15ddbb052a032a43f62", size = 567747, upload-time = "2025-09-08T23:09:43.741Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/db/5c4d6807434751e3f21231bee98109aa57b9b9b55e058e450d0aef59b70f/pyzmq-27.1.0-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:448f9cb54eb0cee4732b46584f2710c8bc178b0e5371d9e4fc8125201e413a74", size = 747371, upload-time = "2025-09-08T23:09:45.575Z" },
-    { url = "https://files.pythonhosted.org/packages/26/af/78ce193dbf03567eb8c0dc30e3df2b9e56f12a670bf7eb20f9fb532c7e8a/pyzmq-27.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:05b12f2d32112bf8c95ef2e74ec4f1d4beb01f8b5e703b38537f8849f92cb9ba", size = 544862, upload-time = "2025-09-08T23:09:47.448Z" },
     { url = "https://files.pythonhosted.org/packages/4c/c6/c4dcdecdbaa70969ee1fdced6d7b8f60cfabe64d25361f27ac4665a70620/pyzmq-27.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:18770c8d3563715387139060d37859c02ce40718d1faf299abddcdcc6a649066", size = 836265, upload-time = "2025-09-08T23:09:49.376Z" },
     { url = "https://files.pythonhosted.org/packages/3e/79/f38c92eeaeb03a2ccc2ba9866f0439593bb08c5e3b714ac1d553e5c96e25/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ac25465d42f92e990f8d8b0546b01c391ad431c3bf447683fdc40565941d0604", size = 800208, upload-time = "2025-09-08T23:09:51.073Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/3f0d0d335c6b3abb9b7b723776d0b21fa7f3a6c819a0db6097059aada160/pyzmq-27.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53b40f8ae006f2734ee7608d59ed661419f087521edbfc2149c3932e9c14808c", size = 567747, upload-time = "2025-09-08T23:09:52.698Z" },
@@ -5879,7 +5432,6 @@ dependencies = [
     { name = "click" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/27/091e140ea834272188e63f8dd6faac1f5c687582b687197b3e0ec3c78ebf/rich_click-1.9.7.tar.gz", hash = "sha256:022997c1e30731995bdbc8ec2f82819340d42543237f033a003c7b1f843fc5dc", size = 74838, upload-time = "2026-01-31T04:29:27.707Z" }
 wheels = [
@@ -5892,20 +5444,6 @@ version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
-    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
-    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
-    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
-    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
     { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
     { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
     { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
@@ -6220,8 +5758,7 @@ dependencies = [
     { name = "cachetools" },
     { name = "click" },
     { name = "gitpython" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy" },
     { name = "packaging" },
     { name = "pandas" },
     { name = "pillow" },
@@ -6253,25 +5790,9 @@ wheels = [
 name = "structlog"
 version = "25.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
-]
-
-[[package]]
-name = "taskgroup"
-version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b1/74babcc824a57904e919f3af16d86c08b524c0691504baf038ef2d7f655c/taskgroup-0.2.2-py2.py3-none-any.whl", hash = "sha256:e2c53121609f4ae97303e9ea1524304b4de6faf9eb2c9280c7f87976479a52fb", size = 14237, upload-time = "2025-01-03T09:24:11.41Z" },
 ]
 
 [[package]]
@@ -6432,8 +5953,6 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pluggy" },
     { name = "pyproject-api" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "virtualenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/9b/5909f40b281ebd37c2f83de5087b9cb8a9a64c33745f334be0aeaedadbbc/tox-4.34.1.tar.gz", hash = "sha256:ef1e82974c2f5ea02954d590ee0b967fad500c3879b264ea19efb9a554f3cc60", size = 205306, upload-time = "2026-01-09T17:42:59.895Z" }
@@ -6447,7 +5966,6 @@ version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tox" },
     { name = "uv" },
 ]
@@ -6662,7 +6180,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
@@ -6686,12 +6203,6 @@ version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/14/ecceb239b65adaaf7fde510aa8bd534075695d1e5f8dadfa32b5723d9cfb/uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c", size = 1343335, upload-time = "2025-10-16T22:16:11.43Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/ae/6f6f9af7f590b319c94532b9567409ba11f4fa71af1148cab1bf48a07048/uvloop-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7cd375a12b71d33d46af85a3343b35d98e8116134ba404bd657b3b1d15988792", size = 742903, upload-time = "2025-10-16T22:16:12.979Z" },
-    { url = "https://files.pythonhosted.org/packages/09/bd/3667151ad0702282a1f4d5d29288fce8a13c8b6858bf0978c219cd52b231/uvloop-0.22.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac33ed96229b7790eb729702751c0e93ac5bc3bcf52ae9eccbff30da09194b86", size = 3648499, upload-time = "2025-10-16T22:16:14.451Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/f6/21657bb3beb5f8c57ce8be3b83f653dd7933c2fd00545ed1b092d464799a/uvloop-0.22.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:481c990a7abe2c6f4fc3d98781cc9426ebd7f03a9aaa7eb03d3bfc68ac2a46bd", size = 3700133, upload-time = "2025-10-16T22:16:16.272Z" },
-    { url = "https://files.pythonhosted.org/packages/09/e0/604f61d004ded805f24974c87ddd8374ef675644f476f01f1df90e4cdf72/uvloop-0.22.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a592b043a47ad17911add5fbd087c76716d7c9ccc1d64ec9249ceafd735f03c2", size = 3512681, upload-time = "2025-10-16T22:16:18.07Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ce/8491fd370b0230deb5eac69c7aae35b3be527e25a911c0acdffb922dc1cd/uvloop-0.22.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1489cf791aa7b6e8c8be1c5a080bae3a672791fcb4e9e12249b05862a2ca9cec", size = 3615261, upload-time = "2025-10-16T22:16:19.596Z" },
     { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420, upload-time = "2025-10-16T22:16:21.187Z" },
     { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", size = 748677, upload-time = "2025-10-16T22:16:22.558Z" },
     { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", size = 3753819, upload-time = "2025-10-16T22:16:23.903Z" },
@@ -6725,6 +6236,56 @@ wheels = [
 ]
 
 [[package]]
+name = "valkey-glide"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "protobuf" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/83/82429b227936b50be8f38a2a8201738f9d15824352576d4b51422a32bf7f/valkey_glide-2.4.0.tar.gz", hash = "sha256:d0473026f9effa65465fa9888251600d4ec1e759d3a4dea0360eb1709a673ba7", size = 890870, upload-time = "2026-05-20T16:10:55.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/f3/c95f4eaed85187e5f6916f5f2ce4b6787e3dd46987cc48ab73a8131a1469/valkey_glide-2.4.0-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:f021cf7683f113e58142866b0afa3bdc7832c1919e1c1eb94c1a076fbdaae656", size = 7475842, upload-time = "2026-05-20T21:57:35.404Z" },
+    { url = "https://files.pythonhosted.org/packages/83/b0/4f421941bbd7bd199078c4da5c796a9b25a4ca97f25bd4f7ee28e2ae59d5/valkey_glide-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:06645f137386bfbc72ec1c1691f29711fcb620cb9a0d1eaeca12585974bd10b9", size = 6950846, upload-time = "2026-05-20T21:57:37.081Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e5/af12bc364293f78c1aea2994e8b1dae426cc9454014c6bb39f00d748f62a/valkey_glide-2.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a73d4a41eba2dc7c01194d76909e34fc68dd1fb2149cc4f4e281bac75383085c", size = 7271553, upload-time = "2026-05-20T21:57:38.986Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/1eae338fe98a9a99675fd64cbd38d6a4143d4dc763f471d2e32359ec7473/valkey_glide-2.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af50749a61897b2c2da805e4bf56e3ecf44c13393d04883834d12a8f2661bd46", size = 7697931, upload-time = "2026-05-20T21:57:40.753Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/53505aa4101cd95c7aa963e959efe74bfea5fdfdcc254954803b9428ea5c/valkey_glide-2.4.0-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:ed3afadd6329f70642c855365de6f359010db05e07917da3bbf7166578895669", size = 7474129, upload-time = "2026-05-20T21:57:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d9/6046a2fd28a91562c2439480886083523d413b6e93c9024185969170ce24/valkey_glide-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:63426bef320c2b3849add7c4eebc2205f2aead29e5ad32b19d19ae73b903df79", size = 6947614, upload-time = "2026-05-20T21:57:44.787Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/19/d8d8db130b4f865b313555a5dbde18606a03618dadb7efed881be27613fb/valkey_glide-2.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a769b85ed07eca851c5cdda769808f3e4133348ca3d76a5e1db3f83fc5790699", size = 7275078, upload-time = "2026-05-20T21:57:46.508Z" },
+    { url = "https://files.pythonhosted.org/packages/57/31/521f604a780888c5050c2da6ca98bfd90f161a7aededa48b4b13ef1a9db5/valkey_glide-2.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b7117519770868c5f1db31cc3f568b1441f4f1e6ee07f8c4f4b7ad6361b11ea", size = 7696980, upload-time = "2026-05-20T21:57:48.255Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d1/33332fbc4a4f97d606434bc8b3b37507c780876973a220e21c0cfd895f8a/valkey_glide-2.4.0-cp313-cp313-macosx_10_7_x86_64.whl", hash = "sha256:c4b1f8ff977ff5ff0879584d7e676715f15595b10f8f6d9b9b465cc3c5251c4d", size = 7474447, upload-time = "2026-05-20T21:57:50.018Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ee/09f438faab5d7d46d720374e42a3fb30446974b01e650bc21a03346e423e/valkey_glide-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0d466a5fc23c588a612473c2a96effb7589293751a5dec08bd8a8f18c0c0400e", size = 6947944, upload-time = "2026-05-20T21:57:52.139Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/b2840085ee3fdc09e5f17123a59a80f278e2afe4caf2bd3923959540d334/valkey_glide-2.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47780fd93b30991f6d9780b501ec9109ec4e2b4238dfb575efc2ac191c8dc69d", size = 7274725, upload-time = "2026-05-20T21:57:53.61Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e3/622cce53ab71a9390de4ee45d91ace3dfd19e0db99b04141156d9c19f2f0/valkey_glide-2.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb5255b3b54e79d01bab6b535ec6ccfafb7ea0601f8c6890a07316643f9983f7", size = 7696630, upload-time = "2026-05-20T21:57:55.496Z" },
+    { url = "https://files.pythonhosted.org/packages/97/3f/091cd9d5ab541c21ffcc0078340a43fb7084cd717934910778f60a6a7de7/valkey_glide-2.4.0-cp314-cp314-macosx_10_7_x86_64.whl", hash = "sha256:7f9ee25fa5db27cfb6eb98ff17e24baac051ac34d005ebd428386fefc73a395d", size = 7473470, upload-time = "2026-05-20T21:57:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/5b/4979833063515919c5d0d97505b882c1fad9040728608a7fdde83dfbae53/valkey_glide-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0df5d69d7d6629297e8742bad33ab5f378fc21e8ae8491eeb276964962955ebe", size = 6950770, upload-time = "2026-05-20T21:57:59.157Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/de/fdc6dace2786e5af9d02763b09fe719d589fde89472fdf068fe12216b04a/valkey_glide-2.4.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd0617276dd47c8650af2d670efd2251c0489cc593e5c3d73ec6d4084a49485d", size = 7276193, upload-time = "2026-05-20T21:58:01.188Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/28/e668a344d97e562ac0b22852e076a8e602bebb4699390380f3684178affa/valkey_glide-2.4.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6e1171e38ac4759ec01208f18e7fc9127a5d0306f733f4e24e86407a335fe42", size = 7695602, upload-time = "2026-05-20T21:58:02.988Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b4/81d9dcafced5dcdb159fc9bb372a32405deb041506fa39acdd438bfbf1aa/valkey_glide-2.4.0-pp311-pypy311_pp73-macosx_10_7_x86_64.whl", hash = "sha256:8dc07919ec72d4c6e5fff0ea3d309b359fe6705eeaeed8f3bd266aface17ce13", size = 7478618, upload-time = "2026-05-20T21:58:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ab/5ca8d31515601e0cff846a4e62af6fbc95a70d274ca1db4cf6a49c6ee297/valkey_glide-2.4.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b23c5d858cae517b1643c4cbefa35745afd5d9251f11fd290a6ae285b22748ed", size = 6949012, upload-time = "2026-05-20T21:58:21.095Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/b04246bca25e32fed0d4b4f6156bd61c735d7f9d84cb5adb7430bc73c595/valkey_glide-2.4.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c878f097b99e4034b32db92a390ea25a765adf7ea9c6cd3a5949010c892f462a", size = 7273352, upload-time = "2026-05-20T21:58:22.852Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0c/9a20f8becba1cb721311da3c8dabfdab6ad6afd3e9041503288227081083/valkey_glide-2.4.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:565a49e57492ce5ade793ecfdf0a8b4444f1d222c65036623a488ce1c80b98bf", size = 7698497, upload-time = "2026-05-20T21:58:24.763Z" },
+]
+
+[[package]]
+name = "valkey-sample"
+version = "0.1.0"
+source = { editable = "samples/valkey" }
+dependencies = [
+    { name = "genkit" },
+    { name = "genkit-plugin-ollama" },
+    { name = "genkit-plugin-valkey" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "genkit-plugin-valkey", editable = "plugins/valkey" },
+]
+
+[[package]]
 name = "vertexai-imagen"
 version = "0.2.0"
 source = { editable = "samples/vertexai-imagen" }
@@ -6751,7 +6312,6 @@ dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
@@ -6764,9 +6324,6 @@ version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390, upload-time = "2024-11-01T14:06:24.793Z" },
-    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389, upload-time = "2024-11-01T14:06:27.112Z" },
-    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020, upload-time = "2024-11-01T14:06:29.876Z" },
     { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
     { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
     { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
@@ -6776,8 +6333,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
     { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
     { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902, upload-time = "2024-11-01T14:06:53.119Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380, upload-time = "2024-11-01T14:06:55.19Z" },
     { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
     { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
     { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
@@ -6799,18 +6354,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/1a/206e8cf2dd86fddf939165a57b4df61607a1e0add2785f170a3f616b7d9f/watchfiles-1.1.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:eef58232d32daf2ac67f42dea51a2c80f0d03379075d44a587051e63cc2e368c", size = 407318, upload-time = "2025-10-14T15:04:18.753Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/0f/abaf5262b9c496b5dad4ed3c0e799cbecb1f8ea512ecb6ddd46646a9fca3/watchfiles-1.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:03fa0f5237118a0c5e496185cafa92878568b652a2e9a9382a5151b1a0380a43", size = 394478, upload-time = "2025-10-14T15:04:20.297Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/04/9cc0ba88697b34b755371f5ace8d3a4d9a15719c07bdc7bd13d7d8c6a341/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ca65483439f9c791897f7db49202301deb6e15fe9f8fe2fed555bf986d10c31", size = 449894, upload-time = "2025-10-14T15:04:21.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/9c/eda4615863cd8621e89aed4df680d8c3ec3da6a4cf1da113c17decd87c7f/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0ab1c1af0cb38e3f598244c17919fb1a84d1629cc08355b0074b6d7f53138ac", size = 459065, upload-time = "2025-10-14T15:04:22.795Z" },
-    { url = "https://files.pythonhosted.org/packages/84/13/f28b3f340157d03cbc8197629bc109d1098764abe1e60874622a0be5c112/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bc570d6c01c206c46deb6e935a260be44f186a2f05179f52f7fcd2be086a94d", size = 488377, upload-time = "2025-10-14T15:04:24.138Z" },
-    { url = "https://files.pythonhosted.org/packages/86/93/cfa597fa9389e122488f7ffdbd6db505b3b915ca7435ecd7542e855898c2/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e84087b432b6ac94778de547e08611266f1f8ffad28c0ee4c82e028b0fc5966d", size = 595837, upload-time = "2025-10-14T15:04:25.057Z" },
-    { url = "https://files.pythonhosted.org/packages/57/1e/68c1ed5652b48d89fc24d6af905d88ee4f82fa8bc491e2666004e307ded1/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:620bae625f4cb18427b1bb1a2d9426dc0dd5a5ba74c7c2cdb9de405f7b129863", size = 473456, upload-time = "2025-10-14T15:04:26.497Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/dc/1a680b7458ffa3b14bb64878112aefc8f2e4f73c5af763cbf0bd43100658/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:544364b2b51a9b0c7000a4b4b02f90e9423d97fbbf7e06689236443ebcad81ab", size = 455614, upload-time = "2025-10-14T15:04:27.539Z" },
-    { url = "https://files.pythonhosted.org/packages/61/a5/3d782a666512e01eaa6541a72ebac1d3aae191ff4a31274a66b8dd85760c/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bbe1ef33d45bc71cf21364df962af171f96ecaeca06bd9e3d0b583efb12aec82", size = 630690, upload-time = "2025-10-14T15:04:28.495Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/73/bb5f38590e34687b2a9c47a244aa4dd50c56a825969c92c9c5fc7387cea1/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1a0bb430adb19ef49389e1ad368450193a90038b5b752f4ac089ec6942c4dff4", size = 622459, upload-time = "2025-10-14T15:04:29.491Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ac/c9bb0ec696e07a20bd58af5399aeadaef195fb2c73d26baf55180fe4a942/watchfiles-1.1.1-cp310-cp310-win32.whl", hash = "sha256:3f6d37644155fb5beca5378feb8c1708d5783145f2a0f1c4d5a061a210254844", size = 272663, upload-time = "2025-10-14T15:04:30.435Z" },
-    { url = "https://files.pythonhosted.org/packages/11/a0/a60c5a7c2ec59fa062d9a9c61d02e3b6abd94d32aac2d8344c4bdd033326/watchfiles-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a36d8efe0f290835fd0f33da35042a1bb5dc0e83cbc092dcf69bce442579e88e", size = 287453, upload-time = "2025-10-14T15:04:31.53Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529, upload-time = "2025-10-14T15:04:32.899Z" },
     { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384, upload-time = "2025-10-14T15:04:33.761Z" },
     { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789, upload-time = "2025-10-14T15:04:34.679Z" },
@@ -6883,10 +6426,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/4c/a888c91e2e326872fa4705095d64acd8aa2fb9c1f7b9bd0588f33850516c/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:17ef139237dfced9da49fb7f2232c86ca9421f666d78c264c7ffca6601d154c3", size = 409611, upload-time = "2025-10-14T15:06:05.809Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c7/5420d1943c8e3ce1a21c0a9330bcf7edafb6aa65d26b21dbb3267c9e8112/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:672b8adf25b1a0d35c96b5888b7b18699d27d4194bac8beeae75be4b7a3fc9b2", size = 396889, upload-time = "2025-10-14T15:06:07.035Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e5/0072cef3804ce8d3aaddbfe7788aadff6b3d3f98a286fdbee9fd74ca59a7/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a13aea58bc2b90173bc69f2a90de8e282648939a00a602e1dc4ee23e26b66d", size = 451616, upload-time = "2025-10-14T15:06:08.072Z" },
-    { url = "https://files.pythonhosted.org/packages/83/4e/b87b71cbdfad81ad7e83358b3e447fedd281b880a03d64a760fe0a11fc2e/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b495de0bb386df6a12b18335a0285dda90260f51bdb505503c02bcd1ce27a8b", size = 458413, upload-time = "2025-10-14T15:06:09.209Z" },
     { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250, upload-time = "2025-10-14T15:06:10.264Z" },
     { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
     { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
@@ -6935,17 +6474,6 @@ version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423, upload-time = "2025-03-05T20:01:35.363Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080, upload-time = "2025-03-05T20:01:37.304Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/4f/b462242432d93ea45f297b6179c7333dd0402b855a912a04e7fc61c0d71f/websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a", size = 173329, upload-time = "2025-03-05T20:01:39.668Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/0c/6afa1f4644d7ed50284ac59cc70ef8abd44ccf7d45850d989ea7310538d0/websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e", size = 182312, upload-time = "2025-03-05T20:01:41.815Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/d4/ffc8bd1350b229ca7a4db2a3e1c482cf87cea1baccd0ef3e72bc720caeec/websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf", size = 181319, upload-time = "2025-03-05T20:01:43.967Z" },
-    { url = "https://files.pythonhosted.org/packages/97/3a/5323a6bb94917af13bbb34009fac01e55c51dfde354f63692bf2533ffbc2/websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb", size = 181631, upload-time = "2025-03-05T20:01:46.104Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/cc/1aeb0f7cee59ef065724041bb7ed667b6ab1eeffe5141696cccec2687b66/websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d", size = 182016, upload-time = "2025-03-05T20:01:47.603Z" },
-    { url = "https://files.pythonhosted.org/packages/79/f9/c86f8f7af208e4161a7f7e02774e9d0a81c632ae76db2ff22549e1718a51/websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9", size = 181426, upload-time = "2025-03-05T20:01:48.949Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/b9/828b0bc6753db905b91df6ae477c0b14a141090df64fb17f8a9d7e3516cf/websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c", size = 181360, upload-time = "2025-03-05T20:01:50.938Z" },
-    { url = "https://files.pythonhosted.org/packages/89/fb/250f5533ec468ba6327055b7d98b9df056fb1ce623b8b6aaafb30b55d02e/websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256", size = 176388, upload-time = "2025-03-05T20:01:52.213Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/46/aca7082012768bb98e5608f01658ff3ac8437e563eca41cf068bd5849a5e/websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41", size = 176830, upload-time = "2025-03-05T20:01:53.922Z" },
     { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423, upload-time = "2025-03-05T20:01:56.276Z" },
     { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082, upload-time = "2025-03-05T20:01:57.563Z" },
     { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330, upload-time = "2025-03-05T20:01:59.063Z" },
@@ -6979,12 +6507,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109, upload-time = "2025-03-05T20:03:17.769Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343, upload-time = "2025-03-05T20:03:19.094Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599, upload-time = "2025-03-05T20:03:21.1Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207, upload-time = "2025-03-05T20:03:23.221Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
-    { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
@@ -7015,16 +6537,6 @@ version = "1.17.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/23/bb82321b86411eb51e5a5db3fb8f8032fd30bd7c2d74bfe936136b2fa1d6/wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04", size = 53482, upload-time = "2025-08-12T05:51:44.467Z" },
-    { url = "https://files.pythonhosted.org/packages/45/69/f3c47642b79485a30a59c63f6d739ed779fb4cc8323205d047d741d55220/wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2", size = 38676, upload-time = "2025-08-12T05:51:32.636Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/71/e7e7f5670c1eafd9e990438e69d8fb46fa91a50785332e06b560c869454f/wrapt-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd341868a4b6714a5962c1af0bd44f7c404ef78720c7de4892901e540417111c", size = 38957, upload-time = "2025-08-12T05:51:54.655Z" },
-    { url = "https://files.pythonhosted.org/packages/de/17/9f8f86755c191d6779d7ddead1a53c7a8aa18bccb7cea8e7e72dfa6a8a09/wrapt-1.17.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9b2601381be482f70e5d1051a5965c25fb3625455a2bf520b5a077b22afb775", size = 81975, upload-time = "2025-08-12T05:52:30.109Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/15/dd576273491f9f43dd09fce517f6c2ce6eb4fe21681726068db0d0467096/wrapt-1.17.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:343e44b2a8e60e06a7e0d29c1671a0d9951f59174f3709962b5143f60a2a98bd", size = 83149, upload-time = "2025-08-12T05:52:09.316Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/c4/5eb4ce0d4814521fee7aa806264bf7a114e748ad05110441cd5b8a5c744b/wrapt-1.17.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:33486899acd2d7d3066156b03465b949da3fd41a5da6e394ec49d271baefcf05", size = 82209, upload-time = "2025-08-12T05:52:10.331Z" },
-    { url = "https://files.pythonhosted.org/packages/31/4b/819e9e0eb5c8dc86f60dfc42aa4e2c0d6c3db8732bce93cc752e604bb5f5/wrapt-1.17.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e6f40a8aa5a92f150bdb3e1c44b7e98fb7113955b2e5394122fa5532fec4b418", size = 81551, upload-time = "2025-08-12T05:52:31.137Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/83/ed6baf89ba3a56694700139698cf703aac9f0f9eb03dab92f57551bd5385/wrapt-1.17.3-cp310-cp310-win32.whl", hash = "sha256:a36692b8491d30a8c75f1dfee65bef119d6f39ea84ee04d9f9311f83c5ad9390", size = 36464, upload-time = "2025-08-12T05:53:01.204Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/90/ee61d36862340ad7e9d15a02529df6b948676b9a5829fd5e16640156627d/wrapt-1.17.3-cp310-cp310-win_amd64.whl", hash = "sha256:afd964fd43b10c12213574db492cb8f73b2f0826c8df07a68288f8f19af2ebe6", size = 38748, upload-time = "2025-08-12T05:53:00.209Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c3/cefe0bd330d389c9983ced15d326f45373f4073c9f4a8c2f99b50bfea329/wrapt-1.17.3-cp310-cp310-win_arm64.whl", hash = "sha256:af338aa93554be859173c39c85243970dc6a289fa907402289eeae7543e1ae18", size = 36810, upload-time = "2025-08-12T05:52:51.906Z" },
     { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
     { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
     { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },


### PR DESCRIPTION
## Summary

Add Valkey vector store plugin (Go, JS, Python)

Adds a Valkey vector store plugin to Genkit across all three runtimes. Each plugin provides an indexer and retriever backed by Valkey's FT.SEARCH module with HNSW vector similarity search.

## Changes

**Go** (`go/plugins/valkey/`)
- `valkey.go` — Plugin implementation using valkey-glide. Registers a `Docstore` that handles indexing (HSET with vector embeddings) and retrieval (FT.SEARCH KNN). Validates embedding dimensions before storing. Includes `Close()` for connection cleanup.
- `valkey_test.go` — Unit tests for utilities (docID, float32 encoding), error paths (embedder failures, count mismatches, invalid options), and a gated integration test (`-test-valkey-addr` flag).
- `go/samples/valkey/main.go` — Self-contained sample using Ollama (`nomic-embed-text`) to index and retrieve documents.

**JavaScript** (`js/plugins/valkey/`)
- `src/index.ts` — Plugin using `@valkey/valkey-glide`. Registers indexer and retriever via `genkitPlugin`. Supports batch embedding via `embedMany`, metadata field indexing for query-time filtering, and configurable distance metrics.
- `test/index.test.ts` — Mock-based unit tests covering index creation, error handling, document parsing, Buffer handling, and the `embedMany` production path.
- `sample.ts` — RAG sample with Ollama embeddings and generation.
- `package.json` — Published as `genkitx-valkey`, depends on `@valkey/valkey-glide@2.4.0`.

**Python** (`py/plugins/valkey/`)
- `plugin.py` — Plugin using `valkey-glide`. Creates GlideClient connections per index, registers indexer/retriever actions. Validates embedding dimensions. Implements `close()` for connection cleanup.
- `tests/test_utils.py` — Unit tests for float32 encoding and doc ID determinism.
- `tests/test_valkey.py` — Integration test gated behind `VALKEY_TEST=1`.
- `tests/test_plugin_unit.py` — Unit tests for error paths using mocked client and embedder.
- `pyproject.toml` — Published as `genkit-plugin-valkey`, depends on `valkey-glide>=2.0.0,<3.0.0`.

**Python core** (`py/packages/genkit/`)
- `_ai/_retriever.py` — New module defining `RetrieverRequest`, `RetrieverResponse`, `IndexerRequest`, `IndexerResponse`, `define_retriever()`, `define_indexer()`.
- `_ai/_aio.py` — Added `Genkit.retrieve()`, `Genkit.index()`, and `Genkit.close()` methods.
- `_core/_plugin.py` — Added `Plugin.close()` lifecycle hook and `_registry` back-reference (set by the registry on plugin registration).
- `_core/_registry.py` — Added `resolve_retriever()` and `resolve_indexer()` convenience methods.
- `__init__.py` — Exported the new retriever/indexer types.

**Samples**
- `py/samples/valkey/` — Python RAG sample with Ollama (proper sample directory structure).
- `js/plugins/valkey/sample.ts` — JS RAG sample with Ollama.
- `go/samples/valkey/main.go` — Go sample with Ollama.

## Tests
- **Go:** `go test ./plugins/valkey/ -v` — unit tests pass without Valkey; integration requires `-test-valkey-addr`
- **JS:** `npx jest` — 31 tests passing with mocked GlideClient/GlideFt
- **Python:** `uv run pytest tests/test_utils.py tests/test_plugin_unit.py` — 21 tests, no Valkey needed; `VALKEY_TEST=1 pytest tests/test_valkey.py` for integration

## Notes
- The `filter` retrieval option is a raw FT.SEARCH expression, documented as unsafe for untrusted user input.
- All three plugins share the same storage schema: HASH keys with `embedding`, `_content`, `_metadata`, `_dataType` fields, prefixed by index name.
- Document IDs are MD5 hashes of the serialized document (for deduplication, not security).
- Index creation is idempotent (swallows "already exists" errors).

Checklist:
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (READMEs for each plugin)
