### PR TITLE
fix(go): prevent panics caused by yield after stop

### DIFF
--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -757,8 +757,8 @@ type StreamValue[Out, Stream any] struct {
 // Out is never set because the output is already available in the Response field.
 type ModelStreamValue = StreamValue[struct{}, *ModelResponseChunk]
 
-// errGenerateStop is a sentinel error used to signal early termination of streaming.
-var errGenerateStop = errors.New("stop")
+// errStop is a sentinel error used to signal early termination of streaming.
+var errStop = errors.New("stop")
 
 // GenerateStream generates a model response and streams the output.
 // It returns an iterator that yields streaming results.
@@ -773,12 +773,17 @@ var errGenerateStop = errors.New("stop")
 // Otherwise the Chunk field of the passed [ModelStreamValue] holds a streamed chunk.
 func GenerateStream(ctx context.Context, r api.Registry, opts ...GenerateOption) iter.Seq2[*ModelStreamValue, error] {
 	return func(yield func(*ModelStreamValue, error) bool) {
+		done := false
 		cb := func(ctx context.Context, chunk *ModelResponseChunk) error {
+			if done {
+				return errStop
+			}
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
 			if !yield(&ModelStreamValue{Chunk: chunk}, nil) {
-				return errGenerateStop
+				done = true
+				return errStop
 			}
 			return nil
 		}
@@ -786,6 +791,9 @@ func GenerateStream(ctx context.Context, r api.Registry, opts ...GenerateOption)
 		allOpts := append(slices.Clone(opts), WithStreaming(cb))
 
 		resp, err := Generate(ctx, r, allOpts...)
+		if done || errors.Is(err, errStop) {
+			return
+		}
 		if err != nil {
 			yield(nil, err)
 		} else {
@@ -807,13 +815,18 @@ func GenerateStream(ctx context.Context, r api.Registry, opts ...GenerateOption)
 // Otherwise the Chunk field of the passed [StreamValue] holds a streamed chunk.
 func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...GenerateOption) iter.Seq2[*StreamValue[Out, Out], error] {
 	return func(yield func(*StreamValue[Out, Out], error) bool) {
+		done := false
 		cb := func(ctx context.Context, chunk *ModelResponseChunk) error {
+			if done {
+				return errStop
+			}
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
 			var streamValue Out
 			if err := chunk.Output(&streamValue); err != nil {
 				yield(nil, err)
+				done = true
 				return err
 			}
 			// Skip yielding if there's no parseable output yet (e.g., incomplete JSON during streaming).
@@ -821,7 +834,8 @@ func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...Ge
 				return nil
 			}
 			if !yield(&StreamValue[Out, Out]{Chunk: streamValue}, nil) {
-				return errGenerateStop
+				done = true
+				return errStop
 			}
 			return nil
 		}
@@ -832,6 +846,9 @@ func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...Ge
 		allOpts = append(allOpts, WithStreaming(cb))
 
 		resp, err := Generate(ctx, r, allOpts...)
+		if done || errors.Is(err, errStop) {
+			return
+		}
 		if err != nil {
 			yield(nil, err)
 			return

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -1933,6 +1933,31 @@ func TestGenerateStream(t *testing.T) {
 			t.Error("expected error from cancelled context")
 		}
 	})
+
+	t.Run("should not yield after stop", func(t *testing.T) {
+		streamModel := DefineModel(r, "test/breakStreamModel", &ModelOptions{
+			Supports: &ModelSupports{
+				Multiturn: true,
+			},
+		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			for range 3 {
+				if err := cb(ctx, &ModelResponseChunk{Content: []*Part{NewTextPart("chunk")}}); err != nil {
+					return nil, err
+				}
+			}
+			return &ModelResponse{
+				Request: req,
+				Message: NewModelTextMessage("done"),
+			}, nil
+		})
+
+		for _, err := range GenerateStream(t.Context(), r, WithModel(streamModel)) {
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			break
+		}
+	})
 }
 
 func TestGenerateDataStream(t *testing.T) {
@@ -2224,6 +2249,35 @@ func TestGenerateDataStream(t *testing.T) {
 
 		if receivedErr == nil {
 			t.Error("expected parsing error to be propagated")
+		}
+	})
+
+	t.Run("should not yield after stop", func(t *testing.T) {
+		streamModel := DefineModel(r, "test/breakDataStreamModel", &ModelOptions{
+			Supports: &ModelSupports{
+				Multiturn:   true,
+				Constrained: ConstrainedSupportAll,
+			},
+		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			for i := range 3 {
+				if err := cb(ctx, &ModelResponseChunk{Content: []*Part{NewJSONPart(fmt.Sprintf(`{"name":"chunk","value":%d}`, i))}}); err != nil {
+					return nil, err
+				}
+			}
+			return &ModelResponse{
+				Request: req,
+				Message: &Message{
+					Role:    RoleModel,
+					Content: []*Part{NewJSONPart(`{"name":"done","value":4}`)},
+				},
+			}, nil
+		})
+
+		for _, err := range GenerateDataStream[streamingTestData](t.Context(), r, WithModel(streamModel)) {
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			break
 		}
 	})
 }

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -285,18 +285,26 @@ func (p *prompt) ExecuteStream(ctx context.Context, opts ...PromptExecuteOption)
 			return
 		}
 
+		done := false
 		cb := func(ctx context.Context, chunk *ModelResponseChunk) error {
+			if done {
+				return errStop
+			}
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
 			if !yield(&ModelStreamValue{Chunk: chunk}, nil) {
-				return errPromptStop
+				done = true
+				return errStop
 			}
 			return nil
 		}
 
 		allOpts := append(slices.Clone(opts), WithStreaming(cb))
 		resp, err := p.Execute(ctx, allOpts...)
+		if done || errors.Is(err, errStop) {
+			return
+		}
 		if err != nil {
 			yield(nil, err)
 			return
@@ -305,9 +313,6 @@ func (p *prompt) ExecuteStream(ctx context.Context, opts ...PromptExecuteOption)
 		yield(&ModelStreamValue{Done: true, Response: resp}, nil)
 	}
 }
-
-// errPromptStop is a sentinel error used to signal early termination of streaming.
-var errPromptStop = errors.New("stop")
 
 // Render renders the prompt template based on user input.
 func (p *prompt) Render(ctx context.Context, input any) (*GenerateActionOptions, error) {
@@ -1025,13 +1030,18 @@ func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts
 			return
 		}
 
+		done := false
 		cb := func(ctx context.Context, chunk *ModelResponseChunk) error {
+			if done {
+				return errStop
+			}
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
 			streamValue, err := extractTypedOutput[Out](chunk)
 			if err != nil {
 				yield(nil, err)
+				done = true
 				return err
 			}
 			// Skip yielding if there's no parseable output yet (e.g., incomplete JSON during streaming).
@@ -1039,13 +1049,17 @@ func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts
 				return nil
 			}
 			if !yield(&StreamValue[Out, Out]{Chunk: streamValue}, nil) {
-				return errGenerateStop
+				done = true
+				return errStop
 			}
 			return nil
 		}
 
 		allOpts := append(slices.Clone(opts), WithInput(input), WithStreaming(cb))
 		resp, err := dp.prompt.Execute(ctx, allOpts...)
+		if done || errors.Is(err, errStop) {
+			return
+		}
 		if err != nil {
 			yield(nil, err)
 			return

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -2149,6 +2149,40 @@ func TestDataPromptExecuteStream(t *testing.T) {
 			t.Errorf("expected error %v, got %v", expectedErr, receivedErr)
 		}
 	})
+
+	t.Run("should not yield after stop", func(t *testing.T) {
+		testModel := DefineModel(r, "test/breakDataPromptStreamModel", &ModelOptions{
+			Supports: &ModelSupports{
+				Multiturn:   true,
+				Constrained: ConstrainedSupportAll,
+			},
+		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			for i := range 3 {
+				if err := cb(ctx, &ModelResponseChunk{Content: []*Part{NewJSONPart(fmt.Sprintf(`{"text":"chunk","index":%d}`, i))}}); err != nil {
+					return nil, err
+				}
+			}
+			return &ModelResponse{
+				Request: req,
+				Message: &Message{
+					Role:    RoleModel,
+					Content: []*Part{NewJSONPart(`{"text":"done","index":4}`)},
+				},
+			}, nil
+		})
+
+		dp := DefineDataPrompt[StreamInput, StreamOutput](r, "breakStreamPrompt",
+			WithModel(testModel),
+			WithPrompt("Test {{topic}}"),
+		)
+
+		for _, err := range dp.ExecuteStream(t.Context(), StreamInput{Topic: "yielding"}) {
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			break
+		}
+	})
 }
 
 func TestPromptExecuteStream(t *testing.T) {
@@ -2261,6 +2295,36 @@ func TestPromptExecuteStream(t *testing.T) {
 		}
 		if config.Temperature != 0.9 {
 			t.Errorf("expected temperature 0.9, got %v", config.Temperature)
+		}
+	})
+
+	t.Run("should not yield after stop", func(t *testing.T) {
+		testModel := DefineModel(r, "test/breakPromptStreamModel", &ModelOptions{
+			Supports: &ModelSupports{
+				Multiturn: true,
+			},
+		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			for range 3 {
+				if err := cb(ctx, &ModelResponseChunk{Content: []*Part{NewTextPart("chunk")}}); err != nil {
+					return nil, err
+				}
+			}
+			return &ModelResponse{
+				Request: req,
+				Message: NewModelTextMessage("done"),
+			}, nil
+		})
+
+		p := DefinePrompt(r, "breakStreamTestPrompt",
+			WithModel(testModel),
+			WithPrompt("Test"),
+		)
+
+		for _, err := range p.ExecuteStream(t.Context()) {
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			break
 		}
 	})
 }

--- a/go/core/flow.go
+++ b/go/core/flow.go
@@ -158,17 +158,22 @@ func (f *Flow[In, Out, Stream]) Run(ctx context.Context, input In) (Out, error) 
 // Otherwise the Stream field of the passed [StreamingFlowValue] holds a streamed result.
 func (f *Flow[In, Out, Stream]) Stream(ctx context.Context, input In) func(func(*StreamingFlowValue[Out, Stream], error) bool) {
 	return func(yield func(*StreamingFlowValue[Out, Stream], error) bool) {
+		done := false
 		cb := func(ctx context.Context, s Stream) error {
+			if done {
+				return errStop
+			}
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
 			if !yield(&StreamingFlowValue[Out, Stream]{Stream: s}, nil) {
+				done = true
 				return errStop
 			}
 			return nil
 		}
 		output, err := (*ActionDef[In, Out, Stream])(f).Run(ctx, input, cb)
-		if errors.Is(err, errStop) {
+		if done || errors.Is(err, errStop) {
 			// Consumer broke out of the loop; don't yield again.
 			return
 		}


### PR DESCRIPTION
**explanation:**
- To convert callback-based streams into Go iterators, a sentinel error is returned to signal that iteration has stopped.
- Calling `yield` once more in this state will cause the Go runtime to panic.
- The `...Stream` methods in `generate.go` and `prompt.go` do not check for the sentinel error and incorrectly `yield` once more to propagate the error.

**fix:**
- Add checks for the sentinel error.
- Add regression tests.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
