### PR TITLE
fix(compat-oai): accumulate streamed tool-call arguments in chunks

### DIFF
--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -35,6 +35,7 @@ import {
   z,
   type ErrorResponseMetadata,
 } from 'genkit';
+import { parsePartialJson } from 'genkit/extract';
 import type { ModelAction, ModelInfo, ToolDefinition } from 'genkit/model';
 import { model } from 'genkit/plugin';
 import OpenAI, { APIError } from 'openai';
@@ -423,19 +424,92 @@ export function fromOpenAIChoice(
 }
 
 /**
+ * Accumulates the streamed fragments of a single tool call. OpenAI streams tool
+ * calls incrementally: the first delta carries `name`/`id` (with empty or
+ * partial `arguments`) and subsequent deltas carry only fragments of the
+ * `arguments` JSON string, keyed by the tool call `index` within the message.
+ */
+export interface ToolCallAccumulator {
+  ref?: string;
+  name?: string;
+  /** Concatenated `arguments` JSON string fragments received so far. */
+  args: string;
+}
+
+/**
+ * Converts a streamed tool-call delta into a partial Genkit ToolRequestPart,
+ * accumulating `arguments` fragments across chunks so that the emitted
+ * `toolRequest` carries the best-effort parsed input instead of `input: ''`.
+ * @param toolCall The streamed tool-call delta.
+ * @param accumulators Per-message tool-call accumulators, keyed by tool call
+ *   index. Mutated in place as fragments arrive.
+ * @returns The partial ToolRequestPart, or `undefined` if there is no
+ *   meaningful data to emit yet.
+ */
+function fromOpenAIToolCallChunk(
+  toolCall: ChatCompletionChunk.Choice.Delta.ToolCall,
+  accumulators: ToolCallAccumulator[]
+): ToolRequestPart | undefined {
+  const index = toolCall.index ?? 0;
+  const acc = (accumulators[index] ??= { args: '' });
+
+  // The first delta for a tool call carries its `id` and function `name`;
+  // subsequent deltas omit them, so carry the accumulated values forward.
+  if (toolCall.id) {
+    acc.ref = toolCall.id;
+  }
+  if (toolCall.function?.name) {
+    acc.name = toolCall.function.name;
+  }
+  if (toolCall.function?.arguments) {
+    acc.args += toolCall.function.arguments;
+  }
+
+  // Best-effort parse of the (possibly incomplete) accumulated arguments.
+  let input: unknown = {};
+  if (acc.args) {
+    try {
+      input = parsePartialJson(acc.args);
+    } catch {
+      input = {};
+    }
+  }
+
+  return {
+    toolRequest: {
+      name: acc.name!,
+      ref: acc.ref,
+      input,
+      partial: true,
+    },
+  };
+}
+
+/**
  * Converts an OpenAI message stream event to a Genkit GenerateResponseData
  * object.
  * @param choice The OpenAI message stream event to convert.
  * @param jsonMode Whether the event is a JSON response.
+ * @param toolCallAccumulators Optional per-message tool-call accumulators (keyed
+ *   by tool call index) used to assemble streamed `arguments` fragments into
+ *   partial tool requests. When omitted, tool-call deltas are converted
+ *   statelessly (legacy behavior).
  * @returns The converted Genkit GenerateResponseData object.
  */
 export function fromOpenAIChunkChoice(
   choice: ChatCompletionChunk.Choice,
-  jsonMode = false
+  jsonMode = false,
+  toolCallAccumulators?: ToolCallAccumulator[]
 ): GenerateResponseData {
-  const toolRequestParts = choice.delta.tool_calls?.map((toolCall) =>
-    fromOpenAIToolCall(toolCall, choice)
-  );
+  const toolRequestParts = toolCallAccumulators
+    ? choice.delta.tool_calls
+        ?.map((toolCall) =>
+          fromOpenAIToolCallChunk(toolCall, toolCallAccumulators)
+        )
+        .filter((p): p is ToolRequestPart => !!p)
+    : choice.delta.tool_calls?.map((toolCall) =>
+        fromOpenAIToolCall(toolCall, choice)
+      );
 
   // Build content array based on what's present in the delta
   let content: Part[] = [];
@@ -591,9 +665,21 @@ export function openAIModelRunner(
           },
           { signal: options?.abortSignal }
         );
+        // Tracks streamed tool-call argument fragments per choice index so we
+        // can accumulate them and emit `partial` tool requests with parsed
+        // input instead of a flurry of empty `input: ''` chunks. OpenAI streams
+        // tool calls incrementally: the first delta carries `name`/`id` and
+        // subsequent deltas carry only fragments of the `arguments` JSON string.
+        const toolCallAccumulators = new Map<number, ToolCallAccumulator[]>();
+        const jsonMode = request.output?.format === 'json';
         for await (const chunk of stream) {
           chunk.choices?.forEach((chunk) => {
-            const c = fromOpenAIChunkChoice(chunk);
+            let accumulators = toolCallAccumulators.get(chunk.index);
+            if (!accumulators) {
+              accumulators = [];
+              toolCallAccumulators.set(chunk.index, accumulators);
+            }
+            const c = fromOpenAIChunkChoice(chunk, jsonMode, accumulators);
             options?.sendChunk!({
               index: chunk.index,
               content: c.message?.content ?? [],

--- a/js/plugins/compat-oai/src/model.ts
+++ b/js/plugins/compat-oai/src/model.ts
@@ -465,6 +465,12 @@ function fromOpenAIToolCallChunk(
     acc.args += toolCall.function.arguments;
   }
 
+  // Without a tool name there is nothing meaningful to emit yet; the name
+  // arrives with the first delta of a tool call, so wait for it.
+  if (!acc.name) {
+    return undefined;
+  }
+
   // Best-effort parse of the (possibly incomplete) accumulated arguments.
   let input: unknown = {};
   if (acc.args) {
@@ -477,7 +483,7 @@ function fromOpenAIToolCallChunk(
 
   return {
     toolRequest: {
-      name: acc.name!,
+      name: acc.name,
       ref: acc.ref,
       input,
       partial: true,

--- a/js/plugins/compat-oai/tests/compat_oai_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_test.ts
@@ -1699,6 +1699,107 @@ describe('openAIModelRunner', () => {
     expect(lastPart.toolRequest.input).toStrictEqual({ city: 'Tokyo' });
   });
 
+  it('should skip tool-call deltas received before the tool name', async () => {
+    // Simulate an (unusual) ordering where an arguments fragment arrives before
+    // the delta that carries the tool name. Such nameless deltas should be
+    // skipped entirely rather than emitting a tool request with no name.
+    const deltas: any[] = [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [{ index: 0, function: { arguments: '{"city":' } }],
+        },
+        finish_reason: null,
+      },
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_abc',
+              function: { name: 'getWeather', arguments: '"Tokyo"}' },
+            },
+          ],
+        },
+        finish_reason: null,
+      },
+    ];
+    const openaiClient = {
+      beta: {
+        chat: {
+          completions: {
+            stream: jest.fn(
+              () =>
+                new (class {
+                  i = 0;
+                  [Symbol.asyncIterator]() {
+                    return {
+                      next: async () => {
+                        if (this.i < deltas.length) {
+                          return {
+                            value: { choices: [deltas[this.i++]] },
+                            done: false,
+                          };
+                        }
+                        return { done: true };
+                      },
+                    };
+                  }
+                  async finalChatCompletion() {
+                    return {
+                      choices: [
+                        {
+                          message: {
+                            role: 'assistant',
+                            tool_calls: [
+                              {
+                                id: 'call_abc',
+                                type: 'function',
+                                function: {
+                                  name: 'getWeather',
+                                  arguments: '{"city":"Tokyo"}',
+                                },
+                              },
+                            ],
+                          },
+                          finish_reason: 'tool_calls',
+                        },
+                      ],
+                    };
+                  }
+                })()
+            ),
+          },
+        },
+      },
+    };
+    const chunks: any[] = [];
+    const runner = openAIModelRunner(
+      'gpt-4o',
+      openaiClient as unknown as OpenAI
+    );
+    await runner(
+      { messages: [] },
+      {
+        streamingRequested: true,
+        sendChunk: (chunk) => chunks.push(chunk),
+      }
+    );
+
+    const toolRequestChunks = chunks.filter((c) =>
+      c.content.some((p: any) => p.toolRequest)
+    );
+    // The first (nameless) delta is skipped, so only one tool-request chunk is
+    // emitted once the name arrives.
+    expect(toolRequestChunks.length).toBe(1);
+    const part = toolRequestChunks[0].content[0];
+    expect(part.toolRequest.name).toBe('getWeather');
+    expect(part.toolRequest.ref).toBe('call_abc');
+    expect(part.toolRequest.partial).toBe(true);
+    expect(part.toolRequest.input).toStrictEqual({ city: 'Tokyo' });
+  });
+
   it('should run with requestBuilder', async () => {
     const openaiClient = {
       chat: {

--- a/js/plugins/compat-oai/tests/compat_oai_test.ts
+++ b/js/plugins/compat-oai/tests/compat_oai_test.ts
@@ -1587,6 +1587,118 @@ describe('openAIModelRunner', () => {
     );
   });
 
+  it('should accumulate streamed tool call arguments into partial tool requests', async () => {
+    // Simulate how OpenAI streams tool calls: the first delta carries the tool
+    // name and id, subsequent deltas carry only fragments of the arguments JSON.
+    const deltas: any[] = [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_abc',
+              function: { name: 'getWeather', arguments: '' },
+            },
+          ],
+        },
+        finish_reason: null,
+      },
+      {
+        index: 0,
+        delta: {
+          tool_calls: [{ index: 0, function: { arguments: '{"city":' } }],
+        },
+        finish_reason: null,
+      },
+      {
+        index: 0,
+        delta: {
+          tool_calls: [{ index: 0, function: { arguments: '"Tokyo"}' } }],
+        },
+        finish_reason: null,
+      },
+    ];
+    const openaiClient = {
+      beta: {
+        chat: {
+          completions: {
+            stream: jest.fn(
+              () =>
+                new (class {
+                  i = 0;
+                  [Symbol.asyncIterator]() {
+                    return {
+                      next: async () => {
+                        if (this.i < deltas.length) {
+                          return {
+                            value: { choices: [deltas[this.i++]] },
+                            done: false,
+                          };
+                        }
+                        return { done: true };
+                      },
+                    };
+                  }
+                  async finalChatCompletion() {
+                    return {
+                      choices: [
+                        {
+                          message: {
+                            role: 'assistant',
+                            tool_calls: [
+                              {
+                                id: 'call_abc',
+                                type: 'function',
+                                function: {
+                                  name: 'getWeather',
+                                  arguments: '{"city":"Tokyo"}',
+                                },
+                              },
+                            ],
+                          },
+                          finish_reason: 'tool_calls',
+                        },
+                      ],
+                    };
+                  }
+                })()
+            ),
+          },
+        },
+      },
+    };
+    const chunks: any[] = [];
+    const runner = openAIModelRunner(
+      'gpt-4o',
+      openaiClient as unknown as OpenAI
+    );
+    await runner(
+      { messages: [] },
+      {
+        streamingRequested: true,
+        sendChunk: (chunk) => chunks.push(chunk),
+      }
+    );
+
+    // Every emitted tool-request chunk should carry the tool name, ref and be
+    // marked partial. No chunk should contain an empty-string input.
+    const toolRequestChunks = chunks.filter((c) =>
+      c.content.some((p: any) => p.toolRequest)
+    );
+    expect(toolRequestChunks.length).toBe(3);
+    for (const chunk of toolRequestChunks) {
+      const part = chunk.content[0];
+      expect(part.toolRequest.name).toBe('getWeather');
+      expect(part.toolRequest.ref).toBe('call_abc');
+      expect(part.toolRequest.partial).toBe(true);
+      expect(part.toolRequest.input).not.toBe('');
+    }
+    // The last chunk should have the fully accumulated, parsed input.
+    const lastPart = toolRequestChunks.at(-1)!.content[0];
+    expect(lastPart.toolRequest.input).toStrictEqual({ city: 'Tokyo' });
+  });
+
   it('should run with requestBuilder', async () => {
     const openaiClient = {
       chat: {


### PR DESCRIPTION
Accumulate incrementally streamed tool-call `arguments` fragments across chunks so partial tool requests carry best-effort parsed input instead of emitting a flurry of empty `input: ''` chunks.

OpenAI streams tool calls incrementally: the first delta carries the `name`/`id` while subsequent deltas carry only fragments of the arguments JSON string keyed by tool call index. The new `fromOpenAIToolCallChunk` helper and per-choice accumulators assemble these fragments and use `parsePartialJson` to produce partial tool requests during streaming.

Before: 

```
data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"name":"getWeather","ref":"call_kdTYWX5JgMTV3Tf2DCDTwFyW","input":""}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"input":""}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"input":""}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"input":""}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"input":""}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"input":""}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[]}}}
```

After:

```
data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"name":"getWeather","ref":"call_5SkRD2naOYgFSSsiSvgNxwss","input":{},"partial":true}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"name":"getWeather","ref":"call_5SkRD2naOYgFSSsiSvgNxwss","input":{},"partial":true}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"name":"getWeather","ref":"call_5SkRD2naOYgFSSsiSvgNxwss","input":{},"partial":true}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"name":"getWeather","ref":"call_5SkRD2naOYgFSSsiSvgNxwss","input":{"location":""},"partial":true}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"name":"getWeather","ref":"call_5SkRD2naOYgFSSsiSvgNxwss","input":{"location":"Tokyo"},"partial":true}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[{"toolRequest":{"name":"getWeather","ref":"call_5SkRD2naOYgFSSsiSvgNxwss","input":{"location":"Tokyo"},"partial":true}}]}}}

data: {"message":{"modelChunk":{"role":"model","index":0,"content":[]}}}

data: {"message":{"modelChunk":{"role":"tool","index":1,"content":[{"toolResponse":{"name":"getWeather","ref":"call_5SkRD2naOYgFSSsiSvgNxwss","output":{"weather":"Sunny in Tokyo","temperature":"71F"}}}]}}}
```