### PR TITLE
fix(go/googlegenai): map tool role to user for Gemini content API

### DIFF
--- a/go/plugins/googlegenai/gemini.go
+++ b/go/plugins/googlegenai/gemini.go
@@ -190,22 +190,9 @@ func generate(
 		return nil, err
 	}
 
-	var contents []*genai.Content
-	for _, m := range input.Messages {
-		// system parts are handled separately
-		if m.Role == ai.RoleSystem {
-			continue
-		}
-
-		parts, err := toGeminiParts(m.Content)
-		if err != nil {
-			return nil, err
-		}
-
-		contents = append(contents, &genai.Content{
-			Parts: parts,
-			Role:  string(m.Role),
-		})
+	contents, err := toGeminiContents(input)
+	if err != nil {
+		return nil, err
 	}
 	if len(contents) == 0 {
 		return nil, fmt.Errorf("at least one message is required in generate request")
@@ -290,6 +277,44 @@ func generate(
 	}
 
 	return r, nil
+}
+
+// toGeminiContents converts the non-system messages of an [*ai.ModelRequest]
+// to a slice of [*genai.Content]. System messages are handled separately via
+// the request's system instruction.
+func toGeminiContents(input *ai.ModelRequest) ([]*genai.Content, error) {
+	var contents []*genai.Content
+	for _, m := range input.Messages {
+		// system parts are handled separately
+		if m.Role == ai.RoleSystem {
+			continue
+		}
+
+		parts, err := toGeminiParts(m.Content)
+		if err != nil {
+			return nil, err
+		}
+
+		contents = append(contents, &genai.Content{
+			Parts: parts,
+			Role:  toGeminiRole(m.Role),
+		})
+	}
+	return contents, nil
+}
+
+// toGeminiRole maps a Genkit [ai.Role] to a Gemini content role. The Gemini
+// Content API only accepts "user" or "model"; tool responses are sent under
+// the "user" role.
+func toGeminiRole(role ai.Role) string {
+	switch role {
+	case ai.RoleModel:
+		return string(ai.RoleModel)
+	case ai.RoleTool:
+		return string(ai.RoleUser)
+	default:
+		return string(ai.RoleUser)
+	}
 }
 
 // toGeminiRequest translates an [*ai.ModelRequest] to

--- a/go/plugins/googlegenai/gemini_test.go
+++ b/go/plugins/googlegenai/gemini_test.go
@@ -1437,4 +1437,3 @@ func TestToGeminiContents(t *testing.T) {
 		}
 	}
 }
-

--- a/go/plugins/googlegenai/gemini_test.go
+++ b/go/plugins/googlegenai/gemini_test.go
@@ -1383,3 +1383,58 @@ func TestFinishReasonMapping(t *testing.T) {
 		})
 	}
 }
+
+// TestToGeminiRole verifies that Genkit roles map to Gemini content roles.
+// The Gemini Content API only accepts "user" or "model"; tool responses must
+// be sent under the "user" role.
+func TestToGeminiRole(t *testing.T) {
+	testCases := []struct {
+		name string
+		role ai.Role
+		want string
+	}{
+		{"user", ai.RoleUser, "user"},
+		{"model", ai.RoleModel, "model"},
+		{"tool maps to user", ai.RoleTool, "user"},
+		{"unknown defaults to user", ai.Role("something"), "user"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := toGeminiRole(tc.role); got != tc.want {
+				t.Errorf("toGeminiRole(%q) = %q, want %q", tc.role, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestToGeminiContents verifies that messages are converted to Gemini contents,
+// that system messages are dropped, and that tool messages are sent as "user".
+func TestToGeminiContents(t *testing.T) {
+	input := &ai.ModelRequest{
+		Messages: []*ai.Message{
+			{Role: ai.RoleSystem, Content: []*ai.Part{ai.NewTextPart("you are helpful")}},
+			{Role: ai.RoleUser, Content: []*ai.Part{ai.NewTextPart("hello")}},
+			{Role: ai.RoleModel, Content: []*ai.Part{ai.NewToolRequestPart(&ai.ToolRequest{Name: "myTool", Input: map[string]any{"Test": "x"}})}},
+			{Role: ai.RoleTool, Content: []*ai.Part{ai.NewToolResponsePart(&ai.ToolResponse{Name: "myTool", Output: "result"})}},
+		},
+	}
+
+	contents, err := toGeminiContents(input)
+	if err != nil {
+		t.Fatalf("toGeminiContents failed: %v", err)
+	}
+
+	// System message should be dropped.
+	if len(contents) != 3 {
+		t.Fatalf("len(contents) = %d, want 3", len(contents))
+	}
+
+	wantRoles := []string{"user", "model", "user"}
+	for i, want := range wantRoles {
+		if contents[i].Role != want {
+			t.Errorf("contents[%d].Role = %q, want %q", i, contents[i].Role, want)
+		}
+	}
+}
+


### PR DESCRIPTION
Extract message-to-content conversion into toGeminiContents and add toGeminiRole to correctly map Genkit roles to Gemini's accepted content roles. The Gemini Content API only accepts "user" or "model", so tool responses are now sent under the "user" role instead of "tool".

Add tests covering role mapping, system message dropping, and tool message conversion.
