### PR TITLE
chore(genkit-tools/common/tests): fix open handle in test

### DIFF
--- a/genkit-tools/common/tests/manager_test.ts
+++ b/genkit-tools/common/tests/manager_test.ts
@@ -43,5 +43,7 @@ describe('RuntimeManager', () => {
     // Simulate event again
     (manager as any).eventEmitter.emit(RuntimeEvent.ADD, { id: '2' });
     expect(listener).toHaveBeenCalledTimes(1); // Should not have increased
+
+    await manager.stop();
   });
 });


### PR DESCRIPTION
This fixes the "A worker process has failed to exit gracefully" problem in the tests. 

Checklist (if applicable):
- [X] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [X] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)
