### PR TITLE
fix(py/plugins/google-genai): list only callable Vertex embedders

### DIFF
--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/google.py
@@ -121,7 +121,11 @@ from genkit.plugins.google_genai.evaluators import (
     VertexAIEvaluationMetricType,
     create_vertex_evaluators,
 )
-from genkit.plugins.google_genai.models.embedder import EMBEDDER_DIMENSIONS, Embedder
+from genkit.plugins.google_genai.models.embedder import (
+    EMBEDDER_DIMENSIONS,
+    VERTEX_KNOWN_EMBEDDERS,
+    Embedder,
+)
 from genkit.plugins.google_genai.models.gemini import (
     SUPPORTED_MODELS,
     GeminiConfigSchema,
@@ -187,10 +191,12 @@ def _list_genai_models(client: genai.Client, is_vertex: bool) -> GenaiModels:
     - Vertex AI returns ``supported_actions = None`` for every publisher model,
       so categorizing by action would skip them all. The Vertex path instead
       categorizes by model name (mirroring the JS plugin's ``listActions``):
-        - 'embedding' in name → embedders
         - 'imagen' in name → imagen
         - 'veo' in name → veo
         - 'gemini'/'gemma' in name (and not an embedding) → gemini
+      Embedders are intentionally NOT discovered here. The Vertex catalog
+      over-lists embedders that are published but not callable, so they
+      are advertised from a curated list (``VERTEX_KNOWN_EMBEDDERS``) instead.
 
     Args:
         client: The Google GenAI client instance.
@@ -223,12 +229,14 @@ def _list_genai_models(client: genai.Client, is_vertex: bool) -> GenaiModels:
             continue
 
         # Vertex AI returns supported_actions=None for every publisher model, so
-        # categorize by name
+        # categorize by name. Embedders are deliberately excluded: the catalog
+        # over-lists embedders that are not callable, so they are advertised from a curated list
+        # (VERTEX_KNOWN_EMBEDDERS) rather than discovered here.
         if is_vertex:
             lower_name = name.lower()
             if 'embedding' in lower_name:
-                models.embedders.append(name)
-            elif 'imagen' in lower_name:
+                continue
+            if 'imagen' in lower_name:
                 models.imagen.append(name)
             elif 'veo' in lower_name:
                 models.veo.append(name)
@@ -817,7 +825,7 @@ class VertexAI(Plugin):
         for name in genai_models.veo:
             actions.append(self._resolve_model(vertexai_name(name)))
 
-        for name in genai_models.embedders:
+        for name in VERTEX_KNOWN_EMBEDDERS:
             actions.append(self._resolve_embedder(vertexai_name(name)))
 
         # Register Vertex AI evaluators
@@ -854,10 +862,14 @@ class VertexAI(Plugin):
         return actions
 
     def _list_known_embedders(self) -> list[Action]:
-        """List known embedders as Action objects."""
-        genai_models = _list_genai_models(self._runtime_client(), is_vertex=True)
+        """List known embedders as Action objects.
+
+        Vertex embedders are advertised from a curated list rather than
+        discovered from the catalog, which over-lists embedders that are not
+        callable. See VERTEX_KNOWN_EMBEDDERS.
+        """
         actions = []
-        for name in genai_models.embedders:
+        for name in VERTEX_KNOWN_EMBEDDERS:
             actions.append(self._resolve_embedder(vertexai_name(name)))
         return actions
 
@@ -1021,15 +1033,14 @@ class VertexAI(Plugin):
                 )
             )
 
-        for name in genai_models.embedders:
-            dims = EMBEDDER_DIMENSIONS.get(name)
+        for name in VERTEX_KNOWN_EMBEDDERS:
             actions_list.append(
                 embedder_action_metadata(
                     name=vertexai_name(name),
                     options=EmbedderOptions(
                         label=f'{PLUGIN_DISPLAY_NAME[VERTEXAI_PLUGIN_NAME]} - {name}',
                         supports=EmbedderSupports(input=['text']),
-                        dimensions=dims,
+                        dimensions=EMBEDDER_DIMENSIONS.get(name),
                     ),
                 )
             )

--- a/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
+++ b/py/plugins/google-genai/src/genkit/plugins/google_genai/models/embedder.py
@@ -75,6 +75,13 @@ EMBEDDER_DIMENSIONS: dict[str, int] = {
     'multimodalembedding@001': 768,
 }
 
+# Curated set of Vertex AI embedders that are verified to be callable.
+VERTEX_KNOWN_EMBEDDERS: tuple[str, ...] = (
+    'text-embedding-005',
+    'text-multilingual-embedding-002',
+    'gemini-embedding-001',
+)
+
 
 class Embedder:
     """Embedder for Google-Genai."""

--- a/py/plugins/google-genai/test/google_plugin_test.py
+++ b/py/plugins/google-genai/test/google_plugin_test.py
@@ -41,6 +41,7 @@ from genkit import (
 from genkit.plugin_api import GENKIT_CLIENT_HEADER
 from genkit.plugins.google_genai import GoogleAI, VertexAI
 from genkit.plugins.google_genai.google import _inject_attribution_headers, googleai_name, vertexai_name
+from genkit.plugins.google_genai.models.embedder import VERTEX_KNOWN_EMBEDDERS
 from genkit.plugins.google_genai.models.gemini import (
     DEFAULT_SUPPORTS_MODEL,
     SUPPORTED_MODELS,
@@ -824,6 +825,7 @@ async def test_vertexai_list_actions_without_supported_actions(vertexai_plugin_i
     mock_client.models.list.return_value = [
         mock_model('publishers/google/models/gemini-2.5-pro'),
         mock_model('publishers/google/models/gemini-embedding-001'),
+        mock_model('publishers/google/models/gemini-embedding-2'),
         mock_model('publishers/google/models/imagen-3.0-generate-002'),
         mock_model('publishers/google/models/veo-2.0-generate-001'),
     ]
@@ -841,6 +843,8 @@ async def test_vertexai_list_actions_without_supported_actions(vertexai_plugin_i
     # gemini-embedding-001 is registered as an embedder, not a gemini model.
     embedder = next(a for a in result if a.name == vertexai_name('gemini-embedding-001'))
     assert embedder.action_type == ActionKind.EMBEDDER
+    # Non-callable embedders over-listed by the catalog must not leak into Gemini text models.
+    assert vertexai_name('gemini-embedding-2') not in names
 
 
 @pytest.mark.asyncio
@@ -925,50 +929,17 @@ async def test_vertexai_list_known_models(vertexai_plugin_instance: VertexAI) ->
 
 @pytest.mark.asyncio
 async def test_vertexai_list_known_embedders(vertexai_plugin_instance: VertexAI) -> None:
-    """Unit test for list known embedders."""
+    """Vertex embedders come from a curated list, not catalog discovery.
 
-    @dataclass
-    class MockModel:
-        name: str
-        description: str = ''
-
-    [
-        MockModel(name='publishers/google/models/gemini-1.5-flash'),
-        MockModel(name='publishers/google/models/gemini-embedding-001'),
-        MockModel(name='publishers/google/models/imagen-3.0-generate-001'),
-        MockModel(name='publishers/google/models/veo-2.0-generate-001'),
-    ]
-
-    mock_client = MagicMock()
-    # Create sophisticated mocks that have supported_actions
-    m1 = MagicMock()
-    m1.name = 'publishers/google/models/gemini-1.5-flash'
-    m1.supported_actions = ['generateContent']
-    m1.description = 'Gemini model'
-
-    m2 = MagicMock()
-    m2.name = 'publishers/google/models/gemini-embedding-001'
-    m2.supported_actions = ['embedContent']
-    m2.description = 'Embedder'
-
-    m3 = MagicMock()
-    m3.name = 'publishers/google/models/imagen-3.0-generate-001'
-    m3.supported_actions = ['predict']
-    m3.description = 'Imagen'
-
-    m4 = MagicMock()
-    m4.name = 'publishers/google/models/veo-2.0-generate-001'
-    m4.supported_actions = ['generateVideos']
-    m4.description = 'Veo'
-
-    mock_client.models.list.return_value = [m1, m2, m3, m4]
-    vertexai_plugin_instance._runtime_client = lambda: mock_client
-
+    The Vertex catalog over-lists embedders that are published but not callable
+    (e.g. gemini-embedding-2), so the plugin advertises only VERTEX_KNOWN_EMBEDDERS.
+    """
     result = vertexai_plugin_instance._list_known_embedders()
 
-    # Verify Embedder
-    action2 = next(a for a in result if a.name == vertexai_name('gemini-embedding-001'))
-    assert action2 is not None
+    listed = {a.name for a in result}
+    assert listed == {vertexai_name(name) for name in VERTEX_KNOWN_EMBEDDERS}
+    assert vertexai_name('gemini-embedding-001') in listed
+    assert vertexai_name('gemini-embedding-2') not in listed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

The Vertex AI plugin discovered embedders by scanning the model catalog for names containing "embedding". Vertex returns its full publisher catalog, including models that are published but not callable in a given project or
region, so this surfaced embedders that fail at call time. For example, `vertexai/gemini-embedding-2` was registered and shown in the Dev UI but returned 404 / FAILED_PRECONDITION when invoked.

This change stops discovering Vertex embedders from the catalog and advertises a curated list of known-callable models instead, matching the JS plugin.

## Why

Vertex AI's `models.list()` returns the global publisher catalog and reports `supported_actions = None` for every entry. Unlike the Gemini API path, the plugin cannot categorize Vertex models by capability, so it fell back to matching the substring "embedding" in the model name. That heuristic cannot tell a model that is listed and callable apart from one that is listed but not callable, so over-listed models leaked into the registry.

The JS plugin already avoids this by not discovery-listing Vertex embedders. It exposes a hand-curated set and keeps resolution permissive. This brings the Python plugin to parity.

## How

- Add `VERTEX_KNOWN_EMBEDDERS` in `models/embedder.py`: `text-embedding-005`,
  `text-multilingual-embedding-002`, `gemini-embedding-001`.
- `_list_genai_models` no longer collects embedders on the Vertex path.
  Name-matched embedding models are skipped so they also do not leak into the
  Gemini bucket.
- `VertexAI.init`, `VertexAI._list_known_embedders`, and `VertexAI.list_actions`
  iterate `VERTEX_KNOWN_EMBEDDERS` instead of discovery output.
- `resolve()` is unchanged and stays permissive, so callers can still reference
  any embedder by explicit name, including newly released models that are not in
  the curated list.
- Update `test_vertexai_list_known_embedders` to assert the advertised set
  equals the curated list and that a non-callable catalog entry
  (`gemini-embedding-2`) is never surfaced.

## Excluded: multimodalembedding@001

`multimodalembedding@001` is deliberately left out. The current `Embedder` routes every request through the SDK's `embed_content`, which on Vertex only emits the text-embedder request shape (`{'content': ...}`) and drops non-text parts. That model rejects that shape, so it cannot be called through this path for either text or media. Proper multimodal support via the `:predict` endpoint with `{text, image, video}` instances is tracked in #5649 , which will re-add the model once that path exists.

## Testing

- `text-embedding-005`, `text-multilingual-embedding-002`, and
  `gemini-embedding-001` verified working against Vertex in the Dev UI.
- Plugin test suite passes.

## Screenshots
<img width="434" height="384" alt="Screenshot 2026-07-06 at 12 39 41" src="https://github.com/user-attachments/assets/02cda25c-9223-4bf3-9041-4140b36dfa9e" />
<img width="999" height="453" alt="Screenshot 2026-07-06 at 12 40 07" src="https://github.com/user-attachments/assets/6831776a-ee4c-4e85-a2e3-7f7c714ede5b" />
<img width="997" height="449" alt="Screenshot 2026-07-06 at 12 40 32" src="https://github.com/user-attachments/assets/eae8aa96-be53-41a8-9ba8-0a57f6cb2da3" />
<img width="998" height="451" alt="Screenshot 2026-07-06 at 12 40 56" src="https://github.com/user-attachments/assets/6b697078-af2e-49a7-93dc-563fb2a29a4e" />
