### PR TITLE
fix(tools): restore usage stats for runAction, streamAction, etc

### DIFF
--- a/genkit-tools/common/src/server/router.ts
+++ b/genkit-tools/common/src/server/router.ts
@@ -31,8 +31,12 @@ import { CancelActionRequestSchema } from '../types/apis';
 import type { EnvironmentVariable } from '../types/env';
 import * as evals from '../types/eval';
 import type { PromptFrontmatter } from '../types/prompt';
-import { logger } from '../utils';
-import { PageViewEvent, ToolsRequestEvent, record } from '../utils/analytics';
+import {
+  PageViewEvent,
+  createToolsRequestEvent,
+  record,
+  recordRequestEvent,
+} from '../utils/analytics';
 import { toolsPackage } from '../utils/package';
 import { fromMessages } from '../utils/prompt';
 
@@ -55,31 +59,10 @@ const t = initTRPC.create({
 
 const analyticsEventForRoute = (
   path: string,
-  input: unknown,
   durationMs: number,
   status: string
 ) => {
-  const event = new ToolsRequestEvent(path);
-  event.duration = durationMs;
-  event.parameters = {
-    ...event.parameters,
-    status,
-  };
-
-  switch (path) {
-    case 'runAction':
-      // set action type (flow, model, etc...)
-      const splits = (input as apis.RunActionRequest).key?.split('/');
-      event.parameters = {
-        ...event.parameters,
-        action: splits.length > 1 ? splits[1] : 'unknown',
-      };
-      break;
-    default:
-    // do nothing
-  }
-
-  return event;
+  return createToolsRequestEvent(path, durationMs, status);
 };
 
 const parseEnv = (environ: NodeJS.ProcessEnv): EnvironmentVariable[] => {
@@ -111,15 +94,11 @@ const loggedProcedure = t.procedure.use(async (opts) => {
 
   const analyticsEvent = analyticsEventForRoute(
     opts.path,
-    opts.rawInput,
     durationMs,
     result.ok ? 'success' : 'failure'
   );
 
-  // fire-and-forget
-  record(analyticsEvent).catch((err) => {
-    logger.error(`Failed to send analytics ${err}`);
-  });
+  recordRequestEvent(analyticsEvent);
 
   return result;
 });

--- a/genkit-tools/common/src/server/server.ts
+++ b/genkit-tools/common/src/server/server.ts
@@ -24,8 +24,12 @@ import os from 'os';
 import path from 'path';
 import type { GenkitToolsError } from '../manager';
 import type { BaseRuntimeManager } from '../manager/manager';
-import { writeToolsInfoFile } from '../utils';
-import { logger } from '../utils/logger';
+import { logger, writeToolsInfoFile } from '../utils';
+import {
+  createToolsRequestEvent,
+  extractActionType,
+  recordRequestEvent,
+} from '../utils/analytics';
 import { toolsPackage } from '../utils/package';
 import { downloadAndExtractUiAssets } from '../utils/ui-assets';
 import { TOOLS_SERVER_ROUTER } from './router';
@@ -83,6 +87,44 @@ class PushableAsyncIterable<T> implements AsyncIterable<T> {
 
 const activeInputStreams = new Map<string, PushableAsyncIterable<any>>();
 
+const loggedExpressRoute = (routeName: string) => {
+  return (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+  ) => {
+    const start = Date.now();
+    let recorded = false;
+
+    const onDone = () => {
+      res.off('finish', onDone);
+      res.off('close', onDone);
+      if (recorded) return;
+      recorded = true;
+
+      const durationMs = Date.now() - start;
+      const status =
+        res.statusCode >= 200 && res.statusCode < 400 && !res.locals?.hasError
+          ? 'success'
+          : 'failure';
+
+      const action =
+        routeName === 'runAction' || routeName === 'streamAction'
+          ? extractActionType(req.body?.key)
+          : undefined;
+
+      recordRequestEvent(
+        createToolsRequestEvent(routeName, durationMs, status, { action })
+      );
+    };
+
+    res.once('finish', onDone);
+    res.once('close', onDone);
+
+    next();
+  };
+};
+
 /**
  * Starts up the Genkit Tools server which includes static files for the UI and the Tools API.
  */
@@ -112,6 +154,7 @@ export function startServer(manager: BaseRuntimeManager, port: number) {
   app.post(
     '/api/runAction',
     bodyParser.json({ limit: MAX_PAYLOAD_SIZE }),
+    loggedExpressRoute('runAction'),
     async (req, res) => {
       // Set headers but don't flush yet - wait for trace ID (if realtime telemetry enabled)
       res.setHeader('Content-Type', 'application/json');
@@ -142,6 +185,7 @@ export function startServer(manager: BaseRuntimeManager, port: number) {
 
         res.end(JSON.stringify(result));
       } catch (err) {
+        res.locals.hasError = true;
         const error = err as GenkitToolsError;
 
         // If headers not sent, we can send error status
@@ -158,6 +202,7 @@ export function startServer(manager: BaseRuntimeManager, port: number) {
   app.post(
     '/api/streamAction',
     bodyParser.json({ limit: MAX_PAYLOAD_SIZE }),
+    loggedExpressRoute('streamAction'),
     async (req, res) => {
       // Set streaming headers but don't flush yet - wait for trace ID (if realtime telemetry enabled)
       res.setHeader('Content-Type', 'text/plain');
@@ -201,6 +246,7 @@ export function startServer(manager: BaseRuntimeManager, port: number) {
         );
         res.write(JSON.stringify(result));
       } catch (err) {
+        res.locals.hasError = true;
         res.write(JSON.stringify({ error: (err as GenkitToolsError).data }));
       } finally {
         if (capturedTraceId) {
@@ -214,6 +260,7 @@ export function startServer(manager: BaseRuntimeManager, port: number) {
   app.post(
     '/api/sendBidiInput',
     bodyParser.json({ limit: MAX_PAYLOAD_SIZE }),
+    loggedExpressRoute('sendBidiInput'),
     (req, res) => {
       const { traceId, chunk } = req.body;
       const stream = activeInputStreams.get(traceId);
@@ -226,24 +273,30 @@ export function startServer(manager: BaseRuntimeManager, port: number) {
     }
   );
 
-  app.post('/api/endBidiInput', bodyParser.json(), (req, res) => {
-    const { traceId } = req.body;
-    const stream = activeInputStreams.get(traceId);
-    if (stream) {
-      stream.close();
-      // Don't delete here, wait for action to complete (finally block)
-      // or delete if we want to ensure no more writes.
-      // If we delete here, subsequent writes will fail, which is correct.
-      // But finally block handles cleanup anyway.
-      res.status(200).send('OK');
-    } else {
-      res.status(404).send('Stream not found');
+  app.post(
+    '/api/endBidiInput',
+    bodyParser.json(),
+    loggedExpressRoute('endBidiInput'),
+    (req, res) => {
+      const { traceId } = req.body;
+      const stream = activeInputStreams.get(traceId);
+      if (stream) {
+        stream.close();
+        // Don't delete here, wait for action to complete (finally block)
+        // or delete if we want to ensure no more writes.
+        // If we delete here, subsequent writes will fail, which is correct.
+        // But finally block handles cleanup anyway.
+        res.status(200).send('OK');
+      } else {
+        res.status(404).send('Stream not found');
+      }
     }
-  });
+  );
 
   app.post(
     '/api/streamTrace',
     bodyParser.json({ limit: MAX_PAYLOAD_SIZE }),
+    loggedExpressRoute('streamTrace'),
     async (req, res) => {
       const { traceId } = req.body;
 
@@ -266,6 +319,7 @@ export function startServer(manager: BaseRuntimeManager, port: number) {
         });
         res.end();
       } catch (err) {
+        res.locals.hasError = true;
         const error = err as GenkitToolsError;
         if (!res.headersSent) {
           res.writeHead(500, {

--- a/genkit-tools/common/src/utils/analytics.ts
+++ b/genkit-tools/common/src/utils/analytics.ts
@@ -118,6 +118,46 @@ export async function record(event: GAEvent): Promise<void> {
   await recordInternal(event, getSession());
 }
 
+/**
+ * Creates a ToolsRequestEvent with validated duration and optional action parameter.
+ */
+export function createToolsRequestEvent(
+  route: string,
+  durationMs: number,
+  status: string,
+  options?: { action?: string }
+): ToolsRequestEvent {
+  const event = new ToolsRequestEvent(route);
+  event.duration = Math.max(1, durationMs);
+  event.parameters = {
+    ...event.parameters,
+    status,
+    ...(options?.action && { action: options.action }),
+  };
+  return event;
+}
+
+/**
+ * Fire-and-forget helper to record a request analytics event with error logging.
+ */
+export function recordRequestEvent(event: GAEvent): void {
+  record(event).catch((err) => {
+    logger.error(`Failed to send analytics ${err}`);
+  });
+}
+
+/**
+ * Extracts action type from a request action key.
+ */
+export function extractActionType(key?: unknown): string {
+  const keyStr = typeof key === 'string' ? key : '';
+  if (keyStr === '/util/generate' || keyStr === 'util/generate') {
+    return keyStr;
+  }
+  const splits = keyStr.split('/');
+  return splits.length > 1 ? splits[1] : 'unknown';
+}
+
 /** Displays a notification that analytics are in use. */
 export async function notifyAnalyticsIfFirstRun(): Promise<void> {
   if (isAnalyticsOptedOut()) return;

--- a/genkit-tools/common/tests/server_test.ts
+++ b/genkit-tools/common/tests/server_test.ts
@@ -26,6 +26,7 @@ import axios from 'axios';
 import getPort from 'get-port';
 import { BaseRuntimeManager } from '../src/manager/manager';
 import { startServer } from '../src/server/server';
+import * as analytics from '../src/utils/analytics';
 
 describe('Tools Server', () => {
   let port: number;
@@ -161,5 +162,354 @@ describe('Tools Server', () => {
     const output = outputChunks.join('');
     expect(output).toContain('chunk1');
     expect(output).toContain('done');
+  });
+
+  describe('analytics events', () => {
+    let recordSpy: jest.Spied<typeof analytics.recordRequestEvent>;
+
+    beforeEach(() => {
+      recordSpy = jest
+        .spyOn(analytics, 'recordRequestEvent')
+        .mockImplementation(() => {});
+      jest.spyOn(analytics, 'record').mockImplementation(async () => {});
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should record analytics event for runAction with valid string key', async () => {
+      mockManager.runAction.mockResolvedValue({ result: 'bar' });
+
+      await axios.post(`http://localhost:${port}/api/runAction`, {
+        key: '/flow/foo',
+        input: 'bar',
+      });
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'runAction',
+            action: 'flow',
+            status: 'success',
+          }),
+        })
+      );
+    });
+
+    it('should record analytics event for runAction with non-string key as unknown action', async () => {
+      mockManager.runAction.mockResolvedValue({ result: 'bar' });
+
+      await axios.post(`http://localhost:${port}/api/runAction`, {
+        key: 123,
+        input: 'bar',
+      });
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'runAction',
+            action: 'unknown',
+            status: 'success',
+          }),
+        })
+      );
+    });
+
+    it('should record analytics event with full path specifically for /util/generate while splitting other util actions', async () => {
+      mockManager.runAction.mockResolvedValue({ result: 'bar' });
+
+      await axios.post(`http://localhost:${port}/api/runAction`, {
+        key: '/util/generate',
+        input: 'bar',
+      });
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'runAction',
+            action: '/util/generate',
+            status: 'success',
+          }),
+        })
+      );
+
+      await axios.post(`http://localhost:${port}/api/runAction`, {
+        key: '/util/other',
+        input: 'bar',
+      });
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'runAction',
+            action: 'util',
+            status: 'success',
+          }),
+        })
+      );
+    });
+
+    it('should record analytics event for streamTrace', async () => {
+      mockManager.streamTrace.mockImplementation(
+        async (_opts: any, cb: any) => {
+          cb({ traceId: 'test-trace' });
+        }
+      );
+      await axios.post(`http://localhost:${port}/api/streamTrace`, {
+        traceId: 'test-trace',
+      });
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'streamTrace',
+            status: 'success',
+          }),
+        })
+      );
+    });
+
+    it('should record failure analytics event for sendBidiInput when stream is not found', async () => {
+      await axios.post(
+        `http://localhost:${port}/api/sendBidiInput`,
+        {
+          traceId: 'non-existent',
+          chunk: 'test',
+        },
+        { validateStatus: () => true }
+      );
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'sendBidiInput',
+            status: 'failure',
+          }),
+        })
+      );
+    });
+
+    it('should record failure analytics event for endBidiInput when stream is not found', async () => {
+      await axios.post(
+        `http://localhost:${port}/api/endBidiInput`,
+        {
+          traceId: 'non-existent',
+        },
+        { validateStatus: () => true }
+      );
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'endBidiInput',
+            status: 'failure',
+          }),
+        })
+      );
+    });
+
+    it('should record failure analytics event for runAction when action fails', async () => {
+      mockManager.runAction.mockRejectedValue({
+        data: { message: 'Action failed' },
+      });
+
+      await axios.post(
+        `http://localhost:${port}/api/runAction`,
+        { key: '/flow/foo', input: 'bar' },
+        { validateStatus: () => true }
+      );
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'runAction',
+            action: 'flow',
+            status: 'failure',
+          }),
+        })
+      );
+    });
+
+    it('should record success analytics event for streamAction', async () => {
+      mockManager.runAction.mockImplementation(async (_input: any, cb: any) => {
+        if (cb) cb({ result: 'chunk' });
+        return { result: 'done' };
+      });
+
+      await axios.post(
+        `http://localhost:${port}/api/streamAction`,
+        { key: '/flow/foo', input: 'bar' },
+        { responseType: 'stream' }
+      );
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'streamAction',
+            action: 'flow',
+            status: 'success',
+          }),
+        })
+      );
+    });
+
+    it('should record failure analytics event for streamAction on error', async () => {
+      mockManager.runAction.mockRejectedValue({
+        data: { message: 'Stream error' },
+      });
+
+      await axios.post(
+        `http://localhost:${port}/api/streamAction`,
+        { key: '/flow/foo', input: 'bar' },
+        { validateStatus: () => true }
+      );
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'streamAction',
+            action: 'flow',
+            status: 'failure',
+          }),
+        })
+      );
+    });
+
+    it('should record success analytics event for sendBidiInput when stream exists', async () => {
+      let inputStream: AsyncIterable<any> | undefined;
+      let finishAction: (() => void) | undefined;
+
+      mockManager.runAction.mockImplementation(
+        async (_input: any, _cb: any, onTraceId: any, stream: any) => {
+          inputStream = stream;
+          if (onTraceId) onTraceId('bidi-send-trace-id');
+          await new Promise<void>((resolve) => {
+            finishAction = resolve;
+          });
+          return { result: 'done' };
+        }
+      );
+
+      const streamActionPromise = axios.post(
+        `http://localhost:${port}/api/streamAction?bidi=true`,
+        { key: '/flow/bidiFlow' },
+        { responseType: 'stream' }
+      );
+
+      while (!inputStream) {
+        await new Promise((r) => setTimeout(r, 10));
+      }
+
+      await axios.post(`http://localhost:${port}/api/sendBidiInput`, {
+        traceId: 'bidi-send-trace-id',
+        chunk: 'hello',
+      });
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'sendBidiInput',
+            status: 'success',
+          }),
+        })
+      );
+
+      await axios
+        .post(`http://localhost:${port}/api/endBidiInput`, {
+          traceId: 'bidi-send-trace-id',
+        })
+        .catch(() => {});
+      if (finishAction) finishAction();
+      await streamActionPromise.catch(() => {});
+    });
+
+    it('should record success analytics event for endBidiInput when stream exists', async () => {
+      let inputStream: AsyncIterable<any> | undefined;
+      let finishAction: (() => void) | undefined;
+
+      mockManager.runAction.mockImplementation(
+        async (_input: any, _cb: any, onTraceId: any, stream: any) => {
+          inputStream = stream;
+          if (onTraceId) onTraceId('bidi-end-trace-id');
+          await new Promise<void>((resolve) => {
+            finishAction = resolve;
+          });
+          return { result: 'done' };
+        }
+      );
+
+      const streamActionPromise = axios.post(
+        `http://localhost:${port}/api/streamAction?bidi=true`,
+        { key: '/flow/bidiFlow' },
+        { responseType: 'stream' }
+      );
+
+      while (!inputStream) {
+        await new Promise((r) => setTimeout(r, 10));
+      }
+
+      await axios.post(`http://localhost:${port}/api/endBidiInput`, {
+        traceId: 'bidi-end-trace-id',
+      });
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'endBidiInput',
+            status: 'success',
+          }),
+        })
+      );
+
+      if (finishAction) finishAction();
+      await streamActionPromise.catch(() => {});
+    });
+
+    it('should record failure analytics event for streamTrace when traceId is missing or stream throws', async () => {
+      await axios.post(
+        `http://localhost:${port}/api/streamTrace`,
+        {},
+        { validateStatus: () => true }
+      );
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'streamTrace',
+            status: 'failure',
+          }),
+        })
+      );
+
+      mockManager.streamTrace.mockRejectedValue({
+        data: { message: 'Trace not found' },
+      });
+      await axios.post(
+        `http://localhost:${port}/api/streamTrace`,
+        { traceId: 'bad-trace' },
+        { validateStatus: () => true }
+      );
+
+      expect(recordSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools_request',
+          parameters: expect.objectContaining({
+            route: 'streamTrace',
+            status: 'failure',
+          }),
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
Currently we track analytics for tRPC. However, when we moved `runAction` to the express server for real time tracing, we lost our metrics. `streamAction` possibly never had metrics.

Add a new middleware that does the same metrics collection for any dev-ui routes directly defined in the express server
