### PR TITLE
fix(go): preserve metadata when mapping multipart tool resp

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -1014,12 +1014,14 @@ func handleToolRequests(ctx context.Context, r api.Registry, req *ModelRequest, 
 		}
 
 		toolReq := revisedMsg.Content[res.index].ToolRequest
-		toolResps = append(toolResps, NewToolResponsePart(&ToolResponse{
+		newToolResp := NewToolResponsePart(&ToolResponse{
 			Name:    toolReq.Name,
 			Ref:     toolReq.Ref,
 			Output:  res.value.Output,
 			Content: res.value.Content,
-		}))
+		})
+		newToolResp.Metadata = res.value.Metadata
+		toolResps = append(toolResps, newToolResp)
 	}
 
 	if hasInterrupts {
@@ -1469,6 +1471,7 @@ func handleResumedToolRequest(ctx context.Context, r api.Registry, genOpts *Gene
 					Output:  multipartResp.Output,
 					Content: multipartResp.Content,
 				})
+				newToolResp.Metadata = multipartResp.Metadata
 
 				return &resumedToolRequestOutput{
 					toolRequest:  newToolReq,

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -1628,7 +1628,7 @@ func TestMultipartTools(t *testing.T) {
 		}
 	})
 
-	t.Run("multipart tool returns content in response", func(t *testing.T) {
+	t.Run("multipart tool returns metadata and content in response", func(t *testing.T) {
 		r := registry.New()
 		ConfigureFormats(r)
 		DefineGenerateAction(context.Background(), r)
@@ -1636,7 +1636,8 @@ func TestMultipartTools(t *testing.T) {
 		multipartTool := DefineMultipartTool(r, "imageGenerator", "generates images",
 			func(ctx *ToolContext, input struct{ Prompt string }) (*MultipartToolResponse, error) {
 				return &MultipartToolResponse{
-					Output: map[string]any{"description": "generated image"},
+					Output:   map[string]any{"description": "generated image"},
+					Metadata: map[string]any{"size": 1},
 					Content: []*Part{
 						NewMediaPart("image/png", "data:image/png;base64,iVBORw0..."),
 					},
@@ -1651,7 +1652,10 @@ func TestMultipartTools(t *testing.T) {
 				if msg.Role == RoleTool {
 					for _, part := range msg.Content {
 						if part.IsToolResponse() {
-							// Verify the content is present
+							// Verify the metadata and content are present
+							if len(part.Metadata) == 0 {
+								return nil, fmt.Errorf("expected tool response to have metadata")
+							}
 							if len(part.ToolResponse.Content) == 0 {
 								return nil, fmt.Errorf("expected tool response to have content")
 							}


### PR DESCRIPTION
**explanation:**
- Both `MultipartToolResponse` and `Part` can have metadata, but `ToolResponse` cannot.
- Using `NewToolResponsePart` for conversion would therefore drop the metadata.

**fix:**
- Copy the field manually.
- Slightly harden an existing test case to detect regressions.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
