### PR TITLE
feat(py/plugins/anthropic): add typed AnthropicConfig schema as customOptions

### DIFF
--- a/py/packages/genkit-anthropic/src/genkit_anthropic/__init__.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/__init__.py
@@ -137,7 +137,7 @@ Example:
 
     ```python
     from genkit import Genkit
-    from genkit_anthropic import Anthropic
+    from genkit_anthropic import Anthropic, AnthropicConfig
 
     # Uses ANTHROPIC_API_KEY env var or pass api_key explicitly
     ai = Genkit(
@@ -152,7 +152,7 @@ Example:
     response = await ai.generate(
         model='anthropic/claude-haiku-4-5',
         prompt='Write a haiku about AI',
-        config={'temperature': 0.7, 'max_tokens': 100},
+        config=AnthropicConfig(temperature=0.7, max_output_tokens=100),
     )
     ```
 
@@ -181,6 +181,31 @@ See Also:
     - Genkit documentation: https://genkit.dev/
 """
 
+from genkit_anthropic.config import (
+    AnthropicConfig,
+    AnyToolChoice,
+    AutoToolChoice,
+    OutputConfig,
+    RequestMetadata,
+    SpecificToolChoice,
+    TaskBudget,
+    ThinkingConfig,
+    ToolChoice,
+    ToolChoiceNone,
+)
 from genkit_anthropic.plugin import Anthropic, anthropic_name
 
-__all__ = ['Anthropic', 'anthropic_name']
+__all__ = [
+    'Anthropic',
+    'AnthropicConfig',
+    'AutoToolChoice',
+    'AnyToolChoice',
+    'OutputConfig',
+    'RequestMetadata',
+    'SpecificToolChoice',
+    'TaskBudget',
+    'ThinkingConfig',
+    'ToolChoice',
+    'ToolChoiceNone',
+    'anthropic_name',
+]

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/config.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/config.py
@@ -191,7 +191,7 @@ class ThinkingConfig(BaseModel):
         if (
             (enabled or budget_implies_enabled)
             and self.budget_tokens is not None
-            and not self.budget_tokens.is_integer()
+            and not float(self.budget_tokens).is_integer()
         ):
             raise ValueError('budgetTokens must be an integer when thinking is enabled')
         return self

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/config.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/config.py
@@ -21,16 +21,28 @@ Extends the shared :class:`ModelConfig` (``version``, ``temperature``,
 
 Unknown keys pass through (``extra='allow'``). Top-level Genkit fields
 accept their usual camelCase aliases, while Anthropic-specific nested keys
-match the Anthropic/JavaScript plugin shape field-by-field.
+match the Anthropic plugin shape field-by-field.
 """
 
 from typing import Annotated, ClassVar, Literal, cast
 
+from anthropic.types.beta.message_create_params import MessageCreateParamsBase as BetaMessageCreateParamsBase
+from anthropic.types.message_create_params import MessageCreateParamsBase
 from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, model_validator
 from pydantic.alias_generators import to_camel
 from pydantic.config import JsonDict
 
 from genkit import ModelConfig
+
+_STABLE_BODY_KEYS = frozenset(MessageCreateParamsBase.__annotations__)
+_BETA_BODY_KEYS = frozenset(BetaMessageCreateParamsBase.__annotations__)
+
+# Accepted by create() alongside the body fields; `stream` is excluded because Genkit owns streaming.
+_REQUEST_KWARG_KEYS = frozenset({'extra_body', 'extra_headers', 'extra_query', 'timeout'})
+
+STABLE_KWARG_KEYS = _STABLE_BODY_KEYS | _REQUEST_KWARG_KEYS
+BETA_KWARG_KEYS = _BETA_BODY_KEYS | _REQUEST_KWARG_KEYS
+BETA_ONLY_KEYS = _BETA_BODY_KEYS - _STABLE_BODY_KEYS
 
 _NESTED_CONFIG = ConfigDict(extra='allow', populate_by_name=True)
 
@@ -163,14 +175,14 @@ def _anthropic_config_schema_extra(schema: JsonDict) -> None:
 class ThinkingConfig(BaseModel):
     """Extended-thinking configuration.
 
-    ``enabled`` and ``adaptive`` are mutually exclusive, and ``budgetTokens``
-    is required when ``enabled`` is true.
+    ``enabled``, ``adaptive`` and ``disabled`` are mutually exclusive, and
+    ``budgetTokens`` is required when ``enabled`` is true.
     """
 
     model_config = _NESTED_CONFIG
 
     enabled: bool | None = None
-    # float, not int: adaptive mode allows a fractional budget it ignores; integers enforced only when enabled.
+    # Adaptive mode allows a fractional budget it ignores; integers enforced only when enabled.
     budget_tokens: float | None = Field(default=None, alias='budgetTokens', ge=1024)
     adaptive: bool | None = None
     display: Literal['summarized', 'omitted'] | None = None
@@ -187,6 +199,8 @@ class ThinkingConfig(BaseModel):
 
         if enabled and adaptive:
             raise ValueError('Cannot use both enabled and adaptive thinking modes simultaneously')
+        if disabled and (enabled or adaptive):
+            raise ValueError('Cannot disable thinking and request an enabled or adaptive thinking mode simultaneously')
         if enabled and self.budget_tokens is None:
             raise ValueError('budgetTokens is required when thinking is enabled')
         if (
@@ -302,9 +316,26 @@ class AnthropicConfig(ModelConfig):
         description='Anthropic beta feature headers to enable for this request.',
     )
 
+    def beta_only_fields(self) -> set[str]:
+        """Return the names of beta-only request fields set on this config."""
+        present = {
+            name
+            for name, value in (self.__pydantic_extra__ or {}).items()
+            if name in BETA_ONLY_KEYS and value is not None
+        }
+        if self.betas:
+            present.add('betas')
+        if self.output_config is not None and self.output_config.task_budget is not None:
+            present.add('output_config.task_budget')
+        return present
+
     @model_validator(mode='after')
     def _check_api_surface(self) -> 'AnthropicConfig':
-        """Reject betas on the stable surface so an explicit apiVersion is never silently overridden."""
-        if self.api_version == 'stable' and self.betas:
-            raise ValueError("betas require the beta API surface; remove betas or set apiVersion to 'beta'")
+        """Reject beta-only fields on the stable surface so an explicit apiVersion is never silently overridden."""
+        if self.api_version != 'stable':
+            return self
+        beta_only = self.beta_only_fields()
+        if beta_only:
+            names = ', '.join(sorted(beta_only))
+            raise ValueError(f"{names} require the beta API surface; remove them or set apiVersion to 'beta'")
         return self

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/config.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/config.py
@@ -1,0 +1,302 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed configuration schema for Anthropic models.
+
+Extends the shared :class:`ModelConfig` (``version``, ``temperature``,
+``maxOutputTokens``, ...) with Anthropic-specific options.
+
+Unknown keys pass through (``extra='allow'``). Top-level Genkit fields
+accept their usual camelCase aliases, while Anthropic-specific nested keys
+match the Anthropic/JavaScript plugin shape field-by-field.
+"""
+
+from typing import Annotated, ClassVar, Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, model_validator
+from pydantic.alias_generators import to_camel
+from pydantic.config import JsonDict
+
+from genkit import ModelConfig
+
+_NESTED_CONFIG = ConfigDict(extra='allow', populate_by_name=True)
+
+_THINKING_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'enabled': {'type': 'boolean'},
+        'budgetTokens': {'type': 'number', 'minimum': 1024},
+        'adaptive': {'type': 'boolean'},
+        'display': {'type': 'string', 'enum': ['summarized', 'omitted']},
+    },
+    'additionalProperties': True,
+    'description': (
+        'The thinking configuration to use for the request. Thinking is a feature that '
+        'allows the model to think about the request and provide a better response.'
+    ),
+}
+
+_OUTPUT_CONFIG_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'effort': {'type': 'string', 'enum': ['low', 'medium', 'high', 'xhigh']},
+        'task_budget': {
+            'type': 'object',
+            'properties': {
+                'type': {'type': 'string', 'const': 'tokens', 'default': 'tokens'},
+                'total': {'type': 'integer', 'minimum': 20000},
+            },
+            'required': ['total'],
+            'additionalProperties': True,
+        },
+    },
+    'additionalProperties': True,
+    'description': 'Configuration for output generation, such as setting the effort parameter and task budgets.',
+}
+
+_TOOL_CHOICE_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'type': {
+            'type': 'string',
+            'enum': ['auto', 'any', 'tool', 'none'],
+            'description': 'Tool choice mode.',
+        },
+        'name': {
+            'type': 'string',
+            'description': 'Tool name to require when type is tool.',
+        },
+    },
+    'required': ['type'],
+    'additionalProperties': True,
+    'description': (
+        'The tool choice to use for the request. This can be used to specify the tool to '
+        'use for the request. If not specified, the model will choose the tool to use.'
+    ),
+}
+
+_METADATA_SCHEMA = {
+    'type': 'object',
+    'properties': {'user_id': {'type': 'string'}},
+    'additionalProperties': True,
+    'description': 'The metadata to include in the request.',
+}
+
+
+def _anthropic_config_schema_extra(schema: JsonDict) -> None:
+    """Tune the advertised Dev UI schema without changing runtime validation."""
+    properties = schema.get('properties')
+    if not isinstance(properties, dict):
+        return
+    props = cast(JsonDict, properties)
+
+    props.update(
+        cast(
+            JsonDict,
+            {
+                'version': {
+                    'type': 'string',
+                    'title': 'Version',
+                    'description': 'Per-request model version override.',
+                },
+                'temperature': {
+                    'type': 'number',
+                    'title': 'Temperature',
+                    'description': 'Controls the randomness of the output.',
+                },
+                'maxOutputTokens': {
+                    'type': 'number',
+                    'title': 'Max output tokens',
+                    'description': 'Maximum number of tokens to generate.',
+                },
+                'topK': {
+                    'type': 'number',
+                    'title': 'Top K',
+                    'description': 'Limits token sampling to the top K candidates.',
+                },
+                'topP': {
+                    'type': 'number',
+                    'title': 'Top P',
+                    'description': 'Limits token sampling by cumulative probability.',
+                },
+                'stopSequences': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'title': 'Stop sequences',
+                    'description': 'Sequences where generation should stop.',
+                },
+                'apiKey': {
+                    'type': 'string',
+                    'title': 'API key',
+                    'description': 'Overrides the plugin-configured Anthropic API key for this request.',
+                },
+                'apiVersion': {
+                    'type': 'string',
+                    'enum': ['stable', 'beta'],
+                    'title': 'API version',
+                    'description': 'Selects the Anthropic API surface for this request.',
+                },
+                'betas': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'title': 'Betas',
+                    'description': 'Anthropic beta feature headers to enable for this request.',
+                },
+            },
+        )
+    )
+
+
+class ThinkingConfig(BaseModel):
+    """Extended-thinking configuration.
+
+    ``enabled`` and ``adaptive`` are mutually exclusive, and ``budgetTokens``
+    is required when ``enabled`` is true.
+    """
+
+    model_config = _NESTED_CONFIG
+
+    enabled: bool | None = None
+    budget_tokens: float | None = Field(default=None, alias='budgetTokens', ge=1024)
+    adaptive: bool | None = None
+    display: Literal['summarized', 'omitted'] | None = None
+
+    @model_validator(mode='after')
+    def _check_thinking(self) -> 'ThinkingConfig':
+        """Enforce cross-field thinking rules."""
+        extra = self.__pydantic_extra__ or {}
+        thinking_type = extra.get('type')
+        enabled = self.enabled is True or thinking_type == 'enabled'
+        adaptive = self.adaptive is True or thinking_type == 'adaptive'
+        disabled = self.enabled is False or thinking_type == 'disabled'
+        budget_implies_enabled = self.budget_tokens is not None and not adaptive and not disabled
+
+        if enabled and adaptive:
+            raise ValueError('Cannot use both enabled and adaptive thinking modes simultaneously')
+        if enabled and self.budget_tokens is None:
+            raise ValueError('budgetTokens is required when thinking is enabled')
+        if (
+            (enabled or budget_implies_enabled)
+            and self.budget_tokens is not None
+            and not self.budget_tokens.is_integer()
+        ):
+            raise ValueError('budgetTokens must be an integer when thinking is enabled')
+        return self
+
+
+class TaskBudget(BaseModel):
+    """Token budget for output generation."""
+
+    model_config = _NESTED_CONFIG
+
+    type: Literal['tokens'] = 'tokens'
+    total: int = Field(ge=20000)
+
+
+class OutputConfig(BaseModel):
+    """Output-generation configuration (effort and task budget)."""
+
+    model_config = _NESTED_CONFIG
+
+    effort: Literal['low', 'medium', 'high', 'xhigh'] | None = None
+    task_budget: TaskBudget | None = Field(default=None, alias='task_budget')
+
+
+class AutoToolChoice(BaseModel):
+    """Let the model decide whether to call a tool."""
+
+    model_config = _NESTED_CONFIG
+    type: Literal['auto']
+
+
+class AnyToolChoice(BaseModel):
+    """Require the model to call some tool."""
+
+    model_config = _NESTED_CONFIG
+    type: Literal['any']
+
+
+class SpecificToolChoice(BaseModel):
+    """Require the model to call the named tool."""
+
+    model_config = _NESTED_CONFIG
+    type: Literal['tool']
+    name: str
+
+
+class ToolChoiceNone(BaseModel):
+    """Prevent the model from calling a tool."""
+
+    model_config = _NESTED_CONFIG
+    type: Literal['none']
+
+
+ToolChoice = Annotated[
+    AutoToolChoice | AnyToolChoice | SpecificToolChoice | ToolChoiceNone,
+    Field(discriminator='type'),
+]
+
+
+class RequestMetadata(BaseModel):
+    """Metadata to include in the request.
+
+    Uses no alias generator, so ``user_id`` stays snake_case.
+    """
+
+    model_config = _NESTED_CONFIG
+
+    user_id: str | None = None
+
+
+class AnthropicConfig(ModelConfig):
+    """Typed configuration for Anthropic (Claude) models.
+
+    Extends the shared :class:`ModelConfig` with Anthropic-specific options.
+    JSON keys stay snake_case for ``tool_choice`` and ``output_config`` and
+    camelCase elsewhere (``apiVersion``, inherited ``maxOutputTokens``).
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra='allow',
+        json_schema_extra=_anthropic_config_schema_extra,
+        populate_by_name=True,
+    )
+
+    SDK_UNSUPPORTED_KEYS: ClassVar[frozenset[str]] = frozenset({'api_version', 'api_key'})
+
+    thinking: Annotated[ThinkingConfig | None, WithJsonSchema(_THINKING_SCHEMA)] = Field(
+        default=None,
+    )
+    output_config: Annotated[OutputConfig | None, WithJsonSchema(_OUTPUT_CONFIG_SCHEMA)] = Field(
+        default=None,
+        alias='output_config',
+    )
+    tool_choice: Annotated[ToolChoice | None, WithJsonSchema(_TOOL_CHOICE_SCHEMA)] = Field(
+        default=None,
+        alias='tool_choice',
+    )
+    metadata: Annotated[RequestMetadata | None, WithJsonSchema(_METADATA_SCHEMA)] = Field(
+        default=None,
+    )
+    api_version: Literal['stable', 'beta'] | None = Field(
+        default=None,
+        description='Selects the Anthropic API surface for this request.',
+    )
+    betas: list[str] | None = Field(
+        default=None,
+        description='Anthropic beta feature headers to enable for this request.',
+    )

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/config.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/config.py
@@ -38,7 +38,7 @@ _THINKING_SCHEMA = {
     'type': 'object',
     'properties': {
         'enabled': {'type': 'boolean'},
-        'budgetTokens': {'type': 'number', 'minimum': 1024},
+        'budgetTokens': {'type': 'integer', 'minimum': 1024},
         'adaptive': {'type': 'boolean'},
         'display': {'type': 'string', 'enum': ['summarized', 'omitted']},
     },
@@ -52,7 +52,7 @@ _THINKING_SCHEMA = {
 _OUTPUT_CONFIG_SCHEMA = {
     'type': 'object',
     'properties': {
-        'effort': {'type': 'string', 'enum': ['low', 'medium', 'high', 'xhigh']},
+        'effort': {'type': 'string', 'enum': ['low', 'medium', 'high', 'xhigh', 'max']},
         'task_budget': {
             'type': 'object',
             'properties': {
@@ -170,6 +170,7 @@ class ThinkingConfig(BaseModel):
     model_config = _NESTED_CONFIG
 
     enabled: bool | None = None
+    # float, not int: adaptive mode allows a fractional budget it ignores; integers enforced only when enabled.
     budget_tokens: float | None = Field(default=None, alias='budgetTokens', ge=1024)
     adaptive: bool | None = None
     display: Literal['summarized', 'omitted'] | None = None
@@ -211,7 +212,7 @@ class OutputConfig(BaseModel):
 
     model_config = _NESTED_CONFIG
 
-    effort: Literal['low', 'medium', 'high', 'xhigh'] | None = None
+    effort: Literal['low', 'medium', 'high', 'xhigh', 'max'] | None = None
     task_budget: TaskBudget | None = Field(default=None, alias='task_budget')
 
 
@@ -300,3 +301,10 @@ class AnthropicConfig(ModelConfig):
         default=None,
         description='Anthropic beta feature headers to enable for this request.',
     )
+
+    @model_validator(mode='after')
+    def _check_api_surface(self) -> 'AnthropicConfig':
+        """Reject betas on the stable surface so an explicit apiVersion is never silently overridden."""
+        if self.api_version == 'stable' and self.betas:
+            raise ValueError("betas require the beta API surface; remove betas or set apiVersion to 'beta'")
+        return self

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -317,19 +317,19 @@ class AnthropicModel:
         if not config.api_key:
             return self.client
 
-        if type(self.client).__module__.startswith('unittest.mock') or not hasattr(self.client, 'api_key'):
+        if not isinstance(self.client, AsyncAnthropic):
             logger.warning('Ignored per-request Anthropic apiKey because the configured client does not support it')
             return self.client
 
-        kwargs: dict[str, Any] = {'api_key': config.api_key}
-        for attr in ('base_url', 'timeout', 'max_retries'):
-            value = getattr(self.client, attr, None)
-            if value is not None:
-                kwargs[attr] = value
-        return AsyncAnthropic(**kwargs)
+        # copy() keeps every other client setting and shares the pooled HTTP transport.
+        return self.client.copy(api_key=config.api_key)
 
     def _uses_beta_api(self, config: AnthropicConfig) -> bool:
-        """Whether this request should use the Anthropic beta API surface."""
+        """Whether this request should use the Anthropic beta API surface.
+
+        Unlike the JS plugin, setting ``betas`` alone selects the beta surface
+        so the requested features are honored instead of silently dropped.
+        """
         return config.api_version == 'beta' or bool(config.betas)
 
     def _build_params(
@@ -358,14 +358,9 @@ class AnthropicModel:
         params['messages'] = self._to_anthropic_messages(request.messages)
         params['max_tokens'] = int(max_tokens)
 
-        # Strip keys the SDK's messages.create does not accept.
-        stripped_keys = []
+        # api_version and api_key select the API surface and client; they are not create() kwargs.
         for key in AnthropicConfig.SDK_UNSUPPORTED_KEYS:
-            if key in params:
-                params.pop(key)
-                stripped_keys.append(key)
-        if stripped_keys:
-            logger.warning('Ignored unsupported Anthropic config keys', keys=sorted(stripped_keys))
+            params.pop(key, None)
 
         if use_beta and betas:
             params['betas'] = betas

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -153,7 +153,9 @@ def _to_anthropic_thinking_config(thinking: dict[str, Any] | None) -> dict[str, 
 
     if thinking_type is not None:
         result['type'] = thinking_type
-    return result or None
+    if 'type' not in result:
+        return None
+    return result
 
 
 def _move_unknown_params_to_extra_body(params: dict[str, Any], use_beta: bool) -> None:

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -49,7 +49,7 @@ from genkit import (
 )
 from genkit.model import get_basic_usage_stats
 from genkit.plugin_api import ActionRunContext
-from genkit_anthropic.config import AnthropicConfig
+from genkit_anthropic.config import BETA_KWARG_KEYS, STABLE_KWARG_KEYS, AnthropicConfig
 from genkit_anthropic.model_info import get_model_info
 from genkit_anthropic.utils import (
     build_cache_usage,
@@ -61,39 +61,7 @@ from genkit_anthropic.utils import (
 logger = structlog.get_logger(__name__)
 
 DEFAULT_MAX_OUTPUT_TOKENS = 4096
-_SDK_KWARG_KEYS = frozenset({
-    'betas',
-    'cache_control',
-    'container',
-    'context_management',
-    'diagnostics',
-    'extra_body',
-    'extra_headers',
-    'extra_query',
-    'fallback_credit_token',
-    'fallbacks',
-    'inference_geo',
-    'max_tokens',
-    'mcp_servers',
-    'messages',
-    'metadata',
-    'model',
-    'output_config',
-    'output_format',
-    'service_tier',
-    'speed',
-    'stop_sequences',
-    'stream',
-    'system',
-    'temperature',
-    'thinking',
-    'timeout',
-    'tool_choice',
-    'tools',
-    'top_k',
-    'top_p',
-    'user_profile_id',
-})
+_THINKING_MODE_KEYS = frozenset({'adaptive', 'budget_tokens', 'enabled', 'type'})
 
 
 class _ModelDumpable(Protocol):
@@ -158,36 +126,40 @@ def _to_anthropic_thinking_config(thinking: dict[str, Any] | None) -> dict[str, 
         return None
 
     thinking_type = thinking.get('type')
-    display = thinking.get('display')
     budget_tokens = thinking.get('budget_tokens')
+    adaptive = thinking.get('adaptive') is True or thinking_type == 'adaptive'
+    enabled = thinking.get('enabled') is True or thinking_type == 'enabled'
+    disabled = thinking.get('enabled') is False or thinking_type == 'disabled'
 
-    if thinking.get('adaptive') is True or thinking_type == 'adaptive':
-        result: dict[str, Any] = {'type': 'adaptive'}
-        if display is not None:
-            result['display'] = display
+    # Keys that are not mode toggles (display, and any forward-compatible field) pass through unchanged.
+    result: dict[str, Any] = {key: value for key, value in thinking.items() if key not in _THINKING_MODE_KEYS}
+
+    if adaptive:
+        result['type'] = 'adaptive'
         return result
 
-    if thinking.get('enabled') is True or thinking_type == 'enabled':
+    if enabled or (budget_tokens is not None and not disabled):
         if budget_tokens is None:
             raise ValueError('budgetTokens is required when thinking is enabled')
         if not float(budget_tokens).is_integer():
             raise ValueError('budgetTokens must be an integer when thinking is enabled')
-        return {'type': 'enabled', 'budget_tokens': int(budget_tokens)}
+        result['type'] = 'enabled'
+        result['budget_tokens'] = int(budget_tokens)
+        return result
 
-    if thinking.get('enabled') is False or thinking_type == 'disabled':
-        return {'type': 'disabled'}
+    if disabled:
+        result['type'] = 'disabled'
+        return result
 
-    if budget_tokens is not None:
-        if not float(budget_tokens).is_integer():
-            raise ValueError('budgetTokens must be an integer when thinking is enabled')
-        return {'type': 'enabled', 'budget_tokens': int(budget_tokens)}
-
-    return None
+    if thinking_type is not None:
+        result['type'] = thinking_type
+    return result or None
 
 
-def _move_unknown_params_to_extra_body(params: dict[str, Any]) -> None:
+def _move_unknown_params_to_extra_body(params: dict[str, Any], use_beta: bool) -> None:
     """Route passthrough body params through the SDK's ``extra_body`` escape hatch."""
-    unknown_keys = [key for key in params if key not in _SDK_KWARG_KEYS]
+    allowed = BETA_KWARG_KEYS if use_beta else STABLE_KWARG_KEYS
+    unknown_keys = [key for key in params if key not in allowed]
     if not unknown_keys:
         return
 
@@ -274,8 +246,12 @@ class AnthropicModel:
         basic_usage = get_basic_usage_stats(input_=request.messages, response=response_message)
 
         finish_reason_map: dict[str, FinishReason] = {
+            'compaction': FinishReason.OTHER,
             'end_turn': FinishReason.STOP,
             'max_tokens': FinishReason.LENGTH,
+            'model_context_window_exceeded': FinishReason.LENGTH,
+            'pause_turn': FinishReason.OTHER,
+            'refusal': FinishReason.BLOCKED,
             'stop_sequence': FinishReason.STOP,
             'tool_use': FinishReason.STOP,
         }
@@ -321,16 +297,25 @@ class AnthropicModel:
             logger.warning('Ignored per-request Anthropic apiKey because the configured client does not support it')
             return self.client
 
+        # copy() cannot unset these, so the override would leave the base credential authenticating the request.
+        if self.client.auth_token is not None:
+            logger.warning('Ignored per-request Anthropic apiKey because the client authenticates with an auth token')
+            return self.client
+
+        if any(name.lower() == 'x-api-key' for name in self.client._custom_headers):  # noqa: SLF001
+            logger.warning('Ignored per-request Anthropic apiKey because the client pins an x-api-key header')
+            return self.client
+
         # copy() keeps every other client setting and shares the pooled HTTP transport.
         return self.client.copy(api_key=config.api_key)
 
     def _uses_beta_api(self, config: AnthropicConfig) -> bool:
         """Whether this request should use the Anthropic beta API surface.
 
-        Setting ``betas`` alone selects the beta surface, so the requested
-        features are honored instead of silently dropped.
+        Any beta-only field selects the beta surface, so the requested features
+        are honored instead of being rejected by the stable surface.
         """
-        return config.api_version == 'beta' or bool(config.betas)
+        return config.api_version == 'beta' or bool(config.beta_only_fields())
 
     def _build_params(
         self,
@@ -361,6 +346,9 @@ class AnthropicModel:
         # api_version and api_key select the API surface and client; they are not create() kwargs.
         for key in AnthropicConfig.SDK_UNSUPPORTED_KEYS:
             params.pop(key, None)
+
+        # Genkit selects the streaming surface from the request context.
+        params.pop('stream', None)
 
         if use_beta and betas:
             params['betas'] = betas
@@ -422,7 +410,11 @@ class AnthropicModel:
                 elif isinstance(request.tool_choice, dict):
                     params['tool_choice'] = request.tool_choice
 
-        _move_unknown_params_to_extra_body(params)
+        # The API rejects tool_choice when the request carries no tools.
+        if not params.get('tools'):
+            params.pop('tool_choice', None)
+
+        _move_unknown_params_to_extra_body(params, use_beta)
         return params
 
     def _supports_constrained(self, has_tools: bool) -> bool:

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -25,7 +25,7 @@ See:
 """
 
 import json
-from typing import Any
+from typing import Any, Protocol, cast
 
 import structlog
 from anthropic import AsyncAnthropic
@@ -49,6 +49,7 @@ from genkit import (
 )
 from genkit.model import get_basic_usage_stats
 from genkit.plugin_api import ActionRunContext
+from genkit_anthropic.config import AnthropicConfig
 from genkit_anthropic.model_info import get_model_info
 from genkit_anthropic.utils import (
     build_cache_usage,
@@ -60,6 +61,47 @@ from genkit_anthropic.utils import (
 logger = structlog.get_logger(__name__)
 
 DEFAULT_MAX_OUTPUT_TOKENS = 4096
+_SDK_KWARG_KEYS = frozenset({
+    'betas',
+    'cache_control',
+    'container',
+    'context_management',
+    'diagnostics',
+    'extra_body',
+    'extra_headers',
+    'extra_query',
+    'fallback_credit_token',
+    'fallbacks',
+    'inference_geo',
+    'max_tokens',
+    'mcp_servers',
+    'messages',
+    'metadata',
+    'model',
+    'output_config',
+    'output_format',
+    'service_tier',
+    'speed',
+    'stop_sequences',
+    'stream',
+    'system',
+    'temperature',
+    'thinking',
+    'timeout',
+    'tool_choice',
+    'tools',
+    'top_k',
+    'top_p',
+    'user_profile_id',
+})
+
+
+class _ModelDumpable(Protocol):
+    """Minimal protocol for Pydantic-like config objects."""
+
+    def model_dump(self, *, exclude_none: bool = False, by_alias: bool = False) -> dict[str, object]:
+        """Dump model fields."""
+        ...
 
 
 def _to_anthropic_schema(schema: dict[str, Any]) -> dict[str, Any]:
@@ -93,6 +135,73 @@ def _to_tool_input_schema(schema: dict[str, Any] | None) -> dict[str, Any]:
     if 'type' not in schema:
         return {**schema, 'type': 'object'}
     return schema
+
+
+def _normalize_config(config: object | None) -> AnthropicConfig:
+    """Normalize supported config inputs to ``AnthropicConfig``."""
+    if config is None:
+        return AnthropicConfig()
+    if isinstance(config, AnthropicConfig):
+        return config
+    if isinstance(config, dict):
+        return AnthropicConfig.model_validate(config)
+    if hasattr(config, 'model_dump'):
+        return AnthropicConfig.model_validate(
+            cast(_ModelDumpable, config).model_dump(exclude_none=True, by_alias=False)
+        )
+    return AnthropicConfig.model_validate({k: v for k, v in vars(config).items() if v is not None})
+
+
+def _to_anthropic_thinking_config(thinking: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Translate the public thinking config to the Anthropic SDK shape."""
+    if not thinking:
+        return None
+
+    thinking_type = thinking.get('type')
+    display = thinking.get('display')
+    budget_tokens = thinking.get('budget_tokens')
+
+    if thinking.get('adaptive') is True or thinking_type == 'adaptive':
+        result: dict[str, Any] = {'type': 'adaptive'}
+        if display is not None:
+            result['display'] = display
+        return result
+
+    if thinking.get('enabled') is True or thinking_type == 'enabled':
+        if budget_tokens is None:
+            raise ValueError('budgetTokens is required when thinking is enabled')
+        if not float(budget_tokens).is_integer():
+            raise ValueError('budgetTokens must be an integer when thinking is enabled')
+        return {'type': 'enabled', 'budget_tokens': int(budget_tokens)}
+
+    if thinking.get('enabled') is False or thinking_type == 'disabled':
+        return {'type': 'disabled'}
+
+    if budget_tokens is not None:
+        if not float(budget_tokens).is_integer():
+            raise ValueError('budgetTokens must be an integer when thinking is enabled')
+        return {'type': 'enabled', 'budget_tokens': int(budget_tokens)}
+
+    return None
+
+
+def _move_unknown_params_to_extra_body(params: dict[str, Any]) -> None:
+    """Route passthrough body params through the SDK's ``extra_body`` escape hatch."""
+    unknown_keys = [key for key in params if key not in _SDK_KWARG_KEYS]
+    if not unknown_keys:
+        return
+
+    extra_body = params.get('extra_body')
+    if extra_body is None:
+        body: dict[str, Any] = {}
+    elif isinstance(extra_body, dict):
+        body = dict(extra_body)
+    else:
+        body = {'extra_body': extra_body}
+
+    for key in unknown_keys:
+        body[key] = params.pop(key)
+    params['extra_body'] = body
 
 
 class AnthropicModel:
@@ -133,16 +242,21 @@ class AnthropicModel:
         Returns:
             Generated response.
         """
-        params = self._build_params(request)
+        config = _normalize_config(request.config)
+        use_beta = self._uses_beta_api(config)
+        client = self._client_for_config(config)
+        params = self._build_params(request, config=config, use_beta=use_beta)
         streaming = ctx and ctx.is_streaming
 
         logger.debug('Anthropic generate request', model=self.model_name, streaming=bool(streaming))
 
         if streaming:
             assert ctx is not None  # streaming requires ctx
-            response = await self._generate_streaming(params, ctx)
+            response = await self._generate_streaming(params, ctx, client=client, use_beta=use_beta)
         else:
-            response = await self.client.messages.create(**params)
+            active_client = cast(Any, client)
+            messages_client = active_client.beta.messages if use_beta else active_client.messages
+            response = await messages_client.create(**params)
 
         logger.debug(
             'Anthropic raw API response',
@@ -198,52 +312,70 @@ class AnthropicModel:
             cache_read_input_tokens=getattr(response.usage, 'cache_read_input_tokens', None) or 0,
         )
 
-    def _build_params(self, request: ModelRequest) -> dict[str, Any]:
-        """Build Anthropic API parameters."""
-        config = request.config
-        params: dict[str, Any] = {}
+    def _client_for_config(self, config: AnthropicConfig) -> object:
+        """Return the request client, applying a per-request API key when supported."""
+        if not config.api_key:
+            return self.client
 
-        if isinstance(config, dict):
-            params = config.copy()
-        elif config:
-            if hasattr(config, 'model_dump'):
-                params = config.model_dump(exclude_none=True, by_alias=False)
-            else:
-                params = {k: v for k, v in vars(config).items() if v is not None}
+        if type(self.client).__module__.startswith('unittest.mock') or not hasattr(self.client, 'api_key'):
+            logger.warning('Ignored per-request Anthropic apiKey because the configured client does not support it')
+            return self.client
+
+        kwargs: dict[str, Any] = {'api_key': config.api_key}
+        for attr in ('base_url', 'timeout', 'max_retries'):
+            value = getattr(self.client, attr, None)
+            if value is not None:
+                kwargs[attr] = value
+        return AsyncAnthropic(**kwargs)
+
+    def _uses_beta_api(self, config: AnthropicConfig) -> bool:
+        """Whether this request should use the Anthropic beta API surface."""
+        return config.api_version == 'beta' or bool(config.betas)
+
+    def _build_params(
+        self,
+        request: ModelRequest,
+        config: AnthropicConfig | None = None,
+        use_beta: bool | None = None,
+    ) -> dict[str, Any]:
+        """Build Anthropic API parameters."""
+        config = config or _normalize_config(request.config)
+        if use_beta is None:
+            use_beta = self._uses_beta_api(config)
+        params = config.model_dump(exclude_none=True, by_alias=False)
 
         # Handle mapped parameters
         max_tokens = params.pop('max_output_tokens', None)
         if max_tokens is None:
-            max_tokens = params.get('max_tokens', DEFAULT_MAX_OUTPUT_TOKENS)
+            max_tokens = params.pop('max_tokens', DEFAULT_MAX_OUTPUT_TOKENS)
 
-        params.get('temperature')
-        params.get('top_p')
-        params.get('stop_sequences')
         thinking = params.pop('thinking', None)
         metadata = params.pop('metadata', None)
+        version = params.pop('version', None)
+        betas = params.pop('betas', None)
 
-        params['model'] = self.model_name
+        params['model'] = version or self.model_name
         params['messages'] = self._to_anthropic_messages(request.messages)
         params['max_tokens'] = int(max_tokens)
 
-        # Remove known genkit keys that don't map directly or are handled
-        params.pop('version', None)  # If version was passed through config
+        # Strip keys the SDK's messages.create does not accept.
+        stripped_keys = []
+        for key in AnthropicConfig.SDK_UNSUPPORTED_KEYS:
+            if key in params:
+                params.pop(key)
+                stripped_keys.append(key)
+        if stripped_keys:
+            logger.warning('Ignored unsupported Anthropic config keys', keys=sorted(stripped_keys))
 
-        if thinking and isinstance(thinking, dict):
-            anthropic_thinking: dict[str, str | int] = {}
-            # Handle boolean enabled -> type="enabled"
-            if thinking.get('enabled') is True or thinking.get('type') == 'enabled':
-                anthropic_thinking['type'] = 'enabled'
+        if use_beta and betas:
+            params['betas'] = betas
 
-            # Handle camelCase -> snake_case for budget tokens
-            tokens = thinking.get('budgetTokens', thinking.get('budget_tokens'))
-            if tokens:
-                anthropic_thinking['budget_tokens'] = int(tokens)
-
-            if anthropic_thinking.get('type') == 'enabled':
+        if isinstance(thinking, dict):
+            anthropic_thinking = _to_anthropic_thinking_config(thinking)
+            if anthropic_thinking is not None:
                 params['thinking'] = anthropic_thinking
 
-        if metadata:
+        if metadata is not None:
             params['metadata'] = metadata
 
         system = self._extract_system(request.messages)
@@ -258,11 +390,13 @@ class AnthropicModel:
             if use_native:
                 assert request.output_schema is not None
                 # Use native structured outputs via output_config.
+                output_config = params.get('output_config') or {}
                 params['output_config'] = {
+                    **output_config,
                     'format': {
                         'type': 'json_schema',
                         'schema': _to_anthropic_schema(request.output_schema),
-                    }
+                    },
                 }
             else:
                 # Fall back to system prompt instruction.
@@ -293,6 +427,7 @@ class AnthropicModel:
                 elif isinstance(request.tool_choice, dict):
                     params['tool_choice'] = request.tool_choice
 
+        _move_unknown_params_to_extra_body(params)
         return params
 
     def _supports_constrained(self, has_tools: bool) -> bool:
@@ -303,7 +438,13 @@ class AnthropicModel:
             return False
         return constrained != Constrained.NO_TOOLS or not has_tools
 
-    async def _generate_streaming(self, params: dict[str, Any], ctx: ActionRunContext) -> AnthropicMessage:
+    async def _generate_streaming(
+        self,
+        params: dict[str, Any],
+        ctx: ActionRunContext,
+        client: object | None = None,
+        use_beta: bool = False,
+    ) -> AnthropicMessage:
         """Handle streaming generation.
 
         Processes Anthropic streaming events including text deltas and
@@ -320,7 +461,10 @@ class AnthropicModel:
         # Track in-progress tool-use blocks by index.
         pending_tools: dict[int, dict[str, Any]] = {}
 
-        async with self.client.messages.stream(**params) as stream:
+        active_client = cast(Any, client or self.client)
+        messages_client = active_client.beta.messages if use_beta else active_client.messages
+
+        async with messages_client.stream(**params) as stream:
             async for chunk in stream:
                 if chunk.type == 'content_block_start' and hasattr(chunk, 'content_block'):
                     block = chunk.content_block
@@ -376,7 +520,7 @@ class AnthropicModel:
                             )
                         )
 
-            return await stream.get_final_message()
+            return cast(AnthropicMessage, await stream.get_final_message())
 
     def _extract_system(self, messages: list[Message]) -> str | None:
         """Extract system prompt from messages."""

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -327,8 +327,8 @@ class AnthropicModel:
     def _uses_beta_api(self, config: AnthropicConfig) -> bool:
         """Whether this request should use the Anthropic beta API surface.
 
-        Unlike the JS plugin, setting ``betas`` alone selects the beta surface
-        so the requested features are honored instead of silently dropped.
+        Setting ``betas`` alone selects the beta surface, so the requested
+        features are honored instead of silently dropped.
         """
         return config.api_version == 'beta' or bool(config.betas)
 

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
@@ -21,7 +21,7 @@ from typing import Any, cast
 import structlog
 from anthropic import AsyncAnthropic
 
-from genkit import ModelConfig, ModelRequest, ModelResponse
+from genkit import ModelRequest, ModelResponse
 from genkit.model import model_action_metadata
 from genkit.plugin_api import (
     Action,
@@ -32,6 +32,7 @@ from genkit.plugin_api import (
     loop_local_client,
     to_json_schema,
 )
+from genkit_anthropic.config import AnthropicConfig
 from genkit_anthropic.model_info import SUPPORTED_ANTHROPIC_MODELS, get_model_info
 from genkit_anthropic.models import AnthropicModel
 
@@ -128,7 +129,7 @@ class Anthropic(Plugin):
                     'supports': (
                         model_info.supports.model_dump(by_alias=True, exclude_none=True) if model_info.supports else {}
                     ),
-                    'customOptions': to_json_schema(ModelConfig),
+                    'customOptions': to_json_schema(AnthropicConfig),
                 },
             },
         )
@@ -146,7 +147,7 @@ class Anthropic(Plugin):
         return model_action_metadata(
             name=anthropic_name(model_id),
             info=get_model_info(model_id).model_dump(by_alias=True, exclude_none=True),
-            config_schema=ModelConfig,
+            config_schema=AnthropicConfig,
         )
 
     async def _fetch_dynamic_model_ids(self) -> list[str]:

--- a/py/packages/genkit-anthropic/tests/anthropic_config_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_config_test.py
@@ -91,6 +91,15 @@ def test_output_config_effort_literal_enforced() -> None:
         AnthropicConfig.model_validate({'output_config': {'effort': 'extreme'}})
 
 
+def test_output_config_effort_max_valid_and_advertised() -> None:
+    cfg = AnthropicConfig.model_validate({'output_config': {'effort': 'max'}})
+    assert cfg.output_config is not None
+    assert cfg.output_config.effort == 'max'
+
+    schema = to_json_schema(AnthropicConfig)
+    assert 'max' in schema['properties']['output_config']['properties']['effort']['enum']
+
+
 # --- tool_choice ------------------------------------------------------------
 
 
@@ -122,6 +131,16 @@ def test_api_version_literal_and_alias() -> None:
     assert cfg.api_version == 'beta'
     with pytest.raises(ValidationError):
         AnthropicConfig.model_validate({'apiVersion': 'nightly'})
+
+
+def test_stable_api_version_with_betas_raises() -> None:
+    with pytest.raises(ValidationError):
+        AnthropicConfig.model_validate({'apiVersion': 'stable', 'betas': ['token-efficient-tools-2025']})
+
+
+def test_beta_api_version_with_betas_valid() -> None:
+    cfg = AnthropicConfig.model_validate({'apiVersion': 'beta', 'betas': ['token-efficient-tools-2025']})
+    assert cfg.betas == ['token-efficient-tools-2025']
 
 
 def test_unknown_extras_survive_validate_dump() -> None:

--- a/py/packages/genkit-anthropic/tests/anthropic_config_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_config_test.py
@@ -194,3 +194,69 @@ def test_json_schema_advertises_js_shaped_keys() -> None:
     assert 'user_id' in text  # metadata.user_id (snake_case)
     assert '$defs' not in schema
     assert '$ref' not in text
+
+
+@pytest.mark.parametrize(
+    'raw',
+    [
+        {'enabled': False, 'type': 'enabled', 'budgetTokens': 2048},
+        {'enabled': True, 'budgetTokens': 2048, 'type': 'disabled'},
+        {'adaptive': True, 'type': 'disabled'},
+    ],
+)
+def test_thinking_rejects_disabled_conflicting_with_enabled_or_adaptive(raw: dict) -> None:
+    """An explicit disable cannot be combined with an enabled or adaptive mode."""
+    with pytest.raises(ValidationError, match='Cannot disable thinking'):
+        ThinkingConfig.model_validate(raw)
+
+
+@pytest.mark.parametrize(
+    'raw',
+    [{'enabled': False}, {'enabled': True, 'budgetTokens': 2048}, {'adaptive': True}, {'type': 'disabled'}],
+)
+def test_thinking_accepts_unambiguous_modes(raw: dict) -> None:
+    """Single-mode thinking configs stay valid."""
+    assert ThinkingConfig.model_validate(raw) is not None
+
+
+@pytest.mark.parametrize(
+    ('raw', 'expected'),
+    [
+        ({'speed': 'fast'}, {'speed'}),
+        ({'betas': ['x']}, {'betas'}),
+        # Setting a beta-only feature at all is intent, even when the value is empty.
+        ({'mcp_servers': []}, {'mcp_servers'}),
+        # An empty betas list requests no beta headers, so it does not select the surface.
+        ({'betas': []}, set()),
+        ({'output_config': {'task_budget': {'total': 20000}}}, {'output_config.task_budget'}),
+        ({'output_config': {'effort': 'high'}}, set()),
+        ({'temperature': 0.5}, set()),
+        ({'future_option': 'x'}, set()),
+    ],
+)
+def test_beta_only_fields_detection(raw: dict, expected: set[str]) -> None:
+    """Only beta-only request fields select the beta surface."""
+    assert AnthropicConfig.model_validate(raw).beta_only_fields() == expected
+
+
+@pytest.mark.parametrize(
+    'raw',
+    [
+        {'apiVersion': 'stable', 'betas': ['x']},
+        {'apiVersion': 'stable', 'speed': 'fast'},
+        {'apiVersion': 'stable', 'output_config': {'task_budget': {'total': 20000}}},
+    ],
+)
+def test_beta_only_fields_rejected_on_stable_surface(raw: dict) -> None:
+    """An explicit stable apiVersion is never silently overridden."""
+    with pytest.raises(ValidationError, match='require the beta API surface'):
+        AnthropicConfig.model_validate(raw)
+
+
+@pytest.mark.parametrize(
+    'raw',
+    [{'apiVersion': 'beta', 'speed': 'fast'}, {'speed': 'fast'}, {'apiVersion': 'stable', 'temperature': 0.5}],
+)
+def test_beta_only_fields_allowed_without_explicit_stable(raw: dict) -> None:
+    """Beta-only fields are accepted unless stable is explicitly requested."""
+    assert AnthropicConfig.model_validate(raw) is not None

--- a/py/packages/genkit-anthropic/tests/anthropic_config_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_config_test.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the typed Anthropic config schema."""
+
+import pytest
+from genkit_anthropic.config import AnthropicConfig, ThinkingConfig
+from pydantic import ValidationError
+
+from genkit.plugin_api import to_json_schema
+
+# --- thinking ---------------------------------------------------------------
+
+
+def test_thinking_enabled_requires_budget() -> None:
+    with pytest.raises(ValidationError):
+        ThinkingConfig.model_validate({'enabled': True})
+
+
+def test_thinking_sdk_native_enabled_requires_budget() -> None:
+    with pytest.raises(ValidationError):
+        ThinkingConfig.model_validate({'type': 'enabled'})
+
+
+def test_thinking_enabled_and_adaptive_mutually_exclusive() -> None:
+    with pytest.raises(ValidationError):
+        ThinkingConfig.model_validate({'enabled': True, 'budgetTokens': 2048, 'adaptive': True})
+
+
+def test_thinking_budget_below_minimum_raises() -> None:
+    with pytest.raises(ValidationError):
+        ThinkingConfig.model_validate({'enabled': True, 'budgetTokens': 512})
+
+
+def test_thinking_enabled_budget_tokens_must_be_integer() -> None:
+    with pytest.raises(ValidationError):
+        ThinkingConfig.model_validate({'enabled': True, 'budgetTokens': 2048.5})
+
+
+def test_thinking_budget_only_must_be_integer() -> None:
+    with pytest.raises(ValidationError):
+        ThinkingConfig.model_validate({'budgetTokens': 2048.5})
+
+
+def test_thinking_budget_tokens_alias_accepted() -> None:
+    cfg = ThinkingConfig.model_validate({'enabled': True, 'budgetTokens': 2048})
+    assert cfg.budget_tokens == 2048
+
+
+def test_thinking_adaptive_with_display_valid() -> None:
+    cfg = ThinkingConfig.model_validate({'adaptive': True, 'display': 'summarized'})
+    assert cfg.adaptive is True
+    assert cfg.display == 'summarized'
+
+
+def test_thinking_adaptive_allows_fractional_ignored_budget() -> None:
+    cfg = ThinkingConfig.model_validate({'adaptive': True, 'budgetTokens': 2048.5})
+    assert cfg.budget_tokens == 2048.5
+
+
+# --- output_config ----------------------------------------------------------
+
+
+def test_output_config_task_budget_below_minimum_raises() -> None:
+    with pytest.raises(ValidationError):
+        AnthropicConfig.model_validate({'output_config': {'task_budget': {'total': 10000}}})
+
+
+def test_output_config_task_budget_type_defaults_to_tokens() -> None:
+    cfg = AnthropicConfig.model_validate({'output_config': {'task_budget': {'total': 20000}}})
+    assert cfg.output_config is not None
+    assert cfg.output_config.task_budget is not None
+    assert cfg.output_config.task_budget.type == 'tokens'
+
+
+def test_output_config_effort_literal_enforced() -> None:
+    with pytest.raises(ValidationError):
+        AnthropicConfig.model_validate({'output_config': {'effort': 'extreme'}})
+
+
+# --- tool_choice ------------------------------------------------------------
+
+
+def test_tool_choice_tool_requires_name() -> None:
+    with pytest.raises(ValidationError):
+        AnthropicConfig.model_validate({'tool_choice': {'type': 'tool'}})
+
+
+@pytest.mark.parametrize(
+    'tool_choice',
+    [
+        {'type': 'auto'},
+        {'type': 'any'},
+        {'type': 'tool', 'name': 'get_weather'},
+        {'type': 'none'},
+    ],
+)
+def test_tool_choice_variants_valid(tool_choice: dict) -> None:
+    cfg = AnthropicConfig.model_validate({'tool_choice': tool_choice})
+    assert cfg.tool_choice is not None
+    assert cfg.tool_choice.type == tool_choice['type']
+
+
+# --- top level --------------------------------------------------------------
+
+
+def test_api_version_literal_and_alias() -> None:
+    cfg = AnthropicConfig.model_validate({'apiVersion': 'beta'})
+    assert cfg.api_version == 'beta'
+    with pytest.raises(ValidationError):
+        AnthropicConfig.model_validate({'apiVersion': 'nightly'})
+
+
+def test_unknown_extras_survive_validate_dump() -> None:
+    cfg = AnthropicConfig.model_validate({'temperature': 0.5, 'foo_bar': 'baz'})
+    dumped = cfg.model_dump(exclude_none=True, by_alias=False)
+    assert dumped['foo_bar'] == 'baz'
+
+
+def test_base_max_output_tokens_alias() -> None:
+    cfg = AnthropicConfig.model_validate({'maxOutputTokens': 256})
+    assert cfg.max_output_tokens == 256
+
+
+# --- JSON-schema parity (alias-drift guard) ---------------------------------
+
+
+def test_json_schema_advertises_js_shaped_keys() -> None:
+    schema = to_json_schema(AnthropicConfig)
+    props = schema['properties']
+
+    # Advertised common and Anthropic-specific keys.
+    for key in (
+        'apiKey',
+        'apiVersion',
+        'betas',
+        'maxOutputTokens',
+        'tool_choice',
+        'metadata',
+        'thinking',
+        'output_config',
+    ):
+        assert key in props, f'missing advertised key {key!r}'
+
+    assert props['maxOutputTokens']['type'] == 'number'
+    assert props['maxOutputTokens']['title'] == 'Max output tokens'
+    assert props['apiKey']['description'] == 'Overrides the plugin-configured Anthropic API key for this request.'
+    assert props['apiVersion']['description'] == 'Selects the Anthropic API surface for this request.'
+    assert props['betas']['description'] == 'Anthropic beta feature headers to enable for this request.'
+    assert props['tool_choice']['type'] == 'object'
+    assert props['tool_choice']['properties']['type']['enum'] == ['auto', 'any', 'tool', 'none']
+    assert 'oneOf' not in props['tool_choice']
+
+    # snake_case keys must NOT drift to camelCase.
+    assert 'toolChoice' not in props
+    assert 'outputConfig' not in props
+
+    # Nested snake_case/camelCase keys are preserved.
+    text = str(schema)
+    assert 'budgetTokens' in text  # thinking.budgetTokens (camelCase)
+    assert 'task_budget' in text  # output_config.task_budget (snake_case)
+    assert 'user_id' in text  # metadata.user_id (snake_case)
+    assert '$defs' not in schema
+    assert '$ref' not in text

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -20,8 +20,11 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from anthropic import AsyncAnthropic
+from genkit_anthropic.config import AnthropicConfig
 from genkit_anthropic.models import AnthropicModel
 from genkit_anthropic.utils import maybe_strip_fences, strip_markdown_fences
+from pydantic import ValidationError
 
 from genkit import (
     Constrained,
@@ -828,3 +831,203 @@ def test_structured_output_with_no_tools_capability() -> None:
     assert 'output_config' in params_without_tools
     assert 'output_config' not in params_with_tools
     assert 'Output valid JSON' in params_with_tools['system']
+
+
+# --- typed config (AnthropicConfig) ----------------------------------------
+
+
+def _mock_client_for_generate() -> MagicMock:
+    """A client whose messages.create returns a minimal text response."""
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(type='text', text='ok')]
+    mock_response.usage = MagicMock(input_tokens=1, output_tokens=1)
+    mock_response.stop_reason = 'end_turn'
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+    mock_client.beta.messages.create = AsyncMock(return_value=mock_response)
+    return mock_client
+
+
+def _text_request(config: Any) -> ModelRequest:
+    return ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
+        config=config,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dict_config_unknown_key_reaches_sdk() -> None:
+    """Unknown extra keys in a dict config pass through the SDK body escape hatch."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request({'temperature': 0.3, 'future_option': 'x'}))
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs['temperature'] == 0.3
+    assert kwargs['extra_body'] == {'future_option': 'x'}
+
+
+@pytest.mark.asyncio
+async def test_typed_config_thinking_translated_for_sdk() -> None:
+    """A typed thinking config is translated to the SDK's snake_case shape."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    config = AnthropicConfig.model_validate({'thinking': {'enabled': True, 'budgetTokens': 2048}})
+    await model.generate(_text_request(config))
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs['thinking'] == {'type': 'enabled', 'budget_tokens': 2048}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'thinking, expected',
+    [
+        ({'adaptive': True, 'display': 'summarized'}, {'type': 'adaptive', 'display': 'summarized'}),
+        ({'enabled': False}, {'type': 'disabled'}),
+        ({'budgetTokens': 2048}, {'type': 'enabled', 'budget_tokens': 2048}),
+    ],
+)
+async def test_typed_config_thinking_variants_translated_for_sdk(
+    thinking: dict[str, Any], expected: dict[str, Any]
+) -> None:
+    """Advertised thinking variants are translated to the SDK shape."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    config = AnthropicConfig.model_validate({'thinking': thinking})
+    await model.generate(_text_request(config))
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs['thinking'] == expected
+
+
+@pytest.mark.asyncio
+async def test_beta_config_uses_beta_sdk_and_sends_betas() -> None:
+    """apiVersion / betas route through the beta SDK surface."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    config = AnthropicConfig.model_validate({
+        'apiVersion': 'beta',
+        'betas': ['token-efficient-tools-2025'],
+    })
+    await model.generate(_text_request(config))
+
+    mock_client.messages.create.assert_not_called()
+    kwargs = mock_client.beta.messages.create.call_args.kwargs
+    assert 'api_version' not in kwargs
+    assert 'apiVersion' not in kwargs
+    assert kwargs['betas'] == ['token-efficient-tools-2025']
+
+
+@pytest.mark.asyncio
+async def test_api_key_does_not_reach_sdk_params() -> None:
+    """apiKey is a client override and is never passed as a messages kwarg."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    config = AnthropicConfig.model_validate({'apiKey': 'secret'})
+    await model.generate(_text_request(config))
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert 'api_key' not in kwargs
+    assert 'apiKey' not in kwargs
+
+
+def test_api_key_config_overrides_real_sdk_client() -> None:
+    """apiKey creates a request-scoped client when the configured client supports it."""
+    base_client = AsyncAnthropic(api_key='base-key')
+    model = AnthropicModel(model_name='claude-sonnet-4', client=base_client)
+
+    client = model._client_for_config(AnthropicConfig.model_validate({'apiKey': 'request-key'}))
+
+    assert client is not base_client
+    assert isinstance(client, AsyncAnthropic)
+    assert client.api_key == 'request-key'
+
+
+@pytest.mark.asyncio
+async def test_invalid_config_raises_from_generate() -> None:
+    """An invalid dict config surfaces a validation error from generate()."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    with pytest.raises(ValidationError):
+        await model.generate(_text_request({'thinking': {'enabled': True}}))
+
+    mock_client.messages.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_config_tool_choice_and_metadata_reach_sdk() -> None:
+    """Config-level tool_choice and metadata reach the SDK kwargs."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    config = AnthropicConfig.model_validate({
+        'tool_choice': {'type': 'tool', 'name': 'get_weather'},
+        'metadata': {'user_id': 'user-123'},
+    })
+    await model.generate(_text_request(config))
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs['tool_choice'] == {'type': 'tool', 'name': 'get_weather'}
+    assert kwargs['metadata'] == {'user_id': 'user-123'}
+
+
+@pytest.mark.asyncio
+async def test_config_tool_choice_none_reaches_sdk() -> None:
+    """Config-level tool_choice none remains valid for dict compatibility."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request({'tool_choice': {'type': 'none'}}))
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs['tool_choice'] == {'type': 'none'}
+
+
+def test_structured_output_merges_existing_output_config() -> None:
+    """Native structured output keeps user-supplied output_config options."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-opus-4-6', client=mock_client)
+    config: Any = AnthropicConfig.model_validate({'output_config': {'effort': 'high', 'task_budget': {'total': 20000}}})
+
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
+        output_format='json',
+        output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+        config=config,
+        output_constrained=True,
+    )
+
+    params = model._build_params(request)
+
+    assert params['output_config']['effort'] == 'high'
+    assert params['output_config']['task_budget'] == {'type': 'tokens', 'total': 20000}
+    assert params['output_config']['format']['type'] == 'json_schema'
+
+
+def test_config_version_overrides_model_name() -> None:
+    """Per-request version maps to the Anthropic model parameter."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    params = model._build_params(_text_request({'version': 'claude-sonnet-4-20260101'}))
+
+    assert params['model'] == 'claude-sonnet-4-20260101'
+
+
+def test_backward_compat_plain_model_config() -> None:
+    """A plain ModelConfig still maps to the same SDK params (no behavior change)."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    params = model._build_params(_text_request(ModelConfig(temperature=0.7, max_output_tokens=100, top_p=0.9)))
+
+    assert params['temperature'] == 0.7
+    assert params['max_tokens'] == 100
+    assert params['top_p'] == 0.9

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -17,10 +17,11 @@
 """Tests for Anthropic models."""
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from anthropic import AsyncAnthropic
+from genkit_anthropic import models as anthropic_models
 from genkit_anthropic.config import AnthropicConfig
 from genkit_anthropic.models import AnthropicModel
 from genkit_anthropic.utils import maybe_strip_fences, strip_markdown_fences
@@ -938,8 +939,8 @@ async def test_api_key_does_not_reach_sdk_params() -> None:
 
 
 def test_api_key_config_overrides_real_sdk_client() -> None:
-    """apiKey creates a request-scoped client when the configured client supports it."""
-    base_client = AsyncAnthropic(api_key='base-key')
+    """apiKey yields a request-scoped copy that keeps client settings and transport."""
+    base_client = AsyncAnthropic(api_key='base-key', default_headers={'X-Custom': 'yes'})
     model = AnthropicModel(model_name='claude-sonnet-4', client=base_client)
 
     client = model._client_for_config(AnthropicConfig.model_validate({'apiKey': 'request-key'}))
@@ -947,6 +948,21 @@ def test_api_key_config_overrides_real_sdk_client() -> None:
     assert client is not base_client
     assert isinstance(client, AsyncAnthropic)
     assert client.api_key == 'request-key'
+    assert client.default_headers.get('X-Custom') == 'yes'
+    assert client._client is base_client._client
+
+
+def test_build_params_consumes_client_level_keys_silently() -> None:
+    """apiVersion/apiKey are honored elsewhere and must not be logged as ignored."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    with patch.object(anthropic_models, 'logger') as mock_logger:
+        params = model._build_params(_text_request({'apiVersion': 'beta', 'apiKey': 'request-key'}))
+
+    mock_logger.warning.assert_not_called()
+    assert 'api_version' not in params
+    assert 'api_key' not in params
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -16,19 +16,20 @@
 
 """Tests for Anthropic models."""
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from anthropic import AsyncAnthropic
 from genkit_anthropic import models as anthropic_models
 from genkit_anthropic.config import AnthropicConfig
-from genkit_anthropic.models import AnthropicModel
+from genkit_anthropic.models import AnthropicModel, _to_anthropic_thinking_config
 from genkit_anthropic.utils import maybe_strip_fences, strip_markdown_fences
 from pydantic import ValidationError
 
 from genkit import (
     Constrained,
+    FinishReason,
     Media,
     MediaPart,
     Message,
@@ -986,6 +987,7 @@ async def test_config_tool_choice_and_metadata_reach_sdk() -> None:
     config = AnthropicConfig.model_validate({
         'tool_choice': {'type': 'tool', 'name': 'get_weather'},
         'metadata': {'user_id': 'user-123'},
+        'tools': [{'name': 'get_weather', 'description': 'Weather', 'input_schema': {'type': 'object'}}],
     })
     await model.generate(_text_request(config))
 
@@ -1000,10 +1002,27 @@ async def test_config_tool_choice_none_reaches_sdk() -> None:
     mock_client = _mock_client_for_generate()
     model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
 
-    await model.generate(_text_request({'tool_choice': {'type': 'none'}}))
+    await model.generate(
+        _text_request({
+            'tool_choice': {'type': 'none'},
+            'tools': [{'name': 'get_weather', 'description': 'Weather', 'input_schema': {'type': 'object'}}],
+        })
+    )
 
     kwargs = mock_client.messages.create.call_args.kwargs
     assert kwargs['tool_choice'] == {'type': 'none'}
+
+
+@pytest.mark.asyncio
+async def test_config_tool_choice_dropped_without_tools() -> None:
+    """Config-level tool_choice is dropped when the request carries no tools."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request({'tool_choice': {'type': 'auto'}}))
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert 'tool_choice' not in kwargs
 
 
 def test_structured_output_merges_existing_output_config() -> None:
@@ -1047,3 +1066,136 @@ def test_backward_compat_plain_model_config() -> None:
     assert params['temperature'] == 0.7
     assert params['max_tokens'] == 100
     assert params['top_p'] == 0.9
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('config', 'kwarg'),
+    [
+        ({'speed': 'fast'}, 'speed'),
+        ({'mcp_servers': [{'type': 'url', 'name': 'x', 'url': 'https://example.com'}]}, 'mcp_servers'),
+        ({'context_management': {'edits': []}}, 'context_management'),
+    ],
+)
+async def test_beta_only_params_select_beta_surface(config: dict, kwarg: str) -> None:
+    """Beta-only params route to the beta surface instead of crashing the stable one."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request(config))
+
+    mock_client.messages.create.assert_not_called()
+    kwargs = mock_client.beta.messages.create.call_args.kwargs
+    assert kwargs[kwarg] == config[kwarg]
+    assert 'extra_body' not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_task_budget_selects_beta_surface() -> None:
+    """output_config.task_budget is beta-only and must not ship on the stable surface."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request({'output_config': {'task_budget': {'total': 20000}}}))
+
+    mock_client.messages.create.assert_not_called()
+    kwargs = mock_client.beta.messages.create.call_args.kwargs
+    assert kwargs['output_config']['task_budget'] == {'type': 'tokens', 'total': 20000}
+
+
+@pytest.mark.asyncio
+async def test_unknown_params_still_route_to_extra_body_on_beta() -> None:
+    """The escape hatch keeps working once the beta surface is selected."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request({'speed': 'fast', 'future_option': 'x'}))
+
+    kwargs = mock_client.beta.messages.create.call_args.kwargs
+    assert kwargs['speed'] == 'fast'
+    assert kwargs['extra_body'] == {'future_option': 'x'}
+
+
+@pytest.mark.asyncio
+async def test_config_stream_does_not_reach_sdk() -> None:
+    """Genkit owns streaming, so a config-level stream flag is dropped."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request({'stream': True}))
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert 'stream' not in kwargs
+    assert 'stream' not in (kwargs.get('extra_body') or {})
+
+
+@pytest.mark.parametrize(
+    ('stop_reason', 'expected'),
+    [
+        ('end_turn', FinishReason.STOP),
+        ('max_tokens', FinishReason.LENGTH),
+        ('model_context_window_exceeded', FinishReason.LENGTH),
+        ('refusal', FinishReason.BLOCKED),
+        ('pause_turn', FinishReason.OTHER),
+        ('compaction', FinishReason.OTHER),
+        ('something_new', FinishReason.UNKNOWN),
+    ],
+)
+@pytest.mark.asyncio
+async def test_finish_reason_mapping(stop_reason: str, expected: FinishReason) -> None:
+    """Anthropic stop reasons map onto Genkit finish reasons."""
+    mock_client = _mock_client_for_generate()
+    mock_client.messages.create.return_value.stop_reason = stop_reason
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    response = await model.generate(_text_request({}))
+
+    assert response.finish_reason == expected
+
+
+def test_per_request_api_key_ignored_when_client_uses_auth_token() -> None:
+    """An auth-token client cannot be re-credentialed by copy(), so the key is ignored."""
+    client = AsyncAnthropic(auth_token='corp-bearer')
+    model = AnthropicModel(model_name='claude-sonnet-4', client=client)
+
+    assert model._client_for_config(AnthropicConfig.model_validate({'apiKey': 'user-key'})) is client
+
+
+def test_per_request_api_key_ignored_when_client_pins_api_key_header() -> None:
+    """A pinned x-api-key header outranks copy(api_key=...), so the key is ignored."""
+    client = AsyncAnthropic(api_key='plugin-key', default_headers={'X-Api-Key': 'pinned'})
+    model = AnthropicModel(model_name='claude-sonnet-4', client=client)
+
+    assert model._client_for_config(AnthropicConfig.model_validate({'apiKey': 'user-key'})) is client
+
+
+def test_per_request_api_key_applied_on_plain_client() -> None:
+    """A plain api-key client is re-credentialed for the request."""
+    client = AsyncAnthropic(api_key='plugin-key')
+    model = AnthropicModel(model_name='claude-sonnet-4', client=client)
+
+    applied = model._client_for_config(AnthropicConfig.model_validate({'apiKey': 'user-key'}))
+
+    assert applied is not client
+    assert cast(AsyncAnthropic, applied).api_key == 'user-key'
+
+
+@pytest.mark.parametrize(
+    ('raw', 'expected'),
+    [
+        (
+            {'enabled': True, 'budgetTokens': 2048, 'display': 'omitted'},
+            {'display': 'omitted', 'type': 'enabled', 'budget_tokens': 2048},
+        ),
+        ({'adaptive': True, 'display': 'summarized'}, {'display': 'summarized', 'type': 'adaptive'}),
+        ({'type': 'interleaved'}, {'type': 'interleaved'}),
+        ({'display': 'summarized'}, {'display': 'summarized'}),
+    ],
+)
+def test_thinking_preserves_display_and_forward_compatible_keys(raw: dict, expected: dict) -> None:
+    """display and unknown thinking keys survive translation to the SDK shape."""
+    thinking = AnthropicConfig.model_validate({'thinking': raw}).model_dump(exclude_none=True, by_alias=False)[
+        'thinking'
+    ]
+
+    assert _to_anthropic_thinking_config(thinking) == expected

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -1189,7 +1189,6 @@ def test_per_request_api_key_applied_on_plain_client() -> None:
         ),
         ({'adaptive': True, 'display': 'summarized'}, {'display': 'summarized', 'type': 'adaptive'}),
         ({'type': 'interleaved'}, {'type': 'interleaved'}),
-        ({'display': 'summarized'}, {'display': 'summarized'}),
     ],
 )
 def test_thinking_preserves_display_and_forward_compatible_keys(raw: dict, expected: dict) -> None:
@@ -1199,3 +1198,13 @@ def test_thinking_preserves_display_and_forward_compatible_keys(raw: dict, expec
     ]
 
     assert _to_anthropic_thinking_config(thinking) == expected
+
+
+@pytest.mark.parametrize('raw', [{'display': 'summarized'}, {}])
+def test_thinking_dropped_when_no_mode_is_set(raw: dict) -> None:
+    """A thinking config with no mode has no SDK type, so it is dropped rather than sent."""
+    thinking = AnthropicConfig.model_validate({'thinking': raw}).model_dump(exclude_none=True, by_alias=False)[
+        'thinking'
+    ]
+
+    assert _to_anthropic_thinking_config(thinking) is None

--- a/py/packages/genkit-anthropic/tests/anthropic_plugin_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_plugin_test.py
@@ -20,6 +20,7 @@ import asyncio
 import queue
 import threading
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -343,6 +344,54 @@ async def test_list_actions_empty_api_response_returns_and_caches_statics() -> N
     # Unlike the error path, an empty-but-successful response is cached.
     _ = await plugin.list_actions()
     assert mock_client.beta.models.list.call_count == 1
+
+
+_ANTHROPIC_CONFIG_KEYS = {
+    'apiKey',
+    'apiVersion',
+    'betas',
+    'maxOutputTokens',
+    'tool_choice',
+    'metadata',
+    'thinking',
+    'output_config',
+}
+
+
+def _custom_options(action_metadata: object) -> dict[str, Any]:
+    metadata = cast(dict[str, Any], action_metadata)
+    model_metadata = cast(dict[str, Any], metadata['model'])
+    return cast(dict[str, Any], model_metadata['customOptions'])
+
+
+@pytest.mark.asyncio
+async def test_resolve_advertises_anthropic_config() -> None:
+    """resolve() metadata customOptions reflects the typed AnthropicConfig."""
+    plugin = Anthropic(api_key='test-key')
+
+    action = await plugin.resolve(ActionKind.MODEL, 'anthropic/claude-sonnet-4')
+
+    assert action is not None
+    custom_options = _custom_options(action.metadata)
+    properties = set(custom_options['properties'].keys())
+    assert _ANTHROPIC_CONFIG_KEYS <= properties
+
+
+@pytest.mark.asyncio
+async def test_list_actions_advertises_anthropic_config() -> None:
+    """list_actions() customOptions reflects the typed AnthropicConfig."""
+    plugin = Anthropic(api_key='test-key')
+    mock_client = MagicMock()
+    mock_client.beta.models.list = MagicMock(side_effect=RuntimeError('offline'))
+    plugin._runtime_client = lambda: mock_client
+
+    actions = await plugin.list_actions()
+
+    assert actions
+    for action in actions:
+        custom_options = _custom_options(action.metadata)
+        properties = set(custom_options['properties'].keys())
+        assert _ANTHROPIC_CONFIG_KEYS <= properties
 
 
 def _create_sample_request() -> ModelRequest:

--- a/py/packages/genkit-vertexai/src/genkit_vertexai/model_garden/anthropic.py
+++ b/py/packages/genkit-vertexai/src/genkit_vertexai/model_garden/anthropic.py
@@ -21,17 +21,11 @@ from collections.abc import Awaitable, Callable
 from typing import cast
 
 from anthropic import AsyncAnthropic, AsyncAnthropicVertex
+from genkit_anthropic.config import AnthropicConfig
 from genkit_anthropic.models import AnthropicModel
-from pydantic import ConfigDict
 
 from genkit import ModelConfig, ModelInfo, ModelRequest, ModelResponse, Supports
 from genkit.plugin_api import ActionRunContext, loop_local_client
-
-
-class AnthropicConfigSchema(ModelConfig):
-    """Configuration for Anthropic models."""
-
-    model_config = ConfigDict(extra='allow')
 
 
 class AnthropicModelGarden:
@@ -95,4 +89,4 @@ class AnthropicModelGarden:
     @staticmethod
     def get_config_schema() -> type[ModelConfig]:
         """Returns the config schema for this model type."""
-        return AnthropicConfigSchema
+        return AnthropicConfig

--- a/py/packages/genkit-vertexai/src/genkit_vertexai/model_garden/anthropic.py
+++ b/py/packages/genkit-vertexai/src/genkit_vertexai/model_garden/anthropic.py
@@ -23,9 +23,34 @@ from typing import cast
 from anthropic import AsyncAnthropic, AsyncAnthropicVertex
 from genkit_anthropic.config import AnthropicConfig
 from genkit_anthropic.models import AnthropicModel
+from pydantic import ConfigDict
+from pydantic.config import JsonDict
 
 from genkit import ModelConfig, ModelInfo, ModelRequest, ModelResponse, Supports
 from genkit.plugin_api import ActionRunContext, loop_local_client
+
+
+def _vertex_anthropic_config_schema_extra(schema: JsonDict) -> None:
+    """Drop options Vertex Model Garden cannot honor from the advertised schema."""
+    base_extra = AnthropicConfig.model_config.get('json_schema_extra')
+    if callable(base_extra):
+        cast(Callable[[JsonDict], None], base_extra)(schema)
+    properties = schema.get('properties')
+    if isinstance(properties, dict):
+        properties.pop('apiKey', None)
+
+
+class VertexAnthropicConfig(AnthropicConfig):
+    """Anthropic config for Vertex Model Garden.
+
+    ``apiKey`` is omitted because :class:`AsyncAnthropicVertex` authenticates
+    with ambient Google credentials and ignores a per-request Anthropic key.
+    """
+
+    model_config = ConfigDict(**{
+        **AnthropicConfig.model_config,
+        'json_schema_extra': _vertex_anthropic_config_schema_extra,
+    })
 
 
 class AnthropicModelGarden:
@@ -89,4 +114,4 @@ class AnthropicModelGarden:
     @staticmethod
     def get_config_schema() -> type[ModelConfig]:
         """Returns the config schema for this model type."""
-        return AnthropicConfig
+        return VertexAnthropicConfig

--- a/py/packages/genkit-vertexai/tests/model_garden/model_garden_test.py
+++ b/py/packages/genkit-vertexai/tests/model_garden/model_garden_test.py
@@ -103,4 +103,12 @@ def test_model_garden_plugin_deprecated_alias() -> None:
 
 def test_anthropic_model_garden_uses_anthropic_config_schema() -> None:
     """Anthropic Model Garden advertises the schema enforced by its handler."""
-    assert AnthropicModelGarden.get_config_schema() is AnthropicConfig
+    schema = AnthropicModelGarden.get_config_schema()
+    assert issubclass(schema, AnthropicConfig)
+
+
+def test_anthropic_model_garden_does_not_advertise_api_key() -> None:
+    """Vertex authenticates with Google credentials, so apiKey is not offered."""
+    properties = AnthropicModelGarden.get_config_schema().model_json_schema()['properties']
+    assert 'apiKey' not in properties
+    assert 'apiVersion' in properties

--- a/py/packages/genkit-vertexai/tests/model_garden/model_garden_test.py
+++ b/py/packages/genkit-vertexai/tests/model_garden/model_garden_test.py
@@ -21,7 +21,9 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from genkit_anthropic.config import AnthropicConfig
 from genkit_vertexai.model_garden import ModelGarden, ModelGardenPlugin
+from genkit_vertexai.model_garden.anthropic import AnthropicModelGarden
 from genkit_vertexai.model_garden.model_garden import ModelGardenModel
 
 
@@ -97,3 +99,8 @@ def test_model_garden_plugin_deprecated_alias() -> None:
     assert len(caught) == 1
     assert 'ModelGardenPlugin is deprecated' in str(caught[0].message)
     assert isinstance(plugin, ModelGarden)
+
+
+def test_anthropic_model_garden_uses_anthropic_config_schema() -> None:
+    """Anthropic Model Garden advertises the schema enforced by its handler."""
+    assert AnthropicModelGarden.get_config_schema() is AnthropicConfig

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -566,15 +566,6 @@ wheels = [
 ]
 
 [[package]]
-name = "chardet"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1851,11 +1842,6 @@ dependencies = [
     { name = "genkit-ollama" },
     { name = "genkit-openai" },
     { name = "genkit-vertexai" },
-    { name = "liccheck" },
-    { name = "mcp" },
-    { name = "python-multipart" },
-    { name = "setuptools" },
-    { name = "strenum", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -1865,17 +1851,14 @@ dev = [
     { name = "ipython", version = "8.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jupyter" },
+    { name = "mcp" },
     { name = "nox" },
     { name = "nox-uv" },
     { name = "pip" },
-    { name = "poethepoet" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
-    { name = "pytest-watcher" },
-    { name = "tox" },
-    { name = "tox-uv" },
     { name = "twine" },
 ]
 lint = [
@@ -1886,6 +1869,7 @@ lint = [
     { name = "grpcio-reflection" },
     { name = "gunicorn" },
     { name = "hypercorn" },
+    { name = "liccheck" },
     { name = "litestar" },
     { name = "mypy" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
@@ -1901,11 +1885,11 @@ lint = [
     { name = "ruff" },
     { name = "secure" },
     { name = "sentry-sdk" },
+    { name = "setuptools" },
     { name = "streamlit" },
     { name = "strenum" },
     { name = "structlog" },
     { name = "ty" },
-    { name = "typos" },
 ]
 
 [package.metadata]
@@ -1923,11 +1907,6 @@ requires-dist = [
     { name = "genkit-ollama", editable = "packages/genkit-ollama" },
     { name = "genkit-openai", editable = "packages/genkit-openai" },
     { name = "genkit-vertexai", editable = "packages/genkit-vertexai" },
-    { name = "liccheck", specifier = ">=0.9.2" },
-    { name = "mcp", specifier = ">=1.25.0" },
-    { name = "python-multipart", specifier = ">=0.0.22" },
-    { name = "setuptools", specifier = ">=75.0.0,<82" },
-    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
 ]
 
 [package.metadata.requires-dev]
@@ -1937,17 +1916,14 @@ dev = [
     { name = "ipython", marker = "python_full_version < '3.11'", specifier = "~=8.22" },
     { name = "ipython", marker = "python_full_version >= '3.11'", specifier = "~=9.0.2" },
     { name = "jupyter", specifier = ">=1.1.1" },
+    { name = "mcp", specifier = ">=1.25.0" },
     { name = "nox", specifier = ">=2025.2.9" },
     { name = "nox-uv", specifier = ">=0.2.2" },
     { name = "pip", specifier = ">=25.0.1" },
-    { name = "poethepoet", specifier = ">=0.33.1" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
-    { name = "pytest-watcher", specifier = ">=0.4.3" },
-    { name = "tox", specifier = ">=4.25.0" },
-    { name = "tox-uv", specifier = ">=1.25.0" },
     { name = "twine", specifier = ">=6.1.0" },
 ]
 lint = [
@@ -1958,6 +1934,7 @@ lint = [
     { name = "grpcio-reflection", specifier = ">=1.68.0" },
     { name = "gunicorn", specifier = ">=22.0.0" },
     { name = "hypercorn", specifier = ">=0.17.0" },
+    { name = "liccheck", specifier = ">=0.9.2" },
     { name = "litestar", specifier = ">=2.20.0" },
     { name = "mypy", specifier = ">=1.14.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20.0" },
@@ -1973,11 +1950,11 @@ lint = [
     { name = "ruff", specifier = ">=0.9" },
     { name = "secure", specifier = ">=1.0.0" },
     { name = "sentry-sdk", specifier = ">=2.0.0" },
+    { name = "setuptools", specifier = ">=75.0.0,<82" },
     { name = "streamlit", specifier = ">=1.41.0" },
     { name = "strenum", specifier = ">=0.4.15" },
     { name = "structlog", specifier = ">=24.0.0" },
     { name = "ty", specifier = ">=0.0.1" },
-    { name = "typos", specifier = ">=1.42.0" },
 ]
 
 [[package]]
@@ -4718,15 +4695,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pastel"
-version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/f1/4594f5e0fcddb6953e5b8fe00da8c317b8b41b547e2b3ae2da7512943c62/pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d", size = 7555, upload-time = "2020-09-16T19:21:12.43Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/18/a8444036c6dd65ba3624c63b734d3ba95ba63ace513078e1580590075d21/pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364", size = 5955, upload-time = "2020-09-16T19:21:11.409Z" },
-]
-
-[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4916,20 +4884,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "poethepoet"
-version = "0.41.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pastel" },
-    { name = "pyyaml" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/b9/fa92286560f70eaa40d473ea48376d20c6c21f63627d33c6bb1c5e385175/poethepoet-0.41.0.tar.gz", hash = "sha256:dcaad621dc061f6a90b17d091bebb9ca043d67bfe9bd6aa4185aea3ebf7ff3e6", size = 87780, upload-time = "2026-02-08T20:45:36.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/5e/0b83e0222ce5921b3f9081eeca8c6fb3e1cfd5ca0d06338adf93b28ce061/poethepoet-0.41.0-py3-none-any.whl", hash = "sha256:4bab9fd8271664c5d21407e8f12827daeb6aa484dc6cc7620f0c3b4e62b42ee4", size = 113590, upload-time = "2026-02-08T20:45:34.697Z" },
 ]
 
 [[package]]
@@ -5380,19 +5334,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyproject-api"
-version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/45/7b/c0e1333b61d41c69e59e5366e727b18c4992688caf0de1be10b3e5265f6b/pyproject_api-1.10.0.tar.gz", hash = "sha256:40c6f2d82eebdc4afee61c773ed208c04c19db4c4a60d97f8d7be3ebc0bbb330", size = 22785, upload-time = "2025-10-09T19:12:27.21Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/cc/cecf97be298bee2b2a37dd360618c819a2a7fd95251d8e480c1f0eb88f3b/pyproject_api-1.10.0-py3-none-any.whl", hash = "sha256:8757c41a79c0f4ab71b99abed52b97ecf66bd20b04fa59da43b5840bac105a09", size = 13218, upload-time = "2025-10-09T19:12:24.428Z" },
-]
-
-[[package]]
 name = "pyrefly"
 version = "0.52.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5520,19 +5461,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
-]
-
-[[package]]
-name = "pytest-watcher"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "watchdog" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/d2/80606077b7fa8784417687f494ff801d7ab817d9a17fc94305811d5919bb/pytest_watcher-0.6.3.tar.gz", hash = "sha256:842dc904264df0ad2d5264153a66bb452fccfa46598cd6e0a5ef1d19afed9b13", size = 601878, upload-time = "2026-01-10T23:28:18.805Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/3f/172d73600ad2771774cda108efb813fc724fc345e5240a81a1085f1ade5d/pytest_watcher-0.6.3-py3-none-any.whl", hash = "sha256:83e7748c933087e8276edb6078663e6afa9926434b4fd8b85cf6b32b1d5bec89", size = 12431, upload-time = "2026-01-10T23:28:17.64Z" },
 ]
 
 [[package]]
@@ -6523,43 +6451,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tox"
-version = "4.34.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cachetools" },
-    { name = "chardet" },
-    { name = "colorama" },
-    { name = "filelock" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "pluggy" },
-    { name = "pyproject-api" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/9b/5909f40b281ebd37c2f83de5087b9cb8a9a64c33745f334be0aeaedadbbc/tox-4.34.1.tar.gz", hash = "sha256:ef1e82974c2f5ea02954d590ee0b967fad500c3879b264ea19efb9a554f3cc60", size = 205306, upload-time = "2026-01-09T17:42:59.895Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0f/fe6629e277ce615e53d0a0b65dc23c88b15a402bb7dbf771f17bbd18f1c4/tox-4.34.1-py3-none-any.whl", hash = "sha256:5610d69708bab578d618959b023f8d7d5d3386ed14a2392aeebf9c583615af60", size = 176812, upload-time = "2026-01-09T17:42:58.629Z" },
-]
-
-[[package]]
-name = "tox-uv"
-version = "1.29.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "tox" },
-    { name = "uv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/90/06752775b8cfadba8856190f5beae9f552547e0f287e0246677972107375/tox_uv-1.29.0.tar.gz", hash = "sha256:30fa9e6ad507df49d3c6a2f88894256bcf90f18e240a00764da6ecab1db24895", size = 23427, upload-time = "2025-10-09T20:40:27.384Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/17/221d62937c4130b044bb437caac4181e7e13d5536bbede65264db1f0ac9f/tox_uv-1.29.0-py3-none-any.whl", hash = "sha256:b1d251286edeeb4bc4af1e24c8acfdd9404700143c2199ccdbb4ea195f7de6cc", size = 17254, upload-time = "2025-10-09T20:40:25.885Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -6691,22 +6582,6 @@ wheels = [
 ]
 
 [[package]]
-name = "typos"
-version = "1.43.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/db/dece16ef4f2fd73b114b3ebd30f3d1b18dbcfc4741a23e9a4c89ec8be707/typos-1.43.4.tar.gz", hash = "sha256:593d2f13f4e6d57bc3062eaf1c35083f86090f84a1868a1c21295b98da88c91e", size = 1798880, upload-time = "2026-02-09T14:26:52.226Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/ad/d028a67fc9428cffafd7222f613f68f5b951b9cdd7c4366ed95a43aaaa77/typos-1.43.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aa3771cfbd78df2dafe77bea4de67cb352b073a92274f6c831f6a7f6a551e646", size = 3449305, upload-time = "2026-02-09T14:26:35.603Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/55/2a943b2e79dd93522c683d9eb63d23813bbb9d3e96d1b65c6315de4c095f/typos-1.43.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:aba0654a8ecb92be31fc559aff1bce68eb132a5f6f065ecfe213cd46cb433179", size = 3344013, upload-time = "2026-02-09T14:26:37.879Z" },
-    { url = "https://files.pythonhosted.org/packages/95/0d/bd2c52e6e6d53b99d7238f60012c9c65d73d139ae338bf29f517ca5e8467/typos-1.43.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7eb60f4b09614b4054495de83d10610da7c11c5fd1e72ad04fc5b20442bee9b", size = 8154117, upload-time = "2026-02-09T14:26:39.819Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/dd/240eeffc8bb3e99c8241df2f57869af72ceb4077de78704f534f40306abf/typos-1.43.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c3e5c915ad2808c66bae041cb29607e1ec506e2a08608f07f4f415020df5590a", size = 7297810, upload-time = "2026-02-09T14:26:42.11Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/07/34e3c7371f0fb65c1f4f5b07a3a6f9147b61361dc8dc8b0989450e49e90b/typos-1.43.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9c9b2e14423c40eb55e5cba8ba96af0827fa1c88ac52f685f17f01971162f6e", size = 7676638, upload-time = "2026-02-09T14:26:44.648Z" },
-    { url = "https://files.pythonhosted.org/packages/86/3f/f7d9135eb04c5106fd213213fcc057d234f89ee6bd8b654451825c8ed83c/typos-1.43.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:36acc5afe8c876c5799b7eab7f66886787861848630ee17a3dcc6455cb6bb143", size = 8105255, upload-time = "2026-02-09T14:26:46.545Z" },
-    { url = "https://files.pythonhosted.org/packages/60/fb/f06d85fb64a1f4d9a636803ea18c68f7ea3478dd5fcb04fbaef105a0bf65/typos-1.43.4-py3-none-win32.whl", hash = "sha256:338d163d8e1dfd4d1a5233561d0d4747bb6f5e377c042be78ac5c1ea8ae553a9", size = 3094938, upload-time = "2026-02-09T14:26:48.58Z" },
-    { url = "https://files.pythonhosted.org/packages/61/78/ecf3f89c98b766ae1185af444bb323b92f2378e2abc5ae0af62021f9a94b/typos-1.43.4-py3-none-win_amd64.whl", hash = "sha256:73fc9858fa40bd89aabf3877f263fb3cce1c9388ed922dd50a1f2643341636f9", size = 3285300, upload-time = "2026-02-09T14:26:50.531Z" },
-]
-
-[[package]]
 name = "tzdata"
 version = "2025.3"
 source = { registry = "https://pypi.org/simple" }
@@ -6731,31 +6606,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "uv"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/9a/fe74aa0127cdc26141364e07abf25e5d69b4bf9788758fad9cfecca637aa/uv-0.10.2.tar.gz", hash = "sha256:b5016f038e191cc9ef00e17be802f44363d1b1cc3ef3454d1d76839a4246c10a", size = 3858864, upload-time = "2026-02-10T19:17:51.609Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/b5/aea88f66284d220be56ef748ed5e1bd11d819be14656a38631f4b55bfd48/uv-0.10.2-py3-none-linux_armv6l.whl", hash = "sha256:69e35aa3e91a245b015365e5e6ca383ecf72a07280c6d00c17c9173f2d3b68ab", size = 22215714, upload-time = "2026-02-10T19:17:34.281Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/72/947ba7737ae6cd50de61d268781b9e7717caa3b07e18238ffd547f9fc728/uv-0.10.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0b7eef95c36fe92e7aac399c0dce555474432cbfeaaa23975ed83a63923f78fd", size = 21276485, upload-time = "2026-02-10T19:18:15.415Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/38/5c3462b927a93be4ccaaa25138926a5fb6c9e1b72884efd7af77e451d82e/uv-0.10.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:acc08e420abab21de987151059991e3f04bc7f4044d94ca58b5dd547995b4843", size = 20048620, upload-time = "2026-02-10T19:17:26.481Z" },
-    { url = "https://files.pythonhosted.org/packages/03/51/d4509b0f5b7740c1af82202e9c69b700d5848b8bd0faa25229e8edd2c19c/uv-0.10.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:aefbcd749ab2ad48bb533ec028607607f7b03be11c83ea152dbb847226cd6285", size = 21870454, upload-time = "2026-02-10T19:17:21.838Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/7e/2bcbafcb424bb885817a7e58e6eec9314c190c55935daaafab1858bb82cd/uv-0.10.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:fad554c38d9988409ceddfac69a465e6e5f925a8b689e7606a395c20bb4d1d78", size = 21839508, upload-time = "2026-02-10T19:17:59.211Z" },
-    { url = "https://files.pythonhosted.org/packages/60/08/16df2c1f8ad121a595316b82f6e381447e8974265b2239c9135eb874f33b/uv-0.10.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6dd2dc41043e92b3316d7124a7bf48c2affe7117c93079419146f083df71933c", size = 21841283, upload-time = "2026-02-10T19:17:41.419Z" },
-    { url = "https://files.pythonhosted.org/packages/76/27/a869fec4c03af5e43db700fabe208d8ee8dbd56e0ff568ba792788d505cd/uv-0.10.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:111c05182c5630ac523764e0ec2e58d7b54eb149dbe517b578993a13c2f71aff", size = 23111967, upload-time = "2026-02-10T19:18:11.764Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/4a/fb38515d966acfbd80179e626985aab627898ffd02c70205850d6eb44df1/uv-0.10.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45c3deaba0343fd27ab5385d6b7cde0765df1a15389ee7978b14a51c32895662", size = 23911019, upload-time = "2026-02-10T19:18:26.947Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/5f/51bcbb490ddb1dcb06d767f0bde649ad2826686b9e30efa57f8ab2750a1d/uv-0.10.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bb2cac4f3be60b64a23d9f035019c30a004d378b563c94f60525c9591665a56b", size = 23030217, upload-time = "2026-02-10T19:17:37.789Z" },
-    { url = "https://files.pythonhosted.org/packages/46/69/144f6db851d49aa6f25b040dc5c8c684b8f92df9e8d452c7abc619c6ec23/uv-0.10.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:937687df0380d636ceafcb728cf6357f0432588e721892128985417b283c3b54", size = 23036452, upload-time = "2026-02-10T19:18:18.97Z" },
-    { url = "https://files.pythonhosted.org/packages/66/29/3c7c4559c9310ed478e3d6c585ee0aad2852dc4d5fb14f4d92a2a12d1728/uv-0.10.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:f90bca8703ae66bccfcfb7313b4b697a496c4d3df662f4a1a2696a6320c47598", size = 21941903, upload-time = "2026-02-10T19:17:30.575Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/5a/42883b5ef2ef0b1bc5b70a1da12a6854a929ff824aa8eb1a5571fb27a39b/uv-0.10.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:cca026c2e584788e1264879a123bf499dd8f169b9cafac4a2065a416e09d3823", size = 22651571, upload-time = "2026-02-10T19:18:22.74Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/b8/e4f1dda1b3b0cc6c8ac06952bfe7bc28893ff016fb87651c8fafc6dfca96/uv-0.10.2-py3-none-musllinux_1_1_i686.whl", hash = "sha256:9f878837938103ee1307ed3ed5d9228118e3932816ab0deb451e7e16dc8ce82a", size = 22321279, upload-time = "2026-02-10T19:17:49.402Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/4b/baa16d46469e024846fc1a8aa0cfa63f1f89ad0fd3eaa985359a168c3fb0/uv-0.10.2-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:6ec75cfe638b316b329474aa798c3988e5946ead4d9e977fe4dc6fc2ea3e0b8b", size = 23252208, upload-time = "2026-02-10T19:17:54.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/84/6a74e5ec2ee90e4314905e6d1d1708d473e06405e492ec38868b42645388/uv-0.10.2-py3-none-win32.whl", hash = "sha256:f7f3c7e09bf53b81f55730a67dd86299158f470dffb2bd279b6432feb198d231", size = 21118543, upload-time = "2026-02-10T19:18:07.296Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/f9/e5cc6cf3a578b87004e857274df97d3cdecd8e19e965869b9b67c094c20c/uv-0.10.2-py3-none-win_amd64.whl", hash = "sha256:7b3685aa1da15acbe080b4cba8684afbb6baf11c9b04d4d4b347cc18b7b9cfa0", size = 23620790, upload-time = "2026-02-10T19:17:45.204Z" },
-    { url = "https://files.pythonhosted.org/packages/df/7a/99979dc08ae6a65f4f7a44c5066699016c6eecdc4e695b7512c2efb53378/uv-0.10.2-py3-none-win_arm64.whl", hash = "sha256:abdd5b3c6b871b17bf852a90346eb7af881345706554fd082346b000a9393afd", size = 22035199, upload-time = "2026-02-10T19:18:03.679Z" },
 ]
 
 [[package]]
@@ -6867,20 +6717,6 @@ version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390, upload-time = "2024-11-01T14:06:24.793Z" },
-    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389, upload-time = "2024-11-01T14:06:27.112Z" },
-    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020, upload-time = "2024-11-01T14:06:29.876Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
-    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
-    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
-    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
-    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
-    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902, upload-time = "2024-11-01T14:06:53.119Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380, upload-time = "2024-11-01T14:06:55.19Z" },
     { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
     { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
     { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },


### PR DESCRIPTION
Closes #5627

The Python plugin advertised the generic `ModelConfig` as `customOptions`, so none of the Anthropic-specific options showed up in reflection, or the Dev UI, and nothing validated them before they hit the API. This adds a typed `AnthropicConfig` modelled on the JS schemas (`AnthropicConfigSchema` and `ThinkingConfigSchema` in `js/plugins/anthropic/src/types.ts`) and advertises it for every Anthropic model, including the Vertex Model Garden ones.

What the config covers:

- `thinking`, with the same rules as JS: `enabled` and `adaptive` are mutually exclusive, and `budgetTokens` is required (an integer >= 1024) when thinking is enabled
- `output_config` with `effort` and `task_budget`
- `tool_choice`: `auto`, `any`, `tool`, plus `none`, which JS doesn't have yet but the API supports
- `metadata`, `apiVersion`, `betas`, and the per-request `apiKey` / `version` overrides inherited from the common config

Request building now actually consumes these instead of dropping them. Thinking configs are translated to the SDK shape, `version` overrides the model id, `apiVersion: 'beta'` routes the request through `client.beta.messages`, `apiKey` swaps in a request-scoped client via `client.copy()`, and a user-supplied `output_config` merges with the structured-output format instead of being clobbered by it. Unknown keys still pass through (`extra='allow'`) and are routed via the SDK's `extra_body` escape hatch, so new API options keep working without a plugin release.

```python
from genkit_anthropic import AnthropicConfig, ThinkingConfig

response = await ai.generate(
    model='anthropic/claude-sonnet-4-6',
    prompt='Why is the sky blue?',
    config=AnthropicConfig(
        max_output_tokens=2048,
        thinking=ThinkingConfig(enabled=True, budget_tokens=1024),
    ),
)
```

Plain-dict configs keep working, they just get validated now. That is a small behavior change worth calling out: a dict like `{'thinking': {'enabled': True}}` with no budget used to be forwarded and fail at the API, and now raises a `ValidationError` before the request is sent.

One deliberate divergence from JS: setting `betas` without `apiVersion` selects the beta surface here. JS silently drops the betas on the stable API in that case, which looks like a bug rather than behavior worth copying, so the Python plugin honors them instead.

## Screenshots
<img width="1314" height="839" alt="Screenshot 2026-07-10 at 15 32 52" src="https://github.com/user-attachments/assets/60c4d13f-578c-4097-b525-81bc54c8ff66" />


## Tests
Tested with unit tests for the validation rules, alias handling, SDK param translation, beta routing, and the advertised JSON schema (104 tests in the plugin plus the Model Garden suite), and verified manually in the Dev UI as shown above.

---
**Thinking validation note:** Python intentionally validates bare `budgetTokens` / `budget_tokens` according to the payload it will send to Anthropic. When a budget is provided without `enabled`, the plugin normalizes it to `{ type: "enabled", budget_tokens: ... }` before calling the SDK, so Python also applies the integer budget rule and rejects fractional values such as `2048.5`. Same for a bare `budgetTokens` with no `enabled` set: it now turns thinking on to match JS, but if the budget is bigger than `max_tokens` (default 4096) the API 400s, nothing guards that yet. Applies through Vertex Model Garden too.

JS currently applies its integer check only when `enabled` is explicit. That may be preserving a looser historical shorthand, or limiting cross-field validation to explicit thinking modes, so this PR does not assume the JS behavior is wrong. The Python behavior is stricter for this edge case because it matches the normalized SDK request shape.

