### PR TITLE
feat(py/plugins/google-genai): Vertex multimodal embeddings via :predict

### DIFF
--- a/py/packages/genkit-google-genai/pyproject.toml
+++ b/py/packages/genkit-google-genai/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
   "genkit",
-  "google-genai>=1.7.0",
+  "google-genai>=1.63.0",
   "google-cloud-aiplatform>=1.77.0",
   "structlog>=25.2.0",
   "strenum>=0.4.15; python_version < '3.11'",

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -324,6 +324,7 @@ def _create_embedder_action(
         options=get_embedder_options(
             name=clean_name,
             label=label,
+            is_vertex=(plugin_name == VERTEXAI_PLUGIN_NAME),
         ),
     )
 
@@ -1043,6 +1044,7 @@ class VertexAI(Plugin):
                     options=get_embedder_options(
                         name=name,
                         label=f'{PLUGIN_DISPLAY_NAME[VERTEXAI_PLUGIN_NAME]} - {name}',
+                        is_vertex=True,
                     ),
                 )
             )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -324,7 +324,6 @@ def _create_embedder_action(
         options=get_embedder_options(
             name=clean_name,
             label=label,
-            is_vertex=(plugin_name == VERTEXAI_PLUGIN_NAME),
         ),
     )
 
@@ -1040,7 +1039,6 @@ class VertexAI(Plugin):
                     options=get_embedder_options(
                         name=name,
                         label=f'{PLUGIN_DISPLAY_NAME[VERTEXAI_PLUGIN_NAME]} - {name}',
-                        is_vertex=True,
                     ),
                 )
             )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -328,7 +328,11 @@ def _create_embedder_action(
     )
 
     async def _run(request: Any) -> Any:  # noqa: ANN401
-        embedder = Embedder(version=clean_name, client=client_getter())
+        embedder = Embedder(
+            version=clean_name,
+            client=client_getter(),
+            is_vertex=(plugin_name == VERTEXAI_PLUGIN_NAME),
+        )
         return await embedder.generate(request)
 
     action = Action(

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
@@ -96,13 +96,13 @@ VERTEX_KNOWN_EMBEDDERS: tuple[str, ...] = (
     'multimodalembedding@001',
 )
 
-# Advertised input modalities for multimodal embedders. Each model belongs to a
-# single backend (gemini-embedding-2* is Google AI only; multimodalembedding@001
-# is Vertex only), so a model name is never ambiguous across backends and no
-# backend scoping is needed. Lookups strip the '@version' suffix first.
-EMBEDDER_INPUT_SUPPORTS: dict[str, list[str]] = {
+# Advertised input modalities, per backend. Unknown names default to text-only.
+GOOGLEAI_EMBEDDER_INPUT_SUPPORTS: dict[str, list[str]] = {
     'gemini-embedding-2-preview': ['text', 'image', 'video'],
     'gemini-embedding-2': ['text', 'image', 'video'],
+}
+
+VERTEX_EMBEDDER_INPUT_SUPPORTS: dict[str, list[str]] = {
     'multimodalembedding': ['text', 'image', 'video'],
 }
 
@@ -112,19 +112,21 @@ def _base_name(name: str) -> str:
     return name.split('@', 1)[0]
 
 
-def get_embedder_options(name: str, label: str) -> EmbedderOptions:
+def get_embedder_options(name: str, label: str, is_vertex: bool = False) -> EmbedderOptions:
     """Return EmbedderOptions metadata for a discovered embedder model.
 
     Args:
         name: The bare (unprefixed) model name, e.g. 'gemini-embedding-2'.
         label: Human-readable label for the embedder.
+        is_vertex: True when resolving for the Vertex backend.
 
     Returns:
         EmbedderOptions describing the model's label, supported inputs and
         static dimensions.
     """
     base = _base_name(name)
-    supports = EMBEDDER_INPUT_SUPPORTS.get(name) or EMBEDDER_INPUT_SUPPORTS.get(base) or ['text']
+    supports_map = VERTEX_EMBEDDER_INPUT_SUPPORTS if is_vertex else GOOGLEAI_EMBEDDER_INPUT_SUPPORTS
+    supports = supports_map.get(name) or supports_map.get(base) or ['text']
     dimensions = EMBEDDER_DIMENSIONS.get(name) or EMBEDDER_DIMENSIONS.get(base)
     return EmbedderOptions(
         label=label,

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
@@ -16,8 +16,9 @@
 
 """Google-Genai embedder model."""
 
+import json
 import sys
-from typing import cast
+from typing import Any, cast
 
 if sys.version_info < (3, 11):
     from strenum import StrEnum
@@ -28,7 +29,7 @@ from google import genai
 from google.genai import types as genai_types
 
 from genkit import DocumentPart, Embedding, EmbedRequest, EmbedResponse
-from genkit._core._typing import DocumentData
+from genkit._core._typing import DocumentData, MediaPart, TextPart
 from genkit.embedder import EmbedderOptions, EmbedderSupports
 from genkit_google_genai.models.utils import PartConverter
 
@@ -67,7 +68,10 @@ class EmbeddingTaskType(StrEnum):
     FACT_VERIFICATION = 'FACT_VERIFICATION'
 
 
-# Static dimensions for known embedders.
+# Static dimensions for known embedders. Keys are version-suffix free
+# (e.g. 'multimodalembedding', not 'multimodalembedding@001') because model
+# discovery returns the bare name on some accounts/regions; lookups strip the
+# '@version' suffix before matching (see get_embedder_options).
 EMBEDDER_DIMENSIONS: dict[str, int] = {
     # Google AI
     'gemini-embedding-2-preview': 3072,
@@ -76,42 +80,55 @@ EMBEDDER_DIMENSIONS: dict[str, int] = {
     # Vertex AI
     'text-embedding-005': 768,
     'text-multilingual-embedding-002': 768,
-    'multimodalembedding@001': 768,
+    'multimodalembedding': 1408,  # default; valid dims 128/256/512/1408 (not 768)
 }
 
 
 # Curated set of Vertex AI embedders that are verified to be callable.
+# The Vertex catalog over-lists embedders (and returns supported_actions=None),
+# so embedders are advertised from this list rather than discovered. Multimodal
+# embedders route through the :predict endpoint (see Embedder._is_multimodal).
 VERTEX_KNOWN_EMBEDDERS: tuple[str, ...] = (
     'text-embedding-005',
     'text-multilingual-embedding-002',
     'gemini-embedding-001',
+    'multimodalembedding@001',
 )
 
-# Advertised input modalities per backend
-GOOGLEAI_EMBEDDER_INPUT_SUPPORTS: dict[str, list[str]] = {
+# Advertised input modalities for multimodal embedders. Each model belongs to a
+# single backend (gemini-embedding-2* is Google AI only; multimodalembedding@001
+# is Vertex only), so a model name is never ambiguous across backends and no
+# backend scoping is needed. Lookups strip the '@version' suffix first.
+EMBEDDER_INPUT_SUPPORTS: dict[str, list[str]] = {
     'gemini-embedding-2-preview': ['text', 'image', 'video'],
     'gemini-embedding-2': ['text', 'image', 'video'],
+    'multimodalembedding': ['text', 'image', 'video'],
 }
 
 
-def get_embedder_options(name: str, label: str, is_vertex: bool = False) -> EmbedderOptions:
+def _base_name(name: str) -> str:
+    """Strip a trailing '@version' suffix from a model name (e.g. '@001')."""
+    return name.split('@', 1)[0]
+
+
+def get_embedder_options(name: str, label: str) -> EmbedderOptions:
     """Return EmbedderOptions metadata for a discovered embedder model.
 
     Args:
         name: The bare (unprefixed) model name, e.g. 'gemini-embedding-2'.
         label: Human-readable label for the embedder.
-        is_vertex: True when resolving for the Vertex backend, which advertises
-            text-only because its embed path cannot deliver media.
 
     Returns:
         EmbedderOptions describing the model's label, supported inputs and
         static dimensions.
     """
-    supports = ['text'] if is_vertex else GOOGLEAI_EMBEDDER_INPUT_SUPPORTS.get(name, ['text'])
+    base = _base_name(name)
+    supports = EMBEDDER_INPUT_SUPPORTS.get(name) or EMBEDDER_INPUT_SUPPORTS.get(base) or ['text']
+    dimensions = EMBEDDER_DIMENSIONS.get(name) or EMBEDDER_DIMENSIONS.get(base)
     return EmbedderOptions(
         label=label,
         supports=EmbedderSupports(input=supports),
-        dimensions=EMBEDDER_DIMENSIONS.get(name),
+        dimensions=dimensions,
     )
 
 
@@ -147,6 +164,8 @@ class Embedder:
                 'Embed request input is empty: provide at least one document with content '
                 '(for example input: [{"content": [{"text": "your text here"}]}]).'
             )
+        if self._is_multimodal():
+            return await self._generate_multimodal(request)
         contents = await self._build_contents(request)
         config = self._genkit_to_googleai_cfg(request)
         response = await self._client.aio.models.embed_content(
@@ -157,6 +176,116 @@ class Embedder:
 
         embeddings = [Embedding(embedding=em.values or []) for em in (response.embeddings or [])]
         return EmbedResponse(embeddings=embeddings)
+
+    def _is_multimodal(self) -> bool:
+        """Whether this embedder uses the Vertex multimodal ``:predict`` API.
+
+        The google-genai ``embed_content`` API only accepts text on Vertex (it
+        silently drops image/video parts), so multimodal embedders must call the
+        ``predict`` endpoint with structured ``{text, image, video}`` instances
+        instead. This mirrors the JS plugin's vertexai embedder.
+        """
+        return 'multimodalembedding' in str(self._version).lower()
+
+    async def _generate_multimodal(self, request: EmbedRequest) -> EmbedResponse:
+        """Embed text/image/video via the Vertex multimodal ``:predict`` endpoint.
+
+        Args:
+            request: Genkit embed request.
+
+        Returns:
+            EmbedResponse
+        """
+        instances = [self._build_multimodal_instance(doc) for doc in request.input]
+
+        payload: dict[str, Any] = {'instances': instances}
+        if request.options:
+            dimension = request.options.get('output_dimensionality') or request.options.get('outputDimensionality')
+            if dimension is not None:
+                payload['parameters'] = {'dimension': dimension}
+
+        # google-genai exposes no typed multimodal-embedding method, so reuse the
+        # client's authenticated low-level transport to POST to :predict. For
+        # Vertex, the project/location prefix is added by the SDK automatically.
+        http_response = await self._client._api_client.async_request(
+            http_method='post',
+            path=f'publishers/google/models/{self._version}:predict',
+            request_dict=payload,
+        )
+        body = json.loads(http_response.body) if http_response.body else {}
+        predictions = body.get('predictions', []) if isinstance(body, dict) else []
+
+        embeddings: list[Embedding] = []
+        for prediction in predictions:
+            embeddings.extend(self._prediction_to_embeddings(prediction))
+        return EmbedResponse(embeddings=embeddings)
+
+    def _build_multimodal_instance(self, doc: DocumentData) -> dict[str, Any]:
+        """Build a Vertex multimodal embedding instance from a Genkit document."""
+        if not isinstance(doc, DocumentData):
+            doc = DocumentData.model_validate(doc)
+
+        instance: dict[str, Any] = {}
+        for p in doc.content:
+            part = p if isinstance(p, DocumentPart) else DocumentPart.model_validate(p)
+            root = part.root
+            if isinstance(root, TextPart):
+                if root.text:
+                    instance['text'] = root.text
+            elif isinstance(root, MediaPart):
+                content_type = root.media.content_type or ''
+                if content_type.startswith('image/'):
+                    instance['image'] = self._media_reference(root.media.url, content_type)
+                elif content_type.startswith('video/'):
+                    video = self._media_reference(root.media.url, content_type, include_mime_type=False)
+                    segment_config = (doc.metadata or {}).get('video_segment_config') or (doc.metadata or {}).get(
+                        'videoSegmentConfig'
+                    )
+                    if segment_config:
+                        video['videoSegmentConfig'] = segment_config
+                    instance['video'] = video
+                else:
+                    raise ValueError(f'Unsupported contentType for multimodal embedding: {content_type!r}')
+
+        if not instance:
+            raise ValueError('Multimodal embed document has no text, image, or video content.')
+        return instance
+
+    @staticmethod
+    def _media_reference(url: str, content_type: str, include_mime_type: bool = True) -> dict[str, str]:
+        """Map a media URL to a Vertex image/video reference (gcsUri or base64)."""
+        if url.startswith('gs://') or url.startswith('http'):
+            ref: dict[str, str] = {'gcsUri': url}
+        elif url.startswith('data:'):
+            ref = {'bytesBase64Encoded': url.split(',', 1)[1]}
+        else:
+            ref = {'bytesBase64Encoded': url}
+        if include_mime_type and content_type:
+            ref['mimeType'] = content_type
+        return ref
+
+    @staticmethod
+    def _prediction_to_embeddings(prediction: dict[str, Any]) -> list[Embedding]:
+        """Convert one multimodal prediction into Genkit embeddings.
+
+        A prediction can carry image, text and/or video embeddings. A single
+        video is split into chunks, yielding one embedding per chunk; the chunk
+        offsets are preserved in each embedding's metadata.
+        """
+        embeddings: list[Embedding] = []
+        if prediction.get('imageEmbedding'):
+            embeddings.append(
+                Embedding(embedding=prediction['imageEmbedding'], metadata={'embedType': 'imageEmbedding'})
+            )
+        if prediction.get('textEmbedding'):
+            embeddings.append(Embedding(embedding=prediction['textEmbedding'], metadata={'embedType': 'textEmbedding'}))
+        for video_embedding in prediction.get('videoEmbeddings', []) or []:
+            values = video_embedding.get('embedding')
+            if values:
+                metadata = {k: v for k, v in video_embedding.items() if k != 'embedding'}
+                metadata['embedType'] = 'videoEmbedding'
+                embeddings.append(Embedding(embedding=values, metadata=metadata))
+        return embeddings
 
     async def _build_contents(self, request: EmbedRequest) -> list[genai.types.Content]:
         """Build google-genai request contents from Genkit request.

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
@@ -77,6 +77,7 @@ EMBEDDER_DIMENSIONS: dict[str, int] = {
     'gemini-embedding-2-preview': 3072,
     'gemini-embedding-2': 3072,
     'gemini-embedding-001': 3072,
+    'text-embedding-004': 768,
     # Vertex AI
     'text-embedding-005': 768,
     'text-multilingual-embedding-002': 768,

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
@@ -191,12 +191,21 @@ class Embedder:
     async def _generate_multimodal(self, request: EmbedRequest) -> EmbedResponse:
         """Embed text/image/video via the Vertex multimodal ``:predict`` endpoint.
 
+        ``multimodalembedding@001`` accepts only one instance per ``:predict``
+        call, so multi-document requests (e.g. ``embed_many``) are rejected
+        rather than sent as an invalid multi-instance payload. Batching multiple
+        documents is not supported yet.
+
         Args:
             request: Genkit embed request.
 
         Returns:
             EmbedResponse
         """
+        if len(request.input) > 1:
+            raise ValueError(
+                'multimodalembedding@001 supports only one document per request; embed documents one at a time.'
+            )
         instances = [self._build_multimodal_instance(doc) for doc in request.input]
 
         payload: dict[str, Any] = {'instances': instances}

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
@@ -222,22 +222,34 @@ class Embedder:
         return EmbedResponse(embeddings=embeddings)
 
     def _build_multimodal_instance(self, doc: DocumentData) -> dict[str, Any]:
-        """Build a Vertex multimodal embedding instance from a Genkit document."""
+        """Build a Vertex multimodal embedding instance from a Genkit document.
+
+        A Vertex instance accepts at most one text, one image and one video
+        field (the three may be combined in a single instance). Multiple text
+        parts are concatenated, matching ``Document.text``; multiple images or
+        multiple videos raise, since the API would otherwise silently keep only
+        the last of each.
+        """
         if not isinstance(doc, DocumentData):
             doc = DocumentData.model_validate(doc)
 
         instance: dict[str, Any] = {}
+        text_parts: list[str] = []
         for p in doc.content:
             part = p if isinstance(p, DocumentPart) else DocumentPart.model_validate(p)
             root = part.root
             if isinstance(root, TextPart):
                 if root.text:
-                    instance['text'] = root.text
+                    text_parts.append(root.text)
             elif isinstance(root, MediaPart):
                 content_type = root.media.content_type or ''
                 if content_type.startswith('image/'):
+                    if 'image' in instance:
+                        raise ValueError('Multimodal embed document cannot contain more than one image.')
                     instance['image'] = self._media_reference(root.media.url, content_type)
                 elif content_type.startswith('video/'):
+                    if 'video' in instance:
+                        raise ValueError('Multimodal embed document cannot contain more than one video.')
                     video = self._media_reference(root.media.url, content_type, include_mime_type=False)
                     segment_config = (doc.metadata or {}).get('video_segment_config') or (doc.metadata or {}).get(
                         'videoSegmentConfig'
@@ -248,15 +260,28 @@ class Embedder:
                 else:
                     raise ValueError(f'Unsupported contentType for multimodal embedding: {content_type!r}')
 
+        if text_parts:
+            instance['text'] = ''.join(text_parts)
+
         if not instance:
             raise ValueError('Multimodal embed document has no text, image, or video content.')
         return instance
 
     @staticmethod
     def _media_reference(url: str, content_type: str, include_mime_type: bool = True) -> dict[str, str]:
-        """Map a media URL to a Vertex image/video reference (gcsUri or base64)."""
-        if url.startswith('gs://') or url.startswith('http'):
+        """Map a media URL to a Vertex image/video reference (gcsUri or base64).
+
+        Unlike the JS plugin, http(s) URLs raise instead of being forwarded as a
+        ``gcsUri``: Vertex only accepts ``gs://`` URIs there, so passing an
+        http(s) URL produces an opaque API error. Failing fast is clearer.
+        """
+        if url.startswith('gs://'):
             ref: dict[str, str] = {'gcsUri': url}
+        elif url.startswith('http'):
+            raise ValueError(
+                'Vertex multimodal embedding does not accept http(s) media URLs. '
+                'Upload the file to Cloud Storage and pass a gs:// URI, or inline it as a data: URL.'
+            )
         elif url.startswith('data:'):
             ref = {'bytesBase64Encoded': url.split(',', 1)[1]}
         else:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
@@ -140,15 +140,19 @@ class Embedder:
         self,
         version: VertexEmbeddingModels | GeminiEmbeddingModels | str,
         client: genai.Client,
+        is_vertex: bool = False,
     ) -> None:
         """Initialize the embedder.
 
         Args:
             version: Embedding model version.
             client: Google-Genai client.
+            is_vertex: Whether the client targets Vertex AI (as opposed to the
+                Gemini Developer API). Multimodal embedding requires Vertex.
         """
         self._client = client
         self._version = version
+        self._is_vertex = is_vertex
 
     async def generate(self, request: EmbedRequest) -> EmbedResponse:
         """Generate embeddings for a given request.
@@ -202,6 +206,11 @@ class Embedder:
         Returns:
             EmbedResponse
         """
+        if not self._is_vertex:
+            raise ValueError(
+                f'{self._version} embedding is only available on Vertex AI; '
+                'it is not supported by the Gemini Developer API. Use the VertexAI plugin instead.'
+            )
         if len(request.input) > 1:
             raise ValueError(
                 'multimodalembedding@001 supports only one document per request; embed documents one at a time.'
@@ -210,14 +219,21 @@ class Embedder:
 
         payload: dict[str, Any] = {'instances': instances}
         if request.options:
-            dimension = request.options.get('output_dimensionality') or request.options.get('outputDimensionality')
+            dimension = request.options.get('output_dimensionality')
             if dimension is not None:
                 payload['parameters'] = {'dimension': dimension}
 
         # google-genai exposes no typed multimodal-embedding method, so reuse the
         # client's authenticated low-level transport to POST to :predict. For
         # Vertex, the project/location prefix is added by the SDK automatically.
-        http_response = await self._client._api_client.async_request(
+        # These are private SDK internals, so guard against them drifting.
+        api_client = getattr(self._client, '_api_client', None)
+        if api_client is None or not hasattr(api_client, 'async_request'):
+            raise RuntimeError(
+                'Multimodal embedding relies on google-genai client internals that are '
+                'unavailable in the installed google-genai version; install google-genai>=1.63.0.'
+            )
+        http_response = await api_client.async_request(
             http_method='post',
             path=f'publishers/google/models/{self._version}:predict',
             request_dict=payload,
@@ -277,7 +293,7 @@ class Embedder:
         return instance
 
     @staticmethod
-    def _media_reference(url: str, content_type: str, include_mime_type: bool = True) -> dict[str, str]:
+    def _media_reference(url: str, content_type: str, include_mime_type: bool = True) -> dict[str, Any]:
         """Map a media URL to a Vertex image/video reference (gcsUri or base64).
 
         Unlike the JS plugin, http(s) URLs raise instead of being forwarded as a
@@ -285,14 +301,20 @@ class Embedder:
         http(s) URL produces an opaque API error. Failing fast is clearer.
         """
         if url.startswith('gs://'):
-            ref: dict[str, str] = {'gcsUri': url}
+            ref: dict[str, Any] = {'gcsUri': url}
         elif url.startswith('http'):
             raise ValueError(
                 'Vertex multimodal embedding does not accept http(s) media URLs. '
                 'Upload the file to Cloud Storage and pass a gs:// URI, or inline it as a data: URL.'
             )
         elif url.startswith('data:'):
-            ref = {'bytesBase64Encoded': url.split(',', 1)[1]}
+            marker = ';base64,'
+            marker_index = url.find(marker)
+            if marker_index == -1:
+                raise ValueError(
+                    'Vertex multimodal embedding requires base64-encoded data: URLs (data:<mimeType>;base64,<data>).'
+                )
+            ref = {'bytesBase64Encoded': url[marker_index + len(marker) :]}
         else:
             ref = {'bytesBase64Encoded': url}
         if include_mime_type and content_type:
@@ -303,9 +325,13 @@ class Embedder:
     def _prediction_to_embeddings(prediction: dict[str, Any]) -> list[Embedding]:
         """Convert one multimodal prediction into Genkit embeddings.
 
-        A prediction can carry image, text and/or video embeddings. A single
-        video is split into chunks, yielding one embedding per chunk; the chunk
-        offsets are preserved in each embedding's metadata.
+        A prediction can carry image, text and/or video embeddings, so one
+        document may fan out to several embeddings (a text+image document yields
+        two; a video yields one embedding per chunk). Embeddings are told apart
+        by their ``embedType`` metadata rather than by position, so consumers
+        must correlate via metadata instead of zipping positionally against the
+        input documents. Video chunk offsets are preserved in each embedding's
+        metadata.
         """
         embeddings: list[Embedding] = []
         if prediction.get('imageEmbedding'):

--- a/py/packages/genkit-google-genai/test/google_plugin_test.py
+++ b/py/packages/genkit-google-genai/test/google_plugin_test.py
@@ -291,6 +291,29 @@ def test_vertexai__resolve_embedder_multimodalembedding(
     assert metadata['embedder']['dimensions'] == 1408
 
 
+@pytest.mark.parametrize(
+    'input_name, expected_model_name',
+    [
+        ('vertexai/gemini-embedding-2', 'vertexai/gemini-embedding-2'),
+        ('gemini-embedding-2', 'vertexai/gemini-embedding-2'),
+    ],
+)
+def test_vertexai__resolve_embedder_scopes_supports_to_text(
+    input_name: str,
+    expected_model_name: str,
+    vertexai_plugin_instance: VertexAI,
+) -> None:
+    """Vertex must not inherit Google AI's multimodal advertisement."""
+    action = vertexai_plugin_instance._resolve_embedder(name=input_name)
+
+    assert action is not None
+    assert action.kind == ActionKind.EMBEDDER
+    assert action.name == expected_model_name
+    metadata = cast(dict[str, Any], action.metadata)
+    assert metadata['embedder']['supports']['input'] == ['text']
+    assert metadata['embedder']['dimensions'] == 3072
+
+
 @pytest.mark.asyncio
 async def test_googleai_list_actions(googleai_plugin_instance: GoogleAI) -> None:
     """Unit test for list actions."""

--- a/py/packages/genkit-google-genai/test/google_plugin_test.py
+++ b/py/packages/genkit-google-genai/test/google_plugin_test.py
@@ -271,24 +271,24 @@ def test_googleai__resolve_embedder(
 @pytest.mark.parametrize(
     'input_name, expected_model_name',
     [
-        ('vertexai/gemini-embedding-2', 'vertexai/gemini-embedding-2'),
-        ('gemini-embedding-2', 'vertexai/gemini-embedding-2'),
+        ('vertexai/multimodalembedding@001', 'vertexai/multimodalembedding@001'),
+        ('multimodalembedding@001', 'vertexai/multimodalembedding@001'),
     ],
 )
-def test_vertexai__resolve_embedder_scopes_supports_to_text(
+def test_vertexai__resolve_embedder_multimodalembedding(
     input_name: str,
     expected_model_name: str,
     vertexai_plugin_instance: VertexAI,
 ) -> None:
-    """Vertex must not inherit Google AI's multimodal advertisement."""
+    """Vertex's multimodalembedding resolves (bare or namespaced) and advertises multimodal."""
     action = vertexai_plugin_instance._resolve_embedder(name=input_name)
 
     assert action is not None
     assert action.kind == ActionKind.EMBEDDER
     assert action.name == expected_model_name
     metadata = cast(dict[str, Any], action.metadata)
-    assert metadata['embedder']['supports']['input'] == ['text']
-    assert metadata['embedder']['dimensions'] == 3072
+    assert metadata['embedder']['supports']['input'] == ['text', 'image', 'video']
+    assert metadata['embedder']['dimensions'] == 1408
 
 
 @pytest.mark.asyncio
@@ -991,6 +991,9 @@ async def test_vertexai_list_known_embedders(vertexai_plugin_instance: VertexAI)
     listed = {a.name for a in result}
     assert listed == {vertexai_name(name) for name in VERTEX_KNOWN_EMBEDDERS}
     assert vertexai_name('gemini-embedding-001') in listed
+    # multimodalembedding@001 is callable (via :predict) and curated in, unlike
+    # the non-callable embedders the catalog over-lists.
+    assert vertexai_name('multimodalembedding@001') in listed
     assert vertexai_name('gemini-embedding-2') not in listed
 
 

--- a/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
@@ -182,3 +182,123 @@ async def test_multimodal_embedding_uses_predict(mocker: MockerFixture) -> None:
     assert response.embeddings[1].metadata is not None
     assert response.embeddings[1].metadata['embedType'] == 'videoEmbedding'
     assert response.embeddings[1].metadata['startOffsetSec'] == 0
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_concatenates_text_parts(mocker: MockerFixture) -> None:
+    """Multiple text parts in one document are concatenated into a single instance text."""
+    request = EmbedRequest(
+        input=[
+            Document(
+                content=[
+                    *Document.from_text('hello ').content,
+                    *Document.from_text('world').content,
+                ]
+            )
+        ]
+    )
+    predict_body = {'predictions': [{'textEmbedding': [0.1, 0.2]}]}
+    client_mock = mocker.AsyncMock()
+    http_response = mocker.Mock()
+    http_response.body = json.dumps(predict_body)
+    client_mock._api_client.async_request.return_value = http_response
+
+    embedder = Embedder('multimodalembedding', client_mock)
+    response = await embedder.generate(request)
+
+    call = client_mock._api_client.async_request.call_args
+    instances = call.kwargs['request_dict']['instances']
+    assert instances[0] == {'text': 'hello world'}
+    assert response.embeddings[0].embedding == [0.1, 0.2]
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_allows_image_and_video_in_one_instance(mocker: MockerFixture) -> None:
+    """Image and video in one document share a single instance (Vertex supports this)."""
+    request = EmbedRequest(
+        input=[
+            Document(
+                content=[
+                    *Document.from_media('gs://bucket/cat.png', 'image/png').content,
+                    *Document.from_media('gs://bucket/clip.mp4', 'video/mp4').content,
+                ]
+            )
+        ]
+    )
+    predict_body = {
+        'predictions': [
+            {
+                'imageEmbedding': [0.1, 0.2],
+                'videoEmbeddings': [{'startOffsetSec': 0, 'endOffsetSec': 5, 'embedding': [0.3, 0.4]}],
+            }
+        ]
+    }
+    client_mock = mocker.AsyncMock()
+    http_response = mocker.Mock()
+    http_response.body = json.dumps(predict_body)
+    client_mock._api_client.async_request.return_value = http_response
+
+    embedder = Embedder('multimodalembedding', client_mock)
+    response = await embedder.generate(request)
+
+    call = client_mock._api_client.async_request.call_args
+    instances = call.kwargs['request_dict']['instances']
+    assert instances[0] == {
+        'image': {'gcsUri': 'gs://bucket/cat.png', 'mimeType': 'image/png'},
+        'video': {'gcsUri': 'gs://bucket/clip.mp4'},
+    }
+    assert len(response.embeddings) == 2
+    assert response.embeddings[0].metadata == {'embedType': 'imageEmbedding'}
+    assert response.embeddings[1].metadata is not None
+    assert response.embeddings[1].metadata['embedType'] == 'videoEmbedding'
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_rejects_multiple_images(mocker: MockerFixture) -> None:
+    """A document with two images is rejected; Vertex accepts one image per instance."""
+    request = EmbedRequest(
+        input=[
+            Document(
+                content=[
+                    *Document.from_media('gs://bucket/a.png', 'image/png').content,
+                    *Document.from_media('gs://bucket/b.png', 'image/png').content,
+                ]
+            )
+        ]
+    )
+    client_mock = mocker.AsyncMock()
+    embedder = Embedder('multimodalembedding', client_mock)
+    with pytest.raises(ValueError, match='more than one image'):
+        await embedder.generate(request)
+    client_mock._api_client.async_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_rejects_multiple_videos(mocker: MockerFixture) -> None:
+    """A document with two videos is rejected; Vertex accepts one video per instance."""
+    request = EmbedRequest(
+        input=[
+            Document(
+                content=[
+                    *Document.from_media('gs://bucket/a.mp4', 'video/mp4').content,
+                    *Document.from_media('gs://bucket/b.mp4', 'video/mp4').content,
+                ]
+            )
+        ]
+    )
+    client_mock = mocker.AsyncMock()
+    embedder = Embedder('multimodalembedding', client_mock)
+    with pytest.raises(ValueError, match='more than one video'):
+        await embedder.generate(request)
+    client_mock._api_client.async_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_rejects_http_url(mocker: MockerFixture) -> None:
+    """http(s) media URLs are rejected; Vertex gcsUri only accepts gs:// (diverges from JS)."""
+    request = EmbedRequest(input=[Document.from_media('https://example.com/cat.png', 'image/png')])
+    client_mock = mocker.AsyncMock()
+    embedder = Embedder('multimodalembedding', client_mock)
+    with pytest.raises(ValueError, match='http'):
+        await embedder.generate(request)
+    client_mock._api_client.async_request.assert_not_called()

--- a/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
@@ -17,6 +17,7 @@
 """Test the Google-Genai embedder model."""
 
 import base64
+import json
 
 import pytest
 from genkit_google_genai.models.embedder import (
@@ -131,9 +132,53 @@ def test_get_embedder_options_multimodal_and_fallback() -> None:
     assert unknown_options.supports.input == ['text']
 
 
-def test_get_embedder_options_supports_are_backend_scoped() -> None:
-    """The same model advertises multimodal on Google AI but text-only on Vertex."""
-    vertex_options = get_embedder_options('gemini-embedding-2', 'Vertex AI - gemini-embedding-2', is_vertex=True)
-    assert vertex_options.supports is not None
-    assert vertex_options.supports.input == ['text']
-    assert vertex_options.dimensions == 3072
+@pytest.mark.parametrize('model_name', ['multimodalembedding', 'multimodalembedding@001'])
+def test_get_embedder_options_multimodalembedding_versioned_and_bare(model_name: str) -> None:
+    """The multimodalembedding model is multimodal with or without the '@001' suffix."""
+    options = get_embedder_options(model_name, f'Vertex AI - {model_name}')
+    assert options.dimensions == 1408
+    assert options.supports is not None
+    assert options.supports.input == ['text', 'image', 'video']
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_uses_predict(mocker: MockerFixture) -> None:
+    """Multimodal embedders hit the :predict endpoint and map image/video results."""
+    request = EmbedRequest(
+        input=[
+            Document.from_media('gs://bucket/cat.png', 'image/png'),
+            Document.from_media('gs://bucket/clip.mp4', 'video/mp4'),
+        ]
+    )
+    predict_body = {
+        'predictions': [
+            {'imageEmbedding': [0.1, 0.2, 0.3]},
+            {'videoEmbeddings': [{'startOffsetSec': 0, 'endOffsetSec': 5, 'embedding': [0.4, 0.5]}]},
+        ]
+    }
+    client_mock = mocker.AsyncMock()
+    http_response = mocker.Mock()
+    http_response.body = json.dumps(predict_body)
+    client_mock._api_client.async_request.return_value = http_response
+
+    embedder = Embedder('multimodalembedding', client_mock)
+    response = await embedder.generate(request)
+
+    # The text embed_content path must not be used for multimodal models.
+    client_mock.aio.models.embed_content.assert_not_called()
+
+    call = client_mock._api_client.async_request.call_args
+    assert call.kwargs['http_method'] == 'post'
+    assert call.kwargs['path'] == 'publishers/google/models/multimodalembedding:predict'
+    instances = call.kwargs['request_dict']['instances']
+    assert instances[0] == {'image': {'gcsUri': 'gs://bucket/cat.png', 'mimeType': 'image/png'}}
+    assert instances[1] == {'video': {'gcsUri': 'gs://bucket/clip.mp4'}}
+
+    assert isinstance(response, EmbedResponse)
+    assert len(response.embeddings) == 2
+    assert response.embeddings[0].embedding == [0.1, 0.2, 0.3]
+    assert response.embeddings[0].metadata == {'embedType': 'imageEmbedding'}
+    assert response.embeddings[1].embedding == [0.4, 0.5]
+    assert response.embeddings[1].metadata is not None
+    assert response.embeddings[1].metadata['embedType'] == 'videoEmbedding'
+    assert response.embeddings[1].metadata['startOffsetSec'] == 0

--- a/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
@@ -151,7 +151,7 @@ async def test_multimodal_embedding_uses_predict(mocker: MockerFixture) -> None:
     http_response.body = json.dumps(predict_body)
     client_mock._api_client.async_request.return_value = http_response
 
-    embedder = Embedder('multimodalembedding', client_mock)
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
     response = await embedder.generate(request)
 
     # The text embed_content path must not be used for multimodal models.
@@ -188,13 +188,14 @@ async def test_multimodal_embedding_concatenates_text_parts(mocker: MockerFixtur
     http_response.body = json.dumps(predict_body)
     client_mock._api_client.async_request.return_value = http_response
 
-    embedder = Embedder('multimodalembedding', client_mock)
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
     response = await embedder.generate(request)
 
     call = client_mock._api_client.async_request.call_args
     instances = call.kwargs['request_dict']['instances']
     assert instances[0] == {'text': 'hello world'}
     assert response.embeddings[0].embedding == [0.1, 0.2]
+    assert response.embeddings[0].metadata == {'embedType': 'textEmbedding'}
 
 
 @pytest.mark.asyncio
@@ -223,7 +224,7 @@ async def test_multimodal_embedding_allows_image_and_video_in_one_instance(mocke
     http_response.body = json.dumps(predict_body)
     client_mock._api_client.async_request.return_value = http_response
 
-    embedder = Embedder('multimodalembedding', client_mock)
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
     response = await embedder.generate(request)
 
     call = client_mock._api_client.async_request.call_args
@@ -254,7 +255,7 @@ async def test_multimodal_embedding_rejects_multiple_images(mocker: MockerFixtur
         ]
     )
     client_mock = mocker.AsyncMock()
-    embedder = Embedder('multimodalembedding', client_mock)
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
     with pytest.raises(ValueError, match='more than one image'):
         await embedder.generate(request)
     client_mock._api_client.async_request.assert_not_called()
@@ -274,7 +275,7 @@ async def test_multimodal_embedding_rejects_multiple_videos(mocker: MockerFixtur
         ]
     )
     client_mock = mocker.AsyncMock()
-    embedder = Embedder('multimodalembedding', client_mock)
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
     with pytest.raises(ValueError, match='more than one video'):
         await embedder.generate(request)
     client_mock._api_client.async_request.assert_not_called()
@@ -285,7 +286,7 @@ async def test_multimodal_embedding_rejects_http_url(mocker: MockerFixture) -> N
     """http(s) media URLs are rejected; Vertex gcsUri only accepts gs:// (diverges from JS)."""
     request = EmbedRequest(input=[Document.from_media('https://example.com/cat.png', 'image/png')])
     client_mock = mocker.AsyncMock()
-    embedder = Embedder('multimodalembedding', client_mock)
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
     with pytest.raises(ValueError, match='http'):
         await embedder.generate(request)
     client_mock._api_client.async_request.assert_not_called()
@@ -305,7 +306,126 @@ async def test_multimodal_embedding_rejects_multiple_documents(mocker: MockerFix
         ]
     )
     client_mock = mocker.AsyncMock()
-    embedder = Embedder('multimodalembedding', client_mock)
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
     with pytest.raises(ValueError, match='one document per request'):
         await embedder.generate(request)
     client_mock._api_client.async_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_rejects_non_vertex_client(mocker: MockerFixture) -> None:
+    """Multimodal embedding is Vertex-only; a Gemini API embedder fails fast, before any request."""
+    request = EmbedRequest(input=[Document.from_media('gs://bucket/cat.png', 'image/png')])
+    client_mock = mocker.AsyncMock()
+    embedder = Embedder('multimodalembedding@001', client_mock, is_vertex=False)
+    with pytest.raises(ValueError, match='only available on Vertex AI'):
+        await embedder.generate(request)
+    client_mock._api_client.async_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_inlines_base64_data_url(mocker: MockerFixture) -> None:
+    """A base64 data: URL is inlined as bytesBase64Encoded, without the data: prefix."""
+    request = EmbedRequest(input=[Document.from_media('data:image/png;base64,AAAA', 'image/png')])
+    predict_body = {'predictions': [{'imageEmbedding': [0.1, 0.2]}]}
+    client_mock = mocker.AsyncMock()
+    http_response = mocker.Mock()
+    http_response.body = json.dumps(predict_body)
+    client_mock._api_client.async_request.return_value = http_response
+
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
+    await embedder.generate(request)
+
+    call = client_mock._api_client.async_request.call_args
+    instances = call.kwargs['request_dict']['instances']
+    assert instances[0] == {'image': {'bytesBase64Encoded': 'AAAA', 'mimeType': 'image/png'}}
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_rejects_non_base64_data_url(mocker: MockerFixture) -> None:
+    """A data: URL without a ';base64,' marker is rejected; Vertex requires base64 bytes."""
+    request = EmbedRequest(input=[Document.from_media('data:image/png,rawbytes', 'image/png')])
+    client_mock = mocker.AsyncMock()
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
+    with pytest.raises(ValueError, match='base64'):
+        await embedder.generate(request)
+    client_mock._api_client.async_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_maps_output_dimensionality(mocker: MockerFixture) -> None:
+    """The output_dimensionality option maps to the :predict parameters.dimension field."""
+    request = EmbedRequest(
+        input=[Document.from_media('gs://bucket/cat.png', 'image/png')],
+        options={'output_dimensionality': 512},
+    )
+    predict_body = {'predictions': [{'imageEmbedding': [0.1, 0.2]}]}
+    client_mock = mocker.AsyncMock()
+    http_response = mocker.Mock()
+    http_response.body = json.dumps(predict_body)
+    client_mock._api_client.async_request.return_value = http_response
+
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
+    await embedder.generate(request)
+
+    call = client_mock._api_client.async_request.call_args
+    assert call.kwargs['request_dict']['parameters'] == {'dimension': 512}
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_omits_parameters_without_dimension(mocker: MockerFixture) -> None:
+    """Options without output_dimensionality do not produce a parameters field."""
+    request = EmbedRequest(
+        input=[Document.from_media('gs://bucket/cat.png', 'image/png')],
+        options={'task_type': 'RETRIEVAL_QUERY'},
+    )
+    predict_body = {'predictions': [{'imageEmbedding': [0.1, 0.2]}]}
+    client_mock = mocker.AsyncMock()
+    http_response = mocker.Mock()
+    http_response.body = json.dumps(predict_body)
+    client_mock._api_client.async_request.return_value = http_response
+
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
+    await embedder.generate(request)
+
+    call = client_mock._api_client.async_request.call_args
+    assert 'parameters' not in call.kwargs['request_dict']
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_maps_video_segment_config(mocker: MockerFixture) -> None:
+    """Document metadata video_segment_config is forwarded as the instance videoSegmentConfig."""
+    segment_config = {'startOffsetSec': 0, 'endOffsetSec': 10, 'intervalSec': 5}
+    request = EmbedRequest(
+        input=[
+            Document(
+                content=Document.from_media('gs://bucket/clip.mp4', 'video/mp4').content,
+                metadata={'video_segment_config': segment_config},
+            )
+        ]
+    )
+    predict_body = {
+        'predictions': [{'videoEmbeddings': [{'startOffsetSec': 0, 'endOffsetSec': 5, 'embedding': [0.3, 0.4]}]}]
+    }
+    client_mock = mocker.AsyncMock()
+    http_response = mocker.Mock()
+    http_response.body = json.dumps(predict_body)
+    client_mock._api_client.async_request.return_value = http_response
+
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
+    await embedder.generate(request)
+
+    call = client_mock._api_client.async_request.call_args
+    instances = call.kwargs['request_dict']['instances']
+    assert instances[0] == {'video': {'gcsUri': 'gs://bucket/clip.mp4', 'videoSegmentConfig': segment_config}}
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_guards_missing_private_transport(mocker: MockerFixture) -> None:
+    """A client missing the private _api_client transport fails with an actionable error."""
+    request = EmbedRequest(input=[Document.from_media('gs://bucket/cat.png', 'image/png')])
+    client_mock = mocker.Mock(spec=[])  # no _api_client attribute at all
+
+    embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
+    with pytest.raises(RuntimeError, match='google-genai>=1.63.0'):
+        await embedder.generate(request)

--- a/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
@@ -143,19 +143,9 @@ def test_get_embedder_options_multimodalembedding_versioned_and_bare(model_name:
 
 @pytest.mark.asyncio
 async def test_multimodal_embedding_uses_predict(mocker: MockerFixture) -> None:
-    """Multimodal embedders hit the :predict endpoint and map image/video results."""
-    request = EmbedRequest(
-        input=[
-            Document.from_media('gs://bucket/cat.png', 'image/png'),
-            Document.from_media('gs://bucket/clip.mp4', 'video/mp4'),
-        ]
-    )
-    predict_body = {
-        'predictions': [
-            {'imageEmbedding': [0.1, 0.2, 0.3]},
-            {'videoEmbeddings': [{'startOffsetSec': 0, 'endOffsetSec': 5, 'embedding': [0.4, 0.5]}]},
-        ]
-    }
+    """A multimodal embed routes through :predict, not the text embed_content path."""
+    request = EmbedRequest(input=[Document.from_media('gs://bucket/cat.png', 'image/png')])
+    predict_body = {'predictions': [{'imageEmbedding': [0.1, 0.2, 0.3]}]}
     client_mock = mocker.AsyncMock()
     http_response = mocker.Mock()
     http_response.body = json.dumps(predict_body)
@@ -171,17 +161,12 @@ async def test_multimodal_embedding_uses_predict(mocker: MockerFixture) -> None:
     assert call.kwargs['http_method'] == 'post'
     assert call.kwargs['path'] == 'publishers/google/models/multimodalembedding:predict'
     instances = call.kwargs['request_dict']['instances']
-    assert instances[0] == {'image': {'gcsUri': 'gs://bucket/cat.png', 'mimeType': 'image/png'}}
-    assert instances[1] == {'video': {'gcsUri': 'gs://bucket/clip.mp4'}}
+    assert instances == [{'image': {'gcsUri': 'gs://bucket/cat.png', 'mimeType': 'image/png'}}]
 
     assert isinstance(response, EmbedResponse)
-    assert len(response.embeddings) == 2
+    assert len(response.embeddings) == 1
     assert response.embeddings[0].embedding == [0.1, 0.2, 0.3]
     assert response.embeddings[0].metadata == {'embedType': 'imageEmbedding'}
-    assert response.embeddings[1].embedding == [0.4, 0.5]
-    assert response.embeddings[1].metadata is not None
-    assert response.embeddings[1].metadata['embedType'] == 'videoEmbedding'
-    assert response.embeddings[1].metadata['startOffsetSec'] == 0
 
 
 @pytest.mark.asyncio
@@ -251,6 +236,8 @@ async def test_multimodal_embedding_allows_image_and_video_in_one_instance(mocke
     assert response.embeddings[0].metadata == {'embedType': 'imageEmbedding'}
     assert response.embeddings[1].metadata is not None
     assert response.embeddings[1].metadata['embedType'] == 'videoEmbedding'
+    # Video chunk offsets are preserved in the embedding metadata.
+    assert response.embeddings[1].metadata['startOffsetSec'] == 0
 
 
 @pytest.mark.asyncio
@@ -300,5 +287,25 @@ async def test_multimodal_embedding_rejects_http_url(mocker: MockerFixture) -> N
     client_mock = mocker.AsyncMock()
     embedder = Embedder('multimodalembedding', client_mock)
     with pytest.raises(ValueError, match='http'):
+        await embedder.generate(request)
+    client_mock._api_client.async_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multimodal_embedding_rejects_multiple_documents(mocker: MockerFixture) -> None:
+    """multimodalembedding@001 accepts one instance per request, so >1 document is rejected.
+
+    Batching (e.g. embed_many) would otherwise send a multi-instance payload that
+    Vertex rejects with an opaque error; fail fast until batching is implemented.
+    """
+    request = EmbedRequest(
+        input=[
+            Document.from_media('gs://bucket/a.png', 'image/png'),
+            Document.from_media('gs://bucket/b.png', 'image/png'),
+        ]
+    )
+    client_mock = mocker.AsyncMock()
+    embedder = Embedder('multimodalembedding', client_mock)
+    with pytest.raises(ValueError, match='one document per request'):
         await embedder.generate(request)
     client_mock._api_client.async_request.assert_not_called()

--- a/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
@@ -135,10 +135,21 @@ def test_get_embedder_options_multimodal_and_fallback() -> None:
 @pytest.mark.parametrize('model_name', ['multimodalembedding', 'multimodalembedding@001'])
 def test_get_embedder_options_multimodalembedding_versioned_and_bare(model_name: str) -> None:
     """The multimodalembedding model is multimodal with or without the '@001' suffix."""
-    options = get_embedder_options(model_name, f'Vertex AI - {model_name}')
+    options = get_embedder_options(model_name, f'Vertex AI - {model_name}', is_vertex=True)
     assert options.dimensions == 1408
     assert options.supports is not None
     assert options.supports.input == ['text', 'image', 'video']
+
+
+def test_get_embedder_options_scopes_supports_per_backend() -> None:
+    """Each backend advertises only its own multimodal models, defaulting to text."""
+    on_vertex = get_embedder_options('gemini-embedding-2', 'Vertex AI - gemini-embedding-2', is_vertex=True)
+    assert on_vertex.supports is not None
+    assert on_vertex.supports.input == ['text']
+
+    on_googleai = get_embedder_options('multimodalembedding@001', 'Google AI - multimodalembedding@001')
+    assert on_googleai.supports is not None
+    assert on_googleai.supports.input == ['text']
 
 
 @pytest.mark.asyncio

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -36,6 +36,7 @@ members = [
     "google-genai-media",
     "middleware",
     "middleware-coding-agent",
+    "ollama-sample",
     "output-formats",
     "prompts",
     "tool-interrupts",
@@ -1780,7 +1781,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
-    { name = "ollama", specifier = "~=0.4" },
+    { name = "ollama", specifier = ">=0.5.3,<1.0" },
     { name = "structlog", specifier = ">=25.2.0" },
 ]
 
@@ -4332,6 +4333,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/5a/652dac4b7affc2b37b95386f8ae78f22808af09d720689e3d7a86b6ed98e/ollama-0.6.1.tar.gz", hash = "sha256:478c67546836430034b415ed64fa890fd3d1ff91781a9d548b3325274e69d7c6", size = 51620, upload-time = "2025-11-13T23:02:17.416Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/4f/4a617ee93d8208d2bcf26b2d8b9402ceaed03e3853c754940e2290fed063/ollama-0.6.1-py3-none-any.whl", hash = "sha256:fc4c984b345735c5486faeee67d8a265214a31cbb828167782dc642ce0a2bf8c", size = 14354, upload-time = "2025-11-13T23:02:16.292Z" },
+]
+
+[[package]]
+name = "ollama-sample"
+version = "0.1.0"
+source = { editable = "samples/ollama-sample" }
+dependencies = [
+    { name = "genkit" },
+    { name = "genkit-ollama" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-ollama", editable = "packages/genkit-ollama" },
+    { name = "pydantic", specifier = ">=2.0.0" },
 ]
 
 [[package]]

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1734,7 +1734,7 @@ dependencies = [
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
     { name = "google-cloud-aiplatform", specifier = ">=1.77.0" },
-    { name = "google-genai", specifier = ">=1.7.0" },
+    { name = "google-genai", specifier = ">=1.63.0" },
     { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
     { name = "structlog", specifier = ">=25.2.0" },
 ]


### PR DESCRIPTION
## What

Adds working image and video embedding support for the Vertex AI `multimodalembedding@001` model in the `google-genai` plugin, and registers correct output dimensions for `multimodalembedding@001` and `text-embedding-004`.

## Why

The plugin advertised `multimodalembedding@001` as accepting image and video input but routed every embed request through `embed_content`. On Vertex AI that call drops non-text parts, so image and video requests failed at runtime with `400 INVALID_ARGUMENT "Empty instances."`. The advertised output dimension of 768 is also not valid for this model; the default is 1408.

## How

- Route multimodal embedders through the Vertex `:predict` endpoint instead of `embed_content`. `Embedder.generate()` checks `_is_multimodal()` and dispatches to `_generate_multimodal()`.
- Build `{text, image, video}` prediction instances per document. Image and video references map `gs://` URLs to `gcsUri` and `data:` URLs to `bytesBase64Encoded`; `http(s)` URLs are rejected, since Vertex only accepts `gs://` there. An optional video segment config is read from document metadata.
- Parse `predictions[]` into one `Embedding` per image, text, and video chunk, tagging each with `metadata.embedType` and preserving video chunk offsets.
- Advertise `multimodalembedding@001` from the curated `VERTEX_KNOWN_EMBEDDERS` list rather than model discovery: the Vertex catalog over-lists embedders and returns `supported_actions=None`, so Vertex embedders are curated, not discovered.
- Resolve dimensions and supported inputs by exact name, with a fallback to the version-stripped base name.
- Register output dimensions: `multimodalembedding` 1408 (model default; valid values 128/256/512/1408) and `text-embedding-004` 768.

## Testing

- `uv run --directory py pytest plugins/google-genai/test/google_plugin_test.py plugins/google-genai/test/models/googlegenai_embedder_test.py` (71 passed)
- `uv run --directory py ruff check` and `ruff format --check` on the changed files (clean)

New tests cover the `:predict` request path and image/video result mapping, curated-list registration of `multimodalembedding@001`, and dimension and input metadata for bare and versioned model names.

## Limitations

- `multimodalembedding@001` accepts a single instance per `:predict` call, so requests with more than one document are rejected with a clear error until batching is implemented. Single document embeds work.
- The advertised dimension (1408) differs from the JS plugin, which still advertises 768. 

## Screenshots
<img width="407" height="460" alt="Screenshot 2026-07-06 at 16 47 43" src="https://github.com/user-attachments/assets/38025faf-61fd-4487-97fe-972891d84026" />
<img width="989" height="776" alt="Screenshot 2026-06-29 at 16 46 56" src="https://github.com/user-attachments/assets/cf554526-6805-4cf7-882d-8ec4e76af676" />
<img width="994" height="716" alt="Screenshot 2026-06-29 at 16 50 55" src="https://github.com/user-attachments/assets/174442b3-d3af-4db2-95d6-b2b268e294ba" />
<img width="990" height="447" alt="Screenshot 2026-06-29 at 16 53 24" src="https://github.com/user-attachments/assets/e0b2b086-0f3c-4ec2-b311-2def7ac663b7" />
