### PR TITLE
feat(js/plugins/twelvelabs): add genkitx-twelvelabs plugin (Pegasus models, Marengo embedders)

### DIFF
--- a/js/index.typedoc.md
+++ b/js/index.typedoc.md
@@ -55,6 +55,7 @@ This reference documents the following packages:
 | **[@genkit-ai/mcp](modules/_genkit-ai_mcp.html)**                                     | Model Context Protocol (MCP) plugin.                                     |
 | **[@genkit-ai/anthropic](modules/_genkit-ai_anthropic.html)**                         | Anthropic (Claude) model plugin.                                         |
 | **[@genkit-ai/compat-oai](modules/_genkit-ai_compat-oai.html)**                       | OpenAI-compatible model plugin.                                          |
+| **[genkitx-twelvelabs](modules/genkitx-twelvelabs.html)**                             | TwelveLabs video AI plugin (Pegasus models, Marengo embedders).          |
 | **[@genkit-ai/fetch](modules/_genkit-ai_fetch.html)**                                 | HTTP fetch utilities for plugins.                                        |
 | **[@genkit-ai/middleware](modules/_genkit-ai_middleware.html)**                       | Model middleware plugin (retry, caching, etc.).                          |
 

--- a/js/plugins/twelvelabs/.npmignore
+++ b/js/plugins/twelvelabs/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+tsconfig.json
+tsup.config.ts

--- a/js/plugins/twelvelabs/LICENSE
+++ b/js/plugins/twelvelabs/LICENSE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+  Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   

--- a/js/plugins/twelvelabs/README.md
+++ b/js/plugins/twelvelabs/README.md
@@ -1,0 +1,75 @@
+# TwelveLabs plugin for Genkit
+
+This Genkit plugin adds [TwelveLabs](https://twelvelabs.io) video AI:
+
+- **Pegasus** video-understanding models, exposed as Genkit **models** — describe,
+  summarize, or answer questions about a video.
+- **Marengo** multimodal embedding models, exposed as Genkit **embedders** —
+  produce 512-dim text embeddings that share a space with TwelveLabs video
+  embeddings (great for video retrieval / RAG).
+
+The plugin is opt-in: nothing is registered unless you list `models` and/or
+`embedders`.
+
+## Installing the plugin
+
+```bash
+npm i --save genkitx-twelvelabs
+```
+
+## Using the plugin
+
+```ts
+import { genkit } from 'genkit';
+import { twelvelabs } from 'genkitx-twelvelabs';
+
+const ai = genkit({
+  plugins: [
+    twelvelabs({
+      // apiKey defaults to process.env.TWELVELABS_API_KEY
+      models: [{ name: 'pegasus1.5' }],
+      embedders: [{ name: 'marengo3.0', dimensions: 512 }],
+    }),
+  ],
+});
+
+async function main() {
+  // Pegasus: describe a video. The video is a media part with a public URL;
+  // TwelveLabs fetches it server-side, so no prior indexing is required.
+  const { text } = await ai.generate({
+    model: 'twelvelabs/pegasus1.5',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { text: 'Describe this video in one sentence.' },
+          {
+            media: {
+              url: 'https://example.com/video.mp4',
+              contentType: 'video/mp4',
+            },
+          },
+        ],
+      },
+    ],
+  });
+  console.log(text);
+
+  // Marengo: embed text into the multimodal space.
+  const embedding = await ai.embed({
+    embedder: 'twelvelabs/marengo3.0',
+    content: 'a cat playing piano',
+  });
+  console.log(embedding[0].embedding.length); // 512
+}
+
+main();
+```
+
+Get a free API key at [twelvelabs.io](https://twelvelabs.io) — there's a
+generous free tier.
+
+The sources for this package are in the main [Genkit](https://github.com/genkit-ai/genkit)
+repo. Please file issues and pull requests against that repo.
+
+License: Apache 2.0

--- a/js/plugins/twelvelabs/package.json
+++ b/js/plugins/twelvelabs/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "genkitx-twelvelabs",
+  "description": "Genkit AI framework plugin for TwelveLabs video AI (Pegasus & Marengo).",
+  "keywords": [
+    "genkit",
+    "genkit-plugin",
+    "genkit-model",
+    "genkit-embedder",
+    "twelvelabs",
+    "pegasus",
+    "marengo",
+    "video",
+    "ai",
+    "genai",
+    "generative-ai"
+  ],
+  "version": "1.38.0",
+  "type": "commonjs",
+  "scripts": {
+    "check": "tsc",
+    "compile": "tsup-node",
+    "build:clean": "rimraf ./lib",
+    "build": "npm-run-all build:clean check compile",
+    "build:watch": "tsup-node --watch",
+    "test": "find tests -name '*_test.ts' ! -name '*_live_test.ts' -exec node --import tsx --test {} +",
+    "test:live": "node --import tsx --test tests/*_test.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/genkit-ai/genkit.git",
+    "directory": "js/plugins/twelvelabs"
+  },
+  "author": "genkit",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "genkit": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.16",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^6.0.1",
+    "tsup": "^8.3.5",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3"
+  },
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./lib/index.js",
+      "import": "./lib/index.mjs",
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  }
+}

--- a/js/plugins/twelvelabs/src/embedder.ts
+++ b/js/plugins/twelvelabs/src/embedder.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { EmbedderAction, Genkit } from 'genkit';
+import {
+  DEFAULT_BASE_URL,
+  type EmbedResponse,
+  type EmbeddingModelDefinition,
+} from './types.js';
+
+interface DefineEmbedderParams {
+  apiKey: string;
+  baseUrl: string;
+  embedder: EmbeddingModelDefinition;
+}
+
+/**
+ * Registers a TwelveLabs Marengo embedder against the `/embed` endpoint.
+ *
+ * Marengo produces multimodal embeddings; here we expose text embedding, which
+ * shares an embedding space with TwelveLabs' video embeddings and is the right
+ * fit for Genkit's text-based `embed()` / retriever flows. The endpoint takes
+ * `multipart/form-data` and returns the vector at
+ * `text_embedding.segments[0].float`.
+ */
+export function defineTwelveLabsEmbedder(
+  ai: Genkit,
+  { apiKey, baseUrl, embedder }: DefineEmbedderParams
+): EmbedderAction<any> {
+  const modelName = embedder.modelName ?? embedder.name;
+  return ai.defineEmbedder(
+    {
+      name: `twelvelabs/${embedder.name}`,
+      info: {
+        label: `TwelveLabs Embedding - ${embedder.name}`,
+        dimensions: embedder.dimensions,
+        supports: {
+          input: ['text'],
+        },
+      },
+    },
+    async (input) => {
+      // The /embed endpoint embeds one input per call, so map over documents.
+      const embeddings = await Promise.all(
+        input.map(async (doc) => {
+          const form = new FormData();
+          form.append('model_name', modelName);
+          form.append('text', doc.text);
+
+          const response = await fetch(`${baseUrl}/embed`, {
+            method: 'POST',
+            headers: { 'x-api-key': apiKey },
+            body: form,
+          });
+
+          if (!response.ok) {
+            const errMsg = await safeErrorMessage(response);
+            throw new Error(
+              `Error fetching embedding from TwelveLabs: ${response.statusText}. ${errMsg}`
+            );
+          }
+
+          const payload = (await response.json()) as EmbedResponse;
+          const embedding = payload.text_embedding?.segments?.[0]?.float;
+          if (!embedding) {
+            throw new Error(
+              'TwelveLabs embedding response did not contain a text embedding.'
+            );
+          }
+          return { embedding };
+        })
+      );
+      return { embeddings };
+    }
+  );
+}
+
+async function safeErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { message?: string };
+    return body.message ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export { DEFAULT_BASE_URL };

--- a/js/plugins/twelvelabs/src/index.ts
+++ b/js/plugins/twelvelabs/src/index.ts
@@ -58,6 +58,9 @@ function resolveApiKey(params?: TwelveLabsPluginParams): string {
 function twelvelabsPlugin(params?: TwelveLabsPluginParams): GenkitPlugin {
   const baseUrl = params?.baseUrl ?? DEFAULT_BASE_URL;
   return genkitPlugin('twelvelabs', async (ai: Genkit) => {
+    if (!params?.models?.length && !params?.embedders?.length) {
+      return;
+    }
     const apiKey = resolveApiKey(params);
     params?.models?.forEach((model) =>
       defineTwelveLabsModel(ai, { apiKey, baseUrl, model })

--- a/js/plugins/twelvelabs/src/index.ts
+++ b/js/plugins/twelvelabs/src/index.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  embedderRef,
+  type EmbedderReference,
+  type Genkit,
+  type ModelReference,
+} from 'genkit';
+import { modelRef } from 'genkit/model';
+import { genkitPlugin, type GenkitPlugin } from 'genkit/plugin';
+import { defineTwelveLabsEmbedder } from './embedder.js';
+import { defineTwelveLabsModel } from './models.js';
+import {
+  DEFAULT_BASE_URL,
+  TwelveLabsConfigSchema,
+  type TwelveLabsConfig,
+  type TwelveLabsPluginParams,
+} from './types.js';
+
+export { TwelveLabsConfigSchema };
+export type { TwelveLabsConfig, TwelveLabsPluginParams };
+
+export type TwelveLabsPlugin = {
+  (params?: TwelveLabsPluginParams): GenkitPlugin;
+
+  model(
+    name: string,
+    config?: TwelveLabsConfig
+  ): ModelReference<typeof TwelveLabsConfigSchema>;
+  embedder(name: string, config?: Record<string, any>): EmbedderReference;
+};
+
+function resolveApiKey(params?: TwelveLabsPluginParams): string {
+  const apiKey = params?.apiKey ?? process.env.TWELVELABS_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'TwelveLabs API key is required. Pass it as `apiKey` or set the ' +
+        'TWELVELABS_API_KEY environment variable. Get a free key at https://twelvelabs.io.'
+    );
+  }
+  return apiKey;
+}
+
+function twelvelabsPlugin(params?: TwelveLabsPluginParams): GenkitPlugin {
+  const baseUrl = params?.baseUrl ?? DEFAULT_BASE_URL;
+  return genkitPlugin('twelvelabs', async (ai: Genkit) => {
+    const apiKey = resolveApiKey(params);
+    params?.models?.forEach((model) =>
+      defineTwelveLabsModel(ai, { apiKey, baseUrl, model })
+    );
+    params?.embedders?.forEach((embedder) =>
+      defineTwelveLabsEmbedder(ai, { apiKey, baseUrl, embedder })
+    );
+  });
+}
+
+/**
+ * Genkit plugin for {@link https://twelvelabs.io | TwelveLabs} video AI.
+ *
+ * Exposes Pegasus video-understanding models (as Genkit models) and Marengo
+ * multimodal embedding models (as Genkit embedders). The plugin is fully
+ * opt-in: nothing is registered unless you list `models` and/or `embedders`.
+ *
+ * @example
+ * ```ts
+ * import { genkit } from 'genkit';
+ * import { twelvelabs } from 'genkitx-twelvelabs';
+ *
+ * const ai = genkit({
+ *   plugins: [
+ *     twelvelabs({
+ *       models: [{ name: 'pegasus1.5' }],
+ *       embedders: [{ name: 'marengo3.0', dimensions: 512 }],
+ *     }),
+ *   ],
+ * });
+ *
+ * // Describe a video (Pegasus). The video is a media part with a public URL.
+ * const { text } = await ai.generate({
+ *   model: 'twelvelabs/pegasus1.5',
+ *   messages: [
+ *     {
+ *       role: 'user',
+ *       content: [
+ *         { text: 'Describe this video.' },
+ *         { media: { url: 'https://example.com/video.mp4', contentType: 'video/mp4' } },
+ *       ],
+ *     },
+ *   ],
+ * });
+ *
+ * // Embed text into the Marengo space (Marengo).
+ * const embedding = await ai.embed({
+ *   embedder: 'twelvelabs/marengo3.0',
+ *   content: 'a cat playing piano',
+ * });
+ * ```
+ */
+export const twelvelabs = twelvelabsPlugin as TwelveLabsPlugin;
+
+twelvelabs.model = (
+  name: string,
+  config?: TwelveLabsConfig
+): ModelReference<typeof TwelveLabsConfigSchema> => {
+  return modelRef({
+    name: `twelvelabs/${name}`,
+    config,
+    configSchema: TwelveLabsConfigSchema,
+  });
+};
+
+twelvelabs.embedder = (
+  name: string,
+  config?: Record<string, any>
+): EmbedderReference => {
+  return embedderRef({
+    name: `twelvelabs/${name}`,
+    config,
+  });
+};
+
+export default twelvelabs;

--- a/js/plugins/twelvelabs/src/models.ts
+++ b/js/plugins/twelvelabs/src/models.ts
@@ -122,10 +122,16 @@ export function defineTwelveLabsModel(
         content: [{ text }],
       };
 
+      const usage = getBasicUsageStats(input.messages, message);
+      if (outputTokens !== undefined) {
+        usage.outputTokens = outputTokens;
+        usage.totalTokens = (usage.inputTokens ?? 0) + outputTokens;
+      }
+
       return {
         message,
         finishReason: 'stop',
-        usage: { ...getBasicUsageStats(input.messages, message), outputTokens },
+        usage,
       } as GenerateResponseData;
     }
   );
@@ -159,8 +165,10 @@ interface SseEvent {
 }
 
 /**
- * Parses the newline-delimited JSON stream returned by `/analyze` when
- * `stream: true`. Each line is a JSON object with an `event_type`.
+ * Parses the Server-Sent Events stream returned by `/analyze` when
+ * `stream: true`. Each event is framed as a `data: {json}` line; blank lines,
+ * keepalive comments (`:` ...) and other SSE fields (`event:`, `id:`) are
+ * ignored, and the terminal `data: [DONE]` sentinel ends the stream.
  */
 async function* readSseEvents(
   body: ReadableStream<Uint8Array>
@@ -175,16 +183,30 @@ async function* readSseEvents(
       buffer += decoder.decode(value, { stream: true });
       let newlineIndex: number;
       while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
-        const line = buffer.slice(0, newlineIndex).trim();
+        const line = buffer.slice(0, newlineIndex);
         buffer = buffer.slice(newlineIndex + 1);
-        if (line) yield JSON.parse(line) as SseEvent;
+        const event = parseSseLine(line);
+        if (event) yield event;
       }
     }
-    const tail = buffer.trim();
-    if (tail) yield JSON.parse(tail) as SseEvent;
+    const event = parseSseLine(buffer);
+    if (event) yield event;
   } finally {
     reader.cancel().catch(() => {});
   }
+}
+
+/**
+ * Extracts a JSON event from a single SSE line. Returns `undefined` for lines
+ * that carry no event data (blank lines, comments, non-`data` fields, or the
+ * `[DONE]` sentinel).
+ */
+function parseSseLine(line: string): SseEvent | undefined {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('data:')) return undefined;
+  const data = trimmed.slice('data:'.length).trim();
+  if (!data || data === '[DONE]') return undefined;
+  return JSON.parse(data) as SseEvent;
 }
 
 async function safeErrorMessage(response: Response): Promise<string> {

--- a/js/plugins/twelvelabs/src/models.ts
+++ b/js/plugins/twelvelabs/src/models.ts
@@ -1,0 +1,197 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Genkit } from 'genkit';
+import { logger } from 'genkit/logging';
+import {
+  getBasicUsageStats,
+  type GenerateRequest,
+  type GenerateResponseData,
+  type MessageData,
+} from 'genkit/model';
+import {
+  TwelveLabsConfigSchema,
+  type AnalyzeResponse,
+  type ModelDefinition,
+  type TwelveLabsConfig,
+} from './types.js';
+
+interface DefineModelParams {
+  apiKey: string;
+  baseUrl: string;
+  model: ModelDefinition;
+}
+
+/**
+ * Registers a TwelveLabs Pegasus video-understanding model against the
+ * `/analyze` endpoint.
+ *
+ * The video is taken from a media part in the request (a direct `http(s)` URL
+ * to a raw media file) and the text parts form the prompt. Pegasus fetches the
+ * video server-side, so no prior indexing is required.
+ */
+export function defineTwelveLabsModel(
+  ai: Genkit,
+  { apiKey, baseUrl, model }: DefineModelParams
+) {
+  return ai.defineModel(
+    {
+      name: `twelvelabs/${model.name}`,
+      label: `TwelveLabs - ${model.name}`,
+      configSchema: TwelveLabsConfigSchema,
+      supports: {
+        multiturn: false,
+        media: true,
+        tools: false,
+        systemRole: false,
+      },
+    },
+    async (input, streamingCallback) => {
+      const config = (input.config ?? {}) as TwelveLabsConfig;
+      const videoUrl = getVideoUrl(input);
+      if (!videoUrl) {
+        throw new Error(
+          'TwelveLabs Pegasus requires a video. Pass it as a media part with a ' +
+            'direct http(s) URL, e.g. { media: { url: "https://.../video.mp4", contentType: "video/mp4" } }.'
+        );
+      }
+
+      const request = {
+        video: { type: 'url', url: videoUrl },
+        prompt: getPrompt(input),
+        model_name: config.modelName ?? model.modelName ?? model.name,
+        temperature: config.temperature,
+        max_tokens: config.maxTokens,
+        stream: !!streamingCallback,
+      };
+      logger.debug(request, 'twelvelabs /analyze request');
+
+      const response = await fetch(`${baseUrl}/analyze`, {
+        method: 'POST',
+        headers: {
+          'x-api-key': apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(request),
+      });
+
+      if (!response.ok || !response.body) {
+        const errMsg = await safeErrorMessage(response);
+        throw new Error(
+          `Error from TwelveLabs /analyze: ${response.statusText}. ${errMsg}`
+        );
+      }
+
+      let text: string;
+      let outputTokens: number | undefined;
+
+      if (streamingCallback) {
+        text = '';
+        for await (const event of readSseEvents(response.body)) {
+          if (event.event_type === 'text_generation' && event.text) {
+            text += event.text;
+            streamingCallback({
+              index: 0,
+              content: [{ text: event.text }],
+            });
+          } else if (event.event_type === 'stream_end') {
+            outputTokens = event.metadata?.usage?.output_tokens;
+          }
+        }
+      } else {
+        const json = (await response.json()) as AnalyzeResponse;
+        text = json.data;
+        outputTokens = json.usage?.output_tokens;
+      }
+
+      const message: MessageData = {
+        role: 'model',
+        content: [{ text }],
+      };
+
+      return {
+        message,
+        finishReason: 'stop',
+        usage: { ...getBasicUsageStats(input.messages, message), outputTokens },
+      } as GenerateResponseData;
+    }
+  );
+}
+
+/** Extracts the first media (video) URL from the request, if any. */
+function getVideoUrl(input: GenerateRequest): string | undefined {
+  for (const message of input.messages) {
+    for (const part of message.content) {
+      if (part.media?.url) {
+        return part.media.url;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Concatenates the text parts of the request into a single prompt. */
+function getPrompt(input: GenerateRequest): string {
+  return input.messages
+    .flatMap((m) => m.content)
+    .map((c) => c.text ?? '')
+    .join('')
+    .trim();
+}
+
+interface SseEvent {
+  event_type?: string;
+  text?: string;
+  metadata?: { usage?: { output_tokens?: number } };
+}
+
+/**
+ * Parses the newline-delimited JSON stream returned by `/analyze` when
+ * `stream: true`. Each line is a JSON object with an `event_type`.
+ */
+async function* readSseEvents(
+  body: ReadableStream<Uint8Array>
+): AsyncGenerator<SseEvent> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 1);
+        if (line) yield JSON.parse(line) as SseEvent;
+      }
+    }
+    const tail = buffer.trim();
+    if (tail) yield JSON.parse(tail) as SseEvent;
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+}
+
+async function safeErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { message?: string };
+    return body.message ?? '';
+  } catch {
+    return '';
+  }
+}

--- a/js/plugins/twelvelabs/src/types.ts
+++ b/js/plugins/twelvelabs/src/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'genkit';
+
+/** The default base URL for the TwelveLabs REST API. */
+export const DEFAULT_BASE_URL = 'https://api.twelvelabs.io/v1.3';
+
+/**
+ * A Pegasus video-understanding model to expose as a Genkit model.
+ *
+ * `name` is the user-facing suffix (the action is registered as
+ * `twelvelabs/<name>`). `modelName` is the identifier sent to the TwelveLabs
+ * API; it defaults to `name` when omitted.
+ */
+export interface ModelDefinition {
+  name: string;
+  modelName?: string;
+}
+
+/**
+ * A Marengo embedding model to expose as a Genkit embedder.
+ *
+ * `dimensions` is the size of the returned vector (Marengo returns 512-dim
+ * float embeddings). `modelName` defaults to `name` when omitted.
+ */
+export interface EmbeddingModelDefinition {
+  name: string;
+  dimensions: number;
+  modelName?: string;
+}
+
+/**
+ * Configuration accepted by the TwelveLabs plugin.
+ */
+export interface TwelveLabsPluginParams {
+  /**
+   * TwelveLabs API key. Falls back to the `TWELVELABS_API_KEY` environment
+   * variable when omitted. Grab a free key at https://twelvelabs.io.
+   */
+  apiKey?: string;
+
+  /**
+   * Pegasus video-understanding models to register, e.g.
+   * `[{ name: 'pegasus1.5' }]`.
+   */
+  models?: ModelDefinition[];
+
+  /**
+   * Marengo embedding models to register, e.g.
+   * `[{ name: 'marengo3.0', dimensions: 512 }]`.
+   */
+  embedders?: EmbeddingModelDefinition[];
+
+  /**
+   * Override the API base URL. Defaults to {@link DEFAULT_BASE_URL}.
+   */
+  baseUrl?: string;
+}
+
+/**
+ * Per-request config for a Pegasus model. Mirrors the TwelveLabs `/analyze`
+ * request options.
+ */
+export const TwelveLabsConfigSchema = z.object({
+  temperature: z.number().min(0).max(1).optional(),
+  maxTokens: z.number().int().positive().optional(),
+  modelName: z
+    .string()
+    .describe('Override the TwelveLabs model_name sent to /analyze.')
+    .optional(),
+});
+
+export type TwelveLabsConfig = z.infer<typeof TwelveLabsConfigSchema>;
+
+// --- TwelveLabs REST API response shapes (the subset we consume) ---
+
+/** Response from `POST /embed` with `model_name` + `text`. */
+export interface EmbedResponse {
+  model_name: string;
+  text_embedding?: {
+    segments: { float: number[] }[];
+  };
+}
+
+/** Non-streaming response from `POST /analyze` (`stream: false`). */
+export interface AnalyzeResponse {
+  id: string;
+  data: string;
+  finish_reason?: string;
+  usage?: { output_tokens?: number };
+}

--- a/js/plugins/twelvelabs/tests/embedder_live_test.ts
+++ b/js/plugins/twelvelabs/tests/embedder_live_test.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as assert from 'assert';
+import { genkit } from 'genkit';
+import { describe, it } from 'node:test';
+import { twelvelabs } from '../src/index.js';
+
+// Live test: requires a real TWELVELABS_API_KEY. Skipped when unset.
+// Run with: TWELVELABS_API_KEY=... pnpm test:live
+const hasKey = !!process.env.TWELVELABS_API_KEY;
+
+describe('twelvelabs live', { skip: !hasKey }, () => {
+  it('embeds text via Marengo and returns a 512-dim vector', async () => {
+    const ai = genkit({
+      plugins: [
+        twelvelabs({ embedders: [{ name: 'marengo3.0', dimensions: 512 }] }),
+      ],
+    });
+    const result = await ai.embed({
+      embedder: 'twelvelabs/marengo3.0',
+      content: 'a cat',
+    });
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].embedding.length, 512);
+  });
+});

--- a/js/plugins/twelvelabs/tests/embedder_test.ts
+++ b/js/plugins/twelvelabs/tests/embedder_test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as assert from 'assert';
+import { genkit, type Genkit } from 'genkit';
+import { beforeEach, describe, it } from 'node:test';
+import { defineTwelveLabsEmbedder } from '../src/embedder.js';
+
+// Mock fetch to simulate the TwelveLabs /embed endpoint.
+global.fetch = (async (input: RequestInfo | URL) => {
+  const url = typeof input === 'string' ? input : input.toString();
+  if (url.includes('/embed')) {
+    return {
+      ok: true,
+      json: async () => ({
+        model_name: 'marengo3.0',
+        text_embedding: { segments: [{ float: [0.1, 0.2, 0.3] }] },
+      }),
+    } as Response;
+  }
+  throw new Error('Unknown API endpoint');
+}) as typeof fetch;
+
+describe('defineTwelveLabsEmbedder', () => {
+  let ai: Genkit;
+  beforeEach(() => {
+    ai = genkit({ plugins: [] });
+  });
+
+  it('returns the embedding vector from the response', async () => {
+    const embedder = defineTwelveLabsEmbedder(ai, {
+      apiKey: 'test-key',
+      baseUrl: 'https://api.twelvelabs.io/v1.3',
+      embedder: { name: 'marengo3.0', dimensions: 512 },
+    });
+    const result = await ai.embed({ embedder, content: 'a cat' });
+    assert.deepStrictEqual(result, [{ embedding: [0.1, 0.2, 0.3] }]);
+  });
+
+  it('surfaces API errors', async () => {
+    const prev = global.fetch;
+    global.fetch = (async () =>
+      ({
+        ok: false,
+        statusText: 'Internal Server Error',
+        json: async () => ({ message: 'boom' }),
+      }) as Response) as typeof fetch;
+    const embedder = defineTwelveLabsEmbedder(ai, {
+      apiKey: 'test-key',
+      baseUrl: 'https://api.twelvelabs.io/v1.3',
+      embedder: { name: 'marengo3.0', dimensions: 512 },
+    });
+    await assert.rejects(
+      () => ai.embed({ embedder, content: 'a cat' }),
+      (error) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /TwelveLabs.*Internal Server Error.*boom/);
+        return true;
+      }
+    );
+    global.fetch = prev;
+  });
+});

--- a/js/plugins/twelvelabs/tests/model_test.ts
+++ b/js/plugins/twelvelabs/tests/model_test.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as assert from 'assert';
+import { genkit, type Genkit } from 'genkit';
+import { beforeEach, describe, it } from 'node:test';
+import { defineTwelveLabsModel } from '../src/models.js';
+
+let lastBody: any;
+
+// Mock fetch to simulate the TwelveLabs /analyze endpoint (stream: false).
+global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = typeof input === 'string' ? input : input.toString();
+  if (url.includes('/analyze')) {
+    lastBody = JSON.parse(init!.body as string);
+    return {
+      ok: true,
+      body: {},
+      json: async () => ({
+        id: 'abc',
+        data: 'A short clip of a tree.',
+        finish_reason: 'stop',
+        usage: { output_tokens: 7 },
+      }),
+    } as unknown as Response;
+  }
+  throw new Error('Unknown API endpoint');
+}) as typeof fetch;
+
+describe('defineTwelveLabsModel', () => {
+  let ai: Genkit;
+  beforeEach(() => {
+    ai = genkit({ plugins: [] });
+  });
+
+  it('sends the video URL + prompt and returns the generated text', async () => {
+    const model = defineTwelveLabsModel(ai, {
+      apiKey: 'test-key',
+      baseUrl: 'https://api.twelvelabs.io/v1.3',
+      model: { name: 'pegasus1.5' },
+    });
+    const { text } = await ai.generate({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { text: 'Describe this video.' },
+            {
+              media: {
+                url: 'https://example.com/v.mp4',
+                contentType: 'video/mp4',
+              },
+            },
+          ],
+        },
+      ],
+    });
+    assert.strictEqual(text, 'A short clip of a tree.');
+    assert.deepStrictEqual(lastBody.video, {
+      type: 'url',
+      url: 'https://example.com/v.mp4',
+    });
+    assert.strictEqual(lastBody.prompt, 'Describe this video.');
+    assert.strictEqual(lastBody.model_name, 'pegasus1.5');
+  });
+
+  it('errors when no video is provided', async () => {
+    const model = defineTwelveLabsModel(ai, {
+      apiKey: 'test-key',
+      baseUrl: 'https://api.twelvelabs.io/v1.3',
+      model: { name: 'pegasus1.5' },
+    });
+    await assert.rejects(
+      () => ai.generate({ model, prompt: 'Describe this video.' }),
+      /requires a video/
+    );
+  });
+});

--- a/js/plugins/twelvelabs/tests/model_test.ts
+++ b/js/plugins/twelvelabs/tests/model_test.ts
@@ -20,11 +20,30 @@ import { defineTwelveLabsModel } from '../src/models.js';
 
 let lastBody: any;
 
-// Mock fetch to simulate the TwelveLabs /analyze endpoint (stream: false).
+// When set, the next /analyze call returns this string as the SSE response
+// body instead of a JSON (stream: false) response.
+let nextSseBody: string | undefined;
+
+function sseStream(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+// Mock fetch to simulate the TwelveLabs /analyze endpoint.
 global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
   const url = typeof input === 'string' ? input : input.toString();
   if (url.includes('/analyze')) {
     lastBody = JSON.parse(init!.body as string);
+    if (nextSseBody !== undefined) {
+      const body = sseStream(nextSseBody);
+      nextSseBody = undefined;
+      return { ok: true, body } as unknown as Response;
+    }
     return {
       ok: true,
       body: {},
@@ -75,6 +94,57 @@ describe('defineTwelveLabsModel', () => {
     });
     assert.strictEqual(lastBody.prompt, 'Describe this video.');
     assert.strictEqual(lastBody.model_name, 'pegasus1.5');
+  });
+
+  it('parses SSE-framed streaming events and recomputes totalTokens', async () => {
+    // Real SSE framing: `data:` prefix, blank separator lines, a keepalive
+    // comment, and a terminal [DONE] sentinel.
+    nextSseBody = [
+      ': keepalive',
+      'data: {"event_type":"text_generation","text":"A short "}',
+      '',
+      'data: {"event_type":"text_generation","text":"clip."}',
+      '',
+      'data: {"event_type":"stream_end","metadata":{"usage":{"output_tokens":7}}}',
+      '',
+      'data: [DONE]',
+      '',
+    ].join('\n');
+
+    const model = defineTwelveLabsModel(ai, {
+      apiKey: 'test-key',
+      baseUrl: 'https://api.twelvelabs.io/v1.3',
+      model: { name: 'pegasus1.5' },
+    });
+
+    const chunks: string[] = [];
+    const { text, usage } = await ai.generate({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { text: 'Describe this video.' },
+            {
+              media: {
+                url: 'https://example.com/v.mp4',
+                contentType: 'video/mp4',
+              },
+            },
+          ],
+        },
+      ],
+      onChunk: (c) => chunks.push(c.text),
+    });
+
+    assert.strictEqual(lastBody.stream, true);
+    assert.strictEqual(text, 'A short clip.');
+    assert.deepStrictEqual(chunks, ['A short ', 'clip.']);
+    assert.strictEqual(usage?.outputTokens, 7);
+    assert.strictEqual(
+      usage?.totalTokens,
+      (usage?.inputTokens ?? 0) + 7
+    );
   });
 
   it('errors when no video is provided', async () => {

--- a/js/plugins/twelvelabs/tsconfig.json
+++ b/js/plugins/twelvelabs/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/js/plugins/twelvelabs/tsup.config.ts
+++ b/js/plugins/twelvelabs/tsup.config.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig, type Options } from 'tsup';
+import { defaultOptions } from '../../tsup.common';
+
+export default defineConfig({
+  ...(defaultOptions as Options),
+});

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -1020,6 +1020,31 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  plugins/twelvelabs:
+    dependencies:
+      genkit:
+        specifier: workspace:^
+        version: link:../../genkit
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.16
+        version: 20.19.37
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.15)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.8.2)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   plugins/vertexai:
     dependencies:
       '@anthropic-ai/sdk':


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds `genkitx-twelvelabs`, a new opt-in plugin that brings [TwelveLabs](https://twelvelabs.io) video AI to Genkit:

- **Pegasus** video-understanding models, exposed as Genkit **models** — describe, summarize, or answer questions about a video. The video is passed as a media part with a public `http(s)` URL; TwelveLabs fetches it server-side via `POST /analyze`, so no prior indexing is required. Supports streaming.
- **Marengo** multimodal embedding models, exposed as Genkit **embedders** — 512-dim text embeddings (via `POST /embed`) that share a space with TwelveLabs video embeddings, which makes them a natural fit for video retrieval / RAG flows.

**Why it helps this project:** Genkit has strong text and image model coverage but no dedicated video-understanding or video-embedding provider. This fills that gap and follows the exact shape of existing plugins (e.g. `genkitx-ollama`): a `genkitPlugin` factory plus `.model()` / `.embedder()` references, `defineModel` / `defineEmbedder`, REST calls with no extra SDK dependency.

**Opt-in / non-breaking:** Nothing is registered unless you list `models` and/or `embedders` in the plugin config. No defaults change and no existing behavior is touched. The package is a brand-new workspace under `js/plugins/twelvelabs`.

**How it was tested:**
- No-network unit tests for both the model and embedder (mocked `fetch`), mirroring existing plugin tests — `pnpm test` (4/4 pass).
- A live test gated on `TWELVELABS_API_KEY` (skipped when unset) that calls Marengo and asserts a 512-dim vector — verified passing against the real API.
- The Pegasus `/analyze` path was smoke-tested against the live API with a public sample video and returned a correct description.
- `tsc` typecheck and `tsup` build pass; `prettier --check` and the repo copyright check pass.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

Checklist:
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (unit tests + live API smoke test, see above)
- [x] Docs updated (plugin README + entry in `js/index.typedoc.md`)
