### PR TITLE
fix(js/plugins/google-genai): validate per-request baseUrl override host

### DIFF
--- a/js/plugins/google-genai/src/googleai/antigravity.ts
+++ b/js/plugins/google-genai/src/googleai/antigravity.ts
@@ -170,6 +170,7 @@ export function defineModel(
   const clientOptions: ClientOptions = {
     apiVersion: pluginOptions?.apiVersion,
     baseUrl: pluginOptions?.baseUrl,
+    allowCustomBaseUrl: pluginOptions?.allowCustomBaseUrl,
     customHeaders: pluginOptions?.customHeaders,
     experimental_debugTraces: pluginOptions?.experimental_debugTraces,
   };

--- a/js/plugins/google-genai/src/googleai/deep-research.ts
+++ b/js/plugins/google-genai/src/googleai/deep-research.ts
@@ -43,6 +43,7 @@ import {
 } from './types.js';
 import {
   calculateApiKey,
+  resolveBaseUrlOverride,
   checkApiKey,
   checkModelName,
   extractVersion,
@@ -282,7 +283,9 @@ export function defineModel(
       const newClientOptions: ClientOptions = {
         ...clientOptions,
         apiKey,
-        baseUrl: baseUrl || clientOptions.baseUrl,
+        baseUrl: baseUrl
+          ? resolveBaseUrlOverride(baseUrl, clientOptions)
+          : clientOptions.baseUrl,
         apiVersion: apiVersion || clientOptions.apiVersion,
       };
 

--- a/js/plugins/google-genai/src/googleai/deep-research.ts
+++ b/js/plugins/google-genai/src/googleai/deep-research.ts
@@ -251,6 +251,7 @@ export function defineModel(
   const clientOptions: ClientOptions = {
     apiVersion: pluginOptions?.apiVersion,
     baseUrl: pluginOptions?.baseUrl,
+    allowCustomBaseUrl: pluginOptions?.allowCustomBaseUrl,
     customHeaders: pluginOptions?.customHeaders,
     experimental_debugTraces: pluginOptions?.experimental_debugTraces,
   };

--- a/js/plugins/google-genai/src/googleai/embedder.ts
+++ b/js/plugins/google-genai/src/googleai/embedder.ts
@@ -159,6 +159,7 @@ export function defineEmbedder(
   const clientOptions: ClientOptions = {
     apiVersion: pluginOptions?.apiVersion,
     baseUrl: pluginOptions?.baseUrl,
+    allowCustomBaseUrl: pluginOptions?.allowCustomBaseUrl,
     customHeaders: pluginOptions?.customHeaders,
     experimental_debugTraces: pluginOptions?.experimental_debugTraces,
   };

--- a/js/plugins/google-genai/src/googleai/gemini.ts
+++ b/js/plugins/google-genai/src/googleai/gemini.ts
@@ -661,6 +661,7 @@ export function defineModel(
   const clientOptions: ClientOptions = {
     apiVersion: pluginOptions?.apiVersion,
     baseUrl: pluginOptions?.baseUrl,
+    allowCustomBaseUrl: pluginOptions?.allowCustomBaseUrl,
     customHeaders: pluginOptions?.customHeaders,
     experimental_debugTraces: pluginOptions?.experimental_debugTraces,
   };

--- a/js/plugins/google-genai/src/googleai/imagen.ts
+++ b/js/plugins/google-genai/src/googleai/imagen.ts
@@ -182,6 +182,7 @@ export function defineModel(
   const clientOptions: ClientOptions = {
     apiVersion: pluginOptions?.apiVersion,
     baseUrl: pluginOptions?.baseUrl,
+    allowCustomBaseUrl: pluginOptions?.allowCustomBaseUrl,
     customHeaders: pluginOptions?.customHeaders,
     experimental_debugTraces: pluginOptions?.experimental_debugTraces,
   };

--- a/js/plugins/google-genai/src/googleai/index.ts
+++ b/js/plugins/google-genai/src/googleai/index.ts
@@ -105,6 +105,7 @@ async function listActions(
     const apiKey = calculateApiKey(options?.apiKey, undefined);
     const allModels = await listModels(apiKey, {
       baseUrl: options?.baseUrl,
+      allowCustomBaseUrl: options?.allowCustomBaseUrl,
       apiVersion: options?.apiVersion,
     });
 

--- a/js/plugins/google-genai/src/googleai/lyria.ts
+++ b/js/plugins/google-genai/src/googleai/lyria.ts
@@ -155,6 +155,7 @@ export function defineModel(
   const clientOptions: ClientOptions = {
     apiVersion: pluginOptions?.apiVersion,
     baseUrl: pluginOptions?.baseUrl,
+    allowCustomBaseUrl: pluginOptions?.allowCustomBaseUrl,
     customHeaders: pluginOptions?.customHeaders,
     experimental_debugTraces: pluginOptions?.experimental_debugTraces,
   };

--- a/js/plugins/google-genai/src/googleai/lyria.ts
+++ b/js/plugins/google-genai/src/googleai/lyria.ts
@@ -33,6 +33,7 @@ import {
 } from './types.js';
 import {
   calculateApiKey,
+  resolveBaseUrlOverride,
   checkApiKey,
   checkModelName,
   extractVersion,
@@ -179,7 +180,9 @@ export function defineModel(
       const newClientOptions: ClientOptions = {
         ...clientOptions,
         apiKey,
-        baseUrl: baseUrl || clientOptions.baseUrl,
+        baseUrl: baseUrl
+          ? resolveBaseUrlOverride(baseUrl, clientOptions)
+          : clientOptions.baseUrl,
         apiVersion: apiVersion || clientOptions.apiVersion,
       };
 

--- a/js/plugins/google-genai/src/googleai/types.ts
+++ b/js/plugins/google-genai/src/googleai/types.ts
@@ -90,6 +90,16 @@ export interface GoogleAIPluginOptions {
    * Additional headers to send along with the request.
    */
   customHeaders?: Record<string, string>;
+  /**
+   * Allow per-request `baseUrl` overrides to point at an arbitrary host.
+   *
+   * Defaults to `false`. When `false`, a per-request `baseUrl` override is
+   * only honored if its host is the default Google endpoint or the host of
+   * the plugin-configured `baseUrl`. This prevents an attacker who can
+   * influence a request's config from redirecting the call (together with the
+   * `x-goog-api-key` header and the prompt body) to a host they control.
+   */
+  allowCustomBaseUrl?: boolean;
 }
 
 /**
@@ -128,6 +138,13 @@ export interface ClientOptions {
    * Base endpoint url. Defaults to "https://generativelanguage.googleapis.com"
    */
   baseUrl?: string;
+  /**
+   * When true, per-request `baseUrl` overrides may target any host. When
+   * false/undefined, overrides are restricted to the default Google endpoint
+   * or the plugin-configured `baseUrl` host. See
+   * {@link GoogleAIPluginOptions.allowCustomBaseUrl}.
+   */
+  allowCustomBaseUrl?: boolean;
   /**
    * Custom HTTP request headers.
    */

--- a/js/plugins/google-genai/src/googleai/utils.ts
+++ b/js/plugins/google-genai/src/googleai/utils.ts
@@ -165,6 +165,52 @@ export function extractImagenImage(
   return undefined;
 }
 
+const DEFAULT_GOOGLEAI_HOST = 'generativelanguage.googleapis.com';
+
+/**
+ * Validate a per-request `baseUrl` override before it is used to build the
+ * request URL. Unless the plugin was constructed with
+ * `allowCustomBaseUrl: true`, the override host must be the default Google
+ * endpoint or the host of the plugin-configured `baseUrl`. This blocks SSRF
+ * and API-key / prompt exfiltration via an attacker-controlled request config.
+ */
+function resolveBaseUrlOverride(
+  override: string,
+  clientOptions: ClientOptions
+): string {
+  let host: string;
+  try {
+    host = new URL(override).host;
+  } catch {
+    throw new GenkitError({
+      status: 'INVALID_ARGUMENT',
+      message: `Invalid baseUrl override: "${override}" is not a valid URL.`,
+    });
+  }
+  if (clientOptions.allowCustomBaseUrl) {
+    return override;
+  }
+  const trustedHosts = new Set<string>([DEFAULT_GOOGLEAI_HOST]);
+  if (clientOptions.baseUrl) {
+    try {
+      trustedHosts.add(new URL(clientOptions.baseUrl).host);
+    } catch {
+      // Plugin-configured baseUrl is malformed; do not use it as a trust anchor.
+    }
+  }
+  if (!trustedHosts.has(host)) {
+    throw new GenkitError({
+      status: 'PERMISSION_DENIED',
+      message:
+        `Per-request baseUrl override host "${host}" is not the default Google ` +
+        `endpoint or the plugin-configured baseUrl host. To allow arbitrary ` +
+        `per-request baseUrl overrides, construct the googleAI plugin with ` +
+        `{ allowCustomBaseUrl: true }.`,
+    });
+  }
+  return override;
+}
+
 /**
  * For each field in ClientOptions, if the request config object has
  * a matching non-empty/non-null field, it overrides the original.
@@ -196,7 +242,7 @@ export function calculateRequestOptions<T extends z.ZodObject<any, any, any>>(
   }
 
   if (typeof reqConfig.baseUrl == 'string') {
-    newOptions.baseUrl = reqConfig.baseUrl;
+    newOptions.baseUrl = resolveBaseUrlOverride(reqConfig.baseUrl, clientOptions);
   }
 
   if (reqConfig.customHeaders && typeof reqConfig.customHeaders === 'object') {

--- a/js/plugins/google-genai/src/googleai/utils.ts
+++ b/js/plugins/google-genai/src/googleai/utils.ts
@@ -174,7 +174,7 @@ const DEFAULT_GOOGLEAI_HOST = 'generativelanguage.googleapis.com';
  * endpoint or the host of the plugin-configured `baseUrl`. This blocks SSRF
  * and API-key / prompt exfiltration via an attacker-controlled request config.
  */
-function resolveBaseUrlOverride(
+export function resolveBaseUrlOverride(
   override: string,
   clientOptions: ClientOptions
 ): string {

--- a/js/plugins/google-genai/src/googleai/veo.ts
+++ b/js/plugins/google-genai/src/googleai/veo.ts
@@ -192,6 +192,7 @@ export function defineModel(
   const clientOptions: ClientOptions = {
     apiVersion: pluginOptions?.apiVersion,
     baseUrl: pluginOptions?.baseUrl,
+    allowCustomBaseUrl: pluginOptions?.allowCustomBaseUrl,
     customHeaders: pluginOptions?.customHeaders,
     experimental_debugTraces: pluginOptions?.experimental_debugTraces,
   };

--- a/js/plugins/google-genai/tests/googleai/utils_test.ts
+++ b/js/plugins/google-genai/tests/googleai/utils_test.ts
@@ -21,6 +21,7 @@ import process from 'process';
 import {
   MISSING_API_KEY_ERROR,
   calculateApiKey,
+  calculateRequestOptions,
   checkApiKey,
   extractVeoImage,
   extractVeoVideo,
@@ -297,5 +298,46 @@ describe('API Key Utils', () => {
       process.env.GOOGLE_API_KEY = 'env_key';
       assert.strictEqual(calculateApiKey('', undefined), 'env_key');
     });
+  });
+});
+
+describe('calculateRequestOptions baseUrl override guard', () => {
+  const base = { apiKey: 'developer-key' };
+
+  it('allows an override to the default Google endpoint', () => {
+    const out = calculateRequestOptions(base, {
+      baseUrl: 'https://generativelanguage.googleapis.com',
+    });
+    assert.strictEqual(out.baseUrl, 'https://generativelanguage.googleapis.com');
+  });
+
+  it('allows an override to the plugin-configured baseUrl host', () => {
+    const out = calculateRequestOptions(
+      { ...base, baseUrl: 'https://proxy.internal.example.com' },
+      { baseUrl: 'https://proxy.internal.example.com/v2' }
+    );
+    assert.strictEqual(out.baseUrl, 'https://proxy.internal.example.com/v2');
+  });
+
+  it('rejects an override to an attacker-controlled host', () => {
+    assert.throws(
+      () => calculateRequestOptions(base, { baseUrl: 'http://attacker.example:8766' }),
+      /PERMISSION_DENIED|not the default Google/
+    );
+  });
+
+  it('rejects an invalid baseUrl override', () => {
+    assert.throws(
+      () => calculateRequestOptions(base, { baseUrl: 'not-a-url' }),
+      /INVALID_ARGUMENT|not a valid URL/
+    );
+  });
+
+  it('allows any host when allowCustomBaseUrl is set on the plugin', () => {
+    const out = calculateRequestOptions(
+      { ...base, allowCustomBaseUrl: true },
+      { baseUrl: 'http://attacker.example:8766' }
+    );
+    assert.strictEqual(out.baseUrl, 'http://attacker.example:8766');
   });
 });

--- a/js/plugins/google-genai/tests/googleai/utils_test.ts
+++ b/js/plugins/google-genai/tests/googleai/utils_test.ts
@@ -22,6 +22,7 @@ import {
   MISSING_API_KEY_ERROR,
   calculateApiKey,
   calculateRequestOptions,
+  resolveBaseUrlOverride,
   checkApiKey,
   extractVeoImage,
   extractVeoVideo,
@@ -339,5 +340,46 @@ describe('calculateRequestOptions baseUrl override guard', () => {
       { baseUrl: 'http://attacker.example:8766' }
     );
     assert.strictEqual(out.baseUrl, 'http://attacker.example:8766');
+  });
+});
+
+describe('resolveBaseUrlOverride (shared guard used by deep-research and lyria)', () => {
+  it('allows the default Google endpoint', () => {
+    assert.strictEqual(
+      resolveBaseUrlOverride('https://generativelanguage.googleapis.com', {}),
+      'https://generativelanguage.googleapis.com'
+    );
+  });
+
+  it('allows the plugin-configured baseUrl host', () => {
+    assert.strictEqual(
+      resolveBaseUrlOverride('https://proxy.internal.example.com/v2', {
+        baseUrl: 'https://proxy.internal.example.com',
+      }),
+      'https://proxy.internal.example.com/v2'
+    );
+  });
+
+  it('rejects an attacker-controlled host', () => {
+    assert.throws(
+      () => resolveBaseUrlOverride('http://attacker.example:8766', {}),
+      /PERMISSION_DENIED|not the default Google/
+    );
+  });
+
+  it('rejects an invalid URL', () => {
+    assert.throws(
+      () => resolveBaseUrlOverride('not-a-url', {}),
+      /INVALID_ARGUMENT|not a valid URL/
+    );
+  });
+
+  it('allows any host when allowCustomBaseUrl is set', () => {
+    assert.strictEqual(
+      resolveBaseUrlOverride('http://attacker.example:8766', {
+        allowCustomBaseUrl: true,
+      }),
+      'http://attacker.example:8766'
+    );
   });
 });


### PR DESCRIPTION
### What

`calculateRequestOptions` (js/plugins/google-genai/src/googleai/utils.ts) applied a per-request `config.baseUrl` override unconditionally. Genkit flow handlers commonly forward user-controlled config into `ai.generate({ config })`, so a value that reaches the request could redirect the Gemini call to an arbitrary host together with the `x-goog-api-key` header and the full prompt body (SSRF + API-key / prompt exfiltration + response forgery). The SDK did not validate that the override host belongs to a Google endpoint, and did not strip the API key when the host changed.

### Fix

Restrict a per-request `baseUrl` override to the default Google endpoint (`generativelanguage.googleapis.com`) or the host of the plugin-configured `baseUrl`. An override to any other host now throws `PERMISSION_DENIED` (and an invalid URL throws `INVALID_ARGUMENT`).

Developers who legitimately need arbitrary per-request hosts can opt back in explicitly at plugin construction:

```ts
googleAI({ allowCustomBaseUrl: true })
```

The trust boundary is moved to plugin construction (developer-controlled) instead of per-request config (which may flow from end users). The plugin-configured `baseUrl` is still honored, so existing custom-proxy setups keep working.

Vertex AI is unaffected: its `calculateRequestOptions` has no `baseUrl` override (it routes by `location`).

### Tests

Adds `calculateRequestOptions` guard tests to `tests/googleai/utils_test.ts`: default Google host allowed, plugin-configured host allowed, attacker host rejected, invalid URL rejected, and `allowCustomBaseUrl` opt-in bypass.

- `pnpm --filter @genkit-ai/google-genai test` → 30/30 pass
- `pnpm --filter @genkit-ai/google-genai run check` (tsc) → clean

Reported via the Google OSS VRP. Signed-off per the DCO.
