### PR TITLE
feat(py/plugins/google-genai): Vertex AI multi-region support and per-request location override

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/constants.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/constants.py
@@ -20,5 +20,43 @@ This module defines constants used throughout the Vertex AI plugin,
 including environment variable names and configuration values.
 """
 
+from typing import TypeGuard
+
 GCLOUD_PROJECT = 'GCLOUD_PROJECT'
+GOOGLE_CLOUD_PROJECT = 'GOOGLE_CLOUD_PROJECT'
+GOOGLE_CLOUD_LOCATION = 'GOOGLE_CLOUD_LOCATION'
+GCLOUD_LOCATION = 'GCLOUD_LOCATION'
 DEFAULT_REGION = 'us-central1'
+
+MULTI_REGIONAL_LOCATIONS = ('us', 'eu')
+
+GLOBAL_LOCATION = 'global'
+
+
+def is_multi_regional_location(location: str | None) -> TypeGuard[str]:
+    """Whether the location is a Vertex AI multi-region ('us' or 'eu')."""
+    return location in MULTI_REGIONAL_LOCATIONS
+
+
+def vertex_api_host(location: str) -> str:
+    """Vertex AI API host for a location.
+
+    Multi-regions are served from dedicated hosts
+    (``aiplatform.{location}.rep.googleapis.com``), 'global' from the bare
+    host, and regions from the ``{location}-aiplatform.googleapis.com``
+    pattern.
+    """
+    if location == GLOBAL_LOCATION:
+        return 'aiplatform.googleapis.com'
+    if is_multi_regional_location(location):
+        return f'aiplatform.{location}.rep.googleapis.com'
+    return f'{location}-aiplatform.googleapis.com'
+
+
+def multi_regional_base_url(location: str) -> str:
+    """Base URL for a Vertex AI multi-region endpoint.
+
+    No trailing slash, so the google-genai SDK's '.googleapis.com' suffix
+    checks recognize this as a Google host.
+    """
+    return f'https://{vertex_api_host(location)}'

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/evaluators/evaluation.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/evaluators/evaluation.py
@@ -73,6 +73,7 @@ from pydantic import BaseModel, ConfigDict
 from genkit import GenkitError
 from genkit.evaluator import BaseDataPoint, Details, EvalFnResponse, Score
 from genkit.plugin_api import GENKIT_CLIENT_HEADER, Action, get_cached_client
+from genkit_google_genai.constants import GLOBAL_LOCATION, is_multi_regional_location, vertex_api_host
 
 if TYPE_CHECKING:
     from genkit import Genkit as GenkitRegistry
@@ -162,6 +163,23 @@ class EvaluatorFactory:
         self.project_id = project_id
         self.location = location
 
+    def _api_host(self) -> str:
+        """Vertex AI host for the configured location.
+
+        The Vertex Evaluation Service is only served regionally, so
+        multi-region and global locations are rejected up front.
+
+        Raises:
+            GenkitError: If the location is a multi-region or 'global'.
+        """
+        if is_multi_regional_location(self.location) or self.location == GLOBAL_LOCATION:
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message=f"The Vertex Evaluation Service does not support the '{self.location}' "
+                'location. Configure a regional location (e.g. us-central1) to use evaluators.',
+            )
+        return vertex_api_host(self.location)
+
     async def evaluate_instances(self, request_body: dict[str, Any]) -> dict[str, Any]:
         """Call the Vertex AI evaluateInstances API.
 
@@ -175,7 +193,7 @@ class EvaluatorFactory:
             GenkitError: If the API call fails.
         """
         location_name = f'projects/{self.project_id}/locations/{self.location}'
-        url = f'https://{self.location}-aiplatform.googleapis.com/v1beta1/{location_name}:evaluateInstances'
+        url = f'https://{self._api_host()}/v1beta1/{location_name}:evaluateInstances'
 
         # Get authentication token
         # Use asyncio.to_thread to avoid blocking the event loop during token refresh

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -816,25 +816,31 @@ class VertexAI(Plugin):
 
         opts = _inject_attribution_headers(http_options, base_url, api_version)
         self._base_url_pinned = bool(opts.base_url)
-        if const.is_multi_regional_location(self._location):
-            if not self._base_url_pinned:
-                # Multi-regions ('us', 'eu') are served from dedicated endpoints
-                # that the google-genai SDK does not derive itself.
-                opts.base_url = const.multi_regional_base_url(self._location)
-            # With an explicit base_url the SDK skips its ADC project lookup,
-            # so the plugin must resolve the project itself.
-            if not self._project and credentials is not None:
+        multi_region = const.is_multi_regional_location(self._location)
+        if multi_region and not self._base_url_pinned:
+            # Multi-regions ('us', 'eu') are served from dedicated endpoints
+            # that the google-genai SDK does not derive itself.
+            opts.base_url = const.multi_regional_base_url(self._location)
+
+        # Resolve the project here rather than leaving it to the SDK: with any
+        # base_url set the SDK skips its own ADC lookup, evaluator registration
+        # needs a concrete project, and doing it now keeps the blocking ADC IO
+        # off the event loop. Express mode (api_key) needs no project, so it
+        # only pays for the probe where a multi-region demands one.
+        if not self._project and (api_key is None or multi_region):
+            if credentials is not None:
                 self._project = getattr(credentials, 'project_id', None)
             if not self._project:
                 try:
                     _, self._project = google_auth_default()
                 except DefaultCredentialsError:
                     self._project = None
-            if not self._project:
-                raise ValueError(
-                    'VertexAI plugin requires a project when using a multi-region location. '
-                    'Set the project parameter or GOOGLE_CLOUD_PROJECT environment variable.'
-                )
+
+        if multi_region and not self._project:
+            raise ValueError(
+                'VertexAI plugin requires a project when using a multi-region location. '
+                'Set the project parameter or GOOGLE_CLOUD_PROJECT environment variable.'
+            )
 
         self._client_kwargs: dict[str, Any] = {
             'vertexai': self._vertexai,

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -97,7 +97,9 @@ from collections.abc import Callable
 from typing import Any
 
 from google import genai
+from google.auth import default as google_auth_default
 from google.auth.credentials import Credentials
+from google.auth.exceptions import DefaultCredentialsError
 from google.genai.client import DebugConfig
 from google.genai.types import HttpOptions, HttpOptionsDict
 
@@ -447,6 +449,7 @@ class GoogleAI(Plugin):
             'debug_config': debug_config,
             'http_options': _inject_attribution_headers(http_options, base_url, api_version),
         }
+        self._base_url_pinned = bool(self._client_kwargs['http_options'].base_url)
         # Single loop-local client accessor used everywhere in plugin runtime paths.
         self._runtime_client = loop_local_client(lambda: genai.client.Client(**self._client_kwargs))
         self._list_actions_cache: list[ActionMetadata] | None = None
@@ -628,7 +631,12 @@ class GoogleAI(Plugin):
             if clean_name.lower().startswith('image'):
                 model = ImagenModel(clean_name, self._runtime_client())
             else:
-                model = GeminiModel(clean_name, self._runtime_client())
+                model = GeminiModel(
+                    clean_name,
+                    self._runtime_client(),
+                    client_kwargs=self._client_kwargs,
+                    base_url_pinned=self._base_url_pinned,
+                )
             return await model.generate(request, ctx)
 
         return Action(
@@ -769,7 +777,7 @@ class VertexAI(Plugin):
         self,
         credentials: Credentials | None = None,
         project: str | None = None,
-        location: str | None = 'us-central1',
+        location: str | None = None,
         debug_config: DebugConfig | None = None,
         http_options: HttpOptions | HttpOptionsDict | None = None,
         api_key: str | None = None,
@@ -783,7 +791,10 @@ class VertexAI(Plugin):
                 Defaults to None, in which case the client uses default authentication
                 mechanisms (e.g., application default credentials or API key).
             project: Name of the Google Cloud project.
-            location: Location of the Google Cloud project.
+            location: Location of the Google Cloud project. Accepts regions
+                (e.g. 'us-central1'), multi-regions ('us', 'eu'), or 'global'.
+                Falls back to the GOOGLE_CLOUD_LOCATION or GCLOUD_LOCATION
+                environment variable, then 'us-central1'.
             debug_config: Configuration for debugging the client. Defaults to None.
             http_options: HTTP options for configuring the client's network requests.
                 Can be an instance of HttpOptions or a dictionary. Defaults to None.
@@ -793,10 +804,37 @@ class VertexAI(Plugin):
             api_version: The API version to use. Defaults to None.
             base_url: The base URL for the API. Defaults to None.
         """
-        # Store project and location on the plugin for reranker resolution.
-        # This avoids reaching into client internals.
-        self._project = project if project else os.getenv(const.GCLOUD_PROJECT)
-        self._location = location if location else const.DEFAULT_REGION
+        # Store project and location on the plugin for evaluator registration
+        # and multi-region routing. This avoids reaching into client internals.
+        self._project = project or os.getenv(const.GCLOUD_PROJECT) or os.getenv(const.GOOGLE_CLOUD_PROJECT)
+        self._location = (
+            location
+            or os.getenv(const.GOOGLE_CLOUD_LOCATION)
+            or os.getenv(const.GCLOUD_LOCATION)
+            or const.DEFAULT_REGION
+        )
+
+        opts = _inject_attribution_headers(http_options, base_url, api_version)
+        self._base_url_pinned = bool(opts.base_url)
+        if const.is_multi_regional_location(self._location):
+            if not self._base_url_pinned:
+                # Multi-regions ('us', 'eu') are served from dedicated endpoints
+                # that the google-genai SDK does not derive itself.
+                opts.base_url = const.multi_regional_base_url(self._location)
+            # With an explicit base_url the SDK skips its ADC project lookup,
+            # so the plugin must resolve the project itself.
+            if not self._project and credentials is not None:
+                self._project = getattr(credentials, 'project_id', None)
+            if not self._project:
+                try:
+                    _, self._project = google_auth_default()
+                except DefaultCredentialsError:
+                    self._project = None
+            if not self._project:
+                raise ValueError(
+                    'VertexAI plugin requires a project when using a multi-region location. '
+                    'Set the project parameter or GOOGLE_CLOUD_PROJECT environment variable.'
+                )
 
         self._client_kwargs: dict[str, Any] = {
             'vertexai': self._vertexai,
@@ -805,7 +843,7 @@ class VertexAI(Plugin):
             'project': self._project,
             'location': self._location,
             'debug_config': debug_config,
-            'http_options': _inject_attribution_headers(http_options, base_url, api_version),
+            'http_options': opts,
         }
         # Single loop-local client accessor used everywhere in plugin runtime paths.
         self._runtime_client = loop_local_client(lambda: genai.client.Client(**self._client_kwargs))
@@ -964,13 +1002,23 @@ class VertexAI(Plugin):
 
         async def _run(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
             if is_tuned_gemini_name(clean_name):
-                model = GeminiModel(clean_name, self._runtime_client())
+                model = GeminiModel(
+                    clean_name,
+                    self._runtime_client(),
+                    client_kwargs=self._client_kwargs,
+                    base_url_pinned=self._base_url_pinned,
+                )
             elif clean_name.lower().startswith('image'):
                 model = ImagenModel(clean_name, self._runtime_client())
             elif is_veo_model(clean_name):
                 model = VeoModel(clean_name, self._runtime_client())
             else:
-                model = GeminiModel(clean_name, self._runtime_client())
+                model = GeminiModel(
+                    clean_name,
+                    self._runtime_client(),
+                    client_kwargs=self._client_kwargs,
+                    base_url_pinned=self._base_url_pinned,
+                )
             return await model.generate(request, ctx)
 
         return Action(
@@ -1075,7 +1123,9 @@ def _inject_attribution_headers(
     if not http_options:
         opts = HttpOptions()
     elif isinstance(http_options, HttpOptions):
-        opts = http_options
+        # Copy so plugin-derived settings never mutate the caller's object
+        # (which may be shared across plugin instances).
+        opts = http_options.model_copy(deep=True)
     else:
         opts = HttpOptions.model_validate(http_options)
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -1669,7 +1669,7 @@ class GeminiModel:
         # plugin's credentials, endpoint, headers, and timeouts.
         kwargs = dict(self._client_kwargs)
         plugin_opts = kwargs.get('http_options')
-        opts = plugin_opts.model_copy() if plugin_opts is not None else genai_types.HttpOptions()
+        opts = plugin_opts.model_copy(deep=True) if plugin_opts is not None else genai_types.HttpOptions()
 
         if api_version:
             opts.api_version = api_version

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -1693,16 +1693,24 @@ class GeminiModel:
         # The plugin's kwargs may carry project=None when the project comes
         # from ADC. Resolve it here, off the event loop: the SDK's own
         # resolution would block the loop, and it skips resolution entirely
-        # when a base_url is set.
-        if self._client.vertexai and not kwargs.get('project'):
+        # when a base_url is set. Express mode (api_key) takes no project --
+        # the SDK rejects the two together -- so the probe is skipped there.
+        if self._client.vertexai and not kwargs.get('project') and not kwargs.get('api_key'):
             kwargs['project'] = getattr(kwargs.get('credentials'), 'project_id', None) or await _adc_project()
-            if not kwargs.get('project') and is_multi_regional_location(kwargs.get('location')):
+        if self._client.vertexai and not kwargs.get('project') and is_multi_regional_location(kwargs.get('location')):
+            if kwargs.get('api_key'):
                 raise GenkitError(
                     status='FAILED_PRECONDITION',
-                    message='A project is required when overriding the location with a '
-                    'multi-region. Set the project parameter or GOOGLE_CLOUD_PROJECT '
-                    'environment variable.',
+                    message='Multi-region locations are not available in Vertex AI express '
+                    'mode (api_key). Configure the plugin with a project and credentials '
+                    'to use multi-region locations.',
                 )
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message='A project is required when overriding the location with a '
+                'multi-region. Set the project parameter or GOOGLE_CLOUD_PROJECT '
+                'environment variable.',
+            )
 
         try:
             return genai.Client(**kwargs)

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -131,9 +131,11 @@ The following models are currently supported by VertexAI API:
 | `gemini-2.5-pro-preview-05-06`       | Gemini 2.5 Pro Preview 05-06         | Supported  |
 """
 
+import asyncio
 import sys
 from datetime import datetime, timedelta, timezone
 
+from genkit_google_genai.constants import is_multi_regional_location, multi_regional_base_url
 from genkit_google_genai.models.context_caching.constants import DEFAULT_TTL
 from genkit_google_genai.models.context_caching.utils import generate_cache_key, validate_context_cache_request
 
@@ -146,6 +148,8 @@ from functools import cached_property
 from typing import Annotated, Any, Any as JsonAny, cast
 
 from google import genai
+from google.auth import default as google_auth_default
+from google.auth.exceptions import DefaultCredentialsError
 from google.genai import types as genai_types
 from google.genai.errors import ClientError
 from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema
@@ -357,6 +361,14 @@ class GeminiConfigSchema(ModelConfig):
     )
     api_version: str | None = Field(
         None, description='Overrides the plugin-configured or default apiVersion, if specified.', alias='apiVersion'
+    )
+    location: str | None = Field(
+        None,
+        description=(
+            'Overrides the plugin-configured location/region for this request '
+            "(Vertex AI only). Accepts regions (e.g. 'us-central1'), "
+            "multi-regions ('us', 'eu'), or 'global'."
+        ),
     )
 
     safety_settings: Annotated[
@@ -1331,6 +1343,26 @@ def google_model_info(
     )
 
 
+_adc_project_cache: str | None = None
+
+
+async def _adc_project() -> str | None:
+    """Resolve the project from application default credentials, cached.
+
+    ADC resolution can do file and metadata-server IO, so it runs in a thread.
+    Only a successful resolution is cached, so a fixed environment is picked
+    up without a restart; concurrent first calls may duplicate the probe,
+    which is benign.
+    """
+    global _adc_project_cache
+    if _adc_project_cache is None:
+        try:
+            _, _adc_project_cache = await asyncio.to_thread(google_auth_default)
+        except DefaultCredentialsError:
+            return None
+    return _adc_project_cache
+
+
 class GeminiModel:
     """Gemini model."""
 
@@ -1338,15 +1370,24 @@ class GeminiModel:
         self,
         version: str | GoogleAIGeminiVersion | VertexAIGeminiVersion,
         client: genai.Client,
+        client_kwargs: dict[str, Any] | None = None,
+        base_url_pinned: bool = False,
     ) -> None:
         """Initialize Gemini model.
 
         Args:
             version: Gemini version
             client: Google AI client
+            client_kwargs: The plugin-level kwargs the client was constructed
+                from. Required for per-request config overrides (api_key,
+                api_version, base_url, location).
+            base_url_pinned: Whether the plugin caller explicitly pinned a
+                base URL (as opposed to one derived from the location).
         """
         self._version = version
         self._client = client
+        self._client_kwargs = client_kwargs
+        self._base_url_pinned = base_url_pinned
 
     def _get_tools(self, request: ModelRequest) -> list[genai_types.Tool]:
         """Generates VertexAI Gemini compatible tool definitions.
@@ -1465,7 +1506,12 @@ class GeminiModel:
         return schema
 
     async def _retrieve_cached_content(
-        self, request: ModelRequest, model_name: str, cache_config: dict, contents: list[genai_types.Content]
+        self,
+        request: ModelRequest,
+        model_name: str,
+        cache_config: dict,
+        contents: list[genai_types.Content],
+        client: genai.Client | None = None,
     ) -> genai_types.CachedContent:
         """Retrieves cached content from the Google API if exists.
 
@@ -1477,11 +1523,14 @@ class GeminiModel:
             model_name: name of the generation model to use
             cache_config: user-defined cache configuration (e.g. ttl_seconds)
             contents: content to submit for cached context creation
+            client: client to use for cache operations. Defaults to the
+                plugin-configured client.
 
         Returns:
             Cached Content instance based on provided params
         """
         validate_context_cache_request(request=request, model_name=model_name)
+        cache_client = client if client is not None else self._client
 
         ttl_value = cache_config.get('ttl_seconds', DEFAULT_TTL)
         ttl: float = float(ttl_value) if ttl_value is not None else DEFAULT_TTL
@@ -1489,7 +1538,7 @@ class GeminiModel:
 
         iterator_config = genai_types.ListCachedContentsConfig()
         cache = None
-        pages = await self._client.aio.caches.list(config=iterator_config)
+        pages = await cache_client.aio.caches.list(config=iterator_config)
 
         async for item in pages:
             if item.display_name == cache_key:
@@ -1497,11 +1546,11 @@ class GeminiModel:
                 break
         if cache and cache.name:
             updated_expiration_time = datetime.now(timezone.utc) + timedelta(seconds=ttl)
-            cache = await self._client.aio.caches.update(
+            cache = await cache_client.aio.caches.update(
                 name=cache.name, config=genai_types.UpdateCachedContentConfig(expire_time=updated_expiration_time)
             )
         else:
-            cache = await self._client.aio.caches.create(
+            cache = await cache_client.aio.caches.create(
                 model=model_name,
                 config=genai_types.CreateCachedContentConfig(
                     contents=cast(genai_types.ContentListUnion, contents),
@@ -1543,81 +1592,19 @@ class GeminiModel:
                 request_cfg = genai_types.GenerateContentConfig()
             request_cfg.response_modalities = ['TEXT', 'IMAGE']
 
-        request_contents, cached_content = await self._build_messages(request=request, model_name=model_name)
+        # Resolve the client before building messages so context-cache
+        # operations run against the same (possibly overridden) region as the
+        # generate call.
+        client = await self._resolve_request_client(request)
+
+        request_contents, cached_content = await self._build_messages(
+            request=request, model_name=model_name, client=client
+        )
 
         if cached_content and cached_content.name:
             if not request_cfg:
                 request_cfg = genai_types.GenerateContentConfig()
             request_cfg.cached_content = cached_content.name
-
-        client = self._client
-        # If config specifies api_key, base_url, or api_version different from default,
-        # create a temporary client with those settings.
-        api_version = None
-        api_key_override = None
-        base_url_override = None
-
-        if request.config:
-            if isinstance(request.config, dict):
-                api_version = request.config.get('api_version')
-                api_key_override = request.config.get('api_key')
-                base_url_override = request.config.get('base_url')
-            else:
-                api_version = getattr(request.config, 'api_version', None)
-                api_key_override = getattr(request.config, 'api_key', None)
-                base_url_override = getattr(request.config, 'base_url', None)
-
-        if api_version or api_key_override or base_url_override:
-            # TODO(#4362): Request public API from google-genai maintainers.
-            # Currently, there is no public way to access the configured api_key, project, or location
-            # from an existing Client instance. We need to access the private _api_client to
-            # clone the configuration when overriding these settings.
-            # This is brittle and relies on internal implementation details of the google-genai library.
-            # If the library changes its internal structure (e.g. renames _api_client or _credentials),
-            # this code WILL BREAK.
-            api_client = self._client._api_client
-            kwargs: dict[str, Any] = {
-                'vertexai': api_client.vertexai,
-            }
-
-            # Set http_options if we have api_version or base_url
-            http_options = {}
-            if api_version:
-                http_options['api_version'] = api_version
-            if base_url_override:
-                http_options['base_url'] = base_url_override
-            if http_options:
-                kwargs['http_options'] = http_options
-
-            if api_client.vertexai:
-                # Vertex AI mode: requires project/location (api_key is optional/unlikely)
-                if api_client.project:
-                    kwargs['project'] = api_client.project
-                if api_client.location:
-                    kwargs['location'] = api_client.location
-                if api_client._credentials:
-                    kwargs['credentials'] = api_client._credentials
-                # Don't pass api_key if we are in Vertex AI mode with credentials/project
-            else:
-                # Google AI mode: primarily uses api_key
-                # Use override if provided, otherwise fall back to existing client's api_key
-                if api_key_override:
-                    kwargs['api_key'] = api_key_override
-                elif api_client.api_key:
-                    kwargs['api_key'] = api_client.api_key
-                # Do NOT pass project/location/credentials if in Google AI mode to be safe
-                if api_client._credentials and not kwargs.get('api_key'):
-                    # Fallback if no api_key but credentials present (unlikely for pure Google AI but possible)
-                    kwargs['credentials'] = api_client._credentials
-
-            try:
-                client = genai.Client(**kwargs)
-            except Exception as e:
-                # If client creation fails (e.g., invalid API key format), raise a clear error
-                raise GenkitError(
-                    status='INVALID_ARGUMENT',
-                    message=f'Failed to create Google AI client: {str(e)}',
-                ) from e
 
         if ctx.is_streaming:
             response = await self._streaming_generate(
@@ -1635,6 +1622,92 @@ class GeminiModel:
         response.usage = self._create_usage_stats(request=request, response=response)
 
         return response
+
+    async def _resolve_request_client(self, request: ModelRequest) -> genai.Client:
+        """Resolve the client to use for a request.
+
+        If the request config overrides api_key, base_url, api_version, or
+        location, a temporary client is created with those settings; otherwise
+        the plugin-configured client is returned.
+        """
+        api_version = None
+        api_key_override = None
+        base_url_override = None
+        location_override = None
+
+        if request.config:
+            if isinstance(request.config, dict):
+                api_version = request.config.get('api_version')
+                api_key_override = request.config.get('api_key')
+                base_url_override = request.config.get('base_url')
+                location_override = request.config.get('location')
+            else:
+                api_version = getattr(request.config, 'api_version', None)
+                api_key_override = getattr(request.config, 'api_key', None)
+                base_url_override = getattr(request.config, 'base_url', None)
+                location_override = getattr(request.config, 'location', None)
+
+        if location_override and not self._client.vertexai:
+            # Location is a Vertex AI concept; ignore it for the Gemini API backend.
+            location_override = None
+
+        if not (api_version or api_key_override or base_url_override or location_override):
+            return self._client
+
+        if self._client_kwargs is None:
+            raise GenkitError(
+                status='FAILED_PRECONDITION',
+                message='Per-request api_key/api_version/base_url/location overrides require '
+                'a model constructed with client_kwargs.',
+            )
+
+        # Clone the plugin-level client kwargs so the temporary client keeps the
+        # plugin's credentials, endpoint, headers, and timeouts.
+        kwargs = dict(self._client_kwargs)
+        plugin_opts = kwargs.get('http_options')
+        opts = plugin_opts.model_copy() if plugin_opts is not None else genai_types.HttpOptions()
+
+        if api_version:
+            opts.api_version = api_version
+        if location_override:
+            kwargs['location'] = location_override
+            if not self._base_url_pinned and not base_url_override:
+                if is_multi_regional_location(location_override):
+                    # Multi-regions are served from dedicated endpoints the SDK
+                    # does not derive itself.
+                    opts.base_url = multi_regional_base_url(location_override)
+                else:
+                    opts.base_url = None
+        if base_url_override:
+            opts.base_url = base_url_override
+        if api_key_override and not self._client.vertexai:
+            kwargs['api_key'] = api_key_override
+            # The SDK rejects credentials and api_key together.
+            kwargs['credentials'] = None
+        kwargs['http_options'] = opts
+
+        # The plugin's kwargs may carry project=None when the project comes
+        # from ADC. Resolve it here, off the event loop: the SDK's own
+        # resolution would block the loop, and it skips resolution entirely
+        # when a base_url is set.
+        if self._client.vertexai and not kwargs.get('project'):
+            kwargs['project'] = getattr(kwargs.get('credentials'), 'project_id', None) or await _adc_project()
+            if not kwargs.get('project') and is_multi_regional_location(kwargs.get('location')):
+                raise GenkitError(
+                    status='FAILED_PRECONDITION',
+                    message='A project is required when overriding the location with a '
+                    'multi-region. Set the project parameter or GOOGLE_CLOUD_PROJECT '
+                    'environment variable.',
+                )
+
+        try:
+            return genai.Client(**kwargs)
+        except Exception as e:
+            # If client creation fails (e.g., invalid API key format), raise a clear error
+            raise GenkitError(
+                status='INVALID_ARGUMENT',
+                message=f'Failed to create google-genai client: {str(e)}',
+            ) from e
 
     async def _generate(
         self,
@@ -1832,13 +1905,15 @@ class GeminiModel:
         }
 
     async def _build_messages(
-        self, request: ModelRequest, model_name: str
+        self, request: ModelRequest, model_name: str, client: genai.Client | None = None
     ) -> tuple[list[genai_types.Content], genai_types.CachedContent | None]:
         """Build google-genai request contents from Genkit request.
 
         Args:
             request: Genkit request.
             model_name: name of generation model to use
+            client: client to use for context-cache operations. Defaults to
+                the plugin-configured client.
 
         Returns:
             list of google-genai contents.
@@ -1864,6 +1939,7 @@ class GeminiModel:
                     model_name=model_name,
                     cache_config=msg.metadata['cache'],
                     contents=request_contents,
+                    client=client,
                 )
                 # The prefix up to this message is now stored in the cache.
                 # Only post-cache messages should be sent in the generate call.
@@ -1986,7 +2062,7 @@ class GeminiModel:
 
     # Keys that are Genkit-specific and must not be forwarded to the API.
     # 'version' overrides the model name, others are client-level settings.
-    _GENKIT_ONLY_KEYS = frozenset(['version', 'api_version', 'api_key', 'base_url', 'context_cache'])
+    _GENKIT_ONLY_KEYS = frozenset(['version', 'api_version', 'api_key', 'base_url', 'location', 'context_cache'])
 
     # Keys that may not be supported by older google-genai SDK versions.
     _SDK_GATED_KEYS = frozenset(['image_config', 'thinking_config', 'response_modalities'])

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -1344,22 +1344,26 @@ def google_model_info(
 
 
 _adc_project_cache: str | None = None
+_adc_project_probed: bool = False
 
 
 async def _adc_project() -> str | None:
     """Resolve the project from application default credentials, cached.
 
-    ADC resolution can do file and metadata-server IO, so it runs in a thread.
-    Only a successful resolution is cached, so a fixed environment is picked
-    up without a restart; concurrent first calls may duplicate the probe,
-    which is benign.
+    ADC resolution can do file and metadata-server IO, so it runs in a thread
+    and is attempted only once per process. A failed or empty resolution is
+    cached too: without ADC configured (express mode, say) every overridden
+    request would otherwise pay for a probe that can stall on the metadata
+    server. Concurrent first calls may duplicate the probe, which is benign.
     """
-    global _adc_project_cache
-    if _adc_project_cache is None:
+    global _adc_project_cache, _adc_project_probed
+    if not _adc_project_probed:
         try:
-            _, _adc_project_cache = await asyncio.to_thread(google_auth_default)
+            _, project = await asyncio.to_thread(google_auth_default)
+            _adc_project_cache = project
         except DefaultCredentialsError:
-            return None
+            _adc_project_cache = None
+        _adc_project_probed = True
     return _adc_project_cache
 
 

--- a/py/packages/genkit-google-genai/test/google_plugin_test.py
+++ b/py/packages/genkit-google-genai/test/google_plugin_test.py
@@ -572,7 +572,7 @@ class TestVertexAIInit(unittest.TestCase):
     """Test cases for VertexAI.__init__ plugin."""
 
     @patch('google.genai.client.Client')
-    @patch.dict(os.environ, {'GCLOUD_PROJECT': 'project'})
+    @patch.dict(os.environ, {'GCLOUD_PROJECT': 'project'}, clear=True)
     def test_init_with_api_key(self, mock_genai_client: MagicMock) -> None:
         """Test using api_key parameter."""
         api_key = 'test_api_key'
@@ -592,7 +592,7 @@ class TestVertexAIInit(unittest.TestCase):
         self.assertIsInstance(runtime_client, MagicMock)
 
     @patch('google.genai.client.Client')
-    @patch.dict(os.environ, {'GCLOUD_PROJECT': 'project'})
+    @patch.dict(os.environ, {'GCLOUD_PROJECT': 'project'}, clear=True)
     def test_init_with_credentials(self, mock_genai_client: MagicMock) -> None:
         """Test using credentials parameter."""
         mock_credentials = MagicMock(spec=Credentials)

--- a/py/packages/genkit-google-genai/tests/vertexai_location_test.py
+++ b/py/packages/genkit-google-genai/tests/vertexai_location_test.py
@@ -17,6 +17,7 @@
 """Tests for Vertex AI multi-region location and per-request location support."""
 
 import os
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -33,15 +34,15 @@ from google import genai
 from google.genai import types as genai_types
 from google.genai.types import HttpOptions
 
-from genkit import GenkitError, Message, ModelRequest, Role, TextPart
+from genkit import GenkitError, Message, ModelRequest, Part, Role, TextPart
 
 US_REP_URL = 'https://aiplatform.us.rep.googleapis.com'
 EU_REP_URL = 'https://aiplatform.eu.rep.googleapis.com'
 
 
-def _text_request(config: dict | None = None) -> ModelRequest:
+def _text_request(config: dict[str, Any] | None = None) -> ModelRequest[Any]:
     return ModelRequest(
-        messages=[Message(role=Role.USER, content=[TextPart(text='hi')])],
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
         config=config,
     )
 
@@ -117,7 +118,9 @@ class TestVertexAIPluginLocation:
     def test_camel_case_base_url_wins_over_multi_region(self) -> None:
         """A camelCase baseUrl inside http_options is honored, not clobbered."""
         with patch('genkit_google_genai.google.genai.client.Client'):
-            plugin = VertexAI(project='p', location='us', http_options={'baseUrl': 'https://example.com/'})
+            # cast: the camelCase alias is what a JS-shaped config passes; the
+            # SDK accepts it at runtime but HttpOptionsDict only spells snake_case.
+            plugin = VertexAI(project='p', location='us', http_options=cast(Any, {'baseUrl': 'https://example.com/'}))
         assert plugin._client_kwargs['http_options'].base_url == 'https://example.com/'
         assert plugin._base_url_pinned is True
 
@@ -176,6 +179,52 @@ class TestVertexAIPluginProject:
                 plugin = VertexAI(location='us')
         assert plugin._project == 'env-p'
         assert plugin._client_kwargs['project'] == 'env-p'
+
+    def test_regional_resolves_project_from_adc(self) -> None:
+        """A regional plugin resolves the project via ADC when none is configured.
+
+        Evaluator registration in init() needs a concrete project, so leaving
+        it unresolved would fail a deployment that relies purely on ADC.
+        """
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                with patch('genkit_google_genai.google.google_auth_default', return_value=(None, 'adc-p')):
+                    plugin = VertexAI(location='us-central1')
+        assert plugin._project == 'adc-p'
+        assert plugin._client_kwargs['project'] == 'adc-p'
+
+    def test_regional_without_adc_project_does_not_raise(self) -> None:
+        """A regional plugin with no resolvable project still constructs.
+
+        Unlike multi-regions, regional endpoints are usable in express mode and
+        the SDK raises its own error later, so construction must not fail here.
+        """
+        from google.auth.exceptions import DefaultCredentialsError
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                with patch(
+                    'genkit_google_genai.google.google_auth_default', side_effect=DefaultCredentialsError('no adc')
+                ):
+                    plugin = VertexAI(location='us-central1')
+        assert plugin._project is None
+
+    def test_api_key_skips_adc_probe(self) -> None:
+        """Express mode (api_key, no project) does not probe ADC."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                with patch('genkit_google_genai.google.google_auth_default') as mock_adc:
+                    plugin = VertexAI(location='us-central1', api_key='k')
+        mock_adc.assert_not_called()
+        assert plugin._project is None
+
+    def test_explicit_project_skips_adc_probe(self) -> None:
+        """An explicit project short-circuits the ADC probe."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                with patch('genkit_google_genai.google.google_auth_default') as mock_adc:
+                    VertexAI(project='p', location='us-central1')
+        mock_adc.assert_not_called()
 
     def test_multi_region_resolves_project_from_adc(self) -> None:
         """With no project configured, a multi-region plugin resolves it via ADC."""
@@ -307,6 +356,11 @@ def _vertex_model(location: str = 'us-central1', base_url: str | None = None, pr
         client_kwargs=plugin._client_kwargs,
         base_url_pinned=plugin._base_url_pinned,
     )
+
+
+def _plugin_client(model: GeminiModel) -> MagicMock:
+    """The mock client the model was constructed with, typed for assertions."""
+    return cast(MagicMock, model._client)
 
 
 class TestResolveRequestClient:
@@ -540,7 +594,8 @@ class TestGenerateUsesResolvedClient:
         with patch('genkit_google_genai.models.gemini.genai.Client', return_value=temp_client):
             result = await model.generate(_text_request({'location': 'europe-west1'}), ctx)
         temp_client.aio.models.generate_content.assert_awaited_once()
-        model._client.aio.models.generate_content.assert_not_called()
+        _plugin_client(model).aio.models.generate_content.assert_not_called()
+        assert result.message is not None
         assert result.message.content[0].root.text == 'ok'
 
     @pytest.mark.asyncio
@@ -566,7 +621,7 @@ class TestGenerateUsesResolvedClient:
         with patch('genkit_google_genai.models.gemini.genai.Client', return_value=temp_client):
             await model.generate(_text_request({'location': 'europe-west1'}), ctx)
         temp_client.aio.models.generate_content_stream.assert_awaited_once()
-        model._client.aio.models.generate_content_stream.assert_not_called()
+        _plugin_client(model).aio.models.generate_content_stream.assert_not_called()
         ctx.send_chunk.assert_called()
 
     @pytest.mark.asyncio
@@ -617,8 +672,8 @@ class TestCachedContentClientRouting:
         )
         cache_client.aio.caches.list.assert_awaited_once()
         cache_client.aio.caches.create.assert_awaited_once()
-        model._client.aio.caches.list.assert_not_called()
-        model._client.aio.caches.create.assert_not_called()
+        _plugin_client(model).aio.caches.list.assert_not_called()
+        _plugin_client(model).aio.caches.create.assert_not_called()
         assert cache.name == 'caches/x'
 
 
@@ -640,7 +695,7 @@ class TestLocationConfigThroughPipeline:
         """Same for a typed GeminiConfigSchema config."""
         model = _vertex_model()
         request = ModelRequest(
-            messages=[Message(role=Role.USER, content=[TextPart(text='hi')])],
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='hi'))])],
             config=GeminiConfigSchema(location='us', temperature=0.1),
         )
         cfg = await model._genkit_to_googleai_cfg(request=request)

--- a/py/packages/genkit-google-genai/tests/vertexai_location_test.py
+++ b/py/packages/genkit-google-genai/tests/vertexai_location_test.py
@@ -49,10 +49,16 @@ def _text_request(config: dict[str, Any] | None = None) -> ModelRequest[Any]:
 
 @pytest.fixture(autouse=True)
 def _reset_adc_project_cache():
-    """Reset the module-level ADC project cache between tests."""
+    """Reset the module-level ADC project cache between tests.
+
+    The probed flag matters as much as the value: leaving it set would make a
+    later test silently skip the ADC lookup it means to exercise.
+    """
     gemini_module._adc_project_cache = None
+    gemini_module._adc_project_probed = False
     yield
     gemini_module._adc_project_cache = None
+    gemini_module._adc_project_probed = False
 
 
 class TestMultiRegionConstants:
@@ -481,6 +487,52 @@ class TestResolveRequestClient:
         ):
             with pytest.raises(GenkitError, match='project is required'):
                 await model._resolve_request_client(_text_request({'location': 'eu'}))
+
+    @pytest.mark.asyncio
+    async def test_failed_adc_probe_is_not_repeated(self) -> None:
+        """A missing ADC setup is probed once, not on every overridden request.
+
+        ADC resolution does blocking file and metadata-server IO, so an
+        environment without ADC (express mode, say) must not pay for a probe
+        per request.
+        """
+        from google.auth.exceptions import DefaultCredentialsError
+
+        model = _vertex_model()
+        model._client_kwargs = dict(model._client_kwargs, project=None)
+        with patch('genkit_google_genai.models.gemini.genai.Client'):
+            with patch(
+                'genkit_google_genai.models.gemini.google_auth_default',
+                side_effect=DefaultCredentialsError('no adc'),
+            ) as mock_adc:
+                await model._resolve_request_client(_text_request({'api_version': 'v1'}))
+                await model._resolve_request_client(_text_request({'api_version': 'v1'}))
+        assert mock_adc.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_adc_project_is_not_repeated(self) -> None:
+        """ADC resolving to no project is also cached, not re-probed."""
+        model = _vertex_model()
+        model._client_kwargs = dict(model._client_kwargs, project=None)
+        with patch('genkit_google_genai.models.gemini.genai.Client'):
+            with patch('genkit_google_genai.models.gemini.google_auth_default', return_value=(None, None)) as mock_adc:
+                await model._resolve_request_client(_text_request({'api_version': 'v1'}))
+                await model._resolve_request_client(_text_request({'api_version': 'v1'}))
+        assert mock_adc.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_successful_adc_probe_is_not_repeated(self) -> None:
+        """A successful resolution stays cached across requests."""
+        model = _vertex_model()
+        model._client_kwargs = dict(model._client_kwargs, project=None)
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            with patch(
+                'genkit_google_genai.models.gemini.google_auth_default', return_value=(None, 'adc-p')
+            ) as mock_adc:
+                await model._resolve_request_client(_text_request({'api_version': 'v1'}))
+                await model._resolve_request_client(_text_request({'api_version': 'v1'}))
+        assert mock_adc.call_count == 1
+        assert mock_ctor.call_args.kwargs['project'] == 'adc-p'
 
     @pytest.mark.asyncio
     async def test_api_version_override_prefills_adc_project(self) -> None:

--- a/py/packages/genkit-google-genai/tests/vertexai_location_test.py
+++ b/py/packages/genkit-google-genai/tests/vertexai_location_test.py
@@ -1,0 +1,648 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Vertex AI multi-region location and per-request location support."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from genkit_google_genai import VertexAI
+from genkit_google_genai.constants import (
+    is_multi_regional_location,
+    multi_regional_base_url,
+    vertex_api_host,
+)
+from genkit_google_genai.evaluators.evaluation import EvaluatorFactory
+from genkit_google_genai.models import gemini as gemini_module
+from genkit_google_genai.models.gemini import GeminiConfigSchema, GeminiModel
+from google import genai
+from google.genai import types as genai_types
+from google.genai.types import HttpOptions
+
+from genkit import GenkitError, Message, ModelRequest, Role, TextPart
+
+US_REP_URL = 'https://aiplatform.us.rep.googleapis.com'
+EU_REP_URL = 'https://aiplatform.eu.rep.googleapis.com'
+
+
+def _text_request(config: dict | None = None) -> ModelRequest:
+    return ModelRequest(
+        messages=[Message(role=Role.USER, content=[TextPart(text='hi')])],
+        config=config,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_adc_project_cache():
+    """Reset the module-level ADC project cache between tests."""
+    gemini_module._adc_project_cache = None
+    yield
+    gemini_module._adc_project_cache = None
+
+
+class TestMultiRegionConstants:
+    """Tests for multi-region helpers."""
+
+    def test_is_multi_regional_location(self) -> None:
+        """Only 'us' and 'eu' are multi-regions."""
+        assert is_multi_regional_location('us') is True
+        assert is_multi_regional_location('eu') is True
+        assert is_multi_regional_location('us-central1') is False
+        assert is_multi_regional_location('global') is False
+        assert is_multi_regional_location(None) is False
+
+    def test_vertex_api_host(self) -> None:
+        """Host selection covers regional, multi-regional, and global."""
+        assert vertex_api_host('us-central1') == 'us-central1-aiplatform.googleapis.com'
+        assert vertex_api_host('global') == 'aiplatform.googleapis.com'
+        assert vertex_api_host('us') == 'aiplatform.us.rep.googleapis.com'
+        assert vertex_api_host('eu') == 'aiplatform.eu.rep.googleapis.com'
+
+    def test_multi_regional_base_url(self) -> None:
+        """Multi-region base URLs use the rep hosts, no trailing slash."""
+        assert multi_regional_base_url('us') == US_REP_URL
+        assert multi_regional_base_url('eu') == EU_REP_URL
+
+
+class TestVertexAIPluginLocation:
+    """Tests for plugin-level location resolution."""
+
+    def test_multi_region_sets_base_url(self) -> None:
+        """A multi-region location routes to the rep endpoint."""
+        with patch('genkit_google_genai.google.genai.client.Client'):
+            plugin = VertexAI(project='p', location='us')
+        assert plugin._location == 'us'
+        assert plugin._client_kwargs['http_options'].base_url == US_REP_URL
+        assert plugin._base_url_pinned is False
+
+    def test_regional_location_leaves_base_url_unset(self) -> None:
+        """Regional locations keep SDK-derived endpoints."""
+        with patch('genkit_google_genai.google.genai.client.Client'):
+            plugin = VertexAI(project='p', location='europe-west1')
+        assert plugin._client_kwargs['http_options'].base_url is None
+
+    def test_global_location_leaves_base_url_unset(self) -> None:
+        """Global location keeps the SDK-derived endpoint."""
+        with patch('genkit_google_genai.google.genai.client.Client'):
+            plugin = VertexAI(project='p', location='global')
+        assert plugin._client_kwargs['http_options'].base_url is None
+
+    def test_explicit_base_url_wins_over_multi_region(self) -> None:
+        """An explicit base_url is not clobbered by multi-region routing."""
+        with patch('genkit_google_genai.google.genai.client.Client'):
+            plugin = VertexAI(project='p', location='us', base_url='https://example.com/')
+        assert plugin._client_kwargs['http_options'].base_url == 'https://example.com/'
+        assert plugin._base_url_pinned is True
+
+    def test_http_options_base_url_wins_over_multi_region(self) -> None:
+        """A base_url inside http_options is not clobbered either."""
+        with patch('genkit_google_genai.google.genai.client.Client'):
+            plugin = VertexAI(project='p', location='eu', http_options={'base_url': 'https://example.com/'})
+        assert plugin._client_kwargs['http_options'].base_url == 'https://example.com/'
+
+    def test_camel_case_base_url_wins_over_multi_region(self) -> None:
+        """A camelCase baseUrl inside http_options is honored, not clobbered."""
+        with patch('genkit_google_genai.google.genai.client.Client'):
+            plugin = VertexAI(project='p', location='us', http_options={'baseUrl': 'https://example.com/'})
+        assert plugin._client_kwargs['http_options'].base_url == 'https://example.com/'
+        assert plugin._base_url_pinned is True
+
+    def test_empty_base_url_treated_as_unset(self) -> None:
+        """An empty base_url string does not defeat multi-region routing."""
+        with patch('genkit_google_genai.google.genai.client.Client'):
+            plugin = VertexAI(project='p', location='us', base_url='')
+        assert plugin._client_kwargs['http_options'].base_url == US_REP_URL
+
+    def test_caller_http_options_not_mutated(self) -> None:
+        """Plugin-derived settings never leak into the caller's HttpOptions."""
+        shared = HttpOptions()
+        with patch('genkit_google_genai.google.genai.client.Client'):
+            plugin_us = VertexAI(project='p', location='us', http_options=shared)
+            plugin_eu = VertexAI(project='p', location='eu', http_options=shared)
+        assert shared.base_url is None
+        assert shared.headers is None
+        assert plugin_us._client_kwargs['http_options'].base_url == US_REP_URL
+        assert plugin_eu._client_kwargs['http_options'].base_url == EU_REP_URL
+        assert plugin_eu._base_url_pinned is False
+
+    def test_location_env_fallback_google_cloud_location(self) -> None:
+        """GOOGLE_CLOUD_LOCATION is consulted when location is not passed."""
+        env = {'GCLOUD_PROJECT': 'p', 'GOOGLE_CLOUD_LOCATION': 'eu'}
+        with patch.dict(os.environ, env, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                plugin = VertexAI()
+        assert plugin._location == 'eu'
+        assert plugin._client_kwargs['http_options'].base_url == EU_REP_URL
+
+    def test_location_env_fallback_chain(self) -> None:
+        """GCLOUD_LOCATION is consulted after GOOGLE_CLOUD_LOCATION."""
+        with patch.dict(os.environ, {'GCLOUD_PROJECT': 'p', 'GCLOUD_LOCATION': 'europe-west1'}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                assert VertexAI()._location == 'europe-west1'
+        env = {'GCLOUD_PROJECT': 'p', 'GOOGLE_CLOUD_LOCATION': 'us-east1', 'GCLOUD_LOCATION': 'europe-west1'}
+        with patch.dict(os.environ, env, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                assert VertexAI()._location == 'us-east1'
+
+    def test_location_defaults_to_us_central1(self) -> None:
+        """Without an explicit location or env vars, us-central1 is used."""
+        with patch.dict(os.environ, {'GCLOUD_PROJECT': 'p'}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                plugin = VertexAI()
+        assert plugin._location == 'us-central1'
+
+
+class TestVertexAIPluginProject:
+    """Tests for plugin-level project resolution."""
+
+    def test_google_cloud_project_env_fallback(self) -> None:
+        """GOOGLE_CLOUD_PROJECT is consulted after GCLOUD_PROJECT."""
+        with patch.dict(os.environ, {'GOOGLE_CLOUD_PROJECT': 'env-p'}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                plugin = VertexAI(location='us')
+        assert plugin._project == 'env-p'
+        assert plugin._client_kwargs['project'] == 'env-p'
+
+    def test_multi_region_resolves_project_from_adc(self) -> None:
+        """With no project configured, a multi-region plugin resolves it via ADC."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                with patch('genkit_google_genai.google.google_auth_default', return_value=(None, 'adc-p')):
+                    plugin = VertexAI(location='us')
+        assert plugin._project == 'adc-p'
+        assert plugin._client_kwargs['project'] == 'adc-p'
+
+    def test_multi_region_without_project_raises(self) -> None:
+        """A multi-region plugin with no resolvable project fails fast."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                with patch('genkit_google_genai.google.google_auth_default', return_value=(None, None)):
+                    with pytest.raises(ValueError, match='multi-region'):
+                        VertexAI(location='eu')
+
+    def test_multi_region_no_adc_raises_friendly_error(self) -> None:
+        """A missing ADC setup surfaces as the friendly ValueError, not a raw auth error."""
+        from google.auth.exceptions import DefaultCredentialsError
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                with patch(
+                    'genkit_google_genai.google.google_auth_default', side_effect=DefaultCredentialsError('no adc')
+                ):
+                    with pytest.raises(ValueError, match='multi-region'):
+                        VertexAI(location='eu')
+
+    def test_multi_region_uses_credentials_project_id(self) -> None:
+        """Explicit credentials carrying project_id avoid the ADC probe."""
+        creds = MagicMock()
+        creds.project_id = 'creds-p'
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                with patch('genkit_google_genai.google.google_auth_default') as mock_adc:
+                    plugin = VertexAI(location='us', credentials=creds)
+        mock_adc.assert_not_called()
+        assert plugin._project == 'creds-p'
+
+    def test_multi_region_with_pinned_base_url_still_resolves_project(self) -> None:
+        """A pinned base_url does not bypass multi-region project resolution.
+
+        The SDK skips its own ADC project lookup whenever a base_url is set,
+        regardless of who set it, so the plugin must resolve the project even
+        when the caller pinned the URL.
+        """
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                with patch('genkit_google_genai.google.google_auth_default', return_value=(None, 'adc-p')):
+                    plugin = VertexAI(location='us', base_url='https://example.com/')
+        assert plugin._project == 'adc-p'
+        assert plugin._client_kwargs['project'] == 'adc-p'
+        assert plugin._client_kwargs['http_options'].base_url == 'https://example.com/'
+
+    def test_multi_region_with_pinned_base_url_without_project_raises(self) -> None:
+        """A pinned base_url plus multi-region still fails fast without a project."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                with patch('genkit_google_genai.google.google_auth_default', return_value=(None, None)):
+                    with pytest.raises(ValueError, match='multi-region'):
+                        VertexAI(location='eu', base_url='https://example.com/')
+
+
+class TestRealClientHonorsPinnedBaseUrl:
+    """Pin the google-genai contract the plugin's routing relies on.
+
+    Every other test mocks genai.Client, so nothing else would notice if an
+    SDK upgrade stopped honoring a user-supplied http_options.base_url (today
+    the SDK re-applies user http_options after computing its own default
+    endpoint). Constructing the client needs no network or ADC because project
+    and location are given explicitly.
+    """
+
+    def test_real_client_keeps_multi_region_base_url(self) -> None:
+        """A real client keeps the rep base_url the plugin pins for 'us'."""
+        with patch.dict(os.environ, {}, clear=True):
+            client = genai.Client(
+                vertexai=True, project='p', location='us', http_options=HttpOptions(base_url=US_REP_URL)
+            )
+        assert client._api_client._http_options.base_url == US_REP_URL
+        assert client._api_client.project == 'p'
+        assert client._api_client.location == 'us'
+
+
+class TestEvaluatorApiHost:
+    """Tests for evaluator endpoint host selection."""
+
+    def test_regional_host(self) -> None:
+        """Regional locations use the {location}-aiplatform pattern."""
+        factory = EvaluatorFactory(project_id='p', location='us-central1')
+        assert factory._api_host() == 'us-central1-aiplatform.googleapis.com'
+
+    def test_global_rejected(self) -> None:
+        """The evaluation service is regional; 'global' is rejected."""
+        factory = EvaluatorFactory(project_id='p', location='global')
+        with pytest.raises(GenkitError, match='does not support'):
+            factory._api_host()
+
+    def test_multi_region_rejected(self) -> None:
+        """The evaluation service is regional; multi-regions are rejected."""
+        factory = EvaluatorFactory(project_id='p', location='eu')
+        with pytest.raises(GenkitError, match='does not support'):
+            factory._api_host()
+
+
+class TestGeminiConfigSchemaLocation:
+    """Tests for the per-request location config field."""
+
+    def test_location_field(self) -> None:
+        """The schema accepts a location override."""
+        assert GeminiConfigSchema(location='eu').location == 'eu'
+        assert GeminiConfigSchema().location is None
+
+
+def _vertex_plugin(location: str = 'us-central1', base_url: str | None = None, project: str | None = 'p') -> VertexAI:
+    with patch('genkit_google_genai.google.genai.client.Client'):
+        return VertexAI(project=project, location=location, base_url=base_url)
+
+
+def _vertex_model(location: str = 'us-central1', base_url: str | None = None, project: str | None = 'p') -> GeminiModel:
+    plugin = _vertex_plugin(location, base_url, project)
+    client = MagicMock()
+    client.vertexai = True
+    return GeminiModel(
+        'gemini-2.5-flash',
+        client,
+        client_kwargs=plugin._client_kwargs,
+        base_url_pinned=plugin._base_url_pinned,
+    )
+
+
+class TestResolveRequestClient:
+    """Tests for per-request client resolution in GeminiModel."""
+
+    @pytest.mark.asyncio
+    async def test_no_overrides_returns_plugin_client(self) -> None:
+        """Without overrides the plugin client is reused."""
+        model = _vertex_model()
+        assert await model._resolve_request_client(_text_request()) is model._client
+
+    @pytest.mark.asyncio
+    async def test_no_overrides_on_multi_region_plugin_returns_plugin_client(self) -> None:
+        """A multi-region plugin without overrides also skips temp-client creation."""
+        model = _vertex_model(location='us')
+        assert await model._resolve_request_client(_text_request()) is model._client
+
+    @pytest.mark.asyncio
+    async def test_location_override_creates_client_with_location(self) -> None:
+        """A regional override is passed through with plugin settings intact."""
+        model = _vertex_model()
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            await model._resolve_request_client(_text_request({'location': 'europe-west1'}))
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs['location'] == 'europe-west1'
+        assert kwargs['project'] == 'p'
+        assert kwargs['http_options'].base_url is None
+        assert 'x-goog-api-client' in kwargs['http_options'].headers
+
+    @pytest.mark.asyncio
+    async def test_multi_region_override_sets_rep_base_url(self) -> None:
+        """A multi-region override routes to the rep endpoint."""
+        model = _vertex_model()
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            await model._resolve_request_client(_text_request({'location': 'eu'}))
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs['location'] == 'eu'
+        assert kwargs['http_options'].base_url == EU_REP_URL
+
+    @pytest.mark.asyncio
+    async def test_api_version_override_keeps_multi_region_base_url(self) -> None:
+        """An apiVersion-only override on a multi-region plugin keeps the rep endpoint."""
+        model = _vertex_model(location='us')
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            await model._resolve_request_client(_text_request({'api_version': 'v1'}))
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs['location'] == 'us'
+        assert kwargs['http_options'].api_version == 'v1'
+        assert kwargs['http_options'].base_url == US_REP_URL
+
+    @pytest.mark.asyncio
+    async def test_regional_override_on_multi_region_plugin_clears_rep_url(self) -> None:
+        """Overriding a multi-region plugin with a region drops the rep endpoint."""
+        model = _vertex_model(location='us')
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            await model._resolve_request_client(_text_request({'location': 'europe-west1'}))
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs['location'] == 'europe-west1'
+        assert kwargs['http_options'].base_url is None
+
+    @pytest.mark.asyncio
+    async def test_pinned_base_url_survives_location_override(self) -> None:
+        """A plugin-pinned base URL (proxy) is preserved across a location override."""
+        model = _vertex_model(base_url='https://corp-proxy.example.com/')
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            await model._resolve_request_client(_text_request({'location': 'us'}))
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs['location'] == 'us'
+        assert kwargs['http_options'].base_url == 'https://corp-proxy.example.com/'
+
+    @pytest.mark.asyncio
+    async def test_pinned_base_url_survives_api_version_override(self) -> None:
+        """A plugin-pinned base URL is preserved across an apiVersion override."""
+        model = _vertex_model(base_url='https://corp-proxy.example.com/')
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            await model._resolve_request_client(_text_request({'api_version': 'v1'}))
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs['http_options'].base_url == 'https://corp-proxy.example.com/'
+        assert kwargs['http_options'].api_version == 'v1'
+
+    @pytest.mark.asyncio
+    async def test_base_url_override_wins(self) -> None:
+        """An explicit per-request base_url beats multi-region derivation."""
+        model = _vertex_model()
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            await model._resolve_request_client(_text_request({'location': 'us', 'base_url': 'https://example.com/'}))
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs['http_options'].base_url == 'https://example.com/'
+
+    @pytest.mark.asyncio
+    async def test_multi_region_override_resolves_missing_project(self) -> None:
+        """A multi-region override with no project falls back to ADC."""
+        model = _vertex_model()
+        model._client_kwargs = dict(model._client_kwargs, project=None)
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            with patch('genkit_google_genai.models.gemini.google_auth_default', return_value=(None, 'adc-p')):
+                await model._resolve_request_client(_text_request({'location': 'eu'}))
+        assert mock_ctor.call_args.kwargs['project'] == 'adc-p'
+
+    @pytest.mark.asyncio
+    async def test_multi_region_override_without_project_raises(self) -> None:
+        """A multi-region override with no resolvable project fails fast."""
+        model = _vertex_model()
+        model._client_kwargs = dict(model._client_kwargs, project=None)
+        with patch('genkit_google_genai.models.gemini.google_auth_default', return_value=(None, None)):
+            with pytest.raises(GenkitError, match='project is required'):
+                await model._resolve_request_client(_text_request({'location': 'eu'}))
+
+    @pytest.mark.asyncio
+    async def test_multi_region_override_no_adc_raises_friendly_error(self) -> None:
+        """DefaultCredentialsError surfaces as the friendly GenkitError."""
+        from google.auth.exceptions import DefaultCredentialsError
+
+        model = _vertex_model()
+        model._client_kwargs = dict(model._client_kwargs, project=None)
+        with patch(
+            'genkit_google_genai.models.gemini.google_auth_default', side_effect=DefaultCredentialsError('no adc')
+        ):
+            with pytest.raises(GenkitError, match='project is required'):
+                await model._resolve_request_client(_text_request({'location': 'eu'}))
+
+    @pytest.mark.asyncio
+    async def test_api_version_override_prefills_adc_project(self) -> None:
+        """Any override on an ADC-project plugin resolves the project off-loop."""
+        model = _vertex_model()
+        model._client_kwargs = dict(model._client_kwargs, project=None)
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            with patch('genkit_google_genai.models.gemini.google_auth_default', return_value=(None, 'adc-p')):
+                await model._resolve_request_client(_text_request({'api_version': 'v1'}))
+        assert mock_ctor.call_args.kwargs['project'] == 'adc-p'
+
+    @pytest.mark.asyncio
+    async def test_base_url_override_prefills_adc_project(self) -> None:
+        """A per-request base_url override keeps project/location resolution intact."""
+        model = _vertex_model()
+        model._client_kwargs = dict(model._client_kwargs, project=None)
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            with patch('genkit_google_genai.models.gemini.google_auth_default', return_value=(None, 'adc-p')):
+                await model._resolve_request_client(_text_request({'base_url': 'https://corp-proxy.example.com/'}))
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs['project'] == 'adc-p'
+        assert kwargs['http_options'].base_url == 'https://corp-proxy.example.com/'
+
+    @pytest.mark.asyncio
+    async def test_credentials_project_id_used_before_adc(self) -> None:
+        """A credentials object carrying project_id avoids the ADC probe."""
+        model = _vertex_model()
+        creds = MagicMock()
+        creds.project_id = 'creds-p'
+        model._client_kwargs = dict(model._client_kwargs, project=None, credentials=creds)
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            with patch('genkit_google_genai.models.gemini.google_auth_default') as mock_adc:
+                await model._resolve_request_client(_text_request({'location': 'eu'}))
+        mock_adc.assert_not_called()
+        assert mock_ctor.call_args.kwargs['project'] == 'creds-p'
+
+    @pytest.mark.asyncio
+    async def test_location_ignored_for_googleai_backend(self) -> None:
+        """Location overrides are ignored for the Gemini API backend."""
+        client = MagicMock()
+        client.vertexai = False
+        model = GeminiModel('gemini-2.5-flash', client, client_kwargs={'vertexai': False, 'api_key': 'k'})
+        assert await model._resolve_request_client(_text_request({'location': 'eu'})) is client
+
+    @pytest.mark.asyncio
+    async def test_api_key_override_for_googleai_backend(self) -> None:
+        """A per-request api_key override replaces the plugin key and drops credentials."""
+        client = MagicMock()
+        client.vertexai = False
+        model = GeminiModel(
+            'gemini-2.5-flash',
+            client,
+            client_kwargs={'vertexai': False, 'api_key': 'plugin-key', 'credentials': MagicMock()},
+        )
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            await model._resolve_request_client(_text_request({'api_key': 'override-key'}))
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs['api_key'] == 'override-key'
+        assert kwargs['credentials'] is None
+
+
+class TestPluginModelWiring:
+    """The plugin must pass its client kwargs into the models it constructs."""
+
+    @pytest.mark.asyncio
+    async def test_vertexai_action_passes_client_kwargs(self) -> None:
+        """The model action constructs GeminiModel with the plugin's kwargs."""
+        plugin = _vertex_plugin(location='us')
+        action = plugin._resolve_model('vertexai/gemini-2.5-flash')
+        with patch('genkit_google_genai.google.GeminiModel') as mock_model:
+            mock_model.return_value.generate = AsyncMock(return_value=MagicMock())
+            await action._fn(_text_request(), MagicMock())
+        kwargs = mock_model.call_args.kwargs
+        assert kwargs['client_kwargs'] is plugin._client_kwargs
+        assert kwargs['base_url_pinned'] is plugin._base_url_pinned
+
+    @pytest.mark.asyncio
+    async def test_googleai_action_passes_client_kwargs(self) -> None:
+        """The GoogleAI model action also passes the plugin's kwargs."""
+        from genkit_google_genai import GoogleAI
+
+        with patch('genkit_google_genai.google.genai.client.Client'):
+            plugin = GoogleAI(api_key='k')
+        action = plugin._resolve_model('googleai/gemini-2.5-flash')
+        with patch('genkit_google_genai.google.GeminiModel') as mock_model:
+            mock_model.return_value.generate = AsyncMock(return_value=MagicMock())
+            await action._fn(_text_request(), MagicMock())
+        kwargs = mock_model.call_args.kwargs
+        assert kwargs['client_kwargs'] is plugin._client_kwargs
+
+
+class TestGenerateUsesResolvedClient:
+    """generate() must issue the API call on the override-resolved client."""
+
+    @pytest.mark.asyncio
+    async def test_generate_calls_temp_client(self) -> None:
+        """A location override routes the generate call through the temp client."""
+        model = _vertex_model()
+        response = genai_types.GenerateContentResponse(
+            candidates=[
+                genai_types.Candidate(
+                    content=genai_types.Content(parts=[genai_types.Part(text='ok')], role='model'),
+                    finish_reason=genai_types.FinishReason.STOP,
+                )
+            ]
+        )
+        temp_client = MagicMock()
+        temp_client.aio.models.generate_content = AsyncMock(return_value=response)
+        ctx = MagicMock()
+        ctx.is_streaming = False
+        with patch('genkit_google_genai.models.gemini.genai.Client', return_value=temp_client):
+            result = await model.generate(_text_request({'location': 'europe-west1'}), ctx)
+        temp_client.aio.models.generate_content.assert_awaited_once()
+        model._client.aio.models.generate_content.assert_not_called()
+        assert result.message.content[0].root.text == 'ok'
+
+    @pytest.mark.asyncio
+    async def test_streaming_generate_calls_temp_client(self) -> None:
+        """A location override routes the streaming call through the temp client."""
+        model = _vertex_model()
+        chunk = genai_types.GenerateContentResponse(
+            candidates=[
+                genai_types.Candidate(
+                    content=genai_types.Content(parts=[genai_types.Part(text='ok')], role='model'),
+                    finish_reason=genai_types.FinishReason.STOP,
+                )
+            ]
+        )
+
+        async def _stream():
+            yield chunk
+
+        temp_client = MagicMock()
+        temp_client.aio.models.generate_content_stream = AsyncMock(return_value=_stream())
+        ctx = MagicMock()
+        ctx.is_streaming = True
+        with patch('genkit_google_genai.models.gemini.genai.Client', return_value=temp_client):
+            await model.generate(_text_request({'location': 'europe-west1'}), ctx)
+        temp_client.aio.models.generate_content_stream.assert_awaited_once()
+        model._client.aio.models.generate_content_stream.assert_not_called()
+        ctx.send_chunk.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_threads_resolved_client_into_message_building(self) -> None:
+        """generate() passes the resolved client to _build_messages (cache ops)."""
+        model = _vertex_model()
+        response = genai_types.GenerateContentResponse(
+            candidates=[
+                genai_types.Candidate(
+                    content=genai_types.Content(parts=[genai_types.Part(text='ok')], role='model'),
+                    finish_reason=genai_types.FinishReason.STOP,
+                )
+            ]
+        )
+        temp_client = MagicMock()
+        temp_client.aio.models.generate_content = AsyncMock(return_value=response)
+        ctx = MagicMock()
+        ctx.is_streaming = False
+        contents = [genai_types.Content(parts=[genai_types.Part(text='hi')], role='user')]
+        with patch('genkit_google_genai.models.gemini.genai.Client', return_value=temp_client):
+            with patch.object(model, '_build_messages', AsyncMock(return_value=(contents, None))) as mock_build:
+                await model.generate(_text_request({'location': 'europe-west1'}), ctx)
+        assert mock_build.call_args.kwargs['client'] is temp_client
+
+
+class TestCachedContentClientRouting:
+    """Context-cache operations must run on the request-resolved client."""
+
+    @pytest.mark.asyncio
+    async def test_retrieve_cached_content_uses_passed_client(self) -> None:
+        """Cache list/create run on the passed client, not the plugin client."""
+        model = _vertex_model()
+
+        async def _no_pages():
+            return
+            yield
+
+        cache_client = MagicMock()
+        cache_client.aio.caches.list = AsyncMock(return_value=_no_pages())
+        cache_client.aio.caches.create = AsyncMock(return_value=genai_types.CachedContent(name='caches/x'))
+        contents = [genai_types.Content(parts=[genai_types.Part(text='hi')], role='user')]
+        cache = await model._retrieve_cached_content(
+            request=_text_request(),
+            model_name='gemini-2.0-flash',
+            cache_config={'ttl_seconds': 60},
+            contents=contents,
+            client=cache_client,
+        )
+        cache_client.aio.caches.list.assert_awaited_once()
+        cache_client.aio.caches.create.assert_awaited_once()
+        model._client.aio.caches.list.assert_not_called()
+        model._client.aio.caches.create.assert_not_called()
+        assert cache.name == 'caches/x'
+
+
+class TestLocationConfigThroughPipeline:
+    """Regression tests: the location key must never reach the API config."""
+
+    @pytest.mark.asyncio
+    async def test_location_stripped_from_generate_content_config(self) -> None:
+        """A config with location converts to GenerateContentConfig without error."""
+        model = _vertex_model()
+        request = _text_request({'location': 'eu', 'temperature': 0.5})
+        cfg = await model._genkit_to_googleai_cfg(request=request)
+        assert cfg is not None
+        assert cfg.temperature == 0.5
+        assert not hasattr(cfg, 'location')
+
+    @pytest.mark.asyncio
+    async def test_typed_config_location_stripped(self) -> None:
+        """Same for a typed GeminiConfigSchema config."""
+        model = _vertex_model()
+        request = ModelRequest(
+            messages=[Message(role=Role.USER, content=[TextPart(text='hi')])],
+            config=GeminiConfigSchema(location='us', temperature=0.1),
+        )
+        cfg = await model._genkit_to_googleai_cfg(request=request)
+        assert cfg is not None
+        assert not hasattr(cfg, 'location')

--- a/py/packages/genkit-google-genai/tests/vertexai_location_test.py
+++ b/py/packages/genkit-google-genai/tests/vertexai_location_test.py
@@ -557,6 +557,52 @@ class TestResolveRequestClient:
         assert kwargs['http_options'].base_url == 'https://corp-proxy.example.com/'
 
     @pytest.mark.asyncio
+    async def test_express_mode_override_skips_adc_probe(self) -> None:
+        """Express mode (api_key) never resolves a project for an override.
+
+        The SDK rejects api_key and project together, so a resolved ADC
+        project on the developer's machine would make an otherwise valid
+        apiVersion override fail client construction.
+        """
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                plugin = VertexAI(api_key='k', location='us-central1')
+        client = MagicMock()
+        client.vertexai = True
+        model = GeminiModel(
+            'gemini-2.5-flash',
+            client,
+            client_kwargs=plugin._client_kwargs,
+            base_url_pinned=plugin._base_url_pinned,
+        )
+        with patch('genkit_google_genai.models.gemini.genai.Client') as mock_ctor:
+            with patch('genkit_google_genai.models.gemini.google_auth_default', return_value=(None, 'adc-p')) as adc:
+                await model._resolve_request_client(_text_request({'api_version': 'v1'}))
+        adc.assert_not_called()
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs['api_key'] == 'k'
+        assert kwargs.get('project') is None
+
+    @pytest.mark.asyncio
+    async def test_express_mode_multi_region_override_raises(self) -> None:
+        """A multi-region override in express mode fails with a clear error."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('genkit_google_genai.google.genai.client.Client'):
+                plugin = VertexAI(api_key='k', location='us-central1')
+        client = MagicMock()
+        client.vertexai = True
+        model = GeminiModel(
+            'gemini-2.5-flash',
+            client,
+            client_kwargs=plugin._client_kwargs,
+            base_url_pinned=plugin._base_url_pinned,
+        )
+        with patch('genkit_google_genai.models.gemini.google_auth_default') as adc:
+            with pytest.raises(GenkitError, match='express'):
+                await model._resolve_request_client(_text_request({'location': 'eu'}))
+        adc.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_credentials_project_id_used_before_adc(self) -> None:
         """A credentials object carrying project_id avoids the ADC probe."""
         model = _vertex_model()


### PR DESCRIPTION
Ports #5753 (JS) to the Python plugin. Fixes #5760.

## What this adds

- Multi-region locations `us`/`eu` route to the dedicated `aiplatform.{location}.rep.googleapis.com` endpoints, which the google-genai SDK does not derive itself.
- Per-request `location` override in `GeminiConfigSchema` (regions, multi-regions, or `global`). Vertex only; ignored for the Gemini API backend.
- Location env fallback: `GOOGLE_CLOUD_LOCATION`, then `GCLOUD_LOCATION`, then `us-central1`. Project resolution gains `GOOGLE_CLOUD_PROJECT` and ADC fallbacks (an explicit base_url makes the SDK skip its own ADC lookup, so the plugin resolves the project itself - enforced whether the base URL is plugin-derived or caller-pinned).
- Per-request override clients are cloned from the plugin's client kwargs instead of the SDK's private `_api_client`, so pinned base URLs, headers, timeouts, and apiVersion survive overrides. Context caches are now created on the same client as the generate call.
- Express mode (api_key) never has a project injected next to its key; a multi-region override in express mode fails fast with a clear error rather than the SDK's constructor error.
- Evaluators reject multi-region/global locations with a clear error; the Vertex Evaluation Service is regional only (confirmed against the live API).

## Behavior change to release-note

The plugin previously ignored location env vars (hard default `us-central1`). Deployments with `GOOGLE_CLOUD_LOCATION` or `GCLOUD_LOCATION` exported will pick them up on upgrade. Matches the SDK's behavior; python reads `GOOGLE_CLOUD_LOCATION` ahead of JS's `GCLOUD_LOCATION`, a deliberate superset.

## Verification

All 397 plugin tests pass (60+ new, including one real offline `genai.Client` construction pinning the SDK's base_url contract), ruff clean, pyright introduces no new errors. Live E2E: multi-region client construction with project from env and pure ADC, `global` generate, and full `generate()` with a per-request location override. Multi-region happy path needs an allowlisted project; imagen/veo/embedders on rep endpoints not verifiable offline (shared-client routing matches the JS design).
