### PR TITLE
fix(js/plugins/google-genai): remove dead contextCache config flag and strip it from requests

### DIFF
--- a/js/plugins/google-genai/src/googleai/gemini.ts
+++ b/js/plugins/google-genai/src/googleai/gemini.ts
@@ -176,13 +176,6 @@ export const GeminiConfigSchema = GenerationCommonConfigSchema.extend({
     .union([z.boolean(), z.object({}).strict()])
     .describe('Enables the model to generate and run code.')
     .optional(),
-  contextCache: z
-    .boolean()
-    .describe(
-      'Context caching allows you to save and reuse precomputed input ' +
-        'tokens that you wish to use repeatedly.'
-    )
-    .optional(),
   functionCallingConfig: z
     .object({
       mode: z.enum(['MODE_UNSPECIFIED', 'AUTO', 'ANY', 'NONE']).optional(),
@@ -751,6 +744,10 @@ export function defineModel(
         tools: toolsFromConfig,
         retrievalConfig,
         serviceTier,
+        // The schema is passthrough, so also strip the removed contextCache
+        // flag; otherwise a stale config would still forward it to the API as
+        // an unknown generationConfig field.
+        contextCache: _contextCache,
         ...restOfConfigOptions
       } = requestOptions;
 

--- a/js/plugins/google-genai/tests/googleai/gemini_test.ts
+++ b/js/plugins/google-genai/tests/googleai/gemini_test.ts
@@ -449,6 +449,27 @@ describe('Google AI Gemini', () => {
         );
       });
 
+      it('strips the removed contextCache flag from the outbound request', async () => {
+        const model = defineModel('gemini-2.5-flash', defaultPluginOptions);
+        mockFetchResponse(defaultApiResponse);
+        const request: GenerateRequest<typeof GeminiConfigSchema> = {
+          ...minimalRequest,
+          // The schema is passthrough, so a stale config still validates; it
+          // must not be forwarded as an unknown generationConfig field.
+          config: { contextCache: true } as any,
+        };
+        await model.run(request);
+
+        const apiRequest: GenerateContentRequest = JSON.parse(
+          fetchStub.lastCall.args[1].body
+        );
+        assert.strictEqual(
+          (apiRequest.generationConfig as any)?.contextCache,
+          undefined,
+          'contextCache should not be in generationConfig'
+        );
+      });
+
       it('uses baseUrl and apiVersion from call config', async () => {
         const model = defineModel('gemini-2.5-flash', {
           ...defaultPluginOptions,


### PR DESCRIPTION
Fixes #5593

## Problem

The googleAI `GeminiConfigSchema` exposes a `contextCache` boolean that is never consumed. From what I can see it is a leftover from the deprecated `@genkit-ai/googleai` plugin's explicit context caching (removed in #4948), superseded by implicit caching on Gemini 2.5+ which needs no config.

It is worse than just a dead option: the schema is `.passthrough()`, and `contextCache` is neither destructured out in the request builder nor stripped by `removeClientOptionOverrides`, so a config that sets it forwards the flag verbatim into `generationConfig` on the outbound request as an unknown field.

```ts
// gemini.ts request builder: not in the destructure list...
const { apiKey, safetySettings, /* ... */ serviceTier, ...restOfConfigOptions } = requestOptions;
// ...so it rides along here
const generationConfig: GenerationConfig = {
  ...removeClientOptionOverrides(restOfConfigOptions),
```

## Change

- Remove `contextCache` from `GeminiConfigSchema` (googleAI only; the vertexai config does not have this flag).
- Strip it in the request-builder destructure so a stale config (which still validates, given passthrough) no longer leaks it into the outbound request.
- Add a regression test asserting the serialized `generationConfig` does not contain it.

## Notes

- This is technically a breaking type change for a public config field, but setting it never had any effect.
- The Python plugin has a separate `contextCache` alias (`py/plugins/google-genai/.../gemini.py`) which reads as out of scope for this JS-only issue; happy to follow up there if useful.

## Verification

- `tsx --test tests/googleai/gemini_test.ts`: 34/34 pass (including the new regression test).
- `tsc --noEmit` clean for the plugin; `prettier --check` clean on the touched files.
- `grep contextCache` across `js/` returns only the intentional strip and its test.
