### PR TITLE
core(reflection): bind reflection server to loopback and validate Host header

### DIFF
--- a/js/core/src/reflection.ts
+++ b/js/core/src/reflection.ts
@@ -43,12 +43,36 @@ export type RunActionResponse = z.infer<typeof RunActionResponseSchema>;
 export interface ReflectionServerOptions {
   /** Port to run the server on. Actual port may be different if chosen port is occupied. Defaults to 3100. */
   port?: number;
+  /** Host/interface to bind the server to. Defaults to `localhost` (loopback only). */
+  host?: string;
   /** Body size limit for the server. Defaults to `30mb`. */
   bodyLimit?: string;
   /** Configured environments. Defaults to `dev`. */
   configuredEnvs?: string[];
   /** Display name that will be shown in developer tooling. */
   name?: string;
+}
+
+/**
+ * Checks whether a `Host` header refers to a loopback interface.
+ *
+ * Used to reject cross-origin/DNS-rebinding requests against the reflection
+ * server, which is bound to loopback and intended only for local dev tooling.
+ */
+function isLoopbackHost(hostHeader: string | undefined): boolean {
+  if (!hostHeader) return true; // no Host -> nothing to spoof
+  let h = hostHeader.trim().toLowerCase();
+  // strip :port (handle [::1]:n)
+  if (h.startsWith('[')) {
+    const c = h.indexOf(']');
+    h = c !== -1 ? h.slice(0, c + 1) : h;
+  } else {
+    const i = h.indexOf(':');
+    if (i !== -1 && h.indexOf(':', i + 1) === -1) h = h.slice(0, i);
+  }
+  return (
+    h === 'localhost' || h === '::1' || h === '[::1]' || h.startsWith('127.')
+  );
 }
 
 /**
@@ -98,6 +122,7 @@ export class ReflectionServer {
     this.registry = registry;
     this.options = {
       port: 3100,
+      host: 'localhost',
       bodyLimit: '30mb',
       configuredEnvs: ['dev'],
       ...options,
@@ -151,6 +176,20 @@ export class ReflectionServer {
     const server = express();
 
     server.use(express.json({ limit: this.options.bodyLimit }));
+    // Reject requests whose Host header is not a loopback address. The
+    // reflection server binds to loopback, but a Host check is still required
+    // to defeat DNS-rebinding (which would otherwise let a remote page reach
+    // the server as if same-origin).
+    server.use((req, res, next) => {
+      if (!isLoopbackHost(req.headers.host)) {
+        res.status(403).json({
+          error:
+            'Request blocked: untrusted Host header. The Genkit reflection server only accepts loopback requests.',
+        });
+        return;
+      }
+      next();
+    });
     server.use((req, res, next) => {
       res.header('x-genkit-version', GENKIT_VERSION);
       next();
@@ -165,7 +204,16 @@ export class ReflectionServer {
       response.status(200).send('OK');
     });
 
-    server.get('/api/__quitquitquit', async (_, response) => {
+    server.get('/api/__quitquitquit', async (req, response) => {
+      // Defense-in-depth: a legitimate CLI/in-process shutdown call carries no
+      // Origin header. Reject any request that does, so a cross-origin page
+      // cannot trivially terminate the dev process via this simple GET.
+      if (req.headers.origin) {
+        response.status(403).json({
+          error: 'Request blocked: cross-origin shutdown is not allowed.',
+        });
+        return;
+      }
       logger.debug('Received quitquitquit');
       response.status(200).send('OK');
       await this.stop();
@@ -436,24 +484,31 @@ export class ReflectionServer {
     });
 
     this.port = await this.findPort();
-    this.server = server.listen(this.port, async () => {
-      logger.debug(
-        `Reflection server (${process.pid}) running on http://localhost:${this.port}`
-      );
-      ReflectionServer.RUNNING_SERVERS.push(this);
-
-      try {
-        await this.registry.listActions();
-        await this.writeRuntimeFile();
-      } catch (e) {
-        logger.error(`Error initializing plugins: ${e}`);
-        try {
-          await this.stop();
-        } catch (err) {
-          logger.error(`Failed to stop server gracefully: ${err}`);
-        }
-      }
+    // Bind to the loopback interface by default so the reflection server is not
+    // reachable from other hosts on the network. Wait for the server to be
+    // listening before resolving: when a host is provided, `listen()` resolves
+    // it asynchronously, so `server.address()` is not populated synchronously.
+    await new Promise<void>((resolve) => {
+      this.server = server.listen(this.port!, this.options.host!, () => {
+        resolve();
+      });
     });
+    logger.debug(
+      `Reflection server (${process.pid}) running on http://localhost:${this.port}`
+    );
+    ReflectionServer.RUNNING_SERVERS.push(this);
+
+    try {
+      await this.registry.listActions();
+      await this.writeRuntimeFile();
+    } catch (e) {
+      logger.error(`Error initializing plugins: ${e}`);
+      try {
+        await this.stop();
+      } catch (err) {
+        logger.error(`Failed to stop server gracefully: ${err}`);
+      }
+    }
   }
 
   /**

--- a/js/core/tests/reflection_test.ts
+++ b/js/core/tests/reflection_test.ts
@@ -63,6 +63,63 @@ describe('ReflectionServer API', () => {
     });
   }
 
+  async function fetchApiWithHost(
+    path: string,
+    hostHeader?: string,
+    extraHeaders?: Record<string, string>
+  ) {
+    return new Promise<{ status: number; body: any }>((resolve, reject) => {
+      const headers: Record<string, string> = { ...extraHeaders };
+      if (hostHeader !== undefined) {
+        headers.Host = hostHeader;
+      }
+      http
+        .get({ host: 'localhost', port, path, headers }, (res) => {
+          let data = '';
+          res.on('data', (chunk) => {
+            data += chunk;
+          });
+          res.on('end', () => {
+            try {
+              resolve({
+                status: res.statusCode || 200,
+                body: JSON.parse(data),
+              });
+            } catch (e) {
+              resolve({ status: res.statusCode || 200, body: data });
+            }
+          });
+        })
+        .on('error', reject);
+    });
+  }
+
+  it('rejects requests with a non-loopback Host header', async () => {
+    const res = await fetchApiWithHost('/api/actions', 'evil.example.com');
+    assert.strictEqual(res.status, 403);
+    assert.match(res.body.error, /untrusted Host header/);
+  });
+
+  it('allows requests with a loopback Host header', async () => {
+    const res = await fetchApiWithHost('/api/actions', `localhost:${port}`);
+    assert.strictEqual(res.status, 200);
+  });
+
+  it('allows requests with a 127.0.0.1 Host header', async () => {
+    const res = await fetchApiWithHost('/api/actions', `127.0.0.1:${port}`);
+    assert.strictEqual(res.status, 200);
+  });
+
+  it('rejects cross-origin requests to /api/__quitquitquit', async () => {
+    const res = await fetchApiWithHost(
+      '/api/__quitquitquit',
+      `localhost:${port}`,
+      { Origin: 'http://evil.example.com' }
+    );
+    assert.strictEqual(res.status, 403);
+    assert.match(res.body.error, /cross-origin shutdown/);
+  });
+
   it('rejects missing type parameter for /api/values', async () => {
     const res = await fetchApi('/api/values');
     assert.strictEqual(res.status, 400);


### PR DESCRIPTION
## Summary

The JS reflection server (`js/core/src/reflection.ts`), which auto-starts in dev (`GENKIT_ENV=dev`), calls `server.listen(this.port, ...)` with no host argument, so Node binds it to **all interfaces (0.0.0.0)**, and the only middleware is `express.json()` — no Host/Origin validation. As a result the reflection API (`/api/runAction`, `/api/actions`, `/api/values`, `/api/__quitquitquit`) is reachable unauthenticated:
- directly from other hosts on the local network (0.0.0.0 bind), and
- from a web page open in the developer's browser via DNS-rebinding (no Host check → rebinding makes the request same-origin, so CORS does not apply).

`/api/runAction` executes any registered action with caller-supplied input/context, and `/api/__quitquitquit` is a simple `GET` that terminates the process.

## Changes

1. **Bind to loopback by default** — `listen()` now binds `localhost` (loopback). Added an optional `host` to `ReflectionServerOptions` (default `"localhost"`) so non-default setups remain configurable.
2. **Host-header validation** — a middleware (registered before the routes) rejects requests whose `Host` is not a loopback address, defeating DNS-rebinding even on the loopback bind.
3. **`__quitquitquit` Origin guard** — defense-in-depth: reject the shutdown `GET` if it carries an `Origin` header (a legitimate CLI/in-process shutdown does not).

A small correctness change accompanies (1): passing a host to `listen()` makes binding asynchronous, so `start()` now awaits the `listening` event before reading `server.address()` (the existing post-listen init — registry warm-up and runtime-file write — is preserved).

## Testing

`tsc --noEmit` clean; prettier clean. Added 4 tests (non-loopback Host → 403; `localhost`/`127.0.0.1` Host → 200; cross-origin `__quitquitquit` → 403); existing reflection tests still pass (8/8).
