### PR TITLE
fix(js): serialize callable middleware functions in reflection v2 listValues

### DIFF
--- a/js/core/src/reflection-v2.ts
+++ b/js/core/src/reflection-v2.ts
@@ -395,8 +395,7 @@ export class ReflectionServerV2 {
     for (const [key, value] of Object.entries(values)) {
       mappedValues[key] =
         value &&
-        typeof value === 'object' &&
-        'toJson' in value &&
+        (value as any).toJson &&
         typeof (value as any).toJson === 'function'
           ? (value as any).toJson()
           : value;

--- a/js/core/tests/reflection-v2_test.ts
+++ b/js/core/tests/reflection-v2_test.ts
@@ -212,6 +212,9 @@ describe('ReflectionServerV2', () => {
     registry.registerValue('middleware', 'mw2', {
       name: 'mw2',
     });
+    const mw3Fn = () => {};
+    (mw3Fn as any).toJson = () => ({ name: 'mw3' });
+    registry.registerValue('middleware', 'mw3', mw3Fn);
 
     const gotListValues = new Promise<void>((resolve, reject) => {
       const timer = setTimeout(
@@ -242,6 +245,8 @@ describe('ReflectionServerV2', () => {
             assert.strictEqual(msg.result.values['mw1'].name, 'mw1');
             assert.ok(msg.result.values['mw2']);
             assert.strictEqual(msg.result.values['mw2'].name, 'mw2');
+            assert.ok(msg.result.values['mw3']);
+            assert.strictEqual(msg.result.values['mw3'].name, 'mw3');
             clearTimeout(timer);
             resolve();
           }


### PR DESCRIPTION
Remove the `typeof value === 'object'` check when mapping values in `ReflectionServerV2.handleListValues` so it matches Reflection V1 (`(value as any).toJson && typeof (value as any).toJson === 'function'`).

Previously, callable middleware functions (`typeof value === 'function'`) with a `.toJson()` method were not serialized because `typeof value === 'object'` evaluated to false, causing `listValues({ type: 'middleware' })` to return `{}` over Reflection API v2.
