### PR TITLE
feat(py/plugins/google-genai): register VertexAI Gemini 3.1 text models

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -817,6 +817,8 @@ GEMINI_3_1_FLASH_LITE = ModelInfo(
         constrained=Constrained.ALL,
         output=['text', 'json'],
     ),
+)
+
 GEMINI_IMAGE_SUPPORTS = Supports(
     multiturn=True,
     media=True,

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py
@@ -806,6 +806,19 @@ GEMINI_3_1_FLASH_LITE_PREVIEW = ModelInfo(
     ),
 )
 
+GEMINI_3_1_FLASH_LITE = ModelInfo(
+    label='Google AI - Gemini 3.1 Flash Lite',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=True,
+        system_role=True,
+        constrained=Constrained.ALL,
+        output=['text', 'json'],
+    ),
+)
+
 GENERIC_GEMINI_MODEL = ModelInfo(
     label='Google AI - Gemini',
     supports=Supports(
@@ -880,6 +893,9 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     | `gemini-2.5-pro-preview-03-25`       | Gemini 2.5 Pro Preview 03-25         | Supported    |
     | `gemini-2.5-pro-preview-05-06`       | Gemini 2.5 Pro Preview 05-06         | Supported    |
     | `gemini-3-flash-preview`             | Gemini 3 Flash Preview               | Supported    |
+    | `gemini-3.5-flash`                   | Gemini 3.5 Flash                     | Supported    |
+    | `gemini-3.1-pro-preview`            | Gemini 3.1 Pro Preview               | Supported    |
+    | `gemini-3.1-flash-lite`             | Gemini 3.1 Flash Lite                | Supported    |
     | `gemini-2.5-pro`                     | Gemini 2.5 Pro                       | Supported    |
     | `gemini-2.5-flash`                   | Gemini 2.5 Flash                     | Supported    |
     | `gemini-2.5-flash-lite`              | Gemini 2.5 Flash Lite                | Supported    |
@@ -912,6 +928,9 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     GEMINI_3_PRO_IMAGE_PREVIEW = 'gemini-3-pro-image-preview'
     GEMINI_2_5_FLASH_IMAGE_PREVIEW = 'gemini-2.5-flash-image-preview'
     GEMINI_2_5_FLASH_IMAGE = 'gemini-2.5-flash-image'
+    GEMINI_3_5_FLASH = 'gemini-3.5-flash'
+    GEMINI_3_1_PRO_PREVIEW = 'gemini-3.1-pro-preview'
+    GEMINI_3_1_FLASH_LITE = 'gemini-3.1-flash-lite'
     GEMMA_3_12B_IT = 'gemma-3-12b-it'
     GEMMA_3_1B_IT = 'gemma-3-1b-it'
     GEMMA_3_27B_IT = 'gemma-3-27b-it'
@@ -1013,6 +1032,7 @@ _add_model(GEMINI_3_5_FLASH, ['gemini-3.5-flash', 'gemini-flash-latest'])
 _add_model(GEMINI_3_1_PRO_PREVIEW, ['gemini-3.1-pro-preview'])
 _add_model(GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS, ['gemini-3.1-pro-preview-customtools'])
 _add_model(GEMINI_3_1_FLASH_LITE_PREVIEW, ['gemini-3.1-flash-lite-preview'])
+_add_model(GEMINI_3_1_FLASH_LITE, ['gemini-3.1-flash-lite'])
 
 
 DEFAULT_SUPPORTS_MODEL = Supports(

--- a/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_gemini_test.py
@@ -400,6 +400,31 @@ def test_gemini_3_1_models_register_real_capabilities(model_name: str) -> None:
     assert model_info.supports.output == ['text', 'json']
 
 
+@pytest.mark.parametrize(
+    'model_name',
+    [
+        'gemini-3.1-pro-preview',
+        'gemini-3.1-flash-lite',
+        'gemini-3.5-flash',
+    ],
+)
+def test_vertexai_gemini_3_x_text_models_register_real_capabilities(model_name: str) -> None:
+    """VertexAI Gemini 3.1/3.5 text models resolve to explicit ModelInfo, not the generic fallback.
+
+    These names are now first-class ``VertexAIGeminiVersion`` members. The generic fallback
+    (DEFAULT_SUPPORTS_MODEL) leaves ``output`` unset, so asserting ``output == ['text', 'json']``
+    alongside tools/constrained proves they carry real capability metadata matching the JS Vertex
+    registry, not the fallback.
+    """
+    model_info = google_model_info(model_name)
+
+    assert model_info.supports is not None
+    assert model_info.supports.tools is True
+    assert model_info.supports.tool_choice is True
+    assert model_info.supports.constrained == Constrained.ALL
+    assert model_info.supports.output == ['text', 'json']
+
+
 @pytest.fixture
 def gemini_model_instance() -> GeminiModel:
     """Common initialization of GeminiModel."""


### PR DESCRIPTION
## What

Registers the VertexAI Gemini 3.1 text models with explicit `ModelInfo` so they
resolve to real capability metadata instead of the generic text fallback, and
adds `gemini-3.5-flash` to the Vertex enum:

- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-lite`
- `gemini-3.5-flash` (added to `VertexAIGeminiVersion` — it already resolved via
  the shared `SUPPORTED_MODELS` dict but was missing from the Vertex enum/docs)

Part of #5542 (Python model-parity work). VertexAI counterpart to #5559.

## Why

Without registration these names fall through to `DEFAULT_SUPPORTS_MODEL`, which
leaves `output` unset and doesn't reflect each model's real capabilities.
Registering them gives the correct `Supports` metadata (tools, tool-choice,
constrained generation, `text`/`json` output) that the framework and Dev UI
rely on. Adding `gemini-3.5-flash` to `VertexAIGeminiVersion` closes a
discoverability/doc gap on the Vertex side.

## How

Touch points in
`py/plugins/google-genai/src/genkit/plugins/google_genai/models/gemini.py`,
following the existing 3.x wiring:

1. `ModelInfo` definition for `gemini-3.1-flash-lite`.
2. Enum members on `VertexAIGeminiVersion` (`gemini-3.5-flash`,
   `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`) + docstring table rows.
3. `_add_model(...)` registration for `gemini-3.1-flash-lite`.

Capabilities were verified against the JS and Go registries rather than copied
from generic defaults — all use the full multimodal/tool profile (`tools=True`,
`tool_choice=True`, `constrained=ALL`, `output=['text', 'json']`).

## Testing

- **Unit tests:** added a parametrized test asserting each VertexAI Gemini 3.x
  text model resolves to real capabilities (`tools`, `tool_choice`,
  `constrained=all`, `output=['text', 'json']`) rather than the fallback.
- **Dev UI (VertexAI):** screenshots below show a successful generate against `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, and `gemini-3.5-flash`, including a structured/JSON run.

### Dev UI screenshots

<img width="1028" height="559" alt="Screenshot 2026-06-19 at 10 11 59" src="https://github.com/user-attachments/assets/b850f640-6a66-49e1-a27c-2e6d8410fa49" />
<img width="784" height="507" alt="Screenshot 2026-06-19 at 10 18 59" src="https://github.com/user-attachments/assets/befad433-8727-457a-a2da-b403d0945fd7" />
<img width="753" height="477" alt="Screenshot 2026-06-19 at 10 28 35" src="https://github.com/user-attachments/assets/8065d86f-8a41-43d6-b021-8c4bed09e909" />
<img width="739" height="527" alt="Screenshot 2026-06-19 at 12 07 43" src="https://github.com/user-attachments/assets/5b43d016-982f-4bab-99bb-3ff39dc9fbaa" />