### PR TITLE
feat(go/plugins/googlegenai): register gemma-4 models for Google AI

### DIFF
--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -169,6 +169,8 @@ func generate(
 		return nil, err
 	}
 
+	isGemma := isGemmaModelName(model)
+
 	var contents []*genai.Content
 	for _, m := range input.Messages {
 		// system parts are handled separately
@@ -176,7 +178,20 @@ func generate(
 			continue
 		}
 
-		parts, err := toGeminiParts(m.Content)
+		content := m.Content
+		if isGemma {
+			// Gemma does not accept previous thoughts; strip reasoning parts and
+			// any part carrying a thought signature before sending (mirrors the JS
+			// google-genai plugin).
+			content = stripGemmaThoughts(content)
+			// Skip a turn that was entirely thoughts: emitting an empty content
+			// block can be rejected by the API. (Go-side guard; JS leaves it.)
+			if len(content) == 0 {
+				continue
+			}
+		}
+
+		parts, err := toGeminiParts(content)
 		if err != nil {
 			return nil, err
 		}
@@ -413,6 +428,44 @@ func hasSpeechVoiceConfig(sc *genai.SpeechConfig) bool {
 
 func isTTSModelName(name string) bool {
 	return strings.Contains(strings.TrimPrefix(name, "googleai/"), "-tts")
+}
+
+// isGemmaModelName reports whether the model is a Gemma model.
+func isGemmaModelName(name string) bool {
+	return strings.HasPrefix(strings.TrimPrefix(name, "googleai/"), "gemma")
+}
+
+// gemmaConfigSchema returns the standard Gemini config schema with the
+// temperature property clamped to [0, 1], matching the JS GemmaConfigSchema
+// (Gemma's valid temperature range is narrower than Gemini's 0-2).
+func gemmaConfigSchema() map[string]any {
+	schema := configToMap(genai.GenerateContentConfig{})
+	if props, ok := schema["properties"].(map[string]any); ok {
+		if temp, ok := props["temperature"].(map[string]any); ok {
+			temp["minimum"] = 0.0
+			temp["maximum"] = 1.0
+		}
+	}
+	return schema
+}
+
+// stripGemmaThoughts removes reasoning parts, and any part carrying a thought
+// signature, from a message's content. Gemma rejects previous thoughts, so they
+// must not be sent back on follow-up turns (mirrors the JS google-genai plugin).
+func stripGemmaThoughts(parts []*ai.Part) []*ai.Part {
+	out := make([]*ai.Part, 0, len(parts))
+	for _, p := range parts {
+		if p.IsReasoning() {
+			continue
+		}
+		if p.Metadata != nil {
+			if _, ok := p.Metadata["signature"]; ok {
+				continue
+			}
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 // translateCandidate translates from a genai.GenerateContentResponse to an ai.ModelResponse.

--- a/go/plugins/googlegenai/gemma_live_test.go
+++ b/go/plugins/googlegenai/gemma_live_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package googlegenai_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+)
+
+// To run against the live Google AI API:
+//
+//	GEMINI_API_KEY=... go test ./plugins/googlegenai/ -run TestGemmaLive -v
+//
+// Skipped automatically when no key is present.
+func TestGemmaLive(t *testing.T) {
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		apiKey = os.Getenv("GOOGLE_API_KEY")
+	}
+	if apiKey == "" {
+		t.Skip("no gemini api key provided, set GEMINI_API_KEY or GOOGLE_API_KEY in environment")
+	}
+
+	ctx := context.Background()
+	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{APIKey: apiKey}))
+
+	// The two known Gemma models registered for Google AI.
+	for _, name := range []string{"gemma-4-31b-it", "gemma-4-26b-a4b-it"} {
+		t.Run(name, func(t *testing.T) {
+			m := googlegenai.GoogleAIModel(g, name)
+
+			resp, err := genkit.Generate(ctx, g,
+				ai.WithModel(m),
+				ai.WithPrompt("Reply with exactly the word: pong"),
+			)
+			if err != nil {
+				t.Fatalf("generate: %v", err)
+			}
+			out := resp.Text()
+			t.Logf("%s response: %q", name, out)
+			if strings.TrimSpace(out) == "" {
+				t.Fatal("empty response text")
+			}
+			if resp.Usage != nil {
+				t.Logf("%s usage: input=%d output=%d total=%d",
+					name, resp.Usage.InputTokens, resp.Usage.OutputTokens, resp.Usage.TotalTokens)
+			}
+		})
+	}
+
+	// Multi-turn: a prior assistant turn that carries reasoning content must not
+	// break Gemma, because reasoning is stripped before the request is sent.
+	t.Run("multi-turn strips prior reasoning", func(t *testing.T) {
+		m := googlegenai.GoogleAIModel(g, "gemma-4-31b-it")
+
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithMessages(
+				ai.NewUserMessage(ai.NewTextPart("My favourite colour is teal. Remember it.")),
+				ai.NewModelMessage(
+					ai.NewReasoningPart("The user told me their favourite colour is teal.", []byte("sig")),
+					ai.NewTextPart("Got it."),
+				),
+				ai.NewUserMessage(ai.NewTextPart("What is my favourite colour? One word.")),
+			),
+		)
+		if err != nil {
+			t.Fatalf("multi-turn generate (reasoning should have been stripped): %v", err)
+		}
+		t.Logf("multi-turn response: %q", resp.Text())
+	})
+
+	// Exercises the tools capability we now advertise (Gemma 4 supports function
+	// calling per its model card). A made-up return value the model cannot guess
+	// proves the tool was actually invoked through Go's path.
+	t.Run("tool calling", func(t *testing.T) {
+		m := googlegenai.GoogleAIModel(g, "gemma-4-31b-it")
+
+		secretTool := genkit.DefineTool(g, "gemmaSecretNumber",
+			"returns the secret number associated with a given name",
+			func(ctx *ai.ToolContext, input struct {
+				Name string `json:"name"`
+			}) (int, error) {
+				return 4242, nil
+			},
+		)
+
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithTools(secretTool),
+			ai.WithPrompt("Use the tool to get the secret number for the name 'genkit', then reply with just that number."),
+		)
+		if err != nil {
+			t.Fatalf("tool-calling generate: %v", err)
+		}
+		out := resp.Text()
+		t.Logf("tool-calling response: %q", out)
+		if !strings.Contains(out, "4242") {
+			t.Errorf("expected the tool's value 4242 in the response, got %q (tool may not have been invoked)", out)
+		}
+	})
+
+	// Exercises the systemRole capability we now advertise. With systemRole=true
+	// the system message flows natively (no simulateSystemPrompt rewrite).
+	t.Run("native system prompt", func(t *testing.T) {
+		m := googlegenai.GoogleAIModel(g, "gemma-4-31b-it")
+
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithSystem("Respond with only the single word BANANA and nothing else, regardless of the question."),
+			ai.WithPrompt("Say hello."),
+		)
+		if err != nil {
+			t.Fatalf("system-prompt generate: %v", err)
+		}
+		out := resp.Text()
+		t.Logf("system-prompt response: %q", out)
+		if !strings.Contains(strings.ToUpper(out), "BANANA") {
+			t.Errorf("system instruction not honoured: response %q does not contain BANANA", out)
+		}
+	})
+
+	// Exercises the constrained-output capability (Constrained: All). JS advertises
+	// constrained 'all' for Gemma; this confirms native structured output works.
+	t.Run("constrained json output", func(t *testing.T) {
+		m := googlegenai.GoogleAIModel(g, "gemma-4-31b-it")
+
+		type capital struct {
+			Country string `json:"country"`
+			City    string `json:"city"`
+		}
+
+		out, _, err := genkit.GenerateData[capital](ctx, g,
+			ai.WithModel(m),
+			ai.WithPrompt("What is the capital of Japan? Respond as JSON with fields country and city."),
+		)
+		if err != nil {
+			t.Fatalf("constrained generate: %v", err)
+		}
+		t.Logf("constrained output: %+v", out)
+		if !strings.EqualFold(out.City, "Tokyo") {
+			t.Errorf("city = %q, want Tokyo", out.City)
+		}
+	})
+
+	// Exercises the media-input capability (Media: true). A generated solid-red
+	// image should be identified, confirming Gemma accepts image input via Go.
+	t.Run("media input", func(t *testing.T) {
+		m := googlegenai.GoogleAIModel(g, "gemma-4-31b-it")
+
+		img := image.NewRGBA(image.Rect(0, 0, 16, 16))
+		for y := 0; y < 16; y++ {
+			for x := 0; x < 16; x++ {
+				img.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+			}
+		}
+		var buf bytes.Buffer
+		if err := png.Encode(&buf, img); err != nil {
+			t.Fatalf("encode png: %v", err)
+		}
+		dataURI := "data:image/png;base64," + base64.StdEncoding.EncodeToString(buf.Bytes())
+
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithModel(m),
+			ai.WithMessages(ai.NewUserMessage(
+				ai.NewTextPart("What single colour dominates this image? Reply with just the colour name."),
+				ai.NewMediaPart("image/png", dataURI),
+			)),
+		)
+		if err != nil {
+			t.Fatalf("media generate: %v", err)
+		}
+		out := resp.Text()
+		t.Logf("media response: %q", out)
+		if !strings.Contains(strings.ToLower(out), "red") {
+			t.Errorf("expected the model to identify red, got %q", out)
+		}
+	})
+}

--- a/go/plugins/googlegenai/gemma_test.go
+++ b/go/plugins/googlegenai/gemma_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package googlegenai
+
+import (
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+)
+
+func TestIsGemmaModelName(t *testing.T) {
+	cases := map[string]bool{
+		"gemma-4-31b-it":            true,
+		"gemma-4-26b-a4b-it":        true,
+		"googleai/gemma-4-31b-it":   true,
+		"gemini-2.5-flash":          false,
+		"googleai/gemini-2.5-flash": false,
+		"imagen-4.0-generate-001":   false,
+	}
+	for name, want := range cases {
+		if got := isGemmaModelName(name); got != want {
+			t.Errorf("isGemmaModelName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestGemmaConfigSchemaClampsTemperature(t *testing.T) {
+	schema := gemmaConfigSchema()
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema has no properties map: %v", schema)
+	}
+	temp, ok := props["temperature"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema has no temperature property: %v", props["temperature"])
+	}
+	if temp["maximum"] != 1.0 {
+		t.Errorf("temperature maximum = %v, want 1.0", temp["maximum"])
+	}
+	if temp["minimum"] != 0.0 {
+		t.Errorf("temperature minimum = %v, want 0.0", temp["minimum"])
+	}
+}
+
+func TestUnregisteredGemmaModelGetsClamp(t *testing.T) {
+	// A gemma model that is not individually registered should still get the
+	// temperature clamp, matching the JS wildcard (gemma-${string}) behavior.
+	opts := GetModelOptions("gemma-5-future-it", googleAIProvider)
+	props, ok := opts.ConfigSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("no properties in schema for unregistered gemma model")
+	}
+	temp, ok := props["temperature"].(map[string]any)
+	if !ok {
+		t.Fatalf("no temperature property for unregistered gemma model")
+	}
+	if temp["maximum"] != 1.0 {
+		t.Errorf("temperature maximum = %v, want 1.0 (clamp should apply to all gemma)", temp["maximum"])
+	}
+}
+
+func TestStripGemmaThoughts(t *testing.T) {
+	keep := ai.NewTextPart("keep me")
+
+	withSig := ai.NewTextPart("has a thought signature")
+	withSig.Metadata = map[string]any{"signature": []byte("sig")}
+
+	parts := []*ai.Part{
+		keep,
+		ai.NewReasoningPart("secret reasoning", []byte("sig")),
+		withSig,
+		ai.NewTextPart("also keep"),
+	}
+
+	got := stripGemmaThoughts(parts)
+
+	if len(got) != 2 {
+		t.Fatalf("stripped to %d parts, want 2: %+v", len(got), got)
+	}
+	if got[0].Text != "keep me" || got[1].Text != "also keep" {
+		t.Errorf("unexpected surviving parts: %q, %q", got[0].Text, got[1].Text)
+	}
+	for _, p := range got {
+		if p.IsReasoning() {
+			t.Error("reasoning part survived the strip")
+		}
+		if p.Metadata != nil {
+			if _, ok := p.Metadata["signature"]; ok {
+				t.Error("part carrying a thought signature survived the strip")
+			}
+		}
+	}
+
+	// An all-thoughts turn strips to empty; the generate path skips such turns
+	// rather than send an empty content block.
+	allThoughts := stripGemmaThoughts([]*ai.Part{
+		ai.NewReasoningPart("only a thought", []byte("sig")),
+	})
+	if len(allThoughts) != 0 {
+		t.Errorf("all-thoughts content stripped to %d parts, want 0", len(allThoughts))
+	}
+}

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -34,17 +34,6 @@ var (
 		Constrained: ai.ConstrainedSupportAll,
 	}
 
-	// GemmaSupports describes model capabilities for Gemma models. Unlike
-	// Gemini, Gemma models do not support a system role or tool calling.
-	GemmaSupports = ai.ModelSupports{
-		Multiturn:   true,
-		Tools:       false,
-		ToolChoice:  false,
-		SystemRole:  false,
-		Media:       true,
-		Constrained: ai.ConstrainedSupportNoTools,
-	}
-
 	// Media describes model capabilities for image generation models (Imagen).
 	Media = ai.ModelSupports{
 		Multiturn:  false,
@@ -299,16 +288,20 @@ var (
 			Supports: &TTSSupports,
 			Stage:    ai.ModelStageUnstable,
 		},
+		// Gemma reuses the standard Gemini capabilities, matching the JS
+		// google-genai plugin. The Gemma-specific behavior (temperature clamped to
+		// [0, 1] via gemmaConfigSchema, applied by name in GetModelOptions; and
+		// stripping prior thoughts in the generate path) is not expressed here.
 		gemma426bA4bIT: {
 			Label:    "Gemma 4 26B",
 			Versions: []string{},
-			Supports: &GemmaSupports,
+			Supports: &Multimodal,
 			Stage:    ai.ModelStageStable,
 		},
 		gemma431bIT: {
 			Label:    "Gemma 4 31B",
 			Versions: []string{},
-			Supports: &GemmaSupports,
+			Supports: &Multimodal,
 			Stage:    ai.ModelStageStable,
 		},
 	}
@@ -489,6 +482,12 @@ func GetModelOptions(name, provider string) ai.ModelOptions {
 		if cfg := mt.DefaultConfig(); cfg != nil {
 			opts.ConfigSchema = configToMap(cfg)
 		}
+	}
+
+	// All gemma-* models clamp temperature to [0, 1] (matches the JS
+	// GemmaConfigSchema), whether or not they are individually registered.
+	if isGemmaModelName(name) {
+		opts.ConfigSchema = gemmaConfigSchema()
 	}
 
 	// Set label with provider prefix

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -34,6 +34,17 @@ var (
 		Constrained: ai.ConstrainedSupportAll,
 	}
 
+	// GemmaSupports describes model capabilities for Gemma models. Unlike
+	// Gemini, Gemma models do not support a system role or tool calling.
+	GemmaSupports = ai.ModelSupports{
+		Multiturn:   true,
+		Tools:       false,
+		ToolChoice:  false,
+		SystemRole:  false,
+		Media:       true,
+		Constrained: ai.ConstrainedSupportNoTools,
+	}
+
 	// Media describes model capabilities for image generation models (Imagen).
 	Media = ai.ModelSupports{
 		Multiturn:  false,
@@ -116,6 +127,9 @@ const (
 	gemini25ProPreviewTTS   = "gemini-2.5-pro-preview-tts"
 	gemini31FlashTTSPreview = "gemini-3.1-flash-tts-preview"
 
+	gemma426bA4bIT = "gemma-4-26b-a4b-it"
+	gemma431bIT    = "gemma-4-31b-it"
+
 	imagen3Generate001       = "imagen-3.0-generate-001"
 	imagen3FastGenerate001   = "imagen-3.0-fast-generate-001"
 	imagen40FastGenerate001  = "imagen-4.0-fast-generate-001"
@@ -185,6 +199,9 @@ var (
 		gemini25FlashPreviewTTS,
 		gemini25ProPreviewTTS,
 		gemini31FlashTTSPreview,
+
+		gemma426bA4bIT,
+		gemma431bIT,
 
 		veo20Generate001,
 		veo30Generate001,
@@ -281,6 +298,18 @@ var (
 			Versions: []string{},
 			Supports: &TTSSupports,
 			Stage:    ai.ModelStageUnstable,
+		},
+		gemma426bA4bIT: {
+			Label:    "Gemma 4 26B",
+			Versions: []string{},
+			Supports: &GemmaSupports,
+			Stage:    ai.ModelStageStable,
+		},
+		gemma431bIT: {
+			Label:    "Gemma 4 31B",
+			Versions: []string{},
+			Supports: &GemmaSupports,
+			Stage:    ai.ModelStageStable,
 		},
 	}
 

--- a/go/plugins/googlegenai/models_test.go
+++ b/go/plugins/googlegenai/models_test.go
@@ -92,7 +92,10 @@ func TestNewGeminiModelsResolveToRegisteredEntries(t *testing.T) {
 }
 
 // gemmaModels are the concrete Gemma models registered for Google AI. They are
-// classified as Gemini-family by prefix but carry Gemma-specific capabilities.
+// classified as Gemini-family by prefix and, matching the JS google-genai
+// plugin, advertise the standard Gemini capabilities (Gemma 4 supports tools and
+// system instructions). Gemma-specific behavior is the temperature clamp and the
+// stripping of prior thoughts in the generate path.
 var gemmaModels = []string{gemma426bA4bIT, gemma431bIT}
 
 func TestGemmaModelsClassifyAsGemini(t *testing.T) {
@@ -110,22 +113,32 @@ func TestGemmaModelOptions(t *testing.T) {
 		if opts.Supports == nil {
 			t.Fatalf("GetModelOptions(%q): Supports is nil", name)
 		}
-		// Gemma differs from Gemini: no system role and no tool calling.
-		if opts.Supports.SystemRole {
-			t.Errorf("GetModelOptions(%q): SystemRole = true, want false", name)
+		// Gemma advertises the standard Gemini capabilities (matches JS).
+		if !opts.Supports.SystemRole {
+			t.Errorf("GetModelOptions(%q): SystemRole = false, want true", name)
 		}
-		if opts.Supports.Tools {
-			t.Errorf("GetModelOptions(%q): Tools = true, want false", name)
+		if !opts.Supports.Tools {
+			t.Errorf("GetModelOptions(%q): Tools = false, want true", name)
 		}
-		if opts.Supports.ToolChoice {
-			t.Errorf("GetModelOptions(%q): ToolChoice = true, want false", name)
+		if !opts.Supports.ToolChoice {
+			t.Errorf("GetModelOptions(%q): ToolChoice = false, want true", name)
 		}
 		if !opts.Supports.Multiturn {
 			t.Errorf("GetModelOptions(%q): Multiturn = false, want true", name)
 		}
-		// Registered (not the unknown-model fallback), so a config schema is set.
+		if !opts.Supports.Media {
+			t.Errorf("GetModelOptions(%q): Media = false, want true", name)
+		}
+		// Registered (not the unknown-model fallback), so a config schema is set,
+		// and it carries the Gemma temperature clamp (applied by name).
 		if opts.ConfigSchema == nil {
 			t.Errorf("GetModelOptions(%q): ConfigSchema is nil", name)
+		} else if props, ok := opts.ConfigSchema["properties"].(map[string]any); ok {
+			if temp, ok := props["temperature"].(map[string]any); ok {
+				if temp["maximum"] != 1.0 {
+					t.Errorf("GetModelOptions(%q): temperature maximum = %v, want 1.0 (Gemma clamp)", name, temp["maximum"])
+				}
+			}
 		}
 	}
 }

--- a/go/plugins/googlegenai/models_test.go
+++ b/go/plugins/googlegenai/models_test.go
@@ -91,6 +91,45 @@ func TestNewGeminiModelsResolveToRegisteredEntries(t *testing.T) {
 	}
 }
 
+// gemmaModels are the concrete Gemma models registered for Google AI. They are
+// classified as Gemini-family by prefix but carry Gemma-specific capabilities.
+var gemmaModels = []string{gemma426bA4bIT, gemma431bIT}
+
+func TestGemmaModelsClassifyAsGemini(t *testing.T) {
+	for _, name := range gemmaModels {
+		if got := ClassifyModel(name); got != ModelTypeGemini {
+			t.Errorf("ClassifyModel(%q) = %v, want ModelTypeGemini", name, got)
+		}
+	}
+}
+
+func TestGemmaModelOptions(t *testing.T) {
+	for _, name := range gemmaModels {
+		opts := GetModelOptions(name, googleAIProvider)
+
+		if opts.Supports == nil {
+			t.Fatalf("GetModelOptions(%q): Supports is nil", name)
+		}
+		// Gemma differs from Gemini: no system role and no tool calling.
+		if opts.Supports.SystemRole {
+			t.Errorf("GetModelOptions(%q): SystemRole = true, want false", name)
+		}
+		if opts.Supports.Tools {
+			t.Errorf("GetModelOptions(%q): Tools = true, want false", name)
+		}
+		if opts.Supports.ToolChoice {
+			t.Errorf("GetModelOptions(%q): ToolChoice = true, want false", name)
+		}
+		if !opts.Supports.Multiturn {
+			t.Errorf("GetModelOptions(%q): Multiturn = false, want true", name)
+		}
+		// Registered (not the unknown-model fallback), so a config schema is set.
+		if opts.ConfigSchema == nil {
+			t.Errorf("GetModelOptions(%q): ConfigSchema is nil", name)
+		}
+	}
+}
+
 // TestNewGeminiModelsProviderSplit pins the per-provider registration from the
 // ticket: GoogleAI gets all except gemini-3.1-flash-lite; VertexAI gets all four.
 func TestNewGeminiModelsProviderSplit(t *testing.T) {
@@ -133,6 +172,17 @@ func TestGeminiEmbedding2Registered(t *testing.T) {
 	for _, want := range []string{"text", "image", "video"} {
 		if !slices.Contains(opts.Supports.Input, want) {
 			t.Errorf("GetEmbedderOptions(%q): Input missing %q, got %v", geminiEmbedding2, want, opts.Supports.Input)
+		}
+	}
+}
+
+func TestGemmaModelsRegisteredForGoogleAIOnly(t *testing.T) {
+	for _, name := range gemmaModels {
+		if !slices.Contains(googleAIModels, name) {
+			t.Errorf("googleAIModels missing %q", name)
+		}
+		if slices.Contains(vertexAIModels, name) {
+			t.Errorf("vertexAIModels should not contain %q (Gemma is Google AI only)", name)
 		}
 	}
 }


### PR DESCRIPTION
This PR registers gemma-4 models for Google AI. This addition went through a series of tests.

Closes: #5466 

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)

