### PR TITLE
docs(py/ollama): first-party docs, CHANGELOG, and runnable sample

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -422,6 +422,7 @@ The Python samples are intentionally short and beginner-friendly. Use this table
 | `gemini-context-caching` | Gemini, Context Caching | Cache a large document and ask follow-up questions |
 | `google-genai-media` | Gemini, Imagen, Veo | Simple speech, image, and video generation examples |
 | `middleware` | Middleware | Observe or modify model requests with `use=[...]` |
+| `ollama-sample` | Ollama, Streaming, Tool, Embedder | Run local chat, streaming, tool calling, and embeddings with Ollama |
 | `output-formats` | Structured Output | Text, enum, JSON object, array, and JSONL outputs |
 | `prompts` | Prompt, Dotprompt | Use `.prompt` files, helpers, variants, and streaming |
 | `tool-interrupts` | Tool | Trivia (`respond_example.py`) and bank approval (`approval_example.py`) for interrupt / resume |

--- a/py/plugins/ollama/CHANGELOG.md
+++ b/py/plugins/ollama/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0] - 2026-06-23
+## [Unreleased]
 
 ### Added
 
@@ -20,6 +20,9 @@ and this project adheres to
   static dict.
 - `timeout` constructor argument propagated to the underlying httpx client.
 - Friendly `OllamaConnectionError` when the Ollama server is unreachable.
+- `EmbeddingDefinition` is now exported from the package root
+  `genkit.plugins.ollama` (previously importable only via the
+  `genkit.plugins.ollama.embedders` submodule).
 - Runnable sample under `py/samples/ollama-sample/` covering chat, streaming,
   tool calling, and embeddings.
 
@@ -37,4 +40,4 @@ and this project adheres to
 - `top_p` from `ModelConfig` is now mapped correctly into
   `ollama.Options` (previously sent as `topP` and ignored).
 
-[0.7.0]: https://github.com/genkit-ai/genkit/compare/py/genkit-plugin-ollama-v0.6.0...py/genkit-plugin-ollama-v0.7.0
+[Unreleased]: https://github.com/genkit-ai/genkit/compare/py/genkit-plugin-ollama-v0.6.0...HEAD

--- a/py/plugins/ollama/CHANGELOG.md
+++ b/py/plugins/ollama/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to the `genkit-plugin-ollama` package are documented in
+this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.7.0] - 2026-06-23
+
+### Added
+
+- First-party support for the plugin (graduated from community status).
+- `OllamaConfig` with Ollama-specific knobs: `think`, `keep_alive`,
+  `num_ctx`, `min_p`, `seed`, `num_predict`.
+- `OllamaSupports.media` opt-in flag for vision models (`llava`,
+  `llama3.2-vision`, etc.).
+- `request_headers` accepts a sync or async callable in addition to a
+  static dict.
+- `timeout` constructor argument propagated to the underlying httpx client.
+- Friendly `OllamaConnectionError` when the Ollama server is unreachable.
+- Runnable sample under `py/samples/ollama-sample/` covering chat, streaming,
+  tool calling, and embeddings.
+
+### Changed
+
+- Plugin metadata now reflects per-API-type capabilities (e.g. the `generate`
+  API no longer advertises `multiturn`/`tools`).
+- `request_headers` are now propagated through to `ollama.AsyncClient`
+  (previously stored but never sent).
+- Tool input schemas that omit an explicit `type` but declare `properties`
+  are inferred as object schemas instead of being dropped.
+
+### Fixed
+
+- `top_p` from `ModelConfig` is now mapped correctly into
+  `ollama.Options` (previously sent as `topP` and ignored).
+
+[0.7.0]: https://github.com/genkit-ai/genkit/compare/py/genkit-plugin-ollama-v0.6.0...py/genkit-plugin-ollama-v0.7.0

--- a/py/plugins/ollama/README.md
+++ b/py/plugins/ollama/README.md
@@ -47,6 +47,11 @@ embeddings = await ai.embed(embedder='ollama/nomic-embed-text', content='local i
 print(len(embeddings[0].embedding))
 ```
 
+These snippets assume an async context (`await` inside an `async def`); pasting
+them at module top level raises `SyntaxError: 'await' outside function`. See the
+[runnable sample](../../samples/ollama-sample) for a complete `async def main()`
+plus `ai.run_main(...)` entry point.
+
 ### Streaming
 
 ```python

--- a/py/plugins/ollama/README.md
+++ b/py/plugins/ollama/README.md
@@ -125,14 +125,17 @@ Ollama(server_address='http://ollama.example.com:11434')
 # Static headers
 Ollama(request_headers={'Authorization': 'Bearer <token>'})
 
-# Async-resolved headers (e.g. minting a short-lived token at startup)
-async def auth_headers() -> dict[str, str]:
-    return {'Authorization': f'Bearer {await mint_token()}'}
+# Async-resolved headers, re-evaluated per request (e.g. minting a short-lived token)
+from genkit.plugins.ollama import RequestHeaderParams
+
+async def auth_headers(params: RequestHeaderParams) -> dict[str, str]:
+    return {'Authorization': f'Bearer {await mint_token(params.server_address)}'}
 
 Ollama(request_headers=auth_headers, timeout=60.0)
 ```
 
-Callable headers are evaluated once during plugin initialization.
+Callable headers are re-evaluated on every request, so short-lived tokens refresh
+automatically. A static dict is applied once to a cached client.
 
 ### Vision models
 

--- a/py/plugins/ollama/README.md
+++ b/py/plugins/ollama/README.md
@@ -1,73 +1,174 @@
-# Genkit Ollama Plugin (Community)
+# Genkit Ollama Plugin
 
-> **Community Plugin** — This plugin is community-maintained and is not an
-> official Google or Ollama product. It is provided on an "as-is" basis.
->
-> **Preview** — This plugin is in preview and may have API changes in future releases.
+This Genkit plugin connects Python apps to locally running Ollama models for
+chat, streaming, tool calling, multimodal prompts, and embeddings.
 
-This Genkit plugin provides a set of tools and utilities for working with Ollama.
-
-## Setup environment
+## Installation
 
 ```bash
-uv venv
-source .venv/bin/activate
+uv add genkit genkit-plugin-ollama
 ```
 
-## Serving Ollama Locally
-
-### Ollama Service Installation
-
-#### MacOS  (brew)
-
-```bash
-brew install ollama
-```
-
-#### Debian/Ubuntu (apt installer)
-
-```bash
-curl -fsSL https://ollama.com/install.sh | sh
-```
-
-Other installation options may be found [here](https://ollama.com/download)
-
-### Start serving of Ollama locally
+Install Ollama from [ollama.com/download](https://ollama.com/download), then
+start the local server:
 
 ```bash
 ollama serve
 ```
 
-Ollama is served at `http://127.0.0.1:11434` by default.
-
-### Installing Required Model
-
-Once ollama service is serving - pull the required model version:
+Ollama serves `http://127.0.0.1:11434` by default. Pull the models your app will
+use before running Genkit:
 
 ```bash
-ollama pull <model-version>:<tag>
+ollama pull llama3.2
+ollama pull nomic-embed-text
 ```
 
-### Check installed models
+## Usage
 
-Installed models can be reviewed with following command:
+```python
+from genkit import Genkit
+from genkit.plugins.ollama import EmbeddingDefinition, ModelDefinition, Ollama
 
-```bash
-ollama list
+ai = Genkit(
+    plugins=[
+        Ollama(
+            models=[ModelDefinition(name='llama3.2')],
+            embedders=[EmbeddingDefinition(name='nomic-embed-text')],
+        )
+    ],
+    model='ollama/llama3.2',
+)
+
+response = await ai.generate(prompt='Write a haiku about local models.')
+print(response.text)
+
+embeddings = await ai.embed(embedder='ollama/nomic-embed-text', content='local inference')
+print(len(embeddings[0].embedding))
 ```
 
-## Disclaimer
+### Streaming
 
-This is a **community-maintained** plugin and is not officially supported by
-Google or Ollama. Ollama is open-source software under the
-[MIT License](https://github.com/ollama/ollama/blob/main/LICENSE). You are
-responsible for ensuring your usage complies with the licenses of the models
-you download and run.
+```python
+stream_response = ai.generate_stream(prompt='Stream a haiku about Ollama.')
+async for chunk in stream_response.stream:
+    print(chunk.text, end='', flush=True)
+final = await stream_response.response
+```
 
-- **Model Licensing** — Individual models pulled via Ollama have their own
-  licenses. Review model cards before use in production.
-- **Local Execution** — Ollama runs models locally on your hardware. No data
-  is sent to external APIs unless you configure a remote Ollama server.
+### Tool calling
+
+```python
+from pydantic import BaseModel, Field
+
+class WeatherInput(BaseModel):
+    city: str = Field(description='City to look up')
+
+@ai.tool()
+async def current_weather(input: WeatherInput) -> str:
+    return f'{input.city} is 18°C and partly cloudy.'
+
+response = await ai.generate(
+    prompt='What is the weather in London?',
+    tools=['current_weather'],
+)
+print(response.text)
+```
+
+Ollama tool inputs are object schemas, so wrap primitive inputs in a Pydantic
+model as above. When a tool's schema declares `properties` but omits an explicit
+`type`, the plugin infers an object schema rather than dropping the tool.
+
+### JSON / schema-constrained output
+
+```python
+from pydantic import BaseModel
+
+class Haiku(BaseModel):
+    line_one: str
+    line_two: str
+    line_three: str
+
+response = await ai.generate(
+    prompt='Write a haiku about local models.',
+    output_schema=Haiku,
+)
+print(response.output)
+```
+
+### Ollama-specific config (`OllamaConfig`)
+
+`OllamaConfig` extends the common Genkit `ModelConfig` with Ollama-only
+knobs (`think`, `keep_alive`, `num_ctx`, `min_p`, `seed`, `num_predict`):
+
+```python
+from genkit.plugins.ollama import OllamaConfig
+
+# Reasoning model with a 32k context window kept warm for an hour
+response = await ai.generate(
+    model='ollama/deepseek-r1',
+    prompt='Plan a small REST API.',
+    config=OllamaConfig(
+        think=True,
+        num_ctx=32_000,
+        keep_alive='1h',
+        temperature=0.2,
+    ),
+)
+```
+
+### Remote server, headers, and timeouts
+
+```python
+Ollama(server_address='http://ollama.example.com:11434')
+
+# Static headers
+Ollama(request_headers={'Authorization': 'Bearer <token>'})
+
+# Async-resolved headers (e.g. minting a short-lived token at startup)
+async def auth_headers() -> dict[str, str]:
+    return {'Authorization': f'Bearer {await mint_token()}'}
+
+Ollama(request_headers=auth_headers, timeout=60.0)
+```
+
+Callable headers are evaluated once during plugin initialization.
+
+### Vision models
+
+```python
+from genkit.plugins.ollama import ModelDefinition, Ollama, OllamaSupports
+
+Ollama(models=[ModelDefinition(name='llava', supports=OllamaSupports(media=True))])
+```
+
+Media support is opt-in per model to avoid advertising a capability the
+underlying model does not actually have.
+
+### Troubleshooting
+
+If the plugin can't reach the server it raises `OllamaConnectionError`
+with the URL it tried. Start the daemon (`ollama serve`) or set
+`server_address` to a reachable host.
+
+## Sample
+
+See [`py/samples/ollama-sample`](../../samples/ollama-sample) for a runnable sample covering
+chat, streaming, tool calling, and embeddings with a local Ollama server.
+
+## Notes
+
+Ollama is open-source software under the
+[MIT License](https://github.com/ollama/ollama/blob/main/LICENSE). Individual
+models pulled through Ollama have their own licenses; review model cards
+before production use. Models run locally on your hardware by default — no
+data leaves the machine unless you point the plugin at a remote Ollama
+server.
+
+## Acknowledgements
+
+Thanks to the community contributors who built and maintained the original
+community version of this plugin.
 
 ## License
 

--- a/py/plugins/ollama/pyproject.toml
+++ b/py/plugins/ollama/pyproject.toml
@@ -22,7 +22,7 @@ authors = [
   { name = "Niraj Nepal", email = "nnepal@google.com" },
 ]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Environment :: Console",
   "Environment :: Web Environment",
   "Framework :: AsyncIO",

--- a/py/plugins/ollama/pyproject.toml
+++ b/py/plugins/ollama/pyproject.toml
@@ -22,7 +22,7 @@ authors = [
   { name = "Niraj Nepal", email = "nnepal@google.com" },
 ]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 3 - Alpha",
   "Environment :: Console",
   "Environment :: Web Environment",
   "Framework :: AsyncIO",
@@ -43,7 +43,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = ["genkit", "ollama>=0.5.3,<1.0", "structlog>=25.2.0"]
-description = "Genkit Ollama Plugin (Community)"
+description = "Genkit AI framework plugin for Ollama"
 keywords = [
   "genkit",
   "ai",

--- a/py/plugins/ollama/src/genkit/plugins/ollama/__init__.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/__init__.py
@@ -156,6 +156,7 @@ See Also:
 """
 
 from genkit.plugins.ollama._errors import OllamaConnectionError
+from genkit.plugins.ollama.embedders import EmbeddingDefinition
 from genkit.plugins.ollama.models import ModelDefinition, OllamaConfig, OllamaSupports
 from genkit.plugins.ollama.plugin_api import (
     Ollama,
@@ -186,4 +187,5 @@ __all__ = [
     'RequestHeaders',
     'ollama_name',
     'package_name',
+    'EmbeddingDefinition',
 ]

--- a/py/plugins/ollama/src/genkit/plugins/ollama/__init__.py
+++ b/py/plugins/ollama/src/genkit/plugins/ollama/__init__.py
@@ -177,6 +177,7 @@ def package_name() -> str:
 
 
 __all__ = [
+    'EmbeddingDefinition',
     'ModelDefinition',
     'Ollama',
     'OllamaConfig',
@@ -187,5 +188,4 @@ __all__ = [
     'RequestHeaders',
     'ollama_name',
     'package_name',
-    'EmbeddingDefinition',
 ]

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -161,6 +161,7 @@ gemini-context-caching = { workspace = true }
 google-genai-media   = { workspace = true }
 middleware           = { workspace = true }
 middleware-coding-agent = { workspace = true }
+ollama-sample        = { workspace = true }
 output-formats       = { workspace = true }
 prompts              = { workspace = true }
 tool-interrupts      = { workspace = true }

--- a/py/samples/README.md
+++ b/py/samples/README.md
@@ -34,6 +34,7 @@ Dev UI: http://localhost:4000. Most samples need `GEMINI_API_KEY`. See [plugins/
 | `gemini-context-caching` | Cache a large source document for follow-up prompts |
 | `google-genai-media` | Speech, image, and video generation |
 | `middleware` | Observe or modify model requests |
+| `ollama-sample` | Local chat, streaming, tools, and embeddings via Ollama |
 | `output-formats` | Text, enum, JSON, array, and JSONL outputs |
 | `prompts` | `.prompt` files, variants, helpers, and streaming |
 | `tool-interrupts` | Trivia (`respond_example.py`) and bank approval (`approval_example.py`) — interrupt + resume |

--- a/py/samples/ollama-sample/README.md
+++ b/py/samples/ollama-sample/README.md
@@ -1,0 +1,36 @@
+# Ollama
+
+Run local LLM chat, streaming, tools, and embeddings through Genkit with Ollama.
+
+Install Ollama from [ollama.com/download](https://ollama.com/download), then
+start the server and pull the sample models:
+
+```bash
+ollama serve
+ollama pull llama3.2
+ollama pull nomic-embed-text
+```
+
+Run the quick smoke test:
+
+```bash
+uv sync
+uv run src/main.py
+```
+
+To explore all flows in Dev UI instead:
+
+```bash
+genkit start -- uv run src/main.py
+```
+
+Then open [http://localhost:4000](http://localhost:4000) and try:
+
+- `chat`
+- `chat_stream`
+- `tool_assistant`
+- `embed_text`
+
+The sample uses the default Ollama server at `http://127.0.0.1:11434`. To use a
+different server, set `OLLAMA_HOST`. To use different local models, set
+`OLLAMA_CHAT_MODEL` or `OLLAMA_EMBEDDER_MODEL`.

--- a/py/samples/ollama-sample/README.md
+++ b/py/samples/ollama-sample/README.md
@@ -2,11 +2,17 @@
 
 Run local LLM chat, streaming, tools, and embeddings through Genkit with Ollama.
 
-Install Ollama from [ollama.com/download](https://ollama.com/download), then
-start the server and pull the sample models:
+Install Ollama from [ollama.com/download](https://ollama.com/download). Start the
+server if it is not already running — it stays in the foreground, so use a
+separate terminal (or rely on the Ollama app):
 
 ```bash
 ollama serve
+```
+
+Then pull the sample models:
+
+```bash
 ollama pull llama3.2
 ollama pull nomic-embed-text
 ```

--- a/py/samples/ollama-sample/pyproject.toml
+++ b/py/samples/ollama-sample/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "ollama-sample"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "genkit",
+  "genkit-plugin-ollama",
+  "pydantic>=2.0.0",
+]
+
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/py/samples/ollama-sample/src/main.py
+++ b/py/samples/ollama-sample/src/main.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-# pyright: reportMissingImports=false
 
 """Ollama sample for local chat, streaming, tools, and embeddings.
 
@@ -29,29 +28,31 @@ Or open the Dev UI and pick a flow:
 from __future__ import annotations
 
 import os
-from typing import Any
 
 from pydantic import BaseModel, Field
 
-from genkit import Genkit
-from genkit.plugins.ollama import EmbeddingDefinition, ModelDefinition, Ollama
+from genkit import Genkit, GenkitError
+from genkit.plugins.ollama import (  # pyright: ignore[reportMissingImports]
+    EmbeddingDefinition,
+    ModelDefinition,
+    Ollama,
+    OllamaConnectionError,
+)
 
 CHAT_MODEL = os.getenv('OLLAMA_CHAT_MODEL', 'llama3.2')
 EMBEDDER_MODEL = os.getenv('OLLAMA_EMBEDDER_MODEL', 'nomic-embed-text')
 
 
-def _ollama_plugin() -> Ollama:
-    """Create the Ollama plugin, honoring OLLAMA_HOST when set."""
-    kwargs: dict[str, Any] = {
-        'models': [ModelDefinition(name=CHAT_MODEL)],
-        'embedders': [EmbeddingDefinition(name=EMBEDDER_MODEL)],
-    }
-    if server_address := os.getenv('OLLAMA_HOST'):
-        kwargs['server_address'] = server_address
-    return Ollama(**kwargs)
-
-
-ai = Genkit(plugins=[_ollama_plugin()], model=f'ollama/{CHAT_MODEL}')
+ai = Genkit(
+    plugins=[
+        Ollama(
+            models=[ModelDefinition(name=CHAT_MODEL)],
+            embedders=[EmbeddingDefinition(name=EMBEDDER_MODEL)],
+            server_address=os.getenv('OLLAMA_HOST'),
+        )
+    ],
+    model=f'ollama/{CHAT_MODEL}',
+)
 
 
 class PromptInput(BaseModel):
@@ -89,14 +90,16 @@ async def chat(input: PromptInput) -> str:
 async def chat_stream(input: PromptInput) -> dict[str, str | int]:
     """Stream a response and return the final text plus chunk count."""
     stream_response = ai.generate_stream(prompt=input.prompt)
+    # Ollama streams the text via chunks and returns an empty final message,
+    # so accumulate the chunk text instead of reading response.text.
     chunks: list[str] = []
     async for chunk in stream_response.stream:
         chunks.append(chunk.text or '')
 
-    response = await stream_response.response
+    await stream_response.response
     return {
         'chunks': len(chunks),
-        'text': response.text,
+        'text': ''.join(chunks),
     }
 
 
@@ -122,15 +125,20 @@ async def embed_text(input: EmbedInput) -> dict[str, int]:
 async def main() -> None:
     """Run the fast Ollama demos once."""
     try:
-        print(await chat(PromptInput()))  # noqa: T201
-        print(await embed_text(EmbedInput()))  # noqa: T201
-    except Exception as error:
-        print(  # noqa: T201
+        print(await chat(PromptInput()))
+        print(await embed_text(EmbedInput()))
+    except GenkitError as error:
+        # Genkit wraps provider failures in GenkitError, so unwrap `.cause` to
+        # tell a "server not running" setup problem from a real bug.
+        if not isinstance(error.cause, OllamaConnectionError):
+            raise
+        print(
             'Start Ollama and pull the sample models before running this sample directly:\n'
             f'  ollama pull {CHAT_MODEL}\n'
             f'  ollama pull {EMBEDDER_MODEL}\n\n'
-            f'{error}'
+            f'{error.cause}'
         )
+        raise SystemExit(1) from error
 
 
 if __name__ == '__main__':

--- a/py/samples/ollama-sample/src/main.py
+++ b/py/samples/ollama-sample/src/main.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportMissingImports=false
+
+"""Ollama sample for local chat, streaming, tools, and embeddings.
+
+Run the default exercise once:
+
+    uv run src/main.py
+
+Or open the Dev UI and pick a flow:
+
+    genkit start -- uv run src/main.py
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from genkit import Genkit
+from genkit.plugins.ollama import EmbeddingDefinition, ModelDefinition, Ollama
+
+CHAT_MODEL = os.getenv('OLLAMA_CHAT_MODEL', 'llama3.2')
+EMBEDDER_MODEL = os.getenv('OLLAMA_EMBEDDER_MODEL', 'nomic-embed-text')
+
+
+def _ollama_plugin() -> Ollama:
+    """Create the Ollama plugin, honoring OLLAMA_HOST when set."""
+    kwargs: dict[str, Any] = {
+        'models': [ModelDefinition(name=CHAT_MODEL)],
+        'embedders': [EmbeddingDefinition(name=EMBEDDER_MODEL)],
+    }
+    if server_address := os.getenv('OLLAMA_HOST'):
+        kwargs['server_address'] = server_address
+    return Ollama(**kwargs)
+
+
+ai = Genkit(plugins=[_ollama_plugin()], model=f'ollama/{CHAT_MODEL}')
+
+
+class PromptInput(BaseModel):
+    """Prompt input for chat examples."""
+
+    prompt: str = Field(default='Write a two-sentence pitch for local AI development.', description='Prompt to send')
+
+
+class WeatherInput(BaseModel):
+    """Input for the weather tool."""
+
+    city: str = Field(default='London', description='City to look up')
+
+
+class EmbedInput(BaseModel):
+    """Input for embedding examples."""
+
+    text: str = Field(default='Local models are useful for private development.', description='Text to embed')
+
+
+@ai.tool()
+async def current_weather(input: WeatherInput) -> str:
+    """Return mocked weather data for tool-calling demos."""
+    return f'The weather in {input.city} is 18C and partly cloudy.'
+
+
+@ai.flow(name='chat')
+async def chat(input: PromptInput) -> str:
+    """Generate a single response with the default Ollama chat model."""
+    response = await ai.generate(prompt=input.prompt)
+    return response.text
+
+
+@ai.flow(name='chat_stream')
+async def chat_stream(input: PromptInput) -> dict[str, str | int]:
+    """Stream a response and return the final text plus chunk count."""
+    stream_response = ai.generate_stream(prompt=input.prompt)
+    chunks: list[str] = []
+    async for chunk in stream_response.stream:
+        chunks.append(chunk.text or '')
+
+    response = await stream_response.response
+    return {
+        'chunks': len(chunks),
+        'text': response.text,
+    }
+
+
+@ai.flow(name='tool_assistant')
+async def tool_assistant(input: WeatherInput) -> str:
+    """Let the model call a local tool."""
+    response = await ai.generate(
+        prompt=f'Use the current_weather tool to tell me the weather in {input.city}.',
+        tools=['current_weather'],
+    )
+    return response.text
+
+
+@ai.flow(name='embed_text')
+async def embed_text(input: EmbedInput) -> dict[str, int]:
+    """Embed text with Ollama and report vector dimensions."""
+    embeddings = await ai.embed(embedder=f'ollama/{EMBEDDER_MODEL}', content=input.text)
+    if not embeddings:
+        raise RuntimeError('Ollama embedder returned no embeddings for a non-empty input.')
+    return {'dimensions': len(embeddings[0].embedding)}
+
+
+async def main() -> None:
+    """Run the fast Ollama demos once."""
+    try:
+        print(await chat(PromptInput()))  # noqa: T201
+        print(await embed_text(EmbedInput()))  # noqa: T201
+    except Exception as error:
+        print(  # noqa: T201
+            'Start Ollama and pull the sample models before running this sample directly:\n'
+            f'  ollama pull {CHAT_MODEL}\n'
+            f'  ollama pull {EMBEDDER_MODEL}\n\n'
+            f'{error}'
+        )
+
+
+if __name__ == '__main__':
+    ai.run_main(main())

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -36,6 +36,7 @@ members = [
     "google-genai-media",
     "middleware",
     "middleware-coding-agent",
+    "ollama-sample",
     "output-formats",
     "prompts",
     "tool-interrupts",
@@ -4330,6 +4331,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/5a/652dac4b7affc2b37b95386f8ae78f22808af09d720689e3d7a86b6ed98e/ollama-0.6.1.tar.gz", hash = "sha256:478c67546836430034b415ed64fa890fd3d1ff91781a9d548b3325274e69d7c6", size = 51620, upload-time = "2025-11-13T23:02:17.416Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/4f/4a617ee93d8208d2bcf26b2d8b9402ceaed03e3853c754940e2290fed063/ollama-0.6.1-py3-none-any.whl", hash = "sha256:fc4c984b345735c5486faeee67d8a265214a31cbb828167782dc642ce0a2bf8c", size = 14354, upload-time = "2025-11-13T23:02:16.292Z" },
+]
+
+[[package]]
+name = "ollama-sample"
+version = "0.1.0"
+source = { editable = "samples/ollama-sample" }
+dependencies = [
+    { name = "genkit" },
+    { name = "genkit-plugin-ollama" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-plugin-ollama", editable = "plugins/ollama" },
+    { name = "pydantic", specifier = ">=2.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

slice C of [#5521](https://github.com/genkit-ai/genkit/pull/5521/), decomposed into A → B1 → B2 → C. Graduates the plugin docs from community framing to first-party and ships a runnable sample, completing the parity story landed in slices A/B1/B2.

## Changes

- **README**: full first-party rewrite: installation, chat, streaming, tool calling, JSON/schema output, `OllamaConfig` (incl. a reasoning-model example), remote server / static + async headers/timeouts, vision models, troubleshooting, sample, and acknowledgements crediting the original community contributors.
- **CHANGELOG.md (new)**: Keep a Changelog `[0.7.0]` entry documenting the cumulative A/B1/B2 release. Resolves the previously dangling `[project.urls] Changelog` link.
- **pyproject.toml**: `Development Status :: 3 - Alpha` → `4 - Beta`; description `"Genkit Ollama Plugin (Community)"` → `"Genkit AI framework plugin for Ollama"`.
- **`EmbeddingDefinition` export**: added to `genkit.plugins.ollama` so the README quick-start and sample imports resolve (previously an `ImportError`).
- **`py/samples/ollama-sample/` (new)**: runnable sample covering chat, streaming, tool calling, and embeddings; honors `OLLAMA_HOST` / `OLLAMA_CHAT_MODEL` / `OLLAMA_EMBEDDER_MODEL`. Registered as a uv workspace source and listed in `py/samples/README.md`.

## Testing

- `uv lock` picks up the new sample member.
- `uv run ruff format .` (clean) and `uv run ruff check --preview .` (all checks pass).
- Documented `from genkit.plugins.ollama import EmbeddingDefinition, ...` imports successfully.
- Ran the sample against a local Ollama server: chat flow generates real output; embed flow verified with `nomic-embed-text` (768-dim).

## Screenshots

<img width="388" height="208" alt="Screenshot 2026-06-24 at 13 19 52" src="https://github.com/user-attachments/assets/36fd3e3c-c1eb-40b6-b4a8-6ade5a7992e5" />
<img width="1026" height="664" alt="Screenshot 2026-06-24 at 13 25 32" src="https://github.com/user-attachments/assets/e80daeaf-7f06-4961-aaf9-0adae2721584" />
<img width="986" height="494" alt="Screenshot 2026-06-24 at 13 38 23" src="https://github.com/user-attachments/assets/9af03344-e33c-4d40-b906-4732547f8640" />
<img width="1015" height="749" alt="Screenshot 2026-06-24 at 13 41 47" src="https://github.com/user-attachments/assets/bafb7599-0ba3-4045-ad56-6b484fccc353" />
