### PR TITLE
feat(go/plugins/googlegenai): add Vertex AI multi-region and apiVersion support

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -41,7 +41,7 @@ require (
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
 	golang.org/x/tools v0.34.0
 	google.golang.org/api v0.236.0
-	google.golang.org/genai v1.51.0
+	google.golang.org/genai v1.57.0
 )
 
 require (

--- a/go/go.sum
+++ b/go/go.sum
@@ -539,8 +539,8 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine/v2 v2.0.6 h1:LvPZLGuchSBslPBp+LAhihBeGSiRh1myRoYK4NtuBIw=
 google.golang.org/appengine/v2 v2.0.6/go.mod h1:WoEXGoXNfa0mLvaH5sV3ZSGXwVmy8yf7Z1JKf3J3wLI=
-google.golang.org/genai v1.51.0 h1:IZGuUqgfx40INv3hLFGCbOSGp0qFqm7LVmDghzNIYqg=
-google.golang.org/genai v1.51.0/go.mod h1:A3kkl0nyBjyFlNjgxIwKq70julKbIxpSxqKO5gw/gmk=
+google.golang.org/genai v1.57.0 h1:qTyG2ynz5dQy2jF4CvZdLHHVslhR0heMue+zM1a4GNM=
+google.golang.org/genai v1.57.0/go.mod h1:A3kkl0nyBjyFlNjgxIwKq70julKbIxpSxqKO5gw/gmk=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=

--- a/go/plugins/googlegenai/README.md
+++ b/go/plugins/googlegenai/README.md
@@ -60,8 +60,9 @@ func main() {
 
  g := genkit.Init(ctx,
   genkit.WithPlugins(&googlegenai.VertexAI{
-   ProjectID: "your-project-id", // Optional: defaults to GOOGLE_CLOUD_PROJECT
-   Location:  "us-central1",     // Optional: defaults to GOOGLE_CLOUD_LOCATION
+   ProjectID:  "your-project-id", // Optional: defaults to GOOGLE_CLOUD_PROJECT
+   Location:   "us-central1",     // Optional: defaults to GOOGLE_CLOUD_LOCATION. Also accepts multi-region ("us", "eu") or "global".
+   APIVersion: "v1",              // Optional: defaults to v1beta1. Can be overridden per-request via config.HTTPOptions.APIVersion.
   }),
  )
 }

--- a/go/plugins/googlegenai/googlegenai.go
+++ b/go/plugins/googlegenai/googlegenai.go
@@ -136,7 +136,9 @@ func (v *VertexAI) Init(ctx context.Context) []api.Action {
 		}
 	}
 
-	if v.APIVersion != "" && v.APIVersion != "v1" && v.APIVersion != "v1beta1" {
+	switch v.APIVersion {
+	case "", "v1", "v1beta1":
+	default:
 		panic(fmt.Sprintf("Vertex AI APIVersion must be %q or %q, got %q", "v1", "v1beta1", v.APIVersion))
 	}
 

--- a/go/plugins/googlegenai/googlegenai.go
+++ b/go/plugins/googlegenai/googlegenai.go
@@ -40,8 +40,9 @@ type GoogleAI struct {
 
 // VertexAI is a Genkit plugin for interacting with the Google Vertex AI service.
 type VertexAI struct {
-	ProjectID string // Google Cloud project to use for Vertex AI. If empty, the value of the environment variable GOOGLE_CLOUD_PROJECT will be consulted.
-	Location  string // Location of the Vertex AI service. If empty, GOOGLE_CLOUD_LOCATION and GOOGLE_CLOUD_REGION environment variables will be consulted, in that order.
+	ProjectID  string // Google Cloud project to use for Vertex AI. If empty, the value of the environment variable GOOGLE_CLOUD_PROJECT will be consulted.
+	Location   string // Location of the Vertex AI service. If empty, GOOGLE_CLOUD_LOCATION and GOOGLE_CLOUD_REGION environment variables will be consulted, in that order. Accepts a regional location (e.g. "us-central1"), a multi-region location ("us" or "eu"), or "global".
+	APIVersion string // API version to use ("v1" or "v1beta1"). If empty, the genai SDK default (v1beta1) is used. Can be overridden per-request via config.HTTPOptions.APIVersion.
 
 	gclient *genai.Client // Client for the Vertex AI service.
 	mu      sync.Mutex    // Mutex to control access.
@@ -134,6 +135,11 @@ func (v *VertexAI) Init(ctx context.Context) []api.Action {
 			panic("Vertex AI requires setting GOOGLE_CLOUD_LOCATION or GOOGLE_CLOUD_REGION in the environment. You can get a location at https://cloud.google.com/vertex-ai/docs/general/locations")
 		}
 	}
+
+	if v.APIVersion != "" && v.APIVersion != "v1" && v.APIVersion != "v1beta1" {
+		panic(fmt.Sprintf("Vertex AI APIVersion must be %q or %q, got %q", "v1", "v1beta1", v.APIVersion))
+	}
+
 	cred, err := credentials.DetectDefault(&credentials.DetectOptions{
 		Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
 	})
@@ -162,7 +168,8 @@ func (v *VertexAI) Init(ctx context.Context) []api.Action {
 		Location:   location,
 		HTTPClient: httpClient,
 		HTTPOptions: genai.HTTPOptions{
-			Headers: genkitClientHeader,
+			Headers:    genkitClientHeader,
+			APIVersion: v.APIVersion,
 		},
 	}
 

--- a/go/plugins/googlegenai/googlegenai_test.go
+++ b/go/plugins/googlegenai/googlegenai_test.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package googlegenai_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+)
+
+// TestVertexAIInit_InvalidAPIVersion verifies that a bad APIVersion is
+// rejected before any credential detection or network access is attempted,
+// so the failure is immediate and clear rather than a confusing 404 at
+// request time.
+func TestVertexAIInit_InvalidAPIVersion(t *testing.T) {
+	v := &googlegenai.VertexAI{
+		ProjectID:  "test-project",
+		Location:   "us-central1",
+		APIVersion: "v1beta", // invalid: valid values are "v1" and "v1beta1"
+	}
+
+	var recovered any
+	func() {
+		defer func() {
+			recovered = recover()
+		}()
+		v.Init(context.Background())
+	}()
+
+	if recovered == nil {
+		t.Fatal("expected Init to panic on invalid APIVersion, but it did not")
+	}
+	msg, ok := recovered.(string)
+	if !ok {
+		t.Fatalf("expected panic value to be a string, got %T: %v", recovered, recovered)
+	}
+	if !strings.Contains(msg, "v1beta") {
+		t.Errorf("panic message %q does not mention the invalid value", msg)
+	}
+}

--- a/go/plugins/googlegenai/vertexai_live_test.go
+++ b/go/plugins/googlegenai/vertexai_live_test.go
@@ -421,4 +421,42 @@ func TestVertexAILive(t *testing.T) {
 			t.Fatal("expected a non-empty response from the tuned endpoint")
 		}
 	})
+	t.Run("multi-region location", func(t *testing.T) {
+		// Multi-region ("us"/"eu") endpoints aren't necessarily enabled on
+		// every Vertex AI project, so this is opt-in like the tuned endpoint
+		// test above rather than assumed to work whenever GOOGLE_CLOUD_PROJECT
+		// is set.
+		multiRegion, ok := requireEnv("GENKIT_VERTEX_MULTIREGION_LOCATION")
+		if !ok {
+			t.Skip("GENKIT_VERTEX_MULTIREGION_LOCATION not set; skipping multi-region live test")
+		}
+		// "us" and "eu" are multi-region locations routed to
+		// aiplatform.{location}.rep.googleapis.com by the genai SDK.
+		plugin := &googlegenai.VertexAI{ProjectID: projectID, Location: multiRegion}
+		gMultiRegion := genkit.Init(ctx, genkit.WithPlugins(plugin))
+		resp, err := genkit.Generate(ctx, gMultiRegion,
+			ai.WithModelName("vertexai/gemini-2.5-flash"),
+			ai.WithPrompt("Say hello in one short sentence."),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(resp.Text()) == "" {
+			t.Fatal("expected a non-empty response from the multi-region endpoint")
+		}
+	})
+	t.Run("plugin-level apiVersion override", func(t *testing.T) {
+		plugin := &googlegenai.VertexAI{ProjectID: projectID, Location: location, APIVersion: "v1"}
+		gAPIVersion := genkit.Init(ctx, genkit.WithPlugins(plugin))
+		resp, err := genkit.Generate(ctx, gAPIVersion,
+			ai.WithModelName("vertexai/gemini-2.5-flash"),
+			ai.WithPrompt("Say hello in one short sentence."),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(resp.Text()) == "" {
+			t.Fatal("expected a non-empty response with apiVersion override")
+		}
+	})
 }


### PR DESCRIPTION
This PR adds Vertex AI multi-region (us/eu) and apiVersion support.

Closes #5759 

Checklist (if applicable):
- [x] PR title is following https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tested (manually, unit tested, etc.)
- [x] Docs updated (updated docs or a docs bug required)