### PR TITLE
feat(cli): add runtime dimension to metrics

### DIFF
--- a/genkit-tools/cli/src/cli.ts
+++ b/genkit-tools/cli/src/cli.ts
@@ -17,6 +17,8 @@
 import { ToolPluginSubCommandsSchema } from '@genkit-ai/tools-common/plugin';
 import {
   RunCommandEvent,
+  detectRuntime,
+  findProjectRoot,
   logger,
   notifyAnalyticsIfFirstRun,
   record,
@@ -110,8 +112,14 @@ export async function startCLI(): Promise<void> {
       }
 
       const { isCompiledBinary } = detectCLIRuntime();
+      const projectRoot = await findProjectRoot();
+      const projectRuntime = await detectRuntime(projectRoot);
       await record(
-        new RunCommandEvent(commandName, isCompiledBinary ? 'binary' : 'node')
+        new RunCommandEvent(
+          commandName,
+          isCompiledBinary ? 'binary' : 'node',
+          projectRuntime
+        )
       );
     });
 

--- a/genkit-tools/cli/src/commands/init-ai-tools/command.ts
+++ b/genkit-tools/cli/src/commands/init-ai-tools/command.ts
@@ -70,10 +70,16 @@ export const initAiTools = new Command('init:ai-tools')
     logger.info('  - Common Genkit features and how to use them');
     logger.info('\n');
     let runtime = await detectRuntime(process.cwd());
-    if (runtime) {
+    if (runtime && SUPPORTED_RUNTIMES[runtime]) {
       logger.info('Detected runtime: ' + SUPPORTED_RUNTIMES[runtime]);
     } else {
-      logger.info('No runtime was detected in the current directory.');
+      if (runtime) {
+        logger.info(
+          `Detected runtime '${runtime}' is not yet supported for AI tools context.`
+        );
+      } else {
+        logger.info('No runtime was detected in the current directory.');
+      }
       const answer = await select({
         message: 'Select a runtime to initialize a Genkit project:',
         choices: Object.keys(SUPPORTED_RUNTIMES).map((runtime) => ({

--- a/genkit-tools/cli/src/commands/init-ai-tools/utils.ts
+++ b/genkit-tools/cli/src/commands/init-ai-tools/utils.ts
@@ -154,7 +154,7 @@ export function getGenkitContext(runtime: Runtime): string {
     case 'go':
       return GoContext;
     default:
-      throw new Error('Unexpected runtime provided', runtime);
+      throw new Error(`Unexpected runtime provided: ${runtime}`);
   }
 }
 

--- a/genkit-tools/common/src/manager/types.ts
+++ b/genkit-tools/common/src/manager/types.ts
@@ -16,7 +16,7 @@
 
 import type { GenkitError } from '../types/error';
 
-export type Runtime = 'nodejs' | 'go' | undefined;
+export type Runtime = 'nodejs' | 'go' | 'python' | 'dart' | undefined;
 
 export class GenkitToolsError extends Error {
   public data?: GenkitError;

--- a/genkit-tools/common/src/server/server.ts
+++ b/genkit-tools/common/src/server/server.ts
@@ -24,7 +24,7 @@ import os from 'os';
 import path from 'path';
 import type { GenkitToolsError } from '../manager';
 import type { BaseRuntimeManager } from '../manager/manager';
-import { logger, writeToolsInfoFile } from '../utils';
+import { detectRuntimeSync, logger, writeToolsInfoFile } from '../utils';
 import {
   createToolsRequestEvent,
   extractActionType,
@@ -94,7 +94,7 @@ class PushableAsyncIterable<T> implements AsyncIterable<T> {
 
 const activeInputStreams = new Map<string, PushableAsyncIterable<any>>();
 
-const loggedExpressRoute = (routeName: string) => {
+const loggedExpressRoute = (routeName: string, projectRuntime?: string) => {
   return (
     req: express.Request,
     res: express.Response,
@@ -121,7 +121,10 @@ const loggedExpressRoute = (routeName: string) => {
           : undefined;
 
       recordRequestEvent(
-        createToolsRequestEvent(routeName, durationMs, status, { action })
+        createToolsRequestEvent(routeName, durationMs, status, {
+          action,
+          project_runtime: projectRuntime,
+        })
       );
     };
 
@@ -140,6 +143,7 @@ export function startServer(
   port: number,
   host: string = DEFAULT_HOST
 ) {
+  const projectRuntime = detectRuntimeSync(manager.projectRoot);
   let server: Server;
   const app = express();
 
@@ -165,7 +169,7 @@ export function startServer(
   app.post(
     '/api/runAction',
     bodyParser.json({ limit: MAX_PAYLOAD_SIZE }),
-    loggedExpressRoute('runAction'),
+    loggedExpressRoute('runAction', projectRuntime),
     async (req, res) => {
       // Set headers but don't flush yet - wait for trace ID (if realtime telemetry enabled)
       res.setHeader('Content-Type', 'application/json');
@@ -213,7 +217,7 @@ export function startServer(
   app.post(
     '/api/streamAction',
     bodyParser.json({ limit: MAX_PAYLOAD_SIZE }),
-    loggedExpressRoute('streamAction'),
+    loggedExpressRoute('streamAction', projectRuntime),
     async (req, res) => {
       // Set streaming headers but don't flush yet - wait for trace ID (if realtime telemetry enabled)
       res.setHeader('Content-Type', 'text/plain');
@@ -271,7 +275,7 @@ export function startServer(
   app.post(
     '/api/sendBidiInput',
     bodyParser.json({ limit: MAX_PAYLOAD_SIZE }),
-    loggedExpressRoute('sendBidiInput'),
+    loggedExpressRoute('sendBidiInput', projectRuntime),
     (req, res) => {
       const { traceId, chunk } = req.body;
       const stream = activeInputStreams.get(traceId);
@@ -287,7 +291,7 @@ export function startServer(
   app.post(
     '/api/endBidiInput',
     bodyParser.json(),
-    loggedExpressRoute('endBidiInput'),
+    loggedExpressRoute('endBidiInput', projectRuntime),
     (req, res) => {
       const { traceId } = req.body;
       const stream = activeInputStreams.get(traceId);
@@ -307,7 +311,7 @@ export function startServer(
   app.post(
     '/api/streamTrace',
     bodyParser.json({ limit: MAX_PAYLOAD_SIZE }),
-    loggedExpressRoute('streamTrace'),
+    loggedExpressRoute('streamTrace', projectRuntime),
     async (req, res) => {
       const { traceId } = req.body;
 

--- a/genkit-tools/common/src/utils/analytics.ts
+++ b/genkit-tools/common/src/utils/analytics.ts
@@ -81,9 +81,13 @@ export class RunCommandEvent extends GAEvent {
   name = 'run_command';
   duration = 1; // Should we actually track command duration?
 
-  constructor(command: string, runtime_type: string) {
+  constructor(command: string, runtime_type: string, project_runtime?: string) {
     super();
-    this.stickyParameters = { command, runtime_type };
+    this.stickyParameters = {
+      command,
+      runtime_type,
+      ...(project_runtime && { project_runtime }),
+    };
   }
 }
 
@@ -125,7 +129,7 @@ export function createToolsRequestEvent(
   route: string,
   durationMs: number,
   status: string,
-  options?: { action?: string }
+  options?: { action?: string; project_runtime?: string }
 ): ToolsRequestEvent {
   const event = new ToolsRequestEvent(route);
   event.duration = Math.max(1, durationMs);
@@ -133,6 +137,9 @@ export function createToolsRequestEvent(
     ...event.parameters,
     status,
     ...(options?.action && { action: options.action }),
+    ...(options?.project_runtime && {
+      project_runtime: options.project_runtime,
+    }),
   };
   return event;
 }

--- a/genkit-tools/common/src/utils/utils.ts
+++ b/genkit-tools/common/src/utils/utils.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as fsSync from 'fs';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import type { Runtime } from '../manager/types';
@@ -122,20 +123,52 @@ export function projectNameFromGenkitFilePath(filePath: string): string {
 }
 
 /**
+ * Maps a filename to a Genkit SDK runtime if it is a recognized marker file.
+ */
+function matchRuntimeMarker(file: string, isFile: boolean): Runtime {
+  if (!isFile) return undefined;
+  if (path.extname(file) === '.go' || file === 'go.mod') {
+    return 'go';
+  }
+  if (file === 'pyproject.toml' || file === 'requirements.txt') {
+    return 'python';
+  }
+  if (file === 'pubspec.yaml') {
+    return 'dart';
+  }
+  return undefined;
+}
+
+/**
  * Detects what runtime is used in the current directory.
  * @returns Runtime of the project directory.
  */
 export async function detectRuntime(directory: string): Promise<Runtime> {
-  const files = await fs.readdir(directory);
-  for (const file of files) {
-    const filePath = path.join(directory, file);
-    const stat = await fs.stat(filePath);
-    if (stat.isFile() && (path.extname(file) === '.go' || file === 'go.mod')) {
-      return 'go';
-    }
-  }
   try {
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const runtime = matchRuntimeMarker(entry.name, entry.isFile());
+      if (runtime) return runtime;
+    }
     await fs.access(path.join(directory, 'package.json'));
+    return 'nodejs';
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Synchronously detects what runtime is used in the current directory.
+ * @returns Runtime of the project directory.
+ */
+export function detectRuntimeSync(directory: string): Runtime {
+  try {
+    const entries = fsSync.readdirSync(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const runtime = matchRuntimeMarker(entry.name, entry.isFile());
+      if (runtime) return runtime;
+    }
+    fsSync.accessSync(path.join(directory, 'package.json'));
     return 'nodejs';
   } catch {
     return undefined;

--- a/js/core/src/reflection-v2.ts
+++ b/js/core/src/reflection-v2.ts
@@ -268,7 +268,7 @@ export class ReflectionServerV2 {
       id: process.env.GENKIT_RUNTIME_ID || this.runtimeId,
       pid: process.pid,
       name: this.options.name || this.runtimeId,
-      genkitVersion: GENKIT_VERSION,
+      genkitVersion: `nodejs/${GENKIT_VERSION}`,
       reflectionApiSpecVersion: GENKIT_REFLECTION_API_SPEC_VERSION,
       envs: this.options.configuredEnvs,
     };


### PR DESCRIPTION
In order to get a better sense of what user segments we have for the CLI and Dev UI, add the project's runtime as a dimension.

bonus fix: add runtime to version info in reflection v2 (to match v1 behavior)