### PR TITLE
feat(py): FirestoreSessionStore for google-cloud plugin

### DIFF
--- a/py/packages/genkit-google-cloud/README.md
+++ b/py/packages/genkit-google-cloud/README.md
@@ -21,3 +21,29 @@ ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
 ```
 
 Requires Google Cloud Application Default Credentials (ADC) or explicit credentials.
+
+
+## Sessions on Firestore
+
+`FirestoreSessionStore` persists agent sessions durably: every turn is
+stored as a snapshot, sessions survive restarts and resume across
+processes, and status subscriptions enable features like a cross-process
+stop button.
+
+```python
+from genkit_google_cloud.session_store.firestore import FirestoreSessionStore
+
+store = FirestoreSessionStore()  # uses Application Default Credentials
+# pass `store` where your agent setup takes a session store
+```
+
+Notes:
+
+- Data lives under three collection roots derived from `collection`
+  (default `genkit-sessions`, plus `-shards` and `-pointers`). Delete all
+  three together when cleaning up.
+- Multi-tenant apps pass `snapshot_path_prefix` to derive a per-tenant
+  path segment from call context.
+- After a regenerate/branch, resume a specific branch by `snapshot_id`;
+  `session_id` lookup follows the most recently written branch.
+- See the class docstring for costs, limits, and lifecycle details.

--- a/py/packages/genkit-google-cloud/pyproject.toml
+++ b/py/packages/genkit-google-cloud/pyproject.toml
@@ -44,6 +44,7 @@ classifiers = [
 ]
 dependencies = [
   "genkit",
+  "google-cloud-firestore>=2.14.0",
   "google-cloud-logging>=3.10.0",
   "opentelemetry-exporter-gcp-trace>=1.9.0",
   "opentelemetry-exporter-gcp-monitoring>=1.9.0",

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/__init__.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/__init__.py
@@ -15,16 +15,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-"""Google Cloud Plugin for Genkit.
+"""Google Cloud plugin for Genkit.
 
-This plugin provides Google Cloud observability integration for Genkit,
-enabling telemetry export to Cloud Trace, Cloud Monitoring, and Cloud Logging.
+Exports Genkit telemetry to Cloud Trace, Cloud Monitoring, and Cloud Logging,
+and provides :class:`FirestoreSessionStore` — a durable agent session store
+backed by Firestore. Turns are saved as JSON Patch diffs between periodic
+full-state checkpoints (sharded so no document approaches Firestore's size
+limit), so apps can resume long conversations across processes without
+secondary indexes.
 
 Example:
     ```python
     from genkit import Genkit
     from genkit_google_genai import GoogleAI
-    from genkit_google_cloud import enable_google_cloud_telemetry
+    from genkit_google_cloud import (
+        FirestoreSessionStore,
+        enable_google_cloud_telemetry,
+    )
 
 
     # 1. Enable Google Cloud Trace and Monitoring export
@@ -34,17 +41,22 @@ Example:
     ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
     await ai.generate(prompt='Hello, world!')
     # => Traces exported asynchronously to Cloud Trace (latency, tokens, status)
+
+    # 3. Persist agent sessions in Firestore (ADC / FIRESTORE_EMULATOR_HOST)
+    store = FirestoreSessionStore()
+    agent = ai.define_agent(name='assistant', store=store)
     ```
 
 Requirements:
-    - Requires Google Cloud Application Default Credentials (ADC) or explicit credentials.
-    - Telemetry export is disabled by default in local dev environments unless explicitly configured.
+    - Google Cloud Application Default Credentials (ADC), or explicit credentials.
+    - Telemetry export is disabled by default in local dev unless explicitly configured.
 
 See Also:
     - Cloud Trace: https://cloud.google.com/trace
     - Cloud Monitoring: https://cloud.google.com/monitoring
 """
 
+from .session_store.firestore import FirestoreSessionStore
 from .telemetry import add_gcp_telemetry, enable_google_cloud_telemetry
 
 
@@ -58,6 +70,7 @@ def package_name() -> str:
 
 
 __all__ = [
+    'FirestoreSessionStore',
     'add_gcp_telemetry',
     'enable_google_cloud_telemetry',
     'package_name',

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/session_store/firestore.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/session_store/firestore.py
@@ -61,6 +61,7 @@ from genkit._ai._agents._session import (
     StateT,
 )
 from genkit._ai._agents._session_stores._util import (
+    TERMINAL_STATUSES,
     SaveFn,
     apply_save,
     iterate_statuses,
@@ -97,13 +98,6 @@ MAX_SHARD_SIZE = 1_000_000
 # Firestore transactions retry internally on contention; after this many
 # attempts the failure surfaces as GenkitError(status='ABORTED').
 DEFAULT_TRANSACTION_MAX_ATTEMPTS = 5
-
-_TERMINAL_STATUSES = frozenset({
-    SnapshotStatus.COMPLETED,
-    SnapshotStatus.FAILED,
-    SnapshotStatus.ABORTED,
-    SnapshotStatus.EXPIRED,
-})
 
 
 @dataclass(eq=False)
@@ -1609,7 +1603,7 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
                 sub.last_status = status
                 with contextlib.suppress(Exception):
                     sub.queue.put_nowait(status)
-                if status not in _TERMINAL_STATUSES:
+                if status not in TERMINAL_STATUSES:
                     return
                 with contextlib.suppress(Exception):
                     sub.queue.put_nowait(None)

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/session_store/firestore.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/session_store/firestore.py
@@ -1,0 +1,1745 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Firestore-backed session store for agent snapshots.
+
+Each turn is persisted as a JSON Patch diff from its parent, with periodic
+full-state checkpoints. Checkpoint state is split across shard documents so no
+single write approaches Firestore's ~1 MiB document limit.
+
+Reads and writes use only document-ID lookups (pointer + snapshot + shards), so
+deployments need no secondary indexes and stay strongly consistent.
+
+Default layout (collection ``genkit-sessions``, prefix ``global``)::
+
+    genkit-sessions/{prefix}/snapshots/{snapshotId}
+    genkit-sessions-shards/{prefix}/shards/{checkpointId}_{index}
+    genkit-sessions-pointers/{prefix}/pointers/{sessionId}
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import threading
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Generic, Literal
+
+from google.api_core import exceptions as google_exceptions
+from google.cloud import firestore
+from google.cloud.firestore import (
+    AsyncClient,
+    AsyncCollectionReference,
+    AsyncDocumentReference,
+    AsyncTransaction,
+    DocumentSnapshot,
+)
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic.alias_generators import to_camel
+
+from genkit._ai._agents._session import (
+    SessionStore,
+    SnapshotStatusStream,
+    SnapshotSubscriber,
+    StateT,
+)
+from genkit._ai._agents._session_stores._util import (
+    SaveFn,
+    apply_save,
+    iterate_statuses,
+    require_one_selector,
+    session_id_of,
+)
+from genkit._ai._json_patch import apply_json_patch, diff_json
+from genkit._core._action import get_current_context
+from genkit._core._error import GenkitError
+from genkit._core._loop_cache import _loop_local_client
+from genkit._core._typing import (
+    AgentFinishReason,
+    GenkitRuntimeError,
+    JsonPatchOp,
+    JsonPatchOperation,
+    SessionSnapshot,
+    SessionState,
+    SnapshotStatus,
+)
+
+DEFAULT_COLLECTION = 'genkit-sessions'
+DEFAULT_PREFIX = 'global'
+logger = logging.getLogger(__name__)
+# Favor common chat workloads: enough diffs between checkpoints to keep write
+# amplification down, small enough that reconstruct stays cheap.
+DEFAULT_CHECKPOINT_INTERVAL = 25
+# Kept well under Firestore's 1 MiB/doc limit so a single shard or diff write
+# cannot be rejected for size.
+DEFAULT_SHARD_SIZE = 512 * 1024
+
+# Ceiling for shard_size: shard documents carry the chunk plus field overhead,
+# so cap below Firestore's 1 MiB document limit with headroom.
+MAX_SHARD_SIZE = 1_000_000
+
+# Firestore transactions retry internally on contention; after this many
+# attempts the failure surfaces as GenkitError(status='ABORTED').
+DEFAULT_TRANSACTION_MAX_ATTEMPTS = 5
+
+_TERMINAL_STATUSES = frozenset({
+    SnapshotStatus.COMPLETED,
+    SnapshotStatus.FAILED,
+    SnapshotStatus.ABORTED,
+    SnapshotStatus.EXPIRED,
+})
+
+
+@dataclass(eq=False)
+class _StatusSubscription:
+    """One ``on_snapshot_status_change`` call: private queue + Firestore watch."""
+
+    queue: asyncio.Queue[SnapshotStatus | None]
+    watch: Any | None = None
+    last_status: SnapshotStatus | None = None
+    closed: bool = False
+
+    __hash__ = object.__hash__
+
+
+@dataclass
+class _StatusLoopState:
+    """Per-event-loop Firestore clients + open status subscriptions."""
+
+    subscriptions: set[_StatusSubscription] = field(default_factory=set)
+    client: AsyncClient | None = None
+    sync_client: firestore.Client | None = None
+    owns_async_client: bool = False
+    owns_sync_client: bool = False
+
+
+class _ShardDoc(BaseModel):
+    """Schema for a checkpoint state shard document stored in Firestore."""
+
+    model_config = ConfigDict(extra='ignore')
+
+    chunk: bytes
+
+    @field_validator('chunk', mode='before')
+    @classmethod
+    def _coerce_chunk(cls, v: object) -> object:
+        """Coerce raw Firestore binary chunk representations to bytes.
+
+        google-cloud-firestore's gRPC deserializer returns zero-copy memoryview
+        objects for binary blob fields in DocumentSnapshot.to_dict().
+        """
+        if isinstance(v, memoryview):
+            return v.tobytes()
+        if isinstance(v, (bytes, bytearray)):
+            return bytes(v)
+        if isinstance(v, str):
+            return v.encode('utf-8')
+        return v
+
+
+class _SnapshotWriteMeta(BaseModel):
+    """Metadata written onto a snapshot doc for later reconstruction."""
+
+    model_config = ConfigDict(
+        extra='ignore',
+        populate_by_name=True,
+        alias_generator=to_camel,
+    )
+
+    kind: Literal['diff', 'checkpoint']
+    checkpoint_id: str
+    checkpoint_shard_count: int = Field(ge=1)
+    # [] means checkpoint; a missing field is corrupt, not an empty path.
+    segment_path: list[str]
+    # Wire form is a JSON string (see ``_SnapshotDoc.state_patch``); this
+    # in-memory meta keeps the parsed op list until the doc is built.
+    state_patch: list[dict[str, Any]] | None = None
+
+
+class _ParentChainMeta(BaseModel):
+    """Parent snapshot metadata required for diff calculation."""
+
+    model_config = ConfigDict(
+        extra='ignore',
+        populate_by_name=True,
+        alias_generator=to_camel,
+    )
+
+    checkpoint_id: str
+    checkpoint_shard_count: int = Field(ge=1)
+    segment_path: list[str]
+
+
+class _SnapshotDoc(BaseModel):
+    """Schema for turn snapshot document stored in Firestore."""
+
+    model_config = ConfigDict(
+        extra='ignore',
+        populate_by_name=True,
+        alias_generator=to_camel,
+    )
+
+    snapshot_id: str
+    session_id: str
+    parent_id: str | None = None
+    created_at: str
+    updated_at: str | None = None
+    status: SnapshotStatus | None = None
+    heartbeat_at: str | None = None
+    finish_reason: AgentFinishReason | None = None
+    error: GenkitRuntimeError | None = None
+    kind: Literal['diff', 'checkpoint']
+    checkpoint_id: str
+    checkpoint_shard_count: int = Field(ge=1)
+    # [] means checkpoint; a missing field is corrupt, not an empty path.
+    segment_path: list[str]
+    # Stored as a JSON string so deep nested state does not hit Firestore's
+    # ~20-level map nesting limit (checkpoints already avoid that via shards).
+    # Typed loosely so pre-release array values reach the decode error path.
+    state_patch: Any = None
+
+    def to_session_snapshot(self, state_raw: dict[str, Any] | SessionState | None = None) -> SessionSnapshot:
+        """Convert Firestore snapshot document and reconstructed state to a SessionSnapshot."""
+        state = _state_from_dict(state_raw)
+        return SessionSnapshot(
+            snapshot_id=self.snapshot_id,
+            session_id=self.session_id,
+            parent_id=self.parent_id,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            heartbeat_at=self.heartbeat_at,
+            status=self.status,
+            finish_reason=self.finish_reason,
+            error=self.error,
+            state=state,
+        )
+
+
+class _PointerDoc(BaseModel):
+    """Schema for session pointer document stored in Firestore."""
+
+    model_config = ConfigDict(
+        extra='ignore',
+        populate_by_name=True,
+        alias_generator=to_camel,
+    )
+
+    current_snapshot_id: str = Field(min_length=1)
+    checkpoint_id: str | None = None
+    checkpoint_shard_count: int | None = Field(default=None, ge=1)
+    segment_path: list[str]
+
+
+def _status_from_doc(doc_snapshot: DocumentSnapshot) -> SnapshotStatus | None:
+    """Extract and validate the snapshot status from a Firestore document."""
+    if not doc_snapshot.exists:
+        return None
+    status_val = (doc_snapshot.to_dict() or {}).get('status')
+    if status_val is None:
+        return None
+    try:
+        out: Any = SnapshotStatus(status_val)
+    except ValueError:
+        logger.warning("Unknown SnapshotStatus '%s' in Firestore document '%s'", status_val, doc_snapshot.id)
+        return None
+    return out
+
+
+def _state_to_dict(state: SessionState | None) -> dict[str, Any]:
+    """Convert a SessionState object to a dictionary representation."""
+    if state is None:
+        return {}
+    try:
+        dumped = state.model_dump(by_alias=True, exclude_none=True, mode='json')
+    except Exception as e:
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=f'session state is not storable: {e}',
+        ) from e
+    return dumped if isinstance(dumped, dict) else {}
+
+
+def _state_from_dict(data: dict[str, Any] | SessionState | None) -> SessionState | None:
+    """Parse a dictionary or SessionState object into a SessionState instance."""
+    if data is None:
+        return None
+    if isinstance(data, SessionState):
+        return data
+    try:
+        return SessionState.model_validate(data)
+    except Exception as e:
+        raise GenkitError(
+            status='DATA_LOSS',
+            message=f'FirestoreSessionStore: corrupt session state document: {e}',
+        ) from e
+
+
+def _json_dumps_utf8(value: Any) -> bytes:  # noqa: ANN401
+    """Compact UTF-8 JSON bytes, or INVALID_ARGUMENT when the value is not storable."""
+    try:
+        return json.dumps(value, separators=(',', ':'), ensure_ascii=False).encode('utf-8')
+    except (TypeError, ValueError, UnicodeEncodeError) as e:
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=f'session state is not storable: {e}',
+        ) from e
+
+
+# google.api_core exception class -> gRPC status name (see _to_genkit_error).
+_GOOGLE_EXC_STATUS: dict[str, str] = {
+    'Aborted': 'ABORTED',
+    'AlreadyExists': 'ALREADY_EXISTS',
+    'Cancelled': 'CANCELLED',
+    'DataLoss': 'DATA_LOSS',
+    'DeadlineExceeded': 'DEADLINE_EXCEEDED',
+    'FailedPrecondition': 'FAILED_PRECONDITION',
+    'Forbidden': 'PERMISSION_DENIED',
+    'InternalServerError': 'INTERNAL',
+    'InvalidArgument': 'INVALID_ARGUMENT',
+    'NotFound': 'NOT_FOUND',
+    'OutOfRange': 'OUT_OF_RANGE',
+    'PermissionDenied': 'PERMISSION_DENIED',
+    'ResourceExhausted': 'RESOURCE_EXHAUSTED',
+    'ServiceUnavailable': 'UNAVAILABLE',
+    'TooManyRequests': 'RESOURCE_EXHAUSTED',
+    'Unauthenticated': 'UNAUTHENTICATED',
+    'Unauthorized': 'UNAUTHENTICATED',
+    'Unknown': 'UNKNOWN',
+}
+
+
+def _to_genkit_error(e: google_exceptions.GoogleAPICallError) -> GenkitError:
+    """Convert a Google API error into a ``GenkitError``.
+
+    The status maps 1:1 from the exception class (both vocabularies are gRPC
+    statuses); the server's message is preserved verbatim, with no diagnosis
+    added.
+    """
+    status = _GOOGLE_EXC_STATUS.get(type(e).__name__, 'UNKNOWN')
+    return GenkitError(
+        status=status,  # type: ignore[arg-type]
+        message=f'FirestoreSessionStore: Firestore rejected the transaction ({type(e).__name__}): {e.message or e}',
+    )
+
+
+class _UserCodeError(Exception):
+    """Carrier: the mutator raised; deliver its exception verbatim."""
+
+
+async def _translate_txn_errors(awaitable: Awaitable[None]) -> None:
+    """Await a transactional coroutine, converting backend failures to ``GenkitError``.
+
+    The store's public contract is that every failure arising from its own
+    serialization, storage, or the Google libraries is a ``GenkitError`` with a
+    gRPC status. Exceptions from caller-supplied mutation functions propagate
+    unchanged (tunneled past library cleanup heuristics that would otherwise
+    misclassify them). Two library quirks are recognized narrowly, both
+    surfacing as a bare ``ValueError``: retry exhaustion (chained from the
+    final ``Aborted``), and a failed rollback on a transaction that never
+    obtained an ID, which masks the original error entirely.
+    """
+    try:
+        await awaitable
+    except _UserCodeError as e:
+        cause = e.__cause__
+        assert cause is not None
+        raise cause from None
+    except ValueError as e:
+        # Private-behavior dependency, deliberately narrow: the firestore
+        # library wraps retry exhaustion as a bare ValueError ("Failed to
+        # commit transaction in N attempts.") chained from the final Aborted.
+        # If a future release changes this shape we fall through to re-raise —
+        # degraded (untyped) but never mistranslated.
+        if isinstance(e.__cause__, google_exceptions.Aborted):
+            raise _to_genkit_error(e.__cause__) from e
+        if e.__cause__ is None and 'no transaction ID' in str(e):
+            # Second shape: a failure early in the transaction lifecycle
+            # (e.g. begin under heavy load) triggers rollback on a
+            # transaction with no ID; the library raises this unchained
+            # ValueError, destroying the original error. The transaction
+            # categorically did not commit, so ABORTED (retryable) is the
+            # honest classification even though the root cause is lost.
+            raise GenkitError(
+                status='ABORTED',
+                message=(
+                    'FirestoreSessionStore: transaction failed before it could be '
+                    f'established and the original error was masked by cleanup: {e}'
+                ),
+            ) from e
+        raise
+    except GenkitError:
+        raise
+    except google_exceptions.RetryError as e:
+        cause = e.cause
+        if isinstance(cause, google_exceptions.GoogleAPICallError):
+            raise _to_genkit_error(cause) from e
+        raise GenkitError(
+            status='ABORTED',
+            message=f'FirestoreSessionStore: Firestore retries exhausted: {e}',
+        ) from e
+    except google_exceptions.GoogleAPICallError as e:
+        raise _to_genkit_error(e) from e
+
+
+def _validate_doc_id(value: str | None, name: str) -> None:
+    """Reject ids that Firestore would treat as path structure, not a document id.
+
+    Ids become single document path segments; a ``/`` re-routes the path (an
+    even segment count silently addresses a different, deeper document — a
+    watch on it registers and then never fires), and ``.``/``..`` are reserved.
+    Leading or trailing whitespace is also rejected so save and get agree on
+    what counts as a valid id. Validating up front turns these failure modes
+    into a typed error.
+    """
+    if (
+        not value
+        or value != value.strip()
+        or not value.strip()
+        or '/' in value
+        or value in ('.', '..')
+        or (value.startswith('__') and value.endswith('__'))
+    ):
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message=(
+                f'FirestoreSessionStore: invalid {name} {value!r}: '
+                "must be a non-empty Firestore document id (no '/', not '.', '..', or "
+                '__reserved__, no leading/trailing whitespace).'
+            ),
+        )
+
+
+def _patch_to_json(patch: list[JsonPatchOperation]) -> list[dict[str, Any]]:
+    r"""Serialize patch ops for storage as valid RFC 6902 documents.
+
+    Deliberately not ``model_dump(exclude_none=True)``: RFC 6902 requires the
+    ``value`` member on add/replace/test operations, so an explicit ``null``
+    must be stored as ``\"value\": null`` rather than an absent key.
+    """
+    out: list[dict[str, Any]] = []
+    for op in patch:
+        d: dict[str, Any] = {'op': op.op.value, 'path': op.path}
+        if op.op in (JsonPatchOp.ADD, JsonPatchOp.REPLACE, JsonPatchOp.TEST):
+            d['value'] = op.value
+        if op.op in (JsonPatchOp.MOVE, JsonPatchOp.COPY):
+            d['from'] = op.from_
+        out.append(d)
+    return out
+
+
+def _encode_state_patch(patch: list[dict[str, Any]] | None) -> str | None:
+    """Serialize a patch op list to the snapshot-doc wire form (JSON string)."""
+    if patch is None:
+        return None
+    return json.dumps(patch, separators=(',', ':'), ensure_ascii=False)
+
+
+def _state_patch_data_loss(snapshot_id: str, detail: str) -> GenkitError:
+    """Build the shared DATA_LOSS error for an unreadable ``statePatch`` field."""
+    return GenkitError(
+        status='DATA_LOSS',
+        message=(
+            f"FirestoreSessionStore: snapshot '{snapshot_id}' has an unreadable "
+            f"'statePatch' field ({detail}). "
+            'Documents written by pre-release versions are not readable; '
+            "delete the session's documents and re-create."
+        ),
+    )
+
+
+def _decode_state_patch(raw: Any, *, snapshot_id: str) -> list[dict[str, Any]]:  # noqa: ANN401
+    r"""Parse the snapshot-doc ``statePatch`` JSON string into op dicts.
+
+    Diff segments always store a JSON string (including ``\"[]\"`` for a
+    zero-change turn). ``None`` / empty string / a missing field are
+    corruption, not an empty patch.
+    """
+    if raw is None or raw == '':
+        raise _state_patch_data_loss(snapshot_id, 'missing or empty')
+    if not isinstance(raw, str):
+        raise _state_patch_data_loss(snapshot_id, f'expected a JSON string; found {type(raw).__name__}')
+    try:
+        parsed = json.loads(raw)
+    except Exception as e:
+        raise _state_patch_data_loss(snapshot_id, 'unparseable') from e
+    if not isinstance(parsed, list):
+        raise _state_patch_data_loss(snapshot_id, 'not a patch array')
+    return parsed
+
+
+def _patch_from_json(raw: list[dict[str, Any]] | None) -> list[JsonPatchOperation]:
+    """Parse raw JSON Patch dicts into ``JsonPatchOperation`` models."""
+    if not raw:
+        return []
+    return [JsonPatchOperation.model_validate(op) for op in raw]
+
+
+def _byte_length(value: Any) -> int:  # noqa: ANN401
+    """UTF-8 byte size of a compact JSON encoding of ``value``.
+
+    Decides when a diff is too large for one Firestore document and should be
+    promoted to a sharded checkpoint. Uses ``ensure_ascii=False`` so multilingual
+    text is measured as the same UTF-8 bytes this store actually writes — escaping
+    non-ASCII would inflate the size and over-promote diffs into checkpoints.
+    """
+    return len(_json_dumps_utf8(value))
+
+
+class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[StateT]):
+    """Durable Firestore store for agent session snapshots.
+
+    Configuration is fixed at construction; to change it, create a new store instance.
+
+    Each turn is saved as a JSON Patch diff from its parent, with periodic
+    full-state checkpoints split across shard documents so no single write
+    approaches Firestore's ~1 MiB limit. Session lookup is a pointer read plus
+    document-ID fetches only — no secondary indexes.
+
+    Uses Application Default Credentials by default, or the emulator when
+    ``FIRESTORE_EMULATOR_HOST`` is set. Pass ``snapshot_path_prefix`` (often
+    derived from call ``context``, e.g. an authenticated user id) when session
+    ids may collide across tenants.
+
+    One store instance is safe to use from more than one asyncio event loop
+    (for example your app and the Dev UI). Each
+    ``on_snapshot_status_change`` call gets its own Firestore listener, and
+    status updates appear after the write commits. If you pass ``client`` /
+    ``sync_client``, the first loop that uses them keeps those instances;
+    later loops get their own clients when we can create matching ones.
+
+    Costs and limits:
+        - **Write contention**: All writes for a session update a single pointer document.
+          Rates above ~1 write/sec contend on it; exhausting retries raises a retryable
+          ``GenkitError(ABORTED)`` (configurable via ``transaction_max_attempts``).
+        - **Diff turn updates**: Updating a diff turn (including heartbeats) re-reads up to
+          ``checkpoint_interval`` parent documents to recompute the patch. At scale, these
+          re-reads dominate Firestore cost ahead of writes. Lowering ``checkpoint_interval``
+          trades cheaper updates for more checkpoint storage.
+        - **Checkpoint updates**: Updating an existing checkpoint turn rewrites the snapshot
+          and all its shard documents, amplifying heartbeats into multi-document writes.
+        - **Status watches**: Watches read only the snapshot document (status field). Each
+          active ``on_snapshot_status_change`` call holds its own background watch thread
+          until a terminal status, stream ``aclose``, or :meth:`close`. Two subscribers on
+          the same snapshot therefore use two watches.
+        - **Event buffering**: Status streams buffer unread events in memory without bound if
+          the subscriber consumes slower than events arrive.
+
+    Interoperability:
+        The Python, JS, and Go stores share the same concepts and storage
+        model; each SDK's surface and behavioral guarantees are idiomatic to
+        its language and documented per SDK. On-disk document formats are
+        maintained independently and may diverge. Use a separate Firestore
+        collection per SDK.
+
+    Data lifecycle:
+        Deleting a session's documents is safe at any time: lookups report
+        the session as absent, and if data is written again the pointer is
+        transparently recreated.
+    """
+
+    _FROZEN = frozenset({'collection', 'shard_size', 'checkpoint_interval', 'transaction_max_attempts'})
+
+    def __setattr__(self, name: str, value: Any) -> None:  # noqa: ANN401
+        """Block post-init reassignment of construction knobs with a typed error."""
+        if name in self._FROZEN and hasattr(self, '_closed'):
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message=(
+                    f'FirestoreSessionStore: {name!r} is fixed at construction; '
+                    'create a new store instance with the desired configuration.'
+                ),
+            )
+        super().__setattr__(name, value)
+
+    def __init__(
+        self,
+        *,
+        client: AsyncClient | None = None,
+        sync_client: firestore.Client | None = None,
+        collection: str = DEFAULT_COLLECTION,
+        snapshot_path_prefix: Callable[[dict[str, Any] | None], str] | None = None,
+        checkpoint_interval: int = DEFAULT_CHECKPOINT_INTERVAL,
+        shard_size: int = DEFAULT_SHARD_SIZE,
+        transaction_max_attempts: int = DEFAULT_TRANSACTION_MAX_ATTEMPTS,
+    ) -> None:
+        """Create a Firestore-backed session store.
+
+        Realtime status watches need a sync ``Client`` (the async client cannot
+        watch documents). Pass ``sync_client`` to own that lifecycle yourself;
+        otherwise one is created lazily per event loop to match that loop's
+        async client and closed by :meth:`close`.
+
+        ``snapshot_path_prefix`` maps request ``context`` (for example auth) to a
+        path segment that isolates tenants when session ids may collide.
+
+        ``transaction_max_attempts`` bounds how many times a contended
+        transaction is retried before failing with status ``ABORTED``. The
+        default suits typical sessions; raise it for workloads with many
+        concurrent writers per session.
+        """
+        _validate_doc_id(collection, 'collection')
+        if checkpoint_interval < 1:
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=f'FirestoreSessionStore: checkpoint_interval must be >= 1, got {checkpoint_interval}.',
+            )
+        if not 0 < shard_size <= MAX_SHARD_SIZE:
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=(
+                    f'FirestoreSessionStore: shard_size must be between 1 and {MAX_SHARD_SIZE} '
+                    f'bytes to stay under the Firestore document limit, got {shard_size}.'
+                ),
+            )
+        if transaction_max_attempts < 1:
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=(
+                    f'FirestoreSessionStore: transaction_max_attempts must be >= 1, got {transaction_max_attempts}.'
+                ),
+            )
+        self._transaction_max_attempts = transaction_max_attempts
+        self._provided_client = client
+        self._provided_sync_client = sync_client
+        self._provided_client_loop: asyncio.AbstractEventLoop | None = None
+        self._provided_sync_loop: asyncio.AbstractEventLoop | None = None
+        self._collection = collection
+        self._prefix_fn = snapshot_path_prefix or (lambda _context: DEFAULT_PREFIX)
+        self._checkpoint_interval = checkpoint_interval
+        self._shard_size = shard_size
+        # Per running event loop: clients + open per-subscribe watches.
+        # Strong keys so we can prune closed loops and tear down their resources.
+        self._status_by_loop: dict[asyncio.AbstractEventLoop, _StatusLoopState] = {}
+        self._status_by_loop_mu = threading.Lock()
+        # Last so post-init frozen-config __setattr__ can key off its presence.
+        self._closed = False
+
+    def _status_loop_state(self) -> _StatusLoopState:
+        """Clients + open status subscriptions for the running event loop.
+
+        Also tears down watches/clients left behind by closed loops so a
+        notebook-style ``asyncio.run`` cell does not leak listeners.
+        """
+        loop = asyncio.get_running_loop()
+        with self._status_by_loop_mu:
+            orphan_watches, orphan_states = self._prune_closed_status_loops_locked()
+            state = self._status_by_loop.get(loop)
+            if state is None:
+                state = _StatusLoopState()
+                self._status_by_loop[loop] = state
+        for watch in orphan_watches:
+            with contextlib.suppress(Exception):
+                watch.unsubscribe()
+        for dead in orphan_states:
+            self._release_loop_clients(dead)
+        return state
+
+    def _prune_closed_status_loops_locked(self) -> tuple[list[Any], list[_StatusLoopState]]:
+        """Drop bags whose event loop is closed. Caller holds mu."""
+        dead = [lp for lp in self._status_by_loop if lp.is_closed()]
+        orphan_watches: list[Any] = []
+        orphan_states: list[_StatusLoopState] = []
+        for lp in dead:
+            state = self._status_by_loop.pop(lp)
+            for sub in state.subscriptions:
+                if sub.watch is not None:
+                    orphan_watches.append(sub.watch)
+                    sub.watch = None
+                sub.closed = True
+            state.subscriptions.clear()
+            orphan_states.append(state)
+        return orphan_watches, orphan_states
+
+    @staticmethod
+    def _release_loop_clients(state: _StatusLoopState, *, async_clients: bool = True) -> None:
+        """Close clients this store created for a loop bag."""
+        if state.owns_sync_client and state.sync_client is not None:
+            with contextlib.suppress(Exception):
+                state.sync_client.close()
+            state.sync_client = None
+            state.owns_sync_client = False
+        if not async_clients:
+            return
+        if state.owns_async_client and state.client is not None:
+            close = getattr(state.client, 'close', None)
+            if close is not None:
+                with contextlib.suppress(Exception):
+                    result = close()
+                    # AsyncClient.close is async on some SDK versions; best-effort.
+                    if asyncio.iscoroutine(result):
+                        result.close()  # type: ignore[attr-defined]
+            state.client = None
+            state.owns_async_client = False
+
+    @staticmethod
+    def _try_clone_async_client(template: Any) -> AsyncClient | None:  # noqa: ANN401
+        """Build a new AsyncClient matching ``template``'s project/database, if possible."""
+        project = getattr(template, 'project', None)
+        if not isinstance(project, str) or not project:
+            return None
+        kwargs: dict[str, Any] = {'project': project}
+        database = getattr(template, '_database', None)
+        if database is not None:
+            kwargs['database'] = database
+        credentials = getattr(template, '_credentials', None)
+        if credentials is not None:
+            kwargs['credentials'] = credentials
+        client_info = getattr(template, '_client_info', None)
+        if client_info is not None:
+            kwargs['client_info'] = client_info
+        client_options = getattr(template, '_client_options', None)
+        if client_options is not None:
+            kwargs['client_options'] = client_options
+        try:
+            return firestore.AsyncClient(**kwargs)
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _ensure_async_client(self) -> AsyncClient:
+        """Async client for the running loop (created or bound lazily)."""
+        state = self._status_loop_state()
+        if state.client is not None:
+            # Keep serving a bound client after close() so in-flight reads that
+            # suspended across close can finish and hit the closed check.
+            return state.client
+        if self._closed:
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message='FirestoreSessionStore: store is closed.',
+            )
+        loop = asyncio.get_running_loop()
+        if self._provided_client is not None and self._provided_client_loop is None:
+            state.client = self._provided_client
+            state.owns_async_client = False
+            self._provided_client_loop = loop
+            return state.client
+        if self._provided_client is not None:
+            cloned = self._try_clone_async_client(self._provided_client)
+            if cloned is not None:
+                state.client = cloned
+                state.owns_async_client = True
+                return state.client
+            # Test doubles / odd clients: share the provided instance.
+            state.client = self._provided_client
+            state.owns_async_client = False
+            return state.client
+        state.client = firestore.AsyncClient()
+        state.owns_async_client = True
+        return state.client
+
+    @property
+    def client(self) -> AsyncClient:
+        """Async Firestore client for the running event loop."""
+        return self._ensure_async_client()
+
+    @client.setter
+    def client(self, value: AsyncClient) -> None:
+        """Bind an async client to the running loop (tests / advanced wiring)."""
+        state = self._status_loop_state()
+        state.client = value
+        state.owns_async_client = False
+
+    @property
+    def sync_client(self) -> firestore.Client | None:
+        """Sync watch client for the running loop, if one has been created."""
+        return self._status_loop_state().sync_client
+
+    @sync_client.setter
+    def sync_client(self, value: firestore.Client | None) -> None:
+        """Set/clear the running loop's sync client (tests rebind watches this way)."""
+        state = self._status_loop_state()
+        state.sync_client = value
+        # Caller-supplied clients are never closed by the store.
+        state.owns_sync_client = False
+
+    @property
+    def _subscriptions(self) -> set[_StatusSubscription]:
+        """Current loop's open status subscriptions (tests and internal helpers)."""
+        return self._status_loop_state().subscriptions
+
+    @property
+    def collection(self) -> str:
+        """Root Firestore collection name for snapshot documents."""
+        return self._collection
+
+    @property
+    def shard_size(self) -> int:
+        """Max UTF-8 bytes per checkpoint shard document."""
+        return self._shard_size
+
+    @property
+    def checkpoint_interval(self) -> int:
+        """Diff-chain length before a new full-state checkpoint is written."""
+        return self._checkpoint_interval
+
+    @property
+    def transaction_max_attempts(self) -> int:
+        """How many times a contended transaction is retried before ABORTED."""
+        return self._transaction_max_attempts
+
+    @property
+    def _lock(self) -> asyncio.Lock:
+        """Loop-local lock for status subscription start/teardown."""
+        getter = getattr(self, '_loop_lock_getter', None)
+        if getter is None:
+            getter = _loop_local_client(lambda: asyncio.Lock())
+            object.__setattr__(self, '_loop_lock_getter', getter)
+        return getter()
+
+    def _prefix(self, context: dict[str, Any] | None) -> str:
+        """Resolve and validate the tenant prefix for this call.
+
+        The prefix is a document id in all three collection roots, so it is
+        held to the same rules as snapshot and session ids — a bad prefix
+        would silently re-route every path under it. Public operations
+        resolve it once at entry and thread the string down so a caller
+        mutating the context mid-await cannot split a write across tenants.
+        """
+        prefix = self._prefix_fn(context)
+        _validate_doc_id(prefix, 'snapshot_path_prefix')
+        return prefix
+
+    def _snapshots_col(self, prefix: str) -> AsyncCollectionReference:
+        """Return the Firestore collection reference for snapshots."""
+        return self.client.collection(self.collection).document(prefix).collection('snapshots')
+
+    def _pointers_col(self, prefix: str) -> AsyncCollectionReference:
+        """Return the Firestore collection reference for session pointers."""
+        return self.client.collection(f'{self.collection}-pointers').document(prefix).collection('pointers')
+
+    def _shards_col(self, prefix: str) -> AsyncCollectionReference:
+        """Return the Firestore collection reference for checkpoint shards."""
+        return self.client.collection(f'{self.collection}-shards').document(prefix).collection('shards')
+
+    def _snapshot_ref(self, snapshot_id: str, prefix: str) -> AsyncDocumentReference:
+        """Return the Firestore document reference for a snapshot ID."""
+        return self._snapshots_col(prefix).document(snapshot_id)
+
+    def _pointer_ref(self, session_id: str, prefix: str) -> AsyncDocumentReference:
+        """Return the Firestore document reference for a session pointer ID."""
+        return self._pointers_col(prefix).document(session_id)
+
+    async def get_snapshot(
+        self,
+        *,
+        snapshot_id: str | None = None,
+        session_id: str | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> SessionSnapshot | None:
+        """Load a snapshot by id, or the current tip of a session.
+
+        Exactly one of ``snapshot_id`` or ``session_id`` must be set. Session
+        lookup follows the pointer document and returns the snapshot most
+        recently written for that session (last writer wins). After a branch
+        (e.g. regenerate), concurrent writers make the current snapshot
+        race-dependent; resume by ``snapshot_id`` when a specific branch
+        matters.
+        """
+        require_one_selector(snapshot_id=snapshot_id, session_id=session_id)
+        if context is None:
+            context = get_current_context()
+        if snapshot_id is not None:
+            _validate_doc_id(snapshot_id, 'snapshot_id')
+        if session_id is not None:
+            _validate_doc_id(session_id, 'session_id')
+        prefix = self._prefix(context)
+        transaction = self.client.transaction(read_only=True, max_attempts=self.transaction_max_attempts)
+        result: SessionSnapshot | None = None
+
+        @firestore.async_transactional
+        async def read_in_transaction(transaction: AsyncTransaction) -> None:
+            nonlocal result
+            if snapshot_id is not None:
+                reconstructed = await self._reconstruct(transaction, snapshot_id, prefix=prefix)
+                result = self._to_snapshot(reconstructed) if reconstructed else None
+                return
+
+            assert session_id is not None
+            pointer_doc = await self._pointer_ref(session_id, prefix).get(transaction=transaction)
+            if not pointer_doc.exists:
+                result = None
+                return
+
+            try:
+                pointer = _PointerDoc.model_validate(pointer_doc.to_dict() or {})
+            except Exception as e:
+                raise GenkitError(
+                    status='DATA_LOSS',
+                    message=f"FirestoreSessionStore: invalid session pointer document for '{session_id}'.",
+                ) from e
+            # Pointer carries the leaf's chain metadata so we can rebuild without
+            # an extra snapshot-doc read when everything is present.
+            current_id = pointer.current_snapshot_id
+            checkpoint_id = pointer.checkpoint_id
+            shard_count = pointer.checkpoint_shard_count
+            if current_id and checkpoint_id and shard_count is not None:
+                reconstructed = await self._reconstruct_from(
+                    transaction,
+                    checkpoint_id=checkpoint_id,
+                    shard_count=shard_count,
+                    segment_path=pointer.segment_path,
+                    target_id=current_id,
+                    prefix=prefix,
+                )
+                if reconstructed is not None:
+                    result = self._to_snapshot(reconstructed)
+                if result is not None:
+                    if result.session_id != session_id:
+                        raise GenkitError(
+                            status='DATA_LOSS',
+                            message=(
+                                f"FirestoreSessionStore: session '{session_id}' pointer resolves to "
+                                f"snapshot '{result.snapshot_id}' owned by session '{result.session_id}'."
+                            ),
+                        )
+                    return
+
+            if current_id:
+                reconstructed = await self._reconstruct(transaction, current_id, prefix=prefix)
+                result = self._to_snapshot(reconstructed)
+                if result is not None and result.session_id != session_id:
+                    raise GenkitError(
+                        status='DATA_LOSS',
+                        message=(
+                            f"FirestoreSessionStore: session '{session_id}' pointer resolves to "
+                            f"snapshot '{result.snapshot_id}' owned by session '{result.session_id}'."
+                        ),
+                    )
+
+        await _translate_txn_errors(read_in_transaction(transaction))
+        return result
+
+    async def save_snapshot(
+        self,
+        snapshot_id: str,
+        fn: SaveFn,
+        *,
+        context: dict[str, Any] | None = None,
+    ) -> SessionSnapshot | None:
+        """Atomically create or update a snapshot and advance its session pointer.
+
+        Abort, heartbeat, and finalize all share this path. A process-local lock
+        can't coordinate across instances, so the snapshot write and pointer
+        update commit together in one Firestore transaction. Status subscribers
+        observe the new status through their own Firestore watches after that
+        commit lands (there is no in-process fan-out from this method).
+
+        Upserts (mutators that rewrite an existing snapshot) must target the
+        current leaf. Rewriting an interior snapshot would break descendants
+        that still apply its diff.
+
+        Terminal statuses are absorbing: rewriting a finished snapshot's
+        state or metadata is allowed, but changing its status raises
+        ``FAILED_PRECONDITION``.
+
+        A snapshot's lineage is fixed at creation: ``parent_id`` cannot change,
+        and only the session's current snapshot may have its state rewritten
+        (metadata such as status and heartbeat may be updated on any snapshot).
+        Interior turns are therefore immutable; to remove content from history,
+        delete the session's documents and re-create what should remain.
+        """
+        _validate_doc_id(snapshot_id, 'snapshot_id')
+        if context is None:
+            context = get_current_context()
+        # Resolve the tenant prefix before the transaction: a failing prefix
+        # function must fail BEFORE anything commits, and the post-commit
+        # notification must use the same prefix the write used.
+        prefix = self._prefix(context)
+        snap_ref = self._snapshot_ref(snapshot_id, prefix)
+        transaction = self.client.transaction(max_attempts=self.transaction_max_attempts)
+        committed: SessionSnapshot | None = None
+
+        @firestore.async_transactional
+        async def rmw(transaction: AsyncTransaction) -> None:
+            nonlocal committed
+            existing_recon = await self._reconstruct(transaction, snapshot_id, prefix=prefix)
+            existing = self._to_snapshot(existing_recon) if existing_recon else None
+            try:
+                next_snapshot = apply_save(existing=existing, snapshot_id=snapshot_id, fn=fn)
+            except GenkitError:
+                raise
+            except BaseException as e:
+                raise _UserCodeError() from e
+            if next_snapshot is None:
+                return
+            _validate_doc_id(next_snapshot.session_id, 'session_id')
+            if next_snapshot.parent_id:
+                _validate_doc_id(next_snapshot.parent_id, 'parent_id')
+
+            sid = next_snapshot.snapshot_id
+            session_id = session_id_of(next_snapshot)
+            if not session_id:
+                raise GenkitError(
+                    status='INVALID_ARGUMENT',
+                    message="FirestoreSessionStore requires 'sessionId' on the snapshot.",
+                )
+            assert sid is not None
+
+            _pointer_ref = self._pointer_ref(session_id, prefix)
+            pointer_snap = await _pointer_ref.get(transaction=transaction)
+            pointer: _PointerDoc | None = None
+            if pointer_snap.exists:
+                try:
+                    pointer = _PointerDoc.model_validate(pointer_snap.to_dict())
+                except Exception:
+                    # Corrupt pointer on the write path: treat as missing so this
+                    # transaction rewrites it wholesale (self-heal), keeping the
+                    # session writable instead of wedging every save.
+                    logger.warning("Rewriting invalid session pointer document for '%s'", session_id)
+            new_state = _state_to_dict(next_snapshot.state)
+
+            meta: _SnapshotWriteMeta
+            if existing_recon is not None:
+                existing_doc, existing_state = existing_recon
+                # Lineage is fixed at create: re-parenting an existing doc (or a
+                # losing concurrent create that retries as an upsert) would
+                # rewrite history under descendants that still apply its diff.
+                old_parent = existing_doc.parent_id or ''
+                new_parent = next_snapshot.parent_id or ''
+                if old_parent != new_parent:
+                    raise GenkitError(
+                        status='FAILED_PRECONDITION',
+                        message=(
+                            f"Snapshot '{sid}' parent_id is immutable "
+                            f"('{old_parent}' -> '{new_parent}'); create a "
+                            'new snapshot to branch.'
+                        ),
+                    )
+                # State is tip-only: an interior rewrite would leave children
+                # applying a patch against a base that no longer matches.
+                # Metadata-only updates (heartbeat, status, …) stay allowed.
+                # A missing pointer proves nothing about interiority, so
+                # deletion self-heal can still rewrite.
+                if existing_state != new_state and pointer is not None and pointer.current_snapshot_id != sid:
+                    raise GenkitError(
+                        status='FAILED_PRECONDITION',
+                        message=(
+                            f"Snapshot '{sid}' is not session '{session_id}'s current "
+                            "snapshot; rewriting an interior snapshot's state would "
+                            "corrupt descendants' diffs; rewrite the session tip or "
+                            'create a new snapshot to branch.'
+                        ),
+                    )
+                if existing_doc.kind == 'checkpoint':
+                    meta = self._write_checkpoint(
+                        transaction,
+                        sid,
+                        new_state,
+                        old_shard_count=existing_doc.checkpoint_shard_count,
+                        prefix=prefix,
+                    )
+                else:
+                    parent_id = existing_doc.parent_id
+                    parent_state = None
+                    if parent_id:
+                        parent_recon = await self._reconstruct(transaction, parent_id, prefix=prefix)
+                        parent_state = parent_recon[1] if parent_recon else None
+                        if parent_recon and parent_recon[0].session_id != next_snapshot.session_id:
+                            raise GenkitError(
+                                status='FAILED_PRECONDITION',
+                                message=(
+                                    f"Snapshot '{sid}' has parent '{parent_id}' owned by session "
+                                    f"'{parent_recon[0].session_id}', not '{next_snapshot.session_id}'."
+                                ),
+                            )
+                    candidate_patch = _patch_to_json(diff_json(from_value=parent_state, to_value=new_state))
+                    # Oversized patches can't live in one doc field; promote to checkpoint.
+                    patch_too_large = _byte_length(candidate_patch) > self.shard_size
+                    if patch_too_large:
+                        meta = self._write_checkpoint(transaction, sid, new_state, prefix=prefix)
+                    else:
+                        meta = _SnapshotWriteMeta(
+                            kind='diff',
+                            checkpoint_id=existing_doc.checkpoint_id,
+                            checkpoint_shard_count=existing_doc.checkpoint_shard_count,
+                            segment_path=existing_doc.segment_path,
+                            state_patch=candidate_patch,
+                        )
+            else:
+                parent_meta = None
+                if next_snapshot.parent_id:
+                    parent_meta = await self._load_parent_chain_meta(
+                        transaction,
+                        next_snapshot.parent_id,
+                        pointer,
+                        prefix=prefix,
+                    )
+                # New root, missing parent chain, or segment full → full checkpoint.
+                if (
+                    not next_snapshot.parent_id
+                    or parent_meta is None
+                    or len(parent_meta.segment_path) + 1 >= self.checkpoint_interval
+                ):
+                    meta = self._write_checkpoint(transaction, sid, new_state, prefix=prefix)
+                else:
+                    parent_recon = await self._reconstruct_from(
+                        transaction,
+                        checkpoint_id=parent_meta.checkpoint_id,
+                        shard_count=parent_meta.checkpoint_shard_count,
+                        segment_path=parent_meta.segment_path,
+                        target_id=next_snapshot.parent_id,
+                        prefix=prefix,
+                    )
+                    parent_state = parent_recon[1] if parent_recon else None
+                    if parent_recon and parent_recon[0].session_id != next_snapshot.session_id:
+                        raise GenkitError(
+                            status='FAILED_PRECONDITION',
+                            message=(
+                                f"Snapshot '{sid}' has parent '{next_snapshot.parent_id}' owned by "
+                                f"session '{parent_recon[0].session_id}', not '{next_snapshot.session_id}'."
+                            ),
+                        )
+                    candidate_patch = _patch_to_json(diff_json(from_value=parent_state, to_value=new_state))
+                    # Oversized patches can't live in one doc field; promote to checkpoint.
+                    patch_too_large = _byte_length(candidate_patch) > self.shard_size
+                    if patch_too_large:
+                        meta = self._write_checkpoint(transaction, sid, new_state, prefix=prefix)
+                    else:
+                        meta = _SnapshotWriteMeta(
+                            kind='diff',
+                            checkpoint_id=parent_meta.checkpoint_id,
+                            checkpoint_shard_count=parent_meta.checkpoint_shard_count,
+                            segment_path=[*parent_meta.segment_path, sid],
+                            state_patch=candidate_patch,
+                        )
+
+            kind = meta.kind
+            checkpoint_id = meta.checkpoint_id
+            checkpoint_shard_count = meta.checkpoint_shard_count
+            segment_path = meta.segment_path
+            state_patch = meta.state_patch
+
+            doc_model = _SnapshotDoc(
+                snapshot_id=sid,
+                session_id=session_id,
+                parent_id=next_snapshot.parent_id,
+                created_at=next_snapshot.created_at,
+                updated_at=next_snapshot.updated_at or next_snapshot.created_at,
+                status=next_snapshot.status,
+                heartbeat_at=next_snapshot.heartbeat_at,
+                finish_reason=next_snapshot.finish_reason,
+                error=next_snapshot.error,
+                kind=kind,
+                checkpoint_id=checkpoint_id,
+                checkpoint_shard_count=checkpoint_shard_count,
+                segment_path=segment_path,
+                state_patch=_encode_state_patch(state_patch),
+            )
+            transaction.set(
+                snap_ref,
+                doc_model.model_dump(by_alias=True, exclude_none=True, mode='json'),
+            )
+            await self._update_pointer_in_transaction(
+                transaction,
+                session_id,
+                sid,
+                pointer=pointer,
+                is_new=existing_recon is None,
+                checkpoint_id=checkpoint_id,
+                checkpoint_shard_count=checkpoint_shard_count,
+                segment_path=segment_path,
+                prefix=prefix,
+            )
+            committed = next_snapshot
+
+        await _translate_txn_errors(rmw(transaction))
+        return committed
+
+    async def on_snapshot_status_change(
+        self, snapshot_id: str, *, context: dict[str, Any] | None = None
+    ) -> SnapshotStatusStream:
+        """Subscribe to status changes for a snapshot.
+
+        Returns an async stream that yields each new status from a dedicated
+        Firestore watch for this call. If the document does not exist yet, the
+        stream stays open and the watch waits for it — missing is not treated
+        as end-of-stream. Likewise, deleting a watched snapshot does not end
+        its subscription; a stream ends with a terminal status or
+        :meth:`close`. Iteration therefore ends in one of two shapes: the last
+        yielded status is terminal (the run resolved), or no terminal was
+        yielded (this store was closed locally; the run may still be live
+        elsewhere).
+
+        Exiting an ``async for`` with ``break`` does not end the subscription;
+        close the stream (``async with`` or ``aclose()``) or it stays open
+        until a terminal status or ``close()``. When ``context`` is omitted, the
+        ambient call context is used — the same default as ``get_snapshot`` and
+        ``save_snapshot``.
+        """
+        _validate_doc_id(snapshot_id, 'snapshot_id')
+        if self._closed:
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message='FirestoreSessionStore: store is closed.',
+            )
+        if context is None:
+            context = get_current_context()
+        # Tenant prefix is captured once so two tenants watching the same
+        # snapshot id get independent listeners.
+        prefix = self._prefix(context)
+        async with self._lock:
+            if self._closed:
+                q: asyncio.Queue[SnapshotStatus | None] = asyncio.Queue()
+                q.put_nowait(None)
+                return iterate_statuses(q)
+
+            sub = _StatusSubscription(queue=asyncio.Queue())
+            state = self._status_loop_state()
+            state.subscriptions.add(sub)
+            try:
+                sub.watch = self._attach_status_watch(snapshot_id, prefix=prefix, sub=sub)
+            except Exception:
+                state.subscriptions.discard(sub)
+                raise
+
+            if self._closed:
+                # close() raced the watch attach; end this stream the way close
+                # ends every other local stream.
+                await self._teardown_subscription(sub)
+                with contextlib.suppress(Exception):
+                    sub.queue.put_nowait(None)
+                return iterate_statuses(sub.queue)
+
+            async def on_close() -> None:
+                async with self._lock:
+                    await self._teardown_subscription(sub)
+
+            return iterate_statuses(sub.queue, on_close=on_close)
+
+    async def _read_snapshot(
+        self,
+        snapshot_id: str,
+        *,
+        prefix: str,
+    ) -> SessionSnapshot | None:
+        """Read a single snapshot by id, reconstructing state from its checkpoint chain."""
+        _validate_doc_id(snapshot_id, 'snapshot_id')
+        transaction = self.client.transaction(read_only=True, max_attempts=self.transaction_max_attempts)
+        result: SessionSnapshot | None = None
+
+        @firestore.async_transactional
+        async def read_in_transaction(transaction: AsyncTransaction) -> None:
+            nonlocal result
+            reconstructed = await self._reconstruct(transaction, snapshot_id, prefix=prefix)
+            result = self._to_snapshot(reconstructed) if reconstructed else None
+
+        await _translate_txn_errors(read_in_transaction(transaction))
+        return result
+
+    async def _update_pointer_in_transaction(
+        self,
+        transaction: AsyncTransaction,
+        session_id: str,
+        snapshot_id: str,
+        *,
+        pointer: _PointerDoc | None,
+        is_new: bool,
+        checkpoint_id: str,
+        checkpoint_shard_count: int,
+        segment_path: list[str],
+        prefix: str,
+    ) -> None:
+        """Advance or refresh the session pointer inside an open transaction.
+
+        The pointer is advanced for a new leaf, refreshed when the current
+        leaf is rewritten, and recreated when missing or invalid (TTL expiry,
+        corruption) — last writer wins. The document is replaced wholesale so
+        a reader never observes a partial update. Writes to other snapshots
+        leave the pointer untouched.
+
+        Callers must pass the pointer already loaded earlier in the same
+        transaction — Firestore rejects reads after any buffered writes.
+        """
+        if not (is_new or pointer is None or pointer.current_snapshot_id == snapshot_id):
+            return
+        payload = _PointerDoc(
+            current_snapshot_id=snapshot_id,
+            checkpoint_id=checkpoint_id,
+            checkpoint_shard_count=checkpoint_shard_count,
+            segment_path=segment_path,
+        ).model_dump(by_alias=True, exclude_none=False, mode='python')
+        payload['updatedAt'] = datetime.now(timezone.utc).isoformat()
+        transaction.set(self._pointer_ref(session_id, prefix), payload)
+
+    async def _load_parent_chain_meta(
+        self,
+        transaction: AsyncTransaction,
+        parent_id: str,
+        pointer: _PointerDoc | None,
+        *,
+        prefix: str,
+    ) -> _ParentChainMeta | None:
+        """Resolve parent checkpoint/segment metadata without materializing state."""
+        if pointer and pointer.current_snapshot_id == parent_id:
+            if pointer.checkpoint_id and pointer.checkpoint_shard_count is not None:
+                return _ParentChainMeta(
+                    checkpoint_id=pointer.checkpoint_id,
+                    checkpoint_shard_count=pointer.checkpoint_shard_count,
+                    segment_path=pointer.segment_path,
+                )
+        snap = await self._snapshot_ref(parent_id, prefix).get(transaction=transaction)
+        if not snap.exists:
+            logger.warning("Parent snapshot document '%s' does not exist", parent_id)
+            return None
+        try:
+            doc = _SnapshotDoc.model_validate(snap.to_dict())
+        except Exception:
+            logger.warning("Parent snapshot document '%s' contains invalid metadata", parent_id)
+            return None
+        return _ParentChainMeta(
+            checkpoint_id=doc.checkpoint_id,
+            checkpoint_shard_count=doc.checkpoint_shard_count,
+            segment_path=doc.segment_path,
+        )
+
+    async def _reconstruct(
+        self,
+        transaction: AsyncTransaction,
+        snapshot_id: str,
+        *,
+        prefix: str,
+    ) -> tuple[_SnapshotDoc, dict[str, Any]] | None:
+        snap = await self._snapshot_ref(snapshot_id, prefix).get(transaction=transaction)
+        if not snap.exists:
+            return None
+        try:
+            doc = _SnapshotDoc.model_validate(snap.to_dict())
+        except Exception as e:
+            # Fail loud: returning None would look like "missing" and let
+            # save_snapshot overwrite the bad leaf as a brand-new checkpoint.
+            raise GenkitError(
+                status='DATA_LOSS',
+                message=f"FirestoreSessionStore: invalid snapshot document '{snap.reference.path}'.",
+            ) from e
+        return await self._reconstruct_from(
+            transaction,
+            checkpoint_id=doc.checkpoint_id,
+            shard_count=doc.checkpoint_shard_count,
+            segment_path=doc.segment_path,
+            target_id=snapshot_id,
+            prefix=prefix,
+        )
+
+    async def _reconstruct_from(
+        self,
+        transaction: AsyncTransaction,
+        *,
+        checkpoint_id: str,
+        shard_count: int,
+        segment_path: list[str],
+        target_id: str,
+        prefix: str,
+    ) -> tuple[_SnapshotDoc, dict[str, Any]] | None:
+        if shard_count < 1:
+            raise GenkitError(
+                status='DATA_LOSS',
+                message=(
+                    f"FirestoreSessionStore: checkpoint '{checkpoint_id}' has invalid "
+                    f'checkpointShardCount {shard_count} (must be >= 1).'
+                ),
+            )
+        target_is_checkpoint = len(segment_path) == 0
+        _snapshots_col = self._snapshots_col(prefix)
+        _shards_col = self._shards_col(prefix)
+        checkpoint_ref = _snapshots_col.document(checkpoint_id)
+        shard_refs = [_shards_col.document(f'{checkpoint_id}_{i}') for i in range(shard_count)]
+        seg_refs = [_snapshots_col.document(sid) for sid in segment_path]
+
+        refs: list[AsyncDocumentReference] = []
+        if target_is_checkpoint:
+            refs.append(checkpoint_ref)
+        refs.extend(shard_refs)
+        refs.extend(seg_refs)
+
+        if not refs:
+            return None
+
+        by_path: dict[str, DocumentSnapshot] = {}
+        # AsyncTransaction.get_all awaits an async generator (library bug), so
+        # batch-read through the client with the open transaction instead.
+        snaps = [snap async for snap in self.client.get_all(refs, transaction=transaction)]
+        for snap in snaps:
+            by_path[snap.reference.path] = snap
+
+        shard_snaps = [by_path[ref.path] for ref in shard_refs]
+        state = self._stitch(shard_snaps)
+
+        if target_is_checkpoint:
+            checkpoint_snap = by_path.get(checkpoint_ref.path)
+            if checkpoint_snap is None or not checkpoint_snap.exists:
+                logger.warning(
+                    "Checkpoint snapshot document '%s' does not exist for target '%s'",
+                    checkpoint_ref.path,
+                    target_id,
+                )
+                return None
+            try:
+                checkpoint_doc = _SnapshotDoc.model_validate(checkpoint_snap.to_dict())
+            except Exception as e:
+                raise GenkitError(
+                    status='DATA_LOSS',
+                    message=f"FirestoreSessionStore: invalid checkpoint document '{checkpoint_ref.path}'.",
+                ) from e
+            if checkpoint_doc.snapshot_id != target_id:
+                # Pointer and snapshot metadata are written in one transaction,
+                # so a doc disagreeing with its own address is corruption.
+                raise GenkitError(
+                    status='DATA_LOSS',
+                    message=(
+                        f"FirestoreSessionStore: checkpoint document '{checkpoint_ref.path}' "
+                        f"snapshotId mismatch (got '{checkpoint_doc.snapshot_id}', expected '{target_id}')."
+                    ),
+                )
+            if not isinstance(state, dict):
+                raise GenkitError(
+                    status='DATA_LOSS',
+                    message=f"FirestoreSessionStore: checkpoint '{checkpoint_id}' shards decode to a non-object state.",
+                )
+            return checkpoint_doc, state
+
+        target_doc: _SnapshotDoc | None = None
+        for ref in seg_refs:
+            seg_snap = by_path.get(ref.path)
+            if seg_snap is None or not seg_snap.exists:
+                if ref is seg_refs[-1]:
+                    # The final segment is the target itself (segmentPath ends
+                    # with the target's own id); a wholly deleted target is
+                    # not-found (e.g. TTL), matching by-id lookup semantics.
+                    return None
+                # An *interior* segment referenced by the target's own
+                # segmentPath: its absence is a broken chain, the same failure
+                # class as a missing shard.
+                raise GenkitError(
+                    status='DATA_LOSS',
+                    message=f"FirestoreSessionStore: missing segment snapshot document '{ref.path}'.",
+                )
+            try:
+                seg_doc = _SnapshotDoc.model_validate(seg_snap.to_dict())
+            except Exception as e:
+                raise GenkitError(
+                    status='DATA_LOSS',
+                    message=f"FirestoreSessionStore: invalid segment document '{ref.path}'.",
+                ) from e
+            try:
+                state = apply_json_patch(
+                    doc=state,
+                    patch=_patch_from_json(_decode_state_patch(seg_doc.state_patch, snapshot_id=seg_doc.snapshot_id)),
+                )
+            except GenkitError:
+                raise
+            except Exception as e:
+                raise GenkitError(
+                    status='DATA_LOSS',
+                    message=(
+                        f"FirestoreSessionStore: snapshot '{seg_doc.snapshot_id}' has an unreadable "
+                        f"'statePatch' field (expected a JSON string; found "
+                        f'{type(seg_doc.state_patch).__name__}). '
+                        'Documents written by pre-release versions are not readable; '
+                        "delete the session's documents and re-create."
+                    ),
+                ) from e
+            target_doc = seg_doc
+
+        if target_doc is None or target_doc.snapshot_id != target_id:
+            raise GenkitError(
+                status='DATA_LOSS',
+                message=(
+                    f"FirestoreSessionStore: segment chain for '{target_id}' ends at "
+                    f"'{target_doc.snapshot_id if target_doc else None}' instead of the target."
+                ),
+            )
+        if not isinstance(state, dict):
+            raise GenkitError(
+                status='DATA_LOSS',
+                message=f"FirestoreSessionStore: reconstructed state for '{target_id}' is not an object.",
+            )
+        return target_doc, state
+
+    def _write_shards(
+        self,
+        transaction: AsyncTransaction,
+        checkpoint_id: str,
+        state: dict[str, Any],
+        *,
+        old_shard_count: int = 0,
+        prefix: str,
+    ) -> int:
+        _shards_col = self._shards_col(prefix)
+        # ensure_ascii=False so multilingual checkpoints stay compact UTF-8;
+        # escaping would inflate size and change shard boundaries. Formats are
+        # independent per runtime — don't share one collection across them.
+        buf = _json_dumps_utf8(state)
+        count = max(1, (len(buf) + self.shard_size - 1) // self.shard_size)
+        for i in range(count):
+            chunk = buf[i * self.shard_size : (i + 1) * self.shard_size]
+            shard_doc = _ShardDoc(chunk=chunk)
+            transaction.set(_shards_col.document(f'{checkpoint_id}_{i}'), shard_doc.model_dump(mode='python'))
+        for i in range(count, old_shard_count):
+            transaction.delete(_shards_col.document(f'{checkpoint_id}_{i}'))
+        return count
+
+    def _write_checkpoint(
+        self,
+        transaction: AsyncTransaction,
+        snapshot_id: str,
+        state: dict[str, Any],
+        *,
+        old_shard_count: int = 0,
+        prefix: str,
+    ) -> _SnapshotWriteMeta:
+        shard_count = self._write_shards(
+            transaction,
+            snapshot_id,
+            state,
+            old_shard_count=old_shard_count,
+            prefix=prefix,
+        )
+        return _SnapshotWriteMeta(
+            kind='checkpoint',
+            checkpoint_id=snapshot_id,
+            checkpoint_shard_count=shard_count,
+            segment_path=[],
+            state_patch=None,
+        )
+
+    def _stitch(self, shard_snaps: list[DocumentSnapshot]) -> dict[str, Any] | None:
+        if not shard_snaps:
+            return {}
+        buffers: list[bytes] = []
+        for snap in shard_snaps:
+            if not snap.exists:
+                raise GenkitError(
+                    status='DATA_LOSS',
+                    message=f"FirestoreSessionStore: missing checkpoint shard '{snap.id}'.",
+                )
+            try:
+                shard = _ShardDoc.model_validate(snap.to_dict())
+            except Exception as e:
+                raise GenkitError(
+                    status='DATA_LOSS',
+                    message=f"FirestoreSessionStore: invalid checkpoint shard '{snap.id}'.",
+                ) from e
+            buffers.append(shard.chunk)
+        try:
+            decoded = json.loads(b''.join(buffers).decode('utf-8'))
+        except Exception as e:
+            shard_ids = ', '.join(snap.id for snap in shard_snaps)
+            raise GenkitError(
+                status='DATA_LOSS',
+                message=f"FirestoreSessionStore: corrupt shard/snapshot document for '{shard_ids}': {e}",
+            ) from e
+        return decoded
+
+    def _to_snapshot(self, reconstructed: tuple[_SnapshotDoc, dict[str, Any]] | None) -> SessionSnapshot | None:
+        if reconstructed is None:
+            return None
+        doc, state_raw = reconstructed
+        return doc.to_session_snapshot(state_raw)
+
+    def _ensure_sync_client(self) -> firestore.Client:
+        """Return this loop's sync client used for realtime watches.
+
+        Uses ``_to_sync_copy()`` on the loop's async client when the
+        constructor did not supply a sync client for this loop.
+        """
+        if self._closed:
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message='FirestoreSessionStore: store is closed.',
+            )
+        state = self._status_loop_state()
+        if state.sync_client is not None:
+            return state.sync_client
+        loop = asyncio.get_running_loop()
+        if self._provided_sync_client is not None and self._provided_sync_loop is None:
+            state.sync_client = self._provided_sync_client
+            state.owns_sync_client = False
+            self._provided_sync_loop = loop
+            return state.sync_client
+        async_client = self._ensure_async_client()
+        if hasattr(async_client, '_to_sync_copy'):
+            state.sync_client = async_client._to_sync_copy()
+            state.owns_sync_client = True
+            return state.sync_client
+        raise GenkitError(
+            status='FAILED_PRECONDITION',
+            message=(
+                'Realtime status watches require a synchronous Firestore client. '
+                'Unable to derive sync client from client. '
+                "Please pass 'sync_client' to FirestoreSessionStore."
+            ),
+        )
+
+    def _attach_status_watch(
+        self,
+        snapshot_id: str,
+        *,
+        prefix: str,
+        sub: _StatusSubscription,
+    ) -> Any:  # noqa: ANN401
+        """Start a dedicated Firestore listener for one status subscription.
+
+        Realtime watches require the sync client: the async client's
+        ``on_snapshot`` is a non-functional stub, so its presence must not
+        be used for dispatch. Caller holds ``_lock``.
+        """
+        sync_client = self._ensure_sync_client()
+        ref = sync_client.collection(self.collection).document(prefix).collection('snapshots').document(snapshot_id)
+        loop = asyncio.get_running_loop()
+
+        def on_snapshot(doc_snapshots: list[DocumentSnapshot], changes: Any, read_time: Any) -> None:  # noqa: ANN401
+            if not doc_snapshots:
+                return
+            status = _status_from_doc(doc_snapshots[0])
+            if status is None:
+                # Missing / deleted: keep waiting; not end-of-stream.
+                return
+
+            def deliver() -> None:
+                if sub.closed:
+                    return
+                if sub.last_status == status:
+                    return
+                sub.last_status = status
+                with contextlib.suppress(Exception):
+                    sub.queue.put_nowait(status)
+                if status not in _TERMINAL_STATUSES:
+                    return
+                with contextlib.suppress(Exception):
+                    sub.queue.put_nowait(None)
+                sub.closed = True
+
+                async def cleanup() -> None:
+                    async with self._lock:
+                        await self._teardown_subscription(sub)
+
+                cleanup_coro = cleanup()
+                try:
+                    asyncio.create_task(cleanup_coro)
+                except RuntimeError:
+                    cleanup_coro.close()
+                    # Loop can't schedule (often shutting down). Consumer already
+                    # has status+EOS — still drop the watch so it doesn't linger.
+                    state = self._status_loop_state()
+                    state.subscriptions.discard(sub)
+                    watch = sub.watch
+                    sub.watch = None
+                    if watch is not None:
+                        self._unsubscribe_watch(watch)
+
+            loop.call_soon_threadsafe(deliver)
+
+        return ref.on_snapshot(on_snapshot)
+
+    async def _teardown_subscription(self, sub: _StatusSubscription) -> None:
+        """Stop one subscription's watch and drop it from the loop bag. Holds ``_lock``."""
+        state = self._status_loop_state()
+        state.subscriptions.discard(sub)
+        watch = sub.watch
+        sub.watch = None
+        sub.closed = True
+        if watch is not None:
+            await asyncio.to_thread(self._unsubscribe_watch, watch)
+
+    def close(self) -> None:
+        """Stop active watches, end local status streams, and release the store's resources.
+
+        Safe to call more than once. Does not close a ``client`` / ``sync_client``
+        the caller passed into the constructor, and never closes async clients.
+        Sync clients this store created per loop are closed here.
+
+        Synchronous and fast: watches are unsubscribed on the calling thread,
+        and every stream from :meth:`on_snapshot_status_change` in THIS
+        process ends so consumers exit their ``async for`` loops. A stream
+        that ends without having yielded a terminal status means the store
+        shut down locally — the run itself may still be live, and subscribers
+        in other processes are unaffected. Ending a run is a different act:
+        write a terminal status, which every subscriber everywhere observes.
+
+        Stream endings are delivered through each subscriber's event loop
+        (subscriptions and clients are loop-local). Loop bags are kept so an
+        in-flight read that suspended across ``close`` can still finish against
+        that loop's async client.
+        """
+        self._closed = True
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        with self._status_by_loop_mu:
+            loop_bags = list(self._status_by_loop.items())
+        for loop, state in loop_bags:
+            subs = list(state.subscriptions)
+            # Clear FIRST so in-flight watch callbacks see closed subs, THEN
+            # stop watches, THEN wake consumers.
+            state.subscriptions.clear()
+            watches: list[Any] = []
+            queues: list[asyncio.Queue[SnapshotStatus | None]] = []
+            for sub in subs:
+                sub.closed = True
+                if sub.watch is not None:
+                    watches.append(sub.watch)
+                    sub.watch = None
+                queues.append(sub.queue)
+            for watch in watches:
+                self._unsubscribe_watch(watch)
+            for q in queues:
+                if running is loop:
+                    with contextlib.suppress(Exception):
+                        q.put_nowait(None)
+                elif not loop.is_closed():
+                    # Foreign thread / other loop: queues are loop-bound.
+                    with contextlib.suppress(RuntimeError):
+                        loop.call_soon_threadsafe(q.put_nowait, None)
+            # Drop owned sync watches clients; keep async clients for in-flight I/O.
+            self._release_loop_clients(state, async_clients=False)
+
+    @staticmethod
+    def _watch_listener_thread(watch: Any) -> threading.Thread | None:  # noqa: ANN401
+        """Return the gRPC watch consumer thread, if the SDK exposes it."""
+        # google.cloud.firestore_v1.watch.Watch holds BackgroundConsumer._thread.
+        consumer = getattr(watch, '_consumer', None)
+        if consumer is None:
+            return None
+        thread = getattr(consumer, '_thread', None)
+        return thread if isinstance(thread, threading.Thread) else None
+
+    @staticmethod
+    def _unsubscribe_watch(watch: Any) -> None:  # noqa: ANN401
+        """Unsubscribe a watch, off-thread when called from its own listener."""
+
+        def stop() -> None:
+            with contextlib.suppress(Exception):
+                watch.unsubscribe()
+
+        background = FirestoreSessionStore._watch_listener_thread(watch)
+        if background is not None and background is threading.current_thread():
+            # Joining the listener thread from itself is impossible; hand
+            # teardown to a short-lived helper so Watch.close can finish.
+            threading.Thread(target=stop, daemon=True, name='fs-watch-teardown').start()
+            return
+        try:
+            watch.unsubscribe()
+        except RuntimeError as e:
+            if 'cannot join current thread' not in str(e):
+                return
+            threading.Thread(target=stop, daemon=True, name='fs-watch-teardown').start()
+        except Exception:
+            return

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/session_store/firestore.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/session_store/firestore.py
@@ -68,7 +68,6 @@ from genkit._ai._agents._session_stores._util import (
     session_id_of,
 )
 from genkit._ai._json_patch import apply_json_patch, diff_json
-from genkit._core._action import get_current_context
 from genkit._core._error import GenkitError
 from genkit._core._loop_cache import _loop_local_client
 from genkit._core._typing import (
@@ -853,8 +852,6 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
         matters.
         """
         require_one_selector(snapshot_id=snapshot_id, session_id=session_id)
-        if context is None:
-            context = get_current_context()
         if snapshot_id is not None:
             _validate_doc_id(snapshot_id, 'snapshot_id')
         if session_id is not None:
@@ -956,8 +953,6 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
         delete the session's documents and re-create what should remain.
         """
         _validate_doc_id(snapshot_id, 'snapshot_id')
-        if context is None:
-            context = get_current_context()
         # Resolve the tenant prefix before the transaction: a failing prefix
         # function must fail BEFORE anything commits, and the post-commit
         # notification must use the same prefix the write used.
@@ -1179,9 +1174,9 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
 
         Exiting an ``async for`` with ``break`` does not end the subscription;
         close the stream (``async with`` or ``aclose()``) or it stays open
-        until a terminal status or ``close()``. When ``context`` is omitted, the
-        ambient call context is used — the same default as ``get_snapshot`` and
-        ``save_snapshot``.
+        until a terminal status or ``close()``. Omitting ``context`` leaves the
+        prefix function with ``None`` (typically the default ``global`` prefix);
+        callers that want ambient action context must pass it in.
         """
         _validate_doc_id(snapshot_id, 'snapshot_id')
         if self._closed:
@@ -1189,8 +1184,6 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
                 status='FAILED_PRECONDITION',
                 message='FirestoreSessionStore: store is closed.',
             )
-        if context is None:
-            context = get_current_context()
         # Tenant prefix is captured once so two tenants watching the same
         # snapshot id get independent listeners.
         prefix = self._prefix(context)

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/session_store/firestore.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/session_store/firestore.py
@@ -40,7 +40,7 @@ import threading
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Generic, Literal
+from typing import Any, Generic, Literal, TypeVar
 
 from google.api_core import exceptions as google_exceptions
 from google.cloud import firestore
@@ -342,8 +342,14 @@ class _UserCodeError(Exception):
     """Carrier: the mutator raised; deliver its exception verbatim."""
 
 
-async def _translate_txn_errors(awaitable: Awaitable[None]) -> None:
+_T = TypeVar('_T')
+
+
+async def _translate_txn_errors(awaitable: Awaitable[_T]) -> _T:
     """Await a transactional coroutine, converting backend failures to ``GenkitError``.
+
+    On success this is the coroutine's return value from the attempt that
+    committed.
 
     The store's public contract is that every failure arising from its own
     serialization, storage, or the Google libraries is a ``GenkitError`` with a
@@ -355,7 +361,7 @@ async def _translate_txn_errors(awaitable: Awaitable[None]) -> None:
     obtained an ID, which masks the original error entirely.
     """
     try:
-        await awaitable
+        return await awaitable
     except _UserCodeError as e:
         cause = e.__cause__
         assert cause is not None
@@ -858,21 +864,17 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
             _validate_doc_id(session_id, 'session_id')
         prefix = self._prefix(context)
         transaction = self.client.transaction(read_only=True, max_attempts=self.transaction_max_attempts)
-        result: SessionSnapshot | None = None
 
         @firestore.async_transactional
-        async def read_in_transaction(transaction: AsyncTransaction) -> None:
-            nonlocal result
+        async def read_in_transaction(transaction: AsyncTransaction) -> SessionSnapshot | None:
             if snapshot_id is not None:
                 reconstructed = await self._reconstruct(transaction, snapshot_id, prefix=prefix)
-                result = self._to_snapshot(reconstructed) if reconstructed else None
-                return
+                return self._to_snapshot(reconstructed) if reconstructed else None
 
             assert session_id is not None
             pointer_doc = await self._pointer_ref(session_id, prefix).get(transaction=transaction)
             if not pointer_doc.exists:
-                result = None
-                return
+                return None
 
             try:
                 pointer = _PointerDoc.model_validate(pointer_doc.to_dict() or {})
@@ -897,16 +899,16 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
                 )
                 if reconstructed is not None:
                     result = self._to_snapshot(reconstructed)
-                if result is not None:
-                    if result.session_id != session_id:
-                        raise GenkitError(
-                            status='DATA_LOSS',
-                            message=(
-                                f"FirestoreSessionStore: session '{session_id}' pointer resolves to "
-                                f"snapshot '{result.snapshot_id}' owned by session '{result.session_id}'."
-                            ),
-                        )
-                    return
+                    if result is not None:
+                        if result.session_id != session_id:
+                            raise GenkitError(
+                                status='DATA_LOSS',
+                                message=(
+                                    f"FirestoreSessionStore: session '{session_id}' pointer resolves to "
+                                    f"snapshot '{result.snapshot_id}' owned by session '{result.session_id}'."
+                                ),
+                            )
+                        return result
 
             if current_id:
                 reconstructed = await self._reconstruct(transaction, current_id, prefix=prefix)
@@ -919,9 +921,10 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
                             f"snapshot '{result.snapshot_id}' owned by session '{result.session_id}'."
                         ),
                     )
+                return result
+            return None
 
-        await _translate_txn_errors(read_in_transaction(transaction))
-        return result
+        return await _translate_txn_errors(read_in_transaction(transaction))
 
     async def save_snapshot(
         self,
@@ -959,11 +962,9 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
         prefix = self._prefix(context)
         snap_ref = self._snapshot_ref(snapshot_id, prefix)
         transaction = self.client.transaction(max_attempts=self.transaction_max_attempts)
-        committed: SessionSnapshot | None = None
 
         @firestore.async_transactional
-        async def rmw(transaction: AsyncTransaction) -> None:
-            nonlocal committed
+        async def rmw(transaction: AsyncTransaction) -> SessionSnapshot | None:
             existing_recon = await self._reconstruct(transaction, snapshot_id, prefix=prefix)
             existing = self._to_snapshot(existing_recon) if existing_recon else None
             try:
@@ -973,7 +974,7 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
             except BaseException as e:
                 raise _UserCodeError() from e
             if next_snapshot is None:
-                return
+                return None
             _validate_doc_id(next_snapshot.session_id, 'session_id')
             if next_snapshot.parent_id:
                 _validate_doc_id(next_snapshot.parent_id, 'parent_id')
@@ -1152,10 +1153,9 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
                 segment_path=segment_path,
                 prefix=prefix,
             )
-            committed = next_snapshot
+            return next_snapshot
 
-        await _translate_txn_errors(rmw(transaction))
-        return committed
+        return await _translate_txn_errors(rmw(transaction))
 
     async def on_snapshot_status_change(
         self, snapshot_id: str, *, context: dict[str, Any] | None = None
@@ -1225,16 +1225,13 @@ class FirestoreSessionStore(SessionStore[StateT], SnapshotSubscriber, Generic[St
         """Read a single snapshot by id, reconstructing state from its checkpoint chain."""
         _validate_doc_id(snapshot_id, 'snapshot_id')
         transaction = self.client.transaction(read_only=True, max_attempts=self.transaction_max_attempts)
-        result: SessionSnapshot | None = None
 
         @firestore.async_transactional
-        async def read_in_transaction(transaction: AsyncTransaction) -> None:
-            nonlocal result
+        async def read_in_transaction(transaction: AsyncTransaction) -> SessionSnapshot | None:
             reconstructed = await self._reconstruct(transaction, snapshot_id, prefix=prefix)
-            result = self._to_snapshot(reconstructed) if reconstructed else None
+            return self._to_snapshot(reconstructed) if reconstructed else None
 
-        await _translate_txn_errors(read_in_transaction(transaction))
-        return result
+        return await _translate_txn_errors(read_in_transaction(transaction))
 
     async def _update_pointer_in_transaction(
         self,

--- a/py/packages/genkit-google-cloud/src/genkit_google_cloud/session_store/firestore.py
+++ b/py/packages/genkit-google-cloud/src/genkit_google_cloud/session_store/firestore.py
@@ -40,7 +40,7 @@ import threading
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal
 
 from google.api_core import exceptions as google_exceptions
 from google.cloud import firestore
@@ -342,10 +342,9 @@ class _UserCodeError(Exception):
     """Carrier: the mutator raised; deliver its exception verbatim."""
 
 
-_T = TypeVar('_T')
-
-
-async def _translate_txn_errors(awaitable: Awaitable[_T]) -> _T:
+async def _translate_txn_errors(
+    awaitable: Awaitable[SessionSnapshot | None],
+) -> SessionSnapshot | None:
     """Await a transactional coroutine, converting backend failures to ``GenkitError``.
 
     On success this is the coroutine's return value from the attempt that

--- a/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
+++ b/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import threading
 from datetime import datetime, timezone
@@ -397,7 +396,7 @@ async def test_firestore_session_store_save_skips_when_mutator_returns_none() ->
             snapshot_id='snap-1',
             session_id='sess-1',
             created_at='2026-07-03T00:00:00Z',
-            status=SnapshotStatus.ABORTED,
+            status=SnapshotStatus.PENDING,
             state=SessionState(session_id='sess-1'),
         ),
     )
@@ -408,8 +407,8 @@ async def test_firestore_session_store_save_skips_when_mutator_returns_none() ->
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_heartbeat_updates_leaf_without_rebranch() -> None:
-    """In-place leaf update refreshes pointer metadata and keeps a single leaf."""
+async def test_firestore_session_store_heartbeat_updates_current_leaf_in_place() -> None:
+    """Heartbeating the tip persists heartbeat_at and keeps the session pointer on that snapshot."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot(
@@ -430,13 +429,14 @@ async def test_firestore_session_store_heartbeat_updates_leaf_without_rebranch()
     saved = await store.save_snapshot('snap-1', beat)
     assert saved is not None
     assert saved.heartbeat_at == '2026-07-03T00:00:05Z'
+    assert h.docs[_snap_path('snap-1')]['heartbeatAt'] == '2026-07-03T00:00:05Z'
     pointer = h.docs[_pointer_path('sess-1')]
-    assert 'isAmbiguous' not in pointer
+    assert pointer['currentSnapshotId'] == 'snap-1'
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_non_leaf_update_leaves_pointer_alone() -> None:
-    """Updating an ancestor must not re-add it to leaves or mark the session ambiguous."""
+async def test_firestore_session_store_ancestor_update_does_not_move_pointer() -> None:
+    """Updating an ancestor snapshot must not move the session's current pointer."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot(
@@ -464,22 +464,22 @@ async def test_firestore_session_store_non_leaf_update_leaves_pointer_alone() ->
 
     def rewrite_a(existing: SessionSnapshot | None) -> SessionSnapshot:
         assert existing is not None
-        return existing.model_copy(update={'status': SnapshotStatus.COMPLETED})
+        return existing.model_copy(update={'heartbeat_at': '2026-07-03T00:00:09Z'})
 
     saved = await store.save_snapshot('snap-A', rewrite_a)
     assert saved is not None
+    assert saved.heartbeat_at == '2026-07-03T00:00:09Z'
     pointer_after = h.docs[_pointer_path('sess-1')]
-    assert pointer_after == pointer_before  # non-current write: pointer fully untouched
     assert pointer_after['currentSnapshotId'] == 'snap-B'
+    assert pointer_after['currentSnapshotId'] == pointer_before['currentSnapshotId']
 
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_branching_last_writer_wins() -> None:
-    """Forked sessions never error: session lookup follows the last-written leaf.
+    """Forks never error: session_id resolves to the last-written new leaf.
 
-    Matches the JS Firestore store exactly — no ambiguity detection, no
-    rejection option; concurrent branch extension makes the current snapshot
-    race-dependent by design. Resume by snapshot_id when a branch matters.
+    Heartbeats on a non-current branch do not move the pointer; extending that
+    branch does. Resume by snapshot_id when a specific branch matters.
     """
     h = FakeStoreHarness()
     store = h.store(checkpoint_interval=25)
@@ -504,7 +504,7 @@ async def test_firestore_session_store_branching_last_writer_wins() -> None:
     await store.save_snapshot('snap-a2', _mk('snap-a2', 'snap-a', custom={'n': 3}))
     loaded = await store.get_snapshot(session_id='sess-1')
     assert loaded is not None and loaded.snapshot_id == 'snap-a2'
-    assert 'leaves' not in h.docs[_pointer_path('sess-1')]
+    assert h.docs[_pointer_path('sess-1')]['currentSnapshotId'] == 'snap-a2'
 
 
 @pytest.mark.asyncio
@@ -534,24 +534,11 @@ async def test_firestore_session_store_missing_pointer_returns_none() -> None:
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_corrupt_pointer_returns_none() -> None:
-    """A pointer that can't reconstruct returns None without rewriting the pointer."""
+async def test_firestore_session_store_dangling_pointer_returns_none() -> None:
+    """Pointer to a missing leaf: session lookup is None (a miss), not DATA_LOSS."""
     h = FakeStoreHarness()
-    h.docs[_snap_path('snap-live')] = {
-        'snapshotId': 'snap-live',
-        'sessionId': 'sess-corrupt',
-        'createdAt': '2026-07-03T00:00:01Z',
-        'kind': 'checkpoint',
-        'checkpointId': 'snap-live',
-        'checkpointShardCount': 1,
-        'segmentPath': [],
-    }
-    h.docs[_shard_path('snap-live', 0)] = {
-        'chunk': json.dumps({'sessionId': 'sess-corrupt'}).encode('utf-8'),
-    }
-    # Structurally valid pointer whose leaf is gone; omit checkpoint meta so
-    # lookup falls through to snapshot-id reconstruct (None), not DATA_LOSS
-    # from missing shards.
+    # Omit checkpoint meta so lookup falls through to snapshot-id reconstruct
+    # (None), not DATA_LOSS from missing shards.
     h.docs[_pointer_path('sess-corrupt')] = {
         'currentSnapshotId': 'snap-deleted',
         'segmentPath': [],
@@ -559,7 +546,6 @@ async def test_firestore_session_store_corrupt_pointer_returns_none() -> None:
 
     store = h.store()
     assert await store.get_snapshot(session_id='sess-corrupt') is None
-    assert h.docs[_pointer_path('sess-corrupt')]['currentSnapshotId'] == 'snap-deleted'
 
 
 @pytest.mark.asyncio
@@ -617,7 +603,7 @@ async def test_firestore_session_store_missing_segment_path_raises() -> None:
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_datetime_in_custom_round_trips() -> None:
-    """SessionState mode='json' coerces datetimes before they are persisted."""
+    """datetime values in SessionState.custom persist/reload as UTC ISO-8601 strings."""
     h = FakeStoreHarness()
     store = h.store()
     when = datetime(2026, 1, 1, tzinfo=timezone.utc)
@@ -679,8 +665,8 @@ async def test_firestore_session_store_oversized_diff_promotes_to_checkpoint() -
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_status_change_and_cleanup() -> None:
-    """Test snapshot status subscription and thread-safe cleanup on terminal status."""
+async def test_firestore_session_store_terminal_status_ends_stream_and_unsubscribes() -> None:
+    """Status stream yields until a terminal status, then ends and drops its watch."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot(
@@ -695,45 +681,16 @@ async def test_firestore_session_store_status_change_and_cleanup() -> None:
     )
 
     watches, captured_cb = _wire_sync_watch(store)
-    queue = await store.on_snapshot_status_change('snap-sub')
+    stream = await store.on_snapshot_status_change('snap-sub')
     assert len(captured_cb) == 1
-    assert len(store._subscriptions) == 1
-    (sub,) = store._subscriptions
-    assert sub.queue.empty()
 
     await _pump_watch(captured_cb, 0, _status_doc('snap-sub', 'pending'))
-    assert await _next_status(queue) == SnapshotStatus.PENDING
+    assert await _next_status(stream) == SnapshotStatus.PENDING
 
     await _pump_watch(captured_cb, 0, _status_doc('snap-sub', 'aborted'))
 
-    assert await _next_status(queue) == SnapshotStatus.ABORTED
-    assert await _stream_ended(queue)
-    watches[0].unsubscribe.assert_called_once()
-    assert len(store._subscriptions) == 0
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_terminal_cleanup_falls_back_when_create_task_fails(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """If the loop can't schedule async teardown, still unsubscribe the watch."""
-    h = FakeStoreHarness()
-    store = h.store()
-    await store.save_snapshot('snap-task', _pending_mk('snap-task'))
-    watches, captured_cb = _wire_sync_watch(store)
-    queue = await store.on_snapshot_status_change('snap-task')
-
-    await _pump_watch(captured_cb, 0, _status_doc('snap-task', 'pending'))
-    assert await _next_status(queue) == SnapshotStatus.PENDING
-
-    def boom(_coro: Any) -> Any:  # noqa: ANN401
-        raise RuntimeError('no running event loop')
-
-    monkeypatch.setattr(asyncio, 'create_task', boom)
-    await _pump_watch(captured_cb, 0, _status_doc('snap-task', 'completed'))
-
-    assert await _next_status(queue) == SnapshotStatus.COMPLETED
-    assert await _stream_ended(queue)
+    assert await _next_status(stream) == SnapshotStatus.ABORTED
+    assert await _stream_ended(stream)
     watches[0].unsubscribe.assert_called_once()
     assert len(store._subscriptions) == 0
 
@@ -770,23 +727,15 @@ async def test_firestore_session_store_close_stops_watches_and_sync_client() -> 
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_close_does_not_close_injected_sync_client() -> None:
-    """Caller-owned sync_client is left open by close()."""
+    """Caller-owned sync_client stays open after close(), even if watches used it."""
     h = FakeStoreHarness()
     injected = MagicMock()
     store = h.store(sync_client=injected)
+    _wire_sync_watch(store)
+    await store.on_snapshot_status_change('snap-close')
+    assert store.sync_client is injected
     store.close()
     injected.close.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_ensure_sync_client_raises_genkit_error() -> None:
-    """_ensure_sync_client() raises GenkitError if client has no _to_sync_copy and no sync_client set."""
-    custom_client = MagicMock(spec=[])
-    store = FirestoreSessionStore(client=custom_client)
-    with pytest.raises(GenkitError) as exc_info:
-        store._ensure_sync_client()
-    assert exc_info.value.status == 'FAILED_PRECONDITION'
-    assert 'Realtime status watches require a synchronous Firestore client' in str(exc_info.value)
 
 
 def _by_user(context: dict[str, Any] | None = None) -> str:
@@ -901,8 +850,8 @@ async def _pump_watch(captured_cb: list[Any], index: int, doc: MagicMock) -> Non
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_upsert_diff_leaf_rewrites_patch() -> None:
-    """Heartbeat/abort-style upsert of an existing diff leaf refreshes statePatch."""
+async def test_firestore_session_store_resave_diff_leaf_refreshes_state() -> None:
+    """Re-saving an existing pending child refreshes stored state and heartbeat."""
     h = FakeStoreHarness()
     store = h.store(checkpoint_interval=25)
 
@@ -958,8 +907,8 @@ async def test_firestore_session_store_upsert_diff_leaf_rewrites_patch() -> None
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_upsert_oversized_diff_promotes_to_checkpoint() -> None:
-    """Upserting a diff leaf with an oversized patch rewrites it as a checkpoint."""
+async def test_firestore_session_store_resave_oversized_diff_promotes_to_checkpoint() -> None:
+    """Re-saving a child with oversized state stores it as a checkpoint."""
     h = FakeStoreHarness()
     store = h.store(shard_size=64, checkpoint_interval=25)
 
@@ -1012,14 +961,10 @@ async def test_firestore_session_store_missing_snapshot_subscribe_waits_for_crea
     watches, captured_cb = _wire_sync_watch(store)
 
     q1 = await store.on_snapshot_status_change('missing')
-    assert all(s.queue.empty() for s in store._subscriptions)
     assert len(captured_cb) == 1
-    assert len(store._subscriptions) == 1
 
     q2 = await store.on_snapshot_status_change('missing')
     assert len(captured_cb) == 2
-    assert len(store._subscriptions) == 2
-    assert all(s.queue.empty() for s in store._subscriptions)
     watches[0].unsubscribe.assert_not_called()
     watches[1].unsubscribe.assert_not_called()
 
@@ -1042,7 +987,7 @@ async def test_firestore_session_store_missing_snapshot_subscribe_waits_for_crea
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_retries_on_aborted_commit() -> None:
-    """@async_transactional retries the RMW closure when commit raises Aborted."""
+    """Save retries on commit contention (Aborted) until the write succeeds."""
     h = FakeStoreHarness()
     store = h.store()
     h.commit_aborts_remaining = 2
@@ -1065,21 +1010,8 @@ async def test_firestore_session_store_retries_on_aborted_commit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fake_harness_rejects_read_after_write() -> None:
-    """Harness mirrors the real client: buffered writes forbid later reads."""
-    h = FakeStoreHarness()
-    store = h.store()
-    ref = store._snapshot_ref('snap-x', 'global')
-    txn = h.client.transaction()
-    await txn._begin()
-    txn.set(ref, {'snapshotId': 'snap-x'})
-    with pytest.raises(ReadAfterWriteError):
-        await ref.get(transaction=txn)
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_upsert_restores_deleted_pointer() -> None:
-    """A leaf upsert restores a missing pointer so session lookup keeps working."""
+async def test_firestore_session_store_save_restores_deleted_pointer() -> None:
+    """Re-saving a leaf after the pointer doc was deleted restores session_id lookup."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot(
@@ -1104,22 +1036,6 @@ async def test_firestore_session_store_upsert_restores_deleted_pointer() -> None
     loaded = await store.get_snapshot(session_id='sess-1')
     assert loaded is not None
     assert loaded.snapshot_id == 'snap-1'
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_forked_pointer_keeps_current_snapshot_id() -> None:
-    """After a fork the pointer is the plain last-writer shape: no branch metadata."""
-    h = FakeStoreHarness()
-    store = h.store(checkpoint_interval=25)
-    await store.save_snapshot('snap-root', _mk('snap-root', None, custom={'n': 0}))
-    await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
-    await store.save_snapshot('snap-b', _mk('snap-b', 'snap-root', custom={'n': 2}))
-
-    pointer = h.docs[_pointer_path('sess-1')]
-    assert pointer['currentSnapshotId'] == 'snap-b'
-    assert 'isAmbiguous' not in pointer
-    assert 'leaves' not in pointer
-    assert isinstance(pointer['updatedAt'], str)
 
 
 @pytest.mark.asyncio
@@ -1216,7 +1132,7 @@ def _mk(sid: str, parent: str | None = None, custom: dict | None = None) -> Any:
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_missing_shard_raises_data_loss() -> None:
-    """A checkpoint whose shard document vanished fails loud, not with partial state."""
+    """A checkpoint whose shard document vanished raises DATA_LOSS, not with partial state."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot('snap-1', _mk('snap-1', custom={'x': 1}))
@@ -1249,6 +1165,7 @@ async def test_firestore_session_store_missing_checkpoint_doc_returns_none() -> 
     del h.docs[_snap_path('snap-1')]
 
     assert await store.get_snapshot(session_id='sess-1') is None
+    assert await store.get_snapshot(snapshot_id='snap-1') is None
 
 
 @pytest.mark.asyncio
@@ -1298,7 +1215,7 @@ async def test_firestore_session_store_missing_segment_raises_data_loss() -> Non
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_corrupt_segment_raises_data_loss() -> None:
-    """A diff chain with an invalid interior segment fails loud."""
+    """A diff chain with an invalid interior segment raises DATA_LOSS."""
     h = FakeStoreHarness()
     store = h.store(checkpoint_interval=25)
     await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
@@ -1329,12 +1246,8 @@ async def test_firestore_session_store_missing_parent_makes_child_a_checkpoint()
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_extending_corrupt_current_leaf_fails_loud() -> None:
-    """A new child of the corrupt *current* leaf raises DATA_LOSS (no diff against garbage).
-
-    The pointer fast-path supplies the parent's chain metadata, so the corruption
-    is discovered during parent reconstruction and surfaces loudly.
-    """
+async def test_firestore_session_store_extending_corrupt_current_leaf_raises_data_loss() -> None:
+    """A child of a corrupt *current* parent raises DATA_LOSS (no lineage from garbage)."""
     h = FakeStoreHarness()
     store = h.store(checkpoint_interval=25)
     await store.save_snapshot('snap-parent', _mk('snap-parent', custom={'n': 0}))
@@ -1347,11 +1260,11 @@ async def test_firestore_session_store_extending_corrupt_current_leaf_fails_loud
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_forking_corrupt_interior_parent_self_heals() -> None:
-    """Forking off a corrupt *non-current* parent self-heals forward as a checkpoint.
+    """Forking off a corrupt *non-current* parent self-heals as a checkpoint.
 
-    Off the pointer fast-path the parent doc must be read directly; when it fails
-    validation the child is written as a full checkpoint with no dependence on the
-    corrupt chain.
+    When the parent is not the session tip, a failed parent read is treated like a
+    missing parent: the child is written as a full checkpoint so the session stays
+    writable. (Corrupt *current* tip fails closed — see extending_corrupt_current_leaf.)
     """
     h = FakeStoreHarness()
     store = h.store(checkpoint_interval=25)
@@ -1436,14 +1349,6 @@ async def test_firestore_session_store_listener_failure_rolls_back_subscription(
     assert len(store._subscriptions) == 0
 
 
-def test_firestore_session_store_close_is_idempotent_without_watches() -> None:
-    """close() with nothing to tear down returns cleanly, twice."""
-    h = FakeStoreHarness()
-    store = h.store()
-    store.close()
-    store.close()
-
-
 @pytest.mark.parametrize(
     ('kwargs', 'fragment'),
     [
@@ -1507,7 +1412,7 @@ async def test_firestore_session_store_non_object_shard_state_raises_data_loss()
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_malformed_state_patch_raises_data_loss() -> None:
-    """A segment whose statePatch fails to parse names the corrupt doc via DATA_LOSS."""
+    """A segment whose statePatch fails to parse surfaces as DATA_LOSS."""
     h = FakeStoreHarness()
     store = h.store(checkpoint_interval=25)
     await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
@@ -1521,8 +1426,8 @@ async def test_firestore_session_store_malformed_state_patch_raises_data_loss() 
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_array_state_patch_names_field() -> None:
-    """Pre-fix array statePatch is DATA_LOSS naming the field and JSON string expectation."""
+async def test_firestore_session_store_array_state_patch_raises_data_loss() -> None:
+    """A statePatch stored as a list (not a JSON string) is DATA_LOSS."""
     h = FakeStoreHarness()
     store = h.store(checkpoint_interval=25)
     await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
@@ -1533,34 +1438,12 @@ async def test_firestore_session_store_array_state_patch_names_field() -> None:
         await store.get_snapshot(snapshot_id='snap-a')
     assert exc_info.value.status == 'DATA_LOSS'
     msg = str(exc_info.value)
-    assert 'statePatch' in msg and 'JSON string' in msg and 'found list' in msg
+    assert 'statePatch' in msg
 
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_null_state_patch_is_data_loss() -> None:
-    """Null/empty/missing statePatch on a diff segment is DATA_LOSS, not a silent []."""
-    from genkit_google_cloud.session_store.firestore import _decode_state_patch
-
-    with pytest.raises(GenkitError) as e_none:
-        _decode_state_patch(None, snapshot_id='snap-a')
-    assert e_none.value.status == 'DATA_LOSS'
-    assert 'statePatch' in str(e_none.value) and 'missing or empty' in str(e_none.value)
-    assert 're-create' in str(e_none.value)
-
-    with pytest.raises(GenkitError) as e_empty:
-        _decode_state_patch('', snapshot_id='snap-a')
-    assert e_empty.value.status == 'DATA_LOSS' and 'missing or empty' in str(e_empty.value)
-
-    assert _decode_state_patch('[]', snapshot_id='snap-a') == []
-
-    with pytest.raises(GenkitError) as e_bad:
-        _decode_state_patch('{', snapshot_id='snap-a')
-    assert 'unparseable' in str(e_bad.value)
-
-    with pytest.raises(GenkitError) as e_obj:
-        _decode_state_patch('{"a":1}', snapshot_id='snap-a')
-    assert 'not a patch array' in str(e_obj.value)
-
+    """Null/empty statePatch on a diff segment is DATA_LOSS; "[]" is a valid zero-change."""
     h = FakeStoreHarness()
     store = h.store(checkpoint_interval=25)
     await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
@@ -1569,7 +1452,7 @@ async def test_firestore_session_store_null_state_patch_is_data_loss() -> None:
     with pytest.raises(GenkitError) as exc_info:
         await store.get_snapshot(snapshot_id='snap-a')
     assert exc_info.value.status == 'DATA_LOSS'
-    assert 'missing or empty' in str(exc_info.value)
+    assert 'statePatch' in str(exc_info.value)
 
     # Legitimate zero-change turn: encoder writes "[]", reconstruct equals parent.
     h.docs[_snap_path('snap-a')]['statePatch'] = '[]'
@@ -1634,13 +1517,10 @@ async def test_firestore_session_store_deleted_diff_leaf_is_not_found_via_both_p
 async def test_firestore_session_store_watch_uses_sync_client_despite_async_stub(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Watches must always attach via the sync client, never the async ref.
+    """Status watches attach via the sync client even if the async ref has on_snapshot.
 
-    Real AsyncDocumentReference exposes an ``on_snapshot`` stub whose body is
-    ``raise NotImplementedError``; a fake ref that mirrors it must not derail
-    the watch onto the async path. Regression for the real-backend bug where
-    every subscription died with NotImplementedError (originally caused by
-    dispatching on ``hasattr(ref, 'on_snapshot')``).
+    The async library's on_snapshot is a NotImplementedError stub; picking it
+    because hasattr is true would break every subscription.
     """
     h = FakeStoreHarness()
     store = h.store()
@@ -1658,7 +1538,6 @@ async def test_firestore_session_store_watch_uses_sync_client_despite_async_stub
     assert hasattr(store._snapshot_ref('snap-w', 'global'), 'on_snapshot')  # the trap is armed
 
     _stream = await store.on_snapshot_status_change('snap-w')
-    assert all(s.queue.empty() for s in store._subscriptions)
     assert len(captured_cb) == 1  # watch attached via the SYNC client
     assert len(store._subscriptions) == 1
     (sub,) = store._subscriptions
@@ -1666,7 +1545,7 @@ async def test_firestore_session_store_watch_uses_sync_client_despite_async_stub
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_retry_exhaustion_raises_typed_aborted() -> None:
+async def test_firestore_session_store_retry_exhaustion_raises_aborted() -> None:
     """Contention beyond transaction_max_attempts surfaces as GenkitError ABORTED."""
     h = FakeStoreHarness()
     store = h.store()
@@ -1676,12 +1555,11 @@ async def test_firestore_session_store_retry_exhaustion_raises_typed_aborted() -
     with pytest.raises(GenkitError) as exc_info:
         await store.save_snapshot('snap-1', _mk('snap-1'))
     assert exc_info.value.status == 'ABORTED'
-    assert 'injected abort' in str(exc_info.value)  # the final Aborted's text, verbatim
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_payload_limit_raises_typed_invalid_argument() -> None:
-    """A Firestore InvalidArgument (e.g. ~10 MiB txn payload) is wrapped with a hint."""
+async def test_firestore_session_store_payload_limit_raises_invalid_argument() -> None:
+    """A Firestore InvalidArgument (e.g. oversized txn) is wrapped as INVALID_ARGUMENT with server text."""
     h = FakeStoreHarness()
     store = h.store()
     h.commit_raises = google_exceptions.InvalidArgument('maximum entity size exceeded')
@@ -1693,21 +1571,18 @@ async def test_firestore_session_store_payload_limit_raises_typed_invalid_argume
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_transaction_max_attempts_plumbed_and_validated() -> None:
-    """The retry knob reaches client.transaction() and rejects nonsense values."""
+async def test_firestore_session_store_transaction_max_attempts_validated() -> None:
+    """transaction_max_attempts rejects nonsense values at construction."""
     h = FakeStoreHarness()
-    store = h.store(transaction_max_attempts=7)
-    await store.save_snapshot('snap-1', _mk('snap-1'))
-    assert h.client.transaction.call_args.kwargs.get('max_attempts') == 7
-
     with pytest.raises(GenkitError) as exc_info:
         h.store(transaction_max_attempts=0)
     assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'transaction_max_attempts' in str(exc_info.value)
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_maps_other_google_errors_mechanically() -> None:
-    """Any GoogleAPICallError maps 1:1 by class with the server message preserved."""
+async def test_firestore_session_store_deadline_exceeded_maps_to_genkit_error() -> None:
+    """Google DeadlineExceeded becomes GenkitError DEADLINE_EXCEEDED (server text kept)."""
     h = FakeStoreHarness()
     store = h.store()
     h.commit_raises = google_exceptions.DeadlineExceeded('deadline of 60.0s exceeded')
@@ -1732,13 +1607,8 @@ async def test_firestore_session_store_non_google_errors_pass_through_untouched(
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_masked_rollback_valueerror_raises_typed_aborted() -> None:
-    """The library's no-transaction-ID ValueError (unchained; original error masked) maps to ABORTED.
-
-    Observed on real Firestore under hot-pointer contention: a failure before
-    the transaction obtains an ID triggers rollback, which raises this bare
-    ValueError and destroys the root cause. Regression for the C-01 raw leak.
-    """
+async def test_firestore_session_store_masked_rollback_valueerror_raises_aborted() -> None:
+    """Firestore's bare "no transaction ID" ValueError (root cause masked) maps to ABORTED."""
     h = FakeStoreHarness()
     store = h.store()
     h.commit_raises = ValueError('The transaction has no transaction ID, so it cannot be rolled back.')
@@ -1755,11 +1625,7 @@ async def test_firestore_session_store_masked_rollback_valueerror_raises_typed_a
 )
 @pytest.mark.asyncio
 async def test_firestore_session_store_rejects_path_structured_ids(bad_id: str) -> None:
-    """Ids that Firestore would parse as path structure fail typed, at every entrypoint.
-
-    Regression for W-08: odd-segment ids leaked a raw client ValueError; even
-    segment ids silently addressed a deeper document and left a zombie watch.
-    """
+    """Path segments, '.', '..', empty, and reserved __id__ are INVALID_ARGUMENT on save/get/subscribe."""
     h = FakeStoreHarness()
     store = h.store()
 
@@ -1776,7 +1642,7 @@ async def test_firestore_session_store_rejects_path_structured_ids(bad_id: str) 
     assert e3.value.status == 'INVALID_ARGUMENT'
 
     with pytest.raises(GenkitError) as e4:
-        await store._read_snapshot(bad_id, prefix='global')
+        await store.on_snapshot_status_change(bad_id)
     assert e4.value.status == 'INVALID_ARGUMENT'
 
 
@@ -1789,18 +1655,12 @@ async def test_firestore_session_store_subscribe_rejects_bad_id_with_no_partial_
     with pytest.raises(GenkitError) as exc_info:
         await store.on_snapshot_status_change('a/b/c')
     assert exc_info.value.status == 'INVALID_ARGUMENT'
-    assert 'a/b/c' not in store._subscriptions
     assert len(store._subscriptions) == 0
 
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_terminal_status_change_raises_failed_precondition() -> None:
-    """Terminal statuses are absorbing: ABORTED can never become COMPLETED.
-
-    Deliberately stricter than JS (which orders writes with a lock but permits
-    the overwrite); an aborted run silently becoming completed misrepresents
-    what happened, and no subscriber can ever observe the second transition.
-    """
+    """Terminal statuses are absorbing: ABORTED cannot be overwritten by COMPLETED."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot(
@@ -1838,6 +1698,7 @@ async def test_firestore_session_store_terminal_resurrection_raises_failed_preco
     with pytest.raises(GenkitError) as exc_info:
         await store.save_snapshot('snap-1', resurrect)
     assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert h.docs[_snap_path('snap-1')]['status'] == 'completed'
 
 
 @pytest.mark.asyncio
@@ -1863,7 +1724,7 @@ async def test_firestore_session_store_same_terminal_status_rewrite_allowed() ->
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_invalid_prefix_raises_before_any_path() -> None:
-    """B1: snapshot_path_prefix is the tenant boundary; a path-structured prefix is rejected everywhere."""
+    """A path-structured tenant prefix is rejected on every store API."""
     h = FakeStoreHarness()
     store = h.store(snapshot_path_prefix=lambda _ctx: 'ten/ant')
 
@@ -1877,12 +1738,13 @@ async def test_firestore_session_store_invalid_prefix_raises_before_any_path() -
             await call
         assert exc_info.value.status == 'INVALID_ARGUMENT'
         assert 'snapshot_path_prefix' in str(exc_info.value)
+    assert h.docs == {}
     assert len(store._subscriptions) == 0
 
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_mutator_supplied_path_ids_rejected() -> None:
-    """B1: session_id/parent_id coming back FROM the mutator are held to the same rules."""
+    """session_id/parent_id returned by the mutator must pass the same id rules."""
     h = FakeStoreHarness()
     store = h.store()
 
@@ -1898,6 +1760,7 @@ async def test_firestore_session_store_mutator_supplied_path_ids_rejected() -> N
     with pytest.raises(GenkitError) as e1:
         await store.save_snapshot('snap-1', bad_session)
     assert e1.value.status == 'INVALID_ARGUMENT' and 'session_id' in str(e1.value)
+    assert _snap_path('snap-1') not in h.docs
 
     def bad_parent(_e: SessionSnapshot | None) -> SessionSnapshot:
         return SessionSnapshot(
@@ -1930,22 +1793,22 @@ async def test_firestore_session_store_empty_current_snapshot_id_is_data_loss() 
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_subscribe_context_kwarg_selects_tenant() -> None:
-    """N11: explicit context= reaches the watch path (ambient context stays the default)."""
+    """Explicit context= scopes the status watch to that tenant's path prefix."""
     h = FakeStoreHarness()
     store = h.store(snapshot_path_prefix=lambda ctx: (ctx or {}).get('tenant', 'global'))
     _watches, captured_cb = _wire_sync_watch(store)
 
-    _stream = await store.on_snapshot_status_change('snap-w', context={'tenant': 't9'})
-    assert all(s.queue.empty() for s in store._subscriptions)
+    stream = await store.on_snapshot_status_change('snap-w', context={'tenant': 't9'})
     assert len(captured_cb) == 1
     sync_mock = cast(Any, store.client)._to_sync_copy.return_value
     sync_mock.collection.return_value.document.assert_any_call('t9')
+    await stream.aclose()
 
 
 @pytest.mark.parametrize('terminal', [SnapshotStatus.EXPIRED, SnapshotStatus.FAILED])
 @pytest.mark.asyncio
-async def test_firestore_session_store_all_terminal_statuses_are_absorbing(terminal: SnapshotStatus) -> None:
-    """R4-High: EXPIRED and FAILED are absorbing too, not just ABORTED/COMPLETED."""
+async def test_firestore_session_store_expired_and_failed_are_absorbing(terminal: SnapshotStatus) -> None:
+    """EXPIRED and FAILED are absorbing too, not only ABORTED/COMPLETED."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot(
@@ -1966,50 +1829,14 @@ async def test_firestore_session_store_all_terminal_statuses_are_absorbing(termi
     with pytest.raises(GenkitError) as exc_info:
         await store.save_snapshot('snap-1', complete)
     assert exc_info.value.status == 'FAILED_PRECONDITION'
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_read_paths_plumb_transaction_max_attempts() -> None:
-    """R4-High: the retry knob reaches read-only transactions too."""
-    h = FakeStoreHarness()
-    store = h.store(transaction_max_attempts=9)
-    await store.save_snapshot('snap-1', _mk('snap-1'))
-    await store.get_snapshot(snapshot_id='snap-1')
-    ro_calls = [c for c in h.client.transaction.call_args_list if c.kwargs.get('read_only')]
-    assert ro_calls, 'expected a read-only transaction'
-    assert all(c.kwargs.get('max_attempts') == 9 for c in ro_calls)
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_promotion_then_prune_cleans_orphan_shards() -> None:
-    """R4-High: a diff promoted to checkpoint, then shrunk, deletes its stale shards."""
-    h = FakeStoreHarness()
-    store = h.store(checkpoint_interval=25, shard_size=120)
-    await store.save_snapshot('snap-root', _mk('snap-root', None, custom={'n': 0}))
-    # Child whose patch exceeds shard_size -> promoted to a multi-shard checkpoint.
-    await store.save_snapshot('snap-big', _mk('snap-big', 'snap-root', custom={'blob': 'X' * 500}))
-    shards_before = [k for k in h.docs if '/shards/' in k and 'snap-big' in k]
-    assert len(shards_before) > 1  # promotion happened, multi-shard
-
-    def shrink(existing: SessionSnapshot | None) -> SessionSnapshot:
-        assert existing is not None
-        return existing.model_copy(update={'state': SessionState(session_id='sess-1', custom={'n': 1})})
-
-    await store.save_snapshot('snap-big', shrink)
-    shards_after = [k for k in h.docs if '/shards/' in k and 'snap-big' in k]
-    assert len(shards_after) < len(shards_before)  # orphans pruned
-    loaded = await store.get_snapshot(snapshot_id='snap-big')
-    assert loaded is not None and loaded.state is not None
-    assert loaded.state.custom == {'n': 1}
+    assert h.docs[_snap_path('snap-1')]['status'] == terminal.value
 
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_watch_isolation_across_tenants_same_snapshot_id() -> None:
-    """B1 regression: two tenants, one snapshot id — independent listeners, queues, teardown.
+    """Same snapshot id under two tenants gets independent watches and teardown.
 
-    Pre-fix, subscriptions were keyed by snapshot_id alone: the second tenant
-    piggybacked on the first tenant's watch, statuses crossed tenants, and the
-    first terminal tore down both.
+    One tenant finishing must not end the other tenant's subscription.
     """
     h = FakeStoreHarness()
     store = h.store(snapshot_path_prefix=lambda ctx: (ctx or {}).get('tenant', 'global'))
@@ -2025,58 +1852,31 @@ async def test_firestore_session_store_watch_isolation_across_tenants_same_snaps
     await store.save_snapshot('snap-x', _mk('snap-x'), context={'tenant': 't1'})
     await _pump_watch(captured_cb, 0, _status_doc('snap-x', 'completed'))
     assert await _next_status(q1) == SnapshotStatus.COMPLETED
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(anext(stream_t2), timeout=0.05)
+    assert await _stream_ended(q1)
+    # t1's terminal tears down only t1's watch; t2 stays subscribed (no cross-talk).
+    assert len(store._subscriptions) == 1
+    watches[0].unsubscribe.assert_called_once()
+    watches[1].unsubscribe.assert_not_called()
+    await stream_t2.aclose()
+    watches[1].unsubscribe.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_stream_survives_polling_timeout() -> None:
-    """A consumer polling with wait_for must not kill the subscription."""
-    h = FakeStoreHarness()
-    store = h.store()
-    watches, captured_cb = _wire_sync_watch(store)
-    stream = await store.on_snapshot_status_change('snap-poll')
-
-    for _ in range(2):
-        pull = asyncio.ensure_future(anext(stream))
-        await asyncio.sleep(0.05)
-        assert not pull.done()
-        pull.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await pull
-
-    await store.save_snapshot('snap-poll', _mk('snap-poll'))
-    await _pump_watch(captured_cb, 0, _status_doc('snap-poll', 'completed'))
-    final = asyncio.ensure_future(anext(stream))
-    for _ in range(200):
-        if final.done():
-            break
-        await asyncio.sleep(0.01)
-    assert final.done() and final.result() == SnapshotStatus.COMPLETED
-
-    store.close()
-    with pytest.raises(StopAsyncIteration):
-        await stream.__anext__()
-    with pytest.raises(StopAsyncIteration):
-        await stream.__anext__()  # ended stays ended (latched)
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_close_delivers_end_of_stream_locally() -> None:
-    """Wake-on-close: a consumer awaiting a queue gets the bare None marker."""
+async def test_firestore_session_store_close_ends_stream_without_terminal_status() -> None:
+    """store.close() ends open status streams without yielding a terminal status."""
     h = FakeStoreHarness()
     store = h.store()
     _wire_sync_watch(store)
     q = await store.on_snapshot_status_change('snap-pending')
 
     store.close()
-    assert await _stream_ended(q)  # bare EOS: ended without resolution
+    assert await _stream_ended(q)
     assert len(store._subscriptions) == 0
 
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_close_from_thread_wakes_waiters() -> None:
-    """close() from a foreign thread delivers the marker via the subscribers' loop."""
+    """close() from a foreign thread ends open streams on the subscribers' loop."""
     h = FakeStoreHarness()
     store = h.store()
     _wire_sync_watch(store)
@@ -2088,8 +1888,8 @@ async def test_firestore_session_store_close_from_thread_wakes_waiters() -> None
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_close_after_terminal_adds_nothing() -> None:
-    """A stream already ended by a terminal status gets no second marker from close."""
+async def test_firestore_session_store_close_after_terminal_is_noop() -> None:
+    """close() after a terminal-ended stream does not emit another event."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot('snap-1', _mk('snap-1'))  # completed
@@ -2100,17 +1900,7 @@ async def test_firestore_session_store_close_after_terminal_adds_nothing() -> No
     assert await _stream_ended(q)
 
     store.close()
-    assert await _stream_ended(q)  # exhausted stream stays ended; close adds nothing
-
-
-@pytest.mark.asyncio
-async def test_sibling_stores_accept_context_kwarg() -> None:
-    """B2: the widened protocol signature is honored by non-tenant stores too."""
-    from genkit._ai._agents._session_stores._inmemory_store import InMemorySessionStore
-
-    mem = InMemorySessionStore()
-    statuses = await mem.on_snapshot_status_change('snap-x', context={'tenant': 't1'})
-    assert hasattr(statuses, '__anext__')  # accepted and ignored, no error
+    assert await _stream_ended(q)
 
 
 @pytest.mark.asyncio
@@ -2127,13 +1917,8 @@ async def test_firestore_session_store_subscribe_after_close_raises() -> None:
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_prefix_failure_never_surfaces_after_commit() -> None:
-    """A failing prefix function fails BEFORE the transaction, never after it.
-
-    Pre-fix, save re-invoked the prefix function after commit for the
-    subscriber notification; a function that failed on that call turned a
-    durably committed write into a raised (and raw) exception.
-    """
+async def test_firestore_session_store_prefix_resolved_before_commit_and_fail_fast() -> None:
+    """Path prefix is resolved before commit; an immediate prefix failure writes nothing."""
     # Commit-aware tripwire: the prefix function itself asserts it is never
     # invoked after the transaction has committed.
     h = FakeStoreHarness()
@@ -2193,18 +1978,6 @@ async def test_firestore_session_store_snapshot_id_collision_across_sessions_rej
 
 
 @pytest.mark.asyncio
-async def test_inmemory_store_snapshot_id_collision_rejected_too() -> None:
-    """The ownership guard lives in shared apply_save: every Python store enforces it."""
-    from genkit._ai._agents._session_stores._inmemory_store import InMemorySessionStore
-
-    mem = InMemorySessionStore()
-    await mem.save_snapshot('turn-1', _owned_snap('turn-1', 'sess-A'))
-    with pytest.raises(GenkitError) as exc_info:
-        await mem.save_snapshot('turn-1', _owned_snap('turn-1', 'sess-B'))
-    assert exc_info.value.status == 'FAILED_PRECONDITION'
-
-
-@pytest.mark.asyncio
 async def test_firestore_session_store_cross_session_parent_rejected() -> None:
     """A new snapshot cannot anchor its diff chain to another session's snapshot."""
     h = FakeStoreHarness()
@@ -2218,7 +1991,7 @@ async def test_firestore_session_store_cross_session_parent_rejected() -> None:
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_pointer_to_foreign_session_is_data_loss() -> None:
+async def test_firestore_session_store_pointer_to_foreign_session_raises_data_loss() -> None:
     """A pointer resolving to another session's snapshot is a corrupt index, not an answer."""
     h = FakeStoreHarness()
     store = h.store()
@@ -2235,7 +2008,7 @@ async def test_firestore_session_store_pointer_to_foreign_session_is_data_loss()
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_interior_state_rewrite_rejected() -> None:
-    """Rewriting an interior snapshot's state would corrupt descendant diffs."""
+    """Interior snapshots (ones with descendants) cannot rewrite state; tip stays readable."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot('parent', _mk('parent', custom={'secret': 'alpha'}))
@@ -2261,7 +2034,7 @@ async def test_firestore_session_store_interior_state_rewrite_rejected() -> None
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_interior_heartbeat_still_allowed() -> None:
-    """Metadata-only rewrites on an interior snapshot must not break the child."""
+    """Interior snapshots may still refresh heartbeat metadata; only state rewrites are blocked."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot('parent', _mk('parent', custom={'secret': 'alpha'}))
@@ -2302,7 +2075,7 @@ async def test_firestore_session_store_parent_id_immutable_on_upsert() -> None:
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_tip_state_rewrite_still_allowed() -> None:
-    """The tip remains writable: heartbeats/finalize that change state still succeed."""
+    """The tip (leaf, no descendants) may rewrite state — contrast interior_state_rewrite_rejected."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot('parent', _mk('parent', custom={'n': 1}))
@@ -2338,15 +2111,6 @@ async def test_firestore_session_store_tip_state_rewrite_still_allowed() -> None
     assert loaded.state.custom == {'n': 3}
 
 
-def test_firestore_session_store_rejects_zero_shard_size() -> None:
-    """shard_size=0 is a typed INVALID_ARGUMENT, not ZeroDivisionError later."""
-    h = FakeStoreHarness()
-    with pytest.raises(GenkitError) as exc_info:
-        h.store(shard_size=0)
-    assert exc_info.value.status == 'INVALID_ARGUMENT'
-    assert 'shard_size' in str(exc_info.value)
-
-
 def test_firestore_session_store_config_frozen_after_init() -> None:
     """collection/shard_size/checkpoint_interval/attempts cannot be reassigned."""
     h = FakeStoreHarness()
@@ -2359,11 +2123,12 @@ def test_firestore_session_store_config_frozen_after_init() -> None:
     assert h.store(collection='custom-col', shard_size=2048).collection == 'custom-col'
 
 
-def test_firestore_session_store_rejects_bad_collection_name() -> None:
+@pytest.mark.parametrize('bad', ['', 'bad/name'])
+def test_firestore_session_store_rejects_bad_collection_name(bad: str) -> None:
     """Collection is a path segment; empty or '/' is INVALID_ARGUMENT at construction."""
     h = FakeStoreHarness()
     with pytest.raises(GenkitError) as exc_info:
-        h.store(collection='bad/name')
+        h.store(collection=bad)
     assert exc_info.value.status == 'INVALID_ARGUMENT'
     assert 'collection' in str(exc_info.value)
 
@@ -2400,10 +2165,9 @@ async def test_firestore_session_store_zero_checkpoint_shard_count_is_data_loss(
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_subscribe_tolerates_missing_shards() -> None:
-    """Status subscribe reads the snapshot doc only; missing shards do not DATA_LOSS the watch."""
+    """Status watches only need the snapshot doc; get_snapshot still DATA_LOSS on missing shards."""
     h = FakeStoreHarness()
     store = h.store()
-    watches, captured_cb = _wire_sync_watch(store)
     await store.save_snapshot(
         'snap-1',
         lambda _e: SessionSnapshot(
@@ -2411,29 +2175,20 @@ async def test_firestore_session_store_subscribe_tolerates_missing_shards() -> N
             session_id='sess-1',
             created_at='2026-07-03T00:00:00Z',
             status=SnapshotStatus.PENDING,
-            state=SessionState(session_id='sess-1', custom={'x': 1}),
+            state=SessionState(session_id='sess-1'),
         ),
     )
     del h.docs[_shard_path('snap-1', 0)]
 
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-1')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+    _watches, captured_cb = _wire_sync_watch(store)
     stream = await store.on_snapshot_status_change('snap-1')
     await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'pending'))
     assert await _next_status(stream) == SnapshotStatus.PENDING
-    assert len(store._subscriptions) == 1
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_mutator_valueerror_propagates_verbatim() -> None:
-    """App ValueError from a mutator must not be misclassified as retryable ABORTED."""
-    h = FakeStoreHarness()
-    store = h.store()
-
-    def boom(_existing: SessionSnapshot | None) -> SessionSnapshot:
-        raise ValueError('no transaction ID')
-
-    with pytest.raises(ValueError, match='no transaction ID') as exc_info:
-        await store.save_snapshot('snap-1', boom)
-    assert not isinstance(exc_info.value, GenkitError)
+    await stream.aclose()
 
 
 @pytest.mark.asyncio
@@ -2550,7 +2305,7 @@ async def test_firestore_session_store_rejects_whitespace_ids() -> None:
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_aclose_tears_down_subscription() -> None:
-    """Closing a stream drops its queue and stops the watch when it was the last consumer."""
+    """aclose() drops this stream's subscription and unsubscribes its dedicated watch."""
     h = FakeStoreHarness()
     store = h.store()
     watches, _captured = _wire_sync_watch(store)
@@ -2594,44 +2349,11 @@ async def test_firestore_session_store_aclose_after_terminal_is_idempotent() -> 
     await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'completed'))
     assert await _next_status(stream) == SnapshotStatus.COMPLETED
     assert await _stream_ended(stream)
-    await stream.aclose()  # type: ignore[attr-defined]
-    await stream.aclose()  # type: ignore[attr-defined]
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_async_with_break_tears_down() -> None:
-    """async with + break is the blessed early-exit shape and releases the watch."""
-    h = FakeStoreHarness()
-    store = h.store()
-    watches, captured_cb = _wire_sync_watch(store)
-    await store.save_snapshot(
-        'snap-1',
-        lambda _e: SessionSnapshot(
-            snapshot_id='snap-1',
-            session_id='sess-1',
-            created_at='2026-07-03T00:00:00Z',
-            status=SnapshotStatus.PENDING,
-            state=SessionState(session_id='sess-1'),
-        ),
-    )
-    stream = await store.on_snapshot_status_change('snap-1')
-    await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'pending'))
-    async with stream:  # type: ignore[attr-defined]
-        async for _status in stream:
-            break
-    assert len(store._subscriptions) == 0
     watches[0].unsubscribe.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_lock_is_private() -> None:
-    """The subscriber lock is private; SessionStore no longer advertises lock."""
-    h = FakeStoreHarness()
-    store = h.store()
-    assert isinstance(store._lock, asyncio.Lock)
-    assert not hasattr(store, 'lock')
-    # Structural SessionStore surface still present (Protocol is not runtime_checkable).
-    assert callable(store.get_snapshot) and callable(store.save_snapshot)
+    assert len(store._subscriptions) == 0
+    await stream.aclose()  # type: ignore[attr-defined]
+    await stream.aclose()  # type: ignore[attr-defined]
+    watches[0].unsubscribe.assert_called_once()
 
 
 def _pending_mk(sid: str) -> Any:  # noqa: ANN401
@@ -2646,7 +2368,7 @@ def _pending_mk(sid: str) -> Any:  # noqa: ANN401
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_close_unsubscribes_inline_normally() -> None:
-    """Normal close() unsubscribes the watch once on the calling thread."""
+    """Happy path: close() unsubscribes on the calling thread (not offloaded)."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot('snap-1', _pending_mk('snap-1'))
@@ -2670,8 +2392,12 @@ async def test_firestore_session_store_close_unsubscribes_inline_normally() -> N
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_close_from_listener_thread_retries_off_thread() -> None:
-    """close() on the watch listener thread finishes unsubscribe on a helper thread."""
+async def test_firestore_session_store_close_from_listener_thread_offloads_unsubscribe() -> None:
+    """If close runs on the Firestore listener thread, unsubscribe hops off-thread.
+
+    Calling unsubscribe on that same thread can deadlock the SDK; the store
+    must finish teardown on a helper thread instead.
+    """
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot('snap-1', _pending_mk('snap-1'))
@@ -2681,6 +2407,7 @@ async def test_firestore_session_store_close_from_listener_thread_retries_off_th
     done = threading.Event()
 
     class FakeConsumer:
+        # Firestore watch objects expose _consumer._thread as the listener thread.
         _thread = listener
 
     watches, captured_cb = _wire_sync_watch(store)
@@ -2715,47 +2442,13 @@ async def test_firestore_session_store_watch_dedupes_repeated_status() -> None:
     pending = _status_doc('snap-1', 'pending')
     await _pump_watch(captured, 0, pending)
     assert await stream.__anext__() == SnapshotStatus.PENDING
+    # Replay pending, then completed → next yield is completed (deduped).
     await _pump_watch(captured, 0, pending)
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(stream.__anext__(), timeout=0.05)
     await _pump_watch(captured, 0, _status_doc('snap-1', 'completed'))
     assert await stream.__anext__() == SnapshotStatus.COMPLETED
     with pytest.raises(StopAsyncIteration):
         await stream.__anext__()
     watches[0].unsubscribe.assert_called_once()
-
-
-def test_firestore_session_store_subscribe_works_after_prior_loop_dies() -> None:
-    """After a notebook-style asyncio.run cell, a new loop can subscribe cleanly."""
-    h = FakeStoreHarness()
-    store = h.store()
-    errors: list[BaseException] = []
-
-    def run_first() -> None:
-        async def body() -> None:
-            await store.save_snapshot('snap-1', _pending_mk('snap-1'))
-            _wire_sync_watch(store)
-            await store.on_snapshot_status_change('snap-1')
-
-        try:
-            asyncio.run(body())
-        except BaseException as e:
-            errors.append(e)
-
-    t = threading.Thread(target=run_first)
-    t.start()
-    t.join(timeout=5.0)
-    assert not t.is_alive()
-    assert errors == []
-
-    async def second() -> None:
-        store.sync_client = None
-        _wire_sync_watch(store)
-        stream = await store.on_snapshot_status_change('snap-1')
-        assert len(store._subscriptions) == 1
-        await stream.aclose()
-
-    asyncio.run(second())
 
 
 def test_firestore_session_store_new_loop_prunes_dead_watch_and_starts_fresh() -> None:
@@ -2787,8 +2480,6 @@ def test_firestore_session_store_new_loop_prunes_dead_watch_and_starts_fresh() -
 
     async def second() -> None:
         nonlocal got_completed
-        # Drop the loop-A-derived sync client so the harness mock rebinds.
-        store.sync_client = None
         watches2, captured2 = _wire_sync_watch(store)
         stream = await store.on_snapshot_status_change('snap-1')
         assert len(store._subscriptions) == 1
@@ -2808,7 +2499,11 @@ def test_firestore_session_store_new_loop_prunes_dead_watch_and_starts_fresh() -
 
 
 def test_firestore_session_store_two_live_loops_have_independent_subscriptions() -> None:
-    """App loop + Dev UI loop can each subscribe on the same store instance."""
+    """App loop + Dev UI loop can each subscribe on the same store instance.
+
+    Subscriptions are loop-local, so each loop's ``_subscriptions`` view shows
+    only its own entries (len==1 here), not a shared global list.
+    """
     h = FakeStoreHarness()
     store = h.store()
     ready = threading.Event()
@@ -2837,7 +2532,6 @@ def test_firestore_session_store_two_live_loops_have_independent_subscriptions()
     assert ready.wait(timeout=5.0)
 
     async def other() -> None:
-        store.sync_client = None
         _watches, captured = _wire_sync_watch(store)
         stream = await store.on_snapshot_status_change('snap-1')
         await _pump_watch(captured, 0, _status_doc('snap-1', 'pending'))
@@ -2857,7 +2551,10 @@ def test_firestore_session_store_two_live_loops_have_independent_subscriptions()
 def test_firestore_session_store_clients_are_loop_local(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Provided async client binds to the first loop; later loops get a clone + own sync."""
+    """One store shared across app + Dev UI: first loop keeps the provided client; later loops get clones.
+
+    Firestore clients are tied to an event loop; reusing loop-A's client on loop-B breaks.
+    """
     clones: list[MagicMock] = []
 
     def fake_async_client(**kwargs: Any) -> MagicMock:  # noqa: ANN401
@@ -2965,12 +2662,11 @@ async def test_firestore_session_store_no_context_defaults_to_global_prefix() ->
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_ambient_context_shared_across_ops() -> None:
-    """get/save/subscribe with no context= all honor the ambient action context."""
+    """get/save with no context= honor the ambient action context for path prefix."""
     from genkit._core._action import _action_context
 
     h = FakeStoreHarness()
     store = h.store(snapshot_path_prefix=lambda c: (c or {}).get('tenant', 'global'))
-    _watches, captured_cb = _wire_sync_watch(store)
     token = _action_context.set({'tenant': 'ambient-t'})
     try:
         await store.save_snapshot(
@@ -2984,10 +2680,6 @@ async def test_firestore_session_store_ambient_context_shared_across_ops() -> No
             ),
         )
         loaded = await store.get_snapshot(snapshot_id='snap-1')
-        stream = await store.on_snapshot_status_change('snap-1')
-        assert len(store._subscriptions) == 1
-        await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'pending'))
-        assert await _next_status(stream) == SnapshotStatus.PENDING
     finally:
         _action_context.reset(token)
 
@@ -3005,19 +2697,23 @@ async def test_firestore_session_store_status_observed_via_watch_not_save() -> N
     watches, captured_cb = _wire_sync_watch(store)
     stream = await store.on_snapshot_status_change('snap-1')
 
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(stream.__anext__(), timeout=0.05)
+    # Outstanding pull must stay pending across save — statuses come from the
+    # watch after commit, not from the local save path. Don't cancel the pull
+    # (wait_for timeout would); just observe that it hasn't completed yet.
+    pull = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0.05)
+    assert not pull.done()
 
     def to_completed(_e: SessionSnapshot | None) -> SessionSnapshot:
         base = _pending_mk('snap-1')(_e)
         return base.model_copy(update={'status': SnapshotStatus.COMPLETED})
 
     await store.save_snapshot('snap-1', to_completed)
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(stream.__anext__(), timeout=0.05)
+    await asyncio.sleep(0.05)
+    assert not pull.done()
 
     await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'completed'))
-    assert await stream.__anext__() == SnapshotStatus.COMPLETED
+    assert await pull == SnapshotStatus.COMPLETED
     with pytest.raises(StopAsyncIteration):
         await stream.__anext__()
     watches[0].unsubscribe.assert_called_once()

--- a/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
+++ b/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
@@ -1034,6 +1034,32 @@ async def test_firestore_session_store_retries_on_aborted_commit() -> None:
 
 
 @pytest.mark.asyncio
+async def test_firestore_session_store_retry_noop_does_not_return_uncommitted() -> None:
+    """A retry that skips the write returns None, not the first attempt's uncommitted snapshot."""
+    h = FakeStoreHarness()
+    store = h.store(transaction_max_attempts=2)
+    h.commit_aborts_remaining = 1
+    calls = 0
+
+    def fn(_existing: SessionSnapshot | None) -> SessionSnapshot | None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return SessionSnapshot(
+                snapshot_id='snap-1',
+                session_id='sess-1',
+                created_at='2026-07-03T00:00:00Z',
+                state=SessionState(session_id='sess-1', custom={'n': 1}),
+            )
+        return None
+
+    saved = await store.save_snapshot('snap-1', fn)
+    assert saved is None
+    assert h.commit_attempts == 2
+    assert await store.get_snapshot(snapshot_id='snap-1') is None
+
+
+@pytest.mark.asyncio
 async def test_firestore_session_store_save_restores_deleted_pointer() -> None:
     """Re-saving a leaf after the pointer doc was deleted restores session_id lookup."""
     h = FakeStoreHarness()
@@ -1578,6 +1604,7 @@ async def test_firestore_session_store_retry_exhaustion_raises_aborted() -> None
     with pytest.raises(GenkitError) as exc_info:
         await store.save_snapshot('snap-1', _mk('snap-1'))
     assert exc_info.value.status == 'ABORTED'
+    assert h.commit_attempts == 2
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
+++ b/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
@@ -443,10 +443,12 @@ async def test_firestore_session_store_heartbeat_updates_current_leaf_in_place()
 
     saved = await store.save_snapshot('snap-1', beat)
     assert saved is not None
-    assert saved.heartbeat_at == '2026-07-03T00:00:05Z'
-    assert h.docs[_snap_path('snap-1')]['heartbeatAt'] == '2026-07-03T00:00:05Z'
-    pointer = h.docs[_pointer_path('sess-1')]
-    assert pointer['currentSnapshotId'] == 'snap-1'
+    reloaded = await store.get_snapshot(snapshot_id='snap-1')
+    assert reloaded is not None
+    assert reloaded.heartbeat_at == '2026-07-03T00:00:05Z'
+    tip = await store.get_snapshot(session_id='sess-1')
+    assert tip is not None
+    assert tip.snapshot_id == 'snap-1'
 
 
 @pytest.mark.asyncio
@@ -1269,7 +1271,7 @@ async def test_firestore_session_store_missing_parent_makes_child_a_checkpoint()
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_extending_corrupt_current_leaf_raises_data_loss() -> None:
-    """A child of a corrupt *current* parent raises DATA_LOSS (no lineage from garbage)."""
+    """A diff child of a corrupt current tip raises DATA_LOSS (parent state is unreadable for the patch)."""
     h = FakeStoreHarness()
     store = h.store(checkpoint_interval=25)
     await store.save_snapshot('snap-parent', _mk('snap-parent', custom={'n': 0}))
@@ -1282,11 +1284,11 @@ async def test_firestore_session_store_extending_corrupt_current_leaf_raises_dat
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_forking_corrupt_interior_parent_self_heals() -> None:
-    """Forking off a corrupt *non-current* parent self-heals as a checkpoint.
+    """Forking off a corrupt non-current parent self-heals as a checkpoint.
 
     When the parent is not the session tip, a failed parent read is treated like a
     missing parent: the child is written as a full checkpoint so the session stays
-    writable. (Corrupt *current* tip fails closed — see extending_corrupt_current_leaf.)
+    writable.
     """
     h = FakeStoreHarness()
     store = h.store(checkpoint_interval=25)
@@ -1616,7 +1618,7 @@ async def test_firestore_session_store_deadline_exceeded_maps_to_genkit_error() 
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_non_google_errors_pass_through_untouched() -> None:
-    """Fail-open: a plain ValueError from the mutation fn is not mistranslated."""
+    """Mutator ValueError surfaces as ValueError, not GenkitError."""
     h = FakeStoreHarness()
     store = h.store()
 
@@ -1665,18 +1667,6 @@ async def test_firestore_session_store_rejects_path_structured_ids(bad_id: str) 
     with pytest.raises(GenkitError) as e4:
         await store.on_snapshot_status_change(bad_id)
     assert e4.value.status == 'INVALID_ARGUMENT'
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_subscribe_rejects_bad_id_with_no_partial_state() -> None:
-    """Subscribe validation fires before ANY registration: no queue, no watch, no zombie."""
-    h = FakeStoreHarness()
-    store = h.store()
-
-    with pytest.raises(GenkitError) as exc_info:
-        await store.on_snapshot_status_change('a/b/c')
-    assert exc_info.value.status == 'INVALID_ARGUMENT'
-    assert len(store._subscriptions) == 0
 
 
 @pytest.mark.asyncio
@@ -1928,21 +1918,26 @@ async def test_firestore_session_store_subscribe_after_close_raises() -> None:
 async def test_firestore_session_store_prefix_resolved_before_commit_and_fail_fast() -> None:
     """Path prefix is resolved before commit; an immediate prefix failure writes nothing."""
     # Commit-aware tripwire: the prefix function itself asserts it is never
-    # invoked after the transaction has committed.
+    # invoked after the transaction has committed. Returning a non-default
+    # prefix also proves the fn ran and its value landed in written paths.
     h = FakeStoreHarness()
 
     def commit_aware_prefix(_ctx: Any) -> str:  # noqa: ANN401
         assert h.commit_attempts == 0, 'prefix function invoked AFTER commit'
-        return 'global'
+        return 'tenant-x'
 
     store = h.store(snapshot_path_prefix=commit_aware_prefix)
     saved = await store.save_snapshot('snap-1', _mk('snap-1'))  # must NOT raise
     assert saved is not None
-    assert any('snap-1' in k for k in h.docs)
+    assert any('tenant-x' in k and 'snap-1' in k for k in h.docs)
 
     # And a prefix that fails immediately fails before anything is written.
     h2 = FakeStoreHarness()
-    store2 = h2.store(snapshot_path_prefix=lambda _c: (_ for _ in ()).throw(KeyError('down')))
+
+    def boom(_ctx: Any) -> str:  # noqa: ANN401
+        raise KeyError('down')
+
+    store2 = h2.store(snapshot_path_prefix=boom)
     with pytest.raises(KeyError):
         await store2.save_snapshot('snap-1', _mk('snap-1'))
     assert not any('snap-1' in k for k in h2.docs)  # nothing committed
@@ -2711,8 +2706,6 @@ async def test_firestore_session_store_status_observed_via_watch_not_save() -> N
     # watch after commit, not from the local save path. Don't cancel the pull
     # (wait_for timeout would); just observe that it hasn't completed yet.
     pull = asyncio.create_task(anext(stream))
-    await asyncio.sleep(0.05)
-    assert not pull.done()
 
     def to_completed(_e: SessionSnapshot | None) -> SessionSnapshot:
         base = _pending_mk('snap-1')(_e)

--- a/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
+++ b/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
@@ -1,0 +1,3023 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for FirestoreSessionStore."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import threading
+from datetime import datetime, timezone
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from genkit_google_cloud import FirestoreSessionStore
+from google.api_core import exceptions as google_exceptions
+from google.cloud import firestore
+from google.cloud.firestore_v1._helpers import ReadAfterWriteError
+
+from genkit._core._error import GenkitError
+from genkit._core._typing import SessionSnapshot, SessionState, SnapshotStatus
+
+
+def _doc(
+    *,
+    path: str,
+    exists: bool = True,
+    data: dict[str, Any] | None = None,
+    doc_id: str | None = None,
+) -> MagicMock:
+    snap = MagicMock()
+    snap.exists = exists
+    snap.id = doc_id or path.rsplit('/', 1)[-1]
+    snap.reference.path = path
+    snap.to_dict.return_value = data
+    return snap
+
+
+async def _next_status(statuses: Any, timeout: float = 2.0) -> Any:  # noqa: ANN401
+    """Next status from a subscription stream, bounded."""
+    return await asyncio.wait_for(anext(statuses), timeout)
+
+
+async def _stream_ended(statuses: Any, timeout: float = 2.0) -> bool:  # noqa: ANN401
+    """True if the stream ends (StopAsyncIteration) within the bound."""
+    try:
+        await asyncio.wait_for(anext(statuses), timeout)
+        return False
+    except StopAsyncIteration:
+        return True
+
+
+class FakeStoreHarness:
+    """In-memory Firestore stand-in wired for AsyncClient-style access.
+
+    Transaction writes are buffered until commit (like the real client), and a
+    read after any buffered write raises ``ReadAfterWriteError``. ``_commit``
+    can be told to raise ``Aborted`` a fixed number of times so retry behavior
+    under ``@async_transactional`` is exercisable.
+    """
+
+    def __init__(self) -> None:
+        self.docs: dict[str, dict[str, Any]] = {}
+        self.deleted: list[str] = []
+        self._pending: list[tuple[str, str, dict[str, Any] | None]] = []
+        self.commit_aborts_remaining = 0
+        self.commit_attempts = 0
+        self.commit_raises: Exception | None = None
+
+        self.client = MagicMock(spec=firestore.AsyncClient)
+        self.transaction = MagicMock()
+        self.transaction._max_attempts = 5
+        self.transaction._read_only = False
+        self.transaction._write_pbs = []
+        self.transaction._id = b'fake-txn'
+        self.transaction._in_progress = False
+        self.client.transaction.return_value = self.transaction
+
+        def clean_up() -> None:
+            self.transaction._write_pbs = []
+            self._pending = []
+            self.transaction._in_progress = False
+
+        async def begin(*, retry_id: Any = None) -> None:  # noqa: ANN401
+            self.transaction._write_pbs = []
+            self._pending = []
+            self.transaction._in_progress = True
+
+        async def commit() -> None:
+            self.commit_attempts += 1
+            if self.commit_raises is not None:
+                exc = self.commit_raises
+                self.commit_raises = None
+                raise exc
+            if self.commit_aborts_remaining > 0:
+                self.commit_aborts_remaining -= 1
+                raise google_exceptions.Aborted('injected abort')
+            for op, path, data in self._pending:
+                if op == 'set':
+                    assert data is not None
+                    self.docs[path] = dict(data)
+                elif op == 'update':
+                    assert data is not None
+                    current = dict(self.docs.get(path, {}))
+                    for key, value in data.items():
+                        if value is firestore.DELETE_FIELD:
+                            current.pop(key, None)
+                        elif value is firestore.SERVER_TIMESTAMP:
+                            current[key] = 'SERVER_TIMESTAMP'
+                        else:
+                            current[key] = value
+                    self.docs[path] = current
+                elif op == 'delete':
+                    self.docs.pop(path, None)
+                    self.deleted.append(path)
+            self.transaction._write_pbs = []
+            self._pending = []
+            self.transaction._in_progress = False
+
+        async def rollback() -> None:
+            self.transaction._write_pbs = []
+            self._pending = []
+            self.transaction._in_progress = False
+
+        self.transaction._clean_up = clean_up
+        self.transaction._begin = begin
+        self.transaction._commit = commit
+        self.transaction._rollback = rollback
+
+        def collection(name: str) -> MagicMock:
+            col = MagicMock()
+            col_name = name
+
+            def document(doc_id: str) -> MagicMock:
+                # prefix doc
+                prefix_ref = MagicMock()
+
+                def subcollection(sub: str) -> MagicMock:
+                    sub_col = MagicMock()
+
+                    def item_document(item_id: str) -> MagicMock:
+                        path = f'{col_name}/{doc_id}/{sub}/{item_id}'
+                        # Match AsyncDocumentReference: no on_snapshot (sync client owns watches).
+                        ref = MagicMock(spec=['get', 'path', 'id', 'collection'])
+                        ref.path = path
+                        ref.id = item_id
+
+                        async def get(*, transaction: Any = None) -> MagicMock:  # noqa: ANN401
+                            self._reject_read_after_write(transaction)
+                            if path in self.docs:
+                                return _doc(path=path, exists=True, data=self.docs[path], doc_id=item_id)
+                            return _doc(path=path, exists=False, data=None, doc_id=item_id)
+
+                        ref.get = get
+                        return ref
+
+                    sub_col.document.side_effect = item_document
+
+                    def where(field: str, op: str, value: Any) -> MagicMock:  # noqa: ANN401
+                        stream_holder = MagicMock()
+                        scoped_prefix = f'{col_name}/{doc_id}/{sub}/'
+
+                        async def stream() -> Any:  # noqa: ANN401
+                            for path, data in list(self.docs.items()):
+                                if not path.startswith(scoped_prefix):
+                                    continue
+                                if data.get(field) == value:
+                                    yield _doc(path=path, data=data)
+
+                        stream_holder.stream = MagicMock(return_value=stream())
+                        return stream_holder
+
+                    sub_col.where.side_effect = where
+                    return sub_col
+
+                prefix_ref.collection.side_effect = subcollection
+                return prefix_ref
+
+            col.document.side_effect = document
+            return col
+
+        self.client.collection.side_effect = collection
+
+        async def get_all(refs: list[Any], transaction: Any = None, **_kwargs: Any) -> Any:  # noqa: ANN401
+            self._reject_read_after_write(transaction)
+            for ref in refs:
+                path = ref.path
+                if path in self.docs:
+                    yield _doc(path=path, exists=True, data=self.docs[path], doc_id=ref.id)
+                else:
+                    yield _doc(path=path, exists=False, data=None, doc_id=ref.id)
+
+        # Production reads go through AsyncClient.get_all(transaction=...); keep
+        # transaction.get_all as a thin alias for older call sites/tests.
+        self.client.get_all = get_all
+        self.transaction.get_all = get_all
+
+        def txn_set(ref: Any, data: dict[str, Any]) -> None:  # noqa: ANN401
+            self.transaction._write_pbs.append(('set', ref.path))
+            self._pending.append(('set', ref.path, dict(data)))
+
+        def txn_update(ref: Any, data: dict[str, Any]) -> None:  # noqa: ANN401
+            self.transaction._write_pbs.append(('update', ref.path))
+            self._pending.append(('update', ref.path, dict(data)))
+
+        def txn_delete(ref: Any) -> None:  # noqa: ANN401
+            self.transaction._write_pbs.append(('delete', ref.path))
+            self._pending.append(('delete', ref.path, None))
+
+        self.transaction.set = txn_set
+        self.transaction.update = txn_update
+        self.transaction.delete = txn_delete
+
+    def _reject_read_after_write(self, transaction: Any) -> None:  # noqa: ANN401
+        if transaction is not None and len(getattr(transaction, '_write_pbs', [])) > 0:
+            raise ReadAfterWriteError('Attempted read after write in a transaction.')
+
+    def store(self, **kwargs: Any) -> FirestoreSessionStore:  # noqa: ANN401
+        return FirestoreSessionStore(client=self.client, **kwargs)
+
+
+def _snap_path(snapshot_id: str, *, prefix: str = 'global') -> str:
+    return f'genkit-sessions/{prefix}/snapshots/{snapshot_id}'
+
+
+def _pointer_path(session_id: str, *, prefix: str = 'global') -> str:
+    return f'genkit-sessions-pointers/{prefix}/pointers/{session_id}'
+
+
+def _shard_path(checkpoint_id: str, index: int, *, prefix: str = 'global') -> str:
+    return f'genkit-sessions-shards/{prefix}/shards/{checkpoint_id}_{index}'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_save_root_writes_checkpoint_shards() -> None:
+    """Root snapshot (no parent) is stored as a sharded checkpoint."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+
+    def save_fn(existing: SessionSnapshot | None) -> SessionSnapshot:
+        return SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.COMPLETED,
+            state=SessionState(session_id='sess-1', messages=[]),
+        )
+
+    saved = await store.save_snapshot('snap-1', save_fn)
+    assert saved is not None
+    assert saved.snapshot_id == 'snap-1'
+
+    snap_doc = h.docs[_snap_path('snap-1')]
+    assert snap_doc['kind'] == 'checkpoint'
+    assert snap_doc['checkpointId'] == 'snap-1'
+    assert snap_doc['segmentPath'] == []
+    assert 'state' not in snap_doc
+    assert 'statePatch' not in snap_doc
+
+    shard = h.docs[_shard_path('snap-1', 0)]
+    assert json.loads(shard['chunk'].decode('utf-8'))['sessionId'] == 'sess-1'
+
+    pointer = h.docs[_pointer_path('sess-1')]
+    assert pointer['currentSnapshotId'] == 'snap-1'
+    assert pointer['checkpointId'] == 'snap-1'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_save_child_writes_diff() -> None:
+    """Child under the checkpoint interval is stored as a JSON Patch diff."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            state=SessionState(session_id='sess-1', custom={'n': 1}),
+        ),
+    )
+    await store.save_snapshot(
+        'snap-2',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-2',
+            parent_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:01Z',
+            state=SessionState(session_id='sess-1', custom={'n': 2}),
+        ),
+    )
+
+    child = h.docs[_snap_path('snap-2')]
+    assert child['kind'] == 'diff'
+    assert child['checkpointId'] == 'snap-1'
+    assert child['segmentPath'] == ['snap-2']
+    assert isinstance(child['statePatch'], str) and child['statePatch']
+
+    loaded = await store.get_snapshot(snapshot_id='snap-2')
+    assert loaded is not None
+    assert loaded.state is not None
+    assert loaded.state.custom == {'n': 2}
+    assert loaded.parent_id == 'snap-1'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_checkpoint_interval_promotes() -> None:
+    """Crossing checkpoint_interval writes a new checkpoint instead of a long diff chain."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=2)
+
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            state=SessionState(session_id='sess-1', custom={'n': 1}),
+        ),
+    )
+    await store.save_snapshot(
+        'snap-2',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-2',
+            parent_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:01Z',
+            state=SessionState(session_id='sess-1', custom={'n': 2}),
+        ),
+    )
+    # segmentPath length for snap-2 is 1; next child would be length 2 >= interval → checkpoint
+    await store.save_snapshot(
+        'snap-3',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-3',
+            parent_id='snap-2',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:02Z',
+            state=SessionState(session_id='sess-1', custom={'n': 3}),
+        ),
+    )
+
+    third = h.docs[_snap_path('snap-3')]
+    assert third['kind'] == 'checkpoint'
+    assert third['checkpointId'] == 'snap-3'
+    assert third['segmentPath'] == []
+    assert _shard_path('snap-3', 0) in h.docs
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_get_by_session_id() -> None:
+    """session_id lookup reconstructs from pointer checkpoint metadata."""
+    h = FakeStoreHarness()
+    store = h.store()
+
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            state=SessionState(session_id='sess-1', custom={'hello': 'world'}),
+        ),
+    )
+
+    loaded = await store.get_snapshot(session_id='sess-1')
+    assert loaded is not None
+    assert loaded.snapshot_id == 'snap-1'
+    assert loaded.state is not None
+    assert loaded.state.custom == {'hello': 'world'}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_save_skips_when_mutator_returns_none() -> None:
+    """Mutator returning None must not write snapshot or pointer docs."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.ABORTED,
+            state=SessionState(session_id='sess-1'),
+        ),
+    )
+    before = dict(h.docs)
+    saved = await store.save_snapshot('snap-1', lambda _existing: None)
+    assert saved is None
+    assert h.docs == before
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_heartbeat_updates_leaf_without_rebranch() -> None:
+    """In-place leaf update refreshes pointer metadata and keeps a single leaf."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.PENDING,
+            state=SessionState(session_id='sess-1'),
+        ),
+    )
+
+    def beat(existing: SessionSnapshot | None) -> SessionSnapshot:
+        assert existing is not None
+        return existing.model_copy(update={'heartbeat_at': '2026-07-03T00:00:05Z'})
+
+    saved = await store.save_snapshot('snap-1', beat)
+    assert saved is not None
+    assert saved.heartbeat_at == '2026-07-03T00:00:05Z'
+    pointer = h.docs[_pointer_path('sess-1')]
+    assert 'isAmbiguous' not in pointer
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_non_leaf_update_leaves_pointer_alone() -> None:
+    """Updating an ancestor must not re-add it to leaves or mark the session ambiguous."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot(
+        'snap-A',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-A',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.COMPLETED,
+            state=SessionState(session_id='sess-1', custom={'n': 1}),
+        ),
+    )
+    await store.save_snapshot(
+        'snap-B',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-B',
+            parent_id='snap-A',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:01Z',
+            status=SnapshotStatus.COMPLETED,
+            state=SessionState(session_id='sess-1', custom={'n': 2}),
+        ),
+    )
+    pointer_before = dict(h.docs[_pointer_path('sess-1')])
+
+    def rewrite_a(existing: SessionSnapshot | None) -> SessionSnapshot:
+        assert existing is not None
+        return existing.model_copy(update={'status': SnapshotStatus.COMPLETED})
+
+    saved = await store.save_snapshot('snap-A', rewrite_a)
+    assert saved is not None
+    pointer_after = h.docs[_pointer_path('sess-1')]
+    assert pointer_after == pointer_before  # non-current write: pointer fully untouched
+    assert pointer_after['currentSnapshotId'] == 'snap-B'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_branching_last_writer_wins() -> None:
+    """Forked sessions never error: session lookup follows the last-written leaf.
+
+    Matches the JS Firestore store exactly — no ambiguity detection, no
+    rejection option; concurrent branch extension makes the current snapshot
+    race-dependent by design. Resume by snapshot_id when a branch matters.
+    """
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+    await store.save_snapshot('snap-root', _mk('snap-root', None, custom={'n': 0}))
+    await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
+    await store.save_snapshot('snap-b', _mk('snap-b', 'snap-root', custom={'n': 2}))
+
+    # Last NEW leaf wins.
+    loaded = await store.get_snapshot(session_id='sess-1')
+    assert loaded is not None and loaded.snapshot_id == 'snap-b'
+
+    # Heartbeating the OTHER branch's leaf does not move the pointer.
+    def beat(existing: SessionSnapshot | None) -> SessionSnapshot | None:
+        assert existing is not None
+        return existing.model_copy(update={'heartbeat_at': '2026-07-03T00:09:00Z'})
+
+    await store.save_snapshot('snap-a', beat)
+    loaded = await store.get_snapshot(session_id='sess-1')
+    assert loaded is not None and loaded.snapshot_id == 'snap-b'
+
+    # Extending the other branch DOES: its new leaf becomes current.
+    await store.save_snapshot('snap-a2', _mk('snap-a2', 'snap-a', custom={'n': 3}))
+    loaded = await store.get_snapshot(session_id='sess-1')
+    assert loaded is not None and loaded.snapshot_id == 'snap-a2'
+    assert 'leaves' not in h.docs[_pointer_path('sess-1')]
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_missing_pointer_returns_none() -> None:
+    """Without a pointer, session_id lookup is None (no collection-query repair)."""
+    h = FakeStoreHarness()
+    h.docs[_snap_path('snap-1')] = {
+        'snapshotId': 'snap-1',
+        'sessionId': 'sess-unpointed',
+        'createdAt': '2026-07-03T00:00:01Z',
+        'kind': 'checkpoint',
+        'checkpointId': 'snap-1',
+        'checkpointShardCount': 1,
+        'segmentPath': [],
+    }
+    h.docs[_shard_path('snap-1', 0)] = {
+        'chunk': json.dumps({'sessionId': 'sess-unpointed'}).encode('utf-8'),
+    }
+
+    store = h.store()
+    assert await store.get_snapshot(session_id='sess-unpointed') is None
+    # Document-ID lookup still works; only the pointer-based path is unavailable.
+    by_id = await store.get_snapshot(snapshot_id='snap-1')
+    assert by_id is not None
+    assert by_id.snapshot_id == 'snap-1'
+    assert _pointer_path('sess-unpointed') not in h.docs
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_corrupt_pointer_returns_none() -> None:
+    """A pointer that can't reconstruct returns None without rewriting the pointer."""
+    h = FakeStoreHarness()
+    h.docs[_snap_path('snap-live')] = {
+        'snapshotId': 'snap-live',
+        'sessionId': 'sess-corrupt',
+        'createdAt': '2026-07-03T00:00:01Z',
+        'kind': 'checkpoint',
+        'checkpointId': 'snap-live',
+        'checkpointShardCount': 1,
+        'segmentPath': [],
+    }
+    h.docs[_shard_path('snap-live', 0)] = {
+        'chunk': json.dumps({'sessionId': 'sess-corrupt'}).encode('utf-8'),
+    }
+    # Structurally valid pointer whose leaf is gone; omit checkpoint meta so
+    # lookup falls through to snapshot-id reconstruct (None), not DATA_LOSS
+    # from missing shards.
+    h.docs[_pointer_path('sess-corrupt')] = {
+        'currentSnapshotId': 'snap-deleted',
+        'segmentPath': [],
+    }
+
+    store = h.store()
+    assert await store.get_snapshot(session_id='sess-corrupt') is None
+    assert h.docs[_pointer_path('sess-corrupt')]['currentSnapshotId'] == 'snap-deleted'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_invalid_snapshot_doc_raises() -> None:
+    """Schema-invalid snapshot docs fail loud instead of looking like a miss."""
+    h = FakeStoreHarness()
+    h.docs[_snap_path('snap-bad')] = {
+        'snapshotId': 'snap-bad',
+        'sessionId': 'sess-1',
+        'createdAt': '2026-07-03T00:00:00Z',
+        'kind': 'not-a-kind',
+        'checkpointId': 'snap-bad',
+        'checkpointShardCount': 1,
+        'segmentPath': [],
+    }
+    before = dict(h.docs[_snap_path('snap-bad')])
+    store = h.store()
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-bad')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot(
+            'snap-bad',
+            lambda _e: SessionSnapshot(
+                snapshot_id='snap-bad',
+                session_id='sess-1',
+                created_at='2026-07-03T00:00:01Z',
+                state=SessionState(session_id='sess-1'),
+            ),
+        )
+    assert exc_info.value.status == 'DATA_LOSS'
+    assert h.docs[_snap_path('snap-bad')] == before
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_missing_segment_path_raises() -> None:
+    """segmentPath is required on snapshot docs (empty list is ok; absent is not)."""
+    h = FakeStoreHarness()
+    h.docs[_snap_path('snap-no-seg')] = {
+        'snapshotId': 'snap-no-seg',
+        'sessionId': 'sess-1',
+        'createdAt': '2026-07-03T00:00:00Z',
+        'kind': 'checkpoint',
+        'checkpointId': 'snap-no-seg',
+        'checkpointShardCount': 1,
+    }
+    store = h.store()
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-no-seg')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_datetime_in_custom_round_trips() -> None:
+    """SessionState mode='json' coerces datetimes before they are persisted."""
+    h = FakeStoreHarness()
+    store = h.store()
+    when = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    await store.save_snapshot(
+        'snap-dt',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-dt',
+            session_id='sess-dt',
+            created_at='2026-07-03T00:00:00Z',
+            state=SessionState(session_id='sess-dt', custom={'when': when}),
+        ),
+    )
+
+    shard = h.docs[_shard_path('snap-dt', 0)]
+    stored = json.loads(shard['chunk'].decode('utf-8'))
+    assert stored['custom']['when'] == '2026-01-01T00:00:00Z'
+
+    loaded = await store.get_snapshot(snapshot_id='snap-dt')
+    assert loaded is not None
+    assert loaded.state is not None
+    assert loaded.state.custom == {'when': '2026-01-01T00:00:00Z'}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_oversized_diff_promotes_to_checkpoint() -> None:
+    """A patch larger than shard_size is stored as a sharded checkpoint."""
+    h = FakeStoreHarness()
+    store = h.store(shard_size=64, checkpoint_interval=25)
+
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            state=SessionState(session_id='sess-1', custom={'n': 1}),
+        ),
+    )
+    await store.save_snapshot(
+        'snap-2',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-2',
+            parent_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:01Z',
+            state=SessionState(session_id='sess-1', custom={'blob': 'x' * 200}),
+        ),
+    )
+
+    child = h.docs[_snap_path('snap-2')]
+    assert child['kind'] == 'checkpoint'
+    assert child['checkpointId'] == 'snap-2'
+    assert 'statePatch' not in child
+    loaded = await store.get_snapshot(snapshot_id='snap-2')
+    assert loaded is not None
+    assert loaded.state is not None
+    assert loaded.state.custom == {'blob': 'x' * 200}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_status_change_and_cleanup() -> None:
+    """Test snapshot status subscription and thread-safe cleanup on terminal status."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot(
+        'snap-sub',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-sub',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.PENDING,
+            state=SessionState(session_id='sess-1'),
+        ),
+    )
+
+    watches, captured_cb = _wire_sync_watch(store)
+    queue = await store.on_snapshot_status_change('snap-sub')
+    assert len(captured_cb) == 1
+    assert len(store._subscriptions) == 1
+    (sub,) = store._subscriptions
+    assert sub.queue.empty()
+
+    await _pump_watch(captured_cb, 0, _status_doc('snap-sub', 'pending'))
+    assert await _next_status(queue) == SnapshotStatus.PENDING
+
+    await _pump_watch(captured_cb, 0, _status_doc('snap-sub', 'aborted'))
+
+    assert await _next_status(queue) == SnapshotStatus.ABORTED
+    assert await _stream_ended(queue)
+    watches[0].unsubscribe.assert_called_once()
+    assert len(store._subscriptions) == 0
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_terminal_cleanup_falls_back_when_create_task_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the loop can't schedule async teardown, still unsubscribe the watch."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-task', _pending_mk('snap-task'))
+    watches, captured_cb = _wire_sync_watch(store)
+    queue = await store.on_snapshot_status_change('snap-task')
+
+    await _pump_watch(captured_cb, 0, _status_doc('snap-task', 'pending'))
+    assert await _next_status(queue) == SnapshotStatus.PENDING
+
+    def boom(_coro: Any) -> Any:  # noqa: ANN401
+        raise RuntimeError('no running event loop')
+
+    monkeypatch.setattr(asyncio, 'create_task', boom)
+    await _pump_watch(captured_cb, 0, _status_doc('snap-task', 'completed'))
+
+    assert await _next_status(queue) == SnapshotStatus.COMPLETED
+    assert await _stream_ended(queue)
+    watches[0].unsubscribe.assert_called_once()
+    assert len(store._subscriptions) == 0
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_close_stops_watches_and_sync_client() -> None:
+    """close() unsubscribes watches and closes a lazily-created sync client."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot(
+        'snap-close',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-close',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.PENDING,
+            state=SessionState(session_id='sess-1'),
+        ),
+    )
+
+    watches, _captured = _wire_sync_watch(store)
+    mock_sync_client = cast(Any, store.client)._to_sync_copy.return_value
+    await store.on_snapshot_status_change('snap-close')
+    assert store.sync_client is mock_sync_client
+    assert len(store._subscriptions) == 1
+    assert all(s.watch is not None for s in store._subscriptions)
+
+    store.close()
+    watches[0].unsubscribe.assert_called_once()
+    mock_sync_client.close.assert_called_once()
+    assert store.sync_client is None
+    assert len(store._subscriptions) == 0
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_close_does_not_close_injected_sync_client() -> None:
+    """Caller-owned sync_client is left open by close()."""
+    h = FakeStoreHarness()
+    injected = MagicMock()
+    store = h.store(sync_client=injected)
+    store.close()
+    injected.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_ensure_sync_client_raises_genkit_error() -> None:
+    """_ensure_sync_client() raises GenkitError if client has no _to_sync_copy and no sync_client set."""
+    custom_client = MagicMock(spec=[])
+    store = FirestoreSessionStore(client=custom_client)
+    with pytest.raises(GenkitError) as exc_info:
+        store._ensure_sync_client()
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert 'Realtime status watches require a synchronous Firestore client' in str(exc_info.value)
+
+
+def _by_user(context: dict[str, Any] | None = None) -> str:
+    """Prefix from authenticated user id (tenant isolation)."""
+    if not isinstance(context, dict):
+        return 'anonymous'
+    auth = context.get('auth')
+    if not isinstance(auth, dict):
+        return 'anonymous'
+    uid = auth.get('uid')
+    return uid if isinstance(uid, str) and uid else 'anonymous'
+
+
+def _ctx(uid: str) -> dict[str, Any]:
+    return {'auth': {'uid': uid}}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_isolates_snapshot_id_per_tenant() -> None:
+    """Same snapshot id under different tenants must not cross-read."""
+    h = FakeStoreHarness()
+    store = h.store(snapshot_path_prefix=_by_user)
+
+    await store.save_snapshot(
+        'shared-id',
+        lambda _e: SessionSnapshot(
+            snapshot_id='shared-id',
+            session_id='sess-a',
+            created_at='2026-07-03T00:00:00Z',
+            state=SessionState(session_id='sess-a', custom={'counter': 1}),
+        ),
+        context=_ctx('alice'),
+    )
+
+    as_alice = await store.get_snapshot(snapshot_id='shared-id', context=_ctx('alice'))
+    assert as_alice is not None
+    assert as_alice.state is not None
+    assert as_alice.state.custom == {'counter': 1}
+
+    as_bob = await store.get_snapshot(snapshot_id='shared-id', context=_ctx('bob'))
+    assert as_bob is None
+
+    assert _snap_path('shared-id', prefix='alice') in h.docs
+    assert _snap_path('shared-id', prefix='global') not in h.docs
+    assert _snap_path('shared-id', prefix='bob') not in h.docs
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_isolates_session_id_per_tenant() -> None:
+    """Same session id resolves only within the caller's tenant prefix."""
+    h = FakeStoreHarness()
+    store = h.store(snapshot_path_prefix=_by_user)
+
+    await store.save_snapshot(
+        'a1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='a1',
+            session_id='shared-sess',
+            created_at='2026-07-03T00:00:00Z',
+            state=SessionState(session_id='shared-sess', custom={'counter': 11}),
+        ),
+        context=_ctx('alice'),
+    )
+
+    as_bob = await store.get_snapshot(session_id='shared-sess', context=_ctx('bob'))
+    assert as_bob is None
+
+    as_alice = await store.get_snapshot(session_id='shared-sess', context=_ctx('alice'))
+    assert as_alice is not None
+    assert as_alice.snapshot_id == 'a1'
+    assert as_alice.state is not None
+    assert as_alice.state.custom == {'counter': 11}
+
+
+def _wire_sync_watch(store: FirestoreSessionStore) -> tuple[list[MagicMock], list[Any]]:
+    """Attach mock sync on_snapshot watches; return (watches, captured_callbacks)."""
+    watches: list[MagicMock] = []
+    captured_cb: list[Any] = []
+
+    def on_snapshot_side_effect(cb: Any) -> Any:  # noqa: ANN401
+        captured_cb.append(cb)
+        watch_mock = MagicMock()
+        watches.append(watch_mock)
+        return watch_mock
+
+    mock_sync_doc_ref = MagicMock()
+    mock_sync_doc_ref.on_snapshot.side_effect = on_snapshot_side_effect
+    mock_sync_col = MagicMock()
+    mock_sync_col.document.return_value = mock_sync_doc_ref
+    mock_sync_doc_ref.collection.return_value = mock_sync_col
+    mock_sync_client = MagicMock()
+    mock_sync_client.collection.return_value = mock_sync_col
+    cast(Any, store.client)._to_sync_copy.return_value = mock_sync_client
+    return watches, captured_cb
+
+
+def _status_doc(snapshot_id: str, status: str, *, session_id: str = 'sess-1') -> MagicMock:
+    doc = MagicMock()
+    doc.exists = True
+    doc.to_dict.return_value = {
+        'snapshotId': snapshot_id,
+        'sessionId': session_id,
+        'createdAt': '2026-07-03T00:00:00Z',
+        'status': status,
+    }
+    return doc
+
+
+async def _pump_watch(captured_cb: list[Any], index: int, doc: MagicMock) -> None:
+    captured_cb[index]([doc], None, None)
+    await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_upsert_diff_leaf_rewrites_patch() -> None:
+    """Heartbeat/abort-style upsert of an existing diff leaf refreshes statePatch."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            state=SessionState(session_id='sess-1', custom={'n': 1}),
+        ),
+    )
+    await store.save_snapshot(
+        'snap-2',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-2',
+            parent_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:01Z',
+            status=SnapshotStatus.PENDING,
+            state=SessionState(session_id='sess-1', custom={'n': 2}),
+        ),
+    )
+    before = h.docs[_snap_path('snap-2')]
+    assert before['kind'] == 'diff'
+    assert before['statePatch']
+
+    await store.save_snapshot(
+        'snap-2',
+        lambda existing: (
+            existing.model_copy(
+                update={
+                    'heartbeat_at': '2026-07-03T00:00:05Z',
+                    'state': SessionState(session_id='sess-1', custom={'n': 3}),
+                }
+            )
+            if existing
+            else None
+        ),
+    )
+
+    after = h.docs[_snap_path('snap-2')]
+    assert after['kind'] == 'diff'
+    assert after['checkpointId'] == 'snap-1'
+    assert after['segmentPath'] == ['snap-2']
+    assert after['statePatch']
+    assert after['statePatch'] != before['statePatch']
+    loaded = await store.get_snapshot(snapshot_id='snap-2')
+    assert loaded is not None
+    assert loaded.state is not None
+    assert loaded.state.custom == {'n': 3}
+    assert loaded.heartbeat_at == '2026-07-03T00:00:05Z'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_upsert_oversized_diff_promotes_to_checkpoint() -> None:
+    """Upserting a diff leaf with an oversized patch rewrites it as a checkpoint."""
+    h = FakeStoreHarness()
+    store = h.store(shard_size=64, checkpoint_interval=25)
+
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            state=SessionState(session_id='sess-1', custom={'n': 1}),
+        ),
+    )
+    await store.save_snapshot(
+        'snap-2',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-2',
+            parent_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:01Z',
+            status=SnapshotStatus.PENDING,
+            state=SessionState(session_id='sess-1', custom={'n': 2}),
+        ),
+    )
+    assert h.docs[_snap_path('snap-2')]['kind'] == 'diff'
+
+    await store.save_snapshot(
+        'snap-2',
+        lambda existing: (
+            existing.model_copy(update={'state': SessionState(session_id='sess-1', custom={'blob': 'x' * 200})})
+            if existing
+            else None
+        ),
+    )
+
+    child = h.docs[_snap_path('snap-2')]
+    assert child['kind'] == 'checkpoint'
+    assert child['checkpointId'] == 'snap-2'
+    assert 'statePatch' not in child
+    loaded = await store.get_snapshot(snapshot_id='snap-2')
+    assert loaded is not None
+    assert loaded.state is not None
+    assert loaded.state.custom == {'blob': 'x' * 200}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_missing_snapshot_subscribe_waits_for_create() -> None:
+    """A missing snapshot stays subscribed; each caller gets its own watch."""
+    h = FakeStoreHarness()
+    store = h.store()
+    watches, captured_cb = _wire_sync_watch(store)
+
+    q1 = await store.on_snapshot_status_change('missing')
+    assert all(s.queue.empty() for s in store._subscriptions)
+    assert len(captured_cb) == 1
+    assert len(store._subscriptions) == 1
+
+    q2 = await store.on_snapshot_status_change('missing')
+    assert len(captured_cb) == 2
+    assert len(store._subscriptions) == 2
+    assert all(s.queue.empty() for s in store._subscriptions)
+    watches[0].unsubscribe.assert_not_called()
+    watches[1].unsubscribe.assert_not_called()
+
+    await store.save_snapshot(
+        'missing',
+        lambda _e: SessionSnapshot(
+            snapshot_id='missing',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.PENDING,
+            state=SessionState(session_id='sess-1'),
+        ),
+    )
+    pending = _status_doc('missing', 'pending')
+    await _pump_watch(captured_cb, 0, pending)
+    await _pump_watch(captured_cb, 1, pending)
+    assert await _next_status(q1) == SnapshotStatus.PENDING
+    assert await _next_status(q2) == SnapshotStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_retries_on_aborted_commit() -> None:
+    """@async_transactional retries the RMW closure when commit raises Aborted."""
+    h = FakeStoreHarness()
+    store = h.store()
+    h.commit_aborts_remaining = 2
+
+    saved = await store.save_snapshot(
+        'snap-retry',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-retry',
+            session_id='sess-retry',
+            created_at='2026-07-03T00:00:00Z',
+            state=SessionState(session_id='sess-retry', custom={'n': 1}),
+        ),
+    )
+    assert saved is not None
+    assert h.commit_attempts == 3
+    loaded = await store.get_snapshot(snapshot_id='snap-retry')
+    assert loaded is not None
+    assert loaded.state is not None
+    assert loaded.state.custom == {'n': 1}
+
+
+@pytest.mark.asyncio
+async def test_fake_harness_rejects_read_after_write() -> None:
+    """Harness mirrors the real client: buffered writes forbid later reads."""
+    h = FakeStoreHarness()
+    store = h.store()
+    ref = store._snapshot_ref('snap-x', 'global')
+    txn = h.client.transaction()
+    await txn._begin()
+    txn.set(ref, {'snapshotId': 'snap-x'})
+    with pytest.raises(ReadAfterWriteError):
+        await ref.get(transaction=txn)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_upsert_restores_deleted_pointer() -> None:
+    """A leaf upsert restores a missing pointer so session lookup keeps working."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.PENDING,
+            state=SessionState(session_id='sess-1'),
+        ),
+    )
+    del h.docs[_pointer_path('sess-1')]
+
+    def beat(existing: SessionSnapshot | None) -> SessionSnapshot | None:
+        assert existing is not None
+        return existing.model_copy(update={'heartbeat_at': '2026-07-03T00:00:05Z'})
+
+    await store.save_snapshot('snap-1', beat)
+    pointer = h.docs[_pointer_path('sess-1')]
+    assert pointer['currentSnapshotId'] == 'snap-1'
+    loaded = await store.get_snapshot(session_id='sess-1')
+    assert loaded is not None
+    assert loaded.snapshot_id == 'snap-1'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_forked_pointer_keeps_current_snapshot_id() -> None:
+    """After a fork the pointer is the plain last-writer shape: no branch metadata."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+    await store.save_snapshot('snap-root', _mk('snap-root', None, custom={'n': 0}))
+    await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
+    await store.save_snapshot('snap-b', _mk('snap-b', 'snap-root', custom={'n': 2}))
+
+    pointer = h.docs[_pointer_path('sess-1')]
+    assert pointer['currentSnapshotId'] == 'snap-b'
+    assert 'isAmbiguous' not in pointer
+    assert 'leaves' not in pointer
+    assert isinstance(pointer['updatedAt'], str)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_null_value_survives_patch_wire() -> None:
+    """Clearing a field to null keeps ``value: null`` on the stored patch op."""
+    h = FakeStoreHarness()
+    store = h.store()
+
+    def mk(sid: str, parent: str | None, custom: dict) -> object:  # noqa: ANN401
+        return lambda _e: SessionSnapshot(
+            snapshot_id=sid,
+            session_id='sess-1',
+            parent_id=parent,
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.COMPLETED,
+            state=SessionState(session_id='sess-1', custom=custom),
+        )
+
+    await store.save_snapshot('snap-1', mk('snap-1', None, {'x': 1}))
+    await store.save_snapshot('snap-2', mk('snap-2', 'snap-1', {'x': None}))
+
+    doc = h.docs[_snap_path('snap-2')]
+    assert doc['kind'] == 'diff'
+    assert isinstance(doc['statePatch'], str)
+    patch = json.loads(doc['statePatch'])
+    ops = [o for o in patch if o['path'] == '/custom/x']
+    assert ops, f'no op for /custom/x in {doc["statePatch"]}'
+    assert ops[0]['op'] == 'replace'
+    assert 'value' in ops[0]
+    assert ops[0]['value'] is None
+
+    loaded = await store.get_snapshot(snapshot_id='snap-2')
+    assert loaded is not None
+    assert loaded.state is not None
+    assert loaded.state.custom == {'x': None}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_cjk_diff_not_prematurely_promoted() -> None:
+    """Multilingual diffs are sized in raw UTF-8, not Unicode-escape length."""
+    text = '中' * 200
+    raw = len(json.dumps(text, ensure_ascii=False).encode('utf-8'))  # ~602
+    escaped = len(json.dumps(text).encode('utf-8'))  # ~1202
+    shard_size = (raw + escaped) // 2  # diff fits raw, not escaped
+    h = FakeStoreHarness()
+    store = h.store(shard_size=shard_size)
+
+    def mk(sid: str, parent: str | None, custom: dict) -> object:  # noqa: ANN401
+        return lambda _e: SessionSnapshot(
+            snapshot_id=sid,
+            session_id='sess-1',
+            parent_id=parent,
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.COMPLETED,
+            state=SessionState(session_id='sess-1', custom=custom),
+        )
+
+    await store.save_snapshot('snap-1', mk('snap-1', None, {}))
+    await store.save_snapshot('snap-2', mk('snap-2', 'snap-1', {'text': text}))
+    assert h.docs[_snap_path('snap-2')]['kind'] == 'diff'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_stamps_parseable_timestamps() -> None:
+    """Store-stamped timestamps are valid ISO-8601 (exact format is not pinned)."""
+    from datetime import datetime as _dt
+
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='',  # force the store to stamp
+            status=SnapshotStatus.COMPLETED,
+            state=SessionState(session_id='sess-1'),
+        ),
+    )
+    assert _dt.fromisoformat(h.docs[_snap_path('snap-1')]['createdAt'])
+    assert _dt.fromisoformat(h.docs[_pointer_path('sess-1')]['updatedAt'])
+
+
+def _mk(sid: str, parent: str | None = None, custom: dict | None = None) -> Any:  # noqa: ANN401
+    return lambda _e: SessionSnapshot(
+        snapshot_id=sid,
+        session_id='sess-1',
+        parent_id=parent,
+        created_at='2026-07-03T00:00:00Z',
+        status=SnapshotStatus.COMPLETED,
+        state=SessionState(session_id='sess-1', custom=custom or {}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_missing_shard_raises_data_loss() -> None:
+    """A checkpoint whose shard document vanished fails loud, not with partial state."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1', custom={'x': 1}))
+    del h.docs[_shard_path('snap-1', 0)]
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-1')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_corrupt_shard_raises_data_loss() -> None:
+    """A shard document that fails schema validation is DATA_LOSS, not garbage state."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1', custom={'x': 1}))
+    h.docs[_shard_path('snap-1', 0)] = {'not_chunk': 1}
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-1')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_missing_checkpoint_doc_returns_none() -> None:
+    """Pointer names a checkpoint whose snapshot doc is gone: lookup degrades to None."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1'))
+    del h.docs[_snap_path('snap-1')]
+
+    assert await store.get_snapshot(session_id='sess-1') is None
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_corrupt_checkpoint_doc_raises_data_loss() -> None:
+    """Pointer fast-path re-reads the checkpoint doc; corruption there is DATA_LOSS."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1'))
+    h.docs[_snap_path('snap-1')]['kind'] = 'not-a-kind'
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(session_id='sess-1')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_checkpoint_id_mismatch_raises_data_loss() -> None:
+    """A doc disagreeing with its own address is corruption, not not-found.
+
+    Pointer and snapshot metadata commit in one transaction, so no legitimate
+    staleness can produce this shape.
+    """
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1'))
+    h.docs[_snap_path('snap-1')]['snapshotId'] = 'snap-other'
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-1')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_missing_segment_raises_data_loss() -> None:
+    """A deleted segment referenced by the target's chain is DATA_LOSS, matching missing shards."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+    await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
+    await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
+    await store.save_snapshot('snap-b', _mk('snap-b', 'snap-a', custom={'n': 2}))
+    del h.docs[_snap_path('snap-a')]
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-b')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_corrupt_segment_raises_data_loss() -> None:
+    """A diff chain with an invalid interior segment fails loud."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+    await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
+    await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
+    await store.save_snapshot('snap-b', _mk('snap-b', 'snap-a', custom={'n': 2}))
+    h.docs[_snap_path('snap-a')]['kind'] = 'not-a-kind'
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-b')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_missing_parent_makes_child_a_checkpoint() -> None:
+    """A new child of a nonexistent parent self-heals forward as a full checkpoint."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+
+    await store.save_snapshot('snap-child', _mk('snap-child', 'snap-ghost', custom={'n': 1}))
+
+    doc = h.docs[_snap_path('snap-child')]
+    assert doc['kind'] == 'checkpoint'
+    assert doc['segmentPath'] == []
+    loaded = await store.get_snapshot(snapshot_id='snap-child')
+    assert loaded is not None
+    assert loaded.state is not None
+    assert loaded.state.custom == {'n': 1}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_extending_corrupt_current_leaf_fails_loud() -> None:
+    """A new child of the corrupt *current* leaf raises DATA_LOSS (no diff against garbage).
+
+    The pointer fast-path supplies the parent's chain metadata, so the corruption
+    is discovered during parent reconstruction and surfaces loudly.
+    """
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+    await store.save_snapshot('snap-parent', _mk('snap-parent', custom={'n': 0}))
+    h.docs[_snap_path('snap-parent')]['kind'] = 'not-a-kind'
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('snap-child', _mk('snap-child', 'snap-parent', custom={'n': 1}))
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_forking_corrupt_interior_parent_self_heals() -> None:
+    """Forking off a corrupt *non-current* parent self-heals forward as a checkpoint.
+
+    Off the pointer fast-path the parent doc must be read directly; when it fails
+    validation the child is written as a full checkpoint with no dependence on the
+    corrupt chain.
+    """
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+    await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
+    await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
+    h.docs[_snap_path('snap-root')]['kind'] = 'not-a-kind'
+
+    await store.save_snapshot('snap-fork', _mk('snap-fork', 'snap-root', custom={'n': 9}))
+
+    doc = h.docs[_snap_path('snap-fork')]
+    assert doc['kind'] == 'checkpoint'
+    assert doc['segmentPath'] == []
+    loaded = await store.get_snapshot(snapshot_id='snap-fork')
+    assert loaded is not None
+    assert loaded.state is not None
+    assert loaded.state.custom == {'n': 9}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_shrinking_checkpoint_prunes_orphan_shards() -> None:
+    """Re-checkpointing with smaller state deletes shards beyond the new count."""
+    h = FakeStoreHarness()
+    store = h.store(shard_size=64)
+
+    await store.save_snapshot('snap-1', _mk('snap-1', custom={'blob': 'x' * 200}))
+    assert _shard_path('snap-1', 0) in h.docs
+    assert _shard_path('snap-1', 2) in h.docs  # >= 3 shards at size 64
+
+    await store.save_snapshot(
+        'snap-1', lambda e: e.model_copy(update={'state': SessionState(session_id='sess-1', custom={})})
+    )
+
+    assert _shard_path('snap-1', 0) in h.docs
+    assert _shard_path('snap-1', 1) not in h.docs
+    assert _shard_path('snap-1', 2) not in h.docs
+    assert _shard_path('snap-1', 1) in h.deleted
+
+    loaded = await store.get_snapshot(snapshot_id='snap-1')
+    assert loaded is not None
+    assert loaded.state is not None
+    assert loaded.state.custom == {}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_missing_session_id_raises_invalid_argument() -> None:
+    """A snapshot without a sessionId cannot be pointer-indexed: INVALID_ARGUMENT."""
+    h = FakeStoreHarness()
+    store = h.store()
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot(
+            'snap-1',
+            lambda _e: SessionSnapshot(
+                snapshot_id='snap-1',
+                session_id='',
+                created_at='2026-07-03T00:00:00Z',
+                status=SnapshotStatus.COMPLETED,
+                state=SessionState(session_id=''),
+            ),
+        )
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'session_id' in str(exc_info.value)
+    assert _pointer_path('') not in h.docs
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_listener_failure_rolls_back_subscription(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the realtime watch cannot start, the queue registration is rolled back."""
+    h = FakeStoreHarness()
+    store = h.store()
+
+    def boom() -> None:
+        raise GenkitError(status='FAILED_PRECONDITION', message='no sync client')
+
+    monkeypatch.setattr(store, '_ensure_sync_client', boom)
+
+    with pytest.raises(GenkitError):
+        await store.on_snapshot_status_change('snap-missing')
+
+    assert len(store._subscriptions) == 0
+
+
+def test_firestore_session_store_close_is_idempotent_without_watches() -> None:
+    """close() with nothing to tear down returns cleanly, twice."""
+    h = FakeStoreHarness()
+    store = h.store()
+    store.close()
+    store.close()
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'fragment'),
+    [
+        ({'checkpoint_interval': 0}, 'checkpoint_interval'),
+        ({'checkpoint_interval': -3}, 'checkpoint_interval'),
+        ({'shard_size': 0}, 'shard_size'),
+        ({'shard_size': 2_000_000}, 'shard_size'),
+    ],
+)
+def test_firestore_session_store_rejects_invalid_tuning(kwargs: dict, fragment: str) -> None:
+    """Out-of-range tuning parameters fail at construction, not at first write."""
+    h = FakeStoreHarness()
+    with pytest.raises(GenkitError) as exc_info:
+        h.store(**kwargs)
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert fragment in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_multibyte_state_survives_shard_boundaries() -> None:
+    """Raw UTF-8 shards may split mid-codepoint; stitch must concatenate before decoding."""
+    h = FakeStoreHarness()
+    store = h.store(shard_size=7)  # tiny shards force splits inside CJK/emoji sequences
+
+    text = '中文😀' * 20
+    await store.save_snapshot('snap-1', _mk('snap-1', custom={'text': text}))
+    assert _shard_path('snap-1', 3) in h.docs  # genuinely multi-shard
+
+    loaded = await store.get_snapshot(snapshot_id='snap-1')
+    assert loaded is not None
+    assert loaded.state is not None
+    assert loaded.state.custom == {'text': text}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_tampered_diff_id_raises_data_loss() -> None:
+    """A diff doc whose snapshotId disagrees with its address fails the end-of-chain check."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+    await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
+    await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
+    h.docs[_snap_path('snap-a')]['snapshotId'] = 'snap-other'
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-a')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_non_object_shard_state_raises_data_loss() -> None:
+    """Shards decoding to valid JSON that is not an object are corruption, not empty state."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1', custom={'x': 1}))
+    h.docs[_shard_path('snap-1', 0)]['chunk'] = b'42'
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-1')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_malformed_state_patch_raises_data_loss() -> None:
+    """A segment whose statePatch fails to parse names the corrupt doc via DATA_LOSS."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+    await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
+    await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
+    h.docs[_snap_path('snap-a')]['statePatch'] = json.dumps([{'op': 'bogus-op', 'path': '/n'}])
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-a')
+    assert exc_info.value.status == 'DATA_LOSS'
+    assert 'statePatch' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_array_state_patch_names_field() -> None:
+    """Pre-fix array statePatch is DATA_LOSS naming the field and JSON string expectation."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+    await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
+    await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
+    h.docs[_snap_path('snap-a')]['statePatch'] = [{'op': 'replace', 'path': '/n', 'value': 1}]
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-a')
+    assert exc_info.value.status == 'DATA_LOSS'
+    msg = str(exc_info.value)
+    assert 'statePatch' in msg and 'JSON string' in msg and 'found list' in msg
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_null_state_patch_is_data_loss() -> None:
+    """Null/empty/missing statePatch on a diff segment is DATA_LOSS, not a silent []."""
+    from genkit_google_cloud.session_store.firestore import _decode_state_patch
+
+    with pytest.raises(GenkitError) as e_none:
+        _decode_state_patch(None, snapshot_id='snap-a')
+    assert e_none.value.status == 'DATA_LOSS'
+    assert 'statePatch' in str(e_none.value) and 'missing or empty' in str(e_none.value)
+    assert 're-create' in str(e_none.value)
+
+    with pytest.raises(GenkitError) as e_empty:
+        _decode_state_patch('', snapshot_id='snap-a')
+    assert e_empty.value.status == 'DATA_LOSS' and 'missing or empty' in str(e_empty.value)
+
+    assert _decode_state_patch('[]', snapshot_id='snap-a') == []
+
+    with pytest.raises(GenkitError) as e_bad:
+        _decode_state_patch('{', snapshot_id='snap-a')
+    assert 'unparseable' in str(e_bad.value)
+
+    with pytest.raises(GenkitError) as e_obj:
+        _decode_state_patch('{"a":1}', snapshot_id='snap-a')
+    assert 'not a patch array' in str(e_obj.value)
+
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+    await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
+    await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
+    h.docs[_snap_path('snap-a')]['statePatch'] = None
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-a')
+    assert exc_info.value.status == 'DATA_LOSS'
+    assert 'missing or empty' in str(exc_info.value)
+
+    # Legitimate zero-change turn: encoder writes "[]", reconstruct equals parent.
+    h.docs[_snap_path('snap-a')]['statePatch'] = '[]'
+    got = await store.get_snapshot(snapshot_id='snap-a')
+    assert got is not None and got.state is not None
+    assert got.state.custom == {'n': 0}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_unparseable_pointer_read_raises_data_loss() -> None:
+    """On reads, a pointer doc that fails validation is a corrupt index, not a missing session."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1'))
+    h.docs[_pointer_path('sess-1')] = {'currentSnapshotId': 'snap-1'}  # no segmentPath: invalid
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(session_id='sess-1')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_unparseable_pointer_write_self_heals() -> None:
+    """On writes, a corrupt pointer is rewritten wholesale so the session stays writable."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1'))
+    h.docs[_pointer_path('sess-1')] = {'currentSnapshotId': 'snap-1'}  # invalid shape
+
+    def beat(existing: SessionSnapshot | None) -> SessionSnapshot | None:
+        assert existing is not None
+        return existing.model_copy(update={'heartbeat_at': '2026-07-03T00:00:05Z'})
+
+    await store.save_snapshot('snap-1', beat)
+    pointer = h.docs[_pointer_path('sess-1')]
+    assert pointer['currentSnapshotId'] == 'snap-1'
+    assert pointer['segmentPath'] == []
+    loaded = await store.get_snapshot(session_id='sess-1')
+    assert loaded is not None
+    assert loaded.snapshot_id == 'snap-1'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_deleted_diff_leaf_is_not_found_via_both_paths() -> None:
+    """A wholly deleted diff leaf is None via session lookup AND by id — never DATA_LOSS.
+
+    The pointer fast path discovers the deletion as a missing *final* segment;
+    that segment is the target itself, so it must match by-id not-found
+    semantics, not the broken-chain rule for interior segments.
+    """
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25)
+    await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
+    await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
+    del h.docs[_snap_path('snap-a')]  # TTL ate the leaf; pointer still names it
+
+    assert await store.get_snapshot(session_id='sess-1') is None
+    assert await store.get_snapshot(snapshot_id='snap-a') is None
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_watch_uses_sync_client_despite_async_stub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Watches must always attach via the sync client, never the async ref.
+
+    Real AsyncDocumentReference exposes an ``on_snapshot`` stub whose body is
+    ``raise NotImplementedError``; a fake ref that mirrors it must not derail
+    the watch onto the async path. Regression for the real-backend bug where
+    every subscription died with NotImplementedError (originally caused by
+    dispatching on ``hasattr(ref, 'on_snapshot')``).
+    """
+    h = FakeStoreHarness()
+    store = h.store()
+    watches, captured_cb = _wire_sync_watch(store)
+
+    orig_snapshot_ref = store._snapshot_ref
+
+    def trapped_snapshot_ref(snapshot_id: str, prefix: str) -> Any:  # noqa: ANN401
+        ref = orig_snapshot_ref(snapshot_id, prefix)
+        # Mirror the real library: the async ref HAS on_snapshot, but it raises.
+        ref.on_snapshot = cast(Any, MagicMock(side_effect=NotImplementedError))
+        return ref
+
+    monkeypatch.setattr(store, '_snapshot_ref', trapped_snapshot_ref)
+    assert hasattr(store._snapshot_ref('snap-w', 'global'), 'on_snapshot')  # the trap is armed
+
+    _stream = await store.on_snapshot_status_change('snap-w')
+    assert all(s.queue.empty() for s in store._subscriptions)
+    assert len(captured_cb) == 1  # watch attached via the SYNC client
+    assert len(store._subscriptions) == 1
+    (sub,) = store._subscriptions
+    assert sub.watch is watches[0]
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_retry_exhaustion_raises_typed_aborted() -> None:
+    """Contention beyond transaction_max_attempts surfaces as GenkitError ABORTED."""
+    h = FakeStoreHarness()
+    store = h.store()
+    h.transaction._max_attempts = 2
+    h.commit_aborts_remaining = 5
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('snap-1', _mk('snap-1'))
+    assert exc_info.value.status == 'ABORTED'
+    assert 'injected abort' in str(exc_info.value)  # the final Aborted's text, verbatim
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_payload_limit_raises_typed_invalid_argument() -> None:
+    """A Firestore InvalidArgument (e.g. ~10 MiB txn payload) is wrapped with a hint."""
+    h = FakeStoreHarness()
+    store = h.store()
+    h.commit_raises = google_exceptions.InvalidArgument('maximum entity size exceeded')
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('snap-1', _mk('snap-1'))
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'maximum entity size exceeded' in str(exc_info.value)  # server text verbatim
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_transaction_max_attempts_plumbed_and_validated() -> None:
+    """The retry knob reaches client.transaction() and rejects nonsense values."""
+    h = FakeStoreHarness()
+    store = h.store(transaction_max_attempts=7)
+    await store.save_snapshot('snap-1', _mk('snap-1'))
+    assert h.client.transaction.call_args.kwargs.get('max_attempts') == 7
+
+    with pytest.raises(GenkitError) as exc_info:
+        h.store(transaction_max_attempts=0)
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_maps_other_google_errors_mechanically() -> None:
+    """Any GoogleAPICallError maps 1:1 by class with the server message preserved."""
+    h = FakeStoreHarness()
+    store = h.store()
+    h.commit_raises = google_exceptions.DeadlineExceeded('deadline of 60.0s exceeded')
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('snap-1', _mk('snap-1'))
+    assert exc_info.value.status == 'DEADLINE_EXCEEDED'
+    assert 'deadline of 60.0s exceeded' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_non_google_errors_pass_through_untouched() -> None:
+    """Fail-open: a plain ValueError from the mutation fn is not mistranslated."""
+    h = FakeStoreHarness()
+    store = h.store()
+
+    def bad_fn(_existing: SessionSnapshot | None) -> SessionSnapshot | None:
+        raise ValueError('user code exploded')
+
+    with pytest.raises(ValueError, match='user code exploded'):
+        await store.save_snapshot('snap-1', bad_fn)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_masked_rollback_valueerror_raises_typed_aborted() -> None:
+    """The library's no-transaction-ID ValueError (unchained; original error masked) maps to ABORTED.
+
+    Observed on real Firestore under hot-pointer contention: a failure before
+    the transaction obtains an ID triggers rollback, which raises this bare
+    ValueError and destroys the root cause. Regression for the C-01 raw leak.
+    """
+    h = FakeStoreHarness()
+    store = h.store()
+    h.commit_raises = ValueError('The transaction has no transaction ID, so it cannot be rolled back.')
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('snap-1', _mk('snap-1'))
+    assert exc_info.value.status == 'ABORTED'
+    assert 'no transaction ID' in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    'bad_id',
+    ['a/b', 'a/b/c', '.', '..', '', '__id__'],
+)
+@pytest.mark.asyncio
+async def test_firestore_session_store_rejects_path_structured_ids(bad_id: str) -> None:
+    """Ids that Firestore would parse as path structure fail typed, at every entrypoint.
+
+    Regression for W-08: odd-segment ids leaked a raw client ValueError; even
+    segment ids silently addressed a deeper document and left a zombie watch.
+    """
+    h = FakeStoreHarness()
+    store = h.store()
+
+    with pytest.raises(GenkitError) as e1:
+        await store.save_snapshot(bad_id, _mk('snap-x'))
+    assert e1.value.status == 'INVALID_ARGUMENT'
+
+    with pytest.raises(GenkitError) as e2:
+        await store.get_snapshot(snapshot_id=bad_id)
+    assert e2.value.status == 'INVALID_ARGUMENT'
+
+    with pytest.raises(GenkitError) as e3:
+        await store.get_snapshot(session_id=bad_id)
+    assert e3.value.status == 'INVALID_ARGUMENT'
+
+    with pytest.raises(GenkitError) as e4:
+        await store._read_snapshot(bad_id, prefix='global')
+    assert e4.value.status == 'INVALID_ARGUMENT'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_subscribe_rejects_bad_id_with_no_partial_state() -> None:
+    """Subscribe validation fires before ANY registration: no queue, no watch, no zombie."""
+    h = FakeStoreHarness()
+    store = h.store()
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.on_snapshot_status_change('a/b/c')
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'a/b/c' not in store._subscriptions
+    assert len(store._subscriptions) == 0
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_terminal_status_change_raises_failed_precondition() -> None:
+    """Terminal statuses are absorbing: ABORTED can never become COMPLETED.
+
+    Deliberately stricter than JS (which orders writes with a lock but permits
+    the overwrite); an aborted run silently becoming completed misrepresents
+    what happened, and no subscriber can ever observe the second transition.
+    """
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.ABORTED,
+            state=SessionState(session_id='sess-1'),
+        ),
+    )
+
+    def complete(existing: SessionSnapshot | None) -> SessionSnapshot:
+        assert existing is not None
+        return existing.model_copy(update={'status': SnapshotStatus.COMPLETED})
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('snap-1', complete)
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert h.docs[_snap_path('snap-1')]['status'] == 'aborted'  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_terminal_resurrection_raises_failed_precondition() -> None:
+    """COMPLETED cannot be resurrected to PENDING either — same absorbing rule."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1'))  # completed
+
+    def resurrect(existing: SessionSnapshot | None) -> SessionSnapshot:
+        assert existing is not None
+        return existing.model_copy(update={'status': SnapshotStatus.PENDING})
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('snap-1', resurrect)
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_same_terminal_status_rewrite_allowed() -> None:
+    """Rewriting a finished snapshot without changing its status stays legal."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1', custom={'n': 1}))  # completed
+
+    def annotate(existing: SessionSnapshot | None) -> SessionSnapshot:
+        assert existing is not None
+        return existing.model_copy(
+            update={'state': SessionState(session_id='sess-1', custom={'n': 1, 'note': 'post-hoc'})}
+        )
+
+    saved = await store.save_snapshot('snap-1', annotate)
+    assert saved is not None
+    loaded = await store.get_snapshot(snapshot_id='snap-1')
+    assert loaded is not None and loaded.state is not None
+    assert loaded.state.custom == {'n': 1, 'note': 'post-hoc'}
+    assert h.docs[_snap_path('snap-1')]['status'] == 'completed'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_invalid_prefix_raises_before_any_path() -> None:
+    """B1: snapshot_path_prefix is the tenant boundary; a path-structured prefix is rejected everywhere."""
+    h = FakeStoreHarness()
+    store = h.store(snapshot_path_prefix=lambda _ctx: 'ten/ant')
+
+    for call in (
+        store.save_snapshot('snap-1', _mk('snap-1')),
+        store.get_snapshot(snapshot_id='snap-1'),
+        store.get_snapshot(session_id='sess-1'),
+        store.on_snapshot_status_change('snap-1'),
+    ):
+        with pytest.raises(GenkitError) as exc_info:
+            await call
+        assert exc_info.value.status == 'INVALID_ARGUMENT'
+        assert 'snapshot_path_prefix' in str(exc_info.value)
+    assert len(store._subscriptions) == 0
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_mutator_supplied_path_ids_rejected() -> None:
+    """B1: session_id/parent_id coming back FROM the mutator are held to the same rules."""
+    h = FakeStoreHarness()
+    store = h.store()
+
+    def bad_session(_e: SessionSnapshot | None) -> SessionSnapshot:
+        return SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='a/b',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.COMPLETED,
+            state=SessionState(session_id='a/b'),
+        )
+
+    with pytest.raises(GenkitError) as e1:
+        await store.save_snapshot('snap-1', bad_session)
+    assert e1.value.status == 'INVALID_ARGUMENT' and 'session_id' in str(e1.value)
+
+    def bad_parent(_e: SessionSnapshot | None) -> SessionSnapshot:
+        return SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            parent_id='x/y',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.COMPLETED,
+            state=SessionState(session_id='sess-1'),
+        )
+
+    with pytest.raises(GenkitError) as e2:
+        await store.save_snapshot('snap-1', bad_parent)
+    assert e2.value.status == 'INVALID_ARGUMENT' and 'parent_id' in str(e2.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_empty_current_snapshot_id_is_data_loss() -> None:
+    """A pointer that exists but names nothing is corrupt, not not-found."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1'))
+    pointer = h.docs[_pointer_path('sess-1')]
+    pointer['currentSnapshotId'] = ''
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(session_id='sess-1')
+    assert exc_info.value.status == 'DATA_LOSS'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_subscribe_context_kwarg_selects_tenant() -> None:
+    """N11: explicit context= reaches the watch path (ambient context stays the default)."""
+    h = FakeStoreHarness()
+    store = h.store(snapshot_path_prefix=lambda ctx: (ctx or {}).get('tenant', 'global'))
+    _watches, captured_cb = _wire_sync_watch(store)
+
+    _stream = await store.on_snapshot_status_change('snap-w', context={'tenant': 't9'})
+    assert all(s.queue.empty() for s in store._subscriptions)
+    assert len(captured_cb) == 1
+    sync_mock = cast(Any, store.client)._to_sync_copy.return_value
+    sync_mock.collection.return_value.document.assert_any_call('t9')
+
+
+@pytest.mark.parametrize('terminal', [SnapshotStatus.EXPIRED, SnapshotStatus.FAILED])
+@pytest.mark.asyncio
+async def test_firestore_session_store_all_terminal_statuses_are_absorbing(terminal: SnapshotStatus) -> None:
+    """R4-High: EXPIRED and FAILED are absorbing too, not just ABORTED/COMPLETED."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=terminal,
+            state=SessionState(session_id='sess-1'),
+        ),
+    )
+
+    def complete(existing: SessionSnapshot | None) -> SessionSnapshot:
+        assert existing is not None
+        return existing.model_copy(update={'status': SnapshotStatus.COMPLETED})
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('snap-1', complete)
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_read_paths_plumb_transaction_max_attempts() -> None:
+    """R4-High: the retry knob reaches read-only transactions too."""
+    h = FakeStoreHarness()
+    store = h.store(transaction_max_attempts=9)
+    await store.save_snapshot('snap-1', _mk('snap-1'))
+    await store.get_snapshot(snapshot_id='snap-1')
+    ro_calls = [c for c in h.client.transaction.call_args_list if c.kwargs.get('read_only')]
+    assert ro_calls, 'expected a read-only transaction'
+    assert all(c.kwargs.get('max_attempts') == 9 for c in ro_calls)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_promotion_then_prune_cleans_orphan_shards() -> None:
+    """R4-High: a diff promoted to checkpoint, then shrunk, deletes its stale shards."""
+    h = FakeStoreHarness()
+    store = h.store(checkpoint_interval=25, shard_size=120)
+    await store.save_snapshot('snap-root', _mk('snap-root', None, custom={'n': 0}))
+    # Child whose patch exceeds shard_size -> promoted to a multi-shard checkpoint.
+    await store.save_snapshot('snap-big', _mk('snap-big', 'snap-root', custom={'blob': 'X' * 500}))
+    shards_before = [k for k in h.docs if '/shards/' in k and 'snap-big' in k]
+    assert len(shards_before) > 1  # promotion happened, multi-shard
+
+    def shrink(existing: SessionSnapshot | None) -> SessionSnapshot:
+        assert existing is not None
+        return existing.model_copy(update={'state': SessionState(session_id='sess-1', custom={'n': 1})})
+
+    await store.save_snapshot('snap-big', shrink)
+    shards_after = [k for k in h.docs if '/shards/' in k and 'snap-big' in k]
+    assert len(shards_after) < len(shards_before)  # orphans pruned
+    loaded = await store.get_snapshot(snapshot_id='snap-big')
+    assert loaded is not None and loaded.state is not None
+    assert loaded.state.custom == {'n': 1}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_watch_isolation_across_tenants_same_snapshot_id() -> None:
+    """B1 regression: two tenants, one snapshot id — independent listeners, queues, teardown.
+
+    Pre-fix, subscriptions were keyed by snapshot_id alone: the second tenant
+    piggybacked on the first tenant's watch, statuses crossed tenants, and the
+    first terminal tore down both.
+    """
+    h = FakeStoreHarness()
+    store = h.store(snapshot_path_prefix=lambda ctx: (ctx or {}).get('tenant', 'global'))
+    watches, captured_cb = _wire_sync_watch(store)
+
+    q1 = await store.on_snapshot_status_change('snap-x', context={'tenant': 't1'})
+    stream_t2 = await store.on_snapshot_status_change('snap-x', context={'tenant': 't2'})
+
+    assert len(captured_cb) == 2  # one listener per tenant, not a shared one
+    assert len(store._subscriptions) == 2
+    assert len([s for s in store._subscriptions if s.watch is not None]) == 2
+
+    await store.save_snapshot('snap-x', _mk('snap-x'), context={'tenant': 't1'})
+    await _pump_watch(captured_cb, 0, _status_doc('snap-x', 'completed'))
+    assert await _next_status(q1) == SnapshotStatus.COMPLETED
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(anext(stream_t2), timeout=0.05)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_stream_survives_polling_timeout() -> None:
+    """A consumer polling with wait_for must not kill the subscription."""
+    h = FakeStoreHarness()
+    store = h.store()
+    watches, captured_cb = _wire_sync_watch(store)
+    stream = await store.on_snapshot_status_change('snap-poll')
+
+    for _ in range(2):
+        pull = asyncio.ensure_future(anext(stream))
+        await asyncio.sleep(0.05)
+        assert not pull.done()
+        pull.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await pull
+
+    await store.save_snapshot('snap-poll', _mk('snap-poll'))
+    await _pump_watch(captured_cb, 0, _status_doc('snap-poll', 'completed'))
+    final = asyncio.ensure_future(anext(stream))
+    for _ in range(200):
+        if final.done():
+            break
+        await asyncio.sleep(0.01)
+    assert final.done() and final.result() == SnapshotStatus.COMPLETED
+
+    store.close()
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()  # ended stays ended (latched)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_close_delivers_end_of_stream_locally() -> None:
+    """Wake-on-close: a consumer awaiting a queue gets the bare None marker."""
+    h = FakeStoreHarness()
+    store = h.store()
+    _wire_sync_watch(store)
+    q = await store.on_snapshot_status_change('snap-pending')
+
+    store.close()
+    assert await _stream_ended(q)  # bare EOS: ended without resolution
+    assert len(store._subscriptions) == 0
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_close_from_thread_wakes_waiters() -> None:
+    """close() from a foreign thread delivers the marker via the subscribers' loop."""
+    h = FakeStoreHarness()
+    store = h.store()
+    _wire_sync_watch(store)
+    q = await store.on_snapshot_status_change('snap-pending')
+
+    getter = asyncio.ensure_future(_stream_ended(q))
+    await asyncio.to_thread(store.close)
+    assert await asyncio.wait_for(getter, timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_close_after_terminal_adds_nothing() -> None:
+    """A stream already ended by a terminal status gets no second marker from close."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1'))  # completed
+    watches, captured_cb = _wire_sync_watch(store)
+    q = await store.on_snapshot_status_change('snap-1')
+    await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'completed'))
+    assert await _next_status(q) == SnapshotStatus.COMPLETED
+    assert await _stream_ended(q)
+
+    store.close()
+    assert await _stream_ended(q)  # exhausted stream stays ended; close adds nothing
+
+
+@pytest.mark.asyncio
+async def test_sibling_stores_accept_context_kwarg() -> None:
+    """B2: the widened protocol signature is honored by non-tenant stores too."""
+    from genkit._ai._agents._session_stores._inmemory_store import InMemorySessionStore
+
+    mem = InMemorySessionStore()
+    statuses = await mem.on_snapshot_status_change('snap-x', context={'tenant': 't1'})
+    assert hasattr(statuses, '__anext__')  # accepted and ignored, no error
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_subscribe_after_close_raises() -> None:
+    """Subscribing to an already-closed store is a typed error, not a zombie stream."""
+    h = FakeStoreHarness()
+    store = h.store()
+    store.close()
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.on_snapshot_status_change('snap-x')
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert 'closed' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_prefix_failure_never_surfaces_after_commit() -> None:
+    """A failing prefix function fails BEFORE the transaction, never after it.
+
+    Pre-fix, save re-invoked the prefix function after commit for the
+    subscriber notification; a function that failed on that call turned a
+    durably committed write into a raised (and raw) exception.
+    """
+    # Commit-aware tripwire: the prefix function itself asserts it is never
+    # invoked after the transaction has committed.
+    h = FakeStoreHarness()
+
+    def commit_aware_prefix(_ctx: Any) -> str:  # noqa: ANN401
+        assert h.commit_attempts == 0, 'prefix function invoked AFTER commit'
+        return 'global'
+
+    store = h.store(snapshot_path_prefix=commit_aware_prefix)
+    saved = await store.save_snapshot('snap-1', _mk('snap-1'))  # must NOT raise
+    assert saved is not None
+    assert any('snap-1' in k for k in h.docs)
+
+    # And a prefix that fails immediately fails before anything is written.
+    h2 = FakeStoreHarness()
+    store2 = h2.store(snapshot_path_prefix=lambda _c: (_ for _ in ()).throw(KeyError('down')))
+    with pytest.raises(KeyError):
+        await store2.save_snapshot('snap-1', _mk('snap-1'))
+    assert not any('snap-1' in k for k in h2.docs)  # nothing committed
+
+
+def _owned_snap(sid: str, session: str, parent: str = '', custom: dict | None = None) -> Any:  # noqa: ANN401
+    def fn(_e: SessionSnapshot | None) -> SessionSnapshot:
+        return SessionSnapshot(
+            snapshot_id=sid,
+            session_id=session,
+            parent_id=parent,
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.COMPLETED,
+            state=SessionState(session_id=session, custom=custom or {}),
+        )
+
+    return fn
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_snapshot_id_collision_across_sessions_rejected() -> None:
+    """Snapshot ids share one namespace per prefix; a foreign session cannot rewrite one.
+
+    Pre-guard, session B saving 'turn-1' silently overwrote session A's
+    'turn-1': A's descendants then reconstructed against B's state — silent
+    cross-session data corruption and leakage with no error anywhere.
+    """
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('turn-1', _owned_snap('turn-1', 'sess-A', custom={'secret': 'alpha'}))
+    await store.save_snapshot('turn-2', _owned_snap('turn-2', 'sess-A', 'turn-1', custom={'secret': 'alpha', 'n': 2}))
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('turn-1', _owned_snap('turn-1', 'sess-B'))
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert 'sess-A' in str(exc_info.value) and 'sess-B' in str(exc_info.value)
+
+    a2 = await store.get_snapshot(snapshot_id='turn-2')  # A's chain intact
+    assert a2 is not None and a2.state is not None
+    assert a2.state.custom == {'secret': 'alpha', 'n': 2}
+
+
+@pytest.mark.asyncio
+async def test_inmemory_store_snapshot_id_collision_rejected_too() -> None:
+    """The ownership guard lives in shared apply_save: every Python store enforces it."""
+    from genkit._ai._agents._session_stores._inmemory_store import InMemorySessionStore
+
+    mem = InMemorySessionStore()
+    await mem.save_snapshot('turn-1', _owned_snap('turn-1', 'sess-A'))
+    with pytest.raises(GenkitError) as exc_info:
+        await mem.save_snapshot('turn-1', _owned_snap('turn-1', 'sess-B'))
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_cross_session_parent_rejected() -> None:
+    """A new snapshot cannot anchor its diff chain to another session's snapshot."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('a-root', _owned_snap('a-root', 'sess-A', custom={'n': 1}))
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('b-child', _owned_snap('b-child', 'sess-B', parent='a-root'))
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert 'owned by' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_pointer_to_foreign_session_is_data_loss() -> None:
+    """A pointer resolving to another session's snapshot is a corrupt index, not an answer."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('a-1', _owned_snap('a-1', 'sess-A'))
+    await store.save_snapshot('b-1', _owned_snap('b-1', 'sess-B'))
+    # Corrupt sess-A's pointer to name sess-B's snapshot (simulates legacy damage).
+    h.docs[_pointer_path('sess-A')] = dict(h.docs[_pointer_path('sess-B')])
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(session_id='sess-A')
+    assert exc_info.value.status == 'DATA_LOSS'
+    assert 'sess-B' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_interior_state_rewrite_rejected() -> None:
+    """Rewriting an interior snapshot's state would corrupt descendant diffs."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('parent', _mk('parent', custom={'secret': 'alpha'}))
+    await store.save_snapshot('child', _mk('child', parent='parent', custom={'secret': 'alpha', 'n': 2}))
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot(
+            'parent',
+            lambda existing: (
+                existing.model_copy(update={'state': SessionState(session_id='sess-1', custom={'secret': 'MUTATED'})})
+                if existing
+                else None
+            ),
+        )
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert 'not session' in str(exc_info.value) and 'current snapshot' in str(exc_info.value)
+    assert 'branch' in str(exc_info.value)
+
+    child = await store.get_snapshot(snapshot_id='child')
+    assert child is not None and child.state is not None
+    assert child.state.custom == {'secret': 'alpha', 'n': 2}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_interior_heartbeat_still_allowed() -> None:
+    """Metadata-only rewrites on an interior snapshot must not break the child."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('parent', _mk('parent', custom={'secret': 'alpha'}))
+    await store.save_snapshot('child', _mk('child', parent='parent', custom={'secret': 'alpha', 'n': 2}))
+    before = await store.get_snapshot(snapshot_id='child')
+    assert before is not None and before.state is not None
+    before_custom = dict(before.state.custom)
+
+    saved = await store.save_snapshot(
+        'parent',
+        lambda existing: existing.model_copy(update={'heartbeat_at': '2026-07-03T00:00:09Z'}) if existing else None,
+    )
+    assert saved is not None
+    assert saved.heartbeat_at == '2026-07-03T00:00:09Z'
+
+    after = await store.get_snapshot(snapshot_id='child')
+    assert after is not None and after.state is not None
+    assert after.state.custom == before_custom == {'secret': 'alpha', 'n': 2}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_parent_id_immutable_on_upsert() -> None:
+    """An upsert cannot re-parent an existing snapshot."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('root-a', _mk('root-a', custom={'n': 1}))
+    await store.save_snapshot('root-b', _mk('root-b', custom={'n': 2}))
+    await store.save_snapshot('leaf', _mk('leaf', parent='root-a', custom={'n': 3}))
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot(
+            'leaf',
+            lambda existing: existing.model_copy(update={'parent_id': 'root-b'}) if existing else None,
+        )
+    assert exc_info.value.status == 'FAILED_PRECONDITION'
+    assert "parent_id is immutable ('root-a' -> 'root-b')" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_tip_state_rewrite_still_allowed() -> None:
+    """The tip remains writable: heartbeats/finalize that change state still succeed."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('parent', _mk('parent', custom={'n': 1}))
+    await store.save_snapshot(
+        'tip',
+        lambda _e: SessionSnapshot(
+            snapshot_id='tip',
+            parent_id='parent',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:01Z',
+            status=SnapshotStatus.PENDING,
+            state=SessionState(session_id='sess-1', custom={'n': 2}),
+        ),
+    )
+
+    saved = await store.save_snapshot(
+        'tip',
+        lambda existing: (
+            existing.model_copy(
+                update={
+                    'status': SnapshotStatus.COMPLETED,
+                    'state': SessionState(session_id='sess-1', custom={'n': 3}),
+                }
+            )
+            if existing
+            else None
+        ),
+    )
+    assert saved is not None
+    assert saved.status == SnapshotStatus.COMPLETED
+    loaded = await store.get_snapshot(snapshot_id='tip')
+    assert loaded is not None and loaded.state is not None
+    assert loaded.state.custom == {'n': 3}
+
+
+def test_firestore_session_store_rejects_zero_shard_size() -> None:
+    """shard_size=0 is a typed INVALID_ARGUMENT, not ZeroDivisionError later."""
+    h = FakeStoreHarness()
+    with pytest.raises(GenkitError) as exc_info:
+        h.store(shard_size=0)
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'shard_size' in str(exc_info.value)
+
+
+def test_firestore_session_store_config_frozen_after_init() -> None:
+    """collection/shard_size/checkpoint_interval/attempts cannot be reassigned."""
+    h = FakeStoreHarness()
+    store = h.store()
+    for attr in ('collection', 'shard_size', 'checkpoint_interval', 'transaction_max_attempts'):
+        with pytest.raises(GenkitError) as exc_info:
+            setattr(store, attr, 'other' if attr == 'collection' else 1)
+        assert exc_info.value.status == 'FAILED_PRECONDITION'
+        assert 'new store instance' in str(exc_info.value)
+    assert h.store(collection='custom-col', shard_size=2048).collection == 'custom-col'
+
+
+def test_firestore_session_store_rejects_bad_collection_name() -> None:
+    """Collection is a path segment; empty or '/' is INVALID_ARGUMENT at construction."""
+    h = FakeStoreHarness()
+    with pytest.raises(GenkitError) as exc_info:
+        h.store(collection='bad/name')
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'collection' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_deep_nested_diff_round_trips() -> None:
+    """Deep nested custom state survives as a JSON-string diff (not a map nesting error)."""
+    h = FakeStoreHarness()
+    store = h.store()
+    nested: Any = 'leaf'
+    for _ in range(25):
+        nested = {'n': nested}
+    await store.save_snapshot('root', _mk('root', custom={'n': 0}))
+    await store.save_snapshot('deep', _mk('deep', parent='root', custom={'tree': nested}))
+    assert isinstance(h.docs[_snap_path('deep')]['statePatch'], str)
+    loaded = await store.get_snapshot(snapshot_id='deep')
+    assert loaded is not None and loaded.state is not None
+    assert loaded.state.custom == {'tree': nested}
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_zero_checkpoint_shard_count_is_data_loss() -> None:
+    """checkpointShardCount < 1 is corruption, not an empty state."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1', custom={'x': 1}))
+    h.docs[_snap_path('snap-1')]['checkpointShardCount'] = 0
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-1')
+    assert exc_info.value.status == 'DATA_LOSS'
+    assert 'invalid snapshot document' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_subscribe_tolerates_missing_shards() -> None:
+    """Status subscribe reads the snapshot doc only; missing shards do not DATA_LOSS the watch."""
+    h = FakeStoreHarness()
+    store = h.store()
+    watches, captured_cb = _wire_sync_watch(store)
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.PENDING,
+            state=SessionState(session_id='sess-1', custom={'x': 1}),
+        ),
+    )
+    del h.docs[_shard_path('snap-1', 0)]
+
+    stream = await store.on_snapshot_status_change('snap-1')
+    await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'pending'))
+    assert await _next_status(stream) == SnapshotStatus.PENDING
+    assert len(store._subscriptions) == 1
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_mutator_valueerror_propagates_verbatim() -> None:
+    """App ValueError from a mutator must not be misclassified as retryable ABORTED."""
+    h = FakeStoreHarness()
+    store = h.store()
+
+    def boom(_existing: SessionSnapshot | None) -> SessionSnapshot:
+        raise ValueError('no transaction ID')
+
+    with pytest.raises(ValueError, match='no transaction ID') as exc_info:
+        await store.save_snapshot('snap-1', boom)
+    assert not isinstance(exc_info.value, GenkitError)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_maps_retry_error_cause() -> None:
+    """RetryError unwraps to its GoogleAPICallError cause when present."""
+    h = FakeStoreHarness()
+    store = h.store()
+    h.commit_raises = google_exceptions.RetryError(
+        'deadline',
+        google_exceptions.DeadlineExceeded('deadline of 60.0s exceeded'),
+    )
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('snap-1', _mk('snap-1'))
+    assert exc_info.value.status == 'DEADLINE_EXCEEDED'
+    assert 'deadline of 60.0s exceeded' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_rejects_unstorable_state() -> None:
+    """Circular / non-JSON state fails as INVALID_ARGUMENT, not a raw encoder error."""
+    h = FakeStoreHarness()
+    store = h.store()
+    cyclic: dict[str, Any] = {}
+    cyclic['self'] = cyclic
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot(
+            'snap-1',
+            lambda _e: SessionSnapshot(
+                snapshot_id='snap-1',
+                session_id='sess-1',
+                created_at='2026-07-03T00:00:00Z',
+                status=SnapshotStatus.COMPLETED,
+                state=SessionState(session_id='sess-1', custom=cyclic),
+            ),
+        )
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'not storable' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_rejects_lone_surrogate_state() -> None:
+    """Lone surrogates in session state are rejected as not storable."""
+    h = FakeStoreHarness()
+    store = h.store()
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot(
+            'snap-1',
+            lambda _e: SessionSnapshot(
+                snapshot_id='snap-1',
+                session_id='sess-1',
+                created_at='2026-07-03T00:00:00Z',
+                status=SnapshotStatus.COMPLETED,
+                state=SessionState(session_id='sess-1', custom={'bad': '\ud800'}),
+            ),
+        )
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'not storable' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_corrupt_shard_json_is_data_loss() -> None:
+    """Unparseable checkpoint shard bytes surface as DATA_LOSS."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1', custom={'x': 1}))
+    h.docs[_shard_path('snap-1', 0)] = {'chunk': b'not-json{'}
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.get_snapshot(snapshot_id='snap-1')
+    assert exc_info.value.status == 'DATA_LOSS'
+    assert 'corrupt' in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_async_mutator_rejected() -> None:
+    """Async save mutators are a typed INVALID_ARGUMENT, not a hung coroutine."""
+    h = FakeStoreHarness()
+    store = h.store()
+
+    async def bad(_existing: SessionSnapshot | None) -> SessionSnapshot:
+        return SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.COMPLETED,
+            state=SessionState(session_id='sess-1'),
+        )
+
+    with pytest.raises(GenkitError) as exc_info:
+        await store.save_snapshot('snap-1', bad)  # type: ignore[arg-type]
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'synchronous' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_rejects_whitespace_ids() -> None:
+    """Leading/trailing whitespace in ids is INVALID_ARGUMENT on save and get."""
+    h = FakeStoreHarness()
+    store = h.store()
+
+    with pytest.raises(GenkitError) as e1:
+        await store.save_snapshot(' snap-1 ', _mk('snap-1'))
+    assert e1.value.status == 'INVALID_ARGUMENT'
+    assert 'whitespace' in str(e1.value)
+
+    with pytest.raises(GenkitError) as e2:
+        await store.get_snapshot(snapshot_id=' snap-1 ')
+    assert e2.value.status == 'INVALID_ARGUMENT'
+    assert 'whitespace' in str(e2.value)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_aclose_tears_down_subscription() -> None:
+    """Closing a stream drops its queue and stops the watch when it was the last consumer."""
+    h = FakeStoreHarness()
+    store = h.store()
+    watches, _captured = _wire_sync_watch(store)
+    stream = await store.on_snapshot_status_change('snap-1')
+    assert len(store._subscriptions) == 1
+    assert all(s.watch is not None for s in store._subscriptions)
+
+    await stream.aclose()  # type: ignore[attr-defined]
+    assert len(store._subscriptions) == 0
+    watches[0].unsubscribe.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_aclose_keeps_watch_while_others_remain() -> None:
+    """Closing one stream unsubscribes only its watch; siblings keep theirs."""
+    h = FakeStoreHarness()
+    store = h.store()
+    watches, _captured = _wire_sync_watch(store)
+    first = await store.on_snapshot_status_change('snap-1')
+    second = await store.on_snapshot_status_change('snap-1')
+    assert len(store._subscriptions) == 2
+
+    await first.aclose()  # type: ignore[attr-defined]
+    assert len(store._subscriptions) == 1
+    watches[0].unsubscribe.assert_called_once()
+    watches[1].unsubscribe.assert_not_called()
+
+    await second.aclose()  # type: ignore[attr-defined]
+    assert len(store._subscriptions) == 0
+    watches[1].unsubscribe.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_aclose_after_terminal_is_idempotent() -> None:
+    """aclose after a terminal teardown is a no-op, not an error."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1'))
+    watches, captured_cb = _wire_sync_watch(store)
+    stream = await store.on_snapshot_status_change('snap-1')
+    await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'completed'))
+    assert await _next_status(stream) == SnapshotStatus.COMPLETED
+    assert await _stream_ended(stream)
+    await stream.aclose()  # type: ignore[attr-defined]
+    await stream.aclose()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_async_with_break_tears_down() -> None:
+    """async with + break is the blessed early-exit shape and releases the watch."""
+    h = FakeStoreHarness()
+    store = h.store()
+    watches, captured_cb = _wire_sync_watch(store)
+    await store.save_snapshot(
+        'snap-1',
+        lambda _e: SessionSnapshot(
+            snapshot_id='snap-1',
+            session_id='sess-1',
+            created_at='2026-07-03T00:00:00Z',
+            status=SnapshotStatus.PENDING,
+            state=SessionState(session_id='sess-1'),
+        ),
+    )
+    stream = await store.on_snapshot_status_change('snap-1')
+    await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'pending'))
+    async with stream:  # type: ignore[attr-defined]
+        async for _status in stream:
+            break
+    assert len(store._subscriptions) == 0
+    watches[0].unsubscribe.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_lock_is_private() -> None:
+    """The subscriber lock is private; SessionStore no longer advertises lock."""
+    h = FakeStoreHarness()
+    store = h.store()
+    assert isinstance(store._lock, asyncio.Lock)
+    assert not hasattr(store, 'lock')
+    # Structural SessionStore surface still present (Protocol is not runtime_checkable).
+    assert callable(store.get_snapshot) and callable(store.save_snapshot)
+
+
+def _pending_mk(sid: str) -> Any:  # noqa: ANN401
+    return lambda _e: SessionSnapshot(
+        snapshot_id=sid,
+        session_id='sess-1',
+        created_at='2026-07-03T00:00:00Z',
+        status=SnapshotStatus.PENDING,
+        state=SessionState(session_id='sess-1'),
+    )
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_close_unsubscribes_inline_normally() -> None:
+    """Normal close() unsubscribes the watch once on the calling thread."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _pending_mk('snap-1'))
+    watches, captured_cb = _wire_sync_watch(store)
+    calls: list[threading.Thread] = []
+
+    def unsubscribe() -> None:
+        calls.append(threading.current_thread())
+
+    stream = await store.on_snapshot_status_change('snap-1')
+    watches[0].unsubscribe.side_effect = unsubscribe
+    assert len(store._subscriptions) == 1
+    await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'pending'))
+    assert await stream.__anext__() == SnapshotStatus.PENDING
+    store.close()
+    assert len(calls) == 1
+    assert calls[0] is threading.current_thread()
+    assert len(store._subscriptions) == 0
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_close_from_listener_thread_retries_off_thread() -> None:
+    """close() on the watch listener thread finishes unsubscribe on a helper thread."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _pending_mk('snap-1'))
+
+    listener = threading.current_thread()
+    unsub_threads: list[threading.Thread] = []
+    done = threading.Event()
+
+    class FakeConsumer:
+        _thread = listener
+
+    watches, captured_cb = _wire_sync_watch(store)
+
+    stream = await store.on_snapshot_status_change('snap-1')
+    watches[0]._consumer = FakeConsumer()
+
+    def unsubscribe() -> None:
+        unsub_threads.append(threading.current_thread())
+        done.set()
+
+    watches[0].unsubscribe.side_effect = unsubscribe
+    assert len(store._subscriptions) == 1
+    await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'pending'))
+    assert await stream.__anext__() == SnapshotStatus.PENDING
+    store.close()
+    assert done.wait(timeout=2.0)
+    assert unsub_threads and all(t is not listener for t in unsub_threads)
+    assert len(store._subscriptions) == 0
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_watch_dedupes_repeated_status() -> None:
+    """A watch replay of the same status yields one event, not duplicates."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _pending_mk('snap-1'))
+    watches, captured = _wire_sync_watch(store)
+    stream = await store.on_snapshot_status_change('snap-1')
+    pending = _status_doc('snap-1', 'pending')
+    await _pump_watch(captured, 0, pending)
+    assert await stream.__anext__() == SnapshotStatus.PENDING
+    await _pump_watch(captured, 0, pending)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(stream.__anext__(), timeout=0.05)
+    await _pump_watch(captured, 0, _status_doc('snap-1', 'completed'))
+    assert await stream.__anext__() == SnapshotStatus.COMPLETED
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()
+    watches[0].unsubscribe.assert_called_once()
+
+
+def test_firestore_session_store_subscribe_works_after_prior_loop_dies() -> None:
+    """After a notebook-style asyncio.run cell, a new loop can subscribe cleanly."""
+    h = FakeStoreHarness()
+    store = h.store()
+    errors: list[BaseException] = []
+
+    def run_first() -> None:
+        async def body() -> None:
+            await store.save_snapshot('snap-1', _pending_mk('snap-1'))
+            _wire_sync_watch(store)
+            await store.on_snapshot_status_change('snap-1')
+
+        try:
+            asyncio.run(body())
+        except BaseException as e:
+            errors.append(e)
+
+    t = threading.Thread(target=run_first)
+    t.start()
+    t.join(timeout=5.0)
+    assert not t.is_alive()
+    assert errors == []
+
+    async def second() -> None:
+        store.sync_client = None
+        _wire_sync_watch(store)
+        stream = await store.on_snapshot_status_change('snap-1')
+        assert len(store._subscriptions) == 1
+        await stream.aclose()
+
+    asyncio.run(second())
+
+
+def test_firestore_session_store_new_loop_prunes_dead_watch_and_starts_fresh() -> None:
+    """A later loop prunes the dead loop's watch and starts its own listener."""
+    h = FakeStoreHarness()
+    store = h.store()
+    unsub_calls: list[int] = []
+
+    def run_first() -> None:
+        async def body() -> None:
+            await store.save_snapshot('snap-1', _pending_mk('snap-1'))
+            watches, _ = _wire_sync_watch(store)
+            await store.on_snapshot_status_change('snap-1')
+
+            def track_unsub() -> None:
+                unsub_calls.append(1)
+
+            watches[0].unsubscribe.side_effect = track_unsub
+            # Notebook pattern: cell ends without aclose.
+
+        asyncio.run(body())
+
+    t = threading.Thread(target=run_first)
+    t.start()
+    t.join(timeout=5.0)
+    assert not t.is_alive()
+
+    got_completed = False
+
+    async def second() -> None:
+        nonlocal got_completed
+        # Drop the loop-A-derived sync client so the harness mock rebinds.
+        store.sync_client = None
+        watches2, captured2 = _wire_sync_watch(store)
+        stream = await store.on_snapshot_status_change('snap-1')
+        assert len(store._subscriptions) == 1
+        assert len(captured2) == 1, 'new loop must start a fresh watch'
+        assert unsub_calls, 'dead loop watch must be unsubscribed on prune'
+        await _pump_watch(captured2, 0, _status_doc('snap-1', 'pending'))
+        assert await stream.__anext__() == SnapshotStatus.PENDING
+
+        await _pump_watch(captured2, 0, _status_doc('snap-1', 'completed'))
+        assert await stream.__anext__() == SnapshotStatus.COMPLETED
+        got_completed = True
+        with pytest.raises(StopAsyncIteration):
+            await stream.__anext__()
+
+    asyncio.run(second())
+    assert got_completed
+
+
+def test_firestore_session_store_two_live_loops_have_independent_subscriptions() -> None:
+    """App loop + Dev UI loop can each subscribe on the same store instance."""
+    h = FakeStoreHarness()
+    store = h.store()
+    ready = threading.Event()
+    release = threading.Event()
+    errors: list[BaseException] = []
+    loop_a_got: list[SnapshotStatus] = []
+
+    def hold_loop() -> None:
+        async def body() -> None:
+            await store.save_snapshot('snap-1', _pending_mk('snap-1'))
+            _watches, captured = _wire_sync_watch(store)
+            stream = await store.on_snapshot_status_change('snap-1')
+            await _pump_watch(captured, 0, _status_doc('snap-1', 'pending'))
+            loop_a_got.append(await stream.__anext__())
+            ready.set()
+            await asyncio.get_running_loop().run_in_executor(None, release.wait)
+            await stream.aclose()
+
+        try:
+            asyncio.run(body())
+        except BaseException as e:
+            errors.append(e)
+
+    t = threading.Thread(target=hold_loop)
+    t.start()
+    assert ready.wait(timeout=5.0)
+
+    async def other() -> None:
+        store.sync_client = None
+        _watches, captured = _wire_sync_watch(store)
+        stream = await store.on_snapshot_status_change('snap-1')
+        await _pump_watch(captured, 0, _status_doc('snap-1', 'pending'))
+        assert await stream.__anext__() == SnapshotStatus.PENDING
+        assert len(store._subscriptions) == 1
+        await stream.aclose()
+
+    try:
+        asyncio.run(other())
+    finally:
+        release.set()
+        t.join(timeout=5.0)
+    assert errors == []
+    assert loop_a_got == [SnapshotStatus.PENDING]
+
+
+def test_firestore_session_store_clients_are_loop_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provided async client binds to the first loop; later loops get a clone + own sync."""
+    clones: list[MagicMock] = []
+
+    def fake_async_client(**kwargs: Any) -> MagicMock:  # noqa: ANN401
+        m = MagicMock(name=f'async-clone-{len(clones)}')
+        m.project = kwargs['project']
+        m._database = kwargs.get('database')
+        m._to_sync_copy = MagicMock(return_value=MagicMock(name=f'sync-clone-{len(clones)}'))
+        clones.append(m)
+        return m
+
+    monkeypatch.setattr(
+        'genkit_google_cloud.session_store.firestore.firestore.AsyncClient',
+        fake_async_client,
+    )
+
+    provided = MagicMock(name='async-provided')
+    provided.project = 'proj-a'
+    provided._database = 'db-a'
+    provided._credentials = object()
+    provided._to_sync_copy = MagicMock(return_value=MagicMock(name='sync-provided'))
+
+    store = FirestoreSessionStore(client=provided)
+    ready = threading.Event()
+    release = threading.Event()
+    clients_a: list[Any] = []
+    syncs_a: list[Any] = []
+    clients_b: list[Any] = []
+    syncs_b: list[Any] = []
+
+    def hold_loop() -> None:
+        async def body() -> None:
+            clients_a.append(store.client)
+            syncs_a.append(store._ensure_sync_client())
+            ready.set()
+            await asyncio.get_running_loop().run_in_executor(None, release.wait)
+
+        asyncio.run(body())
+
+    t = threading.Thread(target=hold_loop)
+    t.start()
+    assert ready.wait(timeout=5.0)
+
+    async def other() -> None:
+        clients_b.append(store.client)
+        syncs_b.append(store._ensure_sync_client())
+
+    try:
+        asyncio.run(other())
+    finally:
+        release.set()
+        t.join(timeout=5.0)
+
+    assert clients_a == [provided]
+    assert clients_b and clients_b[0] is not provided
+    assert clients_b[0] in clones
+    assert syncs_a and syncs_b and syncs_a[0] is not syncs_b[0]
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_prefix_captured_before_awaits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mutating context mid-save cannot split snapshot/shards/pointer across tenants."""
+    h = FakeStoreHarness()
+    ctx: dict[str, Any] = {'tenant': 't-orig'}
+    store = h.store(snapshot_path_prefix=lambda c: (c or {}).get('tenant', 'global'))
+
+    gate = asyncio.Event()
+    inside = asyncio.Event()
+    real_reconstruct = store._reconstruct
+    seen: list[str] = []
+
+    async def gated_reconstruct(transaction: Any, snapshot_id: str, *, prefix: str) -> Any:  # noqa: ANN401
+        seen.append(prefix)
+        if len(seen) == 1:
+            inside.set()
+            await gate.wait()
+            ctx['tenant'] = 't-mutated'
+        return await real_reconstruct(transaction, snapshot_id, prefix=prefix)
+
+    monkeypatch.setattr(store, '_reconstruct', gated_reconstruct)
+
+    task = asyncio.create_task(store.save_snapshot('snap-1', _mk('snap-1', custom={'n': 1}), context=ctx))
+    await inside.wait()
+    assert ctx['tenant'] == 't-orig'  # not yet mutated
+    gate.set()
+    saved = await task
+    assert saved is not None
+    assert seen[0] == 't-orig'
+    assert _snap_path('snap-1', prefix='t-orig') in h.docs
+    assert _pointer_path('sess-1', prefix='t-orig') in h.docs
+    assert _shard_path('snap-1', 0, prefix='t-orig') in h.docs
+    assert not any('/t-mutated/' in path for path in h.docs)
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_no_context_defaults_to_global_prefix() -> None:
+    """Context-free apps keep writing under the default ``global`` prefix."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _mk('snap-1'))
+    assert _snap_path('snap-1', prefix='global') in h.docs
+    assert _pointer_path('sess-1', prefix='global') in h.docs
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_ambient_context_shared_across_ops() -> None:
+    """get/save/subscribe with no context= all honor the ambient action context."""
+    from genkit._core._action import _action_context
+
+    h = FakeStoreHarness()
+    store = h.store(snapshot_path_prefix=lambda c: (c or {}).get('tenant', 'global'))
+    _watches, captured_cb = _wire_sync_watch(store)
+    token = _action_context.set({'tenant': 'ambient-t'})
+    try:
+        await store.save_snapshot(
+            'snap-1',
+            lambda _e: SessionSnapshot(
+                snapshot_id='snap-1',
+                session_id='sess-1',
+                created_at='2026-07-03T00:00:00Z',
+                status=SnapshotStatus.PENDING,
+                state=SessionState(session_id='sess-1'),
+            ),
+        )
+        loaded = await store.get_snapshot(snapshot_id='snap-1')
+        stream = await store.on_snapshot_status_change('snap-1')
+        assert len(store._subscriptions) == 1
+        await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'pending'))
+        assert await _next_status(stream) == SnapshotStatus.PENDING
+    finally:
+        _action_context.reset(token)
+
+    assert loaded is not None and loaded.snapshot_id == 'snap-1'
+    assert _snap_path('snap-1', prefix='ambient-t') in h.docs
+    assert _snap_path('snap-1', prefix='global') not in h.docs
+
+
+@pytest.mark.asyncio
+async def test_firestore_session_store_status_observed_via_watch_not_save() -> None:
+    """Status streams only advance when the Firestore watch fires, not on save."""
+    h = FakeStoreHarness()
+    store = h.store()
+    await store.save_snapshot('snap-1', _pending_mk('snap-1'))
+    watches, captured_cb = _wire_sync_watch(store)
+    stream = await store.on_snapshot_status_change('snap-1')
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(stream.__anext__(), timeout=0.05)
+
+    def to_completed(_e: SessionSnapshot | None) -> SessionSnapshot:
+        base = _pending_mk('snap-1')(_e)
+        return base.model_copy(update={'status': SnapshotStatus.COMPLETED})
+
+    await store.save_snapshot('snap-1', to_completed)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(stream.__anext__(), timeout=0.05)
+
+    await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'completed'))
+    assert await stream.__anext__() == SnapshotStatus.COMPLETED
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()
+    watches[0].unsubscribe.assert_called_once()

--- a/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
+++ b/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
@@ -88,7 +88,15 @@ class FakeStoreHarness:
         self.transaction._write_pbs = []
         self.transaction._id = b'fake-txn'
         self.transaction._in_progress = False
-        self.client.transaction.return_value = self.transaction
+
+        def _transaction(**kwargs: Any) -> MagicMock:
+            # Mirror AsyncClient.transaction(max_attempts=...): the store passes
+            # its public transaction_max_attempts into the SDK txn object.
+            if 'max_attempts' in kwargs:
+                self.transaction._max_attempts = kwargs['max_attempts']
+            return self.transaction
+
+        self.client.transaction.side_effect = _transaction
 
         def clean_up() -> None:
             self.transaction._write_pbs = []
@@ -343,7 +351,11 @@ async def test_firestore_session_store_checkpoint_interval_promotes() -> None:
             state=SessionState(session_id='sess-1', custom={'n': 2}),
         ),
     )
-    # segmentPath length for snap-2 is 1; next child would be length 2 >= interval → checkpoint
+    # Under interval=2, snap-2 is still a diff (path length 1); the next child promotes.
+    second = h.docs[_snap_path('snap-2')]
+    assert second['kind'] == 'diff'
+    assert second['segmentPath'] == ['snap-2']
+
     await store.save_snapshot(
         'snap-3',
         lambda _e: SessionSnapshot(
@@ -360,6 +372,9 @@ async def test_firestore_session_store_checkpoint_interval_promotes() -> None:
     assert third['checkpointId'] == 'snap-3'
     assert third['segmentPath'] == []
     assert _shard_path('snap-3', 0) in h.docs
+    loaded = await store.get_snapshot(snapshot_id='snap-3')
+    assert loaded is not None and loaded.state is not None
+    assert loaded.state.custom == {'n': 3}
 
 
 @pytest.mark.asyncio
@@ -531,21 +546,6 @@ async def test_firestore_session_store_missing_pointer_returns_none() -> None:
     assert by_id is not None
     assert by_id.snapshot_id == 'snap-1'
     assert _pointer_path('sess-unpointed') not in h.docs
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_dangling_pointer_returns_none() -> None:
-    """Pointer to a missing leaf: session lookup is None (a miss), not DATA_LOSS."""
-    h = FakeStoreHarness()
-    # Omit checkpoint meta so lookup falls through to snapshot-id reconstruct
-    # (None), not DATA_LOSS from missing shards.
-    h.docs[_pointer_path('sess-corrupt')] = {
-        'currentSnapshotId': 'snap-deleted',
-        'segmentPath': [],
-    }
-
-    store = h.store()
-    assert await store.get_snapshot(session_id='sess-corrupt') is None
 
 
 @pytest.mark.asyncio
@@ -727,15 +727,31 @@ async def test_firestore_session_store_close_stops_watches_and_sync_client() -> 
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_close_does_not_close_injected_sync_client() -> None:
-    """Caller-owned sync_client stays open after close(), even if watches used it."""
+    """Caller-owned sync_client stays open after close(); watches still unsubscribe."""
     h = FakeStoreHarness()
     injected = MagicMock()
+    watches: list[MagicMock] = []
+
+    def on_snapshot_side_effect(cb: Any) -> Any:  # noqa: ANN401
+        watch_mock = MagicMock()
+        watches.append(watch_mock)
+        return watch_mock
+
+    # Wire watches on the injected client itself — store won't call _to_sync_copy.
+    mock_sync_doc_ref = MagicMock()
+    mock_sync_doc_ref.on_snapshot.side_effect = on_snapshot_side_effect
+    mock_sync_col = MagicMock()
+    mock_sync_col.document.return_value = mock_sync_doc_ref
+    mock_sync_doc_ref.collection.return_value = mock_sync_col
+    injected.collection.return_value = mock_sync_col
+
     store = h.store(sync_client=injected)
-    _wire_sync_watch(store)
     await store.on_snapshot_status_change('snap-close')
     assert store.sync_client is injected
     store.close()
+    watches[0].unsubscribe.assert_called_once()
     injected.close.assert_not_called()
+    assert store.sync_client is injected
 
 
 def _by_user(context: dict[str, Any] | None = None) -> str:
@@ -908,7 +924,7 @@ async def test_firestore_session_store_resave_diff_leaf_refreshes_state() -> Non
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_resave_oversized_diff_promotes_to_checkpoint() -> None:
-    """Re-saving a child with oversized state stores it as a checkpoint."""
+    """Re-saving a diff leaf whose patch exceeds shard_size promotes it to a checkpoint."""
     h = FakeStoreHarness()
     store = h.store(shard_size=64, checkpoint_interval=25)
 
@@ -965,6 +981,12 @@ async def test_firestore_session_store_missing_snapshot_subscribe_waits_for_crea
 
     q2 = await store.on_snapshot_status_change('missing')
     assert len(captured_cb) == 2
+
+    # exists=False watch events must not end the stream or tear down the watch.
+    missing = MagicMock()
+    missing.exists = False
+    await _pump_watch(captured_cb, 0, missing)
+    await _pump_watch(captured_cb, 1, missing)
     watches[0].unsubscribe.assert_not_called()
     watches[1].unsubscribe.assert_not_called()
 
@@ -1412,12 +1434,12 @@ async def test_firestore_session_store_non_object_shard_state_raises_data_loss()
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_malformed_state_patch_raises_data_loss() -> None:
-    """A segment whose statePatch fails to parse surfaces as DATA_LOSS."""
+    """A segment whose statePatch is not valid JSON surfaces as DATA_LOSS."""
     h = FakeStoreHarness()
     store = h.store(checkpoint_interval=25)
     await store.save_snapshot('snap-root', _mk('snap-root', custom={'n': 0}))
     await store.save_snapshot('snap-a', _mk('snap-a', 'snap-root', custom={'n': 1}))
-    h.docs[_snap_path('snap-a')]['statePatch'] = json.dumps([{'op': 'bogus-op', 'path': '/n'}])
+    h.docs[_snap_path('snap-a')]['statePatch'] = '{not-json'
 
     with pytest.raises(GenkitError) as exc_info:
         await store.get_snapshot(snapshot_id='snap-a')
@@ -1548,8 +1570,7 @@ async def test_firestore_session_store_watch_uses_sync_client_despite_async_stub
 async def test_firestore_session_store_retry_exhaustion_raises_aborted() -> None:
     """Contention beyond transaction_max_attempts surfaces as GenkitError ABORTED."""
     h = FakeStoreHarness()
-    store = h.store()
-    h.transaction._max_attempts = 2
+    store = h.store(transaction_max_attempts=2)
     h.commit_aborts_remaining = 5
 
     with pytest.raises(GenkitError) as exc_info:
@@ -1805,10 +1826,13 @@ async def test_firestore_session_store_subscribe_context_kwarg_selects_tenant() 
     await stream.aclose()
 
 
-@pytest.mark.parametrize('terminal', [SnapshotStatus.EXPIRED, SnapshotStatus.FAILED])
 @pytest.mark.asyncio
-async def test_firestore_session_store_expired_and_failed_are_absorbing(terminal: SnapshotStatus) -> None:
-    """EXPIRED and FAILED are absorbing too, not only ABORTED/COMPLETED."""
+async def test_firestore_session_store_failed_is_absorbing() -> None:
+    """FAILED is absorbing too, not only ABORTED/COMPLETED.
+
+    ``expired`` is a read-time heartbeat overlay and is never written to the
+    store, so it is not part of this persist-path contract.
+    """
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot(
@@ -1817,7 +1841,7 @@ async def test_firestore_session_store_expired_and_failed_are_absorbing(terminal
             snapshot_id='snap-1',
             session_id='sess-1',
             created_at='2026-07-03T00:00:00Z',
-            status=terminal,
+            status=SnapshotStatus.FAILED,
             state=SessionState(session_id='sess-1'),
         ),
     )
@@ -1829,7 +1853,7 @@ async def test_firestore_session_store_expired_and_failed_are_absorbing(terminal
     with pytest.raises(GenkitError) as exc_info:
         await store.save_snapshot('snap-1', complete)
     assert exc_info.value.status == 'FAILED_PRECONDITION'
-    assert h.docs[_snap_path('snap-1')]['status'] == terminal.value
+    assert h.docs[_snap_path('snap-1')]['status'] == SnapshotStatus.FAILED.value
 
 
 @pytest.mark.asyncio
@@ -1885,22 +1909,6 @@ async def test_firestore_session_store_close_from_thread_wakes_waiters() -> None
     getter = asyncio.ensure_future(_stream_ended(q))
     await asyncio.to_thread(store.close)
     assert await asyncio.wait_for(getter, timeout=2)
-
-
-@pytest.mark.asyncio
-async def test_firestore_session_store_close_after_terminal_is_noop() -> None:
-    """close() after a terminal-ended stream does not emit another event."""
-    h = FakeStoreHarness()
-    store = h.store()
-    await store.save_snapshot('snap-1', _mk('snap-1'))  # completed
-    watches, captured_cb = _wire_sync_watch(store)
-    q = await store.on_snapshot_status_change('snap-1')
-    await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'completed'))
-    assert await _next_status(q) == SnapshotStatus.COMPLETED
-    assert await _stream_ended(q)
-
-    store.close()
-    assert await _stream_ended(q)
 
 
 @pytest.mark.asyncio
@@ -2048,7 +2056,11 @@ async def test_firestore_session_store_interior_heartbeat_still_allowed() -> Non
         lambda existing: existing.model_copy(update={'heartbeat_at': '2026-07-03T00:00:09Z'}) if existing else None,
     )
     assert saved is not None
-    assert saved.heartbeat_at == '2026-07-03T00:00:09Z'
+    parent = await store.get_snapshot(snapshot_id='parent')
+    assert parent is not None and parent.heartbeat_at == '2026-07-03T00:00:09Z'
+
+    tip = await store.get_snapshot(session_id='sess-1')
+    assert tip is not None and tip.snapshot_id == 'child'
 
     after = await store.get_snapshot(snapshot_id='child')
     assert after is not None and after.state is not None
@@ -2075,7 +2087,7 @@ async def test_firestore_session_store_parent_id_immutable_on_upsert() -> None:
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_tip_state_rewrite_still_allowed() -> None:
-    """The tip (leaf, no descendants) may rewrite state — contrast interior_state_rewrite_rejected."""
+    """The session tip (pointer-current snapshot) may rewrite state — contrast interior_state_rewrite_rejected."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot('parent', _mk('parent', custom={'n': 1}))
@@ -2340,7 +2352,7 @@ async def test_firestore_session_store_aclose_keeps_watch_while_others_remain() 
 
 @pytest.mark.asyncio
 async def test_firestore_session_store_aclose_after_terminal_is_idempotent() -> None:
-    """aclose after a terminal teardown is a no-op, not an error."""
+    """aclose after terminal watch teardown does not unsubscribe again or raise."""
     h = FakeStoreHarness()
     store = h.store()
     await store.save_snapshot('snap-1', _mk('snap-1'))
@@ -2348,9 +2360,12 @@ async def test_firestore_session_store_aclose_after_terminal_is_idempotent() -> 
     stream = await store.on_snapshot_status_change('snap-1')
     await _pump_watch(captured_cb, 0, _status_doc('snap-1', 'completed'))
     assert await _next_status(stream) == SnapshotStatus.COMPLETED
-    assert await _stream_ended(stream)
+    # Wait for terminal cleanup to unsubscribe; don't drain EOS first (that acloses).
+    for _ in range(50):
+        if watches[0].unsubscribe.called:
+            break
+        await asyncio.sleep(0.01)
     watches[0].unsubscribe.assert_called_once()
-    assert len(store._subscriptions) == 0
     await stream.aclose()  # type: ignore[attr-defined]
     await stream.aclose()  # type: ignore[attr-defined]
     watches[0].unsubscribe.assert_called_once()
@@ -2499,11 +2514,7 @@ def test_firestore_session_store_new_loop_prunes_dead_watch_and_starts_fresh() -
 
 
 def test_firestore_session_store_two_live_loops_have_independent_subscriptions() -> None:
-    """App loop + Dev UI loop can each subscribe on the same store instance.
-
-    Subscriptions are loop-local, so each loop's ``_subscriptions`` view shows
-    only its own entries (len==1 here), not a shared global list.
-    """
+    """App loop + Dev UI loop can each subscribe on the same store and receive status independently."""
     h = FakeStoreHarness()
     store = h.store()
     ready = threading.Event()
@@ -2536,7 +2547,6 @@ def test_firestore_session_store_two_live_loops_have_independent_subscriptions()
         stream = await store.on_snapshot_status_change('snap-1')
         await _pump_watch(captured, 0, _status_doc('snap-1', 'pending'))
         assert await stream.__anext__() == SnapshotStatus.PENDING
-        assert len(store._subscriptions) == 1
         await stream.aclose()
 
     try:

--- a/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
+++ b/py/packages/genkit-google-cloud/tests/firestore_session_store_test.py
@@ -2666,8 +2666,8 @@ async def test_firestore_session_store_no_context_defaults_to_global_prefix() ->
 
 
 @pytest.mark.asyncio
-async def test_firestore_session_store_ambient_context_shared_across_ops() -> None:
-    """get/save with no context= honor the ambient action context for path prefix."""
+async def test_firestore_session_store_omitted_context_ignores_ambient_action_context() -> None:
+    """Omitting context= does not read ambient action context (callers must pass it)."""
     from genkit._core._action import _action_context
 
     h = FakeStoreHarness()
@@ -2689,8 +2689,8 @@ async def test_firestore_session_store_ambient_context_shared_across_ops() -> No
         _action_context.reset(token)
 
     assert loaded is not None and loaded.snapshot_id == 'snap-1'
-    assert _snap_path('snap-1', prefix='ambient-t') in h.docs
-    assert _snap_path('snap-1', prefix='global') not in h.docs
+    assert _snap_path('snap-1', prefix='global') in h.docs
+    assert _snap_path('snap-1', prefix='ambient-t') not in h.docs
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-middleware/src/genkit_middleware/_retry.py
+++ b/py/packages/genkit-middleware/src/genkit_middleware/_retry.py
@@ -18,9 +18,9 @@
 
 from __future__ import annotations
 
-import asyncio
 import math
 import random
+from asyncio import sleep
 from collections.abc import Awaitable, Callable
 
 from pydantic import BaseModel, Field
@@ -82,7 +82,7 @@ class Retry(BaseMiddleware[RetryConfig]):
                 # The provider delay is a floor within max_delay_ms, never an override of it.
                 delay_ms = min(delay_ms, self.config.max_delay_ms)
 
-                await asyncio.sleep(delay_ms / 1000.0)
+                await sleep(delay_ms / 1000.0)
                 current_delay_ms = min(current_delay_ms * self.config.backoff_factor, self.config.max_delay_ms)
 
         raise AssertionError('Retry loop exited without returning or raising')  # noqa: EM101

--- a/py/packages/genkit-middleware/tests/retry_test.py
+++ b/py/packages/genkit-middleware/tests/retry_test.py
@@ -140,7 +140,7 @@ async def test_retry_after_is_delay_floor(ctx: GenerateMiddlewareContext) -> Non
             )
         return ModelResponse(message=None)
 
-    with patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep:
+    with patch('genkit_middleware._retry.sleep', new_callable=AsyncMock) as sleep:
         result = await retry.wrap_model(_make_params(), ctx, next_fn)
 
     assert result is not None
@@ -166,7 +166,7 @@ async def test_local_delay_wins_when_larger_than_retry_after(ctx: GenerateMiddle
             )
         return ModelResponse(message=None)
 
-    with patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep:
+    with patch('genkit_middleware._retry.sleep', new_callable=AsyncMock) as sleep:
         result = await retry.wrap_model(_make_params(), ctx, next_fn)
 
     assert result is not None
@@ -192,7 +192,7 @@ async def test_zero_retry_after_preserves_local_delay(ctx: GenerateMiddlewareCon
             )
         return ModelResponse(message=None)
 
-    with patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep:
+    with patch('genkit_middleware._retry.sleep', new_callable=AsyncMock) as sleep:
         result = await retry.wrap_model(_make_params(), ctx, next_fn)
 
     assert result is not None
@@ -220,7 +220,7 @@ async def test_retry_after_floor_is_applied_before_jitter(ctx: GenerateMiddlewar
 
     with (
         patch('genkit_middleware._retry.random.random', return_value=0.5),
-        patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep,
+        patch('genkit_middleware._retry.sleep', new_callable=AsyncMock) as sleep,
     ):
         result = await retry.wrap_model(_make_params(), ctx, next_fn)
 
@@ -247,7 +247,7 @@ async def test_retry_after_is_capped_by_max_delay(ctx: GenerateMiddlewareContext
             )
         return ModelResponse(message=None)
 
-    with patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep:
+    with patch('genkit_middleware._retry.sleep', new_callable=AsyncMock) as sleep:
         result = await retry.wrap_model(_make_params(), ctx, next_fn)
 
     assert result is not None
@@ -279,7 +279,7 @@ async def test_small_retry_after_preserves_local_delay_cap(
 
     with (
         patch('genkit_middleware._retry.random.random', return_value=0.5),
-        patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep,
+        patch('genkit_middleware._retry.sleep', new_callable=AsyncMock) as sleep,
     ):
         result = await retry.wrap_model(_make_params(), ctx, next_fn)
 
@@ -305,7 +305,7 @@ async def test_retry_does_not_retry_unauthenticated_error(ctx: GenerateMiddlewar
         )
 
     with (
-        patch('genkit_middleware._retry.asyncio.sleep', new_callable=AsyncMock) as sleep,
+        patch('genkit_middleware._retry.sleep', new_callable=AsyncMock) as sleep,
         pytest.raises(GenkitError),
     ):
         await retry.wrap_model(_make_params(), ctx, next_fn)

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1191,9 +1191,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "asgiref" },
-    { name = "sqlparse" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "asgiref", marker = "python_full_version < '3.12'" },
+    { name = "sqlparse", marker = "python_full_version < '3.12'" },
+    { name = "tzdata", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
 wheels = [
@@ -1210,9 +1210,9 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "asgiref" },
-    { name = "sqlparse" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "asgiref", marker = "python_full_version >= '3.12'" },
+    { name = "sqlparse", marker = "python_full_version >= '3.12'" },
+    { name = "tzdata", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f1/bf85f0d29ef76abf901f193fe8fef4769d3da7794197832bc30151c071d8/django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269", size = 10924131, upload-time = "2026-05-05T13:54:39.329Z" }
 wheels = [
@@ -1374,7 +1374,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1725,6 +1725,7 @@ version = "0.9.0"
 source = { editable = "packages/genkit-google-cloud" }
 dependencies = [
     { name = "genkit" },
+    { name = "google-cloud-firestore" },
     { name = "google-cloud-logging" },
     { name = "opentelemetry-exporter-gcp-monitoring" },
     { name = "opentelemetry-exporter-gcp-trace" },
@@ -1734,6 +1735,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
+    { name = "google-cloud-firestore", specifier = ">=2.14.0" },
     { name = "google-cloud-logging", specifier = ">=3.10.0" },
     { name = "opentelemetry-exporter-gcp-monitoring", specifier = ">=1.9.0" },
     { name = "opentelemetry-exporter-gcp-trace", specifier = ">=1.9.0" },
@@ -2801,17 +2803,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/61/1810830e8b93c72dcd3c0f150c80a00c3deb229562d9423807ec92c3a539/ipython-8.38.0.tar.gz", hash = "sha256:9cfea8c903ce0867cc2f23199ed8545eb741f3a69420bfcf3743ad1cec856d39", size = 5513996, upload-time = "2026-01-05T10:59:06.901Z" }
 wheels = [
@@ -2829,17 +2831,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/ce/012a0f40ca58a966f87a6e894d6828e2817657cbdf522b02a5d3a87d92ce/ipython-9.0.2.tar.gz", hash = "sha256:ec7b479e3e5656bf4f58c652c120494df1820f4f28f522fb7ca09e213c2aab52", size = 4366102, upload-time = "2025-03-08T15:04:52.885Z" }
 wheels = [
@@ -2851,7 +2853,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -2979,7 +2981,7 @@ name = "jinxed"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon" },
+    { name = "ansicon", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981, upload-time = "2024-07-31T22:39:18.854Z" }
 wheels = [
@@ -6372,8 +6374,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup" },
-    { name = "typing-extensions" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Adds a durable FirestoreSessionStore in `genkit-google-cloud` built on top of the refactored core SessionStore protocol (#6028).