### PR TITLE
feat(python): register new opus models

### DIFF
--- a/py/plugins/anthropic/src/genkit/plugins/anthropic/model_info.py
+++ b/py/plugins/anthropic/src/genkit/plugins/anthropic/model_info.py
@@ -137,6 +137,32 @@ CLAUDE_OPUS_4_6 = ModelInfo(
     ),
 )
 
+CLAUDE_OPUS_4_7 = ModelInfo(
+    label='Anthropic - Claude Opus 4.7',
+    versions=['claude-opus-4-7'],
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        system_role=True,
+        output=['text', 'json'],
+        constrained=Constrained.ALL,
+    ),
+)
+
+CLAUDE_OPUS_4_8 = ModelInfo(
+    label='Anthropic - Claude Opus 4.8',
+    versions=['claude-opus-4-8'],
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        system_role=True,
+        output=['text', 'json'],
+        constrained=Constrained.ALL,
+    ),
+)
+
 SUPPORTED_ANTHROPIC_MODELS: dict[str, ModelInfo] = {
     'claude-3-5-haiku': CLAUDE_3_5_HAIKU,
     'claude-3-5-sonnet': CLAUDE_3_5_SONNET,
@@ -147,6 +173,8 @@ SUPPORTED_ANTHROPIC_MODELS: dict[str, ModelInfo] = {
     'claude-opus-4-1': CLAUDE_OPUS_4_1,
     'claude-opus-4-5': CLAUDE_OPUS_4_5,
     'claude-opus-4-6': CLAUDE_OPUS_4_6,
+    'claude-opus-4-7': CLAUDE_OPUS_4_7,
+    'claude-opus-4-8': CLAUDE_OPUS_4_8,
 }
 
 DEFAULT_SUPPORTS = Supports(

--- a/py/plugins/anthropic/tests/anthropic_models_test.py
+++ b/py/plugins/anthropic/tests/anthropic_models_test.py
@@ -631,10 +631,11 @@ def test_pdf_with_cache_control() -> None:
     assert blocks[0]['cache_control'] == {'type': 'ephemeral'}
 
 
-def test_structured_output_uses_native_output_config() -> None:
+@pytest.mark.parametrize('model_name', ['claude-opus-4-6', 'claude-opus-4-7', 'claude-opus-4-8'])
+def test_structured_output_uses_native_output_config(model_name: str) -> None:
     """Test that JSON schema uses native output_config when model supports it."""
     mock_client = MagicMock()
-    model = AnthropicModel(model_name='claude-opus-4-6', client=mock_client)
+    model = AnthropicModel(model_name=model_name, client=mock_client)
 
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],

--- a/py/plugins/anthropic/tests/anthropic_plugin_test.py
+++ b/py/plugins/anthropic/tests/anthropic_plugin_test.py
@@ -25,6 +25,7 @@ import pytest
 
 from genkit import (
     ActionKind,
+    Constrained,
     Message,
     ModelConfig,
     ModelRequest,
@@ -152,7 +153,7 @@ async def test_anthropic_runtime_clients_are_loop_local(mock_client_ctor: MagicM
 
 def test_supported_models() -> None:
     """Test that all supported models have proper metadata."""
-    assert len(SUPPORTED_MODELS) == 9
+    assert len(SUPPORTED_MODELS) == 11
     assert 'claude-3-haiku' not in SUPPORTED_MODELS
     for _name, info in SUPPORTED_MODELS.items():
         assert info.label is not None
@@ -167,6 +168,17 @@ def test_supported_models() -> None:
         else:
             assert info.supports.media is True
         assert info.supports.system_role is True
+
+    for model_name, expected_label in (
+        ('claude-opus-4-7', 'Anthropic - Claude Opus 4.7'),
+        ('claude-opus-4-8', 'Anthropic - Claude Opus 4.8'),
+    ):
+        info = SUPPORTED_MODELS[model_name]
+        assert info.label == expected_label
+        assert info.versions == [model_name]
+        assert info.supports is not None
+        assert info.supports.output == ['text', 'json']
+        assert info.supports.constrained == Constrained.ALL
 
 
 def test_get_model_info_known() -> None:

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -148,6 +148,7 @@ override-dependencies = ["werkzeug>=3.1.6"]
 
 [tool.uv.sources]
 # Samples (alphabetical by package name from pyproject.toml)
+anthropic-sample     = { workspace = true }
 basic-flows          = { workspace = true }
 context              = { workspace = true }
 django-hello         = { workspace = true }

--- a/py/samples/anthropic-sample/pyproject.toml
+++ b/py/samples/anthropic-sample/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "anthropic-sample"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "genkit",
+  "genkit-plugin-anthropic",
+  "pydantic>=2.10.5",
+  "structlog>=25.2.0",
+  "uvloop>=0.21.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/py/samples/anthropic-sample/pyproject.toml
+++ b/py/samples/anthropic-sample/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
   "genkit-plugin-anthropic",
   "pydantic>=2.10.5",
   "structlog>=25.2.0",
-  "uvloop>=0.21.0",
 ]
 
 [build-system]

--- a/py/samples/anthropic-sample/src/main.py
+++ b/py/samples/anthropic-sample/src/main.py
@@ -1,0 +1,110 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Anthropic's Claude Opus models generation samples."""
+
+from pydantic import BaseModel, Field
+
+from genkit import Genkit
+from genkit.plugins.anthropic import Anthropic
+
+ai = Genkit(plugins=[Anthropic()], model='anthropic/claude-opus-4-8')
+
+
+class TopicInput(BaseModel):
+    """Input for a plain-text generation."""
+
+    topic: str = Field(default='coding', description='Topic for the haiku')
+
+
+class CatInput(BaseModel):
+    """Input for a structured generation."""
+
+    name: str = Field(default='Mittens', description='Name of the cat to invent')
+
+
+class Cat(BaseModel):
+    """Structured cat profile — proves output=['text','json'] + constrained."""
+
+    name: str
+    breed: str
+    age: int
+    personality: str
+
+
+# --- claude-opus-4-7 -------------------------------------------------------
+
+
+@ai.flow()
+async def haiku_opus_4_7(data: TopicInput) -> str:
+    """Plain-text generate against claude-opus-4-7."""
+    response = await ai.generate(
+        model='anthropic/claude-opus-4-7',
+        prompt=f'Write a haiku about {data.topic}.',
+    )
+    return response.text
+
+
+@ai.flow()
+async def cat_opus_4_7(data: CatInput) -> Cat:
+    """Structured/JSON generate against claude-opus-4-7."""
+    response = await ai.generate(
+        model='anthropic/claude-opus-4-7',
+        prompt=f'Invent a cat named {data.name}.',
+        output_format='json',
+        output_schema=Cat,
+    )
+    return response.output
+
+
+# --- claude-opus-4-8 -------------------------------------------------------
+
+
+@ai.flow()
+async def haiku_opus_4_8(data: TopicInput) -> str:
+    """Plain-text generate against claude-opus-4-8."""
+    response = await ai.generate(
+        model='anthropic/claude-opus-4-8',
+        prompt=f'Write a haiku about {data.topic}.',
+    )
+    return response.text
+
+
+@ai.flow()
+async def cat_opus_4_8(data: CatInput) -> Cat:
+    """Structured/JSON generate against claude-opus-4-8."""
+    response = await ai.generate(
+        model='anthropic/claude-opus-4-8',
+        prompt=f'Invent a cat named {data.name}.',
+        output_format='json',
+        output_schema=Cat,
+    )
+    return response.output
+
+
+async def main() -> None:
+    """Run each flow once from the CLI."""
+    try:
+        print(await haiku_opus_4_7(TopicInput()))  # noqa: T201
+        print(await cat_opus_4_7(CatInput()))  # noqa: T201
+        print(await haiku_opus_4_8(TopicInput()))  # noqa: T201
+        print(await cat_opus_4_8(CatInput()))  # noqa: T201
+    except Exception as error:
+        print(f'Set ANTHROPIC_API_KEY to a valid value before running this sample.\n{error}')  # noqa: T201
+
+
+if __name__ == '__main__':
+    ai.run_main(main())

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -124,7 +124,6 @@ dependencies = [
     { name = "genkit-plugin-anthropic" },
     { name = "pydantic" },
     { name = "structlog" },
-    { name = "uvloop" },
 ]
 
 [package.metadata]
@@ -133,7 +132,6 @@ requires-dist = [
     { name = "genkit-plugin-anthropic", editable = "plugins/anthropic" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "structlog", specifier = ">=25.2.0" },
-    { name = "uvloop", specifier = ">=0.21.0" },
 ]
 
 [[package]]

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -11,6 +11,7 @@ resolution-markers = [
 
 [manifest]
 members = [
+    "anthropic-sample",
     "basic-flows",
     "context",
     "django-hello",
@@ -112,6 +113,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/15/b1/91aea3f8fd180d01d133d931a167a78a3737b3fd39ccef2ae8d6619c24fd/anthropic-0.79.0.tar.gz", hash = "sha256:8707aafb3b1176ed6c13e2b1c9fb3efddce90d17aee5d8b83a86c70dcdcca871", size = 509825, upload-time = "2026-02-07T18:06:18.388Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/b2/cc0b8e874a18d7da50b0fda8c99e4ac123f23bf47b471827c5f6f3e4a767/anthropic-0.79.0-py3-none-any.whl", hash = "sha256:04cbd473b6bbda4ca2e41dd670fe2f829a911530f01697d0a1e37321eb75f3cf", size = 405918, upload-time = "2026-02-07T18:06:20.246Z" },
+]
+
+[[package]]
+name = "anthropic-sample"
+version = "0.1.0"
+source = { editable = "samples/anthropic-sample" }
+dependencies = [
+    { name = "genkit" },
+    { name = "genkit-plugin-anthropic" },
+    { name = "pydantic" },
+    { name = "structlog" },
+    { name = "uvloop" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-plugin-anthropic", editable = "plugins/anthropic" },
+    { name = "pydantic", specifier = ">=2.10.5" },
+    { name = "structlog", specifier = ">=25.2.0" },
+    { name = "uvloop", specifier = ">=0.21.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Registers the two latest Claude Opus models in the Python Anthropic plugin's
`SUPPORTED_ANTHROPIC_MODELS`:

- `claude-opus-4-7`
- `claude-opus-4-8`

A slice of #5542 

## Why

Anthropic discovery is static, so any name not in the registry falls back to
`DEFAULT_SUPPORTS` with `output=['text']` only — silently losing json /
constrained support. Both new entries mirror `claude-opus-4-6`: `multiturn`,
`media`, `tools`, `system_role`, `output=['text','json']`, `constrained=ALL`
(verified against the JS/Go registries).

## Tests

- Parametrized `test_structured_output_uses_native_output_config` across
  `claude-opus-4-6`, `-4-7`, and `-4-8`.
- Bumped supported-model count to 11 and added explicit label / versions /
  output / constrained assertions for the new entries.
- Full anthropic plugin suite passes (41 tests).

## Screenshots
<img width="418" height="420" alt="Screenshot 2026-06-19 at 13 17 32" src="https://github.com/user-attachments/assets/87fb36aa-99e9-4861-aed7-ebe639bcdda3" />
<img width="685" height="499" alt="Screenshot 2026-06-19 at 13 18 23" src="https://github.com/user-attachments/assets/c01ac42d-c956-486f-a2cd-32437b674578" />
<img width="649" height="502" alt="Screenshot 2026-06-19 at 13 19 01" src="https://github.com/user-attachments/assets/b55ad5d2-defa-48e8-abe4-4c1c156e92be" />
<img width="1070" height="731" alt="Screenshot 2026-06-19 at 13 19 38" src="https://github.com/user-attachments/assets/ae0f8f2c-7229-4075-ac5c-30beafba0340" />
<img width="1081" height="734" alt="Screenshot 2026-06-19 at 13 20 05" src="https://github.com/user-attachments/assets/3c3f07c2-a5ee-40be-967c-abaec85704f4" />
