### PR TITLE
feat(py/plugins/amazon-bedrock): add model capability registry

### DIFF
--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model capability registry for the Amazon Bedrock plugin.
+
+Ported from the Go plugin's ``models.go``. Capabilities are keyed by base
+Bedrock model ID; cross-region inference-profile prefixes are stripped for
+lookup only - the full original model ID is always sent to Bedrock untouched.
+Unknown chat/text models fall back to modern Converse defaults (multimodal +
+tools) at the unstable stage, so newer or inference-profile-only models remain
+callable without a plugin release.
+"""
+
+from typing import Literal, NamedTuple
+
+from genkit import Constrained, ModelInfo, Stage, Supports
+
+INFERENCE_PROFILE_PREFIXES = (
+    'global.',
+    'us-gov.',
+    'us.',
+    'eu.',
+    'jp.',
+    'apac.',
+    'au.',
+)
+
+
+class ModelCapability(NamedTuple):
+    """Capabilities of a Bedrock chat/text model."""
+
+    multimodal: bool
+    tools: bool
+
+
+MODEL_CAPABILITIES: dict[str, ModelCapability] = {
+    # Anthropic Claude 3 models
+    'anthropic.claude-3-haiku-20240307-v1:0': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-3-sonnet-20240229-v1:0': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-3-opus-20240229-v1:0': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-3-5-haiku-20241022-v1:0': ModelCapability(multimodal=False, tools=True),
+    'anthropic.claude-3-5-sonnet-20240620-v1:0': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-3-5-sonnet-20241022-v2:0': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-3-7-sonnet-20250219-v1:0': ModelCapability(multimodal=True, tools=True),
+    # Anthropic Claude 4/4.5/4.6 models
+    'anthropic.claude-haiku-4-5-20251001-v1:0': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-opus-4-1-20250805-v1:0': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-opus-4-20250514-v1:0': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-sonnet-4-20250514-v1:0': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-sonnet-4-5-20250929-v1:0': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-opus-4-5-20251101-v1:0': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-sonnet-4-6': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-opus-4-6-v1': ModelCapability(multimodal=True, tools=True),
+    # Provisioned-throughput variants (28k/48k/200k context)
+    'anthropic.claude-3-haiku-20240307-v1:0:48k': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-3-haiku-20240307-v1:0:200k': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-3-sonnet-20240229-v1:0:28k': ModelCapability(multimodal=True, tools=True),
+    'anthropic.claude-3-sonnet-20240229-v1:0:200k': ModelCapability(multimodal=True, tools=True),
+    # Amazon Nova models
+    'amazon.nova-micro-v1:0': ModelCapability(multimodal=False, tools=True),
+    'amazon.nova-lite-v1:0': ModelCapability(multimodal=True, tools=True),
+    'amazon.nova-pro-v1:0': ModelCapability(multimodal=True, tools=True),
+    'amazon.nova-premier-v1:0': ModelCapability(multimodal=True, tools=True),
+    # Cohere Command models
+    'cohere.command-r-v1:0': ModelCapability(multimodal=False, tools=True),
+    'cohere.command-r-plus-v1:0': ModelCapability(multimodal=False, tools=True),
+    # Mistral models
+    'mistral.mistral-large-2402-v1:0': ModelCapability(multimodal=False, tools=True),
+    'mistral.mistral-large-2407-v1:0': ModelCapability(multimodal=False, tools=True),
+    'mistral.mistral-small-2402-v1:0': ModelCapability(multimodal=False, tools=True),
+    'mistral.pixtral-large-2502-v1:0': ModelCapability(multimodal=True, tools=True),
+    # AI21 Labs Jamba models
+    'ai21.jamba-1-5-large-v1:0': ModelCapability(multimodal=False, tools=True),
+    'ai21.jamba-1-5-mini-v1:0': ModelCapability(multimodal=False, tools=True),
+    # Meta Llama models
+    'meta.llama3-8b-instruct-v1:0': ModelCapability(multimodal=False, tools=True),
+    'meta.llama3-70b-instruct-v1:0': ModelCapability(multimodal=False, tools=True),
+    'meta.llama3-1-8b-instruct-v1:0': ModelCapability(multimodal=False, tools=True),
+    'meta.llama3-1-70b-instruct-v1:0': ModelCapability(multimodal=False, tools=True),
+    'meta.llama3-1-405b-instruct-v1:0': ModelCapability(multimodal=False, tools=True),
+    'meta.llama3-2-1b-instruct-v1:0': ModelCapability(multimodal=False, tools=True),
+    'meta.llama3-2-3b-instruct-v1:0': ModelCapability(multimodal=False, tools=True),
+    'meta.llama3-2-11b-instruct-v1:0': ModelCapability(multimodal=True, tools=True),
+    'meta.llama3-2-90b-instruct-v1:0': ModelCapability(multimodal=True, tools=True),
+    'meta.llama3-3-70b-instruct-v1:0': ModelCapability(multimodal=False, tools=True),
+    'meta.llama4-maverick-17b-instruct-v1:0': ModelCapability(multimodal=True, tools=True),
+    'meta.llama4-scout-17b-instruct-v1:0': ModelCapability(multimodal=True, tools=True),
+    # DeepSeek models
+    'deepseek.r1-v1:0': ModelCapability(multimodal=False, tools=True),
+    # Writer models
+    'writer.palmyra-x4-v1:0': ModelCapability(multimodal=False, tools=True),
+    'writer.palmyra-x5-v1:0': ModelCapability(multimodal=False, tools=True),
+    # TwelveLabs models
+    'twelvelabs.pegasus-1-2-v1:0': ModelCapability(multimodal=False, tools=True),
+}
+
+
+def strip_inference_profile_prefix(model_id: str) -> str:
+    """Strips a cross-region inference-profile prefix from a model ID.
+
+    Used for capability lookup only; requests always carry the original ID.
+
+    Args:
+        model_id: Bedrock model ID, possibly prefixed (e.g. ``us.anthropic...``).
+
+    Returns:
+        The base model ID without the inference-profile prefix.
+    """
+    for prefix in INFERENCE_PROFILE_PREFIXES:
+        if model_id.startswith(prefix):
+            return model_id.removeprefix(prefix)
+    return model_id
+
+
+def get_model_info(
+    model_name: str,
+    model_type: Literal['chat', 'image', 'embedding'] = 'chat',
+) -> ModelInfo:
+    """Infers Genkit model info for a Bedrock model.
+
+    Args:
+        model_name: Bedrock model ID or inference-profile ID.
+        model_type: Routing type for the model.
+
+    Returns:
+        ModelInfo with capabilities from the registry, or modern Converse
+        defaults at the unstable stage for unknown chat/text models.
+    """
+    if model_type == 'image':
+        return ModelInfo(
+            label=model_name,
+            stage=Stage.STABLE,
+            supports=Supports(
+                multiturn=False,
+                tools=False,
+                tool_choice=False,
+                system_role=False,
+                media=True,
+                constrained=Constrained.NONE,
+            ),
+        )
+
+    if model_type == 'embedding':
+        return ModelInfo(
+            label=model_name,
+            stage=Stage.STABLE,
+            supports=Supports(
+                multiturn=False,
+                tools=False,
+                tool_choice=False,
+                system_role=False,
+                media=False,
+                constrained=Constrained.NONE,
+            ),
+        )
+
+    capability = MODEL_CAPABILITIES.get(strip_inference_profile_prefix(model_name))
+    stage = Stage.STABLE if capability is not None else Stage.UNSTABLE
+    if capability is None:
+        capability = ModelCapability(multimodal=True, tools=True)
+
+    return ModelInfo(
+        label=model_name,
+        stage=stage,
+        supports=Supports(
+            multiturn=True,
+            tools=capability.tools,
+            tool_choice=capability.tools,
+            system_role=True,
+            media=capability.multimodal,
+            constrained=Constrained.NONE,
+        ),
+    )

--- a/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
+++ b/py/packages/genkit-amazon-bedrock/src/genkit_amazon_bedrock/model_info.py
@@ -112,13 +112,18 @@ def strip_inference_profile_prefix(model_id: str) -> str:
     """Strips a cross-region inference-profile prefix from a model ID.
 
     Used for capability lookup only; requests always carry the original ID.
+    Full Bedrock ARNs (foundation-model, inference-profile) are reduced to
+    their resource ID first, across all partitions (``arn:aws:``,
+    ``arn:aws-us-gov:``, ``arn:aws-cn:``).
 
     Args:
-        model_id: Bedrock model ID, possibly prefixed (e.g. ``us.anthropic...``).
+        model_id: Bedrock model ID, inference-profile ID, or full ARN.
 
     Returns:
         The base model ID without the inference-profile prefix.
     """
+    if model_id.startswith('arn:'):
+        model_id = model_id.rsplit('/', 1)[-1]
     for prefix in INFERENCE_PROFILE_PREFIXES:
         if model_id.startswith(prefix):
             return model_id.removeprefix(prefix)

--- a/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
@@ -41,6 +41,31 @@ def test_strip_only_removes_first_matching_prefix() -> None:
     assert strip_inference_profile_prefix('us.us.model') == 'us.model'
 
 
+def test_strip_handles_inference_profile_arn() -> None:
+    arn = 'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0'
+    assert strip_inference_profile_prefix(arn) == 'anthropic.claude-3-5-sonnet-20241022-v2:0'
+
+
+def test_strip_handles_foundation_model_arn() -> None:
+    arn = 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0'
+    assert strip_inference_profile_prefix(arn) == 'anthropic.claude-3-haiku-20240307-v1:0'
+
+
+def test_strip_handles_govcloud_partition_arn() -> None:
+    arn = (
+        'arn:aws-us-gov:bedrock:us-gov-west-1:123456789012:'
+        'inference-profile/us-gov.anthropic.claude-3-5-sonnet-20240620-v1:0'
+    )
+    assert strip_inference_profile_prefix(arn) == 'anthropic.claude-3-5-sonnet-20240620-v1:0'
+
+
+def test_application_inference_profile_arn_falls_back_to_unstable() -> None:
+    arn = 'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123opaque'
+    info = get_model_info(arn)
+    assert info.stage == Stage.UNSTABLE
+    assert info.supports.tools is True
+
+
 def test_us_gov_wins_over_us() -> None:
     assert strip_inference_profile_prefix('us-gov.anthropic.claude-3-opus-20240229-v1:0') == (
         'anthropic.claude-3-opus-20240229-v1:0'

--- a/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
@@ -63,6 +63,7 @@ def test_application_inference_profile_arn_falls_back_to_unstable() -> None:
     arn = 'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123opaque'
     info = get_model_info(arn)
     assert info.stage == Stage.UNSTABLE
+    assert info.supports is not None
     assert info.supports.tools is True
 
 
@@ -75,6 +76,7 @@ def test_us_gov_wins_over_us() -> None:
 def test_known_model_is_stable_with_registry_capabilities() -> None:
     info = get_model_info('anthropic.claude-3-5-haiku-20241022-v1:0')
     assert info.stage == Stage.STABLE
+    assert info.supports is not None
     assert info.supports.multiturn is True
     assert info.supports.system_role is True
     assert info.supports.tools is True
@@ -85,6 +87,7 @@ def test_known_model_is_stable_with_registry_capabilities() -> None:
 def test_inference_profile_id_resolves_registry_entry() -> None:
     info = get_model_info('eu.amazon.nova-micro-v1:0')
     assert info.stage == Stage.STABLE
+    assert info.supports is not None
     assert info.supports.media is False
     assert info.label == 'eu.amazon.nova-micro-v1:0'
 
@@ -92,6 +95,7 @@ def test_inference_profile_id_resolves_registry_entry() -> None:
 def test_unknown_model_defaults_to_unstable_converse_capabilities() -> None:
     info = get_model_info('vendor.brand-new-model-v1:0')
     assert info.stage == Stage.UNSTABLE
+    assert info.supports is not None
     assert info.supports.multiturn is True
     assert info.supports.tools is True
     assert info.supports.media is True
@@ -100,6 +104,7 @@ def test_unknown_model_defaults_to_unstable_converse_capabilities() -> None:
 def test_image_model_supports_media_output_only() -> None:
     info = get_model_info('amazon.titan-image-generator-v1', model_type='image')
     assert info.stage == Stage.STABLE
+    assert info.supports is not None
     assert info.supports.media is True
     assert info.supports.multiturn is False
     assert info.supports.tools is False
@@ -109,6 +114,7 @@ def test_image_model_supports_media_output_only() -> None:
 def test_embedding_model_supports_nothing() -> None:
     info = get_model_info('amazon.titan-embed-text-v2:0', model_type='embedding')
     assert info.stage == Stage.STABLE
+    assert info.supports is not None
     assert info.supports.media is False
     assert info.supports.multiturn is False
     assert info.supports.tools is False

--- a/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
+++ b/py/packages/genkit-amazon-bedrock/tests/model_info_test.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Bedrock model capability registry."""
+
+import pytest
+from genkit_amazon_bedrock.model_info import (
+    INFERENCE_PROFILE_PREFIXES,
+    MODEL_CAPABILITIES,
+    get_model_info,
+    strip_inference_profile_prefix,
+)
+
+from genkit import Stage
+
+
+@pytest.mark.parametrize('prefix', INFERENCE_PROFILE_PREFIXES)
+def test_strip_inference_profile_prefix(prefix: str) -> None:
+    model_id = f'{prefix}anthropic.claude-sonnet-4-5-20250929-v1:0'
+    assert strip_inference_profile_prefix(model_id) == 'anthropic.claude-sonnet-4-5-20250929-v1:0'
+
+
+def test_strip_leaves_bare_model_id_untouched() -> None:
+    assert strip_inference_profile_prefix('amazon.nova-lite-v1:0') == 'amazon.nova-lite-v1:0'
+
+
+def test_strip_only_removes_first_matching_prefix() -> None:
+    assert strip_inference_profile_prefix('us.us.model') == 'us.model'
+
+
+def test_us_gov_wins_over_us() -> None:
+    assert strip_inference_profile_prefix('us-gov.anthropic.claude-3-opus-20240229-v1:0') == (
+        'anthropic.claude-3-opus-20240229-v1:0'
+    )
+
+
+def test_known_model_is_stable_with_registry_capabilities() -> None:
+    info = get_model_info('anthropic.claude-3-5-haiku-20241022-v1:0')
+    assert info.stage == Stage.STABLE
+    assert info.supports.multiturn is True
+    assert info.supports.system_role is True
+    assert info.supports.tools is True
+    assert info.supports.tool_choice is True
+    assert info.supports.media is False
+
+
+def test_inference_profile_id_resolves_registry_entry() -> None:
+    info = get_model_info('eu.amazon.nova-micro-v1:0')
+    assert info.stage == Stage.STABLE
+    assert info.supports.media is False
+    assert info.label == 'eu.amazon.nova-micro-v1:0'
+
+
+def test_unknown_model_defaults_to_unstable_converse_capabilities() -> None:
+    info = get_model_info('vendor.brand-new-model-v1:0')
+    assert info.stage == Stage.UNSTABLE
+    assert info.supports.multiturn is True
+    assert info.supports.tools is True
+    assert info.supports.media is True
+
+
+def test_image_model_supports_media_output_only() -> None:
+    info = get_model_info('amazon.titan-image-generator-v1', model_type='image')
+    assert info.stage == Stage.STABLE
+    assert info.supports.media is True
+    assert info.supports.multiturn is False
+    assert info.supports.tools is False
+    assert info.supports.system_role is False
+
+
+def test_embedding_model_supports_nothing() -> None:
+    info = get_model_info('amazon.titan-embed-text-v2:0', model_type='embedding')
+    assert info.stage == Stage.STABLE
+    assert info.supports.media is False
+    assert info.supports.multiturn is False
+    assert info.supports.tools is False
+
+
+def test_registry_matches_go_plugin_size() -> None:
+    assert len(MODEL_CAPABILITIES) == 47
+
+
+def test_all_registry_keys_are_base_ids() -> None:
+    for model_id in MODEL_CAPABILITIES:
+        assert strip_inference_profile_prefix(model_id) == model_id


### PR DESCRIPTION
Slice 2 of the Amazon Bedrock Python plugin train, into the `py-bedrock-plugin` base branch.

Ports the Go plugin's `models.go` ([aws-bedrock-go-plugin](https://github.com/genkit-ai/aws-bedrock-go-plugin)):

- **47-entry model capability registry** (Claude 3.x/4.x incl. provisioned-throughput variants, Nova, Cohere Command, Mistral/Pixtral, Jamba, Llama 3.x/4, DeepSeek R1, Writer, TwelveLabs) - verified key-for-key and flag-for-flag against the Go source.
- **Inference-profile prefix stripping** (`global. us-gov. us. eu. jp. apac. au.`) for capability lookup only; the full original model ID is always sent to Bedrock untouched.
- **`get_model_info()`**: known models are `stable` with registry capabilities; unknown chat/text models default to multimodal + tools at the `unstable` stage so newer or inference-profile-only models remain callable without a plugin release; image models advertise media output only; embedding models advertise nothing.

Tests: 12 new (prefix stripping incl. `us-gov.` vs `us.` ordering, registry lookups via profile IDs, unknown-model defaults, image/embedding shapes, registry size + base-ID invariants). `ruff` clean, 24/24 plugin tests pass.

Next slice: generate sync path (Converse).