### PR TITLE
fix(py): report finish reason and cumulative usage on Gemini generate_stream turns

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -179,6 +179,34 @@ def _to_dict(obj: JsonAny) -> JsonAny:  # noqa: ANN401
     return obj.model_dump() if isinstance(obj, BaseModel) else obj
 
 
+def _to_finish_reason(fr_name: str | None) -> FinishReason:
+    """Map a google-genai finish reason name onto Genkit's FinishReason."""
+    if fr_name == 'STOP':
+        return FinishReason.STOP
+    if fr_name == 'MAX_TOKENS':
+        return FinishReason.LENGTH
+    if fr_name in ('SAFETY', 'RECITATION', 'BLOCKLIST', 'PROHIBITED_CONTENT', 'SPII'):
+        return FinishReason.BLOCKED
+    return FinishReason.OTHER
+
+
+def _usage_from_metadata(usage_metadata: Any) -> ModelUsage:  # noqa: ANN401
+    """Build ModelUsage from a google-genai usage_metadata block."""
+    if usage_metadata is None:
+        return ModelUsage()
+    return ModelUsage(
+        input_tokens=float(usage_metadata.prompt_token_count or 0),
+        output_tokens=float(usage_metadata.candidates_token_count or 0),
+        total_tokens=float(usage_metadata.total_token_count or 0),
+        thoughts_tokens=float(usage_metadata.thoughts_token_count or 0)
+        if usage_metadata.thoughts_token_count
+        else None,
+        cached_content_tokens=float(usage_metadata.cached_content_token_count or 0)
+        if usage_metadata.cached_content_token_count
+        else None,
+    )
+
+
 from genkit_google_genai.models._deprecations import (  # noqa: E402
     deprecated_enum_metafactory,
 )
@@ -1668,17 +1696,7 @@ class GeminiModel:
                 if not c_content:
                     c_content = [Part(root=TextPart(text=''))]
 
-                c_finish_reason = FinishReason.OTHER
-                if c.finish_reason:
-                    fr_name = c.finish_reason.name
-                    if fr_name == 'STOP':
-                        c_finish_reason = FinishReason.STOP
-                    elif fr_name == 'MAX_TOKENS':
-                        c_finish_reason = FinishReason.LENGTH
-                    elif fr_name in ['SAFETY', 'RECITATION', 'BLOCKLIST', 'PROHIBITED_CONTENT', 'SPII']:
-                        c_finish_reason = FinishReason.BLOCKED
-                    elif fr_name == 'OTHER':
-                        c_finish_reason = FinishReason.OTHER
+                c_finish_reason = _to_finish_reason(c.finish_reason.name if c.finish_reason else None)
 
                 if i == 0:
                     finish_reason = c_finish_reason
@@ -1762,6 +1780,8 @@ class GeminiModel:
             ) from e
 
         accumulated_content: list[Part] = []
+        finish_reason = FinishReason.STOP
+        usage_metadata: Any = None
         async for response_chunk in generator:
             content = await self._contents_from_response(response_chunk)
             if content:  # Only process if we have content
@@ -1772,12 +1792,21 @@ class GeminiModel:
                         role=Role.MODEL,
                     )
                 )
+            # The terminating reason and cumulative token usage ride on the trailing
+            # chunks, so hold onto the latest values we see as the stream drains —
+            # otherwise a streamed turn reports no finish reason and no usage at all.
+            if response_chunk.candidates and response_chunk.candidates[0].finish_reason:
+                finish_reason = _to_finish_reason(response_chunk.candidates[0].finish_reason.name)
+            if response_chunk.usage_metadata is not None:
+                usage_metadata = response_chunk.usage_metadata
 
         return ModelResponse(
             message=Message(
                 role=Role.MODEL,
                 content=accumulated_content,
-            )
+            ),
+            finish_reason=finish_reason,
+            usage=_usage_from_metadata(usage_metadata),
         )
 
     @cached_property

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -186,7 +186,16 @@ def _to_finish_reason(fr: Any) -> FinishReason:  # noqa: ANN401
         return FinishReason.STOP
     if fr_name == 'MAX_TOKENS':
         return FinishReason.LENGTH
-    if fr_name in ('SAFETY', 'RECITATION', 'BLOCKLIST', 'PROHIBITED_CONTENT', 'SPII', 'LANGUAGE', 'MALICIOUS'):
+    if fr_name in (
+        'SAFETY',
+        'RECITATION',
+        'BLOCKLIST',
+        'PROHIBITED_CONTENT',
+        'SPII',
+        'LANGUAGE',
+        'MALICIOUS',
+        'IMAGE_SAFETY',
+    ):
         return FinishReason.BLOCKED
     if fr_name in ('OTHER', 'MALFORMED_FUNCTION_CALL', 'MISSING_THOUGHT_SIGNATURE'):
         return FinishReason.OTHER

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -2109,10 +2109,15 @@ class GeminiModel:
 
         usage = get_basic_usage_stats(input_=request.messages, response=response.message)
         if response.usage:
-            usage.input_tokens = response.usage.input_tokens
-            usage.output_tokens = response.usage.output_tokens
-            usage.total_tokens = response.usage.total_tokens
-            usage.thoughts_tokens = response.usage.thoughts_tokens
-            usage.cached_content_tokens = response.usage.cached_content_tokens
+            if response.usage.input_tokens is not None:
+                usage.input_tokens = response.usage.input_tokens
+            if response.usage.output_tokens is not None:
+                usage.output_tokens = response.usage.output_tokens
+            if response.usage.total_tokens is not None:
+                usage.total_tokens = response.usage.total_tokens
+            if response.usage.thoughts_tokens is not None:
+                usage.thoughts_tokens = response.usage.thoughts_tokens
+            if response.usage.cached_content_tokens is not None:
+                usage.cached_content_tokens = response.usage.cached_content_tokens
 
         return usage

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -194,16 +194,19 @@ def _usage_from_metadata(usage_metadata: Any) -> ModelUsage:  # noqa: ANN401
     """Build ModelUsage from a google-genai usage_metadata block."""
     if usage_metadata is None:
         return ModelUsage()
+
+    prompt_tokens = getattr(usage_metadata, 'prompt_token_count', 0) or 0
+    candidates_tokens = getattr(usage_metadata, 'candidates_token_count', 0) or 0
+    total_tokens = getattr(usage_metadata, 'total_token_count', 0) or 0
+    thoughts_tokens = getattr(usage_metadata, 'thoughts_token_count', None)
+    cached_tokens = getattr(usage_metadata, 'cached_content_token_count', None)
+
     return ModelUsage(
-        input_tokens=float(usage_metadata.prompt_token_count or 0),
-        output_tokens=float(usage_metadata.candidates_token_count or 0),
-        total_tokens=float(usage_metadata.total_token_count or 0),
-        thoughts_tokens=float(usage_metadata.thoughts_token_count or 0)
-        if usage_metadata.thoughts_token_count
-        else None,
-        cached_content_tokens=float(usage_metadata.cached_content_token_count or 0)
-        if usage_metadata.cached_content_token_count
-        else None,
+        input_tokens=float(prompt_tokens),
+        output_tokens=float(candidates_tokens),
+        total_tokens=float(total_tokens),
+        thoughts_tokens=float(thoughts_tokens) if thoughts_tokens else None,
+        cached_content_tokens=float(cached_tokens) if cached_tokens else None,
     )
 
 
@@ -1795,8 +1798,10 @@ class GeminiModel:
             # The terminating reason and cumulative token usage ride on the trailing
             # chunks, so hold onto the latest values we see as the stream drains —
             # otherwise a streamed turn reports no finish reason and no usage at all.
-            if response_chunk.candidates and response_chunk.candidates[0].finish_reason:
-                finish_reason = _to_finish_reason(response_chunk.candidates[0].finish_reason.name)
+            if response_chunk.candidates and response_chunk.candidates[0] is not None:
+                fr = response_chunk.candidates[0].finish_reason
+                if fr:
+                    finish_reason = _to_finish_reason(getattr(fr, 'name', fr))
             if response_chunk.usage_metadata is not None:
                 usage_metadata = response_chunk.usage_metadata
 
@@ -2109,15 +2114,9 @@ class GeminiModel:
 
         usage = get_basic_usage_stats(input_=request.messages, response=response.message)
         if response.usage:
-            if response.usage.input_tokens is not None:
-                usage.input_tokens = response.usage.input_tokens
-            if response.usage.output_tokens is not None:
-                usage.output_tokens = response.usage.output_tokens
-            if response.usage.total_tokens is not None:
-                usage.total_tokens = response.usage.total_tokens
-            if response.usage.thoughts_tokens is not None:
-                usage.thoughts_tokens = response.usage.thoughts_tokens
-            if response.usage.cached_content_tokens is not None:
-                usage.cached_content_tokens = response.usage.cached_content_tokens
+            for field in ('input_tokens', 'output_tokens', 'total_tokens', 'thoughts_tokens', 'cached_content_tokens'):
+                val = getattr(response.usage, field, None)
+                if val is not None:
+                    setattr(usage, field, val)
 
         return usage

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -186,9 +186,9 @@ def _to_finish_reason(fr: Any) -> FinishReason:  # noqa: ANN401
         return FinishReason.STOP
     if fr_name == 'MAX_TOKENS':
         return FinishReason.LENGTH
-    if fr_name in ('SAFETY', 'RECITATION', 'BLOCKLIST', 'PROHIBITED_CONTENT', 'SPII', 'LANGUAGE'):
+    if fr_name in ('SAFETY', 'RECITATION', 'BLOCKLIST', 'PROHIBITED_CONTENT', 'SPII', 'LANGUAGE', 'MALICIOUS'):
         return FinishReason.BLOCKED
-    if fr_name == 'OTHER':
+    if fr_name in ('OTHER', 'MALFORMED_FUNCTION_CALL', 'MISSING_THOUGHT_SIGNATURE'):
         return FinishReason.OTHER
     return FinishReason.UNKNOWN
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -185,9 +185,11 @@ def _to_finish_reason(fr_name: str | None) -> FinishReason:
         return FinishReason.STOP
     if fr_name == 'MAX_TOKENS':
         return FinishReason.LENGTH
-    if fr_name in ('SAFETY', 'RECITATION', 'BLOCKLIST', 'PROHIBITED_CONTENT', 'SPII'):
+    if fr_name in ('SAFETY', 'RECITATION', 'BLOCKLIST', 'PROHIBITED_CONTENT', 'SPII', 'LANGUAGE'):
         return FinishReason.BLOCKED
-    return FinishReason.OTHER
+    if fr_name == 'OTHER':
+        return FinishReason.OTHER
+    return FinishReason.UNKNOWN
 
 
 def _usage_from_metadata(usage_metadata: Any) -> ModelUsage:  # noqa: ANN401
@@ -1719,21 +1721,7 @@ class GeminiModel:
             ),
             finish_reason=finish_reason,
             candidates=candidates,
-            usage=ModelUsage(
-                input_tokens=float(response.usage_metadata.prompt_token_count or 0)
-                if response.usage_metadata
-                else None,
-                output_tokens=float(response.usage_metadata.candidates_token_count or 0)
-                if response.usage_metadata
-                else None,
-                total_tokens=float(response.usage_metadata.total_token_count or 0) if response.usage_metadata else None,
-                thoughts_tokens=float(response.usage_metadata.thoughts_token_count or 0)
-                if response.usage_metadata and response.usage_metadata.thoughts_token_count
-                else None,
-                cached_content_tokens=float(response.usage_metadata.cached_content_token_count or 0)
-                if response.usage_metadata and response.usage_metadata.cached_content_token_count
-                else None,
-            ),
+            usage=_usage_from_metadata(response.usage_metadata),
         )
 
     async def _streaming_generate(
@@ -1783,7 +1771,7 @@ class GeminiModel:
             ) from e
 
         accumulated_content: list[Part] = []
-        finish_reason = FinishReason.STOP
+        finish_reason = FinishReason.UNKNOWN
         usage_metadata: Any = None
         async for response_chunk in generator:
             content = await self._contents_from_response(response_chunk)

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -179,8 +179,9 @@ def _to_dict(obj: JsonAny) -> JsonAny:  # noqa: ANN401
     return obj.model_dump() if isinstance(obj, BaseModel) else obj
 
 
-def _to_finish_reason(fr_name: str | None) -> FinishReason:
-    """Map a google-genai finish reason name onto Genkit's FinishReason."""
+def _to_finish_reason(fr: Any) -> FinishReason:  # noqa: ANN401
+    """Map a google-genai finish reason onto Genkit's FinishReason."""
+    fr_name = getattr(fr, 'name', fr) if fr is not None else None
     if fr_name == 'STOP':
         return FinishReason.STOP
     if fr_name == 'MAX_TOKENS':
@@ -207,8 +208,8 @@ def _usage_from_metadata(usage_metadata: Any) -> ModelUsage:  # noqa: ANN401
         input_tokens=float(prompt_tokens),
         output_tokens=float(candidates_tokens),
         total_tokens=float(total_tokens),
-        thoughts_tokens=float(thoughts_tokens) if thoughts_tokens else None,
-        cached_content_tokens=float(cached_tokens) if cached_tokens else None,
+        thoughts_tokens=float(thoughts_tokens) if thoughts_tokens is not None else None,
+        cached_content_tokens=float(cached_tokens) if cached_tokens is not None else None,
     )
 
 
@@ -1701,7 +1702,7 @@ class GeminiModel:
                 if not c_content:
                     c_content = [Part(root=TextPart(text=''))]
 
-                c_finish_reason = _to_finish_reason(c.finish_reason.name if c.finish_reason else None)
+                c_finish_reason = _to_finish_reason(c.finish_reason)
 
                 if i == 0:
                     finish_reason = c_finish_reason
@@ -1789,7 +1790,7 @@ class GeminiModel:
             if response_chunk.candidates and response_chunk.candidates[0] is not None:
                 fr = response_chunk.candidates[0].finish_reason
                 if fr:
-                    finish_reason = _to_finish_reason(getattr(fr, 'name', fr))
+                    finish_reason = _to_finish_reason(fr)
             if response_chunk.usage_metadata is not None:
                 usage_metadata = response_chunk.usage_metadata
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -193,23 +193,23 @@ def _to_finish_reason(fr: Any) -> FinishReason:  # noqa: ANN401
     return FinishReason.UNKNOWN
 
 
+def _to_float(obj: Any, attr: str) -> float | None:  # noqa: ANN401
+    """Extract an optional numeric attribute as a float."""
+    val = getattr(obj, attr, None)
+    return float(val) if val is not None else None
+
+
 def _usage_from_metadata(usage_metadata: Any) -> ModelUsage:  # noqa: ANN401
     """Build ModelUsage from a google-genai usage_metadata block."""
     if usage_metadata is None:
         return ModelUsage()
 
-    prompt_tokens = getattr(usage_metadata, 'prompt_token_count', 0) or 0
-    candidates_tokens = getattr(usage_metadata, 'candidates_token_count', 0) or 0
-    total_tokens = getattr(usage_metadata, 'total_token_count', 0) or 0
-    thoughts_tokens = getattr(usage_metadata, 'thoughts_token_count', None)
-    cached_tokens = getattr(usage_metadata, 'cached_content_token_count', None)
-
     return ModelUsage(
-        input_tokens=float(prompt_tokens),
-        output_tokens=float(candidates_tokens),
-        total_tokens=float(total_tokens),
-        thoughts_tokens=float(thoughts_tokens) if thoughts_tokens is not None else None,
-        cached_content_tokens=float(cached_tokens) if cached_tokens is not None else None,
+        input_tokens=_to_float(usage_metadata, 'prompt_token_count'),
+        output_tokens=_to_float(usage_metadata, 'candidates_token_count'),
+        total_tokens=_to_float(usage_metadata, 'total_token_count'),
+        thoughts_tokens=_to_float(usage_metadata, 'thoughts_token_count'),
+        cached_content_tokens=_to_float(usage_metadata, 'cached_content_token_count'),
     )
 
 

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -19,6 +19,7 @@
 
 import base64
 import sys
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 if sys.version_info < (3, 11):
@@ -48,6 +49,7 @@ from pytest_mock import MockerFixture
 from genkit import (
     ActionRunContext,
     Constrained,
+    FinishReason,
     MediaPart,
     Message,
     ModelInfo,
@@ -161,6 +163,50 @@ async def test_generate_stream_text_response(mocker: MockerFixture, version: str
     assert isinstance(response, ModelResponse)
     assert response.message is not None
     assert response.message.content == []
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_captures_finish_reason_and_usage(mocker: MockerFixture) -> None:
+    """Test that streaming generate captures trailing finish_reason and usage_metadata."""
+    request = ModelRequest(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[Part(root=TextPart(text='hi'))],
+            ),
+        ]
+    )
+    cand_1 = genai.types.Candidate(content=genai.types.Content(parts=[genai.types.Part(text='Hello')]))
+    resp_1 = genai.types.GenerateContentResponse(candidates=[cand_1])
+
+    cand_2 = genai.types.Candidate(
+        content=genai.types.Content(parts=[genai.types.Part(text=' world!')]),
+        finish_reason=genai.types.FinishReason.STOP,
+    )
+    usage_meta = genai.types.GenerateContentResponseUsageMetadata(
+        prompt_token_count=10,
+        candidates_token_count=5,
+        total_token_count=15,
+    )
+    resp_2 = genai.types.GenerateContentResponse(candidates=[cand_2], usage_metadata=usage_meta)
+
+    googleai_client_mock = mocker.AsyncMock()
+    async def mock_stream() -> Any:  # noqa: ANN401
+        for r in [resp_1, resp_2]:
+            yield r
+    googleai_client_mock.aio.models.generate_content_stream.return_value = mock_stream()
+
+    on_chunk_mock = mocker.MagicMock()
+    gemini = GeminiModel('gemini-2.5-flash', googleai_client_mock)
+    ctx = ActionRunContext(streaming_callback=on_chunk_mock)
+
+    response = await gemini.generate(request, ctx)
+    assert response.finish_reason == FinishReason.STOP
+    assert response.usage is not None
+    assert response.usage.input_tokens == 10
+    assert response.usage.output_tokens == 5
+    assert response.usage.total_tokens == 15
+    assert on_chunk_mock.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -191,9 +191,11 @@ async def test_generate_stream_captures_finish_reason_and_usage(mocker: MockerFi
     resp_2 = genai.types.GenerateContentResponse(candidates=[cand_2], usage_metadata=usage_meta)
 
     googleai_client_mock = mocker.AsyncMock()
+
     async def mock_stream() -> Any:  # noqa: ANN401
         for r in [resp_1, resp_2]:
             yield r
+
     googleai_client_mock.aio.models.generate_content_stream.return_value = mock_stream()
 
     on_chunk_mock = mocker.MagicMock()

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -212,6 +212,35 @@ async def test_generate_stream_captures_finish_reason_and_usage(mocker: MockerFi
 
 
 @pytest.mark.asyncio
+async def test_generate_stream_without_finish_reason(mocker: MockerFixture) -> None:
+    """Test that streaming generate defaults to FinishReason.UNKNOWN when no chunk carries a finish_reason."""
+    request = ModelRequest(
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[Part(root=TextPart(text='hi'))],
+            ),
+        ]
+    )
+    cand_1 = genai.types.Candidate(content=genai.types.Content(parts=[genai.types.Part(text='Hello')]))
+    resp_1 = genai.types.GenerateContentResponse(candidates=[cand_1])
+
+    googleai_client_mock = mocker.AsyncMock()
+
+    async def mock_stream() -> Any:  # noqa: ANN401
+        yield resp_1
+
+    googleai_client_mock.aio.models.generate_content_stream.return_value = mock_stream()
+
+    on_chunk_mock = mocker.MagicMock()
+    gemini = GeminiModel('gemini-2.5-flash', googleai_client_mock)
+    ctx = ActionRunContext(streaming_callback=on_chunk_mock)
+
+    response = await gemini.generate(request, ctx)
+    assert response.finish_reason == FinishReason.UNKNOWN
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize('version', [x for x in IMAGE_GENERATION_VERSIONS])
 async def test_generate_media_response(mocker: MockerFixture, version: str) -> None:
     """Test generate method for media responses."""


### PR DESCRIPTION
## Summary
Fixes `GeminiModel.generate_stream` returning `FinishReason.OTHER` and zero/empty token `usage` stats across streamed responses (`py/packages/genkit-google-genai`).

## Changes
- **Finish Reason & Token Usage (`gemini.py`)**: Extracted `_to_finish_reason` and `_usage_from_metadata` helpers. Inside `_streaming_generate`, trailing `finish_reason` and `usage_metadata` blocks from chunk candidates are retained and passed directly into `ModelResponse`.
- **Usage Nullability Check (`_create_usage_stats`)**: Added null checks (`if response.usage.input_tokens is not None...`) before overriding computed token usage so valid chunk usage is not clobbered by defaults.
- **Unit Test (`googlegenai_gemini_test.py`)**: Added `test_generate_stream_captures_finish_reason_and_usage` asserting that streamed turns cleanly capture `FinishReason.STOP` and accurate `ModelUsage` token counts.