### PR TITLE
fix(tools): detect pubspec.yaml as a project root marker

### DIFF
--- a/genkit-tools/common/src/utils/utils.ts
+++ b/genkit-tools/common/src/utils/utils.ts
@@ -28,7 +28,9 @@ export interface DevToolsInfo {
 }
 
 /**
- * Finds the project root by looking for a `package.json` file.
+ * Finds the project root by walking up the directory tree looking for a file
+ * that marks the root of a supported runtime's project (for example
+ * `package.json` for JS or `pubspec.yaml` for Dart).
  */
 export async function findProjectRoot(): Promise<string> {
   const projectMarkers = [
@@ -38,6 +40,7 @@ export async function findProjectRoot(): Promise<string> {
     'requirements.txt',
     'pom.xml',
     'build.gradle',
+    'pubspec.yaml',
   ];
 
   let currentDir = process.cwd();

--- a/genkit-tools/common/tests/utils/utils_test.ts
+++ b/genkit-tools/common/tests/utils/utils_test.ts
@@ -14,10 +14,61 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from '@jest/globals';
-import { projectNameFromGenkitFilePath } from '../../src/utils';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  findProjectRoot,
+  projectNameFromGenkitFilePath,
+} from '../../src/utils';
 
 describe('utils', () => {
+  describe('findProjectRoot', () => {
+    let tmpDir: string;
+    let originalCwd: string;
+
+    beforeEach(() => {
+      originalCwd = process.cwd();
+      // realpathSync resolves symlinks (for example /var -> /private/var on
+      // macOS) so the temp paths match what process.cwd() reports.
+      tmpDir = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'genkit-find-root-'))
+      );
+    });
+
+    afterEach(() => {
+      process.chdir(originalCwd);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns the directory containing a pubspec.yaml', async () => {
+      const projectDir = path.join(tmpDir, 'dart-app');
+      const nestedDir = path.join(projectDir, 'lib', 'src');
+      fs.mkdirSync(nestedDir, { recursive: true });
+      fs.writeFileSync(path.join(projectDir, 'pubspec.yaml'), 'name: dart_app');
+
+      process.chdir(nestedDir);
+
+      expect(await findProjectRoot()).toEqual(projectDir);
+    });
+
+    it('returns the nearest project root when a Dart project is nested under a package.json', async () => {
+      // Mirrors a Dart project living inside a JS workspace or monorepo. The
+      // CLI should stop at the Dart project rather than climbing to the
+      // workspace package.json above it.
+      const workspaceDir = path.join(tmpDir, 'workspace');
+      const dartDir = path.join(workspaceDir, 'dart-app');
+      fs.mkdirSync(dartDir, { recursive: true });
+      fs.writeFileSync(path.join(workspaceDir, 'package.json'), '{}');
+      fs.writeFileSync(path.join(dartDir, 'pubspec.yaml'), 'name: dart_app');
+
+      process.chdir(dartDir);
+
+      expect(await findProjectRoot()).toEqual(dartDir);
+    });
+  });
+
   describe('projectNameFromGenkitFilePath', () => {
     it('returns unknown for empty string', () => {
       expect(projectNameFromGenkitFilePath('')).toEqual('unknown');


### PR DESCRIPTION
## Description

`findProjectRoot()` in `genkit-tools` did not include `pubspec.yaml` in its list of project markers. When a Dart Genkit project is nested under a directory that contains one of the recognized markers (most commonly a `package.json` from a JS workspace or monorepo), the CLI resolved the project root to that ancestor directory instead of the Dart project directory.

The Dev UI server then watched `<ancestor>/.genkit/runtimes`, but the Dart runtime resolves its own project root from `pubspec.yaml` and writes its runtime file to `<dart-project>/.genkit/runtimes`. The two directories differed, so the Dev UI never discovered the running runtime and stayed on "Waiting to connect to Genkit runtime..." even though the server was up and serving requests.

This adds `pubspec.yaml` to `projectMarkers` so the CLI agrees with the Dart runtime on the project root. Every other supported runtime already has its root marker in the list (`package.json`, `go.mod`, `pyproject.toml`, `requirements.txt`, `pom.xml`, `build.gradle`); Dart's was missing.

Fixes #5502

## Checklist

- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (added unit tests in `genkit-tools/common/tests/utils/utils_test.ts` covering resolution from a `pubspec.yaml` directory and the nested-under-`package.json` case)
- [ ] Docs updated (not required)
