### PR TITLE
fix(py): Release 0.8.1 and add missing `websockets` dependency

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -100,4 +100,4 @@ jobs:
           VERSION="${TAG#py/v}"
           [[ "$VERSION" == "$TAG" ]] && VERSION="${TAG#release/py/}"
           pip install "genkit==${VERSION}"
-          python -c "from genkit.ai import Genkit; print('ok')"
+          python -c "from genkit import Genkit; Genkit(); print('ok')"

--- a/py/packages/genkit-anthropic/pyproject.toml
+++ b/py/packages/genkit-anthropic/pyproject.toml
@@ -58,7 +58,7 @@ license = "Apache-2.0"
 name = "genkit-anthropic"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/packages/genkit-django/pyproject.toml
+++ b/py/packages/genkit-django/pyproject.toml
@@ -63,7 +63,7 @@ license = "Apache-2.0"
 name = "genkit-django"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/packages/genkit-evaluators/pyproject.toml
+++ b/py/packages/genkit-evaluators/pyproject.toml
@@ -38,7 +38,7 @@ license = "Apache-2.0"
 name = "genkit-evaluators"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.urls]
 "Homepage" = "https://github.com/genkit-ai/genkit"

--- a/py/packages/genkit-fastapi/pyproject.toml
+++ b/py/packages/genkit-fastapi/pyproject.toml
@@ -52,7 +52,7 @@ license = "Apache-2.0"
 name = "genkit-fastapi"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/packages/genkit-flask/pyproject.toml
+++ b/py/packages/genkit-flask/pyproject.toml
@@ -64,7 +64,7 @@ license = "Apache-2.0"
 name = "genkit-flask"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/packages/genkit-google-cloud/pyproject.toml
+++ b/py/packages/genkit-google-cloud/pyproject.toml
@@ -66,7 +66,7 @@ license = "Apache-2.0"
 name = "genkit-google-cloud"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/packages/genkit-google-genai/pyproject.toml
+++ b/py/packages/genkit-google-genai/pyproject.toml
@@ -66,7 +66,7 @@ license = "Apache-2.0"
 name = "genkit-google-genai"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/packages/genkit-middleware/pyproject.toml
+++ b/py/packages/genkit-middleware/pyproject.toml
@@ -54,7 +54,7 @@ license = "Apache-2.0"
 name = "genkit-middleware"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.optional-dependencies]
 dev = [

--- a/py/packages/genkit-ollama/pyproject.toml
+++ b/py/packages/genkit-ollama/pyproject.toml
@@ -59,7 +59,7 @@ license = "Apache-2.0"
 name = "genkit-ollama"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/packages/genkit-openai/pyproject.toml
+++ b/py/packages/genkit-openai/pyproject.toml
@@ -58,7 +58,7 @@ license = "Apache-2.0"
 name = "genkit-openai"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/packages/genkit-vertexai/pyproject.toml
+++ b/py/packages/genkit-vertexai/pyproject.toml
@@ -70,7 +70,7 @@ license = "Apache-2.0"
 name = "genkit-vertexai"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.urls]
 "Bug Tracker"   = "https://github.com/genkit-ai/genkit/issues"

--- a/py/packages/genkit/pyproject.toml
+++ b/py/packages/genkit/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
   "starlette>=0.46.1",
   "python-multipart>=0.0.22",
   "sse-starlette>=2.2.1",
+  "websockets>=13.0.0",
   "pillow>=12.1.1",
   "typing_extensions>=4.0",
   "strenum>=0.4.15; python_version < '3.11'",
@@ -76,7 +77,7 @@ license = "Apache-2.0"
 name = "genkit"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.0"
+version = "0.8.1"
 
 [project.optional-dependencies]
 flask                 = ["genkit-flask"]

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1527,7 +1527,7 @@ requires-dist = [
 
 [[package]]
 name = "genkit"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit" }
 dependencies = [
     { name = "anyio" },
@@ -1551,6 +1551,7 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -1602,12 +1603,13 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.0" },
     { name = "uvicorn", specifier = ">=0.34.0" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0" },
+    { name = "websockets", specifier = ">=13.0.0" },
 ]
 provides-extras = ["flask", "google-cloud", "google-genai", "ollama", "openai", "vertex-ai"]
 
 [[package]]
 name = "genkit-anthropic"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit-anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -1622,7 +1624,7 @@ requires-dist = [
 
 [[package]]
 name = "genkit-django"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit-django" }
 dependencies = [
     { name = "django", version = "5.2.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -1640,7 +1642,7 @@ requires-dist = [
 
 [[package]]
 name = "genkit-evaluators"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit-evaluators" }
 dependencies = [
     { name = "genkit" },
@@ -1655,7 +1657,7 @@ requires-dist = [
 
 [[package]]
 name = "genkit-fastapi"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit-fastapi" }
 dependencies = [
     { name = "fastapi" },
@@ -1672,7 +1674,7 @@ requires-dist = [
 
 [[package]]
 name = "genkit-flask"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit-flask" }
 dependencies = [
     { name = "flask" },
@@ -1691,7 +1693,7 @@ requires-dist = [
 
 [[package]]
 name = "genkit-google-cloud"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit-google-cloud" }
 dependencies = [
     { name = "genkit" },
@@ -1712,7 +1714,7 @@ requires-dist = [
 
 [[package]]
 name = "genkit-google-genai"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit-google-genai" }
 dependencies = [
     { name = "genkit" },
@@ -1733,7 +1735,7 @@ requires-dist = [
 
 [[package]]
 name = "genkit-middleware"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit-middleware" }
 dependencies = [
     { name = "genkit" },
@@ -1761,7 +1763,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "genkit-ollama"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit-ollama" }
 dependencies = [
     { name = "genkit" },
@@ -1778,7 +1780,7 @@ requires-dist = [
 
 [[package]]
 name = "genkit-openai"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit-openai" }
 dependencies = [
     { name = "genkit" },
@@ -1795,7 +1797,7 @@ requires-dist = [
 
 [[package]]
 name = "genkit-vertexai"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/genkit-vertexai" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
### Python SDK v0.8.1 Release

This patch release resolves an issue where installing standalone `genkit` without optional plugins could fail to initialize due to a missing dependency, and strengthens automated release testing.

#### Highlights & Fixes
* **Core Dependency Fix:** Explicitly declares `websockets>=13.0.0` as a required core dependency in `pyproject.toml`. Previously, `websockets` was pulled in transitively via provider plugins such as `genkit-google-genai`. This update ensures standalone installs (e.g., bare `pip install genkit`) initialize cleanly out of the box.
* **Release Verification:** Updates the CI smoke test in `publish_python.yml` to import directly from `genkit` and instantiate `Genkit()` across isolated release environments, verifying that core runtime dependencies are present and functional before publication.
* **Lockstep Release:** Bumps all Python package versions to `0.8.1` to maintain ecosystem consistency. The publish scope remains focused on `genkit` core and `genkit-google-genai`.
