### PR TITLE
feat(go/plugins/checks): add Google Check (AI Safety) plugin

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -133,7 +133,7 @@ require (
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/oauth2 v0.30.0
-	golang.org/x/sync v0.16.0 // indirect
+	golang.org/x/sync v0.16.0
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.12.0 // indirect

--- a/go/plugins/checks/README.md
+++ b/go/plugins/checks/README.md
@@ -11,6 +11,12 @@ v1alpha REST API:
 It is a Go port of the JS `@genkit-ai/checks` plugin, built directly on
 `net/http` + Application Default Credentials (there is no first-party Go SDK).
 
+Import path:
+
+```go
+import "github.com/firebase/genkit/go/plugins/checks"
+```
+
 ## Prerequisites
 
 - A Google Cloud project with the **Checks API** enabled and quota.
@@ -29,10 +35,14 @@ Project ID is resolved in this order: explicit `Checks.ProjectID` >
 
 ## Evaluator
 
+Configure `Checks.Metrics` to register the `checks/guardrails` evaluator at
+plugin init time. These metrics apply to evaluator runs only; middleware
+policies are passed separately to `GuardrailMiddleware`.
+
 ```go
 import (
-    "github.com/firebase/genkit/go/genkit"
     "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
     "github.com/firebase/genkit/go/plugins/checks"
 )
 
@@ -56,15 +66,20 @@ resp, err := ev.Evaluate(ctx, &ai.EvaluatorRequest{
 
 The single `checks/guardrails` evaluator scores each datapoint's `Output`
 against **all** configured policies in one API call. Each policy yields a
-`Score{Id: <policyType>, Score: <0–1, if returned>, Details: {"reasoning":
+`Score{Id: <policyType>, Score: <0-1, if returned>, Details: {"reasoning":
 "Status <VIOLATIVE|NON_VIOLATIVE>"}}`. As in the JS plugin, the score is the raw
 likelihood and the violation result is surfaced as reasoning only — no Pass/Fail
 status is synthesized. A score absent from the API response is omitted.
 
+The evaluator classifies `ai.Example.Output`. Non-string outputs are converted
+with `fmt.Sprint`.
+
 ## Guardrails client & middleware
 
 Use the exported `Guardrails` client for synchronous classification, or
-`GuardrailMiddleware` to block generations whose input or output is VIOLATIVE:
+`GuardrailMiddleware` to block generations whose input or output is VIOLATIVE.
+The plugin resolves ADC for evaluator use, but `NewGuardrails` expects an
+explicit token source and project ID:
 
 ```go
 import "golang.org/x/oauth2/google"
@@ -91,6 +106,13 @@ resp, err := genkit.Generate(ctx, g,
 
 `ClassifyContent` retries on `429`/`503` with exponential backoff, honoring
 `Retry-After`.
+
+## Limitations
+
+- The implementation targets the Checks v1alpha `aisafety:classifyContent` API.
+- Classification is text-only. Media parts are not sent to Checks.
+- The evaluator only inspects `Example.Output`, matching the JS plugin.
+- Middleware output blocking is best-effort for streamed responses.
 
 > **Streaming note:** the input guardrail runs before the model is called, so
 > violative prompts are blocked outright. The output guardrail runs after

--- a/go/plugins/checks/README.md
+++ b/go/plugins/checks/README.md
@@ -1,0 +1,111 @@
+# Google Checks plugin
+
+The `checks` plugin integrates [Google Checks AI Safety](https://checks.google.com/ai-safety)
+with Genkit. It provides two shapes over the Checks `aisafety:classifyContent`
+v1alpha REST API:
+
+- a **`checks/guardrails` evaluator** for batch evaluation of a dataset, and
+- an exported **`Guardrails`** client (synchronous classifier) plus a ready
+  **guardrail middleware** that blocks violative model input/output in-flight.
+
+It is a Go port of the JS `@genkit-ai/checks` plugin, built directly on
+`net/http` + Application Default Credentials (there is no first-party Go SDK).
+
+## Prerequisites
+
+- A Google Cloud project with the **Checks API** enabled and quota.
+- Application Default Credentials (e.g. `gcloud auth application-default login`,
+  or a service account). The plugin requests the `cloud-platform` and `checks`
+  OAuth scopes.
+
+Project ID is resolved in this order: explicit `Checks.ProjectID` >
+`GOOGLE_CLOUD_PROJECT` > the ADC project.
+
+## Policies
+
+`DANGEROUS_CONTENT`, `PII_SOLICITING_RECITING`, `HARASSMENT`,
+`SEXUALLY_EXPLICIT`, `HATE_SPEECH`, `MEDICAL_INFO`, `VIOLENCE_AND_GORE`,
+`OBSCENITY_AND_PROFANITY` (constants `checks.DangerousContent`, … on `PolicyType`).
+
+## Evaluator
+
+```go
+import (
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/plugins/checks"
+)
+
+threshold := 0.55
+g := genkit.Init(ctx, genkit.WithPlugins(&checks.Checks{
+    ProjectID: "your-project-id", // or GOOGLE_CLOUD_PROJECT
+    Metrics: []checks.ChecksMetricConfig{
+        {Type: checks.DangerousContent},
+        {Type: checks.Harassment},
+        {Type: checks.ViolenceAndGore, Threshold: &threshold},
+    },
+}))
+
+ev := genkit.LookupEvaluator(g, "checks/guardrails")
+resp, err := ev.Evaluate(ctx, &ai.EvaluatorRequest{
+    Dataset: []*ai.Example{
+        {TestCaseId: "1", Output: "some model output to classify"},
+    },
+})
+```
+
+The single `checks/guardrails` evaluator scores each datapoint's `Output`
+against **all** configured policies in one API call. Each policy yields a
+`Score{Id: <policyType>, Score: <0–1, if returned>, Details: {"reasoning":
+"Status <VIOLATIVE|NON_VIOLATIVE>"}}`. As in the JS plugin, the score is the raw
+likelihood and the violation result is surfaced as reasoning only — no Pass/Fail
+status is synthesized. A score absent from the API response is omitted.
+
+## Guardrails client & middleware
+
+Use the exported `Guardrails` client for synchronous classification, or
+`GuardrailMiddleware` to block generations whose input or output is VIOLATIVE:
+
+```go
+import "golang.org/x/oauth2/google"
+
+creds, _ := google.FindDefaultCredentials(ctx,
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/checks")
+gr := checks.NewGuardrails(creds.TokenSource, "your-project-id")
+
+policies := []checks.ChecksMetricConfig{{Type: checks.DangerousContent}}
+
+// Synchronous classification:
+res, _ := gr.ClassifyContent(ctx, "text to classify", policies)
+
+// As guardrail middleware (blocks VIOLATIVE input/output):
+resp, err := genkit.Generate(ctx, g,
+    ai.WithModelName("googleai/gemini-2.5-flash"),
+    ai.WithUse(checks.GuardrailMiddleware(gr, policies)),
+    ai.WithPrompt("Write a poem about kittens."),
+)
+// On a violation, resp.FinishReason == ai.FinishReasonBlocked and
+// resp.FinishMessage names the violated policies.
+```
+
+`ClassifyContent` retries on `429`/`503` with exponential backoff, honoring
+`Retry-After`.
+
+> **Streaming note:** the input guardrail runs before the model is called, so
+> violative prompts are blocked outright. The output guardrail runs after
+> generation; for **streamed** responses the model's chunks have already been
+> delivered to your callback by the time the output is classified, so output
+> blocking is best-effort for streaming. Use non-streaming generation when the
+> output guardrail must prevent any content from reaching the client.
+
+## Tests
+
+Unit tests run offline against an `httptest.Server` with a fake token source:
+
+```bash
+go test ./plugins/checks/
+```
+
+A runnable sample (needs a real project + ADC) lives at
+[`go/samples/checks`](../../samples/checks).

--- a/go/plugins/checks/checks.go
+++ b/go/plugins/checks/checks.go
@@ -21,6 +21,7 @@ package checks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -74,6 +75,9 @@ type Checks struct {
 	ts        oauth2.TokenSource
 	projectID string
 	endpoint  string // overridable classifyContent URL; defaults to classifyEndpoint (tests).
+	// initErr records a credential/project-resolution failure from Init. It is
+	// returned when the evaluator runs, rather than panicking at startup.
+	initErr error
 }
 
 // classifyURL returns the configured endpoint or the default Checks endpoint.
@@ -90,33 +94,38 @@ var _ api.Plugin = (*Checks)(nil)
 func (c *Checks) Name() string { return provider }
 
 // Init resolves credentials and project ID, then registers the
-// checks/guardrails evaluator (when at least one metric is configured).
+// checks/guardrails evaluator (when at least one metric is configured). A
+// credential or project-resolution failure is recorded in c.initErr and
+// surfaced when the evaluator runs, so a misconfigured plugin doesn't crash the
+// whole application at startup.
 func (c *Checks) Init(ctx context.Context) []api.Action {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.initted {
 		panic("checks.Init already called")
 	}
-
-	creds, err := google.FindDefaultCredentials(ctx, cloudPlatformScope, checksScope)
-	if err != nil {
-		panic(fmt.Sprintf("checks: unable to find default credentials: %v", err))
-	}
-	if creds.TokenSource == nil {
-		panic("checks: missing or invalid credentials")
-	}
-	c.ts = creds.TokenSource
-
-	c.projectID = resolveProjectID(c.ProjectID, creds)
-	if c.projectID == "" {
-		panic("checks: missing project ID; set Checks.ProjectID or the GOOGLE_CLOUD_PROJECT environment variable")
-	}
-
 	c.initted = true
 
+	// No metrics means no evaluator to register, so skip credential and project
+	// resolution entirely — registering the plugin shouldn't require ADC when the
+	// evaluator isn't used (the exported Guardrails client resolves its own creds).
 	if len(c.Metrics) == 0 {
 		return []api.Action{}
 	}
+
+	creds, err := google.FindDefaultCredentials(ctx, cloudPlatformScope, checksScope)
+	if err != nil {
+		c.initErr = fmt.Errorf("checks: unable to find default credentials: %w", err)
+	} else if creds.TokenSource == nil {
+		c.initErr = errors.New("checks: missing or invalid credentials")
+	} else {
+		c.ts = creds.TokenSource
+		c.projectID = resolveProjectID(c.ProjectID, creds)
+		if c.projectID == "" {
+			c.initErr = errors.New("checks: missing project ID; set Checks.ProjectID or the GOOGLE_CLOUD_PROJECT environment variable")
+		}
+	}
+
 	return []api.Action{newEvaluator(c).(api.Action)}
 }
 

--- a/go/plugins/checks/checks.go
+++ b/go/plugins/checks/checks.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package checks provides a Genkit plugin for Google Checks AI Safety. It
+// exposes a "checks/guardrails" evaluator for batch evaluation and an exported
+// [Guardrails] client (plus [GuardrailMiddleware]) for synchronous, in-flight
+// content classification. It is a port of the JS @genkit-ai/checks plugin built
+// directly on net/http + ADC against the Checks v1alpha REST API.
+package checks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/firebase/genkit/go/core/api"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const (
+	provider = "checks"
+
+	// classifyEndpoint is the Checks AI Safety classifyContent REST endpoint.
+	classifyEndpoint = "https://checks.googleapis.com/v1alpha/aisafety:classifyContent"
+
+	cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+	checksScope        = "https://www.googleapis.com/auth/checks"
+)
+
+// PolicyType is a Checks AI safety policy.
+type PolicyType string
+
+const (
+	DangerousContent      PolicyType = "DANGEROUS_CONTENT"
+	PIISolicitingReciting PolicyType = "PII_SOLICITING_RECITING"
+	Harassment            PolicyType = "HARASSMENT"
+	SexuallyExplicit      PolicyType = "SEXUALLY_EXPLICIT"
+	HateSpeech            PolicyType = "HATE_SPEECH"
+	MedicalInfo           PolicyType = "MEDICAL_INFO"
+	ViolenceAndGore       PolicyType = "VIOLENCE_AND_GORE"
+	ObscenityAndProfanity PolicyType = "OBSCENITY_AND_PROFANITY"
+)
+
+// ChecksMetricConfig configures a single policy to evaluate against. Threshold
+// is optional; when nil the API uses its default for that policy.
+type ChecksMetricConfig struct {
+	Type      PolicyType
+	Threshold *float64
+}
+
+// Checks is the Genkit plugin for Google Checks AI Safety.
+type Checks struct {
+	// ProjectID is the Google Cloud project with Checks API quota. If empty,
+	// resolved from GOOGLE_CLOUD_PROJECT then Application Default Credentials.
+	ProjectID string
+	// Metrics is the set of policies the checks/guardrails evaluator scores.
+	Metrics []ChecksMetricConfig
+
+	mu        sync.Mutex
+	initted   bool
+	ts        oauth2.TokenSource
+	projectID string
+	endpoint  string // overridable classifyContent URL; defaults to classifyEndpoint (tests).
+}
+
+// classifyURL returns the configured endpoint or the default Checks endpoint.
+func (c *Checks) classifyURL() string {
+	if c.endpoint != "" {
+		return c.endpoint
+	}
+	return classifyEndpoint
+}
+
+var _ api.Plugin = (*Checks)(nil)
+
+// Name returns the plugin provider name.
+func (c *Checks) Name() string { return provider }
+
+// Init resolves credentials and project ID, then registers the
+// checks/guardrails evaluator (when at least one metric is configured).
+func (c *Checks) Init(ctx context.Context) []api.Action {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.initted {
+		panic("checks.Init already called")
+	}
+
+	creds, err := google.FindDefaultCredentials(ctx, cloudPlatformScope, checksScope)
+	if err != nil {
+		panic(fmt.Sprintf("checks: unable to find default credentials: %v", err))
+	}
+	if creds.TokenSource == nil {
+		panic("checks: missing or invalid credentials")
+	}
+	c.ts = creds.TokenSource
+
+	c.projectID = resolveProjectID(c.ProjectID, creds)
+	if c.projectID == "" {
+		panic("checks: missing project ID; set Checks.ProjectID or the GOOGLE_CLOUD_PROJECT environment variable")
+	}
+
+	c.initted = true
+
+	if len(c.Metrics) == 0 {
+		return []api.Action{}
+	}
+	return []api.Action{newEvaluator(c).(api.Action)}
+}
+
+// resolveProjectID applies the precedence: explicit > GOOGLE_CLOUD_PROJECT > ADC.
+func resolveProjectID(explicit string, creds *google.Credentials) string {
+	if explicit != "" {
+		return explicit
+	}
+	if v := os.Getenv("GOOGLE_CLOUD_PROJECT"); v != "" {
+		return v
+	}
+	if creds != nil {
+		return creds.ProjectID
+	}
+	return ""
+}

--- a/go/plugins/checks/checks_test.go
+++ b/go/plugins/checks/checks_test.go
@@ -17,6 +17,7 @@ package checks
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -34,6 +35,16 @@ type fakeTokenSource struct{}
 
 func (fakeTokenSource) Token() (*oauth2.Token, error) {
 	return &oauth2.Token{AccessToken: "test-token", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour)}, nil
+}
+
+type nilTokenSource struct{}
+
+func (nilTokenSource) Token() (*oauth2.Token, error) { return nil, nil }
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func ptr(f float64) *float64 { return &f }
@@ -113,6 +124,26 @@ func TestClassifyContent_RequestAndResponse(t *testing.T) {
 	}
 }
 
+func TestClassifyContent_NilSafety(t *testing.T) {
+	if _, err := (*Guardrails)(nil).ClassifyContent(context.Background(), "text", nil); err == nil {
+		t.Fatal("expected error for nil guardrails client")
+	}
+	if _, err := newGuardrails(nil, "proj", "http://example.invalid").ClassifyContent(context.Background(), "text", nil); err == nil {
+		t.Fatal("expected error for nil token source")
+	}
+	if _, err := newGuardrails(nilTokenSource{}, "proj", "http://example.invalid").ClassifyContent(context.Background(), "text", nil); err == nil {
+		t.Fatal("expected error for nil token")
+	}
+
+	g := newGuardrails(fakeTokenSource{}, "proj", "http://example.invalid")
+	g.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, nil
+	})}
+	if _, err := g.ClassifyContent(context.Background(), "text", nil); err == nil {
+		t.Fatal("expected error for nil HTTP response")
+	}
+}
+
 func TestEvaluator_FanOutAndMapping(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req classifyRequest
@@ -168,6 +199,27 @@ func TestEvaluator_FanOutAndMapping(t *testing.T) {
 	// Datapoint b is violative.
 	if got := results[1].Evaluation[0].Details["reasoning"]; got != "Status VIOLATIVE" {
 		t.Errorf("datapoint b reasoning = %v, want 'Status VIOLATIVE'", got)
+	}
+}
+
+func TestEvaluator_NilInputs(t *testing.T) {
+	c := &Checks{
+		Metrics:   []ChecksMetricConfig{{Type: HateSpeech}},
+		ts:        fakeTokenSource{},
+		projectID: "proj",
+		initted:   true,
+	}
+	ev := newEvaluator(c)
+	if _, err := ev.Evaluate(context.Background(), nil); err == nil {
+		t.Fatal("expected error for nil evaluator request")
+	}
+
+	result := evaluateOne(context.Background(), nil, nil, nil)
+	if len(result.Evaluation) != 1 {
+		t.Fatalf("nil example result = %+v", result)
+	}
+	if !strings.Contains(result.Evaluation[0].Error, "dataset example is nil") {
+		t.Fatalf("nil example error = %q", result.Evaluation[0].Error)
 	}
 }
 
@@ -241,6 +293,31 @@ func TestGuardrailMiddleware(t *testing.T) {
 	})
 }
 
+func TestGuardrailMiddleware_NilSafety(t *testing.T) {
+	if _, err := GuardrailMiddleware(nil, nil).New(context.Background()); err == nil {
+		t.Fatal("expected error for nil guardrails client")
+	}
+
+	g := newGuardrails(fakeTokenSource{}, "proj", "http://example.invalid")
+	mw := GuardrailMiddleware(g, nil)
+	hooks, err := mw.New(context.Background())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	next := func(context.Context, *ai.ModelParams) (*ai.ModelResponse, error) {
+		return &ai.ModelResponse{}, nil
+	}
+	if _, err := hooks.WrapModel(context.Background(), nil, next); err == nil {
+		t.Fatal("expected error for nil model params")
+	}
+	if _, err := hooks.WrapModel(context.Background(), &ai.ModelParams{}, nil); err == nil {
+		t.Fatal("expected error for nil next callback")
+	}
+	if _, err := hooks.WrapModel(context.Background(), &ai.ModelParams{}, next); err != nil {
+		t.Fatalf("nil request should pass through when there is no text to classify: %v", err)
+	}
+}
+
 func TestClassifyContent_RetriesOn429(t *testing.T) {
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -278,6 +355,53 @@ func TestEvaluatorRegistration(t *testing.T) {
 	}
 	if _, ok := ev.(api.Action); !ok {
 		t.Fatal("evaluator does not implement api.Action — Init cast would panic")
+	}
+}
+
+// TestEvaluator_InitErrSurfaced verifies that a credential/project failure
+// recorded by Init (in c.initErr) is returned when the evaluator runs, rather
+// than having panicked at startup.
+func TestEvaluator_InitErrSurfaced(t *testing.T) {
+	wantErr := errors.New("checks: missing project ID")
+	c := &Checks{Metrics: []ChecksMetricConfig{{Type: HateSpeech}}, initErr: wantErr}
+	ev := newEvaluator(c)
+	_, err := ev.Evaluate(context.Background(), &ai.EvaluatorRequest{
+		Dataset: []*ai.Example{{TestCaseId: "a", Output: "x"}},
+	})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Evaluate err = %v, want %v", err, wantErr)
+	}
+}
+
+// TestGuardrailMiddleware_NoPoliciesSkipsAPI verifies the middleware makes no
+// classifyContent calls when no policies are configured.
+func TestGuardrailMiddleware_NoPoliciesSkipsAPI(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+	}))
+	defer srv.Close()
+
+	g := newGuardrails(fakeTokenSource{}, "proj", srv.URL)
+	hooks, err := GuardrailMiddleware(g, nil).New(context.Background())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	next := func(context.Context, *ai.ModelParams) (*ai.ModelResponse, error) {
+		return &ai.ModelResponse{Message: &ai.Message{Role: ai.RoleModel, Content: []*ai.Part{ai.NewTextPart("a bad answer")}}}, nil
+	}
+	params := &ai.ModelParams{Request: &ai.ModelRequest{
+		Messages: []*ai.Message{{Role: ai.RoleUser, Content: []*ai.Part{ai.NewTextPart("this is bad")}}},
+	}}
+	resp, err := hooks.WrapModel(context.Background(), params, next)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.FinishReason == ai.FinishReasonBlocked {
+		t.Errorf("should not block when no policies are configured, got %+v", resp)
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Errorf("expected 0 classifyContent calls with no policies, got %d", got)
 	}
 }
 

--- a/go/plugins/checks/checks_test.go
+++ b/go/plugins/checks/checks_test.go
@@ -1,0 +1,318 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+type fakeTokenSource struct{}
+
+func (fakeTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{AccessToken: "test-token", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour)}, nil
+}
+
+func ptr(f float64) *float64 { return &f }
+
+// writeResults responds with one policyResult per requested policy, marking a
+// policy VIOLATIVE when the content contains "bad". The first policy carries a
+// score; the rest omit it (to exercise the optional-score path).
+func writeResults(w http.ResponseWriter, req classifyRequest) {
+	violative := strings.Contains(strings.ToLower(req.Input.TextInput.Content), "bad")
+	var results []policyResult
+	for i, p := range req.Policies {
+		r := policyResult{PolicyType: p.PolicyType, ViolationResult: "NOT_VIOLATIVE"}
+		if violative {
+			r.ViolationResult = "VIOLATIVE"
+		}
+		if i == 0 {
+			r.Score = ptr(0.9)
+		}
+		results = append(results, r)
+	}
+	_ = json.NewEncoder(w).Encode(classifyResponse{PolicyResults: results})
+}
+
+func TestClassifyContent_RequestAndResponse(t *testing.T) {
+	var gotAuth, gotProject, gotPath, gotMethod string
+	var gotBody classifyRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotProject = r.Header.Get("x-goog-user-project")
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(classifyResponse{PolicyResults: []policyResult{
+			{PolicyType: "HATE_SPEECH", Score: ptr(0.82), ViolationResult: "VIOLATIVE"},
+			{PolicyType: "HARASSMENT", ViolationResult: "NOT_VIOLATIVE"}, // no score
+		}})
+	}))
+	defer srv.Close()
+
+	g := newGuardrails(fakeTokenSource{}, "my-project", srv.URL)
+	resp, err := g.ClassifyContent(context.Background(), "some text", []ChecksMetricConfig{
+		{Type: HateSpeech, Threshold: ptr(0.5)},
+		{Type: Harassment},
+	})
+	if err != nil {
+		t.Fatalf("ClassifyContent: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want Bearer test-token", gotAuth)
+	}
+	if gotProject != "my-project" {
+		t.Errorf("x-goog-user-project = %q, want my-project", gotProject)
+	}
+	if gotPath == "" {
+		t.Errorf("empty request path")
+	}
+	if gotBody.Input.TextInput.Content != "some text" {
+		t.Errorf("content = %q, want 'some text'", gotBody.Input.TextInput.Content)
+	}
+	if len(gotBody.Policies) != 2 || gotBody.Policies[0].PolicyType != "HATE_SPEECH" || gotBody.Policies[0].Threshold == nil || *gotBody.Policies[0].Threshold != 0.5 {
+		t.Errorf("policies mapped incorrectly: %+v", gotBody.Policies)
+	}
+
+	if len(resp.PolicyResults) != 2 {
+		t.Fatalf("expected 2 policy results, got %d", len(resp.PolicyResults))
+	}
+	if resp.PolicyResults[0].Score == nil || *resp.PolicyResults[0].Score != 0.82 {
+		t.Errorf("result[0] score = %v, want 0.82", resp.PolicyResults[0].Score)
+	}
+	if resp.PolicyResults[1].Score != nil {
+		t.Errorf("result[1] score = %v, want nil (omitted)", resp.PolicyResults[1].Score)
+	}
+}
+
+func TestEvaluator_FanOutAndMapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req classifyRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		writeResults(w, req)
+	}))
+	defer srv.Close()
+
+	c := &Checks{
+		Metrics:   []ChecksMetricConfig{{Type: HateSpeech}, {Type: Harassment}},
+		ts:        fakeTokenSource{},
+		projectID: "proj",
+		endpoint:  srv.URL,
+		initted:   true,
+	}
+	ev := newEvaluator(c)
+
+	resp, err := ev.Evaluate(context.Background(), &ai.EvaluatorRequest{
+		Dataset: []*ai.Example{
+			{TestCaseId: "a", Output: "totally fine"},
+			{TestCaseId: "b", Output: "this is bad content"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	results := *resp
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	// Order preserved.
+	if results[0].TestCaseId != "a" || results[1].TestCaseId != "b" {
+		t.Fatalf("order not preserved: %s, %s", results[0].TestCaseId, results[1].TestCaseId)
+	}
+	// Two policies => two scores per datapoint.
+	if len(results[0].Evaluation) != 2 {
+		t.Fatalf("expected 2 scores, got %d", len(results[0].Evaluation))
+	}
+	s0 := results[0].Evaluation[0]
+	if s0.Id != "HATE_SPEECH" {
+		t.Errorf("score id = %q, want HATE_SPEECH", s0.Id)
+	}
+	if s0.Score == nil || s0.Score.(float64) != 0.9 {
+		t.Errorf("score = %v, want 0.9", s0.Score)
+	}
+	if got := s0.Details["reasoning"]; got != "Status NOT_VIOLATIVE" {
+		t.Errorf("reasoning = %v, want 'Status NOT_VIOLATIVE'", got)
+	}
+	// Second policy of first datapoint has no score (omitted).
+	if results[0].Evaluation[1].Score != nil {
+		t.Errorf("expected nil score for second policy, got %v", results[0].Evaluation[1].Score)
+	}
+	// Datapoint b is violative.
+	if got := results[1].Evaluation[0].Details["reasoning"]; got != "Status VIOLATIVE" {
+		t.Errorf("datapoint b reasoning = %v, want 'Status VIOLATIVE'", got)
+	}
+}
+
+func TestGuardrailMiddleware(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req classifyRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		writeResults(w, req)
+	}))
+	defer srv.Close()
+
+	g := newGuardrails(fakeTokenSource{}, "proj", srv.URL)
+	mw := GuardrailMiddleware(g, []ChecksMetricConfig{{Type: HateSpeech}})
+	hooks, err := mw.New(context.Background())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	userMsg := func(text string) *ai.ModelParams {
+		return &ai.ModelParams{Request: &ai.ModelRequest{
+			Messages: []*ai.Message{{Role: ai.RoleUser, Content: []*ai.Part{ai.NewTextPart(text)}}},
+		}}
+	}
+	modelResp := func(text string) *ai.ModelResponse {
+		return &ai.ModelResponse{Message: &ai.Message{Role: ai.RoleModel, Content: []*ai.Part{ai.NewTextPart(text)}}}
+	}
+
+	t.Run("blocks violative input", func(t *testing.T) {
+		var nextCalled bool
+		next := func(ctx context.Context, p *ai.ModelParams) (*ai.ModelResponse, error) {
+			nextCalled = true
+			return modelResp("ok"), nil
+		}
+		resp, err := hooks.WrapModel(context.Background(), userMsg("this is bad"), next)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if nextCalled {
+			t.Error("next should not be called when input is blocked")
+		}
+		if resp.FinishReason != ai.FinishReasonBlocked || !strings.Contains(resp.FinishMessage, "input") {
+			t.Errorf("expected blocked input response, got %+v", resp)
+		}
+	})
+
+	t.Run("blocks violative output", func(t *testing.T) {
+		next := func(ctx context.Context, p *ai.ModelParams) (*ai.ModelResponse, error) {
+			return modelResp("a bad answer"), nil
+		}
+		resp, err := hooks.WrapModel(context.Background(), userMsg("fine prompt"), next)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.FinishReason != ai.FinishReasonBlocked || !strings.Contains(resp.FinishMessage, "output") {
+			t.Errorf("expected blocked output response, got %+v", resp)
+		}
+	})
+
+	t.Run("passes through when clean", func(t *testing.T) {
+		want := modelResp("a fine answer")
+		next := func(ctx context.Context, p *ai.ModelParams) (*ai.ModelResponse, error) {
+			return want, nil
+		}
+		resp, err := hooks.WrapModel(context.Background(), userMsg("fine prompt"), next)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp != want {
+			t.Errorf("expected pass-through response, got %+v", resp)
+		}
+	})
+}
+
+func TestClassifyContent_RetriesOn429(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(classifyResponse{PolicyResults: []policyResult{
+			{PolicyType: "HATE_SPEECH", Score: ptr(0.1), ViolationResult: "NOT_VIOLATIVE"},
+		}})
+	}))
+	defer srv.Close()
+
+	g := newGuardrails(fakeTokenSource{}, "proj", srv.URL)
+	resp, err := g.ClassifyContent(context.Background(), "text", []ChecksMetricConfig{{Type: HateSpeech}})
+	if err != nil {
+		t.Fatalf("ClassifyContent after retry: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("expected 2 calls (1 retry), got %d", got)
+	}
+	if len(resp.PolicyResults) != 1 {
+		t.Errorf("expected 1 result, got %d", len(resp.PolicyResults))
+	}
+}
+
+// TestEvaluatorRegistration verifies the name and the api.Action cast that
+// Checks.Init relies on (Init itself needs ADC, so it isn't exercised offline).
+func TestEvaluatorRegistration(t *testing.T) {
+	c := &Checks{ts: fakeTokenSource{}, projectID: "p", Metrics: []ChecksMetricConfig{{Type: HateSpeech}}}
+	ev := newEvaluator(c)
+	if ev.Name() != "checks/guardrails" {
+		t.Errorf("name = %q, want checks/guardrails", ev.Name())
+	}
+	if _, ok := ev.(api.Action); !ok {
+		t.Fatal("evaluator does not implement api.Action — Init cast would panic")
+	}
+}
+
+func TestOutputText(t *testing.T) {
+	if got := outputText(nil); got != "" {
+		t.Errorf("outputText(nil) = %q, want empty", got)
+	}
+	if got := outputText("hello"); got != "hello" {
+		t.Errorf("outputText(string) = %q, want hello", got)
+	}
+	if got := outputText(42); got != "42" {
+		t.Errorf("outputText(42) = %q, want 42", got)
+	}
+}
+
+func TestResolveProjectID(t *testing.T) {
+	t.Run("explicit wins", func(t *testing.T) {
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "env-proj")
+		got := resolveProjectID("explicit-proj", &google.Credentials{ProjectID: "adc-proj"})
+		if got != "explicit-proj" {
+			t.Errorf("got %q, want explicit-proj", got)
+		}
+	})
+	t.Run("env over adc", func(t *testing.T) {
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "env-proj")
+		got := resolveProjectID("", &google.Credentials{ProjectID: "adc-proj"})
+		if got != "env-proj" {
+			t.Errorf("got %q, want env-proj", got)
+		}
+	})
+	t.Run("adc fallback", func(t *testing.T) {
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+		got := resolveProjectID("", &google.Credentials{ProjectID: "adc-proj"})
+		if got != "adc-proj" {
+			t.Errorf("got %q, want adc-proj", got)
+		}
+	})
+}

--- a/go/plugins/checks/evaluator.go
+++ b/go/plugins/checks/evaluator.go
@@ -16,6 +16,7 @@ package checks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/firebase/genkit/go/ai"
@@ -39,6 +40,13 @@ func newEvaluator(c *Checks) ai.Evaluator {
 	}
 
 	fn := func(ctx context.Context, req *ai.EvaluatorRequest) (*ai.EvaluatorResponse, error) {
+		if req == nil {
+			return nil, errors.New("checks: evaluator request is nil")
+		}
+		// Init defers credential/project failures to here instead of panicking.
+		if c.initErr != nil {
+			return nil, c.initErr
+		}
 		results := make([]ai.EvaluationResult, len(req.Dataset))
 
 		eg, egctx := errgroup.WithContext(ctx)
@@ -63,11 +71,18 @@ func newEvaluator(c *Checks) ai.Evaluator {
 // evaluateOne classifies a single datapoint. A failed call is isolated to that
 // datapoint's result (as a Score with Error) rather than failing the whole run.
 func evaluateOne(ctx context.Context, g *Guardrails, metrics []ChecksMetricConfig, dp *ai.Example) ai.EvaluationResult {
+	if dp == nil {
+		return ai.EvaluationResult{Evaluation: []ai.Score{{Error: "checks: dataset example is nil"}}}
+	}
 	res := ai.EvaluationResult{TestCaseId: dp.TestCaseId}
 
 	resp, err := g.ClassifyContent(ctx, outputText(dp.Output), metrics)
 	if err != nil {
 		res.Evaluation = []ai.Score{{Error: err.Error()}}
+		return res
+	}
+	if resp == nil {
+		res.Evaluation = []ai.Score{{Error: "checks: classifyContent returned nil response"}}
 		return res
 	}
 

--- a/go/plugins/checks/evaluator.go
+++ b/go/plugins/checks/evaluator.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"golang.org/x/sync/errgroup"
+)
+
+// evaluatorConcurrency bounds parallel classifyContent calls; Checks rate-limits
+// per project.
+const evaluatorConcurrency = 4
+
+// newEvaluator builds the checks/guardrails batch evaluator, which scores each
+// datapoint's output against all configured policies in one API call.
+func newEvaluator(c *Checks) ai.Evaluator {
+	g := newGuardrails(c.ts, c.projectID, c.classifyURL())
+
+	opts := &ai.EvaluatorOptions{
+		DisplayName: "checks/guardrails",
+		Definition:  "Evaluates input text against the configured Checks AI-safety policies.",
+		IsBilled:    true,
+	}
+
+	fn := func(ctx context.Context, req *ai.EvaluatorRequest) (*ai.EvaluatorResponse, error) {
+		results := make([]ai.EvaluationResult, len(req.Dataset))
+
+		eg, egctx := errgroup.WithContext(ctx)
+		eg.SetLimit(evaluatorConcurrency)
+		for i, dp := range req.Dataset {
+			eg.Go(func() error {
+				results[i] = evaluateOne(egctx, g, c.Metrics, dp)
+				return nil
+			})
+		}
+		if err := eg.Wait(); err != nil {
+			return nil, err
+		}
+
+		resp := ai.EvaluatorResponse(results)
+		return &resp, nil
+	}
+
+	return ai.NewBatchEvaluator(api.NewName(provider, "guardrails"), opts, fn)
+}
+
+// evaluateOne classifies a single datapoint. A failed call is isolated to that
+// datapoint's result (as a Score with Error) rather than failing the whole run.
+func evaluateOne(ctx context.Context, g *Guardrails, metrics []ChecksMetricConfig, dp *ai.Example) ai.EvaluationResult {
+	res := ai.EvaluationResult{TestCaseId: dp.TestCaseId}
+
+	resp, err := g.ClassifyContent(ctx, outputText(dp.Output), metrics)
+	if err != nil {
+		res.Evaluation = []ai.Score{{Error: err.Error()}}
+		return res
+	}
+
+	scores := make([]ai.Score, 0, len(resp.PolicyResults))
+	for _, pr := range resp.PolicyResults {
+		s := ai.Score{
+			Id:      pr.PolicyType,
+			Details: map[string]any{"reasoning": "Status " + pr.ViolationResult},
+		}
+		// Score is optional in the API; only set it when present so an absent
+		// score is omitted rather than serialized as null.
+		if pr.Score != nil {
+			s.Score = *pr.Score
+		}
+		scores = append(scores, s)
+	}
+	res.Evaluation = scores
+	return res
+}
+
+// outputText extracts the text to classify from an Example.Output (the field
+// the JS evaluator uses).
+func outputText(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	default:
+		return fmt.Sprint(t)
+	}
+}

--- a/go/plugins/checks/guardrails.go
+++ b/go/plugins/checks/guardrails.go
@@ -1,0 +1,307 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	"golang.org/x/oauth2"
+)
+
+const (
+	violative  = "VIOLATIVE"
+	maxRetries = 3
+)
+
+// --- REST request/response shapes (Checks v1alpha aisafety:classifyContent) ---
+
+type classifyRequest struct {
+	Input    classifyInput    `json:"input"`
+	Policies []classifyPolicy `json:"policies"`
+}
+
+type classifyInput struct {
+	TextInput textInput `json:"text_input"`
+}
+
+type textInput struct {
+	Content string `json:"content"`
+}
+
+type classifyPolicy struct {
+	PolicyType string   `json:"policy_type"`
+	Threshold  *float64 `json:"threshold,omitempty"`
+}
+
+type classifyResponse struct {
+	PolicyResults []policyResult `json:"policyResults"`
+}
+
+type policyResult struct {
+	PolicyType string `json:"policyType"`
+	// Score is optional in the API schema; nil when omitted.
+	Score           *float64 `json:"score,omitempty"`
+	ViolationResult string   `json:"violationResult"`
+}
+
+// Guardrails is a synchronous Checks AI-safety classifier. It is exported for
+// use as in-flight guardrail logic (see [GuardrailMiddleware]).
+type Guardrails struct {
+	ts         oauth2.TokenSource
+	projectID  string
+	endpoint   string
+	httpClient *http.Client
+}
+
+// NewGuardrails creates a Guardrails client. The token source must carry the
+// Checks/cloud-platform scopes; projectID is sent as the x-goog-user-project
+// quota project.
+func NewGuardrails(ts oauth2.TokenSource, projectID string) *Guardrails {
+	return newGuardrails(ts, projectID, classifyEndpoint)
+}
+
+// newGuardrails is the internal constructor with an overridable endpoint (used
+// by the plugin and by tests pointing at an httptest server).
+func newGuardrails(ts oauth2.TokenSource, projectID, endpoint string) *Guardrails {
+	return &Guardrails{
+		ts:         ts,
+		projectID:  projectID,
+		endpoint:   endpoint,
+		httpClient: http.DefaultClient,
+	}
+}
+
+// ClassifyContent classifies content against the given policies, retrying on
+// 429/503 with exponential backoff (honoring Retry-After).
+func (g *Guardrails) ClassifyContent(ctx context.Context, content string, policies []ChecksMetricConfig) (*classifyResponse, error) {
+	payload, err := json.Marshal(classifyRequest{
+		Input:    classifyInput{TextInput: textInput{Content: content}},
+		Policies: toPolicies(policies),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("checks: marshal request: %w", err)
+	}
+
+	var lastErr error
+	delay := 500 * time.Millisecond
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			wait := delay
+			var he *httpError
+			if errors.As(lastErr, &he) && he.retryAfter > wait {
+				wait = he.retryAfter
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(wait):
+			}
+			delay *= 2
+		}
+
+		resp, err := g.do(ctx, payload)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		var he *httpError
+		if !errors.As(err, &he) || !he.retryable {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("checks: classifyContent failed after %d retries: %w", maxRetries, lastErr)
+}
+
+// httpError carries a non-2xx response and whether it is retryable.
+type httpError struct {
+	status     int
+	body       string
+	retryable  bool
+	retryAfter time.Duration
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("checks: API returned status %d: %s", e.status, e.body)
+}
+
+func (g *Guardrails) do(ctx context.Context, payload []byte) (*classifyResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("checks: build request: %w", err)
+	}
+	tok, err := g.ts.Token()
+	if err != nil {
+		return nil, fmt.Errorf("checks: get token: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	req.Header.Set("x-goog-user-project", g.projectID)
+	req.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("checks: request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+	body, _ := io.ReadAll(httpResp.Body)
+
+	if httpResp.StatusCode != http.StatusOK {
+		he := &httpError{status: httpResp.StatusCode, body: string(body)}
+		if httpResp.StatusCode == http.StatusTooManyRequests || httpResp.StatusCode == http.StatusServiceUnavailable {
+			he.retryable = true
+			he.retryAfter = parseRetryAfter(httpResp.Header.Get("Retry-After"))
+		}
+		return nil, he
+	}
+
+	var out classifyResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("checks: parse response: %w", err)
+	}
+	return &out, nil
+}
+
+func toPolicies(metrics []ChecksMetricConfig) []classifyPolicy {
+	policies := make([]classifyPolicy, 0, len(metrics))
+	for _, m := range metrics {
+		policies = append(policies, classifyPolicy{
+			PolicyType: string(m.Type),
+			Threshold:  m.Threshold,
+		})
+	}
+	return policies
+}
+
+// parseRetryAfter parses a Retry-After header value (delay-seconds or HTTP-date).
+func parseRetryAfter(v string) time.Duration {
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// --- Guardrail middleware ---
+
+// GuardrailMiddleware returns an [ai.Middleware] (usable via ai.WithUse) that
+// classifies model input and output against the given policies and blocks
+// generation when any policy is VIOLATIVE.
+func GuardrailMiddleware(g *Guardrails, policies []ChecksMetricConfig) ai.Middleware {
+	return &guardrailMiddleware{g: g, policies: policies}
+}
+
+type guardrailMiddleware struct {
+	g        *Guardrails
+	policies []ChecksMetricConfig
+}
+
+func (m *guardrailMiddleware) Name() string { return provider + "/guardrail" }
+
+func (m *guardrailMiddleware) New(ctx context.Context) (*ai.Hooks, error) {
+	return &ai.Hooks{WrapModel: m.wrapModel}, nil
+}
+
+func (m *guardrailMiddleware) wrapModel(ctx context.Context, params *ai.ModelParams, next ai.ModelNext) (*ai.ModelResponse, error) {
+	// Check input before calling the model.
+	violated, err := m.classify(ctx, messagesText(params.Request.Messages))
+	if err != nil {
+		return nil, err
+	}
+	if len(violated) > 0 {
+		return blockedResponse("input", violated), nil
+	}
+
+	resp, err := next(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check output after generation.
+	if resp != nil && resp.Message != nil {
+		violated, err := m.classify(ctx, partsText(resp.Message.Content))
+		if err != nil {
+			return nil, err
+		}
+		if len(violated) > 0 {
+			return blockedResponse("output", violated), nil
+		}
+	}
+	return resp, nil
+}
+
+// classify runs each non-empty text through the classifier and returns the
+// names of any VIOLATIVE policies found.
+func (m *guardrailMiddleware) classify(ctx context.Context, texts []string) ([]string, error) {
+	var violated []string
+	for _, t := range texts {
+		if strings.TrimSpace(t) == "" {
+			continue
+		}
+		resp, err := m.g.ClassifyContent(ctx, t, m.policies)
+		if err != nil {
+			return nil, err
+		}
+		for _, pr := range resp.PolicyResults {
+			if pr.ViolationResult == violative {
+				violated = append(violated, pr.PolicyType)
+			}
+		}
+	}
+	return violated, nil
+}
+
+func blockedResponse(stage string, policies []string) *ai.ModelResponse {
+	return &ai.ModelResponse{
+		FinishReason:  ai.FinishReasonBlocked,
+		FinishMessage: fmt.Sprintf("Model %s violated Checks policies: [%s], further processing blocked.", stage, strings.Join(policies, " ")),
+	}
+}
+
+func messagesText(messages []*ai.Message) []string {
+	var texts []string
+	for _, msg := range messages {
+		if msg == nil {
+			continue
+		}
+		texts = append(texts, partsText(msg.Content)...)
+	}
+	return texts
+}
+
+func partsText(parts []*ai.Part) []string {
+	var texts []string
+	for _, p := range parts {
+		if p != nil && p.IsText() {
+			texts = append(texts, p.Text)
+		}
+	}
+	return texts
+}

--- a/go/plugins/checks/guardrails.go
+++ b/go/plugins/checks/guardrails.go
@@ -28,11 +28,25 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
 	violative  = "VIOLATIVE"
 	maxRetries = 3
+
+	// maxRetryWait caps the per-attempt backoff so a hostile or misconfigured
+	// Retry-After header can't make the client sleep for an unbounded time.
+	maxRetryWait = 30 * time.Second
+
+	// maxResponseBytes bounds how much of an HTTP response we read. classifyContent
+	// responses are small JSON; the cap is a defensive guard against an unbounded
+	// body (e.g. a misbehaving or overridden endpoint) exhausting memory.
+	maxResponseBytes = 4 << 20 // 4 MiB
+
+	// guardrailConcurrency bounds parallel classifyContent calls made by the
+	// middleware for a single request; Checks rate-limits per project.
+	guardrailConcurrency = 4
 )
 
 // --- REST request/response shapes (Checks v1alpha aisafety:classifyContent) ---
@@ -96,6 +110,12 @@ func newGuardrails(ts oauth2.TokenSource, projectID, endpoint string) *Guardrail
 // ClassifyContent classifies content against the given policies, retrying on
 // 429/503 with exponential backoff (honoring Retry-After).
 func (g *Guardrails) ClassifyContent(ctx context.Context, content string, policies []ChecksMetricConfig) (*classifyResponse, error) {
+	if g == nil {
+		return nil, errors.New("checks: guardrails client is nil")
+	}
+	if g.ts == nil {
+		return nil, errors.New("checks: token source is nil")
+	}
 	payload, err := json.Marshal(classifyRequest{
 		Input:    classifyInput{TextInput: textInput{Content: content}},
 		Policies: toPolicies(policies),
@@ -113,10 +133,16 @@ func (g *Guardrails) ClassifyContent(ctx context.Context, content string, polici
 			if errors.As(lastErr, &he) && he.retryAfter > wait {
 				wait = he.retryAfter
 			}
+			if wait > maxRetryWait {
+				wait = maxRetryWait
+			}
+
+			t := time.NewTimer(wait)
 			select {
 			case <-ctx.Done():
+				t.Stop()
 				return nil, ctx.Err()
-			case <-time.After(wait):
+			case <-t.C:
 			}
 			delay *= 2
 		}
@@ -147,7 +173,11 @@ func (e *httpError) Error() string {
 }
 
 func (g *Guardrails) do(ctx context.Context, payload []byte) (*classifyResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.endpoint, bytes.NewReader(payload))
+	endpoint := g.endpoint
+	if endpoint == "" {
+		endpoint = classifyEndpoint
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("checks: build request: %w", err)
 	}
@@ -155,16 +185,29 @@ func (g *Guardrails) do(ctx context.Context, payload []byte) (*classifyResponse,
 	if err != nil {
 		return nil, fmt.Errorf("checks: get token: %w", err)
 	}
+	if tok == nil {
+		return nil, errors.New("checks: token source returned nil token")
+	}
 	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
 	req.Header.Set("x-goog-user-project", g.projectID)
 	req.Header.Set("Content-Type", "application/json")
 
-	httpResp, err := g.httpClient.Do(req)
+	client := g.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	httpResp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("checks: request failed: %w", err)
 	}
+	if httpResp == nil {
+		return nil, errors.New("checks: request returned nil response")
+	}
 	defer httpResp.Body.Close()
-	body, _ := io.ReadAll(httpResp.Body)
+	body, err := io.ReadAll(io.LimitReader(httpResp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("checks: read response body: %w", err)
+	}
 
 	if httpResp.StatusCode != http.StatusOK {
 		he := &httpError{status: httpResp.StatusCode, body: string(body)}
@@ -226,12 +269,25 @@ type guardrailMiddleware struct {
 func (m *guardrailMiddleware) Name() string { return provider + "/guardrail" }
 
 func (m *guardrailMiddleware) New(ctx context.Context) (*ai.Hooks, error) {
+	if m == nil || m.g == nil {
+		return nil, errors.New("checks: guardrails client is nil")
+	}
 	return &ai.Hooks{WrapModel: m.wrapModel}, nil
 }
 
 func (m *guardrailMiddleware) wrapModel(ctx context.Context, params *ai.ModelParams, next ai.ModelNext) (*ai.ModelResponse, error) {
+	if next == nil {
+		return nil, errors.New("checks: next model callback is nil")
+	}
+	if params == nil {
+		return nil, errors.New("checks: model params are nil")
+	}
+	var messages []*ai.Message
+	if params.Request != nil {
+		messages = params.Request.Messages
+	}
 	// Check input before calling the model.
-	violated, err := m.classify(ctx, messagesText(params.Request.Messages))
+	violated, err := m.classify(ctx, messagesText(messages))
 	if err != nil {
 		return nil, err
 	}
@@ -257,23 +313,55 @@ func (m *guardrailMiddleware) wrapModel(ctx context.Context, params *ai.ModelPar
 	return resp, nil
 }
 
-// classify runs each non-empty text through the classifier and returns the
-// names of any VIOLATIVE policies found.
+// classify runs each non-empty text through the classifier concurrently
+// (bounded by guardrailConcurrency) and returns the names of any VIOLATIVE
+// policies found across all of them.
 func (m *guardrailMiddleware) classify(ctx context.Context, texts []string) ([]string, error) {
-	var violated []string
+	if m == nil || m.g == nil {
+		return nil, errors.New("checks: guardrails client is nil")
+	}
+	if len(m.policies) == 0 {
+		return nil, nil
+	}
+
+	active := make([]string, 0, len(texts))
 	for _, t := range texts {
-		if strings.TrimSpace(t) == "" {
-			continue
+		if strings.TrimSpace(t) != "" {
+			active = append(active, t)
 		}
-		resp, err := m.g.ClassifyContent(ctx, t, m.policies)
-		if err != nil {
-			return nil, err
-		}
-		for _, pr := range resp.PolicyResults {
-			if pr.ViolationResult == violative {
-				violated = append(violated, pr.PolicyType)
+	}
+	if len(active) == 0 {
+		return nil, nil
+	}
+
+	// One slot per text preserves order and lets goroutines write without locking.
+	perText := make([][]string, len(active))
+	eg, egctx := errgroup.WithContext(ctx)
+	eg.SetLimit(guardrailConcurrency)
+	for i, t := range active {
+		eg.Go(func() error {
+			resp, err := m.g.ClassifyContent(egctx, t, m.policies)
+			if err != nil {
+				return fmt.Errorf("checks: classify text %d: %w", i, err)
 			}
-		}
+			if resp == nil {
+				return fmt.Errorf("checks: classifyContent returned nil response for text %d", i)
+			}
+			for _, pr := range resp.PolicyResults {
+				if pr.ViolationResult == violative {
+					perText[i] = append(perText[i], pr.PolicyType)
+				}
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	var violated []string
+	for _, v := range perText {
+		violated = append(violated, v...)
 	}
 	return violated, nil
 }

--- a/go/samples/checks/main.go
+++ b/go/samples/checks/main.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command checks demonstrates the Google Checks plugin: the checks/guardrails
+// evaluator, the synchronous Guardrails client, and (with a model) the guardrail
+// middleware. Requires a Google Cloud project with the Checks API enabled and
+// Application Default Credentials.
+//
+//	go run ./samples/checks -project my-project [-apikey "$GEMINI_API_KEY"]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/checks"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"golang.org/x/oauth2/google"
+)
+
+var (
+	project = flag.String("project", "", "Google Cloud project ID (or set GOOGLE_CLOUD_PROJECT)")
+	apiKey  = flag.String("apikey", "", "Gemini API key (optional; enables the guardrail-middleware demo)")
+)
+
+func main() {
+	flag.Parse()
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+
+	policies := []checks.ChecksMetricConfig{
+		{Type: checks.DangerousContent},
+		{Type: checks.Harassment},
+	}
+
+	plugins := []api.Plugin{&checks.Checks{ProjectID: *project, Metrics: policies}}
+	if *apiKey != "" {
+		plugins = append(plugins, &googlegenai.GoogleAI{APIKey: *apiKey})
+	}
+	g := genkit.Init(ctx, genkit.WithPlugins(plugins...))
+
+	// 1. Batch evaluator.
+	fmt.Println("=== evaluator (checks/guardrails) ===")
+	ev := genkit.LookupEvaluator(g, "checks/guardrails")
+	resp, err := ev.Evaluate(ctx, &ai.EvaluatorRequest{
+		Dataset: []*ai.Example{
+			{TestCaseId: "1", Output: "Here is a recipe for a lovely fruit salad."},
+			{TestCaseId: "2", Output: "Detailed instructions for building a dangerous weapon."},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("evaluate: %w", err)
+	}
+	for _, r := range *resp {
+		fmt.Printf("testCase %s:\n", r.TestCaseId)
+		for _, s := range r.Evaluation {
+			fmt.Printf("  %-24s score=%v  %v\n", s.Id, s.Score, s.Details["reasoning"])
+		}
+	}
+
+	// 2. Synchronous Guardrails client.
+	fmt.Println("\n=== guardrails client ===")
+	creds, err := google.FindDefaultCredentials(ctx,
+		"https://www.googleapis.com/auth/cloud-platform",
+		"https://www.googleapis.com/auth/checks")
+	if err != nil {
+		return fmt.Errorf("find default credentials: %w", err)
+	}
+	projectID := *project
+	if projectID == "" {
+		projectID = creds.ProjectID
+	}
+	gr := checks.NewGuardrails(creds.TokenSource, projectID)
+	cls, err := gr.ClassifyContent(ctx, "How do I make a bomb?", policies)
+	if err != nil {
+		return fmt.Errorf("classify: %w", err)
+	}
+	for _, pr := range cls.PolicyResults {
+		fmt.Printf("  %-24s score=%v  %s\n", pr.PolicyType, scoreStr(pr.Score), pr.ViolationResult)
+	}
+
+	// 3. Guardrail middleware (requires a model).
+	if *apiKey != "" {
+		fmt.Println("\n=== guardrail middleware ===")
+		out, err := genkit.Generate(ctx, g,
+			ai.WithModelName("googleai/gemini-2.5-flash"),
+			ai.WithUse(checks.GuardrailMiddleware(gr, policies)),
+			ai.WithPrompt("Write a short, friendly greeting."),
+		)
+		if err != nil {
+			return fmt.Errorf("generate: %w", err)
+		}
+		if out.FinishReason == ai.FinishReasonBlocked {
+			fmt.Println("  blocked:", out.FinishMessage)
+		} else {
+			fmt.Println("  ", out.Text())
+		}
+	}
+
+	return nil
+}
+
+func scoreStr(s *float64) string {
+	if s == nil {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.3f", *s)
+}


### PR DESCRIPTION
Add Google Checks AI-safety plugin (Go)

  Port of the JS @genkit-ai/checks plugin to Go. Integrates Google Checks AI Safety (https://checks.google.com/ai-safety) for classifying content against safety policies, built directly on net/http + Application Default Credentials against the Checks v1alpha aisafety:classifyContent API (there is no first-party Go SDK).

 Testing
  - Unit tests run fully offline against an httptest.Server with a fake token source — cover request/response
  mapping, evaluator fan-out, middleware blocking, optional-score handling, 429 retry, and project-ID precedence.
  Pass under -race.
  - Manually validated end-to-end against the live Checks API: ADC resolution, scoped auth, transport, the retry
  loop (against a real 429), and error propagation all confirmed working.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
