### PR TITLE
feat(py/ollama): add configurable transport headers and timeouts

### DIFF
--- a/py/plugins/ollama/src/genkit/plugins/ollama/__init__.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/__init__.py
@@ -155,6 +155,7 @@ See Also:
     - Genkit documentation: https://genkit.dev/
 """
 
+from genkit.plugins.ollama._errors import OllamaConnectionError
 from genkit.plugins.ollama.models import ModelDefinition, OllamaConfig, OllamaSupports
 from genkit.plugins.ollama.plugin_api import Ollama, ollama_name
 

--- a/py/plugins/ollama/src/genkit/plugins/ollama/__init__.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/__init__.py
@@ -157,7 +157,13 @@ See Also:
 
 from genkit.plugins.ollama._errors import OllamaConnectionError
 from genkit.plugins.ollama.models import ModelDefinition, OllamaConfig, OllamaSupports
-from genkit.plugins.ollama.plugin_api import Ollama, ollama_name
+from genkit.plugins.ollama.plugin_api import (
+    Ollama,
+    RequestHeaderFunction,
+    RequestHeaderParams,
+    RequestHeaders,
+    ollama_name,
+)
 
 
 def package_name() -> str:
@@ -173,7 +179,11 @@ __all__ = [
     'ModelDefinition',
     'Ollama',
     'OllamaConfig',
+    'OllamaConnectionError',
     'OllamaSupports',
+    'RequestHeaderFunction',
+    'RequestHeaderParams',
+    'RequestHeaders',
     'ollama_name',
     'package_name',
 ]

--- a/py/plugins/ollama/src/genkit/plugins/ollama/_errors.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/_errors.py
@@ -61,6 +61,8 @@ async def wrap_connection_errors(server_address: str) -> AsyncIterator[None]:
     except OllamaConnectionError:
         # Already actionable (e.g. nested wrap); don't re-wrap.
         raise
+    except httpx.TimeoutException as exc:
+        raise OllamaConnectionError(f'Request to Ollama server at {server_address} timed out.') from exc
     except (httpx.TransportError, ConnectionError) as exc:
         raise OllamaConnectionError(
             f'Cannot reach the Ollama server at {server_address}. '

--- a/py/plugins/ollama/src/genkit/plugins/ollama/_errors.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/_errors.py
@@ -1,0 +1,68 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Connection error helpers for the Ollama plugin."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import httpx
+
+
+class OllamaConnectionError(ConnectionError):
+    """Raised when the Ollama server is unreachable.
+
+    Subclasses ``ConnectionError`` so callers catching the standard exception
+    still work.
+    """
+
+
+@asynccontextmanager
+async def wrap_connection_errors(server_address: str) -> AsyncIterator[None]:
+    """Translate transport failures into an actionable OllamaConnectionError.
+
+    Catches two flavours of unreachable-server failure:
+
+    - The ``ollama`` SDK intercepts ``httpx.ConnectError`` and re-raises a plain
+      :class:`ConnectionError`, so that is the error most paths actually surface.
+    - Timeouts the SDK does not intercept (``ReadTimeout``/``PoolTimeout`` and
+      friends) bubble up as ``httpx.TransportError``.
+
+    Genuine server responses are left untouched: the SDK turns
+    ``httpx.HTTPStatusError`` into ``ollama.ResponseError`` (not caught here), and
+    a raw ``HTTPStatusError`` is not a ``TransportError`` either.
+
+    Args:
+        server_address: The Ollama server URL, surfaced in the error message.
+
+    Yields:
+        None. Wraps the enclosed ``async with`` block.
+
+    Raises:
+        OllamaConnectionError: If the enclosed block fails to reach the server.
+    """
+    try:
+        yield
+    except OllamaConnectionError:
+        # Already actionable (e.g. nested wrap); don't re-wrap.
+        raise
+    except (httpx.TransportError, ConnectionError) as exc:
+        raise OllamaConnectionError(
+            f'Cannot reach the Ollama server at {server_address}. '
+            f'Start it with `ollama serve` (or set server_address to a reachable host).'
+        ) from exc

--- a/py/plugins/ollama/src/genkit/plugins/ollama/embedders.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/embedders.py
@@ -77,7 +77,7 @@ class OllamaEmbedder:
         """
         return self._client_factory()
 
-    async def embed(self, request: EmbedRequest) -> EmbedResponse:
+    async def embed(self, request: EmbedRequest, client: ollama_api.AsyncClient | None = None) -> EmbedResponse:
         """Generates embeddings for the provided input text.
 
         Converts the input documents from the Genkit EmbedRequest into a raw
@@ -86,14 +86,18 @@ class OllamaEmbedder:
 
         Args:
             request: The embedding request containing the input documents.
+            client: An optional pre-resolved Ollama client (e.g. one built with
+                per-request headers); falls back to the stored client factory.
 
         Returns:
             An EmbedResponse containing the generated vector embeddings.
         """
+        if client is None:
+            client = self._get_client()
         input_raw: list[str] = []
         for doc in request.input:
             input_raw.extend([str(content.root.text) for content in doc.content if content.root.text is not None])
-        response = await self._get_client().embed(
+        response = await client.embed(
             model=self.embedding_definition.name,
             input=input_raw,
         )

--- a/py/plugins/ollama/src/genkit/plugins/ollama/models.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/models.py
@@ -111,7 +111,9 @@ from genkit import (
 )
 from genkit.model import get_basic_usage_stats
 from genkit.plugin_api import ActionRunContext, get_cached_client
+from genkit.plugins.ollama._errors import wrap_connection_errors
 from genkit.plugins.ollama.constants import (
+    DEFAULT_OLLAMA_SERVER_URL,
     OllamaAPITypes,
 )
 
@@ -185,7 +187,12 @@ class OllamaModel:
     allowing it to be integrated into the Genkit framework for generative tasks.
     """
 
-    def __init__(self, client: Callable, model_definition: ModelDefinition) -> None:
+    def __init__(
+        self,
+        client: Callable,
+        model_definition: ModelDefinition,
+        server_address: str = DEFAULT_OLLAMA_SERVER_URL,
+    ) -> None:
         """Initializes the OllamaModel.
 
         Sets up the client factory for communicating with the Ollama server and stores
@@ -199,9 +206,11 @@ class OllamaModel:
             client: A callable that returns an asynchronous Ollama client instance.
             model_definition: The definition describing the specific Ollama model
                 to be used (e.g., its name, API type, supported features).
+            server_address: The Ollama server URL, surfaced in connectivity errors.
         """
         self._client_factory = client
         self.model_definition = model_definition
+        self._server_address = server_address
 
     def _get_client(self) -> ollama_api.AsyncClient:
         """Creates a fresh async client bound to the current event loop.
@@ -214,12 +223,20 @@ class OllamaModel:
         """
         return self._client_factory()
 
-    async def generate(self, request: ModelRequest, ctx: ActionRunContext | None = None) -> ModelResponse:
+    async def generate(
+        self,
+        request: ModelRequest,
+        ctx: ActionRunContext | None = None,
+        client: ollama_api.AsyncClient | None = None,
+    ) -> ModelResponse:
         """Generate a response from Ollama.
 
         Args:
             request: The request to generate a response for.
             ctx: The context to generate a response for.
+            client: An optional pre-resolved Ollama client to use for this request
+                (e.g. one built with per-request headers). Falls back to the stored
+                client factory when omitted.
 
         Returns:
             The generated response.
@@ -234,7 +251,7 @@ class OllamaModel:
         )
 
         if self.model_definition.api_type == OllamaAPITypes.CHAT:
-            api_response = await self._chat_with_ollama(request=request, ctx=ctx)
+            api_response = await self._chat_with_ollama(request=request, ctx=ctx, client=client)
             if api_response:
                 logger.debug(
                     'Ollama raw API response',
@@ -246,7 +263,7 @@ class OllamaModel:
                     thinking_enabled=self._thinking_requested(request.config),
                 )
         elif self.model_definition.api_type == OllamaAPITypes.GENERATE:
-            api_response = await self._generate_ollama_response(request=request, ctx=ctx)
+            api_response = await self._generate_ollama_response(request=request, ctx=ctx, client=client)
             if api_response:
                 logger.debug(
                     'Ollama raw API response',
@@ -285,18 +302,28 @@ class OllamaModel:
         )
 
     async def _chat_with_ollama(
-        self, request: ModelRequest, ctx: ActionRunContext | None = None
+        self,
+        request: ModelRequest,
+        ctx: ActionRunContext | None = None,
+        client: ollama_api.AsyncClient | None = None,
     ) -> ollama_api.ChatResponse | None:
         """Chat with Ollama.
 
         Args:
             request: The request to chat with Ollama for.
             ctx: The context to chat with Ollama for.
+            client: An optional pre-resolved Ollama client; falls back to the
+                stored client factory when omitted.
 
         Returns:
             The chat response from Ollama.
         """
+        # Resolve media URLs first. build_chat_messages may perform HTTP fetches
+        # for image parts, and those must stay *outside* wrap_connection_errors so
+        # an image-host failure isn't misreported as an Ollama server outage.
         messages = await self.build_chat_messages(request)
+        if client is None:
+            client = self._get_client()
         streaming_request = self.is_streaming_request(ctx=ctx)
 
         if request.output_format or request.output_schema:
@@ -324,96 +351,112 @@ class OllamaModel:
         options = self.build_request_options(config=request.config)
         extra_kwargs = self.build_request_kwargs(config=request.config)
 
+        # Only the Ollama SDK call (and, when streaming, its iteration — where a
+        # connection failure can first surface) is wrapped, so transport errors are
+        # attributed to the Ollama server rather than to media-URL fetches above.
         if streaming_request:
-            # Streaming call with literal stream=True for proper overload resolution
-            chat_response = await self._get_client().chat(  # type: ignore[no-matching-overload]
-                model=self.model_definition.name,
-                messages=messages,
-                tools=tools,
-                options=options,
-                format=fmt,
-                stream=True,
-                **extra_kwargs,
-            )
-            idx = 0
-            async for chunk in chat_response:
-                idx += 1
-                role = self._from_ollama_role(chunk.message.role)
-                if ctx:
-                    ctx.send_chunk(
-                        chunk=ModelResponseChunk(
-                            role=role,
-                            index=idx,
-                            content=self._build_multimodal_chat_response(chat_response=chunk),
+            async with wrap_connection_errors(self._server_address):
+                # Streaming call with literal stream=True for proper overload resolution
+                chat_response = await client.chat(  # type: ignore[no-matching-overload]
+                    model=self.model_definition.name,
+                    messages=messages,
+                    tools=tools,
+                    options=options,
+                    format=fmt,
+                    stream=True,
+                    **extra_kwargs,
+                )
+                idx = 0
+                async for chunk in chat_response:
+                    idx += 1
+                    role = self._from_ollama_role(chunk.message.role)
+                    if ctx:
+                        ctx.send_chunk(
+                            chunk=ModelResponseChunk(
+                                role=role,
+                                index=idx,
+                                content=self._build_multimodal_chat_response(chat_response=chunk),
+                            )
                         )
-                    )
             # For streaming requests, we return None because the response chunks
             # have already been sent via ctx.send_chunk() above. The async generator
             # is now exhausted, and the caller should not expect a return value.
             return None
         else:
-            # Non-streaming call with literal stream=False for proper overload resolution
-            chat_response = await self._get_client().chat(  # type: ignore[no-matching-overload]
-                model=self.model_definition.name,
-                messages=messages,
-                tools=tools,
-                options=options,
-                format=fmt,
-                stream=False,
-                **extra_kwargs,
-            )
+            async with wrap_connection_errors(self._server_address):
+                # Non-streaming call with literal stream=False for proper overload resolution
+                chat_response = await client.chat(  # type: ignore[no-matching-overload]
+                    model=self.model_definition.name,
+                    messages=messages,
+                    tools=tools,
+                    options=options,
+                    format=fmt,
+                    stream=False,
+                    **extra_kwargs,
+                )
             return chat_response
 
     async def _generate_ollama_response(
-        self, request: ModelRequest, ctx: ActionRunContext | None = None
+        self,
+        request: ModelRequest,
+        ctx: ActionRunContext | None = None,
+        client: ollama_api.AsyncClient | None = None,
     ) -> ollama_api.GenerateResponse | None:
         """Generate a response from Ollama.
 
         Args:
             request: The request to generate a response for.
             ctx: The context to generate a response for.
+            client: An optional pre-resolved Ollama client; falls back to the
+                stored client factory when omitted.
 
         Returns:
             The generated response.
         """
         prompt = self.build_prompt(request)
+        if client is None:
+            client = self._get_client()
         streaming_request = self.is_streaming_request(ctx=ctx)
         options = self.build_request_options(config=request.config)
         extra_kwargs = self.build_request_kwargs(config=request.config)
 
+        # Wrap only the Ollama SDK call (and its streamed iteration) so transport
+        # errors are attributed to the Ollama server, matching the chat path.
         if streaming_request:
-            # Streaming call with literal stream=True for proper overload resolution
-            generate_response = await self._get_client().generate(
-                model=self.model_definition.name,
-                prompt=prompt,
-                options=options,
-                stream=True,
-                **extra_kwargs,
-            )
-            idx = 0
-            async for chunk in generate_response:
-                idx += 1
-                if ctx:
-                    ctx.send_chunk(
-                        chunk=ModelResponseChunk(
-                            role=Role.MODEL,
-                            index=idx,
-                            content=self._build_generate_response(generate_response=chunk),
+            async with wrap_connection_errors(self._server_address):
+                # Streaming call with literal stream=True for proper overload resolution
+                generate_response = await client.generate(
+                    model=self.model_definition.name,
+                    prompt=prompt,
+                    options=options,
+                    stream=True,
+                    **extra_kwargs,
+                )
+                idx = 0
+                async for chunk in generate_response:
+                    idx += 1
+                    if ctx:
+                        ctx.send_chunk(
+                            chunk=ModelResponseChunk(
+                                role=Role.MODEL,
+                                index=idx,
+                                content=self._build_generate_response(generate_response=chunk),
+                            )
                         )
-                    )
             # For streaming requests, we return None because the response chunks
             # have already been sent via ctx.send_chunk() above. The async generator
             # is now exhausted, and the caller should not expect a return value.
             return None
         else:
-            # Non-streaming call with literal stream=False for proper overload resolution
-            generate_response = await self._get_client().generate(
-                model=self.model_definition.name,
-                prompt=prompt,
-                options=options,
-                stream=False,
-                **extra_kwargs,
-            )
+            async with wrap_connection_errors(self._server_address):
+                # Non-streaming call with literal stream=False for proper overload resolution
+                generate_response = await client.generate(
+                    model=self.model_definition.name,
+                    prompt=prompt,
+                    options=options,
+                    stream=False,
+                    **extra_kwargs,
+                )
             return generate_response
 
     @staticmethod

--- a/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
@@ -18,6 +18,7 @@
 
 import inspect
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any, cast
 
 import structlog
@@ -111,6 +112,33 @@ def ollama_model_info(model_ref: ModelDefinition, label: str) -> dict[str, objec
     ).model_dump(by_alias=True, exclude_none=True)
 
 
+@dataclass(frozen=True)
+class RequestHeaderParams:
+    """Context passed to a ``request_headers`` callable.
+
+    Mirrors the JS plugin's ``RequestHeaderFunction`` params so a callback can
+    tailor headers to the server, the model, or the specific request — e.g. a
+    freshly minted, per-request auth token. ``model_request`` is set for model
+    actions and ``embed_request`` for embedder actions; both are ``None`` for the
+    ``list_actions`` discovery call.
+    """
+
+    server_address: str
+    model: ModelDefinition | EmbeddingDefinition | None = None
+    model_request: ModelRequest | None = None
+    embed_request: EmbedRequest | None = None
+
+
+# A request_headers callable receives the per-request context and returns the
+# headers to merge (or ``None`` for no extra headers), optionally as an awaitable.
+RequestHeaderFunction = Callable[
+    [RequestHeaderParams],
+    dict[str, str] | None | Awaitable[dict[str, str] | None],
+]
+# request_headers may be a static dict or a (sync/async) callable.
+RequestHeaders = dict[str, str] | RequestHeaderFunction
+
+
 class Ollama(Plugin):
     """Ollama plugin for Genkit.
 
@@ -125,10 +153,7 @@ class Ollama(Plugin):
         models: list[ModelDefinition] | None = None,
         embedders: list[EmbeddingDefinition] | None = None,
         server_address: str | None = None,
-        request_headers: dict[str, str]
-        | Callable[[], dict[str, str]]
-        | Callable[[], Awaitable[dict[str, str]]]
-        | None = None,
+        request_headers: RequestHeaders | None = None,
         timeout: float | None = None,
     ) -> None:
         """Initialize the Ollama plugin.
@@ -141,9 +166,11 @@ class Ollama(Plugin):
                 Ollama server URL if not provided.
             request_headers: Optional HTTP headers to include with requests to the
                 Ollama server. May be a static dict, or a sync/async callable that
-                returns a dict. A callable is resolved per request (matching the JS
-                plugin) so expiring auth tokens take effect; a static dict is applied
-                once to a cached client.
+                takes a :class:`RequestHeaderParams` (server address plus model/request
+                context) and returns a dict (or ``None``). A callable is resolved per
+                request — matching the JS plugin — so expiring auth tokens and
+                request-specific headers take effect; a static dict is applied once to a
+                cached client.
             timeout: Optional request timeout (seconds) forwarded to the underlying
                 httpx client.
         """
@@ -176,39 +203,43 @@ class Ollama(Plugin):
             kwargs['timeout'] = self.timeout
         return ollama_api.AsyncClient(**kwargs)
 
-    async def _client_for_request(self) -> ollama_api.AsyncClient:
+    async def _client_for_request(
+        self,
+        *,
+        model: ModelDefinition | EmbeddingDefinition | None = None,
+        model_request: ModelRequest | None = None,
+        embed_request: EmbedRequest | None = None,
+    ) -> ollama_api.AsyncClient:
         """Return the Ollama client to use for a single request.
 
-        Static (or absent) headers are baked into a per-event-loop cached client.
-        A header *callable* is resolved on every call and applied to a fresh client,
-        so expiring auth tokens or per-request headers take effect — matching the JS
-        plugin, which resolves ``request_headers`` per request.
+        Static (or absent) headers are baked into a per-event-loop cached client. A
+        header *callable* is resolved on every call — receiving the server address
+        plus any model/request context (JS parity) — and applied to a fresh client, so
+        expiring auth tokens or request-specific headers take effect.
+
+        Args:
+            model: The model/embedder definition this request targets, if any.
+            model_request: The generate request, when resolving for a model action.
+            embed_request: The embed request, when resolving for an embedder action.
 
         Returns:
             The Ollama client for this request.
         """
-        if callable(self._request_headers_source):
-            headers = await self._resolve_request_headers()
-            return self._make_client(headers=headers)
-        return self.client()
-
-    async def _resolve_request_headers(self) -> dict[str, str]:
-        """Resolve the configured request headers to a plain dict.
-
-        Static dicts pass through; sync/async callables are invoked once.
-
-        Returns:
-            The resolved HTTP headers.
-        """
         source = self._request_headers_source
-        if source is None:
-            return {}
-        if isinstance(source, dict):
-            return dict(source)
-        result = source()
+        if not callable(source):
+            return self.client()
+
+        params = RequestHeaderParams(
+            server_address=self.server_address,
+            model=model,
+            model_request=model_request,
+            embed_request=embed_request,
+        )
+        result = source(params)
         if inspect.isawaitable(result):
             result = await result
-        return dict(cast(dict[str, str], result))
+        headers = dict(cast(dict[str, str], result)) if result else {}
+        return self._make_client(headers=headers)
 
     async def init(self) -> list:
         """Initialize the Ollama plugin.
@@ -290,10 +321,11 @@ class Ollama(Plugin):
         )
 
         async def _run(request: ModelRequest, ctx: ActionRunContext | None = None) -> ModelResponse:
-            # Resolve per-request headers (no-op for static headers) and let
-            # OllamaModel wrap connection errors at the Ollama SDK boundary, so a
-            # failed media-URL fetch isn't misreported as an Ollama server outage.
-            client = await self._client_for_request()
+            # Resolve per-request headers (no-op for static headers), passing the model
+            # and request context to a header callable (JS parity). OllamaModel wraps
+            # connection errors at the SDK boundary, so a failed media-URL fetch isn't
+            # misreported as an Ollama server outage.
+            client = await self._client_for_request(model=model_ref, model_request=request)
             return await model.generate(request, ctx, client=client)
 
         action = Action(
@@ -330,8 +362,9 @@ class Ollama(Plugin):
         server_address = self.server_address
 
         async def _run(request: EmbedRequest) -> EmbedResponse:
+            # Pass the embedder and embed request to a header callable (JS parity).
             # Embedding requests never fetch media, so the whole SDK call is wrapped.
-            client = await self._client_for_request()
+            client = await self._client_for_request(model=embedder_ref, embed_request=request)
             async with wrap_connection_errors(server_address):
                 return await embedder.embed(request, client=client)
 

--- a/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
@@ -141,7 +141,9 @@ class Ollama(Plugin):
                 Ollama server URL if not provided.
             request_headers: Optional HTTP headers to include with requests to the
                 Ollama server. May be a static dict, or a sync/async callable that
-                returns a dict (resolved once during ``init()``).
+                returns a dict. A callable is resolved per request (matching the JS
+                plugin) so expiring auth tokens take effect; a static dict is applied
+                once to a cached client.
             timeout: Optional request timeout (seconds) forwarded to the underlying
                 httpx client.
         """
@@ -150,21 +152,45 @@ class Ollama(Plugin):
         self.server_address = server_address or DEFAULT_OLLAMA_SERVER_URL
 
         self._request_headers_source = request_headers
-        # Static dicts are usable immediately; callables resolve during init().
+        # Static dicts are baked into the cached client; callables resolve per request.
         self.request_headers = dict(request_headers) if isinstance(request_headers, dict) else {}
         self.timeout = timeout
         self.client = loop_local_client(self._make_client)
 
-    def _make_client(self) -> ollama_api.AsyncClient:
-        """Build an Ollama AsyncClient with the resolved headers and timeout.
+    def _make_client(self, headers: dict[str, str] | None = None) -> ollama_api.AsyncClient:
+        """Build an Ollama AsyncClient with the given (or static) headers and timeout.
+
+        Args:
+            headers: Per-request headers to use instead of the static ``request_headers``
+                (e.g. resolved from a callable). Defaults to the static headers, which is
+                what the per-event-loop cached client is built with.
 
         Returns:
             A new ``ollama.AsyncClient`` targeting the configured server.
         """
-        kwargs: dict[str, Any] = {'host': self.server_address, 'headers': self.request_headers}
+        kwargs: dict[str, Any] = {
+            'host': self.server_address,
+            'headers': self.request_headers if headers is None else headers,
+        }
         if self.timeout is not None:
             kwargs['timeout'] = self.timeout
         return ollama_api.AsyncClient(**kwargs)
+
+    async def _client_for_request(self) -> ollama_api.AsyncClient:
+        """Return the Ollama client to use for a single request.
+
+        Static (or absent) headers are baked into a per-event-loop cached client.
+        A header *callable* is resolved on every call and applied to a fresh client,
+        so expiring auth tokens or per-request headers take effect — matching the JS
+        plugin, which resolves ``request_headers`` per request.
+
+        Returns:
+            The Ollama client for this request.
+        """
+        if callable(self._request_headers_source):
+            headers = await self._resolve_request_headers()
+            return self._make_client(headers=headers)
+        return self.client()
 
     async def _resolve_request_headers(self) -> dict[str, str]:
         """Resolve the configured request headers to a plain dict.
@@ -192,10 +218,8 @@ class Ollama(Plugin):
         Returns:
             List of Action objects for pre-configured models and embedders.
         """
-        # Resolve callable headers before any client is built. Clients are
-        # created lazily per request, so they pick up the resolved headers.
-        self.request_headers = await self._resolve_request_headers()
-
+        # Header callables are resolved per request (see _client_for_request), so
+        # there is nothing to resolve eagerly here; static headers are already set.
         actions = []
 
         # Register pre-configured models
@@ -256,6 +280,7 @@ class Ollama(Plugin):
         model = OllamaModel(
             client=self.client,
             model_definition=model_ref,
+            server_address=self.server_address,
         )
 
         action_metadata = model_action_metadata(
@@ -264,11 +289,12 @@ class Ollama(Plugin):
             info=ollama_model_info(model_ref, f'Ollama - {clean_name}'),
         )
 
-        server_address = self.server_address
-
         async def _run(request: ModelRequest, ctx: ActionRunContext | None = None) -> ModelResponse:
-            async with wrap_connection_errors(server_address):
-                return await model.generate(request, ctx)
+            # Resolve per-request headers (no-op for static headers) and let
+            # OllamaModel wrap connection errors at the Ollama SDK boundary, so a
+            # failed media-URL fetch isn't misreported as an Ollama server outage.
+            client = await self._client_for_request()
+            return await model.generate(request, ctx, client=client)
 
         action = Action(
             kind=ActionKind.MODEL,
@@ -304,8 +330,10 @@ class Ollama(Plugin):
         server_address = self.server_address
 
         async def _run(request: EmbedRequest) -> EmbedResponse:
+            # Embedding requests never fetch media, so the whole SDK call is wrapped.
+            client = await self._client_for_request()
             async with wrap_connection_errors(server_address):
-                return await embedder.embed(request)
+                return await embedder.embed(request, client=client)
 
         return Action(
             kind=ActionKind.EMBEDDER,
@@ -331,7 +359,7 @@ class Ollama(Plugin):
                 - info (dict): The metadata dictionary describing the model configuration and properties.
                 - config_schema (type): The schema class used for validating the model's configuration.
         """
-        client = self.client()
+        client = await self._client_for_request()
         async with wrap_connection_errors(self.server_address):
             response = await client.list()
 

--- a/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
@@ -16,22 +16,32 @@
 
 """Ollama Plugin for Genkit."""
 
-from functools import partial
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
 
 import structlog
 
 import ollama as ollama_api
-from genkit import Constrained, ModelInfo, Supports
-from genkit.embedder import EmbedderOptions, EmbedderSupports, embedder_action_metadata
+from genkit import Constrained, ModelInfo, ModelRequest, ModelResponse, Supports
+from genkit.embedder import (
+    EmbedderOptions,
+    EmbedderSupports,
+    EmbedRequest,
+    EmbedResponse,
+    embedder_action_metadata,
+)
 from genkit.model import model_action_metadata
 from genkit.plugin_api import (
     Action,
     ActionKind,
     ActionMetadata,
+    ActionRunContext,
     Plugin,
     loop_local_client,
     to_json_schema,
 )
+from genkit.plugins.ollama._errors import wrap_connection_errors
 from genkit.plugins.ollama.constants import (
     DEFAULT_OLLAMA_SERVER_URL,
     OllamaAPITypes,
@@ -115,7 +125,11 @@ class Ollama(Plugin):
         models: list[ModelDefinition] | None = None,
         embedders: list[EmbeddingDefinition] | None = None,
         server_address: str | None = None,
-        request_headers: dict[str, str] | None = None,
+        request_headers: dict[str, str]
+        | Callable[[], dict[str, str]]
+        | Callable[[], Awaitable[dict[str, str]]]
+        | None = None,
+        timeout: float | None = None,
     ) -> None:
         """Initialize the Ollama plugin.
 
@@ -126,14 +140,49 @@ class Ollama(Plugin):
             server_address: The URL of the Ollama server. Defaults to a predefined
                 Ollama server URL if not provided.
             request_headers: Optional HTTP headers to include with requests to the
-                Ollama server.
+                Ollama server. May be a static dict, or a sync/async callable that
+                returns a dict (resolved once during ``init()``).
+            timeout: Optional request timeout (seconds) forwarded to the underlying
+                httpx client.
         """
         self.models = models or []
         self.embedders = embedders or []
         self.server_address = server_address or DEFAULT_OLLAMA_SERVER_URL
-        self.request_headers = request_headers or {}
 
-        self.client = loop_local_client(partial(ollama_api.AsyncClient, host=self.server_address))
+        self._request_headers_source = request_headers
+        # Static dicts are usable immediately; callables resolve during init().
+        self.request_headers = dict(request_headers) if isinstance(request_headers, dict) else {}
+        self.timeout = timeout
+        self.client = loop_local_client(self._make_client)
+
+    def _make_client(self) -> ollama_api.AsyncClient:
+        """Build an Ollama AsyncClient with the resolved headers and timeout.
+
+        Returns:
+            A new ``ollama.AsyncClient`` targeting the configured server.
+        """
+        kwargs: dict[str, Any] = {'host': self.server_address, 'headers': self.request_headers}
+        if self.timeout is not None:
+            kwargs['timeout'] = self.timeout
+        return ollama_api.AsyncClient(**kwargs)
+
+    async def _resolve_request_headers(self) -> dict[str, str]:
+        """Resolve the configured request headers to a plain dict.
+
+        Static dicts pass through; sync/async callables are invoked once.
+
+        Returns:
+            The resolved HTTP headers.
+        """
+        source = self._request_headers_source
+        if source is None:
+            return {}
+        if isinstance(source, dict):
+            return dict(source)
+        result = source()
+        if inspect.isawaitable(result):
+            result = await result
+        return dict(cast(dict[str, str], result))
 
     async def init(self) -> list:
         """Initialize the Ollama plugin.
@@ -143,6 +192,10 @@ class Ollama(Plugin):
         Returns:
             List of Action objects for pre-configured models and embedders.
         """
+        # Resolve callable headers before any client is built. Clients are
+        # created lazily per request, so they pick up the resolved headers.
+        self.request_headers = await self._resolve_request_headers()
+
         actions = []
 
         # Register pre-configured models
@@ -211,10 +264,16 @@ class Ollama(Plugin):
             info=ollama_model_info(model_ref, f'Ollama - {clean_name}'),
         )
 
+        server_address = self.server_address
+
+        async def _run(request: ModelRequest, ctx: ActionRunContext | None = None) -> ModelResponse:
+            async with wrap_connection_errors(server_address):
+                return await model.generate(request, ctx)
+
         action = Action(
             kind=ActionKind.MODEL,
             name=name,
-            fn=model.generate,
+            fn=_run,
             metadata=action_metadata.metadata,
         )
 
@@ -242,10 +301,16 @@ class Ollama(Plugin):
             embedding_definition=embedder_ref,
         )
 
+        server_address = self.server_address
+
+        async def _run(request: EmbedRequest) -> EmbedResponse:
+            async with wrap_connection_errors(server_address):
+                return await embedder.embed(request)
+
         return Action(
             kind=ActionKind.EMBEDDER,
             name=name,
-            fn=embedder.embed,
+            fn=_run,
             metadata={
                 'embedder': {
                     'label': f'Ollama Embedding - {clean_name}',
@@ -267,7 +332,8 @@ class Ollama(Plugin):
                 - config_schema (type): The schema class used for validating the model's configuration.
         """
         client = self.client()
-        response = await client.list()
+        async with wrap_connection_errors(self.server_address):
+            response = await client.list()
 
         actions = []
         for model in response.models:

--- a/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
@@ -256,6 +256,10 @@ class Ollama(Plugin):
             inner = getattr(client, '_client', None)
             if inner is not None:
                 await inner.aclose()
+            else:
+                # Defensive: if a future ollama SDK renames/drops ``_client`` this
+                # would silently leak a connection pool per request. Surface it.
+                logger.warning('ollama client exposes no _client; per-request connection pool was not closed')
 
     async def init(self) -> list:
         """Initialize the Ollama plugin.

--- a/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/plugin_api.py
@@ -17,7 +17,8 @@
 """Ollama Plugin for Genkit."""
 
 import inspect
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -203,31 +204,38 @@ class Ollama(Plugin):
             kwargs['timeout'] = self.timeout
         return ollama_api.AsyncClient(**kwargs)
 
+    @asynccontextmanager
     async def _client_for_request(
         self,
         *,
         model: ModelDefinition | EmbeddingDefinition | None = None,
         model_request: ModelRequest | None = None,
         embed_request: EmbedRequest | None = None,
-    ) -> ollama_api.AsyncClient:
-        """Return the Ollama client to use for a single request.
+    ) -> AsyncIterator[ollama_api.AsyncClient]:
+        """Yield the Ollama client to use for a single request.
 
-        Static (or absent) headers are baked into a per-event-loop cached client. A
-        header *callable* is resolved on every call — receiving the server address
-        plus any model/request context (JS parity) — and applied to a fresh client, so
-        expiring auth tokens or request-specific headers take effect.
+        Static (or absent) headers are baked into a per-event-loop cached client that
+        is shared across requests and left open. A header *callable* is resolved on
+        every call — receiving the server address plus any model/request context (JS
+        parity) — and applied to a *fresh* client, so expiring auth tokens or
+        request-specific headers take effect. Because the Ollama SDK bakes headers in
+        at construction (it has no per-request header hook, unlike the JS ``fetch`` and
+        Go ``http.Request`` paths), that fresh client owns its own httpx connection
+        pool; it is closed on exit so long-running callers don't accumulate pools.
 
         Args:
             model: The model/embedder definition this request targets, if any.
             model_request: The generate request, when resolving for a model action.
             embed_request: The embed request, when resolving for an embedder action.
 
-        Returns:
+        Yields:
             The Ollama client for this request.
         """
         source = self._request_headers_source
         if not callable(source):
-            return self.client()
+            # Shared per-event-loop cached client — reused across requests, not closed.
+            yield self.client()
+            return
 
         params = RequestHeaderParams(
             server_address=self.server_address,
@@ -239,7 +247,15 @@ class Ollama(Plugin):
         if inspect.isawaitable(result):
             result = await result
         headers = dict(cast(dict[str, str], result)) if result else {}
-        return self._make_client(headers=headers)
+        client = self._make_client(headers=headers)
+        try:
+            yield client
+        finally:
+            # ollama.AsyncClient exposes no public close, so close the wrapped httpx
+            # client to release this request's connection pool. aclose() is idempotent.
+            inner = getattr(client, '_client', None)
+            if inner is not None:
+                await inner.aclose()
 
     async def init(self) -> list:
         """Initialize the Ollama plugin.
@@ -325,8 +341,8 @@ class Ollama(Plugin):
             # and request context to a header callable (JS parity). OllamaModel wraps
             # connection errors at the SDK boundary, so a failed media-URL fetch isn't
             # misreported as an Ollama server outage.
-            client = await self._client_for_request(model=model_ref, model_request=request)
-            return await model.generate(request, ctx, client=client)
+            async with self._client_for_request(model=model_ref, model_request=request) as client:
+                return await model.generate(request, ctx, client=client)
 
         action = Action(
             kind=ActionKind.MODEL,
@@ -364,9 +380,9 @@ class Ollama(Plugin):
         async def _run(request: EmbedRequest) -> EmbedResponse:
             # Pass the embedder and embed request to a header callable (JS parity).
             # Embedding requests never fetch media, so the whole SDK call is wrapped.
-            client = await self._client_for_request(model=embedder_ref, embed_request=request)
-            async with wrap_connection_errors(server_address):
-                return await embedder.embed(request, client=client)
+            async with self._client_for_request(model=embedder_ref, embed_request=request) as client:
+                async with wrap_connection_errors(server_address):
+                    return await embedder.embed(request, client=client)
 
         return Action(
             kind=ActionKind.EMBEDDER,
@@ -392,9 +408,9 @@ class Ollama(Plugin):
                 - info (dict): The metadata dictionary describing the model configuration and properties.
                 - config_schema (type): The schema class used for validating the model's configuration.
         """
-        client = await self._client_for_request()
-        async with wrap_connection_errors(self.server_address):
-            response = await client.list()
+        async with self._client_for_request() as client:
+            async with wrap_connection_errors(self.server_address):
+                response = await client.list()
 
         actions = []
         for model in response.models:

--- a/py/plugins/ollama/tests/models/ollama_models_test.py
+++ b/py/plugins/ollama/tests/models/ollama_models_test.py
@@ -99,7 +99,9 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         response = await ollama_model.generate(self.request, self.ctx)
 
         # Assertions
-        cast(AsyncMock, ollama_model._chat_with_ollama).assert_awaited_once_with(request=self.request, ctx=self.ctx)
+        cast(AsyncMock, ollama_model._chat_with_ollama).assert_awaited_once_with(
+            request=self.request, ctx=self.ctx, client=None
+        )
         cast(AsyncMock, ollama_model._generate_ollama_response).assert_not_awaited()
         cast(MagicMock, self.ctx.send_chunk).assert_not_called()
         cast(MagicMock, ollama_model._build_multimodal_chat_response).assert_called_once_with(
@@ -156,7 +158,7 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
 
         # Assertions
         cast(AsyncMock, ollama_model._generate_ollama_response).assert_awaited_once_with(
-            request=self.request, ctx=self.ctx
+            request=self.request, ctx=self.ctx, client=None
         )
         cast(AsyncMock, ollama_model._chat_with_ollama).assert_not_called()
         cast(MagicMock, ollama_model.is_streaming_request).assert_called_with(ctx=self.ctx)
@@ -209,6 +211,7 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         cast(AsyncMock, ollama_model._chat_with_ollama).assert_awaited_once_with(
             request=self.request,
             ctx=streaming_ctx,
+            client=None,
         )
         cast(MagicMock, ollama_model.is_streaming_request).assert_called_with(
             ctx=streaming_ctx,
@@ -251,6 +254,7 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         cast(AsyncMock, ollama_model._generate_ollama_response).assert_awaited_once_with(
             request=self.request,
             ctx=streaming_ctx,
+            client=None,
         )
         cast(MagicMock, ollama_model.is_streaming_request).assert_called_with(
             ctx=streaming_ctx,

--- a/py/plugins/ollama/tests/plugin_api_test.py
+++ b/py/plugins/ollama/tests/plugin_api_test.py
@@ -518,7 +518,7 @@ async def test_model_action_does_not_wrap_media_fetch_error() -> None:
         with pytest.raises(httpx.ConnectError):
             await action._fn(request, None)
 
-    cast(AsyncMock, client_mock.chat).assert_not_called()
+    client_mock.chat.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/py/plugins/ollama/tests/plugin_api_test.py
+++ b/py/plugins/ollama/tests/plugin_api_test.py
@@ -420,6 +420,22 @@ async def test_static_headers_reuse_cached_client_and_keep_it_open() -> None:
 
 
 @pytest.mark.asyncio
+async def test_missing_inner_client_logs_instead_of_leaking() -> None:
+    """If a future SDK exposes no _client, cleanup warns rather than silently leaking."""
+    plugin = Ollama(request_headers=lambda params: {'X-Token': 't'})
+
+    sdk_client = MagicMock()
+    sdk_client._client = None  # simulate an SDK without the private httpx client to close
+
+    with patch('ollama.AsyncClient', return_value=sdk_client):
+        with patch('genkit.plugins.ollama.plugin_api.logger') as mock_logger:
+            async with plugin._client_for_request():
+                pass
+
+    cast(MagicMock, mock_logger.warning).assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_list_actions_wraps_connection_error(ollama_plugin_instance: Ollama) -> None:
     """list_actions surfaces transport failures as OllamaConnectionError."""
     client_mock = MagicMock()

--- a/py/plugins/ollama/tests/plugin_api_test.py
+++ b/py/plugins/ollama/tests/plugin_api_test.py
@@ -21,12 +21,24 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import ollama as ollama_api
 import pytest
 from pydantic import BaseModel
 
-from genkit import ActionKind, Media, MediaPart, Message, ModelRequest, Part, Role, TextPart
+from genkit import (
+    ActionKind,
+    Document,
+    EmbedRequest,
+    Media,
+    MediaPart,
+    Message,
+    ModelRequest,
+    Part,
+    Role,
+    TextPart,
+)
 from genkit.plugin_api import to_json_schema
-from genkit.plugins.ollama import Ollama, OllamaConnectionError, ollama_name
+from genkit.plugins.ollama import Ollama, OllamaConnectionError, RequestHeaderParams, ollama_name
 from genkit.plugins.ollama._errors import wrap_connection_errors
 from genkit.plugins.ollama.constants import OllamaAPITypes
 from genkit.plugins.ollama.embedders import EmbeddingDefinition
@@ -280,7 +292,7 @@ def test_make_client_propagates_static_headers() -> None:
 async def test_sync_callable_headers_resolved_per_request() -> None:
     """A sync header callable is resolved on every request, not once at init()."""
     tokens = iter(['t1', 't2'])
-    plugin = Ollama(request_headers=lambda: {'Authorization': next(tokens)})
+    plugin = Ollama(request_headers=lambda params: {'Authorization': next(tokens)})
 
     # init() does not eagerly resolve a callable.
     assert await plugin.init() == []
@@ -299,7 +311,7 @@ async def test_async_callable_headers_resolved_per_request() -> None:
     """An async header callable is awaited on every request, not once at init()."""
     tokens = iter(['a1', 'a2'])
 
-    async def headers() -> dict[str, str]:
+    async def headers(params: RequestHeaderParams) -> dict[str, str]:
         return {'Authorization': next(tokens)}
 
     plugin = Ollama(request_headers=headers)
@@ -313,6 +325,67 @@ async def test_async_callable_headers_resolved_per_request() -> None:
 
     assert async_client.call_args_list[0].kwargs['headers'] == {'Authorization': 'a1'}
     assert async_client.call_args_list[1].kwargs['headers'] == {'Authorization': 'a2'}
+
+
+@pytest.mark.asyncio
+async def test_model_action_passes_request_context_to_header_callable() -> None:
+    """A model header callable receives the server address, model, and model request."""
+    captured: dict[str, Any] = {}
+
+    def make_headers(params: RequestHeaderParams) -> dict[str, str]:
+        captured['params'] = params
+        return {'Authorization': 'Bearer tok'}
+
+    model_def = ModelDefinition(name='m', api_type=OllamaAPITypes.CHAT)
+    plugin = Ollama(models=[model_def], server_address='http://example:11434', request_headers=make_headers)
+
+    sdk_client = AsyncMock()
+    sdk_client.chat.return_value = ollama_api.ChatResponse(message=ollama_api.Message(role='assistant', content='hi'))
+
+    action = plugin._create_model_action(ollama_name('m'))
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hello'))])])
+
+    with patch('ollama.AsyncClient', return_value=sdk_client) as async_client:
+        await action._fn(request, None)
+
+    params = cast(RequestHeaderParams, captured['params'])
+    assert params.server_address == 'http://example:11434'
+    assert params.model is model_def
+    assert params.model_request is request
+    assert params.embed_request is None
+    # The resolved header is applied to the freshly built per-request client.
+    assert async_client.call_args.kwargs['headers'] == {'Authorization': 'Bearer tok'}
+
+
+@pytest.mark.asyncio
+async def test_embedder_action_passes_request_context_to_header_callable() -> None:
+    """An embedder header callable receives the server address, embedder, and embed request."""
+    captured: dict[str, Any] = {}
+
+    def make_headers(params: RequestHeaderParams) -> dict[str, str]:
+        captured['params'] = params
+        return {'X-Token': 'abc'}
+
+    plugin = Ollama(
+        embedders=[EmbeddingDefinition(name='e')],
+        server_address='http://example:11434',
+        request_headers=make_headers,
+    )
+
+    sdk_client = AsyncMock()
+    sdk_client.embed.return_value = ollama_api.EmbedResponse(embeddings=[[0.1, 0.2]])
+
+    action = plugin._create_embedder_action(ollama_name('e'))
+    request = EmbedRequest(input=[Document.from_text(text='hello')])
+
+    with patch('ollama.AsyncClient', return_value=sdk_client):
+        await action._fn(request)
+
+    params = cast(RequestHeaderParams, captured['params'])
+    assert params.server_address == 'http://example:11434'
+    assert params.model is not None and params.model.name == 'e'
+    assert params.embed_request is request
+    assert params.model_request is None
 
 
 @pytest.mark.asyncio

--- a/py/plugins/ollama/tests/plugin_api_test.py
+++ b/py/plugins/ollama/tests/plugin_api_test.py
@@ -24,7 +24,7 @@ import httpx
 import pytest
 from pydantic import BaseModel
 
-from genkit import ActionKind, Message, ModelRequest, Part, Role, TextPart
+from genkit import ActionKind, Media, MediaPart, Message, ModelRequest, Part, Role, TextPart
 from genkit.plugin_api import to_json_schema
 from genkit.plugins.ollama import Ollama, OllamaConnectionError, ollama_name
 from genkit.plugins.ollama._errors import wrap_connection_errors
@@ -277,29 +277,53 @@ def test_make_client_propagates_static_headers() -> None:
 
 
 @pytest.mark.asyncio
-async def test_init_resolves_sync_callable_headers() -> None:
-    """A sync callable for request_headers is resolved during init()."""
-    plugin = Ollama(request_headers=lambda: {'A': '1'})
+async def test_sync_callable_headers_resolved_per_request() -> None:
+    """A sync header callable is resolved on every request, not once at init()."""
+    tokens = iter(['t1', 't2'])
+    plugin = Ollama(request_headers=lambda: {'Authorization': next(tokens)})
 
-    actions = await plugin.init()
+    # init() does not eagerly resolve a callable.
+    assert await plugin.init() == []
+    assert plugin.request_headers == {}
 
-    assert actions == []
-    assert plugin.request_headers == {'A': '1'}
+    with patch('ollama.AsyncClient') as async_client:
+        await plugin._client_for_request()
+        await plugin._client_for_request()
+
+    assert async_client.call_args_list[0].kwargs['headers'] == {'Authorization': 't1'}
+    assert async_client.call_args_list[1].kwargs['headers'] == {'Authorization': 't2'}
 
 
 @pytest.mark.asyncio
-async def test_init_resolves_async_callable_headers() -> None:
-    """An async callable for request_headers is awaited during init()."""
+async def test_async_callable_headers_resolved_per_request() -> None:
+    """An async header callable is awaited on every request, not once at init()."""
+    tokens = iter(['a1', 'a2'])
 
     async def headers() -> dict[str, str]:
-        return {'B': '2'}
+        return {'Authorization': next(tokens)}
 
     plugin = Ollama(request_headers=headers)
 
-    actions = await plugin.init()
+    assert await plugin.init() == []
+    assert plugin.request_headers == {}
 
-    assert actions == []
-    assert plugin.request_headers == {'B': '2'}
+    with patch('ollama.AsyncClient') as async_client:
+        await plugin._client_for_request()
+        await plugin._client_for_request()
+
+    assert async_client.call_args_list[0].kwargs['headers'] == {'Authorization': 'a1'}
+    assert async_client.call_args_list[1].kwargs['headers'] == {'Authorization': 'a2'}
+
+
+@pytest.mark.asyncio
+async def test_static_headers_reuse_cached_client() -> None:
+    """Static headers reuse the per-event-loop cached client across requests."""
+    plugin = Ollama(request_headers={'X-Token': 'abc'})
+
+    first = await plugin._client_for_request()
+    second = await plugin._client_for_request()
+
+    assert first is second
 
 
 @pytest.mark.asyncio
@@ -362,6 +386,46 @@ async def test_model_action_wraps_transport_timeout() -> None:
 
     with pytest.raises(OllamaConnectionError):
         await action._fn(request, None)
+
+
+@pytest.mark.asyncio
+async def test_model_action_does_not_wrap_media_fetch_error() -> None:
+    """A failed media-URL fetch surfaces raw, not as an Ollama server outage.
+
+    build_chat_messages resolves image URLs (an HTTP fetch) before any Ollama SDK
+    call. That transport failure must not be relabelled "Cannot reach the Ollama
+    server", which would point users at the wrong fix.
+    """
+    plugin = Ollama(
+        models=[ModelDefinition(name='m', api_type=OllamaAPITypes.CHAT, supports=OllamaSupports(media=True))]
+    )
+
+    # The Ollama SDK client must never be reached: image resolution fails first.
+    client_mock = MagicMock()
+    client_mock.chat = AsyncMock()
+    plugin.client = lambda: client_mock
+
+    image_client = MagicMock()
+    image_client.get = AsyncMock(side_effect=httpx.ConnectError('image host unreachable'))
+
+    action = plugin._create_model_action(ollama_name('m'))
+    request = ModelRequest(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    Part(root=MediaPart(media=Media(url='http://imgs.example/cat.jpg', content_type='image/jpeg')))
+                ],
+            )
+        ]
+    )
+
+    with patch('genkit.plugins.ollama.models.get_cached_client', return_value=image_client):
+        # The raw httpx.ConnectError propagates; it is not wrapped as OllamaConnectionError.
+        with pytest.raises(httpx.ConnectError):
+            await action._fn(request, None)
+
+    cast(AsyncMock, client_mock.chat).assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/py/plugins/ollama/tests/plugin_api_test.py
+++ b/py/plugins/ollama/tests/plugin_api_test.py
@@ -18,14 +18,16 @@
 
 import unittest
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from pydantic import BaseModel
 
-from genkit import ActionKind
+from genkit import ActionKind, Message, ModelRequest, Part, Role, TextPart
 from genkit.plugin_api import to_json_schema
-from genkit.plugins.ollama import Ollama, ollama_name
+from genkit.plugins.ollama import Ollama, OllamaConnectionError, ollama_name
+from genkit.plugins.ollama._errors import wrap_connection_errors
 from genkit.plugins.ollama.constants import OllamaAPITypes
 from genkit.plugins.ollama.embedders import EmbeddingDefinition
 from genkit.plugins.ollama.models import ModelDefinition, OllamaConfig, OllamaSupports
@@ -223,3 +225,183 @@ async def test_list_actions(ollama_plugin_instance: Ollama) -> None:
             break
 
     assert has_embedder
+
+
+def test_timeout_stored() -> None:
+    """A timeout kwarg is stored on the plugin."""
+    plugin = Ollama(timeout=30.0)
+
+    assert plugin.timeout == 30.0
+
+
+def test_make_client_forwards_host_headers_and_timeout() -> None:
+    """_make_client forwards host, headers, and a non-None timeout to AsyncClient."""
+    plugin = Ollama(
+        server_address='http://example:11434',
+        request_headers={'Authorization': 'Bearer x'},
+        timeout=30.0,
+    )
+
+    with patch('ollama.AsyncClient') as async_client:
+        plugin._make_client()
+
+    async_client.assert_called_once_with(
+        host='http://example:11434',
+        headers={'Authorization': 'Bearer x'},
+        timeout=30.0,
+    )
+
+
+def test_make_client_omits_timeout_when_none() -> None:
+    """With the default timeout (None) the timeout kwarg is omitted entirely."""
+    plugin = Ollama(server_address='http://example:11434')
+
+    with patch('ollama.AsyncClient') as async_client:
+        plugin._make_client()
+
+    _, kwargs = async_client.call_args
+    assert 'timeout' not in kwargs
+    assert kwargs == {'host': 'http://example:11434', 'headers': {}}
+
+
+def test_make_client_propagates_static_headers() -> None:
+    """A static-dict plugin propagates its headers through _make_client."""
+    headers = {'X-Token': 'abc'}
+    plugin = Ollama(request_headers=headers)
+
+    with patch('ollama.AsyncClient') as async_client:
+        plugin._make_client()
+
+    _, kwargs = async_client.call_args
+    assert kwargs['headers'] == headers
+
+
+@pytest.mark.asyncio
+async def test_init_resolves_sync_callable_headers() -> None:
+    """A sync callable for request_headers is resolved during init()."""
+    plugin = Ollama(request_headers=lambda: {'A': '1'})
+
+    actions = await plugin.init()
+
+    assert actions == []
+    assert plugin.request_headers == {'A': '1'}
+
+
+@pytest.mark.asyncio
+async def test_init_resolves_async_callable_headers() -> None:
+    """An async callable for request_headers is awaited during init()."""
+
+    async def headers() -> dict[str, str]:
+        return {'B': '2'}
+
+    plugin = Ollama(request_headers=headers)
+
+    actions = await plugin.init()
+
+    assert actions == []
+    assert plugin.request_headers == {'B': '2'}
+
+
+@pytest.mark.asyncio
+async def test_list_actions_wraps_connection_error(ollama_plugin_instance: Ollama) -> None:
+    """list_actions surfaces transport failures as OllamaConnectionError."""
+    client_mock = MagicMock()
+    client_mock.list = AsyncMock(side_effect=httpx.ConnectError('refused'))
+    ollama_plugin_instance.client = lambda: client_mock
+
+    with pytest.raises(OllamaConnectionError):
+        await ollama_plugin_instance.list_actions()
+
+
+@pytest.mark.asyncio
+async def test_list_actions_does_not_wrap_http_status_error(ollama_plugin_instance: Ollama) -> None:
+    """A genuine HTTP status response is not masked as a connection error."""
+    request = httpx.Request('GET', 'http://localhost:11434/api/tags')
+    response = httpx.Response(500, request=request)
+    client_mock = MagicMock()
+    client_mock.list = AsyncMock(side_effect=httpx.HTTPStatusError('boom', request=request, response=response))
+    ollama_plugin_instance.client = lambda: client_mock
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await ollama_plugin_instance.list_actions()
+
+
+@pytest.mark.asyncio
+async def test_model_action_wraps_connection_error() -> None:
+    """The model action callable surfaces a down server as OllamaConnectionError.
+
+    The ollama SDK converts ``httpx.ConnectError`` into a builtin
+    ``ConnectionError`` before our wrapper sees it, so that is what we simulate.
+    """
+    plugin = Ollama(models=[ModelDefinition(name='m', api_type=OllamaAPITypes.CHAT)])
+
+    client_mock = MagicMock()
+    client_mock.chat = AsyncMock(side_effect=ConnectionError('Failed to connect to Ollama.'))
+    # The model captures the client factory when the action is built, so swap it
+    # in before resolving the action.
+    plugin.client = lambda: client_mock
+
+    action = plugin._create_model_action(ollama_name('m'))
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hello'))])])
+
+    with pytest.raises(OllamaConnectionError):
+        await action._fn(request, None)
+
+
+@pytest.mark.asyncio
+async def test_model_action_wraps_transport_timeout() -> None:
+    """Timeouts the SDK does not intercept (httpx.TransportError) are also wrapped."""
+    plugin = Ollama(models=[ModelDefinition(name='m', api_type=OllamaAPITypes.CHAT)])
+
+    client_mock = MagicMock()
+    client_mock.chat = AsyncMock(side_effect=httpx.ReadTimeout('timed out'))
+    plugin.client = lambda: client_mock
+
+    action = plugin._create_model_action(ollama_name('m'))
+    request = ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hello'))])])
+
+    with pytest.raises(OllamaConnectionError):
+        await action._fn(request, None)
+
+
+@pytest.mark.asyncio
+async def test_wrap_connection_errors_translates_transport_error() -> None:
+    """wrap_connection_errors turns an httpx TransportError into OllamaConnectionError."""
+    with pytest.raises(OllamaConnectionError) as exc_info:
+        async with wrap_connection_errors('http://localhost:11434'):
+            raise httpx.ConnectError('refused')
+
+    assert 'http://localhost:11434' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_wrap_connection_errors_translates_builtin_connection_error() -> None:
+    """wrap_connection_errors turns the SDK's builtin ConnectionError into ours."""
+    with pytest.raises(OllamaConnectionError) as exc_info:
+        async with wrap_connection_errors('http://localhost:11434'):
+            raise ConnectionError('Failed to connect to Ollama.')
+
+    assert 'http://localhost:11434' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_wrap_connection_errors_does_not_double_wrap() -> None:
+    """An already-actionable OllamaConnectionError passes through unchanged."""
+    original = OllamaConnectionError('already wrapped')
+
+    with pytest.raises(OllamaConnectionError) as exc_info:
+        async with wrap_connection_errors('http://localhost:11434'):
+            raise original
+
+    assert exc_info.value is original
+
+
+@pytest.mark.asyncio
+async def test_wrap_connection_errors_passes_through_http_status_error() -> None:
+    """wrap_connection_errors leaves HTTPStatusError untouched."""
+    request = httpx.Request('GET', 'http://localhost:11434/api/tags')
+    response = httpx.Response(500, request=request)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        async with wrap_connection_errors('http://localhost:11434'):
+            raise httpx.HTTPStatusError('boom', request=request, response=response)

--- a/py/plugins/ollama/tests/plugin_api_test.py
+++ b/py/plugins/ollama/tests/plugin_api_test.py
@@ -522,6 +522,26 @@ async def test_model_action_does_not_wrap_media_fetch_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_embedder_action_wraps_connection_error() -> None:
+    """The embedder action surfaces a down server as OllamaConnectionError.
+
+    Mirrors the model/list_actions paths so the embedder endpoint's connection
+    wrapping cannot silently regress.
+    """
+    plugin = Ollama(embedders=[EmbeddingDefinition(name='e')])
+
+    client_mock = MagicMock()
+    client_mock.embed = AsyncMock(side_effect=ConnectionError('Failed to connect to Ollama.'))
+    plugin.client = lambda: client_mock
+
+    action = plugin._create_embedder_action(ollama_name('e'))
+    request = EmbedRequest(input=[Document.from_text(text='hello')])
+
+    with pytest.raises(OllamaConnectionError):
+        await action._fn(request)
+
+
+@pytest.mark.asyncio
 async def test_wrap_connection_errors_translates_transport_error() -> None:
     """wrap_connection_errors turns an httpx TransportError into OllamaConnectionError."""
     with pytest.raises(OllamaConnectionError) as exc_info:
@@ -529,6 +549,18 @@ async def test_wrap_connection_errors_translates_transport_error() -> None:
             raise httpx.ConnectError('refused')
 
     assert 'http://localhost:11434' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_wrap_connection_errors_timeout_has_distinct_message() -> None:
+    """A timeout gets its own 'timed out' message, not the generic unreachable one."""
+    with pytest.raises(OllamaConnectionError) as exc_info:
+        async with wrap_connection_errors('http://localhost:11434'):
+            raise httpx.ReadTimeout('slow')
+
+    message = str(exc_info.value)
+    assert 'timed out' in message
+    assert 'http://localhost:11434' in message
 
 
 @pytest.mark.asyncio

--- a/py/plugins/ollama/tests/plugin_api_test.py
+++ b/py/plugins/ollama/tests/plugin_api_test.py
@@ -298,12 +298,18 @@ async def test_sync_callable_headers_resolved_per_request() -> None:
     assert await plugin.init() == []
     assert plugin.request_headers == {}
 
-    with patch('ollama.AsyncClient') as async_client:
-        await plugin._client_for_request()
-        await plugin._client_for_request()
+    client_mock = MagicMock()
+    client_mock._client.aclose = AsyncMock()
+    with patch('ollama.AsyncClient', return_value=client_mock) as async_client:
+        async with plugin._client_for_request():
+            pass
+        async with plugin._client_for_request():
+            pass
 
     assert async_client.call_args_list[0].kwargs['headers'] == {'Authorization': 't1'}
     assert async_client.call_args_list[1].kwargs['headers'] == {'Authorization': 't2'}
+    # Each fresh per-request client's connection pool is closed on exit.
+    assert client_mock._client.aclose.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -319,12 +325,17 @@ async def test_async_callable_headers_resolved_per_request() -> None:
     assert await plugin.init() == []
     assert plugin.request_headers == {}
 
-    with patch('ollama.AsyncClient') as async_client:
-        await plugin._client_for_request()
-        await plugin._client_for_request()
+    client_mock = MagicMock()
+    client_mock._client.aclose = AsyncMock()
+    with patch('ollama.AsyncClient', return_value=client_mock) as async_client:
+        async with plugin._client_for_request():
+            pass
+        async with plugin._client_for_request():
+            pass
 
     assert async_client.call_args_list[0].kwargs['headers'] == {'Authorization': 'a1'}
     assert async_client.call_args_list[1].kwargs['headers'] == {'Authorization': 'a2'}
+    assert client_mock._client.aclose.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -341,6 +352,7 @@ async def test_model_action_passes_request_context_to_header_callable() -> None:
 
     sdk_client = AsyncMock()
     sdk_client.chat.return_value = ollama_api.ChatResponse(message=ollama_api.Message(role='assistant', content='hi'))
+    sdk_client._client.aclose = AsyncMock()
 
     action = plugin._create_model_action(ollama_name('m'))
     request = ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hello'))])])
@@ -355,6 +367,8 @@ async def test_model_action_passes_request_context_to_header_callable() -> None:
     assert params.embed_request is None
     # The resolved header is applied to the freshly built per-request client.
     assert async_client.call_args.kwargs['headers'] == {'Authorization': 'Bearer tok'}
+    # That fresh client's connection pool is closed once the request completes.
+    sdk_client._client.aclose.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -374,6 +388,7 @@ async def test_embedder_action_passes_request_context_to_header_callable() -> No
 
     sdk_client = AsyncMock()
     sdk_client.embed.return_value = ollama_api.EmbedResponse(embeddings=[[0.1, 0.2]])
+    sdk_client._client.aclose = AsyncMock()
 
     action = plugin._create_embedder_action(ollama_name('e'))
     request = EmbedRequest(input=[Document.from_text(text='hello')])
@@ -386,17 +401,22 @@ async def test_embedder_action_passes_request_context_to_header_callable() -> No
     assert params.model is not None and params.model.name == 'e'
     assert params.embed_request is request
     assert params.model_request is None
+    sdk_client._client.aclose.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_static_headers_reuse_cached_client() -> None:
-    """Static headers reuse the per-event-loop cached client across requests."""
+async def test_static_headers_reuse_cached_client_and_keep_it_open() -> None:
+    """Static headers reuse the per-event-loop cached client and never close it."""
     plugin = Ollama(request_headers={'X-Token': 'abc'})
 
-    first = await plugin._client_for_request()
-    second = await plugin._client_for_request()
+    async with plugin._client_for_request() as first:
+        pass
+    async with plugin._client_for_request() as second:
+        pass
 
+    # Same shared instance both times, and it was not closed on context exit.
     assert first is second
+    assert not first._client.is_closed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Brings the Ollama Python plugin's transport surface to parity with the JS/Go plugins (slice B2 of #5521, stacked on #5658 ).

- **Configurable request headers**:
  - Static dict headers are applied to the cached per-event-loop Ollama client.
  - Sync/async callable headers are resolved **per request** with `RequestHeaderParams` (`server_address`, model/embedder definition, and model/embed request context), matching JS plugin semantics and supporting expiring auth tokens.
  - Callable-header requests use a fresh Ollama client because the Python SDK bakes headers in at construction; that client's wrapped `httpx` pool is closed on exit.
- **`timeout` kwarg** forwarded to the underlying `httpx` client via `_make_client`.
- **Friendly connection errors**: Ollama SDK transport failures on model, embedder, and `list_actions` paths become `OllamaConnectionError` (subclass of `ConnectionError`) naming the address and pointing at `ollama serve`.
- **Scoped error wrapping**: media URL fetch failures remain raw HTTP errors instead of being misreported as Ollama server outages.

### Latent Bugs Fixed

- `request_headers` was stored on the plugin but never passed to the client factory.
- Callable `request_headers` originally required fresh SDK clients but did not close their underlying `httpx` pools.
- Broad connection-error wrapping could label non-Ollama transport failures, such as media fetch failures, as Ollama server connectivity issues.

## Test Plan

- `uv run pytest plugins/ollama/tests/plugin_api_test.py plugins/ollama/tests/models/ollama_models_test.py --no-cov` -> 118 passed
- Live Ollama smoke test:
  - `list_actions()` returned local `qwen3.5:4b` and `nomic-embed-text:latest`
  - chat generate against `qwen3.5:4b` returned `OK`
  - embed against `nomic-embed-text:latest` returned a 768-dimensional embedding
  - callable `request_headers` context was exercised for list/model/embed paths