### PR TITLE
test(go/exp): add agent conformance harness

### DIFF
--- a/go/ai/exp/agents_conformance_test.go
+++ b/go/ai/exp/agents_conformance_test.go
@@ -1,0 +1,1129 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Agent conformance test runner (Go harness).
+//
+// Reads the shared spec from tests/specs/agent.yaml and executes each test
+// case against harness-provided agent implementations. The spec is shared
+// across language implementations (JS, Go, ...) to ensure cross-language
+// compatibility of the Agent abstraction at the wire-protocol level. See
+// docs/agents-conformance-testing.md for the full spec format reference and
+// harness requirements, and js/ai/tests/agents_spec_test.ts for the
+// reference (JS) harness this one mirrors.
+//
+// The harness lives in the external [package exp_test] (not [package exp]) so
+// it exercises only the public API and the production in-memory store
+// (localstore.InMemorySessionStore), matching what the JS harness does.
+package exp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-yaml"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/ai/exp"
+	"github.com/firebase/genkit/go/ai/exp/localstore"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/internal/registry"
+)
+
+// specPath is relative to this package directory (go/ai/exp).
+const specPath = "../../../tests/specs/agent.yaml"
+
+// customState is the single session-state type used by every conformance
+// agent. A free-form map lets the custom-state agents manipulate arbitrary
+// JSON ({counter, status, ...}) while the prompt agents simply ignore it,
+// so one concrete Agent[State] type serves the whole (dynamically-typed)
+// spec — mirroring the JS harness's use of a single dynamic agent type.
+type customState = map[string]any
+
+// ---------------------------------------------------------------------------
+// Spec types
+// ---------------------------------------------------------------------------
+
+type specSuite struct {
+	Tests []specTest `yaml:"tests"`
+}
+
+type specTest struct {
+	Name        string           `yaml:"name"`
+	Description string           `yaml:"description"`
+	Agent       string           `yaml:"agent"`
+	Steps       []map[string]any `yaml:"steps"`
+}
+
+// ---------------------------------------------------------------------------
+// Tool input/output schemas
+// ---------------------------------------------------------------------------
+
+type interruptIn struct {
+	Query string `json:"query"`
+}
+type interruptOut struct {
+	Answer string `json:"answer"`
+}
+type restartIn struct {
+	Action string `json:"action"`
+}
+type restartOut struct {
+	Result string `json:"result"`
+}
+
+// ---------------------------------------------------------------------------
+// Programmable model
+// ---------------------------------------------------------------------------
+
+// programmableModel is a model whose per-call response behavior is set per
+// `send` step via setHandler. It mirrors the JS defineProgrammableModel
+// helper: modelResponses[i] is returned for the i-th generate call and
+// streamChunks[i] (if present) is emitted before it.
+type programmableModel struct {
+	mu      sync.Mutex
+	handler func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error)
+}
+
+func (pm *programmableModel) setHandler(h func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error)) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.handler = h
+}
+
+func (pm *programmableModel) generate(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+	pm.mu.Lock()
+	h := pm.handler
+	pm.mu.Unlock()
+	if h == nil {
+		return nil, fmt.Errorf("programmableModel: no handler set for this step")
+	}
+	return h(ctx, req, cb)
+}
+
+// ---------------------------------------------------------------------------
+// Harness setup
+// ---------------------------------------------------------------------------
+
+type harness struct {
+	pm     *programmableModel
+	agents map[string]*exp.Agent[customState]
+	// stores holds the in-memory store for each server-managed agent, keyed
+	// by agent name, so the getSnapshotData/abort/waitUntilCompleted steps can
+	// resolve snapshots directly (the public, local-caller path).
+	stores map[string]*localstore.InMemorySessionStore[customState]
+}
+
+func setupHarness(t *testing.T) *harness {
+	t.Helper()
+	reg := registry.New()
+	ai.ConfigureFormats(reg)
+
+	pm := &programmableModel{}
+	ai.DefineModel(reg, "programmableModel",
+		&ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true}},
+		pm.generate)
+	ai.DefineGenerateAction(context.Background(), reg)
+
+	// --- Tools ---
+
+	testTool := ai.DefineTool(reg, "testTool", "A simple test tool",
+		func(tc *ai.ToolContext, _ struct{}) (string, error) {
+			return "tool called", nil
+		})
+
+	// interruptTool always pauses the turn, returning the tool request to the
+	// client for external resolution (resume.respond).
+	interruptTool := ai.DefineTool(reg, "interruptTool", "An interrupt tool",
+		func(tc *ai.ToolContext, _ interruptIn) (interruptOut, error) {
+			return interruptOut{}, tc.Interrupt(&ai.InterruptOptions{})
+		})
+
+	// restartTool interrupts on first call and succeeds when restarted with
+	// resumed metadata (resume.restart).
+	restartTool := ai.DefineTool(reg, "restartTool", "A tool that requires confirmation before executing",
+		func(tc *ai.ToolContext, in restartIn) (restartOut, error) {
+			if tc.Resumed == nil {
+				return restartOut{}, tc.Interrupt(&ai.InterruptOptions{
+					Metadata: map[string]any{"requiresConfirmation": true},
+				})
+			}
+			return restartOut{Result: "confirmed: " + in.Action}, nil
+		})
+
+	h := &harness{
+		pm:     pm,
+		agents: map[string]*exp.Agent[customState]{},
+		stores: map[string]*localstore.InMemorySessionStore[customState]{},
+	}
+
+	// newStore makes a fresh store for a server-managed agent and records it.
+	newStore := func(name string) exp.AgentOption[customState] {
+		s := localstore.NewInMemorySessionStore[customState]()
+		h.stores[name] = s
+		return exp.WithSessionStore[customState](s)
+	}
+
+	cfg := map[string]any{"temperature": 1}
+	model := ai.WithModelName("programmableModel")
+
+	// --- Prompt-backed agents ---
+
+	h.agents["promptAgent"] = exp.DefineAgent[customState](reg, "promptAgent",
+		exp.InlinePrompt{model, ai.WithConfig(cfg)})
+
+	h.agents["promptAgentWithStore"] = exp.DefineAgent[customState](reg, "promptAgentWithStore",
+		exp.InlinePrompt{model, ai.WithConfig(cfg)}, newStore("promptAgentWithStore"))
+
+	h.agents["promptAgentWithTools"] = exp.DefineAgent[customState](reg, "promptAgentWithTools",
+		exp.InlinePrompt{model, ai.WithConfig(cfg), ai.WithTools(testTool)})
+
+	h.agents["promptAgentWithInterrupt"] = exp.DefineAgent[customState](reg, "promptAgentWithInterrupt",
+		exp.InlinePrompt{model, ai.WithConfig(cfg), ai.WithTools(interruptTool)},
+		newStore("promptAgentWithInterrupt"))
+
+	h.agents["promptAgentWithRestartTool"] = exp.DefineAgent[customState](reg, "promptAgentWithRestartTool",
+		exp.InlinePrompt{model, ai.WithConfig(cfg), ai.WithTools(restartTool)},
+		newStore("promptAgentWithRestartTool"))
+
+	// --- Custom agents ---
+
+	// customAgentBlocking: server-managed, blocks until its context is
+	// cancelled (abort). Used for abort-while-pending tests.
+	h.agents["customAgentBlocking"] = exp.DefineCustomAgent(reg, "customAgentBlocking",
+		func(ctx context.Context, _ exp.Responder, sess *exp.SessionRunner[customState]) (*exp.AgentResult, error) {
+			if err := sess.Run(ctx, func(ctx context.Context, _ *exp.AgentInput) (*exp.TurnResult, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}); err != nil {
+				return nil, err
+			}
+			return &exp.AgentResult{Message: ai.NewModelTextMessage("unblocked")}, nil
+		}, newStore("customAgentBlocking"))
+
+	// customAgentFailing: server-managed, fails during processing. Used for
+	// detach + background failure tests.
+	h.agents["customAgentFailing"] = exp.DefineCustomAgent(reg, "customAgentFailing",
+		func(ctx context.Context, _ exp.Responder, sess *exp.SessionRunner[customState]) (*exp.AgentResult, error) {
+			if err := sess.Run(ctx, func(ctx context.Context, _ *exp.AgentInput) (*exp.TurnResult, error) {
+				return nil, errors.New("intentional failure")
+			}); err != nil {
+				return nil, err
+			}
+			return &exp.AgentResult{Message: ai.NewModelTextMessage("unreachable")}, nil
+		}, newStore("customAgentFailing"))
+
+	// customAgentWithArtifacts: client-managed, streams and dedupes artifacts.
+	h.agents["customAgentWithArtifacts"] = exp.DefineCustomAgent(reg, "customAgentWithArtifacts",
+		func(ctx context.Context, resp exp.Responder, sess *exp.SessionRunner[customState]) (*exp.AgentResult, error) {
+			if err := sess.Run(ctx, func(ctx context.Context, _ *exp.AgentInput) (*exp.TurnResult, error) {
+				resp.SendArtifact(&exp.Artifact{Name: "doc1", Parts: []*ai.Part{ai.NewTextPart("v1")}})
+				resp.SendArtifact(&exp.Artifact{Name: "doc1", Parts: []*ai.Part{ai.NewTextPart("v2")}})
+				resp.SendArtifact(&exp.Artifact{Name: "doc2", Parts: []*ai.Part{ai.NewTextPart("other")}})
+				return nil, nil
+			}); err != nil {
+				return nil, err
+			}
+			return &exp.AgentResult{
+				Artifacts: sess.Artifacts(),
+				Message:   ai.NewModelTextMessage("done"),
+			}, nil
+		})
+
+	// customAgentWithCustomState: client-managed, increments custom.counter.
+	h.agents["customAgentWithCustomState"] = exp.DefineCustomAgent(reg, "customAgentWithCustomState",
+		counterAgentFunc())
+
+	// customAgentWithMultiCustomState: client-managed, three sequential
+	// custom-state updates in one turn (to exercise the customPatch contract).
+	h.agents["customAgentWithMultiCustomState"] = exp.DefineCustomAgent(reg, "customAgentWithMultiCustomState",
+		func(ctx context.Context, _ exp.Responder, sess *exp.SessionRunner[customState]) (*exp.AgentResult, error) {
+			if err := sess.Run(ctx, func(ctx context.Context, _ *exp.AgentInput) (*exp.TurnResult, error) {
+				sess.UpdateCustom(func(customState) customState {
+					return customState{"counter": float64(1), "status": "working"}
+				})
+				sess.UpdateCustom(func(s customState) customState {
+					out := cloneCustom(s)
+					out["counter"] = float64(2)
+					return out
+				})
+				sess.UpdateCustom(func(s customState) customState {
+					out := cloneCustom(s)
+					out["status"] = "done"
+					return out
+				})
+				return nil, nil
+			}); err != nil {
+				return nil, err
+			}
+			return &exp.AgentResult{Message: ai.NewModelTextMessage("done")}, nil
+		})
+
+	// customAgentWithArtifactsStore: server-managed, adds a numbered artifact
+	// per invocation based on existing count.
+	h.agents["customAgentWithArtifactsStore"] = exp.DefineCustomAgent(reg, "customAgentWithArtifactsStore",
+		func(ctx context.Context, resp exp.Responder, sess *exp.SessionRunner[customState]) (*exp.AgentResult, error) {
+			if err := sess.Run(ctx, func(ctx context.Context, _ *exp.AgentInput) (*exp.TurnResult, error) {
+				count := len(sess.Artifacts()) + 1
+				resp.SendArtifact(&exp.Artifact{
+					Name:  fmt.Sprintf("doc%d", count),
+					Parts: []*ai.Part{ai.NewTextPart(fmt.Sprintf("content%d", count))},
+				})
+				return nil, nil
+			}); err != nil {
+				return nil, err
+			}
+			return &exp.AgentResult{
+				Artifacts: sess.Artifacts(),
+				Message:   ai.NewModelTextMessage("done"),
+			}, nil
+		}, newStore("customAgentWithArtifactsStore"))
+
+	// customAgentWithCustomStateStore: server-managed counter agent.
+	h.agents["customAgentWithCustomStateStore"] = exp.DefineCustomAgent(reg, "customAgentWithCustomStateStore",
+		counterAgentFunc(), newStore("customAgentWithCustomStateStore"))
+
+	return h
+}
+
+// counterAgentFunc returns an agent func that increments custom.counter by 1
+// each turn (default 0 -> 1), used by both the client- and server-managed
+// custom-state agents.
+func counterAgentFunc() exp.AgentFunc[customState] {
+	return func(ctx context.Context, _ exp.Responder, sess *exp.SessionRunner[customState]) (*exp.AgentResult, error) {
+		if err := sess.Run(ctx, func(ctx context.Context, _ *exp.AgentInput) (*exp.TurnResult, error) {
+			sess.UpdateCustom(func(s customState) customState {
+				counter := float64(0)
+				if s != nil {
+					if c, ok := s["counter"].(float64); ok {
+						counter = c
+					}
+				}
+				return customState{"counter": counter + 1}
+			})
+			return nil, nil
+		}); err != nil {
+			return nil, err
+		}
+		return &exp.AgentResult{Message: ai.NewModelTextMessage("done")}, nil
+	}
+}
+
+func cloneCustom(s customState) customState {
+	out := make(customState, len(s)+1)
+	for k, v := range s {
+		out[k] = v
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Test runner
+// ---------------------------------------------------------------------------
+
+func TestAgentConformance(t *testing.T) {
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read spec %s: %v", specPath, err)
+	}
+	var suite specSuite
+	if err := yaml.Unmarshal(data, &suite); err != nil {
+		t.Fatalf("parse spec: %v", err)
+	}
+	if len(suite.Tests) == 0 {
+		t.Fatal("spec contains no tests")
+	}
+
+	for _, tc := range suite.Tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			h := setupHarness(t)
+			agent, ok := h.agents[tc.Agent]
+			if !ok {
+				t.Fatalf("unknown agent %q in test %q", tc.Agent, tc.Name)
+			}
+			store := h.stores[tc.Agent] // nil for client-managed agents
+
+			captures := map[string]any{}
+			for i, step := range tc.Steps {
+				stepType, _ := step["type"].(string)
+				label := fmt.Sprintf("step[%d] (%s)", i, stepType)
+				switch stepType {
+				case "send":
+					h.executeSend(t, label, agent, step, captures)
+				case "getSnapshotData":
+					executeGetSnapshotData(t, label, store, step, captures)
+				case "abort":
+					executeAbort(t, label, agent, store, step, captures)
+				case "waitUntilCompleted":
+					executeWaitUntilCompleted(t, label, store, step, captures)
+				default:
+					t.Fatalf("%s: unknown step type %q", label, stepType)
+				}
+				if t.Failed() {
+					// Stop at the first failing step: later steps usually
+					// depend on captures the failed step would have produced.
+					return
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// send
+// ---------------------------------------------------------------------------
+
+func (h *harness) executeSend(t *testing.T, label string, agent *exp.Agent[customState], step map[string]any, captures map[string]any) {
+	t.Helper()
+	resolved := resolveTemplates(t, label, step, captures)
+
+	// Program the model for this step.
+	if _, hasResp := resolved["modelResponses"]; hasResp {
+		var modelResponses []*ai.ModelResponse
+		jsonConvert(t, label, resolved["modelResponses"], &modelResponses)
+		var streamChunks [][]*ai.ModelResponseChunk
+		if sc, ok := resolved["streamChunks"]; ok {
+			jsonConvert(t, label, sc, &streamChunks)
+		}
+		counter := 0
+		h.pm.setHandler(func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			i := counter
+			counter++
+			if cb != nil && i < len(streamChunks) {
+				for _, chunk := range streamChunks[i] {
+					if err := cb(ctx, chunk); err != nil {
+						return nil, err
+					}
+				}
+			}
+			if i < len(modelResponses) {
+				// Echo the request back on the response, as every real model
+				// does. The prompt agent's tool loop relies on response.Request
+				// to thread intermediate tool-request/response messages into
+				// session history (modelResp.History()); without it the loop
+				// falls back to recording only the final message.
+				resp := modelResponses[i]
+				resp.Request = req
+				return resp, nil
+			}
+			return nil, fmt.Errorf("programmableModel: no response for generate call %d", i)
+		})
+	} else {
+		h.pm.setHandler(nil)
+	}
+
+	// Build invocation options from init.
+	var opts []exp.InvocationOption[customState]
+	if initRaw, ok := resolved["init"].(map[string]any); ok {
+		if sid := asString(initRaw["snapshotId"]); sid != "" {
+			opts = append(opts, exp.WithSnapshotID[customState](sid))
+		}
+		if sess := asString(initRaw["sessionId"]); sess != "" {
+			opts = append(opts, exp.WithSessionID[customState](sess))
+		}
+		if st, ok := initRaw["state"]; ok {
+			var state exp.SessionState[customState]
+			jsonConvert(t, label, st, &state)
+			opts = append(opts, exp.WithState(&state))
+		}
+	}
+
+	// Parse inputs.
+	var inputs []*exp.AgentInput
+	if in, ok := resolved["inputs"]; ok {
+		jsonConvert(t, label, in, &inputs)
+	}
+
+	// Guard against a hung invocation (a regression could leave a turn
+	// blocked forever): a real conformance run completes in milliseconds.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var (
+		output        *exp.AgentOutput[customState]
+		invocationErr error
+		chunks        []*exp.AgentStreamChunk
+	)
+
+	conn, err := agent.Connect(ctx, opts...)
+	if err != nil {
+		invocationErr = err
+	} else {
+		// Drain the stream concurrently with sending so the agent's responder
+		// never blocks on a full stream buffer while inputs are still being
+		// sent (matches the JS harness's concurrent send/stream).
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for chunk, rerr := range conn.Receive() {
+				if rerr != nil {
+					return
+				}
+				chunks = append(chunks, chunk)
+			}
+		}()
+		for _, input := range inputs {
+			// Send errors are not fatal: once an invocation resolves (e.g. a
+			// failed turn) further sends race it; the outcome is on Output.
+			_ = conn.Send(input)
+		}
+		_ = conn.Close()
+		<-done
+		output, invocationErr = conn.Output()
+	}
+
+	// expectError: the turn is expected to throw (API misuse) rather than
+	// resolve with a graceful finishReason:'failed' output. Assert the error's
+	// status (exactly) and message (substring), then stop.
+	if ee, ok := resolved["expectError"].(map[string]any); ok {
+		assertThrownError(t, label, invocationErr, ee)
+		return
+	}
+
+	// --- Assertions ---
+	assertChunks(t, label, chunks, resolved["expectChunks"])
+	if eo, ok := resolved["expectOutput"].(map[string]any); ok {
+		assertOutput(t, label, output, invocationErr, eo)
+	} else if invocationErr != nil {
+		t.Fatalf("%s: invocation failed: %v", label, invocationErr)
+	}
+
+	// --- Captures (read from the raw step; these are plain names) ---
+	if output != nil {
+		if name, ok := step["captureSnapshotId"].(string); ok {
+			if output.SnapshotID == "" {
+				t.Fatalf("%s: captureSnapshotId %q requested but output has no snapshotId", label, name)
+			}
+			captures[name] = output.SnapshotID
+		}
+		if name, ok := step["captureState"].(string); ok {
+			if output.State == nil {
+				t.Fatalf("%s: captureState %q requested but output has no state", label, name)
+			}
+			captures[name] = canon(t, output.State)
+		}
+		if name, ok := step["captureSessionId"].(string); ok {
+			if output.State == nil || output.State.SessionID == "" {
+				t.Fatalf("%s: captureSessionId %q requested but output has no state.sessionId", label, name)
+			}
+			captures[name] = output.State.SessionID
+		}
+	} else {
+		for _, key := range []string{"captureSnapshotId", "captureState", "captureSessionId"} {
+			if name, ok := step[key].(string); ok {
+				t.Fatalf("%s: %s %q requested but invocation produced no output (err: %v)", label, key, name, invocationErr)
+			}
+		}
+	}
+}
+
+// assertChunks performs the semi-strict ordered chunk comparison: same length
+// and order, with type-aware matching per chunk (turnEnd asserts presence and,
+// when specified, finishReason; modelChunk/artifact/customPatch use contains).
+func assertChunks(t *testing.T, label string, actual []*exp.AgentStreamChunk, expectRaw any) {
+	t.Helper()
+	if expectRaw == nil {
+		return
+	}
+	expected, ok := canon(t, expectRaw).([]any)
+	if !ok {
+		t.Fatalf("%s: expectChunks is not a list", label)
+	}
+	actualCanon := make([]any, len(actual))
+	for i, c := range actual {
+		actualCanon[i] = canon(t, c)
+	}
+	if len(actualCanon) != len(expected) {
+		t.Errorf("%s: expected %d chunks, got %d.\n  expected: %s\n  actual:   %s",
+			label, len(expected), len(actualCanon), mustJSON(expected), mustJSON(actualCanon))
+		return
+	}
+	for i := range expected {
+		if err := matchChunk(actualCanon[i], expected[i]); err != nil {
+			t.Errorf("%s: chunk[%d]: %v\n  expected: %s\n  actual:   %s",
+				label, i, err, mustJSON(expected[i]), mustJSON(actualCanon[i]))
+		}
+	}
+}
+
+func matchChunk(actual, expected any) error {
+	em, ok := expected.(map[string]any)
+	if !ok {
+		return matchContains(actual, expected, "chunk")
+	}
+	am, _ := actual.(map[string]any)
+	switch {
+	case hasKey(em, "turnEnd"):
+		te, ok := am["turnEnd"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("expected turnEnd chunk")
+		}
+		// snapshotId is dynamic; only finishReason is asserted when specified.
+		if exTE, _ := em["turnEnd"].(map[string]any); exTE != nil {
+			if fr, ok := exTE["finishReason"]; ok {
+				if !reflect.DeepEqual(te["finishReason"], fr) {
+					return fmt.Errorf("turnEnd.finishReason: want %v, got %v", fr, te["finishReason"])
+				}
+			}
+		}
+		return nil
+	case hasKey(em, "modelChunk"):
+		return matchContains(am["modelChunk"], em["modelChunk"], "modelChunk")
+	case hasKey(em, "artifact"):
+		return matchContains(am["artifact"], em["artifact"], "artifact")
+	case hasKey(em, "customPatch"):
+		return matchContains(am["customPatch"], em["customPatch"], "customPatch")
+	default:
+		return matchContains(actual, expected, "chunk")
+	}
+}
+
+func assertOutput(t *testing.T, label string, output *exp.AgentOutput[customState], invocationErr error, expect map[string]any) {
+	t.Helper()
+
+	wantsFailure := false
+	if fr, ok := expect["finishReason"].(string); ok && fr == "failed" {
+		wantsFailure = true
+	}
+	if _, ok := expect["errorContains"]; ok {
+		wantsFailure = true
+	}
+
+	if invocationErr != nil {
+		// The implementation returned a transport-level error instead of a
+		// graceful AgentOutput. Surface this explicitly: a spec that expects a
+		// graceful failure (finishReason=failed) is not satisfied by a thrown
+		// error, so this fails — and the message makes the mismatch obvious.
+		status := "<none>"
+		var ge *core.GenkitError
+		if errors.As(invocationErr, &ge) {
+			status = string(ge.Status)
+		}
+		if wantsFailure {
+			t.Errorf("%s: expected a graceful failed AgentOutput, but the invocation returned a transport-level error "+
+				"(status=%s): %v", label, status, invocationErr)
+		} else {
+			t.Fatalf("%s: invocation failed: %v", label, invocationErr)
+		}
+		return
+	}
+	if output == nil {
+		t.Fatalf("%s: no output and no error", label)
+	}
+
+	out := canon(t, output).(map[string]any)
+
+	if msg, ok := expect["message"]; ok {
+		if err := matchContains(out["message"], canon(t, msg), "output.message"); err != nil {
+			t.Errorf("%s: %v", label, err)
+		}
+	}
+	if b, _ := expect["hasSnapshotId"].(bool); b {
+		if s, _ := out["snapshotId"].(string); s == "" {
+			t.Errorf("%s: expected output.snapshotId to be a non-empty string", label)
+		}
+	}
+	if b, _ := expect["hasSessionId"].(bool); b {
+		if !hasNonEmptySessionID(out["state"]) {
+			t.Errorf("%s: expected output.state.sessionId to be a non-empty string, got: %s", label, mustJSON(out["state"]))
+		}
+	}
+	if sc, ok := expect["stateContains"]; ok {
+		if err := matchContains(out["state"], canon(t, sc), "output.state"); err != nil {
+			t.Errorf("%s: %v", label, err)
+		}
+	}
+	if ac, ok := expect["artifactsContain"]; ok {
+		assertArtifactsContain(t, label, out["artifacts"], canon(t, ac))
+	}
+	if fr, ok := expect["finishReason"]; ok {
+		if !reflect.DeepEqual(out["finishReason"], fr) {
+			t.Errorf("%s: output.finishReason: want %v, got %v", label, fr, out["finishReason"])
+		}
+	}
+	if ec, ok := expect["errorContains"].(map[string]any); ok {
+		assertErrorContains(t, label, "output.error", out["error"], ec)
+	}
+}
+
+func assertArtifactsContain(t *testing.T, label string, actual any, expected any) {
+	t.Helper()
+	arts, ok := actual.([]any)
+	if !ok {
+		t.Errorf("%s: expected output.artifacts to be a list, got %s", label, mustJSON(actual))
+		return
+	}
+	expArts, _ := expected.([]any)
+	for _, ea := range expArts {
+		em, _ := ea.(map[string]any)
+		name, _ := em["name"].(string)
+		var found map[string]any
+		for _, a := range arts {
+			if am, ok := a.(map[string]any); ok {
+				if n, _ := am["name"].(string); n == name {
+					found = am
+					break
+				}
+			}
+		}
+		if found == nil {
+			t.Errorf("%s: expected artifact %q not found in output.artifacts %s", label, name, mustJSON(actual))
+			continue
+		}
+		if err := matchContains(found, ea, fmt.Sprintf("artifact(%s)", name)); err != nil {
+			t.Errorf("%s: %v", label, err)
+		}
+	}
+}
+
+// assertErrorContains matches a structured error: its presence and its status
+// (exactly). The error message is intentionally NOT asserted — wording is
+// implementation-specific and need not match across language harnesses; the
+// cross-language contract is the error status (category).
+func assertErrorContains(t *testing.T, label, path string, actual any, expect map[string]any) {
+	t.Helper()
+	errObj, ok := actual.(map[string]any)
+	if !ok || errObj == nil {
+		t.Errorf("%s: expected %s to be present, got %s", label, path, mustJSON(actual))
+		return
+	}
+	if st, ok := expect["status"]; ok {
+		if !reflect.DeepEqual(errObj["status"], st) {
+			t.Errorf("%s: %s.status: want %v, got %v", label, path, st, errObj["status"])
+		}
+	}
+}
+
+// assertThrownError checks that an API-misuse send threw a transport-level
+// error (rather than resolving with a graceful output) and that its status
+// matches exactly. The error message is intentionally NOT asserted — wording
+// is implementation-specific and need not match across language harnesses.
+func assertThrownError(t *testing.T, label string, err error, expect map[string]any) {
+	t.Helper()
+	if err == nil {
+		t.Errorf("%s: expected the turn to throw an error, but it resolved successfully", label)
+		return
+	}
+	if st, ok := expect["status"].(string); ok {
+		got := ""
+		var ge *core.GenkitError
+		if errors.As(err, &ge) {
+			got = string(ge.Status)
+		}
+		if got != st {
+			t.Errorf("%s: expectError.status: want %q, got %q (error: %v)", label, st, got, err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getSnapshotData
+// ---------------------------------------------------------------------------
+
+func executeGetSnapshotData(t *testing.T, label string, store *localstore.InMemorySessionStore[customState], step map[string]any, captures map[string]any) {
+	t.Helper()
+	if store == nil {
+		t.Fatalf("%s: agent is client-managed (no store) — getSnapshotData not applicable", label)
+	}
+	resolved := resolveTemplates(t, label, step, captures)
+	snapID := asString(resolved["snapshotId"])
+	sessID := asString(resolved["sessionId"])
+	if (snapID == "") == (sessID == "") {
+		t.Fatalf("%s: getSnapshotData requires exactly one of snapshotId / sessionId", label)
+	}
+
+	ctx := context.Background()
+	var (
+		snap *exp.SessionSnapshot[customState]
+		err  error
+	)
+	if snapID != "" {
+		snap, err = store.GetSnapshot(ctx, snapID)
+	} else {
+		snap, err = store.GetLatestSnapshot(ctx, sessID)
+	}
+
+	if ee, ok := resolved["expectError"].(string); ok {
+		if err == nil {
+			t.Errorf("%s: expected error containing %q, but getSnapshotData succeeded", label, ee)
+		} else if !strings.Contains(err.Error(), ee) {
+			t.Errorf("%s: expected error containing %q, got: %v", label, ee, err)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("%s: getSnapshotData: %v", label, err)
+	}
+	if snap == nil {
+		t.Fatalf("%s: snapshot not found", label)
+	}
+	if es, ok := resolved["expectSnapshot"].(map[string]any); ok {
+		assertSnapshot(t, label, snap, es)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// abort
+// ---------------------------------------------------------------------------
+
+func executeAbort(t *testing.T, label string, agent *exp.Agent[customState], store *localstore.InMemorySessionStore[customState], step map[string]any, captures map[string]any) {
+	t.Helper()
+	if store == nil {
+		t.Fatalf("%s: agent is client-managed (no store) — abort not applicable", label)
+	}
+	resolved := resolveTemplates(t, label, step, captures)
+	snapID := asString(resolved["snapshotId"])
+	if snapID == "" {
+		t.Fatalf("%s: abort requires snapshotId", label)
+	}
+
+	ctx := context.Background()
+
+	// Capture the status before aborting so we can assert expectPreviousStatus.
+	// (Agent.Abort returns the status *after* the attempt, while the spec
+	// asserts the *previous* status — semantically what JS's agent.abort()
+	// returns — so the harness reads it directly first.)
+	var previous exp.SnapshotStatus
+	if snap, _ := store.GetSnapshot(ctx, snapID); snap != nil {
+		previous = normalizeStatus(snap.Status)
+	}
+	if _, err := agent.Abort(ctx, snapID); err != nil {
+		t.Fatalf("%s: abort: %v", label, err)
+	}
+
+	if raw, present := step["expectPreviousStatus"]; present {
+		want := ""
+		if raw != nil { // YAML `~` means "expect absent/empty".
+			want = asString(resolved["expectPreviousStatus"])
+		}
+		if string(previous) != want {
+			t.Errorf("%s: expectPreviousStatus: want %q, got %q", label, want, previous)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// waitUntilCompleted
+// ---------------------------------------------------------------------------
+
+func executeWaitUntilCompleted(t *testing.T, label string, store *localstore.InMemorySessionStore[customState], step map[string]any, captures map[string]any) {
+	t.Helper()
+	if store == nil {
+		t.Fatalf("%s: agent is client-managed (no store) — waitUntilCompleted not applicable", label)
+	}
+	resolved := resolveTemplates(t, label, step, captures)
+	snapID := asString(resolved["snapshotId"])
+	if snapID == "" {
+		t.Fatalf("%s: waitUntilCompleted requires snapshotId", label)
+	}
+	timeout := 5 * time.Second
+	if tm, ok := resolved["timeoutMs"]; ok {
+		timeout = time.Duration(toFloat(tm)) * time.Millisecond
+	}
+
+	terminal := map[exp.SnapshotStatus]bool{
+		exp.SnapshotStatusCompleted: true,
+		exp.SnapshotStatusFailed:    true,
+		exp.SnapshotStatusAborted:   true,
+	}
+
+	ctx := context.Background()
+	deadline := time.Now().Add(timeout)
+	var snap *exp.SessionSnapshot[customState]
+	for time.Now().Before(deadline) {
+		s, err := store.GetSnapshot(ctx, snapID)
+		if err != nil {
+			t.Fatalf("%s: getSnapshot while polling: %v", label, err)
+		}
+		if s != nil && terminal[normalizeStatus(s.Status)] {
+			snap = s
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if snap == nil {
+		t.Fatalf("%s: snapshot %s did not reach a terminal status within %v", label, snapID, timeout)
+	}
+	if es, ok := resolved["expectSnapshot"].(map[string]any); ok {
+		assertSnapshot(t, label, snap, es)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot assertions
+// ---------------------------------------------------------------------------
+
+func assertSnapshot(t *testing.T, label string, snap *exp.SessionSnapshot[customState], expect map[string]any) {
+	t.Helper()
+	snap.Status = normalizeStatus(snap.Status)
+	actual := canon(t, snap).(map[string]any)
+
+	if pid, ok := expect["parentId"]; ok {
+		if !reflect.DeepEqual(actual["parentId"], pid) {
+			t.Errorf("%s: snapshot.parentId: want %v, got %v", label, pid, actual["parentId"])
+		}
+	}
+	if st, ok := expect["status"]; ok {
+		if !reflect.DeepEqual(actual["status"], st) {
+			t.Errorf("%s: snapshot.status: want %v, got %v", label, st, actual["status"])
+		}
+	}
+	if fr, ok := expect["finishReason"]; ok {
+		if !reflect.DeepEqual(actual["finishReason"], fr) {
+			t.Errorf("%s: snapshot.finishReason: want %v, got %v", label, fr, actual["finishReason"])
+		}
+	}
+	if b, _ := expect["hasSessionId"].(bool); b {
+		if !hasNonEmptySessionID(actual["state"]) {
+			t.Errorf("%s: expected snapshot.state.sessionId to be a non-empty string, got: %s", label, mustJSON(actual["state"]))
+		}
+	}
+	if sc, ok := expect["stateContains"]; ok {
+		if err := matchContains(actual["state"], canon(t, sc), "snapshot.state"); err != nil {
+			t.Errorf("%s: %v", label, err)
+		}
+	}
+	if ec, ok := expect["errorContains"].(map[string]any); ok {
+		assertErrorContains(t, label, "snapshot.error", actual["error"], ec)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// "Contains" matchers
+// ---------------------------------------------------------------------------
+
+// matchContains asserts that actual contains all fields specified in expected.
+// Objects are matched key-by-key (extra actual keys ignored); arrays are
+// matched as an ordered subsequence (each expected item appears in order, not
+// necessarily contiguously); scalars must be deep-equal. All values must be in
+// canonical JSON form (string keys, float64 numbers).
+func matchContains(actual, expected any, path string) error {
+	if expected == nil {
+		return nil
+	}
+	switch exp := expected.(type) {
+	case []any:
+		act, ok := actual.([]any)
+		if !ok {
+			return fmt.Errorf("%s: expected array, got %T", path, actual)
+		}
+		return matchSubsequence(act, exp, path)
+	case map[string]any:
+		act, ok := actual.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s: expected object, got %T", path, actual)
+		}
+		for k, v := range exp {
+			if err := matchContains(act[k], v, path+"."+k); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		if !reflect.DeepEqual(actual, expected) {
+			return fmt.Errorf("%s: want %v (%T), got %v (%T)", path, expected, expected, actual, actual)
+		}
+		return nil
+	}
+}
+
+func matchSubsequence(actual, expected []any, path string) error {
+	idx := 0
+	for i, want := range expected {
+		found := false
+		for idx < len(actual) {
+			if matchContains(actual[idx], want, fmt.Sprintf("%s[%d]", path, idx)) == nil {
+				found = true
+				idx++
+				break
+			}
+			idx++
+		}
+		if !found {
+			return fmt.Errorf("%s: expected item %d not found in order: %s", path, i, mustJSON(want))
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Template resolution
+// ---------------------------------------------------------------------------
+
+var (
+	fullTemplateRe   = regexp.MustCompile(`^\{\{(\w+)\}\}$`)
+	inlineTemplateRe = regexp.MustCompile(`\{\{(\w+)\}\}`)
+)
+
+// resolveTemplates recursively replaces `{{name}}` references with previously
+// captured values. A value that is exactly `{{name}}` is replaced by the
+// captured value (which may be a non-string, e.g. a captured state object);
+// inline occurrences are string-substituted.
+func resolveTemplates(t *testing.T, label string, v any, captures map[string]any) map[string]any {
+	t.Helper()
+	resolved, err := resolveValue(v, captures)
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+	m, _ := resolved.(map[string]any)
+	return m
+}
+
+func resolveValue(v any, captures map[string]any) (any, error) {
+	switch x := v.(type) {
+	case string:
+		if m := fullTemplateRe.FindStringSubmatch(x); m != nil {
+			val, ok := captures[m[1]]
+			if !ok {
+				return nil, fmt.Errorf("template reference {{%s}} not found in captures", m[1])
+			}
+			return val, nil
+		}
+		var missing string
+		out := inlineTemplateRe.ReplaceAllStringFunc(x, func(s string) string {
+			name := inlineTemplateRe.FindStringSubmatch(s)[1]
+			val, ok := captures[name]
+			if !ok {
+				missing = name
+				return s
+			}
+			if str, ok := val.(string); ok {
+				return str
+			}
+			return string(mustJSON(val))
+		})
+		if missing != "" {
+			return nil, fmt.Errorf("template reference {{%s}} not found in captures", missing)
+		}
+		return out, nil
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, val := range x {
+			r, err := resolveValue(val, captures)
+			if err != nil {
+				return nil, err
+			}
+			out[k] = r
+		}
+		return out, nil
+	case []any:
+		out := make([]any, len(x))
+		for i, e := range x {
+			r, err := resolveValue(e, captures)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = r
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// canon converts any Go value (struct or yaml-decoded) into canonical JSON
+// form (string-keyed maps, float64 numbers) via a JSON round-trip, so the
+// expected (yaml) and actual (Go struct) sides compare apples-to-apples.
+func canon(t *testing.T, v any) any {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("canon: marshal: %v", err)
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("canon: unmarshal: %v", err)
+	}
+	return out
+}
+
+func jsonConvert(t *testing.T, label string, src, dst any) {
+	t.Helper()
+	b, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("%s: marshal %T: %v", label, src, err)
+	}
+	if err := json.Unmarshal(b, dst); err != nil {
+		t.Fatalf("%s: unmarshal into %T: %v", label, dst, err)
+	}
+}
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return []byte(fmt.Sprintf("%v", v))
+	}
+	return b
+}
+
+func hasKey(m map[string]any, k string) bool {
+	_, ok := m[k]
+	return ok
+}
+
+func hasNonEmptySessionID(state any) bool {
+	m, ok := state.(map[string]any)
+	if !ok {
+		return false
+	}
+	s, _ := m["sessionId"].(string)
+	return s != ""
+}
+
+func normalizeStatus(s exp.SnapshotStatus) exp.SnapshotStatus {
+	if s == "" {
+		return exp.SnapshotStatusCompleted
+	}
+	return s
+}
+
+func asString(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return x
+	default:
+		return fmt.Sprint(x)
+	}
+}
+
+func toFloat(v any) float64 {
+	switch x := v.(type) {
+	case float64:
+		return x
+	case int:
+		return float64(x)
+	case int64:
+		return float64(x)
+	case uint64:
+		return float64(x)
+	default:
+		return 0
+	}
+}

--- a/tests/specs/agent.yaml
+++ b/tests/specs/agent.yaml
@@ -1,0 +1,1396 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# This file describes the behavioral specification for the Agent API.
+# It is designed to be consumed by conformance test harnesses in any
+# language (JS, Go, Dart, Python, etc.) to ensure cross-language
+# compatibility of the Agent abstraction.
+#
+# See docs/agents-conformance-testing.md for harness requirements and
+# full spec format reference.
+
+tests:
+  # ---------------------------------------------------------------------------
+  # Basic single-turn
+  # ---------------------------------------------------------------------------
+  - name: simple single turn - client managed
+    description: >
+      A single user message is sent to a client-managed agent.
+      The agent generates one model response and returns it along with
+      the accumulated session state. A sessionId must be generated.
+    agent: promptAgent
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: hi }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: hello back }] }
+            finishReason: stop
+        expectChunks:
+          # A normal completion carries the model's finishReason on turnEnd.
+          - turnEnd: { finishReason: stop }
+        expectOutput:
+          message: { role: model, content: [{ text: hello back }] }
+          # A normal completion surfaces finishReason 'stop' on the output.
+          finishReason: stop
+          hasSessionId: true
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: hi }] }
+              - { role: model, content: [{ text: hello back }] }
+
+  - name: simple single turn - server managed
+    description: >
+      A single user message is sent to a server-managed agent.
+      The output should contain a snapshotId and no inline state.
+      The snapshot state must contain a generated sessionId.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: hi }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: hello back }] }
+            finishReason: stop
+        expectChunks:
+          - turnEnd: { finishReason: stop }
+        expectOutput:
+          message: { role: model, content: [{ text: hello back }] }
+          finishReason: stop
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: getSnapshotData
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: completed
+          hasSessionId: true
+
+  # ---------------------------------------------------------------------------
+  # Streaming
+  # ---------------------------------------------------------------------------
+  - name: streaming model chunks
+    description: >
+      Model emits streaming chunks during generation. They should be
+      forwarded as modelChunk stream events, followed by a turnEnd.
+    agent: promptAgent
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: hi }] }
+        streamChunks:
+          - [
+              { index: 0, role: model, content: [{ text: 'hel' }] },
+              { index: 0, role: model, content: [{ text: 'lo' }] },
+            ]
+        modelResponses:
+          - message: { role: model, content: [{ text: hello }] }
+            finishReason: stop
+        expectChunks:
+          - modelChunk: { index: 0, role: model, content: [{ text: 'hel' }] }
+          - modelChunk: { index: 0, role: model, content: [{ text: 'lo' }] }
+          - turnEnd: { finishReason: stop }
+        expectOutput:
+          message: { role: model, content: [{ text: hello }] }
+          finishReason: stop
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: hi }] }
+              - { role: model, content: [{ text: hello }] }
+
+  # ---------------------------------------------------------------------------
+  # Multi-turn in one invocation
+  # ---------------------------------------------------------------------------
+  - name: multi-turn in one invocation
+    description: >
+      Two user messages are sent sequentially in one invocation.
+      Both should be processed as separate turns. History must
+      accumulate so the second model call sees the first exchange.
+    agent: promptAgent
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: turn1 }] }
+          - message: { role: user, content: [{ text: turn2 }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply1 }] }
+            finishReason: stop
+          - message: { role: model, content: [{ text: reply2 }] }
+            finishReason: stop
+        expectChunks:
+          # Each turn ends with the model's finishReason.
+          - turnEnd: { finishReason: stop }
+          - turnEnd: { finishReason: stop }
+        expectOutput:
+          message: { role: model, content: [{ text: reply2 }] }
+          finishReason: stop
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: turn1 }] }
+              - { role: model, content: [{ text: reply1 }] }
+              - { role: user, content: [{ text: turn2 }] }
+              - { role: model, content: [{ text: reply2 }] }
+
+  # ---------------------------------------------------------------------------
+  # Tool calling
+  # ---------------------------------------------------------------------------
+  - name: agent calls tools
+    description: >
+      Model issues a tool request, tool executes automatically, and
+      the tool response is fed back to the model which then produces
+      a final text response.
+    agent: promptAgentWithTools
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: do it }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest: { name: testTool, input: {}, ref: ref1 }
+            finishReason: stop
+          - message: { role: model, content: [{ text: done }] }
+            finishReason: stop
+        expectChunks:
+          - modelChunk:
+              role: tool
+              content:
+                - toolResponse:
+                    { name: testTool, ref: ref1, output: 'tool called' }
+          - turnEnd: {}
+        expectOutput:
+          message: { role: model, content: [{ text: done }] }
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: do it }] }
+              - role: model
+                content:
+                  - toolRequest: { name: testTool, input: {}, ref: ref1 }
+              - role: tool
+                content:
+                  - toolResponse:
+                      { name: testTool, output: 'tool called', ref: ref1 }
+              - { role: model, content: [{ text: done }] }
+
+  # ---------------------------------------------------------------------------
+  # Interrupt and resume (multi-invocation)
+  # ---------------------------------------------------------------------------
+  - name: interrupt and resume
+    description: >
+      Model returns an interrupt tool request. The agent saves state
+      and returns the tool request as the output message. The client
+      then resumes with a new invocation providing the tool response
+      via snapshotId. The model receives the full history including
+      the tool response and produces a final answer.
+    agent: promptAgentWithInterrupt
+    steps:
+      # Phase 1: model interrupts
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: hello }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest:
+                    {
+                      name: interruptTool,
+                      input: { query: 'yes?' },
+                      ref: '123',
+                    }
+            finishReason: stop
+        # A tool interrupt pauses the turn — finishReason is 'interrupted'.
+        expectOutput:
+          message:
+            content:
+              - toolRequest:
+                  { name: interruptTool, input: { query: 'yes?' }, ref: '123' }
+          finishReason: interrupted
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      # Phase 2: client resumes with resume.respond
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - resume:
+              respond:
+                - toolResponse:
+                    {
+                      name: interruptTool,
+                      ref: '123',
+                      output: { answer: 'yes indeed' },
+                    }
+        modelResponses:
+          - message: { role: model, content: [{ text: completed }] }
+            finishReason: stop
+        expectOutput:
+          message: { role: model, content: [{ text: completed }] }
+
+  # ---------------------------------------------------------------------------
+  # Interrupt and restart (resume.restart)
+  # ---------------------------------------------------------------------------
+  - name: interrupt and restart
+    description: >
+      Model requests a tool that throws ToolInterruptError on first call.
+      The agent saves state and returns the tool request as output. The
+      client resumes with resume.restart (same input + metadata). The
+      tool re-executes successfully with the resumed metadata and the
+      model produces a final answer.
+    agent: promptAgentWithRestartTool
+    steps:
+      # Phase 1: model requests restartTool, tool interrupts
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: do it }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest:
+                    {
+                      name: restartTool,
+                      input: { action: 'delete' },
+                      ref: 'r1',
+                    }
+            finishReason: stop
+        # ToolInterruptError pauses the turn — finishReason is 'interrupted'.
+        expectOutput:
+          message:
+            content:
+              - toolRequest:
+                  { name: restartTool, input: { action: 'delete' }, ref: 'r1' }
+          finishReason: interrupted
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      # Phase 2: client resumes with resume.restart
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - resume:
+              restart:
+                - toolRequest:
+                    {
+                      name: restartTool,
+                      input: { action: 'delete' },
+                      ref: 'r1',
+                    }
+                  metadata: { resumed: { approved: true } }
+        modelResponses:
+          - message: { role: model, content: [{ text: deleted }] }
+            finishReason: stop
+        expectOutput:
+          message: { role: model, content: [{ text: deleted }] }
+
+  # ---------------------------------------------------------------------------
+  # Resume validation — forged restart rejected
+  # ---------------------------------------------------------------------------
+  - name: restart with forged inputs rejected
+    description: >
+      A malicious client attempts to restart a tool with modified inputs.
+      The agent must reject the restart because the input does not match
+      the original tool request in session history.
+    agent: promptAgentWithRestartTool
+    steps:
+      # Phase 1: model requests restartTool with safe input
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: do it }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest:
+                    {
+                      name: restartTool,
+                      input: { action: 'safe-op' },
+                      ref: 'r1',
+                    }
+            finishReason: stop
+        captureSnapshotId: snap1
+
+      # Phase 2: client forges restart with different input
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - resume:
+              restart:
+                - toolRequest:
+                    {
+                      name: restartTool,
+                      input: { action: '/etc/passwd' },
+                      ref: 'r1',
+                    }
+                  metadata: { resumed: { approved: true } }
+        modelResponses:
+          - message: { role: model, content: [{ text: should not reach }] }
+            finishReason: stop
+        # The agent does not throw — it resolves gracefully with
+        # finishReason 'failed', preserving the original error status.
+        expectOutput:
+          finishReason: failed
+          errorContains:
+            status: INVALID_ARGUMENT
+            message: modified inputs
+
+  # ---------------------------------------------------------------------------
+  # Resume validation — respond referencing non-existent tool
+  # ---------------------------------------------------------------------------
+  - name: respond referencing non-existent tool rejected
+    description: >
+      A client attempts to respond with a tool name/ref that does not
+      match any tool request in the session history. The agent must
+      reject with INVALID_ARGUMENT.
+    agent: promptAgentWithInterrupt
+    steps:
+      # Phase 1: model requests interruptTool
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: hello }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest:
+                    {
+                      name: interruptTool,
+                      input: { query: 'confirm?' },
+                      ref: 'i1',
+                    }
+            finishReason: stop
+        captureSnapshotId: snap1
+
+      # Phase 2: client responds with a fabricated tool name
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - resume:
+              respond:
+                - toolResponse:
+                    {
+                      name: fakeTool,
+                      ref: 'fake-ref',
+                      output: { answer: 'hacked' },
+                    }
+        modelResponses:
+          - message: { role: model, content: [{ text: should not reach }] }
+            finishReason: stop
+        # Resolves gracefully with finishReason 'failed' and INVALID_ARGUMENT.
+        expectOutput:
+          finishReason: failed
+          errorContains:
+            status: INVALID_ARGUMENT
+            message: not found in session history
+
+  # ---------------------------------------------------------------------------
+  # Snapshot chaining
+  # ---------------------------------------------------------------------------
+  - name: snapshot chaining across invocations
+    description: >
+      Two sequential invocations against a server-managed agent.
+      The second invocation resumes from the first snapshot. After
+      both complete, getSnapshotData verifies the parent chain,
+      accumulated history, and that a sessionId is present.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply1 }] }
+            finishReason: stop
+        captureSnapshotId: snap1
+
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - message: { role: user, content: [{ text: second }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply2 }] }
+            finishReason: stop
+        captureSnapshotId: snap2
+
+      - type: getSnapshotData
+        snapshotId: '{{snap2}}'
+        expectSnapshot:
+          parentId: '{{snap1}}'
+          status: completed
+          hasSessionId: true
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: first }] }
+              - { role: model, content: [{ text: reply1 }] }
+              - { role: user, content: [{ text: second }] }
+              - { role: model, content: [{ text: reply2 }] }
+
+  # ---------------------------------------------------------------------------
+  # Client-managed state across invocations
+  # ---------------------------------------------------------------------------
+  - name: client-managed state across invocations
+    description: >
+      Two sequential invocations against a client-managed agent.
+      The second invocation seeds session state from the first
+      invocation's output state. History should accumulate and the
+      sessionId must be preserved across invocations.
+    agent: promptAgent
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply1 }] }
+            finishReason: stop
+        captureState: state1
+        captureSessionId: sid1
+
+      - type: send
+        init: { state: '{{state1}}' }
+        inputs:
+          - message: { role: user, content: [{ text: second }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply2 }] }
+            finishReason: stop
+        expectOutput:
+          message: { role: model, content: [{ text: reply2 }] }
+          stateContains:
+            sessionId: '{{sid1}}'
+            messages:
+              - { role: user, content: [{ text: first }] }
+              - { role: model, content: [{ text: reply1 }] }
+              - { role: user, content: [{ text: second }] }
+              - { role: model, content: [{ text: reply2 }] }
+
+  # ===========================================================================
+  # Phase 2: Detach, Abort, Artifacts, Custom State
+  # ===========================================================================
+
+  # ---------------------------------------------------------------------------
+  # Detach & background execution
+  # ---------------------------------------------------------------------------
+  - name: detach and background completion
+    description: >
+      A detach flag causes the agent to return immediately with a
+      pending snapshot. The background continues processing and
+      eventually the snapshot reaches "done" status with accumulated
+      state.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: process this }] }
+            detach: true
+        modelResponses:
+          - message: { role: model, content: [{ text: done in background }] }
+            finishReason: stop
+        expectOutput:
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: waitUntilCompleted
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: completed
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: process this }] }
+              - { role: model, content: [{ text: done in background }] }
+
+  - name: detach with background failure
+    description: >
+      When a detached agent fails in the background, the snapshot
+      status should be set to "failed".
+    agent: customAgentFailing
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: fail }] }
+            detach: true
+        expectOutput:
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: waitUntilCompleted
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: failed
+          # A failed run records finishReason 'failed' on the snapshot,
+          # distinct from the snapshot status.
+          finishReason: failed
+
+  # ---------------------------------------------------------------------------
+  # Abort
+  # ---------------------------------------------------------------------------
+  - name: abort pending agent
+    description: >
+      Abort a detached agent that is still processing. The abort
+      should return "pending" as the previous status and the snapshot
+      should be set to "aborted".
+    agent: customAgentBlocking
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: do work }] }
+            detach: true
+        expectOutput:
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: abort
+        snapshotId: '{{snap1}}'
+        expectPreviousStatus: pending
+
+      - type: getSnapshotData
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: aborted
+
+  - name: abort completed agent
+    description: >
+      Abort an agent that has already finished. The abort returns
+      "done" as previous status but the snapshot remains "done"
+      because terminal states (done, failed, aborted) cannot be
+      overridden — only "pending" can transition to "aborted".
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: hi }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: hello }] }
+            finishReason: stop
+        captureSnapshotId: snap1
+
+      - type: abort
+        snapshotId: '{{snap1}}'
+        expectPreviousStatus: completed
+
+      - type: getSnapshotData
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: completed
+
+  - name: server-managed agent rejects init state
+    description: >
+      When a server-managed agent receives init.state, it must throw a
+      FAILED_PRECONDITION error (mapped to an HTTP status by the server
+      handler). Server-managed agents expect a snapshotId, not the full state
+      blob. This is API misuse, so it is a thrown error rather than a graceful
+      'failed' output.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init:
+          state:
+            messages:
+              - { role: user, content: [{ text: stale history }] }
+            custom: { shouldBeIgnored: true }
+            artifacts: []
+        inputs:
+          - message: { role: user, content: [{ text: fresh message }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply }] }
+            finishReason: stop
+        # API misuse: the turn throws rather than resolving with a graceful
+        # 'failed' output.
+        expectError:
+          status: FAILED_PRECONDITION
+          message: Cannot send 'state' to agent
+
+  - name: pure detach without payload
+    description: >
+      A detach-only message (no messages or resume payloads) sent as a
+      separate input should detach immediately without processing an
+      extra turn. The agent should return a pending snapshot.
+    agent: customAgentBlocking
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: work }] }
+          - detach: true
+        expectOutput:
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: getSnapshotData
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: pending
+
+      - type: abort
+        snapshotId: '{{snap1}}'
+        expectPreviousStatus: pending
+
+  - name: failed snapshot includes error details
+    description: >
+      When a detached agent fails in the background, the snapshot
+      should include error details with the failure message.
+    agent: customAgentFailing
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: fail }] }
+            detach: true
+        expectOutput:
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: waitUntilCompleted
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: failed
+          finishReason: failed
+          errorContains:
+            message: intentional failure
+
+  - name: abort non-existent snapshot
+    description: >
+      Aborting a snapshot that does not exist should not throw and
+      should return no previous status.
+    agent: promptAgentWithStore
+    steps:
+      - type: abort
+        snapshotId: non-existent-id
+        expectPreviousStatus: ~
+
+  # ---------------------------------------------------------------------------
+  # Artifacts
+  # ---------------------------------------------------------------------------
+  - name: artifacts streamed and deduplicated
+    description: >
+      Custom agent adds artifacts during execution. Artifact chunks
+      are streamed in order. Same-named artifacts are deduplicated
+      (updated) so the final output contains only the latest version.
+    agent: customAgentWithArtifacts
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: go }] }
+        expectChunks:
+          - artifact: { name: doc1, parts: [{ text: v1 }] }
+          - artifact: { name: doc1, parts: [{ text: v2 }] }
+          - artifact: { name: doc2, parts: [{ text: other }] }
+          - turnEnd: {}
+        expectOutput:
+          message: { role: model, content: [{ text: done }] }
+          artifactsContain:
+            - name: doc1
+              parts: [{ text: v2 }]
+            - name: doc2
+              parts: [{ text: other }]
+
+  # ---------------------------------------------------------------------------
+  # Custom state
+  # ---------------------------------------------------------------------------
+  - name: custom state updated during execution
+    description: >
+      Custom agent updates custom state during processing. The output
+      state should contain the updated custom data.
+    agent: customAgentWithCustomState
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: go }] }
+        expectOutput:
+          message: { role: model, content: [{ text: done }] }
+          stateContains:
+            custom: { counter: 1 }
+
+  - name: custom state persisted across invocations
+    description: >
+      Custom state is preserved when seeded from a previous
+      invocation's output. The counter should increment across
+      invocations.
+    agent: customAgentWithCustomState
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+        expectOutput:
+          stateContains:
+            custom: { counter: 1 }
+        captureState: state1
+
+      - type: send
+        init: { state: '{{state1}}' }
+        inputs:
+          - message: { role: user, content: [{ text: second }] }
+        expectOutput:
+          stateContains:
+            custom: { counter: 2 }
+            messages:
+              - { role: user, content: [{ text: first }] }
+              - { role: user, content: [{ text: second }] }
+
+  # ---------------------------------------------------------------------------
+  # Custom state streamed live as customPatch chunks
+  # ---------------------------------------------------------------------------
+  - name: custom state streamed as customPatch chunk
+    description: >
+      A single custom-state mutation during a turn is auto-emitted to the
+      client as a `customPatch` stream chunk. The first (and here only) patch
+      of a turn is a whole-document replace at the root pointer ('') carrying
+      the full transformed custom state. The final output state still reflects
+      the same custom data.
+    agent: customAgentWithCustomState
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: go }] }
+        expectChunks:
+          - customPatch:
+              - { op: replace, path: '', value: { counter: 1 } }
+          - turnEnd: {}
+        expectOutput:
+          message: { role: model, content: [{ text: done }] }
+          stateContains:
+            custom: { counter: 1 }
+
+  - name: customPatch first chunk is whole-document replace then incremental
+    description: >
+      Multiple custom-state mutations within a single turn produce multiple
+      `customPatch` chunks. The first patch is a whole-document replace at the
+      root pointer ('') re-basing the client with the full custom state.
+      Subsequent patches are incremental RFC 6902 diffs targeting only the
+      changed members (matched on op + path; values are partially asserted).
+      The final output state contains the fully accumulated custom data.
+    agent: customAgentWithMultiCustomState
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: go }] }
+        expectChunks:
+          # First mutation -> whole-document replace at root.
+          - customPatch:
+              - op: replace
+                path: ''
+                value: { counter: 1, status: working }
+          # Second mutation -> incremental replace of /counter.
+          - customPatch:
+              - op: replace
+                path: /counter
+                value: 2
+          # Third mutation -> incremental replace of /status.
+          - customPatch:
+              - op: replace
+                path: /status
+                value: done
+          - turnEnd: {}
+        expectOutput:
+          message: { role: model, content: [{ text: done }] }
+          stateContains:
+            custom: { counter: 2, status: done }
+
+  - name: detached run emits no customPatch chunks
+    description: >
+      A detached run streams no chunks to the connection (it returns a pending
+      snapshot immediately and continues in the background). In particular no
+      `customPatch` chunks are emitted even though the agent mutates custom
+      state. The mutation is still persisted and observable on the completed
+      snapshot.
+    agent: customAgentWithCustomStateStore
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: go }] }
+            detach: true
+        # No customPatch (or any) chunks are streamed for a detached run.
+        expectChunks: []
+        expectOutput:
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: waitUntilCompleted
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: completed
+          stateContains:
+            custom: { counter: 1 }
+
+  # ===========================================================================
+  # Phase 3: Additional API Coverage
+  # ===========================================================================
+
+  # ---------------------------------------------------------------------------
+  # Snapshot branching
+  # ---------------------------------------------------------------------------
+  - name: snapshot branching across invocations
+    description: >
+      Two different continuations from the same snapshot produce
+      independent histories. Each child snapshot must have the same
+      parentId but divergent message histories after the branch point.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: root }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: rootReply }] }
+            finishReason: stop
+        captureSnapshotId: snap1
+
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - message: { role: user, content: [{ text: branch-a }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply-a }] }
+            finishReason: stop
+        captureSnapshotId: snap2a
+
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - message: { role: user, content: [{ text: branch-b }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply-b }] }
+            finishReason: stop
+        captureSnapshotId: snap2b
+
+      - type: getSnapshotData
+        snapshotId: '{{snap2a}}'
+        expectSnapshot:
+          parentId: '{{snap1}}'
+          status: completed
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: root }] }
+              - { role: model, content: [{ text: rootReply }] }
+              - { role: user, content: [{ text: branch-a }] }
+              - { role: model, content: [{ text: reply-a }] }
+
+      - type: getSnapshotData
+        snapshotId: '{{snap2b}}'
+        expectSnapshot:
+          parentId: '{{snap1}}'
+          status: completed
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: root }] }
+              - { role: model, content: [{ text: rootReply }] }
+              - { role: user, content: [{ text: branch-b }] }
+              - { role: model, content: [{ text: reply-b }] }
+
+  # ---------------------------------------------------------------------------
+  # Multiple tool calls in one model response
+  # ---------------------------------------------------------------------------
+  - name: multiple tool calls in one model response
+    description: >
+      Model issues two tool requests in a single message. Both tools
+      execute automatically and their responses are fed back to the
+      model which then produces a final text response.
+    agent: promptAgentWithTools
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: do both }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest: { name: testTool, input: {}, ref: ref1 }
+                - toolRequest: { name: testTool, input: {}, ref: ref2 }
+            finishReason: stop
+          - message: { role: model, content: [{ text: all done }] }
+            finishReason: stop
+        expectOutput:
+          message: { role: model, content: [{ text: all done }] }
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: do both }] }
+              - role: model
+                content:
+                  - toolRequest: { name: testTool, input: {}, ref: ref1 }
+                  - toolRequest: { name: testTool, input: {}, ref: ref2 }
+              - role: tool
+                content:
+                  - toolResponse:
+                      { name: testTool, output: 'tool called', ref: ref1 }
+                  - toolResponse:
+                      { name: testTool, output: 'tool called', ref: ref2 }
+              - { role: model, content: [{ text: all done }] }
+
+  # ---------------------------------------------------------------------------
+  # Multiple interrupt tool requests
+  # ---------------------------------------------------------------------------
+  - name: interrupt with multiple tool requests
+    description: >
+      Model returns two interrupt tool requests in a single message.
+      The agent returns both tool requests to the client as the output
+      message. The client resumes by providing responses for both tools.
+    agent: promptAgentWithInterrupt
+    steps:
+      # Phase 1: model returns two interrupt requests
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: confirm both }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest:
+                    { name: interruptTool, input: { query: 'q1?' }, ref: 'i1' }
+                - toolRequest:
+                    { name: interruptTool, input: { query: 'q2?' }, ref: 'i2' }
+            finishReason: stop
+        expectOutput:
+          message:
+            content:
+              - toolRequest:
+                  { name: interruptTool, input: { query: 'q1?' }, ref: 'i1' }
+              - toolRequest:
+                  { name: interruptTool, input: { query: 'q2?' }, ref: 'i2' }
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      # Phase 2: client responds to both
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - resume:
+              respond:
+                - toolResponse:
+                    {
+                      name: interruptTool,
+                      ref: 'i1',
+                      output: { answer: 'yes1' },
+                    }
+                - toolResponse:
+                    {
+                      name: interruptTool,
+                      ref: 'i2',
+                      output: { answer: 'yes2' },
+                    }
+        modelResponses:
+          - message: { role: model, content: [{ text: both confirmed }] }
+            finishReason: stop
+        expectOutput:
+          message: { role: model, content: [{ text: both confirmed }] }
+
+  # ---------------------------------------------------------------------------
+  # Interrupt resume — full state accumulation
+  # ---------------------------------------------------------------------------
+  - name: interrupt resume state accumulation
+    description: >
+      After interrupt and resume, the accumulated state must contain
+      the full exchange: user message, model tool request, client
+      tool response, and the final model response.
+    agent: promptAgentWithInterrupt
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: check }] }
+        modelResponses:
+          - message:
+              role: model
+              content:
+                - toolRequest:
+                    { name: interruptTool, input: { query: 'ok?' }, ref: 't1' }
+            finishReason: stop
+        captureSnapshotId: snap1
+
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - resume:
+              respond:
+                - toolResponse:
+                    {
+                      name: interruptTool,
+                      ref: 't1',
+                      output: { answer: 'confirmed' },
+                    }
+        modelResponses:
+          - message: { role: model, content: [{ text: done }] }
+            finishReason: stop
+        captureSnapshotId: snap2
+
+      - type: getSnapshotData
+        snapshotId: '{{snap2}}'
+        expectSnapshot:
+          status: completed
+          stateContains:
+            messages:
+              - { role: user, content: [{ text: check }] }
+              - role: model
+                content:
+                  - toolRequest:
+                      {
+                        name: interruptTool,
+                        input: { query: 'ok?' },
+                        ref: 't1',
+                      }
+              - role: tool
+                content:
+                  - toolResponse:
+                      {
+                        name: interruptTool,
+                        ref: 't1',
+                        output: { answer: 'confirmed' },
+                      }
+              - { role: model, content: [{ text: done }] }
+
+  # ---------------------------------------------------------------------------
+  # Artifacts across invocations (server-managed)
+  # ---------------------------------------------------------------------------
+  - name: artifacts persisted across invocations
+    description: >
+      Artifacts added in the first invocation persist in the server-managed
+      snapshot. The second invocation loads the snapshot, adds a new artifact,
+      and the output contains both the original and new artifacts.
+    agent: customAgentWithArtifactsStore
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+        expectOutput:
+          hasSnapshotId: true
+          artifactsContain:
+            - name: doc1
+              parts: [{ text: content1 }]
+        captureSnapshotId: snap1
+
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - message: { role: user, content: [{ text: second }] }
+        expectOutput:
+          artifactsContain:
+            - name: doc1
+              parts: [{ text: content1 }]
+            - name: doc2
+              parts: [{ text: content2 }]
+
+  # ---------------------------------------------------------------------------
+  # Custom state via server-managed store
+  # ---------------------------------------------------------------------------
+  - name: custom state persisted via server-managed store
+    description: >
+      Custom state is preserved when resuming from a server-managed
+      snapshot. The counter should increment across invocations and
+      be visible in the snapshot state.
+    agent: customAgentWithCustomStateStore
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+        captureSnapshotId: snap1
+
+      - type: send
+        init: { snapshotId: '{{snap1}}' }
+        inputs:
+          - message: { role: user, content: [{ text: second }] }
+        captureSnapshotId: snap2
+
+      - type: getSnapshotData
+        snapshotId: '{{snap2}}'
+        expectSnapshot:
+          status: completed
+          stateContains:
+            custom: { counter: 2 }
+            messages:
+              - { role: user, content: [{ text: first }] }
+              - { role: user, content: [{ text: second }] }
+
+  # ---------------------------------------------------------------------------
+  # Abort terminal states — failed and aborted
+  # ---------------------------------------------------------------------------
+  - name: abort failed agent
+    description: >
+      Abort an agent that has already failed. The abort returns "failed"
+      as the previous status but the snapshot remains "failed" because
+      terminal states cannot be overridden.
+    agent: customAgentFailing
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: fail }] }
+            detach: true
+        expectOutput:
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: waitUntilCompleted
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: failed
+          finishReason: failed
+
+      - type: abort
+        snapshotId: '{{snap1}}'
+        expectPreviousStatus: failed
+
+      - type: getSnapshotData
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: failed
+
+  - name: abort already aborted agent
+    description: >
+      Abort an agent that was already aborted. The abort returns
+      "aborted" as previous status and the snapshot remains "aborted".
+    agent: customAgentBlocking
+    steps:
+      - type: send
+        init: {}
+        inputs:
+          - message: { role: user, content: [{ text: work }] }
+            detach: true
+        expectOutput:
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: abort
+        snapshotId: '{{snap1}}'
+        expectPreviousStatus: pending
+
+      - type: abort
+        snapshotId: '{{snap1}}'
+        expectPreviousStatus: aborted
+
+      - type: getSnapshotData
+        snapshotId: '{{snap1}}'
+        expectSnapshot:
+          status: aborted
+
+  # ===========================================================================
+  # Phase 4: Server-managed sessions by sessionId
+  # ===========================================================================
+  #
+  # Server-managed agents can be resumed by a bare `sessionId` (a UUID) in
+  # addition to an exact `snapshotId`. This is the simple case used by
+  # `useChat`-style clients: the client tracks only a stable session id and the
+  # store resolves the session's latest (leaf) snapshot on each turn.
+
+  # ---------------------------------------------------------------------------
+  # Resume a server-managed session by sessionId
+  # ---------------------------------------------------------------------------
+  - name: resume server-managed session by sessionId
+    description: >
+      A server-managed agent is invoked twice using the same caller-provided
+      sessionId (a UUID). The first turn seeds a fresh session bound to that
+      sessionId; the second turn resumes the session's latest snapshot without a
+      snapshotId. History must accumulate and the resulting snapshot must carry
+      the same sessionId and chain to the first snapshot.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: { sessionId: 11111111-1111-4111-8111-111111111111 }
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply1 }] }
+            finishReason: stop
+        expectOutput:
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: send
+        init: { sessionId: 11111111-1111-4111-8111-111111111111 }
+        inputs:
+          - message: { role: user, content: [{ text: second }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply2 }] }
+            finishReason: stop
+        captureSnapshotId: snap2
+
+      - type: getSnapshotData
+        snapshotId: '{{snap2}}'
+        expectSnapshot:
+          parentId: '{{snap1}}'
+          status: completed
+          stateContains:
+            sessionId: 11111111-1111-4111-8111-111111111111
+            messages:
+              - { role: user, content: [{ text: first }] }
+              - { role: model, content: [{ text: reply1 }] }
+              - { role: user, content: [{ text: second }] }
+              - { role: model, content: [{ text: reply2 }] }
+
+  # ---------------------------------------------------------------------------
+  # Fetch the latest snapshot by sessionId
+  # ---------------------------------------------------------------------------
+  - name: fetch latest snapshot by sessionId
+    description: >
+      getSnapshotData can resolve a snapshot by sessionId, returning the
+      session's latest (leaf) snapshot. After two linear turns the leaf is the
+      second snapshot, whose parent is the first.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: { sessionId: 22222222-2222-4222-8222-222222222222 }
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply1 }] }
+            finishReason: stop
+        captureSnapshotId: snap1
+
+      - type: send
+        init: { sessionId: 22222222-2222-4222-8222-222222222222 }
+        inputs:
+          - message: { role: user, content: [{ text: second }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply2 }] }
+            finishReason: stop
+
+      - type: getSnapshotData
+        sessionId: 22222222-2222-4222-8222-222222222222
+        expectSnapshot:
+          parentId: '{{snap1}}'
+          status: completed
+          hasSessionId: true
+          stateContains:
+            sessionId: 22222222-2222-4222-8222-222222222222
+            messages:
+              - { role: user, content: [{ text: first }] }
+              - { role: model, content: [{ text: reply1 }] }
+              - { role: user, content: [{ text: second }] }
+              - { role: model, content: [{ text: reply2 }] }
+
+  # ---------------------------------------------------------------------------
+  # Non-UUID sessionId accepted
+  # ---------------------------------------------------------------------------
+  - name: non-UUID sessionId accepted
+    description: >
+      A sessionId can be any non-empty string (not necessarily a UUID).
+      Sending an application-specific (non-UUID) sessionId to a server-managed
+      agent is accepted; the session is bound to that id and is resumable by it.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: { sessionId: my-app-session-123 }
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply1 }] }
+            finishReason: stop
+        expectOutput:
+          finishReason: stop
+          hasSnapshotId: true
+        captureSnapshotId: snap1
+
+      - type: getSnapshotData
+        sessionId: my-app-session-123
+        expectSnapshot:
+          status: completed
+          stateContains:
+            sessionId: my-app-session-123
+            messages:
+              - { role: user, content: [{ text: first }] }
+              - { role: model, content: [{ text: reply1 }] }
+
+  # ---------------------------------------------------------------------------
+  # Client-managed agent rejects sessionId
+  # ---------------------------------------------------------------------------
+  - name: client-managed agent rejects sessionId
+    description: >
+      A client-managed agent (no store) cannot resume by sessionId because it
+      has nowhere to load the session from. Sending init.sessionId must be
+      rejected with FAILED_PRECONDITION.
+    agent: promptAgent
+    steps:
+      - type: send
+        init: { sessionId: 44444444-4444-4444-8444-444444444444 }
+        inputs:
+          - message: { role: user, content: [{ text: hi }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: hello }] }
+            finishReason: stop
+        # API misuse: the turn throws with the original FAILED_PRECONDITION
+        # status rather than resolving with a graceful 'failed' output.
+        expectError:
+          status: FAILED_PRECONDITION
+          message: "Cannot use 'sessionId'"
+
+  # ---------------------------------------------------------------------------
+  # snapshotId + sessionId: snapshotId selects, sessionId guards ownership
+  # ---------------------------------------------------------------------------
+  - name: snapshotId and matching sessionId together resume
+    description: >
+      init may carry both a snapshotId (the exact snapshot to resume) and a
+      sessionId. When the snapshot belongs to that session, the sessionId acts
+      as an ownership guard and the resume proceeds normally.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: { sessionId: 55555555-5555-4555-8555-555555555555 }
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply1 }] }
+            finishReason: stop
+        captureSnapshotId: snap1
+
+      - type: send
+        init:
+          snapshotId: '{{snap1}}'
+          sessionId: 55555555-5555-4555-8555-555555555555
+        inputs:
+          - message: { role: user, content: [{ text: second }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply2 }] }
+            finishReason: stop
+        expectOutput:
+          finishReason: stop
+
+  - name: snapshotId with mismatched sessionId rejected
+    description: >
+      When init carries both a snapshotId and a sessionId, the snapshot must
+      belong to that session. A mismatch is rejected.
+    agent: promptAgentWithStore
+    steps:
+      - type: send
+        init: { sessionId: 55555555-5555-4555-8555-555555555555 }
+        inputs:
+          - message: { role: user, content: [{ text: first }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply1 }] }
+            finishReason: stop
+        captureSnapshotId: snap1
+
+      - type: send
+        init:
+          snapshotId: '{{snap1}}'
+          sessionId: 99999999-9999-4999-8999-999999999999
+        inputs:
+          - message: { role: user, content: [{ text: second }] }
+        modelResponses:
+          - message: { role: model, content: [{ text: reply2 }] }
+            finishReason: stop
+        # API misuse: the turn throws with the original INVALID_ARGUMENT status
+        # rather than resolving with a graceful 'failed' output.
+        expectError:
+          status: INVALID_ARGUMENT
+          message: 'does not belong to session'


### PR DESCRIPTION
Adds a Go conformance harness that drives the shared agent spec (`tests/specs/agent.yaml`, mirroring JS [#5256](https://github.com/genkit-ai/genkit/pull/5256)) against the exp agent API through its public surface and the production in-memory store.

39/39 pass. Asserts behavior and error status (category); exact error-message wording is not asserted, since it is implementation-specific.