### PR TITLE
feat(py): share per-generate context bag between middleware, model, and tools

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -44,6 +44,7 @@ from genkit._core._action import (
     Action,
     ActionKind,
     ActionRunContext,
+    bind_context,
     get_current_context,
 )
 from genkit._core._error import GenkitError
@@ -461,9 +462,10 @@ async def generate_with_request(
     Core generate business logic. `ai.generate` veneer and the registered
     `/util/generate` action funnel through here.
 
-    Context is read off the ambient scope the caller bound, so the model,
-    middleware, and tools all see the same bag without it being threaded
-    through as a parameter.
+    This call uses one context bag for the whole generation: the ambient scope
+    the caller bound, or a new empty dict if none was bound. It's shared by reference
+    with the middleware and re-bound as the ambient scope, so anything middleware
+    adds or changes is seen by the model and every tool the model triggers.
     """
     # Shallow-copy the wire-shape struct so per-field updates below (and any
     # future mutations) don't leak back to the caller's ``raw_request``.
@@ -473,10 +475,16 @@ async def generate_with_request(
     if raw_request.tools:
         raw_request.tools = await expand_wildcard_tools(registry, raw_request.tools)
 
+    # One context bag for the whole call: use the ambient scope if present so
+    # middleware can add or change what the model and the tools it triggers all
+    # see. If no context was bound, create an empty dict and bind it as ambient below.
+    curr_ctx = get_current_context()
+    ctx_bag: dict[str, object] = curr_ctx if curr_ctx is not None else {}
+
     middleware = resolve_middleware_from_use(registry, raw_request.use)
     run_ctx = GenerateMiddlewareContext(
         registry=registry,
-        context=dict(get_current_context() or {}),
+        context=ctx_bag,
         on_chunk=on_chunk,
     )
 
@@ -502,13 +510,16 @@ async def generate_with_request(
     else:
         mw_pipeline = _GenerateMiddlewarePipeline(middleware=[], ctx=run_ctx)
 
-    return await _generate_action_turn(
-        registry=registry,
-        raw_request=raw_request,
-        mw_pipeline=mw_pipeline,
-        message_index=message_index,
-        current_turn=current_turn,
-    )
+    # Bind the shared bag as ambient for the whole (recursive) turn loop, so the
+    # model call and the tools it triggers read the same object middleware holds.
+    with bind_context(ctx_bag):
+        return await _generate_action_turn(
+            registry=registry,
+            raw_request=raw_request,
+            mw_pipeline=mw_pipeline,
+            message_index=message_index,
+            current_turn=current_turn,
+        )
 
 
 async def _generate_action_turn(
@@ -668,10 +679,12 @@ async def _generate_action_turn(
         request = _params.request
 
         async def next_fn(params: ModelHookParams, c: GenerateMiddlewareContext) -> ModelResponse:
+            # No explicit context: the model reads the ambient bag, the same
+            # object c.context points at, so middleware edits reach the model
+            # just like they reach the tools it triggers.
             return (
                 await model.run(
                     input=params.request,
-                    context=c.context,
                     on_chunk=c.on_chunk,
                 )
             ).response

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -676,6 +676,23 @@ def get_current_context() -> dict[str, object] | None:
 
 
 @contextmanager
+def bind_context(context: dict[str, object]) -> Generator[None, None, None]:
+    """Bind ``context`` as the ambient action context, even when it's empty.
+
+    The generate engine owns one context bag per call and shares that exact dict
+    with the middleware, the model, and the tools the model triggers. Binding it
+    here — unlike :func:`context_scope`, which skips a falsy bag so it won't
+    shadow an outer scope — lets middleware start from an empty bag and add auth
+    or tenant data that the model and those tools then read off the same object.
+    """
+    token = _action_context.set(context)
+    try:
+        yield
+    finally:
+        _action_context.reset(token)
+
+
+@contextmanager
 def context_scope(context: dict[str, object] | None) -> Generator[None, None, None]:
     """Bind ``context`` as the ambient action context for the duration of the block.
 
@@ -691,11 +708,8 @@ def context_scope(context: dict[str, object] | None) -> Generator[None, None, No
     if not context:
         yield
         return
-    token = _action_context.set(context)
-    try:
+    with bind_context(context):
         yield
-    finally:
-        _action_context.reset(token)
 
 
 def set_action_name(action: Action[Any, Any, Any], name: str) -> None:

--- a/py/packages/genkit/tests/genkit/ai/generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/generate_test.py
@@ -1262,6 +1262,157 @@ async def test_tool_sees_context_from_ambient_context_scope() -> None:
 
 
 @pytest.mark.asyncio
+async def test_middleware_context_mutation_reaches_tool() -> None:
+    """A value middleware adds to the shared bag is visible to a tool the model calls.
+
+    The model, middleware, and the tools the model triggers all read one context
+    bag, so something middleware resolves (say, a tenant) reaches a tool in the
+    same turn rather than only the model.
+    """
+    from genkit._ai._tools import ToolRunContext
+
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+
+    @ai.middleware(name='inject_tenant', description='inject tenant into context')
+    class InjectTenant(BaseMiddleware):
+        async def wrap_model(
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            ctx.context['tenant'] = 'acme'
+            return await next_fn(params, ctx)
+
+    seen: dict[str, object] = {}
+
+    @ai.tool(name='tenant_reader')
+    async def tenant_reader(_: dict, ctx: ToolRunContext) -> str:  # noqa: ARG001
+        seen['tenant'] = (ctx.context or {}).get('tenant')
+        return 'ok'
+
+    pm.responses.append(
+        ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='tenant_reader', input={}, ref='r1')))
+                ],
+            ),
+        )
+    )
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(TextPart(text='done'))]),
+        )
+    )
+
+    response = await ai.generate(
+        model='programmableModel',
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='hi'))])],
+        tools=['tenant_reader'],
+        use=[MiddlewareRef(name='inject_tenant')],
+        context={'auth': 'alice'},
+    )
+
+    assert response.text == 'done'
+    assert seen['tenant'] == 'acme'
+
+
+@pytest.mark.asyncio
+async def test_middleware_context_mutation_reaches_ambient_dict() -> None:
+    """Middleware mutates the exact dictionary instance bound to the ambient scope.
+
+    Avoid copying the dictionary if it already exists, so middleware edits reach
+    the ambient dictionary instance.
+    """
+    ai = Genkit()
+    define_echo_model(ai)
+
+    @ai.middleware(name='adds_key', description='adds a key to context')
+    class AddsKey(BaseMiddleware):
+        async def wrap_model(
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            ctx.context['added'] = True
+            return await next_fn(params, ctx)
+
+    caller_ctx: dict[str, object] = {'auth': 'alice'}
+    await ai.generate(
+        model='echoModel',
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='hi'))])],
+        use=[MiddlewareRef(name='adds_key')],
+        context=caller_ctx,
+    )
+
+    assert caller_ctx == {'auth': 'alice', 'added': True}
+
+
+@pytest.mark.asyncio
+async def test_middleware_injects_context_from_empty_reaches_tool() -> None:
+    """Middleware can populate context from nothing and a tool still sees it.
+
+    Even a generate with no context bound starts an owned, mutable bag, so
+    middleware that injects request metadata (e.g. from a header) reaches the
+    tools the model triggers.
+    """
+    from genkit._ai._tools import ToolRunContext
+
+    ai = Genkit()
+    pm, _ = define_programmable_model(ai)
+
+    @ai.middleware(name='inject_from_empty', description='inject into empty context')
+    class InjectFromEmpty(BaseMiddleware):
+        async def wrap_model(
+            self,
+            params: ModelHookParams,
+            ctx: GenerateMiddlewareContext,
+            next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            ctx.context['origin'] = 'middleware'
+            return await next_fn(params, ctx)
+
+    seen: dict[str, object] = {}
+
+    @ai.tool(name='origin_reader')
+    async def origin_reader(_: dict, ctx: ToolRunContext) -> str:  # noqa: ARG001
+        seen['origin'] = (ctx.context or {}).get('origin')
+        return 'ok'
+
+    pm.responses.append(
+        ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='origin_reader', input={}, ref='r1')))
+                ],
+            ),
+        )
+    )
+    pm.responses.append(
+        ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(role=Role.MODEL, content=[Part(TextPart(text='done'))]),
+        )
+    )
+
+    response = await ai.generate(
+        model='programmableModel',
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='hi'))])],
+        tools=['origin_reader'],
+        use=[MiddlewareRef(name='inject_from_empty')],
+    )
+
+    assert response.text == 'done'
+    assert seen['origin'] == 'middleware'
+
+
+@pytest.mark.asyncio
 async def test_middleware_wrap_tool_interrupt_handled_as_interrupt_not_crash() -> None:
     """Interrupt raised by wrap_tool middleware is converted to an interrupt part.
 


### PR DESCRIPTION
## Summary

Each generate call now owns one context bag: a copy of the ambient scope, shared by reference with the middleware and re-bound as the ambient scope for the whole turn loop. The model reads it off the scope like the tools already do (dropped context= on the model call), so whatever middleware adds or changes reaches the model AND every tool the model triggers. The copy keeps those edits out of the caller's own dict. New bind_context binds the bag even when it starts empty, so middleware can populate context from scratch.

## Behavior change

Middleware context mutations now reach tools (previously reached only the model).

## Tests added

- middleware->tool propagation
- caller-dict isolation
- empty-start injection->tool
