### PR TITLE
test(py/plugins/anthropic): add live thinking coverage and budget sam…

### DIFF
--- a/py/packages/genkit-anthropic/tests/anthropic_live_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_live_test.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live tests against the real Anthropic API.
+
+Skipped unless ``ANTHROPIC_API_KEY`` is set.
+
+Run from ``py/`` with:
+
+    ANTHROPIC_API_KEY=your-key uv run pytest packages/genkit-anthropic/tests/anthropic_live_test.py -ra --no-cov
+"""
+
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from anthropic import AsyncAnthropic
+from genkit_anthropic.models import AnthropicModel
+
+from genkit import (
+    Message,
+    ModelRequest,
+    ModelResponseChunk,
+    Part,
+    ReasoningPart,
+    Role,
+    TextPart,
+)
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not os.environ.get('ANTHROPIC_API_KEY'),
+        reason='ANTHROPIC_API_KEY not found in the environment',
+    ),
+]
+
+_ENABLED_THINKING_CONFIG: dict[str, Any] = {
+    'thinking': {'enabled': True, 'budgetTokens': 1024},
+    'maxOutputTokens': 2048,
+}
+
+
+def _request(prompt: str, config: Any) -> ModelRequest:
+    return ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text=prompt))])],
+        config=config,
+    )
+
+
+def _text_of(message: Message) -> str:
+    return ''.join(part.root.text for part in message.content if isinstance(part.root, TextPart))
+
+
+def _reasoning_of(message: Message) -> list[ReasoningPart]:
+    return [part.root for part in message.content if isinstance(part.root, ReasoningPart)]
+
+
+async def test_thinking_enabled_budget() -> None:
+    """A manual thinking budget returns reasoning with a signature."""
+    model = AnthropicModel(model_name='claude-haiku-4-5', client=AsyncAnthropic())
+
+    response = await model.generate(
+        _request(
+            'What is 15 + 27? Think it through, then answer with just the number.',
+            _ENABLED_THINKING_CONFIG,
+        )
+    )
+
+    assert response.message is not None
+    assert _text_of(response.message).strip()
+    reasoning = _reasoning_of(response.message)
+    assert ''.join(part.reasoning for part in reasoning)
+    assert any(part.metadata and part.metadata.get('thoughtSignature') for part in reasoning)
+
+
+async def test_thinking_enabled_budget_streaming() -> None:
+    """Thinking deltas stream as reasoning chunks and match the final reasoning."""
+    model = AnthropicModel(model_name='claude-haiku-4-5', client=AsyncAnthropic())
+    ctx = MagicMock()
+    ctx.is_streaming = True
+    chunks: list[ModelResponseChunk] = []
+    ctx.send_chunk = chunks.append
+
+    response = await model.generate(
+        _request(
+            'What is 12 * 12? Think it through, then answer with just the number.',
+            _ENABLED_THINKING_CONFIG,
+        ),
+        ctx,
+    )
+
+    streamed_reasoning = ''.join(
+        part.root.reasoning for chunk in chunks for part in chunk.content if isinstance(part.root, ReasoningPart)
+    )
+    streamed_text = ''.join(
+        part.root.text for chunk in chunks for part in chunk.content if isinstance(part.root, TextPart)
+    )
+    assert streamed_reasoning
+    assert streamed_text.strip()
+
+    assert response.message is not None
+    final_reasoning = ''.join(part.reasoning for part in _reasoning_of(response.message))
+    assert streamed_reasoning == final_reasoning
+    assert streamed_text == _text_of(response.message)
+    assert response.usage is not None
+    assert (response.usage.output_tokens or 0) > 0
+
+
+async def test_thinking_adaptive() -> None:
+    """Adaptive thinking with display is accepted by Opus 4.7+ models."""
+    model = AnthropicModel(model_name='claude-opus-4-8', client=AsyncAnthropic())
+
+    response = await model.generate(
+        _request(
+            'Write a one-sentence story about a robot.',
+            {'thinking': {'adaptive': True, 'display': 'summarized'}},
+        )
+    )
+
+    assert response.message is not None
+    assert _text_of(response.message).strip()
+
+
+async def test_thinking_disabled() -> None:
+    """Disabled thinking is accepted and yields no reasoning parts."""
+    model = AnthropicModel(model_name='claude-haiku-4-5', client=AsyncAnthropic())
+
+    response = await model.generate(
+        _request('What is 2 + 2? Answer with just the number.', {'thinking': {'enabled': False}})
+    )
+
+    assert response.message is not None
+    assert _text_of(response.message).strip()
+    assert not _reasoning_of(response.message)

--- a/py/packages/genkit-anthropic/tests/anthropic_live_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_live_test.py
@@ -16,6 +16,8 @@
 
 """Live tests against the real Anthropic API.
 
+Requests go through a ``Genkit`` instance with the plugin registered, so
+plugin resolution and the framework config path are exercised end to end.
 Skipped unless ``ANTHROPIC_API_KEY`` is set.
 
 Run from ``py/`` with:
@@ -25,21 +27,12 @@ Run from ``py/`` with:
 
 import os
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
-from anthropic import AsyncAnthropic
-from genkit_anthropic.models import AnthropicModel
+from anthropic import BadRequestError
+from genkit_anthropic import Anthropic
 
-from genkit import (
-    Message,
-    ModelRequest,
-    ModelResponseChunk,
-    Part,
-    ReasoningPart,
-    Role,
-    TextPart,
-)
+from genkit import Genkit, GenkitError, Message, ReasoningPart
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -55,95 +48,95 @@ _ENABLED_THINKING_CONFIG: dict[str, Any] = {
 }
 
 
-def _request(prompt: str, config: Any) -> ModelRequest:
-    return ModelRequest(
-        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text=prompt))])],
-        config=config,
-    )
-
-
-def _text_of(message: Message) -> str:
-    return ''.join(part.root.text for part in message.content if isinstance(part.root, TextPart))
+@pytest.fixture
+def ai() -> Genkit:
+    """Genkit instance with the Anthropic plugin registered."""
+    return Genkit(plugins=[Anthropic()])
 
 
 def _reasoning_of(message: Message) -> list[ReasoningPart]:
     return [part.root for part in message.content if isinstance(part.root, ReasoningPart)]
 
 
-async def test_thinking_enabled_budget() -> None:
+async def test_thinking_enabled_budget(ai: Genkit) -> None:
     """A manual thinking budget returns reasoning with a signature."""
-    model = AnthropicModel(model_name='claude-haiku-4-5', client=AsyncAnthropic())
-
-    response = await model.generate(
-        _request(
-            'What is 15 + 27? Think it through, then answer with just the number.',
-            _ENABLED_THINKING_CONFIG,
-        )
+    response = await ai.generate(
+        model='anthropic/claude-haiku-4-5',
+        prompt='What is 15 + 27? Think it through, then answer with just the number.',
+        config=_ENABLED_THINKING_CONFIG,
     )
 
     assert response.message is not None
-    assert _text_of(response.message).strip()
+    assert response.text.strip()
     reasoning = _reasoning_of(response.message)
     assert ''.join(part.reasoning for part in reasoning)
     assert any(part.metadata and part.metadata.get('thoughtSignature') for part in reasoning)
 
 
-async def test_thinking_enabled_budget_streaming() -> None:
+async def test_thinking_enabled_budget_streaming(ai: Genkit) -> None:
     """Thinking deltas stream as reasoning chunks and match the final reasoning."""
-    model = AnthropicModel(model_name='claude-haiku-4-5', client=AsyncAnthropic())
-    ctx = MagicMock()
-    ctx.is_streaming = True
-    chunks: list[ModelResponseChunk] = []
-    ctx.send_chunk = chunks.append
-
-    response = await model.generate(
-        _request(
-            'What is 12 * 12? Think it through, then answer with just the number.',
-            _ENABLED_THINKING_CONFIG,
-        ),
-        ctx,
+    stream_response = ai.generate_stream(
+        model='anthropic/claude-haiku-4-5',
+        prompt='What is 12 * 12? Think it through, then answer with just the number.',
+        config=_ENABLED_THINKING_CONFIG,
     )
 
-    streamed_reasoning = ''.join(
-        part.root.reasoning for chunk in chunks for part in chunk.content if isinstance(part.root, ReasoningPart)
-    )
-    streamed_text = ''.join(
-        part.root.text for chunk in chunks for part in chunk.content if isinstance(part.root, TextPart)
-    )
-    assert streamed_reasoning
-    assert streamed_text.strip()
+    streamed_reasoning: list[str] = []
+    streamed_text: list[str] = []
+    async for chunk in stream_response.stream:
+        for part in chunk.content:
+            if isinstance(part.root, ReasoningPart):
+                streamed_reasoning.append(part.root.reasoning)
+        if chunk.text:
+            streamed_text.append(chunk.text)
+    response = await stream_response.response
+
+    assert ''.join(streamed_reasoning)
+    assert ''.join(streamed_text).strip()
 
     assert response.message is not None
     final_reasoning = ''.join(part.reasoning for part in _reasoning_of(response.message))
-    assert streamed_reasoning == final_reasoning
-    assert streamed_text == _text_of(response.message)
+    assert ''.join(streamed_reasoning) == final_reasoning
+    assert ''.join(streamed_text) == response.text
     assert response.usage is not None
     assert (response.usage.output_tokens or 0) > 0
 
 
-async def test_thinking_adaptive() -> None:
+async def test_thinking_adaptive(ai: Genkit) -> None:
     """Adaptive thinking with display is accepted by Opus 4.7+ models."""
-    model = AnthropicModel(model_name='claude-opus-4-8', client=AsyncAnthropic())
-
-    response = await model.generate(
-        _request(
-            'Write a one-sentence story about a robot.',
-            {'thinking': {'adaptive': True, 'display': 'summarized'}},
-        )
+    response = await ai.generate(
+        model='anthropic/claude-opus-4-8',
+        prompt='Write a one-sentence story about a robot.',
+        config={'thinking': {'adaptive': True, 'display': 'summarized'}},
     )
 
     assert response.message is not None
-    assert _text_of(response.message).strip()
+    assert response.text.strip()
 
 
-async def test_thinking_disabled() -> None:
+async def test_thinking_disabled(ai: Genkit) -> None:
     """Disabled thinking is accepted and yields no reasoning parts."""
-    model = AnthropicModel(model_name='claude-haiku-4-5', client=AsyncAnthropic())
-
-    response = await model.generate(
-        _request('What is 2 + 2? Answer with just the number.', {'thinking': {'enabled': False}})
+    response = await ai.generate(
+        model='anthropic/claude-haiku-4-5',
+        prompt='What is 2 + 2? Answer with just the number.',
+        config={'thinking': {'enabled': False}},
     )
 
     assert response.message is not None
-    assert _text_of(response.message).strip()
+    assert response.text.strip()
     assert not _reasoning_of(response.message)
+
+
+async def test_thinking_budget_rejected_on_adaptive_only_model(ai: Genkit) -> None:
+    """Models that only support adaptive thinking reject a manual budget with a 400."""
+    with pytest.raises(GenkitError) as excinfo:
+        await ai.generate(
+            model='anthropic/claude-opus-4-8',
+            prompt='What is 2 + 2? Answer with just the number.',
+            config=_ENABLED_THINKING_CONFIG,
+        )
+
+    cause: BaseException | None = excinfo.value
+    while isinstance(cause, GenkitError):
+        cause = cause.cause
+    assert isinstance(cause, BadRequestError)

--- a/py/packages/genkit-anthropic/tests/anthropic_models_test.py
+++ b/py/packages/genkit-anthropic/tests/anthropic_models_test.py
@@ -890,8 +890,17 @@ async def test_typed_config_thinking_translated_for_sdk() -> None:
     'thinking, expected',
     [
         ({'adaptive': True, 'display': 'summarized'}, {'type': 'adaptive', 'display': 'summarized'}),
+        ({'adaptive': True}, {'type': 'adaptive'}),
         ({'enabled': False}, {'type': 'disabled'}),
         ({'budgetTokens': 2048}, {'type': 'enabled', 'budget_tokens': 2048}),
+        # Non-mode keys (display, forward-compatible fields) pass through in every mode.
+        (
+            {'enabled': True, 'budgetTokens': 2048, 'display': 'summarized'},
+            {'type': 'enabled', 'budget_tokens': 2048, 'display': 'summarized'},
+        ),
+        # SDK-native type spellings are accepted alongside the boolean flags.
+        ({'type': 'adaptive'}, {'type': 'adaptive'}),
+        ({'type': 'disabled'}, {'type': 'disabled'}),
     ],
 )
 async def test_typed_config_thinking_variants_translated_for_sdk(

--- a/py/samples/anthropic-sample/src/main.py
+++ b/py/samples/anthropic-sample/src/main.py
@@ -180,6 +180,43 @@ async def thinking_tool_round_trip(data: WeatherInput, ctx: ActionRunContext) ->
     }
 
 
+# --- claude-haiku-4-5 (manual thinking budget) ------------------------------
+
+
+@ai.flow(name='thinking_budget_story')
+async def thinking_budget_story(data: TopicInput, ctx: ActionRunContext) -> dict[str, object]:
+    """Streams a story using a manual thinking budget on a pre-4.7 model."""
+    stream_response = ai.generate_stream(
+        model='anthropic/claude-haiku-4-5',
+        prompt=f'Tell me a very short story about {data.topic}.',
+        config={
+            'thinking': {'enabled': True, 'budgetTokens': 1024},
+            'maxOutputTokens': 2048,
+        },
+    )
+
+    streamed_reasoning: list[str] = []
+    streamed_text: list[str] = []
+    async for chunk in stream_response.stream:
+        for part in chunk.content:
+            root = part.root
+            if isinstance(root, ReasoningPart):
+                streamed_reasoning.append(root.reasoning)
+                ctx.send_chunk(f'[thinking] {root.reasoning}')
+        if chunk.text:
+            streamed_text.append(chunk.text)
+            ctx.send_chunk(chunk.text)
+
+    response = await stream_response.response
+    summary = _thinking_summary(response)
+    return {
+        **summary,
+        'final_text': response.text,
+        'streamed_reasoning_chunks': len(streamed_reasoning),
+        'streamed_text': ''.join(streamed_text),
+    }
+
+
 async def main() -> None:
     """Run the lightweight flows once from the CLI."""
     try:


### PR DESCRIPTION
Closes #5629

## What

The request-side thinking modes already landed: the typed config and mode mapping in #5720, and the response/reasoning side in #5724. This PR closes out the issue with the coverage that was still missing:

- A live test module, `anthropic_live_test.py`, the first one in the py tree. It mirrors the Go plugin's `anthropic_live_test.go`: skipped unless `ANTHROPIC_API_KEY` is set, so CI never runs it. Four tests: a manual thinking budget (non-streaming and streaming, asserting reasoning comes back with a signature and that streamed reasoning and text match the final message), adaptive thinking with `display` on claude-opus-4-8, and disabled thinking.
- Four more unit-test variants for the thinking mapping: adaptive without display, display passing through alongside enabled, and the SDK-native `{'type': 'adaptive'}` and `{'type': 'disabled'}` spellings.
- A `thinking_budget_story` sample flow on claude-haiku-4-5, so the sample demonstrates both modes the way the Go sample does.

## Scope

This is parity work only. The issue also asked for model-aware validation and a local `max_tokens > budgetTokens` guard, but neither JS nor Go has those, so they are intentionally left out. Invalid combinations surface as API errors for now, and translating those into proper Genkit statuses is tracked in #5630.
## Testing

- `uv run pytest packages/genkit-anthropic/tests/ --no-cov`: 190 passed, 4 live tests skipped without a key
- `ANTHROPIC_API_KEY=... uv run pytest packages/genkit-anthropic/tests/anthropic_live_test.py -ra --no-cov` to run the live tests locally

## Flow Screenshot
<img width="1011" height="781" alt="Screenshot 2026-07-20 at 16 09 36" src="https://github.com/user-attachments/assets/e6fbeb55-cfe5-43bc-b252-289f79b36fef" />
