### PR TITLE
docs(py): clarify genkit.plugins namespace discovery and add test

### DIFF
--- a/py/packages/genkit/src/genkit/plugins/__init__.py
+++ b/py/packages/genkit/src/genkit/plugins/__init__.py
@@ -16,7 +16,7 @@
 
 """Namespace package for Genkit plugins.
 
-This is a namespace package that allows plugins to be discovered from
+This package acts as a namespace allowing plugins to be discovered from
 multiple installed packages. Each plugin can be imported as:
 
     from genkit.plugins.<plugin_name> import <PluginClass>
@@ -24,4 +24,17 @@ multiple installed packages. Each plugin can be imported as:
 For example:
     from genkit.plugins.google_genai import GoogleGenai
     from genkit.plugins.anthropic import Anthropic
+
+Because this module ships an ``__init__.py``, ``genkit.plugins`` is a regular
+package, not a PEP 420 namespace. Its ``__path__`` is extended at runtime by
+``genkit._core._plugins.extend_plugin_namespace`` (called from
+``genkit.__init__``), which scans ``sys.path`` for ``genkit/plugins`` dirs.
+
+``pkgutil.extend_path`` is not used: it searches ``genkit.__path__`` rather than
+``sys.path``, and a single-directory ``genkit`` package does not span the other
+distributions, so it would find nothing.
+
+A native PEP 420 namespace would require ``genkit`` itself to be a pure namespace
+package (no ``__init__.py``, like ``google.cloud.*``), giving up the populated
+top-level ``genkit`` API. So the runtime scan stays.
 """

--- a/py/packages/genkit/tests/genkit/core/plugins_discovery_test.py
+++ b/py/packages/genkit/tests/genkit/core/plugins_discovery_test.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for runtime plugin-namespace discovery.
+
+``genkit.plugins`` is a regular package whose ``__path__`` is extended at
+runtime by ``extend_plugin_namespace`` so that plugins shipped as separate
+distributions (each contributing a bare ``genkit/plugins/<name>`` directory)
+become importable as ``genkit.plugins.<name>``. These tests exercise that
+discovery against a fake plugin laid out on a temporary ``sys.path`` entry.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import genkit.plugins
+from genkit._core._plugins import extend_plugin_namespace
+
+FAKE_PLUGIN = 'fake_discovery_plugin'
+
+
+def _write_fake_plugin(root: Path) -> Path:
+    """Lay out ``<root>/genkit/plugins/<FAKE_PLUGIN>`` as a PEP 420 portion.
+
+    Mirrors how a real plugin distribution ships: no ``genkit/__init__.py`` and
+    no ``genkit/plugins/__init__.py``, only the leaf plugin package.
+    """
+    plugin_dir = root / 'genkit' / 'plugins' / FAKE_PLUGIN
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / '__init__.py').write_text('SENTINEL = "discovered"\n')
+    return root / 'genkit' / 'plugins'
+
+
+@pytest.fixture
+def isolated_namespace() -> Iterator[None]:
+    """Snapshot and restore global discovery state mutated by the tests."""
+    original_path = list(genkit.plugins.__path__)
+    original_sys_path = list(sys.path)
+    try:
+        yield
+    finally:
+        genkit.plugins.__path__[:] = original_path
+        sys.path[:] = original_sys_path
+        sys.modules.pop(f'genkit.plugins.{FAKE_PLUGIN}', None)
+        # Importing the submodule sets it as an attribute on the parent module;
+        # popping sys.modules alone leaves that attribute behind.
+        if hasattr(genkit.plugins, FAKE_PLUGIN):
+            delattr(genkit.plugins, FAKE_PLUGIN)
+        importlib.invalidate_caches()
+
+
+def test_discovers_plugin_dir_on_sys_path(tmp_path: Path, isolated_namespace: None) -> None:
+    """A ``genkit/plugins`` directory on ``sys.path`` is grafted in and importable."""
+    plugins_dir = _write_fake_plugin(tmp_path)
+    sys.path.insert(0, str(tmp_path))
+    importlib.invalidate_caches()
+
+    extend_plugin_namespace()
+
+    assert str(plugins_dir) in genkit.plugins.__path__
+
+    module = importlib.import_module(f'genkit.plugins.{FAKE_PLUGIN}')
+    assert module.SENTINEL == 'discovered'
+
+
+def test_discovery_is_idempotent(tmp_path: Path, isolated_namespace: None) -> None:
+    """Repeated calls do not append duplicate ``__path__`` entries."""
+    plugins_dir = _write_fake_plugin(tmp_path)
+    sys.path.insert(0, str(tmp_path))
+    importlib.invalidate_caches()
+
+    extend_plugin_namespace()
+    extend_plugin_namespace()
+
+    assert genkit.plugins.__path__.count(str(plugins_dir)) == 1
+
+
+def test_ignores_sys_path_entry_without_plugins_dir(tmp_path: Path, isolated_namespace: None) -> None:
+    """A ``sys.path`` entry lacking ``genkit/plugins`` is left untouched."""
+    sys.path.insert(0, str(tmp_path))
+    importlib.invalidate_caches()
+
+    extend_plugin_namespace()
+
+    assert str(tmp_path / 'genkit' / 'plugins') not in genkit.plugins.__path__


### PR DESCRIPTION
## What

Reword the `genkit.plugins` package docstring so it correctly explains our
plugin-discovery setup, and add a regression test for the runtime discovery that
nothing currently covers. Doc + test only, no behaviour change.

## Why

In genkit-ai/genkit#5521 I'd added `pkgutil.extend_path` to
`genkit/plugins/__init__.py`, then removed it again once it turned out to be a
no-op, leaving a comment so the next person doesn't re-add it. While reviewing, we
realised the comment's stated reason was wrong: it claimed `extend_path` only
picks up portions that ship their own `genkit/plugins/__init__.py`. Reading the
CPython source, that isn't how it works (modern `extend_path` handles PEP 420
portions with no `__init__.py`).

The real reason `extend_path` is useless here:

```python
# pkgutil.extend_path, paraphrased
parent_package, _, final_name = name.rpartition('.')   # "genkit", "plugins"
search_path = sys.modules[parent_package].__path__     # genkit.__path__, NOT sys.path
```

It only searches the parent package's `__path__`. `genkit` is a regular
single-directory package, so its `__path__` doesn't span the separately installed
plugin distributions, and there's nothing for `extend_path` to find. Our runtime
`extend_plugin_namespace` (in `genkit/_core/_plugins.py`, called from
`genkit/__init__.py`) scans `sys.path` instead, which does reach them.

I've reworded the docstring to say that, and to clarify that `genkit.plugins` is a
regular package (it ships `__init__.py`) whose `__path__` is extended at runtime,
rather than a strict PEP 420 namespace package.

## Test

Adds `tests/genkit/core/plugins_discovery_test.py` covering `extend_plugin_namespace`:

- a fake plugin laid out on a temporary `sys.path` entry (as a bare PEP 420
  portion, matching how real plugins ship) is discovered and importable
- discovery is idempotent (no duplicate `__path__` entries on repeat calls)
- a `sys.path` entry without `genkit/plugins` is ignored

There was no test for this mechanism before. Run:

```bash
cd py/packages/genkit && uv run pytest tests/genkit/core/plugins_discovery_test.py -v
```

All three pass locally; ruff check/format clean.

## Worth a careful look at

- My reading of `extend_path` vs `extend_plugin_namespace` above, in case I've
  misjudged the behaviour.
- Whether the test isolation (snapshot/restore of `genkit.plugins.__path__` and
  `sys.path`) is solid enough not to leak into other tests.
