### PR TITLE
fix(py/plugins/google-genai): map tool role to "user" for Gemini compatibility

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -1943,7 +1943,8 @@ class GeminiModel:
                     content_parts.extend(converted)
                 else:
                     content_parts.append(converted)
-            request_contents.append(genai_types.Content(parts=content_parts, role=msg.role))
+            role = 'user' if msg.role == Role.TOOL else msg.role
+            request_contents.append(genai_types.Content(parts=content_parts, role=role))
 
             if msg.metadata and msg.metadata.get('cache'):
                 cache = await self._retrieve_cached_content(

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -1137,3 +1137,30 @@ def test_gemini_model__pick_plugin_schema_routes_by_model_family(
     picked = model._pick_plugin_schema({})
 
     assert type(picked) is expected_schema
+
+
+@pytest.mark.asyncio
+async def test_gemini_model__build_messages_maps_tool_role_to_user(
+    gemini_model_instance: GeminiModel,
+) -> None:
+    """Messages with Role.TOOL are mapped to 'user' in Gemini request Content."""
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.USER, content=[Part(root=TextPart(text='What is the weather in Seattle?'))]),
+            Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='I will check.'))],
+            ),
+            Message(
+                role=Role.TOOL,
+                content=[Part(root=TextPart(text='Sunny, 72°F in Seattle'))],
+            ),
+        ],
+    )
+
+    contents, cache = await gemini_model_instance._build_messages(request, model_name='gemini-2.5-flash')
+    assert cache is None
+    assert len(contents) == 3
+    assert contents[0].role == 'user'
+    assert contents[1].role == 'model'
+    assert contents[2].role == 'user'


### PR DESCRIPTION
Gemini 3.6 / `gemini-flash-latest` enforce strict turn role validation and reject role `"tool"` with 400 Bad Request (`Role 'tool' is not supported`). This mirrors PR #5777 from JS to map `Role.TOOL` to `"user"` when building request contents in the Python SDK.

Tested with live multi-turn tool calling across `gemini-flash-latest`, `gemini-3.6-flash`, and `gemini-3.5-flash`.