### PR TITLE
fix(py/plugins/anthropic): add dynamic model listing via beta.models.list with static fallback

### DIFF
--- a/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
@@ -18,6 +18,7 @@
 
 from typing import Any, cast
 
+import structlog
 from anthropic import AsyncAnthropic
 
 from genkit import ModelConfig, ModelRequest, ModelResponse
@@ -33,6 +34,8 @@ from genkit.plugin_api import (
 )
 from genkit_anthropic.model_info import SUPPORTED_ANTHROPIC_MODELS, get_model_info
 from genkit_anthropic.models import AnthropicModel
+
+logger = structlog.get_logger(__name__)
 
 ANTHROPIC_PLUGIN_NAME = 'anthropic'
 
@@ -73,6 +76,7 @@ class Anthropic(Plugin):
         self.models = models or list(SUPPORTED_ANTHROPIC_MODELS.keys())
         self._anthropic_params = anthropic_params
         self._runtime_client = loop_local_client(lambda: AsyncAnthropic(**cast(dict[str, Any], self._anthropic_params)))
+        self._list_actions_cache: list[ActionMetadata] | None = None
 
     async def init(self) -> list[Action]:
         """Initialize plugin.
@@ -129,19 +133,73 @@ class Anthropic(Plugin):
             },
         )
 
+    def _model_metadata(self, model_id: str) -> ActionMetadata:
+        """Build ActionMetadata for a single (bare, unprefixed) Anthropic model id.
+
+        Args:
+            model_id: Bare model id (no ``anthropic/`` prefix).
+
+        Returns:
+            ActionMetadata for the model, using curated info if known, else a
+            generic fallback.
+        """
+        return model_action_metadata(
+            name=anthropic_name(model_id),
+            info=get_model_info(model_id).model_dump(by_alias=True, exclude_none=True),
+            config_schema=ModelConfig,
+        )
+
+    async def _fetch_dynamic_model_ids(self) -> list[str]:
+        """Fetch all available model ids from the Anthropic API.
+
+        Uses the beta models endpoint (matching JS, so both stable and beta
+        models are discovered) and fully paginates via ``async for`` (matching
+        Go's completeness, rather than JS's first-page-only read).
+
+        Returns:
+            Model ids in API order.
+        """
+        model_ids: list[str] = []
+        async for model in self._runtime_client().beta.models.list():
+            if model.id:
+                model_ids.append(model.id)
+        return model_ids
+
     async def list_actions(self) -> list[ActionMetadata]:
         """List available Anthropic models.
 
+        Queries the Anthropic API for currently available models and returns
+        the union of API-discovered models and any statically known models
+        not already covered by the API response (API ids first, in API
+        order, then remaining static ids, deduplicated by bare id). The
+        successful result is cached for the lifetime of the plugin instance.
+        If the API call fails, logs a warning and returns the static model
+        list only, without caching the failure, so the next call retries the
+        API.
+
         Returns:
-            List of ActionMetadata for all supported models.
+            List of ActionMetadata for all discovered/supported models.
         """
-        actions = []
-        for model_name, model_info in SUPPORTED_ANTHROPIC_MODELS.items():
-            actions.append(
-                model_action_metadata(
-                    name=anthropic_name(model_name),
-                    info=model_info.model_dump(by_alias=True, exclude_none=True),
-                    config_schema=ModelConfig,
-                )
-            )
+        if self._list_actions_cache is not None:
+            return self._list_actions_cache
+
+        try:
+            model_ids = await self._fetch_dynamic_model_ids()
+        except Exception as e:
+            logger.warning('Failed to list Anthropic models from API, using static model list', error=str(e))
+            return [self._model_metadata(model_id) for model_id in SUPPORTED_ANTHROPIC_MODELS]
+
+        seen: set[str] = set()
+        ordered_ids: list[str] = []
+        for model_id in model_ids:
+            if model_id and model_id not in seen:
+                seen.add(model_id)
+                ordered_ids.append(model_id)
+        for model_id in SUPPORTED_ANTHROPIC_MODELS:
+            if model_id not in seen:
+                seen.add(model_id)
+                ordered_ids.append(model_id)
+
+        actions = [self._model_metadata(model_id) for model_id in ordered_ids]
+        self._list_actions_cache = actions
         return actions

--- a/py/packages/genkit-anthropic/tests/anthropic_plugin_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_plugin_test.py
@@ -19,6 +19,7 @@
 import asyncio
 import queue
 import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -206,6 +207,142 @@ def test_get_model_info_unknown() -> None:
     assert info.supports is not None
     assert info.supports.multiturn is True
     assert info.supports.tools is True
+
+
+class _FakeModelPage:
+    """Minimal async-iterable stand-in for the SDK's AsyncPaginator[BetaModelInfo].
+
+    ``client.beta.models.list()`` in the real SDK is a synchronous call that
+    returns an object iterated over with ``async for`` (auto-paginating). A
+    plain ``MagicMock`` does not reliably support the async-iterator protocol,
+    so this tiny fake implements it directly.
+    """
+
+    def __init__(self, items: list[SimpleNamespace]) -> None:
+        self._items = items
+
+    def __aiter__(self) -> '_FakeModelPage':
+        self._iter = iter(self._items)
+        return self
+
+    async def __anext__(self) -> SimpleNamespace:
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+@pytest.mark.asyncio
+async def test_list_actions_dynamic_union_dedup_and_fallback_info() -> None:
+    """Dynamic models union with statics, dedup by id, unknown ids get generic info."""
+    plugin = Anthropic(api_key='test-key')
+    mock_client = MagicMock()
+    api_items = [
+        SimpleNamespace(id='claude-mythos-5'),  # unknown id -> generic fallback info
+        SimpleNamespace(id='claude-sonnet-4'),  # known static id -> must appear once, curated info
+        SimpleNamespace(id='claude-unknown-xyz'),  # unknown id -> generic fallback info
+    ]
+    mock_client.beta.models.list = MagicMock(return_value=_FakeModelPage(api_items))
+    plugin._runtime_client = lambda: mock_client
+
+    actions = await plugin.list_actions()
+    names = [a.name for a in actions]
+
+    # No duplicates.
+    assert len(names) == len(set(names))
+
+    # API ids present, in API order, first.
+    assert names[0] == 'anthropic/claude-mythos-5'
+    assert names[1] == 'anthropic/claude-sonnet-4'
+    assert names[2] == 'anthropic/claude-unknown-xyz'
+
+    # Static-only ids the mock didn't return are still present (appended after API ids).
+    for model_id in SUPPORTED_MODELS:
+        if model_id != 'claude-sonnet-4':
+            assert anthropic_name(model_id) in names
+    assert len(names) == 3 + len(SUPPORTED_MODELS) - 1
+
+    # Curated info preserved for a known id returned by the API.
+    sonnet_action = next(a for a in actions if a.name == 'anthropic/claude-sonnet-4')
+    assert sonnet_action.metadata is not None
+    assert sonnet_action.metadata['model']['label'] == 'Anthropic - Claude Sonnet 4'
+
+    # Unknown ids get the generic fallback info, not curated.
+    mythos_action = next(a for a in actions if a.name == 'anthropic/claude-mythos-5')
+    assert mythos_action.metadata is not None
+    assert mythos_action.metadata['model']['label'] == 'Anthropic - claude-mythos-5'
+    assert mythos_action.metadata['model']['supports']['output'] == ['text']
+
+
+@pytest.mark.asyncio
+async def test_list_actions_falls_back_to_static_on_error_uncached() -> None:
+    """API errors fall back to the static list without caching the failure."""
+    plugin = Anthropic(api_key='test-key')
+    mock_client = MagicMock()
+    mock_client.beta.models.list = MagicMock(side_effect=RuntimeError('boom'))
+    plugin._runtime_client = lambda: mock_client
+
+    actions = await plugin.list_actions()
+    names = {a.name for a in actions}
+    assert names == {anthropic_name(model_id) for model_id in SUPPORTED_MODELS}
+
+    _ = await plugin.list_actions()
+    assert mock_client.beta.models.list.call_count == 2  # not cached on failure
+
+
+@pytest.mark.asyncio
+async def test_list_actions_caches_on_success() -> None:
+    """A successful API fetch is memoized for the plugin's lifetime."""
+    plugin = Anthropic(api_key='test-key')
+    mock_client = MagicMock()
+    mock_client.beta.models.list = MagicMock(return_value=_FakeModelPage([SimpleNamespace(id='claude-sonnet-4')]))
+    plugin._runtime_client = lambda: mock_client
+
+    first = await plugin.list_actions()
+    second = await plugin.list_actions()
+    assert mock_client.beta.models.list.call_count == 1
+    assert first is second
+
+
+@pytest.mark.asyncio
+async def test_list_actions_skips_empty_model_ids() -> None:
+    """Models with an empty or missing id are dropped, not turned into bogus actions."""
+    plugin = Anthropic(api_key='test-key')
+    mock_client = MagicMock()
+    api_items = [
+        SimpleNamespace(id='claude-sonnet-4'),
+        SimpleNamespace(id=''),  # empty id -> dropped
+        SimpleNamespace(id=None),  # missing id -> dropped
+    ]
+    mock_client.beta.models.list = MagicMock(return_value=_FakeModelPage(api_items))
+    plugin._runtime_client = lambda: mock_client
+
+    actions = await plugin.list_actions()
+    names = [a.name for a in actions]
+
+    # The valid id is present; the empty/missing ones produce no action.
+    assert 'anthropic/claude-sonnet-4' in names
+    assert 'anthropic/' not in names
+    assert 'anthropic/None' not in names
+    # Only the static set is advertised (the one API id overlaps it).
+    assert len(names) == len(SUPPORTED_MODELS)
+
+
+@pytest.mark.asyncio
+async def test_list_actions_empty_api_response_returns_and_caches_statics() -> None:
+    """A successful but empty API response still advertises (and caches) the static set."""
+    plugin = Anthropic(api_key='test-key')
+    mock_client = MagicMock()
+    mock_client.beta.models.list = MagicMock(return_value=_FakeModelPage([]))
+    plugin._runtime_client = lambda: mock_client
+
+    actions = await plugin.list_actions()
+    names = {a.name for a in actions}
+    assert names == {anthropic_name(model_id) for model_id in SUPPORTED_MODELS}
+
+    # Unlike the error path, an empty-but-successful response is cached.
+    _ = await plugin.list_actions()
+    assert mock_client.beta.models.list.call_count == 1
 
 
 def _create_sample_request() -> ModelRequest:


### PR DESCRIPTION
## Summary
The Python plugin's `list_actions` was fully static, so anything not hard-coded in `SUPPORTED_ANTHROPIC_MODELS` (new releases, access-gated models like claude-mythos-5) never showed up in reflection or the dev UI until someone edited the registry by hand. JS already lists models from the API and Go does too, so this brings Python in line.

Closes #5633

## Changes

- `list_actions` now calls `client.beta.models.list()` (same endpoint JS uses, so beta models are included) and follows pagination like the Go plugin.
- The API result is merged with the static set, deduped by id, API order first. JS keeps its known models visible by registering them eagerly at init; our plugin is lazy (`init` returns `[]`), so folding the statics into `list_actions` gets the same observable surface.
- On API failure it logs a warning and returns the static list without caching, so the next reflection request retries. This matters because the registry swallows `list_actions` exceptions, and an unhandled error would drop the plugin from listing entirely.
- Successful results are memoized for the plugin's lifetime, same as JS and the same `_list_actions_cache` pattern genkit-openai already uses. Went with that over Go's 1h TTL for consistency with the existing Python plugins.

Each discovered id still resolves through `get_model_info`, so known ids keep their curated metadata and unknown ids get the generic fallback. No date suffix stripping (JS doesn't do it either). `model_info.py` and `resolve()` are untouched, and the Vertex Model Garden Anthropic plugin is out of scope.

## Tests
Five new cases in `anthropic_plugin_test.py` covering the union/dedup path with curated vs generic info, static fallback on error (and that failures aren't cached), caching on success, empty/None model ids being skipped, and an empty but successful response still advertising the static set. Full package suite passes (71 tests).