### PR TITLE
chore(py): promote using latest model aliases instead of specific versions

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -112,7 +112,7 @@ action resolution, and action discovery.
   │                                                                     │
   │  Phase 2: LAZY INIT (on first action resolution)                   │
   │  ──────────                                                        │
-  │  await ai.generate(model='googleai/gemini-2.0-flash', ...)        │
+  │  await ai.generate(model='googleai/gemini-flash-latest', ...)      │
   │       │                                                            │
   │       ▼                                                            │
   │  registry._ensure_plugin_initialized('googleai')                   │
@@ -126,7 +126,7 @@ action resolution, and action discovery.
   │                                                                     │
   │  Phase 3: ACTION RESOLUTION (on each usage)                        │
   │  ─────────────────────                                             │
-  │  await plugin.resolve(ActionKind.MODEL, 'googleai/gemini-2.0-flash')│
+  │  await plugin.resolve(ActionKind.MODEL, 'googleai/gemini-flash-latest')│
   │       │                                                            │
   │       ▼                                                            │
   │  Action instance returned and cached in registry                   │
@@ -144,29 +144,29 @@ action resolution, and action discovery.
 
 ### How the Registry Resolves Actions
 
-When you call `ai.generate(model='googleai/gemini-2.0-flash')`, the
+When you call `ai.generate(model='googleai/gemini-flash-latest')`, the
 registry uses a multi-step resolution algorithm:
 
 ```
-  ai.generate(model="googleai/gemini-2.0-flash")
+  ai.generate(model="googleai/gemini-flash-latest")
        │
        ▼
   ┌──────────────────────────────────────────────────────────────────┐
   │  Step 1: CACHE HIT?                                              │
-  │  Is "googleai/gemini-2.0-flash" already in registry._entries?    │
+  │  Is "googleai/gemini-flash-latest" already in registry._entries? │
   │     ├── YES → return cached Action (fast path)                   │
   │     └── NO  → continue to Step 2                                 │
   ├──────────────────────────────────────────────────────────────────┤
   │  Step 2: NAMESPACED or UNPREFIXED?                               │
   │  Does the name contain "/"?                                      │
   │     │                                                            │
-  │     ├── YES ("googleai/gemini-2.0-flash")                        │
+  │     ├── YES ("googleai/gemini-flash-latest")                     │
   │     │    ├── Find plugin "googleai"                               │
   │     │    ├── await _ensure_plugin_initialized("googleai")         │
   │     │    ├── Check cache again (init may have registered it)     │
-  │     │    └── await plugin.resolve(MODEL, "googleai/gemini-2.0")  │
+  │     │    └── await plugin.resolve(MODEL, "googleai/gemini-flash")│
   │     │                                                            │
-  │     └── NO ("gemini-2.0-flash")                                  │
+  │     └── NO ("gemini-flash-latest")                               │
   │          ├── Try ALL plugins                                      │
   │          ├── If 1 match  → use it                                 │
   │          ├── If 2+ match → ValueError (ambiguous)                │

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/__init__.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/__init__.py
@@ -133,7 +133,7 @@ Supported Models:
     ┌─────────────────────────────────────────────────────────────────────────┐
     │ Plugin     │ Models                                                     │
     ├────────────┼─────────────────────────────────────────────────────────────┤
-    │ GoogleAI   │ gemini-2.0-flash, gemini-2.5-flash, gemini-2.5-pro, etc.  │
+    │ GoogleAI   │ gemini-flash-latest, gemini-pro-latest, etc.              │
     │ VertexAI   │ Same Gemini models + imagen-4.0-generate-001               │
     └────────────┴─────────────────────────────────────────────────────────────┘
 
@@ -157,7 +157,7 @@ Example:
     from genkit.plugins.google_genai import GoogleAI
 
     # Uses GEMINI_API_KEY env var or pass api_key explicitly
-    ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-2.0-flash')
+    ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
 
     response = await ai.generate(prompt='Hello, world!')
     print(response.text)
@@ -178,7 +178,7 @@ Example:
     # Uses default GCP credentials; optionally pass project/location
     ai = Genkit(
         plugins=[VertexAI(project='my-project', location='us-central1')],
-        model='vertexai/gemini-2.0-flash',
+        model='vertexai/gemini-2.5-flash',
     )
 
     response = await ai.generate(prompt='Hello, world!')

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -64,7 +64,7 @@ Key Concepts:
     |                    | used, avoiding upfront initialization overhead.       |
     +--------------------+-------------------------------------------------------+
     | Namespacing        | Models are prefixed with plugin name (e.g.,           |
-    |                    | 'googleai/gemini-2.0-flash-001').                     |
+    |                    | 'googleai/gemini-flash-latest').                      |
     +--------------------+-------------------------------------------------------+
 
 Supported Model Types:
@@ -82,7 +82,7 @@ Example:
     >>>
     >>> # Use any available model - no pre-registration needed
     >>> response = await ai.generate(
-    ...     model='googleai/gemini-2.0-flash-001',
+    ...     model='googleai/gemini-flash-latest',
     ...     prompt='Hello, world!',
     ... )
 
@@ -325,7 +325,7 @@ class GoogleAI(Plugin):
         +------------------+-------------------+--------------------------------+
         | Type             | Action Kind       | Example                        |
         +------------------+-------------------+--------------------------------+
-        | Gemini/Gemma     | MODEL             | googleai/gemini-2.0-flash-001  |
+        | Gemini/Gemma     | MODEL             | googleai/gemini-flash-latest   |
         | Imagen           | MODEL             | googleai/imagen-3.0-generate   |
         | Embedders        | EMBEDDER          | googleai/gemini-embedding-001  |
         | Veo (video)      | BACKGROUND_MODEL  | googleai/veo-2.0-generate-001  |
@@ -339,7 +339,7 @@ class GoogleAI(Plugin):
         >>>
         >>> # Text generation
         >>> response = await ai.generate(
-        ...     model='googleai/gemini-2.0-flash-001',
+        ...     model='googleai/gemini-flash-latest',
         ...     prompt='Explain quantum computing',
         ... )
         >>>
@@ -688,7 +688,7 @@ class VertexAI(Plugin):
         +------------------+-------------------+--------------------------------+
         | Type             | Action Kind       | Example                        |
         +------------------+-------------------+--------------------------------+
-        | Gemini/Gemma     | MODEL             | vertexai/gemini-2.0-flash-001  |
+        | Gemini/Gemma     | MODEL             | vertexai/gemini-2.5-flash      |
         | Imagen           | MODEL             | vertexai/imagen-3.0-generate   |
         | Veo (video)      | MODEL             | vertexai/veo-2.0-generate-001  |
         | Embedders        | EMBEDDER          | vertexai/text-embedding-005    |
@@ -702,7 +702,7 @@ class VertexAI(Plugin):
         >>>
         >>> # Text generation
         >>> response = await ai.generate(
-        ...     model='vertexai/gemini-2.0-flash-001',
+        ...     model='vertexai/gemini-2.5-flash',
         ...     prompt='Explain quantum computing',
         ... )
         >>>

--- a/py/samples/django-hello/recipes/views.py
+++ b/py/samples/django-hello/recipes/views.py
@@ -27,11 +27,10 @@ from genkit._core._action import ActionRunContext
 from genkit.plugin_api import RequestData
 from genkit.plugins.django import genkit_django_handler
 from genkit.plugins.google_genai import GoogleAI
-from genkit.plugins.google_genai.models.gemini import GoogleAIGeminiVersion
 
 ai = Genkit(
     plugins=[GoogleAI()],
-    model=f'googleai/{GoogleAIGeminiVersion.GEMINI_3_FLASH_PREVIEW}',
+    model='googleai/gemini-flash-latest',
 )
 
 

--- a/py/samples/flask-hello/src/main.py
+++ b/py/samples/flask-hello/src/main.py
@@ -26,11 +26,10 @@ from genkit._core._action import ActionRunContext
 from genkit._core._context import RequestData
 from genkit.plugins.flask import genkit_flask_handler
 from genkit.plugins.google_genai import GoogleAI
-from genkit.plugins.google_genai.models.gemini import GoogleAIGeminiVersion
 
 ai = Genkit(
     plugins=[GoogleAI()],
-    model=f'googleai/{GoogleAIGeminiVersion.GEMINI_3_FLASH_PREVIEW}',
+    model='googleai/gemini-flash-latest',
 )
 
 app = Flask(__name__)


### PR DESCRIPTION
This PR updates the Genkit Python documentation and examples to promote gemini-flash-latest and gemini-pro-latest generic aliases, replacing references to specific model versions like gemini-2.0-flash-001 or gemini-2.0-flash.