### PR TITLE
fix(cli): declare zod as a direct dependency

### DIFF
--- a/genkit-tools/cli/package.json
+++ b/genkit-tools/cli/package.json
@@ -42,7 +42,8 @@
     "open": "^6.3.0",
     "ora": "^5.4.1",
     "semver": "^7.7.2",
-    "yaml": "^2.8.0"
+    "yaml": "^2.8.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/genkit-tools/cli/tests/deps_test.ts
+++ b/genkit-tools/cli/tests/deps_test.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync, readdirSync } from 'fs';
+import { join, relative } from 'path';
+
+const cliRoot = join(__dirname, '..');
+const srcRoot = join(cliRoot, 'src');
+const zodImportPattern = /\bfrom\s+['"]zod['"]|require\(['"]zod['"]\)/;
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return sourceFiles(entryPath);
+    }
+    return entryPath.endsWith('.ts') ? [entryPath] : [];
+  });
+}
+
+describe('package dependencies', () => {
+  it('declares zod when CLI source imports it directly', () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(cliRoot, 'package.json'), 'utf8')
+    ) as { dependencies?: Record<string, string> };
+
+    const zodImporters = sourceFiles(srcRoot)
+      .filter((file) => zodImportPattern.test(readFileSync(file, 'utf8')))
+      .map((file) => relative(cliRoot, file))
+      .sort();
+
+    expect(zodImporters.length).toBeGreaterThan(0);
+    expect(packageJson.dependencies?.zod).toBe('^3.22.4');
+  });
+});

--- a/genkit-tools/pnpm-lock.yaml
+++ b/genkit-tools/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       yaml:
         specifier: ^2.8.0
         version: 2.8.2
+      zod:
+        specifier: ^3.22.4
+        version: 3.25.67
     devDependencies:
       '@jest/globals':
         specifier: ^29.7.0


### PR DESCRIPTION
`genkit --version` could fail after a pnpm global install because the CLI imports `zod` from its MCP code without declaring it as a direct dependency. This declares `zod` on `genkit-cli` with the same range used by the other Genkit tools packages. After this, `genkit --version` should print the installed version instead of `Cannot find module 'zod'`.

I added a package-dependency guard for the CLI `zod` importers and checked it with `pnpm --dir cli test -- deps_test.ts`, `pnpm format`, and `pnpm format:check`. Fixes #5691

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (not applicable; dependency manifest fix)
