### PR TITLE
feat(py/plugins/anthropic): surface extended thinking (extract, stream, signature round-trip)

### DIFF
--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -33,6 +33,7 @@ from anthropic.types import Message as AnthropicMessage
 
 from genkit import (
     Constrained,
+    CustomPart,
     FinishReason,
     MediaPart,
     Message,
@@ -41,6 +42,7 @@ from genkit import (
     ModelResponseChunk,
     ModelUsage,
     Part,
+    ReasoningPart,
     Role,
     TextPart,
     ToolRequest,
@@ -54,6 +56,8 @@ from genkit_anthropic.model_info import get_model_info
 from genkit_anthropic.utils import (
     build_cache_usage,
     get_cache_control,
+    get_redacted_thinking_data,
+    get_thinking_signature,
     maybe_strip_fences,
     to_anthropic_media,
 )
@@ -436,8 +440,9 @@ class AnthropicModel:
     ) -> AnthropicMessage:
         """Handle streaming generation.
 
-        Processes Anthropic streaming events including text deltas and
-        tool-use blocks.  Tool-use blocks arrive as:
+        Processes Anthropic streaming events including text deltas,
+        thinking deltas, redacted thinking blocks, and tool-use blocks.
+        Tool-use blocks arrive as:
 
         1. ``content_block_start`` with ``content_block.type == 'tool_use'``
         2. Zero or more ``content_block_delta`` with ``delta.type == 'input_json_delta'``
@@ -465,6 +470,15 @@ class AnthropicModel:
                                 'name': getattr(block, 'name', ''),
                                 'input_json': '',
                             }
+                    elif getattr(block, 'type', None) == 'redacted_thinking' and hasattr(block, 'data'):
+                        # Redacted thinking arrives complete in the start event; no deltas follow.
+                        ctx.send_chunk(
+                            ModelResponseChunk(
+                                role=Role.MODEL,
+                                index=0,
+                                content=[Part(root=CustomPart(custom={'redactedThinking': block.data}))],  # pyright: ignore[reportAttributeAccessIssue]
+                            )
+                        )
 
                 elif chunk.type == 'content_block_delta' and hasattr(chunk, 'delta'):
                     delta = chunk.delta
@@ -476,6 +490,16 @@ class AnthropicModel:
                                 content=[Part(root=TextPart(text=str(delta.text)))],  # pyright: ignore[reportAttributeAccessIssue]
                             )
                         )
+                    elif getattr(delta, 'type', None) == 'thinking_delta' and hasattr(delta, 'thinking'):
+                        ctx.send_chunk(
+                            ModelResponseChunk(
+                                role=Role.MODEL,
+                                index=0,
+                                content=[Part(root=ReasoningPart(reasoning=str(delta.thinking)))],  # pyright: ignore[reportAttributeAccessIssue]
+                            )
+                        )
+                    # signature_delta is intentionally not streamed. The signature
+                    # is recovered from the final message via _to_genkit_content.
                     elif getattr(delta, 'type', None) == 'input_json_delta' and hasattr(delta, 'partial_json'):
                         idx = getattr(chunk, 'index', None)
                         if idx is not None and idx in pending_tools:
@@ -540,9 +564,10 @@ class AnthropicModel:
                 actual_part = part.root if isinstance(part, Part) else part
                 block = self._to_anthropic_block(actual_part)
                 if block is not None:
-                    # Apply cache_control from part metadata if present.
+                    # Apply cache_control from part metadata if present; the API
+                    # rejects it on thinking blocks.
                     cache_meta = get_cache_control(actual_part)
-                    if cache_meta:
+                    if cache_meta and block['type'] not in ('thinking', 'redacted_thinking'):
                         block['cache_control'] = cache_meta
                     content.append(block)
             result.append({'role': role, 'content': content})
@@ -551,8 +576,8 @@ class AnthropicModel:
     def _to_anthropic_block(self, part: Any) -> dict[str, Any] | None:  # noqa: ANN401
         """Convert a single Genkit content part to an Anthropic content block.
 
-        Handles TextPart, MediaPart (images + PDFs), ToolRequestPart,
-        and ToolResponsePart.
+        Handles reasoning parts, redacted thinking custom parts, TextPart,
+        MediaPart (images + PDFs), ToolRequestPart, and ToolResponsePart.
 
         Args:
             part: The actual (unwrapped) content part.
@@ -560,6 +585,22 @@ class AnthropicModel:
         Returns:
             An Anthropic content block dict, or None if unrecognized.
         """
+        # Attribute check (not isinstance): JSON-parsed reasoning parts deserialize as DataPart.
+        reasoning = getattr(part, 'reasoning', None)
+        if reasoning:
+            signature = get_thinking_signature(part)
+            if not signature:
+                raise ValueError(
+                    'Anthropic thinking parts require a signature when sending back '
+                    'to the API. Preserve the `metadata.thoughtSignature` value from '
+                    'the original response.'
+                )
+            return {'type': 'thinking', 'thinking': reasoning, 'signature': signature}
+
+        redacted_thinking = get_redacted_thinking_data(part)
+        if redacted_thinking is not None:
+            return {'type': 'redacted_thinking', 'data': redacted_thinking}
+
         if isinstance(part, TextPart):
             return {'type': 'text', 'text': part.text}
         if isinstance(part, MediaPart):
@@ -597,4 +638,16 @@ class AnthropicModel:
                         )
                     )
                 )
+            elif block.type == 'thinking':
+                signature = getattr(block, 'signature', None)
+                parts.append(
+                    Part(
+                        root=ReasoningPart(
+                            reasoning=block.thinking,
+                            metadata={'thoughtSignature': signature} if signature else None,
+                        )
+                    )
+                )
+            elif block.type == 'redacted_thinking':
+                parts.append(Part(root=CustomPart(custom={'redactedThinking': block.data})))
         return parts

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/utils.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/utils.py
@@ -48,6 +48,8 @@ __all__ = [
     'TEXT_MIME_TYPE',
     'build_cache_usage',
     'get_cache_control',
+    'get_redacted_thinking_data',
+    'get_thinking_signature',
     'maybe_strip_fences',
     'strip_markdown_fences',
     'to_anthropic_document',
@@ -130,6 +132,36 @@ def get_cache_control(part: Any) -> dict[str, str] | None:  # noqa: ANN401
     if cache_ctrl and isinstance(cache_ctrl, dict):
         return cache_ctrl
     return None
+
+
+def get_redacted_thinking_data(part: Any) -> str | None:  # noqa: ANN401
+    """Extract redacted thinking data from a part's custom field."""
+    custom = getattr(part, 'custom', None)
+    if not isinstance(custom, dict):
+        return None
+    redacted = custom.get('redactedThinking')
+    return redacted if isinstance(redacted, str) else None
+
+
+def get_thinking_signature(part: Any) -> str | None:  # noqa: ANN401
+    """Extract the Anthropic thinking signature from a part's metadata.
+
+    Reads ``metadata.thoughtSignature`` (JS naming), falling back to
+    ``metadata.signature`` (Go naming) as an input alias.
+    """
+    metadata = getattr(part, 'metadata', None)
+    if not isinstance(metadata, dict):
+        return None
+
+    signature = metadata.get('thoughtSignature')
+    if signature is None:
+        signature = metadata.get('signature')
+    if isinstance(signature, bytes):
+        try:
+            signature = signature.decode('utf-8')
+        except UnicodeDecodeError:
+            return None
+    return signature if isinstance(signature, str) else None
 
 
 def to_anthropic_document(url: str, content_type: str) -> dict[str, Any]:

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -29,6 +29,7 @@ from pydantic import ValidationError
 
 from genkit import (
     Constrained,
+    CustomPart,
     FinishReason,
     Media,
     MediaPart,
@@ -39,6 +40,7 @@ from genkit import (
     ModelRequest,
     ModelResponseChunk,
     Part,
+    ReasoningPart,
     Role,
     Supports,
     TextPart,
@@ -1208,3 +1210,410 @@ def test_thinking_dropped_when_no_mode_is_set(raw: dict) -> None:
     ]
 
     assert _to_anthropic_thinking_config(thinking) is None
+
+
+@pytest.mark.asyncio
+async def test_generate_with_thinking_block() -> None:
+    """Test that thinking blocks become ReasoningPart values with signatures."""
+    sample_request = _create_sample_request()
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = [
+        MagicMock(type='thinking', thinking='Let me reason.', signature='sig-abc'),
+        MagicMock(type='text', text='Answer'),
+    ]
+    mock_response.usage = MagicMock(input_tokens=10, output_tokens=15)
+    mock_response.stop_reason = 'end_turn'
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+    response = await model.generate(sample_request)
+
+    assert response.message is not None
+    assert len(response.message.content) == 2
+    reasoning_part = response.message.content[0].root
+    assert isinstance(reasoning_part, ReasoningPart)
+    assert reasoning_part.reasoning == 'Let me reason.'
+    assert reasoning_part.metadata == {'thoughtSignature': 'sig-abc'}
+
+    text_part = response.message.content[1].root
+    assert isinstance(text_part, TextPart)
+    assert text_part.text == 'Answer'
+
+
+@pytest.mark.asyncio
+async def test_generate_thinking_block_without_signature_omits_metadata() -> None:
+    """Test that thinking blocks without signatures omit metadata."""
+    sample_request = _create_sample_request()
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(type='thinking', thinking='No signature.', signature=None)]
+    mock_response.usage = MagicMock(input_tokens=10, output_tokens=15)
+    mock_response.stop_reason = 'end_turn'
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+    response = await model.generate(sample_request)
+
+    assert response.message is not None
+    reasoning_part = response.message.content[0].root
+    assert isinstance(reasoning_part, ReasoningPart)
+    assert reasoning_part.reasoning == 'No signature.'
+    assert reasoning_part.metadata is None
+
+
+@pytest.mark.asyncio
+async def test_generate_with_redacted_thinking_block() -> None:
+    """Test that redacted thinking blocks become CustomPart values."""
+    sample_request = _create_sample_request()
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(type='redacted_thinking', data='opaque-blob')]
+    mock_response.usage = MagicMock(input_tokens=10, output_tokens=15)
+    mock_response.stop_reason = 'end_turn'
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+    response = await model.generate(sample_request)
+
+    assert response.message is not None
+    custom_part = response.message.content[0].root
+    assert isinstance(custom_part, CustomPart)
+    assert custom_part.custom == {'redactedThinking': 'opaque-blob'}
+
+
+@pytest.mark.asyncio
+async def test_streaming_thinking_deltas() -> None:
+    """Test that thinking deltas stream as reasoning chunks."""
+    sample_request = _create_sample_request()
+    mock_client = MagicMock()
+
+    chunks = [
+        MagicMock(type='content_block_start', index=0, content_block=MagicMock(type='thinking')),
+        MagicMock(type='content_block_delta', index=0, delta=MagicMock(type='thinking_delta', thinking='Think')),
+        MagicMock(type='content_block_delta', index=0, delta=MagicMock(type='thinking_delta', thinking='ing')),
+        MagicMock(type='content_block_delta', index=0, delta=MagicMock(type='signature_delta', signature='sig-abc')),
+        MagicMock(type='content_block_stop', index=0),
+        MagicMock(type='content_block_delta', delta=MagicMock(type='text_delta', text='Answer')),
+    ]
+    final_content = [
+        MagicMock(type='thinking', thinking='Thinking', signature='sig-abc'),
+        MagicMock(type='text', text='Answer'),
+    ]
+    mock_client.messages.stream.return_value = MockStreamManager(chunks, final_content=final_content)
+
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    ctx = MagicMock()
+    ctx.is_streaming = True
+    collected_chunks: list[ModelResponseChunk] = []
+    ctx.send_chunk = lambda chunk: collected_chunks.append(chunk)
+
+    response = await model.generate(sample_request, ctx)
+
+    assert len(collected_chunks) == 3
+
+    first_part = collected_chunks[0].content[0].root
+    assert isinstance(first_part, ReasoningPart)
+    assert first_part.reasoning == 'Think'
+
+    second_part = collected_chunks[1].content[0].root
+    assert isinstance(second_part, ReasoningPart)
+    assert second_part.reasoning == 'ing'
+
+    third_part = collected_chunks[2].content[0].root
+    assert isinstance(third_part, TextPart)
+    assert third_part.text == 'Answer'
+
+    assert response.message is not None
+    final_reasoning_part = response.message.content[0].root
+    assert isinstance(final_reasoning_part, ReasoningPart)
+    assert final_reasoning_part.reasoning == 'Thinking'
+    assert final_reasoning_part.metadata == {'thoughtSignature': 'sig-abc'}
+
+
+@pytest.mark.asyncio
+async def test_streaming_redacted_thinking_block() -> None:
+    """Test that redacted thinking blocks stream as custom chunks and reach the final response."""
+    sample_request = _create_sample_request()
+    mock_client = MagicMock()
+
+    chunks = [
+        MagicMock(
+            type='content_block_start',
+            index=0,
+            content_block=MagicMock(type='redacted_thinking', data='opaque-blob'),
+        ),
+        MagicMock(type='content_block_stop', index=0),
+        MagicMock(type='content_block_delta', delta=MagicMock(type='text_delta', text='Answer')),
+    ]
+    final_content = [
+        MagicMock(type='redacted_thinking', data='opaque-blob'),
+        MagicMock(type='text', text='Answer'),
+    ]
+    mock_client.messages.stream.return_value = MockStreamManager(chunks, final_content=final_content)
+
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    ctx = MagicMock()
+    ctx.is_streaming = True
+    collected_chunks: list[ModelResponseChunk] = []
+    ctx.send_chunk = lambda chunk: collected_chunks.append(chunk)
+
+    response = await model.generate(sample_request, ctx)
+
+    assert len(collected_chunks) == 2
+
+    first_part = collected_chunks[0].content[0].root
+    assert isinstance(first_part, CustomPart)
+    assert first_part.custom == {'redactedThinking': 'opaque-blob'}
+
+    second_part = collected_chunks[1].content[0].root
+    assert isinstance(second_part, TextPart)
+    assert second_part.text == 'Answer'
+
+    assert response.message is not None
+    final_first_part = response.message.content[0].root
+    assert isinstance(final_first_part, CustomPart)
+    assert final_first_part.custom == {'redactedThinking': 'opaque-blob'}
+
+
+@pytest.mark.asyncio
+async def test_streaming_thinking_then_tool_use_interleave() -> None:
+    """Test a turn that streams a thinking block followed by a tool_use block."""
+    sample_request = _create_sample_request()
+    mock_client = MagicMock()
+
+    tool_block = MagicMock(type='tool_use', id='tool_abc')
+    tool_block.name = 'get_weather'
+    chunks = [
+        MagicMock(type='content_block_start', index=0, content_block=MagicMock(type='thinking')),
+        MagicMock(type='content_block_delta', index=0, delta=MagicMock(type='thinking_delta', thinking='Need')),
+        MagicMock(type='content_block_delta', index=0, delta=MagicMock(type='thinking_delta', thinking=' a tool')),
+        MagicMock(type='content_block_delta', index=0, delta=MagicMock(type='signature_delta', signature='sig-abc')),
+        MagicMock(type='content_block_stop', index=0),
+        MagicMock(type='content_block_start', index=1, content_block=tool_block),
+        MagicMock(
+            type='content_block_delta',
+            index=1,
+            delta=MagicMock(type='input_json_delta', partial_json='{"location"'),
+        ),
+        MagicMock(
+            type='content_block_delta',
+            index=1,
+            delta=MagicMock(type='input_json_delta', partial_json=': "Paris"}'),
+        ),
+        MagicMock(type='content_block_stop', index=1),
+    ]
+
+    final_tool = MagicMock(type='tool_use', id='tool_abc', input={'location': 'Paris'})
+    final_tool.name = 'get_weather'
+    final_content = [
+        MagicMock(type='thinking', thinking='Need a tool', signature='sig-abc'),
+        final_tool,
+    ]
+    mock_client.messages.stream.return_value = MockStreamManager(chunks, final_content=final_content)
+
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    ctx = MagicMock()
+    ctx.is_streaming = True
+    collected_chunks: list[ModelResponseChunk] = []
+    ctx.send_chunk = lambda chunk: collected_chunks.append(chunk)
+
+    response = await model.generate(sample_request, ctx)
+
+    # Two reasoning chunks, then one tool request chunk.
+    assert len(collected_chunks) == 3
+
+    first_part = collected_chunks[0].content[0].root
+    assert isinstance(first_part, ReasoningPart)
+    assert first_part.reasoning == 'Need'
+
+    second_part = collected_chunks[1].content[0].root
+    assert isinstance(second_part, ReasoningPart)
+    assert second_part.reasoning == ' a tool'
+
+    tool_part = collected_chunks[2].content[0].root
+    assert isinstance(tool_part, ToolRequestPart)
+    assert tool_part.tool_request.name == 'get_weather'
+    assert tool_part.tool_request.ref == 'tool_abc'
+    assert tool_part.tool_request.input == {'location': 'Paris'}
+
+    # The final message keeps both blocks, with the signature on the reasoning part.
+    assert response.message is not None
+    assert len(response.message.content) == 2
+    final_reasoning_part = response.message.content[0].root
+    assert isinstance(final_reasoning_part, ReasoningPart)
+    assert final_reasoning_part.reasoning == 'Need a tool'
+    assert final_reasoning_part.metadata == {'thoughtSignature': 'sig-abc'}
+    final_tool_part = response.message.content[1].root
+    assert isinstance(final_tool_part, ToolRequestPart)
+    assert final_tool_part.tool_request.name == 'get_weather'
+
+
+def test_reasoning_part_encodes_as_thinking_block() -> None:
+    """Test that signed ReasoningPart values encode as Anthropic thinking blocks."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    messages = [
+        Message(
+            role=Role.MODEL,
+            content=[Part(root=ReasoningPart(reasoning='step', metadata={'thoughtSignature': 'sig-abc'}))],
+        ),
+    ]
+
+    anthropic_messages = model._to_anthropic_messages(messages)
+
+    assert anthropic_messages[0]['content'][0] == {
+        'type': 'thinking',
+        'thinking': 'step',
+        'signature': 'sig-abc',
+    }
+
+
+@pytest.mark.parametrize('signature', ['sig-go', b'sig-go'])
+def test_reasoning_part_accepts_go_style_signature_alias(signature: str | bytes) -> None:
+    """Test that metadata.signature is accepted as an outbound alias."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    messages = [
+        Message(
+            role=Role.MODEL,
+            content=[Part(root=ReasoningPart(reasoning='step', metadata={'signature': signature}))],
+        ),
+    ]
+
+    anthropic_messages = model._to_anthropic_messages(messages)
+    block = anthropic_messages[0]['content'][0]
+    assert block['type'] == 'thinking'
+    assert block['signature'] == 'sig-go'
+
+
+def test_reasoning_part_without_signature_raises() -> None:
+    """Test that non-empty reasoning cannot be sent back without a signature."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    messages = [
+        Message(
+            role=Role.MODEL,
+            content=[Part(root=ReasoningPart(reasoning='step'))],
+        ),
+    ]
+
+    with pytest.raises(ValueError, match='require a signature'):
+        model._to_anthropic_messages(messages)
+
+
+def test_empty_reasoning_part_is_skipped() -> None:
+    """Test that empty reasoning parts produce no Anthropic block."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    messages = [
+        Message(
+            role=Role.MODEL,
+            content=[Part(root=ReasoningPart(reasoning='', metadata={'thoughtSignature': 'sig-abc'}))],
+        ),
+    ]
+
+    anthropic_messages = model._to_anthropic_messages(messages)
+    assert anthropic_messages[0]['content'] == []
+
+
+def test_redacted_thinking_part_round_trips() -> None:
+    """Test that redacted thinking custom data encodes as a redacted block."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    messages = [
+        Message(
+            role=Role.MODEL,
+            content=[Part(root=CustomPart(custom={'redactedThinking': 'opaque-blob'}))],
+        ),
+    ]
+
+    anthropic_messages = model._to_anthropic_messages(messages)
+    assert anthropic_messages[0]['content'][0] == {
+        'type': 'redacted_thinking',
+        'data': 'opaque-blob',
+    }
+
+
+def test_thinking_blocks_do_not_get_cache_control() -> None:
+    """Test that cache_control metadata is not applied to thinking blocks."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    cache_meta = {'cache_control': {'type': 'ephemeral'}}
+    messages = [
+        Message(
+            role=Role.MODEL,
+            content=[
+                Part(
+                    root=ReasoningPart(
+                        reasoning='step',
+                        metadata={'thoughtSignature': 'sig-abc', **cache_meta},
+                    )
+                ),
+                Part(root=CustomPart(custom={'redactedThinking': 'opaque-blob'}, metadata=cache_meta)),
+                Part(root=TextPart(text='Answer', metadata=cache_meta)),
+            ],
+        ),
+    ]
+
+    anthropic_messages = model._to_anthropic_messages(messages)
+    thinking_block, redacted_block, text_block = anthropic_messages[0]['content']
+
+    assert thinking_block['type'] == 'thinking'
+    assert 'cache_control' not in thinking_block
+    assert redacted_block['type'] == 'redacted_thinking'
+    assert 'cache_control' not in redacted_block
+    assert text_block['cache_control'] == {'type': 'ephemeral'}
+
+
+def test_deserialized_reasoning_part_round_trips() -> None:
+    """Test that reasoning history parsed from JSON encodes as a thinking block."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    messages = [
+        Message.model_validate({
+            'role': 'model',
+            'content': [{'reasoning': 'step', 'metadata': {'thoughtSignature': 'sig-abc'}}],
+        }),
+    ]
+
+    anthropic_messages = model._to_anthropic_messages(messages)
+
+    assert anthropic_messages[0]['content'][0] == {
+        'type': 'thinking',
+        'thinking': 'step',
+        'signature': 'sig-abc',
+    }
+
+
+def test_deserialized_redacted_thinking_part_round_trips() -> None:
+    """Test that redacted thinking history parsed from JSON encodes as a redacted block."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    messages = [
+        Message.model_validate({
+            'role': 'model',
+            'content': [{'custom': {'redactedThinking': 'opaque-blob'}}],
+        }),
+    ]
+
+    anthropic_messages = model._to_anthropic_messages(messages)
+
+    assert anthropic_messages[0]['content'][0] == {
+        'type': 'redacted_thinking',
+        'data': 'opaque-blob',
+    }

--- a/py/packages/genkit-anthropic/tests/anthropic_utils_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_utils_test.py
@@ -29,6 +29,8 @@ from genkit_anthropic.utils import (
     TEXT_MIME_TYPE,
     build_cache_usage,
     get_cache_control,
+    get_redacted_thinking_data,
+    get_thinking_signature,
     to_anthropic_document,
     to_anthropic_image,
     to_anthropic_media,
@@ -93,6 +95,80 @@ class TestGetCacheControl:
 
         result = get_cache_control(FakePart())
         assert result == {'type': 'ephemeral'}
+
+
+# ---------------------------------------------------------------------------
+# get_thinking_signature tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetThinkingSignature:
+    """Tests for get_thinking_signature utility."""
+
+    def test_returns_none_for_no_metadata(self) -> None:
+        """Returns None when part has no metadata."""
+        part = TextPart(text='hello')
+        assert get_thinking_signature(part) is None
+
+    def test_returns_none_when_metadata_key_absent(self) -> None:
+        """Returns None when metadata has no signature keys."""
+        part = TextPart(text='hello', metadata=Metadata({'other_key': 'value'}))
+        assert get_thinking_signature(part) is None
+
+    def test_reads_thought_signature(self) -> None:
+        """Reads JS-style thoughtSignature metadata."""
+        part = TextPart(text='hello', metadata=Metadata({'thoughtSignature': 'sig-js'}))
+        assert get_thinking_signature(part) == 'sig-js'
+
+    def test_falls_back_to_signature(self) -> None:
+        """Reads Go-style signature metadata when thoughtSignature is absent."""
+        part = TextPart(text='hello', metadata=Metadata({'signature': 'sig-go'}))
+        assert get_thinking_signature(part) == 'sig-go'
+
+    def test_prefers_thought_signature(self) -> None:
+        """Prefers JS-style metadata when both aliases are present."""
+        part = TextPart(text='hello', metadata=Metadata({'thoughtSignature': 'sig-js', 'signature': 'sig-go'}))
+        assert get_thinking_signature(part) == 'sig-js'
+
+    def test_decodes_bytes_signature(self) -> None:
+        """Decodes Go-style raw byte signatures."""
+        part = TextPart(text='hello', metadata=Metadata({'signature': b'sig-go'}))
+        assert get_thinking_signature(part) == 'sig-go'
+
+    def test_returns_none_for_non_string_signature(self) -> None:
+        """Returns None when signature metadata is not string-like."""
+        part = TextPart(text='hello', metadata=Metadata({'signature': 123}))
+        assert get_thinking_signature(part) is None
+
+
+# ---------------------------------------------------------------------------
+# get_redacted_thinking_data tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetRedactedThinkingData:
+    """Tests for get_redacted_thinking_data utility."""
+
+    def test_returns_none_for_no_custom(self) -> None:
+        """Returns None when part has no custom field."""
+        part = TextPart(text='hello')
+        assert get_redacted_thinking_data(part) is None
+
+    def test_extracts_redacted_thinking(self) -> None:
+        """Extracts redacted thinking custom data."""
+
+        class FakePart:
+            custom = {'redactedThinking': 'opaque-blob'}
+
+        assert get_redacted_thinking_data(FakePart()) == 'opaque-blob'
+
+    def test_returns_none_for_non_string_redacted_thinking(self) -> None:
+        """Returns None when redacted thinking data is not a string."""
+
+        class FakePart:
+            custom = {'redactedThinking': 123}
+
+        assert get_redacted_thinking_data(FakePart()) is None
 
 
 # ---------------------------------------------------------------------------

--- a/py/samples/anthropic-sample/src/main.py
+++ b/py/samples/anthropic-sample/src/main.py
@@ -19,7 +19,7 @@
 from genkit_anthropic import Anthropic
 from pydantic import BaseModel, Field
 
-from genkit import Genkit
+from genkit import ActionRunContext, Genkit, ModelResponse, ReasoningPart
 
 ai = Genkit(plugins=[Anthropic()], model='anthropic/claude-opus-4-8')
 
@@ -43,6 +43,50 @@ class Cat(BaseModel):
     breed: str
     age: int
     personality: str
+
+
+class WeatherInput(BaseModel):
+    """Input for the weather tool and thinking round-trip flow."""
+
+    city: str = Field(default='Reykjavik', description='City to look up')
+
+
+@ai.tool()
+async def current_weather(input: WeatherInput) -> str:
+    """Return mocked weather data for tool-calling demos."""
+    return f'The weather in {input.city} is 3C, windy, and clear.'
+
+
+def _thinking_summary(response: ModelResponse) -> dict[str, object]:
+    """Summarize reasoning parts across the full generate transcript."""
+    reasoning_parts: list[str] = []
+    signature_present: list[bool] = []
+    content_types: list[str] = []
+
+    for message in response.messages:
+        for part in message.content:
+            root = part.root
+            if root.text is not None:
+                content_types.append('text')
+            elif root.tool_request is not None:
+                content_types.append('tool_request')
+            elif root.tool_response is not None:
+                content_types.append('tool_response')
+            elif isinstance(root, ReasoningPart):
+                content_types.append('reasoning')
+                reasoning_parts.append(root.reasoning)
+                signature_present.append(bool(root.metadata and root.metadata.get('thoughtSignature')))
+            elif root.custom is not None:
+                content_types.append('custom')
+            else:
+                content_types.append(type(root).__name__)
+
+    return {
+        'content_types': content_types,
+        'reasoning_parts': len(reasoning_parts),
+        'reasoning_preview': ''.join(reasoning_parts)[:1000],
+        'thinking_signatures_present': signature_present,
+    }
 
 
 # --- claude-opus-4-7 -------------------------------------------------------
@@ -95,8 +139,49 @@ async def cat_opus_4_8(data: CatInput) -> Cat:
     return response.output
 
 
+@ai.flow(name='thinking_tool_round_trip')
+async def thinking_tool_round_trip(data: WeatherInput, ctx: ActionRunContext) -> dict[str, object]:
+    """Dev UI check for Anthropic thinking streaming and signature round-trip."""
+    # Opus 4.7+ accept only adaptive thinking; older models use type=enabled with a budget.
+    stream_response = ai.generate_stream(
+        model='anthropic/claude-opus-4-8',
+        prompt=(
+            f'You must call the current_weather tool exactly once for {data.city}. '
+            'Think through the request before and after the tool call, then answer in one concise sentence.'
+        ),
+        tools=['current_weather'],
+        config={
+            'thinking': {'type': 'adaptive'},
+            'max_tokens': 4096,
+        },
+        max_turns=3,
+    )
+
+    streamed_reasoning: list[str] = []
+    streamed_text: list[str] = []
+    async for chunk in stream_response.stream:
+        for part in chunk.content:
+            root = part.root
+            if isinstance(root, ReasoningPart):
+                streamed_reasoning.append(root.reasoning)
+                ctx.send_chunk(f'[thinking] {root.reasoning}')
+        if chunk.text:
+            streamed_text.append(chunk.text)
+            ctx.send_chunk(chunk.text)
+
+    response = await stream_response.response
+    summary = _thinking_summary(response)
+    return {
+        **summary,
+        'final_text': response.text,
+        'streamed_reasoning_chunks': len(streamed_reasoning),
+        'streamed_reasoning_preview': ''.join(streamed_reasoning)[:1000],
+        'streamed_text': ''.join(streamed_text),
+    }
+
+
 async def main() -> None:
-    """Run each flow once from the CLI."""
+    """Run the lightweight flows once from the CLI."""
     try:
         print(await haiku_opus_4_7(TopicInput()))  # noqa: T201
         print(await cat_opus_4_7(CatInput()))  # noqa: T201

--- a/py/samples/anthropic-sample/src/main.py
+++ b/py/samples/anthropic-sample/src/main.py
@@ -151,7 +151,7 @@ async def thinking_tool_round_trip(data: WeatherInput, ctx: ActionRunContext) ->
         ),
         tools=['current_weather'],
         config={
-            'thinking': {'type': 'adaptive'},
+            'thinking': {'type': 'adaptive', 'display': 'summarized'},
             'max_tokens': 4096,
         },
         max_turns=3,


### PR DESCRIPTION
Closes #5628 (part of the #5617 epic)

## What

Returns extended thinking to callers in the Python Anthropic plugin. Thinking blocks now come back as reasoning parts in both streaming and non-streaming responses, thinking deltas stream as they arrive, and the reasoning signature is preserved so a reasoning turn can be continued later. Redacted thinking blocks are captured and round-tripped too.

## Why

Extended thinking could already be requested via config, but the reasoning never made it back out. The response converter only mapped `text` and `tool_use` blocks, and the stream handler only surfaced text and tool input deltas. So callers could not read the model's reasoning, could not render it while it streamed, and could not continue a reasoning conversation, because the signature (which Anthropic requires when thinking is sent back on a later turn) was dropped. JS and Go already do all of this; this brings Python in line with them.

## How

- `_to_genkit_content` maps `thinking` blocks to `ReasoningPart`, storing the signature under `metadata.thoughtSignature` (JS naming), and maps `redacted_thinking` blocks to `CustomPart` with `custom.redactedThinking`, the same shape JS uses.
- `_generate_streaming` emits reasoning chunks for `thinking_delta` events, and a custom chunk for `redacted_thinking` blocks (those arrive complete in `content_block_start`, no deltas follow). `signature_delta` is intentionally not streamed, matching JS; the signature is recovered from the final message instead.
- `_to_anthropic_block` gets the missing outbound branch: reasoning parts encode as `thinking` blocks with their signature, and raise a clear error if the signature is missing (same error message as JS). `get_thinking_signature` reads `metadata.thoughtSignature` first and falls back to the Go-style `metadata.signature` alias, decoding bytes if needed.
- The outbound check is attribute-based (`part.reasoning`) rather than isinstance. Reasoning parts parsed from JSON resolve to `DataPart` in the core `Part` union, so an isinstance check would silently drop them and break round-trips for Dev UI traffic, dict-built messages, and history produced by Go or JS.
- `cache_control` metadata is no longer attached to `thinking` or `redacted_thinking` blocks. The API rejects it there, and JS never attaches it to those block types.

## Tests

- New unit tests cover extraction (with and without a signature), redacted thinking capture, streaming (thinking deltas, `signature_delta` ignored but present on the final message, redacted chunk emission), outbound encoding, the Go alias (string and bytes), the missing-signature error, empty reasoning parts, JSON-deserialized round-trips for both reasoning and redacted parts, and the `cache_control` exclusion.
- All 90 package tests pass: `uv run pytest packages/genkit-anthropic/tests/`
- The signature is an opaque server value, so the true round-trip can only be verified live. The anthropic sample now has a `thinking_tool_round_trip` flow that enables thinking, streams the reasoning, and completes a tool call in a multi-turn conversation, which exercises the signature round-trip end to end from the Dev UI.

## Screenshots
<img width="989" height="787" alt="Screenshot 2026-07-10 at 20 05 38" src="https://github.com/user-attachments/assets/b37c49d7-39fd-4092-aa8b-dcd0a5fd145a" />
