### PR TITLE
feat(js/middleware): add handoff middleware for agent transfer pattern

### DIFF
--- a/js/plugins/middleware/README.md
+++ b/js/plugins/middleware/README.md
@@ -244,3 +244,66 @@ const response = await ai.generate({
   ]
 });
 ```
+
+### 8. Handoff Middleware (`handoff`)
+
+Enables the **agent transfer / handoff** pattern. A single host agent hosts several **personas** (specialized sub-agents); at any moment exactly one is _active_ and drives the model with its own system prompt and tools. The middleware injects a `transfer_to_<persona>` tool for each persona — when the model calls one, the active persona swaps (system prompt + visible tools) for all subsequent turns, so the user keeps talking directly to the specialist. Personas can transfer back to the default (e.g. triage) or to each other.
+
+How it differs from `agents`: the `agents` middleware **delegates** a one-shot subtask to a sub-agent and returns its result to the orchestrator (the orchestrator stays in control). `handoff` **transfers control** — the persona itself changes and stays changed across turns.
+
+The active persona is tracked statelessly from the conversation history (the most recent successful transfer wins), so it survives multi-turn conversations and works with or without a session.
+
+**Options:**
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `personas` | `{ name, description?, system, tools? }[]` | — (required) | The specialized agents the conversation can be handed off between. `tools` are names of tools registered via `ai.defineTool`. |
+| `defaultPersona` | `string` | first persona | Persona that drives the conversation before any transfer. |
+| `toolPrefix` | `string` | `'transfer_to'` | Prefix for generated transfer tool names. Set to `''` for bare persona names. |
+| `maxTransfers` | `number` | unlimited | Maximum transfers per generate call. Prevents runaway transfer loops. |
+
+```typescript
+import { genkit } from 'genkit';
+import { handoff } from '@genkit-ai/middleware';
+
+const ai = genkit({ ... });
+
+ai.defineTool({ name: 'lookupOrder', /* ... */ }, async (i) => { /* ... */ });
+ai.defineTool({ name: 'issueRefund', /* ... */ }, async (i) => { /* ... */ });
+ai.defineTool({ name: 'getInvoice', /* ... */ }, async (i) => { /* ... */ });
+
+const customerService = ai.defineAgent({
+  name: 'customerService',
+  system: 'You are Acme support. Always be friendly and concise.',
+  use: [
+    handoff({
+      personas: [
+        {
+          name: 'triage',
+          description: 'Figures out the user’s issue and routes them.',
+          system: 'You triage support requests and transfer to a specialist.',
+        },
+        {
+          name: 'refund',
+          description: 'Handles refund requests.',
+          system: 'You handle refunds. Look up the order before refunding.',
+          tools: ['lookupOrder', 'issueRefund'],
+        },
+        {
+          name: 'billing',
+          description: 'Handles billing and invoice questions.',
+          system: 'You answer billing questions.',
+          tools: ['getInvoice'],
+        },
+      ],
+      defaultPersona: 'triage',
+      maxTransfers: 5,
+    }),
+  ],
+});
+```
+
+**Notes / limitations:**
+- Persona `tools` must be names of registered tools (`ai.defineTool`). Only the active persona's tools are exposed to the model each turn; the transfer tools are always available so any persona can hand off. Tools not owned by any persona (e.g. shared host-agent tools) are left untouched.
+- The middleware chain is fixed for the duration of a `generate()` call, so per-persona _middleware_ (e.g. a different `artifacts()` per persona) is not supported. Put shared middleware on the host agent. The system prompt and tools do swap per persona.
+

--- a/js/plugins/middleware/src/handoff.ts
+++ b/js/plugins/middleware/src/handoff.ts
@@ -1,0 +1,425 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  generateMiddleware,
+  z,
+  type GenerateMiddleware,
+  type MessageData,
+} from 'genkit';
+import { tool } from 'genkit/beta';
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+/**
+ * A single specialized agent ("persona") the conversation can be handed off to.
+ *
+ * Unlike the `agents` middleware (which *delegates* a one-shot subtask and gets
+ * a result back), a handoff *swaps the active persona*: its system instructions
+ * and tools replace the active set for all subsequent turns, so the user keeps
+ * talking directly to the specialist until it transfers again.
+ */
+const PersonaSchema = z.object({
+  name: z
+    .string()
+    .describe('Unique persona name (e.g. "triage", "refund", "billing").'),
+  description: z
+    .string()
+    .optional()
+    .describe(
+      'Short description of what this persona handles. Shown to other ' +
+        'personas as the description of the transfer tool that targets it, ' +
+        'so they know when to hand off to it.'
+    ),
+  system: z
+    .string()
+    .describe(
+      'System instructions that drive this persona while it is active.'
+    ),
+  tools: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Names of registered tools (from ai.defineTool) this persona can use. ' +
+        'Only the active persona\u2019s tools are exposed to the model; other ' +
+        "personas' tools are hidden until the conversation is handed to them."
+    ),
+});
+
+export const HandoffOptionsSchema = z.object({
+  personas: z
+    .array(PersonaSchema)
+    .describe(
+      'The specialized agents the conversation can be handed off between.'
+    ),
+  defaultPersona: z
+    .string()
+    .optional()
+    .describe(
+      'Name of the persona that drives the conversation before any transfer ' +
+        'happens. Defaults to the first persona in the list.'
+    ),
+  toolPrefix: z
+    .string()
+    .optional()
+    .describe(
+      'Prefix for generated transfer tool names. Defaults to "transfer_to" ' +
+        '(tools become transfer_to_<persona>). Set to empty string to use ' +
+        'bare persona names.'
+    ),
+  maxTransfers: z
+    .number()
+    .optional()
+    .describe(
+      'Maximum number of transfers allowed per generate call. Prevents ' +
+        'runaway transfer loops (e.g. two personas bouncing back and forth).'
+    ),
+});
+
+export type HandoffOptions = z.infer<typeof HandoffOptionsSchema>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface Persona {
+  name: string;
+  description?: string;
+  system: string;
+  tools: string[];
+}
+
+function makeToolName(prefix: string, personaName: string): string {
+  return prefix ? `${prefix}_${personaName}` : personaName;
+}
+
+// ---------------------------------------------------------------------------
+// Middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a middleware that enables the "agent transfer" / handoff pattern.
+ *
+ * A single host agent hosts several **personas** (specialized sub-agents). At
+ * any moment exactly one persona is *active*: its system instructions and tools
+ * drive the model. The middleware injects a `transfer_to_<persona>` tool for
+ * every persona; when the model calls one, the active persona swaps for all
+ * subsequent turns, so the user keeps talking directly to the new specialist.
+ * Personas can transfer back to the default (e.g. a triage agent) or to any
+ * other persona, enabling multi-turn conversations that flow between
+ * specialists.
+ *
+ * The active persona is tracked statelessly from the conversation history (the
+ * most recent successful transfer tool response wins), so it survives multi-turn
+ * conversations and works with both client- and server-managed agents, with or
+ * without a session.
+ *
+ * How it differs from the `agents` middleware: `agents` *delegates* a
+ * self-contained subtask to a sub-agent and returns its result to the
+ * orchestrator (the orchestrator stays in control). `handoff` *transfers
+ * control*: the persona itself changes and stays changed across turns.
+ *
+ * Notes / limitations:
+ *
+ * - Persona `tools` must be names of tools registered via `ai.defineTool`. Only
+ *   the active persona's tools are exposed to the model; the transfer tools are
+ *   always available so any persona can hand off.
+ * - The middleware chain is fixed for the duration of a `generate()` call, so
+ *   per-persona *middleware* (e.g. a different `artifacts()` per persona) is not
+ *   supported. Put shared middleware on the host agent. The system prompt and
+ *   tools do swap per persona.
+ *
+ * @example
+ * ```typescript
+ * ai.defineTool({ name: 'lookupOrder', ... }, async (i) => { ... });
+ * ai.defineTool({ name: 'issueRefund', ... }, async (i) => { ... });
+ * ai.defineTool({ name: 'getInvoice',  ... }, async (i) => { ... });
+ *
+ * const customerService = ai.defineAgent({
+ *   name: 'customerService',
+ *   system: 'You are Acme support. Always be friendly and concise.',
+ *   use: [
+ *     handoff({
+ *       personas: [
+ *         {
+ *           name: 'triage',
+ *           description: 'Figures out the user\u2019s issue and routes them.',
+ *           system: 'You triage support requests and transfer to a specialist.',
+ *         },
+ *         {
+ *           name: 'refund',
+ *           description: 'Handles refund requests.',
+ *           system: 'You handle refunds. Look up the order before refunding.',
+ *           tools: ['lookupOrder', 'issueRefund'],
+ *         },
+ *         {
+ *           name: 'billing',
+ *           description: 'Handles billing and invoice questions.',
+ *           system: 'You answer billing questions.',
+ *           tools: ['getInvoice'],
+ *         },
+ *       ],
+ *       defaultPersona: 'triage',
+ *       maxTransfers: 5,
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export const handoff: GenerateMiddleware<typeof HandoffOptionsSchema> =
+  generateMiddleware(
+    {
+      name: 'handoff',
+      description:
+        'Enables the agent transfer pattern: swaps the active persona ' +
+        '(system prompt + tools) when the model calls a transfer tool.',
+      configSchema: HandoffOptionsSchema,
+    },
+    ({ config }) => {
+      if (!config?.personas || config.personas.length === 0) {
+        throw new Error(
+          'handoff middleware requires at least one persona in the "personas" option.'
+        );
+      }
+
+      const prefix = config.toolPrefix ?? 'transfer_to';
+      const maxTransfers = config.maxTransfers;
+
+      const personas: Persona[] = config.personas.map((p) => ({
+        name: p.name,
+        description: p.description,
+        system: p.system,
+        tools: p.tools ?? [],
+      }));
+
+      const personasByName = new Map<string, Persona>(
+        personas.map((p) => [p.name, p])
+      );
+
+      const defaultPersonaName = config.defaultPersona ?? personas[0].name;
+      if (!personasByName.has(defaultPersonaName)) {
+        throw new Error(
+          `handoff middleware: defaultPersona "${defaultPersonaName}" is not ` +
+            `one of the configured personas.`
+        );
+      }
+
+      // Map transfer tool name -> target persona name (for active-persona
+      // detection from history and the system-prompt listing).
+      const toolNameToPersona = new Map<string, string>();
+      for (const p of personas) {
+        toolNameToPersona.set(makeToolName(prefix, p.name), p.name);
+      }
+
+      // Union of every persona's tools. These are "managed": only the active
+      // persona's tools are exposed each turn, the rest are stripped from
+      // `request.tools`. Tools NOT in this set (e.g. host-agent shared tools)
+      // are left untouched.
+      const managedToolNames = new Set<string>(
+        personas.flatMap((p) => p.tools)
+      );
+
+      // Shared per-generate state (instantiate runs once per generate() call).
+      const shared = { transferCount: 0 };
+
+      const MARKER_KEY = 'handoff-instructions';
+
+      /**
+       * Determines the active persona by scanning history backwards for the
+       * most recent *successful* transfer tool response. Falls back to the
+       * default persona when no transfer has happened.
+       */
+      function getActivePersona(messages: MessageData[]): Persona {
+        for (let i = messages.length - 1; i >= 0; i--) {
+          const m = messages[i];
+          if (m.role !== 'tool') continue;
+          for (let j = m.content.length - 1; j >= 0; j--) {
+            const tr = m.content[j].toolResponse;
+            if (!tr || !toolNameToPersona.has(tr.name)) continue;
+            const output = tr.output as { transferred?: boolean } | undefined;
+            if (output?.transferred === true) {
+              const target = toolNameToPersona.get(tr.name)!;
+              return (
+                personasByName.get(target) ??
+                personasByName.get(defaultPersonaName)!
+              );
+            }
+            // A refused/failed transfer doesn't change the persona; keep
+            // looking for an earlier successful one.
+          }
+        }
+        return personasByName.get(defaultPersonaName)!;
+      }
+
+      function buildInstructions(active: Persona): string {
+        const transferTargets = personas
+          .filter((p) => p.name !== active.name)
+          .map((p) => {
+            const toolName = makeToolName(prefix, p.name);
+            const desc = p.description ?? `The "${p.name}" agent.`;
+            return `  - ${toolName}: ${desc}`;
+          })
+          .join('\n');
+
+        const transferSection = transferTargets
+          ? `\nIf the user's needs fall outside your specialty, transfer the ` +
+            `conversation to another agent using one of these tools:\n` +
+            `${transferTargets}\n` +
+            `When you transfer, the other agent takes over the conversation ` +
+            `directly. Provide a brief reason so they have context.\n`
+          : '';
+
+        return (
+          `<active-agent name="${active.name}">\n` +
+          `You are now acting as the "${active.name}" agent.\n` +
+          `${active.system}\n` +
+          transferSection +
+          `</active-agent>`
+        );
+      }
+
+      // ── Transfer tools (always available so any persona can hand off) ──
+      const transferTools = personas.map((persona) => {
+        const toolName = makeToolName(prefix, persona.name);
+        const description =
+          `Transfer the conversation to the "${persona.name}" agent. ` +
+          (persona.description ?? '') +
+          ` After transferring, the "${persona.name}" agent takes over and ` +
+          `responds to the user directly.`;
+
+        return tool(
+          {
+            name: toolName,
+            description,
+            inputSchema: z.object({
+              reason: z
+                .string()
+                .optional()
+                .describe(
+                  'Brief context for the receiving agent: why you are ' +
+                    'transferring and what the user needs.'
+                ),
+            }),
+            outputSchema: z.object({
+              transferred: z.boolean(),
+              to: z.string(),
+              message: z.string(),
+            }),
+          },
+          async (input) => {
+            if (
+              maxTransfers !== undefined &&
+              shared.transferCount >= maxTransfers
+            ) {
+              return {
+                transferred: false,
+                to: persona.name,
+                message:
+                  `Transfer limit reached (${maxTransfers}). Continue ` +
+                  `handling the request as the current agent.`,
+              };
+            }
+            shared.transferCount++;
+            return {
+              transferred: true,
+              to: persona.name,
+              message:
+                `Transferred to the "${persona.name}" agent.` +
+                (input.reason ? ` Context: ${input.reason}` : ''),
+            };
+          }
+        );
+      });
+
+      return {
+        tools: transferTools,
+
+        generate: async (envelope, ctx, next) => {
+          const { request } = envelope;
+          const messages = [...request.messages];
+
+          const active = getActivePersona(messages);
+          const instructions = buildInstructions(active);
+
+          // ── Expose only the active persona's tools ──────────────────
+          // Strip every managed (persona-owned) tool, then add back the
+          // active persona's tools. Idempotent across turns and leaves
+          // non-persona tools (host shared tools) untouched. Transfer tools
+          // are injected separately via `tools` above and stay available.
+          const baseTools = (request.tools ?? []).filter(
+            (t) => !managedToolNames.has(t)
+          );
+          const tools = [...baseTools, ...active.tools];
+
+          // ── Inject / refresh the active persona's instructions ──────
+          let markerMsgIndex = -1;
+          let markerPartIndex = -1;
+          for (let i = 0; i < messages.length && markerMsgIndex === -1; i++) {
+            const content = messages[i].content;
+            for (let j = 0; j < content.length; j++) {
+              const p = content[j];
+              if (p.text && p.metadata?.[MARKER_KEY] === true) {
+                markerMsgIndex = i;
+                markerPartIndex = j;
+                break;
+              }
+            }
+          }
+
+          if (markerMsgIndex !== -1) {
+            // Refresh in place if the active persona changed.
+            const existing = messages[markerMsgIndex].content[markerPartIndex];
+            if (existing.text !== instructions) {
+              const newContent = [...messages[markerMsgIndex].content];
+              newContent[markerPartIndex] = {
+                text: instructions,
+                metadata: { [MARKER_KEY]: true },
+              };
+              messages[markerMsgIndex] = {
+                ...messages[markerMsgIndex],
+                content: newContent,
+              };
+            }
+          } else {
+            const systemIdx = messages.findIndex((m) => m.role === 'system');
+            if (systemIdx !== -1) {
+              messages[systemIdx] = {
+                ...messages[systemIdx],
+                content: [
+                  ...messages[systemIdx].content,
+                  { text: instructions, metadata: { [MARKER_KEY]: true } },
+                ],
+              };
+            } else {
+              messages.unshift({
+                role: 'system',
+                content: [
+                  { text: instructions, metadata: { [MARKER_KEY]: true } },
+                ],
+              });
+            }
+          }
+
+          return next(
+            { ...envelope, request: { ...request, messages, tools } },
+            ctx
+          );
+        },
+      };
+    }
+  );

--- a/js/plugins/middleware/src/index.ts
+++ b/js/plugins/middleware/src/index.ts
@@ -18,6 +18,7 @@ export { agents } from './agents.js';
 export { artifacts } from './artifacts.js';
 export { fallback } from './fallback.js';
 export { filesystem } from './filesystem.js';
+export { handoff } from './handoff.js';
 export { retry } from './retry.js';
 export { skills } from './skills.js';
 export { toolApproval } from './tool-approval.js';

--- a/js/plugins/middleware/tests/handoff_test.ts
+++ b/js/plugins/middleware/tests/handoff_test.ts
@@ -1,0 +1,450 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { z } from 'genkit';
+import { genkit } from 'genkit/beta';
+import { describe, it } from 'node:test';
+import { handoff } from '../src/handoff.js';
+
+const triagePersona = {
+  name: 'triage',
+  description: 'Figures out the issue and routes the user.',
+  system: 'You triage support requests.',
+};
+const refundPersona = {
+  name: 'refund',
+  description: 'Handles refund requests.',
+  system: 'You handle refunds.',
+  tools: ['lookupOrder', 'issueRefund'],
+};
+const billingPersona = {
+  name: 'billing',
+  description: 'Handles billing questions.',
+  system: 'You handle billing.',
+  tools: ['getInvoice'],
+};
+
+/** Registers no-op tools used by personas so their names resolve. */
+function defineSupportTools(ai: ReturnType<typeof genkit>) {
+  ai.defineTool(
+    {
+      name: 'lookupOrder',
+      description: 'Look up an order.',
+      inputSchema: z.object({ id: z.string() }),
+      outputSchema: z.string(),
+    },
+    async () => 'order-ok'
+  );
+  ai.defineTool(
+    {
+      name: 'issueRefund',
+      description: 'Issue a refund.',
+      inputSchema: z.object({ id: z.string() }),
+      outputSchema: z.string(),
+    },
+    async () => 'refunded'
+  );
+  ai.defineTool(
+    {
+      name: 'getInvoice',
+      description: 'Get an invoice.',
+      inputSchema: z.object({ id: z.string() }),
+      outputSchema: z.string(),
+    },
+    async () => 'invoice'
+  );
+}
+
+function systemText(req: { messages?: any[] }): string {
+  const sys = req.messages?.find((m) => m.role === 'system');
+  return (sys?.content ?? []).map((p: any) => p.text ?? '').join('\n');
+}
+
+describe('handoff middleware', () => {
+  it('injects transfer tools and the default persona system prompt', async () => {
+    const ai = genkit({});
+    defineSupportTools(ai);
+
+    let capturedSystem = '';
+    let capturedTools: string[] | undefined;
+    const model = ai.defineModel(
+      { name: 'handoff-default-' + Math.random() },
+      async (req) => {
+        capturedSystem = systemText(req);
+        capturedTools = req.tools?.map((t: any) => t.name);
+        return {
+          message: { role: 'model' as const, content: [{ text: 'hello' }] },
+        };
+      }
+    );
+
+    await ai.generate({
+      model,
+      prompt: 'hi',
+      use: [
+        handoff({
+          personas: [triagePersona, refundPersona, billingPersona],
+          defaultPersona: 'triage',
+        }),
+      ],
+    });
+
+    // Default persona is triage.
+    assert.ok(
+      capturedSystem.includes('"triage"'),
+      'System should activate the triage persona'
+    );
+    assert.ok(
+      capturedSystem.includes('You triage support requests.'),
+      'System should contain triage instructions'
+    );
+    // Transfer tools to other personas are listed.
+    assert.ok(capturedSystem.includes('transfer_to_refund'));
+    assert.ok(capturedSystem.includes('transfer_to_billing'));
+
+    // All transfer tools are available; no persona business tools exposed yet
+    // (triage has none).
+    assert.ok(capturedTools?.includes('transfer_to_refund'));
+    assert.ok(capturedTools?.includes('transfer_to_triage'));
+    assert.ok(
+      !capturedTools?.includes('issueRefund'),
+      'Refund tools should not be exposed while triage is active'
+    );
+  });
+
+  it('swaps system prompt and tools after a transfer', async () => {
+    const ai = genkit({});
+    defineSupportTools(ai);
+
+    const turns: { system: string; tools: string[] }[] = [];
+    let turn = 0;
+    const model = ai.defineModel(
+      { name: 'handoff-swap-' + Math.random() },
+      async (req) => {
+        turn++;
+        turns.push({
+          system: systemText(req),
+          tools: (req.tools ?? []).map((t: any) => t.name),
+        });
+        if (turn === 1) {
+          // Triage decides to transfer to refund.
+          return {
+            message: {
+              role: 'model' as const,
+              content: [
+                {
+                  toolRequest: {
+                    name: 'transfer_to_refund',
+                    input: { reason: 'user wants a refund' },
+                  },
+                },
+              ],
+            },
+          };
+        }
+        // After the transfer, the refund persona responds.
+        return {
+          message: {
+            role: 'model' as const,
+            content: [{ text: 'I can help with your refund.' }],
+          },
+        };
+      }
+    );
+
+    const res = await ai.generate({
+      model,
+      prompt: 'I want my money back',
+      use: [
+        handoff({
+          personas: [triagePersona, refundPersona, billingPersona],
+          defaultPersona: 'triage',
+        }),
+      ],
+    });
+
+    assert.strictEqual(turns.length, 2, 'Should have two model turns');
+
+    // Turn 1: triage active, no refund tools.
+    assert.ok(turns[0].system.includes('"triage"'));
+    assert.ok(!turns[0].tools.includes('issueRefund'));
+
+    // Turn 2: refund active, refund tools exposed, transfer tools still there.
+    assert.ok(
+      turns[1].system.includes('"refund"'),
+      'After transfer the refund persona should be active'
+    );
+    assert.ok(turns[1].system.includes('You handle refunds.'));
+    assert.ok(
+      turns[1].tools.includes('lookupOrder'),
+      'Refund persona tools should now be exposed'
+    );
+    assert.ok(turns[1].tools.includes('issueRefund'));
+    assert.ok(
+      turns[1].tools.includes('transfer_to_triage'),
+      'Transfer tools should remain available so the persona can hand back'
+    );
+    // Billing's tool should still be hidden.
+    assert.ok(!turns[1].tools.includes('getInvoice'));
+
+    assert.ok(res.text.includes('refund'));
+  });
+
+  it('supports handing back to the default persona', async () => {
+    const ai = genkit({});
+    defineSupportTools(ai);
+
+    const systems: string[] = [];
+    let turn = 0;
+    const model = ai.defineModel(
+      { name: 'handoff-back-' + Math.random() },
+      async (req) => {
+        turn++;
+        systems.push(systemText(req));
+        if (turn === 1) {
+          return {
+            message: {
+              role: 'model' as const,
+              content: [
+                { toolRequest: { name: 'transfer_to_refund', input: {} } },
+              ],
+            },
+          };
+        }
+        if (turn === 2) {
+          // Refund hands back to triage.
+          return {
+            message: {
+              role: 'model' as const,
+              content: [
+                { toolRequest: { name: 'transfer_to_triage', input: {} } },
+              ],
+            },
+          };
+        }
+        return {
+          message: {
+            role: 'model' as const,
+            content: [{ text: 'Anything else?' }],
+          },
+        };
+      }
+    );
+
+    await ai.generate({
+      model,
+      prompt: 'refund then something else',
+      use: [
+        handoff({
+          personas: [triagePersona, refundPersona, billingPersona],
+        }),
+      ],
+    });
+
+    assert.strictEqual(systems.length, 3);
+    assert.ok(systems[0].includes('"triage"'), 'turn 1 triage');
+    assert.ok(systems[1].includes('"refund"'), 'turn 2 refund');
+    assert.ok(
+      systems[2].includes('"triage"'),
+      'turn 3 should be back to triage'
+    );
+  });
+
+  it('persists the active persona across separate generate calls (multi-turn)', async () => {
+    const ai = genkit({});
+    defineSupportTools(ai);
+
+    // Simulate history where a transfer to billing already happened.
+    const priorMessages = [
+      { role: 'user' as const, content: [{ text: 'I have a billing issue' }] },
+      {
+        role: 'model' as const,
+        content: [
+          {
+            toolRequest: {
+              name: 'transfer_to_billing',
+              ref: '1',
+              input: {},
+            },
+          },
+        ],
+      },
+      {
+        role: 'tool' as const,
+        content: [
+          {
+            toolResponse: {
+              name: 'transfer_to_billing',
+              ref: '1',
+              output: {
+                transferred: true,
+                to: 'billing',
+                message: 'Transferred to the "billing" agent.',
+              },
+            },
+          },
+        ],
+      },
+      {
+        role: 'model' as const,
+        content: [{ text: 'I can help with billing.' }],
+      },
+    ];
+
+    let capturedSystem = '';
+    let capturedTools: string[] = [];
+    const model = ai.defineModel(
+      { name: 'handoff-persist-' + Math.random() },
+      async (req) => {
+        capturedSystem = systemText(req);
+        capturedTools = (req.tools ?? []).map((t: any) => t.name);
+        return {
+          message: {
+            role: 'model' as const,
+            content: [{ text: 'here is your invoice' }],
+          },
+        };
+      }
+    );
+
+    await ai.generate({
+      model,
+      messages: [
+        ...priorMessages,
+        { role: 'user', content: [{ text: 'what is my latest invoice?' }] },
+      ],
+      use: [
+        handoff({
+          personas: [triagePersona, refundPersona, billingPersona],
+          defaultPersona: 'triage',
+        }),
+      ],
+    });
+
+    assert.ok(
+      capturedSystem.includes('"billing"'),
+      'Billing persona should remain active based on history'
+    );
+    assert.ok(capturedTools.includes('getInvoice'));
+    assert.ok(!capturedTools.includes('issueRefund'));
+  });
+
+  it('enforces maxTransfers', async () => {
+    const ai = genkit({});
+    defineSupportTools(ai);
+
+    let turn = 0;
+    const model = ai.defineModel(
+      { name: 'handoff-max-' + Math.random() },
+      async () => {
+        turn++;
+        if (turn <= 3) {
+          // Keep bouncing between personas.
+          const target = turn % 2 === 1 ? 'refund' : 'triage';
+          return {
+            message: {
+              role: 'model' as const,
+              content: [
+                { toolRequest: { name: `transfer_to_${target}`, input: {} } },
+              ],
+            },
+          };
+        }
+        return {
+          message: { role: 'model' as const, content: [{ text: 'done' }] },
+        };
+      }
+    );
+
+    const res = await ai.generate({
+      model,
+      prompt: 'bounce around',
+      use: [
+        handoff({
+          personas: [triagePersona, refundPersona],
+          maxTransfers: 2,
+        }),
+      ],
+    });
+
+    const toolMsgs = res.messages.filter((m) => m.role === 'tool');
+    const limitHit = toolMsgs.some((m) =>
+      m.content.some((p) => {
+        const out = p.toolResponse?.output as { message?: string };
+        return out?.message?.includes('Transfer limit reached');
+      })
+    );
+    assert.ok(limitHit, 'Should hit the transfer limit');
+  });
+
+  it('supports a custom tool prefix', async () => {
+    const ai = genkit({});
+    defineSupportTools(ai);
+
+    let capturedSystem = '';
+    let capturedTools: string[] = [];
+    const model = ai.defineModel(
+      { name: 'handoff-prefix-' + Math.random() },
+      async (req) => {
+        capturedSystem = systemText(req);
+        capturedTools = (req.tools ?? []).map((t: any) => t.name);
+        return {
+          message: { role: 'model' as const, content: [{ text: 'ok' }] },
+        };
+      }
+    );
+
+    await ai.generate({
+      model,
+      prompt: 'hi',
+      use: [
+        handoff({
+          personas: [triagePersona, refundPersona],
+          toolPrefix: 'route_to',
+        }),
+      ],
+    });
+
+    assert.ok(capturedSystem.includes('route_to_refund'));
+    assert.ok(capturedTools.includes('route_to_refund'));
+  });
+
+  it('throws if no personas are provided', () => {
+    const ai = genkit({});
+    assert.throws(() => {
+      handoff.instantiate({
+        config: { personas: [] },
+        ai,
+        pluginConfig: undefined,
+      });
+    }, /at least one persona/);
+  });
+
+  it('throws if defaultPersona is not a configured persona', () => {
+    const ai = genkit({});
+    assert.throws(() => {
+      handoff.instantiate({
+        config: {
+          personas: [triagePersona],
+          defaultPersona: 'nope',
+        },
+        ai,
+        pluginConfig: undefined,
+      });
+    }, /defaultPersona/);
+  });
+});

--- a/js/testapps/agents/src/customer-service-agent.ts
+++ b/js/testapps/agents/src/customer-service-agent.ts
@@ -42,7 +42,7 @@
  *       → triage transfers to billing.
  */
 
-import { handoff } from '@genkit-ai/middleware';
+import { handoff, retry } from '@genkit-ai/middleware';
 import { z } from 'genkit';
 import { ai, defaultModel } from './genkit.js';
 
@@ -130,6 +130,9 @@ export const customerServiceAgent = ai.defineAgent({
     'You are Acme Corp customer support. Always be warm, concise, and helpful.',
   maxTurns: 10,
   use: [
+    // Retry transient model errors (e.g. rate limits / unavailability) with
+    // exponential backoff before they bubble up to the user.
+    retry({ maxRetries: 3 }),
     handoff({
       personas: [
         {

--- a/js/testapps/agents/src/customer-service-agent.ts
+++ b/js/testapps/agents/src/customer-service-agent.ts
@@ -1,0 +1,229 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Agent Transfer / Handoff Demo — demonstrates the `handoff` middleware.
+ *
+ * This sample models a customer-service experience where the user always talks
+ * to a single agent, but the *persona* driving that agent changes as the
+ * conversation evolves:
+ *
+ *   • The `triage` persona greets the user, figures out their issue, and
+ *     transfers them to a specialist.
+ *   • The `refund` persona handles refunds and has access to order/refund
+ *     tools (`lookupOrder`, `issueRefund`).
+ *   • The `billing` persona answers invoice/billing questions and has access
+ *     to `getInvoice`.
+ *
+ * Unlike the `agents` (delegation) middleware — where an orchestrator fires off
+ * a one-shot subtask and gets a result back — `handoff` *transfers control*.
+ * When the model calls a `transfer_to_<persona>` tool, the middleware swaps the
+ * active system prompt and the visible toolset for all subsequent turns, so the
+ * user keeps talking directly to the specialist. Specialists can transfer back
+ * to triage or to each other.
+ *
+ * Try it:
+ *   - "I was charged twice for order #1234, I want a refund"
+ *       → triage transfers to refund, which looks up the order and refunds it.
+ *   - "Why is my latest invoice so high?"
+ *       → triage transfers to billing.
+ */
+
+import { handoff } from '@genkit-ai/middleware';
+import { z } from 'genkit';
+import { ai, defaultModel } from './genkit.js';
+
+// ---------------------------------------------------------------------------
+// Tools — the specialist personas use these. Only the *active* persona's tools
+// are exposed to the model at any given turn (the handoff middleware gates
+// tool visibility by name).
+// ---------------------------------------------------------------------------
+
+export const lookupOrder = ai.defineTool(
+  {
+    name: 'lookupOrder',
+    description: 'Look up an order by its ID to inspect its details.',
+    inputSchema: z.object({
+      orderId: z.string().describe('The order ID, e.g. "1234".'),
+    }),
+    outputSchema: z.object({
+      orderId: z.string(),
+      item: z.string(),
+      amount: z.number(),
+      status: z.string(),
+    }),
+  },
+  async ({ orderId }) => ({
+    orderId,
+    item: 'Wireless Headphones',
+    amount: 79.99,
+    status: 'delivered',
+  })
+);
+
+export const issueRefund = ai.defineTool(
+  {
+    name: 'issueRefund',
+    description: 'Issue a refund for an order.',
+    inputSchema: z.object({
+      orderId: z.string().describe('The order ID to refund.'),
+      amount: z.number().describe('The amount to refund.'),
+    }),
+    outputSchema: z.object({
+      refundId: z.string(),
+      orderId: z.string(),
+      amount: z.number(),
+    }),
+  },
+  async ({ orderId, amount }) => ({
+    refundId: `rf-${Date.now()}`,
+    orderId,
+    amount,
+  })
+);
+
+export const getInvoice = ai.defineTool(
+  {
+    name: 'getInvoice',
+    description: 'Fetch the most recent invoice for the current customer.',
+    inputSchema: z.object({}),
+    outputSchema: z.object({
+      invoiceId: z.string(),
+      total: z.number(),
+      lineItems: z.array(z.object({ name: z.string(), amount: z.number() })),
+    }),
+  },
+  async () => ({
+    invoiceId: 'inv-2026-04',
+    total: 129.97,
+    lineItems: [
+      { name: 'Subscription (Pro)', amount: 49.99 },
+      { name: 'Overage charges', amount: 79.98 },
+    ],
+  })
+);
+
+// ---------------------------------------------------------------------------
+// The host agent — a single agent that hosts multiple personas via `handoff`.
+//
+// The agent-level `system` prompt holds the shared brand voice; the active
+// persona's instructions are layered on top each turn by the middleware.
+// ---------------------------------------------------------------------------
+
+export const customerServiceAgent = ai.defineAgent({
+  name: 'customerServiceAgent',
+  model: defaultModel,
+  system:
+    'You are Acme Corp customer support. Always be warm, concise, and helpful.',
+  maxTurns: 10,
+  use: [
+    handoff({
+      personas: [
+        {
+          name: 'triage',
+          description:
+            "Greets the user, figures out the user's issue, and routes them to the right specialist.",
+          system:
+            'You are the first point of contact. Greet the user, ask a clarifying ' +
+            'question if needed to understand their issue, then transfer them to the ' +
+            'specialist best suited to help. Do not try to resolve refund or billing ' +
+            'issues yourself — transfer instead.',
+        },
+        {
+          name: 'refund',
+          description: 'Handles refund and return requests.',
+          system:
+            'You are the refunds specialist. Always look up the order with ' +
+            'lookupOrder before issuing a refund, confirm the amount, then use ' +
+            'issueRefund. If the user has a non-refund question, transfer them back ' +
+            'to triage.',
+          tools: ['lookupOrder', 'issueRefund'],
+        },
+        {
+          name: 'billing',
+          description: 'Answers billing and invoice questions.',
+          system:
+            'You are the billing specialist. Use getInvoice to inspect the ' +
+            "customer's latest invoice and explain charges clearly. If the user " +
+            'wants a refund, transfer them to the refund agent.',
+          tools: ['getInvoice'],
+        },
+      ],
+      defaultPersona: 'triage',
+      maxTransfers: 5,
+    }),
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// Test flow — a single user turn (triage will typically transfer and the
+// specialist will respond in the same generate call).
+// ---------------------------------------------------------------------------
+
+export const testCustomerServiceAgent = ai.defineFlow(
+  {
+    name: 'testCustomerServiceAgent',
+    inputSchema: z
+      .string()
+      .default(
+        'I was charged twice for order #1234 and I would like a refund.'
+      ),
+    outputSchema: z.any(),
+  },
+  async (text, { sendChunk }) => {
+    const chat = customerServiceAgent.chat();
+    const turn = chat.sendStream(text);
+    for await (const chunk of turn.stream) {
+      sendChunk(chunk.raw);
+    }
+    const res = await turn.response;
+    return res.raw;
+  }
+);
+
+// ---------------------------------------------------------------------------
+// Test flow — multi-turn conversation that flows across personas. The active
+// persona persists across turns (the same chat/session is reused).
+// ---------------------------------------------------------------------------
+
+export const testCustomerServiceConversation = ai.defineFlow(
+  {
+    name: 'testCustomerServiceConversation',
+    inputSchema: z.any(),
+    outputSchema: z.any(),
+  },
+  async (_input, { sendChunk }) => {
+    const chat = customerServiceAgent.chat();
+
+    const say = async (text: string) => {
+      sendChunk({ user: text });
+      const turn = chat.sendStream(text);
+      for await (const chunk of turn.stream) {
+        sendChunk(chunk.raw);
+      }
+      return (await turn.response).raw;
+    };
+
+    // Triage → refund.
+    await say('Hi, I need a refund for order #1234.');
+    // Still in the refund persona; ask a billing question → refund transfers
+    // back to triage, which routes to billing.
+    const last = await say(
+      'Thanks! While I have you — why was my latest invoice so high?'
+    );
+    return last;
+  }
+);

--- a/js/testapps/agents/src/index.ts
+++ b/js/testapps/agents/src/index.ts
@@ -49,6 +49,12 @@ import {
   testCodingAgent,
 } from './coding-agent.js';
 import {
+  customerServiceAgent,
+  testCustomerServiceAgent,
+  testCustomerServiceConversation,
+} from './customer-service-agent.js';
+
+import {
   orchestratorAgent,
   testOrchestratorAgent,
   testOrchestratorAgentSimple,
@@ -93,6 +99,9 @@ void [
   testCodingAgent,
   listWorkspaceFiles,
   readWorkspaceFile,
+  customerServiceAgent,
+  testCustomerServiceAgent,
+  testCustomerServiceConversation,
 ];
 
 export * from './background-agent.js';
@@ -155,6 +164,7 @@ exposeAgent('taskAgent', taskAgent);
 exposeAgent('orchestratorAgent', orchestratorAgent);
 exposeAgent('tripPlannerAgent', tripPlannerAgent, { snapshot: true });
 exposeAgent('codingAgent', codingAgent, { snapshot: true });
+exposeAgent('customerServiceAgent', customerServiceAgent);
 
 // Workspace browser — exposed as Genkit flows via expressHandler
 app.post('/api/workspace/files', expressHandler(listWorkspaceFiles));

--- a/js/testapps/agents/web/src/App.tsx
+++ b/js/testapps/agents/web/src/App.tsx
@@ -31,6 +31,7 @@ const NAV_ITEMS = [
   { to: '/tasks', icon: '✅', label: 'Task Tracker (Custom State)' },
   { to: '/research', icon: '🔬', label: 'Research (Custom Agent)' },
   { to: '/subagents', icon: '🤝', label: 'Sub-Agent Delegation' },
+  { to: '/customer-service', icon: '🔀', label: 'Customer Service (Handoff)' },
   { to: '/trip-planner', icon: '✈️', label: 'Trip Planner (Prompt File)' },
 ];
 

--- a/js/testapps/agents/web/src/main.tsx
+++ b/js/testapps/agents/web/src/main.tsx
@@ -26,6 +26,7 @@ import BankingInterrupt from './pages/BankingInterrupt';
 import BranchingChat from './pages/BranchingChat';
 import ClientState from './pages/ClientState';
 import CodingAgent from './pages/CodingAgent';
+import CustomerService from './pages/CustomerService';
 import ResearchAgent from './pages/ResearchAgent';
 import SubAgentChat from './pages/SubAgentChat';
 import TaskTracker from './pages/TaskTracker';
@@ -50,6 +51,7 @@ createRoot(document.getElementById('root')!).render(
           <Route path="tasks" element={<TaskTracker />} />
           <Route path="research" element={<ResearchAgent />} />
           <Route path="subagents" element={<SubAgentChat />} />
+          <Route path="customer-service" element={<CustomerService />} />
           <Route path="trip-planner" element={<TripPlanner />} />
           <Route path="trip-planner/:snapshotId" element={<TripPlanner />} />
           <Route path="coding-agent" element={<CodingAgent />} />

--- a/js/testapps/agents/web/src/pages/CustomerService.tsx
+++ b/js/testapps/agents/web/src/pages/CustomerService.tsx
@@ -1,0 +1,256 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { remoteAgent, type AgentChat } from 'genkit/beta/client';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { ChatUI, type ChatMessage } from '../components/ChatUI';
+
+// ---------------------------------------------------------------------------
+// Customer Service Handoff — a single agent that hosts multiple personas
+//
+// Demonstrates:
+//   • The `handoff` middleware for agent transfer / handoff
+//   • The `remoteAgent` client for streaming responses
+//   • Inline rendering of `transfer_to_<persona>` tool calls so you can watch
+//     control move between the triage, refund, and billing personas
+//   • Multi-turn session — the active persona persists across turns
+// ---------------------------------------------------------------------------
+
+const ENDPOINT = '/api/customerServiceAgent';
+
+// Maps a transfer tool name (e.g. `transfer_to_refund`) to its persona.
+function personaFromToolName(name: string): string | undefined {
+  const m = /^transfer_to_(.+)$/.exec(name);
+  return m?.[1];
+}
+
+export default function CustomerService() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [streamingText, setStreamingText] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [activePersona, setActivePersona] = useState('triage');
+
+  // Typed HTTP client. Tracks session state across turns for us.
+  const agent = useMemo(() => remoteAgent({ url: ENDPOINT }), []);
+
+  // The conversation. Created on first send and reused for follow-up turns.
+  const chatRef = useRef<AgentChat | null>(null);
+
+  const handleSend = useCallback(
+    async (text: string) => {
+      if (loading) return;
+
+      setMessages((prev) => [...prev, { role: 'user', text }]);
+      setLoading(true);
+      setStreamingText('');
+
+      if (!chatRef.current) {
+        chatRef.current = agent.chat();
+      }
+      const chat = chatRef.current;
+
+      try {
+        const turn = chat.sendStream(text);
+
+        let accumulated = '';
+        for await (const chunk of turn.stream) {
+          for (const part of chunk.raw.modelChunk?.content ?? []) {
+            if (part.toolRequest) {
+              const tr = part.toolRequest;
+              const persona = personaFromToolName(tr.name);
+              if (persona) {
+                const inp = tr.input as { reason?: string } | undefined;
+                const label = inp?.reason
+                  ? `🔀 Transferring to "${persona}": ${inp.reason}`
+                  : `🔀 Transferring to "${persona}"`;
+                setMessages((prev) => [...prev, { role: 'tool', text: label }]);
+              } else {
+                setMessages((prev) => [
+                  ...prev,
+                  {
+                    role: 'tool',
+                    text: `🔧 ${tr.name}(${JSON.stringify(tr.input)})`,
+                  },
+                ]);
+              }
+            } else if (part.toolResponse) {
+              const tr = part.toolResponse;
+              const persona = personaFromToolName(tr.name);
+              if (persona) {
+                const out = tr.output as
+                  | { transferred?: boolean; message?: string }
+                  | undefined;
+                if (out?.transferred) {
+                  setActivePersona(persona);
+                }
+                setMessages((prev) => [
+                  ...prev,
+                  {
+                    role: 'tool',
+                    text: out?.transferred
+                      ? `✅ Now talking to the "${persona}" specialist.`
+                      : `⚠️ ${out?.message ?? 'Transfer declined.'}`,
+                  },
+                ]);
+              } else {
+                setMessages((prev) => [
+                  ...prev,
+                  {
+                    role: 'tool',
+                    text: `✅ ${tr.name} → ${JSON.stringify(tr.output)}`,
+                  },
+                ]);
+              }
+            }
+          }
+
+          if (chunk.text) {
+            accumulated = chunk.accumulatedText;
+            setStreamingText(accumulated);
+          }
+        }
+
+        const res = await turn.response;
+        setStreamingText('');
+
+        setMessages((prev) => [
+          ...prev,
+          { role: 'model', text: res.text || accumulated },
+        ]);
+      } catch (err: unknown) {
+        setStreamingText('');
+        const errMsg = err instanceof Error ? err.message : String(err);
+        setMessages((prev) => [
+          ...prev,
+          { role: 'system', text: `Error: ${errMsg}` },
+        ]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [agent, loading]
+  );
+
+  return (
+    <div className="page-with-sidebar">
+      <ChatUI
+        title="Customer Service"
+        description={`Acme Corp support — currently handled by the "${activePersona}" persona. Control transfers between personas as your needs change.`}
+        suggestions={[
+          'I was charged twice for order #1234 and I would like a refund.',
+          'Why is my latest invoice so high?',
+          'Hi, I have a question about my account.',
+        ]}
+        messages={messages}
+        streamingText={streamingText}
+        loading={loading}
+        onSend={handleSend}
+        renderMarkdown
+      />
+
+      <aside className="info-sidebar">
+        <h3>🔀 How It Works</h3>
+        <ol>
+          <li>
+            A single <strong>customerServiceAgent</strong> hosts three{' '}
+            <strong>personas</strong> via the <code>handoff</code> middleware:{' '}
+            <strong>triage</strong>, <strong>refund</strong>, and{' '}
+            <strong>billing</strong>.
+          </li>
+          <li>
+            Each persona has its own <em>system prompt</em> and <em>toolset</em>.
+            Only the active persona's tools are visible to the model.
+          </li>
+          <li>
+            The middleware injects a <code>transfer_to_&lt;persona&gt;</code>{' '}
+            tool. When the model calls it, the active system prompt and visible
+            tools are swapped for all subsequent turns.
+          </li>
+          <li>
+            Unlike delegation (<code>agents</code> middleware), control{' '}
+            <strong>transfers</strong> — the user keeps talking directly to the
+            specialist, who can transfer back or to another persona.
+          </li>
+        </ol>
+
+        <h4>Personas</h4>
+        <ul>
+          <li>
+            <strong>triage</strong> — greets, diagnoses, and routes (no tools).
+          </li>
+          <li>
+            <strong>refund</strong> — <code>lookupOrder</code>,{' '}
+            <code>issueRefund</code>.
+          </li>
+          <li>
+            <strong>billing</strong> — <code>getInvoice</code>.
+          </li>
+        </ul>
+
+        <h4>Try It</h4>
+        <ul>
+          <li>
+            <em>"I want a refund for order #1234"</em> → triage transfers to
+            refund
+          </li>
+          <li>
+            <em>"Why is my invoice so high?"</em> → triage transfers to billing
+          </li>
+          <li>
+            Ask a billing question mid-refund → refund transfers back to triage,
+            which routes to billing
+          </li>
+        </ul>
+
+        <h4>Key APIs</h4>
+        <pre>{`const agent = ai.defineAgent({
+  name: 'customerServiceAgent',
+  model: '...',
+  system: 'Shared brand voice…',
+  use: [
+    handoff({
+      personas: [
+        { name: 'triage', system: '…' },
+        {
+          name: 'refund',
+          system: '…',
+          tools: ['lookupOrder', 'issueRefund'],
+        },
+        {
+          name: 'billing',
+          system: '…',
+          tools: ['getInvoice'],
+        },
+      ],
+      defaultPersona: 'triage',
+      maxTransfers: 5,
+    }),
+  ],
+});`}</pre>
+
+        <h4>Architecture</h4>
+        <p>
+          The <code>handoff</code> middleware from{' '}
+          <code>@genkit-ai/middleware</code> runs on every turn of the tool
+          loop. It tracks the active persona by scanning the message history for
+          the most recent successful transfer, then layers that persona's system
+          prompt onto the agent's shared prompt and gates the visible tools by
+          name.
+        </p>
+      </aside>
+    </div>
+  );
+}


### PR DESCRIPTION
Introduce a new `handoff` middleware that enables the agent transfer/handoff pattern, where a host agent hosts multiple specialized personas and transfers control between them via generated `transfer_to_<persona>` tools. The active persona is tracked statelessly from conversation history, swapping system prompts and visible tools across turns.

- Export `handoff` from the middleware package index
- Document the middleware with options, usage, and limitations in README
- Add a customer-service agent testapp example demonstrating the pattern
