### PR TITLE
feat(go/plugins/googlegenai): add Imagen 4 model family for Google AI

### DIFF
--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -93,8 +93,11 @@ const (
 	gemini31FlashLitePreview  = "gemini-3.1-flash-lite-preview"
 	gemini31FlashImagePreview = "gemini-3.1-flash-image-preview"
 
-	imagen3Generate001     = "imagen-3.0-generate-001"
-	imagen3FastGenerate001 = "imagen-3.0-fast-generate-001"
+	imagen3Generate001       = "imagen-3.0-generate-001"
+	imagen3FastGenerate001   = "imagen-3.0-fast-generate-001"
+	imagen40FastGenerate001  = "imagen-4.0-fast-generate-001"
+	imagen40Generate001      = "imagen-4.0-generate-001"
+	imagen40UltraGenerate001 = "imagen-4.0-ultra-generate-001"
 
 	veo20Generate001         = "veo-2.0-generate-001"
 	veo30Generate001         = "veo-3.0-generate-001"
@@ -143,6 +146,10 @@ var (
 		gemini25Pro,
 		gemini31FlashLitePreview,
 		gemini31FlashImagePreview,
+
+		imagen40FastGenerate001,
+		imagen40Generate001,
+		imagen40UltraGenerate001,
 
 		veo20Generate001,
 		veo30Generate001,
@@ -209,6 +216,24 @@ var (
 		},
 		imagen3FastGenerate001: {
 			Label:    "Imagen 3 Fast Generate 001",
+			Versions: []string{},
+			Supports: &Media,
+			Stage:    ai.ModelStageStable,
+		},
+		imagen40FastGenerate001: {
+			Label:    "Imagen 4 Fast Generate 001",
+			Versions: []string{},
+			Supports: &Media,
+			Stage:    ai.ModelStageStable,
+		},
+		imagen40Generate001: {
+			Label:    "Imagen 4 Generate 001",
+			Versions: []string{},
+			Supports: &Media,
+			Stage:    ai.ModelStageStable,
+		},
+		imagen40UltraGenerate001: {
+			Label:    "Imagen 4 Ultra Generate 001",
 			Versions: []string{},
 			Supports: &Media,
 			Stage:    ai.ModelStageStable,

--- a/go/plugins/googlegenai/models_test.go
+++ b/go/plugins/googlegenai/models_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package googlegenai
+
+import (
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+)
+
+func TestImagen4ModelOptions(t *testing.T) {
+	tests := []struct {
+		name  string
+		label string
+	}{
+		{imagen40FastGenerate001, "Google AI - Imagen 4 Fast Generate 001"},
+		{imagen40Generate001, "Google AI - Imagen 4 Generate 001"},
+		{imagen40UltraGenerate001, "Google AI - Imagen 4 Ultra Generate 001"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyModel(tt.name); got != ModelTypeImagen {
+				t.Fatalf("ClassifyModel(%q) = %v, want %v", tt.name, got, ModelTypeImagen)
+			}
+
+			opts := GetModelOptions(tt.name, googleAIProvider)
+			if opts.Label != tt.label {
+				t.Fatalf("label = %q, want %q", opts.Label, tt.label)
+			}
+			if opts.Stage != ai.ModelStageStable {
+				t.Fatalf("stage = %v, want %v", opts.Stage, ai.ModelStageStable)
+			}
+			if opts.Supports != &Media {
+				t.Fatalf("supports = %#v, want Media", opts.Supports)
+			}
+			if opts.ConfigSchema == nil {
+				t.Fatal("ConfigSchema should be populated for Imagen 4")
+			}
+		})
+	}
+}
+
+func TestListModelsIncludesImagen4ForGoogleAI(t *testing.T) {
+	models, err := listModels(googleAIProvider)
+	if err != nil {
+		t.Fatalf("listModels(%q) error = %v", googleAIProvider, err)
+	}
+
+	for _, name := range []string{
+		imagen40FastGenerate001,
+		imagen40Generate001,
+		imagen40UltraGenerate001,
+	} {
+		if _, ok := models[name]; !ok {
+			t.Fatalf("Google AI models missing %q", name)
+		}
+	}
+}


### PR DESCRIPTION
Register the Imagen 4 models for the Google AI provider, matching the JS plugin's googleai/imagen.ts:

  - imagen-4.0-fast-generate-001
  - imagen-4.0-generate-001
  - imagen-4.0-ultra-generate-001

Closes: #5460 

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
