### PR TITLE
fix(tools): bind dev servers to localhost by default

### DIFF
--- a/genkit-tools/cli/src/commands/server-harness.ts
+++ b/genkit-tools/cli/src/commands/server-harness.ts
@@ -38,7 +38,8 @@ export const SERVER_HARNESS_COMMAND = '__server-harness' as const;
 export const serverHarness = new Command('__server-harness')
   .argument('<port>', 'Port to serve on')
   .argument('<logFile>', 'Log file path')
-  .action(async (port: string, logFile: string) => {
+  .argument('[host]', 'Host to serve on', 'localhost')
+  .action(async (port: string, logFile: string, host: string) => {
     redirectStdoutToFile(logFile);
 
     process.on('error', (error): void => {
@@ -56,5 +57,5 @@ export const serverHarness = new Command('__server-harness')
       projectRoot: await findProjectRoot(),
       manageHealth: true,
     });
-    await startServer(manager, portNum);
+    await startServer(manager, portNum, { host });
   });

--- a/genkit-tools/cli/src/commands/start.ts
+++ b/genkit-tools/cli/src/commands/start.ts
@@ -26,6 +26,7 @@ import {
   startDevProcessManager,
   startManager,
 } from '../utils/manager-utils';
+import { httpUrl } from '../utils/url';
 
 interface RunOptions {
   noui?: boolean;
@@ -129,7 +130,7 @@ export const start = new Command('start')
       }
       startServer(manager, port, { host });
       if (options.open) {
-        open(`http://${host}:${port}`);
+        open(httpUrl(host, port));
       }
     }
     await processPromise;

--- a/genkit-tools/cli/src/commands/start.ts
+++ b/genkit-tools/cli/src/commands/start.ts
@@ -30,6 +30,7 @@ import {
 interface RunOptions {
   noui?: boolean;
   port?: string;
+  host?: string;
   open?: boolean;
   disableRealtimeTelemetry?: boolean;
   corsOrigin?: string;
@@ -42,6 +43,7 @@ export const start = new Command('start')
   .description('runs a command in Genkit dev mode')
   .option('-n, --noui', 'do not start the Dev UI', false)
   .option('-p, --port <port>', 'port for the Dev UI')
+  .option('--host <host>', 'host for the Dev UI', 'localhost')
   .option('-o, --open', 'Open the browser on UI start up')
   .option(
     '--disable-realtime-telemetry',
@@ -115,6 +117,7 @@ export const start = new Command('start')
     }
     if (!options.noui) {
       let port: number;
+      const host = options.host ?? 'localhost';
       if (options.port) {
         port = Number(options.port);
         if (isNaN(port) || port < 0) {
@@ -124,9 +127,9 @@ export const start = new Command('start')
       } else {
         port = await getPort({ port: makeRange(4000, 4099) });
       }
-      startServer(manager, port);
+      startServer(manager, port, { host });
       if (options.open) {
-        open(`http://localhost:${port}`);
+        open(`http://${host}:${port}`);
       }
     }
     await processPromise;

--- a/genkit-tools/cli/src/commands/ui-start.ts
+++ b/genkit-tools/cli/src/commands/ui-start.ts
@@ -39,6 +39,7 @@ import {
 
 interface StartOptions {
   port?: string;
+  host?: string;
   open?: boolean;
 }
 
@@ -48,6 +49,7 @@ export const uiStart = new Command('ui:start')
     'start the Developer UI which connects to runtimes in the same directory'
   )
   .option('-p, --port <number>', 'Port to serve on (defaults to 4000)')
+  .option('--host <host>', 'Host to serve on', 'localhost')
   .option('-o, --open', 'Open the browser on UI start up')
   .action(async (options: StartOptions) => {
     let port: number;
@@ -60,6 +62,8 @@ export const uiStart = new Command('ui:start')
     } else {
       port = await getPort({ port: makeRange(4000, 4099) });
     }
+    const host = options.host ?? 'localhost';
+    const url = `http://${host}:${port}`;
     const serversDir = await findServersDir(await findProjectRoot());
     const toolsJsonPath = path.join(serversDir, 'tools.json');
     try {
@@ -86,7 +90,7 @@ export const uiStart = new Command('ui:start')
     }
     logger.info('Starting...');
     try {
-      await startAndWaitUntilHealthy(port, serversDir);
+      await startAndWaitUntilHealthy(port, host, serversDir);
     } catch (error) {
       logger.error(`Failed to start Genkit Developer UI: ${error}`);
       return;
@@ -97,7 +101,7 @@ export const uiStart = new Command('ui:start')
         toolsJsonPath,
         JSON.stringify(
           {
-            url: `http://localhost:${port}`,
+            url,
             timestamp: new Date().toISOString(),
           },
           null,
@@ -110,18 +114,18 @@ export const uiStart = new Command('ui:start')
       );
     }
     logger.info(
-      `\n  ${clc.green(`Genkit Developer UI started at: http://localhost:${port}`)}`
+      `\n  ${clc.green(`Genkit Developer UI started at: ${url}`)}`
     );
     logger.info(`  To stop the UI, run \`genkit ui:stop\`.\n`);
     try {
-      await axios.get(`http://localhost:${port}/api/trpc/listActions`);
+      await axios.get(`${url}/api/trpc/listActions`);
     } catch (error) {
       logger.info(
         'Set env variable `GENKIT_ENV` to `dev` and start your app code to interact with it in the UI.'
       );
     }
     if (options.open) {
-      open(`http://localhost:${port}`);
+      open(url);
     }
   });
 
@@ -130,6 +134,7 @@ export const uiStart = new Command('ui:start')
  */
 async function startAndWaitUntilHealthy(
   port: number,
+  host: string,
   serversDir: string
 ): Promise<ChildProcess> {
   // Detect runtime environment
@@ -143,7 +148,10 @@ async function startAndWaitUntilHealthy(
 
   // Build spawn configuration
   const logPath = path.join(serversDir, 'devui.log');
-  const spawnConfig = buildServerHarnessSpawnConfig(cliRuntime, port, logPath);
+  const spawnConfig =
+    host === 'localhost'
+      ? buildServerHarnessSpawnConfig(cliRuntime, port, logPath)
+      : buildServerHarnessSpawnConfig(cliRuntime, port, logPath, host);
 
   // Validate executable path
   const isExecutable = await validateExecutablePath(spawnConfig.command);
@@ -182,7 +190,7 @@ async function startAndWaitUntilHealthy(
     });
 
     // Wait for the UI to become healthy
-    waitUntilHealthy(`http://localhost:${port}`, 10000 /* 10 seconds */)
+    waitUntilHealthy(`http://${host}:${port}`, 10000 /* 10 seconds */)
       .then((isHealthy) => {
         if (isHealthy) {
           child.unref();

--- a/genkit-tools/cli/src/commands/ui-start.ts
+++ b/genkit-tools/cli/src/commands/ui-start.ts
@@ -149,10 +149,12 @@ async function startAndWaitUntilHealthy(
 
   // Build spawn configuration
   const logPath = path.join(serversDir, 'devui.log');
-  const spawnConfig =
-    host === 'localhost'
-      ? buildServerHarnessSpawnConfig(cliRuntime, port, logPath)
-      : buildServerHarnessSpawnConfig(cliRuntime, port, logPath, host);
+  const spawnConfig = buildServerHarnessSpawnConfig(
+    cliRuntime,
+    port,
+    logPath,
+    host
+  );
 
   // Validate executable path
   const isExecutable = await validateExecutablePath(spawnConfig.command);

--- a/genkit-tools/cli/src/commands/ui-start.ts
+++ b/genkit-tools/cli/src/commands/ui-start.ts
@@ -36,6 +36,7 @@ import {
   buildServerHarnessSpawnConfig,
   validateExecutablePath,
 } from '../utils/spawn-config';
+import { httpUrl } from '../utils/url';
 
 interface StartOptions {
   port?: string;
@@ -63,7 +64,7 @@ export const uiStart = new Command('ui:start')
       port = await getPort({ port: makeRange(4000, 4099) });
     }
     const host = options.host ?? 'localhost';
-    const url = `http://${host}:${port}`;
+    const url = httpUrl(host, port);
     const serversDir = await findServersDir(await findProjectRoot());
     const toolsJsonPath = path.join(serversDir, 'tools.json');
     try {
@@ -190,7 +191,7 @@ async function startAndWaitUntilHealthy(
     });
 
     // Wait for the UI to become healthy
-    waitUntilHealthy(`http://${host}:${port}`, 10000 /* 10 seconds */)
+    waitUntilHealthy(httpUrl(host, port), 10000 /* 10 seconds */)
       .then((isHealthy) => {
         if (isHealthy) {
           child.unref();

--- a/genkit-tools/cli/src/utils/spawn-config.ts
+++ b/genkit-tools/cli/src/utils/spawn-config.ts
@@ -76,7 +76,8 @@ function isValidPort(port: number): boolean {
 export function buildServerHarnessSpawnConfig(
   cliRuntime: CLIRuntimeInfo,
   port: number,
-  logPath: string
+  logPath: string,
+  host: string = 'localhost'
 ): SpawnConfig {
   // Validate inputs
   if (!cliRuntime) {
@@ -93,23 +94,26 @@ export function buildServerHarnessSpawnConfig(
   if (!logPath) {
     throw new Error('Log path is required');
   }
+  if (!host) {
+    throw new Error('Host is required');
+  }
 
   let command = cliRuntime.execPath;
   let args: string[];
 
+  const harnessArgs = [SERVER_HARNESS_COMMAND, port.toString(), logPath];
+  if (host !== 'localhost') {
+    harnessArgs.push(host);
+  }
+
   if (cliRuntime.type === 'compiled-binary') {
     // For compiled binaries, execute directly with arguments
-    args = [SERVER_HARNESS_COMMAND, port.toString(), logPath];
+    args = harnessArgs;
   } else {
     // For interpreted runtimes (Node.js, Bun), include script path if available
     args = cliRuntime.scriptPath
-      ? [
-          cliRuntime.scriptPath,
-          SERVER_HARNESS_COMMAND,
-          port.toString(),
-          logPath,
-        ]
-      : [SERVER_HARNESS_COMMAND, port.toString(), logPath];
+      ? [cliRuntime.scriptPath, ...harnessArgs]
+      : harnessArgs;
   }
 
   // Build spawn options with platform-specific settings

--- a/genkit-tools/cli/src/utils/url.ts
+++ b/genkit-tools/cli/src/utils/url.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function formatHostForUrl(host: string): string {
+  if (host.includes(':') && !host.startsWith('[')) {
+    return `[${host}]`;
+  }
+  return host;
+}
+
+export function httpUrl(host: string, port: number): string {
+  return `http://${formatHostForUrl(host)}:${port}`;
+}

--- a/genkit-tools/cli/src/utils/url.ts
+++ b/genkit-tools/cli/src/utils/url.ts
@@ -15,6 +15,9 @@
  */
 
 export function formatHostForUrl(host: string): string {
+  if (host === '0.0.0.0' || host === '::') {
+    return 'localhost';
+  }
   if (host.includes(':') && !host.startsWith('[')) {
     return `[${host}]`;
   }

--- a/genkit-tools/cli/tests/commands/start_test.ts
+++ b/genkit-tools/cli/tests/commands/start_test.ts
@@ -23,6 +23,7 @@ import {
   it,
   jest,
 } from '@jest/globals';
+import open from 'open';
 import { start } from '../../src/commands/start';
 import * as managerUtils from '../../src/utils/manager-utils';
 
@@ -40,6 +41,8 @@ jest.mock('get-port', () => ({
   makeRange: jest.fn(),
 }));
 jest.mock('open');
+
+const mockedOpen = open as jest.MockedFunction<typeof open>;
 
 describe('start command', () => {
   let startDevProcessManagerSpy: any;
@@ -165,5 +168,24 @@ describe('start command', () => {
     expect(startServerSpy).toHaveBeenCalledWith(expect.anything(), 4040, {
       host: '127.0.0.1',
     });
+  });
+
+  it('should format IPv6 hosts when opening the Dev UI', async () => {
+    await start.parseAsync([
+      'node',
+      'genkit',
+      '--host',
+      '::1',
+      '--port',
+      '4040',
+      '--open',
+      'run',
+      'app',
+    ]);
+
+    expect(startServerSpy).toHaveBeenCalledWith(expect.anything(), 4040, {
+      host: '::1',
+    });
+    expect(mockedOpen).toHaveBeenCalledWith('http://[::1]:4040');
   });
 });

--- a/genkit-tools/cli/tests/commands/start_test.ts
+++ b/genkit-tools/cli/tests/commands/start_test.ts
@@ -65,6 +65,10 @@ describe('start command', () => {
 
     // Reset args
     start.args = [];
+    start.setOptionValue('host', undefined);
+    start.setOptionValue('port', undefined);
+    start.setOptionValue('noui', undefined);
+    start.setOptionValue('open', undefined);
   });
 
   afterEach(() => {
@@ -144,5 +148,22 @@ describe('start command', () => {
       expect.anything(),
       expect.objectContaining({ disableRealtimeTelemetry: true })
     );
+  });
+
+  it('should pass host option to the Dev UI server', async () => {
+    await start.parseAsync([
+      'node',
+      'genkit',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      '4040',
+      'run',
+      'app',
+    ]);
+
+    expect(startServerSpy).toHaveBeenCalledWith(expect.anything(), 4040, {
+      host: '127.0.0.1',
+    });
   });
 });

--- a/genkit-tools/cli/tests/commands/ui-start_test.ts
+++ b/genkit-tools/cli/tests/commands/ui-start_test.ts
@@ -153,6 +153,9 @@ describe('ui:start', () => {
     mockedSpawn.mockReturnValue(mockChildProcess as any);
     mockedWaitUntilHealthy.mockResolvedValue(true);
     mockedClc.green.mockImplementation((text) => `GREEN:${text}`);
+    uiStart.setOptionValue('host', undefined);
+    uiStart.setOptionValue('port', undefined);
+    uiStart.setOptionValue('open', undefined);
   });
 
   describe('port validation', () => {
@@ -333,6 +336,32 @@ describe('ui:start', () => {
       const actualPort = spawnConfigCall[1];
 
       expect(mockedOpen).toHaveBeenCalledWith(`http://localhost:${actualPort}`);
+    });
+
+    it('should pass custom host to the server harness', async () => {
+      await createCommand().parseAsync([
+        'node',
+        'ui:start',
+        '--port',
+        '8080',
+        '--host',
+        '127.0.0.1',
+      ]);
+
+      expect(mockedBuildServerHarnessSpawnConfig).toHaveBeenCalledWith(
+        mockCLIRuntime,
+        8080,
+        mockLogPath,
+        '127.0.0.1'
+      );
+      expect(mockedWaitUntilHealthy).toHaveBeenCalledWith(
+        'http://127.0.0.1:8080',
+        10000
+      );
+      expect(mockedFs.writeFile).toHaveBeenCalledWith(
+        mockToolsJsonPath,
+        expect.stringContaining('"url": "http://127.0.0.1:8080"')
+      );
     });
 
     it('should handle server startup failure', async () => {
@@ -569,7 +598,7 @@ describe('ui:start', () => {
       // The debug message should contain the spawn command and args
       expect(mockedLogger.debug).toHaveBeenCalledWith(
         expect.stringMatching(
-          /^Spawning: \/usr\/bin\/node \/usr\/lib\/node_modules\/genkit-cli\/dist\/bin\/genkit\.js server-harness \d+ \/mock\/project\/root\/\.genkit\/servers\/devui\.log$/
+          /^Spawning: \/usr\/bin\/node \/usr\/lib\/node_modules\/genkit-cli\/dist\/bin\/genkit\.js server-harness \d+ .*devui\.log$/
         )
       );
     });

--- a/genkit-tools/cli/tests/commands/ui-start_test.ts
+++ b/genkit-tools/cli/tests/commands/ui-start_test.ts
@@ -201,7 +201,8 @@ describe('ui:start', () => {
       expect(mockedBuildServerHarnessSpawnConfig).toHaveBeenCalledWith(
         mockCLIRuntime,
         0,
-        mockLogPath
+        mockLogPath,
+        'localhost'
       );
     });
 
@@ -296,7 +297,8 @@ describe('ui:start', () => {
       expect(mockedBuildServerHarnessSpawnConfig).toHaveBeenCalledWith(
         mockCLIRuntime,
         actualPort,
-        mockLogPath
+        mockLogPath,
+        'localhost'
       );
       expect(mockedValidateExecutablePath).toHaveBeenCalledWith(
         mockSpawnConfig.command
@@ -492,7 +494,8 @@ describe('ui:start', () => {
       expect(mockedBuildServerHarnessSpawnConfig).toHaveBeenCalledWith(
         bunRuntime,
         actualPort,
-        mockLogPath
+        mockLogPath,
+        'localhost'
       );
     });
 
@@ -520,7 +523,8 @@ describe('ui:start', () => {
       expect(mockedBuildServerHarnessSpawnConfig).toHaveBeenCalledWith(
         binaryRuntime,
         actualPort,
-        mockLogPath
+        mockLogPath,
+        'localhost'
       );
     });
   });

--- a/genkit-tools/cli/tests/commands/ui-start_test.ts
+++ b/genkit-tools/cli/tests/commands/ui-start_test.ts
@@ -338,29 +338,29 @@ describe('ui:start', () => {
       expect(mockedOpen).toHaveBeenCalledWith(`http://localhost:${actualPort}`);
     });
 
-    it('should pass custom host to the server harness', async () => {
+    it('should pass custom IPv6 host to the server harness and format URLs', async () => {
       await createCommand().parseAsync([
         'node',
         'ui:start',
         '--port',
         '8080',
         '--host',
-        '127.0.0.1',
+        '::1',
       ]);
 
       expect(mockedBuildServerHarnessSpawnConfig).toHaveBeenCalledWith(
         mockCLIRuntime,
         8080,
         mockLogPath,
-        '127.0.0.1'
+        '::1'
       );
       expect(mockedWaitUntilHealthy).toHaveBeenCalledWith(
-        'http://127.0.0.1:8080',
+        'http://[::1]:8080',
         10000
       );
       expect(mockedFs.writeFile).toHaveBeenCalledWith(
         mockToolsJsonPath,
-        expect.stringContaining('"url": "http://127.0.0.1:8080"')
+        expect.stringContaining('"url": "http://[::1]:8080"')
       );
     });
 

--- a/genkit-tools/cli/tests/utils/spawn-config_test.ts
+++ b/genkit-tools/cli/tests/utils/spawn-config_test.ts
@@ -274,6 +274,31 @@ describe('spawn-config', () => {
         expect(config.args).toContain('8080');
       });
 
+      it('should pass custom hosts to the server harness', () => {
+        const cliRuntime: CLIRuntimeInfo = {
+          type: 'node',
+          execPath: '/usr/bin/node',
+          scriptPath: '/script.js',
+          isCompiledBinary: false,
+          platform: 'linux',
+        };
+
+        const config = buildServerHarnessSpawnConfig(
+          cliRuntime,
+          mockPort,
+          mockLogPath,
+          '127.0.0.1'
+        );
+
+        expect(config.args).toEqual([
+          '/script.js',
+          SERVER_HARNESS_COMMAND,
+          '4000',
+          '/path/to/devui.log',
+          '127.0.0.1',
+        ]);
+      });
+
       it('should handle paths with spaces', () => {
         const cliRuntime: CLIRuntimeInfo = {
           type: 'node',

--- a/genkit-tools/cli/tests/utils/url_test.ts
+++ b/genkit-tools/cli/tests/utils/url_test.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import { formatHostForUrl, httpUrl } from '../../src/utils/url';
+
+describe('url utils', () => {
+  it('formats IPv6 hosts for URLs', () => {
+    expect(formatHostForUrl('::1')).toBe('[::1]');
+    expect(httpUrl('::1', 4000)).toBe('http://[::1]:4000');
+  });
+
+  it('maps wildcard bind hosts to localhost URLs', () => {
+    expect(formatHostForUrl('0.0.0.0')).toBe('localhost');
+    expect(formatHostForUrl('::')).toBe('localhost');
+    expect(httpUrl('0.0.0.0', 4000)).toBe('http://localhost:4000');
+    expect(httpUrl('::', 4000)).toBe('http://localhost:4000');
+  });
+});

--- a/genkit-tools/common/src/manager/manager-v2.ts
+++ b/genkit-tools/common/src/manager/manager-v2.ts
@@ -51,6 +51,10 @@ import {
 
 const DEFAULT_REFLECTION_HOST = 'localhost';
 
+function getReflectionHost(): string {
+  return process.env.GENKIT_REFLECTION_HOST || DEFAULT_REFLECTION_HOST;
+}
+
 interface JsonRpcRequest {
   jsonrpc: '2.0';
   method: string;
@@ -135,7 +139,8 @@ export class RuntimeManagerV2 extends BaseRuntimeManager {
     if (!port) {
       port = await getPort({ port: makeRange(3200, 3400) });
     }
-    this.wss = new WebSocketServer({ port, host: DEFAULT_REFLECTION_HOST });
+    const host = getReflectionHost();
+    this.wss = new WebSocketServer({ port, host });
 
     this._port = port;
     logger.info(`Starting reflection server: ws://localhost:${port}`);

--- a/genkit-tools/common/src/manager/manager-v2.ts
+++ b/genkit-tools/common/src/manager/manager-v2.ts
@@ -49,6 +49,8 @@ import {
   StreamingCallback,
 } from './types';
 
+const DEFAULT_REFLECTION_HOST = 'localhost';
+
 interface JsonRpcRequest {
   jsonrpc: '2.0';
   method: string;
@@ -133,7 +135,7 @@ export class RuntimeManagerV2 extends BaseRuntimeManager {
     if (!port) {
       port = await getPort({ port: makeRange(3200, 3400) });
     }
-    this.wss = new WebSocketServer({ port });
+    this.wss = new WebSocketServer({ port, host: DEFAULT_REFLECTION_HOST });
 
     this._port = port;
     logger.info(`Starting reflection server: ws://localhost:${port}`);

--- a/genkit-tools/common/src/server/router.ts
+++ b/genkit-tools/common/src/server/router.ts
@@ -82,6 +82,17 @@ const analyticsEventForRoute = (
   return event;
 };
 
+const REDACTED_ENV_VALUE = '[redacted]';
+const SENSITIVE_ENV_NAME_PATTERN =
+  /(api_?key|token|secret|password|passwd|pwd|credential|auth|cookie|session|private|cert)/i;
+
+const sanitizeEnvValue = (name: string, value: string | undefined): string => {
+  if (!value) {
+    return '';
+  }
+  return SENSITIVE_ENV_NAME_PATTERN.test(name) ? REDACTED_ENV_VALUE : value;
+};
+
 const parseEnv = (environ: NodeJS.ProcessEnv): EnvironmentVariable[] => {
   const environmentVars: EnvironmentVariable[] = [];
 
@@ -97,7 +108,7 @@ const parseEnv = (environ: NodeJS.ProcessEnv): EnvironmentVariable[] => {
       return 0;
     })
     .forEach(([name, value]) => {
-      environmentVars.push({ name, value: value || '' });
+      environmentVars.push({ name, value: sanitizeEnvValue(name, value) });
     });
 
   return environmentVars;

--- a/genkit-tools/common/src/server/router.ts
+++ b/genkit-tools/common/src/server/router.ts
@@ -84,7 +84,7 @@ const analyticsEventForRoute = (
 
 const REDACTED_ENV_VALUE = '[redacted]';
 const SENSITIVE_ENV_NAME_PATTERN =
-  /(api_?key|token|secret|password|passwd|pwd|credential|auth|cookie|session|private|cert)/i;
+  /(api_?key|token|secret|password|passwd|pwd|credentials?|auth|cookie|session|private|cert|dsn|database|db_?(url|uri|dsn|conn(?:ection)?_?string)|conn(?:ection)?_?string)/i;
 
 const sanitizeEnvValue = (name: string, value: string | undefined): string => {
   if (!value) {

--- a/genkit-tools/common/src/server/server.ts
+++ b/genkit-tools/common/src/server/server.ts
@@ -49,6 +49,9 @@ export interface StartServerOptions {
 }
 
 function formatHostForUrl(host: string): string {
+  if (host === '0.0.0.0' || host === '::') {
+    return 'localhost';
+  }
   return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
 }
 

--- a/genkit-tools/common/src/server/server.ts
+++ b/genkit-tools/common/src/server/server.ts
@@ -42,6 +42,15 @@ const UI_ASSETS_ROOT = path.resolve(
 );
 const UI_ASSETS_SERVE_PATH = path.resolve(UI_ASSETS_ROOT, 'ui', 'browser');
 const API_BASE_PATH = '/api';
+export const DEFAULT_SERVER_HOST = 'localhost';
+
+export interface StartServerOptions {
+  host?: string;
+}
+
+function formatHostForUrl(host: string): string {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
 
 class PushableAsyncIterable<T> implements AsyncIterable<T> {
   private queue: T[] = [];
@@ -86,9 +95,14 @@ const activeInputStreams = new Map<string, PushableAsyncIterable<any>>();
 /**
  * Starts up the Genkit Tools server which includes static files for the UI and the Tools API.
  */
-export function startServer(manager: BaseRuntimeManager, port: number) {
+export function startServer(
+  manager: BaseRuntimeManager,
+  port: number,
+  options: StartServerOptions = {}
+) {
   let server: Server;
   const app = express();
+  const host = options.host ?? DEFAULT_SERVER_HOST;
 
   app.use(
     cors({
@@ -320,8 +334,8 @@ export function startServer(manager: BaseRuntimeManager, port: number) {
   };
   app.use(errorHandler);
 
-  server = app.listen(port, async () => {
-    const uiUrl = 'http://localhost:' + port;
+  server = app.listen(port, host, async () => {
+    const uiUrl = `http://${formatHostForUrl(host)}:${port}`;
     const projectRoot = manager.projectRoot;
     logger.info(`${clc.green(clc.bold('Project root:'))} ${projectRoot}`);
     logger.info(`${clc.green(clc.bold('Genkit Developer UI:'))} ${uiUrl}`);

--- a/genkit-tools/common/tests/server_test.ts
+++ b/genkit-tools/common/tests/server_test.ts
@@ -88,6 +88,11 @@ describe('Tools Server', () => {
 
   it('should redact sensitive environment variable values', async () => {
     process.env.GENKIT_TEST_API_KEY = 'test-secret-value';
+    process.env.GENKIT_TEST_DATABASE_URL = 'postgres://user:pass@host/db';
+    process.env.GENKIT_TEST_SENTRY_DSN = 'https://key@sentry.example/1';
+    process.env.GENKIT_TEST_CONNECTION_STRING =
+      'Server=host;User Id=user;Password=pass';
+    process.env.GENKIT_TEST_CONNECT_TIMEOUT = '30';
     process.env.GENKIT_TEST_PUBLIC_VALUE = 'test-public-value';
 
     try {
@@ -104,6 +109,36 @@ describe('Tools Server', () => {
       });
       expect(
         environmentVars.find(
+          (env: any) => env.name === 'GENKIT_TEST_DATABASE_URL'
+        )
+      ).toEqual({
+        name: 'GENKIT_TEST_DATABASE_URL',
+        value: '[redacted]',
+      });
+      expect(
+        environmentVars.find((env: any) => env.name === 'GENKIT_TEST_SENTRY_DSN')
+      ).toEqual({
+        name: 'GENKIT_TEST_SENTRY_DSN',
+        value: '[redacted]',
+      });
+      expect(
+        environmentVars.find(
+          (env: any) => env.name === 'GENKIT_TEST_CONNECTION_STRING'
+        )
+      ).toEqual({
+        name: 'GENKIT_TEST_CONNECTION_STRING',
+        value: '[redacted]',
+      });
+      expect(
+        environmentVars.find(
+          (env: any) => env.name === 'GENKIT_TEST_CONNECT_TIMEOUT'
+        )
+      ).toEqual({
+        name: 'GENKIT_TEST_CONNECT_TIMEOUT',
+        value: '30',
+      });
+      expect(
+        environmentVars.find(
           (env: any) => env.name === 'GENKIT_TEST_PUBLIC_VALUE'
         )
       ).toEqual({
@@ -112,6 +147,10 @@ describe('Tools Server', () => {
       });
     } finally {
       delete process.env.GENKIT_TEST_API_KEY;
+      delete process.env.GENKIT_TEST_DATABASE_URL;
+      delete process.env.GENKIT_TEST_SENTRY_DSN;
+      delete process.env.GENKIT_TEST_CONNECTION_STRING;
+      delete process.env.GENKIT_TEST_CONNECT_TIMEOUT;
       delete process.env.GENKIT_TEST_PUBLIC_VALUE;
     }
   });

--- a/genkit-tools/common/tests/server_test.ts
+++ b/genkit-tools/common/tests/server_test.ts
@@ -86,6 +86,36 @@ describe('Tools Server', () => {
     );
   });
 
+  it('should redact sensitive environment variable values', async () => {
+    process.env.GENKIT_TEST_API_KEY = 'test-secret-value';
+    process.env.GENKIT_TEST_PUBLIC_VALUE = 'test-public-value';
+
+    try {
+      const response = await axios.get(
+        `http://localhost:${port}/api/getGenkitEnvironment`
+      );
+      const environmentVars = response.data.result.data.environmentVars;
+
+      expect(
+        environmentVars.find((env: any) => env.name === 'GENKIT_TEST_API_KEY')
+      ).toEqual({
+        name: 'GENKIT_TEST_API_KEY',
+        value: '[redacted]',
+      });
+      expect(
+        environmentVars.find(
+          (env: any) => env.name === 'GENKIT_TEST_PUBLIC_VALUE'
+        )
+      ).toEqual({
+        name: 'GENKIT_TEST_PUBLIC_VALUE',
+        value: 'test-public-value',
+      });
+    } finally {
+      delete process.env.GENKIT_TEST_API_KEY;
+      delete process.env.GENKIT_TEST_PUBLIC_VALUE;
+    }
+  });
+
   it('should handle bidi streaming', async () => {
     let inputStream: AsyncIterable<any> | undefined;
     let finishAction: (() => void) | undefined;

--- a/genkit-tools/telemetry-server/src/index.ts
+++ b/genkit-tools/telemetry-server/src/index.ts
@@ -37,6 +37,9 @@ const broadcastManager = new BroadcastManager();
 const DEFAULT_TELEMETRY_HOST = 'localhost';
 
 function formatHostForUrl(host: string): string {
+  if (host === '0.0.0.0' || host === '::') {
+    return 'localhost';
+  }
   return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
 }
 

--- a/genkit-tools/telemetry-server/src/index.ts
+++ b/genkit-tools/telemetry-server/src/index.ts
@@ -34,6 +34,11 @@ export { TraceQuerySchema, type TraceQuery, type TraceStore } from './types';
 
 let server: http.Server;
 const broadcastManager = new BroadcastManager();
+const DEFAULT_TELEMETRY_HOST = 'localhost';
+
+function formatHostForUrl(host: string): string {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
 
 /**
  * Starts the telemetry server with the provided params
@@ -51,9 +56,11 @@ export async function startTelemetryServer(params: {
    */
   maxRequestBodySize?: string | number;
   corsOrigin?: string | RegExp;
+  host?: string;
 }) {
   await params.traceStore.init();
   await params.logStore.init();
+  const host = params.host ?? DEFAULT_TELEMETRY_HOST;
 
   const api = express();
   // Allow all origins and expose trace ID header
@@ -312,8 +319,10 @@ export async function startTelemetryServer(params: {
     res.status(500).json(errorResponse);
   });
 
-  server = api.listen(params.port, () => {
-    logger.info(`Telemetry API running on http://localhost:${params.port}`);
+  server = api.listen(params.port, host, () => {
+    logger.info(
+      `Telemetry API running on http://${formatHostForUrl(host)}:${params.port}`
+    );
   });
 
   server.on('error', (error) => {


### PR DESCRIPTION
Hardens local Genkit developer tooling by binding the Dev UI, telemetry server, and experimental reflection WebSocket server to localhost by default.

Adds a --host option for callers who intentionally need another Dev UI bind address, and redacts sensitive-looking entries returned by /api/getGenkitEnvironment.

Verification:
- pnpm -C genkit-tools\common test -- server_test
- pnpm -C genkit-tools\cli test -- start_test ui-start_test spawn-config_test
- pnpm -C genkit-tools\common build
- pnpm -C genkit-tools\telemetry-server build
- pnpm -C genkit-tools\cli build