### PR TITLE
refactor(py): bind caller context as ambient scope at generate/prompt boundary

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -75,7 +75,7 @@ from genkit._ai._resource import (
     define_resource,
 )
 from genkit._ai._tools import Tool, define_interrupt, define_tool
-from genkit._core._action import Action, ActionKind, get_current_context
+from genkit._core._action import Action, ActionKind, context_scope, get_current_context
 from genkit._core._background import (
     BackgroundAction,
     CancelModelOpFn,
@@ -936,11 +936,11 @@ class Genkit:
             use=refs,
         )
         gen_options = await to_generate_action_options(child_registry, prompt_config)
-        return await generate_action(
-            child_registry,
-            gen_options,
-            context=context if context else get_current_context(),
-        )
+        # Bind context as ambient for the turn so the model, middleware, and the
+        # tools the model triggers all read the same bag; an explicit context
+        # wins, else we inherit whatever scope the caller is already inside.
+        with context_scope(context if context else get_current_context()):
+            return await generate_action(child_registry, gen_options)
 
     # Overload: output_schema=type[T] -> ModelStreamResponse[T]
     @overload
@@ -1054,12 +1054,12 @@ class Genkit:
                 use=refs,
             )
             gen_options = await to_generate_action_options(child_registry, prompt_config)
-            return await generate_action(
-                child_registry,
-                gen_options,
-                on_chunk=lambda c: channel.send(c),
-                context=context if context else get_current_context(),
-            )
+            with context_scope(context if context else get_current_context()):
+                return await generate_action(
+                    child_registry,
+                    gen_options,
+                    on_chunk=lambda c: channel.send(c),
+                )
 
         response_future: asyncio.Future[ModelResponse[Any]] = asyncio.create_task(_run_generate())
         channel.set_close_future(response_future)

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -44,6 +44,7 @@ from genkit._core._action import (
     Action,
     ActionKind,
     ActionRunContext,
+    get_current_context,
 )
 from genkit._core._error import GenkitError
 from genkit._core._logger import get_logger
@@ -402,11 +403,12 @@ def define_generate_action(registry: Registry) -> None:
         ctx: ActionRunContext,
     ) -> ModelResponse:
         on_chunk = cast(Callable[[ModelResponseChunk], None], ctx.streaming_callback) if ctx.is_streaming else None
+        # The action runtime already bound the request context as ambient before
+        # dispatching us, so the engine reads it off the scope like everything else.
         return await generate_with_request(
             registry=registry,
             raw_request=input,
             on_chunk=on_chunk,
-            context=dict(ctx.context),
         )
 
     _ = registry.register_action(
@@ -422,13 +424,16 @@ async def generate_action(
     on_chunk: Callable[[ModelResponseChunk], None] | None = None,
     message_index: int = 0,
     current_turn: int = 0,
-    context: dict[str, Any] | None = None,
 ) -> ModelResponse:
     """Open the user-facing ``generate`` span and delegate to the engine.
 
     Thin wrapper so in-process callers get a trace span named ``generate``
     around the whole call.  The registered ``/util/generate`` action skips
     this wrapper because the action runtime already opens its own span.
+
+    Context flows in ambiently: callers bind it with ``context_scope`` (the
+    veneer and prompt do this at their boundary) so the model, middleware, and
+    the tools the model triggers all read the same bag off the scope.
     """
     span_name = 'generate'
     with run_in_new_span(SpanMetadata(name=span_name, type='util', input=raw_request)) as span:
@@ -438,7 +443,6 @@ async def generate_action(
             on_chunk=on_chunk,
             message_index=message_index,
             current_turn=current_turn,
-            context=context,
         )
         with contextlib.suppress(Exception):
             span.set_attribute('genkit:output', result.model_dump_json(by_alias=True, exclude_none=True))
@@ -451,12 +455,15 @@ async def generate_with_request(
     on_chunk: Callable[[ModelResponseChunk], None] | None = None,
     message_index: int = 0,
     current_turn: int = 0,
-    context: dict[str, Any] | None = None,
 ) -> ModelResponse:
     """Resolve ``raw_request.use`` and run the generation.
 
     Core generate business logic. `ai.generate` veneer and the registered
     `/util/generate` action funnel through here.
+
+    Context is read off the ambient scope the caller bound, so the model,
+    middleware, and tools all see the same bag without it being threaded
+    through as a parameter.
     """
     # Shallow-copy the wire-shape struct so per-field updates below (and any
     # future mutations) don't leak back to the caller's ``raw_request``.
@@ -469,7 +476,7 @@ async def generate_with_request(
     middleware = resolve_middleware_from_use(registry, raw_request.use)
     run_ctx = GenerateMiddlewareContext(
         registry=registry,
-        custom_context=dict(context or {}),
+        context=dict(get_current_context() or {}),
         on_chunk=on_chunk,
     )
 
@@ -664,7 +671,7 @@ async def _generate_action_turn(
             return (
                 await model.run(
                     input=params.request,
-                    context=c.custom_context,
+                    context=c.context,
                     on_chunk=c.on_chunk,
                 )
             ).response

--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -52,6 +52,7 @@ from genkit._core._action import (
     Action,
     ActionKind,
     StreamingCallback,
+    context_scope,
     create_action_key,
     get_current_context,
 )
@@ -360,12 +361,12 @@ class ExecutablePrompt(Generic[InputT, OutputT]):
         child_registry, gen_options = await _prepare(self, input, opts)
         on_chunk = opts.get('on_chunk')
         context = opts.get('context')
-        result = await generate_action(
-            child_registry,
-            gen_options,
-            on_chunk=on_chunk,
-            context=context if context else get_current_context(),
-        )
+        with context_scope(context if context else get_current_context()):
+            result = await generate_action(
+                child_registry,
+                gen_options,
+                on_chunk=on_chunk,
+            )
         return cast(ModelResponse[OutputT], result)
 
     def _prompt_config_for_call(self, opts: PromptGenerateOptions) -> PromptConfig:
@@ -927,7 +928,10 @@ async def render_prompt_config_for_executable_call(
     before :func:`to_generate_action_options`.
     """
     ri = coerce_prompt_template_input(template_input)
-    render_context = opts.get('context')
+    # Fall back to the ambient context so a template that interpolates context
+    # values renders the same bag the model and tools see, rather than blanks,
+    # when the caller set context via a scope instead of passing it explicitly.
+    render_context = opts.get('context') or get_current_context()
     message_history = opts.get('messages')
     cache = executable_prompt._cache_prompt
     extra_docs = opts.get('docs')

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -21,7 +21,8 @@ import inspect
 import json
 import re
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Mapping
+from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, ClassVar, Generic, NamedTuple, cast, get_type_hints
 
@@ -672,6 +673,29 @@ def get_current_context() -> dict[str, object] | None:
     the private _action_context ContextVar.
     """
     return _action_context.get(None)
+
+
+@contextmanager
+def context_scope(context: dict[str, object] | None) -> Generator[None, None, None]:
+    """Bind ``context`` as the ambient action context for the duration of the block.
+
+    Everything that runs inside — tool calls, sub-actions, nested generate, and
+    prompt rendering — reads the same context. Handing context to a top-level
+    call otherwise reaches the model but silently skips the tools it triggers,
+    because those tools resolve their context from the ambient var rather than an
+    argument.
+
+    A falsy context is a no-op so callers can wrap unconditionally without
+    clobbering an outer scope with an empty bag.
+    """
+    if not context:
+        yield
+        return
+    token = _action_context.set(context)
+    try:
+        yield
+    finally:
+        _action_context.reset(token)
 
 
 def set_action_name(action: Action[Any, Any, Any], name: str) -> None:

--- a/py/packages/genkit/src/genkit/_core/_middleware.py
+++ b/py/packages/genkit/src/genkit/_core/_middleware.py
@@ -127,13 +127,13 @@ class ToolHookParams(BaseModel):
 class GenerateMiddlewareContext:
     """Per-``generate()`` runtime services shared by every middleware in ``use=[...]``.
 
-    Holds the call-scoped registry, caller-provided metadata (``custom_context``),
-    and streaming hooks for the whole generate invocation. Hook ``params`` carry
-    per-turn request data only.
+    Holds the call-scoped registry, the caller-provided request ``context`` (auth,
+    tenant, and other metadata — the same dict tools see), and streaming hooks for
+    the whole generate invocation. Hook ``params`` carry per-turn request data only.
     """
 
     registry: RegistryLike
-    custom_context: dict[str, object] = field(default_factory=dict)
+    context: dict[str, object] = field(default_factory=dict)
     on_chunk: Callable[[ModelResponseChunk], None] | None = None
     abort_signal: Any | None = None
     telemetry_labels: dict[str, str] | None = None

--- a/py/packages/genkit/tests/genkit/ai/generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_test.py
@@ -746,7 +746,7 @@ class AddContextMiddleware(BaseMiddleware):
         ctx: GenerateMiddlewareContext,
         next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        ctx.custom_context['banana'] = True
+        ctx.context['banana'] = True
         return await next_fn(params, ctx)
 
 
@@ -765,7 +765,7 @@ class InjectContextMiddleware(BaseMiddleware):
                     messages=[
                         Message(
                             role=Role.USER,
-                            content=[Part(TextPart(text=f'{txt} {ctx.custom_context}'))],
+                            content=[Part(TextPart(text=f'{txt} {ctx.context}'))],
                         ),
                     ],
                 ),
@@ -783,24 +783,26 @@ class ContextMiddlewarePlugin(ExtensionMiddlewarePlugin):
 
 @pytest.mark.asyncio
 async def test_generate_middleware_can_modify_context() -> None:
-    """Test that middleware can modify custom_context on the shared generate ctx."""
+    """Test that middleware can modify context on the shared generate ctx."""
+    from genkit._core._action import context_scope
+
     ai = Genkit(plugins=[ContextMiddlewarePlugin()])
     define_echo_model(ai)
 
-    response = await generate_action(
-        ai.registry,
-        GenerateActionOptions(
-            model='echoModel',
-            messages=[
-                Message(
-                    role=Role.USER,
-                    content=[Part(TextPart(text='hi'))],
-                ),
-            ],
-            use=[MiddlewareRef(name='add_ctx'), MiddlewareRef(name='inject_ctx')],
-        ),
-        context={'foo': 'bar'},
-    )
+    with context_scope({'foo': 'bar'}):
+        response = await generate_action(
+            ai.registry,
+            GenerateActionOptions(
+                model='echoModel',
+                messages=[
+                    Message(
+                        role=Role.USER,
+                        content=[Part(TextPart(text='hi'))],
+                    ),
+                ],
+                use=[MiddlewareRef(name='add_ctx'), MiddlewareRef(name='inject_ctx')],
+            ),
+        )
 
     assert response.text == '''[ECHO] user: "hi {'foo': 'bar', 'banana': True}"'''
 
@@ -1166,6 +1168,97 @@ async def test_wrap_tool_called_on_tool_execution() -> None:
     )
     assert response.text == 'done'
     assert tool_names == ['myTool']
+
+
+@pytest.mark.asyncio
+async def test_tool_sees_context_from_top_level_generate() -> None:
+    """A tool triggered by a top-level generate sees the ``context`` passed to it.
+
+    Regression: the context handed to ``generate`` used to reach the model and
+    middleware but not the tools the model called, so an auth check inside a tool
+    silently saw nothing on a bare generate call.
+    """
+    from genkit._ai._tools import ToolRunContext
+
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+
+    seen: dict[str, object] = {}
+
+    @ai.tool(name='whoami')
+    async def whoami(_: dict, ctx: ToolRunContext) -> str:  # noqa: ARG001
+        seen['auth'] = (ctx.context or {}).get('auth')
+        return 'ok'
+
+    pm.responses.append(
+        ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name='whoami', input={}, ref='r1')))],
+            ),
+        )
+    )
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(TextPart(text='done'))]),
+        )
+    )
+
+    response = await ai.generate(
+        model='programmableModel',
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='hi'))])],
+        tools=['whoami'],
+        context={'auth': 'alice'},
+    )
+
+    assert response.text == 'done'
+    assert seen['auth'] == 'alice'
+
+
+@pytest.mark.asyncio
+async def test_tool_sees_context_from_ambient_context_scope() -> None:
+    """A bare generate with no explicit context inherits an ambient ``context_scope``."""
+    from genkit._ai._tools import ToolRunContext
+    from genkit._core._action import context_scope
+
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+
+    seen: dict[str, object] = {}
+
+    @ai.tool(name='whoami2')
+    async def whoami2(_: dict, ctx: ToolRunContext) -> str:  # noqa: ARG001
+        seen['auth'] = (ctx.context or {}).get('auth')
+        return 'ok'
+
+    pm.responses.append(
+        ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name='whoami2', input={}, ref='r1')))],
+            ),
+        )
+    )
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(TextPart(text='done'))]),
+        )
+    )
+
+    with context_scope({'auth': 'bob'}):
+        response = await generate_action(
+            ai.registry,
+            GenerateActionOptions(
+                model='programmableModel',
+                messages=[Message(role=Role.USER, content=[Part(TextPart(text='hi'))])],
+                tools=['whoami2'],
+            ),
+        )
+
+    assert response.text == 'done'
+    assert seen['auth'] == 'bob'
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/ai/prompt_test.py
@@ -291,6 +291,24 @@ async def test_prompt_rendering_dotprompt(
     assert response.text == want_rendered
 
 
+@pytest.mark.asyncio
+async def test_prompt_template_reads_ambient_context_scope() -> None:
+    """A dotprompt template interpolates context from an ambient scope, not just explicit context=."""
+    from genkit._core._action import context_scope
+
+    ai, *_ = setup_test()
+
+    my_prompt = ai.define_prompt(
+        model='echoModel',
+        prompt='hello ({{@auth.email}})',
+    )
+
+    with context_scope({'auth': {'email': 'a@b.c'}}):
+        response = await my_prompt({})
+
+    assert 'a@b.c' in response.text
+
+
 # Tests for prompt variants and partials
 @pytest.mark.asyncio
 async def test_load_prompt_variant() -> None:

--- a/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
+++ b/py/packages/genkit/tests/genkit/core/endpoints/reflection_test.py
@@ -356,7 +356,7 @@ async def test_values_middleware_includes_derived_config_schema() -> None:
         config_schema = entry['configSchema']
         assert config_schema['type'] == 'object'
         # Author-defined fields show up; framework-injected ones (registry,
-        # custom_context / on_chunk) must not leak into the form.
+        # context / on_chunk) must not leak into the form.
         assert set(config_schema['properties'].keys()) == {'models', 'statuses', 'isolate_config'}
     finally:
         await client.aclose()

--- a/py/packages/genkit/tests/genkit/core/reflection_v2_test.py
+++ b/py/packages/genkit/tests/genkit/core/reflection_v2_test.py
@@ -333,7 +333,7 @@ async def test_reflection_server_v2_list_values_includes_derived_config_schema(
         config_schema = entry['configSchema']
         assert config_schema['type'] == 'object'
         # Author-defined fields show up; framework-injected ones (registry,
-        # custom_context / on_chunk) must not leak into the form.
+        # context / on_chunk) must not leak into the form.
         props = config_schema['properties']
         assert set(props.keys()) == {'models', 'statuses', 'isolate_config'}
         assert props['models']['type'] == 'array'

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -1086,7 +1086,7 @@ async def test_generate_passes_through_current_action_context() -> None:
                         messages=[
                             Message(
                                 role=Role.USER,
-                                content=[Part(root=TextPart(text=f'{txt} {ctx.custom_context}'))],
+                                content=[Part(root=TextPart(text=f'{txt} {ctx.context}'))],
                             ),
                         ],
                     ),
@@ -1129,7 +1129,7 @@ async def test_generate_uses_explicitly_passed_in_context() -> None:
                         messages=[
                             Message(
                                 role=Role.USER,
-                                content=[Part(root=TextPart(text=f'{txt} {ctx.custom_context}'))],
+                                content=[Part(root=TextPart(text=f'{txt} {ctx.context}'))],
                             ),
                         ],
                     ),
@@ -1172,7 +1172,7 @@ async def test_generate_uses_inline_middleware_instance_with_context() -> None:
                         messages=[
                             Message(
                                 role=Role.USER,
-                                content=[Part(root=TextPart(text=f'{txt} {ctx.custom_context}'))],
+                                content=[Part(root=TextPart(text=f'{txt} {ctx.context}'))],
                             ),
                         ],
                     ),

--- a/py/plugins/middleware/src/genkit/plugins/middleware/_fallback.py
+++ b/py/plugins/middleware/src/genkit/plugins/middleware/_fallback.py
@@ -85,7 +85,7 @@ class Fallback(BaseMiddleware[FallbackConfig]):
             try:
                 result = await fallback_action.run(
                     input=params.request,
-                    context=ctx.custom_context,
+                    context=ctx.context,
                     on_chunk=on_chunk,
                 )
                 return result.response  # type: ignore[return-value]


### PR DESCRIPTION
## Summary

Binds the caller's context as an ambient scope at the boundary (generate/generate_stream veneers + prompt), drops the internal context= relay through generate_action/generate_with_request, so the model, middleware, prompt templates, and every tool the model triggers all read the same bag. context_scope stays internal (imported from genkit._core._action in tests, not exported from the package root).

## Changes

- Binds ambient scope at `generate` / `generate_stream` / prompt boundaries.
- Drops internal `context=` relay through `generate_action` / `generate_with_request`.
- Keeps `context_scope` internal (`genkit._core._action`).
