### PR TITLE
feat(tools): include structured output in exported .prompt files

### DIFF
--- a/genkit-tools/common/src/server/router.ts
+++ b/genkit-tools/common/src/server/router.ts
@@ -30,7 +30,6 @@ import * as apis from '../types/apis';
 import { CancelActionRequestSchema } from '../types/apis';
 import type { EnvironmentVariable } from '../types/env';
 import * as evals from '../types/eval';
-import type { PromptFrontmatter } from '../types/prompt';
 import {
   PageViewEvent,
   SelectContentEvent,
@@ -39,7 +38,7 @@ import {
   recordRequestEvent,
 } from '../utils/analytics';
 import { toolsPackage } from '../utils/package';
-import { fromMessages } from '../utils/prompt';
+import { toPromptFile } from '../utils/prompt';
 
 const t = initTRPC.create({
   errorFormatter(opts) {
@@ -137,15 +136,7 @@ export const TOOLS_SERVER_ROUTER = (manager: BaseRuntimeManager) =>
     /** Generate a .prompt file from messages and model config. */
     createPrompt: loggedProcedure
       .input(apis.CreatePromptRequestSchema)
-      .mutation(async ({ input }) => {
-        const frontmatter: PromptFrontmatter = {
-          model: input.model.replace('/model/', ''),
-          config: input.config,
-          tools: input.tools?.map((toolDefinition) => toolDefinition.name),
-          use: input.use,
-        };
-        return fromMessages(frontmatter, input.messages);
-      }),
+      .mutation(async ({ input }) => toPromptFile(input)),
 
     /** Retrieves all traces for a given environment (e.g. dev or prod). */
     listTraces: loggedProcedure

--- a/genkit-tools/common/src/types/apis.ts
+++ b/genkit-tools/common/src/types/apis.ts
@@ -178,6 +178,25 @@ export const CreatePromptRequestSchema = z.object({
   config: GenerationCommonConfigSchema.passthrough().optional(),
   tools: z.array(ToolDefinitionSchema).optional(),
   use: z.array(MiddlewareRefSchema).optional(),
+  input: z
+    .object({
+      schema: z.unknown().optional(),
+      jsonSchema: z.unknown().optional(),
+      default: z.any().optional(),
+    })
+    .passthrough()
+    .optional(),
+  output: z
+    .object({
+      format: z.string().optional(),
+      // Resolved JSON Schema lives under jsonSchema for a generate action; a
+      // model request carries it under schema. Either is accepted.
+      jsonSchema: z.unknown().optional(),
+      schema: z.unknown().optional(),
+      contentType: z.string().optional(),
+    })
+    .passthrough()
+    .optional(),
 });
 
 export type CreatePromptRequest = z.infer<typeof CreatePromptRequestSchema>;

--- a/genkit-tools/common/src/utils/prompt.ts
+++ b/genkit-tools/common/src/utils/prompt.ts
@@ -18,7 +18,90 @@ import { stringify } from 'yaml';
 import type { MessageData, Part } from '../types/model';
 import type { PromptFrontmatter } from '../types/prompt';
 
-export function fromMessages(
+function toFrontmatterSchema(config?: {
+  schema?: unknown;
+  jsonSchema?: unknown;
+}): unknown | undefined {
+  const schema = config?.jsonSchema ?? config?.schema;
+  return schema && typeof schema === 'object' ? schema : undefined;
+}
+
+/**
+ * Maps a generate request's output config onto `.prompt` frontmatter. The
+ * frontmatter format is limited to json/text/media, so the JSON-producing
+ * formats (json, jsonl, array, enum) map onto `json`. Returns undefined when
+ * there is nothing to record.
+ */
+export function toFrontmatterOutput(output?: {
+  format?: string;
+  jsonSchema?: unknown;
+  schema?: unknown;
+}): PromptFrontmatter['output'] | undefined {
+  if (!output) return undefined;
+  const result: NonNullable<PromptFrontmatter['output']> = {};
+  if (output.format === 'text') {
+    result.format = 'text';
+  } else if (output.format === 'media') {
+    result.format = 'media';
+  } else if (output.format) {
+    result.format = 'json';
+  }
+  const schema = toFrontmatterSchema(output);
+  if (schema !== undefined) {
+    result.schema = schema;
+  }
+  return result.format || result.schema ? result : undefined;
+}
+
+/**
+ * Maps a request's input config onto `.prompt` frontmatter. Returns undefined
+ * when there is nothing to record.
+ */
+export function toFrontmatterInput(input?: {
+  schema?: unknown;
+  jsonSchema?: unknown;
+  default?: unknown;
+}): PromptFrontmatter['input'] | undefined {
+  if (!input) return undefined;
+  const result: NonNullable<PromptFrontmatter['input']> = {
+    schema: toFrontmatterSchema(input),
+    default: input.default,
+  };
+  return result.schema || result.default !== undefined ? result : undefined;
+}
+
+/**
+ * Converts a prompt creation request into a complete `.prompt` template file string.
+ */
+export function toPromptFile(request: {
+  model: string;
+  messages: MessageData[];
+  config?: Record<string, unknown>;
+  tools?: { name: string }[];
+  use?: PromptFrontmatter['use'];
+  input?: {
+    schema?: unknown;
+    jsonSchema?: unknown;
+    default?: unknown;
+  };
+  output?: {
+    format?: string;
+    jsonSchema?: unknown;
+    schema?: unknown;
+  };
+}): string {
+  const frontmatter: PromptFrontmatter = {
+    model: request.model.replace('/model/', ''),
+    config: request.config,
+    tools: request.tools?.map((toolDefinition) => toolDefinition.name),
+    use: request.use,
+    input: toFrontmatterInput(request.input),
+    output: toFrontmatterOutput(request.output),
+  };
+  return renderPromptFile(frontmatter, request.messages);
+}
+
+export function renderPromptFile(
   frontmatter: PromptFrontmatter,
   messages: MessageData[]
 ): string {

--- a/genkit-tools/common/tests/utils/prompt_test.ts
+++ b/genkit-tools/common/tests/utils/prompt_test.ts
@@ -16,10 +16,15 @@
 
 import { describe, expect, it } from '@jest/globals';
 import type { MessageData } from '../../src/types/model';
-import type { PromptFrontmatter } from '../../src/types/prompt';
-import { fromMessages } from '../../src/utils/prompt';
+import { PromptFrontmatter } from '../../src/types/prompt';
+import {
+  renderPromptFile,
+  toFrontmatterInput,
+  toFrontmatterOutput,
+  toPromptFile,
+} from '../../src/utils/prompt';
 
-describe('fromMessages', () => {
+describe('renderPromptFile', () => {
   it('builds a template from messages', () => {
     const frontmatter: PromptFrontmatter = {
       name: 'my-prompt',
@@ -51,7 +56,7 @@ describe('fromMessages', () => {
       '\n' +
       '{{role "model"}}\n' +
       'I am Oz -- the Great and Powerful.{{media url:https://example.com/image.jpg}}\n';
-    expect(fromMessages(frontmatter, messages)).toStrictEqual(expected);
+    expect(renderPromptFile(frontmatter, messages)).toStrictEqual(expected);
   });
 
   it('handles toolRequest by omitting the entire message', () => {
@@ -83,7 +88,7 @@ describe('fromMessages', () => {
       '\n' +
       '{{! message with role "user" omitted (toolRequest). }}\n';
 
-    expect(fromMessages(frontmatter, messages)).toStrictEqual(expected);
+    expect(renderPromptFile(frontmatter, messages)).toStrictEqual(expected);
   });
 
   it('omits messages entirely composed of unsupported parts', () => {
@@ -106,7 +111,7 @@ describe('fromMessages', () => {
       '\n' +
       '{{! message with role "model" omitted (toolResponse). }}\n';
 
-    expect(fromMessages(frontmatter, messages)).toStrictEqual(expected);
+    expect(renderPromptFile(frontmatter, messages)).toStrictEqual(expected);
   });
 
   it('omits messages composed of other unsupported parts with "unsupported content" reason', () => {
@@ -127,7 +132,7 @@ describe('fromMessages', () => {
       '\n' +
       '{{! message with role "model" omitted (unsupported content). }}\n';
 
-    expect(fromMessages(frontmatter, messages)).toStrictEqual(expected);
+    expect(renderPromptFile(frontmatter, messages)).toStrictEqual(expected);
   });
 
   it('handles mixed support messages without toolRequest by commenting parts', () => {
@@ -153,7 +158,7 @@ describe('fromMessages', () => {
       '{{role "user"}}\n' +
       'Here is data: {{! data part omitted }} and more text.\n';
 
-    expect(fromMessages(frontmatter, messages)).toStrictEqual(expected);
+    expect(renderPromptFile(frontmatter, messages)).toStrictEqual(expected);
   });
 
   it('recursively cleans empty objects and arrays from frontmatter', () => {
@@ -179,6 +184,110 @@ describe('fromMessages', () => {
       '  - name: fallback\n' +
       '---\n';
 
-    expect(fromMessages(frontmatter, messages)).toStrictEqual(expected);
+    expect(renderPromptFile(frontmatter, messages)).toStrictEqual(expected);
+  });
+});
+
+describe('toFrontmatterInput', () => {
+  const SCHEMA = {
+    type: 'object',
+    properties: { name: { type: 'string' } },
+  };
+
+  it('returns undefined when there is no input', () => {
+    expect(toFrontmatterInput(undefined)).toBeUndefined();
+  });
+
+  it('maps schema and default values', () => {
+    expect(
+      toFrontmatterInput({ schema: SCHEMA, default: { name: 'World' } })
+    ).toEqual({
+      schema: SCHEMA,
+      default: { name: 'World' },
+    });
+  });
+});
+
+describe('toFrontmatterOutput', () => {
+  const SCHEMA = {
+    type: 'object',
+    properties: { title: { type: 'string' } },
+    required: ['title'],
+  };
+
+  it('returns undefined when there is no output', () => {
+    expect(toFrontmatterOutput(undefined)).toBeUndefined();
+  });
+
+  it('reads the schema from jsonSchema and maps json formats', () => {
+    expect(toFrontmatterOutput({ format: 'json', jsonSchema: SCHEMA })).toEqual(
+      { format: 'json', schema: SCHEMA }
+    );
+  });
+
+  it('reads the schema from the schema field (model request shape)', () => {
+    expect(toFrontmatterOutput({ format: 'json', schema: SCHEMA })).toEqual({
+      format: 'json',
+      schema: SCHEMA,
+    });
+  });
+
+  it('maps json-producing formats onto json', () => {
+    expect(
+      toFrontmatterOutput({ format: 'jsonl', jsonSchema: SCHEMA })?.format
+    ).toBe('json');
+  });
+
+  it('keeps the text format', () => {
+    expect(toFrontmatterOutput({ format: 'text' })).toEqual({ format: 'text' });
+  });
+
+  it('keeps the media format', () => {
+    expect(toFrontmatterOutput({ format: 'media' })).toEqual({
+      format: 'media',
+    });
+  });
+});
+
+describe('toPromptFile', () => {
+  it('converts a request object into a .prompt template string', () => {
+    const request = {
+      model: '/model/googleai/gemini-pro',
+      config: { temperature: 0.7 },
+      tools: [{ name: 'getWeather' }],
+      messages: [{ role: 'user' as const, content: [{ text: 'Hello' }] }],
+      input: {
+        schema: { type: 'object', properties: { name: { type: 'string' } } },
+      },
+      output: {
+        format: 'json',
+        schema: { type: 'object', properties: { answer: { type: 'string' } } },
+      },
+    };
+    const expected =
+      '---\n' +
+      'model: googleai/gemini-pro\n' +
+      'config:\n' +
+      '  temperature: 0.7\n' +
+      'tools:\n' +
+      '  - getWeather\n' +
+      'input:\n' +
+      '  schema:\n' +
+      '    type: object\n' +
+      '    properties:\n' +
+      '      name:\n' +
+      '        type: string\n' +
+      'output:\n' +
+      '  format: json\n' +
+      '  schema:\n' +
+      '    type: object\n' +
+      '    properties:\n' +
+      '      answer:\n' +
+      '        type: string\n' +
+      '---\n' +
+      '\n' +
+      '{{role "user"}}\n' +
+      'Hello\n';
+    expect(toPromptFile(request)).toStrictEqual(expected);
   });
 });


### PR DESCRIPTION
## Summary

This is the **server-side counterpart** to the editable output config added to the model runner in **genkit-ai/genkit-ui#1919**. That PR lets you set structured output in the Dev UI model runner; this PR makes the **Export to `.prompt`** action actually include it.

> Linked PR: https://github.com/genkit-ai/genkit-ui/pull/1919

Previously `createPrompt` dropped the generation's `output` config entirely, so a flow that used structured output lost its schema when exported. The exported front matter now includes the output, with the JSON Schema written as **Picoschema**.

### Before
```yaml
---
model: googleai/gemini-flash-latest
config:
  temperature: 0.7
---
```

### After
```yaml
---
model: googleai/gemini-flash-latest
config:
  temperature: 0.7
output:
  format: json
  schema:
    title: string
    servings: integer, number of servings
    ingredients(array):
      name: string
      onSale: boolean
    steps(array): string
---
```

## What changed

- **`CreatePromptRequestSchema`** now accepts `output` (it was being stripped by tRPC input validation before reaching the frontmatter).
- **`createPrompt`** maps the output config onto the frontmatter, reading the schema from `jsonSchema` (generate action shape) or `schema` (model request shape), and mapping the JSON-producing formats (`json`, `jsonl`, `array`, `enum`) onto `json`.
- **`jsonSchemaToPicoschema`** converts an object JSON Schema into the compact Picoschema form: required/optional (`?`), descriptions, enums, scalar and object arrays, nested objects, and `additionalProperties` wildcards. Non-object top-level schemas (a bare array or scalar) pass through as raw JSON Schema, which Dotprompt also accepts.

## Testing

- Unit tests in `genkit-tools/common/tests/utils/prompt_test.ts` cover the converter and the frontmatter mapping (15 cases).
- Verified end to end against a running Dev UI: exporting a structured-output prompt from the model runner now produces the Picoschema `output` block above.

## Notes

- The frontmatter `format` field is limited to `json`/`text`/`media`, so `jsonl`/`array`/`enum` export as `format: json` with the schema preserved. Exact format fidelity could be a follow-up.

## Checklist

- [x] PR title follows https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (unit tests + end-to-end via the Dev UI export)
- [ ] Docs updated (not required)