### PR TITLE
feat(js/plugins/fastify): add @genkit-ai/fastify plugin (fastifyHandler)

### DIFF
--- a/js/plugins/fastify/.guides/usage.md
+++ b/js/plugins/fastify/.guides/usage.md
@@ -1,0 +1,107 @@
+Genkit's Fastify integration makes it easy to expose Genkit flows as Fastify API endpoints:
+
+```ts
+import Fastify from 'fastify';
+import { fastifyHandler } from '@genkit-ai/fastify';
+import { simpleFlow } from './flows/simple-flow.js';
+
+const app = Fastify();
+
+app.post('/simpleFlow', fastifyHandler(simpleFlow));
+
+await app.listen({ port: 8080 });
+```
+
+You can also handle auth using context providers:
+
+```ts
+import { UserFacingError } from 'genkit';
+import { ContextProvider, RequestData } from 'genkit/context';
+
+const contextProvider: ContextProvider<Context> = (req: RequestData) => {
+  if (req.headers['authorization'] !== 'open sesame') {
+    throw new UserFacingError('PERMISSION_DENIED', 'not authorized');
+  }
+  return {
+    auth: {
+      user: 'Ali Baba',
+    },
+  };
+};
+
+app.post('/simpleFlow', fastifyHandler(simpleFlow, { contextProvider }));
+```
+
+Flows and actions exposed using the `fastifyHandler` function can be accessed using the `genkit/beta/client` library:
+
+```ts
+import { runFlow, streamFlow } from 'genkit/beta/client';
+
+const result = await runFlow({
+  url: `http://localhost:${port}/simpleFlow`,
+  input: 'say hello',
+});
+
+console.log(result); // hello
+```
+
+```ts
+// set auth headers (when using auth policies)
+const result = await runFlow({
+  url: `http://localhost:${port}/simpleFlow`,
+  headers: {
+    Authorization: 'open sesame',
+  },
+  input: 'say hello',
+});
+
+console.log(result); // hello
+```
+
+```ts
+// and streamed
+const result = streamFlow({
+  url: `http://localhost:${port}/simpleFlow`,
+  input: 'say hello',
+});
+for await (const chunk of result.stream) {
+  console.log(chunk);
+}
+console.log(await result.output);
+```
+
+You can register the `genkitFastify` plugin to quickly expose multiple flows and actions:
+
+```ts
+import Fastify from 'fastify';
+import { genkitFastify } from '@genkit-ai/fastify';
+import { genkit } from 'genkit';
+
+const ai = genkit({});
+
+export const menuSuggestionFlow = ai.defineFlow(
+  {
+    name: 'menuSuggestionFlow',
+  },
+  async (restaurantTheme) => {
+    // ...
+  }
+);
+
+const app = Fastify();
+await app.register(genkitFastify, {
+  flows: [menuSuggestionFlow],
+});
+await app.listen({ port: 8080 });
+```
+
+You can prefix the exposed routes and attach per-flow options:
+
+```ts
+import { genkitFastify, withFlowOptions } from '@genkit-ai/fastify';
+
+await app.register(genkitFastify, {
+  pathPrefix: '/api',
+  flows: [withFlowOptions(menuSuggestionFlow, { contextProvider })],
+});
+```

--- a/js/plugins/fastify/.npmignore
+++ b/js/plugins/fastify/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+tsconfig.json
+tsup.config.ts

--- a/js/plugins/fastify/README.md
+++ b/js/plugins/fastify/README.md
@@ -1,0 +1,82 @@
+# Genkit Fastify Plugin
+
+This plugin provides utilities for conveniently exposing Genkit flows and actions via a [Fastify](https://fastify.dev/) HTTP server as REST APIs.
+
+Fastify is not Web Fetch native and has no built-in Genkit integration, so wiring a flow into Fastify by hand requires bridging Fastify's `request`/`reply` to the Genkit action protocol (including Server-Sent Events for streaming). This plugin does that bridging for you, so a flow mounts in one line, just like [`@genkit-ai/express`](https://www.npmjs.com/package/@genkit-ai/express) does for Express.
+
+See the [official documentation](https://genkit.dev/docs/frameworks/) for more.
+
+## Installation
+
+```bash
+npm i @genkit-ai/fastify
+```
+
+## Usage
+
+Mount a single flow with `fastifyHandler`:
+
+```ts
+import Fastify from 'fastify';
+import { fastifyHandler } from '@genkit-ai/fastify';
+
+const simpleFlow = ai.defineFlow('simpleFlow', async (input, { sendChunk }) => {
+  const { text } = await ai.generate({
+    model: googleAI.model('gemini-2.5-flash'),
+    prompt: input,
+    onChunk: (c) => sendChunk(c.text),
+  });
+  return text;
+});
+
+const app = Fastify();
+
+app.post('/simpleFlow', fastifyHandler(simpleFlow));
+
+await app.listen({ port: 8080 });
+```
+
+The handler reads `{ data }` from the JSON body, runs the flow, and streams chunks back as Server-Sent Events when the caller sends `Accept: text/event-stream` (or `?stream=true`) — exactly what the `runFlow` and `streamFlow` clients in `genkit/beta/client` expect.
+
+### Expose multiple flows with the plugin
+
+Register `genkitFastify` to mount several flows at once. Each flow is exposed at `/<flowName>` (override with `withFlowOptions`):
+
+```ts
+import Fastify from 'fastify';
+import { genkitFastify, withFlowOptions } from '@genkit-ai/fastify';
+
+const app = Fastify();
+
+await app.register(genkitFastify, {
+  pathPrefix: '/api',
+  flows: [
+    simpleFlow,
+    withFlowOptions(secureFlow, { contextProvider }),
+  ],
+});
+
+await app.listen({ port: 8080 });
+```
+
+### Handle auth with context providers
+
+```ts
+import { UserFacingError } from 'genkit';
+import { ContextProvider, RequestData } from 'genkit/context';
+
+const contextProvider: ContextProvider<Context> = (req: RequestData) => {
+  if (req.headers['authorization'] !== 'open sesame') {
+    throw new UserFacingError('PERMISSION_DENIED', 'not authorized');
+  }
+  return { auth: { user: 'Ali Baba' } };
+};
+
+app.post('/secureFlow', fastifyHandler(secureFlow, { contextProvider }));
+```
+
+The sources for this package are in the main [Genkit](https://github.com/genkit-ai/genkit) repo. Please file issues and pull requests against that repo.
+
+Usage information and reference details can be found in [Genkit documentation](https://genkit.dev/docs/get-started).
+
+License: Apache 2.0

--- a/js/plugins/fastify/package.json
+++ b/js/plugins/fastify/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@genkit-ai/fastify",
+  "description": "Genkit AI framework plugin for Fastify server",
+  "keywords": [
+    "genkit",
+    "genkit-plugin",
+    "fastify",
+    "ai",
+    "genai",
+    "generative-ai"
+  ],
+  "version": "0.1.0",
+  "type": "commonjs",
+  "scripts": {
+    "check": "tsc",
+    "compile": "tsup-node",
+    "build:clean": "rimraf ./lib",
+    "build": "npm-run-all build:clean check compile",
+    "build:watch": "tsup-node --watch",
+    "test": "node --import tsx --test tests/*_test.ts",
+    "test:watch": "node --import tsx --watch --test tests/*_test.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/genkit-ai/genkit.git",
+    "directory": "js/plugins/fastify"
+  },
+  "author": "genkit",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "genkit": "workspace:^",
+    "fastify": "^4.0.0 || ^5.0.0"
+  },
+  "devDependencies": {
+    "get-port": "^5.1.0",
+    "fastify": "^5.0.0",
+    "@types/node": "^20.11.16",
+    "genkit": "workspace:*",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
+    "tsup": "^8.3.5",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3"
+  },
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
+    }
+  }
+}

--- a/js/plugins/fastify/src/index.ts
+++ b/js/plugins/fastify/src/index.ts
@@ -132,7 +132,7 @@ export function fastifyHandler<
     });
 
     if (
-      request.headers['accept'] === 'text/event-stream' ||
+      request.headers['accept']?.includes('text/event-stream') ||
       stream === 'true'
     ) {
       // Headers set by earlier hooks/plugins (e.g. @fastify/cors) live on the
@@ -218,6 +218,9 @@ async function runActionWithDurableStreaming<
   }
   try {
     let onChunk = (chunk: z.infer<S>) => {
+      // The client may have disconnected mid-stream; writing to a destroyed
+      // response would throw.
+      if (response.destroyed) return;
       response.write(
         'data: ' + JSON.stringify({ message: chunk }) + streamDelimiter
       );
@@ -238,10 +241,12 @@ async function runActionWithDurableStreaming<
       taskQueue!.enqueue(() => durableStream!.done(result.result));
       await taskQueue!.merge();
     }
-    response.write(
-      'data: ' + JSON.stringify({ result: result.result }) + streamDelimiter
-    );
-    response.end();
+    if (!response.destroyed) {
+      response.write(
+        'data: ' + JSON.stringify({ result: result.result }) + streamDelimiter
+      );
+      response.end();
+    }
   } catch (e) {
     if (durableStream) {
       taskQueue!.enqueue(() => durableStream!.error(e));
@@ -250,12 +255,14 @@ async function runActionWithDurableStreaming<
     logger.error(
       `Streaming request failed with error: ${getErrorMessage(e)}\n${getErrorStack(e)}`
     );
-    response.write(
-      `error: ${JSON.stringify({
-        error: getCallableJSON(e),
-      })}${streamDelimiter}`
-    );
-    response.end();
+    if (!response.destroyed) {
+      response.write(
+        `error: ${JSON.stringify({
+          error: getCallableJSON(e),
+        })}${streamDelimiter}`
+      );
+      response.end();
+    }
   }
 }
 
@@ -267,11 +274,15 @@ async function subscribeToStream(
   try {
     await streamManager.subscribe(streamId, {
       onChunk: (chunk) => {
+        // The subscribing client may have disconnected; skip writes to a
+        // destroyed response to avoid throwing.
+        if (response.destroyed) return;
         response.write(
           'data: ' + JSON.stringify({ message: chunk }) + streamDelimiter
         );
       },
       onDone: (output) => {
+        if (response.destroyed) return;
         response.write(
           'data: ' + JSON.stringify({ result: output }) + streamDelimiter
         );
@@ -281,6 +292,7 @@ async function subscribeToStream(
         logger.error(
           `Streaming request failed with error: ${getErrorMessage(err)}\n${getErrorStack(err)}`
         );
+        if (response.destroyed) return;
         response.write(
           `error: ${JSON.stringify({
             error: getCallableJSON(err),

--- a/js/plugins/fastify/src/index.ts
+++ b/js/plugins/fastify/src/index.ts
@@ -111,11 +111,15 @@ export function fastifyHandler<
         (await opts?.contextProvider?.({
           method: request.method as RequestData['method'],
           headers: Object.fromEntries(
-            Object.entries(request.headers).map(([key, value]) => [
-              key.toLowerCase(),
-              // RFC 9110 5.3: combine repeated field lines with a comma.
-              Array.isArray(value) ? value.join(', ') : String(value),
-            ])
+            Object.entries(request.headers)
+              // Skip headers explicitly set to undefined so they don't become
+              // the literal string "undefined" via String(value).
+              .filter(([, value]) => value !== undefined)
+              .map(([key, value]) => [
+                key.toLowerCase(),
+                // RFC 9110 5.3: combine repeated field lines with a comma.
+                Array.isArray(value) ? value.join(', ') : String(value),
+              ])
           ),
           input,
         })) || {};
@@ -301,18 +305,32 @@ async function subscribeToStream(
   streamId: string,
   response: ServerResponse
 ): Promise<void> {
+  // Send the streaming headers lazily on the first event so that a
+  // StreamNotFoundError can still respond with a clean 204. Without this the
+  // subscribe path would emit body bytes with no Content-Type, which some
+  // clients and proxies refuse to treat as a stream.
+  const ensureHeaders = () => {
+    if (!response.headersSent) {
+      response.writeHead(200, {
+        'Content-Type': 'text/plain',
+        'Transfer-Encoding': 'chunked',
+      });
+    }
+  };
   try {
     await streamManager.subscribe(streamId, {
       onChunk: (chunk) => {
         // The subscribing client may have disconnected; skip writes to a
         // destroyed response to avoid throwing.
         if (response.destroyed) return;
+        ensureHeaders();
         response.write(
           'data: ' + JSON.stringify({ message: chunk }) + streamDelimiter
         );
       },
       onDone: (output) => {
         if (response.destroyed) return;
+        ensureHeaders();
         response.write(
           'data: ' + JSON.stringify({ result: output }) + streamDelimiter
         );
@@ -323,6 +341,7 @@ async function subscribeToStream(
           `Streaming request failed with error: ${getErrorMessage(err)}\n${getErrorStack(err)}`
         );
         if (response.destroyed) return;
+        ensureHeaders();
         response.write(
           `error: ${JSON.stringify({
             error: getCallableJSON(err),
@@ -332,12 +351,14 @@ async function subscribeToStream(
       },
     });
   } catch (e: any) {
+    if (response.destroyed) return;
     if (e instanceof StreamNotFoundError) {
       response.writeHead(204);
       response.end();
       return;
     }
     if (e.status === 'DEADLINE_EXCEEDED') {
+      ensureHeaders();
       response.write(
         `error: ${JSON.stringify({
           error: getCallableJSON(e),
@@ -468,17 +489,23 @@ export const genkitFastify: FastifyPluginAsync<GenkitFastifyOptions> = async (
   opts
 ) => {
   const pathPrefix = opts.pathPrefix ?? '';
+  // Fastify requires route paths to start with a single '/'. Normalize so a
+  // prefix without a leading slash ('api') or with stray slashes ('/api/')
+  // still produces a valid route.
+  const cleanPath = (p: string) => ('/' + p).replace(/\/+/g, '/');
   logger.debug('Registering Genkit flow routes:');
   for (const flow of opts.flows ?? []) {
     if ('flow' in flow) {
-      const flowPath = `${pathPrefix}/${
-        ('options' in flow && flow.options.path) || flow.flow.__action.name
-      }`;
+      const flowPath = cleanPath(
+        `${pathPrefix}/${
+          ('options' in flow && flow.options.path) || flow.flow.__action.name
+        }`
+      );
       const options =
         'options' in flow ? flow.options : { contextProvider: flow.context };
       registerFlow(instance, flowPath, fastifyHandler(flow.flow, options));
     } else {
-      const flowPath = `${pathPrefix}/${flow.__action.name}`;
+      const flowPath = cleanPath(`${pathPrefix}/${flow.__action.name}`);
       registerFlow(instance, flowPath, fastifyHandler(flow));
     }
   }

--- a/js/plugins/fastify/src/index.ts
+++ b/js/plugins/fastify/src/index.ts
@@ -113,7 +113,8 @@ export function fastifyHandler<
           headers: Object.fromEntries(
             Object.entries(request.headers).map(([key, value]) => [
               key.toLowerCase(),
-              Array.isArray(value) ? value.join(' ') : String(value),
+              // RFC 9110 5.3: combine repeated field lines with a comma.
+              Array.isArray(value) ? value.join(', ') : String(value),
             ])
           ),
           input,
@@ -130,6 +131,10 @@ export function fastifyHandler<
     request.raw.on('close', () => {
       abortController.abort();
     });
+    // When/if a request timeout is configured, the socket emits 'timeout'.
+    request.raw.on('timeout', () => {
+      abortController.abort();
+    });
 
     if (
       request.headers['accept']?.toLowerCase().includes('text/event-stream') ||
@@ -144,36 +149,61 @@ export function fastifyHandler<
       // to serialize and send a reply while we stream raw SSE bytes.
       reply.hijack();
       const raw = reply.raw;
-      for (const [key, value] of Object.entries(pendingHeaders)) {
-        if (value !== undefined) {
-          raw.setHeader(key, value);
+      // hijack() also bypasses Fastify's error handling, so an error thrown
+      // while setting up the stream (e.g. streamManager.open, or a rethrow from
+      // subscribeToStream) would leave the socket open and leak the connection.
+      // Catch it here and close the response cleanly.
+      try {
+        for (const [key, value] of Object.entries(pendingHeaders)) {
+          if (value !== undefined) {
+            raw.setHeader(key, value);
+          }
+        }
+
+        const streamManager = opts?.streamManager;
+        if (streamManager && streamId) {
+          await subscribeToStream(streamManager, streamId, raw);
+          return;
+        }
+
+        const streamIdToUse = randomUUID();
+        const headers: Record<string, string> = {
+          'Content-Type': 'text/plain',
+          'Transfer-Encoding': 'chunked',
+        };
+        if (streamManager) {
+          headers['x-genkit-stream-id'] = streamIdToUse;
+        }
+        raw.writeHead(200, headers);
+        await runActionWithDurableStreaming(
+          action,
+          streamManager,
+          streamIdToUse,
+          input,
+          context,
+          raw,
+          abortController.signal
+        );
+      } catch (e) {
+        logger.error(
+          `Streaming request failed with error: ${getErrorMessage(e)}\n${getErrorStack(e)}`
+        );
+        if (raw.destroyed) {
+          // Client already gone; nothing to send.
+        } else if (raw.headersSent) {
+          // Streaming already started: emit a trailing SSE error frame.
+          raw.write(
+            `error: ${JSON.stringify({ error: getCallableJSON(e) })}${streamDelimiter}`
+          );
+          raw.end();
+        } else {
+          // Nothing sent yet: respond with a normal API error.
+          raw.writeHead(getHttpStatus(e), {
+            'Content-Type': 'application/json',
+          });
+          raw.end(JSON.stringify(getCallableJSON(e)));
         }
       }
-
-      const streamManager = opts?.streamManager;
-      if (streamManager && streamId) {
-        await subscribeToStream(streamManager, streamId, raw);
-        return;
-      }
-
-      const streamIdToUse = randomUUID();
-      const headers: Record<string, string> = {
-        'Content-Type': 'text/plain',
-        'Transfer-Encoding': 'chunked',
-      };
-      if (streamManager) {
-        headers['x-genkit-stream-id'] = streamIdToUse;
-      }
-      raw.writeHead(200, headers);
-      await runActionWithDurableStreaming(
-        action,
-        streamManager,
-        streamIdToUse,
-        input,
-        context,
-        raw,
-        abortController.signal
-      );
     } else {
       try {
         const result = await action.run(input, {

--- a/js/plugins/fastify/src/index.ts
+++ b/js/plugins/fastify/src/index.ts
@@ -1,0 +1,430 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Action,
+  ActionStreamInput,
+  AsyncTaskQueue,
+  Flow,
+  StreamNotFoundError,
+  type ActionContext,
+  type StreamManager,
+  type z,
+} from 'genkit/beta';
+import {
+  getCallableJSON,
+  getHttpStatus,
+  type ContextProvider,
+  type RequestData,
+} from 'genkit/context';
+import { logger } from 'genkit/logging';
+import type {
+  FastifyInstance,
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+  RouteHandlerMethod,
+} from 'fastify';
+import type { ServerResponse } from 'http';
+import { getErrorMessage, getErrorStack } from './utils.js';
+
+const streamDelimiter = '\n\n';
+
+// Let the runtime provide the randomUUID function.
+const randomUUID = () => globalThis.crypto.randomUUID();
+
+/**
+ * Options for a {@link fastifyHandler} (context provider, stream manager).
+ */
+export interface FastifyHandlerOptions<
+  C extends ActionContext = ActionContext,
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+> {
+  contextProvider?: ContextProvider<C, I>;
+  streamManager?: StreamManager;
+}
+
+/**
+ * Exposes the provided flow (or any action) as a Fastify route handler.
+ *
+ * Fastify is not Web Fetch native, so this handler bridges Fastify's
+ * `request`/`reply` to the Genkit action protocol that `runFlow`/`streamFlow`
+ * clients expect: it reads `{ data }` from the parsed JSON body, runs the
+ * action, and streams chunks back as Server-Sent Events when the caller asks
+ * for them (`Accept: text/event-stream` or `?stream=true`).
+ *
+ * @example
+ * ```typescript
+ * import Fastify from 'fastify';
+ * import { fastifyHandler } from '@genkit-ai/fastify';
+ *
+ * const app = Fastify();
+ * app.post('/simpleFlow', fastifyHandler(simpleFlow));
+ * await app.listen({ port: 8080 });
+ * ```
+ */
+export function fastifyHandler<
+  C extends ActionContext = ActionContext,
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  S extends z.ZodTypeAny = z.ZodTypeAny,
+>(
+  action: Action<I, O, S>,
+  opts?: FastifyHandlerOptions<C, I>
+): RouteHandlerMethod {
+  return async (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ): Promise<void> => {
+    const stream = (request.query as { stream?: string } | undefined)?.stream;
+    const streamIdHeader = request.headers['x-genkit-stream-id'];
+    const streamId = Array.isArray(streamIdHeader)
+      ? streamIdHeader[0]
+      : streamIdHeader;
+
+    if (request.body === undefined || request.body === null) {
+      const errMsg =
+        `Error: request.body is undefined. ` +
+        `Possible reasons: missing 'content-type: application/json' in request ` +
+        `headers, or a content type parser that did not populate request.body. `;
+      logger.error(errMsg);
+      reply.code(400).send({ message: errMsg, status: 'INVALID_ARGUMENT' });
+      return;
+    }
+
+    const input = (request.body as { data?: z.infer<I> }).data as z.infer<I>;
+    let context: Record<string, any>;
+
+    try {
+      context =
+        (await opts?.contextProvider?.({
+          method: request.method as RequestData['method'],
+          headers: Object.fromEntries(
+            Object.entries(request.headers).map(([key, value]) => [
+              key.toLowerCase(),
+              Array.isArray(value) ? value.join(' ') : String(value),
+            ])
+          ),
+          input,
+        })) || {};
+    } catch (e: any) {
+      logger.error(
+        `Auth policy failed with error: ${getErrorMessage(e)}\n${getErrorStack(e)}`
+      );
+      reply.code(getHttpStatus(e)).send(getCallableJSON(e));
+      return;
+    }
+
+    const abortController = new AbortController();
+    request.raw.on('close', () => {
+      abortController.abort();
+    });
+
+    if (request.headers['accept'] === 'text/event-stream' || stream === 'true') {
+      // Take ownership of the underlying response so Fastify does not also try
+      // to serialize and send a reply while we stream raw SSE bytes.
+      reply.hijack();
+      const raw = reply.raw;
+
+      const streamManager = opts?.streamManager;
+      if (streamManager && streamId) {
+        await subscribeToStream(streamManager, streamId, raw);
+        return;
+      }
+
+      const streamIdToUse = randomUUID();
+      const headers: Record<string, string> = {
+        'Content-Type': 'text/plain',
+        'Transfer-Encoding': 'chunked',
+      };
+      if (streamManager) {
+        headers['x-genkit-stream-id'] = streamIdToUse;
+      }
+      raw.writeHead(200, headers);
+      await runActionWithDurableStreaming(
+        action,
+        streamManager,
+        streamIdToUse,
+        input,
+        context,
+        raw,
+        abortController.signal
+      );
+    } else {
+      try {
+        const result = await action.run(input, {
+          context,
+          abortSignal: abortController.signal,
+        });
+        // Responses for non-streaming flows are passed back with the flow result stored in a field called "result."
+        reply
+          .header('x-genkit-trace-id', result.telemetry.traceId)
+          .header('x-genkit-span-id', result.telemetry.spanId)
+          .code(200)
+          .send({ result: result.result });
+      } catch (e) {
+        // Errors for non-streaming flows are passed back as standard API errors.
+        logger.error(
+          `Non-streaming request failed with error: ${getErrorMessage(e)}\n${getErrorStack(e)}`
+        );
+        reply.code(getHttpStatus(e)).send(getCallableJSON(e));
+      }
+    }
+  };
+}
+
+async function runActionWithDurableStreaming<
+  I extends z.ZodTypeAny,
+  O extends z.ZodTypeAny,
+  S extends z.ZodTypeAny,
+>(
+  action: Action<I, O, S>,
+  streamManager: StreamManager | undefined,
+  streamId: string,
+  input: z.infer<I>,
+  context: ActionContext,
+  response: ServerResponse,
+  abortSignal: AbortSignal
+) {
+  let taskQueue: AsyncTaskQueue | undefined;
+  let durableStream: ActionStreamInput<any, any> | undefined;
+  if (streamManager) {
+    taskQueue = new AsyncTaskQueue();
+    durableStream = await streamManager.open(streamId);
+  }
+  try {
+    let onChunk = (chunk: z.infer<S>) => {
+      response.write(
+        'data: ' + JSON.stringify({ message: chunk }) + streamDelimiter
+      );
+    };
+    if (streamManager) {
+      const originalOnChunk = onChunk;
+      onChunk = (chunk: z.infer<S>) => {
+        originalOnChunk(chunk);
+        taskQueue!.enqueue(() => durableStream!.write(chunk));
+      };
+    }
+    const result = await action.run(input, {
+      onChunk,
+      context,
+      abortSignal,
+    });
+    if (streamManager) {
+      taskQueue!.enqueue(() => durableStream!.done(result.result));
+      await taskQueue!.merge();
+    }
+    response.write(
+      'data: ' + JSON.stringify({ result: result.result }) + streamDelimiter
+    );
+    response.end();
+  } catch (e) {
+    if (durableStream) {
+      taskQueue!.enqueue(() => durableStream!.error(e));
+      await taskQueue!.merge();
+    }
+    logger.error(
+      `Streaming request failed with error: ${getErrorMessage(e)}\n${getErrorStack(e)}`
+    );
+    response.write(
+      `error: ${JSON.stringify({
+        error: getCallableJSON(e),
+      })}${streamDelimiter}`
+    );
+    response.end();
+  }
+}
+
+async function subscribeToStream(
+  streamManager: StreamManager,
+  streamId: string,
+  response: ServerResponse
+): Promise<void> {
+  try {
+    await streamManager.subscribe(streamId, {
+      onChunk: (chunk) => {
+        response.write(
+          'data: ' + JSON.stringify({ message: chunk }) + streamDelimiter
+        );
+      },
+      onDone: (output) => {
+        response.write(
+          'data: ' + JSON.stringify({ result: output }) + streamDelimiter
+        );
+        response.end();
+      },
+      onError: (err) => {
+        logger.error(
+          `Streaming request failed with error: ${getErrorMessage(err)}\n${getErrorStack(err)}`
+        );
+        response.write(
+          `error: ${JSON.stringify({
+            error: getCallableJSON(err),
+          })}${streamDelimiter}`
+        );
+        response.end();
+      },
+    });
+  } catch (e: any) {
+    if (e instanceof StreamNotFoundError) {
+      response.writeHead(204);
+      response.end();
+      return;
+    }
+    if (e.status === 'DEADLINE_EXCEEDED') {
+      response.write(
+        `error: ${JSON.stringify({
+          error: getCallableJSON(e),
+        })}${streamDelimiter}`
+      );
+      response.end();
+      return;
+    }
+    throw e;
+  }
+}
+
+/**
+ * A wrapper object containing a flow with its associated context provider.
+ * @deprecated Use {@link withFlowOptions} instead.
+ */
+export type FlowWithContextProvider<
+  C extends ActionContext = ActionContext,
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  S extends z.ZodTypeAny = z.ZodTypeAny,
+> = {
+  flow: Flow<I, O, S>;
+  context: ContextProvider<C, I>;
+};
+
+/**
+ * A wrapper object containing a flow with its associated options.
+ */
+export type FlowWithOptions<
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  S extends z.ZodTypeAny = z.ZodTypeAny,
+> = {
+  flow: Flow<I, O, S>;
+  options: {
+    contextProvider?: ContextProvider<any, I>;
+    streamManager?: StreamManager;
+    path?: string;
+  };
+};
+
+/**
+ * Attaches a context provider to a flow.
+ * @deprecated Use {@link withFlowOptions} instead.
+ */
+export function withContextProvider<
+  C extends ActionContext = ActionContext,
+  I extends z.ZodTypeAny = z.ZodTypeAny,
+  O extends z.ZodTypeAny = z.ZodTypeAny,
+  S extends z.ZodTypeAny = z.ZodTypeAny,
+>(
+  flow: Flow<I, O, S>,
+  context: ContextProvider<C, I>
+): FlowWithContextProvider<C, I, O, S> {
+  return {
+    flow,
+    context,
+  };
+}
+
+/**
+ * Attaches options (context provider, stream manager, custom path) to a flow
+ * for use with the {@link genkitFastify} plugin.
+ */
+export function withFlowOptions<
+  I extends z.ZodTypeAny,
+  O extends z.ZodTypeAny,
+  S extends z.ZodTypeAny,
+>(
+  flow: Flow<I, O, S>,
+  options: {
+    contextProvider?: ContextProvider<any, I>;
+    streamManager?: StreamManager;
+    path?: string;
+  }
+): FlowWithOptions<I, O, S> {
+  return {
+    flow,
+    options,
+  };
+}
+
+/**
+ * Options for the {@link genkitFastify} plugin.
+ */
+export interface GenkitFastifyOptions {
+  /** Flows (or flows wrapped with {@link withFlowOptions}) to expose as routes. */
+  flows: (
+    | Flow<any, any, any>
+    | FlowWithContextProvider<any, any, any>
+    | FlowWithOptions<any, any, any>
+  )[];
+  /** HTTP path prefix prepended to each exposed flow (e.g. `/api`). */
+  pathPrefix?: string;
+}
+
+function registerFlow(instance: FastifyInstance, path: string, handler: RouteHandlerMethod) {
+  logger.debug(` - POST ${path}`);
+  instance.post(path, handler);
+}
+
+/**
+ * A Fastify plugin that exposes a set of Genkit flows as POST routes. Register
+ * it with `app.register` for an ergonomic, multi-flow setup:
+ *
+ * @example
+ * ```typescript
+ * import Fastify from 'fastify';
+ * import { genkitFastify, withFlowOptions } from '@genkit-ai/fastify';
+ *
+ * const app = Fastify();
+ * await app.register(genkitFastify, {
+ *   flows: [
+ *     menuSuggestionFlow,
+ *     withFlowOptions(secureFlow, { contextProvider }),
+ *   ],
+ * });
+ * await app.listen({ port: 8080 });
+ * ```
+ */
+export const genkitFastify: FastifyPluginAsync<GenkitFastifyOptions> = async (
+  instance,
+  opts
+) => {
+  const pathPrefix = opts.pathPrefix ?? '';
+  logger.debug('Registering Genkit flow routes:');
+  for (const flow of opts.flows ?? []) {
+    if ('flow' in flow) {
+      const flowPath = `${pathPrefix}/${
+        ('options' in flow && flow.options.path) || flow.flow.__action.name
+      }`;
+      const options =
+        'options' in flow ? flow.options : { contextProvider: flow.context };
+      registerFlow(instance, flowPath, fastifyHandler(flow.flow, options));
+    } else {
+      const flowPath = `${pathPrefix}/${flow.__action.name}`;
+      registerFlow(instance, flowPath, fastifyHandler(flow));
+    }
+  }
+};
+
+export default genkitFastify;

--- a/js/plugins/fastify/src/index.ts
+++ b/js/plugins/fastify/src/index.ts
@@ -132,7 +132,7 @@ export function fastifyHandler<
     });
 
     if (
-      request.headers['accept']?.includes('text/event-stream') ||
+      request.headers['accept']?.toLowerCase().includes('text/event-stream') ||
       stream === 'true'
     ) {
       // Headers set by earlier hooks/plugins (e.g. @fastify/cors) live on the

--- a/js/plugins/fastify/src/index.ts
+++ b/js/plugins/fastify/src/index.ts
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+import { randomUUID } from 'crypto';
+import type {
+  FastifyInstance,
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+  RouteHandlerMethod,
+} from 'fastify';
 import {
   Action,
   ActionStreamInput,
@@ -31,20 +39,10 @@ import {
   type RequestData,
 } from 'genkit/context';
 import { logger } from 'genkit/logging';
-import type {
-  FastifyInstance,
-  FastifyPluginAsync,
-  FastifyReply,
-  FastifyRequest,
-  RouteHandlerMethod,
-} from 'fastify';
 import type { ServerResponse } from 'http';
 import { getErrorMessage, getErrorStack } from './utils.js';
 
 const streamDelimiter = '\n\n';
-
-// Let the runtime provide the randomUUID function.
-const randomUUID = () => globalThis.crypto.randomUUID();
 
 /**
  * Options for a {@link fastifyHandler} (context provider, stream manager).
@@ -133,7 +131,10 @@ export function fastifyHandler<
       abortController.abort();
     });
 
-    if (request.headers['accept'] === 'text/event-stream' || stream === 'true') {
+    if (
+      request.headers['accept'] === 'text/event-stream' ||
+      stream === 'true'
+    ) {
       // Headers set by earlier hooks/plugins (e.g. @fastify/cors) live on the
       // Fastify reply. hijack() stops Fastify from flushing them to the socket,
       // so copy them onto the raw response ourselves before streaming, or the
@@ -392,7 +393,11 @@ export interface GenkitFastifyOptions {
   pathPrefix?: string;
 }
 
-function registerFlow(instance: FastifyInstance, path: string, handler: RouteHandlerMethod) {
+function registerFlow(
+  instance: FastifyInstance,
+  path: string,
+  handler: RouteHandlerMethod
+) {
   logger.debug(` - POST ${path}`);
   instance.post(path, handler);
 }

--- a/js/plugins/fastify/src/index.ts
+++ b/js/plugins/fastify/src/index.ts
@@ -134,10 +134,20 @@ export function fastifyHandler<
     });
 
     if (request.headers['accept'] === 'text/event-stream' || stream === 'true') {
+      // Headers set by earlier hooks/plugins (e.g. @fastify/cors) live on the
+      // Fastify reply. hijack() stops Fastify from flushing them to the socket,
+      // so copy them onto the raw response ourselves before streaming, or the
+      // browser would reject the streamed response for missing CORS headers.
+      const pendingHeaders = reply.getHeaders();
       // Take ownership of the underlying response so Fastify does not also try
       // to serialize and send a reply while we stream raw SSE bytes.
       reply.hijack();
       const raw = reply.raw;
+      for (const [key, value] of Object.entries(pendingHeaders)) {
+        if (value !== undefined) {
+          raw.setHeader(key, value);
+        }
+      }
 
       const streamManager = opts?.streamManager;
       if (streamManager && streamId) {

--- a/js/plugins/fastify/src/utils.ts
+++ b/js/plugins/fastify/src/utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Extracts error message from the given error object, or if input is not an error then just turn the error into a string.
+ */
+export function getErrorMessage(e: any): string {
+  if (e instanceof Error) {
+    return e.message;
+  }
+  return `${e}`;
+}
+
+/**
+ * Extracts stack trace from the given error object, or if input is not an error then returns undefined.
+ */
+export function getErrorStack(e: any): string | undefined {
+  if (e instanceof Error) {
+    return e.stack;
+  }
+  return undefined;
+}

--- a/js/plugins/fastify/tests/fastify_test.ts
+++ b/js/plugins/fastify/tests/fastify_test.ts
@@ -154,6 +154,12 @@ describe('fastifyHandler', async () => {
     app = Fastify();
     port = await getPort();
 
+    // Simulates a plugin/hook (e.g. @fastify/cors) that sets response headers
+    // before the handler runs. These must survive reply.hijack() when streaming.
+    app.addHook('onRequest', async (_req, reply) => {
+      reply.header('x-pre-hijack', 'preserved');
+    });
+
     app.post('/voidInput', fastifyHandler(voidInput));
     app.post('/stringInput', fastifyHandler(stringInput));
     app.post('/objectInput', fastifyHandler(objectInput));
@@ -443,6 +449,22 @@ describe('fastifyHandler', async () => {
       ]);
 
       assert.strictEqual(await result.output, 'Echo v2: olleh');
+    });
+
+    it('preserves headers set by earlier hooks on a streamed response', async () => {
+      // A streamed response goes through reply.hijack(); headers set by hooks
+      // (like CORS) must still reach the client. Without this, the browser
+      // rejects the streamed response even when the preflight passed.
+      const response = await fetch(`http://localhost:${port}/streamingFlow`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream',
+        },
+        body: JSON.stringify({ data: { question: 'hi' } }),
+      });
+      assert.strictEqual(response.headers.get('x-pre-hijack'), 'preserved');
+      await response.text(); // drain the stream
     });
 
     it('should return 204 for a non-existent stream', async () => {

--- a/js/plugins/fastify/tests/fastify_test.ts
+++ b/js/plugins/fastify/tests/fastify_test.ts
@@ -1,0 +1,511 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import Fastify, { type FastifyInstance } from 'fastify';
+import {
+  UserFacingError,
+  genkit,
+  z,
+  type GenerateResponseData,
+  type Genkit,
+} from 'genkit';
+import { InMemoryStreamManager } from 'genkit/beta';
+import { runFlow, streamFlow } from 'genkit/beta/client';
+import type { ContextProvider, RequestData } from 'genkit/context';
+import type { GenerateResponseChunkData, ModelAction } from 'genkit/model';
+import getPort from 'get-port';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import {
+  fastifyHandler,
+  genkitFastify,
+  withFlowOptions,
+} from '../src/index.js';
+
+interface Context {
+  auth: {
+    user: string;
+  };
+}
+
+const contextProvider: ContextProvider<Context> = (req: RequestData) => {
+  assert.ok(req.method, 'method must be set');
+  assert.ok(req.headers, 'headers must be set');
+  assert.ok(req.input, 'input must be set');
+
+  if (req.headers['authorization'] !== 'open sesame') {
+    throw new UserFacingError('PERMISSION_DENIED', 'not authorized');
+  }
+  return {
+    auth: {
+      user: 'Ali Baba',
+    },
+  };
+};
+
+describe('fastifyHandler', async () => {
+  let app: FastifyInstance;
+  let port: number;
+
+  beforeEach(async () => {
+    const ai = genkit({});
+    const echoModel = defineEchoModel(ai);
+
+    const voidInput = ai.defineFlow('voidInput', async () => {
+      return 'banana';
+    });
+
+    const stringInput = ai.defineFlow('stringInput', async (input) => {
+      const { text } = await ai.generate({
+        model: 'echoModel',
+        prompt: input,
+      });
+      return text;
+    });
+
+    const objectInput = ai.defineFlow(
+      { name: 'objectInput', inputSchema: z.object({ question: z.string() }) },
+      async (input) => {
+        const { text } = await ai.generate({
+          model: 'echoModel',
+          prompt: input.question,
+        });
+        return text;
+      }
+    );
+
+    const streamingFlow = ai.defineFlow(
+      {
+        name: 'streamingFlow',
+        inputSchema: z.object({ question: z.string() }),
+      },
+      async (input, sendChunk) => {
+        const { text } = await ai.generate({
+          model: 'echoModel',
+          prompt: input.question,
+          onChunk: sendChunk,
+        });
+        return text;
+      }
+    );
+
+    const flowWithAuth = ai.defineFlow(
+      {
+        name: 'flowWithAuth',
+        inputSchema: z.object({ question: z.string() }),
+      },
+      async (input, { context }) => {
+        return `${input.question} - ${JSON.stringify(context!.auth)}`;
+      }
+    );
+
+    app = Fastify();
+    port = await getPort();
+
+    app.post('/voidInput', fastifyHandler(voidInput));
+    app.post('/stringInput', fastifyHandler(stringInput));
+    app.post('/objectInput', fastifyHandler(objectInput));
+    app.post('/streamingFlow', fastifyHandler(streamingFlow));
+    app.post(
+      '/streamingFlowDurable',
+      fastifyHandler(streamingFlow, {
+        streamManager: new InMemoryStreamManager(),
+      })
+    );
+    app.post('/flowWithAuth', fastifyHandler(flowWithAuth, { contextProvider }));
+    // Can also expose any action.
+    app.post('/echoModel', fastifyHandler(echoModel));
+    app.post(
+      '/echoModelWithAuth',
+      fastifyHandler(echoModel, { contextProvider })
+    );
+
+    await app.listen({ port });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('runFlow', () => {
+    it('should call a void input flow', async () => {
+      const result = await runFlow({
+        url: `http://localhost:${port}/voidInput`,
+      });
+      assert.strictEqual(result, 'banana');
+    });
+
+    it('should run a flow with string input', async () => {
+      const result = await runFlow({
+        url: `http://localhost:${port}/stringInput`,
+        input: 'hello',
+      });
+      assert.strictEqual(result, 'Echo: hello');
+    });
+
+    it('should run a flow with object input', async () => {
+      const result = await runFlow({
+        url: `http://localhost:${port}/objectInput`,
+        input: {
+          question: 'olleh',
+        },
+      });
+      assert.strictEqual(result, 'Echo: olleh');
+    });
+
+    it('should fail a bad input', async () => {
+      const result = runFlow({
+        url: `http://localhost:${port}/objectInput`,
+        input: {
+          badField: 'hello',
+        },
+      });
+      await assert.rejects(result, (err: Error) => {
+        return err.message.includes('INVALID_ARGUMENT');
+      });
+    });
+
+    it('should call a flow with auth', async () => {
+      const result = await runFlow<string>({
+        url: `http://localhost:${port}/flowWithAuth`,
+        input: {
+          question: 'hello',
+        },
+        headers: {
+          Authorization: 'open sesame',
+        },
+      });
+      assert.strictEqual(result, 'hello - {"user":"Ali Baba"}');
+    });
+
+    it('should fail a flow with bad auth', async () => {
+      const result = runFlow({
+        url: `http://localhost:${port}/flowWithAuth`,
+        input: {
+          question: 'hello',
+        },
+        headers: {
+          Authorization: 'thief #24',
+        },
+      });
+      await assert.rejects(result, (err) => {
+        return (err as Error).message.includes('not authorized');
+      });
+    });
+
+    it('should call a model', async () => {
+      const result = await runFlow({
+        url: `http://localhost:${port}/echoModel`,
+        input: {
+          messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+        },
+      });
+      assert.strictEqual(result.finishReason, 'stop');
+      assert.deepStrictEqual(result.message, {
+        role: 'model',
+        content: [{ text: 'Echo: hello' }],
+      });
+    });
+
+    it('should call a model with auth', async () => {
+      const result = await runFlow<GenerateResponseData>({
+        url: `http://localhost:${port}/echoModelWithAuth`,
+        input: {
+          messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+        },
+        headers: {
+          Authorization: 'open sesame',
+        },
+      });
+      assert.strictEqual(result.finishReason, 'stop');
+      assert.deepStrictEqual(result.message, {
+        role: 'model',
+        content: [{ text: 'Echo: hello' }],
+      });
+    });
+
+    it('should fail a model with bad auth', async () => {
+      const result = runFlow({
+        url: `http://localhost:${port}/echoModelWithAuth`,
+        input: {
+          messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+        },
+        headers: {
+          Authorization: 'thief #24',
+        },
+      });
+      await assert.rejects(result, (err) => {
+        return (err as Error).message.includes('not authorized');
+      });
+    });
+  });
+
+  describe('streamFlow', () => {
+    it('stream a flow', async () => {
+      const result = streamFlow<string, GenerateResponseChunkData>({
+        url: `http://localhost:${port}/streamingFlow`,
+        input: {
+          question: 'olleh',
+        },
+      });
+
+      const gotChunks: GenerateResponseChunkData[] = [];
+      for await (const chunk of result.stream) {
+        gotChunks.push(chunk);
+      }
+
+      assert.deepStrictEqual(gotChunks, [
+        { index: 0, role: 'model', content: [{ text: '3' }] },
+        { index: 0, role: 'model', content: [{ text: '2' }] },
+        { index: 0, role: 'model', content: [{ text: '1' }] },
+      ]);
+
+      assert.strictEqual(await result.output, 'Echo: olleh');
+    });
+
+    it('should create and subscribe to a durable stream', async () => {
+      const result = streamFlow({
+        url: `http://localhost:${port}/streamingFlowDurable`,
+        input: {
+          question: 'durable',
+        },
+      });
+
+      const streamId = await result.streamId;
+      assert.ok(streamId);
+
+      const subscription = streamFlow({
+        url: `http://localhost:${port}/streamingFlowDurable`,
+        input: {
+          question: 'durable',
+        },
+        streamId: streamId!,
+      });
+
+      const gotChunks: GenerateResponseChunkData[] = [];
+      for await (const chunk of subscription.stream) {
+        gotChunks.push(chunk);
+      }
+
+      const originalChunks: GenerateResponseChunkData[] = [];
+      for await (const chunk of result.stream) {
+        originalChunks.push(chunk);
+      }
+
+      assert.deepStrictEqual(gotChunks, originalChunks);
+      assert.strictEqual(await subscription.output, 'Echo: durable');
+      assert.strictEqual(await result.output, 'Echo: durable');
+    });
+
+    it('should return 204 for a non-existent stream', async () => {
+      try {
+        const result = streamFlow({
+          url: `http://localhost:${port}/streamingFlowDurable`,
+          input: {
+            question: 'durable',
+          },
+          streamId: 'non-existent-stream-id',
+        });
+        for await (const _ of result.stream) {
+        }
+        assert.fail('should have thrown');
+      } catch (err: any) {
+        assert.strictEqual(err.message, 'NOT_FOUND: Stream not found.');
+      }
+    });
+
+    it('stream a model', async () => {
+      const result = streamFlow({
+        url: `http://localhost:${port}/echoModel`,
+        input: {
+          messages: [{ role: 'user', content: [{ text: 'olleh' }] }],
+        },
+      });
+
+      const gotChunks: any[] = [];
+      for await (const chunk of result.stream) {
+        gotChunks.push(chunk);
+      }
+
+      const output = await result.output;
+      assert.strictEqual(output.finishReason, 'stop');
+      assert.deepStrictEqual(output.message, {
+        role: 'model',
+        content: [{ text: 'Echo: olleh' }],
+      });
+
+      assert.deepStrictEqual(gotChunks, [
+        { content: [{ text: '3' }] },
+        { content: [{ text: '2' }] },
+        { content: [{ text: '1' }] },
+      ]);
+    });
+  });
+});
+
+describe('genkitFastify', async () => {
+  let app: FastifyInstance;
+  let port: number;
+
+  beforeEach(async () => {
+    const ai = genkit({});
+    defineEchoModel(ai);
+
+    const voidInput = ai.defineFlow('voidInput', async () => {
+      return 'banana';
+    });
+
+    const stringInput = ai.defineFlow('stringInput', async (input) => {
+      const { text } = await ai.generate({
+        model: 'echoModel',
+        prompt: input,
+      });
+      return text;
+    });
+
+    const streamingFlow = ai.defineFlow(
+      {
+        name: 'streamingFlow',
+        inputSchema: z.object({ question: z.string() }),
+      },
+      async (input, sendChunk) => {
+        const { text } = await ai.generate({
+          model: 'echoModel',
+          prompt: input.question,
+          onChunk: sendChunk,
+        });
+        return text;
+      }
+    );
+
+    const flowWithAuth = ai.defineFlow(
+      {
+        name: 'flowWithAuth',
+        inputSchema: z.object({ question: z.string() }),
+      },
+      async (input, { context }) => {
+        return `${input.question} - ${JSON.stringify(context!.auth)}`;
+      }
+    );
+
+    app = Fastify();
+    port = await getPort();
+
+    await app.register(genkitFastify, {
+      pathPrefix: '/api',
+      flows: [
+        voidInput,
+        stringInput,
+        streamingFlow,
+        withFlowOptions(flowWithAuth, { contextProvider }),
+      ],
+    });
+
+    await app.listen({ port });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should call a void input flow at the prefixed path', async () => {
+    const result = await runFlow({
+      url: `http://localhost:${port}/api/voidInput`,
+    });
+    assert.strictEqual(result, 'banana');
+  });
+
+  it('should run a flow with string input', async () => {
+    const result = await runFlow({
+      url: `http://localhost:${port}/api/stringInput`,
+      input: 'hello',
+    });
+    assert.strictEqual(result, 'Echo: hello');
+  });
+
+  it('should call a flow with auth', async () => {
+    const result = await runFlow<string>({
+      url: `http://localhost:${port}/api/flowWithAuth`,
+      input: { question: 'hello' },
+      headers: { Authorization: 'open sesame' },
+    });
+    assert.strictEqual(result, 'hello - {"user":"Ali Baba"}');
+  });
+
+  it('should fail a flow with bad auth', async () => {
+    const result = runFlow({
+      url: `http://localhost:${port}/api/flowWithAuth`,
+      input: { question: 'hello' },
+      headers: { Authorization: 'thief #24' },
+    });
+    await assert.rejects(result, (err) => {
+      return (err as Error).message.includes('not authorized');
+    });
+  });
+
+  it('stream a flow', async () => {
+    const result = streamFlow<string, GenerateResponseChunkData>({
+      url: `http://localhost:${port}/api/streamingFlow`,
+      input: { question: 'olleh' },
+    });
+
+    const gotChunks: GenerateResponseChunkData[] = [];
+    for await (const chunk of result.stream) {
+      gotChunks.push(chunk);
+    }
+
+    assert.deepStrictEqual(gotChunks, [
+      { index: 0, role: 'model', content: [{ text: '3' }] },
+      { index: 0, role: 'model', content: [{ text: '2' }] },
+      { index: 0, role: 'model', content: [{ text: '1' }] },
+    ]);
+
+    assert.strictEqual(await result.output, 'Echo: olleh');
+  });
+});
+
+export function defineEchoModel(ai: Genkit): ModelAction {
+  return ai.defineModel(
+    {
+      name: 'echoModel',
+    },
+    async (request, streamingCallback) => {
+      streamingCallback?.({ content: [{ text: '3' }] });
+      streamingCallback?.({ content: [{ text: '2' }] });
+      streamingCallback?.({ content: [{ text: '1' }] });
+      return {
+        message: {
+          role: 'model',
+          content: [
+            {
+              text:
+                'Echo: ' +
+                request.messages
+                  .map(
+                    (m) =>
+                      (m.role === 'user' || m.role === 'model'
+                        ? ''
+                        : `${m.role}: `) + m.content.map((c) => c.text).join()
+                  )
+                  .join(),
+            },
+          ],
+        },
+        finishReason: 'stop',
+      };
+    }
+  );
+}

--- a/js/plugins/fastify/tests/fastify_test.ts
+++ b/js/plugins/fastify/tests/fastify_test.ts
@@ -182,6 +182,18 @@ describe('fastifyHandler', async () => {
       fastifyHandler(echoModel, { contextProvider })
     );
     app.post('/abortableFlow', fastifyHandler(abortableFlow));
+    // A stream manager whose open() rejects, to exercise the error path after
+    // reply.hijack() (the response must still be closed, not leaked).
+    const throwingStreamManager = {
+      open: async () => {
+        throw new Error('open failed');
+      },
+      subscribe: async () => {},
+    } as unknown as InMemoryStreamManager;
+    app.post(
+      '/streamSetupThrows',
+      fastifyHandler(streamingFlow, { streamManager: throwingStreamManager })
+    );
 
     await app.listen({ port });
   });
@@ -484,6 +496,24 @@ describe('fastifyHandler', async () => {
       });
       const text = await response.text();
       assert.match(text, /^data: /m); // SSE frames, not a single JSON body
+    });
+
+    it('closes the hijacked response if stream setup throws', async () => {
+      // streamManager.open() rejects after reply.hijack(); the handler must
+      // close the response with an error rather than leak the open socket.
+      const response = await fetch(
+        `http://localhost:${port}/streamSetupThrows`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'text/event-stream',
+          },
+          body: JSON.stringify({ data: { question: 'hi' } }),
+        }
+      );
+      const text = await response.text(); // resolves (no hang)
+      assert.match(text, /error:/);
     });
 
     it('should return 204 for a non-existent stream', async () => {

--- a/js/plugins/fastify/tests/fastify_test.ts
+++ b/js/plugins/fastify/tests/fastify_test.ts
@@ -444,6 +444,33 @@ describe('fastifyHandler', async () => {
       assert.strictEqual(await subscription.output, 'Echo: durable');
     });
 
+    it('sends streaming headers when subscribing to a durable stream', async () => {
+      // The subscribe path must still set Content-Type/Transfer-Encoding so
+      // clients and proxies treat the response as a stream.
+      const result = streamFlow({
+        url: `http://localhost:${port}/streamingFlowDurable`,
+        input: { question: 'durable' },
+      });
+      const streamId = await result.streamId;
+      assert.ok(streamId);
+
+      const response = await fetch(
+        `http://localhost:${port}/streamingFlowDurable`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'text/event-stream',
+            'x-genkit-stream-id': streamId!,
+          },
+          body: JSON.stringify({ data: { question: 'durable' } }),
+        }
+      );
+      assert.match(response.headers.get('content-type') ?? '', /text\/plain/);
+      await response.text(); // drain
+      await result.output;
+    });
+
     it('stream a flow (v2 model)', async () => {
       const result = streamFlow<string, GenerateResponseChunkData>({
         url: `http://localhost:${port}/streamingFlowV2`,
@@ -690,6 +717,37 @@ describe('genkitFastify', async () => {
 
     assert.strictEqual(await result.output, 'Echo: olleh');
   });
+});
+
+describe('genkitFastify path normalization', async () => {
+  let app: FastifyInstance;
+  let port: number;
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  // A prefix without a leading slash or with stray slashes would otherwise
+  // throw when Fastify registers the route.
+  for (const prefix of ['api', '/api/', 'api//']) {
+    it(`normalizes pathPrefix "${prefix}" to a valid route`, async () => {
+      const ai = genkit({});
+      const voidInput = ai.defineFlow('voidInput', async () => 'banana');
+
+      app = Fastify();
+      port = await getPort();
+      await app.register(genkitFastify, {
+        pathPrefix: prefix,
+        flows: [voidInput],
+      });
+      await app.listen({ port });
+
+      const result = await runFlow({
+        url: `http://localhost:${port}/api/voidInput`,
+      });
+      assert.strictEqual(result, 'banana');
+    });
+  }
 });
 
 export function defineEchoModel(ai: Genkit): ModelAction {

--- a/js/plugins/fastify/tests/fastify_test.ts
+++ b/js/plugins/fastify/tests/fastify_test.ts
@@ -59,10 +59,13 @@ const contextProvider: ContextProvider<Context> = (req: RequestData) => {
 describe('fastifyHandler', async () => {
   let app: FastifyInstance;
   let port: number;
+  let abortableFlowResult: [string, boolean] | undefined;
 
   beforeEach(async () => {
+    abortableFlowResult = undefined;
     const ai = genkit({});
     const echoModel = defineEchoModel(ai);
+    defineEchoModelV2(ai);
 
     const voidInput = ai.defineFlow('voidInput', async () => {
       return 'banana';
@@ -102,6 +105,21 @@ describe('fastifyHandler', async () => {
       }
     );
 
+    const streamingFlowV2 = ai.defineFlow(
+      {
+        name: 'streamingFlowV2',
+        inputSchema: z.object({ question: z.string() }),
+      },
+      async (input, sendChunk) => {
+        const { text } = await ai.generate({
+          model: 'echoModelV2',
+          prompt: input.question,
+          onChunk: sendChunk,
+        });
+        return text;
+      }
+    );
+
     const flowWithAuth = ai.defineFlow(
       {
         name: 'flowWithAuth',
@@ -112,6 +130,27 @@ describe('fastifyHandler', async () => {
       }
     );
 
+    const abortableFlow = ai.defineFlow(
+      {
+        name: 'abortableFlow',
+      },
+      async (_, { abortSignal, sendChunk }) => {
+        let itersLeft = 20;
+        while (itersLeft > 0 && !abortSignal.aborted) {
+          await new Promise((r) => {
+            setTimeout(r, 100);
+          });
+          sendChunk(itersLeft);
+          itersLeft--;
+        }
+        abortableFlowResult = [
+          itersLeft > 0 ? 'success' : 'failure',
+          abortSignal.aborted,
+        ];
+        return itersLeft > 0 ? 'success' : 'failure';
+      }
+    );
+
     app = Fastify();
     port = await getPort();
 
@@ -119,6 +158,7 @@ describe('fastifyHandler', async () => {
     app.post('/stringInput', fastifyHandler(stringInput));
     app.post('/objectInput', fastifyHandler(objectInput));
     app.post('/streamingFlow', fastifyHandler(streamingFlow));
+    app.post('/streamingFlowV2', fastifyHandler(streamingFlowV2));
     app.post(
       '/streamingFlowDurable',
       fastifyHandler(streamingFlow, {
@@ -132,6 +172,7 @@ describe('fastifyHandler', async () => {
       '/echoModelWithAuth',
       fastifyHandler(echoModel, { contextProvider })
     );
+    app.post('/abortableFlow', fastifyHandler(abortableFlow));
 
     await app.listen({ port });
   });
@@ -251,6 +292,49 @@ describe('fastifyHandler', async () => {
         return (err as Error).message.includes('not authorized');
       });
     });
+
+    it('should set x-genkit-trace-id and x-genkit-span-id headers', async () => {
+      const response = await fetch(`http://localhost:${port}/voidInput`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: null }),
+      });
+      assert.strictEqual(response.status, 200);
+      assert.ok(response.headers.get('x-genkit-trace-id'));
+      assert.ok(response.headers.get('x-genkit-span-id'));
+    });
+
+    it('should return 400 when the body is missing', async () => {
+      const response = await fetch(`http://localhost:${port}/voidInput`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      assert.strictEqual(response.status, 400);
+    });
+
+    // TODO: This test is flaky, skipping until fixed (mirrors the express plugin).
+    it.skip('should abort a flow', async () => {
+      const controller = new AbortController();
+      const response = fetch(`http://localhost:${port}/abortableFlow`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream',
+        },
+        body: JSON.stringify({ data: null }),
+        signal: controller.signal,
+      });
+
+      setTimeout(() => controller.abort(), 10);
+
+      await assert.rejects(response); // abort error
+
+      await new Promise((r) => {
+        setTimeout(r, 200);
+      });
+
+      assert.deepStrictEqual(abortableFlowResult, ['success', true]);
+    });
   });
 
   describe('streamFlow', () => {
@@ -308,6 +392,57 @@ describe('fastifyHandler', async () => {
       assert.deepStrictEqual(gotChunks, originalChunks);
       assert.strictEqual(await subscription.output, 'Echo: durable');
       assert.strictEqual(await result.output, 'Echo: durable');
+    });
+
+    it('should subscribe to a stream in progress', async () => {
+      const result = streamFlow({
+        url: `http://localhost:${port}/streamingFlowDurable`,
+        input: {
+          question: 'durable',
+        },
+      });
+
+      const streamId = await result.streamId;
+      assert.ok(streamId);
+
+      // Don't wait for the original stream to finish.
+      const subscription = streamFlow({
+        url: `http://localhost:${port}/streamingFlowDurable`,
+        input: {
+          question: 'durable',
+        },
+        streamId: streamId!,
+      });
+
+      const gotChunks: GenerateResponseChunkData[] = [];
+      for await (const chunk of subscription.stream) {
+        gotChunks.push(chunk);
+      }
+
+      assert.deepStrictEqual(gotChunks.length, 3);
+      assert.strictEqual(await subscription.output, 'Echo: durable');
+    });
+
+    it('stream a flow (v2 model)', async () => {
+      const result = streamFlow<string, GenerateResponseChunkData>({
+        url: `http://localhost:${port}/streamingFlowV2`,
+        input: {
+          question: 'olleh',
+        },
+      });
+
+      const gotChunks: GenerateResponseChunkData[] = [];
+      for await (const chunk of result.stream) {
+        gotChunks.push(chunk);
+      }
+
+      assert.deepStrictEqual(gotChunks, [
+        { index: 0, role: 'model', content: [{ text: '3' }] },
+        { index: 0, role: 'model', content: [{ text: '2' }] },
+        { index: 0, role: 'model', content: [{ text: '1' }] },
+      ]);
+
+      assert.strictEqual(await result.output, 'Echo v2: olleh');
     });
 
     it('should return 204 for a non-existent stream', async () => {
@@ -411,6 +546,7 @@ describe('genkitFastify', async () => {
         stringInput,
         streamingFlow,
         withFlowOptions(flowWithAuth, { contextProvider }),
+        withFlowOptions(stringInput, { path: 'customPath' }),
       ],
     });
 
@@ -431,6 +567,14 @@ describe('genkitFastify', async () => {
   it('should run a flow with string input', async () => {
     const result = await runFlow({
       url: `http://localhost:${port}/api/stringInput`,
+      input: 'hello',
+    });
+    assert.strictEqual(result, 'Echo: hello');
+  });
+
+  it('should route to a flow with a custom path option', async () => {
+    const result = await runFlow({
+      url: `http://localhost:${port}/api/customPath`,
       input: 'hello',
     });
     assert.strictEqual(result, 'Echo: hello');
@@ -493,6 +637,40 @@ export function defineEchoModel(ai: Genkit): ModelAction {
             {
               text:
                 'Echo: ' +
+                request.messages
+                  .map(
+                    (m) =>
+                      (m.role === 'user' || m.role === 'model'
+                        ? ''
+                        : `${m.role}: `) + m.content.map((c) => c.text).join()
+                  )
+                  .join(),
+            },
+          ],
+        },
+        finishReason: 'stop',
+      };
+    }
+  );
+}
+
+export function defineEchoModelV2(ai: Genkit): ModelAction {
+  return ai.defineModel(
+    {
+      apiVersion: 'v2',
+      name: 'echoModelV2',
+    },
+    async (request, { sendChunk }) => {
+      sendChunk({ content: [{ text: '3' }] });
+      sendChunk({ content: [{ text: '2' }] });
+      sendChunk({ content: [{ text: '1' }] });
+      return {
+        message: {
+          role: 'model',
+          content: [
+            {
+              text:
+                'Echo v2: ' +
                 request.messages
                   .map(
                     (m) =>

--- a/js/plugins/fastify/tests/fastify_test.ts
+++ b/js/plugins/fastify/tests/fastify_test.ts
@@ -171,7 +171,10 @@ describe('fastifyHandler', async () => {
         streamManager: new InMemoryStreamManager(),
       })
     );
-    app.post('/flowWithAuth', fastifyHandler(flowWithAuth, { contextProvider }));
+    app.post(
+      '/flowWithAuth',
+      fastifyHandler(flowWithAuth, { contextProvider })
+    );
     // Can also expose any action.
     app.post('/echoModel', fastifyHandler(echoModel));
     app.post(

--- a/js/plugins/fastify/tests/fastify_test.ts
+++ b/js/plugins/fastify/tests/fastify_test.ts
@@ -470,14 +470,15 @@ describe('fastifyHandler', async () => {
       await response.text(); // drain the stream
     });
 
-    it('detects streaming when Accept lists multiple media types', async () => {
-      // Clients can send e.g. "text/event-stream, */*"; the handler should
-      // still stream rather than fall back to a single JSON response.
+    it('detects streaming for a multi-value, mixed-case Accept header', async () => {
+      // Clients/proxies can send a media-type list and mixed casing, e.g.
+      // "Text/Event-Stream, */*"; the handler should still stream rather than
+      // fall back to a single JSON response.
       const response = await fetch(`http://localhost:${port}/streamingFlow`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Accept: 'text/event-stream, */*',
+          Accept: 'Text/Event-Stream, */*',
         },
         body: JSON.stringify({ data: { question: 'hi' } }),
       });

--- a/js/plugins/fastify/tests/fastify_test.ts
+++ b/js/plugins/fastify/tests/fastify_test.ts
@@ -470,6 +470,21 @@ describe('fastifyHandler', async () => {
       await response.text(); // drain the stream
     });
 
+    it('detects streaming when Accept lists multiple media types', async () => {
+      // Clients can send e.g. "text/event-stream, */*"; the handler should
+      // still stream rather than fall back to a single JSON response.
+      const response = await fetch(`http://localhost:${port}/streamingFlow`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream, */*',
+        },
+        body: JSON.stringify({ data: { question: 'hi' } }),
+      });
+      const text = await response.text();
+      assert.match(text, /^data: /m); // SSE frames, not a single JSON body
+    });
+
     it('should return 204 for a non-existent stream', async () => {
       try {
         const result = streamFlow({

--- a/js/plugins/fastify/tsconfig.json
+++ b/js/plugins/fastify/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/js/plugins/fastify/tsup.config.ts
+++ b/js/plugins/fastify/tsup.config.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig, type Options } from 'tsup';
+import { defaultOptions } from '../../tsup.common';
+
+export default defineConfig({
+  ...(defaultOptions as Options),
+});

--- a/js/plugins/fastify/typedoc.json
+++ b/js/plugins/fastify/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "entryPoints": ["src/index.ts"]
+}

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -193,7 +193,7 @@ importers:
         version: 4.1.1
       '@genkit-ai/firebase':
         specifier: ^1.16.1
-        version: 1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+        version: 1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
 
   doc-snippets:
     dependencies:
@@ -564,6 +564,36 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.20.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  plugins/fastify:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.16
+        version: 20.19.37
+      fastify:
+        specifier: ^5.0.0
+        version: 5.8.5
+      genkit:
+        specifier: workspace:*
+        version: link:../../genkit
+      get-port:
+        specifier: ^5.1.0
+        version: 5.1.1
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3143,8 +3173,26 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
 
   '@firebase/ai@1.4.1':
     resolution: {integrity: sha512-bcusQfA/tHjUjBTnMx6jdoPMpDl3r8K15Z+snHz9wq0Foox0F/V+kNLXucEOHoTL2hTc9l+onZCyBJs2QoIC3g==}
@@ -3383,11 +3431,11 @@ packages:
     resolution: {integrity: sha512-Lm/ZLhDZcBECta3TmCQSngiQykFdfw+QtI1/GYMsZd4l3nG+P8WLB16XuS7WaBGLQ+9E+cOcWQsth9cayuGt8g==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@genkit-ai/ai@1.35.0':
-    resolution: {integrity: sha512-P66XQgX4//2JhyoUwTGpEWzdH07ss/vKEeEpTlj0DkyUE+LvCYTxn6etBl6XITOp6LsmOKM2bqWgD/Xh5XsBQg==}
+  '@genkit-ai/ai@1.36.0':
+    resolution: {integrity: sha512-xMDfclS4sMLEl4YQP92XlxnPxuehz+90iuysg2gRGfHXXz6iRSGjWVq7QycBWqMmZ7OYHfgTgYz4CgL63Ezl0A==}
 
-  '@genkit-ai/core@1.35.0':
-    resolution: {integrity: sha512-Yfq4XUGTkM6wgBwqhpxHVU/TruscwWKbv5TT9FYzCk2N66rK8PgQGmTSiFDuPDwZ1YG26pQcq31jISZ93c+kZQ==}
+  '@genkit-ai/core@1.36.0':
+    resolution: {integrity: sha512-kkWzROCNPz8Ol2OtBDjsNk2zaS32axIomuR3wm0iHjkR8NdFYPk9Ab4J80EKiUEGdhXiIwvO+4RhqOgy7zYm1A==}
 
   '@genkit-ai/express@1.29.0':
     resolution: {integrity: sha512-+Mf8e45RbAlvns3a3hvIDpUAjNyWTIu1cy7vV86+6NvpPqPhkEaPkptgIX7KIXsPBEwiwsEM4SXx80M/TRbmTg==}
@@ -3955,6 +4003,7 @@ packages:
   '@langchain/community@0.0.53':
     resolution: {integrity: sha512-iFqZPt4MRssGYsQoKSXWJQaYTZCC7WNuilp2JCCs3wKmJK3l6mR0eV+PDrnT+TaDHUVxt/b0rwgM0sOiy0j2jA==}
     engines: {node: '>=18'}
+    deprecated: This package has been deprecated. See https://github.com/langchain-ai/langchainjs-community/issues/61 for more info
     peerDependencies:
       '@aws-crypto/sha256-js': ^5.0.0
       '@aws-sdk/client-bedrock-agent-runtime': ^3.485.0
@@ -5139,6 +5188,9 @@ packages:
     resolution: {integrity: sha512-gbe/4SowHc64pHIm0kBdgY9hVdzsQnnnpcWviwYMB33gOmsL8brvE8fUSpl1dLDvdyXzKcQkzdBsjCDlqgpdMA==}
     engines: {node: '>=14.0.0'}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -5620,6 +5672,9 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -5770,9 +5825,16 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -5877,6 +5939,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   beasties@0.3.5:
     resolution: {integrity: sha512-NaWu+f4YrJxEttJSm16AzMIFtVldCvaJ68b1L098KpqXmxt9xOLtKoLkKxb8ekhOrLqEJAbvT6n6SEvB/sac7A==}
@@ -6279,6 +6342,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -6454,6 +6521,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -6785,6 +6856,9 @@ packages:
     resolution: {integrity: sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==}
     engines: {node: '>=18.0.0'}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -6793,6 +6867,12 @@ packages:
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-json-stringify@6.4.0:
+    resolution: {integrity: sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
@@ -6806,6 +6886,12 @@ packages:
   fast-xml-parser@5.5.3:
     resolution: {integrity: sha512-Ymnuefk6VzAhT3SxLzVUw+nMio/wB1NGypHkgetwtXcK1JfryaHk4DWQFGVwQ9XgzyS5iRZ7C2ZGI4AMsdMZ6A==}
     hasBin: true
+
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   faye-websocket@0.11.4:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
@@ -6859,6 +6945,10 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-my-way@9.6.0:
+    resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
+    engines: {node: '>=20'}
 
   find-package@1.0.0:
     resolution: {integrity: sha512-yVn71XCCaNgxz58ERTl8nA/8YYtIQDY9mHSrgFBfiFtdNNfY0h183Vh8BRkKxD8x9TUw3ec290uJKhDVxqGZBw==}
@@ -7025,8 +7115,8 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
-  genkit@1.35.0:
-    resolution: {integrity: sha512-n98e5j+0PYyRE52gkApCadXufUjJBi8UGYlTX7Uc0Bbpws0G05w5PoCkLOoFwaHZmUmOHfcV2erqTSmEOCbSGQ==}
+  genkit@1.36.0:
+    resolution: {integrity: sha512-5kwpWAOiIusWKOrYlUpuU60SSjxuyzcAqJTwM8c89NHWj0AsUqJKcgHAmm2JTbfJRAMXlPfgOLxNi1qGyqI+yQ==}
 
   genkitx-openai@0.30.0:
     resolution: {integrity: sha512-6Dt3o6f+cKrZ1njSzYj2rm0U8SE5nQDwpz5VbFuLjaloE5BBj2c9OSlPGegdcz4PN5wBocGKiNsaKn0t5PpJdA==}
@@ -7374,6 +7464,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   is-any-array@2.0.1:
     resolution: {integrity: sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==}
@@ -7822,6 +7916,9 @@ packages:
     resolution: {integrity: sha512-SiSJQ805W1sDUCD1+/t1/1BIrveq2Fe9HJqENxZmMCILmrPI7WhS/pePpIOx85v6/H2z1Vy7AI08GV2TzfXocg==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
@@ -8119,6 +8216,9 @@ packages:
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -8711,6 +8811,10 @@ packages:
   ollama@0.5.18:
     resolution: {integrity: sha512-lTFqTf9bo7Cd3hpF6CviBe/DEhewjoZYd9N/uCe7O20qYTvGqrNOFOBDj3lbZgFWHUgDv5EeyusYxsZSLS8nvg==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -8985,10 +9089,6 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -9001,6 +9101,16 @@ packages:
   pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -9089,6 +9199,12 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -9176,6 +9292,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
   railroad-diagrams@1.0.0:
     resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
 
@@ -9242,6 +9361,13 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -9313,6 +9439,10 @@ packages:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
     engines: {node: '>=0.12'}
 
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
   retry-request@7.0.2:
     resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
     engines: {node: '>=14'}
@@ -9328,6 +9458,10 @@ packages:
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
@@ -9383,6 +9517,10 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-regex2@5.1.1:
+    resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
+    hasBin: true
+
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
@@ -9397,6 +9535,9 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver-diff@3.1.1:
     resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==}
@@ -9435,6 +9576,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -9544,6 +9688,9 @@ packages:
   socks@2.8.7:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   sort-any@4.0.7:
     resolution: {integrity: sha512-UuZVEXClHW+bVa6ZBQ4biTWmLXMP7y6/jv5arfA0rKk7ZExy+5Zm19uekIqqDx6ZuvUMu7z5Ba9FfBi6FlGXPQ==}
@@ -9810,6 +9957,10 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
+
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
@@ -9841,6 +9992,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toad-cache@3.7.1:
+    resolution: {integrity: sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==}
+    engines: {node: '>=20'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -11254,7 +11409,30 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+
   '@fastify/busboy@3.2.0': {}
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.4.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.4.0
 
   '@firebase/ai@1.4.1(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)':
     dependencies:
@@ -11615,9 +11793,9 @@ snapshots:
     dependencies:
       retry: 0.13.1
 
-  '@genkit-ai/ai@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/ai@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/core': 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/core': 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.37
       colorette: 2.0.20
@@ -11639,7 +11817,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@genkit-ai/core@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/core@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.52.1
@@ -11663,7 +11841,7 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
-      '@genkit-ai/firebase': 1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/firebase': 1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
     transitivePeerDependencies:
       - '@google-cloud/firestore'
       - bufferutil
@@ -11684,12 +11862,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@genkit-ai/firebase@1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/firebase@1.29.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
       firebase-admin: 13.8.0(encoding@0.1.13)
-      genkit: 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
     optionalDependencies:
       firebase: 11.10.0
     transitivePeerDependencies:
@@ -11697,12 +11875,12 @@ snapshots:
       - supports-color
     optional: true
 
-  '@genkit-ai/firebase@1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/firebase@1.30.1(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
-      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/google-cloud': 1.30.1(encoding@0.1.13)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
       firebase-admin: 13.8.0(encoding@0.1.13)
-      genkit: 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
     optionalDependencies:
       firebase: 11.10.0
     transitivePeerDependencies:
@@ -11710,7 +11888,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@genkit-ai/google-cloud@1.30.1(encoding@0.1.13)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
+  '@genkit-ai/google-cloud@1.30.1(encoding@0.1.13)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))':
     dependencies:
       '@google-cloud/logging-winston': 6.0.1(encoding@0.1.13)(winston@3.19.0)
       '@google-cloud/modelarmor': 0.4.1
@@ -11727,7 +11905,7 @@ snapshots:
       '@opentelemetry/sdk-metrics': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-node': 0.52.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.25.1(@opentelemetry/api@1.9.0)
-      genkit: 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
+      genkit: 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)
       google-auth-library: 9.15.1(encoding@0.1.13)
       node-fetch: 3.3.2
       winston: 3.19.0
@@ -13558,6 +13736,8 @@ snapshots:
       cross-fetch: 3.2.0(encoding@0.1.13)
       encoding: 0.1.13
 
+  '@pinojs/redact@0.4.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -14037,6 +14217,8 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  abstract-logging@2.0.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -14204,9 +14386,16 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.20.1
 
   b4a@1.8.0: {}
 
@@ -14765,6 +14954,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   core-util-is@1.0.3: {}
 
   cors@2.8.6:
@@ -14923,6 +15114,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   destroy@1.2.0: {}
 
@@ -15437,11 +15630,26 @@ snapshots:
 
   farmhash-modern@1.1.0: {}
 
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
 
   fast-json-stable-stringify@2.1.0: {}
+
+  fast-json-stringify@6.4.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
 
   fast-sha256@1.3.0: {}
 
@@ -15459,6 +15667,28 @@ snapshots:
       strnum: 2.2.0
     optional: true
 
+  fastify@5.8.5:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.4.0
+      find-my-way: 9.6.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.4
+      toad-cache: 3.7.1
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   faye-websocket@0.11.4:
     dependencies:
       websocket-driver: 0.7.4
@@ -15466,10 +15696,6 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -15532,6 +15758,12 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  find-my-way@9.6.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.1
 
   find-package@1.0.0:
     dependencies:
@@ -15855,10 +16087,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0):
+  genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0):
     dependencies:
-      '@genkit-ai/ai': 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
-      '@genkit-ai/core': 1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.35.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/ai': 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
+      '@genkit-ai/core': 1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0)(genkit@1.36.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@13.8.0(encoding@0.1.13))(firebase@11.10.0))
       uuid: 10.0.0
     transitivePeerDependencies:
       - '@google-cloud/firestore'
@@ -16301,6 +16533,8 @@ snapshots:
   ip-regex@4.3.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.4.0: {}
 
   is-any-array@2.0.1: {}
 
@@ -16910,6 +17144,10 @@ snapshots:
 
   json-ptr@3.1.1: {}
 
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
   json-schema-to-ts@3.1.1:
     dependencies:
       '@babel/runtime': 7.28.6
@@ -17177,6 +17415,12 @@ snapshots:
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
 
   lilconfig@3.1.3: {}
 
@@ -17767,7 +18011,7 @@ snapshots:
       chalk: 2.4.2
       cross-spawn: 7.0.6
       memorystream: 0.3.1
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
       shell-quote: 1.8.3
@@ -17805,6 +18049,8 @@ snapshots:
   ollama@0.5.18:
     dependencies:
       whatwg-fetch: 3.6.20
+
+  on-exit-leak-free@2.1.2: {}
 
   on-finished@2.3.0:
     dependencies:
@@ -18119,13 +18365,31 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pidtree@0.3.1: {}
 
   pify@3.0.0: {}
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
 
   pirates@4.0.7: {}
 
@@ -18213,6 +18477,10 @@ snapshots:
   proc-log@6.1.0: {}
 
   process-nextick-args@2.0.1: {}
+
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
 
   process@0.11.10: {}
 
@@ -18316,6 +18584,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  quick-format-unescaped@4.0.4: {}
+
   railroad-diagrams@1.0.0: {}
 
   randexp@0.4.6:
@@ -18411,6 +18681,10 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  real-require@0.2.0: {}
+
+  real-require@1.0.0: {}
+
   rechoir@0.8.0:
     dependencies:
       resolve: 1.22.10
@@ -18488,6 +18762,8 @@ snapshots:
 
   ret@0.1.15: {}
 
+  ret@0.5.0: {}
+
   retry-request@7.0.2(encoding@0.1.13):
     dependencies:
       '@types/request': 2.48.13
@@ -18507,6 +18783,8 @@ snapshots:
   retry@0.12.0: {}
 
   retry@0.13.1: {}
+
+  reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
 
@@ -18598,6 +18876,10 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-regex2@5.1.1:
+    dependencies:
+      ret: 0.5.0
+
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
@@ -18611,6 +18893,8 @@ snapshots:
       '@parcel/watcher': 2.5.6
 
   scheduler@0.27.0: {}
+
+  secure-json-parse@4.1.0: {}
 
   semver-diff@3.1.1:
     dependencies:
@@ -18675,6 +18959,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -18860,6 +19146,10 @@ snapshots:
     dependencies:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
 
   sort-any@4.0.7: {}
 
@@ -19202,6 +19492,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
+
   through2@2.0.5:
     dependencies:
       readable-stream: 2.3.8
@@ -19220,8 +19514,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tmp@0.2.5: {}
 
@@ -19230,6 +19524,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toad-cache@3.7.1: {}
 
   toidentifier@1.0.1: {}
 

--- a/js/typedoc.json
+++ b/js/typedoc.json
@@ -7,6 +7,7 @@
     "plugins/anthropic",
     "plugins/firebase",
     "plugins/express",
+    "plugins/fastify",
     "plugins/fetch",
     "plugins/google-cloud",
     "plugins/middleware",


### PR DESCRIPTION
## What

Adds a first-class `@genkit-ai/fastify` plugin so Genkit flows mount on Fastify in one line, the same way `@genkit-ai/express` works for Express.

Closes #5476.

## Why

Fastify is not Web Fetch native and had no Genkit handler, so serving a flow on Fastify required hand-rolling a ~55-line adapter that bridges Fastify's `request`/`reply` to the Web `Request`/`Response` that `@genkit-ai/fetch`'s `fetchHandlers` expects (URL/headers/body reconstruction, `reply.hijack()`, `Readable.fromWeb(...).pipe(reply.raw)`, abort wiring). That adapter was the only non-idiomatic boilerplate in the Fastify backend tutorial. #5476 has the full before/after.

## API

```ts
import Fastify from 'fastify';
import { fastifyHandler } from '@genkit-ai/fastify';

const app = Fastify();
app.post('/simpleFlow', fastifyHandler(simpleFlow));
await app.listen({ port: 8080 });
```

- `fastifyHandler(action, opts?)`: a Fastify route handler for a single flow or action. Mirrors `expressHandler`, including `contextProvider` (auth) and `streamManager` (durable streams) options, and SSE streaming via `reply.hijack()`.
- `genkitFastify`: a registerable Fastify plugin that exposes many flows at once, with `pathPrefix` and per-flow `withFlowOptions`, analogous to `startFlowServer`.

```ts
await app.register(genkitFastify, {
  pathPrefix: '/api',
  flows: [simpleFlow, withFlowOptions(secureFlow, { contextProvider })],
});
```

## Changes

### (1) New `@genkit-ai/fastify` plugin
**Files:** `js/plugins/fastify/**` (`src/index.ts`, `src/utils.ts`, `package.json`, `tsconfig.json`, `tsup.config.ts`, `typedoc.json`, `.npmignore`, `README.md`, `.guides/usage.md`), `js/typedoc.json`.
**Why:** Give Fastify users an ergonomic, supported path instead of copy-pasting an adapter, at parity with the Express plugin.
**What:** Exports `fastifyHandler`, `genkitFastify`, `withFlowOptions`, `withContextProvider`, and the associated types. Follows the existing `plugins/express` / `plugins/fetch` layouts exactly (same scaffolding files, `src/index.ts` + `src/utils.ts`, tsup/tsconfig/typedoc). Emits the exact same SSE wire protocol as `expressHandler`/`fetchHandlers` (`data: {message}` chunks, terminal `data: {result}`, `error:` frames), so `genkit/beta/client` `runFlow`/`streamFlow` work unchanged. `fastify` is a peer dependency (`^4.0.0 || ^5.0.0`); no runtime dependencies. Registered in `js/typedoc.json` so it appears in the API reference.

### (2) Test coverage matching the express/fetch suites
**Files:** `js/plugins/fastify/tests/fastify_test.ts`
**Why:** Match the depth of the sibling plugins' suites.
**What:** Covers `runFlow` (void/string/object input, bad input, model actions), `streamFlow`, durable streams (create / subscribe / subscribe-in-progress / 204-not-found), v2-model streaming, auth via context providers, trace headers, 400 on missing body, `withFlowOptions` path routing, and the `genkitFastify` plugin with a path prefix. Includes a parity (skipped, flaky) abort test mirroring the express plugin.

### (3) Preserve hook-set headers on streamed responses
**Files:** `js/plugins/fastify/src/index.ts`
**Why:** `reply.hijack()` stops Fastify from flushing headers set by earlier hooks (notably `@fastify/cors`) to the socket, so streamed responses were missing those headers. Browsers then rejected the streamed flow response even though the CORS preflight passed. (Found while testing the plugin against a real Angular + Fastify app.)
**What:** Capture `reply.getHeaders()` and copy them onto `reply.raw` before streaming. Added a regression test asserting a hook-set header survives on a streamed response.

### (4) Match the Node `randomUUID` idiom + run the repo formatter
**Files:** `js/plugins/fastify/src/index.ts`, `js/plugins/fastify/tests/fastify_test.ts`
**Why:** Fastify is a Node-only framework, so its closest sibling is the Express plugin, not the edge-runtime-oriented fetch plugin.
**What:** Use `import { randomUUID } from 'crypto'` (like `@genkit-ai/express`) instead of the fetch plugin's `globalThis.crypto` idiom. Ran prettier with `prettier-plugin-organize-imports` so import ordering matches the rest of the workspace.

### (5) Guard streamed writes with `response.destroyed`
**Files:** `js/plugins/fastify/src/index.ts`
**Why:** If the client disconnects mid-stream the raw socket is destroyed, and a subsequent `write()`/`end()` throws `ERR_STREAM_DESTROYED`. The `request.raw.on('close')` abort stops the action, but there's a race window. (PR review feedback.)
**What:** Added `response.destroyed` guards at every streamed write site in both the streaming handler and the durable-stream subscriber. In `onError` the `logger.error` is kept before the guard so failures are still logged.

### (6) Broaden + case-normalize the `Accept` header check
**Files:** `js/plugins/fastify/src/index.ts`, `js/plugins/fastify/tests/fastify_test.ts`
**Why:** `Accept` is a list header whose media types are case-insensitive per the HTTP spec; clients/proxies legitimately send e.g. `text/event-stream, */*` or `Text/Event-Stream`. A strict `=== 'text/event-stream'` comparison fails those and falls back to a single non-streamed JSON response. (PR review feedback.)
**What:** Use `request.headers['accept']?.toLowerCase().includes('text/event-stream')`. The regression test sends a multi-value, mixed-case header (`Text/Event-Stream, */*`) to cover both list parsing and case-insensitivity.

### (7) Close the hijacked response if stream setup throws
**Files:** `js/plugins/fastify/src/index.ts`, `js/plugins/fastify/tests/fastify_test.ts`
**Why:** `reply.hijack()` bypasses Fastify's error handling. An error thrown while setting up the stream (e.g. `streamManager.open()` rejecting, or a rethrow from `subscribeToStream`) would escape the handler and leave the hijacked socket open, leaking the connection and hanging the client. (PR review feedback.)
**What:** Wrapped the post-`hijack()` streaming block in try/catch. On error it logs, then closes the response: a trailing SSE `error:` frame if streaming already started (`headersSent`), or a normal API error (`getHttpStatus`/`getCallableJSON`) if nothing was sent yet; it no-ops if the socket is already destroyed. Added a regression test (a stream manager whose `open()` rejects -> the request resolves with an error frame instead of hanging).

### (8) Abort on request `timeout`, for parity with express
**Files:** `js/plugins/fastify/src/index.ts`
**Why:** The express handler aborts the action on both `close` and `timeout`; the fastify handler only aborted on `close`. (PR review feedback from @cabljac.)
**What:** Added `request.raw.on('timeout', () => abortController.abort())`.

### (9) Join repeated header values with a comma (RFC 9110 5.3)
**Files:** `js/plugins/fastify/src/index.ts`
**Why:** When building the `headers` passed to the context provider, repeated field lines were joined with a space; RFC 9110 5.3 specifies a comma, which downstream parsers of multi-valued headers expect. (PR review feedback.)
**What:** `Array.isArray(value) ? value.join(', ') : String(value)`. The same fix is applied to the express handler in #5481.

## Verification
- `pnpm --filter @genkit-ai/fastify build` (includes `tsc`) and `pnpm --filter @genkit-ai/fastify test` both pass: 27 tests, 26 pass, 1 skip (the parity abort test).
- prettier clean.

## Related
Changes (5), (6), and (9) are also applied to the existing `@genkit-ai/express` and `@genkit-ai/fetch` handlers in #5481 (the `response.destroyed` guard does not apply to fetch, which writes to a Web `WritableStream`; the comma-join applies to express only, since fetch already combines repeated headers via the Web Headers API).
