### PR TITLE
fix(js/plugins/vercel-ai): drop misleading @ai-sdk/react peer dependency

### DIFF
--- a/js/plugins/vercel-ai/package.json
+++ b/js/plugins/vercel-ai/package.json
@@ -65,14 +65,8 @@
     "test": "tsx --test ./tests/*_test.ts"
   },
   "peerDependencies": {
-    "@ai-sdk/react": "^3.0.0",
     "ai": "^6.0.0",
     "genkit": "workspace:^"
-  },
-  "peerDependenciesMeta": {
-    "@ai-sdk/react": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@ai-sdk/react": "^3.0.0",


### PR DESCRIPTION
## Summary

`@genkit-ai/vercel-ai` declares `@ai-sdk/react` as an (optional) **peer dependency**, which implies React-only support. But `GenkitChatTransport` (from `@genkit-ai/vercel-ai/client`) implements the framework-agnostic `ChatTransport` from the `ai` core package and works with any Vercel AI SDK UI binding — Vue, Svelte, Angular, or none.

The package's shipped source imports **only** from `ai`:

```ts
// js/plugins/vercel-ai/src/client.ts
import type { ChatTransport, UIMessage, UIMessageChunk } from 'ai';
```

`@ai-sdk/react` appears only inside a JSDoc `@example` comment, never as a runtime import. This removes it from `peerDependencies` and `peerDependenciesMeta` so the metadata reflects the actual (binding-agnostic) dependency surface. It stays in `devDependencies`, which the package's own examples/tests use.

Fixes #5616
ISSUE: #5616

## Verification

- Confirmed no file under `src/` imports `@ai-sdk/react` (only the JSDoc example references it).
- `package.json` remains valid; `@ai-sdk/react` is retained as a devDependency.