### PR TITLE
feat(py/plugins/google-genai): register Gemini 3.x image models

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -173,15 +173,24 @@ class GenaiModels:
 def _list_genai_models(client: genai.Client, is_vertex: bool) -> GenaiModels:
     """Discover and categorize available models from the Google GenAI API.
 
-    This function queries the API for all available models and categorizes them
-    based on their supported_actions field. Models marked as deprecated are
-    excluded.
+    This function queries the API for all available models and categorizes them.
+    Models marked as deprecated are excluded.
 
-    The categorization logic:
+    Two categorization strategies are used depending on the backend:
+
+    - Google AI populates each model's ``supported_actions`` field, so models
+      are categorized by action:
         - 'embedContent' action → embedders
-        - 'predict' + 'imagen' in name → imagen (Vertex AI)
+        - 'predict' + 'imagen' in name → imagen
         - 'generateVideos' or 'veo' in name → veo
         - 'generateContent' + 'gemini'/'gemma' in name → gemini
+    - Vertex AI returns ``supported_actions = None`` for every publisher model,
+      so categorizing by action would skip them all. The Vertex path instead
+      categorizes by model name (mirroring the JS plugin's ``listActions``):
+        - 'embedding' in name → embedders
+        - 'imagen' in name → imagen
+        - 'veo' in name → veo
+        - 'gemini'/'gemma' in name (and not an embedding) → gemini
 
     Args:
         client: The Google GenAI client instance.
@@ -211,6 +220,20 @@ def _list_genai_models(client: genai.Client, is_vertex: bool) -> GenaiModels:
 
         description = (m.description or '').lower()
         if 'deprecated' in description:
+            continue
+
+        # Vertex AI returns supported_actions=None for every publisher model, so
+        # categorize by name
+        if is_vertex:
+            lower_name = name.lower()
+            if 'embedding' in lower_name:
+                models.embedders.append(name)
+            elif 'imagen' in lower_name:
+                models.imagen.append(name)
+            elif 'veo' in lower_name:
+                models.veo.append(name)
+            elif 'gemini' in lower_name or 'gemma' in lower_name:
+                models.gemini.append(name)
             continue
 
         if not m.supported_actions:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -872,7 +872,15 @@ GENERIC_TTS_MODEL = ModelInfo(
 
 GENERIC_IMAGE_MODEL = ModelInfo(
     label='Google AI - Gemini Image',
-    supports=GEMINI_IMAGE_SUPPORTS,
+    supports=Supports(
+        multiturn=False,
+        media=True,
+        tools=False,
+        tool_choice=False,
+        system_role=True,
+        constrained=Constrained.ALL,
+        output=['media'],
+    ),
 )
 
 GENERIC_GEMMA_MODEL = ModelInfo(

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -806,6 +806,45 @@ GEMINI_3_1_FLASH_LITE_PREVIEW = ModelInfo(
     ),
 )
 
+GEMINI_IMAGE_SUPPORTS = Supports(
+    multiturn=True,
+    media=True,
+    tools=True,
+    tool_choice=True,
+    system_role=True,
+    constrained=Constrained.ALL,
+)
+
+GEMINI_3_PRO_IMAGE = ModelInfo(
+    label='Google AI - Gemini 3 Pro Image',
+    supports=GEMINI_IMAGE_SUPPORTS,
+)
+
+GEMINI_3_1_FLASH_IMAGE = ModelInfo(
+    label='Google AI - Gemini 3.1 Flash Image',
+    supports=GEMINI_IMAGE_SUPPORTS,
+)
+
+GEMINI_3_1_FLASH_IMAGE_PREVIEW = ModelInfo(
+    label='Google AI - Gemini 3.1 Flash Image Preview',
+    supports=GEMINI_IMAGE_SUPPORTS,
+)
+
+GEMINI_3_PRO_IMAGE_PREVIEW = ModelInfo(
+    label='Google AI - Gemini 3 Pro Image Preview',
+    supports=GEMINI_IMAGE_SUPPORTS,
+)
+
+GEMINI_2_5_FLASH_IMAGE = ModelInfo(
+    label='Google AI - Gemini 2.5 Flash Image',
+    supports=GEMINI_IMAGE_SUPPORTS,
+)
+
+GEMINI_2_5_FLASH_IMAGE_PREVIEW = ModelInfo(
+    label='Google AI - Gemini 2.5 Flash Image Preview',
+    supports=GEMINI_IMAGE_SUPPORTS,
+)
+
 GENERIC_GEMINI_MODEL = ModelInfo(
     label='Google AI - Gemini',
     supports=Supports(
@@ -833,15 +872,7 @@ GENERIC_TTS_MODEL = ModelInfo(
 
 GENERIC_IMAGE_MODEL = ModelInfo(
     label='Google AI - Gemini Image',
-    supports=Supports(
-        multiturn=False,
-        media=True,
-        tools=False,
-        tool_choice=False,
-        system_role=True,
-        constrained=Constrained.ALL,
-        output=['media'],
-    ),
+    supports=GEMINI_IMAGE_SUPPORTS,
 )
 
 GENERIC_GEMMA_MODEL = ModelInfo(
@@ -885,6 +916,8 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     | `gemini-2.5-flash-lite`              | Gemini 2.5 Flash Lite                | Supported    |
     | `gemini-2.5-flash-preview-tts`       | Gemini 2.5 Flash Preview TTS         | Supported    |
     | `gemini-2.5-pro-preview-tts`         | Gemini 2.5 Pro Preview TTS           | Supported    |
+    | `gemini-3-pro-image`                 | Gemini 3 Pro Image                   | Supported    |
+    | `gemini-3.1-flash-image`             | Gemini 3.1 Flash Image               | Supported    |
     | `gemini-3-pro-image-preview`         | Gemini 3 Pro Image Preview           | Supported    |
     | `gemini-2.5-flash-image-preview`     | Gemini 2.5 Flash Image Preview       | Supported    |
     | `gemini-2.5-flash-image`             | Gemini 2.5 Flash Image               | Supported    |
@@ -909,6 +942,8 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_2_5_FLASH_LITE = 'gemini-2.5-flash-lite'
     GEMINI_2_5_FLASH_PREVIEW_TTS = 'gemini-2.5-flash-preview-tts'
     GEMINI_2_5_PRO_PREVIEW_TTS = 'gemini-2.5-pro-preview-tts'
+    GEMINI_3_PRO_IMAGE = 'gemini-3-pro-image'
+    GEMINI_3_1_FLASH_IMAGE = 'gemini-3.1-flash-image'
     GEMINI_3_PRO_IMAGE_PREVIEW = 'gemini-3-pro-image-preview'
     GEMINI_2_5_FLASH_IMAGE_PREVIEW = 'gemini-2.5-flash-image-preview'
     GEMINI_2_5_FLASH_IMAGE = 'gemini-2.5-flash-image'
@@ -943,6 +978,9 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     | `gemini-2.5-flash-lite`              | Gemini 2.5 Flash Lite                | Supported  |
     | `gemini-2.5-flash-preview-tts`       | Gemini 2.5 Flash Preview TTS         | Supported  |
     | `gemini-2.5-pro-preview-tts`         | Gemini 2.5 Pro Preview TTS           | Supported  |
+    | `gemini-3-pro-image`                 | Gemini 3 Pro Image                   | Supported  |
+    | `gemini-3.1-flash-image`             | Gemini 3.1 Flash Image               | Supported  |
+    | `gemini-3.1-flash-image-preview`     | Gemini 3.1 Flash Image Preview       | Supported  |
     | `gemini-3-pro-image-preview`         | Gemini 3 Pro Image Preview           | Supported  |
     | `gemini-2.5-flash-image-preview`     | Gemini 2.5 Flash Image Preview       | Supported  |
     | `gemini-2.5-flash-image`             | Gemini 2.5 Flash Image               | Supported  |
@@ -970,6 +1008,9 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_2_5_FLASH_LITE = 'gemini-2.5-flash-lite'
     GEMINI_2_5_FLASH_PREVIEW_TTS = 'gemini-2.5-flash-preview-tts'
     GEMINI_2_5_PRO_PREVIEW_TTS = 'gemini-2.5-pro-preview-tts'
+    GEMINI_3_PRO_IMAGE = 'gemini-3-pro-image'
+    GEMINI_3_1_FLASH_IMAGE = 'gemini-3.1-flash-image'
+    GEMINI_3_1_FLASH_IMAGE_PREVIEW = 'gemini-3.1-flash-image-preview'
     GEMINI_3_PRO_IMAGE_PREVIEW = 'gemini-3-pro-image-preview'
     GEMINI_2_5_FLASH_IMAGE_PREVIEW = 'gemini-2.5-flash-image-preview'
     GEMINI_2_5_FLASH_IMAGE = 'gemini-2.5-flash-image'
@@ -1013,6 +1054,12 @@ _add_model(GEMINI_3_5_FLASH, ['gemini-3.5-flash', 'gemini-flash-latest'])
 _add_model(GEMINI_3_1_PRO_PREVIEW, ['gemini-3.1-pro-preview'])
 _add_model(GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS, ['gemini-3.1-pro-preview-customtools'])
 _add_model(GEMINI_3_1_FLASH_LITE_PREVIEW, ['gemini-3.1-flash-lite-preview'])
+_add_model(GEMINI_3_PRO_IMAGE, ['gemini-3-pro-image'])
+_add_model(GEMINI_3_1_FLASH_IMAGE, ['gemini-3.1-flash-image'])
+_add_model(GEMINI_3_1_FLASH_IMAGE_PREVIEW, ['gemini-3.1-flash-image-preview'])
+_add_model(GEMINI_3_PRO_IMAGE_PREVIEW, ['gemini-3-pro-image-preview'])
+_add_model(GEMINI_2_5_FLASH_IMAGE_PREVIEW, ['gemini-2.5-flash-image-preview'])
+_add_model(GEMINI_2_5_FLASH_IMAGE, ['gemini-2.5-flash-image'])
 
 
 DEFAULT_SUPPORTS_MODEL = Supports(

--- a/py/plugins/google-genai/test/google_plugin_test.py
+++ b/py/plugins/google-genai/test/google_plugin_test.py
@@ -805,6 +805,45 @@ async def test_vertexai_list_actions(vertexai_plugin_instance: VertexAI) -> None
 
 
 @pytest.mark.asyncio
+async def test_vertexai_list_actions_without_supported_actions(vertexai_plugin_instance: VertexAI) -> None:
+    """Regression test for #5572.
+
+    Vertex AI's ``client.models.list()`` returns publisher models with
+    ``supported_actions = None``. Discovery must categorize these by name
+    rather than skipping them, otherwise no Vertex models appear in the Dev UI.
+    """
+
+    def mock_model(name: str) -> MagicMock:
+        m = MagicMock()
+        m.name = name
+        m.supported_actions = None  # Vertex leaves this unset.
+        m.description = ''
+        return m
+
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = [
+        mock_model('publishers/google/models/gemini-2.5-pro'),
+        mock_model('publishers/google/models/gemini-embedding-001'),
+        mock_model('publishers/google/models/imagen-3.0-generate-002'),
+        mock_model('publishers/google/models/veo-2.0-generate-001'),
+    ]
+    vertexai_plugin_instance._runtime_client = lambda: mock_client
+
+    result = await vertexai_plugin_instance.list_actions()
+    names = {a.name for a in result}
+
+    # Gemini text model discovered despite supported_actions=None.
+    assert vertexai_name('gemini-2.5-pro') in names
+    # Imagen and Veo discovered.
+    assert vertexai_name('imagen-3.0-generate-002') in names
+    assert vertexai_name('veo-2.0-generate-001') in names
+
+    # gemini-embedding-001 is registered as an embedder, not a gemini model.
+    embedder = next(a for a in result if a.name == vertexai_name('gemini-embedding-001'))
+    assert embedder.action_type == ActionKind.EMBEDDER
+
+
+@pytest.mark.asyncio
 async def test_googleai_resolve_background_model(googleai_plugin_instance: GoogleAI) -> None:
     """Test resolve action for background model."""
     plugin = googleai_plugin_instance

--- a/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
@@ -451,6 +451,25 @@ async def test_generate_with_system_instructions(mocker: MockerFixture) -> None:
                 ),
             ),
         ),
+        (
+            # An unregistered image model falls back to GENERIC_IMAGE_MODEL via
+            # is_image_model(). That fallback must stay restrictive (single-turn,
+            # no tools, output=['media']) because pure image-generation models are
+            # not conversational/tool-capable.
+            'gemini-2.0-flash-preview-image-generation',
+            ModelInfo(
+                label='Google AI - Gemini Image',
+                supports=Supports(
+                    multiturn=False,
+                    media=True,
+                    tools=False,
+                    tool_choice=False,
+                    system_role=True,
+                    constrained=Constrained.ALL,
+                    output=['media'],
+                ),
+            ),
+        ),
     ],
 )
 def test_google_model_info(input: str, expected: ModelInfo) -> None:

--- a/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
@@ -42,6 +42,7 @@ from genkit import (
     ModelResponse,
     Part,
     Role,
+    Supports,
     TextPart,
     ToolDefinition,
 )
@@ -364,6 +365,90 @@ async def test_generate_with_system_instructions(mocker: MockerFixture) -> None:
             ModelInfo(
                 label='Google AI - gemini-4-0-pro-delux-max',
                 supports=DEFAULT_SUPPORTS_MODEL,
+            ),
+        ),
+        (
+            'gemini-3-pro-image',
+            ModelInfo(
+                label='Google AI - Gemini 3 Pro Image',
+                supports=Supports(
+                    multiturn=True,
+                    media=True,
+                    tools=True,
+                    tool_choice=True,
+                    system_role=True,
+                    constrained=Constrained.ALL,
+                ),
+            ),
+        ),
+        (
+            'gemini-3.1-flash-image',
+            ModelInfo(
+                label='Google AI - Gemini 3.1 Flash Image',
+                supports=Supports(
+                    multiturn=True,
+                    media=True,
+                    tools=True,
+                    tool_choice=True,
+                    system_role=True,
+                    constrained=Constrained.ALL,
+                ),
+            ),
+        ),
+        (
+            'gemini-3.1-flash-image-preview',
+            ModelInfo(
+                label='Google AI - Gemini 3.1 Flash Image Preview',
+                supports=Supports(
+                    multiturn=True,
+                    media=True,
+                    tools=True,
+                    tool_choice=True,
+                    system_role=True,
+                    constrained=Constrained.ALL,
+                ),
+            ),
+        ),
+        (
+            'gemini-3-pro-image-preview',
+            ModelInfo(
+                label='Google AI - Gemini 3 Pro Image Preview',
+                supports=Supports(
+                    multiturn=True,
+                    media=True,
+                    tools=True,
+                    tool_choice=True,
+                    system_role=True,
+                    constrained=Constrained.ALL,
+                ),
+            ),
+        ),
+        (
+            'gemini-2.5-flash-image',
+            ModelInfo(
+                label='Google AI - Gemini 2.5 Flash Image',
+                supports=Supports(
+                    multiturn=True,
+                    media=True,
+                    tools=True,
+                    tool_choice=True,
+                    system_role=True,
+                    constrained=Constrained.ALL,
+                ),
+            ),
+        ),
+        (
+            'gemini-2.5-flash-image-preview',
+            ModelInfo(
+                label='Google AI - Gemini 2.5 Flash Image Preview',
+                supports=Supports(
+                    multiturn=True,
+                    media=True,
+                    tools=True,
+                    tool_choice=True,
+                    system_role=True,
+                    constrained=Constrained.ALL,
+                ),
             ),
         ),
     ],
@@ -904,6 +989,12 @@ def test_gemini_model__normalize_config_respects_version_override() -> None:
     [
         ('gemini-2.5-flash-preview-tts', GeminiTtsConfigSchema),
         ('gemini-2.0-flash-preview-image-generation', GeminiImageConfigSchema),
+        ('gemini-3-pro-image', GeminiImageConfigSchema),
+        ('gemini-3.1-flash-image', GeminiImageConfigSchema),
+        ('gemini-3.1-flash-image-preview', GeminiImageConfigSchema),
+        ('gemini-3-pro-image-preview', GeminiImageConfigSchema),
+        ('gemini-2.5-flash-image', GeminiImageConfigSchema),
+        ('gemini-2.5-flash-image-preview', GeminiImageConfigSchema),
         ('gemma-2-27b-it', GemmaConfigSchema),
         ('gemini-2.0-flash-001', GeminiConfigSchema),
     ],


### PR DESCRIPTION
## What

Registers the Gemini 3.x native image models for both GoogleAI and VertexAI with explicit `ModelInfo` so they resolve to correct image capability metadata instead of falling through the `is_image_model` `-image` substring heuristic:

- `gemini-3-pro-image` (GoogleAI + VertexAI)
- `gemini-3.1-flash-image` (GoogleAI + VertexAI)
- `gemini-3.1-flash-image-preview` (GoogleAI)

Also registers the previously-unregistered `gemini-3-pro-image-preview`, `gemini-2.5-flash-image`, and `gemini-2.5-flash-image-preview` explicitly rather than via the fallback.

Part of the Python model-parity work (parent #5542).

> **Stacked on #5575** (`fix(py/plugins/google-genai): discover Vertex AI models by name`).

## Why

Without explicit registration these names fall through `is_image_model('-image')` to `GENERIC_IMAGE_MODEL`, which declared Imagen-style capabilities (`multiturn=False`, `tools=False`, `output=['media']`). That's wrong for native Gemini image models, which are conversational, tool-capable, and emit text+image. Explicit registration gives them the correct multimodal `Supports` plus `GeminiImageConfigSchema` that the framework and Dev UI rely on.

Combined with #5575 (which makes VertexAI models discoverable by name), the VertexAI image models now appear in the Dev UI picker with correct capabilities — matching the existing GoogleAI behaviour and the JS/Go runtimes.

## How

Changes in `py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py`, following the existing 3.x wiring and verified against the JS and Go registries:

1. Shared `GEMINI_IMAGE_SUPPORTS` and per-model `ModelInfo` definitions.
2. Enum members on `GoogleAIGeminiVersion` and `VertexAIGeminiVersion` (+ docstring table rows). `gemini-3.1-flash-image-preview` is GoogleAI-only, matching the API surface.
3. `_add_model(...)` registrations for all six models.
4. `GENERIC_IMAGE_MODEL` corrected to the same supports so any unlisted image model is also categorized correctly.

Capabilities mirror the other runtimes:

- Full multimodal/tool profile (`multiturn`, `media`, `tools`, `tool_choice`, `constrained=ALL`) — matching Go's `Multimodal` and JS's `GENERIC_IMAGE_MODEL`.
- **No explicit `output` modality** — strict JS/Go parity (both leave it unset; image bytes return via response parts, and request-time `response_modalities=['TEXT', 'IMAGE']` is unchanged).

Request-side modality handling already covers these names via `is_image_model`, and config-schema routing already returns `GeminiImageConfigSchema`, so no changes were needed there or in `google.py`.

## Testing

- **Unit tests:** extended `test_google_model_info` (each image model resolves to the explicit multimodal `ModelInfo`, not the generic fallback) and `test_gemini_model__pick_plugin_schema_routes_by_model_family` (each maps to `GeminiImageConfigSchema`). Full `googlegenai_gemini_test.py` suite passes (153 tests); `ruff` clean.
- **Dev UI:** screenshots below show successful image generations for these models

### Dev UI screenshots

<img width="1019" height="532" alt="Screenshot 2026-06-18 at 11 46 06" src="https://github.com/user-attachments/assets/d601bd0c-e8f0-4847-886f-f904f15a48fd" />
<img width="749" height="547" alt="Screenshot 2026-06-18 at 11 47 54" src="https://github.com/user-attachments/assets/18a02827-dda9-45dc-8b0b-42b309ab51a6" />
<img width="665" height="544" alt="Screenshot 2026-06-18 at 11 48 54" src="https://github.com/user-attachments/assets/ad76498d-a5d4-466c-a006-7693f0d1ec32" />
