### PR TITLE
chore(py/plugins/anthropic): bump anthropic SDK lower bound to >=0.96.0

### DIFF
--- a/py/plugins/anthropic/pyproject.toml
+++ b/py/plugins/anthropic/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
   "Typing :: Typed",
   "License :: OSI Approved :: Apache Software License",
 ]
-dependencies = ["genkit", "anthropic>=0.40.0"]
+dependencies = ["genkit", "anthropic>=0.96.0"]
 description = "Genkit Anthropic Plugin (Community)"
 keywords = [
   "genkit",

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.79.0"
+version = "0.112.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -110,9 +110,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/b1/91aea3f8fd180d01d133d931a167a78a3737b3fd39ccef2ae8d6619c24fd/anthropic-0.79.0.tar.gz", hash = "sha256:8707aafb3b1176ed6c13e2b1c9fb3efddce90d17aee5d8b83a86c70dcdcca871", size = 509825, upload-time = "2026-02-07T18:06:18.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/dd/808c144d4a883fcfd12fe0d7689b1d86bbbea6666c1cc957ad19f1017c22/anthropic-0.112.0.tar.gz", hash = "sha256:e180cd91aa5b9b32e4007fe69892ab128d8a86b9f90825103b1903fbc977d0af", size = 937460, upload-time = "2026-06-24T18:45:56.844Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/b2/cc0b8e874a18d7da50b0fda8c99e4ac123f23bf47b471827c5f6f3e4a767/anthropic-0.79.0-py3-none-any.whl", hash = "sha256:04cbd473b6bbda4ca2e41dd670fe2f829a911530f01697d0a1e37321eb75f3cf", size = 405918, upload-time = "2026-02-07T18:06:20.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/26/ea71185027956325be1903d4fcaf7461d5ef40ca8f0e64f992e24ea9db0e/anthropic-0.112.0-py3-none-any.whl", hash = "sha256:bcc6268612c716dbb77133dd60fc41d26016d1b81dee9a52314d210193638751", size = 931954, upload-time = "2026-06-24T18:45:58.205Z" },
 ]
 
 [[package]]
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "anthropic", specifier = ">=0.96.0" },
     { name = "genkit", editable = "packages/genkit" },
 ]
 


### PR DESCRIPTION
## What

Raises the published minimum for `genkit-plugin-anthropic` from `anthropic>=0.40.0` to `anthropic>=0.96.0` and regenerates the shared workspace lock to match.

`0.96.0` is the lowest release that covers the full SDK surface the Anthropic Python parity epic (#5617) needs:

- `output_config` / structured outputs (first in 0.77.0)
- `effort` (including `"max"`), thinking `adaptive`, and the Files API (0.79.0)
- beta `output_config.task_budget` (0.96.0)

Raising the floor first means the parity work is written against the new types from the start instead of being rewritten later. This is the P0 prerequisite for #5617.

## How

- `py/plugins/anthropic/pyproject.toml`: `anthropic>=0.40.0` -> `anthropic>=0.96.0`.
- `py/uv.lock`: regenerated with `uv lock --upgrade-package anthropic`, which moves `anthropic` from `0.79.0` to `0.112.0` (latest). No new packages are added; the 8 existing transitive deps are unchanged.

The vertex-ai model-garden Claude path keeps its own `anthropic>=0.40.0` declaration and picks up the newer resolved version through the shared lock. It stays out of scope for the parity epic.

## Verification

- `uv lock --check --directory py` passes (the CI lockfile gate).
- Resolved `anthropic` in the lock is `0.112.0`, which satisfies `>=0.96.0`.
- `uv sync --directory py` resolves cleanly.
- `uv run --directory py pytest plugins/anthropic plugins/vertex-ai/tests/model_garden`: 69 passed.
- `uv run --directory py liccheck -s pyproject.toml`: 127 packages, all authorised (no new license surface).
- Lock diff touches only the `anthropic` block plus its specifier, with no new `[[package]]` entries.

## Notes

- No plugin version bump or CHANGELOG edit since version bumps land in dedicated commits in this repo.
- CI exercises the resolved version (`>=0.96.0`), since there is no lowest-direct-floor job today.

Closes #5622.