### PR TITLE
chore(py): add django and middleware plugins to python publish list

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -54,13 +54,15 @@ jobs:
             py/packages/genkit
             py/plugins/anthropic
             py/plugins/compat-oai
-            py/plugins/google-cloud
-            py/plugins/google-genai
-            py/plugins/ollama
+            py/plugins/django
+            py/plugins/evaluators
             py/plugins/fastapi
             py/plugins/flask
+            py/plugins/google-cloud
+            py/plugins/google-genai
+            py/plugins/middleware
+            py/plugins/ollama
             py/plugins/vertex-ai
-            py/plugins/evaluators
           )
 
           FAILED=()


### PR DESCRIPTION
This PR adds the newly created django and middleware plugins to the PyPI auto-publishing workflow list.