### PR TITLE
feat(js/testing): mockModel + echoModel for genkit/testing

### DIFF
--- a/js/ai/src/testing/index.ts
+++ b/js/ai/src/testing/index.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-export { testModels } from './model-tester.js';
 export {
   echoModel,
   mockModel,
@@ -23,6 +22,7 @@ export {
   type MockContext,
   type MockModel,
   type MockModelOptions,
-  type MockResponse,
   type MockRespondFn,
+  type MockResponse,
 } from './mock-model.js';
+export { testModels } from './model-tester.js';

--- a/js/ai/src/testing/index.ts
+++ b/js/ai/src/testing/index.ts
@@ -24,4 +24,5 @@ export {
   type MockModel,
   type MockModelOptions,
   type MockResponse,
+  type MockRespondFn,
 } from './mock-model.js';

--- a/js/ai/src/testing/index.ts
+++ b/js/ai/src/testing/index.ts
@@ -22,6 +22,7 @@ export {
   type MockContext,
   type MockModel,
   type MockModelOptions,
+  type MockRespond,
   type MockRespondFn,
   type MockResponse,
 } from './mock-model.js';

--- a/js/ai/src/testing/mock-model.ts
+++ b/js/ai/src/testing/mock-model.ts
@@ -1,0 +1,258 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { HasRegistry, Registry } from '@genkit-ai/core/registry';
+import { Message } from '../message.js';
+import {
+  defineModel,
+  type GenerateRequest,
+  type GenerateResponseChunkData,
+  type GenerateResponseData,
+  type ModelAction,
+  type ModelInfo,
+  type Part,
+} from '../model.js';
+
+/**
+ * A streamed chunk a mock model may emit. A bare string is shorthand for a
+ * single text part (`{ content: [{ text }] }`).
+ */
+export type MockChunk = string | GenerateResponseChunkData;
+
+/** Context passed to a {@link MockModelOptions.respond} callback. */
+export interface MockContext {
+  /**
+   * Emit a streamed chunk. A no-op unless the caller used `generateStream` /
+   * `{ onChunk }`. A string is shorthand for a text part.
+   */
+  sendChunk: (chunk: MockChunk) => void;
+}
+
+/**
+ * What a {@link MockModelOptions.respond} callback may return. From lightest to
+ * fullest control:
+ * - a `string` — shorthand for a single text response;
+ * - an object with any of `text` / `toolRequests` / `content` — the common
+ *   cases, assembled into a well-formed response for you;
+ * - a full {@link GenerateResponseData} (anything with a `message`) — used as-is.
+ */
+export interface MockResponseObject {
+  /** Text content of the model message. */
+  text?: string;
+  /** Tool/function calls to emit, by tool name. */
+  toolRequests?: Array<{ name: string; input?: unknown; ref?: string }>;
+  /** Escape hatch: raw message parts, prepended before `text`/`toolRequests`. */
+  content?: Part[];
+  finishReason?: GenerateResponseData['finishReason'];
+  usage?: GenerateResponseData['usage'];
+}
+
+export type MockResponse = string | MockResponseObject | GenerateResponseData;
+
+/** Options for {@link mockModel}. */
+export interface MockModelOptions {
+  /** Registered model name. Defaults to `'mockModel'`. */
+  name?: string;
+  /** Model metadata (e.g. `supports`, `versions`). */
+  info?: ModelInfo;
+  /**
+   * Called once per `generate` call. Return the response to give back. Receives
+   * the resolved request and a {@link MockContext} for streaming. Defaults to
+   * returning empty text.
+   */
+  respond?: (
+    request: GenerateRequest,
+    context: MockContext
+  ) => MockResponse | Promise<MockResponse>;
+}
+
+/**
+ * A mock model with typed inspection of the calls it received. The extra
+ * members are read-only views over the recorded calls.
+ */
+export type MockModel = ModelAction & {
+  /** The request from the most recent call, or `undefined` if never called. */
+  readonly lastRequest: GenerateRequest | undefined;
+  /**
+   * The final message of the most recent request, wrapped as a {@link Message}
+   * so you can read it the same way you read a response — `.text`, `.media`,
+   * `.toolRequests`, etc. `undefined` if the model was never called.
+   *
+   * ```ts
+   * assert.match(model.lastMessage!.text, /Summarize: long text/);
+   * ```
+   */
+  readonly lastMessage: Message | undefined;
+  /** Every request this model received, oldest first. */
+  readonly requests: GenerateRequest[];
+  /** How many times this model was called. */
+  readonly requestCount: number;
+};
+
+function resolveRegistry(registry: Registry | HasRegistry): Registry {
+  return (registry as HasRegistry).registry ?? (registry as Registry);
+}
+
+function toChunkData(chunk: MockChunk): GenerateResponseChunkData {
+  return typeof chunk === 'string' ? { content: [{ text: chunk }] } : chunk;
+}
+
+function toResponseData(response: MockResponse): GenerateResponseData {
+  if (typeof response === 'string') {
+    return {
+      message: { role: 'model', content: [{ text: response }] },
+      finishReason: 'stop',
+    };
+  }
+  if ('message' in response && response.message) {
+    return { finishReason: 'stop', ...(response as GenerateResponseData) };
+  }
+  const obj = response as MockResponseObject;
+  const content: Part[] = [...(obj.content ?? [])];
+  if (obj.text !== undefined) {
+    content.push({ text: obj.text });
+  }
+  for (const tool of obj.toolRequests ?? []) {
+    content.push({
+      toolRequest: { name: tool.name, input: tool.input ?? {}, ref: tool.ref },
+    });
+  }
+  return {
+    message: { role: 'model', content },
+    finishReason: obj.finishReason ?? 'stop',
+    usage: obj.usage,
+  };
+}
+
+/**
+ * Defines a programmable mock model for tests. Drive each call's response with
+ * `respond`, and inspect what the model was called with via `lastRequest` /
+ * `requests` / `requestCount`.
+ *
+ * ```ts
+ * const model = mockModel(ai, { respond: () => ({ text: 'a summary' }) });
+ * const out = (await ai.generate({ model, prompt: 'Summarize: ...' })).text;
+ * assert.match(model.lastRequest!.messages.at(-1)!.content[0].text!, /Summarize/);
+ * ```
+ *
+ * Streaming and tool calls are first-class:
+ *
+ * ```ts
+ * mockModel(ai, {
+ *   respond: (req, { sendChunk }) => {
+ *     sendChunk('hel');
+ *     sendChunk('lo');
+ *     return { text: 'hello' };
+ *   },
+ * });
+ *
+ * mockModel(ai, {
+ *   respond: () => ({ toolRequests: [{ name: 'lookup', input: { id: 1 } }] }),
+ * });
+ * ```
+ *
+ * @param registry a `Genkit` instance (or anything holding a `Registry`).
+ * @param options model name, metadata, and the `respond` callback.
+ */
+export function mockModel(
+  registry: Registry | HasRegistry,
+  options: MockModelOptions = {}
+): MockModel {
+  const requests: GenerateRequest[] = [];
+  const respond = options.respond ?? (() => ({ text: '' }));
+
+  const model = defineModel(
+    resolveRegistry(registry),
+    {
+      apiVersion: 'v2',
+      // info widened to satisfy defineModel's overload resolution, mirroring
+      // the internal helpers in js/ai/tests/helpers.ts.
+      ...((options.info as any) ?? {}),
+      name: options.name ?? 'mockModel',
+    },
+    async (request, { sendChunk }) => {
+      // Snapshot so later mutation of the request can't alter recorded history.
+      requests.push(JSON.parse(JSON.stringify(request)));
+      const context: MockContext = {
+        sendChunk: (chunk) => sendChunk?.(toChunkData(chunk)),
+      };
+      return toResponseData(await respond(request, context));
+    }
+  ) as MockModel;
+
+  Object.defineProperties(model, {
+    requests: { get: () => requests },
+    lastRequest: { get: () => requests[requests.length - 1] },
+    lastMessage: {
+      get: () => {
+        const last = requests[requests.length - 1]?.messages.at(-1);
+        return last ? new Message(last) : undefined;
+      },
+    },
+    requestCount: { get: () => requests.length },
+  });
+  return model;
+}
+
+/** Options for {@link echoModel}. */
+export interface EchoModelOptions {
+  /** Registered model name. Defaults to `'echoModel'`. */
+  name?: string;
+  /** Model metadata. */
+  info?: ModelInfo;
+}
+
+/**
+ * Defines a zero-config mock model that echoes the rendered request back as
+ * text — useful for asserting prompt and message assembly (what the model
+ * *would have seen*). Supports the same inspection members as {@link mockModel}.
+ *
+ * ```ts
+ * const model = echoModel(ai);
+ * const res = await ai.generate({ model, system: 'Be terse', prompt: 'hi' });
+ * assert.match(res.text, /system: Be terse/);
+ * ```
+ *
+ * @param registry a `Genkit` instance (or anything holding a `Registry`).
+ * @param options model name and metadata.
+ */
+export function echoModel(
+  registry: Registry | HasRegistry,
+  options: EchoModelOptions = {}
+): MockModel {
+  return mockModel(registry, {
+    name: options.name ?? 'echoModel',
+    info: options.info,
+    respond: (request) => ({
+      content: [
+        {
+          text:
+            'Echo: ' +
+            request.messages
+              .map(
+                (m) =>
+                  (m.role === 'user' || m.role === 'model'
+                    ? ''
+                    : `${m.role}: `) +
+                  m.content.map((c) => c.text ?? '').join('')
+              )
+              .join(''),
+        },
+        { text: '; config: ' + JSON.stringify(request.config) },
+      ],
+    }),
+  });
+}

--- a/js/ai/src/testing/mock-model.ts
+++ b/js/ai/src/testing/mock-model.ts
@@ -72,7 +72,16 @@ export type MockRespondFn = (
 export interface MockModelOptions {
   /** Registered model name. Defaults to `'mockModel'`. */
   name?: string;
-  /** Model metadata (e.g. `supports`, `versions`). */
+  /**
+   * Model metadata (e.g. `supports`, `versions`).
+   *
+   * `supports.constrained` defaults to `'all'` (native constrained generation),
+   * so a `generate` with an `output.schema` reaches `respond` with that schema
+   * on `request.output.schema`. Pass `supports: { constrained: 'none' }` to
+   * instead exercise the framework's simulated path, where the schema is
+   * injected into the prompt (and thus visible in `lastRequestText`) and
+   * stripped from what `respond` sees.
+   */
   info?: ModelInfo;
   /**
    * What to respond with on each `generate` call. Defaults to empty text.
@@ -297,6 +306,11 @@ function toResponseData(response: MockResponse): GenerateResponseData {
  * });
  * ```
  *
+ * For structured output, the mock defaults to native constrained generation
+ * (`supports.constrained: 'all'`), so `respond` sees `request.output.schema`
+ * and no schema blob is injected into the prompt. Override with
+ * `supports: { constrained: 'none' }` to test the simulated path.
+ *
  * @param registry a `Genkit` instance (or anything holding a `Registry`).
  * @param options model name, metadata, and the `respond` callback.
  */
@@ -316,7 +330,12 @@ export function mockModel(
       // `configSchema`/`stage` aren't part of DefineModelOptions.
       versions: options.info?.versions,
       label: options.info?.label,
-      supports: options.info?.supports,
+      // Default to native constrained generation (like modern provider models),
+      // so a structured-output request reaches `respond` with `output.schema`
+      // intact instead of the framework injecting a schema blob into the prompt
+      // and stripping it. Spread last so callers can opt out with
+      // `supports: { constrained: 'none' }` to exercise the simulated path.
+      supports: { constrained: 'all', ...options.info?.supports },
     },
     async (request, { sendChunk }) => {
       // Snapshot so later mutation of the request can't alter recorded history.

--- a/js/ai/src/testing/mock-model.ts
+++ b/js/ai/src/testing/mock-model.ts
@@ -96,6 +96,17 @@ export type MockModel = ModelAction & {
    * ```
    */
   readonly lastRequestMessage: Message | undefined;
+  /**
+   * The full assembled conversation of the most recent request, flattened to a
+   * single string (system + every message, in order). Use it for prompt-
+   * assembly assertions on any mock — including ones returning structured
+   * output, where {@link echoModel} can't be used. `undefined` if never called.
+   *
+   * ```ts
+   * assert.match(model.lastRequestText!, /system: Be terse/);
+   * ```
+   */
+  readonly lastRequestText: string | undefined;
   /** Every request this model received, oldest first. */
   readonly requests: GenerateRequest[];
   /** How many times this model was called. */
@@ -110,9 +121,11 @@ function toChunkData(chunk: MockChunk): GenerateResponseChunkData {
   return typeof chunk === 'string' ? { content: [{ text: chunk }] } : chunk;
 }
 
-/** Renders a single request part to text for {@link echoModel}. Non-text parts
- * (media, tool requests/responses, reasoning, data) are rendered as a labelled
- * placeholder rather than silently dropped. */
+/**
+ * Renders a single request part to text for {@link renderRequestText}. Non-text
+ * parts (media, tool requests/responses, reasoning, resource, data, custom) are
+ * rendered as a labelled placeholder rather than silently dropped.
+ */
 function renderPart(part: Part): string {
   if (part.text !== undefined) return part.text;
   if (part.media) {
@@ -132,6 +145,22 @@ function renderPart(part: Part): string {
   if (part.data !== undefined) return `[data: ${JSON.stringify(part.data)}]`;
   if (part.custom !== undefined) return `[custom: ${JSON.stringify(part.custom)}]`;
   return '';
+}
+
+/**
+ * Flattens a request's full message list to text — system and tool messages are
+ * prefixed with their role; `user`/`model` are not. This is the assembled
+ * conversation the model would have seen, used by both {@link echoModel} and
+ * {@link MockModel.lastRequestText}.
+ */
+function renderRequestText(request: GenerateRequest): string {
+  return request.messages
+    .map(
+      (m) =>
+        (m.role === 'user' || m.role === 'model' ? '' : `${m.role}: `) +
+        m.content.map(renderPart).join('')
+    )
+    .join('');
 }
 
 function toResponseData(response: MockResponse): GenerateResponseData {
@@ -228,6 +257,12 @@ export function mockModel(
         return last ? new Message(last) : undefined;
       },
     },
+    lastRequestText: {
+      get: () => {
+        const last = requests[requests.length - 1];
+        return last ? renderRequestText(last) : undefined;
+      },
+    },
     requestCount: { get: () => requests.length },
   });
   return model;
@@ -242,15 +277,23 @@ export interface EchoModelOptions {
 }
 
 /**
- * Defines a zero-config mock model that echoes the rendered request back as
- * text — useful for asserting prompt and message assembly (what the model
- * *would have seen*). Supports the same inspection members as {@link mockModel}.
+ * A {@link mockModel} preset for *text* paths: a zero-config model that echoes
+ * the rendered request back as text, for asserting prompt and message assembly
+ * (what the model *would have seen*). Supports the same inspection members as
+ * {@link mockModel}.
  *
  * ```ts
  * const model = echoModel(ai);
  * const res = await ai.generate({ model, system: 'Be terse', prompt: 'hi' });
  * assert.match(res.text, /system: Be terse/);
  * ```
+ *
+ * Because it returns text, it can't satisfy a structured **output schema** —
+ * Genkit derives `output` by parsing the response text and validating it, which
+ * prose can't pass. If the request carries an output schema, `echoModel` throws
+ * an explanatory error. For structured-output paths, use {@link mockModel} with
+ * a conforming response and assert assembly via {@link MockModel.lastRequestText}
+ * / {@link MockModel.lastRequest} instead.
  *
  * @param registry a `Genkit` instance (or anything holding a `Registry`).
  * @param options model name and metadata.
@@ -261,23 +304,30 @@ export function echoModel(
 ): MockModel {
   return mockModel(registry, {
     name: options.name ?? 'echoModel',
-    info: options.info,
-    respond: (request) => ({
-      content: [
-        {
-          text:
-            'Echo: ' +
-            request.messages
-              .map(
-                (m) =>
-                  (m.role === 'user' || m.role === 'model'
-                    ? ''
-                    : `${m.role}: `) + m.content.map(renderPart).join('')
-              )
-              .join(''),
-        },
-        { text: '; config: ' + JSON.stringify(request.config) },
-      ],
-    }),
+    // Declare native constrained support so the framework hands the output
+    // schema to the model directly (in `request.output.schema`) rather than
+    // injecting it as prompt text — that lets the guard below detect it
+    // reliably, and keeps the echo free of framework-injected schema blobs.
+    info: {
+      ...options.info,
+      supports: { ...options.info?.supports, constrained: 'all' },
+    },
+    respond: (request) => {
+      if (request.output?.schema) {
+        throw new Error(
+          "echoModel returns text and can't satisfy an output schema: this " +
+            'request asks for structured output. Either move `output: { schema }` ' +
+            'to the generate()/flow call site so the prompt stays text-only, or ' +
+            'use mockModel(...) with a conforming response and assert prompt ' +
+            'assembly via model.lastRequestText / model.lastRequest.'
+        );
+      }
+      return {
+        content: [
+          { text: 'Echo: ' + renderRequestText(request) },
+          { text: '; config: ' + JSON.stringify(request.config) },
+        ],
+      };
+    },
   });
 }

--- a/js/ai/src/testing/mock-model.ts
+++ b/js/ai/src/testing/mock-model.ts
@@ -86,6 +86,7 @@ export interface MockModelOptions {
   /**
    * What to respond with on each `generate` call. Defaults to empty text.
    *
+   * - A **single response** (string / object) is returned on every call.
    * - A **callback** `(request, { sendChunk }) => response` is invoked once per
    *   call, so you can branch on request history (for tool loops) and stream via
    *   `sendChunk`.
@@ -95,12 +96,23 @@ export interface MockModelOptions {
    *   (Queued items are static, so streaming needs the callback form.)
    *
    * ```ts
+   * mockModel(ai, { respond: 'always this' });
    * mockModel(ai, { respond: ['first', 'second'] });
    * mockModel(ai, { respond: ['ok', new Error('rate limited')] });
    * ```
    */
-  respond?: MockRespondFn | Array<MockResponse | Error>;
+  respond?: MockRespond;
 }
+
+/**
+ * Anything accepted as respond behavior: a single {@link MockResponse}, a
+ * per-call callback, or a queue of responses/errors. See
+ * {@link MockModelOptions.respond}.
+ */
+export type MockRespond =
+  | MockRespondFn
+  | MockResponse
+  | Array<MockResponse | Error>;
 
 /**
  * A mock model with typed inspection of the calls it received. The extra
@@ -149,6 +161,32 @@ export type MockModel = ModelAction & {
   readonly requests: GenerateRequest[];
   /** How many times this model was called. */
   readonly requestCount: number;
+  /**
+   * Replaces the respond behavior for subsequent calls. Accepts everything
+   * {@link MockModelOptions.respond} does; an array re-arms as a fresh queue.
+   * Recorded history is untouched — use {@link MockModel.reset} for that.
+   *
+   * Together with `reset()` this supports the register-once idiom: define the
+   * mock once per test file, then give each test its own behavior.
+   *
+   * ```ts
+   * const model = mockModel(ai, { name: 'menuModel' });
+   * beforeEach(() => model.reset());
+   *
+   * test('...', async () => {
+   *   model.respondWith({ text: 'scripted' });
+   *   // ...
+   * });
+   * ```
+   */
+  respondWith(respond: MockRespond): void;
+  /**
+   * Clears recorded history (`requests`, `requestCount`, …) and restores the
+   * respond behavior given at construction, re-arming a queued `respond` from
+   * its first item. Call it in `beforeEach` so tests sharing a mock stay
+   * order-independent.
+   */
+  reset(): void;
 };
 
 function resolveRegistry(registry: Registry | HasRegistry): Registry {
@@ -225,20 +263,25 @@ function renderRequestText(request: GenerateRequest): string {
 }
 
 /**
- * Normalizes the `respond` option into a single callback. An array becomes a
- * queue consumed one item per call, with the last item repeating once
- * exhausted; a queued `Error` is thrown when reached.
+ * Normalizes the `respond` option into a single callback. A single response is
+ * returned on every call; an array becomes a queue consumed one item per call,
+ * with the last item repeating once exhausted; a queued `Error` is thrown when
+ * reached.
  */
-function toRespondFn(respond: MockModelOptions['respond']): MockRespondFn {
-  if (!Array.isArray(respond)) {
-    return respond ?? (() => ({ text: '' }));
+function toRespondFn(respond: MockRespond | undefined): MockRespondFn {
+  if (respond === undefined) {
+    return () => ({ text: '' });
   }
-  if (respond.length === 0) {
+  if (typeof respond === 'function') {
+    return respond;
+  }
+  const queue = Array.isArray(respond) ? respond : [respond];
+  if (queue.length === 0) {
     return () => ({ text: '' });
   }
   let i = 0;
   return () => {
-    const item = respond[Math.min(i, respond.length - 1)];
+    const item = queue[Math.min(i, queue.length - 1)];
     i++;
     if (item instanceof Error) throw item;
     return item;
@@ -247,8 +290,9 @@ function toRespondFn(respond: MockModelOptions['respond']): MockRespondFn {
 
 function toResponseData(response: MockResponse): GenerateResponseData {
   // A `respond` that streams but returns nothing (void) yields an empty message
-  // rather than throwing on the `'message' in response` check below.
-  if (!response) {
+  // rather than throwing on the `'message' in response` check below. Checked
+  // against null/undefined only, so `respond: ''` still means empty *text*.
+  if (response === undefined || response === null) {
     return { message: { role: 'model', content: [] }, finishReason: 'stop' };
   }
   if (typeof response === 'string') {
@@ -319,7 +363,7 @@ export function mockModel(
   options: MockModelOptions = {}
 ): MockModel {
   const requests: GenerateRequest[] = [];
-  const respond = toRespondFn(options.respond);
+  let respond = toRespondFn(options.respond);
 
   const model = defineModel(
     resolveRegistry(registry),
@@ -380,6 +424,17 @@ export function mockModel(
           })),
     },
     requestCount: { get: () => requests.length },
+    respondWith: {
+      value: (next: MockRespond) => {
+        respond = toRespondFn(next);
+      },
+    },
+    reset: {
+      value: () => {
+        requests.length = 0;
+        respond = toRespondFn(options.respond);
+      },
+    },
   });
   return model;
 }

--- a/js/ai/src/testing/mock-model.ts
+++ b/js/ai/src/testing/mock-model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,28 @@ function toChunkData(chunk: MockChunk): GenerateResponseChunkData {
   return typeof chunk === 'string' ? { content: [{ text: chunk }] } : chunk;
 }
 
+/** Renders a single request part to text for {@link echoModel}. Non-text parts
+ * (media, tool requests/responses, reasoning, data) are rendered as a labelled
+ * placeholder rather than silently dropped. */
+function renderPart(part: Part): string {
+  if (part.text !== undefined) return part.text;
+  if (part.media) {
+    const type = part.media.contentType ? ` ${part.media.contentType}` : '';
+    return `[media${type}: ${part.media.url}]`;
+  }
+  if (part.toolRequest) {
+    const { name, input } = part.toolRequest;
+    return `[toolRequest ${name}(${JSON.stringify(input)})]`;
+  }
+  if (part.toolResponse) {
+    const { name, output } = part.toolResponse;
+    return `[toolResponse ${name}: ${JSON.stringify(output)}]`;
+  }
+  if (part.reasoning !== undefined) return `[reasoning: ${part.reasoning}]`;
+  if (part.data !== undefined) return `[data: ${JSON.stringify(part.data)}]`;
+  return '';
+}
+
 function toResponseData(response: MockResponse): GenerateResponseData {
   if (typeof response === 'string') {
     return {
@@ -178,14 +200,16 @@ export function mockModel(
     resolveRegistry(registry),
     {
       apiVersion: 'v2',
-      // info widened to satisfy defineModel's overload resolution, mirroring
-      // the internal helpers in js/ai/tests/helpers.ts.
-      ...((options.info as any) ?? {}),
       name: options.name ?? 'mockModel',
+      // Forward only the metadata fields defineModel accepts; ModelInfo's
+      // `configSchema`/`stage` aren't part of DefineModelOptions.
+      versions: options.info?.versions,
+      label: options.info?.label,
+      supports: options.info?.supports,
     },
     async (request, { sendChunk }) => {
       // Snapshot so later mutation of the request can't alter recorded history.
-      requests.push(JSON.parse(JSON.stringify(request)));
+      requests.push(structuredClone(request));
       const context: MockContext = {
         sendChunk: (chunk) => sendChunk?.(toChunkData(chunk)),
       };
@@ -246,8 +270,7 @@ export function echoModel(
                 (m) =>
                   (m.role === 'user' || m.role === 'model'
                     ? ''
-                    : `${m.role}: `) +
-                  m.content.map((c) => c.text ?? '').join('')
+                    : `${m.role}: `) + m.content.map(renderPart).join('')
               )
               .join(''),
         },

--- a/js/ai/src/testing/mock-model.ts
+++ b/js/ai/src/testing/mock-model.ts
@@ -128,7 +128,9 @@ function renderPart(part: Part): string {
     return `[toolResponse ${name}: ${JSON.stringify(output)}]`;
   }
   if (part.reasoning !== undefined) return `[reasoning: ${part.reasoning}]`;
+  if (part.resource) return `[resource: ${part.resource.uri}]`;
   if (part.data !== undefined) return `[data: ${JSON.stringify(part.data)}]`;
+  if (part.custom !== undefined) return `[custom: ${JSON.stringify(part.custom)}]`;
   return '';
 }
 

--- a/js/ai/src/testing/mock-model.ts
+++ b/js/ai/src/testing/mock-model.ts
@@ -127,7 +127,7 @@ function toResponseData(response: MockResponse): GenerateResponseData {
   }
   for (const tool of obj.toolRequests ?? []) {
     content.push({
-      toolRequest: { name: tool.name, input: tool.input ?? {}, ref: tool.ref },
+      toolRequest: { name: tool.name, input: tool.input, ref: tool.ref },
     });
   }
   return {
@@ -194,7 +194,7 @@ export function mockModel(
   ) as MockModel;
 
   Object.defineProperties(model, {
-    requests: { get: () => requests },
+    requests: { get: () => [...requests] },
     lastRequest: { get: () => requests[requests.length - 1] },
     lastMessage: {
       get: () => {

--- a/js/ai/src/testing/mock-model.ts
+++ b/js/ai/src/testing/mock-model.ts
@@ -92,10 +92,10 @@ export type MockModel = ModelAction & {
    * `.toolRequests`, etc. `undefined` if the model was never called.
    *
    * ```ts
-   * assert.match(model.lastMessage!.text, /Summarize: long text/);
+   * assert.match(model.lastRequestMessage!.text, /Summarize: long text/);
    * ```
    */
-  readonly lastMessage: Message | undefined;
+  readonly lastRequestMessage: Message | undefined;
   /** Every request this model received, oldest first. */
   readonly requests: GenerateRequest[];
   /** How many times this model was called. */
@@ -196,7 +196,7 @@ export function mockModel(
   Object.defineProperties(model, {
     requests: { get: () => [...requests] },
     lastRequest: { get: () => requests[requests.length - 1] },
-    lastMessage: {
+    lastRequestMessage: {
       get: () => {
         const last = requests[requests.length - 1]?.messages.at(-1);
         return last ? new Message(last) : undefined;

--- a/js/ai/src/testing/mock-model.ts
+++ b/js/ai/src/testing/mock-model.ts
@@ -62,6 +62,12 @@ export interface MockResponseObject {
 
 export type MockResponse = string | MockResponseObject | GenerateResponseData;
 
+/** A `respond` callback: given the request, returns the response to emit. */
+export type MockRespondFn = (
+  request: GenerateRequest,
+  context: MockContext
+) => MockResponse | Promise<MockResponse>;
+
 /** Options for {@link mockModel}. */
 export interface MockModelOptions {
   /** Registered model name. Defaults to `'mockModel'`. */
@@ -69,14 +75,22 @@ export interface MockModelOptions {
   /** Model metadata (e.g. `supports`, `versions`). */
   info?: ModelInfo;
   /**
-   * Called once per `generate` call. Return the response to give back. Receives
-   * the resolved request and a {@link MockContext} for streaming. Defaults to
-   * returning empty text.
+   * What to respond with on each `generate` call. Defaults to empty text.
+   *
+   * - A **callback** `(request, { sendChunk }) => response` is invoked once per
+   *   call, so you can branch on request history (for tool loops) and stream via
+   *   `sendChunk`.
+   * - An **array** is a queue consumed one item per call, with the last item
+   *   repeating once exhausted — handy for scripted multi-turn tests. A queued
+   *   `Error` is thrown when reached, to inject a failure on a given turn.
+   *   (Queued items are static, so streaming needs the callback form.)
+   *
+   * ```ts
+   * mockModel(ai, { respond: ['first', 'second'] });
+   * mockModel(ai, { respond: ['ok', new Error('rate limited')] });
+   * ```
    */
-  respond?: (
-    request: GenerateRequest,
-    context: MockContext
-  ) => MockResponse | Promise<MockResponse>;
+  respond?: MockRespondFn | Array<MockResponse | Error>;
 }
 
 /**
@@ -107,6 +121,17 @@ export type MockModel = ModelAction & {
    * ```
    */
   readonly lastRequestText: string | undefined;
+  /**
+   * The tool results fed back to the model in the most recent request, in order.
+   * Use it to assert which tools ran and what they returned, without digging
+   * through message content yourself. Empty if the model was never called or saw
+   * no tool results.
+   *
+   * ```ts
+   * assert.deepStrictEqual(model.toolResponses.map((t) => t.name), ['lookup']);
+   * ```
+   */
+  readonly toolResponses: Array<{ name: string; ref?: string; output: unknown }>;
   /** Every request this model received, oldest first. */
   readonly requests: GenerateRequest[];
   /** How many times this model was called. */
@@ -163,6 +188,29 @@ function renderRequestText(request: GenerateRequest): string {
         m.content.map(renderPart).join('')
     )
     .join('\n');
+}
+
+/**
+ * Normalizes the `respond` option into a single callback. An array becomes a
+ * queue consumed one item per call, with the last item repeating once
+ * exhausted; a queued `Error` is thrown when reached.
+ */
+function toRespondFn(
+  respond: MockModelOptions['respond']
+): MockRespondFn {
+  if (!Array.isArray(respond)) {
+    return respond ?? (() => ({ text: '' }));
+  }
+  if (respond.length === 0) {
+    return () => ({ text: '' });
+  }
+  let i = 0;
+  return () => {
+    const item = respond[Math.min(i, respond.length - 1)];
+    i++;
+    if (item instanceof Error) throw item;
+    return item;
+  };
 }
 
 function toResponseData(response: MockResponse): GenerateResponseData {
@@ -229,7 +277,7 @@ export function mockModel(
   options: MockModelOptions = {}
 ): MockModel {
   const requests: GenerateRequest[] = [];
-  const respond = options.respond ?? (() => ({ text: '' }));
+  const respond = toRespondFn(options.respond);
 
   const model = defineModel(
     resolveRegistry(registry),
@@ -272,6 +320,17 @@ export function mockModel(
         const last = requests[requests.length - 1];
         return last ? renderRequestText(last) : undefined;
       },
+    },
+    toolResponses: {
+      get: () =>
+        (requests[requests.length - 1]?.messages ?? [])
+          .flatMap((m) => m.content)
+          .filter((p) => p.toolResponse)
+          .map((p) => ({
+            name: p.toolResponse!.name,
+            ref: p.toolResponse!.ref,
+            output: p.toolResponse!.output,
+          })),
     },
     requestCount: { get: () => requests.length },
   });

--- a/js/ai/src/testing/mock-model.ts
+++ b/js/ai/src/testing/mock-model.ts
@@ -149,7 +149,9 @@ function renderPart(part: Part): string {
 
 /**
  * Flattens a request's full message list to text — system and tool messages are
- * prefixed with their role; `user`/`model` are not. This is the assembled
+ * prefixed with their role; `user`/`model` are not. Messages are newline-
+ * separated so adjacent messages' text can't fuse into a single token (which
+ * would silently break boundary-spanning assertions). This is the assembled
  * conversation the model would have seen, used by both {@link echoModel} and
  * {@link MockModel.lastRequestText}.
  */
@@ -160,7 +162,7 @@ function renderRequestText(request: GenerateRequest): string {
         (m.role === 'user' || m.role === 'model' ? '' : `${m.role}: `) +
         m.content.map(renderPart).join('')
     )
-    .join('');
+    .join('\n');
 }
 
 function toResponseData(response: MockResponse): GenerateResponseData {
@@ -171,7 +173,9 @@ function toResponseData(response: MockResponse): GenerateResponseData {
     };
   }
   if ('message' in response && response.message) {
-    return { finishReason: 'stop', ...(response as GenerateResponseData) };
+    const data = response as GenerateResponseData;
+    // Default finishReason without letting an explicit `undefined` clobber it.
+    return { ...data, finishReason: data.finishReason ?? 'stop' };
   }
   const obj = response as MockResponseObject;
   const content: Part[] = [...(obj.content ?? [])];
@@ -249,8 +253,14 @@ export function mockModel(
   ) as MockModel;
 
   Object.defineProperties(model, {
-    requests: { get: () => [...requests] },
-    lastRequest: { get: () => requests[requests.length - 1] },
+    // Return clones so callers can't mutate recorded history through a view.
+    requests: { get: () => requests.map((r) => structuredClone(r)) },
+    lastRequest: {
+      get: () => {
+        const last = requests[requests.length - 1];
+        return last ? structuredClone(last) : undefined;
+      },
+    },
     lastRequestMessage: {
       get: () => {
         const last = requests[requests.length - 1]?.messages.at(-1);

--- a/js/ai/src/testing/mock-model.ts
+++ b/js/ai/src/testing/mock-model.ts
@@ -131,7 +131,11 @@ export type MockModel = ModelAction & {
    * assert.deepStrictEqual(model.toolResponses.map((t) => t.name), ['lookup']);
    * ```
    */
-  readonly toolResponses: Array<{ name: string; ref?: string; output: unknown }>;
+  readonly toolResponses: Array<{
+    name: string;
+    ref?: string;
+    output: unknown;
+  }>;
   /** Every request this model received, oldest first. */
   readonly requests: GenerateRequest[];
   /** How many times this model was called. */
@@ -140,6 +144,26 @@ export type MockModel = ModelAction & {
 
 function resolveRegistry(registry: Registry | HasRegistry): Registry {
   return (registry as HasRegistry).registry ?? (registry as Registry);
+}
+
+/**
+ * Snapshots a request so later mutation can't alter recorded history. Prefers a
+ * deep `structuredClone`, but falls back to a message/part-level copy when the
+ * request carries non-serializable values (e.g. a function or class instance in
+ * `config`), which would otherwise throw a `DataCloneError`.
+ */
+function cloneRequest(request: GenerateRequest): GenerateRequest {
+  try {
+    return structuredClone(request);
+  } catch {
+    return {
+      ...request,
+      messages: request.messages.map((m) => ({
+        ...m,
+        content: m.content.map((c) => ({ ...c })),
+      })),
+    };
+  }
 }
 
 function toChunkData(chunk: MockChunk): GenerateResponseChunkData {
@@ -168,7 +192,8 @@ function renderPart(part: Part): string {
   if (part.reasoning !== undefined) return `[reasoning: ${part.reasoning}]`;
   if (part.resource) return `[resource: ${part.resource.uri}]`;
   if (part.data !== undefined) return `[data: ${JSON.stringify(part.data)}]`;
-  if (part.custom !== undefined) return `[custom: ${JSON.stringify(part.custom)}]`;
+  if (part.custom !== undefined)
+    return `[custom: ${JSON.stringify(part.custom)}]`;
   return '';
 }
 
@@ -195,9 +220,7 @@ function renderRequestText(request: GenerateRequest): string {
  * queue consumed one item per call, with the last item repeating once
  * exhausted; a queued `Error` is thrown when reached.
  */
-function toRespondFn(
-  respond: MockModelOptions['respond']
-): MockRespondFn {
+function toRespondFn(respond: MockModelOptions['respond']): MockRespondFn {
   if (!Array.isArray(respond)) {
     return respond ?? (() => ({ text: '' }));
   }
@@ -214,6 +237,11 @@ function toRespondFn(
 }
 
 function toResponseData(response: MockResponse): GenerateResponseData {
+  // A `respond` that streams but returns nothing (void) yields an empty message
+  // rather than throwing on the `'message' in response` check below.
+  if (!response) {
+    return { message: { role: 'model', content: [] }, finishReason: 'stop' };
+  }
   if (typeof response === 'string') {
     return {
       message: { role: 'model', content: [{ text: response }] },
@@ -292,7 +320,7 @@ export function mockModel(
     },
     async (request, { sendChunk }) => {
       // Snapshot so later mutation of the request can't alter recorded history.
-      requests.push(structuredClone(request));
+      requests.push(cloneRequest(request));
       const context: MockContext = {
         sendChunk: (chunk) => sendChunk?.(toChunkData(chunk)),
       };
@@ -302,11 +330,11 @@ export function mockModel(
 
   Object.defineProperties(model, {
     // Return clones so callers can't mutate recorded history through a view.
-    requests: { get: () => requests.map((r) => structuredClone(r)) },
+    requests: { get: () => requests.map((r) => cloneRequest(r)) },
     lastRequest: {
       get: () => {
         const last = requests[requests.length - 1];
-        return last ? structuredClone(last) : undefined;
+        return last ? cloneRequest(last) : undefined;
       },
     },
     lastRequestMessage: {

--- a/js/genkit/src/testing.ts
+++ b/js/genkit/src/testing.ts
@@ -41,6 +41,7 @@ export {
   type MockContext,
   type MockModel,
   type MockModelOptions,
+  type MockRespond,
   type MockRespondFn,
   type MockResponse,
 } from '@genkit-ai/ai/testing';

--- a/js/genkit/src/testing.ts
+++ b/js/genkit/src/testing.ts
@@ -17,14 +17,29 @@
  */
 
 /**
- * Testing utilities — helpers for testing model plugins, including the
- * `testModels` test harness.
+ * Testing utilities for Genkit apps and model plugins.
+ *
+ * - {@link mockModel} — a programmable mock model with typed call inspection,
+ *   for testing flows, prompts, and tools deterministically.
+ * - {@link echoModel} — a zero-config model that echoes the rendered request,
+ *   for asserting prompt/message assembly.
+ * - `testModels` — a conformance harness for model *plugin* authors.
  *
  * ```ts
- * import { testModels } from 'genkit/testing';
+ * import { mockModel, echoModel, testModels } from 'genkit/testing';
  * ```
  *
  * @module testing
  */
 
-export { testModels } from '@genkit-ai/ai/testing';
+export {
+  echoModel,
+  mockModel,
+  testModels,
+  type EchoModelOptions,
+  type MockChunk,
+  type MockContext,
+  type MockModel,
+  type MockModelOptions,
+  type MockResponse,
+} from '@genkit-ai/ai/testing';

--- a/js/genkit/src/testing.ts
+++ b/js/genkit/src/testing.ts
@@ -42,4 +42,5 @@ export {
   type MockModel,
   type MockModelOptions,
   type MockResponse,
+  type MockRespondFn,
 } from '@genkit-ai/ai/testing';

--- a/js/genkit/src/testing.ts
+++ b/js/genkit/src/testing.ts
@@ -41,6 +41,6 @@ export {
   type MockContext,
   type MockModel,
   type MockModelOptions,
-  type MockResponse,
   type MockRespondFn,
+  type MockResponse,
 } from '@genkit-ai/ai/testing';

--- a/js/genkit/tests/mock-model_test.ts
+++ b/js/genkit/tests/mock-model_test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/genkit/tests/mock-model_test.ts
+++ b/js/genkit/tests/mock-model_test.ts
@@ -39,7 +39,7 @@ describe('mockModel', () => {
 
     assert.strictEqual(await summarize('long text'), 'a summary');
     assert.strictEqual(model.requestCount, 1);
-    assert.match(model.lastMessage!.text, /Summarize: long text/);
+    assert.match(model.lastRequestMessage!.text, /Summarize: long text/);
   });
 
   it('accepts a bare string as shorthand for text', async () => {

--- a/js/genkit/tests/mock-model_test.ts
+++ b/js/genkit/tests/mock-model_test.ts
@@ -247,6 +247,52 @@ describe('mockModel', () => {
     assert.match(model.lastRequestText!, /system: Be terse/);
     assert.match(model.lastRequestText!, /hello/);
   });
+
+  it('exposes the output schema to respond by default (native constrained)', async () => {
+    let seenSchema: unknown;
+    const model = mockModel(ai, {
+      respond: (req) => {
+        seenSchema = req.output?.schema;
+        return { text: JSON.stringify({ x: 'ok' }) };
+      },
+    });
+
+    await ai.generate({
+      model,
+      prompt: 'hello',
+      output: { schema: z.object({ x: z.string() }) },
+    });
+
+    // Native constrained: the schema is handed to the model on the request...
+    assert.ok(seenSchema, 'respond should see request.output.schema');
+    // ...not injected into the prompt.
+    assert.doesNotMatch(
+      model.lastRequestText!,
+      /conform to the following schema/i
+    );
+  });
+
+  it('simulates constrained output when supports.constrained is none', async () => {
+    let seenSchema: unknown = 'unset';
+    const model = mockModel(ai, {
+      info: { supports: { constrained: 'none' } },
+      respond: (req) => {
+        seenSchema = req.output?.schema;
+        return { text: JSON.stringify({ x: 'ok' }) };
+      },
+    });
+
+    await ai.generate({
+      model,
+      prompt: 'hello',
+      output: { schema: z.object({ x: z.string() }) },
+    });
+
+    // Simulated path strips the schema from what the model sees...
+    assert.strictEqual(seenSchema, undefined);
+    // ...and injects it into the prompt instead.
+    assert.match(model.lastRequestText!, /conform to the following schema/i);
+  });
 });
 
 describe('echoModel', () => {

--- a/js/genkit/tests/mock-model_test.ts
+++ b/js/genkit/tests/mock-model_test.ts
@@ -180,6 +180,70 @@ describe('mockModel', () => {
     await assert.rejects(ai.generate({ model, prompt: 'b' }), /rate limited/);
   });
 
+  it('treats an empty-string response as empty text, not a missing message', async () => {
+    const model = mockModel(ai, { respond: '' });
+    const res = await ai.generate({ model, prompt: 'x' });
+    assert.strictEqual(res.text, '');
+    assert.deepStrictEqual(res.message?.content, [{ text: '' }]);
+  });
+
+  it('accepts a single static response, returned on every call', async () => {
+    const model = mockModel(ai, { respond: 'always this' });
+
+    assert.strictEqual(
+      (await ai.generate({ model, prompt: 'a' })).text,
+      'always this'
+    );
+    assert.strictEqual(
+      (await ai.generate({ model, prompt: 'b' })).text,
+      'always this'
+    );
+  });
+
+  it('swaps behavior for subsequent calls via respondWith', async () => {
+    const model = mockModel(ai, { respond: 'initial' });
+
+    assert.strictEqual(
+      (await ai.generate({ model, prompt: 'a' })).text,
+      'initial'
+    );
+
+    model.respondWith(['first', 'second']);
+    assert.strictEqual(
+      (await ai.generate({ model, prompt: 'b' })).text,
+      'first'
+    );
+    assert.strictEqual(
+      (await ai.generate({ model, prompt: 'c' })).text,
+      'second'
+    );
+    // respondWith leaves recorded history untouched.
+    assert.strictEqual(model.requestCount, 3);
+  });
+
+  it('clears history and re-arms the construction respond via reset', async () => {
+    const model = mockModel(ai, { respond: ['first', 'second'] });
+
+    await ai.generate({ model, prompt: 'a' });
+    await ai.generate({ model, prompt: 'b' });
+    model.respondWith('overridden');
+    assert.strictEqual(
+      (await ai.generate({ model, prompt: 'c' })).text,
+      'overridden'
+    );
+
+    model.reset();
+
+    assert.strictEqual(model.requestCount, 0);
+    assert.deepStrictEqual(model.requests, []);
+    assert.strictEqual(model.lastRequest, undefined);
+    // Back to the construction-time queue, re-armed from its first item.
+    assert.strictEqual(
+      (await ai.generate({ model, prompt: 'd' })).text,
+      'first'
+    );
+  });
+
   it('exposes tool results fed back to the model via toolResponses', async () => {
     const lookup = ai.defineTool(
       {

--- a/js/genkit/tests/mock-model_test.ts
+++ b/js/genkit/tests/mock-model_test.ts
@@ -381,42 +381,46 @@ describe('mockModel — interrupts and agent handoff', () => {
     assert.strictEqual(model.requestCount, 2);
   });
 
-  it('models an agent handoff: a prompt-as-tool swaps the system preamble', async () => {
-    const app = genkitBeta({ model: 'handoffModel' });
+  it('drives a defineAgent tool loop with mockModel, exposing the preamble', async () => {
+    // Migrated from an `app.chat(promptAgent)` handoff test: the beta Chat API
+    // (and its cross-agent preamble swap) was removed in #5248. This keeps the
+    // same mockModel surface under test — a multi-turn tool loop, with the
+    // agent's rendered system preamble asserted via `lastRequestText` — using
+    // the current `defineAgent(...).chat().send(...)` API.
+    const app = genkitBeta({ model: 'agentModel' });
 
-    app.definePrompt({
-      name: 'agentB',
-      description: 'Handles B things.',
-      system: 'You are agent B.',
-    });
-    const agentA = app.definePrompt({
-      name: 'agentA',
-      description: 'Handles A things.',
-      system: 'You are agent A.',
-      tools: ['agentB'],
-    });
+    app.defineTool(
+      { name: 'lookup', description: "Look up today's special." },
+      async () => 'Mushroom risotto'
+    );
 
     const model = mockModel(app, {
-      name: 'handoffModel',
+      name: 'agentModel',
       info: { supports: { tools: true } },
       respond: (req) => {
-        // Once agent B's preamble is in the request, we've been handed off —
-        // answer as B. Until then, request the handoff to agentB.
-        const handedOff = req.messages.some((m) =>
-          m.content.some((c) => c.text?.includes('You are agent B'))
+        // The model's two-turn view of one `send`: call the tool, then once its
+        // result is in the conversation, finish.
+        const sawToolResult = req.messages.some((m) =>
+          m.content.some((c) => c.toolResponse?.output === 'Mushroom risotto')
         );
-        return handedOff
-          ? { text: 'handled by agent B' }
-          : { toolRequests: [{ name: 'agentB', input: {} }] };
+        return sawToolResult
+          ? { text: 'Booked: Mushroom risotto' }
+          : { toolRequests: [{ name: 'lookup', input: {} }] };
       },
     });
 
-    const chat = app.chat(agentA);
-    const { text } = await chat.send('help me');
+    const agent = app.defineAgent({
+      name: 'concierge',
+      model: 'agentModel',
+      system: 'You are the booking concierge.',
+      tools: ['lookup'],
+    });
 
-    assert.strictEqual(text, 'handled by agent B');
-    // The handoff swapped the preamble the model sees from A to B.
-    assert.match(model.lastRequestText!, /You are agent B/);
+    const { text } = await agent.chat().send('book me the special');
+
+    assert.strictEqual(text, 'Booked: Mushroom risotto');
     assert.strictEqual(model.requestCount, 2);
+    // The agent's system preamble is what the model saw.
+    assert.match(model.lastRequestText!, /You are the booking concierge/);
   });
 });

--- a/js/genkit/tests/mock-model_test.ts
+++ b/js/genkit/tests/mock-model_test.ts
@@ -115,6 +115,40 @@ describe('mockModel', () => {
     assert.match(captured!.messages.at(-1)!.content[0].text!, /first/);
   });
 
+  it('separates adjacent messages so their text does not fuse', async () => {
+    const model = mockModel(ai, { respond: () => ({ text: 'ok' }) });
+    await ai.generate({ model, system: 'alpha', prompt: 'beta' });
+
+    // The last word of one message must not run into the first of the next,
+    // or boundary-spanning assertions silently break.
+    assert.doesNotMatch(model.lastRequestText!, /alphabeta/);
+    assert.match(model.lastRequestText!, /alpha\nbeta/);
+  });
+
+  it('returns a defensive copy from lastRequest and requests', async () => {
+    const model = mockModel(ai, { respond: () => ({ text: 'ok' }) });
+    await ai.generate({ model, prompt: 'hello' });
+
+    // Mutating the view must not corrupt recorded history.
+    model.lastRequest!.messages.length = 0;
+    model.requests[0].messages.length = 0;
+
+    assert.ok(model.lastRequest!.messages.length > 0);
+    assert.ok(model.requests[0].messages.length > 0);
+  });
+
+  it('defaults finishReason to stop when a full response leaves it undefined', async () => {
+    const model = mockModel(ai, {
+      respond: () => ({
+        message: { role: 'model', content: [{ text: 'x' }] },
+        finishReason: undefined,
+      }),
+    });
+
+    const res = await ai.generate({ model, prompt: 'hi' });
+    assert.strictEqual(res.finishReason, 'stop');
+  });
+
   it('flattens the whole assembled request via lastRequestText', async () => {
     // Works even with an output schema, where echoModel can't be used: the mock
     // returns conforming JSON, and assembly is asserted by inspection.

--- a/js/genkit/tests/mock-model_test.ts
+++ b/js/genkit/tests/mock-model_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { echoModel, mockModel } from '@genkit-ai/ai/testing';
+import { echoModel, mockModel, type MockResponse } from '@genkit-ai/ai/testing';
 import { z } from '@genkit-ai/core';
 import { initNodeFeatures } from '@genkit-ai/core/node';
 import * as assert from 'assert';
@@ -34,8 +34,10 @@ describe('mockModel', () => {
   it('returns the scripted text and records the request', async () => {
     const model = mockModel(ai, { respond: () => ({ text: 'a summary' }) });
 
-    const summarize = ai.defineFlow('summarize', async (doc: string) =>
-      (await ai.generate({ model, prompt: `Summarize: ${doc}` })).text
+    const summarize = ai.defineFlow(
+      'summarize',
+      async (doc: string) =>
+        (await ai.generate({ model, prompt: `Summarize: ${doc}` })).text
     );
 
     assert.strictEqual(await summarize('long text'), 'a summary');
@@ -153,7 +155,10 @@ describe('mockModel', () => {
   it('consumes an array of responses one per call, repeating the last', async () => {
     const model = mockModel(ai, { respond: ['first', 'second'] });
 
-    assert.strictEqual((await ai.generate({ model, prompt: 'a' })).text, 'first');
+    assert.strictEqual(
+      (await ai.generate({ model, prompt: 'a' })).text,
+      'first'
+    );
     assert.strictEqual(
       (await ai.generate({ model, prompt: 'b' })).text,
       'second'
@@ -172,10 +177,7 @@ describe('mockModel', () => {
     });
 
     assert.strictEqual((await ai.generate({ model, prompt: 'a' })).text, 'ok');
-    await assert.rejects(
-      ai.generate({ model, prompt: 'b' }),
-      /rate limited/
-    );
+    await assert.rejects(ai.generate({ model, prompt: 'b' }), /rate limited/);
   });
 
   it('exposes tool results fed back to the model via toolResponses', async () => {
@@ -192,7 +194,10 @@ describe('mockModel', () => {
     const model = mockModel(ai, {
       info: { supports: { tools: true } },
       // A queued tool loop: request the tool, then answer.
-      respond: [{ toolRequests: [{ name: 'lookup', input: { id: 1 } }] }, 'done'],
+      respond: [
+        { toolRequests: [{ name: 'lookup', input: { id: 1 } }] },
+        'done',
+      ],
     });
 
     await ai.generate({ model, prompt: 'go', tools: [lookup] });
@@ -202,6 +207,27 @@ describe('mockModel', () => {
       ['lookup']
     );
     assert.strictEqual(model.toolResponses[0].output, 'item-1');
+  });
+
+  it('treats a falsy respond result as an empty response', async () => {
+    // A callback that streams but forgets to return (void) must not crash.
+    const model = mockModel(ai, {
+      respond: () => undefined as unknown as MockResponse,
+    });
+    const res = await ai.generate({ model, prompt: 'x' });
+    assert.strictEqual(res.text, '');
+  });
+
+  it('records a request even when it carries a non-serializable value', async () => {
+    const model = mockModel(ai, { respond: () => 'ok' });
+    // A function in config can't be structuredClone'd; recording must not throw.
+    await ai.generate({
+      model,
+      prompt: 'hi',
+      config: { onEvent: () => 1 } as unknown as Record<string, unknown>,
+    });
+    assert.strictEqual(model.requestCount, 1);
+    assert.match(model.lastRequestText!, /hi/);
   });
 
   it('flattens the whole assembled request via lastRequestText', async () => {

--- a/js/genkit/tests/mock-model_test.ts
+++ b/js/genkit/tests/mock-model_test.ts
@@ -19,6 +19,7 @@ import { z } from '@genkit-ai/core';
 import { initNodeFeatures } from '@genkit-ai/core/node';
 import * as assert from 'assert';
 import { beforeEach, describe, it } from 'node:test';
+import { genkit as genkitBeta, type GenkitBeta } from '../src/beta';
 import { genkit, type Genkit } from '../src/genkit';
 
 initNodeFeatures();
@@ -198,5 +199,98 @@ describe('echoModel', () => {
       }),
       /can't satisfy an output schema/
     );
+  });
+});
+
+// These cover the two features most likely to need dedicated helpers —
+// interrupts (human-in-the-loop) and agent handoff — and show that `mockModel`
+// already tests them with no extra machinery: an interrupt is just a tool
+// request the framework turns into a pause, and a handoff is just a
+// prompt-as-tool request. Both live on the beta surface (`chat`, resume).
+describe('mockModel — interrupts and agent handoff', () => {
+  let ai: GenkitBeta;
+
+  beforeEach(() => {
+    ai = genkitBeta({});
+  });
+
+  it('drives an interrupt round-trip, then resumes to completion', async () => {
+    // A human-in-the-loop tool: it interrupts on first run, and completes once
+    // the generation is resumed with an answer.
+    const confirmAction = ai.defineTool(
+      { name: 'confirmAction', description: 'needs human confirmation' },
+      async (_input, { interrupt, resumed }) => {
+        if (resumed) return 'approved';
+        return interrupt({ ask: 'Proceed?' });
+      }
+    );
+
+    let turn = 0;
+    const model = mockModel(ai, {
+      info: { supports: { tools: true } },
+      respond: () =>
+        turn++ === 0
+          ? { toolRequests: [{ name: 'confirmAction', input: {} }] }
+          : { text: 'all done' },
+    });
+
+    // Turn 1: the model calls the tool, the tool interrupts, generation pauses.
+    const paused = await ai.generate({
+      model,
+      prompt: 'do the thing',
+      tools: [confirmAction],
+    });
+    assert.strictEqual(paused.interrupts.length, 1);
+    assert.strictEqual(paused.interrupts[0].toolRequest.name, 'confirmAction');
+
+    // Turn 2: a human approves; resuming re-runs the tool and the model finishes.
+    const finished = await ai.generate({
+      model,
+      messages: paused.messages,
+      tools: [confirmAction],
+      resume: { respond: confirmAction.respond(paused.interrupts[0], 'yes') },
+    });
+
+    assert.strictEqual(finished.text, 'all done');
+    assert.strictEqual(model.requestCount, 2);
+  });
+
+  it('models an agent handoff: a prompt-as-tool swaps the system preamble', async () => {
+    const app = genkitBeta({ model: 'handoffModel' });
+
+    app.definePrompt({
+      name: 'agentB',
+      description: 'Handles B things.',
+      system: 'You are agent B.',
+    });
+    const agentA = app.definePrompt({
+      name: 'agentA',
+      description: 'Handles A things.',
+      system: 'You are agent A.',
+      tools: ['agentB'],
+    });
+
+    const model = mockModel(app, {
+      name: 'handoffModel',
+      info: { supports: { tools: true } },
+      respond: (req) => {
+        // Once agent B's preamble is in the request, we've been handed off —
+        // answer as B. Until then, request the handoff to agentB.
+        const handedOff = req.messages.some((m) =>
+          m.content.some((c) => c.text?.includes('You are agent B'))
+        );
+        return handedOff
+          ? { text: 'handled by agent B' }
+          : { toolRequests: [{ name: 'agentB', input: {} }] };
+      },
+    });
+
+    const chat = app.chat(agentA);
+    const { text } = await chat.send('help me');
+
+    assert.strictEqual(text, 'handled by agent B');
+    // The handoff swapped the preamble the model sees from A to B.
+    assert.match(model.lastRequestText!, /You are agent B/);
+    assert.strictEqual(model.requestCount, 2);
   });
 });

--- a/js/genkit/tests/mock-model_test.ts
+++ b/js/genkit/tests/mock-model_test.ts
@@ -114,6 +114,24 @@ describe('mockModel', () => {
 
     assert.match(captured!.messages.at(-1)!.content[0].text!, /first/);
   });
+
+  it('flattens the whole assembled request via lastRequestText', async () => {
+    // Works even with an output schema, where echoModel can't be used: the mock
+    // returns conforming JSON, and assembly is asserted by inspection.
+    const model = mockModel(ai, {
+      respond: () => ({ text: JSON.stringify({ x: 'ok' }) }),
+    });
+
+    await ai.generate({
+      model,
+      system: 'Be terse',
+      prompt: 'hello',
+      output: { schema: z.object({ x: z.string() }) },
+    });
+
+    assert.match(model.lastRequestText!, /system: Be terse/);
+    assert.match(model.lastRequestText!, /hello/);
+  });
 });
 
 describe('echoModel', () => {
@@ -133,5 +151,18 @@ describe('echoModel', () => {
 
     assert.match(res.text, /system: Be terse/);
     assert.match(res.text, /hello/);
+  });
+
+  it('throws a clear error when the request carries an output schema', async () => {
+    const model = echoModel(ai);
+
+    await assert.rejects(
+      ai.generate({
+        model,
+        prompt: 'hi',
+        output: { schema: z.object({ x: z.string() }) },
+      }),
+      /can't satisfy an output schema/
+    );
   });
 });

--- a/js/genkit/tests/mock-model_test.ts
+++ b/js/genkit/tests/mock-model_test.ts
@@ -150,6 +150,60 @@ describe('mockModel', () => {
     assert.strictEqual(res.finishReason, 'stop');
   });
 
+  it('consumes an array of responses one per call, repeating the last', async () => {
+    const model = mockModel(ai, { respond: ['first', 'second'] });
+
+    assert.strictEqual((await ai.generate({ model, prompt: 'a' })).text, 'first');
+    assert.strictEqual(
+      (await ai.generate({ model, prompt: 'b' })).text,
+      'second'
+    );
+    // Past the end, the last response repeats rather than throwing.
+    assert.strictEqual(
+      (await ai.generate({ model, prompt: 'c' })).text,
+      'second'
+    );
+    assert.strictEqual(model.requestCount, 3);
+  });
+
+  it('throws a queued Error to inject a failure on a given turn', async () => {
+    const model = mockModel(ai, {
+      respond: ['ok', new Error('rate limited')],
+    });
+
+    assert.strictEqual((await ai.generate({ model, prompt: 'a' })).text, 'ok');
+    await assert.rejects(
+      ai.generate({ model, prompt: 'b' }),
+      /rate limited/
+    );
+  });
+
+  it('exposes tool results fed back to the model via toolResponses', async () => {
+    const lookup = ai.defineTool(
+      {
+        name: 'lookup',
+        description: 'look something up',
+        inputSchema: z.object({ id: z.number() }),
+        outputSchema: z.string(),
+      },
+      async ({ id }) => `item-${id}`
+    );
+
+    const model = mockModel(ai, {
+      info: { supports: { tools: true } },
+      // A queued tool loop: request the tool, then answer.
+      respond: [{ toolRequests: [{ name: 'lookup', input: { id: 1 } }] }, 'done'],
+    });
+
+    await ai.generate({ model, prompt: 'go', tools: [lookup] });
+
+    assert.deepStrictEqual(
+      model.toolResponses.map((t) => t.name),
+      ['lookup']
+    );
+    assert.strictEqual(model.toolResponses[0].output, 'item-1');
+  });
+
   it('flattens the whole assembled request via lastRequestText', async () => {
     // Works even with an output schema, where echoModel can't be used: the mock
     // returns conforming JSON, and assembly is asserted by inspection.

--- a/js/genkit/tests/mock-model_test.ts
+++ b/js/genkit/tests/mock-model_test.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { echoModel, mockModel } from '@genkit-ai/ai/testing';
+import { z } from '@genkit-ai/core';
+import { initNodeFeatures } from '@genkit-ai/core/node';
+import * as assert from 'assert';
+import { beforeEach, describe, it } from 'node:test';
+import { genkit, type Genkit } from '../src/genkit';
+
+initNodeFeatures();
+
+describe('mockModel', () => {
+  let ai: Genkit;
+
+  beforeEach(() => {
+    ai = genkit({});
+  });
+
+  it('returns the scripted text and records the request', async () => {
+    const model = mockModel(ai, { respond: () => ({ text: 'a summary' }) });
+
+    const summarize = ai.defineFlow('summarize', async (doc: string) =>
+      (await ai.generate({ model, prompt: `Summarize: ${doc}` })).text
+    );
+
+    assert.strictEqual(await summarize('long text'), 'a summary');
+    assert.strictEqual(model.requestCount, 1);
+    assert.match(model.lastMessage!.text, /Summarize: long text/);
+  });
+
+  it('accepts a bare string as shorthand for text', async () => {
+    const model = mockModel(ai, { respond: () => 'hi there' });
+    const res = await ai.generate({ model, prompt: 'x' });
+    assert.strictEqual(res.text, 'hi there');
+  });
+
+  it('streams chunks via sendChunk', async () => {
+    const model = mockModel(ai, {
+      respond: (_req, { sendChunk }) => {
+        sendChunk('hel');
+        sendChunk('lo');
+        return { text: 'hello' };
+      },
+    });
+
+    const { response, stream } = ai.generateStream({ model, prompt: 'hi' });
+    const chunks: string[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk.text);
+    }
+
+    assert.deepStrictEqual(chunks, ['hel', 'lo']);
+    assert.strictEqual((await response).text, 'hello');
+  });
+
+  it('emits tool requests that the framework dispatches', async () => {
+    const lookup = ai.defineTool(
+      {
+        name: 'lookup',
+        description: 'look something up',
+        inputSchema: z.object({ id: z.number() }),
+        outputSchema: z.string(),
+      },
+      async ({ id }) => `item-${id}`
+    );
+
+    const model = mockModel(ai, {
+      info: { supports: { tools: true } },
+      respond: (req) => {
+        const toolResponded = req.messages.some((m) =>
+          m.content.some((c) => c.toolResponse)
+        );
+        return toolResponded
+          ? { text: 'done' }
+          : { toolRequests: [{ name: 'lookup', input: { id: 1 } }] };
+      },
+    });
+
+    const res = await ai.generate({ model, prompt: 'go', tools: [lookup] });
+
+    assert.strictEqual(res.text, 'done');
+    assert.strictEqual(model.requestCount, 2);
+  });
+
+  it('records every request, oldest first', async () => {
+    const model = mockModel(ai, { respond: () => ({ text: 'ok' }) });
+    await ai.generate({ model, prompt: 'first' });
+    await ai.generate({ model, prompt: 'second' });
+
+    assert.strictEqual(model.requests.length, 2);
+    assert.match(model.requests[0].messages.at(-1)!.content[0].text!, /first/);
+    assert.match(model.requests[1].messages.at(-1)!.content[0].text!, /second/);
+  });
+
+  it('snapshots the request so later runs do not mutate history', async () => {
+    const model = mockModel(ai, { respond: () => ({ text: 'ok' }) });
+    await ai.generate({ model, prompt: 'first' });
+    const captured = model.lastRequest;
+    await ai.generate({ model, prompt: 'second' });
+
+    assert.match(captured!.messages.at(-1)!.content[0].text!, /first/);
+  });
+});
+
+describe('echoModel', () => {
+  let ai: Genkit;
+
+  beforeEach(() => {
+    ai = genkit({});
+  });
+
+  it('echoes the rendered request, for prompt-assembly assertions', async () => {
+    const model = echoModel(ai);
+    const res = await ai.generate({
+      model,
+      system: 'Be terse',
+      prompt: 'hello',
+    });
+
+    assert.match(res.text, /system: Be terse/);
+    assert.match(res.text, /hello/);
+  });
+});

--- a/js/package.json
+++ b/js/package.json
@@ -14,8 +14,9 @@
     "pack:ai": "cd ai && pnpm pack --pack-destination ../../dist",
     "pack:genkit": "cd genkit && pnpm pack --pack-destination ../../dist",
     "pack:plugins": "for i in plugins/*/; do cd $i && pnpm pack --pack-destination ../../../dist && cd ../..; done",
-    "test:all": "pnpm -r --workspace-concurrency -1 -F \"./(ai|core|plugins|genkit)/**\" test && pnpm test:esm",
+    "test:all": "pnpm -r --workspace-concurrency -1 -F \"./(ai|core|plugins|genkit)/**\" test && pnpm test:esm && pnpm test:testing-sample",
     "test:esm": "cd testapps/esm && pnpm test",
+    "test:testing-sample": "cd testapps/testing-sample && pnpm test && pnpm test:vitest",
     "gendocs": "pnpm build && pnpm typedoc",
     "typedoc-html": "typedoc --sortEntryPoints false --options typedoc.json"
   },

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -196,7 +196,7 @@ importers:
         version: 4.1.1
       '@genkit-ai/firebase':
         specifier: ^1.16.1
-        version: 1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+        version: 1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
 
   doc-snippets:
     dependencies:
@@ -1267,7 +1267,7 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: ^20.3.1
-        version: 20.3.26(e6cb669c5737e0a482bfe14152ad6630)
+        version: 20.3.26(182e1bf26b21f667a99f055cdf7683fa)
       '@angular/cli':
         specifier: ^20.3.1
         version: 20.3.26(@cfworker/json-schema@4.1.1)(@types/node@20.19.37)(chokidar@4.0.3)
@@ -2172,6 +2172,28 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  testapps/testing-sample:
+    dependencies:
+      genkit:
+        specifier: workspace:*
+        version: link:../../genkit
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.13
+    devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.15.32)(typescript@5.9.3))(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
 
   testapps/vercel-ai-elements:
     dependencies:
@@ -3892,11 +3914,11 @@ packages:
     resolution: {integrity: sha512-Lm/ZLhDZcBECta3TmCQSngiQykFdfw+QtI1/GYMsZd4l3nG+P8WLB16XuS7WaBGLQ+9E+cOcWQsth9cayuGt8g==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@genkit-ai/ai@1.37.0':
-    resolution: {integrity: sha512-SQnis1/NJeaGOiFnstmCJ7iGxVj/lwsQpwCXgG+JQrspAvGEIpSHCVBkreUpw6Dy7r0mVCHKup7L1NqBJbvCZg==}
+  '@genkit-ai/ai@1.39.0':
+    resolution: {integrity: sha512-e1ZI2ib4Y8ha2Zj/rN7Uioxd16rWMhalPe3krypLw8B4G36X8KZCqj2UhucKbCZJIffU0cxEvag7BP+JVQnsyQ==}
 
-  '@genkit-ai/core@1.37.0':
-    resolution: {integrity: sha512-Bq/HTwRhFoWjn4bbN0gnegsO/0dSYRUtbkWj/xwYfTycSCzVTqQJt3eNJXL6Dd5qSlGa3sWjYTsksiLqfroDzg==}
+  '@genkit-ai/core@1.39.0':
+    resolution: {integrity: sha512-MI0cpmwc4K/KPVsXFAcHviOybt3T3IsVSsN37cEcOzo7mmv+s0JSdooxlQgZn68B6e3I8BNLL3Vk1vyc6qIlCw==}
 
   '@genkit-ai/express@1.29.0':
     resolution: {integrity: sha512-+Mf8e45RbAlvns3a3hvIDpUAjNyWTIu1cy7vV86+6NvpPqPhkEaPkptgIX7KIXsPBEwiwsEM4SXx80M/TRbmTg==}
@@ -4121,89 +4143,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -4960,30 +4998,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.96':
     resolution: {integrity: sha512-UvOi7fii3IE2KDfEfhh8m+LpzSRvhGK7o1eho99M2M0HTik11k3GX+2qgVx9EtujN3/bhFFS1kSO3+vPMaJ0Mg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.96':
     resolution: {integrity: sha512-MBSukhGCQ5nRtf9NbFYWOU080yqkZU1PbuH4o1ROvB4CbPl12fchDR35tU83Wz8gWIM9JTn99lBn9DenPIv7Ig==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.96':
     resolution: {integrity: sha512-I/ccu2SstyKiV3HIeVzyBIWfrJo8cN7+MSQZPnabewWV6hfJ2nY7Df2WqOHmobBRUw84uGR6zfQHsUEio/m5Vg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.96':
     resolution: {integrity: sha512-H3uov7qnTl73GDT4h52lAqpJPsl1tIUyNPWJyhQ6gHakohNqqRq3uf80+NEpzcytKGEOENP1wX3yGwZxhjiWEQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.96':
     resolution: {integrity: sha512-ATp6Y+djOjYtkfV/VRH7CZ8I1MEtkUQBmKUbuWw5zWEHHqfL0cEcInE4Cxgx7zkNAhEdBbnH8HMVrqNp+/gwxA==}
@@ -5042,42 +5085,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -5136,24 +5186,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.7':
     resolution: {integrity: sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.7':
     resolution: {integrity: sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.7':
     resolution: {integrity: sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.7':
     resolution: {integrity: sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==}
@@ -5703,36 +5757,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -6735,66 +6795,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -7008,24 +7081,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -7102,6 +7179,9 @@ packages:
 
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/connect@3.4.36':
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
@@ -7210,6 +7290,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -7512,51 +7595,61 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -7601,6 +7694,35 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -7792,6 +7914,10 @@ packages:
 
   as-array@2.0.0:
     resolution: {integrity: sha512-1Sd1LrodN0XYxYeZcN1J4xYZvmvTwD5tDWaPUGPIzH1mFsmzsPnVtd2exWhecMjtZk/wYWjNZJiD3b1SLCeJqg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -8095,6 +8221,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -8132,6 +8262,10 @@ packages:
 
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   check-node-version@4.2.1:
     resolution: {integrity: sha512-YYmFYHV/X7kSJhuN/QYHUu998n/TRuDe8UenM3+m5NrkiH670lb9ILqHIvBencvJc4SDh+XcbXMR4b+TtubJiw==}
@@ -8738,6 +8872,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-equal-in-any-order@2.2.0:
     resolution: {integrity: sha512-lUYf3Oz/HrPcNmKe+S+QSdY5/hzKleftcFBWLwbHNZ5007RUKgN0asWlAHuQGvT9djYd9PYQFiu0TyNS+h3j/g==}
 
@@ -9013,6 +9151,9 @@ packages:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -9207,6 +9348,9 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -9270,6 +9414,10 @@ packages:
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -9604,8 +9752,8 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
-  genkit@1.37.0:
-    resolution: {integrity: sha512-CkQc8Pf9XYbg13O8RCY6bXxxGypTUNL+A/nm5iLfB/IDni1P5lS8cATFdtvgs0OeCgIr9mD69O5J5EK6Ndiziw==}
+  genkit@1.39.0:
+    resolution: {integrity: sha512-Qz9ef/LfAEDMzO1+Nd6l6dMYK/V4ZfWDIp79rz/1V6xDM5VuJMkoqOTCDwXAviuAnjoO2noJug2wIK81ilMhWA==}
 
   genkitx-openai@0.30.0:
     resolution: {integrity: sha512-6Dt3o6f+cKrZ1njSzYj2rm0U8SE5nQDwpz5VbFuLjaloE5BBj2c9OSlPGegdcz4PN5wBocGKiNsaKn0t5PpJdA==}
@@ -10557,6 +10705,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
@@ -10981,24 +11132,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -11140,6 +11295,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -12128,6 +12286,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pdf-lib@1.17.1:
     resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
@@ -12933,6 +13095,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -13057,6 +13222,9 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
@@ -13067,6 +13235,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -13197,6 +13368,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   strnum@2.2.0:
     resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
@@ -13343,6 +13517,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
@@ -13357,6 +13534,18 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.4.1:
     resolution: {integrity: sha512-sc2nGvGbixlJRHwTh/qQdPXTxJU1UDJboGPQm4d/01YUJ9r/u6aeIulQvEaxUlvKDN7hb1qCLjax+jhVAPLa/g==}
@@ -13825,6 +14014,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -13903,6 +14097,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   void-elements@2.0.1:
@@ -14001,6 +14223,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@3.1.0:
@@ -14343,7 +14570,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/build@20.3.26(e6cb669c5737e0a482bfe14152ad6630)':
+  '@angular/build@20.3.26(182e1bf26b21f667a99f055cdf7683fa)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.26(chokidar@4.0.3)
@@ -14384,6 +14611,7 @@ snapshots:
       lmdb: 3.4.2
       postcss: 8.5.15
       tailwindcss: 4.3.0
+      vitest: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.37)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.14.6(@types/node@20.19.37)(typescript@5.9.3))(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -15680,9 +15908,9 @@ snapshots:
     dependencies:
       retry: 0.13.1
 
-  '@genkit-ai/ai@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/ai@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/core': 1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/core': 1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.37
       colorette: 2.0.20
@@ -15704,7 +15932,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@genkit-ai/core@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/core@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.52.1
@@ -15728,7 +15956,7 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
-      '@genkit-ai/firebase': 1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/firebase': 1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
     transitivePeerDependencies:
       - '@google-cloud/firestore'
       - bufferutil
@@ -15749,12 +15977,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@genkit-ai/firebase@1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/firebase@1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
       firebase-admin: 13.8.0(encoding@0.1.13)
-      genkit: 1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
     optionalDependencies:
       firebase: 11.10.0
     transitivePeerDependencies:
@@ -15762,12 +15990,12 @@ snapshots:
       - supports-color
     optional: true
 
-  '@genkit-ai/firebase@1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/firebase@1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
       firebase-admin: 13.8.0(encoding@0.1.13)
-      genkit: 1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
     optionalDependencies:
       firebase: 11.10.0
     transitivePeerDependencies:
@@ -15775,7 +16003,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@genkit-ai/google-cloud@1.30.1(encoding@0.1.13)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/google-cloud@1.30.1(encoding@0.1.13)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
       '@google-cloud/logging-winston': 6.0.1(encoding@0.1.13)(winston@3.19.0)
       '@google-cloud/modelarmor': 0.4.1
@@ -15792,7 +16020,7 @@ snapshots:
       '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-node': 0.52.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.25.1(@opentelemetry/api@1.9.0)
-      genkit: 1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
       google-auth-library: 9.15.1(encoding@0.1.13)
       node-fetch: 3.3.2
       winston: 3.19.0
@@ -16219,6 +16447,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.37
 
+  '@inquirer/confirm@6.1.0(@types/node@22.15.32)':
+    dependencies:
+      '@inquirer/core': 11.2.0(@types/node@22.15.32)
+      '@inquirer/type': 4.0.6(@types/node@22.15.32)
+    optionalDependencies:
+      '@types/node': 22.15.32
+    optional: true
+
   '@inquirer/core@10.3.2(@types/node@20.19.37)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -16243,6 +16479,19 @@ snapshots:
       signal-exit: 4.1.0
     optionalDependencies:
       '@types/node': 20.19.37
+
+  '@inquirer/core@11.2.0(@types/node@22.15.32)':
+    dependencies:
+      '@inquirer/ansi': 2.0.6
+      '@inquirer/figures': 2.0.6
+      '@inquirer/type': 4.0.6(@types/node@22.15.32)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 4.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.15.32
+    optional: true
 
   '@inquirer/editor@4.2.23(@types/node@20.19.37)':
     dependencies:
@@ -16342,6 +16591,11 @@ snapshots:
   '@inquirer/type@4.0.6(@types/node@20.19.37)':
     optionalDependencies:
       '@types/node': 20.19.37
+
+  '@inquirer/type@4.0.6(@types/node@22.15.32)':
+    optionalDependencies:
+      '@types/node': 22.15.32
+    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -19064,6 +19318,11 @@ snapshots:
 
   '@types/caseless@0.12.5': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.36':
     dependencies:
       '@types/node': 20.19.37
@@ -19201,6 +19460,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -19614,6 +19875,59 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(msw@2.14.6(@types/node@20.19.37)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.37)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@20.19.37)(typescript@5.9.3)
+      vite: 6.4.2(@types/node@20.19.37)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
+    optional: true
+
+  '@vitest/mocker@3.2.6(msw@2.14.6(@types/node@22.15.32)(typescript@5.9.3))(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@22.15.32)(typescript@5.9.3)
+      vite: 6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   '@yarnpkg/lockfile@1.1.0': {}
 
   abbrev@4.0.0: {}
@@ -19848,6 +20162,8 @@ snapshots:
   arrify@2.0.1: {}
 
   as-array@2.0.0: {}
+
+  assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
 
@@ -20196,6 +20512,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -20227,6 +20551,8 @@ snapshots:
   chardet@2.1.1: {}
 
   charenc@0.0.2: {}
+
+  check-error@2.1.3: {}
 
   check-node-version@4.2.1:
     dependencies:
@@ -20837,6 +21163,8 @@ snapshots:
 
   dedent@1.7.2: {}
 
+  deep-eql@5.0.2: {}
+
   deep-equal-in-any-order@2.2.0:
     dependencies:
       sort-any: 4.0.7
@@ -21223,6 +21551,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -21360,7 +21690,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -21393,7 +21723,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -21408,7 +21738,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -21563,6 +21893,10 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -21650,6 +21984,8 @@ snapshots:
       - supports-color
 
   exit@0.1.2: {}
+
+  expect-type@1.4.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -22253,10 +22589,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0):
+  genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0):
     dependencies:
-      '@genkit-ai/ai': 1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
-      '@genkit-ai/core': 1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.37.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/ai': 1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/core': 1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.39.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       uuid: 10.0.0
     transitivePeerDependencies:
       - '@google-cloud/firestore'
@@ -23520,6 +23856,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
@@ -24059,6 +24397,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
 
@@ -24800,6 +25140,32 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  msw@2.14.6(@types/node@22.15.32)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.1.0(@types/node@22.15.32)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.0
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   mustache@4.2.0: {}
 
   mute-stream@0.0.8: {}
@@ -25381,6 +25747,8 @@ snapshots:
       util: 0.10.4
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pdf-lib@1.17.1:
     dependencies:
@@ -26494,6 +26862,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -26647,6 +27017,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
@@ -26655,6 +27027,8 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -26844,6 +27218,10 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   strnum@2.2.0:
     optional: true
@@ -27038,6 +27416,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyexec@1.2.2: {}
@@ -27051,6 +27431,12 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@7.4.1: {}
 
@@ -27597,6 +27983,67 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@20.19.37)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.2(@types/node@20.19.37)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    optional: true
+
+  vite-node@3.2.4(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@6.4.2(@types/node@20.19.37)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.5
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.37
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      sass: 1.90.0
+      tsx: 4.21.0
+      yaml: 2.8.2
+    optional: true
+
   vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.5
@@ -27630,6 +28077,91 @@ snapshots:
       sass: 1.90.0
       tsx: 4.21.0
       yaml: 2.8.2
+
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@20.19.37)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.14.6(@types/node@20.19.37)(typescript@5.9.3))(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(msw@2.14.6(@types/node@20.19.37)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.37)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.2(@types/node@20.19.37)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@20.19.37)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 20.19.37
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    optional: true
+
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.15.32)(typescript@5.9.3))(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(msw@2.14.6(@types/node@22.15.32)(typescript@5.9.3))(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.90.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 22.15.32
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   void-elements@2.0.1:
     optional: true
@@ -27748,6 +28280,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@3.1.0:
     dependencies:

--- a/js/testapps/testing-sample/README.md
+++ b/js/testapps/testing-sample/README.md
@@ -10,7 +10,10 @@ streaming deterministically, without a live model, network, or API key.
 - a `recommendDish` flow that asks for a **structured** recommendation, then
   applies its own logic — validating the result and deriving `withinBudget`;
 - a `streamRecommendation` flow that streams the model's tokens out through the
-  flow's own stream.
+  flow's own stream;
+- a `confirmBooking` tool that `interrupt()`s for human confirmation
+  (human-in-the-loop). This is why the app imports `genkit/beta` — interrupts
+  are a beta feature; everything else works identically on the stable `genkit`.
 
 `createMenuApp()` is a factory so each test builds a fresh, isolated app. The
 default model is referenced by name only (`'menuModel'`), so tests register a
@@ -24,7 +27,16 @@ mock under that name and the app code runs unchanged.
   *your* code, not the model.
 - **Error paths** — script an invalid response and assert the flow rejects it.
 - **Tool round-trip** — return `toolRequests` from the mock; the framework
-  dispatches the real tool and calls the model again with the result.
+  dispatches the real tool and calls the model again with the result. Assert
+  what ran via `model.toolResponses` (the tool results fed back to the model).
+- **Scripting with a queue** — pass `respond: [...]` an array consumed one item
+  per call (last repeating), so a multi-turn tool interaction needs no branching
+  callback.
+- **Injected failures** — a queued `Error` (`respond: [new Error(...)]`) is
+  thrown when reached, to test how a flow handles a model failure.
+- **Human-in-the-loop** — the model requests `confirmBooking`, the tool
+  interrupts, generation pauses (`response.interrupts`), then `restart` resumes
+  it with the human's decision so the tool books the dish.
 - **Streaming through a flow** — drive `flow.stream(...)`, emit chunks via
   `sendChunk`, and assert chunks arrive through the flow plus the final output.
 - **`echoModel`** — a zero-config model that echoes the whole assembled request
@@ -34,8 +46,8 @@ mock under that name and the app code runs unchanged.
 - **Inspection** — `model.lastRequest` / `lastRequestMessage` (a genkit
   `Message`, so `.text` / `.media` work like on a response) / `lastRequestText`
   (the full assembled conversation as a string — works on *any* mock, including
-  structured-output paths where `echoModel` can't be used) / `requests` /
-  `requestCount`.
+  structured-output paths where `echoModel` can't be used) / `toolResponses` /
+  `requests` / `requestCount`.
 
 `genkit/testing` is runner-agnostic. The same patterns are shown twice:
 `tests/menu_test.ts` under Node's built-in `node:test`, and

--- a/js/testapps/testing-sample/README.md
+++ b/js/testapps/testing-sample/README.md
@@ -11,7 +11,7 @@ code runs unchanged.
 `tests/menu_test.ts` shows the patterns:
 
 - **`mockModel`** — script the model response, then assert flow output and
-  inspect what the model was called with: `model.lastMessage` (a genkit
+  inspect what the model was called with: `model.lastRequestMessage` (a genkit
   `Message`, so `.text` / `.media` work like on a response), plus
   `model.lastRequest`, `model.requests`, `model.requestCount`.
 - **Tool calls** — return `toolRequests` from the mock; the framework dispatches

--- a/js/testapps/testing-sample/README.md
+++ b/js/testapps/testing-sample/README.md
@@ -15,9 +15,13 @@ streaming deterministically, without a live model, network, or API key.
   (human-in-the-loop). This is why the app imports `genkit/beta` — interrupts
   are a beta feature; everything else works identically on the stable `genkit`.
 
-`createMenuApp()` is a factory so each test builds a fresh, isolated app. The
-default model is referenced by name only (`'menuModel'`), so tests register a
-mock under that name and the app code runs unchanged.
+The app is a standard module-level Genkit singleton. Its default model is
+referenced by name only (`'menuModel'`), so tests register a mock under that
+name and the app code runs unchanged. Each test *file* gets a fresh process
+(and so a fresh registry) from the runner — `node --test`, Jest, and Vitest all
+isolate per file — so a file registers its mock **once** and tests share it:
+`reset()` in `beforeEach` clears recorded history, and each test scripts its
+own behavior with `respondWith(...)`.
 
 `tests/menu_test.ts` shows the patterns:
 
@@ -29,29 +33,32 @@ mock under that name and the app code runs unchanged.
 - **Tool round-trip** — return `toolRequests` from the mock; the framework
   dispatches the real tool and calls the model again with the result. Assert
   what ran via `model.toolResponses` (the tool results fed back to the model).
-- **Scripting with a queue** — pass `respond: [...]` an array consumed one item
-  per call (last repeating), so a multi-turn tool interaction needs no branching
-  callback.
-- **Injected failures** — a queued `Error` (`respond: [new Error(...)]`) is
+- **Scripting with a queue** — pass `respondWith([...])` an array consumed one
+  item per call (last repeating), so a multi-turn tool interaction needs no
+  branching callback.
+- **Injected failures** — a queued `Error` (`respondWith([new Error(...)])`) is
   thrown when reached, to test how a flow handles a model failure.
 - **Human-in-the-loop** — the model requests `confirmBooking`, the tool
   interrupts, generation pauses (`response.interrupts`), then `restart` resumes
   it with the human's decision so the tool books the dish.
 - **Streaming through a flow** — drive `flow.stream(...)`, emit chunks via
   `sendChunk`, and assert chunks arrive through the flow plus the final output.
-- **`echoModel`** — a zero-config model that echoes the whole assembled request
-  (system + Handlebars-rendered messages), for asserting prompt assembly. It's a
-  *text*-path preset: if the request carries an output schema it throws an
-  explanatory error (text can't satisfy a schema) — use `mockModel` there.
+- **`echoModel`** (`tests/prompt_test.ts`) — a zero-config model that echoes
+  the whole assembled request (system + Handlebars-rendered messages), for
+  asserting prompt assembly. It lives in its own test file because
+  `menu_test.ts` already claims `'menuModel'` with a `mockModel`, and per-file
+  process isolation keeps the registrations apart. It's a *text*-path preset:
+  if the request carries an output schema it throws an explanatory error (text
+  can't satisfy a schema) — use `mockModel` there.
 - **Inspection** — `model.lastRequest` / `lastRequestMessage` (a genkit
   `Message`, so `.text` / `.media` work like on a response) / `lastRequestText`
   (the full assembled conversation as a string — works on *any* mock, including
   structured-output paths where `echoModel` can't be used) / `toolResponses` /
   `requests` / `requestCount`.
 
-`genkit/testing` is runner-agnostic. The same patterns are shown twice:
-`tests/menu_test.ts` under Node's built-in `node:test`, and
-`tests/menu.vitest.test.ts` under vitest.
+`genkit/testing` is runner-agnostic. The same patterns are shown twice: under
+Node's built-in `node:test` (`tests/menu_test.ts`, `tests/prompt_test.ts`) and
+under vitest (`tests/menu.vitest.test.ts`, `tests/prompt.vitest.test.ts`).
 
 ## Run
 

--- a/js/testapps/testing-sample/README.md
+++ b/js/testapps/testing-sample/README.md
@@ -1,0 +1,33 @@
+# testing-sample
+
+Demonstrates `genkit/testing` — unit-testing Genkit flows, prompts, tools, and
+streaming deterministically, without a live model, network, or API key.
+
+`src/menu.ts` defines a normal app: a `recommendDish` flow that calls
+`ai.generate` with a `dailySpecial` tool. The default model is referenced by
+name only (`'menuModel'`), so tests register a mock under that name and the flow
+code runs unchanged.
+
+`tests/menu_test.ts` shows the patterns:
+
+- **`mockModel`** — script the model response, then assert flow output and
+  inspect what the model was called with: `model.lastMessage` (a genkit
+  `Message`, so `.text` / `.media` work like on a response), plus
+  `model.lastRequest`, `model.requests`, `model.requestCount`.
+- **Tool calls** — return `toolRequests` from the mock; the framework dispatches
+  the real tool and calls the model again with the result.
+- **Streaming** — emit chunks via `sendChunk` and assert on the stream.
+- **`echoModel`** — zero-config model that echoes the rendered request, for
+  asserting prompt/message assembly.
+
+`genkit/testing` is runner-agnostic. The same patterns are shown twice:
+`tests/menu_test.ts` under Node's built-in `node:test`, and
+`tests/menu.vitest.test.ts` under vitest.
+
+## Run
+
+```sh
+pnpm i
+pnpm test          # node:test
+pnpm test:vitest   # vitest
+```

--- a/js/testapps/testing-sample/README.md
+++ b/js/testapps/testing-sample/README.md
@@ -3,22 +3,36 @@
 Demonstrates `genkit/testing` — unit-testing Genkit flows, prompts, tools, and
 streaming deterministically, without a live model, network, or API key.
 
-`src/menu.ts` defines a normal app: a `recommendDish` flow that calls
-`ai.generate` with a `dailySpecial` tool. The default model is referenced by
-name only (`'menuModel'`), so tests register a mock under that name and the flow
-code runs unchanged.
+`src/menu.ts` defines a normal app with logic worth testing:
+
+- a `recommendPrompt` dotprompt (Handlebars template + system instruction + the
+  `dailySpecial` tool);
+- a `recommendDish` flow that asks for a **structured** recommendation, then
+  applies its own logic — validating the result and deriving `withinBudget`;
+- a `streamRecommendation` flow that streams the model's tokens out through the
+  flow's own stream.
+
+`createMenuApp()` is a factory so each test builds a fresh, isolated app. The
+default model is referenced by name only (`'menuModel'`), so tests register a
+mock under that name and the app code runs unchanged.
 
 `tests/menu_test.ts` shows the patterns:
 
-- **`mockModel`** — script the model response, then assert flow output and
-  inspect what the model was called with: `model.lastRequestMessage` (a genkit
-  `Message`, so `.text` / `.media` work like on a response), plus
-  `model.lastRequest`, `model.requests`, `model.requestCount`.
-- **Tool calls** — return `toolRequests` from the mock; the framework dispatches
-  the real tool and calls the model again with the result.
-- **Streaming** — emit chunks via `sendChunk` and assert on the stream.
-- **`echoModel`** — zero-config model that echoes the rendered request, for
-  asserting prompt/message assembly.
+- **Structured output + your own logic** — the mock returns JSON; the test pins
+  down the flow's derivation (`withinBudget`) and validation. The same model
+  output with a lower budget flips `withinBudget` — proving the test exercises
+  *your* code, not the model.
+- **Error paths** — script an invalid response and assert the flow rejects it.
+- **Tool round-trip** — return `toolRequests` from the mock; the framework
+  dispatches the real tool and calls the model again with the result.
+- **Streaming through a flow** — drive `flow.stream(...)`, emit chunks via
+  `sendChunk`, and assert chunks arrive through the flow plus the final output.
+- **`echoModel`** — a zero-config model that echoes the whole assembled request
+  (system + Handlebars-rendered messages), for asserting prompt assembly. Use it
+  for text paths; `mockModel` for structured output.
+- **Inspection** — `model.lastRequest` / `lastRequestMessage` (a genkit
+  `Message`, so `.text` / `.media` work like on a response) / `requests` /
+  `requestCount`.
 
 `genkit/testing` is runner-agnostic. The same patterns are shown twice:
 `tests/menu_test.ts` under Node's built-in `node:test`, and

--- a/js/testapps/testing-sample/README.md
+++ b/js/testapps/testing-sample/README.md
@@ -28,10 +28,13 @@ mock under that name and the app code runs unchanged.
 - **Streaming through a flow** — drive `flow.stream(...)`, emit chunks via
   `sendChunk`, and assert chunks arrive through the flow plus the final output.
 - **`echoModel`** — a zero-config model that echoes the whole assembled request
-  (system + Handlebars-rendered messages), for asserting prompt assembly. Use it
-  for text paths; `mockModel` for structured output.
+  (system + Handlebars-rendered messages), for asserting prompt assembly. It's a
+  *text*-path preset: if the request carries an output schema it throws an
+  explanatory error (text can't satisfy a schema) — use `mockModel` there.
 - **Inspection** — `model.lastRequest` / `lastRequestMessage` (a genkit
-  `Message`, so `.text` / `.media` work like on a response) / `requests` /
+  `Message`, so `.text` / `.media` work like on a response) / `lastRequestText`
+  (the full assembled conversation as a string — works on *any* mock, including
+  structured-output paths where `echoModel` can't be used) / `requests` /
   `requestCount`.
 
 `genkit/testing` is runner-agnostic. The same patterns are shown twice:

--- a/js/testapps/testing-sample/README.md
+++ b/js/testapps/testing-sample/README.md
@@ -17,9 +17,10 @@ streaming deterministically, without a live model, network, or API key.
 
 The app is a standard module-level Genkit singleton. Its default model is
 referenced by name only (`'menuModel'`), so tests register a mock under that
-name and the app code runs unchanged. Each test *file* gets a fresh process
-(and so a fresh registry) from the runner — `node --test`, Jest, and Vitest all
-isolate per file — so a file registers its mock **once** and tests share it:
+name and the app code runs unchanged. Each test *file* gets its own process or
+module graph (and so a fresh registry) from the runner — `node --test` spawns
+a child process per file; Jest and Vitest isolate each file's module registry —
+so a file registers its mock **once** and tests share it:
 `reset()` in `beforeEach` clears recorded history, and each test scripts its
 own behavior with `respondWith(...)`.
 

--- a/js/testapps/testing-sample/package.json
+++ b/js/testapps/testing-sample/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "testing-sample",
+  "version": "1.0.0",
+  "description": "Sample app demonstrating genkit/testing: unit-testing flows, prompts, tools, and streaming with mockModel / echoModel.",
+  "main": "lib/index.js",
+  "private": true,
+  "scripts": {
+    "start": "node lib/index.js",
+    "compile": "tsc",
+    "build": "pnpm build:clean && pnpm compile",
+    "build:clean": "rimraf ./lib",
+    "test": "node --import tsx --test tests/*_test.ts",
+    "test:vitest": "vitest run",
+    "genkit:dev": "genkit start -- tsx --watch src/index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "genkit": "workspace:*",
+    "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "rimraf": "^6.0.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.6"
+  }
+}

--- a/js/testapps/testing-sample/package.json
+++ b/js/testapps/testing-sample/package.json
@@ -2,16 +2,17 @@
   "name": "testing-sample",
   "version": "1.0.0",
   "description": "Sample app demonstrating genkit/testing: unit-testing flows, prompts, tools, and streaming with mockModel / echoModel.",
-  "main": "lib/index.js",
+  "main": "lib/menu.js",
+  "type": "module",
   "private": true,
   "scripts": {
-    "start": "node lib/index.js",
+    "start": "node lib/menu.js",
     "compile": "tsc",
     "build": "pnpm build:clean && pnpm compile",
     "build:clean": "rimraf ./lib",
     "test": "node --import tsx --test tests/*_test.ts",
     "test:vitest": "vitest run",
-    "genkit:dev": "genkit start -- tsx --watch src/index.ts"
+    "genkit:dev": "genkit start -- tsx --watch src/menu.ts"
   },
   "keywords": [],
   "author": "",

--- a/js/testapps/testing-sample/src/menu.ts
+++ b/js/testapps/testing-sample/src/menu.ts
@@ -17,8 +17,8 @@
 // `genkit/beta` is a superset of `genkit` — used here because the
 // human-in-the-loop `confirmBooking` tool relies on interrupts, a beta feature.
 // Everything else in this app works identically on the stable `genkit` entry.
-import { genkit } from 'genkit/beta';
 import { z } from 'genkit';
+import { genkit } from 'genkit/beta';
 
 /** What we ask the model to produce: a structured recommendation. */
 export const RecommendationSchema = z.object({

--- a/js/testapps/testing-sample/src/menu.ts
+++ b/js/testapps/testing-sample/src/menu.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { genkit, z } from 'genkit';
+// `genkit/beta` is a superset of `genkit` — used here because the
+// human-in-the-loop `confirmBooking` tool relies on interrupts, a beta feature.
+// Everything else in this app works identically on the stable `genkit` entry.
+import { genkit } from 'genkit/beta';
+import { z } from 'genkit';
 
 /** What we ask the model to produce: a structured recommendation. */
 export const RecommendationSchema = z.object({
@@ -134,9 +138,29 @@ export function createMenuApp() {
     }
   );
 
+  /**
+   * A human-in-the-loop tool: booking a dish needs explicit confirmation, so the
+   * tool `interrupt()`s on first run to hand control back to the caller, and
+   * completes once generation is resumed with the human's answer. Tests drive
+   * the pause -> resume round-trip with `mockModel` (see menu_test.ts).
+   */
+  const confirmBooking = ai.defineTool(
+    {
+      name: 'confirmBooking',
+      description: 'Confirm with the user before booking a dish.',
+      inputSchema: z.object({ dish: z.string() }),
+      outputSchema: z.string(),
+    },
+    async ({ dish }, { interrupt, resumed }) => {
+      if (resumed) return `Booked: ${dish}.`;
+      return interrupt({ dish });
+    }
+  );
+
   return {
     ai,
     dailySpecial,
+    confirmBooking,
     recommendPrompt,
     recommendDish,
     streamRecommendation,
@@ -150,6 +174,7 @@ export function createMenuApp() {
 export const {
   ai,
   dailySpecial,
+  confirmBooking,
   recommendPrompt,
   recommendDish,
   streamRecommendation,

--- a/js/testapps/testing-sample/src/menu.ts
+++ b/js/testapps/testing-sample/src/menu.ts
@@ -16,19 +16,41 @@
 
 import { genkit, z } from 'genkit';
 
+/** What we ask the model to produce: a structured recommendation. */
+export const RecommendationSchema = z.object({
+  dish: z.string(),
+  reason: z.string(),
+  priceUSD: z.number(),
+});
+
+/** What the flow returns to its caller, after applying our own logic. */
+export const DishResultSchema = z.object({
+  dish: z.string(),
+  reason: z.string(),
+  /** Derived by the flow, not by the model. */
+  withinBudget: z.boolean(),
+});
+
+/** Flow input. */
+export const RecommendInputSchema = z.object({
+  restaurant: z.string(),
+  mood: z.string(),
+  budgetUSD: z.number(),
+});
+
 /**
- * Builds the app's Genkit instance, tool, and flow. Exposed as a factory so
- * each test can build a fresh, isolated app (its own registry) and register a
- * mock under the default model name without colliding with other tests. The
- * default model is referenced by name only — in production you'd register it
- * from a provider plugin (e.g. googleAI), and in tests you register a mock
- * under the same name. Either way the flow code below is unchanged.
+ * Builds the app's Genkit instance, tool, prompt, and flows. Exposed as a
+ * factory so each test can build a fresh, isolated app (its own registry) and
+ * register a mock under the default model name without colliding with other
+ * tests. The default model is referenced by name only — in production you'd
+ * register it from a provider plugin (e.g. googleAI), and in tests you register
+ * a mock under the same name. Either way the app code below is unchanged.
  */
 export function createMenuApp() {
   const ai = genkit({ model: 'menuModel' });
 
   /**
-   * A tool the model can call to look up today's specials for a restaurant.
+   * A tool the model can call to look up today's special for a restaurant.
    * In a real app this would hit a database; here it is deterministic.
    */
   const dailySpecial = ai.defineTool(
@@ -43,29 +65,92 @@ export function createMenuApp() {
   );
 
   /**
-   * A flow that asks a model to recommend a dish, with the `dailySpecial` tool
-   * available. Returns the model's text recommendation.
+   * A dotprompt: a Handlebars template with a system instruction and the
+   * `dailySpecial` tool. Tests use `echoModel` to assert this renders correctly
+   * (system + interpolated variables). The structured output schema is supplied
+   * by the flow at call time (see below) so the prompt itself stays text-
+   * renderable — `echoModel` produces text, which a strict output schema would
+   * reject.
+   */
+  const recommendPrompt = ai.definePrompt({
+    name: 'recommendPrompt',
+    input: { schema: RecommendInputSchema },
+    system: 'You are a concise restaurant concierge.',
+    prompt:
+      'Recommend a dish at {{restaurant}} for someone feeling {{mood}}. ' +
+      'Their budget is {{budgetUSD}} USD.',
+    tools: [dailySpecial],
+  });
+
+  /**
+   * A flow with real logic worth testing: it asks the model (via the prompt)
+   * for a structured recommendation, validates it, and derives `withinBudget`
+   * itself — that derivation, not the model, is what the tests pin down.
    */
   const recommendDish = ai.defineFlow(
     {
       name: 'recommendDish',
-      inputSchema: z.object({ restaurant: z.string(), mood: z.string() }),
-      outputSchema: z.string(),
+      inputSchema: RecommendInputSchema,
+      outputSchema: DishResultSchema,
     },
-    async ({ restaurant, mood }) => {
-      const { text } = await ai.generate({
-        prompt: `Recommend a dish at ${restaurant} for someone feeling ${mood}.`,
-        tools: [dailySpecial],
+    async (input) => {
+      const { output } = await recommendPrompt(input, {
+        output: { schema: RecommendationSchema },
       });
-      return text;
+      if (!output) {
+        throw new Error('Model did not return a structured recommendation.');
+      }
+      if (output.priceUSD <= 0) {
+        throw new Error('Recommendation has a non-positive price.');
+      }
+      return {
+        dish: output.dish,
+        reason: output.reason,
+        withinBudget: output.priceUSD <= input.budgetUSD,
+      };
     }
   );
 
-  return { ai, dailySpecial, recommendDish };
+  /**
+   * A streaming flow: it forwards the model's tokens out through the flow's own
+   * stream (and returns the final text). Tests drive it with `flow.stream(...)`
+   * to assert chunks arrive through the flow, not just from the model directly.
+   */
+  const streamRecommendation = ai.defineFlow(
+    {
+      name: 'streamRecommendation',
+      inputSchema: z.object({ restaurant: z.string(), mood: z.string() }),
+      outputSchema: z.string(),
+      streamSchema: z.string(),
+    },
+    async ({ restaurant, mood }, { sendChunk }) => {
+      const { response, stream } = ai.generateStream({
+        prompt: `Recommend a dish at ${restaurant} for someone feeling ${mood}.`,
+      });
+      for await (const chunk of stream) {
+        sendChunk(chunk.text);
+      }
+      return (await response).text;
+    }
+  );
+
+  return {
+    ai,
+    dailySpecial,
+    recommendPrompt,
+    recommendDish,
+    streamRecommendation,
+  };
 }
 
 /**
  * The default app singleton, used by the dev server (`pnpm genkit:dev`). Tests
  * call {@link createMenuApp} directly for isolation.
  */
-export const { ai, dailySpecial, recommendDish } = createMenuApp();
+export const {
+  ai,
+  dailySpecial,
+  recommendPrompt,
+  recommendDish,
+  streamRecommendation,
+} = createMenuApp();

--- a/js/testapps/testing-sample/src/menu.ts
+++ b/js/testapps/testing-sample/src/menu.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { genkit, z } from 'genkit';
+
+/**
+ * The app's Genkit instance. The default model is referenced by name only —
+ * in production you'd register it from a provider plugin (e.g. googleAI), and
+ * in tests you register a mock under the same name. Either way the flow code
+ * below is unchanged.
+ */
+export const ai = genkit({ model: 'menuModel' });
+
+/**
+ * A tool the model can call to look up today's specials for a restaurant.
+ * In a real app this would hit a database; here it is deterministic.
+ */
+export const dailySpecial = ai.defineTool(
+  {
+    name: 'dailySpecial',
+    description: "Get today's special dish for a restaurant.",
+    inputSchema: z.object({ restaurant: z.string() }),
+    outputSchema: z.string(),
+  },
+  async ({ restaurant }) => `${restaurant}'s special today is mushroom risotto.`
+);
+
+/**
+ * A flow that asks a model to recommend a dish, with the `dailySpecial` tool
+ * available. Returns the model's text recommendation.
+ */
+export const recommendDish = ai.defineFlow(
+  {
+    name: 'recommendDish',
+    inputSchema: z.object({ restaurant: z.string(), mood: z.string() }),
+    outputSchema: z.string(),
+  },
+  async ({ restaurant, mood }) => {
+    const { text } = await ai.generate({
+      prompt: `Recommend a dish at ${restaurant} for someone feeling ${mood}.`,
+      tools: [dailySpecial],
+    });
+    return text;
+  }
+);

--- a/js/testapps/testing-sample/src/menu.ts
+++ b/js/testapps/testing-sample/src/menu.ts
@@ -43,139 +43,116 @@ export const RecommendInputSchema = z.object({
 });
 
 /**
- * Builds the app's Genkit instance, tool, prompt, and flows. Exposed as a
- * factory so each test can build a fresh, isolated app (its own registry) and
- * register a mock under the default model name without colliding with other
- * tests. The default model is referenced by name only — in production you'd
- * register it from a provider plugin (e.g. googleAI), and in tests you register
- * a mock under the same name. Either way the app code below is unchanged.
+ * The app's Genkit instance, a plain module-level singleton — the standard
+ * Genkit app structure. The default model is referenced by name only: in
+ * production you'd register it from a provider plugin (e.g. googleAI), and in
+ * tests you register a mock under the same name. Either way the app code below
+ * is unchanged. Test runners (`node --test`, Jest, Vitest) isolate each test
+ * file in its own process/module graph, so every test file gets a fresh
+ * registry for free; within a file, tests share one mock and use
+ * `reset()` / `respondWith()` (see the tests).
  */
-export function createMenuApp() {
-  const ai = genkit({ model: 'menuModel' });
-
-  /**
-   * A tool the model can call to look up today's special for a restaurant.
-   * In a real app this would hit a database; here it is deterministic.
-   */
-  const dailySpecial = ai.defineTool(
-    {
-      name: 'dailySpecial',
-      description: "Get today's special dish for a restaurant.",
-      inputSchema: z.object({ restaurant: z.string() }),
-      outputSchema: z.string(),
-    },
-    async ({ restaurant }) =>
-      `${restaurant}'s special today is mushroom risotto.`
-  );
-
-  /**
-   * A dotprompt: a Handlebars template with a system instruction and the
-   * `dailySpecial` tool. Tests use `echoModel` to assert this renders correctly
-   * (system + interpolated variables). The structured output schema is supplied
-   * by the flow at call time (see below) so the prompt itself stays text-
-   * renderable — `echoModel` produces text, which a strict output schema would
-   * reject.
-   */
-  const recommendPrompt = ai.definePrompt({
-    name: 'recommendPrompt',
-    input: { schema: RecommendInputSchema },
-    system: 'You are a concise restaurant concierge.',
-    prompt:
-      'Recommend a dish at {{restaurant}} for someone feeling {{mood}}. ' +
-      'Their budget is {{budgetUSD}} USD.',
-    tools: [dailySpecial],
-  });
-
-  /**
-   * A flow with real logic worth testing: it asks the model (via the prompt)
-   * for a structured recommendation, validates it, and derives `withinBudget`
-   * itself — that derivation, not the model, is what the tests pin down.
-   */
-  const recommendDish = ai.defineFlow(
-    {
-      name: 'recommendDish',
-      inputSchema: RecommendInputSchema,
-      outputSchema: DishResultSchema,
-    },
-    async (input) => {
-      const { output } = await recommendPrompt(input, {
-        output: { schema: RecommendationSchema },
-      });
-      if (!output) {
-        throw new Error('Model did not return a structured recommendation.');
-      }
-      if (output.priceUSD <= 0) {
-        throw new Error('Recommendation has a non-positive price.');
-      }
-      return {
-        dish: output.dish,
-        reason: output.reason,
-        withinBudget: output.priceUSD <= input.budgetUSD,
-      };
-    }
-  );
-
-  /**
-   * A streaming flow: it forwards the model's tokens out through the flow's own
-   * stream (and returns the final text). Tests drive it with `flow.stream(...)`
-   * to assert chunks arrive through the flow, not just from the model directly.
-   */
-  const streamRecommendation = ai.defineFlow(
-    {
-      name: 'streamRecommendation',
-      inputSchema: z.object({ restaurant: z.string(), mood: z.string() }),
-      outputSchema: z.string(),
-      streamSchema: z.string(),
-    },
-    async ({ restaurant, mood }, { sendChunk }) => {
-      const { response, stream } = ai.generateStream({
-        prompt: `Recommend a dish at ${restaurant} for someone feeling ${mood}.`,
-      });
-      for await (const chunk of stream) {
-        sendChunk(chunk.text);
-      }
-      return (await response).text;
-    }
-  );
-
-  /**
-   * A human-in-the-loop tool: booking a dish needs explicit confirmation, so the
-   * tool `interrupt()`s on first run to hand control back to the caller, and
-   * completes once generation is resumed with the human's answer. Tests drive
-   * the pause -> resume round-trip with `mockModel` (see menu_test.ts).
-   */
-  const confirmBooking = ai.defineTool(
-    {
-      name: 'confirmBooking',
-      description: 'Confirm with the user before booking a dish.',
-      inputSchema: z.object({ dish: z.string() }),
-      outputSchema: z.string(),
-    },
-    async ({ dish }, { interrupt, resumed }) => {
-      if (resumed) return `Booked: ${dish}.`;
-      return interrupt({ dish });
-    }
-  );
-
-  return {
-    ai,
-    dailySpecial,
-    confirmBooking,
-    recommendPrompt,
-    recommendDish,
-    streamRecommendation,
-  };
-}
+export const ai = genkit({ model: 'menuModel' });
 
 /**
- * The default app singleton, used by the dev server (`pnpm genkit:dev`). Tests
- * call {@link createMenuApp} directly for isolation.
+ * A tool the model can call to look up today's special for a restaurant.
+ * In a real app this would hit a database; here it is deterministic.
  */
-export const {
-  ai,
-  dailySpecial,
-  confirmBooking,
-  recommendPrompt,
-  recommendDish,
-  streamRecommendation,
-} = createMenuApp();
+export const dailySpecial = ai.defineTool(
+  {
+    name: 'dailySpecial',
+    description: "Get today's special dish for a restaurant.",
+    inputSchema: z.object({ restaurant: z.string() }),
+    outputSchema: z.string(),
+  },
+  async ({ restaurant }) => `${restaurant}'s special today is mushroom risotto.`
+);
+
+/**
+ * A dotprompt: a Handlebars template with a system instruction and the
+ * `dailySpecial` tool. Tests use `echoModel` to assert this renders correctly
+ * (system + interpolated variables). The structured output schema is supplied
+ * by the flow at call time (see below) so the prompt itself stays text-
+ * renderable — `echoModel` produces text, which a strict output schema would
+ * reject.
+ */
+export const recommendPrompt = ai.definePrompt({
+  name: 'recommendPrompt',
+  input: { schema: RecommendInputSchema },
+  system: 'You are a concise restaurant concierge.',
+  prompt:
+    'Recommend a dish at {{restaurant}} for someone feeling {{mood}}. ' +
+    'Their budget is {{budgetUSD}} USD.',
+  tools: [dailySpecial],
+});
+
+/**
+ * A flow with real logic worth testing: it asks the model (via the prompt)
+ * for a structured recommendation, validates it, and derives `withinBudget`
+ * itself — that derivation, not the model, is what the tests pin down.
+ */
+export const recommendDish = ai.defineFlow(
+  {
+    name: 'recommendDish',
+    inputSchema: RecommendInputSchema,
+    outputSchema: DishResultSchema,
+  },
+  async (input) => {
+    const { output } = await recommendPrompt(input, {
+      output: { schema: RecommendationSchema },
+    });
+    if (!output) {
+      throw new Error('Model did not return a structured recommendation.');
+    }
+    if (output.priceUSD <= 0) {
+      throw new Error('Recommendation has a non-positive price.');
+    }
+    return {
+      dish: output.dish,
+      reason: output.reason,
+      withinBudget: output.priceUSD <= input.budgetUSD,
+    };
+  }
+);
+
+/**
+ * A streaming flow: it forwards the model's tokens out through the flow's own
+ * stream (and returns the final text). Tests drive it with `flow.stream(...)`
+ * to assert chunks arrive through the flow, not just from the model directly.
+ */
+export const streamRecommendation = ai.defineFlow(
+  {
+    name: 'streamRecommendation',
+    inputSchema: z.object({ restaurant: z.string(), mood: z.string() }),
+    outputSchema: z.string(),
+    streamSchema: z.string(),
+  },
+  async ({ restaurant, mood }, { sendChunk }) => {
+    const { response, stream } = ai.generateStream({
+      prompt: `Recommend a dish at ${restaurant} for someone feeling ${mood}.`,
+    });
+    for await (const chunk of stream) {
+      sendChunk(chunk.text);
+    }
+    return (await response).text;
+  }
+);
+
+/**
+ * A human-in-the-loop tool: booking a dish needs explicit confirmation, so the
+ * tool `interrupt()`s on first run to hand control back to the caller, and
+ * completes once generation is resumed with the human's answer. Tests drive
+ * the pause -> resume round-trip with `mockModel` (see menu_test.ts).
+ */
+export const confirmBooking = ai.defineTool(
+  {
+    name: 'confirmBooking',
+    description: 'Confirm with the user before booking a dish.',
+    inputSchema: z.object({ dish: z.string() }),
+    outputSchema: z.string(),
+  },
+  async ({ dish }, { interrupt, resumed }) => {
+    if (resumed) return `Booked: ${dish}.`;
+    return interrupt({ dish });
+  }
+);

--- a/js/testapps/testing-sample/src/menu.ts
+++ b/js/testapps/testing-sample/src/menu.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,42 +17,55 @@
 import { genkit, z } from 'genkit';
 
 /**
- * The app's Genkit instance. The default model is referenced by name only —
- * in production you'd register it from a provider plugin (e.g. googleAI), and
- * in tests you register a mock under the same name. Either way the flow code
- * below is unchanged.
+ * Builds the app's Genkit instance, tool, and flow. Exposed as a factory so
+ * each test can build a fresh, isolated app (its own registry) and register a
+ * mock under the default model name without colliding with other tests. The
+ * default model is referenced by name only — in production you'd register it
+ * from a provider plugin (e.g. googleAI), and in tests you register a mock
+ * under the same name. Either way the flow code below is unchanged.
  */
-export const ai = genkit({ model: 'menuModel' });
+export function createMenuApp() {
+  const ai = genkit({ model: 'menuModel' });
+
+  /**
+   * A tool the model can call to look up today's specials for a restaurant.
+   * In a real app this would hit a database; here it is deterministic.
+   */
+  const dailySpecial = ai.defineTool(
+    {
+      name: 'dailySpecial',
+      description: "Get today's special dish for a restaurant.",
+      inputSchema: z.object({ restaurant: z.string() }),
+      outputSchema: z.string(),
+    },
+    async ({ restaurant }) =>
+      `${restaurant}'s special today is mushroom risotto.`
+  );
+
+  /**
+   * A flow that asks a model to recommend a dish, with the `dailySpecial` tool
+   * available. Returns the model's text recommendation.
+   */
+  const recommendDish = ai.defineFlow(
+    {
+      name: 'recommendDish',
+      inputSchema: z.object({ restaurant: z.string(), mood: z.string() }),
+      outputSchema: z.string(),
+    },
+    async ({ restaurant, mood }) => {
+      const { text } = await ai.generate({
+        prompt: `Recommend a dish at ${restaurant} for someone feeling ${mood}.`,
+        tools: [dailySpecial],
+      });
+      return text;
+    }
+  );
+
+  return { ai, dailySpecial, recommendDish };
+}
 
 /**
- * A tool the model can call to look up today's specials for a restaurant.
- * In a real app this would hit a database; here it is deterministic.
+ * The default app singleton, used by the dev server (`pnpm genkit:dev`). Tests
+ * call {@link createMenuApp} directly for isolation.
  */
-export const dailySpecial = ai.defineTool(
-  {
-    name: 'dailySpecial',
-    description: "Get today's special dish for a restaurant.",
-    inputSchema: z.object({ restaurant: z.string() }),
-    outputSchema: z.string(),
-  },
-  async ({ restaurant }) => `${restaurant}'s special today is mushroom risotto.`
-);
-
-/**
- * A flow that asks a model to recommend a dish, with the `dailySpecial` tool
- * available. Returns the model's text recommendation.
- */
-export const recommendDish = ai.defineFlow(
-  {
-    name: 'recommendDish',
-    inputSchema: z.object({ restaurant: z.string(), mood: z.string() }),
-    outputSchema: z.string(),
-  },
-  async ({ restaurant, mood }) => {
-    const { text } = await ai.generate({
-      prompt: `Recommend a dish at ${restaurant} for someone feeling ${mood}.`,
-      tools: [dailySpecial],
-    });
-    return text;
-  }
-);
+export const { ai, dailySpecial, recommendDish } = createMenuApp();

--- a/js/testapps/testing-sample/tests/menu.vitest.test.ts
+++ b/js/testapps/testing-sample/tests/menu.vitest.test.ts
@@ -14,41 +14,38 @@
  * limitations under the License.
  */
 
-import { echoModel, mockModel } from 'genkit/testing';
+import { mockModel } from 'genkit/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createMenuApp } from '../src/menu.js';
+import {
+  ai,
+  confirmBooking,
+  recommendDish,
+  streamRecommendation,
+} from '../src/menu.js';
 
 // The same patterns as menu_test.ts, written with vitest instead of node:test —
-// `genkit/testing` is runner-agnostic. Build a fresh app per test, then register
-// the mock under the app's default model name ('menuModel') so the app runs
-// unchanged.
-type App = ReturnType<typeof createMenuApp>;
-let ai: App['ai'];
-let confirmBooking: App['confirmBooking'];
-let recommendDish: App['recommendDish'];
-let recommendPrompt: App['recommendPrompt'];
-let streamRecommendation: App['streamRecommendation'];
-beforeEach(() => {
-  ({
-    ai,
-    confirmBooking,
-    recommendDish,
-    recommendPrompt,
-    streamRecommendation,
-  } = createMenuApp());
+// `genkit/testing` is runner-agnostic. One mock is registered under the app's
+// default model name for the whole file (vitest isolates each test file in its
+// own worker, so this can't collide with other files); each test scripts its
+// own behavior with `respondWith(...)` after `reset()` clears shared state.
+const model = mockModel(ai, {
+  name: 'menuModel',
+  info: { supports: { tools: true } },
 });
 
+beforeEach(() => model.reset());
+
 describe('recommendDish flow — structured output + business logic (vitest)', () => {
-  const respondWithRecommendation = () => ({
+  const recommendation = {
     text: JSON.stringify({
       dish: 'Mushroom risotto',
       reason: 'Comforting and in season.',
       priceUSD: 18,
     }),
-  });
+  };
 
   it('parses the structured recommendation and applies the budget logic', async () => {
-    mockModel(ai, { name: 'menuModel', respond: respondWithRecommendation });
+    model.respondWith(recommendation);
 
     // Same model output, two budgets — only our logic decides `withinBudget`.
     const ok = await recommendDish({
@@ -61,14 +58,11 @@ describe('recommendDish flow — structured output + business logic (vitest)', (
   });
 
   it('rejects a recommendation the flow considers invalid', async () => {
-    mockModel(ai, {
-      name: 'menuModel',
-      respond: () => ({
-        text: JSON.stringify({
-          dish: 'Free water',
-          reason: 'Out of stock on everything else.',
-          priceUSD: 0,
-        }),
+    model.respondWith({
+      text: JSON.stringify({
+        dish: 'Free water',
+        reason: 'Out of stock on everything else.',
+        priceUSD: 0,
       }),
     });
 
@@ -80,27 +74,23 @@ describe('recommendDish flow — structured output + business logic (vitest)', (
 
 describe('recommendDish flow — tool round-trip (vitest)', () => {
   it('runs dailySpecial, then returns the structured recommendation', async () => {
-    const model = mockModel(ai, {
-      name: 'menuModel',
-      info: { supports: { tools: true } },
-      respond: (req) => {
-        const toolAnswered = req.messages.some((m) =>
-          m.content.some((c) => c.toolResponse)
-        );
-        return toolAnswered
-          ? {
-              text: JSON.stringify({
-                dish: 'Mushroom risotto',
-                reason: "It's the daily special.",
-                priceUSD: 22,
-              }),
-            }
-          : {
-              toolRequests: [
-                { name: 'dailySpecial', input: { restaurant: 'Lumen' } },
-              ],
-            };
-      },
+    model.respondWith((req) => {
+      const toolAnswered = req.messages.some((m) =>
+        m.content.some((c) => c.toolResponse)
+      );
+      return toolAnswered
+        ? {
+            text: JSON.stringify({
+              dish: 'Mushroom risotto',
+              reason: "It's the daily special.",
+              priceUSD: 22,
+            }),
+          }
+        : {
+            toolRequests: [
+              { name: 'dailySpecial', input: { restaurant: 'Lumen' } },
+            ],
+          };
     });
 
     const out = await recommendDish({
@@ -117,22 +107,17 @@ describe('recommendDish flow — tool round-trip (vitest)', () => {
 
 describe('human-in-the-loop with interrupts (vitest)', () => {
   it('pauses on confirmBooking, then resumes to complete the booking', async () => {
-    const model = mockModel(ai, {
-      name: 'menuModel',
-      info: { supports: { tools: true } },
-      // Queued responses: request the interrupting tool, then answer.
-      respond: [
-        {
-          toolRequests: [
-            { name: 'confirmBooking', input: { dish: 'Mushroom risotto' } },
-          ],
-        },
-        { text: 'Enjoy your meal!' },
-      ],
-    });
+    // Queued responses: request the interrupting tool, then answer.
+    model.respondWith([
+      {
+        toolRequests: [
+          { name: 'confirmBooking', input: { dish: 'Mushroom risotto' } },
+        ],
+      },
+      { text: 'Enjoy your meal!' },
+    ]);
 
     const paused = await ai.generate({
-      model,
       prompt: 'Book the risotto.',
       tools: [confirmBooking],
     });
@@ -140,7 +125,6 @@ describe('human-in-the-loop with interrupts (vitest)', () => {
     expect(paused.interrupts[0].toolRequest.name).toBe('confirmBooking');
 
     const done = await ai.generate({
-      model,
       messages: paused.messages,
       tools: [confirmBooking],
       resume: {
@@ -158,33 +142,13 @@ describe('human-in-the-loop with interrupts (vitest)', () => {
   });
 });
 
-describe('prompt assembly with echoModel (vitest)', () => {
-  it('shows the full rendered request — system + interpolated template', async () => {
-    echoModel(ai, { name: 'menuModel', info: { supports: { tools: true } } });
-
-    const res = await recommendPrompt({
-      restaurant: 'Lumen',
-      mood: 'tired',
-      budgetUSD: 40,
-    });
-
-    expect(res.text).toMatch(/system: You are a concise restaurant concierge/);
-    expect(res.text).toMatch(
-      /Recommend a dish at Lumen for someone feeling tired\. Their budget is 40 USD/
-    );
-  });
-});
-
 describe('streamRecommendation flow — streaming through the flow (vitest)', () => {
   it('forwards model chunks out through the flow stream', async () => {
-    mockModel(ai, {
-      name: 'menuModel',
-      respond: (_req, { sendChunk }) => {
-        sendChunk('Try ');
-        sendChunk('the ');
-        sendChunk('risotto.');
-        return { text: 'Try the risotto.' };
-      },
+    model.respondWith((_req, { sendChunk }) => {
+      sendChunk('Try ');
+      sendChunk('the ');
+      sendChunk('risotto.');
+      return { text: 'Try the risotto.' };
     });
 
     const { stream, output } = streamRecommendation.stream({

--- a/js/testapps/testing-sample/tests/menu.vitest.test.ts
+++ b/js/testapps/testing-sample/tests/menu.vitest.test.ts
@@ -31,7 +31,7 @@ describe('recommendDish flow (vitest)', () => {
     const out = await recommendDish({ restaurant: 'Lumen', mood: 'cozy' });
 
     expect(out).toBe('Try the risotto.');
-    expect(model.lastMessage!.text).toMatch(
+    expect(model.lastRequestMessage!.text).toMatch(
       /Recommend a dish at Lumen for someone feeling cozy/
     );
   });

--- a/js/testapps/testing-sample/tests/menu.vitest.test.ts
+++ b/js/testapps/testing-sample/tests/menu.vitest.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { echoModel, mockModel } from 'genkit/testing';
+import { describe, expect, it } from 'vitest';
+import { ai, recommendDish } from '../src/menu.js';
+
+// The same patterns as menu_test.ts, written with vitest instead of node:test —
+// `genkit/testing` is runner-agnostic. Register the mock under the app's default
+// model name ('menuModel') so the flow runs unchanged.
+describe('recommendDish flow (vitest)', () => {
+  it('returns the model recommendation', async () => {
+    const model = mockModel(ai, {
+      name: 'menuModel',
+      respond: () => ({ text: 'Try the risotto.' }),
+    });
+
+    const out = await recommendDish({ restaurant: 'Lumen', mood: 'cozy' });
+
+    expect(out).toBe('Try the risotto.');
+    expect(model.lastMessage!.text).toMatch(
+      /Recommend a dish at Lumen for someone feeling cozy/
+    );
+  });
+
+  it('runs the tool the model calls, then returns the final text', async () => {
+    const model = mockModel(ai, {
+      name: 'menuModel',
+      info: { supports: { tools: true } },
+      respond: (req) => {
+        const toolAnswered = req.messages.some((m) =>
+          m.content.some((c) => c.toolResponse)
+        );
+        return toolAnswered
+          ? { text: 'Go for the mushroom risotto.' }
+          : {
+              toolRequests: [
+                { name: 'dailySpecial', input: { restaurant: 'Lumen' } },
+              ],
+            };
+      },
+    });
+
+    const out = await recommendDish({ restaurant: 'Lumen', mood: 'curious' });
+
+    expect(out).toBe('Go for the mushroom risotto.');
+    expect(model.requestCount).toBe(2);
+  });
+});
+
+describe('streaming (vitest)', () => {
+  it('streams chunks through generateStream', async () => {
+    mockModel(ai, {
+      name: 'menuModel',
+      respond: (_req, { sendChunk }) => {
+        sendChunk('Try ');
+        sendChunk('the ');
+        sendChunk('risotto.');
+        return { text: 'Try the risotto.' };
+      },
+    });
+
+    const { response, stream } = ai.generateStream({ prompt: 'recommend' });
+    const chunks: string[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk.text);
+    }
+
+    expect(chunks).toEqual(['Try ', 'the ', 'risotto.']);
+    expect((await response).text).toBe('Try the risotto.');
+  });
+});
+
+describe('prompt assembly with echoModel (vitest)', () => {
+  it('shows what the model would have seen', async () => {
+    echoModel(ai, { name: 'menuModel' });
+
+    const out = await recommendDish({ restaurant: 'Lumen', mood: 'tired' });
+
+    expect(out).toMatch(/Recommend a dish at Lumen for someone feeling tired/);
+  });
+});

--- a/js/testapps/testing-sample/tests/menu.vitest.test.ts
+++ b/js/testapps/testing-sample/tests/menu.vitest.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,19 @@
  */
 
 import { echoModel, mockModel } from 'genkit/testing';
-import { describe, expect, it } from 'vitest';
-import { ai, recommendDish } from '../src/menu.js';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createMenuApp } from '../src/menu.js';
 
 // The same patterns as menu_test.ts, written with vitest instead of node:test —
-// `genkit/testing` is runner-agnostic. Register the mock under the app's default
-// model name ('menuModel') so the flow runs unchanged.
+// `genkit/testing` is runner-agnostic. Build a fresh app per test, then register
+// the mock under the app's default model name ('menuModel') so the flow runs
+// unchanged.
+let ai: ReturnType<typeof createMenuApp>['ai'];
+let recommendDish: ReturnType<typeof createMenuApp>['recommendDish'];
+beforeEach(() => {
+  ({ ai, recommendDish } = createMenuApp());
+});
+
 describe('recommendDish flow (vitest)', () => {
   it('returns the model recommendation', async () => {
     const model = mockModel(ai, {

--- a/js/testapps/testing-sample/tests/menu.vitest.test.ts
+++ b/js/testapps/testing-sample/tests/menu.vitest.test.ts
@@ -20,30 +20,60 @@ import { createMenuApp } from '../src/menu.js';
 
 // The same patterns as menu_test.ts, written with vitest instead of node:test —
 // `genkit/testing` is runner-agnostic. Build a fresh app per test, then register
-// the mock under the app's default model name ('menuModel') so the flow runs
+// the mock under the app's default model name ('menuModel') so the app runs
 // unchanged.
-let ai: ReturnType<typeof createMenuApp>['ai'];
-let recommendDish: ReturnType<typeof createMenuApp>['recommendDish'];
+type App = ReturnType<typeof createMenuApp>;
+let ai: App['ai'];
+let recommendDish: App['recommendDish'];
+let recommendPrompt: App['recommendPrompt'];
+let streamRecommendation: App['streamRecommendation'];
 beforeEach(() => {
-  ({ ai, recommendDish } = createMenuApp());
+  ({ ai, recommendDish, recommendPrompt, streamRecommendation } =
+    createMenuApp());
 });
 
-describe('recommendDish flow (vitest)', () => {
-  it('returns the model recommendation', async () => {
-    const model = mockModel(ai, {
-      name: 'menuModel',
-      respond: () => ({ text: 'Try the risotto.' }),
-    });
-
-    const out = await recommendDish({ restaurant: 'Lumen', mood: 'cozy' });
-
-    expect(out).toBe('Try the risotto.');
-    expect(model.lastRequestMessage!.text).toMatch(
-      /Recommend a dish at Lumen for someone feeling cozy/
-    );
+describe('recommendDish flow — structured output + business logic (vitest)', () => {
+  const respondWithRecommendation = () => ({
+    text: JSON.stringify({
+      dish: 'Mushroom risotto',
+      reason: 'Comforting and in season.',
+      priceUSD: 18,
+    }),
   });
 
-  it('runs the tool the model calls, then returns the final text', async () => {
+  it('parses the structured recommendation and applies the budget logic', async () => {
+    mockModel(ai, { name: 'menuModel', respond: respondWithRecommendation });
+
+    // Same model output, two budgets — only our logic decides `withinBudget`.
+    const ok = await recommendDish({
+      restaurant: 'Lumen',
+      mood: 'cozy',
+      budgetUSD: 30,
+    });
+    expect(ok.dish).toBe('Mushroom risotto');
+    expect(ok.withinBudget).toBe(true);
+  });
+
+  it('rejects a recommendation the flow considers invalid', async () => {
+    mockModel(ai, {
+      name: 'menuModel',
+      respond: () => ({
+        text: JSON.stringify({
+          dish: 'Free water',
+          reason: 'Out of stock on everything else.',
+          priceUSD: 0,
+        }),
+      }),
+    });
+
+    await expect(
+      recommendDish({ restaurant: 'Lumen', mood: 'broke', budgetUSD: 30 })
+    ).rejects.toThrow(/non-positive price/);
+  });
+});
+
+describe('recommendDish flow — tool round-trip (vitest)', () => {
+  it('runs dailySpecial, then returns the structured recommendation', async () => {
     const model = mockModel(ai, {
       name: 'menuModel',
       info: { supports: { tools: true } },
@@ -52,7 +82,13 @@ describe('recommendDish flow (vitest)', () => {
           m.content.some((c) => c.toolResponse)
         );
         return toolAnswered
-          ? { text: 'Go for the mushroom risotto.' }
+          ? {
+              text: JSON.stringify({
+                dish: 'Mushroom risotto',
+                reason: "It's the daily special.",
+                priceUSD: 22,
+              }),
+            }
           : {
               toolRequests: [
                 { name: 'dailySpecial', input: { restaurant: 'Lumen' } },
@@ -61,15 +97,36 @@ describe('recommendDish flow (vitest)', () => {
       },
     });
 
-    const out = await recommendDish({ restaurant: 'Lumen', mood: 'curious' });
+    const out = await recommendDish({
+      restaurant: 'Lumen',
+      mood: 'curious',
+      budgetUSD: 40,
+    });
 
-    expect(out).toBe('Go for the mushroom risotto.');
+    expect(out.dish).toBe('Mushroom risotto');
     expect(model.requestCount).toBe(2);
   });
 });
 
-describe('streaming (vitest)', () => {
-  it('streams chunks through generateStream', async () => {
+describe('prompt assembly with echoModel (vitest)', () => {
+  it('shows the full rendered request — system + interpolated template', async () => {
+    echoModel(ai, { name: 'menuModel', info: { supports: { tools: true } } });
+
+    const res = await recommendPrompt({
+      restaurant: 'Lumen',
+      mood: 'tired',
+      budgetUSD: 40,
+    });
+
+    expect(res.text).toMatch(/system: You are a concise restaurant concierge/);
+    expect(res.text).toMatch(
+      /Recommend a dish at Lumen for someone feeling tired\. Their budget is 40 USD/
+    );
+  });
+});
+
+describe('streamRecommendation flow — streaming through the flow (vitest)', () => {
+  it('forwards model chunks out through the flow stream', async () => {
     mockModel(ai, {
       name: 'menuModel',
       respond: (_req, { sendChunk }) => {
@@ -80,23 +137,17 @@ describe('streaming (vitest)', () => {
       },
     });
 
-    const { response, stream } = ai.generateStream({ prompt: 'recommend' });
+    const { stream, output } = streamRecommendation.stream({
+      restaurant: 'Lumen',
+      mood: 'cozy',
+    });
+
     const chunks: string[] = [];
     for await (const chunk of stream) {
-      chunks.push(chunk.text);
+      chunks.push(chunk);
     }
 
     expect(chunks).toEqual(['Try ', 'the ', 'risotto.']);
-    expect((await response).text).toBe('Try the risotto.');
-  });
-});
-
-describe('prompt assembly with echoModel (vitest)', () => {
-  it('shows what the model would have seen', async () => {
-    echoModel(ai, { name: 'menuModel' });
-
-    const out = await recommendDish({ restaurant: 'Lumen', mood: 'tired' });
-
-    expect(out).toMatch(/Recommend a dish at Lumen for someone feeling tired/);
+    expect(await output).toBe('Try the risotto.');
   });
 });

--- a/js/testapps/testing-sample/tests/menu.vitest.test.ts
+++ b/js/testapps/testing-sample/tests/menu.vitest.test.ts
@@ -24,11 +24,12 @@ import { createMenuApp } from '../src/menu.js';
 // unchanged.
 type App = ReturnType<typeof createMenuApp>;
 let ai: App['ai'];
+let confirmBooking: App['confirmBooking'];
 let recommendDish: App['recommendDish'];
 let recommendPrompt: App['recommendPrompt'];
 let streamRecommendation: App['streamRecommendation'];
 beforeEach(() => {
-  ({ ai, recommendDish, recommendPrompt, streamRecommendation } =
+  ({ ai, confirmBooking, recommendDish, recommendPrompt, streamRecommendation } =
     createMenuApp());
 });
 
@@ -105,6 +106,50 @@ describe('recommendDish flow — tool round-trip (vitest)', () => {
 
     expect(out.dish).toBe('Mushroom risotto');
     expect(model.requestCount).toBe(2);
+    expect(model.toolResponses[0]?.name).toBe('dailySpecial');
+  });
+});
+
+describe('human-in-the-loop with interrupts (vitest)', () => {
+  it('pauses on confirmBooking, then resumes to complete the booking', async () => {
+    const model = mockModel(ai, {
+      name: 'menuModel',
+      info: { supports: { tools: true } },
+      // Queued responses: request the interrupting tool, then answer.
+      respond: [
+        {
+          toolRequests: [
+            { name: 'confirmBooking', input: { dish: 'Mushroom risotto' } },
+          ],
+        },
+        { text: 'Enjoy your meal!' },
+      ],
+    });
+
+    const paused = await ai.generate({
+      model,
+      prompt: 'Book the risotto.',
+      tools: [confirmBooking],
+    });
+    expect(paused.interrupts.length).toBe(1);
+    expect(paused.interrupts[0].toolRequest.name).toBe('confirmBooking');
+
+    const done = await ai.generate({
+      model,
+      messages: paused.messages,
+      tools: [confirmBooking],
+      resume: {
+        restart: confirmBooking.restart(paused.interrupts[0], {
+          confirmed: true,
+        }),
+      },
+    });
+
+    expect(done.text).toBe('Enjoy your meal!');
+    expect(model.requestCount).toBe(2);
+    expect(String(model.toolResponses[0]?.output)).toMatch(
+      /Booked: Mushroom risotto/
+    );
   });
 });
 

--- a/js/testapps/testing-sample/tests/menu.vitest.test.ts
+++ b/js/testapps/testing-sample/tests/menu.vitest.test.ts
@@ -29,8 +29,13 @@ let recommendDish: App['recommendDish'];
 let recommendPrompt: App['recommendPrompt'];
 let streamRecommendation: App['streamRecommendation'];
 beforeEach(() => {
-  ({ ai, confirmBooking, recommendDish, recommendPrompt, streamRecommendation } =
-    createMenuApp());
+  ({
+    ai,
+    confirmBooking,
+    recommendDish,
+    recommendPrompt,
+    streamRecommendation,
+  } = createMenuApp());
 });
 
 describe('recommendDish flow — structured output + business logic (vitest)', () => {

--- a/js/testapps/testing-sample/tests/menu_test.ts
+++ b/js/testapps/testing-sample/tests/menu_test.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { echoModel, mockModel } from 'genkit/testing';
+import { ai, recommendDish } from '../src/menu.js';
+
+// Register the mock under the app's default model name ('menuModel'), so the
+// flow's `ai.generate({ prompt, tools })` resolves to it with no code change.
+describe('recommendDish flow', () => {
+  it('returns the model recommendation', async () => {
+    const model = mockModel(ai, {
+      name: 'menuModel',
+      respond: () => ({ text: 'Try the risotto.' }),
+    });
+
+    const out = await recommendDish({ restaurant: 'Lumen', mood: 'cozy' });
+
+    assert.equal(out, 'Try the risotto.');
+    // The flow rendered our inputs into the prompt the model saw. `lastMessage`
+    // is a genkit Message, so `.text` works just like it does on a response.
+    assert.match(
+      model.lastMessage!.text,
+      /Recommend a dish at Lumen for someone feeling cozy/
+    );
+  });
+
+  it('exposes the dailySpecial tool to the model', async () => {
+    const model = mockModel(ai, {
+      name: 'menuModel',
+      info: { supports: { tools: true } },
+      respond: () => ({ text: 'ok' }),
+    });
+
+    await recommendDish({ restaurant: 'Lumen', mood: 'hungry' });
+
+    const toolNames = (model.lastRequest!.tools ?? []).map((t) => t.name);
+    assert.ok(toolNames.includes('dailySpecial'));
+  });
+
+  it('runs the tool the model calls, then returns the final text', async () => {
+    const model = mockModel(ai, {
+      name: 'menuModel',
+      info: { supports: { tools: true } },
+      respond: (req) => {
+        const toolAnswered = req.messages.some((m) =>
+          m.content.some((c) => c.toolResponse)
+        );
+        return toolAnswered
+          ? { text: 'Go for the mushroom risotto.' }
+          : {
+              toolRequests: [
+                { name: 'dailySpecial', input: { restaurant: 'Lumen' } },
+              ],
+            };
+      },
+    });
+
+    const out = await recommendDish({ restaurant: 'Lumen', mood: 'curious' });
+
+    assert.equal(out, 'Go for the mushroom risotto.');
+    // Two turns: the tool request, then the follow-up with the tool result.
+    assert.equal(model.requestCount, 2);
+    const toolResult = model.lastRequest!.messages
+      .flatMap((m) => m.content)
+      .find((c) => c.toolResponse);
+    assert.match(String(toolResult?.toolResponse?.output), /mushroom risotto/);
+  });
+});
+
+describe('prompt assembly with echoModel', () => {
+  it('shows what the model would have seen', async () => {
+    const model = echoModel(ai, { name: 'menuModel' });
+
+    const out = await recommendDish({ restaurant: 'Lumen', mood: 'tired' });
+
+    assert.match(out, /Recommend a dish at Lumen for someone feeling tired/);
+    assert.ok(model.requestCount >= 1);
+  });
+});
+
+describe('streaming', () => {
+  it('streams chunks through generateStream', async () => {
+    const model = mockModel(ai, {
+      name: 'menuModel',
+      respond: (_req, { sendChunk }) => {
+        sendChunk('Try ');
+        sendChunk('the ');
+        sendChunk('risotto.');
+        return { text: 'Try the risotto.' };
+      },
+    });
+
+    const { response, stream } = ai.generateStream({ prompt: 'recommend' });
+    const chunks: string[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk.text);
+    }
+
+    assert.deepEqual(chunks, ['Try ', 'the ', 'risotto.']);
+    assert.equal((await response).text, 'Try the risotto.');
+    assert.equal(model.requestCount, 1);
+  });
+});

--- a/js/testapps/testing-sample/tests/menu_test.ts
+++ b/js/testapps/testing-sample/tests/menu_test.ts
@@ -31,10 +31,11 @@ describe('recommendDish flow', () => {
     const out = await recommendDish({ restaurant: 'Lumen', mood: 'cozy' });
 
     assert.equal(out, 'Try the risotto.');
-    // The flow rendered our inputs into the prompt the model saw. `lastMessage`
-    // is a genkit Message, so `.text` works just like it does on a response.
+    // The flow rendered our inputs into the prompt the model saw.
+    // `lastRequestMessage` is a genkit Message, so `.text` works just like it
+    // does on a response.
     assert.match(
-      model.lastMessage!.text,
+      model.lastRequestMessage!.text,
       /Recommend a dish at Lumen for someone feeling cozy/
     );
   });

--- a/js/testapps/testing-sample/tests/menu_test.ts
+++ b/js/testapps/testing-sample/tests/menu_test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,22 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
 import { echoModel, mockModel } from 'genkit/testing';
-import { ai, recommendDish } from '../src/menu.js';
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import { createMenuApp } from '../src/menu.js';
 
-// Register the mock under the app's default model name ('menuModel'), so the
-// flow's `ai.generate({ prompt, tools })` resolves to it with no code change.
+// Build a fresh app (its own Genkit registry) for each test, then register the
+// mock under the app's default model name ('menuModel') so the flow's
+// `ai.generate({ prompt, tools })` resolves to it with no code change. The
+// fresh instance keeps tests isolated and avoids re-registering the same model
+// name on a shared registry.
+let ai: ReturnType<typeof createMenuApp>['ai'];
+let recommendDish: ReturnType<typeof createMenuApp>['recommendDish'];
+beforeEach(() => {
+  ({ ai, recommendDish } = createMenuApp());
+});
+
 describe('recommendDish flow', () => {
   it('returns the model recommendation', async () => {
     const model = mockModel(ai, {

--- a/js/testapps/testing-sample/tests/menu_test.ts
+++ b/js/testapps/testing-sample/tests/menu_test.ts
@@ -80,6 +80,24 @@ describe('recommendDish flow — structured output + business logic', () => {
     assert.equal(out.withinBudget, false);
   });
 
+  it('inspects prompt assembly on the structured path via lastRequestText', async () => {
+    // echoModel can't be used here — the prompt requests structured output, and
+    // echo returns text. Inspect the recorded request instead: `lastRequestText`
+    // flattens the whole assembled conversation (system + rendered template).
+    const model = mockModel(ai, {
+      name: 'menuModel',
+      respond: respondWithRecommendation,
+    });
+
+    await recommendDish({ restaurant: 'Lumen', mood: 'cozy', budgetUSD: 30 });
+
+    assert.match(model.lastRequestText!, /You are a concise restaurant concierge/);
+    assert.match(
+      model.lastRequestText!,
+      /Recommend a dish at Lumen for someone feeling cozy/
+    );
+  });
+
   it('rejects a recommendation the flow considers invalid', async () => {
     // The model returns a structurally-valid but business-invalid price; the
     // flow's guard, not the framework, is what throws.

--- a/js/testapps/testing-sample/tests/menu_test.ts
+++ b/js/testapps/testing-sample/tests/menu_test.ts
@@ -14,49 +14,44 @@
  * limitations under the License.
  */
 
-import { echoModel, mockModel } from 'genkit/testing';
+import { mockModel } from 'genkit/testing';
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
-import { createMenuApp } from '../src/menu.js';
+import {
+  ai,
+  confirmBooking,
+  recommendDish,
+  streamRecommendation,
+} from '../src/menu.js';
 
-// Build a fresh app (its own Genkit registry) for each test, then register the
-// mock under the app's default model name ('menuModel') so the app's
-// `ai.generate` / prompt resolves to it with no code change. The fresh instance
-// keeps tests isolated and avoids re-registering the same model name on a
-// shared registry.
-type App = ReturnType<typeof createMenuApp>;
-let ai: App['ai'];
-let confirmBooking: App['confirmBooking'];
-let recommendDish: App['recommendDish'];
-let recommendPrompt: App['recommendPrompt'];
-let streamRecommendation: App['streamRecommendation'];
-beforeEach(() => {
-  ({
-    ai,
-    confirmBooking,
-    recommendDish,
-    recommendPrompt,
-    streamRecommendation,
-  } = createMenuApp());
+// Register ONE mock under the app's default model name ('menuModel'), once for
+// this whole file — the app's `ai.generate` / prompt resolves to it with no
+// code change. Test runners (`node --test`, Jest, Vitest) run each test file
+// in its own process/module graph, so this registration can't collide with
+// other test files. Within the file, `reset()` in beforeEach clears recorded
+// history and re-arms the construction respond, and each test scripts its own
+// behavior with `respondWith(...)`.
+const model = mockModel(ai, {
+  name: 'menuModel',
+  info: { supports: { tools: true } },
 });
+
+beforeEach(() => model.reset());
 
 // Structured output is the highest-value case: the model returns JSON, and the
 // flow's *own* logic (validation, deriving `withinBudget`) is what we pin down.
 describe('recommendDish flow — structured output + business logic', () => {
   // A fixed, deterministic structured response from the "model".
-  const respondWithRecommendation = () => ({
+  const recommendation = {
     text: JSON.stringify({
       dish: 'Mushroom risotto',
       reason: 'Comforting and in season.',
       priceUSD: 18,
     }),
-  });
+  };
 
   it('parses the structured recommendation and marks it within budget', async () => {
-    const model = mockModel(ai, {
-      name: 'menuModel',
-      respond: respondWithRecommendation,
-    });
+    model.respondWith(recommendation);
 
     const out = await recommendDish({
       restaurant: 'Lumen',
@@ -72,10 +67,7 @@ describe('recommendDish flow — structured output + business logic', () => {
   it('marks the SAME model output over budget when the budget is lower', async () => {
     // Identical model response as above — only the flow's input changes. This
     // proves the test exercises *our* budget logic, not the model.
-    mockModel(ai, {
-      name: 'menuModel',
-      respond: respondWithRecommendation,
-    });
+    model.respondWith(recommendation);
 
     const out = await recommendDish({
       restaurant: 'Lumen',
@@ -90,10 +82,7 @@ describe('recommendDish flow — structured output + business logic', () => {
     // echoModel can't be used here — the prompt requests structured output, and
     // echo returns text. Inspect the recorded request instead: `lastRequestText`
     // flattens the whole assembled conversation (system + rendered template).
-    const model = mockModel(ai, {
-      name: 'menuModel',
-      respond: respondWithRecommendation,
-    });
+    model.respondWith(recommendation);
 
     await recommendDish({ restaurant: 'Lumen', mood: 'cozy', budgetUSD: 30 });
 
@@ -110,14 +99,11 @@ describe('recommendDish flow — structured output + business logic', () => {
   it('rejects a recommendation the flow considers invalid', async () => {
     // The model returns a structurally-valid but business-invalid price; the
     // flow's guard, not the framework, is what throws.
-    mockModel(ai, {
-      name: 'menuModel',
-      respond: () => ({
-        text: JSON.stringify({
-          dish: 'Free water',
-          reason: 'Out of stock on everything else.',
-          priceUSD: 0,
-        }),
+    model.respondWith({
+      text: JSON.stringify({
+        dish: 'Free water',
+        reason: 'Out of stock on everything else.',
+        priceUSD: 0,
       }),
     });
 
@@ -130,29 +116,25 @@ describe('recommendDish flow — structured output + business logic', () => {
 
 describe('recommendDish flow — tool round-trip', () => {
   it('runs dailySpecial, then returns the structured recommendation', async () => {
-    const model = mockModel(ai, {
-      name: 'menuModel',
-      info: { supports: { tools: true } },
-      respond: (req) => {
-        const toolAnswered = req.messages.some((m) =>
-          m.content.some((c) => c.toolResponse)
-        );
-        // First turn: ask for the special. Second turn (after the tool ran):
-        // return the structured recommendation.
-        return toolAnswered
-          ? {
-              text: JSON.stringify({
-                dish: 'Mushroom risotto',
-                reason: "It's the daily special.",
-                priceUSD: 22,
-              }),
-            }
-          : {
-              toolRequests: [
-                { name: 'dailySpecial', input: { restaurant: 'Lumen' } },
-              ],
-            };
-      },
+    model.respondWith((req) => {
+      const toolAnswered = req.messages.some((m) =>
+        m.content.some((c) => c.toolResponse)
+      );
+      // First turn: ask for the special. Second turn (after the tool ran):
+      // return the structured recommendation.
+      return toolAnswered
+        ? {
+            text: JSON.stringify({
+              dish: 'Mushroom risotto',
+              reason: "It's the daily special.",
+              priceUSD: 22,
+            }),
+          }
+        : {
+            toolRequests: [
+              { name: 'dailySpecial', input: { restaurant: 'Lumen' } },
+            ],
+          };
     });
 
     const out = await recommendDish({
@@ -171,37 +153,13 @@ describe('recommendDish flow — tool round-trip', () => {
   });
 });
 
-describe('prompt assembly with echoModel', () => {
-  it('shows the full rendered request — system + interpolated template', async () => {
-    // echoModel echoes the whole assembled conversation, so we can assert on
-    // the system instruction *and* the Handlebars-rendered user message — what
-    // the model would have seen — without a live model.
-    echoModel(ai, { name: 'menuModel', info: { supports: { tools: true } } });
-
-    const res = await recommendPrompt({
-      restaurant: 'Lumen',
-      mood: 'tired',
-      budgetUSD: 40,
-    });
-
-    assert.match(res.text, /system: You are a concise restaurant concierge/);
-    assert.match(
-      res.text,
-      /Recommend a dish at Lumen for someone feeling tired\. Their budget is 40 USD/
-    );
-  });
-});
-
 describe('streamRecommendation flow — streaming through the flow', () => {
   it('forwards model chunks out through the flow stream', async () => {
-    mockModel(ai, {
-      name: 'menuModel',
-      respond: (_req, { sendChunk }) => {
-        sendChunk('Try ');
-        sendChunk('the ');
-        sendChunk('risotto.');
-        return { text: 'Try the risotto.' };
-      },
+    model.respondWith((_req, { sendChunk }) => {
+      sendChunk('Try ');
+      sendChunk('the ');
+      sendChunk('risotto.');
+      return { text: 'Try the risotto.' };
     });
 
     const { stream, output } = streamRecommendation.stream({
@@ -221,26 +179,22 @@ describe('streamRecommendation flow — streaming through the flow', () => {
 
 describe('scripting responses with a queue', () => {
   it('scripts a two-turn tool interaction with an array of responses', async () => {
-    const model = mockModel(ai, {
-      name: 'menuModel',
-      info: { supports: { tools: true } },
-      // Turn 1: ask for the special. Turn 2: return the recommendation. The
-      // array is consumed one item per call, so no branching callback is needed.
-      respond: [
-        {
-          toolRequests: [
-            { name: 'dailySpecial', input: { restaurant: 'Lumen' } },
-          ],
-        },
-        {
-          text: JSON.stringify({
-            dish: 'Mushroom risotto',
-            reason: "It's the daily special.",
-            priceUSD: 22,
-          }),
-        },
-      ],
-    });
+    // Turn 1: ask for the special. Turn 2: return the recommendation. The
+    // array is consumed one item per call, so no branching callback is needed.
+    model.respondWith([
+      {
+        toolRequests: [
+          { name: 'dailySpecial', input: { restaurant: 'Lumen' } },
+        ],
+      },
+      {
+        text: JSON.stringify({
+          dish: 'Mushroom risotto',
+          reason: "It's the daily special.",
+          priceUSD: 22,
+        }),
+      },
+    ]);
 
     const out = await recommendDish({
       restaurant: 'Lumen',
@@ -258,10 +212,7 @@ describe('model failure handling', () => {
   it('surfaces a model error injected via a queued Error', async () => {
     // A queued Error is thrown when reached — here on the very first call — so
     // you can test how a flow behaves when the model fails.
-    mockModel(ai, {
-      name: 'menuModel',
-      respond: [new Error('model overloaded')],
-    });
+    model.respondWith([new Error('model overloaded')]);
 
     await assert.rejects(
       recommendDish({ restaurant: 'Lumen', mood: 'cozy', budgetUSD: 30 }),
@@ -272,22 +223,17 @@ describe('model failure handling', () => {
 
 describe('human-in-the-loop with interrupts', () => {
   it('pauses on confirmBooking, then resumes to complete the booking', async () => {
-    const model = mockModel(ai, {
-      name: 'menuModel',
-      info: { supports: { tools: true } },
-      respond: [
-        {
-          toolRequests: [
-            { name: 'confirmBooking', input: { dish: 'Mushroom risotto' } },
-          ],
-        },
-        { text: 'Enjoy your meal!' },
-      ],
-    });
+    model.respondWith([
+      {
+        toolRequests: [
+          { name: 'confirmBooking', input: { dish: 'Mushroom risotto' } },
+        ],
+      },
+      { text: 'Enjoy your meal!' },
+    ]);
 
     // First pass: the tool interrupts, so generation pauses awaiting the human.
     const paused = await ai.generate({
-      model,
       prompt: 'Book the risotto.',
       tools: [confirmBooking],
     });
@@ -297,7 +243,6 @@ describe('human-in-the-loop with interrupts', () => {
     // The human confirms; `restart` re-runs the tool with the decision (so its
     // `resumed` branch books the dish), then the model finishes.
     const done = await ai.generate({
-      model,
       messages: paused.messages,
       tools: [confirmBooking],
       resume: {

--- a/js/testapps/testing-sample/tests/menu_test.ts
+++ b/js/testapps/testing-sample/tests/menu_test.ts
@@ -157,10 +157,8 @@ describe('recommendDish flow — tool round-trip', () => {
     // Two turns: the tool request, then the follow-up with the tool result.
     assert.equal(model.requestCount, 2);
     // The tool's output was fed back to the model.
-    const toolResult = model.lastRequest!.messages
-      .flatMap((m) => m.content)
-      .find((c) => c.toolResponse);
-    assert.match(String(toolResult?.toolResponse?.output), /mushroom risotto/);
+    assert.equal(model.toolResponses[0]?.name, 'dailySpecial');
+    assert.match(String(model.toolResponses[0]?.output), /mushroom risotto/);
   });
 });
 

--- a/js/testapps/testing-sample/tests/menu_test.ts
+++ b/js/testapps/testing-sample/tests/menu_test.ts
@@ -26,11 +26,12 @@ import { createMenuApp } from '../src/menu.js';
 // shared registry.
 type App = ReturnType<typeof createMenuApp>;
 let ai: App['ai'];
+let confirmBooking: App['confirmBooking'];
 let recommendDish: App['recommendDish'];
 let recommendPrompt: App['recommendPrompt'];
 let streamRecommendation: App['streamRecommendation'];
 beforeEach(() => {
-  ({ ai, recommendDish, recommendPrompt, streamRecommendation } =
+  ({ ai, confirmBooking, recommendDish, recommendPrompt, streamRecommendation } =
     createMenuApp());
 });
 
@@ -207,5 +208,97 @@ describe('streamRecommendation flow — streaming through the flow', () => {
 
     assert.deepEqual(chunks, ['Try ', 'the ', 'risotto.']);
     assert.equal(await output, 'Try the risotto.');
+  });
+});
+
+describe('scripting responses with a queue', () => {
+  it('scripts a two-turn tool interaction with an array of responses', async () => {
+    const model = mockModel(ai, {
+      name: 'menuModel',
+      info: { supports: { tools: true } },
+      // Turn 1: ask for the special. Turn 2: return the recommendation. The
+      // array is consumed one item per call, so no branching callback is needed.
+      respond: [
+        {
+          toolRequests: [
+            { name: 'dailySpecial', input: { restaurant: 'Lumen' } },
+          ],
+        },
+        {
+          text: JSON.stringify({
+            dish: 'Mushroom risotto',
+            reason: "It's the daily special.",
+            priceUSD: 22,
+          }),
+        },
+      ],
+    });
+
+    const out = await recommendDish({
+      restaurant: 'Lumen',
+      mood: 'curious',
+      budgetUSD: 40,
+    });
+
+    assert.equal(out.dish, 'Mushroom risotto');
+    assert.equal(model.requestCount, 2);
+    assert.equal(model.toolResponses[0]?.name, 'dailySpecial');
+  });
+});
+
+describe('model failure handling', () => {
+  it('surfaces a model error injected via a queued Error', async () => {
+    // A queued Error is thrown when reached — here on the very first call — so
+    // you can test how a flow behaves when the model fails.
+    mockModel(ai, {
+      name: 'menuModel',
+      respond: [new Error('model overloaded')],
+    });
+
+    await assert.rejects(
+      recommendDish({ restaurant: 'Lumen', mood: 'cozy', budgetUSD: 30 }),
+      /model overloaded/
+    );
+  });
+});
+
+describe('human-in-the-loop with interrupts', () => {
+  it('pauses on confirmBooking, then resumes to complete the booking', async () => {
+    const model = mockModel(ai, {
+      name: 'menuModel',
+      info: { supports: { tools: true } },
+      respond: [
+        {
+          toolRequests: [
+            { name: 'confirmBooking', input: { dish: 'Mushroom risotto' } },
+          ],
+        },
+        { text: 'Enjoy your meal!' },
+      ],
+    });
+
+    // First pass: the tool interrupts, so generation pauses awaiting the human.
+    const paused = await ai.generate({
+      model,
+      prompt: 'Book the risotto.',
+      tools: [confirmBooking],
+    });
+    assert.equal(paused.interrupts.length, 1);
+    assert.equal(paused.interrupts[0].toolRequest.name, 'confirmBooking');
+
+    // The human confirms; `restart` re-runs the tool with the decision (so its
+    // `resumed` branch books the dish), then the model finishes.
+    const done = await ai.generate({
+      model,
+      messages: paused.messages,
+      tools: [confirmBooking],
+      resume: {
+        restart: confirmBooking.restart(paused.interrupts[0], { confirmed: true }),
+      },
+    });
+
+    assert.equal(done.text, 'Enjoy your meal!');
+    assert.equal(model.requestCount, 2);
+    assert.match(String(model.toolResponses[0]?.output), /Booked: Mushroom risotto/);
   });
 });

--- a/js/testapps/testing-sample/tests/menu_test.ts
+++ b/js/testapps/testing-sample/tests/menu_test.ts
@@ -31,8 +31,13 @@ let recommendDish: App['recommendDish'];
 let recommendPrompt: App['recommendPrompt'];
 let streamRecommendation: App['streamRecommendation'];
 beforeEach(() => {
-  ({ ai, confirmBooking, recommendDish, recommendPrompt, streamRecommendation } =
-    createMenuApp());
+  ({
+    ai,
+    confirmBooking,
+    recommendDish,
+    recommendPrompt,
+    streamRecommendation,
+  } = createMenuApp());
 });
 
 // Structured output is the highest-value case: the model returns JSON, and the
@@ -92,7 +97,10 @@ describe('recommendDish flow — structured output + business logic', () => {
 
     await recommendDish({ restaurant: 'Lumen', mood: 'cozy', budgetUSD: 30 });
 
-    assert.match(model.lastRequestText!, /You are a concise restaurant concierge/);
+    assert.match(
+      model.lastRequestText!,
+      /You are a concise restaurant concierge/
+    );
     assert.match(
       model.lastRequestText!,
       /Recommend a dish at Lumen for someone feeling cozy/
@@ -293,12 +301,17 @@ describe('human-in-the-loop with interrupts', () => {
       messages: paused.messages,
       tools: [confirmBooking],
       resume: {
-        restart: confirmBooking.restart(paused.interrupts[0], { confirmed: true }),
+        restart: confirmBooking.restart(paused.interrupts[0], {
+          confirmed: true,
+        }),
       },
     });
 
     assert.equal(done.text, 'Enjoy your meal!');
     assert.equal(model.requestCount, 2);
-    assert.match(String(model.toolResponses[0]?.output), /Booked: Mushroom risotto/);
+    assert.match(
+      String(model.toolResponses[0]?.output),
+      /Booked: Mushroom risotto/
+    );
   });
 });

--- a/js/testapps/testing-sample/tests/menu_test.ts
+++ b/js/testapps/testing-sample/tests/menu_test.ts
@@ -20,49 +20,89 @@ import { beforeEach, describe, it } from 'node:test';
 import { createMenuApp } from '../src/menu.js';
 
 // Build a fresh app (its own Genkit registry) for each test, then register the
-// mock under the app's default model name ('menuModel') so the flow's
-// `ai.generate({ prompt, tools })` resolves to it with no code change. The
-// fresh instance keeps tests isolated and avoids re-registering the same model
-// name on a shared registry.
-let ai: ReturnType<typeof createMenuApp>['ai'];
-let recommendDish: ReturnType<typeof createMenuApp>['recommendDish'];
+// mock under the app's default model name ('menuModel') so the app's
+// `ai.generate` / prompt resolves to it with no code change. The fresh instance
+// keeps tests isolated and avoids re-registering the same model name on a
+// shared registry.
+type App = ReturnType<typeof createMenuApp>;
+let ai: App['ai'];
+let recommendDish: App['recommendDish'];
+let recommendPrompt: App['recommendPrompt'];
+let streamRecommendation: App['streamRecommendation'];
 beforeEach(() => {
-  ({ ai, recommendDish } = createMenuApp());
+  ({ ai, recommendDish, recommendPrompt, streamRecommendation } =
+    createMenuApp());
 });
 
-describe('recommendDish flow', () => {
-  it('returns the model recommendation', async () => {
+// Structured output is the highest-value case: the model returns JSON, and the
+// flow's *own* logic (validation, deriving `withinBudget`) is what we pin down.
+describe('recommendDish flow — structured output + business logic', () => {
+  // A fixed, deterministic structured response from the "model".
+  const respondWithRecommendation = () => ({
+    text: JSON.stringify({
+      dish: 'Mushroom risotto',
+      reason: 'Comforting and in season.',
+      priceUSD: 18,
+    }),
+  });
+
+  it('parses the structured recommendation and marks it within budget', async () => {
     const model = mockModel(ai, {
       name: 'menuModel',
-      respond: () => ({ text: 'Try the risotto.' }),
+      respond: respondWithRecommendation,
     });
 
-    const out = await recommendDish({ restaurant: 'Lumen', mood: 'cozy' });
+    const out = await recommendDish({
+      restaurant: 'Lumen',
+      mood: 'cozy',
+      budgetUSD: 30,
+    });
 
-    assert.equal(out, 'Try the risotto.');
-    // The flow rendered our inputs into the prompt the model saw.
-    // `lastRequestMessage` is a genkit Message, so `.text` works just like it
-    // does on a response.
-    assert.match(
-      model.lastRequestMessage!.text,
-      /Recommend a dish at Lumen for someone feeling cozy/
+    assert.equal(out.dish, 'Mushroom risotto');
+    assert.equal(out.withinBudget, true);
+    assert.equal(model.requestCount, 1);
+  });
+
+  it('marks the SAME model output over budget when the budget is lower', async () => {
+    // Identical model response as above — only the flow's input changes. This
+    // proves the test exercises *our* budget logic, not the model.
+    mockModel(ai, {
+      name: 'menuModel',
+      respond: respondWithRecommendation,
+    });
+
+    const out = await recommendDish({
+      restaurant: 'Lumen',
+      mood: 'cozy',
+      budgetUSD: 15,
+    });
+
+    assert.equal(out.withinBudget, false);
+  });
+
+  it('rejects a recommendation the flow considers invalid', async () => {
+    // The model returns a structurally-valid but business-invalid price; the
+    // flow's guard, not the framework, is what throws.
+    mockModel(ai, {
+      name: 'menuModel',
+      respond: () => ({
+        text: JSON.stringify({
+          dish: 'Free water',
+          reason: 'Out of stock on everything else.',
+          priceUSD: 0,
+        }),
+      }),
+    });
+
+    await assert.rejects(
+      recommendDish({ restaurant: 'Lumen', mood: 'broke', budgetUSD: 30 }),
+      /non-positive price/
     );
   });
+});
 
-  it('exposes the dailySpecial tool to the model', async () => {
-    const model = mockModel(ai, {
-      name: 'menuModel',
-      info: { supports: { tools: true } },
-      respond: () => ({ text: 'ok' }),
-    });
-
-    await recommendDish({ restaurant: 'Lumen', mood: 'hungry' });
-
-    const toolNames = (model.lastRequest!.tools ?? []).map((t) => t.name);
-    assert.ok(toolNames.includes('dailySpecial'));
-  });
-
-  it('runs the tool the model calls, then returns the final text', async () => {
+describe('recommendDish flow — tool round-trip', () => {
+  it('runs dailySpecial, then returns the structured recommendation', async () => {
     const model = mockModel(ai, {
       name: 'menuModel',
       info: { supports: { tools: true } },
@@ -70,8 +110,16 @@ describe('recommendDish flow', () => {
         const toolAnswered = req.messages.some((m) =>
           m.content.some((c) => c.toolResponse)
         );
+        // First turn: ask for the special. Second turn (after the tool ran):
+        // return the structured recommendation.
         return toolAnswered
-          ? { text: 'Go for the mushroom risotto.' }
+          ? {
+              text: JSON.stringify({
+                dish: 'Mushroom risotto',
+                reason: "It's the daily special.",
+                priceUSD: 22,
+              }),
+            }
           : {
               toolRequests: [
                 { name: 'dailySpecial', input: { restaurant: 'Lumen' } },
@@ -80,11 +128,17 @@ describe('recommendDish flow', () => {
       },
     });
 
-    const out = await recommendDish({ restaurant: 'Lumen', mood: 'curious' });
+    const out = await recommendDish({
+      restaurant: 'Lumen',
+      mood: 'curious',
+      budgetUSD: 40,
+    });
 
-    assert.equal(out, 'Go for the mushroom risotto.');
+    assert.equal(out.dish, 'Mushroom risotto');
+    assert.equal(out.withinBudget, true);
     // Two turns: the tool request, then the follow-up with the tool result.
     assert.equal(model.requestCount, 2);
+    // The tool's output was fed back to the model.
     const toolResult = model.lastRequest!.messages
       .flatMap((m) => m.content)
       .find((c) => c.toolResponse);
@@ -93,19 +147,29 @@ describe('recommendDish flow', () => {
 });
 
 describe('prompt assembly with echoModel', () => {
-  it('shows what the model would have seen', async () => {
-    const model = echoModel(ai, { name: 'menuModel' });
+  it('shows the full rendered request — system + interpolated template', async () => {
+    // echoModel echoes the whole assembled conversation, so we can assert on
+    // the system instruction *and* the Handlebars-rendered user message — what
+    // the model would have seen — without a live model.
+    echoModel(ai, { name: 'menuModel', info: { supports: { tools: true } } });
 
-    const out = await recommendDish({ restaurant: 'Lumen', mood: 'tired' });
+    const res = await recommendPrompt({
+      restaurant: 'Lumen',
+      mood: 'tired',
+      budgetUSD: 40,
+    });
 
-    assert.match(out, /Recommend a dish at Lumen for someone feeling tired/);
-    assert.ok(model.requestCount >= 1);
+    assert.match(res.text, /system: You are a concise restaurant concierge/);
+    assert.match(
+      res.text,
+      /Recommend a dish at Lumen for someone feeling tired\. Their budget is 40 USD/
+    );
   });
 });
 
-describe('streaming', () => {
-  it('streams chunks through generateStream', async () => {
-    const model = mockModel(ai, {
+describe('streamRecommendation flow — streaming through the flow', () => {
+  it('forwards model chunks out through the flow stream', async () => {
+    mockModel(ai, {
       name: 'menuModel',
       respond: (_req, { sendChunk }) => {
         sendChunk('Try ');
@@ -115,14 +179,17 @@ describe('streaming', () => {
       },
     });
 
-    const { response, stream } = ai.generateStream({ prompt: 'recommend' });
+    const { stream, output } = streamRecommendation.stream({
+      restaurant: 'Lumen',
+      mood: 'cozy',
+    });
+
     const chunks: string[] = [];
     for await (const chunk of stream) {
-      chunks.push(chunk.text);
+      chunks.push(chunk);
     }
 
     assert.deepEqual(chunks, ['Try ', 'the ', 'risotto.']);
-    assert.equal((await response).text, 'Try the risotto.');
-    assert.equal(model.requestCount, 1);
+    assert.equal(await output, 'Try the risotto.');
   });
 });

--- a/js/testapps/testing-sample/tests/prompt.vitest.test.ts
+++ b/js/testapps/testing-sample/tests/prompt.vitest.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { echoModel } from 'genkit/testing';
+import { describe, expect, it } from 'vitest';
+import { ai, recommendPrompt } from '../src/menu.js';
+
+// `echoModel` gets its own test file because menu.vitest.test.ts already
+// claims 'menuModel' with a `mockModel` — vitest gives each file its own
+// worker (and so a fresh registry), so the two registrations never meet.
+echoModel(ai, { name: 'menuModel', info: { supports: { tools: true } } });
+
+describe('prompt assembly with echoModel (vitest)', () => {
+  it('shows the full rendered request — system + interpolated template', async () => {
+    const res = await recommendPrompt({
+      restaurant: 'Lumen',
+      mood: 'tired',
+      budgetUSD: 40,
+    });
+
+    expect(res.text).toMatch(/system: You are a concise restaurant concierge/);
+    expect(res.text).toMatch(
+      /Recommend a dish at Lumen for someone feeling tired\. Their budget is 40 USD/
+    );
+  });
+});

--- a/js/testapps/testing-sample/tests/prompt_test.ts
+++ b/js/testapps/testing-sample/tests/prompt_test.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { echoModel } from 'genkit/testing';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { ai, recommendPrompt } from '../src/menu.js';
+
+// This file registers `echoModel` under the app's default model name. It lives
+// in its own test file because menu_test.ts already claims 'menuModel' with a
+// `mockModel` — and since the test runner gives each file a fresh process (and
+// so a fresh registry), the two registrations never meet.
+echoModel(ai, { name: 'menuModel', info: { supports: { tools: true } } });
+
+describe('prompt assembly with echoModel', () => {
+  it('shows the full rendered request — system + interpolated template', async () => {
+    // echoModel echoes the whole assembled conversation, so we can assert on
+    // the system instruction *and* the Handlebars-rendered user message — what
+    // the model would have seen — without a live model.
+    const res = await recommendPrompt({
+      restaurant: 'Lumen',
+      mood: 'tired',
+      budgetUSD: 40,
+    });
+
+    assert.match(res.text, /system: You are a concise restaurant concierge/);
+    assert.match(
+      res.text,
+      /Recommend a dish at Lumen for someone feeling tired\. Their budget is 40 USD/
+    );
+  });
+});

--- a/js/testapps/testing-sample/tests/prompt_test.ts
+++ b/js/testapps/testing-sample/tests/prompt_test.ts
@@ -21,8 +21,9 @@ import { ai, recommendPrompt } from '../src/menu.js';
 
 // This file registers `echoModel` under the app's default model name. It lives
 // in its own test file because menu_test.ts already claims 'menuModel' with a
-// `mockModel` — and since the test runner gives each file a fresh process (and
-// so a fresh registry), the two registrations never meet.
+// `mockModel` — and since the test runner isolates each file (`node --test`
+// spawns a child process per file, so each gets a fresh registry), the two
+// registrations never meet.
 echoModel(ai, { name: 'menuModel', info: { supports: { tools: true } } });
 
 describe('prompt assembly with echoModel', () => {

--- a/js/testapps/testing-sample/tsconfig.json
+++ b/js/testapps/testing-sample/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "noImplicitReturns": true,
+    "noUnusedLocals": false,
+    "outDir": "lib",
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2017",
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "compileOnSave": true,
+  "include": ["src", "tests"]
+}

--- a/js/testapps/testing-sample/vitest.config.ts
+++ b/js/testapps/testing-sample/vitest.config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/js/testapps/testing-sample/vitest.config.ts
+++ b/js/testapps/testing-sample/vitest.config.ts
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-export { testModels } from './model-tester.js';
-export {
-  echoModel,
-  mockModel,
-  type EchoModelOptions,
-  type MockChunk,
-  type MockContext,
-  type MockModel,
-  type MockModelOptions,
-  type MockResponse,
-} from './mock-model.js';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Only the vitest example; the `*_test.ts` files run under node:test.
+    include: ['tests/**/*.vitest.test.ts'],
+  },
+});


### PR DESCRIPTION
Implementation of the JS testing-module RFC (#5438).

## What

Promotes Genkit internal model-mocking helpers into the public `genkit/testing` surface so app developers can unit-test flows, prompts, tools, and chat deterministically, with no live model, network, or API key.

- `mockModel(ai, { respond })` - programmable mock. `respond(req, { sendChunk })` drives each call response, including text, structured output, tool requests, or a stream. Typed inspection includes `model.lastMessage`, `model.lastRequest`, `model.requests`, and `model.requestCount`.
- `echoModel(ai)` - zero-config model that echoes the rendered request as text, for asserting prompt/message assembly.
- Re-exported from `@genkit-ai/ai/testing` and `genkit/testing`, alongside the existing `testModels`.

Inspection reads in Genkit idiom: `model.lastMessage!.text` instead of reaching into raw request message content.

## Files

| File | What |
|---|---|
| `js/ai/src/testing/mock-model.ts` | implementation + types |
| `js/ai/src/testing/index.ts`, `js/genkit/src/testing.ts` | re-exports |
| `js/genkit/tests/mock-model_test.ts` | unit tests for text, streaming, tool round-trip, inspection, and echo |
| `js/testapps/testing-sample/` | sample app with a `recommendDish` flow and `dailySpecial` tool |
| `js/testapps/testing-sample/tests/menu_test.ts` | Node `node:test` coverage |
| `js/testapps/testing-sample/tests/menu.vitest.test.ts` | vitest coverage |

## Why a dedicated fake model, not middleware

The RFC alternatives section weighs model middleware as the closest mechanism. This PR implements `mockModel` and `echoModel` as real `defineModel` actions using apiVersion v2, mirroring the existing internal `defineProgrammableModel` approach.

- Avoids `Function.length` streaming behavior in model middleware dispatch.
- Keeps typed inspection on the returned model action.
- Promotes existing fake-model logic rather than rebuilding it on a different substrate.

## Scope notes

- `autoModel` is not included; it remains an RFC open question for follow-up.
- The global no-real-model-calls guard is not included in this PR.

Refs #5438.

---

## Updates since first draft

Inspection members were renamed and expanded during review, and a few ergonomics were borrowed from the AI SDK / LangChain test fakes:

- **Inspection:** `lastMessage` → `lastRequestMessage`; added `lastRequestText` (whole assembled conversation flattened, works even on structured-output paths where `echoModel` can't) and `toolResponses` (tool results fed back to the model, so tests assert which tools ran and what they returned without digging through message content).
- **Response queue:** `respond` also accepts an array — a queue consumed one item per call, last item repeating — for scripted multi-turn tests without a branching callback.
- **Error injection:** a queued `Error` is thrown when reached, giving declarative failure testing (retry/fallback paths).
- **`echoModel` output-schema guard:** throws a clear error if the request carries an output schema (prose can't satisfy it), pointing at `mockModel` + `lastRequestText` instead.
- **Robustness:** request snapshots are `structuredClone`d and read-through views are cloned so tests can't mutate recorded history; `renderRequestText` newline-separates messages so adjacent text can't fuse.

Tests grew accordingly: `mock-model_test.ts` now **17 pass** (adds queue, error injection, `toolResponses`, defensive-copy, and — notably — **interrupt round-trip and agent-handoff** cases proving `mockModel` already covers those without dedicated helpers). Sample: **7** node + **5** vitest.

## Update: resettable mocks (register-once idiom)

Mock lifecycle was tied to registry registration, which pushed tests toward a fresh-Genkit-instance-per-test factory - a nonstandard app structure prescribed just to be testable. Following the established fake-model idiom (jest mocks, AI SDK / LangChain test fakes) instead:

- **`model.reset()`** - clears recorded history and re-arms the construction-time `respond` (a queue restarts from its first item). Call in `beforeEach`.
- **`model.respondWith(...)`** - swaps respond behavior for subsequent calls; recorded history untouched.
- **`respond` accepts a single static response**, returned on every call (alongside the existing callback and queue forms).

The testing-sample app is back to a standard module-level singleton. Tests register **one** mock per file under the app's default model name and rely on the runner's per-file isolation (`node --test` spawns a child process per file; Jest and Vitest isolate each file's module graph), with `reset()` in `beforeEach` and per-test `respondWith(...)`. `echoModel` moved to its own test files since the menu tests claim the same model name.

Tests: **25** unit (adds single-response, `respondWith` swap, `reset` re-arm, and empty-string-response regression) + **10** node + **6** vitest.

## Follow-up (separate PR)

Chat/session testing has one small gap: there is no public in-memory `SessionStore`, so users wanting to pre-seed / inspect / test their own store re-implement it (the internal tests literally do — `TestMemorySessionStore`). A production-quality `inMemorySessionStore()` factory already exists at `js/ai/src/session.ts` but isn't exported. Follow-up: **export `inMemorySessionStore()`** from the public package (optionally re-exported via `genkit/testing`). This is a core public-API change, kept out of this testing-utility PR deliberately. Interrupts and agent handoff need **no** new helpers (covered by tests here); `mockRetriever`/`mockEmbedder` are out of scope pending their roadmap.

