### PR TITLE
fix(js/plugins/google-genai): map tool role to "user" for Gemini compatibility

### DIFF
--- a/js/plugins/google-genai/src/common/converters.ts
+++ b/js/plugins/google-genai/src/common/converters.ts
@@ -318,7 +318,7 @@ function toGeminiRole(
         throw new Error('system role is not supported');
       }
     case 'tool':
-      return 'function';
+      return 'user';
     default:
       return 'user';
   }

--- a/js/plugins/google-genai/tests/common/converters_test.ts
+++ b/js/plugins/google-genai/tests/common/converters_test.ts
@@ -93,7 +93,7 @@ describe('toGeminiMessage', () => {
         ],
       },
       expectedOutput: {
-        role: 'function',
+        role: 'user',
         parts: [
           {
             functionResponse: {
@@ -142,7 +142,7 @@ describe('toGeminiMessage', () => {
         ],
       },
       expectedOutput: {
-        role: 'function',
+        role: 'user',
         parts: [
           {
             functionResponse: {
@@ -189,7 +189,7 @@ describe('toGeminiMessage', () => {
         ],
       },
       expectedOutput: {
-        role: 'function',
+        role: 'user',
         parts: [
           {
             functionResponse: {
@@ -231,7 +231,7 @@ describe('toGeminiMessage', () => {
         ],
       },
       expectedOutput: {
-        role: 'function',
+        role: 'user',
         parts: [
           {
             functionResponse: {
@@ -469,7 +469,7 @@ describe('toGeminiMessage', () => {
         ],
       },
       expectedOutput: {
-        role: 'function',
+        role: 'user',
         parts: [
           {
             codeExecutionResult: {


### PR DESCRIPTION
Change the tool role mapping from 'function' to 'user' in the Gemini message converter. For latest models the Gemini API expects function responses to use the 'user' role rather than 'function', ensuring proper message handling. This works fine for older models too.

Update corresponding test expectations to reflect the new role mapping.

