### PR TITLE
fix(core): bind reflection server to loopback only

### DIFF
--- a/js/core/src/reflection.ts
+++ b/js/core/src/reflection.ts
@@ -436,7 +436,12 @@ export class ReflectionServer {
     });
 
     this.port = await this.findPort();
-    this.server = server.listen(this.port, async () => {
+    // Bind to loopback only. The reflection server is a local development API
+    // with no authentication, so it must not be exposed on all interfaces.
+    // Use the explicit IPv4 loopback address (rather than 'localhost', which on
+    // Node 17+ can resolve to the IPv6 '::1' only) so the bind is deterministic
+    // across platforms and matches the Go runtime, which binds 127.0.0.1.
+    this.server = server.listen(this.port, '127.0.0.1', async () => {
       logger.debug(
         `Reflection server (${process.pid}) running on http://localhost:${this.port}`
       );


### PR DESCRIPTION
## Summary

The JS reflection server (`js/core/src/reflection.ts`) starts with `server.listen(this.port, ...)` and no host argument, so Node binds it to all interfaces (`0.0.0.0`/`::`) even though it logs that it is "running on http://localhost" and it is an unauthenticated local development API (it exposes `/api/runAction`, `/api/notify`, and other endpoints).

The Go (`go/genkit/reflection.go` -> `127.0.0.1`) and Python (`py/.../_reflection.py` -> `host='localhost'`) runtimes already bind loopback. This change aligns the JS runtime with them.

## Change

Pass `'localhost'` as the host to `server.listen(...)` so the reflection dev server is reachable only from the local machine. This matches the existing log message and the Go/Python behavior, and is transparent to the local `genkit` CLI tooling which connects via `http://localhost:${port}`.
