### PR TITLE
feat(python): support snake_case 'tool_approved' in ToolApproval middleware

### DIFF
--- a/py/plugins/middleware/src/genkit/plugins/middleware/_tool_approval.py
+++ b/py/plugins/middleware/src/genkit/plugins/middleware/_tool_approval.py
@@ -51,7 +51,7 @@ class ToolApproval(BaseMiddleware[ToolApprovalConfig]):
 
         metadata = params.tool_request_part.metadata or {}
         resumed = metadata.get('resumed')
-        if isinstance(resumed, dict) and resumed.get('toolApproved'):
+        if isinstance(resumed, dict) and (resumed.get('toolApproved') or resumed.get('tool_approved')):
             return await next_fn(params, ctx)
 
         tool_input = params.tool_request_part.tool_request.input

--- a/py/plugins/middleware/tests/tool_approval_test.py
+++ b/py/plugins/middleware/tests/tool_approval_test.py
@@ -105,3 +105,23 @@ async def test_tool_approval_empty_allowed_list(ctx: GenerateMiddlewareContext) 
 
     with pytest.raises(Interrupt):
         await approval.wrap_tool(params, ctx, next_fn)
+
+
+@pytest.mark.asyncio
+async def test_tool_approval_resumed_with_snake_case_approval(ctx: GenerateMiddlewareContext) -> None:
+    """Test that resumed tools with tool_approved snake_case metadata pass through."""
+    approval = ToolApproval(allowed_tools=[])
+
+    async def next_fn(params, ctx):
+        return MultipartToolResponse(output='approved')
+
+    tool = _make_tool('some_tool')
+    tool_request = ToolRequest(name='some_tool', input={})
+    tool_request_part = ToolRequestPart(
+        tool_request=tool_request,
+        metadata={'resumed': {'tool_approved': True}},
+    )
+    params = ToolHookParams(tool_request_part=tool_request_part, tool=tool)
+
+    result = await approval.wrap_tool(params, ctx, next_fn)
+    assert result is not None


### PR DESCRIPTION
PEP 8 standards dictate that Python variables, attributes, and dictionary keys (which represent configuration fields or attributes) should follow the snake_case naming convention. Using camelCase keys like 'toolApproved' in Python dictionaries feels non-idiomatic and leads to friction/errors for Python developers.

This PR updates the ToolApproval middleware to accept both the pythonic 'tool_approved' key and the cross-language 'toolApproved' key in the resumed metadata dictionary. This allows us to recommend the snake_case pattern which looks natural in docs, while still allowing `{'toolApproved': True}`. Since Go/JS docs recommend camelCase, it's very possible for coding agents to get confused.