### PR TITLE
fix(agents): reject empty prompt-agent turns

### DIFF
--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -2495,7 +2495,7 @@ func toolRefSuffix(ref string) string {
 func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) AgentFunc[State] {
 	return func(ctx context.Context, resp Responder, sess *SessionRunner[State]) (*AgentResult, error) {
 		if err := sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
-			if input.Message == nil && input.Resume == nil {
+			if !hasInputPayload(input) {
 				return nil, core.NewError(core.INVALID_ARGUMENT, "agent input message or resume is required")
 			}
 			if err := validateUserMessage(input.Message); err != nil {

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -2495,6 +2495,9 @@ func toolRefSuffix(ref string) string {
 func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) AgentFunc[State] {
 	return func(ctx context.Context, resp Responder, sess *SessionRunner[State]) (*AgentResult, error) {
 		if err := sess.Run(ctx, func(ctx context.Context, input *AgentInput) (*TurnResult, error) {
+			if input.Message == nil && input.Resume == nil {
+				return nil, core.NewError(core.INVALID_ARGUMENT, "agent input message or resume is required")
+			}
 			if err := validateUserMessage(input.Message); err != nil {
 				return nil, err
 			}

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -2374,11 +2374,22 @@ func TestPromptAgent_RejectsInvalidInputMessage(t *testing.T) {
 	tests := []struct {
 		name    string
 		message *ai.Message
+		resume  *ToolResume
 		wantMsg string
 	}{
 		{
 			name:    "missing message",
 			message: nil,
+			wantMsg: "message",
+		},
+		{
+			// A Resume struct that is non-nil but carries no Respond/Restart
+			// entries must be treated the same as no Resume at all; only
+			// checking for a nil Resume would let this slip through to the
+			// model with an effectively empty turn.
+			name:    "empty resume payload",
+			message: nil,
+			resume:  &ToolResume{},
 			wantMsg: "message",
 		},
 		{
@@ -2404,7 +2415,7 @@ func TestPromptAgent_RejectsInvalidInputMessage(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			out, err := af.Run(ctx, &AgentInput{Message: tc.message})
+			out, err := af.Run(ctx, &AgentInput{Message: tc.message, Resume: tc.resume})
 			if err != nil {
 				t.Fatalf("Run: %v", err)
 			}

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -2361,7 +2361,14 @@ func TestPromptAgent_RunText(t *testing.T) {
 func TestPromptAgent_RejectsInvalidInputMessage(t *testing.T) {
 	ctx := context.Background()
 	reg := setupPromptTestRegistry(t)
-	ai.DefinePrompt(reg, "rejectPrompt", ai.WithModelName("test/echo"))
+	var modelCalls atomic.Int64
+	ai.DefineModel(reg, "test/reject", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true}},
+		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			modelCalls.Add(1)
+			return &ai.ModelResponse{Message: ai.NewModelTextMessage("unexpected")}, nil
+		},
+	)
+	ai.DefinePrompt(reg, "rejectPrompt", ai.WithModelName("test/reject"))
 	af := DefinePromptAgent[testState](reg, "rejectPrompt")
 
 	tests := []struct {
@@ -2369,6 +2376,11 @@ func TestPromptAgent_RejectsInvalidInputMessage(t *testing.T) {
 		message *ai.Message
 		wantMsg string
 	}{
+		{
+			name:    "missing message",
+			message: nil,
+			wantMsg: "message",
+		},
 		{
 			name:    "non-user role",
 			message: &ai.Message{Role: ai.RoleModel, Content: []*ai.Part{ai.NewTextPart("hi")}},
@@ -2409,6 +2421,9 @@ func TestPromptAgent_RejectsInvalidInputMessage(t *testing.T) {
 				t.Errorf("Error.Message = %q, want substring %q", out.Error.Message, tc.wantMsg)
 			}
 		})
+	}
+	if got := modelCalls.Load(); got != 0 {
+		t.Fatalf("model calls = %d, want 0", got)
 	}
 }
 

--- a/go/genkit/reflection_v2_test.go
+++ b/go/genkit/reflection_v2_test.go
@@ -24,11 +24,14 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
+	"github.com/firebase/genkit/go/ai"
+	aix "github.com/firebase/genkit/go/ai/exp"
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/tracing"
@@ -704,6 +707,88 @@ loop:
 	}
 	if out != "processed" {
 		t.Errorf("result = %q, want %q", out, "processed")
+	}
+}
+
+func TestReflectionServerV2_PromptAgentRejectsEmptyStreamInput(t *testing.T) {
+	m := newFakeManager(t)
+	defer m.close()
+
+	g := Init(context.Background())
+	var modelCalls atomic.Int64
+	DefineModel(g, "test/agent-empty-guard", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true}},
+		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			modelCalls.Add(1)
+			return &ai.ModelResponse{Message: ai.NewModelTextMessage("unexpected")}, nil
+		},
+	)
+	aix.DefineAgent[any](g.reg, "promptAgent", aix.InlinePrompt{ai.WithModelName("test/agent-empty-guard")})
+
+	ctx, cancel := startRuntime(t, g, m)
+	defer cancel()
+
+	conn := m.waitForConnection(t)
+	m.ackRegister(t, ctx, conn)
+
+	m.write(t, ctx, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "runAction",
+		"params": map[string]any{
+			"key":         "/agent/promptAgent",
+			"streamInput": true,
+		},
+		"id": "agent-empty-1",
+	})
+	m.write(t, ctx, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "sendInputStreamChunk",
+		"params":  map[string]any{"requestId": "agent-empty-1", "chunk": map[string]any{}},
+	})
+	m.write(t, ctx, conn, map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "endInputStream",
+		"params":  map[string]any{"requestId": "agent-empty-1"},
+	})
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for response")
+		default:
+		}
+		msg := m.read(t, ctx, conn)
+		if msg["method"] == "runActionState" {
+			continue // ignore notifications (e.g., runActionState)
+		}
+		if errObj, ok := msg["error"].(map[string]any); ok {
+			t.Fatalf("expected failed agent output, got error: %v", errObj)
+		}
+		result, ok := msg["result"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected result object, got %v", msg)
+		}
+		output, ok := result["result"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected agent output object, got %v", result["result"])
+		}
+		if output["finishReason"] != "failed" {
+			t.Errorf("finishReason = %v, want failed", output["finishReason"])
+		}
+		errObj, ok := output["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected agent output error, got %v", output["error"])
+		}
+		if errObj["status"] != string(core.INVALID_ARGUMENT) {
+			t.Errorf("error status = %v, want %s", errObj["status"], core.INVALID_ARGUMENT)
+		}
+		if !strings.Contains(errObj["message"].(string), "message") {
+			t.Errorf("error message = %q, want substring %q", errObj["message"], "message")
+		}
+		if got := modelCalls.Load(); got != 0 {
+			t.Fatalf("model calls = %d, want 0", got)
+		}
+		return
 	}
 }
 

--- a/go/genkit/servers_agent_test.go
+++ b/go/genkit/servers_agent_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -63,11 +64,16 @@ type agentHTTPResult struct {
 // session source) are hard HTTP errors.
 func TestHandlerAgent(t *testing.T) {
 	g := genkit.Init(context.Background(), genkit.WithExperimental())
+	var modelCalls atomic.Int64
 
 	// Replies "echo <n>" where n is the number of messages the model saw,
 	// so resumed history is observable; fails when asked to.
 	genkit.DefineModel(g, "test/echo", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true}},
 		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			modelCalls.Add(1)
+			if len(req.Messages) == 0 {
+				return nil, core.NewError(core.INTERNAL, "model saw empty messages")
+			}
 			last := req.Messages[len(req.Messages)-1]
 			if last.Role == ai.RoleUser && strings.Contains(last.Text(), "fail") {
 				return nil, core.NewError(core.RESOURCE_EXHAUSTED, "model on fire")
@@ -223,6 +229,30 @@ func TestHandlerAgent(t *testing.T) {
 		// The failed output still hands back the last-good state.
 		if len(res.State) == 0 {
 			t.Error("failed output must carry the last-good state")
+		}
+	})
+
+	t.Run("missing turn message fails before model invocation", func(t *testing.T) {
+		before := modelCalls.Load()
+		code, body := post(t, "agentClient", `{"data":{}}`, false)
+		if code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (failure rides the output); body = %s", code, body)
+		}
+		res := parseResult(t, body)
+		if res.FinishReason != "failed" {
+			t.Errorf("finishReason = %q, want %q", res.FinishReason, "failed")
+		}
+		if res.Error == nil {
+			t.Fatalf("missing error in failed output: %s", body)
+		}
+		if res.Error.Status != "INVALID_ARGUMENT" {
+			t.Errorf("error.status = %q, want INVALID_ARGUMENT", res.Error.Status)
+		}
+		if !strings.Contains(res.Error.Message, "message") {
+			t.Errorf("error.message = %q, want substring %q", res.Error.Message, "message")
+		}
+		if got := modelCalls.Load(); got != before {
+			t.Fatalf("model calls = %d, want %d", got, before)
 		}
 	})
 


### PR DESCRIPTION
This PR tightens prompt-backed agent input validation.

For agents created with `DefineAgent` / `DefinePromptAgent`, Genkit now rejects a turn when both `Message` and `Resume` are missing. That means malformed inputs like `{"data":{}}` fail early with `INVALID_ARGUMENT` instead of reaching the model provider with an `empty/nil` message list.

This preserves valid paths:
  - normal user turns with `Message`
  - interrupted tool continuations with `Resume`

It also adds regression coverage for the direct agent API, HTTP agent route, and Dev UI/reflection V2 stream-input path to prove the model is not invoked for empty prompt-agent turns.

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)
