### PR TITLE
feat(py/plugins/google-genai): register Gemini embedding 2

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -105,7 +105,7 @@ import genkit.plugins.google_genai.constants as const
 from genkit import ModelInfo
 from genkit._core._action import ActionRunContext
 from genkit._core._model import ModelRequest, ModelResponse
-from genkit.embedder import EmbedderOptions, EmbedderSupports, embedder_action_metadata
+from genkit.embedder import embedder_action_metadata
 from genkit.evaluator import EvalFnResponse, EvalRequest
 from genkit.model import BackgroundAction, model_action_metadata
 from genkit.plugin_api import (
@@ -122,9 +122,9 @@ from genkit.plugins.google_genai.evaluators import (
     create_vertex_evaluators,
 )
 from genkit.plugins.google_genai.models.embedder import (
-    EMBEDDER_DIMENSIONS,
     VERTEX_KNOWN_EMBEDDERS,
     Embedder,
+    get_embedder_options,
 )
 from genkit.plugins.google_genai.models.gemini import (
     SUPPORTED_MODELS,
@@ -320,11 +320,7 @@ def _create_embedder_action(
     label = f'{PLUGIN_DISPLAY_NAME[plugin_name]} - {clean_name}'
     action_metadata = embedder_action_metadata(
         name=name,
-        options=EmbedderOptions(
-            label=label,
-            supports=EmbedderSupports(input=['text']),
-            dimensions=EMBEDDER_DIMENSIONS.get(clean_name),
-        ),
+        options=get_embedder_options(name=clean_name, label=label),
     )
 
     async def _run(request: Any) -> Any:  # noqa: ANN401
@@ -694,10 +690,9 @@ class GoogleAI(Plugin):
             actions_list.append(
                 embedder_action_metadata(
                     name=googleai_name(name),
-                    options=EmbedderOptions(
+                    options=get_embedder_options(
+                        name=name,
                         label=f'{PLUGIN_DISPLAY_NAME[GOOGLEAI_PLUGIN_NAME]} - {name}',
-                        supports=EmbedderSupports(input=['text']),
-                        dimensions=EMBEDDER_DIMENSIONS.get(name),
                     ),
                 )
             )
@@ -1037,10 +1032,9 @@ class VertexAI(Plugin):
             actions_list.append(
                 embedder_action_metadata(
                     name=vertexai_name(name),
-                    options=EmbedderOptions(
+                    options=get_embedder_options(
+                        name=name,
                         label=f'{PLUGIN_DISPLAY_NAME[VERTEXAI_PLUGIN_NAME]} - {name}',
-                        supports=EmbedderSupports(input=['text']),
-                        dimensions=EMBEDDER_DIMENSIONS.get(name),
                     ),
                 )
             )

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -317,10 +317,15 @@ def _create_embedder_action(
         Action object for the embedder.
     """
     clean_name = name.replace(f'{plugin_name}/', '') if name.startswith(plugin_name) else name
+    full_name = f'{plugin_name}/{clean_name}'
     label = f'{PLUGIN_DISPLAY_NAME[plugin_name]} - {clean_name}'
     action_metadata = embedder_action_metadata(
-        name=name,
-        options=get_embedder_options(name=clean_name, label=label),
+        name=full_name,
+        options=get_embedder_options(
+            name=clean_name,
+            label=label,
+            is_vertex=(plugin_name == VERTEXAI_PLUGIN_NAME),
+        ),
     )
 
     async def _run(request: Any) -> Any:  # noqa: ANN401
@@ -329,7 +334,7 @@ def _create_embedder_action(
 
     action = Action(
         kind=ActionKind.EMBEDDER,
-        name=name,
+        name=full_name,
         fn=_run,
         metadata=action_metadata.metadata,
     )
@@ -1035,6 +1040,7 @@ class VertexAI(Plugin):
                     options=get_embedder_options(
                         name=name,
                         label=f'{PLUGIN_DISPLAY_NAME[VERTEXAI_PLUGIN_NAME]} - {name}',
+                        is_vertex=True,
                     ),
                 )
             )

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
@@ -29,6 +29,7 @@ from google.genai import types as genai_types
 
 from genkit import DocumentPart, Embedding, EmbedRequest, EmbedResponse
 from genkit._core._typing import DocumentData
+from genkit.embedder import EmbedderOptions, EmbedderSupports
 from genkit.plugins.google_genai.models.utils import PartConverter
 
 
@@ -47,6 +48,8 @@ class VertexEmbeddingModels(StrEnum):
 class GeminiEmbeddingModels(StrEnum):
     """Embedding models supported by Google-Genai gemini."""
 
+    GEMINI_EMBEDDING_2_PREVIEW = 'gemini-embedding-2-preview'
+    GEMINI_EMBEDDING_2 = 'gemini-embedding-2'
     GEMINI_EMBEDDING_EXP_03_07 = 'gemini-embedding-exp-03-07'
     TEXT_EMBEDDING_004 = 'text-embedding-004'
     GEMINI_EMBEDDING_001 = 'gemini-embedding-001'
@@ -68,6 +71,7 @@ class EmbeddingTaskType(StrEnum):
 EMBEDDER_DIMENSIONS: dict[str, int] = {
     # Google AI
     'gemini-embedding-2-preview': 3072,
+    'gemini-embedding-2': 3072,
     'gemini-embedding-001': 3072,
     # Vertex AI
     'text-embedding-005': 768,
@@ -81,6 +85,21 @@ VERTEX_KNOWN_EMBEDDERS: tuple[str, ...] = (
     'text-multilingual-embedding-002',
     'gemini-embedding-001',
 )
+
+EMBEDDER_INPUT_SUPPORTS: dict[str, list[str]] = {
+    'gemini-embedding-2-preview': ['text', 'image', 'video'],
+    'gemini-embedding-2': ['text', 'image', 'video'],
+}
+
+
+def get_embedder_options(name: str, label: str) -> EmbedderOptions:
+    """Return EmbedderOptions metadata for a discovered embedder model."""
+    supports = EMBEDDER_INPUT_SUPPORTS.get(name, ['text'])
+    return EmbedderOptions(
+        label=label,
+        supports=EmbedderSupports(input=supports),
+        dimensions=EMBEDDER_DIMENSIONS.get(name),
+    )
 
 
 class Embedder:

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
@@ -86,15 +86,27 @@ VERTEX_KNOWN_EMBEDDERS: tuple[str, ...] = (
     'gemini-embedding-001',
 )
 
-EMBEDDER_INPUT_SUPPORTS: dict[str, list[str]] = {
+# Advertised input modalities per backend
+GOOGLEAI_EMBEDDER_INPUT_SUPPORTS: dict[str, list[str]] = {
     'gemini-embedding-2-preview': ['text', 'image', 'video'],
     'gemini-embedding-2': ['text', 'image', 'video'],
 }
 
 
-def get_embedder_options(name: str, label: str) -> EmbedderOptions:
-    """Return EmbedderOptions metadata for a discovered embedder model."""
-    supports = EMBEDDER_INPUT_SUPPORTS.get(name, ['text'])
+def get_embedder_options(name: str, label: str, is_vertex: bool = False) -> EmbedderOptions:
+    """Return EmbedderOptions metadata for a discovered embedder model.
+
+    Args:
+        name: The bare (unprefixed) model name, e.g. 'gemini-embedding-2'.
+        label: Human-readable label for the embedder.
+        is_vertex: True when resolving for the Vertex backend, which advertises
+            text-only because its embed path cannot deliver media.
+
+    Returns:
+        EmbedderOptions describing the model's label, supported inputs and
+        static dimensions.
+    """
+    supports = ['text'] if is_vertex else GOOGLEAI_EMBEDDER_INPUT_SUPPORTS.get(name, ['text'])
     return EmbedderOptions(
         label=label,
         supports=EmbedderSupports(input=supports),

--- a/py/plugins/google-genai/test/google_plugin_test.py
+++ b/py/plugins/google-genai/test/google_plugin_test.py
@@ -40,7 +40,12 @@ from genkit import (
 )
 from genkit.plugin_api import GENKIT_CLIENT_HEADER
 from genkit.plugins.google_genai import GoogleAI, VertexAI
-from genkit.plugins.google_genai.google import _inject_attribution_headers, googleai_name, vertexai_name
+from genkit.plugins.google_genai.google import (
+    _inject_attribution_headers,
+    _list_genai_models,
+    googleai_name,
+    vertexai_name,
+)
 from genkit.plugins.google_genai.models.embedder import VERTEX_KNOWN_EMBEDDERS
 from genkit.plugins.google_genai.models.gemini import (
     DEFAULT_SUPPORTS_MODEL,
@@ -236,16 +241,17 @@ def test_googleai__resolve_model(
 
 
 @pytest.mark.parametrize(
-    'model_name, expected_model_name, clean_name',
+    'expected_model_name, expected_dimensions, expected_support_inputs',
     [
-        ('gemini-pro-deluxe-max', 'googleai/gemini-pro-deluxe-max', 'gemini-pro-deluxe-max'),
-        ('googleai/gemini-pro-deluxe-max', 'googleai/gemini-pro-deluxe-max', 'gemini-pro-deluxe-max'),
+        ('googleai/gemini-embedding-2', 3072, ['text', 'image', 'video']),
+        ('googleai/gemini-embedding-2-preview', 3072, ['text', 'image', 'video']),
+        ('googleai/custom-embedder', None, ['text']),
     ],
 )
 def test_googleai__resolve_embedder(
-    model_name: str,
     expected_model_name: str,
-    clean_name: str,
+    expected_dimensions: int | None,
+    expected_support_inputs: list[str],
     googleai_plugin_instance: GoogleAI,
 ) -> None:
     """Tests for GoogleAI._resolve_embedder method."""
@@ -256,6 +262,8 @@ def test_googleai__resolve_embedder(
     assert action is not None
     assert action.kind == ActionKind.EMBEDDER
     assert action.name == expected_model_name
+    assert action.metadata['embedder']['dimensions'] == expected_dimensions
+    assert action.metadata['embedder']['supports']['input'] == expected_support_inputs
 
 
 @pytest.mark.asyncio
@@ -270,6 +278,8 @@ async def test_googleai_list_actions(googleai_plugin_instance: GoogleAI) -> None
 
     models_return_value = [
         MockModel(supported_actions=['generateContent'], name='models/gemini-pro'),
+        MockModel(supported_actions=['embedContent'], name='models/gemini-embedding-2'),
+        MockModel(supported_actions=['embedContent'], name='models/gemini-embedding-2-preview'),
         MockModel(supported_actions=['embedContent'], name='models/gemini-embedding-001'),
         MockModel(supported_actions=['generateContent'], name='models/gemini-2.0-flash-tts'),  # TTS
     ]
@@ -288,6 +298,20 @@ async def test_googleai_list_actions(googleai_plugin_instance: GoogleAI) -> None
     action2 = next(a for a in result if a.name == googleai_name('gemini-embedding-001'))
     assert action2 is not None
     assert action2.action_type == ActionKind.EMBEDDER
+    assert action2.metadata['embedder']['dimensions'] == 3072
+    assert action2.metadata['embedder']['supports']['input'] == ['text']
+
+    action2b = next(a for a in result if a.name == googleai_name('gemini-embedding-2'))
+    assert action2b is not None
+    assert action2b.action_type == ActionKind.EMBEDDER
+    assert action2b.metadata['embedder']['dimensions'] == 3072
+    assert action2b.metadata['embedder']['supports']['input'] == ['text', 'image', 'video']
+
+    action2c = next(a for a in result if a.name == googleai_name('gemini-embedding-2-preview'))
+    assert action2c is not None
+    assert action2c.action_type == ActionKind.EMBEDDER
+    assert action2c.metadata['embedder']['dimensions'] == 3072
+    assert action2c.metadata['embedder']['supports']['input'] == ['text', 'image', 'video']
 
     # Check TTS
     action3 = next(a for a in result if a.name == googleai_name('gemini-2.0-flash-tts'))
@@ -951,6 +975,21 @@ async def test_vertexai_resolve_evaluator(vertexai_plugin_instance: VertexAI) ->
     assert action is not None
     assert action.kind == ActionKind.EVALUATOR
     assert action.name == vertexai_name('fluency')
+
+
+def test_list_genai_models_classifies_gemini_embedding_2_as_embedder() -> None:
+    """gemini-embedding-2 should always be discovered in the embedder list."""
+    mock_client = MagicMock()
+
+    embedder_model = MagicMock()
+    embedder_model.name = 'models/gemini-embedding-2'
+    embedder_model.supported_actions = ['embedContent']
+    embedder_model.description = 'Gemini embedding model'
+
+    mock_client.models.list.return_value = [embedder_model]
+    discovered = _list_genai_models(mock_client, is_vertex=False)
+
+    assert 'gemini-embedding-2' in discovered.embedders
 
 
 def test_config_schema_extra_fields() -> None:

--- a/py/plugins/google-genai/test/google_plugin_test.py
+++ b/py/plugins/google-genai/test/google_plugin_test.py
@@ -42,7 +42,6 @@ from genkit.plugin_api import GENKIT_CLIENT_HEADER
 from genkit.plugins.google_genai import GoogleAI, VertexAI
 from genkit.plugins.google_genai.google import (
     _inject_attribution_headers,
-    _list_genai_models,
     googleai_name,
     vertexai_name,
 )
@@ -241,14 +240,22 @@ def test_googleai__resolve_model(
 
 
 @pytest.mark.parametrize(
-    'expected_model_name, expected_dimensions, expected_support_inputs',
+    'input_name, expected_model_name, expected_dimensions, expected_support_inputs',
     [
-        ('googleai/gemini-embedding-2', 3072, ['text', 'image', 'video']),
-        ('googleai/gemini-embedding-2-preview', 3072, ['text', 'image', 'video']),
-        ('googleai/custom-embedder', None, ['text']),
+        ('googleai/gemini-embedding-2', 'googleai/gemini-embedding-2', 3072, ['text', 'image', 'video']),
+        # Bare (unprefixed) names resolve to the namespaced action name.
+        ('gemini-embedding-2', 'googleai/gemini-embedding-2', 3072, ['text', 'image', 'video']),
+        (
+            'googleai/gemini-embedding-2-preview',
+            'googleai/gemini-embedding-2-preview',
+            3072,
+            ['text', 'image', 'video'],
+        ),
+        ('googleai/custom-embedder', 'googleai/custom-embedder', None, ['text']),
     ],
 )
 def test_googleai__resolve_embedder(
+    input_name: str,
     expected_model_name: str,
     expected_dimensions: int | None,
     expected_support_inputs: list[str],
@@ -257,13 +264,35 @@ def test_googleai__resolve_embedder(
     """Tests for GoogleAI._resolve_embedder method."""
     plugin = googleai_plugin_instance
 
-    action = plugin._resolve_embedder(name=expected_model_name)
+    action = plugin._resolve_embedder(name=input_name)
 
     assert action is not None
     assert action.kind == ActionKind.EMBEDDER
     assert action.name == expected_model_name
     assert action.metadata['embedder']['dimensions'] == expected_dimensions
     assert action.metadata['embedder']['supports']['input'] == expected_support_inputs
+
+
+@pytest.mark.parametrize(
+    'input_name, expected_model_name',
+    [
+        ('vertexai/gemini-embedding-2', 'vertexai/gemini-embedding-2'),
+        ('gemini-embedding-2', 'vertexai/gemini-embedding-2'),
+    ],
+)
+def test_vertexai__resolve_embedder_scopes_supports_to_text(
+    input_name: str,
+    expected_model_name: str,
+    vertexai_plugin_instance: VertexAI,
+) -> None:
+    """Vertex must not inherit Google AI's multimodal advertisement."""
+    action = vertexai_plugin_instance._resolve_embedder(name=input_name)
+
+    assert action is not None
+    assert action.kind == ActionKind.EMBEDDER
+    assert action.name == expected_model_name
+    assert action.metadata['embedder']['supports']['input'] == ['text']
+    assert action.metadata['embedder']['dimensions'] == 3072
 
 
 @pytest.mark.asyncio
@@ -975,21 +1004,6 @@ async def test_vertexai_resolve_evaluator(vertexai_plugin_instance: VertexAI) ->
     assert action is not None
     assert action.kind == ActionKind.EVALUATOR
     assert action.name == vertexai_name('fluency')
-
-
-def test_list_genai_models_classifies_gemini_embedding_2_as_embedder() -> None:
-    """gemini-embedding-2 should always be discovered in the embedder list."""
-    mock_client = MagicMock()
-
-    embedder_model = MagicMock()
-    embedder_model.name = 'models/gemini-embedding-2'
-    embedder_model.supported_actions = ['embedContent']
-    embedder_model.description = 'Gemini embedding model'
-
-    mock_client.models.list.return_value = [embedder_model]
-    discovered = _list_genai_models(mock_client, is_vertex=False)
-
-    assert 'gemini-embedding-2' in discovered.embedders
 
 
 def test_config_schema_extra_fields() -> None:

--- a/py/plugins/google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_embedder_test.py
@@ -16,13 +16,22 @@
 
 """Test the Google-Genai embedder model."""
 
+import base64
+
 import pytest
 from google import genai
 from pytest_mock import MockerFixture
 
-from genkit import Document, EmbedRequest, EmbedResponse
+from genkit import (
+    Document,
+    DocumentPart,
+    EmbedRequest,
+    EmbedResponse,
+    Media,
+    MediaPart,
+    TextPart,
+)
 from genkit.plugins.google_genai.models.embedder import (
-    EMBEDDER_DIMENSIONS,
     Embedder,
     GeminiEmbeddingModels,
     get_embedder_options,
@@ -58,6 +67,48 @@ async def test_embedding(mocker: MockerFixture, version: GeminiEmbeddingModels) 
 
 
 @pytest.mark.asyncio
+async def test_embedding_forwards_media_parts(mocker: MockerFixture) -> None:
+    """Multimodal docs forward media parts to the client alongside the text."""
+    text = 'a photo'
+    raw_image = b'fake-image-bytes'
+    data_url = f'data:image/png;base64,{base64.b64encode(raw_image).decode()}'
+    embedding_values = [0.0017063986, -0.044727605, 0.043327782, 0.00044852644]
+
+    doc = Document(
+        content=[
+            DocumentPart(root=TextPart(text=text)),
+            DocumentPart(root=MediaPart(media=Media(url=data_url, content_type='image/png'))),
+        ]
+    )
+    request = EmbedRequest(input=[doc])
+    api_response = genai.types.EmbedContentResponse(embeddings=[genai.types.ContentEmbedding(values=embedding_values)])
+    googleai_client_mock = mocker.AsyncMock()
+    googleai_client_mock.aio.models.embed_content.return_value = api_response
+
+    embedder = Embedder(GeminiEmbeddingModels.GEMINI_EMBEDDING_2, googleai_client_mock)
+
+    response = await embedder.generate(request)
+
+    googleai_client_mock.assert_has_calls([
+        mocker.call.aio.models.embed_content(
+            model=GeminiEmbeddingModels.GEMINI_EMBEDDING_2,
+            contents=[
+                genai.types.Content(
+                    parts=[
+                        genai.types.Part.from_text(text=text),
+                        genai.types.Part(inline_data=genai.types.Blob(mime_type='image/png', data=raw_image)),
+                    ]
+                )
+            ],
+            config=None,
+        )
+    ])
+    assert isinstance(response, EmbedResponse)
+    assert len(response.embeddings) == 1
+    assert response.embeddings[0].embedding == embedding_values
+
+
+@pytest.mark.asyncio
 async def test_embedding_rejects_empty_input(mocker: MockerFixture) -> None:
     """Empty input must not call the API (avoids opaque BatchEmbedContents errors)."""
     googleai_client_mock = mocker.AsyncMock()
@@ -65,19 +116,6 @@ async def test_embedding_rejects_empty_input(mocker: MockerFixture) -> None:
     with pytest.raises(ValueError, match='Embed request input is empty'):
         await embedder.generate(EmbedRequest(input=[]))
     googleai_client_mock.aio.models.embed_content.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    'model_name, expected_dimensions',
-    [
-        ('gemini-embedding-2-preview', 3072),
-        ('gemini-embedding-2', 3072),
-        ('gemini-embedding-001', 3072),
-    ],
-)
-def test_embedder_dimensions_known_models(model_name: str, expected_dimensions: int) -> None:
-    """Known Gemini embedders expose the expected static dimensions."""
-    assert EMBEDDER_DIMENSIONS[model_name] == expected_dimensions
 
 
 def test_get_embedder_options_multimodal_and_fallback() -> None:
@@ -91,3 +129,11 @@ def test_get_embedder_options_multimodal_and_fallback() -> None:
     assert unknown_options.dimensions is None
     assert unknown_options.supports is not None
     assert unknown_options.supports.input == ['text']
+
+
+def test_get_embedder_options_supports_are_backend_scoped() -> None:
+    """The same model advertises multimodal on Google AI but text-only on Vertex."""
+    vertex_options = get_embedder_options('gemini-embedding-2', 'Vertex AI - gemini-embedding-2', is_vertex=True)
+    assert vertex_options.supports is not None
+    assert vertex_options.supports.input == ['text']
+    assert vertex_options.dimensions == 3072

--- a/py/plugins/google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/plugins/google-genai/test/models/googlegenai_embedder_test.py
@@ -22,8 +22,10 @@ from pytest_mock import MockerFixture
 
 from genkit import Document, EmbedRequest, EmbedResponse
 from genkit.plugins.google_genai.models.embedder import (
+    EMBEDDER_DIMENSIONS,
     Embedder,
     GeminiEmbeddingModels,
+    get_embedder_options,
 )
 
 
@@ -63,3 +65,29 @@ async def test_embedding_rejects_empty_input(mocker: MockerFixture) -> None:
     with pytest.raises(ValueError, match='Embed request input is empty'):
         await embedder.generate(EmbedRequest(input=[]))
     googleai_client_mock.aio.models.embed_content.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    'model_name, expected_dimensions',
+    [
+        ('gemini-embedding-2-preview', 3072),
+        ('gemini-embedding-2', 3072),
+        ('gemini-embedding-001', 3072),
+    ],
+)
+def test_embedder_dimensions_known_models(model_name: str, expected_dimensions: int) -> None:
+    """Known Gemini embedders expose the expected static dimensions."""
+    assert EMBEDDER_DIMENSIONS[model_name] == expected_dimensions
+
+
+def test_get_embedder_options_multimodal_and_fallback() -> None:
+    """Gemini embedding 2 models are multimodal while unknown stays text-only."""
+    options = get_embedder_options('gemini-embedding-2', 'Google AI - gemini-embedding-2')
+    assert options.dimensions == 3072
+    assert options.supports is not None
+    assert options.supports.input == ['text', 'image', 'video']
+
+    unknown_options = get_embedder_options('custom-embedder', 'Google AI - custom-embedder')
+    assert unknown_options.dimensions is None
+    assert unknown_options.supports is not None
+    assert unknown_options.supports.input == ['text']


### PR DESCRIPTION
## What

Registers the exact gemini-embedding-2 model name for the Python Google GenAI plugin and carries its embedder metadata through action registration.

- **Dimensions:** 3072
- **Supported input:** `text`, `image`, `video`

Also introduces a `get_embedder_options(name, label)` helper in
`models/embedder.py` that centralises building `EmbedderOptions`
(label, supported input, dimensions) for discovered embedders, and
wires it into the GoogleAI plugin, the VertexAI plugin, and
`_create_embedder_action`.

A slice of #5542 

## Why

`gemini-embedding-2` was not registered, so it carried no dimension
or input-type metadata. Separately, embedder metadata was built inline
in three places with `supports=EmbedderSupports(input=['text'])`
hardcoded, which means that multimodal embedders were always advertised as
text-only. Centralising the lookup fixes that and removes the duplication.

## How

- Add `gemini-embedding-2` to GeminiEmbeddingModels.
- Add the `EMBEDDER_DIMENSIONS` (3072) and a new
  `EMBEDDER_INPUT_SUPPORTS` map (`text`/`image`/`video`).
- Add `get_embedder_options()` which reads both maps (defaulting input
  to `['text']` for models not listed) and returns the `EmbedderOptions`.
- Replace the three inline `EmbedderOptions(...)` constructions with
  calls to the helper.
- Add tests for embedder dimensions, supported inputs, and discovery metadata.

## Validation
- Dev UI tested locally.
- `uv run --directory plugins/google-genai python -m pytest test/` — 242 passed

## Screenshots
<img width="836" height="780" alt="image" src="https://github.com/user-attachments/assets/715eed30-43ed-42e7-b4d7-af1ce604798c" />
<img width="1356" height="1436" alt="image" src="https://github.com/user-attachments/assets/832825a5-65a7-40f5-b4bb-2002f0a4f07c" />
<img width="1344" height="652" alt="image" src="https://github.com/user-attachments/assets/d50d34b3-d3a2-4447-bba3-a27d48a83b57" />
<img width="1012" height="787" alt="Screenshot 2026-06-29 at 14 33 39" src="https://github.com/user-attachments/assets/2adf61a4-9e8f-4293-8935-68efbedb0790" />
<img width="987" height="770" alt="Screenshot 2026-06-29 at 14 34 12" src="https://github.com/user-attachments/assets/2dfc965e-93e8-4acb-a062-91883e79b27e" />



