### PR TITLE
feat(go): implement telemetry label propagation via context

### DIFF
--- a/go/core/action.go
+++ b/go/core/action.go
@@ -292,11 +292,12 @@ func (a *Action[In, Out, Stream]) runWithTelemetry(ctx context.Context, input In
 // the tracing package from parent span presence.
 func (a *Action[In, Out, Stream]) spanMetadata(ctx context.Context, spanInit any) *tracing.SpanMetadata {
 	sm := &tracing.SpanMetadata{
-		Name:     a.desc.Name,
-		Type:     "action",
-		Subtype:  string(a.desc.Type), // The actual action type becomes the subtype.
-		Metadata: make(map[string]string),
-		Init:     spanInit,
+		Name:            a.desc.Name,
+		Type:            "action",
+		Subtype:         string(a.desc.Type), // The actual action type becomes the subtype.
+		Metadata:        make(map[string]string),
+		TelemetryLabels: tracing.TelemetryLabelsFromContext(ctx),
+		Init:            spanInit,
 	}
 	if flowName := FlowNameFromContext(ctx); flowName != "" {
 		sm.Metadata["flow:name"] = flowName

--- a/go/core/tracing/tracing.go
+++ b/go/core/tracing/tracing.go
@@ -480,10 +480,24 @@ var spanMetaKey = base.NewContextKey[*spanMetadata]()
 // telemetryCbKey is the context key for telemetry callbacks.
 var telemetryCbKey = base.NewContextKey[func(traceID, spanID string)]()
 
+// telemetryLabelsKey is the context key for telemetry labels.
+var telemetryLabelsKey = base.NewContextKey[map[string]string]()
+
 // WithTelemetryCallback returns a context with the telemetry callback attached.
 // Used by the reflection server to pass callbacks to actions.
 func WithTelemetryCallback(ctx context.Context, cb func(traceID, spanID string)) context.Context {
 	return telemetryCbKey.NewContext(ctx, cb)
+}
+
+// WithTelemetryLabels returns a context with the telemetry labels attached.
+// Used by the reflection server to pass labels to actions.
+func WithTelemetryLabels(ctx context.Context, labels map[string]string) context.Context {
+	return telemetryLabelsKey.NewContext(ctx, labels)
+}
+
+// TelemetryLabelsFromContext retrieves the telemetry labels from context, or nil if not set.
+func TelemetryLabelsFromContext(ctx context.Context) map[string]string {
+	return telemetryLabelsKey.FromContext(ctx)
 }
 
 // telemetryCallback retrieves the telemetry callback from context, or nil if not set.

--- a/go/genkit/reflection.go
+++ b/go/genkit/reflection.go
@@ -729,12 +729,13 @@ func runAction(ctx context.Context, g *Genkit, key string, input, init json.RawM
 	ctx = core.WithActionContext(ctx, runtimeContext)
 
 	// Parse telemetry attributes if provided
-	var telemetryAttributes map[string]string
-	if telemetryLabels != nil {
+	if base.HasJSONValue(telemetryLabels) {
+		var telemetryAttributes map[string]string
 		err := json.Unmarshal(telemetryLabels, &telemetryAttributes)
 		if err != nil {
-			return nil, core.NewError(core.INTERNAL, "Error unmarshalling telemetryLabels: %v", err)
+			return nil, core.NewError(core.INVALID_ARGUMENT, "Error unmarshalling telemetryLabels: %v", err)
 		}
+		ctx = tracing.WithTelemetryLabels(ctx, telemetryAttributes)
 	}
 
 	// Run the action and capture trace ID. We need to ensure there's a valid trace context.

--- a/go/genkit/reflection_test.go
+++ b/go/genkit/reflection_test.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -187,6 +188,19 @@ func TestServeMux(t *testing.T) {
 	})
 
 	t.Run("run action", func(t *testing.T) {
+		core.DefineAction(g.reg, "test/checkLabels", api.ActionTypeCustom, nil,
+			nil,
+			func(ctx context.Context, in any) (any, error) {
+				labels := tracing.TelemetryLabelsFromContext(ctx)
+				if labels == nil {
+					return nil, errors.New("no telemetry labels found in context")
+				}
+				if labels["test_k"] != "test_v" {
+					return nil, fmt.Errorf("unexpected telemetry labels: %v", labels)
+				}
+				return "ok", nil
+			})
+
 		tests := []struct {
 			name       string
 			body       string
@@ -206,10 +220,10 @@ func TestServeMux(t *testing.T) {
 				wantResult: "2",
 			},
 			{
-				name:       "check telemetry labels",
-				body:       `{"key": "/custom/test/dec", "input": 3,"telemetryLabels":{"test_k":"test_v"}}`,
+				name:       "verify telemetry labels in context",
+				body:       `{"key": "/custom/test/checkLabels", "input": null, "telemetryLabels": {"test_k": "test_v"}}`,
 				wantStatus: http.StatusOK,
-				wantResult: "2",
+				wantResult: "\"ok\"",
 			},
 			{
 				name:       "invalid action key",


### PR DESCRIPTION
This change allows the reflection server to pass telemetry labels (e.g., 'genkitx:ignore-trace') down to the action execution layer. This ensures that tool-initiated actions like snapshot lookups can be correctly filtered from the Dev UI trace list.
