### PR TITLE
fix(py/plugins/anthropic): map API errors and Retry-After

### DIFF
--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -25,6 +25,7 @@ See:
 """
 
 import json
+import math
 import time
 from email.utils import parsedate_to_datetime
 from typing import Any, Protocol, cast
@@ -106,15 +107,17 @@ def _parse_retry_after_ms(value: str) -> float | None:
     except ValueError:
         pass
     else:
-        if seconds >= 0:
-            return seconds * 1000
+        # Check the scaled value: a large finite input can overflow to inf.
+        retry_after_ms = seconds * 1000
+        if seconds >= 0 and math.isfinite(retry_after_ms):
+            return retry_after_ms
 
     try:
         retry_at = parsedate_to_datetime(value)
         if retry_at is None:
             return None
         retry_at_ms = retry_at.timestamp() * 1000
-    except (OverflowError, TypeError, ValueError):
+    except (OSError, OverflowError, TypeError, ValueError):
         return None
     return max(0.0, retry_at_ms - time.time() * 1000)
 

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -25,16 +25,20 @@ See:
 """
 
 import json
+import time
+from email.utils import parsedate_to_datetime
 from typing import Any, Protocol, cast
 
 import structlog
-from anthropic import AsyncAnthropic
+from anthropic import APIError, AsyncAnthropic
 from anthropic.types import Message as AnthropicMessage
 
 from genkit import (
     Constrained,
     CustomPart,
+    ErrorResponseMetadata,
     FinishReason,
+    GenkitError,
     MediaPart,
     Message,
     ModelRequest,
@@ -50,7 +54,7 @@ from genkit import (
     ToolResponsePart,
 )
 from genkit.model import get_basic_usage_stats
-from genkit.plugin_api import ActionRunContext
+from genkit.plugin_api import ActionRunContext, StatusName
 from genkit_anthropic.config import BETA_KWARG_KEYS, STABLE_KWARG_KEYS, AnthropicConfig
 from genkit_anthropic.model_info import get_model_info
 from genkit_anthropic.utils import (
@@ -74,6 +78,64 @@ class _ModelDumpable(Protocol):
     def model_dump(self, *, exclude_none: bool = False, by_alias: bool = False) -> dict[str, object]:
         """Dump model fields."""
         ...
+
+
+_ANTHROPIC_STATUS_MAP: dict[int, StatusName] = {
+    400: 'INVALID_ARGUMENT',
+    401: 'UNAUTHENTICATED',
+    403: 'PERMISSION_DENIED',
+    429: 'RESOURCE_EXHAUSTED',
+    500: 'INTERNAL',
+    503: 'UNAVAILABLE',
+    529: 'UNAVAILABLE',
+}
+
+
+def _parse_retry_after_ms(value: str) -> float | None:
+    """Parse an HTTP Retry-After value into milliseconds.
+
+    Supports both delay-seconds and HTTP-date values, matching the
+    JavaScript Anthropic adapter.
+    """
+    value = value.strip()
+    if not value:
+        return None
+
+    try:
+        seconds = float(value)
+    except ValueError:
+        pass
+    else:
+        if seconds >= 0:
+            return seconds * 1000
+
+    try:
+        retry_at = parsedate_to_datetime(value)
+        if retry_at is None:
+            return None
+        retry_at_ms = retry_at.timestamp() * 1000
+    except (OverflowError, TypeError, ValueError):
+        return None
+    return max(0.0, retry_at_ms - time.time() * 1000)
+
+
+def _from_anthropic_error(error: APIError) -> GenkitError:
+    """Convert an Anthropic SDK error to its Genkit equivalent."""
+    status_code = getattr(error, 'status_code', None)
+    status = _ANTHROPIC_STATUS_MAP.get(status_code, 'UNKNOWN') if isinstance(status_code, int) else 'UNKNOWN'
+
+    response = getattr(error, 'response', None)
+    retry_after_header = response.headers.get('retry-after') if response is not None else None
+    retry_after_ms = _parse_retry_after_ms(retry_after_header) if retry_after_header else None
+    response_metadata: ErrorResponseMetadata | None = None
+    if retry_after_ms is not None:
+        response_metadata = {'retry_after_ms': retry_after_ms}
+
+    return GenkitError(
+        status=status,
+        message=error.message,
+        response_metadata=response_metadata,
+    )
 
 
 def _to_anthropic_schema(schema: dict[str, Any]) -> dict[str, Any]:
@@ -228,13 +290,16 @@ class AnthropicModel:
 
         logger.debug('Anthropic generate request', model=self.model_name, streaming=bool(streaming))
 
-        if streaming:
-            assert ctx is not None  # streaming requires ctx
-            response = await self._generate_streaming(params, ctx, client=client, use_beta=use_beta)
-        else:
-            active_client = cast(Any, client)
-            messages_client = active_client.beta.messages if use_beta else active_client.messages
-            response = await messages_client.create(**params)
+        try:
+            if streaming:
+                assert ctx is not None  # streaming requires ctx
+                response = await self._generate_streaming(params, ctx, client=client, use_beta=use_beta)
+            else:
+                active_client = cast(Any, client)
+                messages_client = active_client.beta.messages if use_beta else active_client.messages
+                response = await messages_client.create(**params)
+        except APIError as error:
+            raise _from_anthropic_error(error) from error
 
         logger.debug(
             'Anthropic raw API response',

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -113,10 +113,7 @@ def _parse_retry_after_ms(value: str) -> float | None:
             return retry_after_ms
 
     try:
-        retry_at = parsedate_to_datetime(value)
-        if retry_at is None:
-            return None
-        retry_at_ms = retry_at.timestamp() * 1000
+        retry_at_ms = parsedate_to_datetime(value).timestamp() * 1000
     except (OSError, OverflowError, TypeError, ValueError):
         return None
     return max(0.0, retry_at_ms - time.time() * 1000)

--- a/py/packages/genkit-anthropic/tests/anthropic_error_handling_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_error_handling_test.py
@@ -202,6 +202,12 @@ def test_parse_retry_after_rejects_blank_and_malformed_values(value: str) -> Non
     assert anthropic_models._parse_retry_after_ms(value) is None
 
 
+@pytest.mark.parametrize('value', ['inf', 'Infinity', 'nan', '1e999', '1e307'])
+def test_parse_retry_after_rejects_non_finite_delays(value: str) -> None:
+    """Reject delays that are, or scale to, non-finite milliseconds."""
+    assert anthropic_models._parse_retry_after_ms(value) is None
+
+
 def test_parse_retry_after_future_http_date(monkeypatch: pytest.MonkeyPatch) -> None:
     """Convert a future HTTP-date to a relative millisecond delay."""
     monkeypatch.setattr(anthropic_models.time, 'time', lambda: 1_700_000_000.0)
@@ -216,8 +222,17 @@ def test_parse_retry_after_past_http_date(monkeypatch: pytest.MonkeyPatch) -> No
     assert anthropic_models._parse_retry_after_ms('Tue, 14 Nov 2023 22:13:15 GMT') == 0.0
 
 
+def test_parse_retry_after_returns_none_on_timestamp_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ignore platform timestamp failures for parseable dates."""
+    retry_at = MagicMock()
+    retry_at.timestamp.side_effect = OSError
+    monkeypatch.setattr(anthropic_models, 'parsedate_to_datetime', lambda _: retry_at)
+
+    assert anthropic_models._parse_retry_after_ms('Thu, 01 Jan 1601 00:00:00') is None
+
+
 @pytest.mark.asyncio
-@pytest.mark.parametrize('retry_after', [None, '', '   ', 'not-a-delay'])
+@pytest.mark.parametrize('retry_after', [None, '', '   ', 'not-a-delay', 'inf', '1e999'])
 async def test_generate_omits_invalid_retry_after_metadata(retry_after: str | None) -> None:
     """Leave response metadata unset when Retry-After cannot be parsed."""
     api_error = _status_error(429, retry_after=retry_after)

--- a/py/packages/genkit-anthropic/tests/anthropic_error_handling_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_error_handling_test.py
@@ -1,0 +1,229 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Anthropic API error handling."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import genkit_anthropic.models as anthropic_models
+import httpx
+import pytest
+from anthropic import APIConnectionError, APIError, APIStatusError
+from genkit_anthropic.models import AnthropicModel
+
+from genkit import GenkitError, Message, ModelRequest, Part, Role, TextPart
+from genkit.plugin_api import StatusName
+
+_ERROR_MESSAGE = 'Anthropic request failed'
+
+
+def _request() -> ModelRequest:
+    """Create a minimal model request."""
+    return ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hello'))])],
+    )
+
+
+def _http_request() -> httpx.Request:
+    """Create the request required by Anthropic SDK errors."""
+    return httpx.Request('POST', 'https://api.anthropic.com/v1/messages')
+
+
+def _status_error(status_code: int, retry_after: str | None = None) -> APIStatusError:
+    """Create a real Anthropic status error."""
+    request = _http_request()
+    headers = {'retry-after': retry_after} if retry_after is not None else None
+    response = httpx.Response(status_code, request=request, headers=headers)
+    return APIStatusError(_ERROR_MESSAGE, response=response, body={'type': 'error'})
+
+
+def _model_failing_with(error: Exception) -> AnthropicModel:
+    """Create a model whose non-streaming request raises an error."""
+    client = MagicMock()
+    client.messages.create = AsyncMock(side_effect=error)
+    return AnthropicModel(model_name='claude-sonnet-4', client=client)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('status_code', 'expected_status'),
+    [
+        (400, 'INVALID_ARGUMENT'),
+        (401, 'UNAUTHENTICATED'),
+        (403, 'PERMISSION_DENIED'),
+        (429, 'RESOURCE_EXHAUSTED'),
+        (500, 'INTERNAL'),
+        (503, 'UNAVAILABLE'),
+        (529, 'UNAVAILABLE'),
+        (404, 'UNKNOWN'),
+    ],
+)
+async def test_generate_maps_anthropic_status_errors(status_code: int, expected_status: StatusName) -> None:
+    """Map only the status codes supported by the JavaScript adapter."""
+    api_error = _status_error(status_code)
+    model = _model_failing_with(api_error)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(_request())
+
+    error = exc_info.value
+    assert error.status == expected_status
+    assert error.original_message == _ERROR_MESSAGE
+    assert error.cause is None
+    assert error.__cause__ is api_error
+    assert error.response_metadata is None
+    assert error.to_callable_serializable().message == _ERROR_MESSAGE
+    assert error.to_serializable().message == _ERROR_MESSAGE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'api_error',
+    [
+        APIError(_ERROR_MESSAGE, _http_request(), body=None),
+        APIConnectionError(message=_ERROR_MESSAGE, request=_http_request()),
+    ],
+    ids=['base-api-error', 'connection-error'],
+)
+async def test_generate_maps_anthropic_errors_without_responses_to_unknown(api_error: APIError) -> None:
+    """Anthropic errors without an HTTP response map to UNKNOWN."""
+    model = _model_failing_with(api_error)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(_request())
+
+    error = exc_info.value
+    assert error.status == 'UNKNOWN'
+    assert error.original_message == _ERROR_MESSAGE
+    assert error.cause is None
+    assert error.__cause__ is api_error
+    assert error.response_metadata is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('status_code', 'expected_status'),
+    [
+        (429, 'RESOURCE_EXHAUSTED'),
+        (503, 'UNAVAILABLE'),
+        (529, 'UNAVAILABLE'),
+    ],
+)
+async def test_generate_attaches_retry_after_metadata(status_code: int, expected_status: StatusName) -> None:
+    """Attach parsed retry metadata for retryable Anthropic responses."""
+    api_error = _status_error(status_code, retry_after='2.5')
+    model = _model_failing_with(api_error)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(_request())
+
+    error = exc_info.value
+    assert error.status == expected_status
+    assert error.response_metadata == {'retry_after_ms': 2500.0}
+    assert error.cause is None
+    assert error.__cause__ is api_error
+
+
+@pytest.mark.asyncio
+async def test_generate_leaves_non_anthropic_errors_untouched() -> None:
+    """Do not wrap exceptions that were not raised by the Anthropic SDK."""
+    provider_error = RuntimeError('unexpected failure')
+    model = _model_failing_with(provider_error)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await model.generate(_request())
+
+    assert exc_info.value is provider_error
+
+
+class _FailingStreamManager:
+    """Async stream manager that raises an Anthropic error on entry."""
+
+    def __init__(self, error: APIError) -> None:
+        self.error = error
+
+    async def __aenter__(self) -> Any:  # noqa: ANN401
+        raise self.error
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_generate_maps_streaming_anthropic_errors() -> None:
+    """Apply the same mapping across the streaming context lifecycle."""
+    api_error = _status_error(503, retry_after='1')
+    client = MagicMock()
+    client.messages.stream.return_value = _FailingStreamManager(api_error)
+    model = AnthropicModel(model_name='claude-sonnet-4', client=client)
+    ctx = MagicMock()
+    ctx.is_streaming = True
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(_request(), ctx)
+
+    error = exc_info.value
+    assert error.status == 'UNAVAILABLE'
+    assert error.response_metadata == {'retry_after_ms': 1000.0}
+    assert error.cause is None
+    assert error.__cause__ is api_error
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected_ms'),
+    [
+        ('2', 2000.0),
+        (' 1.5 ', 1500.0),
+        ('0', 0.0),
+    ],
+)
+def test_parse_retry_after_delay_seconds(value: str, expected_ms: float) -> None:
+    """Parse whole, fractional, and zero delay-seconds values."""
+    assert anthropic_models._parse_retry_after_ms(value) == expected_ms
+
+
+@pytest.mark.parametrize('value', ['', '   ', 'not-a-delay'])
+def test_parse_retry_after_rejects_blank_and_malformed_values(value: str) -> None:
+    """Do not attach metadata for blank or malformed header values."""
+    assert anthropic_models._parse_retry_after_ms(value) is None
+
+
+def test_parse_retry_after_future_http_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Convert a future HTTP-date to a relative millisecond delay."""
+    monkeypatch.setattr(anthropic_models.time, 'time', lambda: 1_700_000_000.0)
+
+    assert anthropic_models._parse_retry_after_ms('Tue, 14 Nov 2023 22:13:25 GMT') == 5000.0
+
+
+def test_parse_retry_after_past_http_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clamp a past HTTP-date delay to zero."""
+    monkeypatch.setattr(anthropic_models.time, 'time', lambda: 1_700_000_000.0)
+
+    assert anthropic_models._parse_retry_after_ms('Tue, 14 Nov 2023 22:13:15 GMT') == 0.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('retry_after', [None, '', '   ', 'not-a-delay'])
+async def test_generate_omits_invalid_retry_after_metadata(retry_after: str | None) -> None:
+    """Leave response metadata unset when Retry-After cannot be parsed."""
+    api_error = _status_error(429, retry_after=retry_after)
+    model = _model_failing_with(api_error)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await model.generate(_request())
+
+    assert exc_info.value.response_metadata is None

--- a/py/packages/genkit-middleware/src/genkit_middleware/_retry.py
+++ b/py/packages/genkit-middleware/src/genkit_middleware/_retry.py
@@ -72,9 +72,16 @@ class Retry(BaseMiddleware[RetryConfig]):
                     raise
 
                 delay_ms = current_delay_ms
+                retry_after_ms: float | None = None
+                if isinstance(e, GenkitError) and e.response_metadata is not None:
+                    retry_after_ms = e.response_metadata.get('retry_after_ms')
+                    if retry_after_ms is not None:
+                        delay_ms = max(delay_ms, retry_after_ms)
+
                 if not self.config.no_jitter:
                     delay_ms += 1000.0 * math.pow(2, attempt) * random.random()
-                delay_ms = min(delay_ms, self.config.max_delay_ms)
+                if retry_after_ms is None or retry_after_ms <= self.config.max_delay_ms:
+                    delay_ms = min(delay_ms, self.config.max_delay_ms)
 
                 await asyncio.sleep(delay_ms / 1000.0)
                 current_delay_ms = min(current_delay_ms * self.config.backoff_factor, self.config.max_delay_ms)

--- a/py/packages/genkit-middleware/src/genkit_middleware/_retry.py
+++ b/py/packages/genkit-middleware/src/genkit_middleware/_retry.py
@@ -72,7 +72,6 @@ class Retry(BaseMiddleware[RetryConfig]):
                     raise
 
                 delay_ms = current_delay_ms
-                retry_after_ms: float | None = None
                 if isinstance(e, GenkitError) and e.response_metadata is not None:
                     retry_after_ms = e.response_metadata.get('retry_after_ms')
                     if retry_after_ms is not None:
@@ -80,8 +79,8 @@ class Retry(BaseMiddleware[RetryConfig]):
 
                 if not self.config.no_jitter:
                     delay_ms += 1000.0 * math.pow(2, attempt) * random.random()
-                if retry_after_ms is None or retry_after_ms <= self.config.max_delay_ms:
-                    delay_ms = min(delay_ms, self.config.max_delay_ms)
+                # The provider delay is a floor within max_delay_ms, never an override of it.
+                delay_ms = min(delay_ms, self.config.max_delay_ms)
 
                 await asyncio.sleep(delay_ms / 1000.0)
                 current_delay_ms = min(current_delay_ms * self.config.backoff_factor, self.config.max_delay_ms)

--- a/py/packages/genkit-middleware/tests/retry_test.py
+++ b/py/packages/genkit-middleware/tests/retry_test.py
@@ -124,8 +124,8 @@ async def test_retry_non_genkit_error(ctx: GenerateMiddlewareContext) -> None:
 
 @pytest.mark.asyncio
 async def test_retry_after_is_delay_floor(ctx: GenerateMiddlewareContext) -> None:
-    """Provider retry delay overrides a smaller capped local delay."""
-    retry = Retry(max_retries=1, initial_delay_ms=100, max_delay_ms=1000, no_jitter=True)
+    """Provider retry delay overrides a smaller local delay."""
+    retry = Retry(max_retries=1, initial_delay_ms=100, max_delay_ms=10000, no_jitter=True)
 
     call_count = 0
 
@@ -203,7 +203,7 @@ async def test_zero_retry_after_preserves_local_delay(ctx: GenerateMiddlewareCon
 @pytest.mark.asyncio
 async def test_retry_after_floor_is_applied_before_jitter(ctx: GenerateMiddlewareContext) -> None:
     """Apply jitter after the provider floor, matching the JavaScript middleware."""
-    retry = Retry(max_retries=1, initial_delay_ms=100, max_delay_ms=1000)
+    retry = Retry(max_retries=1, initial_delay_ms=100, max_delay_ms=10000)
 
     call_count = 0
 
@@ -227,6 +227,32 @@ async def test_retry_after_floor_is_applied_before_jitter(ctx: GenerateMiddlewar
     assert result is not None
     assert call_count == 2
     sleep.assert_awaited_once_with(5.5)
+
+
+@pytest.mark.asyncio
+async def test_retry_after_is_capped_by_max_delay(ctx: GenerateMiddlewareContext) -> None:
+    """A provider delay beyond the configured ceiling does not extend the wait."""
+    retry = Retry(max_retries=1, initial_delay_ms=100, max_delay_ms=60000, no_jitter=True)
+
+    call_count = 0
+
+    async def next_fn(params, ctx):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise GenkitError(
+                message='Rate limited',
+                status='RESOURCE_EXHAUSTED',
+                response_metadata={'retry_after_ms': 86_400_000},
+            )
+        return ModelResponse(message=None)
+
+    with patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep:
+        result = await retry.wrap_model(_make_params(), ctx, next_fn)
+
+    assert result is not None
+    assert call_count == 2
+    sleep.assert_awaited_once_with(60.0)
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-middleware/tests/retry_test.py
+++ b/py/packages/genkit-middleware/tests/retry_test.py
@@ -17,6 +17,7 @@
 """Tests for Retry middleware."""
 
 from typing import NoReturn
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from genkit_middleware import Retry
@@ -119,3 +120,169 @@ async def test_retry_non_genkit_error(ctx: GenerateMiddlewareContext) -> None:
     result = await retry.wrap_model(_make_params(), ctx, next_fn)
     assert result is not None
     assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_after_is_delay_floor(ctx: GenerateMiddlewareContext) -> None:
+    """Provider retry delay overrides a smaller capped local delay."""
+    retry = Retry(max_retries=1, initial_delay_ms=100, max_delay_ms=1000, no_jitter=True)
+
+    call_count = 0
+
+    async def next_fn(params, ctx):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise GenkitError(
+                message='Rate limited',
+                status='RESOURCE_EXHAUSTED',
+                response_metadata={'retry_after_ms': 5000},
+            )
+        return ModelResponse(message=None)
+
+    with patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep:
+        result = await retry.wrap_model(_make_params(), ctx, next_fn)
+
+    assert result is not None
+    assert call_count == 2
+    sleep.assert_awaited_once_with(5.0)
+
+
+@pytest.mark.asyncio
+async def test_local_delay_wins_when_larger_than_retry_after(ctx: GenerateMiddlewareContext) -> None:
+    """Computed local delay is retained when it exceeds provider guidance."""
+    retry = Retry(max_retries=1, initial_delay_ms=500, no_jitter=True)
+
+    call_count = 0
+
+    async def next_fn(params, ctx):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise GenkitError(
+                message='Rate limited',
+                status='RESOURCE_EXHAUSTED',
+                response_metadata={'retry_after_ms': 10},
+            )
+        return ModelResponse(message=None)
+
+    with patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep:
+        result = await retry.wrap_model(_make_params(), ctx, next_fn)
+
+    assert result is not None
+    assert call_count == 2
+    sleep.assert_awaited_once_with(0.5)
+
+
+@pytest.mark.asyncio
+async def test_zero_retry_after_preserves_local_delay(ctx: GenerateMiddlewareContext) -> None:
+    """A zero provider delay is handled as metadata while the local delay wins."""
+    retry = Retry(max_retries=1, initial_delay_ms=100, no_jitter=True)
+
+    call_count = 0
+
+    async def next_fn(params, ctx):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise GenkitError(
+                message='Rate limited',
+                status='RESOURCE_EXHAUSTED',
+                response_metadata={'retry_after_ms': 0},
+            )
+        return ModelResponse(message=None)
+
+    with patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep:
+        result = await retry.wrap_model(_make_params(), ctx, next_fn)
+
+    assert result is not None
+    assert call_count == 2
+    sleep.assert_awaited_once_with(0.1)
+
+
+@pytest.mark.asyncio
+async def test_retry_after_floor_is_applied_before_jitter(ctx: GenerateMiddlewareContext) -> None:
+    """Apply jitter after the provider floor, matching the JavaScript middleware."""
+    retry = Retry(max_retries=1, initial_delay_ms=100, max_delay_ms=1000)
+
+    call_count = 0
+
+    async def next_fn(params, ctx):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise GenkitError(
+                message='Rate limited',
+                status='RESOURCE_EXHAUSTED',
+                response_metadata={'retry_after_ms': 5000},
+            )
+        return ModelResponse(message=None)
+
+    with (
+        patch('genkit_middleware._retry.random.random', return_value=0.5),
+        patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep,
+    ):
+        result = await retry.wrap_model(_make_params(), ctx, next_fn)
+
+    assert result is not None
+    assert call_count == 2
+    sleep.assert_awaited_once_with(5.5)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('retry_after_ms', [0, 1])
+async def test_small_retry_after_preserves_local_delay_cap(
+    ctx: GenerateMiddlewareContext,
+    retry_after_ms: float,
+) -> None:
+    """A small provider floor does not disable the configured local delay cap."""
+    retry = Retry(max_retries=1, initial_delay_ms=100, max_delay_ms=100)
+
+    call_count = 0
+
+    async def next_fn(params, ctx):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise GenkitError(
+                message='Rate limited',
+                status='RESOURCE_EXHAUSTED',
+                response_metadata={'retry_after_ms': retry_after_ms},
+            )
+        return ModelResponse(message=None)
+
+    with (
+        patch('genkit_middleware._retry.random.random', return_value=0.5),
+        patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep,
+    ):
+        result = await retry.wrap_model(_make_params(), ctx, next_fn)
+
+    assert result is not None
+    assert call_count == 2
+    sleep.assert_awaited_once_with(0.1)
+
+
+@pytest.mark.asyncio
+async def test_retry_does_not_retry_unauthenticated_error(ctx: GenerateMiddlewareContext) -> None:
+    """Provider delay metadata does not make authentication errors retryable."""
+    retry = Retry(max_retries=3, no_jitter=True)
+
+    call_count = 0
+
+    async def next_fn(params, ctx) -> NoReturn:
+        nonlocal call_count
+        call_count += 1
+        raise GenkitError(
+            message='Invalid API key',
+            status='UNAUTHENTICATED',
+            response_metadata={'retry_after_ms': 5000},
+        )
+
+    with (
+        patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep,
+        pytest.raises(GenkitError),
+    ):
+        await retry.wrap_model(_make_params(), ctx, next_fn)
+
+    assert call_count == 1
+    sleep.assert_not_awaited()

--- a/py/packages/genkit/src/genkit/__init__.py
+++ b/py/packages/genkit/src/genkit/__init__.py
@@ -31,7 +31,7 @@ from genkit._ai._tools import (
     tool,
 )
 from genkit._core._action import Action, ActionRunContext, StreamResponse
-from genkit._core._error import GenkitError, PublicError
+from genkit._core._error import ErrorResponseMetadata, GenkitError, PublicError
 from genkit._core._model import Document
 from genkit._core._plugin import Plugin
 from genkit._core._typing import (
@@ -96,6 +96,7 @@ __all__ = [
     'ModelInfo',
     'ModelStreamResponse',
     # Errors
+    'ErrorResponseMetadata',
     'GenkitError',
     'PublicError',
     # Tools

--- a/py/packages/genkit/src/genkit/_core/_error.py
+++ b/py/packages/genkit/src/genkit/_core/_error.py
@@ -17,7 +17,7 @@
 """Error classes and utilities for the Genkit framework."""
 
 from enum import IntEnum
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
@@ -153,6 +153,17 @@ class HttpErrorWireFormat(BaseModel):
     status: str = StatusCodes.INTERNAL.name
 
 
+class ErrorResponseMetadata(TypedDict, total=False):
+    """Metadata from the HTTP response that triggered an error.
+
+    This metadata is available only in-process and is not serialized into
+    callable or reflection error wire formats.
+    """
+
+    retry_after_ms: float
+    headers: dict[str, str]
+
+
 class GenkitInterrupt(Exception):  # noqa: N818 - marker base class; intentionally not suffixed *Error
     """Marker base class for tool interrupts.
 
@@ -174,6 +185,7 @@ class GenkitError(Exception):
         details: Any = None,  # noqa: ANN401
         trace_id: str | None = None,
         source: str | None = None,
+        response_metadata: ErrorResponseMetadata | None = None,
     ) -> None:
         """Initialize a GenkitError.
 
@@ -184,6 +196,7 @@ class GenkitError(Exception):
             details: Optional detail information.
             trace_id: A unique identifier for tracing the action execution.
             source: Optional source of the error.
+            response_metadata: Optional HTTP response metadata for in-process use.
         """
         temp_status: StatusName
         if status:
@@ -216,6 +229,7 @@ class GenkitError(Exception):
         self.source: str | None = source
         self.trace_id: str | None = trace_id
         self.cause: Exception | None = cause
+        self.response_metadata: ErrorResponseMetadata | None = response_metadata
 
     def to_callable_serializable(self) -> HttpErrorWireFormat:
         """Returns a JSON-serializable representation of this object.

--- a/py/packages/genkit/tests/genkit/core/error_test.py
+++ b/py/packages/genkit/tests/genkit/core/error_test.py
@@ -16,6 +16,7 @@
 
 """Unit tests for the error module."""
 
+from genkit import ErrorResponseMetadata
 from genkit._core._error import (
     GenkitError,
     PublicError,
@@ -63,6 +64,22 @@ def test_genkit_error_to_json() -> None:
     assert serializable.message == 'Resource not found'
     assert serializable.details is not None
     assert serializable.details.model_dump()['id'] == 123
+
+
+def test_genkit_error_response_metadata_is_in_process_only() -> None:
+    response_metadata: ErrorResponseMetadata = {
+        'retry_after_ms': 1500.5,
+        'headers': {'retry-after': '1.5005'},
+    }
+    error = GenkitError(
+        status='RESOURCE_EXHAUSTED',
+        message='Rate limited',
+        response_metadata=response_metadata,
+    )
+
+    assert error.response_metadata == response_metadata
+    assert 'response_metadata' not in error.to_callable_serializable().model_dump()
+    assert 'response_metadata' not in error.to_serializable().model_dump()
 
 
 def test_public_error() -> None:


### PR DESCRIPTION
## Summary

Fixes #5630.

This brings Python Anthropic error handling in line with the existing JS implementation.

The change:

- Maps Anthropic API errors to the equivalent Genkit status codes
- Handles errors from both streaming and non-streaming requests
- Parses numeric and HTTP-date `Retry-After` values
- Exposes retry metadata on `GenkitError` for in-process use
- Keeps response metadata out of callable and reflection serialization
- Updates retry middleware to treat the provider delay as a minimum


## Testing

- Added Anthropic error handling and `Retry-After` coverage
- Added core error serialisation coverage
- Added retry middleware delay precedence coverage
- 113 targeted tests passing