### PR TITLE
feat(py/plugins/google-genai): register Gemini 3.1 text models

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -766,6 +766,46 @@ GEMINI_3_5_FLASH = ModelInfo(
     ),
 )
 
+GEMINI_3_1_PRO_PREVIEW = ModelInfo(
+    label='Google AI - Gemini 3.1 Pro Preview',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained=Constrained.ALL,
+        output=['text', 'json'],
+    ),
+)
+
+# customtools is registered identically to pro-preview (no distinct config in JS).
+GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS = ModelInfo(
+    label='Google AI - Gemini 3.1 Pro Preview (Custom Tools)',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained=Constrained.ALL,
+        output=['text', 'json'],
+    ),
+)
+
+GEMINI_3_1_FLASH_LITE_PREVIEW = ModelInfo(
+    label='Google AI - Gemini 3.1 Flash Lite Preview',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained=Constrained.ALL,
+        output=['text', 'json'],
+    ),
+)
+
 GENERIC_GEMINI_MODEL = ModelInfo(
     label='Google AI - Gemini',
     supports=Supports(
@@ -906,6 +946,9 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     | `gemini-3-pro-image-preview`         | Gemini 3 Pro Image Preview           | Supported  |
     | `gemini-2.5-flash-image-preview`     | Gemini 2.5 Flash Image Preview       | Supported  |
     | `gemini-2.5-flash-image`             | Gemini 2.5 Flash Image               | Supported  |
+    | `gemini-3.1-pro-preview`             | Gemini 3.1 Pro Preview               | Supported  |
+    | `gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools  | Supported  |
+    | `gemini-3.1-flash-lite-preview`      | Gemini 3.1 Flash Lite Preview        | Supported  |
     | `gemma-3-12b-it`                     | Gemma 3 12B IT                       | Supported  |
     | `gemma-3-1b-it`                      | Gemma 3 1B IT                        | Supported  |
     | `gemma-3-27b-it`                     | Gemma 3 27B IT                       | Supported  |
@@ -930,6 +973,9 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_3_PRO_IMAGE_PREVIEW = 'gemini-3-pro-image-preview'
     GEMINI_2_5_FLASH_IMAGE_PREVIEW = 'gemini-2.5-flash-image-preview'
     GEMINI_2_5_FLASH_IMAGE = 'gemini-2.5-flash-image'
+    GEMINI_3_1_PRO_PREVIEW = 'gemini-3.1-pro-preview'
+    GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS = 'gemini-3.1-pro-preview-customtools'
+    GEMINI_3_1_FLASH_LITE_PREVIEW = 'gemini-3.1-flash-lite-preview'
     GEMMA_3_12B_IT = 'gemma-3-12b-it'
     GEMMA_3_1B_IT = 'gemma-3-1b-it'
     GEMMA_3_27B_IT = 'gemma-3-27b-it'
@@ -964,6 +1010,9 @@ _add_model(GEMINI_2_5_FLASH_LITE, ['gemini-2.5-flash-lite'])
 _add_model(GEMINI_3_FLASH_PREVIEW, ['gemini-3-flash-preview'])
 _add_model(GEMINI_3_PRO_PREVIEW, ['gemini-3-pro-preview', 'gemini-pro-latest'])
 _add_model(GEMINI_3_5_FLASH, ['gemini-3.5-flash', 'gemini-flash-latest'])
+_add_model(GEMINI_3_1_PRO_PREVIEW, ['gemini-3.1-pro-preview'])
+_add_model(GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS, ['gemini-3.1-pro-preview-customtools'])
+_add_model(GEMINI_3_1_FLASH_LITE_PREVIEW, ['gemini-3.1-flash-lite-preview'])
 
 
 DEFAULT_SUPPORTS_MODEL = Supports(

--- a/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
@@ -34,6 +34,7 @@ from pytest_mock import MockerFixture
 
 from genkit import (
     ActionRunContext,
+    Constrained,
     MediaPart,
     Message,
     ModelInfo,
@@ -372,6 +373,31 @@ def test_google_model_info(input: str, expected: ModelInfo) -> None:
     model_info = google_model_info(input)
 
     assert model_info == expected
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    [
+        'gemini-3.1-pro-preview',
+        'gemini-3.1-pro-preview-customtools',
+        'gemini-3.1-flash-lite-preview',
+    ],
+)
+def test_gemini_3_1_models_register_real_capabilities(model_name: str) -> None:
+    """Gemini 3.1 text models resolve to explicit ModelInfo, not the generic fallback.
+
+    The generic fallback (DEFAULT_SUPPORTS_MODEL) leaves ``output`` unset, so asserting
+    ``output == ['text', 'json']`` alongside tools/constrained proves these names are
+    registered with real capability metadata matching the JS/Go registries.
+    """
+    model_info = google_model_info(model_name)
+
+    assert model_info.label.startswith('Google AI - Gemini 3.1')
+    assert model_info.supports is not None
+    assert model_info.supports.tools is True
+    assert model_info.supports.tool_choice is True
+    assert model_info.supports.constrained == Constrained.ALL
+    assert model_info.supports.output == ['text', 'json']
 
 
 @pytest.fixture


### PR DESCRIPTION
## What

Registers three GoogleAI Gemini 3.1 text models with explicit `ModelInfo` so they
resolve to real capability metadata instead of the generic text fallback:

- `gemini-3.1-pro-preview`
- `gemini-3.1-pro-preview-customtools`
- `gemini-3.1-flash-lite-preview`

Part of #5542 (Python model-parity work).

## Why

Without registration these names fall through to `DEFAULT_SUPPORTS_MODEL`, which
leaves `output` unset and doesn't reflect each model's real capabilities.
Registering them gives the correct `Supports` metadata (tools, tool-choice,
constrained generation, `text`/`json` output) that the framework and Dev UI
rely on.

## How

Three touch points in
`py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py`,
following the existing 3.x wiring:

1. `ModelInfo` definitions for each model.
2. Enum members on `GoogleAIGeminiVersion` (+ docstring table rows).
3. `_add_model(...)` registrations.

Capabilities were verified against the JS and Go registries rather than copied
from generic defaults:

- All three use the full multimodal/tool profile (`tools=True`,
  `constrained=ALL`, `output=['text', 'json']`) — matching Go's `Multimodal`
  and JS's generic `commonRef`.
- **`flash-lite-preview` keeps tools enabled** (not `NO_TOOLS`): both Go
  (`Multimodal`) and JS register it tool-capable.
- **`customtools` is registered identically to `pro-preview`**: in JS it's a
  plain `commonRef` with no distinct config or tool path, so no special handling
  is needed.

VertexAI registration is intentionally out of scope (separate parity slice).

## Testing

- **Unit tests:** added a parametrized test asserting each model resolves to real
  capabilities (`tools`, `tool_choice`, `constrained=all`, `output=['text', 'json']`)
  rather than the fallback. `ruff` and `ruff format` clean.
- **Dev UI (GoogleAI):** screenshots below show each model in the picker and a
  successful generate, including a structured/JSON run.

### Dev UI screenshots

<img width="496" height="433" alt="Screenshot 2026-06-15 at 12 51 07" src="https://github.com/user-attachments/assets/684a17bd-0da7-4835-a4c9-4c0a902c889a" />
<img width="1029" height="803" alt="Screenshot 2026-06-15 at 12 53 04" src="https://github.com/user-attachments/assets/f10e1ca2-6fac-44f6-ad31-a3d5619330b7" />
<img width="1115" height="812" alt="Screenshot 2026-06-15 at 13 01 24" src="https://github.com/user-attachments/assets/9a7c8d50-47ad-4f7b-bd9f-86c09ce48d2e" />
