### PR TITLE
feat(py/plugins/anthropic): add stable/beta API selection

### DIFF
--- a/py/packages/genkit-anthropic/src/genkit_anthropic/config.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/config.py
@@ -165,7 +165,10 @@ def _anthropic_config_schema_extra(schema: JsonDict) -> None:
                     'type': 'array',
                     'items': {'type': 'string'},
                     'title': 'Betas',
-                    'description': 'Anthropic beta feature headers to enable for this request.',
+                    'description': (
+                        'Anthropic beta feature headers to enable for this request. '
+                        'An empty list suppresses the defaults.'
+                    ),
                 },
             },
         )
@@ -313,7 +316,7 @@ class AnthropicConfig(ModelConfig):
     )
     betas: list[str] | None = Field(
         default=None,
-        description='Anthropic beta feature headers to enable for this request.',
+        description='Anthropic beta feature headers to enable for this request. An empty list suppresses the defaults.',
     )
 
     def beta_only_fields(self) -> set[str]:

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -443,7 +443,11 @@ class AnthropicModel:
         params.pop('stream', None)
 
         if use_beta:
-            params['betas'] = list(betas) if betas is not None else list(BETA_APIS)
+            beta_headers = list(BETA_APIS if betas is None else betas)
+            # The Python SDK serializes [] as an empty anthropic-beta header,
+            # which the API rejects. Omit the kwarg to request no beta headers.
+            if beta_headers:
+                params['betas'] = beta_headers
 
         if isinstance(thinking, dict):
             anthropic_thinking = _to_anthropic_thinking_config(thinking)

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -28,7 +28,7 @@ import json
 import math
 import time
 from email.utils import parsedate_to_datetime
-from typing import Any, Protocol, cast
+from typing import Any, Literal, Protocol, cast
 
 import structlog
 from anthropic import APIError, AsyncAnthropic
@@ -70,6 +70,13 @@ from genkit_anthropic.utils import (
 logger = structlog.get_logger(__name__)
 
 DEFAULT_MAX_OUTPUT_TOKENS = 4096
+# Keep in sync with ``js/plugins/anthropic/src/runner/beta.ts``.
+BETA_APIS: tuple[str, ...] = (
+    'files-api-2025-04-14',
+    'effort-2025-11-24',
+    'structured-outputs-2025-11-13',
+    'task-budgets-2026-03-13',
+)
 _THINKING_MODE_KEYS = frozenset({'adaptive', 'budget_tokens', 'enabled', 'type'})
 
 
@@ -257,7 +264,12 @@ class AnthropicModel:
         - Tool use / function calling
     """
 
-    def __init__(self, model_name: str, client: AsyncAnthropic) -> None:
+    def __init__(
+        self,
+        model_name: str,
+        client: AsyncAnthropic,
+        default_api_version: Literal['stable', 'beta'] | None = None,
+    ) -> None:
         """Initialize Anthropic model.
 
         Sets up the client for communicating with the Anthropic API
@@ -266,11 +278,14 @@ class AnthropicModel:
         Args:
             model_name: Name of the Anthropic model.
             client: AsyncAnthropic client instance.
+            default_api_version: Default API surface when a request does not
+                provide an explicit ``apiVersion``.
         """
         model_info = get_model_info(model_name)
         self._model_info = model_info
         self.model_name = model_info.versions[0] if model_info.versions else model_name
         self.client = client
+        self._default_api_version = default_api_version
 
     async def generate(self, request: ModelRequest, ctx: ActionRunContext | None = None) -> ModelResponse:
         """Generate response from Anthropic.
@@ -383,10 +398,16 @@ class AnthropicModel:
     def _uses_beta_api(self, config: AnthropicConfig) -> bool:
         """Whether this request should use the Anthropic beta API surface.
 
-        Any beta-only field selects the beta surface, so the requested features
-        are honored instead of being rejected by the stable surface.
+        An explicit per-request API version takes precedence. Otherwise, any
+        beta-only field selects the beta surface so a request-level feature is
+        not suppressed by a plugin-wide default. Requests without either use
+        the plugin default, falling back to stable.
         """
-        return config.api_version == 'beta' or bool(config.beta_only_fields())
+        if config.api_version is not None:
+            return config.api_version == 'beta'
+        if config.beta_only_fields():
+            return True
+        return self._default_api_version == 'beta'
 
     def _build_params(
         self,
@@ -421,8 +442,8 @@ class AnthropicModel:
         # Genkit selects the streaming surface from the request context.
         params.pop('stream', None)
 
-        if use_beta and betas:
-            params['betas'] = betas
+        if use_beta:
+            params['betas'] = list(betas) if betas is not None else list(BETA_APIS)
 
         if isinstance(thinking, dict):
             anthropic_thinking = _to_anthropic_thinking_config(thinking)

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -70,7 +70,6 @@ from genkit_anthropic.utils import (
 logger = structlog.get_logger(__name__)
 
 DEFAULT_MAX_OUTPUT_TOKENS = 4096
-# Keep in sync with ``js/plugins/anthropic/src/runner/beta.ts``.
 BETA_APIS: tuple[str, ...] = (
     'files-api-2025-04-14',
     'effort-2025-11-24',
@@ -443,7 +442,9 @@ class AnthropicModel:
         params.pop('stream', None)
 
         if use_beta:
-            beta_headers = betas if betas is not None else list(BETA_APIS)
+            # Resold surfaces (Vertex, Bedrock) do not offer every default beta, so only the direct API gets them.
+            default_betas = list(BETA_APIS) if isinstance(self.client, AsyncAnthropic) else []
+            beta_headers = betas if betas is not None else default_betas
             # The Python SDK serializes [] as an empty anthropic-beta header,
             # which the API rejects. Omit the kwarg to request no beta headers.
             if beta_headers:

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/models.py
@@ -443,7 +443,7 @@ class AnthropicModel:
         params.pop('stream', None)
 
         if use_beta:
-            beta_headers = list(BETA_APIS if betas is None else betas)
+            beta_headers = betas if betas is not None else list(BETA_APIS)
             # The Python SDK serializes [] as an empty anthropic-beta header,
             # which the API rejects. Omit the kwarg to request no beta headers.
             if beta_headers:

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
@@ -16,7 +16,7 @@
 
 """Anthropic plugin for Genkit."""
 
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import structlog
 from anthropic import AsyncAnthropic
@@ -64,17 +64,30 @@ class Anthropic(Plugin):
     def __init__(
         self,
         models: list[str] | None = None,
+        *,
+        api_version: Literal['stable', 'beta'] | None = None,
         **anthropic_params: object,
     ) -> None:
         """Initializes Anthropic plugin with given configuration.
 
         Args:
             models: List of model names to register. Defaults to all supported models.
+            api_version: Default API surface unless overridden by per-request
+                config. An explicit config ``apiVersion`` always takes
+                precedence. Defaults to stable.
             **anthropic_params: Additional parameters passed to the AsyncAnthropic client.
                 This may include api_key, base_url, timeout, and other configuration
                 settings required by Anthropic's API.
+
+        Raises:
+            ValueError: If ``api_version`` is not ``'stable'``, ``'beta'``, or
+                ``None``.
         """
+        if api_version not in (None, 'stable', 'beta'):
+            raise ValueError("api_version must be 'stable', 'beta', or None")
+
         self.models = models or list(SUPPORTED_ANTHROPIC_MODELS.keys())
+        self._default_api_version = api_version
         self._anthropic_params = anthropic_params
         self._runtime_client = loop_local_client(lambda: AsyncAnthropic(**cast(dict[str, Any], self._anthropic_params)))
         self._list_actions_cache: list[ActionMetadata] | None = None
@@ -117,7 +130,11 @@ class Anthropic(Plugin):
         model_info = get_model_info(clean_name)
 
         async def _generate(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
-            model = AnthropicModel(model_name=clean_name, client=self._runtime_client())
+            model = AnthropicModel(
+                model_name=clean_name,
+                client=self._runtime_client(),
+                default_api_version=self._default_api_version,
+            )
             return await model.generate(request, ctx)
 
         return Action(

--- a/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
+++ b/py/packages/genkit-anthropic/src/genkit_anthropic/plugin.py
@@ -87,7 +87,7 @@ class Anthropic(Plugin):
             raise ValueError("api_version must be 'stable', 'beta', or None")
 
         self.models = models or list(SUPPORTED_ANTHROPIC_MODELS.keys())
-        self._default_api_version = api_version
+        self._default_api_version: Literal['stable', 'beta'] | None = api_version
         self._anthropic_params = anthropic_params
         self._runtime_client = loop_local_client(lambda: AsyncAnthropic(**cast(dict[str, Any], self._anthropic_params)))
         self._list_actions_cache: list[ActionMetadata] | None = None

--- a/py/packages/genkit-anthropic/tests/anthropic_config_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_config_test.py
@@ -178,7 +178,10 @@ def test_json_schema_advertises_js_shaped_keys() -> None:
     assert props['maxOutputTokens']['title'] == 'Max output tokens'
     assert props['apiKey']['description'] == 'Overrides the plugin-configured Anthropic API key for this request.'
     assert props['apiVersion']['description'] == 'Selects the Anthropic API surface for this request.'
-    assert props['betas']['description'] == 'Anthropic beta feature headers to enable for this request.'
+    assert (
+        props['betas']['description']
+        == 'Anthropic beta feature headers to enable for this request. An empty list suppresses the defaults.'
+    )
     assert props['tool_choice']['type'] == 'object'
     assert props['tool_choice']['properties']['type']['enum'] == ['auto', 'any', 'tool', 'none']
     assert 'oneOf' not in props['tool_choice']

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -969,7 +969,26 @@ async def test_beta_surface_preserves_empty_betas_opt_out() -> None:
 
     await model.generate(_text_request({'apiVersion': 'beta', 'betas': []}))
 
-    assert mock_client.beta.messages.create.call_args.kwargs['betas'] == []
+    mock_client.beta.messages.create.assert_awaited_once()
+    mock_client.messages.create.assert_not_called()
+    assert 'betas' not in mock_client.beta.messages.create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_beta_streaming_omits_empty_betas_opt_out() -> None:
+    """Streaming also omits the SDK kwarg rather than sending an empty header."""
+    mock_client = MagicMock()
+    final_content = [MagicMock(type='text', text='ok')]
+    mock_client.beta.messages.stream.return_value = MockStreamManager([], final_content=final_content)
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+    ctx = MagicMock()
+    ctx.is_streaming = True
+
+    await model.generate(_text_request({'apiVersion': 'beta', 'betas': []}), ctx)
+
+    mock_client.beta.messages.stream.assert_called_once()
+    mock_client.messages.stream.assert_not_called()
+    assert 'betas' not in mock_client.beta.messages.stream.call_args.kwargs
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -20,7 +20,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from anthropic import AsyncAnthropic
+from anthropic import AsyncAnthropic, AsyncAnthropicVertex
 from genkit_anthropic import models as anthropic_models
 from genkit_anthropic.config import AnthropicConfig
 from genkit_anthropic.models import BETA_APIS, AnthropicModel, _to_anthropic_thinking_config
@@ -845,12 +845,31 @@ def test_structured_output_with_no_tools_capability() -> None:
 
 
 def _mock_client_for_generate() -> MagicMock:
-    """A client whose messages.create returns a minimal text response."""
-    mock_client = MagicMock()
+    """A direct API client whose messages.create returns a minimal text response."""
+    mock_client = MagicMock(spec=AsyncAnthropic)
     mock_response = MagicMock()
     mock_response.content = [MagicMock(type='text', text='ok')]
     mock_response.usage = MagicMock(input_tokens=1, output_tokens=1)
     mock_response.stop_reason = 'end_turn'
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+    mock_client.beta.messages.create = AsyncMock(return_value=mock_response)
+    # The real client only gains these on instantiation; _client_for_config reads them.
+    mock_client.auth_token = None
+    mock_client._custom_headers = {}
+    mock_client.copy = MagicMock(return_value=mock_client)
+    return mock_client
+
+
+def _mock_vertex_client_for_generate() -> MagicMock:
+    """A resold-surface client, which is not an ``AsyncAnthropic`` instance."""
+    mock_client = MagicMock(spec=AsyncAnthropicVertex)
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(type='text', text='ok')]
+    mock_response.usage = MagicMock(input_tokens=1, output_tokens=1)
+    mock_response.stop_reason = 'end_turn'
+    # The Vertex client only gains these attributes on instantiation, so the spec omits them.
+    mock_client.messages = MagicMock()
+    mock_client.beta = MagicMock()
     mock_client.messages.create = AsyncMock(return_value=mock_response)
     mock_client.beta.messages.create = AsyncMock(return_value=mock_response)
     return mock_client
@@ -926,7 +945,7 @@ async def test_api_surface_resolution_routes_create(
 @pytest.mark.asyncio
 async def test_default_api_version_beta_routes_streaming() -> None:
     """The configured beta default applies to streaming as well as create."""
-    mock_client = MagicMock()
+    mock_client = MagicMock(spec=AsyncAnthropic)
     final_content = [MagicMock(type='text', text='ok')]
     mock_client.beta.messages.stream.return_value = MockStreamManager([], final_content=final_content)
     model = AnthropicModel(
@@ -972,6 +991,42 @@ async def test_beta_surface_preserves_empty_betas_opt_out() -> None:
     mock_client.beta.messages.create.assert_awaited_once()
     mock_client.messages.create.assert_not_called()
     assert 'betas' not in mock_client.beta.messages.create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_resold_surface_omits_default_betas() -> None:
+    """Resold surfaces do not offer every default beta, so none are assumed."""
+    mock_client = _mock_vertex_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request({'apiVersion': 'beta'}))
+
+    mock_client.beta.messages.create.assert_awaited_once()
+    assert 'betas' not in mock_client.beta.messages.create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_resold_surface_beta_only_field_routes_beta_without_defaults() -> None:
+    """A beta-only field still selects the beta surface without assuming default headers."""
+    mock_client = _mock_vertex_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request({'output_config': {'task_budget': {'total': 20000}}}))
+
+    mock_client.beta.messages.create.assert_awaited_once()
+    mock_client.messages.create.assert_not_called()
+    assert 'betas' not in mock_client.beta.messages.create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_resold_surface_forwards_explicit_betas() -> None:
+    """An explicit betas list is still forwarded on resold surfaces."""
+    mock_client = _mock_vertex_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request({'apiVersion': 'beta', 'betas': ['context-1m-2025-08-07']}))
+
+    assert mock_client.beta.messages.create.call_args.kwargs['betas'] == ['context-1m-2025-08-07']
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -23,7 +23,7 @@ import pytest
 from anthropic import AsyncAnthropic
 from genkit_anthropic import models as anthropic_models
 from genkit_anthropic.config import AnthropicConfig
-from genkit_anthropic.models import AnthropicModel, _to_anthropic_thinking_config
+from genkit_anthropic.models import BETA_APIS, AnthropicModel, _to_anthropic_thinking_config
 from genkit_anthropic.utils import maybe_strip_fences, strip_markdown_fences
 from pydantic import ValidationError
 
@@ -861,6 +861,115 @@ def _text_request(config: Any) -> ModelRequest:
         messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))])],
         config=config,
     )
+
+
+@pytest.mark.parametrize(
+    ('config', 'default_api_version', 'expected'),
+    [
+        ({'apiVersion': 'beta'}, 'stable', True),
+        ({'apiVersion': 'stable'}, 'beta', False),
+        ({}, 'beta', True),
+        ({}, 'stable', False),
+        ({}, None, False),
+        ({'metadata': {'user_id': 'test-user'}}, 'beta', True),
+        ({'metadata': {'user_id': 'test-user'}}, 'stable', False),
+        ({'betas': ['custom-beta']}, None, True),
+        ({'betas': ['custom-beta']}, 'stable', True),
+        ({'output_config': {'task_budget': {'total': 20000}}}, None, True),
+        ({'betas': []}, None, False),
+    ],
+)
+def test_api_surface_resolution(config: dict[str, Any], default_api_version: Any, expected: bool) -> None:
+    """Resolve request override, feature signals, plugin default, then stable."""
+    model = AnthropicModel(
+        model_name='claude-sonnet-4',
+        client=MagicMock(),
+        default_api_version=default_api_version,
+    )
+
+    assert model._uses_beta_api(AnthropicConfig.model_validate(config)) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('default_api_version', 'config', 'use_beta'),
+    [
+        ('beta', {}, True),
+        ('beta', {'apiVersion': 'stable'}, False),
+        ('stable', {'apiVersion': 'beta'}, True),
+    ],
+)
+async def test_api_surface_resolution_routes_create(
+    default_api_version: Any,
+    config: dict[str, Any],
+    use_beta: bool,
+) -> None:
+    """The resolved API surface selects the matching SDK create method."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(
+        model_name='claude-sonnet-4',
+        client=mock_client,
+        default_api_version=default_api_version,
+    )
+
+    await model.generate(_text_request(config))
+
+    if use_beta:
+        mock_client.beta.messages.create.assert_awaited_once()
+        mock_client.messages.create.assert_not_called()
+    else:
+        mock_client.messages.create.assert_awaited_once()
+        mock_client.beta.messages.create.assert_not_called()
+        assert 'betas' not in mock_client.messages.create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_default_api_version_beta_routes_streaming() -> None:
+    """The configured beta default applies to streaming as well as create."""
+    mock_client = MagicMock()
+    final_content = [MagicMock(type='text', text='ok')]
+    mock_client.beta.messages.stream.return_value = MockStreamManager([], final_content=final_content)
+    model = AnthropicModel(
+        model_name='claude-sonnet-4',
+        client=mock_client,
+        default_api_version='beta',
+    )
+    ctx = MagicMock()
+    ctx.is_streaming = True
+
+    await model.generate(_text_request({}), ctx)
+
+    mock_client.beta.messages.stream.assert_called_once()
+    mock_client.messages.stream.assert_not_called()
+    assert mock_client.beta.messages.stream.call_args.kwargs['betas'] == list(BETA_APIS)
+
+
+@pytest.mark.asyncio
+async def test_beta_surface_sends_default_betas() -> None:
+    """Beta calls send the same default beta headers as the JS plugin."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request({'apiVersion': 'beta'}))
+
+    assert mock_client.beta.messages.create.call_args.kwargs['betas'] == list(BETA_APIS)
+    assert list(BETA_APIS) == [
+        'files-api-2025-04-14',
+        'effort-2025-11-24',
+        'structured-outputs-2025-11-13',
+        'task-budgets-2026-03-13',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_beta_surface_preserves_empty_betas_opt_out() -> None:
+    """An explicit empty list opts out of the default beta headers."""
+    mock_client = _mock_client_for_generate()
+    model = AnthropicModel(model_name='claude-sonnet-4', client=mock_client)
+
+    await model.generate(_text_request({'apiVersion': 'beta', 'betas': []}))
+
+    assert mock_client.beta.messages.create.call_args.kwargs['betas'] == []
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-anthropic/tests/anthropic_plugin_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_plugin_test.py
@@ -21,7 +21,7 @@ import queue
 import threading
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from genkit_anthropic import Anthropic, anthropic_name
@@ -87,6 +87,51 @@ def test_custom_models() -> None:
     """Test plugin initialization with custom models."""
     plugin = Anthropic(api_key='test-key', models=['claude-sonnet-4'])
     assert plugin.models == ['claude-sonnet-4']
+
+
+@patch('genkit_anthropic.plugin.AsyncAnthropic')
+def test_api_version_is_stored_without_leaking_to_sdk(mock_client_ctor: MagicMock) -> None:
+    """Plugin API version is a model default, not an AsyncAnthropic kwarg."""
+    mock_client = MagicMock()
+    mock_client_ctor.return_value = mock_client
+    plugin = Anthropic(api_key='test-key', api_version='beta')
+
+    async def _get_client() -> object:
+        return plugin._runtime_client()
+
+    assert asyncio.run(_get_client()) is mock_client
+    assert plugin._default_api_version == 'beta'
+    assert 'api_version' not in plugin._anthropic_params
+    mock_client_ctor.assert_called_once_with(api_key='test-key')
+
+
+def test_invalid_api_version_fails_fast() -> None:
+    """Invalid plugin API versions fail before an SDK client can be created."""
+    with pytest.raises(ValueError, match='api_version'):
+        Anthropic(api_version=cast(Any, 'Beta'))
+
+
+@patch('genkit_anthropic.plugin.AsyncAnthropic')
+@pytest.mark.asyncio
+async def test_plugin_beta_default_routes_action_run_to_beta_surface(mock_client_ctor: MagicMock) -> None:
+    """The plugin-wide beta default reaches models resolved as public actions."""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(type='text', text='ok')]
+    mock_response.usage = MagicMock(input_tokens=1, output_tokens=1)
+    mock_response.stop_reason = 'end_turn'
+
+    mock_client = MagicMock()
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+    mock_client.beta.messages.create = AsyncMock(return_value=mock_response)
+    mock_client_ctor.return_value = mock_client
+
+    plugin = Anthropic(api_key='test-key', api_version='beta')
+    action = plugin._create_model_action('anthropic/claude-sonnet-4')
+
+    await action.run(_create_sample_request())
+
+    mock_client.beta.messages.create.assert_awaited_once()
+    mock_client.messages.create.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/py/samples/anthropic-sample/src/main.py
+++ b/py/samples/anthropic-sample/src/main.py
@@ -14,14 +14,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Anthropic's Claude Opus models generation samples."""
+"""Anthropic generation samples, including stable/beta API selection."""
 
 from genkit_anthropic import Anthropic
 from pydantic import BaseModel, Field
 
 from genkit import ActionRunContext, Genkit, ModelResponse, ReasoningPart
 
-ai = Genkit(plugins=[Anthropic()], model='anthropic/claude-opus-4-8')
+# Beta is the plugin-wide default. Individual requests can still select the
+# stable surface with config.apiVersion.
+ai = Genkit(plugins=[Anthropic(api_version='beta')], model='anthropic/claude-opus-4-8')
+
+LIVE_TEST_MODEL = 'anthropic/claude-haiku-4-5'
 
 
 class TopicInput(BaseModel):
@@ -89,6 +93,60 @@ def _thinking_summary(response: ModelResponse) -> dict[str, object]:
     }
 
 
+# --- stable/beta API selection ---------------------------------------------
+
+
+@ai.flow()
+async def beta_plugin_default(data: TopicInput) -> str:
+    """Use the plugin-wide beta default and its default beta headers."""
+    response = await ai.generate(
+        model=LIVE_TEST_MODEL,
+        prompt=f'Write a one-line fact about {data.topic}.',
+        config={'maxOutputTokens': 64},
+    )
+    return response.text
+
+
+@ai.flow()
+async def stable_request_override(data: TopicInput) -> str:
+    """Override the plugin-wide beta default for one stable API request."""
+    response = await ai.generate(
+        model=LIVE_TEST_MODEL,
+        prompt=f'Write a one-line fact about {data.topic}.',
+        config={'apiVersion': 'stable', 'maxOutputTokens': 64},
+    )
+    return response.text
+
+
+@ai.flow()
+async def beta_without_default_headers(data: TopicInput) -> str:
+    """Use the beta API while opting out of the plugin's default beta headers."""
+    response = await ai.generate(
+        model=LIVE_TEST_MODEL,
+        prompt=f'Write a one-line fact about {data.topic}.',
+        config={'apiVersion': 'beta', 'betas': [], 'maxOutputTokens': 64},
+    )
+    return response.text
+
+
+@ai.flow()
+async def beta_plugin_default_stream(data: TopicInput, ctx: ActionRunContext) -> str:
+    """Stream through the beta API selected by the plugin-wide default."""
+    stream_response = ai.generate_stream(
+        model=LIVE_TEST_MODEL,
+        prompt=f'Write a short poem about {data.topic}.',
+        config={'maxOutputTokens': 64},
+    )
+    chunks: list[str] = []
+    async for chunk in stream_response.stream:
+        if chunk.text:
+            ctx.send_chunk(chunk.text)
+            chunks.append(chunk.text)
+
+    await stream_response.response
+    return ''.join(chunks)
+
+
 # --- claude-opus-4-7 -------------------------------------------------------
 
 
@@ -98,6 +156,7 @@ async def haiku_opus_4_7(data: TopicInput) -> str:
     response = await ai.generate(
         model='anthropic/claude-opus-4-7',
         prompt=f'Write a haiku about {data.topic}.',
+        config={'apiVersion': 'stable'},
     )
     return response.text
 
@@ -108,6 +167,7 @@ async def cat_opus_4_7(data: CatInput) -> Cat:
     response = await ai.generate(
         model='anthropic/claude-opus-4-7',
         prompt=f'Invent a cat named {data.name}.',
+        config={'apiVersion': 'stable'},
         output_format='json',
         output_schema=Cat,
     )
@@ -123,6 +183,7 @@ async def haiku_opus_4_8(data: TopicInput) -> str:
     response = await ai.generate(
         model='anthropic/claude-opus-4-8',
         prompt=f'Write a haiku about {data.topic}.',
+        config={'apiVersion': 'stable'},
     )
     return response.text
 
@@ -133,6 +194,7 @@ async def cat_opus_4_8(data: CatInput) -> Cat:
     response = await ai.generate(
         model='anthropic/claude-opus-4-8',
         prompt=f'Invent a cat named {data.name}.',
+        config={'apiVersion': 'stable'},
         output_format='json',
         output_schema=Cat,
     )
@@ -151,6 +213,7 @@ async def thinking_tool_round_trip(data: WeatherInput, ctx: ActionRunContext) ->
         ),
         tools=['current_weather'],
         config={
+            'apiVersion': 'stable',
             'thinking': {'type': 'adaptive', 'display': 'summarized'},
             'max_tokens': 4096,
         },


### PR DESCRIPTION
Stacked on #5720. Closes #5635.

Adds a plugin-level `api_version` default for the Python Anthropic plugin, alongside the existing per-request `apiVersion` config.

- `Anthropic(api_version='beta')` now routes ordinary requests through `client.beta.messages`.
- Per-request `apiVersion` overrides the plugin default.
- Beta calls receive the same default beta headers as the JS plugin.
- `betas=[]` is preserved as an explicit opt-out.
- Stable requests continue using `client.messages` without beta headers.
- Invalid plugin `api_version` values fail early instead of leaking into the Anthropic SDK constructor.

One intentional Python behavior is retained from #5720: beta-only request fields are treated as an implicit per-request beta selection, so they outrank a plugin-wide `api_version='stable'` default. Explicit `apiVersion: 'stable'` remains authoritative and rejects conflicting beta-only fields during config validation.

This also means Vertex Model Garden requests using `apiVersion: 'beta'` will receive the same default beta headers. The SDK supports those parameters, but this has not been live-tested against Vertex.

Tests cover resolution precedence, non-streaming and streaming routing, default headers, empty `betas`, constructor validation, and plugin-to-model wiring. For manual verification, four Dev UI flows were created: `beta_plugin_default`, `stable_request_override`, `beta_without_default_headers`, and `beta_plugin_default_stream`. Together, they cover plugin-default beta routing, per-request stable override, empty-header opt-out, and beta streaming. The empty-list case remains on the beta surface but omits the SDK betas argument to avoid sending an invalid empty anthropic-beta header. Screenshots are attached below

## Screenshots
<img width="1014" height="420" alt="Screenshot 2026-07-16 at 17 11 28" src="https://github.com/user-attachments/assets/dac8b16e-cf63-4f29-8dd4-299ecbae6d2b" />
<img width="1009" height="607" alt="Screenshot 2026-07-16 at 17 12 41" src="https://github.com/user-attachments/assets/c35cd232-1030-4045-b274-a9dd3e5c4e5b" />
<img width="1023" height="494" alt="Screenshot 2026-07-16 at 17 59 59" src="https://github.com/user-attachments/assets/7f4039f6-87d0-48f5-8e5d-65ada26b14e9" />
<img width="1011" height="463" alt="Screenshot 2026-07-16 at 18 00 45" src="https://github.com/user-attachments/assets/e11aeb14-153a-4b71-81ef-590204011951" />
