### PR TITLE
docs(go/plugins/googlegenai): document gemini-3.1 tts model behaviour and add sample

### DIFF
--- a/go/plugins/googlegenai/README.md
+++ b/go/plugins/googlegenai/README.md
@@ -26,21 +26,21 @@ You can use either the Google AI (Gemini API) or Vertex AI backend.
 
 ```go
 import (
- "context"
- "log"
+	"context"
+	"log"
 
- "github.com/firebase/genkit/go/genkit"
- "github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
 )
 
 func main() {
- ctx := context.Background()
+	ctx := context.Background()
 
- g := genkit.Init(ctx,
-  genkit.WithPlugins(&googlegenai.GoogleAI{
-   APIKey: "your-api-key", // Optional: defaults to GEMINI_API_KEY or GOOGLE_API_KEY env var
-  }),
- )
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&googlegenai.GoogleAI{
+			APIKey: "your-api-key", // Optional: defaults to GEMINI_API_KEY or GOOGLE_API_KEY env var
+		}),
+	)
 }
 ```
 
@@ -48,22 +48,22 @@ func main() {
 
 ```go
 import (
- "context"
- "log"
+	"context"
+	"log"
 
- "github.com/firebase/genkit/go/genkit"
- "github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
 )
 
 func main() {
- ctx := context.Background()
+	ctx := context.Background()
 
- g := genkit.Init(ctx,
-  genkit.WithPlugins(&googlegenai.VertexAI{
-   ProjectID: "your-project-id", // Optional: defaults to GOOGLE_CLOUD_PROJECT
-   Location:  "us-central1",     // Optional: defaults to GOOGLE_CLOUD_LOCATION
-  }),
- )
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&googlegenai.VertexAI{
+			ProjectID: "your-project-id", // Optional: defaults to GOOGLE_CLOUD_PROJECT
+			Location:  "us-central1",     // Optional: defaults to GOOGLE_CLOUD_LOCATION
+		}),
+	)
 }
 ```
 
@@ -93,26 +93,26 @@ Commonly used models include:
 
 ```go
 import (
- "context"
- "fmt"
- "log"
+	"context"
+	"fmt"
+	"log"
 
- "github.com/firebase/genkit/go/ai"
- "github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
 )
 
 func main() {
- // ... Init genkit with googlegenai plugin ...
+	// ... Init genkit with googlegenai plugin ...
 
- resp, err := genkit.Generate(ctx, g,
-  ai.WithModelName("googleai/gemini-2.5-flash"),
-  ai.WithPrompt("Explain how neural networks learn in simple terms."),
- )
- if err != nil {
-  log.Fatal(err)
- }
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModelName("googleai/gemini-2.5-flash"),
+		ai.WithPrompt("Explain how neural networks learn in simple terms."),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
 
- fmt.Println(resp.Text())
+	fmt.Println(resp.Text())
 }
 ```
 
@@ -124,18 +124,18 @@ Gemini models support structured output generation, which guarantees that the mo
 
 ```go
 type Character struct {
- Name string `json:"name"`
- Bio  string `json:"bio"`
- Age  int    `json:"age"`
+	Name string `json:"name"`
+	Bio  string `json:"bio"`
+	Age  int    `json:"age"`
 }
 
 // Automatically infers schema from the struct and unmarshals the result
 char, resp, err := genkit.GenerateData[Character](ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
- ai.WithPrompt("Generate a profile for a fictional character"),
+	ai.WithModelName("googleai/gemini-2.5-flash"),
+	ai.WithPrompt("Generate a profile for a fictional character"),
 )
 if err != nil {
- log.Fatal(err)
+	log.Fatal(err)
 }
 
 fmt.Printf("Name: %s, Age: %d\n", char.Name, char.Age)
@@ -147,17 +147,17 @@ You can also use the standard `Generate` function and unmarshal manually:
 
 ```go
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
- ai.WithPrompt("Generate a profile for a fictional character"),
- ai.WithOutputType(Character{}),
+	ai.WithModelName("googleai/gemini-2.5-flash"),
+	ai.WithPrompt("Generate a profile for a fictional character"),
+	ai.WithOutputType(Character{}),
 )
 if err != nil {
- log.Fatal(err)
+	log.Fatal(err)
 }
 
 var char Character
 if err := resp.Output(&char); err != nil {
- log.Fatal(err)
+	log.Fatal(err)
 }
 ```
 
@@ -179,14 +179,14 @@ Gemini 2.5 and newer models use an internal thinking process that improves reaso
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
- ai.WithPrompt("what is heavier, one kilo of steel or one kilo of feathers"),
- ai.WithConfig(&genai.GenerateContentConfig{
-  ThinkingConfig: &genai.ThinkingConfig{
-   ThinkingBudget: genai.Ptr[int32](1024), // Number of thinking tokens
-   IncludeThoughts: true,                  // Include thought summaries
-  },
- }),
+	ai.WithModelName("googleai/gemini-2.5-flash"),
+	ai.WithPrompt("what is heavier, one kilo of steel or one kilo of feathers"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		ThinkingConfig: &genai.ThinkingConfig{
+			ThinkingBudget:  genai.Ptr[int32](1024), // Number of thinking tokens
+			IncludeThoughts: true,                   // Include thought summaries
+		},
+	}),
 )
 ```
 
@@ -200,17 +200,17 @@ cachedMsg := ai.NewUserTextMessage(largeContent).WithCacheTTL(300)
 
 // First request - content will be cached
 resp1, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
- ai.WithMessages(cachedMsg),
- ai.WithPrompt("Task 1..."),
+	ai.WithModelName("googleai/gemini-2.5-flash"),
+	ai.WithMessages(cachedMsg),
+	ai.WithPrompt("Task 1..."),
 )
 
 // Second request with same prefix - eligible for cache hit
 resp2, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
- // Reuse the history from previous response or construct messages with same prefix
- ai.WithMessages(resp1.History()...),
- ai.WithPrompt("Task 2..."),
+	ai.WithModelName("googleai/gemini-2.5-flash"),
+	// Reuse the history from previous response or construct messages with same prefix
+	ai.WithMessages(resp1.History()...),
+	ai.WithPrompt("Task 2..."),
 )
 ```
 
@@ -222,20 +222,20 @@ You can configure safety settings to control content filtering:
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
- ai.WithPrompt("Your prompt here"),
- ai.WithConfig(&genai.GenerateContentConfig{
-  SafetySettings: []*genai.SafetySetting{
-   {
-    Category:  genai.HarmCategoryHateSpeech,
-    Threshold: genai.HarmBlockThresholdBlockLowAndAbove,
-   },
-   {
-    Category:  genai.HarmCategoryDangerousContent,
-    Threshold: genai.HarmBlockThresholdBlockMediumAndAbove,
-   },
-  },
- }),
+	ai.WithModelName("googleai/gemini-2.5-flash"),
+	ai.WithPrompt("Your prompt here"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		SafetySettings: []*genai.SafetySetting{
+			{
+				Category:  genai.HarmCategoryHateSpeech,
+				Threshold: genai.HarmBlockThresholdBlockLowAndAbove,
+			},
+			{
+				Category:  genai.HarmCategoryDangerousContent,
+				Threshold: genai.HarmBlockThresholdBlockMediumAndAbove,
+			},
+		},
+	}),
 )
 ```
 
@@ -247,15 +247,15 @@ Enable Google Search to provide answers with current information and verifiable 
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
- ai.WithPrompt("What are the top tech news stories this week?"),
- ai.WithConfig(&genai.GenerateContentConfig{
-  Tools: []*genai.Tool{
-   {
-    GoogleSearch: &genai.GoogleSearch{},
-   },
-  },
- }),
+	ai.WithModelName("googleai/gemini-2.5-flash"),
+	ai.WithPrompt("What are the top tech news stories this week?"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		Tools: []*genai.Tool{
+			{
+				GoogleSearch: &genai.GoogleSearch{},
+			},
+		},
+	}),
 )
 ```
 
@@ -267,34 +267,34 @@ Enable Google Maps to provide location-aware responses.
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
- ai.WithPrompt("Find coffee shops near Times Square"),
- ai.WithConfig(&genai.GenerateContentConfig{
-  Tools: []*genai.Tool{
-   {
-    GoogleMaps: &genai.GoogleMaps{
-     EnableWidget: genai.Ptr(true),
-    },
-   },
-  },
-  ToolConfig: &genai.ToolConfig{
-   RetrievalConfig: &genai.RetrievalConfig{
-    LatLng: &genai.LatLng{
-     Latitude:  genai.Ptr(37.7749),
-     Longitude: genai.Ptr(-122.4194),
-    },
-   },
-  },
- }),
+	ai.WithModelName("googleai/gemini-2.5-flash"),
+	ai.WithPrompt("Find coffee shops near Times Square"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		Tools: []*genai.Tool{
+			{
+				GoogleMaps: &genai.GoogleMaps{
+					EnableWidget: genai.Ptr(true),
+				},
+			},
+		},
+		ToolConfig: &genai.ToolConfig{
+			RetrievalConfig: &genai.RetrievalConfig{
+				LatLng: &genai.LatLng{
+					Latitude:  genai.Ptr(37.7749),
+					Longitude: genai.Ptr(-122.4194),
+				},
+			},
+		},
+	}),
 )
 
 // Access grounding metadata (e.g., for map widget)
 if custom, ok := resp.Custom["candidates"].([]*genai.Candidate); ok {
- for _, cand := range custom {
-  if cand.GroundingMetadata != nil && cand.GroundingMetadata.GoogleMapsWidgetContextToken != "" {
-   fmt.Printf("Map Widget Token: %s\n", cand.GroundingMetadata.GoogleMapsWidgetContextToken)
-  }
- }
+	for _, cand := range custom {
+		if cand.GroundingMetadata != nil && cand.GroundingMetadata.GoogleMapsWidgetContextToken != "" {
+			fmt.Printf("Map Widget Token: %s\n", cand.GroundingMetadata.GoogleMapsWidgetContextToken)
+		}
+	}
 }
 ```
 
@@ -306,15 +306,15 @@ Enable the model to write and execute Python code for calculations and logic.
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-pro"),
- ai.WithPrompt("Calculate the 20th Fibonacci number"),
- ai.WithConfig(&genai.GenerateContentConfig{
-  Tools: []*genai.Tool{
-   {
-    CodeExecution: &genai.ToolCodeExecution{},
-   },
-  },
- }),
+	ai.WithModelName("googleai/gemini-2.5-pro"),
+	ai.WithPrompt("Calculate the 20th Fibonacci number"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		Tools: []*genai.Tool{
+			{
+				CodeExecution: &genai.ToolCodeExecution{},
+			},
+		},
+	}),
 )
 ```
 
@@ -326,18 +326,18 @@ Some Gemini models (like `gemini-2.5-flash-image`) can output images natively al
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash-image"),
- ai.WithPrompt("Create a picture of a futuristic city and describe it"),
- ai.WithConfig(&genai.GenerateContentConfig{
-  ResponseModalities: []string{"IMAGE", "TEXT"},
- }),
+	ai.WithModelName("googleai/gemini-2.5-flash-image"),
+	ai.WithPrompt("Create a picture of a futuristic city and describe it"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		ResponseModalities: []string{"IMAGE", "TEXT"},
+	}),
 )
 
 for _, part := range resp.Message.Content {
- if part.IsMedia() {
-  fmt.Printf("Generated image: %s\n", part.ContentType)
-  // Access data via part.Text (data URI) or helper functions
- }
+	if part.IsMedia() {
+		fmt.Printf("Generated image: %s\n", part.ContentType)
+		// Access data via part.Text (data URI) or helper functions
+	}
 }
 ```
 
@@ -355,13 +355,13 @@ videoPart := ai.NewMediaPart("video/mp4", "https://example.com/video.mp4")
 imagePart := ai.NewMediaPart("image/jpeg", "data:image/jpeg;base64,...")
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
- ai.WithMessages(
-  ai.NewUserMessage(
-   ai.NewTextPart("Describe this content"),
-   videoPart,
-  ),
- ),
+	ai.WithModelName("googleai/gemini-2.5-flash"),
+	ai.WithMessages(
+		ai.NewUserMessage(
+			ai.NewTextPart("Describe this content"),
+			videoPart,
+		),
+	),
 )
 ```
 
@@ -377,11 +377,11 @@ resp, err := genkit.Generate(ctx, g,
 
 ```go
 res, err := genkit.Embed(ctx, g,
- ai.WithEmbedderName("googleai/gemini-embedding-001"),
- ai.WithTextDocs("Machine learning models process data to make predictions."),
+	ai.WithEmbedderName("googleai/gemini-embedding-001"),
+	ai.WithTextDocs("Machine learning models process data to make predictions."),
 )
 if err != nil {
- log.Fatal(err)
+	log.Fatal(err)
 }
 
 fmt.Printf("Embedding: %v\n", res.Embeddings[0].Embedding)
@@ -402,13 +402,13 @@ fmt.Printf("Embedding: %v\n", res.Embeddings[0].Embedding)
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/imagen-3.0-generate-001"),
- ai.WithPrompt("A serene Japanese garden with cherry blossoms"),
- ai.WithConfig(&genai.GenerateImagesConfig{
-  NumberOfImages: 4,
-  AspectRatio:    "16:9",
-  PersonGeneration: "allow_adult",
- }),
+	ai.WithModelName("googleai/imagen-3.0-generate-001"),
+	ai.WithPrompt("A serene Japanese garden with cherry blossoms"),
+	ai.WithConfig(&genai.GenerateImagesConfig{
+		NumberOfImages:   4,
+		AspectRatio:      "16:9",
+		PersonGeneration: "allow_adult",
+	}),
 )
 
 // Access generated images in resp.Message.Content
@@ -458,18 +458,18 @@ Your application should be prepared to handle both formats. For example, to save
 
 ```go
 for _, part := range op.Output.Message.Content {
- if part.IsMedia() {
-  if strings.HasPrefix(part.Text, "data:video/mp4;base64,") {
-   // Handle base64 encoded bytes (Common for Vertex AI default)
-   data := strings.TrimPrefix(part.Text, "data:video/mp4;base64,")
-   b, _ := base64.StdEncoding.DecodeString(data)
-   os.WriteFile("video.mp4", b, 0644)
-  } else {
-   // Handle remote URI (Common for Google AI or Vertex AI with GCS)
-   // You would typically use an HTTP client or Google Cloud Storage client here
-   fmt.Printf("Video available at URI: %s\n", part.Text)
-  }
- }
+	if part.IsMedia() {
+		if strings.HasPrefix(part.Text, "data:video/mp4;base64,") {
+			// Handle base64 encoded bytes (Common for Vertex AI default)
+			data := strings.TrimPrefix(part.Text, "data:video/mp4;base64,")
+			b, _ := base64.StdEncoding.DecodeString(data)
+			os.WriteFile("video.mp4", b, 0644)
+		} else {
+			// Handle remote URI (Common for Google AI or Vertex AI with GCS)
+			// You would typically use an HTTP client or Google Cloud Storage client here
+			fmt.Printf("Video available at URI: %s\n", part.Text)
+		}
+	}
 }
 ```
 
@@ -487,16 +487,16 @@ Generate a video from a text description.
 
 ```go
 op, err := genkit.GenerateOperation(ctx, g,
- ai.WithModelName("googleai/veo-3.1-generate-preview"),
- ai.WithMessages(ai.NewUserTextMessage("A majestic dragon soaring over a mystical forest at dawn.")),
- ai.WithConfig(&genai.GenerateVideosConfig{
-  AspectRatio:     "16:9",
-  DurationSeconds: genai.Ptr(int32(8)),
-  Resolution:      "720p",
- }),
+	ai.WithModelName("googleai/veo-3.1-generate-preview"),
+	ai.WithMessages(ai.NewUserTextMessage("A majestic dragon soaring over a mystical forest at dawn.")),
+	ai.WithConfig(&genai.GenerateVideosConfig{
+		AspectRatio:     "16:9",
+		DurationSeconds: genai.Ptr(int32(8)),
+		Resolution:      "720p",
+	}),
 )
 if err != nil {
- log.Fatal(err)
+	log.Fatal(err)
 }
 
 // Poll for completion
@@ -512,14 +512,14 @@ Animate a static image using a text prompt.
 imagePart := ai.NewMediaPart("image/jpeg", "data:image/jpeg;base64,...")
 
 op, err := genkit.GenerateOperation(ctx, g,
- ai.WithModelName("googleai/veo-3.1-generate-preview"),
- ai.WithMessages(ai.NewUserMessage(
-  ai.NewTextPart("The cat wakes up and starts accelerating the go-kart."),
-  imagePart,
- )),
- ai.WithConfig(&genai.GenerateVideosConfig{
-  AspectRatio: "16:9",
- }),
+	ai.WithModelName("googleai/veo-3.1-generate-preview"),
+	ai.WithMessages(ai.NewUserMessage(
+		ai.NewTextPart("The cat wakes up and starts accelerating the go-kart."),
+		imagePart,
+	)),
+	ai.WithConfig(&genai.GenerateVideosConfig{
+		AspectRatio: "16:9",
+	}),
 )
 ```
 
@@ -534,20 +534,20 @@ Edit or transform an existing video.
 videoPart := ai.NewMediaPart("video/mp4", "https://generativelanguage.googleapis.com/...")
 
 op, err := genkit.GenerateOperation(ctx, g,
- ai.WithModelName("googleai/veo-3.1-generate-preview"),
- ai.WithMessages(ai.NewUserMessage(
-  ai.NewTextPart("Change the video style to be a cartoon from 1950."),
-  videoPart,
- )),
- ai.WithConfig(&genai.GenerateVideosConfig{
-  AspectRatio: "16:9",
- }),
+	ai.WithModelName("googleai/veo-3.1-generate-preview"),
+	ai.WithMessages(ai.NewUserMessage(
+		ai.NewTextPart("Change the video style to be a cartoon from 1950."),
+		videoPart,
+	)),
+	ai.WithConfig(&genai.GenerateVideosConfig{
+		AspectRatio: "16:9",
+	}),
 )
 ```
 
 ## Speech Models
 
-Use `gemini-2.5-flash` or `gemini-2.5-pro` with audio output modality.
+Use `gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts` or `gemini-3.1-flash-tts-preview` with audio output modality.
 
 ### Usage
 
@@ -555,19 +555,164 @@ Use `gemini-2.5-flash` or `gemini-2.5-pro` with audio output modality.
 import "google.golang.org/genai"
 
 resp, err := genkit.Generate(ctx, g,
- ai.WithModelName("googleai/gemini-2.5-flash"),
- ai.WithPrompt("Say that Genkit is an amazing AI framework"),
- ai.WithConfig(&genai.GenerateContentConfig{
-  ResponseModalities: []string{"AUDIO"},
-  SpeechConfig: &genai.SpeechConfig{
-   VoiceConfig: &genai.VoiceConfig{
-    PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
-     VoiceName: "Algenib",
-    },
-   },
-  },
- }),
+	ai.WithModelName("googleai/gemini-2.5-flash-preview-tts"),
+	ai.WithPrompt("Say that Genkit is an amazing AI framework"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		ResponseModalities: []string{"AUDIO"},
+		SpeechConfig: &genai.SpeechConfig{
+			VoiceConfig: &genai.VoiceConfig{
+				PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
+					VoiceName: "Algenib",
+				},
+			},
+		},
+	}),
 )
 
 // The audio data will be in resp.Message.Content as a media part
 ```
+
+
+#### Note on using gemini-3.1-flash-tts-preview
+This model returns raw PCM audio, which needs to be wrapped in a WAV container to become directly playable. The other Gemini TTS models return WAV audio, so no conversion is needed.
+
+#### Define the helper functions below
+```go
+func wavFromPCM(pcm []byte, channels, sampleRate, bitsPerSample int) []byte {
+	var buf bytes.Buffer
+	dataSize := uint32(len(pcm))
+	byteRate := uint32(sampleRate * channels * bitsPerSample / 8)
+	blockAlign := uint16(channels * bitsPerSample / 8)
+
+	buf.WriteString("RIFF")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(36)+dataSize)
+	buf.WriteString("WAVE")
+	buf.WriteString("fmt ")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(16))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(1))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(channels))
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(sampleRate))
+	_ = binary.Write(&buf, binary.LittleEndian, byteRate)
+	_ = binary.Write(&buf, binary.LittleEndian, blockAlign)
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(bitsPerSample))
+	buf.WriteString("data")
+	_ = binary.Write(&buf, binary.LittleEndian, dataSize)
+	buf.Write(pcm)
+	return buf.Bytes()
+}
+
+func decodeMediaData(part *ai.Part) (string, []byte, error) {
+	if part == nil || !part.IsMedia() {
+		return "", nil, errors.New("part is not media")
+	}
+	contentType := part.ContentType
+	if payload, ok := strings.CutPrefix(part.Text, "data:"); ok {
+		header, encoded, ok := strings.Cut(payload, ",")
+		if !ok {
+			return "", nil, errors.New("invalid media data URI")
+		}
+		if mediaType, _, ok := strings.Cut(header, ";"); ok && mediaType != "" {
+			contentType = mediaType
+		}
+		data, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return "", nil, err
+		}
+		return contentType, data, nil
+	}
+	return "", nil, errors.New("media part is not inline data")
+}
+
+func writePlayableAudio(path string, part *ai.Part) error {
+	contentType, data, err := decodeMediaData(part)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = contentType
+	}
+
+	switch strings.ToLower(mediaType) {
+	case "audio/l16":
+		// Assumes mono 24kHz 16-bit PCM for this model output.
+		return os.WriteFile(path, wavFromPCM(data, 1, 24000, 16), 0644)
+	default:
+		return os.WriteFile(path, data, 0644)
+	}
+}
+
+func firstAudioPart(resp *ai.ModelResponse) *ai.Part {
+	if resp == nil || resp.Message == nil {
+		return nil
+	}
+	for _, part := range resp.Message.Content {
+		if part.IsAudio() {
+			return part
+		}
+	}
+	return nil
+
+}
+```
+
+#### Example usage of these functions in a flow
+
+```go
+type TTSInput struct {
+	Text string `json:"text"`
+}
+
+type TTSOutput struct {
+	AudioPath string `json:"audioPath"`
+}
+
+ttsFlow := genkit.DefineFlow(g, "ttsFlow", func(ctx context.Context, input *TTSInput) (*TTSOutput, error) {
+	prompt := "Say that Genkit is an amazing AI framework"
+	if input != nil && input.Text != "" {
+		prompt = fmt.Sprintf("Say: %s", input.Text)
+	}
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModelName("googleai/gemini-3.1-flash-tts-preview"),
+		ai.WithPrompt(prompt),
+		ai.WithConfig(&genai.GenerateContentConfig{
+			ResponseModalities: []string{"AUDIO"},
+			SpeechConfig: &genai.SpeechConfig{
+				VoiceConfig: &genai.VoiceConfig{
+					PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
+						VoiceName: "Algenib",
+					},
+				},
+			},
+		}),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	audio := firstAudioPart(resp)
+	if audio == nil {
+		return nil, errors.New("no audio part in response")
+	}
+
+	tmpFile, err := os.CreateTemp("", "genkit-tts-*.wav")
+	if err != nil {
+		return nil, err
+	}
+	path := tmpFile.Name()
+	tmpFile.Close()
+
+	if err := writePlayableAudio(path, audio); err != nil {
+		return nil, err
+	}
+
+	return &TTSOutput{AudioPath: path}, nil
+})
+```
+The example above uses `gemini-3.1-flash-tts-preview` to generate PCM output, converts it to WAV, and returns the generated file path.

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -62,7 +62,7 @@ var (
 		Tools:      false,
 		ToolChoice: false,
 		SystemRole: false,
-		Output:     []string{"audio"},
+		Output:     []string{"media"},
 	}
 )
 

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -52,6 +52,18 @@ var (
 		Output:      []string{"media"},
 		LongRunning: true,
 	}
+
+	// TTSSupports describes model capabilities for text-to-speech models
+	// (gemini-*-tts). They emit audio and, unlike conversational Gemini models,
+	// do not support tools, multi-turn history, or system roles.
+	TTSSupports = ai.ModelSupports{
+		Multiturn:  false,
+		Media:      false,
+		Tools:      false,
+		ToolChoice: false,
+		SystemRole: false,
+		Output:     []string{"audio"},
+	}
 )
 
 // Default options for unknown models of each type.
@@ -92,6 +104,10 @@ const (
 
 	gemini31FlashLitePreview  = "gemini-3.1-flash-lite-preview"
 	gemini31FlashImagePreview = "gemini-3.1-flash-image-preview"
+
+	gemini25FlashPreviewTTS = "gemini-2.5-flash-preview-tts"
+	gemini25ProPreviewTTS   = "gemini-2.5-pro-preview-tts"
+	gemini31FlashTTSPreview = "gemini-3.1-flash-tts-preview"
 
 	imagen3Generate001     = "imagen-3.0-generate-001"
 	imagen3FastGenerate001 = "imagen-3.0-fast-generate-001"
@@ -143,6 +159,10 @@ var (
 		gemini25Pro,
 		gemini31FlashLitePreview,
 		gemini31FlashImagePreview,
+
+		gemini25FlashPreviewTTS,
+		gemini25ProPreviewTTS,
+		gemini31FlashTTSPreview,
 
 		veo20Generate001,
 		veo30Generate001,
@@ -196,6 +216,24 @@ var (
 			Label:    "Gemini 3.1 Flash Image Preview",
 			Versions: []string{},
 			Supports: &Multimodal,
+			Stage:    ai.ModelStageUnstable,
+		},
+		gemini25FlashPreviewTTS: {
+			Label:    "Gemini 2.5 Flash Preview TTS",
+			Versions: []string{},
+			Supports: &TTSSupports,
+			Stage:    ai.ModelStageUnstable,
+		},
+		gemini25ProPreviewTTS: {
+			Label:    "Gemini 2.5 Pro Preview TTS",
+			Versions: []string{},
+			Supports: &TTSSupports,
+			Stage:    ai.ModelStageUnstable,
+		},
+		gemini31FlashTTSPreview: {
+			Label:    "Gemini 3.1 Flash TTS Preview",
+			Versions: []string{},
+			Supports: &TTSSupports,
 			Stage:    ai.ModelStageUnstable,
 		},
 	}

--- a/go/plugins/googlegenai/tts_test.go
+++ b/go/plugins/googlegenai/tts_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package googlegenai
+
+import (
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+)
+
+// ttsModels are the dedicated text-to-speech models registered for Google AI.
+var ttsModels = []string{
+	gemini25FlashPreviewTTS,
+	gemini25ProPreviewTTS,
+	gemini31FlashTTSPreview,
+}
+
+func TestTTSModelClassification(t *testing.T) {
+	t.Parallel()
+
+	// TTS models keep the "gemini" prefix, so they classify as regular Gemini
+	// models and reuse the standard content-generation action path.
+	for _, name := range ttsModels {
+		if mt := ClassifyModel(name); mt != ModelTypeGemini {
+			t.Errorf("ClassifyModel(%q) = %v, want ModelTypeGemini", name, mt)
+		}
+	}
+}
+
+func TestTTSModelOptions(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range ttsModels {
+		t.Run(name, func(t *testing.T) {
+			opts := GetModelOptions(name, googleAIProvider)
+			if opts.Supports == nil {
+				t.Fatal("Supports is nil")
+			}
+			if opts.Supports != &TTSSupports {
+				t.Errorf("Supports = %p, want &TTSSupports (%p)", opts.Supports, &TTSSupports)
+			}
+			// TTS models emit audio and do not converse or call tools.
+			if got := opts.Supports.Output; len(got) != 1 || got[0] != "audio" {
+				t.Errorf("Output = %v, want [audio]", got)
+			}
+			if opts.Supports.Tools {
+				t.Error("Tools = true, want false")
+			}
+			if opts.Supports.Multiturn {
+				t.Error("Multiturn = true, want false")
+			}
+			if opts.Supports.Media {
+				t.Error("Media = true, want false")
+			}
+			if opts.Stage != ai.ModelStageUnstable {
+				t.Errorf("Stage = %v, want Unstable", opts.Stage)
+			}
+			// ConfigSchema falls back to GenerateContentConfig, which carries the
+			// speechConfig field used to select voices.
+			if opts.ConfigSchema == nil {
+				t.Error("ConfigSchema is nil, want GenerateContentConfig schema")
+			}
+		})
+	}
+}
+
+func TestTTSModelsRegisteredForGoogleAIOnly(t *testing.T) {
+	t.Parallel()
+
+	googleModels, err := listModels(googleAIProvider)
+	if err != nil {
+		t.Fatalf("listModels(googleAI) error = %v", err)
+	}
+	vertexModels, err := listModels(vertexAIProvider)
+	if err != nil {
+		t.Fatalf("listModels(vertexAI) error = %v", err)
+	}
+
+	for _, name := range ttsModels {
+		if _, ok := googleModels[name]; !ok {
+			t.Errorf("Google AI model list is missing TTS model %q", name)
+		}
+		if _, ok := vertexModels[name]; ok {
+			t.Errorf("Vertex AI model list unexpectedly includes TTS model %q", name)
+		}
+	}
+}

--- a/go/plugins/googlegenai/tts_test.go
+++ b/go/plugins/googlegenai/tts_test.go
@@ -40,9 +40,9 @@ func TestTTSModelOptions(t *testing.T) {
 			if opts.Supports != &TTSSupports {
 				t.Errorf("Supports = %p, want &TTSSupports (%p)", opts.Supports, &TTSSupports)
 			}
-			// TTS models emit audio and do not converse or call tools.
-			if got := opts.Supports.Output; len(got) != 1 || got[0] != "audio" {
-				t.Errorf("Output = %v, want [audio]", got)
+			// TTS models emit media and do not converse or call tools.
+			if got := opts.Supports.Output; len(got) != 1 || got[0] != "media" {
+				t.Errorf("Output = %v, want [media]", got)
 			}
 			if opts.Supports.Tools {
 				t.Error("Tools = true, want false")

--- a/go/samples/text-to-speech/main.go
+++ b/go/samples/text-to-speech/main.go
@@ -15,16 +15,110 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
+	"mime"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 	"google.golang.org/genai"
 )
+
+type ttsInput struct {
+	Text string `json:"text"`
+}
+
+type ttsOutput struct {
+	AudioPath string `json:"audioPath"`
+}
+
+func wavFromPCM(pcm []byte, channels, sampleRate, bitsPerSample int) []byte {
+	var buf bytes.Buffer
+	dataSize := uint32(len(pcm))
+	byteRate := uint32(sampleRate * channels * bitsPerSample / 8)
+	blockAlign := uint16(channels * bitsPerSample / 8)
+
+	buf.WriteString("RIFF")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(36)+dataSize)
+	buf.WriteString("WAVE")
+	buf.WriteString("fmt ")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(16))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(1))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(channels))
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(sampleRate))
+	_ = binary.Write(&buf, binary.LittleEndian, byteRate)
+	_ = binary.Write(&buf, binary.LittleEndian, blockAlign)
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(bitsPerSample))
+	buf.WriteString("data")
+	_ = binary.Write(&buf, binary.LittleEndian, dataSize)
+	buf.Write(pcm)
+	return buf.Bytes()
+}
+
+func decodeMediaData(part *ai.Part) (string, []byte, error) {
+	if part == nil || !part.IsMedia() {
+		return "", nil, errors.New("part is not media")
+	}
+	contentType := part.ContentType
+	if payload, ok := strings.CutPrefix(part.Text, "data:"); ok {
+		header, encoded, ok := strings.Cut(payload, ",")
+		if !ok {
+			return "", nil, errors.New("invalid media data URI")
+		}
+		if mediaType, _, ok := strings.Cut(header, ";"); ok && mediaType != "" {
+			contentType = mediaType
+		}
+		data, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return "", nil, err
+		}
+		return contentType, data, nil
+	}
+	return "", nil, errors.New("media part is not inline data")
+}
+
+func writePlayableAudio(path string, part *ai.Part) error {
+	contentType, data, err := decodeMediaData(part)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = contentType
+	}
+
+	switch strings.ToLower(mediaType) {
+	case "audio/l16":
+		return os.WriteFile(path, wavFromPCM(data, 1, 24000, 16), 0644)
+	default:
+		return os.WriteFile(path, data, 0644)
+	}
+}
+
+func firstAudioPart(resp *ai.ModelResponse) *ai.Part {
+	if resp == nil || resp.Message == nil {
+		return nil
+	}
+	for _, part := range resp.Message.Content {
+		if part.IsAudio() {
+			return part
+		}
+	}
+	return nil
+}
 
 func main() {
 	ctx := context.Background()
@@ -33,14 +127,18 @@ func main() {
 	// Config parameter, the Google AI plugin will get the API key from the
 	// GEMINI_API_KEY or GOOGLE_API_KEY environment variable, which is the recommended
 	// practice.
-	g := genkit.Init(ctx,
+	g1 := genkit.Init(ctx,
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
 		genkit.WithDefaultModel("googleai/gemini-2.5-flash-preview-tts"),
 	)
 
 	// Define a simple flow that generates an audio from a given text
-	genkit.DefineFlow(g, "text-to-speech-flow", func(ctx context.Context, input any) (string, error) {
-		resp, err := genkit.Generate(ctx, g,
+	genkit.DefineFlow(g1, "text-to-speech-flow", func(ctx context.Context, input *ttsInput) (string, error) {
+		prompt := "Say: Genkit is the best Gen AI library!"
+		if input != nil && input.Text != "" {
+			prompt = fmt.Sprintf("Say: %s", input.Text)
+		}
+		resp, err := genkit.Generate(ctx, g1,
 			ai.WithConfig(&genai.GenerateContentConfig{
 				Temperature:        genai.Ptr[float32](1.0),
 				ResponseModalities: []string{"AUDIO"},
@@ -52,18 +150,65 @@ func main() {
 					},
 				},
 			}),
-			ai.WithPrompt("Say: Genkit is the best Gen AI library!"))
+			ai.WithPrompt(prompt))
 		if err != nil {
 			return "", err
 		}
 
-		// base64 encoded audio
-		text := resp.Text()
-		return text, nil
+		// Inline audio is exposed as a data URI string.
+		return resp.Media(), nil
+	})
+
+	g2 := genkit.Init(ctx,
+		genkit.WithPlugins(&googlegenai.GoogleAI{}),
+		genkit.WithDefaultModel("googleai/gemini-3.1-flash-tts-preview"),
+	)
+
+	// Define a simple flow that generates an audio from input text
+	genkit.DefineFlow(g2, "text-to-speech-flow-with-gemini-3.1-model", func(ctx context.Context, input *ttsInput) (*ttsOutput, error) {
+		prompt := "Say: Genkit is the best Gen AI library!"
+		if input != nil && input.Text != "" {
+			prompt = fmt.Sprintf("Say: %s", input.Text)
+		}
+		resp, err := genkit.Generate(ctx, g2,
+			ai.WithConfig(&genai.GenerateContentConfig{
+				Temperature:        genai.Ptr[float32](1.0),
+				ResponseModalities: []string{"AUDIO"},
+				SpeechConfig: &genai.SpeechConfig{
+					VoiceConfig: &genai.VoiceConfig{
+						PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{
+							VoiceName: "Algenib",
+						},
+					},
+				},
+			}),
+			ai.WithPrompt(prompt))
+
+		if err != nil {
+			return nil, err
+		}
+
+		audio := firstAudioPart(resp)
+		if audio == nil {
+			return nil, errors.New("no audio part in response")
+		}
+
+		tmpFile, err := os.CreateTemp("", "genkit-tts-*.wav")
+		if err != nil {
+			return nil, err
+		}
+		path := tmpFile.Name()
+		tmpFile.Close()
+
+		if err := writePlayableAudio(path, audio); err != nil {
+			return nil, err
+		}
+
+		return &ttsOutput{AudioPath: path}, nil
 	})
 
 	// Define a simple flow that generates audio transcripts from a given audio
-	genkit.DefineFlow(g, "speech-to-text-flow", func(ctx context.Context, input any) (string, error) {
+	genkit.DefineFlow(g1, "speech-to-text-flow", func(ctx context.Context, input any) (string, error) {
 		audio, err := os.Open("./genkit.wav")
 		if err != nil {
 			return "", err
@@ -74,7 +219,7 @@ func main() {
 		if err != nil {
 			return "", err
 		}
-		resp, err := genkit.Generate(ctx, g,
+		resp, err := genkit.Generate(ctx, g1,
 			ai.WithModelName("googleai/gemini-2.5-flash"),
 			ai.WithMessages(ai.NewUserMessage(
 				ai.NewTextPart("Can you transcribe the next audio?"),

--- a/go/samples/text-to-speech/main.go
+++ b/go/samples/text-to-speech/main.go
@@ -127,18 +127,18 @@ func main() {
 	// Config parameter, the Google AI plugin will get the API key from the
 	// GEMINI_API_KEY or GOOGLE_API_KEY environment variable, which is the recommended
 	// practice.
-	g1 := genkit.Init(ctx,
+	g := genkit.Init(ctx,
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
 		genkit.WithDefaultModel("googleai/gemini-2.5-flash-preview-tts"),
 	)
 
 	// Define a simple flow that generates an audio from a given text
-	genkit.DefineFlow(g1, "text-to-speech-flow", func(ctx context.Context, input *ttsInput) (string, error) {
+	genkit.DefineFlow(g, "text-to-speech-flow", func(ctx context.Context, input *ttsInput) (string, error) {
 		prompt := "Say: Genkit is the best Gen AI library!"
 		if input != nil && input.Text != "" {
 			prompt = fmt.Sprintf("Say: %s", input.Text)
 		}
-		resp, err := genkit.Generate(ctx, g1,
+		resp, err := genkit.Generate(ctx, g,
 			ai.WithConfig(&genai.GenerateContentConfig{
 				Temperature:        genai.Ptr[float32](1.0),
 				ResponseModalities: []string{"AUDIO"},
@@ -159,18 +159,14 @@ func main() {
 		return resp.Media(), nil
 	})
 
-	g2 := genkit.Init(ctx,
-		genkit.WithPlugins(&googlegenai.GoogleAI{}),
-		genkit.WithDefaultModel("googleai/gemini-3.1-flash-tts-preview"),
-	)
-
 	// Define a simple flow that generates an audio from input text
-	genkit.DefineFlow(g2, "text-to-speech-flow-with-gemini-3.1-model", func(ctx context.Context, input *ttsInput) (*ttsOutput, error) {
+	genkit.DefineFlow(g, "text-to-speech-flow-with-gemini-3.1-model", func(ctx context.Context, input *ttsInput) (*ttsOutput, error) {
 		prompt := "Say: Genkit is the best Gen AI library!"
 		if input != nil && input.Text != "" {
 			prompt = fmt.Sprintf("Say: %s", input.Text)
 		}
-		resp, err := genkit.Generate(ctx, g2,
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModelName("googleai/gemini-3.1-flash-tts-preview"),
 			ai.WithConfig(&genai.GenerateContentConfig{
 				Temperature:        genai.Ptr[float32](1.0),
 				ResponseModalities: []string{"AUDIO"},
@@ -208,7 +204,7 @@ func main() {
 	})
 
 	// Define a simple flow that generates audio transcripts from a given audio
-	genkit.DefineFlow(g1, "speech-to-text-flow", func(ctx context.Context, input any) (string, error) {
+	genkit.DefineFlow(g, "speech-to-text-flow", func(ctx context.Context, input any) (string, error) {
 		audio, err := os.Open("./genkit.wav")
 		if err != nil {
 			return "", err
@@ -219,7 +215,7 @@ func main() {
 		if err != nil {
 			return "", err
 		}
-		resp, err := genkit.Generate(ctx, g1,
+		resp, err := genkit.Generate(ctx, g,
 			ai.WithModelName("googleai/gemini-2.5-flash"),
 			ai.WithMessages(ai.NewUserMessage(
 				ai.NewTextPart("Can you transcribe the next audio?"),


### PR DESCRIPTION
## Summary

Document the dedicated Gemini TTS models in the Go `googlegenai` plugin and add a sample showing how to use them, including the Gemini 3.1 PCM-to-WAV handling needed to produce playable output.

## Problem/Root Cause

The Go plugin exposed dedicated Gemini TTS model IDs, but the behavior and usage of those models were not documented. In particular, `gemini-3.1-flash-tts-preview` returns PCM audio rather than a directly playable WAV file, so users needed sample code showing how to decode the inline media response and wrap it in a WAV container.

## Solution/Changes

- Register the dedicated Gemini TTS models with TTS-specific capabilities in the Google AI model registry.
- Add tests covering model classification, declared capabilities, and Google AI-only registration.
- Expand the plugin README with TTS model documentation, usage examples, and a note describing the Gemini 3.1 PCM output behavior.
- Update the Go text-to-speech sample to:
  - return inline media for the Gemini 2.5 TTS flow
  - add a Gemini 3.1 flow that decodes inline PCM audio, converts it to WAV, and returns the generated file path

## Testing

- Added `go/plugins/googlegenai/tts_test.go` covering TTS model registration and capabilities.
- Ran `go test ./plugins/googlegenai/...`
- Ran `go build ./samples/text-to-speech`
