### PR TITLE
feat(dev-ui): add ui component metadata

### DIFF
--- a/js/ai/src/index.ts
+++ b/js/ai/src/index.ts
@@ -65,6 +65,7 @@ export {
 } from './generate/middleware.js';
 export { GenkitAI } from './genkit-ai.js';
 export { Message } from './message.js';
+export { GENKIT_UI_METADATA, GENKIT_UI_WIDGETS } from './metadata.js';
 export {
   GenerateResponseChunkSchema,
   GenerationCommonConfigSchema,

--- a/js/ai/src/metadata.ts
+++ b/js/ai/src/metadata.ts
@@ -63,9 +63,3 @@ export const GENKIT_UI_WIDGETS = {
   /** A widget for configuring LLM model safety settings. */
   SAFETY_SETTINGS: 'safety-settings',
 } as const;
-
-/**
- * Union type of standard Genkit UI widget names.
- */
-export type GenkitUiWidget =
-  (typeof GENKIT_UI_WIDGETS)[keyof typeof GENKIT_UI_WIDGETS];

--- a/js/core/src/error.ts
+++ b/js/core/src/error.ts
@@ -15,8 +15,13 @@
  */
 
 import type { Registry } from './registry.js';
-import { httpStatusCode, type StatusName } from './statusTypes.js';
+import {
+  StatusNameSchema,
+  httpStatusCode,
+  type StatusName,
+} from './statusTypes.js';
 
+export { StatusNameSchema };
 export type { StatusName };
 
 export interface HttpErrorWireFormat {

--- a/js/core/src/index.ts
+++ b/js/core/src/index.ts
@@ -83,11 +83,6 @@ export {
   type FlowFn,
   type FlowSideChannel,
 } from './flow.js';
-export {
-  GENKIT_UI_METADATA,
-  GENKIT_UI_WIDGETS,
-  type GenkitUiWidget,
-} from './metadata.js';
 export * from './plugin.js';
 export * from './reflection.js';
 export {

--- a/js/core/src/index.ts
+++ b/js/core/src/index.ts
@@ -65,6 +65,7 @@ export {
 } from './dynamic-action-provider.js';
 export {
   GenkitError,
+  StatusNameSchema,
   UnstableApiError,
   UserFacingError,
   assertUnstable,
@@ -82,6 +83,11 @@ export {
   type FlowFn,
   type FlowSideChannel,
 } from './flow.js';
+export {
+  GENKIT_UI_METADATA,
+  GENKIT_UI_WIDGETS,
+  type GenkitUiWidget,
+} from './metadata.js';
 export * from './plugin.js';
 export * from './reflection.js';
 export {

--- a/js/core/src/metadata.ts
+++ b/js/core/src/metadata.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Metadata keys used for UI-specific schema annotations.
+ */
+export const GENKIT_UI_METADATA = {
+  /**
+   * Provides data to populate both standard and customized UI widgets.
+   *
+   * e.g.
+   *
+   * {
+   *   [GENKIT_UI_METADATA.DATA_SOURCE]: {
+   *     action: '/custom/foo',
+   *     allowCustomValues: true
+   *   }
+   * }
+   */
+  DATA_SOURCE: 'x-genkit-ui-data-source',
+
+  /**
+   * Provides a display name or label for the UI. By default, the Dev UI will
+   * transform schema fields to "Sentence case". There are times where this is
+   * not desirable and needs to be overwritten, such as abbreviations or
+   * acronyms (e.g. "Top P", "Top K") and proper nouns (e.g. "Google Search
+   * retrieval").
+   *
+   * e.g. { [GENKIT_UI_METADATA.DISPLAY_NAME]: 'Top P' }
+   */
+  DISPLAY_NAME: 'x-genkit-ui-display-name',
+
+  /**
+   * Specifies the UI component (widget) to use for a schema field. Commonly
+   * used for model and middleware configuration. Useful to resolve ambiguity
+   * when multiple inputs could apply, or to provide a tailored user experience
+   * for complex inputs.
+   *
+   * e.g. { [GENKIT_UI_METADATA.WIDGET]: GENKIT_UI_WIDGETS.MODEL_LIST }
+   */
+  WIDGET: 'x-genkit-ui-widget',
+} as const;
+
+/**
+ * Standard UI widget names used with GENKIT_UI_METADATA.WIDGET.
+ */
+export const GENKIT_UI_WIDGETS = {
+  /** A widget for configuring a list of models. */
+  MODEL_LIST: 'model-list-config',
+  /** A widget for configuring LLM model safety settings. */
+  SAFETY_SETTINGS: 'safety-settings',
+} as const;
+
+/**
+ * Union type of standard Genkit UI widget names.
+ */
+export type GenkitUiWidget =
+  (typeof GENKIT_UI_WIDGETS)[keyof typeof GENKIT_UI_WIDGETS];

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -19,7 +19,6 @@ import * as assert from 'assert';
 import { afterEach, describe, it, mock } from 'node:test';
 
 import { setGenkitRuntimeConfig } from '../src/config.js';
-import { GENKIT_UI_METADATA } from '../src/metadata.js';
 import {
   ValidationError,
   annotateSchema,
@@ -170,53 +169,44 @@ describe('toJsonSchema', () => {
 describe('annotateSchema()', () => {
   it('should merge annotations into the JSON schema', () => {
     const schema = annotateSchema(z.string(), {
-      [GENKIT_UI_METADATA.DATA_SOURCE]: 'my-action',
+      'x-test': 'foo',
     });
 
     const json = toJsonSchema({ schema });
-    assert.strictEqual(json[GENKIT_UI_METADATA.DATA_SOURCE], 'my-action');
+    assert.strictEqual(json['x-test'], 'foo');
   });
 
   it('should merge annotations for nested fields', () => {
     const schema = z.object({
       field: annotateSchema(z.string(), {
-        [GENKIT_UI_METADATA.DATA_SOURCE]: 'nested-action',
+        'x-test': 'bar',
       }),
     });
 
     const json = toJsonSchema({ schema });
-    assert.strictEqual(
-      json.properties.field[GENKIT_UI_METADATA.DATA_SOURCE],
-      'nested-action'
-    );
+    assert.strictEqual(json.properties.field['x-test'], 'bar');
   });
 
   it('should merge annotations for array items', () => {
     const schema = z.array(
       annotateSchema(z.string(), {
-        [GENKIT_UI_METADATA.DATA_SOURCE]: 'array-action',
+        'x-test': 'baz',
       })
     );
 
     const json = toJsonSchema({ schema });
-    assert.strictEqual(
-      json.items[GENKIT_UI_METADATA.DATA_SOURCE],
-      'array-action'
-    );
+    assert.strictEqual(json.items['x-test'], 'baz');
   });
 
   it('should merge annotations for optional fields', () => {
     const schema = z.object({
       field: annotateSchema(z.string(), {
-        [GENKIT_UI_METADATA.DATA_SOURCE]: 'optional-action',
+        'x-test': 'qux',
       }).optional(),
     });
 
     const json = toJsonSchema({ schema });
-    assert.strictEqual(
-      json.properties.field[GENKIT_UI_METADATA.DATA_SOURCE],
-      'optional-action'
-    );
+    assert.strictEqual(json.properties.field['x-test'], 'qux');
   });
 
   it('should favor outer annotations over inner ones', () => {
@@ -272,14 +262,14 @@ describe('annotateSchema()', () => {
   });
 
   it('should merge annotations for ZodRecord (additionalProperties)', () => {
-    const schema = z.record(annotateSchema(z.string(), { 'x-hint': 'value' }));
+    const schema = z.record(annotateSchema(z.string(), { 'x-hint': 'foo' }));
 
     const json = toJsonSchema({ schema });
     assert.ok(
       json.additionalProperties,
       'JSON schema should have additionalProperties'
     );
-    assert.strictEqual(json.additionalProperties['x-hint'], 'value');
+    assert.strictEqual(json.additionalProperties['x-hint'], 'foo');
   });
 
   it('should merge annotations for ZodTuple (items array)', () => {

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -19,6 +19,7 @@ import * as assert from 'assert';
 import { afterEach, describe, it, mock } from 'node:test';
 
 import { setGenkitRuntimeConfig } from '../src/config.js';
+import { GENKIT_UI_METADATA } from '../src/metadata.js';
 import {
   ValidationError,
   annotateSchema,
@@ -169,23 +170,23 @@ describe('toJsonSchema', () => {
 describe('annotateSchema()', () => {
   it('should merge annotations into the JSON schema', () => {
     const schema = annotateSchema(z.string(), {
-      'x-genkit-data-source': 'my-action',
+      [GENKIT_UI_METADATA.DATA_SOURCE]: 'my-action',
     });
 
     const json = toJsonSchema({ schema });
-    assert.strictEqual(json['x-genkit-data-source'], 'my-action');
+    assert.strictEqual(json[GENKIT_UI_METADATA.DATA_SOURCE], 'my-action');
   });
 
   it('should merge annotations for nested fields', () => {
     const schema = z.object({
       field: annotateSchema(z.string(), {
-        'x-genkit-data-source': 'nested-action',
+        [GENKIT_UI_METADATA.DATA_SOURCE]: 'nested-action',
       }),
     });
 
     const json = toJsonSchema({ schema });
     assert.strictEqual(
-      json.properties.field['x-genkit-data-source'],
+      json.properties.field[GENKIT_UI_METADATA.DATA_SOURCE],
       'nested-action'
     );
   });
@@ -193,24 +194,27 @@ describe('annotateSchema()', () => {
   it('should merge annotations for array items', () => {
     const schema = z.array(
       annotateSchema(z.string(), {
-        'x-genkit-data-source': 'array-action',
+        [GENKIT_UI_METADATA.DATA_SOURCE]: 'array-action',
       })
     );
 
     const json = toJsonSchema({ schema });
-    assert.strictEqual(json.items['x-genkit-data-source'], 'array-action');
+    assert.strictEqual(
+      json.items[GENKIT_UI_METADATA.DATA_SOURCE],
+      'array-action'
+    );
   });
 
   it('should merge annotations for optional fields', () => {
     const schema = z.object({
       field: annotateSchema(z.string(), {
-        'x-genkit-data-source': 'optional-action',
+        [GENKIT_UI_METADATA.DATA_SOURCE]: 'optional-action',
       }).optional(),
     });
 
     const json = toJsonSchema({ schema });
     assert.strictEqual(
-      json.properties.field['x-genkit-data-source'],
+      json.properties.field[GENKIT_UI_METADATA.DATA_SOURCE],
       'optional-action'
     );
   });

--- a/js/genkit/src/common.ts
+++ b/js/genkit/src/common.ts
@@ -131,11 +131,14 @@ export {
 export { dynamicTool, tool } from '@genkit-ai/ai/tool';
 export {
   GENKIT_CLIENT_HEADER,
+  GENKIT_UI_METADATA,
+  GENKIT_UI_WIDGETS,
   GENKIT_VERSION,
   GenkitError,
   OperationSchema,
   ReflectionServer,
   StatusCodes,
+  StatusNameSchema,
   StatusSchema,
   UserFacingError,
   annotateSchema,
@@ -160,6 +163,7 @@ export {
   type FlowFn,
   type FlowSideChannel,
   type GenkitRuntimeConfig,
+  type GenkitUiWidget,
   type JSONSchema,
   type JSONSchema7,
   type Middleware,

--- a/js/genkit/src/common.ts
+++ b/js/genkit/src/common.ts
@@ -19,6 +19,8 @@ export {
   BaseDataPointSchema,
   Document,
   DocumentDataSchema,
+  GENKIT_UI_METADATA,
+  GENKIT_UI_WIDGETS,
   GenerateResponse,
   GenerateResponseChunk,
   GenerationBlockedError,
@@ -131,8 +133,6 @@ export {
 export { dynamicTool, tool } from '@genkit-ai/ai/tool';
 export {
   GENKIT_CLIENT_HEADER,
-  GENKIT_UI_METADATA,
-  GENKIT_UI_WIDGETS,
   GENKIT_VERSION,
   GenkitError,
   OperationSchema,
@@ -163,7 +163,6 @@ export {
   type FlowFn,
   type FlowSideChannel,
   type GenkitRuntimeConfig,
-  type GenkitUiWidget,
   type JSONSchema,
   type JSONSchema7,
   type Middleware,

--- a/js/plugins/google-genai/src/googleai/gemini.ts
+++ b/js/plugins/google-genai/src/googleai/gemini.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { ActionMetadata, GenkitError, modelActionMetadata, z } from 'genkit';
+import {
+  ActionMetadata,
+  GENKIT_UI_METADATA,
+  GENKIT_UI_WIDGETS,
+  GenkitError,
+  annotateSchema,
+  modelActionMetadata,
+  z,
+} from 'genkit';
 import {
   CandidateData,
   GenerationCommonConfigDescriptions,
@@ -154,13 +162,16 @@ export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
       'Overrides the plugin-configured or default apiVersion, if specified.'
     )
     .optional(),
-  safetySettings: z
-    .array(SafetySettingsSchema)
-    .describe(
-      'Adjust how likely you are to see responses that could be harmful. ' +
-        'Content is blocked based on the probability that it is harmful.'
-    )
-    .optional(),
+  safetySettings: annotateSchema(
+    z
+      .array(SafetySettingsSchema)
+      .describe(
+        'Adjust how likely you are to see responses that could be harmful. ' +
+          'Content is blocked based on the probability that it is harmful.'
+      )
+      .optional(),
+    { [GENKIT_UI_METADATA.WIDGET]: GENKIT_UI_WIDGETS.SAFETY_SETTINGS }
+  ),
   codeExecution: z
     .union([z.boolean(), z.object({}).strict()])
     .describe('Enables the model to generate and run code.')

--- a/js/plugins/google-genai/src/vertexai/gemini.ts
+++ b/js/plugins/google-genai/src/vertexai/gemini.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { ActionMetadata, GenkitError, modelActionMetadata, z } from 'genkit';
+import {
+  ActionMetadata,
+  GENKIT_UI_METADATA,
+  GENKIT_UI_WIDGETS,
+  GenkitError,
+  annotateSchema,
+  modelActionMetadata,
+  z,
+} from 'genkit';
 import {
   CandidateData,
   GenerationCommonConfigDescriptions,
@@ -185,13 +193,16 @@ export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
    * }
    * ```
    */
-  safetySettings: z
-    .array(SafetySettingsSchema)
-    .describe(
-      'Adjust how likely you are to see responses that could be harmful. ' +
-        'Content is blocked based on the probability that it is harmful.'
-    )
-    .optional(),
+  safetySettings: annotateSchema(
+    z
+      .array(SafetySettingsSchema)
+      .describe(
+        'Adjust how likely you are to see responses that could be harmful. ' +
+          'Content is blocked based on the probability that it is harmful.'
+      )
+      .optional(),
+    { [GENKIT_UI_METADATA.WIDGET]: GENKIT_UI_WIDGETS.SAFETY_SETTINGS }
+  ),
 
   /**
    * Vertex retrieval options.

--- a/js/plugins/middleware/src/fallback.ts
+++ b/js/plugins/middleware/src/fallback.ts
@@ -15,8 +15,12 @@
  */
 
 import {
+  GENKIT_UI_METADATA,
+  GENKIT_UI_WIDGETS,
   GenkitError,
   ModelReferenceSchema,
+  StatusNameSchema,
+  annotateSchema,
   generateMiddleware,
   z,
   type GenerateMiddleware,
@@ -40,15 +44,18 @@ export const FallbackOptionsSchema = z
     /**
      * An array of models to try in order.
      */
-    models: z
-      .array(ModelReferenceSchema)
-      .describe('An array of models to try in order.'),
+    models: annotateSchema(
+      z
+        .array(ModelReferenceSchema)
+        .describe('An array of models to try in order.'),
+      { [GENKIT_UI_METADATA.WIDGET]: GENKIT_UI_WIDGETS.MODEL_LIST }
+    ),
     /**
      * An array of `StatusName` values that should trigger a fallback.
      * @default ['UNAVAILABLE', 'DEADLINE_EXCEEDED', 'RESOURCE_EXHAUSTED', 'ABORTED', 'INTERNAL', 'NOT_FOUND', 'UNIMPLEMENTED']
      */
     statuses: z
-      .array(z.string())
+      .array(StatusNameSchema)
       .optional()
       .describe(
         'An array of StatusName values that should trigger a fallback.'

--- a/js/plugins/middleware/src/retry.ts
+++ b/js/plugins/middleware/src/retry.ts
@@ -17,6 +17,7 @@
 import {
   GenerateMiddleware,
   GenkitError,
+  StatusNameSchema,
   generateMiddleware,
   z,
   type StatusName,
@@ -38,7 +39,7 @@ export const RetryOptionsSchema = z
      * @default ['UNAVAILABLE', 'DEADLINE_EXCEEDED', 'RESOURCE_EXHAUSTED', 'ABORTED', 'INTERNAL']
      */
     statuses: z
-      .array(z.string())
+      .array(StatusNameSchema)
       .optional()
       .describe('An array of StatusName values that should trigger a retry.'),
     /**


### PR DESCRIPTION
Adds initial metadata fields for Dev UI, and maps safetySettings and fallback middleware (models) to their respective ui components.

A small schema update to expose `StatusNameSchema` was also included.

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)
