### PR TITLE
fix(py/ollama): accumulate streaming content in final ModelResponse

### DIFF
--- a/py/packages/genkit-ollama/src/genkit_ollama/models.py
+++ b/py/packages/genkit-ollama/src/genkit_ollama/models.py
@@ -277,9 +277,6 @@ class OllamaModel:
         else:
             raise ValueError(f'Unresolved API type: {self.model_definition.api_type}')
 
-        if self.is_streaming_request(ctx=ctx):
-            content = []
-
         response_message = Message(
             role=Role.MODEL,
             content=content,
@@ -367,9 +364,13 @@ class OllamaModel:
                     **extra_kwargs,
                 )
                 idx = 0
+                accumulated_text = ''
+                last_chunk: ollama_api.ChatResponse | None = None
                 async for chunk in chat_response:
                     idx += 1
+                    last_chunk = chunk
                     role = self._from_ollama_role(chunk.message.role)
+                    accumulated_text += chunk.message.content or ''
                     if ctx:
                         ctx.send_chunk(
                             chunk=ModelResponseChunk(
@@ -378,9 +379,9 @@ class OllamaModel:
                                 content=self._build_multimodal_chat_response(chat_response=chunk),
                             )
                         )
-            # For streaming requests, we return None because the response chunks
-            # have already been sent via ctx.send_chunk() above. The async generator
-            # is now exhausted, and the caller should not expect a return value.
+            if last_chunk is not None:
+                last_chunk.message.content = accumulated_text
+                return last_chunk
             return None
         else:
             async with wrap_connection_errors(self._server_address):
@@ -433,8 +434,12 @@ class OllamaModel:
                     **extra_kwargs,
                 )
                 idx = 0
+                accumulated_text = ''
+                last_chunk: ollama_api.GenerateResponse | None = None
                 async for chunk in generate_response:
                     idx += 1
+                    last_chunk = chunk
+                    accumulated_text += chunk.response or ''
                     if ctx:
                         ctx.send_chunk(
                             chunk=ModelResponseChunk(
@@ -443,9 +448,9 @@ class OllamaModel:
                                 content=self._build_generate_response(generate_response=chunk),
                             )
                         )
-            # For streaming requests, we return None because the response chunks
-            # have already been sent via ctx.send_chunk() above. The async generator
-            # is now exhausted, and the caller should not expect a return value.
+            if last_chunk is not None:
+                last_chunk.response = accumulated_text
+                return last_chunk
             return None
         else:
             async with wrap_connection_errors(self._server_address):

--- a/py/packages/genkit-ollama/src/genkit_ollama/models.py
+++ b/py/packages/genkit-ollama/src/genkit_ollama/models.py
@@ -277,6 +277,9 @@ class OllamaModel:
         else:
             raise ValueError(f'Unresolved API type: {self.model_definition.api_type}')
 
+        if not api_response and self.is_streaming_request(ctx=ctx):
+            content = []
+
         response_message = Message(
             role=Role.MODEL,
             content=content,
@@ -313,7 +316,11 @@ class OllamaModel:
                 stored client factory when omitted.
 
         Returns:
-            The chat response from Ollama.
+            The chat response from Ollama. For streaming requests, returns the
+            last streamed chunk with ``message.content``, ``message.thinking``,
+            and ``message.tool_calls`` replaced by the values accumulated across
+            all chunks; other fields reflect the final chunk. Returns ``None``
+            if the stream yielded no chunks.
         """
         # Resolve media URLs first. build_chat_messages may perform HTTP fetches
         # for image parts, and those must stay *outside* wrap_connection_errors so
@@ -365,12 +372,17 @@ class OllamaModel:
                 )
                 idx = 0
                 accumulated_text = ''
+                accumulated_thinking = ''
+                accumulated_tool_calls: list[ollama_api.Message.ToolCall] = []
                 last_chunk: ollama_api.ChatResponse | None = None
                 async for chunk in chat_response:
                     idx += 1
                     last_chunk = chunk
                     role = self._from_ollama_role(chunk.message.role)
                     accumulated_text += chunk.message.content or ''
+                    accumulated_thinking += chunk.message.thinking or ''
+                    if chunk.message.tool_calls:
+                        accumulated_tool_calls.extend(chunk.message.tool_calls)
                     if ctx:
                         ctx.send_chunk(
                             chunk=ModelResponseChunk(
@@ -381,6 +393,8 @@ class OllamaModel:
                         )
             if last_chunk is not None:
                 last_chunk.message.content = accumulated_text
+                last_chunk.message.thinking = accumulated_thinking or None
+                last_chunk.message.tool_calls = accumulated_tool_calls or None
                 return last_chunk
             return None
         else:
@@ -412,7 +426,11 @@ class OllamaModel:
                 stored client factory when omitted.
 
         Returns:
-            The generated response.
+            The generated response from Ollama. For streaming requests,
+            returns the last streamed chunk with ``response`` and ``thinking``
+            replaced by the values accumulated across all chunks; other fields
+            reflect the final chunk. Returns ``None`` if the stream yielded
+            no chunks.
         """
         prompt = self.build_prompt(request)
         if client is None:
@@ -435,11 +453,13 @@ class OllamaModel:
                 )
                 idx = 0
                 accumulated_text = ''
+                accumulated_thinking = ''
                 last_chunk: ollama_api.GenerateResponse | None = None
                 async for chunk in generate_response:
                     idx += 1
                     last_chunk = chunk
                     accumulated_text += chunk.response or ''
+                    accumulated_thinking += chunk.thinking or ''
                     if ctx:
                         ctx.send_chunk(
                             chunk=ModelResponseChunk(
@@ -450,6 +470,7 @@ class OllamaModel:
                         )
             if last_chunk is not None:
                 last_chunk.response = accumulated_text
+                last_chunk.thinking = accumulated_thinking or None
                 return last_chunk
             return None
         else:

--- a/py/packages/genkit-ollama/tests/models/ollama_models_test.py
+++ b/py/packages/genkit-ollama/tests/models/ollama_models_test.py
@@ -314,6 +314,44 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(cast(ModelUsage, response.usage).input_tokens, None)
         self.assertEqual(cast(ModelUsage, response.usage).output_tokens, None)
 
+    @patch(
+        'genkit.model.get_basic_usage_stats',
+        return_value=ModelUsage(),
+    )
+    async def test_generate_chat_streaming_zero_chunks(self, mock_get_basic_usage_stats: MagicMock) -> None:
+        """Streaming with zero chunks returns empty content, not the error default."""
+        model_def = ModelDefinition(name='chat-model', api_type=OllamaAPITypes.CHAT)
+        ollama_model = OllamaModel(client=self.mock_client, model_definition=model_def)
+        streaming_ctx = ActionRunContext(streaming_callback=MagicMock())
+
+        cast(Any, ollama_model)._chat_with_ollama = AsyncMock(return_value=None)
+        cast(Any, ollama_model).is_streaming_request = MagicMock(return_value=True)
+        cast(Any, ollama_model).get_usage_info = MagicMock(return_value=ModelUsage())
+
+        response = await ollama_model.generate(self.request, streaming_ctx)
+
+        self.assertIsNotNone(response.message)
+        self.assertEqual(cast(Message, response.message).content, [])
+
+    @patch(
+        'genkit.model.get_basic_usage_stats',
+        return_value=ModelUsage(),
+    )
+    async def test_generate_generate_streaming_zero_chunks(self, mock_get_basic_usage_stats: MagicMock) -> None:
+        """Streaming with zero chunks returns empty content, not the error default."""
+        model_def = ModelDefinition(name='generate-model', api_type=OllamaAPITypes.GENERATE)
+        ollama_model = OllamaModel(client=self.mock_client, model_definition=model_def)
+        streaming_ctx = ActionRunContext(streaming_callback=MagicMock())
+
+        cast(Any, ollama_model)._generate_ollama_response = AsyncMock(return_value=None)
+        cast(Any, ollama_model).is_streaming_request = MagicMock(return_value=True)
+        cast(Any, ollama_model).get_usage_info = MagicMock(return_value=ModelUsage())
+
+        response = await ollama_model.generate(self.request, streaming_ctx)
+
+        self.assertIsNotNone(response.message)
+        self.assertEqual(cast(Message, response.message).content, [])
+
 
 class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
     """Unit tests for OllamaModel._chat_with_ollama method."""
@@ -433,7 +471,6 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
 
         response = await self.ollama_model._chat_with_ollama(self.request, self.ctx)
 
-        self.assertIsNotNone(response)
         assert response is not None
         self.assertEqual(response.message.content, 'chunk1chunk2')
         self.mock_build_chat_messages.assert_called_once_with(self.request)
@@ -645,7 +682,6 @@ class TestOllamaModelGenerateOllamaResponse(unittest.IsolatedAsyncioTestCase):
 
         response = await self.ollama_model._generate_ollama_response(self.request, self.ctx)
 
-        self.assertIsNotNone(response)
         assert response is not None
         self.assertEqual(response.response, 'chunk1 chunk2')
         self.mock_build_prompt.assert_called_once_with(self.request)

--- a/py/packages/genkit-ollama/tests/models/ollama_models_test.py
+++ b/py/packages/genkit-ollama/tests/models/ollama_models_test.py
@@ -434,6 +434,7 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
         response = await self.ollama_model._chat_with_ollama(self.request, self.ctx)
 
         self.assertIsNotNone(response)
+        assert response is not None
         self.assertEqual(response.message.content, 'chunk1chunk2')
         self.mock_build_chat_messages.assert_called_once_with(self.request)
         self.mock_is_streaming_request.assert_called_once_with(ctx=self.ctx)
@@ -645,6 +646,7 @@ class TestOllamaModelGenerateOllamaResponse(unittest.IsolatedAsyncioTestCase):
         response = await self.ollama_model._generate_ollama_response(self.request, self.ctx)
 
         self.assertIsNotNone(response)
+        assert response is not None
         self.assertEqual(response.response, 'chunk1 chunk2')
         self.mock_build_prompt.assert_called_once_with(self.request)
         self.mock_is_streaming_request.assert_called_once_with(ctx=self.ctx)

--- a/py/packages/genkit-ollama/tests/models/ollama_models_test.py
+++ b/py/packages/genkit-ollama/tests/models/ollama_models_test.py
@@ -217,7 +217,10 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
             ctx=streaming_ctx,
         )
         self.assertIsNotNone(response.message)
-        self.assertEqual(cast(Message, response.message).content, [])
+        self.assertEqual(
+            cast(Message, response.message).content,
+            [Part(root=TextPart(text='Parsed chat content'))],
+        )
 
     @patch(
         'genkit.model.get_basic_usage_stats',
@@ -260,7 +263,10 @@ class TestOllamaModelGenerate(unittest.IsolatedAsyncioTestCase):
             ctx=streaming_ctx,
         )
         self.assertIsNotNone(response.message)
-        self.assertEqual(cast(Message, response.message).content, [])
+        self.assertEqual(
+            cast(Message, response.message).content,
+            [Part(root=TextPart(text='Generated text'))],
+        )
 
     @patch(
         'genkit.model.get_basic_usage_stats',
@@ -427,10 +433,8 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
 
         response = await self.ollama_model._chat_with_ollama(self.request, self.ctx)
 
-        # For streaming requests, the method returns None because response chunks
-        # are sent incrementally via ctx.send_chunk() rather than returned at the end.
-        # This is the expected behavior for streaming APIs.
-        self.assertIsNone(response)
+        self.assertIsNotNone(response)
+        self.assertEqual(response.message.content, 'chunk1chunk2')
         self.mock_build_chat_messages.assert_called_once_with(self.request)
         self.mock_is_streaming_request.assert_called_once_with(ctx=self.ctx)
         self.mock_ollama_client_instance.chat.assert_awaited_once_with(
@@ -640,11 +644,8 @@ class TestOllamaModelGenerateOllamaResponse(unittest.IsolatedAsyncioTestCase):
 
         response = await self.ollama_model._generate_ollama_response(self.request, self.ctx)
 
-        # For streaming requests, the method returns None because response chunks
-        # are sent incrementally via ctx.send_chunk() rather than returned at the end.
-        # This is the expected behavior for streaming APIs.
-        self.assertIsNone(response)
-
+        self.assertIsNotNone(response)
+        self.assertEqual(response.response, 'chunk1 chunk2')
         self.mock_build_prompt.assert_called_once_with(self.request)
         self.mock_is_streaming_request.assert_called_once_with(ctx=self.ctx)
         self.mock_ollama_client_instance.generate.assert_awaited_once_with(

--- a/py/packages/genkit-ollama/tests/models/ollama_models_test.py
+++ b/py/packages/genkit-ollama/tests/models/ollama_models_test.py
@@ -488,6 +488,83 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
         cast(MagicMock, self.ctx.send_chunk).assert_any_call(chunk=ANY)
         self.mock_build_multimodal_response.assert_any_call(chat_response=ANY)
 
+    async def test_streaming_chat_accumulates_thinking(self) -> None:
+        """Thinking from non-final chunks is concatenated into the returned response."""
+        self.mock_is_streaming_request.return_value = True
+        self.ctx = ActionRunContext(streaming_callback=MagicMock())
+        cast(Any, self.ctx).send_chunk = MagicMock()
+
+        async def mock_streaming_chunks() -> AsyncIterator[ollama_api.ChatResponse]:
+            yield ollama_api.ChatResponse(
+                message=ollama_api.Message(role='assistant', content='Hello ', thinking='step1 '),
+            )
+            yield ollama_api.ChatResponse(
+                message=ollama_api.Message(role='assistant', content='world', thinking='step2'),
+            )
+            yield ollama_api.ChatResponse(
+                message=ollama_api.Message(role='assistant', content='', thinking=''),
+            )
+
+        self.mock_ollama_client_instance.chat.return_value = mock_streaming_chunks()
+
+        response = await self.ollama_model._chat_with_ollama(self.request, self.ctx)
+
+        assert response is not None
+        self.assertEqual(response.message.content, 'Hello world')
+        self.assertEqual(response.message.thinking, 'step1 step2')
+
+        parts = OllamaModel._build_multimodal_chat_response(chat_response=response)
+        reasoning_parts = [p for p in parts if isinstance(p.root, ReasoningPart)]
+        self.assertEqual(len(reasoning_parts), 1)
+        self.assertEqual(reasoning_parts[0].root.reasoning, 'step1 step2')
+
+    async def test_streaming_chat_accumulates_tool_calls(self) -> None:
+        """Tool calls from a mid-stream chunk survive into the returned response."""
+        self.mock_is_streaming_request.return_value = True
+        self.ctx = ActionRunContext(streaming_callback=MagicMock())
+        cast(Any, self.ctx).send_chunk = MagicMock()
+
+        tool_call = ollama_api.Message.ToolCall(
+            function=ollama_api.Message.ToolCall.Function(
+                name='search', arguments={'q': 'test'}
+            )
+        )
+
+        async def mock_streaming_chunks() -> AsyncIterator[ollama_api.ChatResponse]:
+            yield ollama_api.ChatResponse(
+                message=ollama_api.Message(role='assistant', content='', tool_calls=[tool_call]),
+            )
+            yield ollama_api.ChatResponse(
+                message=ollama_api.Message(role='assistant', content=''),
+            )
+
+        self.mock_ollama_client_instance.chat.return_value = mock_streaming_chunks()
+
+        response = await self.ollama_model._chat_with_ollama(self.request, self.ctx)
+
+        assert response is not None
+        self.assertIsNotNone(response.message.tool_calls)
+        self.assertEqual(len(response.message.tool_calls), 1)
+        self.assertEqual(response.message.tool_calls[0].function.name, 'search')
+        self.assertEqual(response.message.tool_calls[0].function.arguments, {'q': 'test'})
+
+    async def test_streaming_chat_empty_stream_returns_none(self) -> None:
+        """An empty stream (zero chunks) returns None from the real helper."""
+        self.mock_is_streaming_request.return_value = True
+        self.ctx = ActionRunContext(streaming_callback=MagicMock())
+        cast(Any, self.ctx).send_chunk = MagicMock()
+
+        async def mock_empty_stream() -> AsyncIterator[ollama_api.ChatResponse]:
+            return
+            yield
+
+        self.mock_ollama_client_instance.chat.return_value = mock_empty_stream()
+
+        response = await self.ollama_model._chat_with_ollama(self.request, self.ctx)
+
+        self.assertIsNone(response)
+        cast(MagicMock, self.ctx.send_chunk).assert_not_called()
+
     async def test_streaming_chat_empty_role_maps_to_model(self) -> None:
         """Streamed chunks with an empty role should be labeled MODEL, not TOOL."""
         self.mock_is_streaming_request.return_value = True

--- a/py/packages/genkit-ollama/tests/models/ollama_models_test.py
+++ b/py/packages/genkit-ollama/tests/models/ollama_models_test.py
@@ -525,9 +525,7 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
         cast(Any, self.ctx).send_chunk = MagicMock()
 
         tool_call = ollama_api.Message.ToolCall(
-            function=ollama_api.Message.ToolCall.Function(
-                name='search', arguments={'q': 'test'}
-            )
+            function=ollama_api.Message.ToolCall.Function(name='search', arguments={'q': 'test'})
         )
 
         async def mock_streaming_chunks() -> AsyncIterator[ollama_api.ChatResponse]:
@@ -543,7 +541,7 @@ class TestOllamaModelChatWithOllama(unittest.IsolatedAsyncioTestCase):
         response = await self.ollama_model._chat_with_ollama(self.request, self.ctx)
 
         assert response is not None
-        self.assertIsNotNone(response.message.tool_calls)
+        assert response.message.tool_calls is not None
         self.assertEqual(len(response.message.tool_calls), 1)
         self.assertEqual(response.message.tool_calls[0].function.name, 'search')
         self.assertEqual(response.message.tool_calls[0].function.arguments, {'q': 'test'})


### PR DESCRIPTION
Fixes #5700

The Python Ollama plugin's streaming path discarded the aggregated content from the final `ModelResponse`. After streaming all chunks via `ctx.send_chunk()`, callers who awaited the final response got an empty `response.text` / `message.content == []`.

**Root cause:**

The streaming helpers (`_chat_with_ollama` / `_generate_ollama_response`) send each chunk via `ctx.send_chunk()` but return `None`, so no content is ever accumulated into the final response. Additionally, `generate()` explicitly resets `content = []` for streaming requests, ensuring the final `ModelResponse` is always empty.

**Fix:**

- `_chat_with_ollama`: accumulate `chunk.message.content` across streamed chunks and return the last `ChatResponse` with the full aggregated text.
- `_generate_ollama_response`: same pattern — accumulate `chunk.response` and return the last `GenerateResponse` with full text.
- `generate()`: remove the `content = []` reset for streaming requests so the aggregated content flows through to the final `ModelResponse`.

This aligns the Python Ollama plugin with the JS and Go implementations, which both return a fully populated final response after streaming.

Checklist:
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [ ] Docs updated (updated docs or a docs bug required)