### PR TITLE
fix(go): implement recursive schema reference resolution

### DIFF
--- a/go/core/action.go
+++ b/go/core/action.go
@@ -237,6 +237,10 @@ func (a *Action[In, Out, Stream]) Run(ctx context.Context, input In, cb StreamCa
 // inject a per-call one-shot adapter; spanInit, when non-nil, is recorded as
 // the span's genkit:init attribute.
 func (a *Action[In, Out, Stream]) runWithTelemetry(ctx context.Context, input In, cb StreamCallback[Stream], fn StreamingFunc[In, Out, Stream], spanInit any) (output api.ActionRunResult[Out], err error) {
+	return a.runWithTelemetryInternal(ctx, input, cb, fn, spanInit, nil, nil)
+}
+
+func (a *Action[In, Out, Stream]) runWithTelemetryInternal(ctx context.Context, input In, cb StreamCallback[Stream], fn StreamingFunc[In, Out, Stream], spanInit any, inputSchema, outputSchema map[string]any) (output api.ActionRunResult[Out], err error) {
 	logger.FromContext(ctx).Debug("Action.Run", "name", a.Name())
 	defer func() {
 		logger.FromContext(ctx).Debug("Action.Run",
@@ -255,16 +259,18 @@ func (a *Action[In, Out, Stream]) runWithTelemetry(ctx context.Context, input In
 			start := time.Now()
 			defer func() { recordActionMetrics(ctx, a.desc.Name, start, err) }()
 
-			var inputSchema map[string]any
-			inputSchema, err = ResolveSchema(a.registry, a.desc.InputSchema)
-			if err != nil {
-				return base.Zero[Out](), NewError(INVALID_ARGUMENT, "invalid input schema for action %q: %v", a.desc.Key, err)
+			if inputSchema == nil {
+				inputSchema, err = ResolveSchema(a.registry, a.desc.InputSchema)
+				if err != nil {
+					return base.Zero[Out](), NewError(INVALID_ARGUMENT, "invalid input schema for action %q: %v", a.desc.Key, err)
+				}
 			}
 
-			var outputSchema map[string]any
-			outputSchema, err = a.resolveOutputSchema()
-			if err != nil {
-				return base.Zero[Out](), err
+			if outputSchema == nil {
+				outputSchema, err = a.resolveOutputSchema()
+				if err != nil {
+					return base.Zero[Out](), err
+				}
 			}
 
 			if err = base.ValidateValue(input, inputSchema); err != nil {
@@ -351,7 +357,17 @@ func (a *Action[In, Out, Stream]) RunJSONWithTelemetry(ctx context.Context, inpu
 // runJSONWithTelemetry is the shared JSON execution path. fn and spanInit
 // follow the same contract as runWithTelemetry.
 func (a *Action[In, Out, Stream]) runJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb StreamCallback[json.RawMessage], fn StreamingFunc[In, Out, Stream], spanInit any) (*api.ActionRunResult[json.RawMessage], error) {
-	i, err := base.UnmarshalAndNormalize[In](input, a.desc.InputSchema)
+	inputSchema, err := ResolveSchema(a.registry, a.desc.InputSchema)
+	if err != nil {
+		return nil, NewError(INVALID_ARGUMENT, "invalid input schema for action %q: %v", a.desc.Key, err)
+	}
+
+	outputSchema, err := a.resolveOutputSchema()
+	if err != nil {
+		return nil, err
+	}
+
+	i, err := base.UnmarshalAndNormalize[In](input, inputSchema)
 	if err != nil {
 		return nil, NewSchemaValidationError(a.desc.Key, err)
 	}
@@ -367,7 +383,7 @@ func (a *Action[In, Out, Stream]) runJSONWithTelemetry(ctx context.Context, inpu
 		}
 	}
 
-	r, err := a.runWithTelemetry(ctx, i, scb, fn, spanInit)
+	r, err := a.runWithTelemetryInternal(ctx, i, scb, fn, spanInit, inputSchema, outputSchema)
 	if err != nil {
 		return &api.ActionRunResult[json.RawMessage]{
 			TraceId: r.TraceId,

--- a/go/core/core.go
+++ b/go/core/core.go
@@ -66,22 +66,130 @@ func SchemaRef(name string) map[string]any {
 // Returns the original schema if no $ref is present, or the resolved schema if found.
 // Returns an error if the schema reference cannot be resolved.
 func ResolveSchema(r api.Registry, schema map[string]any) (map[string]any, error) {
+	return resolveSchema(r, schema, nil, 0)
+}
+
+const maxSchemaDepth = 50
+
+func resolveSchema(r api.Registry, schema map[string]any, seen map[uintptr]bool, depth int) (map[string]any, error) {
 	if schema == nil {
 		return nil, nil
 	}
-	ref, ok := schema["$ref"].(string)
-	if !ok {
+	if depth > maxSchemaDepth {
+		return nil, fmt.Errorf("schema reference too deep (possible cycle)")
+	}
+
+	if ref, ok := schema["$ref"].(string); ok {
+		if schemaName, found := strings.CutPrefix(ref, "genkit:"); found {
+			resolved := r.LookupSchema(schemaName)
+			if resolved == nil {
+				return nil, fmt.Errorf("schema %q not found", schemaName)
+			}
+
+			if seen[reflect.ValueOf(resolved).Pointer()] {
+				return schema, nil
+			}
+
+			newSeen := make(map[uintptr]bool, len(seen)+1)
+			for k, v := range seen {
+				newSeen[k] = v
+			}
+			newSeen[reflect.ValueOf(schema).Pointer()] = true
+
+			// Recursive call to resolve any refs within the looked-up schema.
+			return resolveSchema(r, resolved, newSeen, depth+1)
+		}
+		// If it's a non-genkit $ref, we return the schema as-is to allow
+		// the underlying validator to handle it.
 		return schema, nil
 	}
-	schemaName, found := strings.CutPrefix(ref, "genkit:")
-	if !found {
+
+	ptr := reflect.ValueOf(schema).Pointer()
+	if seen[ptr] {
 		return schema, nil
 	}
-	resolved := r.LookupSchema(schemaName)
-	if resolved == nil {
-		return nil, fmt.Errorf("schema %q not found", schemaName)
+
+	newSeen := make(map[uintptr]bool, len(seen)+1)
+	for k, v := range seen {
+		newSeen[k] = v
 	}
-	return resolved, nil
+	newSeen[ptr] = true
+	seen = newSeen
+
+	// Iterate and recursively resolve any nested maps or arrays.
+	// We only clone the schema if a change is actually made.
+	var newSchema map[string]any
+	for k, v := range schema {
+		resolved, err := resolveValue(r, v, seen, depth+1)
+		if err != nil {
+			return nil, err
+		}
+
+		if newSchema == nil && !isSame(v, resolved) {
+			newSchema = make(map[string]any, len(schema))
+			for k2, v2 := range schema {
+				newSchema[k2] = v2
+			}
+		}
+		if newSchema != nil {
+			newSchema[k] = resolved
+		}
+	}
+
+	if newSchema == nil {
+		return schema, nil
+	}
+	return newSchema, nil
+}
+
+func resolveValue(r api.Registry, v any, seen map[uintptr]bool, depth int) (any, error) {
+	switch val := v.(type) {
+	case map[string]any:
+		return resolveSchema(r, val, seen, depth)
+	case []any:
+		return resolveArray(r, val, seen, depth)
+	default:
+		return v, nil
+	}
+}
+
+func resolveArray(r api.Registry, arr []any, seen map[uintptr]bool, depth int) ([]any, error) {
+	if depth > maxSchemaDepth {
+		return nil, fmt.Errorf("schema reference too deep (possible cycle)")
+	}
+	var newArray []any
+	for i, v := range arr {
+		resolved, err := resolveValue(r, v, seen, depth+1)
+		if err != nil {
+			return nil, err
+		}
+
+		if newArray == nil && !isSame(v, resolved) {
+			newArray = make([]any, len(arr))
+			copy(newArray, arr[:i])
+		}
+		if newArray != nil {
+			newArray[i] = resolved
+		}
+	}
+	if newArray == nil {
+		return arr, nil
+	}
+	return newArray, nil
+}
+
+func isSame(a, b any) bool {
+	if reflect.TypeOf(a) != reflect.TypeOf(b) {
+		return false
+	}
+	va := reflect.ValueOf(a)
+	vb := reflect.ValueOf(b)
+	switch va.Kind() {
+	case reflect.Map, reflect.Slice:
+		return va.Pointer() == vb.Pointer()
+	default:
+		return a == b
+	}
 }
 
 // InferSchemaMap infers a JSON schema from a Go value and converts it to a map.

--- a/go/core/core_test.go
+++ b/go/core/core_test.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/firebase/genkit/go/internal/registry"
@@ -194,16 +195,108 @@ func TestResolveSchema(t *testing.T) {
 		}
 	})
 
+	t.Run("resolves multi-level genkit ref", func(t *testing.T) {
+		r := registry.New()
+		innerInnerSchema := map[string]any{
+			"type": "string",
+		}
+		r.RegisterSchema("InnerInner", innerInnerSchema)
+
+		innerSchema := map[string]any{
+			"$ref": "genkit:InnerInner",
+		}
+		r.RegisterSchema("Inner", innerSchema)
+
+		outerSchema := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"field": map[string]any{
+					"$ref": "genkit:Inner",
+				},
+			},
+		}
+
+		resolved, err := ResolveSchema(r, outerSchema)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		props := resolved["properties"].(map[string]any)
+		field := props["field"].(map[string]any)
+		if diff := cmp.Diff(innerInnerSchema, field); diff != "" {
+			t.Errorf("multi-level schema mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("returns error for missing schema", func(t *testing.T) {
 		r := registry.New()
 		refSchema := map[string]any{
 			"$ref": "genkit:NonExistent",
 		}
-
 		_, err := ResolveSchema(r, refSchema)
-
 		if err == nil {
 			t.Error("expected error for missing schema, got nil")
+		}
+	})
+
+	t.Run("handles circular genkit ref without stack overflow", func(t *testing.T) {
+		r := registry.New()
+		nodeSchema := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"child": map[string]any{
+					"$ref": "genkit:Node",
+				},
+			},
+		}
+		r.RegisterSchema("Node", nodeSchema)
+
+		resolved, err := ResolveSchema(r, nodeSchema)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		props := resolved["properties"].(map[string]any)
+		child := props["child"].(map[string]any)
+		if ref, ok := child["$ref"].(string); !ok || ref != "genkit:Node" {
+			t.Errorf("expected child to remain a ref, got %v", child)
+		}
+	})
+
+	t.Run("resolves ref in nested array", func(t *testing.T) {
+		r := registry.New()
+		r.RegisterSchema("Item", map[string]any{"type": "string"})
+		schema := map[string]any{
+			"type": "array",
+			"items": []any{
+				map[string]any{"$ref": "genkit:Item"},
+			},
+		}
+		resolved, err := ResolveSchema(r, schema)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		items := resolved["items"].([]any)
+		item := items[0].(map[string]any)
+		if item["type"] != "string" {
+			t.Errorf("expected type string, got %v", item["type"])
+		}
+	})
+
+	t.Run("returns same instance when no resolution needed", func(t *testing.T) {
+		r := registry.New()
+		schema := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"foo": map[string]any{"type": "string"},
+			},
+		}
+		resolved, err := ResolveSchema(r, schema)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if reflect.ValueOf(schema).Pointer() != reflect.ValueOf(resolved).Pointer() {
+			t.Error("expected same schema instance, but it was cloned")
 		}
 	})
 }

--- a/go/plugins/compat_oai/generate_live_test.go
+++ b/go/plugins/compat_oai/generate_live_test.go
@@ -69,7 +69,7 @@ func TestGenerator_Complete(t *testing.T) {
 
 	resp, err := g.WithMessages(messages).Generate(context.Background(), req, nil)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if len(resp.Message.Content) == 0 {
 		t.Error("empty messages content, got 0")
@@ -103,7 +103,7 @@ func TestGenerator_Stream(t *testing.T) {
 
 	_, err := g.WithMessages(messages).Generate(context.Background(), req, handleChunk)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if len(chunks) == 0 {
 		t.Error("expecting stream chunks, got: 0")

--- a/go/plugins/firebase/telemetry_test.go
+++ b/go/plugins/firebase/telemetry_test.go
@@ -55,6 +55,7 @@ func TestProjectIDResolution(t *testing.T) {
 		} else {
 			os.Unsetenv("GOOGLE_CLOUD_PROJECT")
 		}
+		os.Unsetenv("GCLOUD_PROJECT")
 
 		result := resolveFirebaseProjectID(tt.input)
 		if result != tt.expected {
@@ -64,5 +65,6 @@ func TestProjectIDResolution(t *testing.T) {
 		// Cleanup
 		os.Unsetenv("FIREBASE_PROJECT_ID")
 		os.Unsetenv("GOOGLE_CLOUD_PROJECT")
+		os.Unsetenv("GCLOUD_PROJECT")
 	}
 }


### PR DESCRIPTION
This change fixes "Reference must be canonical" validation errors when running actions through the JSON path (e.g., via the Dev UI).

The Go framework now:
1. Recursively resolves 'genkit:' schema references within nested objects and arrays in ResolveSchema.
2. Ensures schema resolution is performed in runJSONWithTelemetry before input validation.

This ensures that strict JSON schema validators see fully-resolved definitions rather than internal Genkit reference strings.
