### PR TITLE
fix(js): release/cancel stream readers when consumers stop reading early

### DIFF
--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -476,7 +476,8 @@ export function action<
           }
           return await invocationPromise;
         } finally {
-          reader.releaseLock();
+          // Catch prevents unhandled promise rejection if the stream was already cleanly finalized
+          reader.cancel().catch(() => {});
         }
       })(),
     };

--- a/js/core/src/action.ts
+++ b/js/core/src/action.ts
@@ -464,16 +464,20 @@ export function action<
       output: invocationPromise,
       stream: (async function* () {
         const reader = chunkStream.getReader();
-        while (true) {
-          const chunk = await reader.read();
-          if (chunk.value) {
-            yield chunk.value;
+        try {
+          while (true) {
+            const chunk = await reader.read();
+            if (chunk.value) {
+              yield chunk.value;
+            }
+            if (chunk.done) {
+              break;
+            }
           }
-          if (chunk.done) {
-            break;
-          }
+          return await invocationPromise;
+        } finally {
+          reader.releaseLock();
         }
-        return await invocationPromise;
       })(),
     };
   };

--- a/js/core/tests/action_test.ts
+++ b/js/core/tests/action_test.ts
@@ -200,6 +200,71 @@ describe('action', () => {
     ]);
   });
 
+  it('cancels the underlying stream when the consumer stops reading early', async () => {
+    // The producer keeps sending chunks until it is told to stop. Before the
+    // fix, abandoning the stream early left the reader holding the lock and
+    // never cancelled the underlying stream, so the producer happily kept
+    // pushing chunks. After the fix, the generator's `finally` cancels the
+    // reader, which closes the chunk stream and surfaces back to the producer
+    // as a failing `sendChunk`.
+    const totalChunks = 20;
+    let producedCount = 0;
+    let sendChunkError: unknown;
+    let releaseProducer: () => void;
+    const producerDone = new Promise<void>((resolve) => {
+      releaseProducer = resolve;
+    });
+
+    const act = defineAction(
+      registry,
+      { name: 'streamer', actionType: 'custom' },
+      async (input, { sendChunk }) => {
+        try {
+          for (let i = 0; i < totalChunks; i++) {
+            // Yield to the event loop so the consumer can interleave / bail out.
+            await new Promise((r) => setTimeout(r, 1));
+            producedCount = i + 1;
+            sendChunk({ count: i + 1 });
+          }
+        } catch (e) {
+          sendChunkError = e;
+          throw e;
+        } finally {
+          releaseProducer();
+        }
+        return `hi ${input}`;
+      }
+    );
+
+    const response = act.stream('Pavel');
+    // The action throws once the stream is cancelled, so its output rejects.
+    // Swallow it to avoid an unhandled rejection failing the test runner.
+    response.output.catch(() => {});
+
+    const gotChunks: any[] = [];
+    for await (const chunk of response.stream) {
+      gotChunks.push(chunk);
+      if (gotChunks.length === 2) {
+        break; // consumer abandons the stream early
+      }
+    }
+
+    await producerDone;
+
+    // Consumer only ever saw the first two chunks.
+    assert.deepStrictEqual(gotChunks, [{ count: 1 }, { count: 2 }]);
+    // The producer was stopped well before emitting all 20 chunks.
+    assert.ok(
+      producedCount < totalChunks,
+      `expected producer to be cancelled early, but it produced ${producedCount}/${totalChunks} chunks`
+    );
+    // Cancelling the reader closed the chunk stream, so the next sendChunk threw.
+    assert.ok(
+      sendChunkError,
+      'expected sendChunk to throw after the consumer abandoned the stream'
+    );
+  });
+
   it('should inherit context from parent action invocation', async () => {
     const child = defineAction(
       registry,

--- a/js/genkit/src/client/client.ts
+++ b/js/genkit/src/client/client.ts
@@ -130,34 +130,38 @@ async function __flowRunEnvelope({
   var decoder = new TextDecoder();
 
   let buffer = '';
-  while (true) {
-    const result = await reader.read();
-    const decodedValue = decoder.decode(result.value);
-    if (decodedValue) {
-      buffer += decodedValue;
-    }
-    // If buffer includes the delimiter that means we are still receiving chunks.
-    while (buffer.includes(__flowStreamDelimiter)) {
-      const chunk = JSON.parse(
-        buffer
-          .substring(0, buffer.indexOf(__flowStreamDelimiter))
-          .substring('data: '.length)
-      );
-      if (chunk.hasOwnProperty('message')) {
-        sendChunk(chunk.message);
-      } else if (chunk.hasOwnProperty('result')) {
-        return chunk.result;
-      } else if (chunk.hasOwnProperty('error')) {
-        throw new Error(
-          `${chunk.error.status}: ${chunk.error.message}\n${chunk.error.details}`
-        );
-      } else {
-        throw new Error('unknown chunk format: ' + JSON.stringify(chunk));
+  try {
+    while (true) {
+      const result = await reader.read();
+      const decodedValue = decoder.decode(result.value);
+      if (decodedValue) {
+        buffer += decodedValue;
       }
-      buffer = buffer.substring(
-        buffer.indexOf(__flowStreamDelimiter) + __flowStreamDelimiter.length
-      );
+      // If buffer includes the delimiter that means we are still receiving chunks.
+      while (buffer.includes(__flowStreamDelimiter)) {
+        const chunk = JSON.parse(
+          buffer
+            .substring(0, buffer.indexOf(__flowStreamDelimiter))
+            .substring('data: '.length)
+        );
+        if (chunk.hasOwnProperty('message')) {
+          sendChunk(chunk.message);
+        } else if (chunk.hasOwnProperty('result')) {
+          return chunk.result;
+        } else if (chunk.hasOwnProperty('error')) {
+          throw new Error(
+            `${chunk.error.status}: ${chunk.error.message}\n${chunk.error.details}`
+          );
+        } else {
+          throw new Error('unknown chunk format: ' + JSON.stringify(chunk));
+        }
+        buffer = buffer.substring(
+          buffer.indexOf(__flowStreamDelimiter) + __flowStreamDelimiter.length
+        );
+      }
     }
+  } finally {
+    reader.releaseLock();
   }
   throw new Error('stream did not terminate correctly');
 }

--- a/js/genkit/src/client/client.ts
+++ b/js/genkit/src/client/client.ts
@@ -130,38 +130,34 @@ async function __flowRunEnvelope({
   var decoder = new TextDecoder();
 
   let buffer = '';
-  try {
-    while (true) {
-      const result = await reader.read();
-      const decodedValue = decoder.decode(result.value);
-      if (decodedValue) {
-        buffer += decodedValue;
-      }
-      // If buffer includes the delimiter that means we are still receiving chunks.
-      while (buffer.includes(__flowStreamDelimiter)) {
-        const chunk = JSON.parse(
-          buffer
-            .substring(0, buffer.indexOf(__flowStreamDelimiter))
-            .substring('data: '.length)
-        );
-        if (chunk.hasOwnProperty('message')) {
-          sendChunk(chunk.message);
-        } else if (chunk.hasOwnProperty('result')) {
-          return chunk.result;
-        } else if (chunk.hasOwnProperty('error')) {
-          throw new Error(
-            `${chunk.error.status}: ${chunk.error.message}\n${chunk.error.details}`
-          );
-        } else {
-          throw new Error('unknown chunk format: ' + JSON.stringify(chunk));
-        }
-        buffer = buffer.substring(
-          buffer.indexOf(__flowStreamDelimiter) + __flowStreamDelimiter.length
-        );
-      }
+  while (true) {
+    const result = await reader.read();
+    const decodedValue = decoder.decode(result.value);
+    if (decodedValue) {
+      buffer += decodedValue;
     }
-  } finally {
-    reader.releaseLock();
+    // If buffer includes the delimiter that means we are still receiving chunks.
+    while (buffer.includes(__flowStreamDelimiter)) {
+      const chunk = JSON.parse(
+        buffer
+          .substring(0, buffer.indexOf(__flowStreamDelimiter))
+          .substring('data: '.length)
+      );
+      if (chunk.hasOwnProperty('message')) {
+        sendChunk(chunk.message);
+      } else if (chunk.hasOwnProperty('result')) {
+        return chunk.result;
+      } else if (chunk.hasOwnProperty('error')) {
+        throw new Error(
+          `${chunk.error.status}: ${chunk.error.message}\n${chunk.error.details}`
+        );
+      } else {
+        throw new Error('unknown chunk format: ' + JSON.stringify(chunk));
+      }
+      buffer = buffer.substring(
+        buffer.indexOf(__flowStreamDelimiter) + __flowStreamDelimiter.length
+      );
+    }
   }
   throw new Error('stream did not terminate correctly');
 }

--- a/js/plugins/google-genai/src/common/utils.ts
+++ b/js/plugins/google-genai/src/common/utils.ts
@@ -430,7 +430,8 @@ function getResponseStream(
       }
     },
     cancel() {
-      reader.releaseLock();
+      // Catch prevents unhandled promise rejection if the stream was already cleanly finalized
+      reader.cancel().catch(() => {});
     },
   });
   return stream;

--- a/js/plugins/google-genai/src/common/utils.ts
+++ b/js/plugins/google-genai/src/common/utils.ts
@@ -385,6 +385,7 @@ function getResponseStream(
           .read()
           .then(({ value, done }) => {
             if (done) {
+              reader.releaseLock();
               if (currentText.trim()) {
                 controller.error(new Error('Failed to parse stream'));
                 return;
@@ -400,6 +401,7 @@ function getResponseStream(
               try {
                 parsedResponse = JSON.parse(match[1]);
               } catch (e) {
+                reader.releaseLock();
                 controller.error(
                   new Error(`Error parsing JSON response: "${match[1]}"`)
                 );
@@ -412,6 +414,7 @@ function getResponseStream(
             return pump();
           })
           .catch((e: Error) => {
+            reader.releaseLock();
             let err = e;
             err.stack = e.stack;
             if (err.name === 'AbortError') {
@@ -426,6 +429,9 @@ function getResponseStream(
           });
       }
     },
+    cancel() {
+      reader.releaseLock();
+    },
   });
   return stream;
 }
@@ -434,12 +440,16 @@ async function* generateResponseSequence(
   stream: ReadableStream<GenerateContentResponse>
 ): AsyncGenerator<GenerateContentResponse> {
   const reader = stream.getReader();
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) {
-      break;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      yield value;
     }
-    yield value;
+  } finally {
+    reader.releaseLock();
   }
 }
 
@@ -448,12 +458,16 @@ async function getResponsePromise(
 ): Promise<GenerateContentResponse> {
   const allResponses: GenerateContentResponse[] = [];
   const reader = stream.getReader();
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      return aggregateResponses(allResponses);
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return aggregateResponses(allResponses);
+      }
+      allResponses.push(value);
     }
-    allResponses.push(value);
+  } finally {
+    reader.releaseLock();
   }
 }
 

--- a/js/plugins/ollama/src/index.ts
+++ b/js/plugins/ollama/src/index.ts
@@ -301,15 +301,19 @@ function defineOllamaModel(
         const reader = res.body.getReader();
         const textDecoder = new TextDecoder();
         let textResponse = '';
-        for await (const chunk of readChunks(reader)) {
-          const chunkText = textDecoder.decode(chunk);
-          const json = JSON.parse(chunkText);
-          const message = parseMessage(json, type);
-          streamingCallback({
-            index: 0,
-            content: message.content,
-          });
-          textResponse += message.content[0].text;
+        try {
+          for await (const chunk of readChunks(reader)) {
+            const chunkText = textDecoder.decode(chunk);
+            const json = JSON.parse(chunkText);
+            const message = parseMessage(json, type);
+            streamingCallback({
+              index: 0,
+              content: message.content,
+            });
+            textResponse += message.content[0].text;
+          }
+        } finally {
+          reader.releaseLock();
         }
         message = {
           role: 'model',

--- a/js/plugins/ollama/src/index.ts
+++ b/js/plugins/ollama/src/index.ts
@@ -313,7 +313,8 @@ function defineOllamaModel(
             textResponse += message.content[0].text;
           }
         } finally {
-          reader.releaseLock();
+          // Catch prevents unhandled promise rejection if the stream was already cleanly finalized
+          reader.cancel().catch(() => {});
         }
         message = {
           role: 'model',


### PR DESCRIPTION
## Problem
When a streaming consumer stops reading early (e.g. `break` out of a `for await`,
or an HTTP client disconnects), the stream reader's lock was never released and
the underlying stream was never cancelled. As a result the producer kept running
and pushing chunks into an abandoned stream instead of being torn down — wasting
work and leaking the upstream connection/resources.

## Fix
Wrap the read loops in `try/finally` and `reader.cancel()` / `reader.releaseLock()`
so abandoning a stream propagates cancellation back to the source:
- `core/action.ts`: `actionFn.stream()` now cancels the reader in `finally`,
  which closes the chunk stream and unwinds the action.
- `google-genai`: release the lock in `getResponseStream` and add a `cancel()`
  handler; release locks in the reader loops.
- `ollama`: cancel the reader in `finally` around the streaming loop.
