### PR TITLE
fix(py/plugins/google-genai): discover Vertex AI models by name

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -173,15 +173,24 @@ class GenaiModels:
 def _list_genai_models(client: genai.Client, is_vertex: bool) -> GenaiModels:
     """Discover and categorize available models from the Google GenAI API.
 
-    This function queries the API for all available models and categorizes them
-    based on their supported_actions field. Models marked as deprecated are
-    excluded.
+    This function queries the API for all available models and categorizes them.
+    Models marked as deprecated are excluded.
 
-    The categorization logic:
+    Two categorization strategies are used depending on the backend:
+
+    - Google AI populates each model's ``supported_actions`` field, so models
+      are categorized by action:
         - 'embedContent' action → embedders
-        - 'predict' + 'imagen' in name → imagen (Vertex AI)
+        - 'predict' + 'imagen' in name → imagen
         - 'generateVideos' or 'veo' in name → veo
         - 'generateContent' + 'gemini'/'gemma' in name → gemini
+    - Vertex AI returns ``supported_actions = None`` for every publisher model,
+      so categorizing by action would skip them all. The Vertex path instead
+      categorizes by model name (mirroring the JS plugin's ``listActions``):
+        - 'embedding' in name → embedders
+        - 'imagen' in name → imagen
+        - 'veo' in name → veo
+        - 'gemini'/'gemma' in name (and not an embedding) → gemini
 
     Args:
         client: The Google GenAI client instance.
@@ -211,6 +220,20 @@ def _list_genai_models(client: genai.Client, is_vertex: bool) -> GenaiModels:
 
         description = (m.description or '').lower()
         if 'deprecated' in description:
+            continue
+
+        # Vertex AI returns supported_actions=None for every publisher model, so
+        # categorize by name instead of gating on supported_actions.
+        if is_vertex:
+            lower_name = name.lower()
+            if 'embedding' in lower_name:
+                models.embedders.append(name)
+            if 'imagen' in lower_name:
+                models.imagen.append(name)
+            if 'veo' in lower_name:
+                models.veo.append(name)
+            if ('gemini' in lower_name or 'gemma' in lower_name) and 'embedding' not in lower_name:
+                models.gemini.append(name)
             continue
 
         if not m.supported_actions:

--- a/py/plugins/google-genai/test/google_plugin_test.py
+++ b/py/plugins/google-genai/test/google_plugin_test.py
@@ -805,6 +805,45 @@ async def test_vertexai_list_actions(vertexai_plugin_instance: VertexAI) -> None
 
 
 @pytest.mark.asyncio
+async def test_vertexai_list_actions_without_supported_actions(vertexai_plugin_instance: VertexAI) -> None:
+    """Regression test for #5572.
+
+    Vertex AI's ``client.models.list()`` returns publisher models with
+    ``supported_actions = None``. Discovery must categorize these by name
+    rather than skipping them, otherwise no Vertex models appear in the Dev UI.
+    """
+
+    def mock_model(name: str) -> MagicMock:
+        m = MagicMock()
+        m.name = name
+        m.supported_actions = None  # Vertex leaves this unset.
+        m.description = ''
+        return m
+
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = [
+        mock_model('publishers/google/models/gemini-2.5-pro'),
+        mock_model('publishers/google/models/gemini-embedding-001'),
+        mock_model('publishers/google/models/imagen-3.0-generate-002'),
+        mock_model('publishers/google/models/veo-2.0-generate-001'),
+    ]
+    vertexai_plugin_instance._runtime_client = lambda: mock_client
+
+    result = await vertexai_plugin_instance.list_actions()
+    names = {a.name for a in result}
+
+    # Gemini text model discovered despite supported_actions=None.
+    assert vertexai_name('gemini-2.5-pro') in names
+    # Imagen and Veo discovered.
+    assert vertexai_name('imagen-3.0-generate-002') in names
+    assert vertexai_name('veo-2.0-generate-001') in names
+
+    # gemini-embedding-001 is registered as an embedder, not a gemini model.
+    embedder = next(a for a in result if a.name == vertexai_name('gemini-embedding-001'))
+    assert embedder.action_type == ActionKind.EMBEDDER
+
+
+@pytest.mark.asyncio
 async def test_googleai_resolve_background_model(googleai_plugin_instance: GoogleAI) -> None:
     """Test resolve action for background model."""
     plugin = googleai_plugin_instance


### PR DESCRIPTION
## Problem

In the Python `google-genai` plugin, **no Vertex AI models appear in the Dev UI model picker**. The discovery helper `_list_genai_models` categorizes each model by its `supported_actions` field and short-circuits with `if not m.supported_actions: continue`. For the **Vertex AI** backend, `client.models.list()` returns publisher models with `supported_actions = None`, so *every* model is skipped — the gemini/imagen/veo/embedder lists come back empty and nothing is registered via `list_actions`.

The Google AI backend *does* populate `supported_actions`, so it is unaffected. Models a user hard-codes in flow code still work because they resolve on-demand via `resolve()`, which bypasses `_list_genai_models` — only automatic discovery was broken.

Fixes #5572

## Fix

On the Vertex path, categorize models **by name** (mirroring the JS plugin's `listActions` in `js/plugins/google-genai/src/vertexai/gemini.ts`) instead of gating on `supported_actions`. The Google AI path is unchanged and keeps using `supported_actions`. `gemini-embedding-*` is excluded from the gemini bucket so it registers as an embedder, not a text model.

## Testing

- Added `test_vertexai_list_actions_without_supported_actions`, a regression test that mocks Vertex's real behavior (`supported_actions = None`) and asserts gemini/imagen/veo/embedder actions are still discovered.
- `uv run pytest test/google_plugin_test.py` — 51 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)