### PR TITLE
fix(genkit-tools): prevent path traversal and bind to localhost

### DIFF
--- a/genkit-tools/cli/src/commands/start.ts
+++ b/genkit-tools/cli/src/commands/start.ts
@@ -30,6 +30,7 @@ import {
 interface RunOptions {
   noui?: boolean;
   port?: string;
+  host?: string;
   open?: boolean;
   disableRealtimeTelemetry?: boolean;
   corsOrigin?: string;
@@ -42,6 +43,11 @@ export const start = new Command('start')
   .description('runs a command in Genkit dev mode')
   .option('-n, --noui', 'do not start the Dev UI', false)
   .option('-p, --port <port>', 'port for the Dev UI')
+  .option(
+    '--host <host>',
+    'host/interface to bind the Dev UI to (defaults to 127.0.0.1). ' +
+      'Use 0.0.0.0 to expose to the network, e.g. for container or remote dev.'
+  )
   .option('-o, --open', 'Open the browser on UI start up')
   .option(
     '--disable-realtime-telemetry',
@@ -124,7 +130,7 @@ export const start = new Command('start')
       } else {
         port = await getPort({ port: makeRange(4000, 4099) });
       }
-      startServer(manager, port);
+      startServer(manager, port, options.host);
       if (options.open) {
         open(`http://localhost:${port}`);
       }

--- a/genkit-tools/common/src/eval/localFileDatasetStore.ts
+++ b/genkit-tools/common/src/eval/localFileDatasetStore.ts
@@ -64,6 +64,40 @@ export class LocalFileDatasetStore implements DatasetStore {
     this.cachedDatasetStore = null;
   }
 
+  /**
+   * Resolves the on-disk path for a given dataset id, guarding against path
+   * traversal. Dataset ids arrive from unauthenticated tRPC input
+   * (`getDataset`, `updateDataset`, `deleteDataset`), so they must be treated
+   * as untrusted. Ids are expected to be simple file-name-safe tokens; anything
+   * containing a path separator, a traversal segment, a null byte, or that
+   * would otherwise resolve outside of `storeRoot` is rejected.
+   */
+  private resolveDatasetPath(datasetId: string): string {
+    if (
+      typeof datasetId !== 'string' ||
+      datasetId.length === 0 ||
+      datasetId === '.' ||
+      datasetId === '..' ||
+      datasetId.includes('/') ||
+      datasetId.includes('\\') ||
+      datasetId.includes('\0')
+    ) {
+      throw new Error(`Invalid dataset id: ${JSON.stringify(datasetId)}`);
+    }
+    const filePath = path.resolve(
+      this.storeRoot,
+      this.generateFileName(datasetId)
+    );
+    // Defense in depth: ensure the resolved path stays within storeRoot. Using
+    // `path.relative` handles case-insensitive file systems and Windows drive
+    // letters more robustly than a `startsWith` prefix check.
+    const relative = path.relative(this.storeRoot, filePath);
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error(`Invalid dataset id: ${JSON.stringify(datasetId)}`);
+    }
+    return filePath;
+  }
+
   async createDataset(req: CreateDatasetRequest): Promise<DatasetMetadata> {
     return this.createDatasetInternal(req);
   }
@@ -111,10 +145,7 @@ export class LocalFileDatasetStore implements DatasetStore {
 
   async updateDataset(req: UpdateDatasetRequest): Promise<DatasetMetadata> {
     const { datasetId, data, schema, targetAction, metricRefs } = req;
-    const filePath = path.resolve(
-      this.storeRoot,
-      this.generateFileName(datasetId)
-    );
+    const filePath = this.resolveDatasetPath(datasetId);
     if (!fs.existsSync(filePath)) {
       throw new Error(`Update dataset failed: dataset not found`);
     }
@@ -156,10 +187,7 @@ export class LocalFileDatasetStore implements DatasetStore {
   }
 
   async getDataset(datasetId: string): Promise<Dataset> {
-    const filePath = path.resolve(
-      this.storeRoot,
-      this.generateFileName(datasetId)
-    );
+    const filePath = this.resolveDatasetPath(datasetId);
     if (!fs.existsSync(filePath)) {
       throw new Error(`Dataset not found for dataset ID ${datasetId}`);
     }
@@ -180,10 +208,7 @@ export class LocalFileDatasetStore implements DatasetStore {
   }
 
   async deleteDataset(datasetId: string): Promise<void> {
-    const filePath = path.resolve(
-      this.storeRoot,
-      this.generateFileName(datasetId)
-    );
+    const filePath = this.resolveDatasetPath(datasetId);
     await rm(filePath);
 
     const metadataMap = await this.getMetadataMap();

--- a/genkit-tools/common/src/server/router.ts
+++ b/genkit-tools/common/src/server/router.ts
@@ -57,6 +57,19 @@ const t = initTRPC.create({
   },
 });
 
+/**
+ * Schema for a dataset id supplied by an (unauthenticated) client. Dataset ids
+ * are used to build on-disk file paths, so they must be constrained to simple
+ * file-name-safe tokens to prevent path traversal. This mirrors the validation
+ * used when a dataset is created (see `generateDatasetId`).
+ */
+const DatasetIdSchema = z
+  .string()
+  .regex(
+    /^[A-Za-z][A-Za-z0-9_.-]{4,34}[A-Za-z0-9]$/,
+    'Invalid dataset id: must be 6-36 characters, alphanumeric with hyphens, dots and underscores, starting with a letter and ending with a letter or number.'
+  );
+
 const analyticsEventForRoute = (
   path: string,
   durationMs: number,
@@ -212,7 +225,7 @@ export const TOOLS_SERVER_ROUTER = (manager: BaseRuntimeManager) =>
 
     /** Retrieves an existing dataset */
     getDataset: loggedProcedure
-      .input(z.string())
+      .input(DatasetIdSchema)
       .output(evals.DatasetSchema)
       .query(async ({ input }) => {
         const response = await getDatasetStore().getDataset(input);
@@ -239,7 +252,7 @@ export const TOOLS_SERVER_ROUTER = (manager: BaseRuntimeManager) =>
 
     /** Deletes an exsting dataset */
     deleteDataset: loggedProcedure
-      .input(z.string())
+      .input(DatasetIdSchema)
       .output(z.void())
       .mutation(async ({ input }) => {
         const response = await getDatasetStore().deleteDataset(input);

--- a/genkit-tools/common/src/server/server.ts
+++ b/genkit-tools/common/src/server/server.ts
@@ -35,6 +35,13 @@ import { downloadAndExtractUiAssets } from '../utils/ui-assets';
 import { TOOLS_SERVER_ROUTER } from './router';
 
 const MAX_PAYLOAD_SIZE = 30000000;
+/**
+ * Default host for the Dev UI / Tools API server. Binding to loopback keeps the
+ * (unauthenticated) developer server off the network by default. Callers can
+ * opt into a different interface (e.g. `0.0.0.0` for container/remote dev) by
+ * passing an explicit host.
+ */
+const DEFAULT_HOST = '127.0.0.1';
 const UI_ASSETS_GCS_BUCKET = `https://storage.googleapis.com/genkit-assets`;
 const UI_ASSETS_ZIP_FILE_NAME = `${toolsPackage.version}.zip`;
 const UI_ASSETS_ZIP_GCS_PATH = `${UI_ASSETS_GCS_BUCKET}/${UI_ASSETS_ZIP_FILE_NAME}`;
@@ -128,7 +135,11 @@ const loggedExpressRoute = (routeName: string) => {
 /**
  * Starts up the Genkit Tools server which includes static files for the UI and the Tools API.
  */
-export function startServer(manager: BaseRuntimeManager, port: number) {
+export function startServer(
+  manager: BaseRuntimeManager,
+  port: number,
+  host: string = DEFAULT_HOST
+) {
   let server: Server;
   const app = express();
 
@@ -374,7 +385,7 @@ export function startServer(manager: BaseRuntimeManager, port: number) {
   };
   app.use(errorHandler);
 
-  server = app.listen(port, async () => {
+  server = app.listen(port, host, async () => {
     const uiUrl = 'http://localhost:' + port;
     const projectRoot = manager.projectRoot;
     logger.info(`${clc.green(clc.bold('Project root:'))} ${projectRoot}`);

--- a/genkit-tools/common/tests/eval/localFileDatasetStore_test.ts
+++ b/genkit-tools/common/tests/eval/localFileDatasetStore_test.ts
@@ -665,6 +665,57 @@ describe('localFileDatasetStore', () => {
     });
   });
 
+  describe('path traversal protection', () => {
+    const MALICIOUS_IDS = [
+      '../evil',
+      '../../etc/passwd',
+      '/etc/passwd',
+      '..',
+      '.',
+      'foo/bar',
+      'foo\\bar',
+      'foo\0bar',
+      '',
+    ];
+
+    beforeEach(() => {
+      // Pretend every file exists so that, absent the guard, the operation
+      // would proceed to touch the filesystem.
+      fs.existsSync = jest.fn(() => true);
+      fs.promises.readFile = jest.fn(async () =>
+        Promise.resolve(JSON.stringify({}) as any)
+      );
+      fs.promises.writeFile = jest.fn(async () => Promise.resolve(undefined));
+      fs.promises.rm = jest.fn(async () => Promise.resolve());
+    });
+
+    for (const maliciousId of MALICIOUS_IDS) {
+      it(`rejects getDataset for id ${JSON.stringify(maliciousId)}`, async () => {
+        await expect(DatasetStore.getDataset(maliciousId)).rejects.toThrow(
+          'Invalid dataset id'
+        );
+        expect(fs.promises.readFile).not.toHaveBeenCalled();
+      });
+
+      it(`rejects deleteDataset for id ${JSON.stringify(maliciousId)}`, async () => {
+        await expect(DatasetStore.deleteDataset(maliciousId)).rejects.toThrow(
+          'Invalid dataset id'
+        );
+        expect(fs.promises.rm).not.toHaveBeenCalled();
+      });
+
+      it(`rejects updateDataset for id ${JSON.stringify(maliciousId)}`, async () => {
+        await expect(
+          DatasetStore.updateDataset({
+            datasetId: maliciousId,
+            data: SAMPLE_DATASET_1_V1,
+          })
+        ).rejects.toThrow('Invalid dataset id');
+        expect(fs.promises.writeFile).not.toHaveBeenCalled();
+      });
+    }
+  });
+
   describe('generateDatasetId', () => {
     it('returns ID if present', async () => {
       const id = await (

--- a/genkit-tools/telemetry-server/src/file-trace-store.ts
+++ b/genkit-tools/telemetry-server/src/file-trace-store.ts
@@ -84,11 +84,11 @@ export class LocalFileTraceStore implements TraceStore {
       throw new Error(`Invalid trace id: ${JSON.stringify(id)}`);
     }
     const filePath = path.resolve(this.storeRoot, id);
-    // Defense in depth: ensure the resolved path stays within storeRoot.
-    if (
-      filePath !== this.storeRoot &&
-      !filePath.startsWith(this.storeRoot + path.sep)
-    ) {
+    // Defense in depth: ensure the resolved path stays within storeRoot. Using
+    // `path.relative` handles case-insensitive file systems and Windows drive
+    // letters more robustly than a `startsWith` prefix check.
+    const relative = path.relative(this.storeRoot, filePath);
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
       throw new Error(`Invalid trace id: ${JSON.stringify(id)}`);
     }
     return filePath;

--- a/genkit-tools/telemetry-server/src/file-trace-store.ts
+++ b/genkit-tools/telemetry-server/src/file-trace-store.ts
@@ -63,6 +63,37 @@ export class LocalFileTraceStore implements TraceStore {
     this.index = new Index(this.indexRoot);
   }
 
+  /**
+   * Resolves the on-disk path for a given trace id, guarding against path
+   * traversal. The `id` originates from unauthenticated HTTP input
+   * (`POST /api/traces` body and `GET /api/traces/:traceId`), so it must be
+   * treated as untrusted. Trace ids are expected to be simple file-name-safe
+   * tokens; anything containing a path separator, a traversal segment, a null
+   * byte, or that would otherwise resolve outside of `storeRoot` is rejected.
+   */
+  private resolveTracePath(id: string): string {
+    if (
+      typeof id !== 'string' ||
+      id.length === 0 ||
+      id === '.' ||
+      id === '..' ||
+      id.includes('/') ||
+      id.includes('\\') ||
+      id.includes('\0')
+    ) {
+      throw new Error(`Invalid trace id: ${JSON.stringify(id)}`);
+    }
+    const filePath = path.resolve(this.storeRoot, id);
+    // Defense in depth: ensure the resolved path stays within storeRoot.
+    if (
+      filePath !== this.storeRoot &&
+      !filePath.startsWith(this.storeRoot + path.sep)
+    ) {
+      throw new Error(`Invalid trace id: ${JSON.stringify(id)}`);
+    }
+    return filePath;
+  }
+
   async init() {
     const metadata = this.index.getMetadata();
     // if the metadata file doesn't exist or it was for the older version or if
@@ -94,7 +125,7 @@ export class LocalFileTraceStore implements TraceStore {
   }
 
   async load(id: string): Promise<TraceData | undefined> {
-    const filePath = path.resolve(this.storeRoot, `${id}`);
+    const filePath = this.resolveTracePath(id);
     if (!fs.existsSync(filePath)) {
       return undefined;
     }
@@ -165,10 +196,7 @@ export class LocalFileTraceStore implements TraceStore {
         }
         trace = existing;
       }
-      fs.writeFileSync(
-        path.resolve(this.storeRoot, `${id}`),
-        JSON.stringify(trace)
-      );
+      fs.writeFileSync(this.resolveTracePath(id), JSON.stringify(trace));
       const hasRootSpan = !!Object.values(rawTrace.spans).find(
         (s) => !s.parentSpanId
       );
@@ -221,7 +249,7 @@ export class LocalFileTraceStore implements TraceStore {
       : 0;
     const stopAt = startFrom + (query?.limit || 10);
     const traces = files.slice(startFrom, stopAt).map((id) => {
-      const filePath = path.resolve(this.storeRoot, `${id}`);
+      const filePath = this.resolveTracePath(id);
       const data = fs.readFileSync(filePath, 'utf8');
       const parsed = JSON.parse(data);
       // For backwards compatibility, new field.

--- a/genkit-tools/telemetry-server/src/index.ts
+++ b/genkit-tools/telemetry-server/src/index.ts
@@ -99,6 +99,13 @@ export async function startTelemetryServer(params: {
    */
   maxRequestBodySize?: string | number;
   corsOrigin?: string | RegExp;
+  /**
+   * The network interface to bind to. Defaults to '127.0.0.1' so the
+   * telemetry server is only reachable from the local machine. This is a
+   * developer-facing tool with no authentication, so it should not be exposed
+   * to other hosts by default.
+   */
+  host?: string;
 }) {
   await params.traceStore.init();
   await params.logStore.init();
@@ -337,8 +344,9 @@ export async function startTelemetryServer(params: {
     res.status(500).json(errorResponse);
   });
 
-  server = api.listen(params.port, () => {
-    logger.info(`Telemetry API running on http://localhost:${params.port}`);
+  const host = params.host ?? '127.0.0.1';
+  server = api.listen(params.port, host, () => {
+    logger.info(`Telemetry API running on http://${host}:${params.port}`);
   });
 
   server.on('error', (error) => {

--- a/genkit-tools/telemetry-server/tests/file_store_test.ts
+++ b/genkit-tools/telemetry-server/tests/file_store_test.ts
@@ -315,6 +315,94 @@ describe('local-file-store', () => {
   }
 });
 
+describe('local-file-store path traversal', () => {
+  let storeRoot: string;
+  let indexRoot: string;
+  let store: LocalFileTraceStore;
+
+  beforeEach(() => {
+    const base = path.resolve(
+      os.tmpdir(),
+      `./telemetry-server-traversal-test-${Date.now()}-${Math.floor(
+        Math.random() * 1000
+      )}`
+    );
+    storeRoot = path.resolve(base, 'traces');
+    indexRoot = path.resolve(base, 'traces_idx');
+    store = new LocalFileTraceStore({ storeRoot, indexRoot });
+  });
+
+  afterEach(() => {
+    fs.rmSync(storeRoot, { recursive: true, force: true });
+    fs.rmSync(indexRoot, { recursive: true, force: true });
+  });
+
+  const maliciousIds = [
+    '../../pwned',
+    '../../../etc/passwd',
+    '..\\..\\pwned',
+    '/etc/passwd',
+    'foo/bar',
+    'foo\\bar',
+    '.',
+    '..',
+    'has\0null',
+    '',
+  ];
+
+  const trace = {
+    traceId: 'x',
+    displayName: 'trace',
+    spans: { [SPAN_A]: span('x', SPAN_A, 100, 100) },
+  } as TraceData;
+
+  for (const id of maliciousIds) {
+    it(`rejects save with malicious id ${JSON.stringify(id)}`, async () => {
+      await assert.rejects(() => store.save(id, trace), /Invalid trace id/);
+    });
+
+    it(`rejects load with malicious id ${JSON.stringify(id)}`, async () => {
+      await assert.rejects(() => store.load(id), /Invalid trace id/);
+    });
+  }
+
+  it('does not write outside of storeRoot on traversal save', async () => {
+    const outside = path.resolve(storeRoot, '..', 'pwned');
+    await assert.rejects(
+      () => store.save('../pwned', trace),
+      /Invalid trace id/
+    );
+    assert.strictEqual(fs.existsSync(outside), false);
+  });
+
+  it('does not read outside of storeRoot on traversal load', async () => {
+    // Plant a file just outside storeRoot and confirm it cannot be read.
+    const secretPath = path.resolve(storeRoot, '..', 'secret');
+    fs.writeFileSync(secretPath, JSON.stringify({ hello: 'world' }));
+    try {
+      await assert.rejects(() => store.load('../secret'), /Invalid trace id/);
+    } finally {
+      fs.rmSync(secretPath, { force: true });
+    }
+  });
+
+  it('still allows valid trace ids', async () => {
+    const validTrace = {
+      traceId: 'valid_1234',
+      displayName: 'trace',
+      spans: { [SPAN_A]: span('valid_1234', SPAN_A, 100, 100) },
+    } as TraceData;
+    await store.save('valid_1234', validTrace);
+    const loaded = await store.load('valid_1234');
+    assert.ok(loaded);
+    assert.strictEqual(loaded?.traceId, 'valid_1234');
+    // The store writes trace files under `<storeRoot>/.genkit/traces`.
+    assert.ok(
+      fs.existsSync(path.resolve(storeRoot, '.genkit/traces', 'valid_1234'))
+    );
+  });
+});
+
 describe('index', () => {
   let indexRoot: string;
   let index: Index;

--- a/js/core/src/reflection.ts
+++ b/js/core/src/reflection.ts
@@ -443,24 +443,30 @@ export class ReflectionServer {
     });
 
     this.port = await this.findPort();
-    this.server = server.listen(this.port, async () => {
-      logger.debug(
-        `Reflection server (${process.pid}) running on http://localhost:${this.port}`
-      );
-      ReflectionServer.RUNNING_SERVERS.push(this);
-
-      try {
-        await this.registry.listActions();
-        await this.writeRuntimeFile();
-      } catch (e) {
-        logger.error(`Error initializing plugins: ${e}`);
-        try {
-          await this.stop();
-        } catch (err) {
-          logger.error(`Failed to stop server gracefully: ${err}`);
-        }
-      }
+    // Bind to loopback so the (unauthenticated) reflection server is not
+    // exposed on the network by default. `GENKIT_REFLECTION_HOST` can be set
+    // (e.g. to `0.0.0.0`) for container/remote dev scenarios.
+    const host = process.env.GENKIT_REFLECTION_HOST || '127.0.0.1';
+    await new Promise<void>((resolve) => {
+      this.server = server.listen(this.port!, host, resolve);
     });
+
+    logger.debug(
+      `Reflection server (${process.pid}) running on http://localhost:${this.port}`
+    );
+    ReflectionServer.RUNNING_SERVERS.push(this);
+
+    try {
+      await this.registry.listActions();
+      await this.writeRuntimeFile();
+    } catch (e) {
+      logger.error(`Error initializing plugins: ${e}`);
+      try {
+        await this.stop();
+      } catch (err) {
+        logger.error(`Failed to stop server gracefully: ${err}`);
+      }
+    }
   }
 
   /**

--- a/js/core/tests/reflection_test.ts
+++ b/js/core/tests/reflection_test.ts
@@ -53,7 +53,7 @@ describe('ReflectionServer API', () => {
   async function fetchApi(path: string) {
     return new Promise<{ status: number; body: any }>((resolve, reject) => {
       http
-        .get(`http://localhost:${port}${path}`, (res) => {
+        .get(`http://127.0.0.1:${port}${path}`, (res) => {
           let data = '';
           res.on('data', (chunk) => {
             data += chunk;
@@ -117,7 +117,7 @@ describe('ReflectionServer API', () => {
     return new Promise<{ status: number; body: any }>((resolve, reject) => {
       const payload = JSON.stringify(body);
       const req = http.request(
-        `http://localhost:${port}${path}`,
+        `http://127.0.0.1:${port}${path}`,
         {
           method: 'POST',
           headers: {


### PR DESCRIPTION
Add resolveTracePath and resolveDatasetPath to validate untrusted trace and dataset ids against path traversal (separators, traversal segments, null bytes, and paths escaping storeRoot) in the file trace store and the local file dataset store, and tighten the getDataset/deleteDataset tRPC inputs to a validated id schema. Also bind the telemetry server, Dev UI / Tools API server, and reflection server to 127.0.0.1 by default via a configurable host option (with a `genkit start --host` flag and GENKIT_REFLECTION_HOST env var to opt into other interfaces), since these are unauthenticated developer tools that should not be exposed to other hosts. Includes tests covering traversal attempts on both stores.
