### PR TITLE
feat(py): [google-genai] add developer-friendly onboarding message for missing GEMINI_API_KEY

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -417,9 +417,15 @@ class GoogleAI(Plugin):
         """
         api_key = api_key if api_key else os.getenv('GEMINI_API_KEY')
         if not api_key and credentials is None:
-            raise ValueError(
-                'Gemini api key should be passed in plugin params or as a GEMINI_API_KEY environment variable'
+            msg = (
+                '\n[Genkit] GEMINI_API_KEY environment variable not set.\n\n'
+                'To get started with Google AI models:\n'
+                '1. Obtain an API key from Google AI Studio: https://aistudio.google.com/app/apikey\n'
+                '2. Set your key in the terminal environment:\n'
+                '   export GEMINI_API_KEY="your-api-key"\n\n'
+                'Documentation: https://genkit.dev/docs/python/integrations/google-genai/\n'
             )
+            raise ValueError(msg)
 
         self._client_kwargs: dict[str, Any] = {
             'vertexai': self._vertexai,

--- a/py/plugins/google-genai/test/google_plugin_test.py
+++ b/py/plugins/google-genai/test/google_plugin_test.py
@@ -125,7 +125,7 @@ class TestGoogleAIInit(unittest.TestCase):
             patch.dict(os.environ, {'GEMINI_API_KEY': ''}, clear=True),
             self.assertRaisesRegex(
                 ValueError,
-                'Gemini api key should be passed in plugin params or as a GEMINI_API_KEY environment variable',
+                r'GEMINI_API_KEY environment variable not set',
             ),
         ):
             GoogleAI()

--- a/py/plugins/google-genai/tests/google_genai_plugin_test.py
+++ b/py/plugins/google-genai/tests/google_genai_plugin_test.py
@@ -83,7 +83,10 @@ def test_googleai_initialization_without_api_key() -> None:
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(ValueError) as exc_info:
             GoogleAI()
-        assert 'GEMINI_API_KEY' in str(exc_info.value)
+        assert 'GEMINI_API_KEY environment variable not set' in str(exc_info.value)
+        assert 'Obtain an API key from Google AI Studio' in str(exc_info.value)
+        assert 'https://aistudio.google.com/app/apikey' in str(exc_info.value)
+        assert 'https://genkit.dev/docs/python/integrations/google-genai/' in str(exc_info.value)
 
 
 def test_vertexai_initialization() -> None:


### PR DESCRIPTION
### Description
Updates the Python `google-genai` plugin (`GoogleAI.__init__`) to display structured, developer-friendly onboarding instructions directly within the Python exception traceback whenever `GEMINI_API_KEY` is not set in the environment or passed explicitly.

---

### CLI Experience: Before vs. After

#### ❌ Before
When running a Genkit script (`python main.py` or `genkit start`) without `GEMINI_API_KEY`:
```console
Traceback (most recent call last):
  File "main.py", line 4, in <module>
    ai = Genkit(plugins=[GoogleAI()])
  File "/genkit/plugins/google_genai/google.py", line 420, in __init__
    raise ValueError(
ValueError: Gemini api key should be passed in plugin params or as a GEMINI_API_KEY environment variable
```

#### ✅ After
When running without `GEMINI_API_KEY`, Genkit displays structured onboarding steps and documentation links cleanly at the end of the traceback:
```console
Traceback (most recent call last):
  File "main.py", line 4, in <module>
    ai = Genkit(plugins=[GoogleAI()])
  File "/genkit/plugins/google_genai/google.py", line 428, in __init__
    raise ValueError(msg)
ValueError: 
[Genkit] GEMINI_API_KEY environment variable not set.

To get started with Google AI models:
1. Obtain an API key from Google AI Studio: https://aistudio.google.com/app/apikey
2. Set your key in the terminal environment:
   export GEMINI_API_KEY="your-api-key"

Documentation: https://genkit.dev/docs/python/integrations/google-genai/
```

---

### Changes
- Replaced previous generic `ValueError` message with actionable onboarding steps pointing to Google AI Studio and Genkit documentation.
- Removed duplicate stdout printing so the message appears cleanly once at the end of the exception traceback.
- Updated all relevant unit tests in `test/google_plugin_test.py` and `tests/google_genai_plugin_test.py`.

### Verification
- Rebased cleanly off `main`.
- Ran `pytest plugins/google-genai` (308 tests passed).
- Verified type and style checks with `ruff format`, `ruff check --preview`, and `pyrefly check`.