### PR TITLE
fix(js/plugins): harden streaming in express and fetch handlers

### DIFF
--- a/js/plugins/express/src/index.ts
+++ b/js/plugins/express/src/index.ts
@@ -85,11 +85,15 @@ export function expressHandler<
         (await opts?.contextProvider?.({
           method: request.method as RequestData['method'],
           headers: Object.fromEntries(
-            Object.entries(request.headers).map(([key, value]) => [
-              key.toLowerCase(),
-              // RFC 9110 5.3: combine repeated field lines with a comma.
-              Array.isArray(value) ? value.join(', ') : String(value),
-            ])
+            Object.entries(request.headers)
+              // Skip headers explicitly set to undefined so they don't become
+              // the literal string "undefined" via String(value).
+              .filter(([, value]) => value !== undefined)
+              .map(([key, value]) => [
+                key.toLowerCase(),
+                // RFC 9110 5.3: combine repeated field lines with a comma.
+                Array.isArray(value) ? value.join(', ') : String(value),
+              ])
           ),
           input,
         })) || {};

--- a/js/plugins/express/src/index.ts
+++ b/js/plugins/express/src/index.ts
@@ -110,7 +110,7 @@ export function expressHandler<
     });
 
     if (
-      request.get('Accept')?.includes('text/event-stream') ||
+      request.get('Accept')?.toLowerCase().includes('text/event-stream') ||
       stream === 'true'
     ) {
       const streamManager = opts?.streamManager;

--- a/js/plugins/express/src/index.ts
+++ b/js/plugins/express/src/index.ts
@@ -87,7 +87,8 @@ export function expressHandler<
           headers: Object.fromEntries(
             Object.entries(request.headers).map(([key, value]) => [
               key.toLowerCase(),
-              Array.isArray(value) ? value.join(' ') : String(value),
+              // RFC 9110 5.3: combine repeated field lines with a comma.
+              Array.isArray(value) ? value.join(', ') : String(value),
             ])
           ),
           input,

--- a/js/plugins/express/src/index.ts
+++ b/js/plugins/express/src/index.ts
@@ -109,7 +109,10 @@ export function expressHandler<
       abortController.abort();
     });
 
-    if (request.get('Accept') === 'text/event-stream' || stream === 'true') {
+    if (
+      request.get('Accept')?.includes('text/event-stream') ||
+      stream === 'true'
+    ) {
       const streamManager = opts?.streamManager;
       if (streamManager && streamId) {
         await subscribeToStream(streamManager, streamId, response);
@@ -180,6 +183,9 @@ async function runActionWithDurableStreaming<
   }
   try {
     let onChunk = (chunk: z.infer<S>) => {
+      // The client may have disconnected mid-stream; writing to a destroyed
+      // response would throw.
+      if (response.destroyed) return;
       response.write(
         'data: ' + JSON.stringify({ message: chunk }) + streamDelimiter
       );
@@ -200,10 +206,12 @@ async function runActionWithDurableStreaming<
       taskQueue!.enqueue(() => durableStream!.done(result.result));
       await taskQueue!.merge();
     }
-    response.write(
-      'data: ' + JSON.stringify({ result: result.result }) + streamDelimiter
-    );
-    response.end();
+    if (!response.destroyed) {
+      response.write(
+        'data: ' + JSON.stringify({ result: result.result }) + streamDelimiter
+      );
+      response.end();
+    }
   } catch (e) {
     if (durableStream) {
       taskQueue!.enqueue(() => durableStream!.error(e));
@@ -214,12 +222,14 @@ async function runActionWithDurableStreaming<
         (e as Error).stack
       }`
     );
-    response.write(
-      `error: ${JSON.stringify({
-        error: getCallableJSON(e),
-      })}${streamDelimiter}`
-    );
-    response.end();
+    if (!response.destroyed) {
+      response.write(
+        `error: ${JSON.stringify({
+          error: getCallableJSON(e),
+        })}${streamDelimiter}`
+      );
+      response.end();
+    }
   }
 }
 
@@ -231,11 +241,15 @@ async function subscribeToStream(
   try {
     await streamManager.subscribe(streamId, {
       onChunk: (chunk) => {
+        // The subscribing client may have disconnected; skip writes to a
+        // destroyed response to avoid throwing.
+        if (response.destroyed) return;
         response.write(
           'data: ' + JSON.stringify({ message: chunk }) + streamDelimiter
         );
       },
       onDone: (output) => {
+        if (response.destroyed) return;
         response.write(
           'data: ' + JSON.stringify({ result: output }) + streamDelimiter
         );
@@ -247,6 +261,7 @@ async function subscribeToStream(
             (err as Error).stack
           }`
         );
+        if (response.destroyed) return;
         response.write(
           `error: ${JSON.stringify({
             error: getCallableJSON(err),

--- a/js/plugins/express/src/index.ts
+++ b/js/plugins/express/src/index.ts
@@ -272,6 +272,9 @@ async function subscribeToStream(
       },
     });
   } catch (e: any) {
+    // The subscribing client may have disconnected; skip writes to a
+    // destroyed response to avoid throwing.
+    if (response.destroyed) return;
     if (e instanceof StreamNotFoundError) {
       response.status(204).end();
       return;

--- a/js/plugins/express/tests/express_test.ts
+++ b/js/plugins/express/tests/express_test.ts
@@ -422,14 +422,15 @@ describe('expressHandler', async () => {
       }
     });
 
-    it('detects streaming when Accept lists multiple media types', async () => {
-      // Clients can send e.g. "text/event-stream, */*"; the handler should
-      // still stream rather than fall back to a single JSON response.
+    it('detects streaming for a multi-value, mixed-case Accept header', async () => {
+      // Clients/proxies can send a media-type list and mixed casing, e.g.
+      // "Text/Event-Stream, */*"; the handler should still stream rather than
+      // fall back to a single JSON response.
       const response = await fetch(`http://localhost:${port}/streamingFlow`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Accept: 'text/event-stream, */*',
+          Accept: 'Text/Event-Stream, */*',
         },
         body: JSON.stringify({ data: { question: 'hi' } }),
       });

--- a/js/plugins/express/tests/express_test.ts
+++ b/js/plugins/express/tests/express_test.ts
@@ -405,7 +405,7 @@ describe('expressHandler', async () => {
       assert.strictEqual(await subscription.output, 'Echo: durable');
     });
 
-    it.only('should return 204 for a non-existent stream', async () => {
+    it('should return 204 for a non-existent stream', async () => {
       try {
         const result = streamFlow({
           url: `http://localhost:${port}/streamingFlowDurable`,

--- a/js/plugins/express/tests/express_test.ts
+++ b/js/plugins/express/tests/express_test.ts
@@ -422,6 +422,21 @@ describe('expressHandler', async () => {
       }
     });
 
+    it('detects streaming when Accept lists multiple media types', async () => {
+      // Clients can send e.g. "text/event-stream, */*"; the handler should
+      // still stream rather than fall back to a single JSON response.
+      const response = await fetch(`http://localhost:${port}/streamingFlow`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream, */*',
+        },
+        body: JSON.stringify({ data: { question: 'hi' } }),
+      });
+      const text = await response.text();
+      assert.match(text, /^data: /m); // SSE frames, not a single JSON body
+    });
+
     it('stream a model', async () => {
       const result = streamFlow({
         url: `http://localhost:${port}/echoModel`,

--- a/js/plugins/fetch/src/index.ts
+++ b/js/plugins/fetch/src/index.ts
@@ -361,7 +361,8 @@ async function handleActionRequest<
   }
 
   const acceptHeader = request.headers.get('Accept') || '';
-  const isStreaming = acceptHeader === 'text/event-stream' || shouldStream;
+  const isStreaming =
+    acceptHeader.includes('text/event-stream') || shouldStream;
 
   if (isStreaming) {
     const streamManager = options?.streamManager;

--- a/js/plugins/fetch/src/index.ts
+++ b/js/plugins/fetch/src/index.ts
@@ -362,7 +362,7 @@ async function handleActionRequest<
 
   const acceptHeader = request.headers.get('Accept') || '';
   const isStreaming =
-    acceptHeader.includes('text/event-stream') || shouldStream;
+    acceptHeader.toLowerCase().includes('text/event-stream') || shouldStream;
 
   if (isStreaming) {
     const streamManager = options?.streamManager;

--- a/js/plugins/fetch/tests/web_test.ts
+++ b/js/plugins/fetch/tests/web_test.ts
@@ -328,7 +328,7 @@ describe('fetchHandler (single action)', () => {
       assert.ok(response.headers.get('x-genkit-span-id'));
     });
 
-    it('streams when Accept lists multiple media types', async () => {
+    it('streams for a multi-value, mixed-case Accept header', async () => {
       const ai = genkit({});
       defineEchoModel(ai);
       const flow = ai.defineFlow(
@@ -345,13 +345,14 @@ describe('fetchHandler (single action)', () => {
           return text;
         }
       );
-      // Clients can send e.g. "text/event-stream, */*"; the handler should
-      // still stream rather than fall back to a single JSON response.
+      // Clients/proxies can send a media-type list and mixed casing, e.g.
+      // "Text/Event-Stream, */*"; the handler should still stream rather than
+      // fall back to a single JSON response.
       const request = new Request('http://localhost/streamingFlow', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Accept: 'text/event-stream, */*',
+          Accept: 'Text/Event-Stream, */*',
         },
         body: JSON.stringify({ data: { question: 'hi' } }),
       });

--- a/js/plugins/fetch/tests/web_test.ts
+++ b/js/plugins/fetch/tests/web_test.ts
@@ -327,6 +327,40 @@ describe('fetchHandler (single action)', () => {
       assert.ok(response.headers.get('x-genkit-trace-id'));
       assert.ok(response.headers.get('x-genkit-span-id'));
     });
+
+    it('streams when Accept lists multiple media types', async () => {
+      const ai = genkit({});
+      defineEchoModel(ai);
+      const flow = ai.defineFlow(
+        {
+          name: 'streamingFlow',
+          inputSchema: z.object({ question: z.string() }),
+        },
+        async (input, sendChunk) => {
+          const { text } = await ai.generate({
+            model: 'echoModel',
+            prompt: input.question,
+            onChunk: sendChunk,
+          });
+          return text;
+        }
+      );
+      // Clients can send e.g. "text/event-stream, */*"; the handler should
+      // still stream rather than fall back to a single JSON response.
+      const request = new Request('http://localhost/streamingFlow', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream, */*',
+        },
+        body: JSON.stringify({ data: { question: 'hi' } }),
+      });
+      const response = await fetchHandler(flow)(request);
+      assert.strictEqual(
+        response.headers.get('Content-Type'),
+        'text/event-stream'
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## What

Applies the streaming-robustness fixes from the new `@genkit-ai/fastify` PR (#5477) to the existing `@genkit-ai/express` and `@genkit-ai/fetch` handlers, where applicable. These were surfaced by `gemini-code-assist` reviews on #5477; the same issues exist in these two plugins.

After this change all three HTTP adaptors (express, fetch, fastify) handle the `Accept` header, client mid-stream disconnects, and repeated request headers consistently.

## Changes

### (1) express: guard streamed writes with `response.destroyed`
**Files:** `js/plugins/express/src/index.ts`
**Why:** If the client disconnects mid-stream, the underlying socket/response is destroyed. A subsequent `response.write()` / `response.end()` throws `ERR_STREAM_DESTROYED`, which can surface as an unhandled exception and crash the process. The existing `request.on('close')` abort stops the action, but there is a race window where a queued chunk, the final result frame, or an error frame can still be written after the socket is gone.
**What:** Added `if (response.destroyed) return;` (and `if (!response.destroyed) { ... }` around the terminal write+`end()`) at every streamed write site, in both `runActionWithDurableStreaming` (per-chunk write, final result write, catch-block error write) and `subscribeToStream` (`onChunk`, `onDone`, `onError`). In `onError` the `logger.error` is intentionally kept before the guard so failures are still logged even when the client is gone.

### (2) express: broaden + case-normalize the `Accept` header check
**Files:** `js/plugins/express/src/index.ts`
**Why:** `Accept` is a list header whose media types are case-insensitive per the HTTP spec. Clients/proxies legitimately send e.g. `text/event-stream, */*`, `application/json, text/event-stream`, or even `Text/Event-Stream`. A strict `=== 'text/event-stream'` comparison fails all of those and falls back to a single non-streamed JSON response.
**What:** Changed `request.get('Accept') === 'text/event-stream'` to `request.get('Accept')?.toLowerCase().includes('text/event-stream')`. (The `.toLowerCase()` was added per a follow-up review comment.) Backward compatible with the official `genkit/beta/client` (which sends exactly `text/event-stream`).

### (3) fetch: broaden + case-normalize the `Accept` header check
**Files:** `js/plugins/fetch/src/index.ts`
**Why:** Same `Accept`-list and case-insensitivity reasoning as above.
**What:** Changed `acceptHeader === 'text/event-stream'` to `acceptHeader.toLowerCase().includes('text/event-stream')`.
**Note:** The `response.destroyed` guard from change (1) is deliberately **not** applied to fetch. The fetch handler writes to a Web `WritableStream` (via a `WritableStreamDefaultWriter`), not a Node `ServerResponse`, so there is no `.destroyed` to check; client-disconnect there is already handled through `request.signal`.

### (4) express test: drop a stray `it.only`
**Files:** `js/plugins/express/tests/express_test.ts`
**Why:** The "should return 204 for a non-existent stream" test was marked `it.only`. Node's runner ignores `.only` without the `--test-only` flag (and prints a warning), so it's harmless today, but it would silently suppress the rest of the suite if that flag were ever enabled. This is a pre-existing issue, fixed here as a drive-by since this PR already touches the file.
**What:** `it.only(...)` -> `it(...)`.

### (5) express: join repeated header values with a comma (RFC 9110 5.3)
**Files:** `js/plugins/express/src/index.ts`
**Why:** When building the `headers` passed to the context provider, repeated request header field lines were joined with a space; RFC 9110 5.3 specifies a comma, which downstream parsers of multi-valued headers expect. (Surfaced as review feedback on the fastify handler in #5477; the same pre-existing pattern exists here.)
**What:** `Array.isArray(value) ? value.join(', ') : String(value)`. Not needed for fetch, which combines repeated headers via the Web Headers API already.

### (6) tests: `Accept` regression coverage
**Files:** `js/plugins/express/tests/express_test.ts`, `js/plugins/fetch/tests/web_test.ts`
**Why:** Lock in changes (2) and (3) so a future strict-equality or case-sensitive regression is caught.
**What:** Added a test to each suite that sends a multi-value, mixed-case header (`Accept: Text/Event-Stream, */*`) and asserts the response streams (express: SSE `data:` frames in the body; fetch: `Content-Type: text/event-stream`). The single test exercises both list parsing and case-insensitivity.

## Verification
- express: 27 tests, 26 pass, 1 pre-existing skip (the flaky abort test); the `it.only` runner warning is gone.
- fetch: 33 pass.
- `tsc` build and prettier clean for both plugins.

## Not changed
- No `response.destroyed` guard in fetch (not applicable; see change (3) note).
- No comma-join change in fetch (not applicable; Web Headers API already combines repeated headers).
- No behavior change for the official client or for single-value `Accept: text/event-stream` requests.
