### PR TITLE
fix(py): gate Anthropic structured output on constraints

### DIFF
--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -32,6 +32,7 @@ from anthropic import AsyncAnthropic
 from anthropic.types import Message as AnthropicMessage
 
 from genkit import (
+    Constrained,
     FinishReason,
     MediaPart,
     Message,
@@ -235,8 +236,13 @@ class AnthropicModel:
 
         # Handle JSON output constraint
         if request.output_format == 'json':
-            supports_json = 'json' in (self._model_info.supports.output or []) if self._model_info.supports else False
-            if request.output_schema and supports_json:
+            use_native = (
+                request.output_schema is not None
+                and bool(request.output_constrained)
+                and self._supports_constrained(bool(request.tools))
+            )
+            if use_native:
+                assert request.output_schema is not None
                 # Use native structured outputs via output_config.
                 params['output_config'] = {
                     'format': {
@@ -247,7 +253,7 @@ class AnthropicModel:
             else:
                 # Fall back to system prompt instruction.
                 instruction = '\n\nOutput valid JSON. Do not wrap the JSON in markdown code fences.'
-                if request.output_schema:
+                if request.output_schema is not None:
                     schema_str = json.dumps(request.output_schema, indent=2)
                     instruction += f'\n\nFollow this JSON schema:\n{schema_str}'
                 system = (system or '') + instruction
@@ -274,6 +280,14 @@ class AnthropicModel:
                     params['tool_choice'] = request.tool_choice
 
         return params
+
+    def _supports_constrained(self, has_tools: bool) -> bool:
+        """Return whether this model supports native constrained output."""
+        supports = self._model_info.supports
+        constrained = supports.constrained if supports else None
+        if constrained is None or constrained == Constrained.NONE:
+            return False
+        return constrained != Constrained.NO_TOOLS or not has_tools
 
     async def _generate_streaming(self, params: dict[str, Any], ctx: ActionRunContext) -> AnthropicMessage:
         """Handle streaming generation.

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -24,15 +24,18 @@ from genkit_anthropic.models import AnthropicModel
 from genkit_anthropic.utils import maybe_strip_fences, strip_markdown_fences
 
 from genkit import (
+    Constrained,
     Media,
     MediaPart,
     Message,
     Metadata,
     ModelConfig,
+    ModelInfo,
     ModelRequest,
     ModelResponseChunk,
     Part,
     Role,
+    Supports,
     TextPart,
     ToolDefinition,
     ToolRequestPart,
@@ -641,6 +644,7 @@ def test_structured_output_uses_native_output_config(model_name: str) -> None:
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
         output_format='json',
         output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+        output_constrained=True,
     )
 
     params = model._build_params(request)
@@ -650,14 +654,32 @@ def test_structured_output_uses_native_output_config(model_name: str) -> None:
     assert params['output_config']['format']['schema']['additionalProperties'] is False
 
 
-def test_structured_output_falls_back_to_system_prompt() -> None:
-    """Test that JSON without schema falls back to system prompt instruction."""
+def test_structured_output_uses_native_output_config_for_empty_schema() -> None:
+    """Test that an empty, but present, schema enables native structured output."""
     mock_client = MagicMock()
-    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+    model = AnthropicModel(model_name='claude-opus-4-6', client=mock_client)
 
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate JSON'))])],
         output_format='json',
+        output_schema={},
+        output_constrained=True,
+    )
+
+    params = model._build_params(request)
+
+    assert params['output_config']['format'] == {'type': 'json_schema', 'schema': {}}
+
+
+def test_structured_output_falls_back_to_system_prompt() -> None:
+    """Test that JSON without schema falls back to system prompt instruction."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-opus-4-6', client=mock_client)
+
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate JSON'))])],
+        output_format='json',
+        output_constrained=True,
     )
 
     params = model._build_params(request)
@@ -667,17 +689,39 @@ def test_structured_output_falls_back_to_system_prompt() -> None:
     assert 'Output valid JSON' in params['system']
 
 
+@pytest.mark.parametrize('output_constrained', [None, False])
+def test_structured_output_falls_back_when_unconstrained(output_constrained: bool | None) -> None:
+    """Test that callers can opt out of native constrained output."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-opus-4-6', client=mock_client)
+
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
+        output_format='json',
+        output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+        output_constrained=output_constrained,
+    )
+
+    params = model._build_params(request)
+
+    assert 'output_config' not in params
+    assert 'Output valid JSON' in params['system']
+    assert 'Follow this JSON schema' in params['system']
+    assert '"name"' in params['system']
+
+
 def test_structured_output_falls_back_for_unsupported_models() -> None:
     """Test that JSON with schema falls back to system prompt for unsupported models."""
     mock_client = MagicMock()
     # Unknown models resolve to the generic fallback in model_info.py, whose
-    # supports.output is ['text'] — no native JSON support.
+    # supports.constrained is unset — no native constrained-output support.
     model = AnthropicModel(model_name='claude-unknown-model', client=mock_client)
 
     request = ModelRequest(
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
         output_format='json',
         output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+        output_constrained=True,
     )
 
     params = model._build_params(request)
@@ -687,3 +731,54 @@ def test_structured_output_falls_back_for_unsupported_models() -> None:
     assert 'Output valid JSON' in params['system']
     assert 'Follow this JSON schema' in params['system']
     assert '"name"' in params['system']
+
+
+def test_structured_output_falls_back_when_model_disallows_constraints() -> None:
+    """Test that an explicit constrained=none capability disables native output."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-opus-4-6', client=mock_client)
+    model._model_info = ModelInfo(label='Test model', supports=Supports(constrained=Constrained.NONE))
+
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
+        output_format='json',
+        output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+        output_constrained=True,
+    )
+
+    params = model._build_params(request)
+
+    assert 'output_config' not in params
+    assert 'Output valid JSON' in params['system']
+
+
+def test_structured_output_with_no_tools_capability() -> None:
+    """Test that no-tools constrained output is disabled only when tools are present."""
+    mock_client = MagicMock()
+    model = AnthropicModel(model_name='claude-opus-4-6', client=mock_client)
+    model._model_info = ModelInfo(label='Test model', supports=Supports(constrained=Constrained.NO_TOOLS))
+
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Generate a cat'))])],
+        output_format='json',
+        output_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+        output_constrained=True,
+    )
+    params_without_tools = model._build_params(request)
+
+    request_with_tools = request.model_copy(
+        update={
+            'tools': [
+                ToolDefinition(
+                    name='get_weather',
+                    description='Get weather for a location',
+                    input_schema={'type': 'object'},
+                )
+            ]
+        }
+    )
+    params_with_tools = model._build_params(request_with_tools)
+
+    assert 'output_config' in params_without_tools
+    assert 'output_config' not in params_with_tools
+    assert 'Output valid JSON' in params_with_tools['system']


### PR DESCRIPTION
## What

The Anthropic Python plugin was triggering native constrained output (`output_config`
with a JSON schema) off the wrong condition. It keyed off `output_format == 'json'`
plus a schema plus model support, which conflates "I want JSON-ish text" with "I want
constrained decoding." A caller who only asked for unconstrained JSON could get forced
into native structured output.

This changes the gate to key off the caller's actual intent (`request.output_constrained`)
together with model support, matching how JS and Go already work.

## Why

Parity with JS/Go. Both plugins gate native structured output on the same triple of
format + schema + the caller's constrained intent:

- Go: `i.Output.Format == "json" && i.Output.Schema != nil && i.Output.Constrained`
  (`go/plugins/internal/anthropic/anthropic.go`)
- JS: `output.schema && output.constrained && output.format === 'json'`
  (`js/plugins/anthropic/src/runner/beta.ts`)

In JS/Go the model-capability check lives in core (the `simulateConstrainedGeneration`
middleware in JS, `supportsConstrained` in Go), which downgrades unsupported models to a
prompt-instruction fallback. Python core has no equivalent step yet, so the plugin carries
the model-support check and system-prompt fallback itself. This is the Pythonic stand-in
for that core middleware.

Closes #5632.

## Changes

- Gate `output_config` on `output_schema` present + `output_constrained` truthy +
  `_supports_constrained(has_tools)`, replacing the old `'json' in supports.output` check.
- Add `_supports_constrained`, mirroring the JS/Go capability gate including the
  `no-tools` case.
- Keep the existing system-prompt JSON fallback and fence-stripping behaviour unchanged.

## Testing

- Native `output_config` only when `constrained=True` and the model supports it.
- Fallback to system prompt for unconstrained JSON (`None` and `False`), missing schema,
  unknown models, explicit `constrained=none`, and `no-tools` with tools present.
- `uv run --directory py pytest packages/genkit-anthropic/tests/ -v` passes (71 tests)
