### PR TITLE
fix(py): reliably clean up CLI runtime metadata on SIGINT/SIGTERM

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -121,7 +121,7 @@ from genkit._core._typing import (
 )
 
 from ._decorators import _FlowDecorator, _FlowDecoratorWithChunk
-from ._runtime import RuntimeManager
+from ._runtime import RuntimeManager, setup_signal_handlers
 
 logger = get_logger(__name__)
 
@@ -173,6 +173,7 @@ class Genkit:
         # daemon thread so it's available regardless of which web framework (or
         # none) the user chooses.
         if is_dev_environment():
+            setup_signal_handlers()
             self._start_reflection_background()
 
         # Load prompts

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -173,6 +173,10 @@ class Genkit:
         # daemon thread so it's available regardless of which web framework (or
         # none) the user chooses.
         if is_dev_environment():
+            # SIGINT (Ctrl+C) always hits handle_signal. SIGTERM inside the
+            # run_main wait loop is stolen by anyio (clean exit → atexit);
+            # elsewhere SIGTERM also goes through handle_signal. Both paths
+            # remove the runtime discovery files.
             setup_signal_handlers()
             self._start_reflection_background()
 

--- a/py/packages/genkit/src/genkit/_ai/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_runtime.py
@@ -21,10 +21,12 @@ from __future__ import annotations
 import atexit
 import json
 import os
+import signal
 import sys
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from types import TracebackType
+from types import FrameType, TracebackType
 
 from genkit._core._constants import GENKIT_VERSION
 from genkit._core._logger import get_logger
@@ -33,6 +35,32 @@ from genkit._core._reflection import ServerSpec
 logger = get_logger(__name__)
 
 DEFAULT_RUNTIME_DIR_NAME = '.genkit/runtimes'
+ACTIVE_CLEANUPS: list[Callable[[], None]] = []
+SIGNALS_REGISTERED = False
+
+
+def setup_signal_handlers() -> None:
+    """Setup global signal handlers once on the main thread."""
+    global SIGNALS_REGISTERED
+    if SIGNALS_REGISTERED:
+        return
+
+    def handle_signal(signum: int, frame: FrameType | None) -> None:
+        cleanups = list(ACTIVE_CLEANUPS)
+        for cleanup_fn in cleanups:
+            try:
+                cleanup_fn()
+            except Exception:  # noqa: S110
+                pass
+        sys.exit(128 + signum)
+
+    try:
+        signal.signal(signal.SIGINT, handle_signal)
+        signal.signal(signal.SIGTERM, handle_signal)
+        SIGNALS_REGISTERED = True
+    except ValueError:
+        # Ignore if called from a background thread
+        pass
 
 
 def _remove_file(file_path: Path | None) -> bool:
@@ -247,10 +275,15 @@ class RuntimeManager:
 
         self._runtime_file_path = _create_and_write_runtime_file(self._runtime_dir, self.spec)
         _register_atexit_cleanup_handler(self._runtime_file_path)
+        ACTIVE_CLEANUPS.append(self.cleanup)
         return self._runtime_file_path
 
     def cleanup(self) -> None:
         """Explicitly cleanup the runtime file."""
+        if self.cleanup in ACTIVE_CLEANUPS:
+            ACTIVE_CLEANUPS.remove(self.cleanup)
+
         if self._runtime_file_path:
             logger.debug(f'Cleaning up runtime file: {self._runtime_file_path}')
             _ = _remove_file(self._runtime_file_path)
+            self._runtime_file_path = None

--- a/py/packages/genkit/src/genkit/_ai/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_runtime.py
@@ -37,7 +37,7 @@ logger = get_logger(__name__)
 
 DEFAULT_RUNTIME_DIR_NAME = '.genkit/runtimes'
 ACTIVE_CLEANUPS: list[Callable[[], None]] = []
-ACTIVE_CLEANUPS_LOCK = threading.Lock()
+ACTIVE_CLEANUPS_LOCK = threading.RLock()
 SIGNALS_REGISTERED = False
 
 
@@ -66,7 +66,7 @@ def setup_signal_handlers() -> None:
 
             if callable(handler):
                 handler(signum, frame)
-            elif handler == signal.SIG_DFL:
+            else:
                 sys.exit(128 + signum)
 
         signal.signal(signal.SIGINT, handle_signal)

--- a/py/packages/genkit/src/genkit/_ai/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_runtime.py
@@ -23,6 +23,7 @@ import json
 import os
 import signal
 import sys
+import threading
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
@@ -36,6 +37,7 @@ logger = get_logger(__name__)
 
 DEFAULT_RUNTIME_DIR_NAME = '.genkit/runtimes'
 ACTIVE_CLEANUPS: list[Callable[[], None]] = []
+ACTIVE_CLEANUPS_LOCK = threading.Lock()
 SIGNALS_REGISTERED = False
 
 
@@ -45,16 +47,28 @@ def setup_signal_handlers() -> None:
     if SIGNALS_REGISTERED:
         return
 
-    def handle_signal(signum: int, frame: FrameType | None) -> None:
-        cleanups = list(ACTIVE_CLEANUPS)
-        for cleanup_fn in cleanups:
-            try:
-                cleanup_fn()
-            except Exception:  # noqa: S110
-                pass
-        sys.exit(128 + signum)
-
     try:
+        original_sigint = signal.getsignal(signal.SIGINT)
+        original_sigterm = signal.getsignal(signal.SIGTERM)
+
+        def handle_signal(signum: int, frame: FrameType | None) -> None:
+            handler = original_sigint if signum == signal.SIGINT else original_sigterm
+            if handler == signal.SIG_IGN:
+                return
+
+            with ACTIVE_CLEANUPS_LOCK:
+                cleanups = list(ACTIVE_CLEANUPS)
+            for cleanup_fn in cleanups:
+                try:
+                    cleanup_fn()
+                except Exception:  # noqa: S110
+                    pass
+
+            if callable(handler):
+                handler(signum, frame)
+            elif handler == signal.SIG_DFL:
+                sys.exit(128 + signum)
+
         signal.signal(signal.SIGINT, handle_signal)
         signal.signal(signal.SIGTERM, handle_signal)
         SIGNALS_REGISTERED = True
@@ -275,13 +289,15 @@ class RuntimeManager:
 
         self._runtime_file_path = _create_and_write_runtime_file(self._runtime_dir, self.spec)
         _register_atexit_cleanup_handler(self._runtime_file_path)
-        ACTIVE_CLEANUPS.append(self.cleanup)
+        with ACTIVE_CLEANUPS_LOCK:
+            ACTIVE_CLEANUPS.append(self.cleanup)
         return self._runtime_file_path
 
     def cleanup(self) -> None:
         """Explicitly cleanup the runtime file."""
-        if self.cleanup in ACTIVE_CLEANUPS:
-            ACTIVE_CLEANUPS.remove(self.cleanup)
+        with ACTIVE_CLEANUPS_LOCK:
+            if self.cleanup in ACTIVE_CLEANUPS:
+                ACTIVE_CLEANUPS.remove(self.cleanup)
 
         if self._runtime_file_path:
             logger.debug(f'Cleaning up runtime file: {self._runtime_file_path}')

--- a/py/packages/genkit/src/genkit/_ai/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_runtime.py
@@ -73,7 +73,10 @@ def setup_signal_handlers() -> None:
         signal.signal(signal.SIGTERM, handle_signal)
         SIGNALS_REGISTERED = True
     except ValueError:
-        # Ignore if called from a background thread
+        # In Python, signal.signal() can only be invoked from the primary main thread
+        # of the main process; calling it from a background worker thread raises ValueError.
+        # OS termination signals are only ever delivered to the main thread anyway, so
+        # registering handlers on background threads is both impossible and unnecessary.
         pass
 
 

--- a/py/packages/genkit/src/genkit/_ai/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_runtime.py
@@ -37,6 +37,8 @@ logger = get_logger(__name__)
 
 DEFAULT_RUNTIME_DIR_NAME = '.genkit/runtimes'
 ACTIVE_CLEANUPS: list[Callable[[], None]] = []
+# RLock so a SIGINT/SIGTERM mid-update can re-enter: signal handlers run on the
+# main thread, and a plain Lock would deadlock if that thread already holds it.
 ACTIVE_CLEANUPS_LOCK = threading.RLock()
 SIGNALS_REGISTERED = False
 


### PR DESCRIPTION
When running local dev sessions (`genkit start`), stopping the server with `Ctrl+C` (`SIGINT`) or process termination (`SIGTERM`) bypasses Python's default `atexit` callbacks. Because of this, dead `<id>.json` discovery files were being left behind in `.genkit/runtimes/`, causing the Dev UI to spam connection errors and display unresponsive ghost runtimes in the dashboard.

This PR adds lightweight global signal handling during dev mode initialization (`is_dev_environment()`) so we reliably sweep and clean up local discovery files on exit without interfering with existing server termination workflows (like Uvicorn's shutdown handlers).