### PR TITLE
docs/test: promote and verify typed model configuration schemas in Python

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -1083,7 +1083,7 @@ class Genkit:
                 prompt='Hello!',
                 config=config,
             )
-            async for chunk in stream:
+            async for chunk in stream.stream:
                 print(chunk.text, end='')
             ```
         """

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -581,7 +581,23 @@ class Genkit:
         input_schema: type | dict[str, object] | str | None = None,
         output_schema: type | dict[str, object] | str | None = None,
     ) -> ExecutablePrompt[Any, Any]:
-        """Register a prompt template."""
+        """Register a prompt template.
+
+        Args:
+            config: Optional default configuration for the prompt. This can be a raw dict
+                or a typed configuration object (e.g. `GeminiConfigSchema` from
+                `genkit.plugins.google_genai`) to provide type safety and IDE autocomplete.
+
+        Example:
+            ```python
+            from genkit.plugins.google_genai import GeminiConfigSchema
+
+            my_prompt = ai.define_prompt(
+                prompt='Tell me a joke about {{topic}}.',
+                config=GeminiConfigSchema(temperature=0.9),
+            )
+            ```
+        """
         executable_prompt = ExecutablePrompt(
             self.registry,
             variant=variant,
@@ -908,6 +924,32 @@ class Genkit:
         ``tools`` is typed as ``Sequence`` rather than ``list`` because ``Sequence``
         is covariant: ``list[Tool]`` or ``list[str]`` are both assignable to
         ``Sequence[str | Tool]``, but not to ``list[str | Tool]``.
+
+        Args:
+            config: Optional configuration for the model. This can be a raw dict
+                or a typed configuration object (e.g. `GeminiConfigSchema` from
+                `genkit.plugins.google_genai`) to provide type safety and IDE autocomplete.
+
+        Example:
+            Using a typed config object (recommended):
+            ```python
+            from genkit.plugins.google_genai import GeminiConfigSchema
+
+            config = GeminiConfigSchema(temperature=0.7, code_execution=True)
+            response = await ai.generate(
+                model='googleai/gemini-2.0-flash',
+                prompt='Hello!',
+                config=config,
+            )
+            ```
+            Using a dictionary:
+            ```python
+            response = await ai.generate(
+                model='googleai/gemini-2.0-flash',
+                prompt='Hello!',
+                config={'temperature': 0.7, 'codeExecution': True},
+            )
+            ```
         """
         # One call-scoped registry layer holds anything inline (tools +
         # middleware) so it dies with the call and stays out of self.registry.
@@ -1023,7 +1065,28 @@ class Genkit:
         docs: list[Document] | None = None,
         timeout: float | None = None,
     ) -> ModelStreamResponse[Any]:
-        """Stream generated text, returning a ModelStreamResponse with .stream and .response."""
+        """Stream generated text, returning a ModelStreamResponse with .stream and .response.
+
+        Args:
+            config: Optional configuration for the model. This can be a raw dict
+                or a typed configuration object (e.g. `GeminiConfigSchema` from
+                `genkit.plugins.google_genai`) to provide type safety and IDE autocomplete.
+
+        Example:
+            Using a typed config object (recommended):
+            ```python
+            from genkit.plugins.google_genai import GeminiConfigSchema
+
+            config = GeminiConfigSchema(temperature=0.7, code_execution=True)
+            stream = ai.generate_stream(
+                model='googleai/gemini-2.0-flash',
+                prompt='Hello!',
+                config=config,
+            )
+            async for chunk in stream:
+                print(chunk.text, end='')
+            ```
+        """
         channel: Channel[ModelResponseChunk, ModelResponse[Any]] = Channel(timeout=timeout)
 
         async def _run_generate() -> ModelResponse[Any]:

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -937,7 +937,7 @@ class Genkit:
 
             config = GeminiConfigSchema(temperature=0.7, code_execution=True)
             response = await ai.generate(
-                model='googleai/gemini-2.0-flash',
+                model='googleai/gemini-flash-latest',
                 prompt='Hello!',
                 config=config,
             )
@@ -945,7 +945,7 @@ class Genkit:
             Using a dictionary:
             ```python
             response = await ai.generate(
-                model='googleai/gemini-2.0-flash',
+                model='googleai/gemini-flash-latest',
                 prompt='Hello!',
                 config={'temperature': 0.7, 'codeExecution': True},
             )
@@ -1079,7 +1079,7 @@ class Genkit:
 
             config = GeminiConfigSchema(temperature=0.7, code_execution=True)
             stream = ai.generate_stream(
-                model='googleai/gemini-2.0-flash',
+                model='googleai/gemini-flash-latest',
                 prompt='Hello!',
                 config=config,
             )

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -18,6 +18,7 @@ from genkit import (
     Interrupt,
     Message,
     MiddlewareRef,
+    ModelConfig,
     ModelResponse,
     ModelResponseChunk,
     respond_to_interrupt,
@@ -78,12 +79,16 @@ async def test_generate_uses_default_model(setup_test: SetupFixture) -> None:
     want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
 
     response = await ai.generate(prompt='hi', config={'temperature': 11})
-
     assert response.text == want_txt
 
-    stream_result = ai.generate_stream(prompt='hi', config={'temperature': 11})
+    response_typed = await ai.generate(prompt='hi', config=ModelConfig(temperature=11))
+    assert response_typed.text == want_txt
 
+    stream_result = ai.generate_stream(prompt='hi', config={'temperature': 11})
     assert (await stream_result.response).text == want_txt
+
+    stream_result_typed = ai.generate_stream(prompt='hi', config=ModelConfig(temperature=11))
+    assert (await stream_result_typed.response).text == want_txt
 
 
 @pytest.mark.asyncio

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/__init__.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/__init__.py
@@ -159,7 +159,16 @@ Example:
     # Uses GEMINI_API_KEY env var or pass api_key explicitly
     ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-2.0-flash')
 
+    # Simple generation:
     response = await ai.generate(prompt='Hello, world!')
+    print(response.text)
+
+    # Generation with typed configuration (recommended for IDE autocompletion):
+    from genkit.plugins.google_genai import GeminiConfigSchema
+    response = await ai.generate(
+        prompt='Hello, world!',
+        config=GeminiConfigSchema(temperature=0.7, code_execution=True)
+    )
     print(response.text)
 
     # Embeddings

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/__init__.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/__init__.py
@@ -157,7 +157,7 @@ Example:
     from genkit.plugins.google_genai import GoogleAI
 
     # Uses GEMINI_API_KEY env var or pass api_key explicitly
-    ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-2.0-flash')
+    ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
 
     # Simple generation:
     response = await ai.generate(prompt='Hello, world!')

--- a/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
@@ -179,7 +179,7 @@ async def test_generate_media_response(mocker: MockerFixture, version: str) -> N
                 ],
             ),
         ],
-        config={'response_modalities': modalities},
+        config=GeminiConfigSchema(response_modalities=modalities),
     )
 
     candidate = genai.types.Candidate(
@@ -898,3 +898,27 @@ def test_gemini_model__pick_plugin_schema_routes_by_model_family(
     picked = model._pick_plugin_schema({})
 
     assert type(picked) is expected_schema
+
+
+@pytest.mark.asyncio
+async def test_gemini_model__handles_gemini_config_schema_directly(
+    gemini_model_instance: GeminiModel,
+) -> None:
+    """The model correctly processes a raw GeminiConfigSchema object directly."""
+    config_obj = GeminiConfigSchema(
+        temperature=0.7,
+        code_execution=True,
+    )
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+        config=config_obj,
+    )
+
+    cfg = await gemini_model_instance._genkit_to_googleai_cfg(request)
+
+    assert cfg is not None
+    assert cfg.temperature == 0.7
+    assert cfg.tools is not None
+    code_exec_tools = [t for t in cfg.tools if isinstance(t, genai_types.Tool) and t.code_execution is not None]
+    assert len(code_exec_tools) == 1
+


### PR DESCRIPTION
This PR updates the Genkit Python SDK documentation/docstrings and test files to guide developers to use typed configuration objects (e.g., GeminiConfigSchema, ModelConfig) rather than plain dictionaries for model generation.