### PR TITLE
fix(go): prevent goroutine leak on tool error

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -945,7 +945,7 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 		return nil, nil, nil
 	}
 
-	resultChan := make(chan result[*MultipartToolResponse])
+	resultChan := make(chan result[*MultipartToolResponse], toolCount)
 	toolMsg := &Message{Role: RoleTool}
 	revisedMsg := clone(resp.Message)
 
@@ -1522,16 +1522,21 @@ func handleResumeOption(ctx context.Context, r api.Registry, genOpts *GenerateAc
 		return nil, core.NewError(core.FAILED_PRECONDITION, "handleResumeOption: cannot resume generation unless the last message is by a model with at least one tool request")
 	}
 
-	resultChan := make(chan result[*resumedToolRequestOutput])
-	newContent := make([]*Part, len(lastMessage.Content))
 	toolReqCount := 0
+	for _, part := range lastMessage.Content {
+		if part.IsToolRequest() {
+			toolReqCount++
+		}
+	}
+
+	resultChan := make(chan result[*resumedToolRequestOutput], toolReqCount)
+	newContent := make([]*Part, len(lastMessage.Content))
 
 	for i, part := range lastMessage.Content {
 		if !part.IsToolRequest() {
 			newContent[i] = part
 			continue
 		}
-		toolReqCount++
 
 		go func(idx int, p *Part) {
 			output, err := handleResumedToolRequest(ctx, r, genOpts, p, runTool)

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -21,8 +21,10 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/internal/registry"
@@ -2485,4 +2487,65 @@ func TestGenerateWithMarkdownJSON(t *testing.T) {
 			t.Errorf("Unexpected output: %+v", out)
 		}
 	})
+}
+
+func TestGenerateNoGoroutineLeak(t *testing.T) {
+	r := registry.New()
+	ConfigureFormats(r)
+	DefineGenerateAction(t.Context(), r)
+
+	done := make(chan struct{})
+
+	slowTool := DefineTool(r, "slow", "slow",
+		func(*ToolContext, any) (any, error) {
+			<-done
+			return nil, nil
+		},
+	)
+
+	failTool := DefineTool(r, "fail", "fail",
+		func(*ToolContext, any) (any, error) {
+			return nil, errors.New("boom")
+		},
+	)
+
+	testModel := DefineModel(r, "test/testModel", &ModelOptions{
+		Supports: &ModelSupports{
+			Multiturn: true,
+			Tools:     true,
+		},
+	}, func(_ context.Context, req *ModelRequest, _ ModelStreamCallback) (*ModelResponse, error) {
+		return &ModelResponse{
+			Request: req,
+			Message: &Message{
+				Role: RoleModel,
+				Content: []*Part{
+					NewToolRequestPart(&ToolRequest{Name: "slow", Input: map[string]any{}, Ref: "a"}),
+					NewToolRequestPart(&ToolRequest{Name: "slow", Input: map[string]any{}, Ref: "b"}),
+					NewToolRequestPart(&ToolRequest{Name: "slow", Input: map[string]any{}, Ref: "c"}),
+					NewToolRequestPart(&ToolRequest{Name: "fail", Input: map[string]any{}, Ref: "d"}),
+				},
+			},
+		}, nil
+	})
+
+	before := runtime.NumGoroutine()
+
+	if _, err := Generate(t.Context(), r,
+		WithModel(testModel),
+		WithTools(slowTool, failTool),
+	); err == nil {
+		t.Fatal("expected tool error")
+	}
+
+	close(done)
+
+	for i := 0; i < 100; i++ {
+		if runtime.NumGoroutine() <= before {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("goroutines leaked: %d", runtime.NumGoroutine()-before)
 }


### PR DESCRIPTION
**explanation:** 
- The `handleToolRequests` helper in `generate.go` spawns a worker goroutine for each tool request.
- The worker goroutines send the tool results to an unbuffered channel. 
- If any tool errors out, the receiver exits without draining the channel and all remaining worker goroutines are permanently blocked on the send.

**fix:** 
- Buffer the channel so all worker goroutines can send and exit.
- Add a regression test.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
