### PR TITLE
feat(plugins/google-genai/vertexai): Updates to google-genai/vertexai to support apiVersion and multi-regional locations

### DIFF
--- a/js/plugins/google-genai/README.md
+++ b/js/plugins/google-genai/README.md
@@ -60,6 +60,7 @@ const ai = genkit({
   plugins: [
     // Using Application Default Credentials (Recommended for full features)
     vertexAI({ location: 'us-central1' }), // Regional endpoint
+    // vertexAI({ location: 'us', apiVersion: 'v1' }), // Multi-regional endpoint, overriding apiVersion
     // vertexAI({ location: 'global' }),      // Global endpoint
 
     // OR

--- a/js/plugins/google-genai/src/vertexai/client.ts
+++ b/js/plugins/google-genai/src/vertexai/client.ts
@@ -323,6 +323,8 @@ export async function veoCheckOperation(
   });
 }
 
+const SUPPORTED_API_VERSIONS = ['v1beta1', 'v1'] as const;
+
 export function getVertexAIUrl(params: {
   includeProjectAndLocation: boolean; // False for listModels, true for most others
   resourcePath: string;
@@ -332,12 +334,19 @@ export function getVertexAIUrl(params: {
 }): string {
   checkSupportedResourceMethod(params);
 
-  const DEFAULT_API_VERSION = 'v1beta1';
-  const API_BASE_PATH = 'aiplatform.googleapis.com';
+  // https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/agent-locations
+  // https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations
 
+  const apiVersion = params.clientOptions.apiVersion ?? 'v1beta1';
+  if (!SUPPORTED_API_VERSIONS.includes(apiVersion))
+    throw new Error(`Invalid apiVersion [${apiVersion}] for VertexAi client`);
+
+  const API_BASE_PATH = 'aiplatform.googleapis.com';
   let basePath: string;
 
-  if (params.clientOptions.kind == 'regional') {
+  if (params.clientOptions.kind === 'multi-regional') {
+    basePath = `aiplatform.${params.clientOptions.location}.googleapis.com`;
+  } else if (params.clientOptions.kind == 'regional') {
     basePath = `${params.clientOptions.location}-${API_BASE_PATH}`;
   } else {
     basePath = API_BASE_PATH;
@@ -352,7 +361,7 @@ export function getVertexAIUrl(params: {
     resourcePath = `${parent}/${params.resourcePath}`;
   }
 
-  let url = `https://${basePath}/${DEFAULT_API_VERSION}/${resourcePath}`;
+  let url = `https://${basePath}/${apiVersion}/${resourcePath}`;
   if (params.resourceMethod) {
     url += `:${params.resourceMethod}`;
   }

--- a/js/plugins/google-genai/src/vertexai/types.ts
+++ b/js/plugins/google-genai/src/vertexai/types.ts
@@ -50,6 +50,9 @@ import {
   isRetrievalTool,
 } from '../common/types.js';
 
+export const SUPPORTED_API_VERSIONS = ['v1beta1', 'v1'] as const;
+export const MULTI_REGIONAL_LOCATIONS = ['us', 'eu'] as const;
+
 // This makes it easier to import all types from one place
 export {
   FunctionCallingMode,
@@ -91,6 +94,8 @@ export interface VertexPluginOptions {
   apiKey?: string | false;
   /** The Google Cloud project id to call. */
   projectId?: string;
+  /** The API version to use (defaults to v1beta1) */
+  apiVersion?: (typeof SUPPORTED_API_VERSIONS)[number];
   /** The Google Cloud region to call. */
   location?: string;
   /** Provide custom authentication configuration for connecting to Vertex AI. */
@@ -102,6 +107,7 @@ export interface VertexPluginOptions {
 }
 
 interface BaseClientOptions {
+  apiVersion?: VertexPluginOptions['apiVersion'];
   /** timeout in milli seconds. time out value needs to be non negative. */
   timeout?: number;
   signal?: AbortSignal;
@@ -110,20 +116,31 @@ interface BaseClientOptions {
   experimental_debugTraces?: boolean;
 }
 
-export interface RegionalClientOptions extends BaseClientOptions {
-  kind: 'regional';
-  location: string;
+interface SharedLocationBasedClientOptions {
   projectId: string;
   authClient: GoogleAuth;
   apiKey?: string; // In addition to regular auth
 }
 
-export interface GlobalClientOptions extends BaseClientOptions {
+export interface MultiRegionalClientOptions
+  extends BaseClientOptions,
+    SharedLocationBasedClientOptions {
+  kind: 'multi-regional';
+  location: (typeof MULTI_REGIONAL_LOCATIONS)[number];
+}
+
+export interface RegionalClientOptions
+  extends BaseClientOptions,
+    SharedLocationBasedClientOptions {
+  kind: 'regional';
+  location: string;
+}
+
+export interface GlobalClientOptions
+  extends BaseClientOptions,
+    SharedLocationBasedClientOptions {
   kind: 'global';
   location: 'global';
-  projectId: string;
-  authClient: GoogleAuth;
-  apiKey?: string; // In addition to regular auth
 }
 
 export interface ExpressClientOptions extends BaseClientOptions {
@@ -134,6 +151,7 @@ export interface ExpressClientOptions extends BaseClientOptions {
 /** Resolved options for use with the client */
 export type ClientOptions =
   | RegionalClientOptions
+  | MultiRegionalClientOptions
   | GlobalClientOptions
   | ExpressClientOptions;
 

--- a/js/plugins/google-genai/src/vertexai/utils.ts
+++ b/js/plugins/google-genai/src/vertexai/utils.ts
@@ -16,10 +16,12 @@
 
 import { GenkitError, z } from 'genkit';
 import { GoogleAuth } from 'google-auth-library';
-import type {
+import {
   ClientOptions,
   ExpressClientOptions,
   GlobalClientOptions,
+  MULTI_REGIONAL_LOCATIONS,
+  MultiRegionalClientOptions,
   RegionalClientOptions,
   VertexPluginOptions,
 } from './types.js';
@@ -71,17 +73,18 @@ export async function getDerivedOptions(
   if (options?.location == 'global') {
     return await getGlobalDerivedOptions(AuthClass, options);
   } else if (options?.location) {
-    return await getRegionalDerivedOptions(AuthClass, options);
+    return await getRegionalOrMultiRegionalDerivedOptions(AuthClass, options);
   } else if (options?.apiKey !== undefined) {
     // apiKey = false still indicates apiKey expectation
     return getExpressDerivedOptions(options);
   }
 
   // If we got here then we're relying on environment variables.
-  // Try regional first, it's the most common usage.
+  // Try regional or multi-regional first, they are the the most common usages.
   try {
-    const regionalOptions = await getRegionalDerivedOptions(AuthClass, options);
-    return regionalOptions;
+    const regionalOrMultiRegionalOptions =
+      await getRegionalOrMultiRegionalDerivedOptions(AuthClass, options);
+    return regionalOrMultiRegionalOptions;
   } catch (e: unknown) {
     /* no-op - try global next */
   }
@@ -157,6 +160,9 @@ async function getGlobalDerivedOptions(
   if (options?.apiKey) {
     clientOpt.apiKey = options.apiKey;
   }
+  if (options?.apiVersion) {
+    clientOpt.apiVersion = options.apiVersion;
+  }
 
   return clientOpt;
 }
@@ -169,13 +175,14 @@ function getExpressDerivedOptions(
     kind: 'express',
     apiKey,
     experimental_debugTraces: options?.experimental_debugTraces,
+    ...(options?.apiVersion ? { apiVersion: options.apiVersion } : {}),
   };
 }
 
-async function getRegionalDerivedOptions(
+async function getRegionalOrMultiRegionalDerivedOptions(
   AuthClass: typeof GoogleAuth,
   options?: VertexPluginOptions
-): Promise<RegionalClientOptions> {
+): Promise<RegionalClientOptions | MultiRegionalClientOptions> {
   let authOptions = options?.googleAuth;
   let authClient: GoogleAuth;
   const providedProjectId =
@@ -219,17 +226,28 @@ async function getRegionalDerivedOptions(
     );
   }
 
-  const clientOpt: RegionalClientOptions = {
-    kind: 'regional',
-    location,
+  const clientOptBase: Omit<RegionalClientOptions, 'location' | 'kind'> &
+    Omit<MultiRegionalClientOptions, 'kind' | 'location'> = {
     projectId,
     authClient,
     experimental_debugTraces: options?.experimental_debugTraces,
+    ...(options?.apiKey ? { apiKey: options.apiKey } : {}),
+    ...(options?.apiVersion ? { apiVersion: options.apiVersion } : {}),
   };
-  if (options?.apiKey) {
-    clientOpt.apiKey = options.apiKey;
+
+  if (MULTI_REGIONAL_LOCATIONS.includes(location as any)) {
+    return {
+      kind: 'multi-regional',
+      location,
+      ...clientOptBase,
+    } as MultiRegionalClientOptions;
+  } else {
+    return {
+      kind: 'regional',
+      location,
+      ...clientOptBase,
+    } as RegionalClientOptions;
   }
-  return clientOpt;
 }
 
 export type RequestClientOptions = ClientOptions & {

--- a/js/plugins/google-genai/tests/vertexai/client_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/client_test.ts
@@ -311,6 +311,80 @@ describe('Vertex AI Client', () => {
       });
     });
 
+    describe('Multi-regional', () => {
+      const opts: ClientOptions = {
+        kind: 'multi-regional',
+        projectId: 'test-proj',
+        location: 'us',
+        authClient: {} as any,
+      };
+
+      it('should build URL for listModels', () => {
+        const url = getVertexAIUrl({
+          includeProjectAndLocation: false,
+          resourcePath: 'publishers/google/models',
+          clientOptions: opts,
+        });
+        assert.strictEqual(
+          url,
+          'https://aiplatform.us.googleapis.com/v1beta1/publishers/google/models'
+        );
+      });
+
+      it('should build URL for generateContent', () => {
+        const url = getVertexAIUrl({
+          includeProjectAndLocation: true,
+          resourcePath: 'publishers/google/models/gemini-2.0-pro',
+          resourceMethod: 'generateContent',
+          clientOptions: opts,
+        });
+        assert.strictEqual(
+          url,
+          'https://aiplatform.us.googleapis.com/v1beta1/projects/test-proj/locations/us/publishers/google/models/gemini-2.0-pro:generateContent'
+        );
+      });
+    });
+
+    describe('apiVersion options', () => {
+      it('should use specified apiVersion if provided in clientOptions', () => {
+        const opts: ClientOptions = {
+          kind: 'regional',
+          projectId: 'test-proj',
+          location: 'us-east1',
+          authClient: {} as any,
+          apiVersion: 'v1',
+        };
+        const url = getVertexAIUrl({
+          includeProjectAndLocation: true,
+          resourcePath: 'publishers/google/models/gemini-2.0-pro',
+          resourceMethod: 'generateContent',
+          clientOptions: opts,
+        });
+        assert.strictEqual(
+          url,
+          'https://us-east1-aiplatform.googleapis.com/v1/projects/test-proj/locations/us-east1/publishers/google/models/gemini-2.0-pro:generateContent'
+        );
+      });
+
+      it('should throw if specified apiVersion is not supported', () => {
+        const opts: ClientOptions = {
+          kind: 'regional',
+          projectId: 'test-proj',
+          location: 'us-east1',
+          authClient: {} as any,
+          apiVersion: 'v2' as any,
+        };
+        assert.throws(() => {
+          getVertexAIUrl({
+            includeProjectAndLocation: true,
+            resourcePath: 'publishers/google/models/gemini-2.0-pro',
+            resourceMethod: 'generateContent',
+            clientOptions: opts,
+          });
+        }, /Invalid apiVersion \[v2\] for VertexAi client/);
+      });
+    });
+
     describe('Express', () => {
       const opts: ClientOptions = {
         kind: 'express',

--- a/js/plugins/google-genai/tests/vertexai/index_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/index_test.ts
@@ -36,6 +36,7 @@ import { vertexAI } from '../../src/vertexai/index.js';
 import type {
   ExpressClientOptions,
   GlobalClientOptions,
+  MultiRegionalClientOptions,
   RegionalClientOptions,
 } from '../../src/vertexai/types.js';
 import {
@@ -47,6 +48,14 @@ describe('VertexAI Plugin', () => {
   const regionalMockDerivedOptions: RegionalClientOptions = {
     kind: 'regional' as const,
     location: 'us-central1',
+    projectId: 'test-project',
+    authClient: {
+      getAccessToken: async () => 'fake-test-token',
+    } as unknown as GoogleAuth,
+  };
+  const multiRegionalMockDerivedOptions: MultiRegionalClientOptions = {
+    kind: 'multi-regional' as const,
+    location: 'us',
     projectId: 'test-project',
     authClient: {
       getAccessToken: async () => 'fake-test-token',
@@ -557,6 +566,79 @@ describe('VertexAI Plugin', () => {
         assert.strictEqual(headers['Authorization'], 'Bearer fake-test-token');
         assert.strictEqual(headers['x-goog-api-key'], 'test-api-key');
         assert.ok(!url.includes('?key=test-api-key'));
+      });
+    });
+
+    describe('With Multi-Regional Options', () => {
+      beforeEach(() => {
+        UTILS_TEST_ONLY.setMockDerivedOptions(multiRegionalMockDerivedOptions);
+        ai = genkit({ plugins: [vertexAI()] });
+      });
+
+      it('should use auth token and multi-regional URL for Gemini generateContent', async () => {
+        const modelRef = vertexAI.model('gemini-2.5-flash');
+        const generateAction = await ai.registry.lookupAction(
+          '/model/' + modelRef.name
+        );
+        assert.ok(generateAction, `/model/${modelRef.name} action not found`);
+
+        fetchMock.mock.mockImplementation(async () =>
+          createMockApiResponse({
+            candidates: [
+              {
+                index: 0,
+                content: { role: 'model', parts: [{ text: 'response' }] },
+              },
+            ],
+          })
+        );
+
+        await generateAction({
+          messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+          config: {},
+        } as GenerateRequest);
+
+        const fetchCall = fetchMock.mock.calls[0];
+        const headers = fetchCall.arguments[1].headers;
+        const url = fetchCall.arguments[0];
+        assert.strictEqual(headers['Authorization'], 'Bearer fake-test-token');
+        assert.ok(url.includes('aiplatform.us.googleapis.com'));
+      });
+    });
+
+    describe('With apiVersion Option', () => {
+      it('should pass apiVersion through to request URL', async () => {
+        UTILS_TEST_ONLY.setMockDerivedOptions({
+          ...regionalMockDerivedOptions,
+          apiVersion: 'v1',
+        });
+        ai = genkit({ plugins: [vertexAI({ apiVersion: 'v1' })] });
+
+        const modelRef = vertexAI.model('gemini-2.5-flash');
+        const generateAction = await ai.registry.lookupAction(
+          '/model/' + modelRef.name
+        );
+        assert.ok(generateAction, `/model/${modelRef.name} action not found`);
+
+        fetchMock.mock.mockImplementation(async () =>
+          createMockApiResponse({
+            candidates: [
+              {
+                index: 0,
+                content: { role: 'model', parts: [{ text: 'response' }] },
+              },
+            ],
+          })
+        );
+
+        await generateAction({
+          messages: [{ role: 'user', content: [{ text: 'hi' }] }],
+          config: {},
+        } as GenerateRequest);
+
+        const fetchCall = fetchMock.mock.calls[0];
+        const url = fetchCall.arguments[0];
+        assert.ok(url.includes('/v1/projects/'));
       });
     });
 

--- a/js/plugins/google-genai/tests/vertexai/utils_test.ts
+++ b/js/plugins/google-genai/tests/vertexai/utils_test.ts
@@ -22,6 +22,7 @@ import * as sinon from 'sinon';
 import {
   ExpressClientOptions,
   GlobalClientOptions,
+  MultiRegionalClientOptions,
   RegionalClientOptions,
   VertexPluginOptions,
 } from '../../src/vertexai/types.js';
@@ -109,6 +110,34 @@ describe('Vertex AI Utils', () => {
         assert.ok(options.authClient);
         sinon.assert.calledOnce(mockAuthClass);
         sinon.assert.notCalled(authInstance.getProjectId);
+      });
+
+      it('should use multi-regional options when location is in MULTI_REGIONAL_LOCATIONS', async () => {
+        const pluginOptions: VertexPluginOptions = {
+          projectId: 'options-project',
+          location: 'us',
+        };
+        const options = (await getDerivedOptions(
+          pluginOptions,
+          mockAuthClass as any
+        )) as MultiRegionalClientOptions;
+        assert.strictEqual(options.kind, 'multi-regional');
+        assert.strictEqual(options.projectId, 'options-project');
+        assert.strictEqual(options.location, 'us');
+        assert.ok(options.authClient);
+      });
+
+      it('should pass apiVersion to regional options if provided', async () => {
+        const pluginOptions: VertexPluginOptions = {
+          projectId: 'options-project',
+          location: 'options-location',
+          apiVersion: 'v1',
+        };
+        const options = (await getDerivedOptions(
+          pluginOptions,
+          mockAuthClass as any
+        )) as RegionalClientOptions;
+        assert.strictEqual(options.apiVersion, 'v1');
       });
 
       it('should use GCLOUD_PROJECT and GCLOUD_LOCATION env vars', async () => {
@@ -249,6 +278,19 @@ describe('Vertex AI Utils', () => {
         sinon.assert.notCalled(authInstance.getProjectId);
       });
 
+      it('should pass apiVersion to global options if provided', async () => {
+        const pluginOptions: VertexPluginOptions = {
+          location: 'global',
+          projectId: 'options-project',
+          apiVersion: 'v1',
+        };
+        const options = (await getDerivedOptions(
+          pluginOptions,
+          mockAuthClass as any
+        )) as GlobalClientOptions;
+        assert.strictEqual(options.apiVersion, 'v1');
+      });
+
       it('should use env project for global options', async () => {
         process.env.GCLOUD_PROJECT = 'env-project';
         const pluginOptions: VertexPluginOptions = { location: 'global' };
@@ -312,6 +354,18 @@ describe('Vertex AI Utils', () => {
         assert.strictEqual(options.kind, 'express');
         assert.strictEqual(options.apiKey, 'key1');
         sinon.assert.notCalled(mockAuthClass);
+      });
+
+      it('should pass apiVersion to express options if provided', async () => {
+        const pluginOptions: VertexPluginOptions = {
+          apiKey: 'key1',
+          apiVersion: 'v1',
+        };
+        const options = (await getDerivedOptions(
+          pluginOptions,
+          mockAuthClass as any
+        )) as ExpressClientOptions;
+        assert.strictEqual(options.apiVersion, 'v1');
       });
 
       it('should use express options with apiKey false in options', async () => {


### PR DESCRIPTION
VertexAI (renamed to Enterprise Agent Platform by google) supports [multi-regional endpoints](https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/agent-locations) that have different base location URLs than were currently supported. This PR addresses support for that, and also allows specifically setting the api version (to `v1` or `v1beta1` ... was hardcoded to `v1beta1` before)

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [X] Docs updated (updated docs or a docs bug required)
