### PR TITLE
chore(js): add missing license headers to vercel-ai-elements configs

### DIFF
--- a/js/testapps/vercel-ai-elements/eslint.config.mjs
+++ b/js/testapps/vercel-ai-elements/eslint.config.mjs
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import nextVitals from 'eslint-config-next/core-web-vitals';
 import nextTs from 'eslint-config-next/typescript';
 import { defineConfig, globalIgnores } from 'eslint/config';

--- a/js/testapps/vercel-ai-elements/postcss.config.mjs
+++ b/js/testapps/vercel-ai-elements/postcss.config.mjs
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const config = {
   plugins: {
     '@tailwindcss/postcss': {},


### PR DESCRIPTION
## What

Adds the Apache 2.0 license header to two config files in the
`vercel-ai-elements` testapp that were missing it:

- `js/testapps/vercel-ai-elements/eslint.config.mjs`
- `js/testapps/vercel-ai-elements/postcss.config.mjs`

## Why

These two files were added in #5426 without a license header. The
license check (`bin/check_license`) scans the whole repo, so any branch
that includes these files fails it. The failure shows up as the
"Security and Compliance" job.

It went unnoticed at the time because that check only runs when a PR
touches `py/**`, `genkit-tools/**`, or `.github/workflows/python.yml`
(see the path filter at the top of `python.yml`). #5426 was JS only, so
the job never ran on it. The first PR (#5595) to touch Python after #5426 merged
is the one that surfaced it.

## How

Prepended the standard header used elsewhere in this testapp (for
example `next.config.ts`), keeping the `Copyright 2026 Google LLC` line
and the block comment style so it matches the surrounding files.

## Testing

- Confirmed these were the only two files the check flagged, and that
  every other source file in the testapp (the `.tsx` components, the
  `route.ts` handlers, the shadcn `ui` files) already has a header.