### PR TITLE
test(js): fix async assertions and force exit on test completion

### DIFF
--- a/js/ai/package.json
+++ b/js/ai/package.json
@@ -15,7 +15,7 @@
     "build:clean": "rimraf ./lib",
     "build": "npm-run-all build:clean check compile",
     "build:watch": "tsup-node --watch",
-    "test": "node --import tsx --test ./tests/**/*_test.ts ./tests/*_test.ts",
+    "test": "node --import tsx --test --test-force-exit ./tests/**/*_test.ts ./tests/*_test.ts",
     "test:watch": "node --watch --import tsx --test ./tests/**/*_test.ts ./tests/*_test.ts",
     "test:single": "node --import tsx --test"
   },

--- a/js/plugins/google-cloud/tests/metrics_test.ts
+++ b/js/plugins/google-cloud/tests/metrics_test.ts
@@ -112,7 +112,7 @@ describe('GoogleCloudMetrics', () => {
       return explode();
     });
 
-    assert.rejects(async () => {
+    await assert.rejects(async () => {
       await testFlow();
     });
 
@@ -242,7 +242,7 @@ describe('GoogleCloudMetrics', () => {
       return explode();
     });
 
-    assert.rejects(async () => {
+    await assert.rejects(async () => {
       return ai.generate({
         model: testModel,
         prompt: 'test prompt',
@@ -344,7 +344,7 @@ describe('GoogleCloudMetrics', () => {
         return Promise.reject(new Error('failed'));
       });
 
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await flow();
       });
 
@@ -379,7 +379,7 @@ describe('GoogleCloudMetrics', () => {
         return 'done';
       });
 
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await flow();
       });
 
@@ -424,7 +424,7 @@ describe('GoogleCloudMetrics', () => {
         return 'done';
       });
 
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await flow();
       });
 
@@ -463,7 +463,7 @@ describe('GoogleCloudMetrics', () => {
         return 'done';
       });
 
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await flow();
       });
 
@@ -504,7 +504,7 @@ describe('GoogleCloudMetrics', () => {
         return 'not failing';
       });
 
-      assert.rejects(async () => {
+      await assert.rejects(async () => {
         await flow();
       });
 

--- a/js/plugins/vercel-ai/package.json
+++ b/js/plugins/vercel-ai/package.json
@@ -62,7 +62,7 @@
     "build:clean": "rimraf ./lib",
     "build": "npm-run-all build:clean check compile",
     "build:watch": "tsup-node --watch",
-    "test": "tsx --test ./tests/*_test.ts"
+    "test": "tsx --test --test-force-exit ./tests/*_test.ts"
   },
   "peerDependencies": {
     "@ai-sdk/react": "^3.0.0",


### PR DESCRIPTION
Add missing `await` to `assert.rejects` calls in google-cloud metrics tests to ensure rejections are properly verified. Add `--test-force-exit` flag to ai and vercel-ai test scripts to prevent hanging processes after tests complete.

