### PR TITLE
chore(py/samples): drop redundant uvloop dependency

### DIFF
--- a/py/samples/context/pyproject.toml
+++ b/py/samples/context/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
   "genkit-plugin-google-genai",
   "pydantic>=2.0.0",
   "structlog>=24.0.0",
-  "uvloop>=0.21.0",
 ]
 
 [build-system]

--- a/py/samples/gemini-code-execution/pyproject.toml
+++ b/py/samples/gemini-code-execution/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
   "genkit-plugin-google-genai",
   "pydantic>=2.10.5",
   "structlog>=25.2.0",
-  "uvloop>=0.21.0",
 ]
 
 [build-system]

--- a/py/samples/gemini-context-caching/pyproject.toml
+++ b/py/samples/gemini-context-caching/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
   "httpx",
   "pydantic>=2.10.5",
   "structlog>=25.2.0",
-  "uvloop>=0.21.0",
 ]
 
 [build-system]

--- a/py/samples/middleware-coding-agent/pyproject.toml
+++ b/py/samples/middleware-coding-agent/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
   "genkit-plugin-middleware",
   "pydantic>=2.10.5",
   "structlog>=25.2.0",
-  "uvloop>=0.21.0",
 ]
 
 [build-system]

--- a/py/samples/middleware/pyproject.toml
+++ b/py/samples/middleware/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
   "genkit-plugin-middleware",
   "pydantic>=2.0.0",
   "structlog>=24.0.0",
-  "uvloop>=0.21.0",
 ]
 
 [build-system]

--- a/py/samples/output-formats/pyproject.toml
+++ b/py/samples/output-formats/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
   "genkit-plugin-google-genai",
   "pydantic>=2.10.5",
   "structlog>=25.2.0",
-  "uvloop>=0.21.0",
 ]
 
 [build-system]

--- a/py/samples/prompts/pyproject.toml
+++ b/py/samples/prompts/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
   "genkit-plugin-google-genai",
   "pydantic>=2.10.5",
   "structlog>=25.2.0",
-  "uvloop>=0.21.0",
 ]
 
 [build-system]

--- a/py/samples/tool-interrupts/pyproject.toml
+++ b/py/samples/tool-interrupts/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
   "genkit-plugin-google-genai",
   "pydantic>=2.10.5",
   "structlog>=25.2.0",
-  "uvloop>=0.21.0",
 ]
 
 [build-system]

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -713,7 +713,6 @@ dependencies = [
     { name = "genkit-plugin-google-genai" },
     { name = "pydantic" },
     { name = "structlog" },
-    { name = "uvloop" },
 ]
 
 [package.metadata]
@@ -722,7 +721,6 @@ requires-dist = [
     { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "structlog", specifier = ">=24.0.0" },
-    { name = "uvloop", specifier = ">=0.21.0" },
 ]
 
 [[package]]
@@ -1504,7 +1502,6 @@ dependencies = [
     { name = "genkit-plugin-google-genai" },
     { name = "pydantic" },
     { name = "structlog" },
-    { name = "uvloop" },
 ]
 
 [package.metadata]
@@ -1513,7 +1510,6 @@ requires-dist = [
     { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "structlog", specifier = ">=25.2.0" },
-    { name = "uvloop", specifier = ">=0.21.0" },
 ]
 
 [[package]]
@@ -1526,7 +1522,6 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "structlog" },
-    { name = "uvloop" },
 ]
 
 [package.metadata]
@@ -1536,7 +1531,6 @@ requires-dist = [
     { name = "httpx" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "structlog", specifier = ">=25.2.0" },
-    { name = "uvloop", specifier = ">=0.21.0" },
 ]
 
 [[package]]
@@ -3628,7 +3622,6 @@ dependencies = [
     { name = "genkit-plugin-middleware" },
     { name = "pydantic" },
     { name = "structlog" },
-    { name = "uvloop" },
 ]
 
 [package.metadata]
@@ -3638,7 +3631,6 @@ requires-dist = [
     { name = "genkit-plugin-middleware", editable = "plugins/middleware" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "structlog", specifier = ">=24.0.0" },
-    { name = "uvloop", specifier = ">=0.21.0" },
 ]
 
 [[package]]
@@ -3651,7 +3643,6 @@ dependencies = [
     { name = "genkit-plugin-middleware" },
     { name = "pydantic" },
     { name = "structlog" },
-    { name = "uvloop" },
 ]
 
 [package.metadata]
@@ -3661,7 +3652,6 @@ requires-dist = [
     { name = "genkit-plugin-middleware", editable = "plugins/middleware" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "structlog", specifier = ">=25.2.0" },
-    { name = "uvloop", specifier = ">=0.21.0" },
 ]
 
 [[package]]
@@ -4581,7 +4571,6 @@ dependencies = [
     { name = "genkit-plugin-google-genai" },
     { name = "pydantic" },
     { name = "structlog" },
-    { name = "uvloop" },
 ]
 
 [package.metadata]
@@ -4590,7 +4579,6 @@ requires-dist = [
     { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "structlog", specifier = ">=25.2.0" },
-    { name = "uvloop", specifier = ">=0.21.0" },
 ]
 
 [[package]]
@@ -4976,7 +4964,6 @@ dependencies = [
     { name = "genkit-plugin-google-genai" },
     { name = "pydantic" },
     { name = "structlog" },
-    { name = "uvloop" },
 ]
 
 [package.metadata]
@@ -4985,7 +4972,6 @@ requires-dist = [
     { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "structlog", specifier = ">=25.2.0" },
-    { name = "uvloop", specifier = ">=0.21.0" },
 ]
 
 [[package]]
@@ -6489,7 +6475,6 @@ dependencies = [
     { name = "genkit-plugin-google-genai" },
     { name = "pydantic" },
     { name = "structlog" },
-    { name = "uvloop" },
 ]
 
 [package.metadata]
@@ -6498,7 +6483,6 @@ requires-dist = [
     { name = "genkit-plugin-google-genai", editable = "plugins/google-genai" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "structlog", specifier = ">=25.2.0" },
-    { name = "uvloop", specifier = ">=0.21.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Removes the bare `uvloop>=0.21.0` dependency from 8 Python samples:
`context`, `gemini-code-execution`, `gemini-context-caching`,
`middleware`, `middleware-coding-agent`, `output-formats`, `prompts`,
and `tool-interrupts`.

## Why

These samples declared `uvloop>=0.21.0` with no platform marker. uvloop
ships no Windows wheels, so the bare pin makes the samples fail to
install on Windows.

The dependency is also redundant: the core `genkit` package already
declares `uvloop>=0.21.0; sys_platform != 'win32'`, and `run_loop`
imports it optionally with an asyncio fallback. None of these samples
import uvloop directly.

## How

Deleted the `uvloop` line from each sample's `pyproject.toml`. On
non-Windows platforms uvloop is still installed transitively via the
`genkit` dependency, so the optional speedup in `run_loop` is unaffected.
On Windows, the install is no longer blocked and `run_loop` falls back to
asyncio as intended.

## Testing

- `grep` confirms no remaining `uvloop` references in any sample
  `pyproject.toml` and no direct `uvloop` imports in sample `src/`.
- Regenerated `py/uv.lock`; `uv lock --check` passes.
- Confirmed uvloop still resolves transitively via `genkit` core
  (`uv pip show uvloop` → `Required-by: genkit`) and imports in a
  synced sample env, so the `run_loop` speedup is unaffected on
  non-Windows.
