### PR TITLE
feat(go/plugins/googlegenai): register gemini-3.* and gemini-embedding-2

### DIFF
--- a/go/plugins/googlegenai/model_type.go
+++ b/go/plugins/googlegenai/model_type.go
@@ -30,11 +30,13 @@ func ClassifyModel(name string) ModelType {
 		return ModelTypeVeo
 	case strings.HasPrefix(name, "imagen"), strings.HasPrefix(name, "image"):
 		return ModelTypeImagen
+	case strings.Contains(name, "embedding"):
+		// Covers: text-embedding-*, embedding-*, textembedding-*,
+		// multimodalembedding, gemini-embedding-*. Checked before the gemini
+		// prefix so gemini-embedding-* classifies as an embedder, not a model.
+		return ModelTypeEmbedder
 	case strings.HasPrefix(name, "gemini"), strings.HasPrefix(name, "gemma"):
 		return ModelTypeGemini
-	case strings.Contains(name, "embedding"):
-		// Covers: text-embedding-*, embedding-*, textembedding-*, multimodalembedding
-		return ModelTypeEmbedder
 	default:
 		return ModelTypeUnknown
 	}

--- a/go/plugins/googlegenai/models.go
+++ b/go/plugins/googlegenai/models.go
@@ -93,6 +93,11 @@ const (
 	gemini31FlashLitePreview  = "gemini-3.1-flash-lite-preview"
 	gemini31FlashImagePreview = "gemini-3.1-flash-image-preview"
 
+	gemini35Flash      = "gemini-3.5-flash"
+	gemini31FlashLite  = "gemini-3.1-flash-lite"
+	gemini31FlashImage = "gemini-3.1-flash-image"
+	gemini3ProImage    = "gemini-3-pro-image"
+
 	imagen3Generate001       = "imagen-3.0-generate-001"
 	imagen3FastGenerate001   = "imagen-3.0-fast-generate-001"
 	imagen40FastGenerate001  = "imagen-4.0-fast-generate-001"
@@ -114,6 +119,7 @@ const (
 	textembeddinggeckomultilingual001 = "textembedding-gecko-multilingual@001"
 	textmultilingualembedding002      = "text-multilingual-embedding-002"
 	multimodalembedding               = "multimodalembedding"
+	geminiEmbedding2                  = "gemini-embedding-2"
 )
 
 var (
@@ -127,6 +133,10 @@ var (
 		gemini25Pro,
 		gemini31FlashLitePreview,
 		gemini31FlashImagePreview,
+		gemini35Flash,
+		gemini31FlashLite,
+		gemini31FlashImage,
+		gemini3ProImage,
 
 		imagen3Generate001,
 		imagen3FastGenerate001,
@@ -146,6 +156,9 @@ var (
 		gemini25Pro,
 		gemini31FlashLitePreview,
 		gemini31FlashImagePreview,
+		gemini35Flash,
+		gemini31FlashImage,
+		gemini3ProImage,
 
 		imagen40FastGenerate001,
 		imagen40Generate001,
@@ -204,6 +217,30 @@ var (
 			Versions: []string{},
 			Supports: &Multimodal,
 			Stage:    ai.ModelStageUnstable,
+		},
+		gemini35Flash: {
+			Label:    "Gemini 3.5 Flash",
+			Versions: []string{},
+			Supports: &Multimodal,
+			Stage:    ai.ModelStageStable,
+		},
+		gemini31FlashLite: {
+			Label:    "Gemini 3.1 Flash Lite",
+			Versions: []string{},
+			Supports: &Multimodal,
+			Stage:    ai.ModelStageStable,
+		},
+		gemini31FlashImage: {
+			Label:    "Gemini 3.1 Flash Image",
+			Versions: []string{},
+			Supports: &Multimodal,
+			Stage:    ai.ModelStageStable,
+		},
+		gemini3ProImage: {
+			Label:    "Gemini 3 Pro Image",
+			Versions: []string{},
+			Supports: &Multimodal,
+			Stage:    ai.ModelStageStable,
 		},
 	}
 
@@ -331,6 +368,17 @@ var (
 		multimodalembedding: {
 			Dimensions: 768,
 			Label:      "Google Gen AI - Text Embedding Gecko (Legacy)",
+			Supports: &ai.EmbedderSupports{
+				Input: []string{
+					"text",
+					"image",
+					"video",
+				},
+			},
+		},
+		geminiEmbedding2: {
+			Dimensions: 3072,
+			Label:      "Gemini Embedding 2",
 			Supports: &ai.EmbedderSupports{
 				Input: []string{
 					"text",

--- a/go/plugins/googlegenai/models_test.go
+++ b/go/plugins/googlegenai/models_test.go
@@ -4,6 +4,7 @@
 package googlegenai
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
@@ -55,6 +56,83 @@ func TestListModelsIncludesImagen4ForGoogleAI(t *testing.T) {
 	} {
 		if _, ok := models[name]; !ok {
 			t.Fatalf("Google AI models missing %q", name)
+		}
+	}
+}
+
+// newlyRegisteredGeminiModels are the P0 Gemini-family models added for
+// Go<->JS registration parity.
+var newlyRegisteredGeminiModels = []string{
+	gemini35Flash,
+	gemini31FlashLite,
+	gemini31FlashImage,
+	gemini3ProImage,
+}
+
+// TestNewGeminiModelsResolveToRegisteredEntries verifies each model resolves to
+// its concrete map entry (Stable stage, multimodal supports, labelled) rather
+// than the unknown-model fallback (defaultGeminiOpts, which is Unstable).
+func TestNewGeminiModelsResolveToRegisteredEntries(t *testing.T) {
+	for _, name := range newlyRegisteredGeminiModels {
+		if got := ClassifyModel(name); got != ModelTypeGemini {
+			t.Errorf("ClassifyModel(%q) = %v, want ModelTypeGemini", name, got)
+		}
+
+		opts := GetModelOptions(name, googleAIProvider)
+		if opts.Stage != ai.ModelStageStable {
+			t.Errorf("GetModelOptions(%q).Stage = %q, want Stable (likely hit the unknown-model fallback)", name, opts.Stage)
+		}
+		if opts.Supports == nil || !opts.Supports.Multiturn || !opts.Supports.Media {
+			t.Errorf("GetModelOptions(%q): expected multimodal supports, got %+v", name, opts.Supports)
+		}
+		if opts.ConfigSchema == nil {
+			t.Errorf("GetModelOptions(%q): ConfigSchema is nil", name)
+		}
+	}
+}
+
+// TestNewGeminiModelsProviderSplit pins the per-provider registration from the
+// ticket: GoogleAI gets all except gemini-3.1-flash-lite; VertexAI gets all four.
+func TestNewGeminiModelsProviderSplit(t *testing.T) {
+	for _, name := range newlyRegisteredGeminiModels {
+		if !slices.Contains(vertexAIModels, name) {
+			t.Errorf("vertexAIModels missing %q", name)
+		}
+	}
+
+	for _, name := range []string{gemini35Flash, gemini31FlashImage, gemini3ProImage} {
+		if !slices.Contains(googleAIModels, name) {
+			t.Errorf("googleAIModels missing %q", name)
+		}
+	}
+
+	// gemini-3.1-flash-lite is VertexAI-only per the ticket.
+	if slices.Contains(googleAIModels, gemini31FlashLite) {
+		t.Errorf("googleAIModels should not contain %q (VertexAI only)", gemini31FlashLite)
+	}
+}
+
+// TestGeminiEmbedding2Registered verifies the embedder resolves via the embedder
+// path with the correct dimensionality and multimodal input.
+func TestGeminiEmbedding2Registered(t *testing.T) {
+	// gemini-embedding-2 starts with the "gemini" prefix but must classify as an
+	// embedder, not a generative model (the "embedding" check precedes the
+	// "gemini" prefix check in ClassifyModel).
+	if got := ClassifyModel(geminiEmbedding2); got != ModelTypeEmbedder {
+		t.Errorf("ClassifyModel(%q) = %v, want ModelTypeEmbedder", geminiEmbedding2, got)
+	}
+
+	opts := GetEmbedderOptions(geminiEmbedding2, googleAIProvider)
+
+	if opts.Dimensions != 3072 {
+		t.Errorf("GetEmbedderOptions(%q).Dimensions = %d, want 3072", geminiEmbedding2, opts.Dimensions)
+	}
+	if opts.Supports == nil {
+		t.Fatalf("GetEmbedderOptions(%q): Supports is nil", geminiEmbedding2)
+	}
+	for _, want := range []string{"text", "image", "video"} {
+		if !slices.Contains(opts.Supports.Input, want) {
+			t.Errorf("GetEmbedderOptions(%q): Input missing %q, got %v", geminiEmbedding2, want, opts.Supports.Input)
 		}
 	}
 }


### PR DESCRIPTION
This PR registers gemini-3.* and gemini-embedding-2 models for Google AI and Vertex AI. This addition went through a series of tests.

Closes: #5493  

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
