### PR TITLE
feat(py/ollama): model config schema, request options, and reasoning

### DIFF
--- a/py/plugins/ollama/pyproject.toml
+++ b/py/plugins/ollama/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
   "Typing :: Typed",
   "License :: OSI Approved :: Apache Software License",
 ]
-dependencies = ["genkit", "ollama~=0.4", "structlog>=25.2.0"]
+dependencies = ["genkit", "ollama>=0.5.3,<1.0", "structlog>=25.2.0"]
 description = "Genkit Ollama Plugin (Community)"
 keywords = [
   "genkit",

--- a/py/plugins/ollama/src/genkit/plugins/ollama/__init__.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/__init__.py
@@ -155,6 +155,7 @@ See Also:
     - Genkit documentation: https://genkit.dev/
 """
 
+from genkit.plugins.ollama.models import ModelDefinition, OllamaConfig, OllamaSupports
 from genkit.plugins.ollama.plugin_api import Ollama, ollama_name
 
 
@@ -168,7 +169,10 @@ def package_name() -> str:
 
 
 __all__ = [
+    'ModelDefinition',
     'Ollama',
+    'OllamaConfig',
+    'OllamaSupports',
     'ollama_name',
     'package_name',
 ]

--- a/py/plugins/ollama/src/genkit/plugins/ollama/models.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/models.py
@@ -596,9 +596,9 @@ class OllamaModel:
         ``think`` and ``keep_alive`` are top-level parameters of the Ollama
         ``chat``/``generate`` calls — not sampler ``options``. The framework
         dumps a ``BaseModel`` config to a dict before the model fn sees it, so
-        this reads them from either an :class:`OllamaConfig` instance *or* a
-        dumped dict (whose declared keys arrive camelCased, hence the
-        snake-casing) and returns only the values that are set.
+        this reads them from any :class:`ModelConfig` instance *or* a dumped
+        dict. Both paths snake-case the keys (declared fields and ``extra``
+        keys can arrive camelCased) and return only the values that are set.
 
         Args:
             config: The configuration to extract request kwargs from.
@@ -606,9 +606,10 @@ class OllamaModel:
         Returns:
             A dict with ``think``/``keep_alive`` entries that are not ``None``.
         """
-        if isinstance(config, OllamaConfig):
-            think: Any = config.think
-            keep_alive: Any = config.keep_alive
+        if isinstance(config, ModelConfig):
+            snake = {to_snake(k): v for k, v in config.model_dump(exclude_none=True).items()}
+            think: Any = snake.get('think')
+            keep_alive: Any = snake.get('keep_alive')
         elif isinstance(config, dict):
             snake = {to_snake(k): v for k, v in cast(dict[str, Any], config).items()}
             think = snake.get('think')

--- a/py/plugins/ollama/src/genkit/plugins/ollama/models.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/models.py
@@ -83,12 +83,13 @@ behavioral divergence from the JS plugin.
 """
 
 import mimetypes
+import re
 from collections.abc import Callable
 from typing import Any, Literal, cast
 
 import structlog
-from pydantic import BaseModel
-from pydantic.alias_generators import to_snake
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel, to_snake
 
 import ollama as ollama_api
 from genkit import (
@@ -101,6 +102,7 @@ from genkit import (
     ModelResponseChunk,
     ModelUsage,
     Part,
+    ReasoningPart,
     Role,
     TextPart,
     ToolRequest,
@@ -115,11 +117,57 @@ from genkit.plugins.ollama.constants import (
 
 logger = structlog.get_logger(__name__)
 
+# Matches <think>/<thinking> blocks case-insensitively (``i``) across newlines
+# (``s``), non-greedy (``.*?``) so multiple blocks in one response are captured
+# individually. Mirrors the Go plugin's ``thinkingRegex``.
+_THINKING_RE = re.compile(r'(?is)<(?:think|thinking)>(.*?)</(?:think|thinking)>')
+
+
+def _parse_thinking(content: str) -> tuple[str, str]:
+    """Split inline ``<think>``/``<thinking>`` blocks out of model content.
+
+    Mirrors the Go plugin's ``parseThinking``: returns the joined reasoning text
+    and the remaining content with the thinking blocks removed (both stripped).
+
+    Args:
+        content: The raw model content possibly containing thinking tags.
+
+    Returns:
+        A ``(reasoning, rest)`` tuple. ``reasoning`` is empty when no tags match,
+        in which case ``rest`` is the original content unchanged.
+    """
+    blocks = _THINKING_RE.findall(content)
+    if not blocks:
+        return '', content
+    reasoning = '\n\n'.join(block.strip() for block in blocks)
+    rest = _THINKING_RE.sub('', content).strip()
+    return reasoning, rest
+
+
+class OllamaConfig(ModelConfig):
+    """Configuration schema for Ollama models.
+
+    Extends the shared :class:`ModelConfig` with Ollama-specific sampler
+    knobs and the ``think`` chain-of-thought control. Unknown keys are
+    accepted (``extra='allow'``) and forwarded to the Ollama server's
+    ``options`` so newer sampler parameters work without an SDK bump.
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, extra='allow', populate_by_name=True)
+
+    think: bool | Literal['low', 'medium', 'high'] | None = None
+    keep_alive: float | str | None = None
+    num_ctx: int | None = None
+    min_p: float | None = None
+    seed: int | None = None
+    num_predict: int | None = None
+
 
 class OllamaSupports(BaseModel):
     """Supports for Ollama models."""
 
     tools: bool = True
+    media: bool = False
 
 
 class ModelDefinition(BaseModel):
@@ -195,6 +243,7 @@ class OllamaModel:
                 )
                 content = self._build_multimodal_chat_response(
                     chat_response=api_response,
+                    thinking_enabled=self._thinking_requested(request.config),
                 )
         elif self.model_definition.api_type == OllamaAPITypes.GENERATE:
             api_response = await self._generate_ollama_response(request=request, ctx=ctx)
@@ -204,7 +253,10 @@ class OllamaModel:
                     model=self.model_definition.name,
                     response=str(api_response.response)[:500],
                 )
-                content = [Part(root=TextPart(text=api_response.response))]
+                content = self._build_generate_response(
+                    generate_response=api_response,
+                    thinking_enabled=self._thinking_requested(request.config),
+                )
         else:
             raise ValueError(f'Unresolved API type: {self.model_definition.api_type}')
 
@@ -270,6 +322,7 @@ class OllamaModel:
             for tool in request.tools or []
         ]
         options = self.build_request_options(config=request.config)
+        extra_kwargs = self.build_request_kwargs(config=request.config)
 
         if streaming_request:
             # Streaming call with literal stream=True for proper overload resolution
@@ -280,11 +333,12 @@ class OllamaModel:
                 options=options,
                 format=fmt,
                 stream=True,
+                **extra_kwargs,
             )
             idx = 0
             async for chunk in chat_response:
                 idx += 1
-                role = Role.TOOL if chunk.message.role == 'tool' else Role.MODEL
+                role = self._from_ollama_role(chunk.message.role)
                 if ctx:
                     ctx.send_chunk(
                         chunk=ModelResponseChunk(
@@ -306,6 +360,7 @@ class OllamaModel:
                 options=options,
                 format=fmt,
                 stream=False,
+                **extra_kwargs,
             )
             return chat_response
 
@@ -324,6 +379,7 @@ class OllamaModel:
         prompt = self.build_prompt(request)
         streaming_request = self.is_streaming_request(ctx=ctx)
         options = self.build_request_options(config=request.config)
+        extra_kwargs = self.build_request_kwargs(config=request.config)
 
         if streaming_request:
             # Streaming call with literal stream=True for proper overload resolution
@@ -332,6 +388,7 @@ class OllamaModel:
                 prompt=prompt,
                 options=options,
                 stream=True,
+                **extra_kwargs,
             )
             idx = 0
             async for chunk in generate_response:
@@ -341,7 +398,7 @@ class OllamaModel:
                         chunk=ModelResponseChunk(
                             role=Role.MODEL,
                             index=idx,
-                            content=[Part(root=TextPart(text=chunk.response))],
+                            content=self._build_generate_response(generate_response=chunk),
                         )
                     )
             # For streaming requests, we return None because the response chunks
@@ -355,25 +412,46 @@ class OllamaModel:
                 prompt=prompt,
                 options=options,
                 stream=False,
+                **extra_kwargs,
             )
             return generate_response
 
     @staticmethod
     def _build_multimodal_chat_response(
         chat_response: ollama_api.ChatResponse,
+        thinking_enabled: bool = False,
     ) -> list[Part]:
         """Build the multimodal chat response.
 
         Args:
             chat_response: The chat response to build the multimodal response for.
+            thinking_enabled: Whether the request explicitly enabled thinking. When
+                the model returns no dedicated ``thinking`` field, this allows the
+                ``<think>``/``<thinking>`` content fallback to run (matching the Go
+                plugin). It is only applied to complete (non-streaming) responses,
+                never to partial streamed chunks where a tag may be split.
 
         Returns:
             The multimodal chat response.
         """
         content = []
         chat_response_message = chat_response.message
-        if chat_response_message.content:
-            content.append(Part(root=TextPart(text=chat_response.message.content or '')))
+        text = chat_response_message.content or ''
+        # ``think`` chain-of-thought arrives on ``message.thinking``; surface it
+        # as a leading ReasoningPart so the Dev UI renders it separately from
+        # the answer text. Covers both streaming deltas and the final message.
+        thinking = getattr(chat_response_message, 'thinking', None)
+        if thinking:
+            content.append(Part(root=ReasoningPart(reasoning=thinking)))
+        elif thinking_enabled and text:
+            # Fallback for models that inline <think>…</think> in content instead
+            # of populating the dedicated field. Gated on an explicit think request
+            # so ordinary text containing these tags is never hijacked.
+            reasoning, text = _parse_thinking(text)
+            if reasoning:
+                content.append(Part(root=ReasoningPart(reasoning=reasoning)))
+        if text:
+            content.append(Part(root=TextPart(text=text)))
         if chat_response_message.images:
             for image in chat_response_message.images:
                 content.append(
@@ -402,33 +480,172 @@ class OllamaModel:
         return content
 
     @staticmethod
+    def _build_generate_response(
+        generate_response: ollama_api.GenerateResponse,
+        thinking_enabled: bool = False,
+    ) -> list[Part]:
+        """Build the response parts for a ``generate`` endpoint response.
+
+        Mirrors :meth:`_build_multimodal_chat_response` for the ``generate`` API,
+        which returns plain text (no media/tool calls): ``think`` reasoning is
+        surfaced as a leading ReasoningPart so the Dev UI renders it separately
+        from the answer text.
+
+        Args:
+            generate_response: A complete generate response or a streamed chunk.
+            thinking_enabled: Whether the request explicitly enabled thinking. When
+                the model returns no dedicated ``thinking`` field, this allows the
+                ``<think>``/``<thinking>`` content fallback to run (matching the Go
+                plugin). It is only applied to complete (non-streaming) responses,
+                never to partial streamed chunks where a tag may be split.
+
+        Returns:
+            The reasoning/text parts for the response.
+        """
+        content: list[Part] = []
+        text = generate_response.response or ''
+        thinking = getattr(generate_response, 'thinking', None)
+        if thinking:
+            content.append(Part(root=ReasoningPart(reasoning=thinking)))
+        elif thinking_enabled and text:
+            reasoning, text = _parse_thinking(text)
+            if reasoning:
+                content.append(Part(root=ReasoningPart(reasoning=reasoning)))
+        if text:
+            content.append(Part(root=TextPart(text=text)))
+        return content
+
+    @staticmethod
     def build_request_options(
         config: ModelConfig | ollama_api.Options | dict[str, object] | None,
-    ) -> ollama_api.Options:
-        """Build request options for the generate API.
+    ) -> dict[str, Any]:
+        """Build the sampler ``options`` mapping for the chat/generate APIs.
+
+        Accepts an :class:`OllamaConfig`/:class:`ModelConfig` instance, a raw
+        ``Options``, or a plain dict (e.g. a config already dumped to JSON by
+        the framework — see :meth:`build_request_kwargs`). All inputs are
+        normalised to snake-cased Ollama option fields:
+
+        - ``think``/``keep_alive`` are stripped — they are top-level request
+          kwargs, not sampler options (Ollama rejects them inside ``options``).
+        - Genkit's ``max_output_tokens`` maps to Ollama's ``num_predict``; an
+          explicit ``num_predict`` wins when both are present.
+        - ``stop_sequences`` maps to ``stop``; ``version``/``api_key`` (genkit
+          bookkeeping) are dropped.
+        - ``OllamaConfig`` extras (e.g. ``repeatPenalty``) are forwarded
+          snake-cased so newer sampler knobs pass through untouched.
+
+        Known knobs are routed through ``ollama_api.Options`` purely for type
+        coercion (genkit types ``max_output_tokens``/``top_k`` as floats, but
+        Ollama's ``num_predict``/``top_k`` are integers). The result is then
+        returned as a plain mapping — *not* an ``Options`` — and any knob the
+        installed ``Options`` model doesn't yet field (e.g. ``min_p``) is merged
+        back in, so newer sampler parameters still reach the server.
 
         Args:
             config: The configuration to build the request options for.
 
         Returns:
-            The request options for the generate API.
+            A mapping of snake-cased Ollama sampler options.
         """
         if config is None:
-            return ollama_api.Options()
-        if isinstance(config, ModelConfig):
-            config = dict(
-                top_k=config.top_k,
-                top_p=config.top_p,
-                stop=config.stop_sequences,
-                temperature=config.temperature,
-                num_predict=config.max_output_tokens,
-            )
-        if isinstance(config, dict):
-            # Snake-case keys so camelCase knobs (e.g. ``topP``) map to the
-            # server field instead of being silently dropped by Options.
-            config = ollama_api.Options(**{to_snake(k): v for k, v in cast(dict[str, Any], config).items()})
+            return {}
+        if isinstance(config, ollama_api.Options):
+            return config.model_dump(exclude_none=True)
 
-        return config
+        if isinstance(config, ModelConfig):
+            # Covers OllamaConfig (a ModelConfig subclass) and plain ModelConfig.
+            # model_dump defaults to by_alias=False, so declared fields come out
+            # snake_cased; only extras keep the key they were supplied with.
+            # to_snake below normalises both.
+            raw: dict[str, Any] = config.model_dump(exclude_none=True)
+        else:
+            raw = {k: v for k, v in cast(dict[str, Any], config).items() if v is not None}
+
+        # Snake-case so camelCase knobs (e.g. ``topP``) hit the server field
+        # instead of being silently dropped.
+        knobs = {to_snake(k): v for k, v in raw.items()}
+
+        # Top-level request kwargs, not sampler options.
+        knobs.pop('think', None)
+        knobs.pop('keep_alive', None)
+        # Genkit bookkeeping that Ollama does not understand.
+        knobs.pop('version', None)
+        knobs.pop('api_key', None)
+
+        if 'stop_sequences' in knobs:
+            knobs['stop'] = knobs.pop('stop_sequences')
+
+        max_tokens = knobs.pop('max_output_tokens', None)
+        if max_tokens is not None and knobs.get('num_predict') is None:
+            knobs['num_predict'] = max_tokens
+
+        # Coerce the knobs Options models (int num_predict/top_k, etc.), then
+        # merge back any it drops (e.g. min_p) so they still reach the server.
+        options: dict[str, Any] = ollama_api.Options(**knobs).model_dump(exclude_none=True)
+        for key, value in knobs.items():
+            options.setdefault(key, value)
+        return options
+
+    @staticmethod
+    def build_request_kwargs(
+        config: ModelConfig | ollama_api.Options | dict[str, object] | None,
+    ) -> dict[str, Any]:
+        """Extract top-level chat/generate kwargs from the config.
+
+        ``think`` and ``keep_alive`` are top-level parameters of the Ollama
+        ``chat``/``generate`` calls — not sampler ``options``. The framework
+        dumps a ``BaseModel`` config to a dict before the model fn sees it, so
+        this reads them from either an :class:`OllamaConfig` instance *or* a
+        dumped dict (whose declared keys arrive camelCased, hence the
+        snake-casing) and returns only the values that are set.
+
+        Args:
+            config: The configuration to extract request kwargs from.
+
+        Returns:
+            A dict with ``think``/``keep_alive`` entries that are not ``None``.
+        """
+        if isinstance(config, OllamaConfig):
+            think: Any = config.think
+            keep_alive: Any = config.keep_alive
+        elif isinstance(config, dict):
+            snake = {to_snake(k): v for k, v in cast(dict[str, Any], config).items()}
+            think = snake.get('think')
+            keep_alive = snake.get('keep_alive')
+        else:
+            return {}
+
+        kwargs: dict[str, Any] = {}
+        if think is not None:
+            kwargs['think'] = think
+        if keep_alive is not None:
+            kwargs['keep_alive'] = keep_alive
+        return kwargs
+
+    @staticmethod
+    def _thinking_requested(
+        config: ModelConfig | ollama_api.Options | dict[str, object] | None,
+    ) -> bool:
+        """Whether the request explicitly enabled thinking.
+
+        Mirrors the Go plugin's ``ThinkOption.IsEnabled``: a boolean ``think`` is
+        taken as-is, a non-empty effort string (``low``/``medium``/``high``) counts
+        as enabled, and anything else is disabled. Used to gate the ``<think>`` tag
+        content fallback in :meth:`_build_multimodal_chat_response`.
+
+        Args:
+            config: The request configuration.
+
+        Returns:
+            ``True`` when thinking was explicitly requested, ``False`` otherwise.
+        """
+        think = OllamaModel.build_request_kwargs(config).get('think')
+        if isinstance(think, bool):
+            return think
+        if isinstance(think, str):
+            return think != ''
+        return False
 
     @staticmethod
     def build_prompt(request: ModelRequest) -> str:
@@ -532,6 +749,37 @@ class OllamaModel:
 
         # Local file path or raw base64 — pass through to Image.
         return url
+
+    @staticmethod
+    def _from_ollama_role(role: str | None) -> Role:
+        """Map an Ollama message role onto a Genkit :class:`Role`.
+
+        Ollama streams deltas with an empty role and labels the rest as
+        ``assistant``/``tool``/``user``/``system``. Anything unexpected falls
+        back to ``MODEL`` (with a warning) so an unknown role never aborts a
+        stream.
+
+        Args:
+            role: The role string from an Ollama message, possibly empty.
+
+        Returns:
+            The corresponding Genkit role.
+        """
+        match role:
+            case 'assistant':
+                return Role.MODEL
+            case 'tool':
+                return Role.TOOL
+            case 'user':
+                return Role.USER
+            case 'system':
+                return Role.SYSTEM
+            case '' | None:
+                # Ollama commonly sends an empty role on streamed deltas.
+                return Role.MODEL
+            case _:
+                logger.warning('Unknown Ollama role; defaulting to MODEL', role=role)
+                return Role.MODEL
 
     @staticmethod
     def _to_ollama_role(

--- a/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
@@ -21,7 +21,7 @@ from functools import partial
 import structlog
 
 import ollama as ollama_api
-from genkit import ModelConfig
+from genkit import Constrained, ModelInfo, Supports
 from genkit.embedder import EmbedderOptions, EmbedderSupports, embedder_action_metadata
 from genkit.model import model_action_metadata
 from genkit.plugin_api import (
@@ -42,11 +42,20 @@ from genkit.plugins.ollama.embedders import (
 )
 from genkit.plugins.ollama.models import (
     ModelDefinition,
+    OllamaConfig,
     OllamaModel,
+    OllamaSupports,
 )
 
 OLLAMA_PLUGIN_NAME = 'ollama'
 logger = structlog.get_logger(__name__)
+
+# Models that are dynamically discovered (``list_actions``) or resolved on
+# demand can't be capability-probed, so we advertise the full generic
+# capability set. This mirrors the JS plugin's ``GENERIC_MODEL_INFO`` and the
+# Go plugin's ``defaultOllamaSupports``, which both enable every capability for
+# models that weren't explicitly pre-configured.
+_DYNAMIC_MODEL_SUPPORTS = OllamaSupports(tools=True, media=True)
 
 
 def ollama_name(name: str) -> str:
@@ -59,6 +68,37 @@ def ollama_name(name: str) -> str:
         The name of the Ollama model.
     """
     return f'{OLLAMA_PLUGIN_NAME}/{name}'
+
+
+def ollama_model_info(model_ref: ModelDefinition, label: str) -> dict[str, object]:
+    """Build Dev UI capability metadata for an Ollama model.
+
+    Capabilities are gated on the model's API type so the Dev UI advertises
+    only what the endpoint actually supports: the ``chat`` endpoint is
+    multiturn and can use tools/media, whereas the ``generate`` endpoint is
+    single-turn text-in/text-out.
+
+    Args:
+        model_ref: The model definition describing its API type and supports.
+        label: The human-readable label to show in the Dev UI.
+
+    Returns:
+        The serialized :class:`ModelInfo` metadata (camelCase aliases, no
+        ``None`` values) ready to embed under ``metadata['model']``.
+    """
+    is_chat = model_ref.api_type == OllamaAPITypes.CHAT
+    return ModelInfo(
+        label=label,
+        supports=Supports(
+            multiturn=is_chat,
+            media=is_chat and model_ref.supports.media,
+            tools=is_chat and model_ref.supports.tools,
+            system_role=True,
+            # Deliberate JS/Go deviation. we match other Python plugins for Dev UI consistency.
+            output=['text', 'json'],
+            constrained=Constrained.ALL,
+        ),
+    ).model_dump(by_alias=True, exclude_none=True)
 
 
 class Ollama(Plugin):
@@ -154,31 +194,35 @@ class Ollama(Plugin):
                 model_ref = model_def
                 break
 
-        # If not found in pre-configured models, create a default one
+        # If not found in pre-configured models, create a generic one. Dynamically
+        # resolved models advertise the full capability set (see JS/Go parity note
+        # on _DYNAMIC_MODEL_SUPPORTS).
         if model_ref is None:
-            model_ref = ModelDefinition(name=clean_name)
+            model_ref = ModelDefinition(name=clean_name, supports=_DYNAMIC_MODEL_SUPPORTS)
 
         model = OllamaModel(
             client=self.client,
             model_definition=model_ref,
         )
 
-        return Action(
+        action_metadata = model_action_metadata(
+            name=name,
+            config_schema=OllamaConfig,
+            info=ollama_model_info(model_ref, f'Ollama - {clean_name}'),
+        )
+
+        action = Action(
             kind=ActionKind.MODEL,
             name=name,
             fn=model.generate,
-            metadata={
-                'model': {
-                    'label': f'Ollama - {clean_name}',
-                    'multiturn': model_ref.api_type == OllamaAPITypes.CHAT,
-                    'system_role': True,
-                    'tools': model_ref.supports.tools,
-                    'output': ['text', 'json'],
-                    'constrained': 'all',
-                    'customOptions': to_json_schema(ModelConfig),
-                },
-            },
+            metadata=action_metadata.metadata,
         )
+
+        # Explicitly set schemas (always present in the action metadata).
+        action.input_schema = action_metadata.input_json_schema  # type: ignore[invalid-assignment]
+        action.output_schema = action_metadata.output_json_schema  # type: ignore[invalid-assignment]
+
+        return action
 
     def _create_embedder_action(self, name: str) -> Action:
         """Create an Action object for an Ollama embedder.
@@ -245,15 +289,11 @@ class Ollama(Plugin):
                 actions.append(
                     model_action_metadata(
                         name=ollama_name(name),
-                        config_schema=ModelConfig,
-                        info={
-                            'label': f'Ollama - {name}',
-                            'multiturn': True,
-                            'system_role': True,
-                            'tools': True,
-                            'output': ['text', 'json'],
-                            'constrained': 'all',
-                        },
+                        config_schema=OllamaConfig,
+                        info=ollama_model_info(
+                            ModelDefinition(name=name, supports=_DYNAMIC_MODEL_SUPPORTS),
+                            f'Ollama - {name}',
+                        ),
                     )
                 )
         return actions

--- a/py/plugins/ollama/tests/models/ollama_models_test.py
+++ b/py/plugins/ollama/tests/models/ollama_models_test.py
@@ -35,12 +35,13 @@ from genkit import (
     ModelResponseChunk,
     ModelUsage,
     Part,
+    ReasoningPart,
     Role,
     TextPart,
     ToolRequestPart,
 )
 from genkit.plugins.ollama.constants import OllamaAPITypes
-from genkit.plugins.ollama.models import ModelDefinition, OllamaModel, _convert_parameters
+from genkit.plugins.ollama.models import ModelDefinition, OllamaConfig, OllamaModel, _convert_parameters
 
 
 class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
@@ -102,7 +103,7 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         cast(AsyncMock, ollama_model._generate_ollama_response).assert_not_awaited()
         cast(MagicMock, self.ctx.send_chunk).assert_not_called()
         cast(MagicMock, ollama_model._build_multimodal_chat_response).assert_called_once_with(
-            chat_response=mock_chat_response
+            chat_response=mock_chat_response, thinking_enabled=False
         )
         cast(MagicMock, ollama_model.is_streaming_request).assert_called_with(ctx=self.ctx)
         cast(MagicMock, ollama_model.get_usage_info).assert_called_once()
@@ -728,22 +729,409 @@ def test_convert_parameters_untyped_property_falls_back_to_none() -> None:
 
 
 class TestBuildRequestOptions:
-    """Tests for OllamaModel.build_request_options."""
+    """Tests for OllamaModel.build_request_options.
 
-    def test_none_returns_empty_options(self) -> None:
-        """None config produces empty Options."""
-        options = OllamaModel.build_request_options(None)
-        assert options.model_dump(exclude_none=True) == {}
+    The method returns a plain mapping (not ``ollama_api.Options``) so that
+    sampler knobs the installed ``Options`` model doesn't field — e.g.
+    ``min_p`` on ollama 0.6.1 — still reach the server.
+    """
+
+    def test_none_returns_empty_mapping(self) -> None:
+        """None config produces an empty options mapping."""
+        assert OllamaModel.build_request_options(None) == {}
+
+    def test_options_input_is_normalised_to_dict(self) -> None:
+        """A raw Options input is returned as a plain mapping."""
+        options = OllamaModel.build_request_options(ollama_api.Options(num_ctx=512))
+        assert options == {'num_ctx': 512}
 
     def test_model_config_top_p(self) -> None:
-        """ModelConfig.top_p maps to the Options.top_p server field."""
+        """ModelConfig.top_p maps to the top_p server field."""
         options = OllamaModel.build_request_options(ModelConfig(top_p=0.9))
-        assert options.top_p == 0.9
+        assert options['top_p'] == 0.9
+
+    def test_model_config_max_output_tokens_maps_to_int_num_predict(self) -> None:
+        """max_output_tokens (float in genkit) maps to an int num_predict."""
+        options = OllamaModel.build_request_options(ModelConfig(max_output_tokens=128))
+        assert options['num_predict'] == 128
+        assert isinstance(options['num_predict'], int)
 
     def test_raw_dict_camel_case_top_p(self) -> None:
-        """A camelCase ``topP`` knob is snake-cased onto Options.top_p."""
+        """A camelCase ``topP`` knob is snake-cased onto top_p."""
         options = OllamaModel.build_request_options({'topP': 0.9})
-        assert options.top_p == 0.9
+        assert options['top_p'] == 0.9
+
+    def test_ollama_config_instance_forwards_knobs(self) -> None:
+        """An OllamaConfig instance forwards Ollama-only sampler knobs."""
+        options = OllamaModel.build_request_options(OllamaConfig(num_ctx=4096, seed=42, temperature=0.5))
+        assert options['num_ctx'] == 4096
+        assert options['seed'] == 42
+        assert options['temperature'] == 0.5
+
+    def test_min_p_is_preserved(self) -> None:
+        """min_p survives even though ollama 0.6.1's Options model drops it."""
+        options = OllamaModel.build_request_options(OllamaConfig(min_p=0.05))
+        assert options['min_p'] == 0.05
+
+    def test_ollama_config_extras_snake_cased(self) -> None:
+        """Unknown OllamaConfig knobs are forwarded snake-cased (instance + camel)."""
+        snake = OllamaModel.build_request_options(OllamaConfig(repeat_penalty=1.1))
+        assert snake['repeat_penalty'] == 1.1
+        camel = OllamaModel.build_request_options(OllamaConfig(repeatPenalty=1.2))
+        assert camel['repeat_penalty'] == 1.2
+
+    def test_num_predict_wins_over_max_output_tokens(self) -> None:
+        """An explicit num_predict beats the inherited max_output_tokens."""
+        options = OllamaModel.build_request_options(OllamaConfig(num_predict=10, max_output_tokens=99))
+        assert options['num_predict'] == 10
+
+    def test_think_and_keep_alive_excluded_from_options(self) -> None:
+        """think/keep_alive are request kwargs, never sampler options."""
+        options = OllamaModel.build_request_options(OllamaConfig(think=True, keep_alive='5m', num_ctx=2048))
+        assert 'think' not in options
+        assert 'keep_alive' not in options
+        assert options['num_ctx'] == 2048
+
+    def test_dumped_dict_path_matches_instance(self) -> None:
+        """A dumped OllamaConfig (dict) yields the same options as the instance."""
+        cfg = OllamaConfig(think=True, keep_alive='5m', num_ctx=4096, temperature=0.5, max_output_tokens=100)
+        dumped = cfg.model_dump(exclude_none=True, mode='json')
+
+        from_dict = OllamaModel.build_request_options(dumped)
+        from_instance = OllamaModel.build_request_options(cfg)
+
+        assert from_dict == from_instance
+        assert from_dict == {'num_ctx': 4096, 'num_predict': 100, 'temperature': 0.5}
+
+
+class TestBuildRequestKwargs:
+    """Tests for OllamaModel.build_request_kwargs."""
+
+    def test_instance_surfaces_think_and_keep_alive(self) -> None:
+        """An OllamaConfig instance surfaces think/keep_alive as top-level kwargs."""
+        kwargs = OllamaModel.build_request_kwargs(OllamaConfig(think=True, keep_alive='5m'))
+        assert kwargs == {'think': True, 'keep_alive': '5m'}
+
+    def test_dumped_dict_surfaces_think_and_keep_alive(self) -> None:
+        """A dumped OllamaConfig (camelCased keys) still surfaces think/keep_alive."""
+        dumped = OllamaConfig(think='low', keep_alive='10m').model_dump(exclude_none=True, mode='json')
+        # The dumped dict carries the camelCase alias for keep_alive.
+        assert 'keepAlive' in dumped
+        kwargs = OllamaModel.build_request_kwargs(dumped)
+        assert kwargs == {'think': 'low', 'keep_alive': '10m'}
+
+    def test_absent_knobs_yield_empty_kwargs(self) -> None:
+        """Configs without think/keep_alive produce no extra kwargs."""
+        assert OllamaModel.build_request_kwargs(OllamaConfig(num_ctx=2048)) == {}
+        assert OllamaModel.build_request_kwargs(None) == {}
+        assert OllamaModel.build_request_kwargs(ModelConfig(top_p=0.9)) == {}
+
+
+class TestFromOllamaRole:
+    """Tests for OllamaModel._from_ollama_role."""
+
+    def test_known_roles(self) -> None:
+        """Each known Ollama role maps to its Genkit counterpart."""
+        assert OllamaModel._from_ollama_role('assistant') == Role.MODEL
+        assert OllamaModel._from_ollama_role('tool') == Role.TOOL
+        assert OllamaModel._from_ollama_role('user') == Role.USER
+        assert OllamaModel._from_ollama_role('system') == Role.SYSTEM
+
+    def test_empty_role_defaults_to_model(self) -> None:
+        """An empty/None role (common on streamed deltas) defaults to MODEL."""
+        assert OllamaModel._from_ollama_role('') == Role.MODEL
+        assert OllamaModel._from_ollama_role(None) == Role.MODEL
+
+    def test_unknown_role_warns_and_defaults_to_model(self) -> None:
+        """An unrecognized role warns and falls back to MODEL."""
+        with patch('genkit.plugins.ollama.models.logger') as mock_logger:
+            assert OllamaModel._from_ollama_role('wizard') == Role.MODEL
+            cast(MagicMock, mock_logger.warning).assert_called_once()
+
+
+class TestReasoning:
+    """Tests for surfacing message.thinking as a leading ReasoningPart."""
+
+    def test_thinking_yields_leading_reasoning_part(self) -> None:
+        """A message with ``thinking`` prepends a ReasoningPart before text."""
+        response = ollama_api.ChatResponse(
+            message=ollama_api.Message(role='assistant', content='The answer is 4.', thinking='2+2 is 4'),
+        )
+        content = OllamaModel._build_multimodal_chat_response(chat_response=response)
+
+        assert isinstance(content[0].root, ReasoningPart)
+        assert content[0].root.reasoning == '2+2 is 4'
+        assert isinstance(content[1].root, TextPart)
+        assert content[1].root.text == 'The answer is 4.'
+
+    def test_no_thinking_has_no_reasoning_part(self) -> None:
+        """Without ``thinking`` no ReasoningPart is emitted."""
+        response = ollama_api.ChatResponse(
+            message=ollama_api.Message(role='assistant', content='Hi'),
+        )
+        content = OllamaModel._build_multimodal_chat_response(chat_response=response)
+
+        assert all(not isinstance(part.root, ReasoningPart) for part in content)
+
+    def test_think_tag_fallback_extracts_reasoning(self) -> None:
+        """With thinking requested and no dedicated field, inline <think> tags are
+        surfaced as reasoning and stripped from the text (Go parseThinking parity)."""
+        response = ollama_api.ChatResponse(
+            message=ollama_api.Message(role='assistant', content='<think>2+2 is 4</think>The answer is 4.'),
+        )
+        content = OllamaModel._build_multimodal_chat_response(chat_response=response, thinking_enabled=True)
+
+        assert isinstance(content[0].root, ReasoningPart)
+        assert content[0].root.reasoning == '2+2 is 4'
+        assert isinstance(content[1].root, TextPart)
+        assert content[1].root.text == 'The answer is 4.'
+
+    def test_think_tag_not_parsed_when_thinking_disabled(self) -> None:
+        """Without an explicit think request, <think> tags stay verbatim in the text."""
+        response = ollama_api.ChatResponse(
+            message=ollama_api.Message(role='assistant', content='<think>hidden</think>visible'),
+        )
+        content = OllamaModel._build_multimodal_chat_response(chat_response=response, thinking_enabled=False)
+
+        assert all(not isinstance(part.root, ReasoningPart) for part in content)
+        assert content[0].root.text == '<think>hidden</think>visible'
+
+    def test_dedicated_thinking_field_wins_over_tags(self) -> None:
+        """The dedicated thinking field takes precedence; content tags are left intact."""
+        response = ollama_api.ChatResponse(
+            message=ollama_api.Message(role='assistant', content='<think>inline</think>answer', thinking='structured'),
+        )
+        content = OllamaModel._build_multimodal_chat_response(chat_response=response, thinking_enabled=True)
+
+        assert isinstance(content[0].root, ReasoningPart)
+        assert content[0].root.reasoning == 'structured'
+        # The content tags are not double-processed when the dedicated field exists.
+        assert content[1].root.text == '<think>inline</think>answer'
+
+    def test_multiple_think_blocks_joined_and_stripped(self) -> None:
+        """Multiple <think>/<thinking> blocks are joined with blank lines and removed."""
+        response = ollama_api.ChatResponse(
+            message=ollama_api.Message(
+                role='assistant',
+                content='<think>first</think>mid<thinking>second</thinking>end',
+            ),
+        )
+        content = OllamaModel._build_multimodal_chat_response(chat_response=response, thinking_enabled=True)
+
+        assert content[0].root.reasoning == 'first\n\nsecond'
+        assert content[1].root.text == 'midend'
+
+    def test_think_only_content_yields_no_text_part(self) -> None:
+        """Content that is entirely a think block produces reasoning but no text."""
+        response = ollama_api.ChatResponse(
+            message=ollama_api.Message(role='assistant', content='<think>just reasoning</think>'),
+        )
+        content = OllamaModel._build_multimodal_chat_response(chat_response=response, thinking_enabled=True)
+
+        assert len(content) == 1
+        assert isinstance(content[0].root, ReasoningPart)
+        assert content[0].root.reasoning == 'just reasoning'
+
+
+class TestReasoningStreaming(unittest.IsolatedAsyncioTestCase):
+    """Reasoning is also surfaced on streamed chunks (same builder path)."""
+
+    async def test_streaming_chunk_yields_reasoning_part(self) -> None:
+        """A streamed chunk carrying ``thinking`` emits a leading ReasoningPart."""
+        client_instance = AsyncMock()
+        factory = MagicMock(return_value=client_instance)
+        model = OllamaModel(
+            client=factory,
+            model_definition=ModelDefinition(name='m', api_type=OllamaAPITypes.CHAT),
+        )
+
+        async def chunks() -> AsyncIterator[ollama_api.ChatResponse]:
+            yield ollama_api.ChatResponse(
+                message=ollama_api.Message(role='assistant', content='4', thinking='2+2'),
+            )
+
+        client_instance.chat.return_value = chunks()
+
+        ctx = ActionRunContext(streaming_callback=MagicMock())
+        sent: list[ModelResponseChunk] = []
+        cast(Any, ctx).send_chunk = MagicMock(side_effect=lambda chunk: sent.append(chunk))
+
+        request = ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])])
+        with patch.object(model, 'build_chat_messages', new_callable=AsyncMock, return_value=[]):
+            await model._chat_with_ollama(request=request, ctx=ctx)
+
+        assert len(sent) == 1
+        first_part = sent[0].content[0]
+        assert isinstance(first_part.root, ReasoningPart)
+        assert first_part.root.reasoning == '2+2'
+
+    async def test_streaming_chunk_does_not_parse_think_tags(self) -> None:
+        """Inline <think> tags in a streamed chunk are left untouched even when think
+        is enabled — a tag may be split across chunks, so only the dedicated field is
+        surfaced mid-stream. Matches the Go plugin's translateChatChunk."""
+        client_instance = AsyncMock()
+        factory = MagicMock(return_value=client_instance)
+        model = OllamaModel(
+            client=factory,
+            model_definition=ModelDefinition(name='m', api_type=OllamaAPITypes.CHAT),
+        )
+
+        async def chunks() -> AsyncIterator[ollama_api.ChatResponse]:
+            yield ollama_api.ChatResponse(
+                message=ollama_api.Message(role='assistant', content='<think>partial'),
+            )
+
+        client_instance.chat.return_value = chunks()
+
+        ctx = ActionRunContext(streaming_callback=MagicMock())
+        sent: list[ModelResponseChunk] = []
+        cast(Any, ctx).send_chunk = MagicMock(side_effect=lambda chunk: sent.append(chunk))
+
+        request = ModelRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+            config=OllamaConfig(think=True),
+        )
+        with patch.object(model, 'build_chat_messages', new_callable=AsyncMock, return_value=[]):
+            await model._chat_with_ollama(request=request, ctx=ctx)
+
+        assert len(sent) == 1
+        parts = sent[0].content
+        assert all(not isinstance(part.root, ReasoningPart) for part in parts)
+        assert parts[0].root.text == '<think>partial'
+
+
+class TestReasoningGenerate:
+    """Tests for surfacing GenerateResponse.thinking as a leading ReasoningPart."""
+
+    def test_thinking_yields_leading_reasoning_part(self) -> None:
+        """A generate response with ``thinking`` prepends a ReasoningPart before text."""
+        response = ollama_api.GenerateResponse(response='The answer is 4.', thinking='2+2 is 4')
+        content = OllamaModel._build_generate_response(generate_response=response)
+
+        assert isinstance(content[0].root, ReasoningPart)
+        assert content[0].root.reasoning == '2+2 is 4'
+        assert isinstance(content[1].root, TextPart)
+        assert content[1].root.text == 'The answer is 4.'
+
+    def test_no_thinking_has_no_reasoning_part(self) -> None:
+        """Without ``thinking`` no ReasoningPart is emitted."""
+        response = ollama_api.GenerateResponse(response='Hi')
+        content = OllamaModel._build_generate_response(generate_response=response)
+
+        assert all(not isinstance(part.root, ReasoningPart) for part in content)
+
+    def test_think_tag_fallback_extracts_reasoning(self) -> None:
+        """With thinking requested and no dedicated field, inline <think> tags are
+        surfaced as reasoning and stripped from the text (Go parseThinking parity)."""
+        response = ollama_api.GenerateResponse(response='<think>2+2 is 4</think>The answer is 4.')
+        content = OllamaModel._build_generate_response(generate_response=response, thinking_enabled=True)
+
+        assert isinstance(content[0].root, ReasoningPart)
+        assert content[0].root.reasoning == '2+2 is 4'
+        assert isinstance(content[1].root, TextPart)
+        assert content[1].root.text == 'The answer is 4.'
+
+    def test_think_tag_not_parsed_when_thinking_disabled(self) -> None:
+        """Without an explicit think request, <think> tags stay verbatim in the text."""
+        response = ollama_api.GenerateResponse(response='<think>hidden</think>visible')
+        content = OllamaModel._build_generate_response(generate_response=response, thinking_enabled=False)
+
+        assert all(not isinstance(part.root, ReasoningPart) for part in content)
+        assert content[0].root.text == '<think>hidden</think>visible'
+
+    def test_dedicated_thinking_field_wins_over_tags(self) -> None:
+        """The dedicated thinking field takes precedence; content tags are left intact."""
+        response = ollama_api.GenerateResponse(response='<think>inline</think>answer', thinking='structured')
+        content = OllamaModel._build_generate_response(generate_response=response, thinking_enabled=True)
+
+        assert isinstance(content[0].root, ReasoningPart)
+        assert content[0].root.reasoning == 'structured'
+        assert content[1].root.text == '<think>inline</think>answer'
+
+
+class TestReasoningGenerateStreaming(unittest.IsolatedAsyncioTestCase):
+    """Reasoning is also surfaced on streamed generate chunks (same builder path)."""
+
+    async def test_streaming_chunk_yields_reasoning_part(self) -> None:
+        """A streamed generate chunk carrying ``thinking`` emits a leading ReasoningPart."""
+        client_instance = AsyncMock()
+        factory = MagicMock(return_value=client_instance)
+        model = OllamaModel(
+            client=factory,
+            model_definition=ModelDefinition(name='m', api_type=OllamaAPITypes.GENERATE),
+        )
+
+        async def chunks() -> AsyncIterator[ollama_api.GenerateResponse]:
+            yield ollama_api.GenerateResponse(response='4', thinking='2+2')
+
+        client_instance.generate.return_value = chunks()
+
+        ctx = ActionRunContext(streaming_callback=MagicMock())
+        sent: list[ModelResponseChunk] = []
+        cast(Any, ctx).send_chunk = MagicMock(side_effect=lambda chunk: sent.append(chunk))
+
+        request = ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])])
+        with patch.object(model, 'build_prompt', return_value='hi'):
+            await model._generate_ollama_response(request=request, ctx=ctx)
+
+        assert len(sent) == 1
+        first_part = sent[0].content[0]
+        assert isinstance(first_part.root, ReasoningPart)
+        assert first_part.root.reasoning == '2+2'
+
+    async def test_streaming_chunk_does_not_parse_think_tags(self) -> None:
+        """Inline <think> tags in a streamed generate chunk are left untouched even when
+        think is enabled — a tag may be split across chunks, so only the dedicated field
+        is surfaced mid-stream. Matches the Go plugin's translateChatChunk."""
+        client_instance = AsyncMock()
+        factory = MagicMock(return_value=client_instance)
+        model = OllamaModel(
+            client=factory,
+            model_definition=ModelDefinition(name='m', api_type=OllamaAPITypes.GENERATE),
+        )
+
+        async def chunks() -> AsyncIterator[ollama_api.GenerateResponse]:
+            yield ollama_api.GenerateResponse(response='<think>partial')
+
+        client_instance.generate.return_value = chunks()
+
+        ctx = ActionRunContext(streaming_callback=MagicMock())
+        sent: list[ModelResponseChunk] = []
+        cast(Any, ctx).send_chunk = MagicMock(side_effect=lambda chunk: sent.append(chunk))
+
+        request = ModelRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
+            config=OllamaConfig(think=True),
+        )
+        with patch.object(model, 'build_prompt', return_value='hi'):
+            await model._generate_ollama_response(request=request, ctx=ctx)
+
+        assert len(sent) == 1
+        parts = sent[0].content
+        assert all(not isinstance(part.root, ReasoningPart) for part in parts)
+        assert parts[0].root.text == '<think>partial'
+
+
+class TestThinkingRequested:
+    """Tests for OllamaModel._thinking_requested (mirrors Go ThinkOption.IsEnabled)."""
+
+    def test_bool_true_enables(self) -> None:
+        """think=True enables the fallback."""
+        assert OllamaModel._thinking_requested(OllamaConfig(think=True)) is True
+
+    def test_bool_false_disables(self) -> None:
+        """think=False disables the fallback."""
+        assert OllamaModel._thinking_requested(OllamaConfig(think=False)) is False
+
+    def test_effort_string_enables(self) -> None:
+        """A non-empty effort string (low/medium/high) enables the fallback."""
+        assert OllamaModel._thinking_requested(OllamaConfig(think='high')) is True
+
+    def test_absent_or_none_disables(self) -> None:
+        """Configs without think, and None, do not enable the fallback."""
+        assert OllamaModel._thinking_requested(OllamaConfig(num_ctx=8)) is False
+        assert OllamaModel._thinking_requested(None) is False
+        assert OllamaModel._thinking_requested({'think': 'low'}) is True
 
 
 class TestResolveImage(unittest.IsolatedAsyncioTestCase):

--- a/py/plugins/ollama/tests/models/ollama_models_test.py
+++ b/py/plugins/ollama/tests/models/ollama_models_test.py
@@ -820,6 +820,16 @@ class TestBuildRequestKwargs:
         kwargs = OllamaModel.build_request_kwargs(dumped)
         assert kwargs == {'think': 'low', 'keep_alive': '10m'}
 
+    def test_plain_model_config_extras_surface_think_and_keep_alive(self) -> None:
+        """A plain ModelConfig carrying think/keep_alive as extras surfaces them.
+
+        ModelConfig has ``extra='allow'``, so the knobs can ride on a base
+        ModelConfig instance (including camelCased), not just OllamaConfig.
+        """
+        config = ModelConfig.model_validate({'think': True, 'keepAlive': '5m'})
+        kwargs = OllamaModel.build_request_kwargs(config)
+        assert kwargs == {'think': True, 'keep_alive': '5m'}
+
     def test_absent_knobs_yield_empty_kwargs(self) -> None:
         """Configs without think/keep_alive produce no extra kwargs."""
         assert OllamaModel.build_request_kwargs(OllamaConfig(num_ctx=2048)) == {}

--- a/py/plugins/ollama/tests/models/ollama_models_test.py
+++ b/py/plugins/ollama/tests/models/ollama_models_test.py
@@ -374,6 +374,29 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
 
         self.mock_build_multimodal_response.assert_not_called()
 
+    async def test_think_and_keep_alive_forwarded_as_top_level_kwargs(self) -> None:
+        """think/keep_alive reach the chat call as top-level kwargs, not sampler options.
+
+        Guards the JS/Go parity wiring: build_request_kwargs feeds ``**extra_kwargs``
+        into client.chat(), so dropping that spread would silently regress reasoning
+        and model keep-alive.
+        """
+        request = ModelRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hello'))])],
+            config={'think': 'low', 'keepAlive': '5m'},
+        )
+        self.mock_ollama_client_instance.chat.return_value = ollama_api.ChatResponse(
+            message=ollama_api.Message(role='', content='ok')
+        )
+
+        await self.ollama_model._chat_with_ollama(request, self.ctx)
+
+        call_kwargs = self.mock_ollama_client_instance.chat.await_args.kwargs
+        assert call_kwargs['think'] == 'low'
+        assert call_kwargs['keep_alive'] == '5m'
+        # Sampler options stay separate from the top-level kwargs.
+        assert call_kwargs['options'] == self.mock_build_request_options.return_value
+
     async def test_streaming_chat_success(self) -> None:
         """Test _chat_with_ollama in streaming mode with multiple chunks."""
         self.mock_is_streaming_request.return_value = True
@@ -563,6 +586,21 @@ class TestOllamaModelGenerateOllamaResponse(unittest.IsolatedAsyncioTestCase):
         self.patcher_build_prompt.stop()
         self.patcher_is_streaming_request.stop()
         self.patcher_build_request_options.stop()
+
+    async def test_think_and_keep_alive_forwarded_as_top_level_kwargs(self) -> None:
+        """think/keep_alive reach the generate call as top-level kwargs, matching chat."""
+        request = ModelRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hello'))])],
+            config={'think': True, 'keepAlive': '10m'},
+        )
+        self.mock_ollama_client_instance.generate.return_value = ollama_api.GenerateResponse(response='ok')
+
+        await self.ollama_model._generate_ollama_response(request, self.ctx)
+
+        call_kwargs = self.mock_ollama_client_instance.generate.await_args.kwargs
+        assert call_kwargs['think'] is True
+        assert call_kwargs['keep_alive'] == '10m'
+        assert call_kwargs['options'] == self.mock_build_request_options.return_value
 
     async def test_non_streaming_generate_success(self) -> None:
         """Test _generate_ollama_response in non-streaming mode with successful response."""
@@ -802,6 +840,15 @@ class TestBuildRequestOptions:
 
         assert from_dict == from_instance
         assert from_dict == {'num_ctx': 4096, 'num_predict': 100, 'temperature': 0.5}
+
+    def test_stop_sequences_map_to_stop_list(self) -> None:
+        """stop_sequences maps to Ollama's stop field, preserved as a list.
+
+        Go parity: stop is sent as a list, unlike the JS plugin which joins it.
+        """
+        options = OllamaModel.build_request_options(ModelConfig(stop_sequences=['STOP', '###']))
+        assert options['stop'] == ['STOP', '###']
+        assert 'stop_sequences' not in options
 
 
 class TestBuildRequestKwargs:

--- a/py/plugins/ollama/tests/plugin_api_test.py
+++ b/py/plugins/ollama/tests/plugin_api_test.py
@@ -24,9 +24,11 @@ import pytest
 from pydantic import BaseModel
 
 from genkit import ActionKind
+from genkit.plugin_api import to_json_schema
 from genkit.plugins.ollama import Ollama, ollama_name
+from genkit.plugins.ollama.constants import OllamaAPITypes
 from genkit.plugins.ollama.embedders import EmbeddingDefinition
-from genkit.plugins.ollama.models import ModelDefinition
+from genkit.plugins.ollama.models import ModelDefinition, OllamaConfig, OllamaSupports
 
 
 class TestOllamaInit(unittest.TestCase):
@@ -107,12 +109,69 @@ async def test_resolve_action(kind: ActionKind, name: str, ollama_plugin_instanc
     if kind == ActionKind.MODEL:
         model_meta = cast(dict[str, Any], metadata['model'])
         assert model_meta['label'] == f'Ollama - {name}'
-        assert model_meta['multiturn']
-        assert model_meta['system_role']
+        supports = cast(dict[str, Any], model_meta['supports'])
+        # Default model is CHAT → multiturn, and always advertises system role.
+        assert supports['multiturn']
+        assert supports['systemRole']
     else:
         embedder_meta = cast(dict[str, Any], metadata['embedder'])
         assert embedder_meta['label'] == f'Ollama Embedding - {name}'
         assert embedder_meta['supports'] == {'input': ['text']}
+
+
+@pytest.mark.asyncio
+async def test_create_model_action_chat_with_media() -> None:
+    """A CHAT model with media support advertises multiturn/tools/media."""
+    plugin = Ollama(
+        models=[ModelDefinition(name='llava', api_type=OllamaAPITypes.CHAT, supports=OllamaSupports(media=True))]
+    )
+    action = plugin._create_model_action(ollama_name('llava'))
+
+    supports = cast(dict[str, Any], cast(dict[str, Any], action.metadata)['model']['supports'])
+    assert supports['multiturn'] is True
+    assert supports['tools'] is True
+    assert supports['media'] is True
+
+
+@pytest.mark.asyncio
+async def test_create_model_action_generate_gates_capabilities() -> None:
+    """A GENERATE model reports multiturn/tools/media all False."""
+    plugin = Ollama(models=[ModelDefinition(name='gen', api_type=OllamaAPITypes.GENERATE)])
+    action = plugin._create_model_action(ollama_name('gen'))
+
+    supports = cast(dict[str, Any], cast(dict[str, Any], action.metadata)['model']['supports'])
+    assert supports['multiturn'] is False
+    assert supports['tools'] is False
+    assert supports['media'] is False
+    assert supports['systemRole'] is True
+
+
+@pytest.mark.asyncio
+async def test_dynamic_model_advertises_generic_capabilities() -> None:
+    """A dynamically-resolved model (not pre-configured) advertises the full
+    generic capability set, matching the JS GENERIC_MODEL_INFO and the Go
+    defaultOllamaSupports for un-probed models."""
+    plugin = Ollama()
+    action = plugin._create_model_action(ollama_name('some-unconfigured-model'))
+
+    supports = cast(dict[str, Any], cast(dict[str, Any], action.metadata)['model']['supports'])
+    assert supports['multiturn'] is True
+    assert supports['tools'] is True
+    assert supports['media'] is True
+    assert supports['systemRole'] is True
+
+
+@pytest.mark.asyncio
+async def test_create_model_action_custom_options_is_ollama_config() -> None:
+    """The model action advertises OllamaConfig (with Ollama-only knobs) as its schema."""
+    plugin = Ollama(models=[ModelDefinition(name='m')])
+    action = plugin._create_model_action(ollama_name('m'))
+
+    model_meta = cast(dict[str, Any], cast(dict[str, Any], action.metadata)['model'])
+    assert model_meta['customOptions'] == to_json_schema(OllamaConfig)
+    props = cast(dict[str, Any], model_meta['customOptions']['properties'])
+    assert 'think' in props
+    assert 'keepAlive' in props
 
 
 # _define_ollama_model and _define_ollama_embedder methods no longer exist in new plugin architecture

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
-    { name = "ollama", specifier = "~=0.4" },
+    { name = "ollama", specifier = ">=0.5.3,<1.0" },
     { name = "structlog", specifier = ">=25.2.0" },
 ]
 


### PR DESCRIPTION
Stacked on #5657.

## Summary

Slice B1 of the Ollama Python plugin port: the **model surface**. Adds a typed config schema, Ollama's `think` reasoning support across both the chat and generate endpoints, and per-API-type capability metadata, verified for parity with the JS (`js/plugins/ollama`) and Go (`go/plugins/ollama`) plugins.

## Changes

**Config schema & request building** (`models.py`)
- New `OllamaConfig(ModelConfig)` with named Ollama knobs: `think`, `keepAlive`, `numCtx`, `minP`, `seed`, `numPredict` (camelCase aliases, `extra='allow'` passthrough for newer sampler params).
- `build_request_options()` returns a plain mapping so knobs the installed `Options` model doesn't field yet (e.g. `min_p`) still reach the server; `build_request_kwargs()` pulls `think`/`keep_alive` out as **top-level** chat/generate kwargs (not `options`).

**Reasoning**
- Surfaces `message.thinking` as a leading `ReasoningPart` on the chat endpoint (streaming + non-streaming).
- `_build_generate_response()` does the same for the generate endpoint, so reasoning is no longer dropped there (non-streaming response and streamed chunks both handled).
- Adds the Go plugin's `<think>`/`<thinking>` content fallback for models that inline reasoning instead of using the dedicated field; gated on an explicit think request and applied only to complete (non-streaming) responses, on both endpoints.

**Capability metadata** (`plugin_api.py`)
- `ollama_model_info()` gates `multiturn`/`media`/`tools` on API type and registers `OllamaConfig` as the action config schema.
- Dynamically discovered/resolved models advertise the full generic capability set (`_DYNAMIC_MODEL_SUPPORTS`), matching JS `GENERIC_MODEL_INFO` and Go `defaultOllamaSupports`.

**Role mapping**
- `_from_ollama_role()` maps assistant→MODEL, tool→TOOL, user→USER, system→SYSTEM; empty/unknown fall back to MODEL.

**Dependencies**
- Bumps the `ollama` client floor to `>=0.5.3` (from `~=0.4`). `think` and its `low`/`medium`/`high` levels are passed to `chat()` and `generate()`, but the old floor allowed 0.4.x releases without the `think` kwarg, which raised `TypeError` at request time. 0.5.3 is the first release with `think` on both endpoints plus the intensity levels.

## JS/Go parity notes

Verified each behaviour against both reference plugins:
- `think`/`keep_alive` sent **top-level**. This matches Go's `ollamaChatRequest` (JS spreads them into `options`, which looks like a bug).
- `stop` sent as a **list**. This matches Go (JS `.join('')` is a bug).
- `<think>` fallback mirrors Go's `parseThinking`, and like Go's `translateChatChunk` it is not applied to partial streamed chunks, on either endpoint.

## On `output` / `constrained`

`output=['text','json']` and `constrained=all` are kept to match the current Python plugin ecosystem (anthropic/google-genai/compat-oai). Both JS and Go plugins omit these hints, so this is a deliberate divergence for Dev UI consistency rather than byte-parity with JS/Go. It is now called out in a code comment so it is not "fixed" back by mistake.

## Testing

From `py/plugins/ollama`:
- `uv run pytest tests/ -q` → **108 passed**
- `uv run ruff format . && uv run ruff check --preview .` → clean
- `uv run pyright src tests` → **20 errors / 0 warnings**, all pre-existing namespace-import resolution and untouched-code artifacts (present on the base branch too)
