### PR TITLE
fix(py/plugins/anthropic): default tool input_schema to {type: object}

### DIFF
--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -80,6 +80,20 @@ def _to_anthropic_schema(schema: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _to_tool_input_schema(schema: dict[str, Any] | None) -> dict[str, Any]:
+    """Ensure a tool input schema is valid for the Anthropic API.
+
+    Anthropic requires ``input_schema.type`` to be present and rejects a
+    missing or empty schema with a 400, so no-input tools get a default
+    object schema.
+    """
+    if not schema:
+        return {'type': 'object', 'properties': {}}
+    if 'type' not in schema:
+        return {**schema, 'type': 'object'}
+    return schema
+
+
 class AnthropicModel:
     """Represents an Anthropic language model for use with Genkit.
 
@@ -260,7 +274,7 @@ class AnthropicModel:
                 {
                     'name': t.name,
                     'description': t.description,
-                    'input_schema': t.input_schema,
+                    'input_schema': _to_tool_input_schema(t.input_schema),
                 }
                 for t in request.tools
             ]

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -126,6 +126,52 @@ async def test_generate_with_tools() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_defaults_empty_tool_input_schema() -> None:
+    """Test that tools with a missing or empty input schema get a default object schema."""
+    populated_schema = {
+        'type': 'object',
+        'properties': {'location': {'type': 'string', 'description': 'Location name'}},
+        'required': ['location'],
+    }
+    request = ModelRequest(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[Part(root=TextPart(text='Hello'))],
+            )
+        ],
+        config=ModelConfig(),
+        tools=[
+            ToolDefinition(name='no_schema_tool', description='Tool with no input schema', input_schema=None),
+            ToolDefinition(name='empty_schema_tool', description='Tool with empty input schema', input_schema={}),
+            ToolDefinition(
+                name='untyped_schema_tool',
+                description='Tool with a schema missing a top-level type',
+                input_schema={'properties': {'location': {'type': 'string'}}},
+            ),
+            ToolDefinition(name='get_weather', description='Get weather for a location', input_schema=populated_schema),
+        ],
+    )
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(type='text', text='Done')]
+    mock_response.usage = MagicMock(input_tokens=5, output_tokens=5)
+    mock_response.stop_reason = 'end_turn'
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+    await model.generate(request)
+
+    sent_tools = mock_client.messages.create.call_args.kwargs['tools']
+    default_schema = {'type': 'object', 'properties': {}}
+    assert sent_tools[0]['input_schema'] == default_schema
+    assert sent_tools[1]['input_schema'] == default_schema
+    assert sent_tools[2]['input_schema'] == {'properties': {'location': {'type': 'string'}}, 'type': 'object'}
+    assert sent_tools[3]['input_schema'] == populated_schema
+
+
+@pytest.mark.asyncio
 async def test_generate_with_config() -> None:
     """Test generation with custom config."""
     mock_client = MagicMock()


### PR DESCRIPTION
Closes #5631

The Python Anthropic plugin was forwarding tool input schemas to the API as-is. A tool with no inputs ends up with an empty schema (genkit core produces {} for no-arg tools, and hand-built ToolDefinitions can have None), which the Anthropic API rejects with a 400. JS and Go already handle this, so this brings Python in line:

- a missing or empty schema becomes `{"type": "object", "properties": {}}`, the same default Go uses
- a non-empty schema without a top-level `type` gets `"type": "object"` merged in, same as the JS runner
- everything else passes through untouched

The conversion happens in one place (`_build_params` in models.py) and both the streaming and non-streaming paths share it, so both are covered.