### PR TITLE
fix(compat-oai): map maxOutputTokens to max_tokens

### DIFF
--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -487,7 +487,7 @@ export function toOpenAIRequestBody(
   );
   const {
     temperature,
-    maxOutputTokens, // unused
+    maxOutputTokens: max_tokens,
     topK, // unused
     topP: top_p,
     frequencyPenalty: frequency_penalty,
@@ -510,6 +510,7 @@ export function toOpenAIRequestBody(
     messages,
     tools: tools.length > 0 ? tools : undefined,
     temperature,
+    max_tokens,
     top_p,
     stop,
     frequency_penalty,

--- a/js/plugins/compat-oai/tests/compat_oai_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_test.ts
@@ -717,6 +717,7 @@ describe('toOpenAiRequestBody', () => {
         tools: [],
         output: { format: 'text' },
         config: {
+          maxOutputTokens: 128,
           topP: 1,
           frequency_penalty: 0.7,
           logit_bias: {
@@ -741,6 +742,7 @@ describe('toOpenAiRequestBody', () => {
         ],
         model: 'gpt-3.5-turbo',
         response_format: { type: 'text' },
+        max_tokens: 128,
         top_p: 1,
         frequency_penalty: 0.7,
         logit_bias: {


### PR DESCRIPTION
## Summary
Map Genkit `maxOutputTokens` to the OpenAI-compatible `max_tokens` request field in the compat-oai plugin.

## Motivation
`maxOutputTokens` is currently destructured from Genkit request config but not included in the OpenAI-compatible request body, so providers that rely on `max_tokens` ignore the requested output limit.

Fixes #4425

## Changes
- Rename the destructured `maxOutputTokens` config value to `max_tokens`.
- Include `max_tokens` in the OpenAI-compatible request body.
- Add focused test coverage in `toOpenAIRequestBody`.

## Testing
- `pnpm install --filter @genkit-ai/compat-oai... --frozen-lockfile --ignore-scripts`
- `pnpm --filter @genkit-ai/compat-oai... build`
- `pnpm --filter @genkit-ai/compat-oai exec jest --runTestsByPath tests/compat_oai_test.ts --coverage=false` → `53 passed`
- `pnpm --filter @genkit-ai/compat-oai check`
- `git diff --check`
- Secret scan on diff: clean