### PR TITLE
fix(go/plugins/ollama): register embedders by model name, not server address

### DIFF
--- a/go/plugins/ollama/README.md
+++ b/go/plugins/ollama/README.md
@@ -201,6 +201,8 @@ You can define and use text embedding models hosted on Ollama (e.g., `nomic-embe
 `dimensions` is required and should match the model's embedding size. The embedder is
 retrieved by model name.
 
+Note: Existing callers should replace server-address lookups with model-name lookups and pass dimensions to `DefineEmbedder`
+
 ### Defining an Embedder
 
 ```go

--- a/go/plugins/ollama/README.md
+++ b/go/plugins/ollama/README.md
@@ -198,6 +198,8 @@ resp, err := genkit.Generate(ctx, g,
 ## Embedding Models
 
 You can define and use text embedding models hosted on Ollama (e.g., `nomic-embed-text`).
+`dimensions` is required and should match the model's embedding size. The embedder is
+retrieved by model name.
 
 ### Defining an Embedder
 

--- a/go/plugins/ollama/README.md
+++ b/go/plugins/ollama/README.md
@@ -203,9 +203,9 @@ You can define and use text embedding models hosted on Ollama (e.g., `nomic-embe
 
 ```go
 // Define an embedder model
-o.DefineEmbedder(g, "http://localhost:11434", "nomic-embed-text", nil)
+o.DefineEmbedder(g, "nomic-embed-text", 768, nil)
 
-embedder := ollama.Embedder(g, "http://localhost:11434")
+embedder := ollama.Embedder(g, "nomic-embed-text")
 ```
 
 ### Usage

--- a/go/plugins/ollama/embed.go
+++ b/go/plugins/ollama/embed.go
@@ -163,27 +163,27 @@ func (o *Ollama) DefineEmbedder(g *genkit.Genkit, model string, dimensions int, 
 
 	meta.Dimensions = dimensions
 
-		return genkit.DefineEmbedder(g, api.NewName(provider, model), meta, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
-			normalizedReq := *req
+	return genkit.DefineEmbedder(g, api.NewName(provider, model), meta, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+		normalizedReq := *req
 
-			if req.Options == nil {
+		if req.Options == nil {
+			normalizedReq.Options = &EmbedOptions{Model: model}
+		} else if opts, ok := req.Options.(*EmbedOptions); ok {
+			if opts == nil {
 				normalizedReq.Options = &EmbedOptions{Model: model}
-			} else if opts, ok := req.Options.(*EmbedOptions); ok {
-				if opts == nil {
-					normalizedReq.Options = &EmbedOptions{Model: model}
-				} else {
-					normalisedOpts := *opts
-					if normalisedOpts.Model == "" {
-						normalisedOpts.Model = model
-					} else if normalisedOpts.Model != model {
-						return nil, fmt.Errorf("invalid embedding model: embedder bound to model %q, got %q", model, opts.Model)
-					}
-					normalizedReq.Options = &normalisedOpts
+			} else {
+				normalisedOpts := *opts
+				if normalisedOpts.Model == "" {
+					normalisedOpts.Model = model
+				} else if normalisedOpts.Model != model {
+					return nil, fmt.Errorf("invalid embedding model: embedder bound to model %q, got %q", model, opts.Model)
 				}
+				normalizedReq.Options = &normalisedOpts
 			}
+		}
 
-			return embed(ctx, o.ServerAddress, &normalizedReq)
-		})
+		return embed(ctx, o.ServerAddress, &normalizedReq)
+	})
 }
 
 // IsDefinedEmbedder reports whether the embedder with the given model is defined by this plugin.

--- a/go/plugins/ollama/embed.go
+++ b/go/plugins/ollama/embed.go
@@ -160,14 +160,21 @@ func (o *Ollama) DefineEmbedder(g *genkit.Genkit, model string, dimensions int, 
 	meta.Dimensions = dimensions
 
 	return genkit.DefineEmbedder(g, api.NewName(provider, model), meta, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+		normalizedReq := *req
+
 		if req.Options == nil {
-			req.Options = &EmbedOptions{Model: model}
+			normalizedReq.Options = &EmbedOptions{Model: model}
 		} else if opts, ok := req.Options.(*EmbedOptions); ok {
-			if opts.Model == "" {
-				opts.Model = model
+			normalisedOpts := *opts
+			if normalisedOpts.Model == "" {
+				normalisedOpts.Model = model
+			} else if normalisedOpts.Model != model {
+				return nil, fmt.Errorf("invalid embedding model: embedder bound to model %q, got %q", model, opts.Model)
 			}
+			normalizedReq.Options = &normalisedOpts
 		}
-		return embed(ctx, o.ServerAddress, req)
+
+		return embed(ctx, o.ServerAddress, &normalizedReq)
 	})
 }
 

--- a/go/plugins/ollama/embed.go
+++ b/go/plugins/ollama/embed.go
@@ -135,7 +135,31 @@ func (o *Ollama) DefineEmbedder(g *genkit.Genkit, model string, dimensions int, 
 	if !o.initted {
 		panic("ollama.Init not called")
 	}
-	return genkit.DefineEmbedder(g, api.NewName(provider, model), embedOpts, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+
+	meta := &ai.EmbedderOptions{}
+
+	if embedOpts != nil {
+		*meta = *embedOpts
+	}
+
+	if embedOpts != nil && embedOpts.Supports != nil {
+		supports := *embedOpts.Supports
+		meta.Supports = &supports
+	}
+
+	if meta.Label == "" {
+		meta.Label = "Ollama Embedding - " + model
+	}
+	if meta.Supports == nil {
+		meta.Supports = &ai.EmbedderSupports{}
+	}
+	if len(meta.Supports.Input) == 0 {
+		meta.Supports.Input = []string{"text"}
+	}
+
+	meta.Dimensions = dimensions
+
+	return genkit.DefineEmbedder(g, api.NewName(provider, model), meta, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
 		if req.Options == nil {
 			req.Options = &EmbedOptions{Model: model}
 		} else if opts, ok := req.Options.(*EmbedOptions); ok {

--- a/go/plugins/ollama/embed.go
+++ b/go/plugins/ollama/embed.go
@@ -128,14 +128,14 @@ func concatenateText(doc *ai.Document) string {
 	return result
 }
 
-// DefineEmbedder defines an embedder with a given server address.
-func (o *Ollama) DefineEmbedder(g *genkit.Genkit, serverAddress string, model string, embedOpts *ai.EmbedderOptions) ai.Embedder {
+// DefineEmbedder defines an embedder with a given model.
+func (o *Ollama) DefineEmbedder(g *genkit.Genkit, model string, dimensions int, embedOpts *ai.EmbedderOptions) ai.Embedder {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if !o.initted {
 		panic("ollama.Init not called")
 	}
-	return genkit.DefineEmbedder(g, api.NewName(provider, serverAddress), embedOpts, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+	return genkit.DefineEmbedder(g, api.NewName(provider, model), embedOpts, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
 		if req.Options == nil {
 			req.Options = &EmbedOptions{Model: model}
 		} else if opts, ok := req.Options.(*EmbedOptions); ok {
@@ -143,7 +143,7 @@ func (o *Ollama) DefineEmbedder(g *genkit.Genkit, serverAddress string, model st
 				opts.Model = model
 			}
 		}
-		return embed(ctx, serverAddress, req)
+		return embed(ctx, o.ServerAddress, req)
 	})
 }
 

--- a/go/plugins/ollama/embed.go
+++ b/go/plugins/ollama/embed.go
@@ -147,13 +147,13 @@ func (o *Ollama) DefineEmbedder(g *genkit.Genkit, model string, dimensions int, 
 	})
 }
 
-// IsDefinedEmbedder reports whether the embedder with the given server address is defined by this plugin.
-func IsDefinedEmbedder(g *genkit.Genkit, serverAddress string) bool {
-	return genkit.LookupEmbedder(g, api.NewName(provider, serverAddress)) != nil
+// IsDefinedEmbedder reports whether the embedder with the given model is defined by this plugin.
+func IsDefinedEmbedder(g *genkit.Genkit, model string) bool {
+	return genkit.LookupEmbedder(g, api.NewName(provider, model)) != nil
 }
 
-// Embedder returns the [ai.Embedder] with the given server address.
+// Embedder returns the [ai.Embedder] with the given model.
 // It returns nil if the embedder was not defined.
-func Embedder(g *genkit.Genkit, serverAddress string) ai.Embedder {
-	return genkit.LookupEmbedder(g, api.NewName(provider, serverAddress))
+func Embedder(g *genkit.Genkit, model string) ai.Embedder {
+	return genkit.LookupEmbedder(g, api.NewName(provider, model))
 }

--- a/go/plugins/ollama/embed.go
+++ b/go/plugins/ollama/embed.go
@@ -136,6 +136,10 @@ func (o *Ollama) DefineEmbedder(g *genkit.Genkit, model string, dimensions int, 
 		panic("ollama.Init not called")
 	}
 
+	if dimensions <= 0 {
+		panic("ollama.DefineEmbedder: dimensions must be greater than 0")
+	}
+
 	meta := &ai.EmbedderOptions{}
 
 	if embedOpts != nil {

--- a/go/plugins/ollama/embed.go
+++ b/go/plugins/ollama/embed.go
@@ -163,23 +163,27 @@ func (o *Ollama) DefineEmbedder(g *genkit.Genkit, model string, dimensions int, 
 
 	meta.Dimensions = dimensions
 
-	return genkit.DefineEmbedder(g, api.NewName(provider, model), meta, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
-		normalizedReq := *req
+		return genkit.DefineEmbedder(g, api.NewName(provider, model), meta, func(ctx context.Context, req *ai.EmbedRequest) (*ai.EmbedResponse, error) {
+			normalizedReq := *req
 
-		if req.Options == nil {
-			normalizedReq.Options = &EmbedOptions{Model: model}
-		} else if opts, ok := req.Options.(*EmbedOptions); ok {
-			normalisedOpts := *opts
-			if normalisedOpts.Model == "" {
-				normalisedOpts.Model = model
-			} else if normalisedOpts.Model != model {
-				return nil, fmt.Errorf("invalid embedding model: embedder bound to model %q, got %q", model, opts.Model)
+			if req.Options == nil {
+				normalizedReq.Options = &EmbedOptions{Model: model}
+			} else if opts, ok := req.Options.(*EmbedOptions); ok {
+				if opts == nil {
+					normalizedReq.Options = &EmbedOptions{Model: model}
+				} else {
+					normalisedOpts := *opts
+					if normalisedOpts.Model == "" {
+						normalisedOpts.Model = model
+					} else if normalisedOpts.Model != model {
+						return nil, fmt.Errorf("invalid embedding model: embedder bound to model %q, got %q", model, opts.Model)
+					}
+					normalizedReq.Options = &normalisedOpts
+				}
 			}
-			normalizedReq.Options = &normalisedOpts
-		}
 
-		return embed(ctx, o.ServerAddress, &normalizedReq)
-	})
+			return embed(ctx, o.ServerAddress, &normalizedReq)
+		})
 }
 
 // IsDefinedEmbedder reports whether the embedder with the given model is defined by this plugin.

--- a/go/plugins/ollama/embed_test.go
+++ b/go/plugins/ollama/embed_test.go
@@ -228,6 +228,12 @@ func TestDefineEmbedderRequestOptionsHandling(t *testing.T) {
 			wantHTTPCalls: 1,
 		},
 		{
+			name:          "typed nil options use bound model",
+			options:       (*EmbedOptions)(nil),
+			wantModel:     model,
+			wantHTTPCalls: 1,
+		},
+		{
 			name:          "empty model uses bound model without mutating caller options",
 			options:       &EmbedOptions{},
 			wantModel:     model,

--- a/go/plugins/ollama/embed_test.go
+++ b/go/plugins/ollama/embed_test.go
@@ -21,10 +21,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/genkit"
 )
 
 func TestEmbedValidRequest(t *testing.T) {
@@ -65,4 +68,270 @@ func TestEmbedInvalidServerAddress(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "invalid server address") {
 		t.Fatalf("expected invalid server address error, got %v", err)
 	}
+}
+
+func TestDefineEmbedderRegistersByModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(ollamaEmbedResponse{
+			Embeddings: [][]float32{{0.1, 0.2, 0.3}},
+		})
+	}))
+	defer server.Close()
+
+	model := "nomic-embed-text"
+	g, o := newTestGenkit(t, server.URL)
+	o.DefineEmbedder(g, model, 768, nil)
+
+	if !IsDefinedEmbedder(g, model) {
+		t.Fatal("expected embedder to be registered by model")
+	}
+	if got := Embedder(g, model); got == nil {
+		t.Fatal("expected embedder lookup by model to succeed")
+	}
+	if IsDefinedEmbedder(g, server.URL) {
+		t.Fatal("expected server-address lookup to fail")
+	}
+}
+
+func TestDefineEmbedderSetsDefaultMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(ollamaEmbedResponse{
+			Embeddings: [][]float32{{0.1, 0.2, 0.3}},
+		})
+	}))
+	defer server.Close()
+
+	model := "nomic-embed-text"
+	g, o := newTestGenkit(t, server.URL)
+	embedder := o.DefineEmbedder(g, model, 768, nil)
+
+	action, ok := embedder.(api.Action)
+	if !ok {
+		t.Fatal("expected embedder to implement api.Action")
+	}
+
+	desc := action.Desc()
+	if got, want := desc.Name, api.NewName(provider, model); got != want {
+		t.Fatalf("Desc().Name = %q, want %q", got, want)
+	}
+
+	info, ok := desc.Metadata["info"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected info metadata, got %T", desc.Metadata["info"])
+	}
+	if got, want := info["label"], "Ollama Embedding - "+model; got != want {
+		t.Fatalf("label = %v, want %q", got, want)
+	}
+	if got, want := info["dimensions"], 768; got != want {
+		t.Fatalf("dimensions = %v, want %d", got, want)
+	}
+
+	supports, ok := info["supports"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected supports metadata, got %T", info["supports"])
+	}
+	input, ok := supports["input"].([]string)
+	if !ok {
+		t.Fatalf("expected supports.input to be []string, got %T", supports["input"])
+	}
+	if want := []string{"text"}; !reflect.DeepEqual(input, want) {
+		t.Fatalf("supports.input = %v, want %v", input, want)
+	}
+}
+
+func TestDefineEmbedderPreservesProvidedMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(ollamaEmbedResponse{
+			Embeddings: [][]float32{{0.1, 0.2, 0.3}},
+		})
+	}))
+	defer server.Close()
+
+	g, o := newTestGenkit(t, server.URL)
+	embedder := o.DefineEmbedder(g, "nomic-embed-text", 768, &ai.EmbedderOptions{
+		Label: "Custom Label",
+		Supports: &ai.EmbedderSupports{
+			Input:        []string{"text", "image"},
+			Multilingual: true,
+		},
+		ConfigSchema: map[string]any{"type": "object"},
+	})
+
+	action := embedder.(api.Action)
+	desc := action.Desc()
+
+	info := desc.Metadata["info"].(map[string]any)
+	if got, want := info["label"], "Custom Label"; got != want {
+		t.Fatalf("label = %v, want %q", got, want)
+	}
+	if got, want := info["dimensions"], 768; got != want {
+		t.Fatalf("dimensions = %v, want %d", got, want)
+	}
+
+	supports := info["supports"].(map[string]any)
+	input := supports["input"].([]string)
+	if want := []string{"text", "image"}; !reflect.DeepEqual(input, want) {
+		t.Fatalf("supports.input = %v, want %v", input, want)
+	}
+	if got, want := supports["multilingual"], true; got != want {
+		t.Fatalf("supports.multilingual = %v, want %v", got, want)
+	}
+
+	embedderMeta, ok := desc.Metadata["embedder"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected embedder metadata, got %T", desc.Metadata["embedder"])
+	}
+	if got, ok := embedderMeta["customOptions"].(map[string]any); !ok || got["type"] != "object" {
+		t.Fatalf("customOptions = %v, want schema map", embedderMeta["customOptions"])
+	}
+}
+
+func TestDefineEmbedderRequestOptionsHandling(t *testing.T) {
+	var seenModels []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/embed"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+
+		var body ollamaEmbedRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		seenModels = append(seenModels, body.Model)
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(ollamaEmbedResponse{
+			Embeddings: [][]float32{{0.1, 0.2, 0.3}},
+		})
+	}))
+	defer server.Close()
+
+	model := "nomic-embed-text"
+	g, o := newTestGenkit(t, server.URL)
+	embedder := o.DefineEmbedder(g, model, 768, nil)
+
+	tests := []struct {
+		name          string
+		options       any
+		wantModel     string
+		wantErr       string
+		wantHTTPCalls int
+		assertOpts    func(*testing.T, any)
+	}{
+		{
+			name:          "nil options use bound model",
+			options:       nil,
+			wantModel:     model,
+			wantHTTPCalls: 1,
+		},
+		{
+			name:          "empty model uses bound model without mutating caller options",
+			options:       &EmbedOptions{},
+			wantModel:     model,
+			wantHTTPCalls: 1,
+			assertOpts: func(t *testing.T, options any) {
+				t.Helper()
+				opts := options.(*EmbedOptions)
+				if opts.Model != "" {
+					t.Fatalf("caller options mutated to %q, want empty string", opts.Model)
+				}
+			},
+		},
+		{
+			name:          "same model allowed",
+			options:       &EmbedOptions{Model: model},
+			wantModel:     model,
+			wantHTTPCalls: 1,
+		},
+		{
+			name:          "different model rejected",
+			options:       &EmbedOptions{Model: "other-model"},
+			wantErr:       `invalid embedding model: embedder bound to model "nomic-embed-text", got "other-model"`,
+			wantHTTPCalls: 0,
+		},
+		{
+			name:          "wrong options type preserves existing error",
+			options:       map[string]any{"model": model},
+			wantErr:       "invalid options type: expected *EmbedOptions",
+			wantHTTPCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			beforeCalls := len(seenModels)
+			resp, err := embedder.Embed(context.Background(), &ai.EmbedRequest{
+				Input: []*ai.Document{
+					ai.DocumentFromText("test", nil),
+				},
+				Options: tt.options,
+			})
+
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("err = %v, want %q", err, tt.wantErr)
+				}
+				if got := len(seenModels) - beforeCalls; got != tt.wantHTTPCalls {
+					t.Fatalf("http calls = %d, want %d", got, tt.wantHTTPCalls)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Embed() error = %v", err)
+			}
+			if resp == nil || len(resp.Embeddings) != 1 {
+				t.Fatalf("expected 1 embedding, got %#v", resp)
+			}
+			if got := len(seenModels) - beforeCalls; got != tt.wantHTTPCalls {
+				t.Fatalf("http calls = %d, want %d", got, tt.wantHTTPCalls)
+			}
+			if got := seenModels[len(seenModels)-1]; got != tt.wantModel {
+				t.Fatalf("request model = %q, want %q", got, tt.wantModel)
+			}
+			if tt.assertOpts != nil {
+				tt.assertOpts(t, tt.options)
+			}
+		})
+	}
+}
+
+func TestDefineEmbedderRejectsNonPositiveDimensions(t *testing.T) {
+	g, o := newTestGenkit(t, "http://localhost:11434")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic")
+		}
+		if got, want := r, "ollama.DefineEmbedder: dimensions must be greater than 0"; got != want {
+			t.Fatalf("panic = %v, want %q", got, want)
+		}
+	}()
+
+	o.DefineEmbedder(g, "nomic-embed-text", 0, nil)
+}
+
+func TestDefineEmbedderDuplicateModelPanics(t *testing.T) {
+	g, o := newTestGenkit(t, "http://localhost:11434")
+	o.DefineEmbedder(g, "nomic-embed-text", 768, nil)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected duplicate registration panic")
+		}
+	}()
+
+	o.DefineEmbedder(g, "nomic-embed-text", 768, nil)
+}
+
+func newTestGenkit(t *testing.T, serverAddress string) (*genkit.Genkit, *Ollama) {
+	t.Helper()
+
+	o := &Ollama{ServerAddress: serverAddress}
+	g := genkit.Init(context.Background(), genkit.WithPlugins(o))
+	return g, o
 }

--- a/go/plugins/ollama/embed_test.go
+++ b/go/plugins/ollama/embed_test.go
@@ -94,6 +94,67 @@ func TestDefineEmbedderRegistersByModel(t *testing.T) {
 	}
 }
 
+func TestDefineEmbedderRegistersDistinctModelsOnSameServer(t *testing.T) {
+	g, o := newTestGenkit(t, "http://localhost:11434")
+
+	firstModel := "nomic-embed-text"
+	secondModel := "mxbai-embed-large"
+
+	firstDefined := o.DefineEmbedder(g, firstModel, 768, nil)
+	secondDefined := o.DefineEmbedder(g, secondModel, 1024, nil)
+
+	if !IsDefinedEmbedder(g, firstModel) {
+		t.Fatalf("expected %q embedder to be registered", firstModel)
+	}
+	if !IsDefinedEmbedder(g, secondModel) {
+		t.Fatalf("expected %q embedder to be registered", secondModel)
+	}
+
+	firstLookup := Embedder(g, firstModel)
+	secondLookup := Embedder(g, secondModel)
+
+	if firstLookup == nil {
+		t.Fatalf("expected lookup for %q to succeed", firstModel)
+	}
+	if secondLookup == nil {
+		t.Fatalf("expected lookup for %q to succeed", secondModel)
+	}
+
+	firstDefinedAction, ok := firstDefined.(api.Action)
+	if !ok {
+		t.Fatalf("expected %q embedder to implement api.Action", firstModel)
+	}
+	secondDefinedAction, ok := secondDefined.(api.Action)
+	if !ok {
+		t.Fatalf("expected %q embedder to implement api.Action", secondModel)
+	}
+
+	firstLookupAction, ok := firstLookup.(api.Action)
+	if !ok {
+		t.Fatalf("expected lookup for %q to implement api.Action", firstModel)
+	}
+	secondLookupAction, ok := secondLookup.(api.Action)
+	if !ok {
+		t.Fatalf("expected lookup for %q to implement api.Action", secondModel)
+	}
+
+	if got, want := firstDefinedAction.Desc().Name, api.NewName(provider, firstModel); got != want {
+		t.Fatalf("first Desc().Name = %q, want %q", got, want)
+	}
+	if got, want := secondDefinedAction.Desc().Name, api.NewName(provider, secondModel); got != want {
+		t.Fatalf("second Desc().Name = %q, want %q", got, want)
+	}
+	if got, want := firstLookupAction.Desc().Name, api.NewName(provider, firstModel); got != want {
+		t.Fatalf("lookup first Desc().Name = %q, want %q", got, want)
+	}
+	if got, want := secondLookupAction.Desc().Name, api.NewName(provider, secondModel); got != want {
+		t.Fatalf("lookup second Desc().Name = %q, want %q", got, want)
+	}
+	if firstDefinedAction.Desc().Name == secondDefinedAction.Desc().Name {
+		t.Fatal("expected embedders with different models to have distinct registration names")
+	}
+}
+
 func TestDefineEmbedderSetsDefaultMetadata(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Resolves #5470 

## Summary

- Align the Go Ollama embedder API with the JS plugin by registering and looking up embedders as `ollama/<model>` instead of `ollama/<serverAddress>`.
- Populate embedder metadata consistently and harden request handling so model-bound embedders set dimensions and text-input defaults, reject conflicting model overrides, and handle nil options safely.

## Problem

The Go `ollama` plugin diverged from the JS implementation by keying embedders with server address rather than model name. That meant multiple embedders on the same Ollama server could collide, and callers could not look them up by `ollama/<model>` the way other Genkit surfaces expect. The Go embedder registration path also omitted metadata such as `dimensions` and `supports.input`, and the request path allowed invalid or ambiguous options to flow through without validating that the request model matched the model the embedder was defined for.

## Changes

`DefineEmbedder`, `Embedder`, and `IsDefinedEmbedder` now use the model name as the embedder identity, while requests continue to execute against the plugin's configured server address. `DefineEmbedder` now requires `dimensions`, applies default metadata for the label and text input support, and preserves any caller-provided metadata overrides. The embed request path now normalizes nil and typed-nil options, fills in the bound model when it is omitted, and returns an error if a request tries to override the embedder with a different model. The README examples were updated to reflect the new model-based API and the required `dimensions` argument.

*Note: This PR adds validation for the dimensions param (i.e. don't accept non-positive dimensions. I don't think the JS SDK does this currently so not sure if we want this or not)

## Testing

- Added and updated `go/plugins/ollama/embed_test.go` coverage for model-based registration and lookup, default and custom metadata, request option normalization, conflicting model rejection, non-positive dimensions validation, duplicate model registration, and typed-nil options.
