### PR TITLE
feat(py): background models + Google AI Interactions (Veo, Deep Research, Antigravity, Lyria)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ next-env.d.ts
 
 # Code Coverage
 js/plugins/compat-oai/coverage/
+.smoke-env
+live-smoke-audit/

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/__init__.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/__init__.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google AI Interactions API types, converters, and HTTP client."""
+
+from genkit_google_genai._interactions.client import InteractionsClient
+from genkit_google_genai._interactions.converters import (
+    ensure_tool_ids,
+    from_interaction,
+    from_interaction_content,
+    from_interaction_step,
+    from_interaction_sync,
+    to_interaction_content,
+    to_interaction_role,
+    to_interaction_steps,
+    to_interaction_tool,
+)
+from genkit_google_genai._interactions.types import (
+    API_REVISION,
+    CreateInteractionRequest,
+    GeminiInteraction,
+)
+
+__all__ = [
+    'API_REVISION',
+    'CreateInteractionRequest',
+    'GeminiInteraction',
+    'InteractionsClient',
+    'ensure_tool_ids',
+    'from_interaction',
+    'from_interaction_content',
+    'from_interaction_step',
+    'from_interaction_sync',
+    'to_interaction_content',
+    'to_interaction_role',
+    'to_interaction_steps',
+    'to_interaction_tool',
+]

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
@@ -1,0 +1,230 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Raw HTTP client for the Google AI Interactions API."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any
+
+import httpx
+
+from genkit import GenkitError
+from genkit._core._error import ErrorResponseMetadata, StatusName
+from genkit.plugin_api import GENKIT_CLIENT_HEADER
+from genkit_google_genai._interactions.types import (
+    API_REVISION,
+    ClientOptions,
+    CreateInteractionRequest,
+    GeminiInteraction,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_VERSION = 'v1beta'
+DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com'
+
+
+def get_google_ai_url(
+    *,
+    resource_path: str,
+    resource_method: str | None = None,
+    query_params: str | None = None,
+    client_options: ClientOptions | None = None,
+) -> str:
+    """Build a Google AI REST URL for the given resource path."""
+    api_version = (client_options or {}).get('api_version') or DEFAULT_API_VERSION
+    base_url = (client_options or {}).get('base_url') or DEFAULT_BASE_URL
+    url = f'{base_url}/{api_version}/{resource_path}'
+    if resource_method:
+        url += f':{resource_method}'
+    if query_params:
+        url += f'?{query_params}'
+    return url
+
+
+def _parse_retry_after_ms(value: str) -> float | None:
+    if not value or not value.strip():
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        seconds = -1.0
+    if seconds >= 0:
+        return seconds * 1000
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+    return max(0.0, (retry_at - datetime.now(timezone.utc)).total_seconds() * 1000)
+
+
+def _status_for_http_code(status_code: int) -> StatusName:
+    match status_code:
+        case 429:
+            return 'RESOURCE_EXHAUSTED'
+        case 400:
+            return 'INVALID_ARGUMENT'
+        case 499:
+            return 'CANCELLED'
+        case 500:
+            return 'INTERNAL'
+        case 503:
+            return 'UNAVAILABLE'
+        case _:
+            return 'UNKNOWN'
+
+
+def _build_headers(api_key: str | None, client_options: ClientOptions | None) -> dict[str, str]:
+    custom_headers = dict((client_options or {}).get('custom_headers') or {})
+    custom_headers.pop('x-goog-api-key', None)
+    custom_headers.pop('x-goog-api-client', None)
+    headers = {
+        **custom_headers,
+        'Content-Type': 'application/json',
+        'x-goog-api-client': GENKIT_CLIENT_HEADER,
+        'Api-Revision': API_REVISION,
+    }
+    if api_key:
+        headers['x-goog-api-key'] = api_key
+    return headers
+
+
+class InteractionsClient:
+    """HTTP client for Google AI Interactions endpoints."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        client_options: ClientOptions | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._client_options = client_options or {}
+        self._http_client = http_client
+        self._owns_client = http_client is None
+
+    async def __aenter__(self) -> InteractionsClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client when owned by this instance."""
+        if self._owns_client and self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._http_client is None:
+            timeout = self._client_options.get('timeout')
+            timeout_config = timeout if timeout is not None and timeout >= 0 else None
+            self._http_client = httpx.AsyncClient(timeout=timeout_config)
+        return self._http_client
+
+    async def create_interaction(self, request: CreateInteractionRequest) -> GeminiInteraction:
+        """Create a new interaction."""
+        url = get_google_ai_url(resource_path='interactions', client_options=self._client_options)
+        return await self._request('POST', url, json_body=request)
+
+    async def get_interaction(self, interaction_id: str) -> GeminiInteraction:
+        """Fetch an interaction by ID."""
+        url = get_google_ai_url(
+            resource_path=f'interactions/{interaction_id}',
+            client_options=self._client_options,
+        )
+        return await self._request('GET', url)
+
+    async def cancel_interaction(self, interaction_id: str) -> GeminiInteraction:
+        """Cancel an in-progress interaction."""
+        url = get_google_ai_url(
+            resource_path=f'interactions/{interaction_id}/cancel',
+            client_options=self._client_options,
+        )
+        try:
+            await self._request('POST', url)
+            raise GenkitError(status='CANCELLED', message='successfully cancelled')
+        except GenkitError as error:
+            if error.status == 'CANCELLED':
+                return {'id': interaction_id, 'status': 'cancelled'}
+            raise
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        json_body: CreateInteractionRequest | None = None,
+    ) -> GeminiInteraction:
+        headers = _build_headers(self._api_key, self._client_options)
+        client = self._get_client()
+        try:
+            response = await client.request(
+                method,
+                url,
+                headers=headers,
+                json=json_body,
+            )
+        except httpx.HTTPError as error:
+            logger.exception('Interactions request failed')
+            raise GenkitError(status='UNKNOWN', message=f'Failed to fetch from {url}: {error}') from error
+
+        if response.is_success:
+            if not response.content:
+                return {}
+            return response.json()
+
+        error_text = response.text
+        error_message = error_text
+        error_detail: Any | None = None
+        try:
+            payload = response.json()
+            error_detail = payload
+            api_error = payload.get('error') if isinstance(payload, dict) else None
+            if isinstance(api_error, dict) and api_error.get('message'):
+                error_message = api_error['message']
+                details = api_error.get('details')
+                if isinstance(details, list):
+                    detail_lines: list[str] = []
+                    for detail in details:
+                        if isinstance(detail, dict) and isinstance(detail.get('detail'), str):
+                            detail_text = detail['detail']
+                            if '[ORIGINAL ERROR]' in detail_text:
+                                detail_text = detail_text.split('[ORIGINAL ERROR]', 1)[1].split('[', 1)[0].strip()
+                            detail_lines.append(f'{detail_text}\nRaw: {json.dumps(detail, indent=2)}')
+                        else:
+                            detail_lines.append(json.dumps(detail, indent=2))
+                    if detail_lines:
+                        error_message += '\nDetails:\n' + '\n'.join(detail_lines)
+        except json.JSONDecodeError:
+            pass
+
+        retry_after_ms = _parse_retry_after_ms(response.headers.get('retry-after', ''))
+        response_metadata: ErrorResponseMetadata | None = (
+            {'retry_after_ms': retry_after_ms} if retry_after_ms is not None else None
+        )
+        raise GenkitError(
+            status=_status_for_http_code(response.status_code),
+            message=(f'Error fetching from {url}: [{response.status_code} {response.reason_phrase}] {error_message}'),
+            details=error_detail,
+            response_metadata=response_metadata,
+        )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
@@ -119,7 +119,7 @@ class InteractionsClient:
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self._api_key = api_key
-        self._client_options = client_options or {}
+        self._client_options: ClientOptions = client_options or {}
         self._http_client = http_client
         self._owns_client = http_client is None
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
@@ -1,0 +1,684 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Converters between Genkit message parts and Interactions API wire shapes."""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from typing import Any, cast
+
+from genkit import CustomPart, Media, MediaPart, Part, ReasoningPart, TextPart, ToolRequestPart, ToolResponsePart
+from genkit.model import Error, FinishReason, Message, ModelResponse, ModelUsage, Operation, ToolDefinition
+from genkit_google_genai._interactions.types import (
+    AudioContent,
+    ClientOptions,
+    CodeExecutionCallStep,
+    CodeExecutionResultStep,
+    Content,
+    DocumentContent,
+    FunctionCallContent,
+    FunctionResultContent,
+    GeminiInteraction,
+    GoogleSearchCallStep,
+    GoogleSearchResultStep,
+    ImageContent,
+    InteractionFunctionTool,
+    InteractionTool,
+    Step,
+    TextContent,
+    ThoughtContent,
+    Usage,
+    VideoContent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def clean_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Strip schema keys the Interactions API rejects."""
+    out = copy.deepcopy(schema)
+    for key in list(out):
+        if key in ('$schema', 'additionalProperties'):
+            del out[key]
+            continue
+        value = out[key]
+        if isinstance(value, dict):
+            out[key] = clean_schema(value)
+        elif key == 'type' and isinstance(value, list):
+            out[key] = next((item for item in value if item != 'null'), value[0] if value else value)
+    return out
+
+
+def ensure_tool_ids(messages: list[Message]) -> list[Message]:
+    """Assign stable tool call IDs so wire payloads stay pairable."""
+    generated_ids: list[str] = []
+    next_id_counter = 0
+
+    new_messages = [message.model_copy(deep=True) for message in messages]
+
+    for message in new_messages:
+        for part in message.content:
+            root = part.root
+            if isinstance(root, ToolRequestPart) and root.tool_request and not root.tool_request.ref:
+                new_id = f'genkit-auto-id-{next_id_counter}'
+                next_id_counter += 1
+                root.tool_request.ref = new_id
+                generated_ids.append(new_id)
+
+    # Responses without refs reuse request IDs in order; unmatched ones get orphan IDs.
+    for message in new_messages:
+        for part in message.content:
+            root = part.root
+            if isinstance(root, ToolResponsePart) and root.tool_response and not root.tool_response.ref:
+                matched_id = generated_ids.pop(0) if generated_ids else None
+                if matched_id:
+                    root.tool_response.ref = matched_id
+                else:
+                    root.tool_response.ref = f'genkit-orphan-id-{next_id_counter}'
+                    next_id_counter += 1
+
+    return new_messages
+
+
+def to_interaction_tool(tool: ToolDefinition) -> InteractionTool:
+    """Convert a Genkit tool definition to an Interactions function tool."""
+    func: InteractionFunctionTool = {
+        'type': 'function',
+        'name': tool.name,
+        'description': tool.description,
+    }
+    if tool.input_schema is not None:
+        if isinstance(tool.input_schema, dict):
+            func['parameters'] = clean_schema(tool.input_schema)
+        else:
+            func['parameters'] = clean_schema(dict(tool.input_schema))
+    return func
+
+
+def to_interaction_content(part: Part) -> Content | None:
+    """Convert a Genkit part to an Interactions content block."""
+    root = part.root
+    if isinstance(root, TextPart):
+        return {'type': 'text', 'text': root.text}
+    if isinstance(root, MediaPart) and root.media is not None:
+        return to_interaction_media(root)
+    logger.warning('Unsupported part type for Interaction input: %s', part.model_dump(by_alias=True))
+    return None
+
+
+def to_interaction_media(part: MediaPart) -> Content:
+    """Convert a media part to an Interactions image/audio/video/document block."""
+    if part.media is None:
+        raise ValueError('Media part missing media')
+    url = part.media.url
+    content_type = part.media.content_type
+    if not content_type:
+        raise ValueError('Media part missing contentType')
+
+    data: str | None = None
+    uri: str | None = None
+    if url.startswith('data:'):
+        data = url[url.index(',') + 1 :]
+    else:
+        uri = url
+
+    out: dict[str, Any] = {'mime_type': content_type}
+    if data is not None:
+        out['data'] = data
+    if uri is not None:
+        out['uri'] = uri
+
+    if content_type.startswith('image/'):
+        out['type'] = 'image'
+        return cast(ImageContent, out)
+    if content_type.startswith('audio/'):
+        out['type'] = 'audio'
+        return cast(AudioContent, out)
+    if content_type.startswith('video/'):
+        out['type'] = 'video'
+        return cast(VideoContent, out)
+    if content_type == 'application/pdf':
+        out['type'] = 'document'
+        return cast(DocumentContent, out)
+
+    raise ValueError(f'Unsupported media type: {content_type}')
+
+
+def to_interaction_role(role: str) -> str:
+    """Map a Genkit message role to the Interactions API role."""
+    if role == 'user':
+        return 'user'
+    if role == 'model':
+        return 'model'
+    if role == 'tool':
+        return 'user'
+    if role == 'system':
+        raise ValueError('System role should be handled as system_instruction, not part of turns.')
+    return 'user'
+
+
+def to_interaction_steps(messages: list[Message]) -> list[Step]:
+    """Convert Genkit messages to Interactions API steps."""
+    steps: list[Step] = []
+
+    for message in messages:
+        normal_content: list[Content] = []
+        for part in message.content:
+            root = part.root
+            if isinstance(root, ToolRequestPart) and root.tool_request:
+                tool_request = root.tool_request
+                steps.append(
+                    cast(
+                        FunctionCallContent,
+                        {
+                            'type': 'function_call',
+                            'name': tool_request.name,
+                            'arguments': tool_request.input if isinstance(tool_request.input, dict) else {},
+                            'id': tool_request.ref or '',
+                        },
+                    )
+                )
+            elif isinstance(root, ToolResponsePart) and root.tool_response:
+                tool_response = root.tool_response
+                output = tool_response.output
+                if not isinstance(output, (dict, str)) and output is not None:
+                    output = {'result': output}
+                steps.append(
+                    cast(
+                        FunctionResultContent,
+                        {
+                            'type': 'function_result',
+                            'name': tool_response.name,
+                            'result': output,
+                            'call_id': tool_response.ref or '',
+                        },
+                    )
+                )
+            elif isinstance(root, CustomPart):
+                custom = root.custom or {}
+                metadata = root.metadata or {}
+                if 'googleSearchCall' in custom:
+                    gs_call = custom['googleSearchCall']
+                    steps.append(
+                        cast(
+                            GoogleSearchCallStep,
+                            {
+                                'type': 'google_search_call',
+                                'id': gs_call['id'],
+                                'arguments': gs_call['arguments'],
+                                'signature': metadata.get('thoughtSignature'),
+                            },
+                        )
+                    )
+                elif 'googleSearchResult' in custom:
+                    gs_result = custom['googleSearchResult']
+                    steps.append(
+                        cast(
+                            GoogleSearchResultStep,
+                            {
+                                'type': 'google_search_result',
+                                'call_id': gs_result['callId'],
+                                'result': gs_result['result'],
+                                'signature': metadata.get('thoughtSignature'),
+                            },
+                        )
+                    )
+                elif 'executableCode' in custom:
+                    exec_code = custom['executableCode']
+                    steps.append(
+                        cast(
+                            CodeExecutionCallStep,
+                            {
+                                'type': 'code_execution_call',
+                                'id': metadata['callId'],
+                                'arguments': {
+                                    'code': exec_code['code'],
+                                    'language': exec_code.get('language', 'PYTHON'),
+                                },
+                                'signature': metadata.get('thoughtSignature'),
+                            },
+                        )
+                    )
+                elif 'codeExecutionResult' in custom:
+                    exec_result = custom['codeExecutionResult']
+                    steps.append(
+                        cast(
+                            CodeExecutionResultStep,
+                            {
+                                'type': 'code_execution_result',
+                                'call_id': metadata['callId'],
+                                'result': exec_result['output'],
+                                'signature': metadata.get('thoughtSignature'),
+                            },
+                        )
+                    )
+                else:
+                    content = to_interaction_content(part)
+                    if content is not None:
+                        normal_content.append(content)
+            elif isinstance(root, ReasoningPart):
+                metadata = root.metadata or {}
+                steps.append(
+                    cast(
+                        ThoughtContent,
+                        {
+                            'type': 'thought',
+                            'summary': [{'type': 'text', 'text': root.reasoning}],
+                            'signature': metadata.get('thoughtSignature'),
+                        },
+                    )
+                )
+            else:
+                content = to_interaction_content(part)
+                if content is not None:
+                    normal_content.append(content)
+
+        if normal_content:
+            if message.role == 'model':
+                steps.append({'type': 'model_output', 'content': normal_content})
+            else:
+                steps.append({'type': 'user_input', 'content': normal_content})
+
+    return steps
+
+
+def from_interaction_content(content: Content) -> Part:
+    """Convert an Interactions content block back to a Genkit part."""
+    content_type = content.get('type')
+    if content_type == 'text':
+        return from_text_content(cast(TextContent, content))
+    if content_type == 'image':
+        return from_image_content(cast(ImageContent, content))
+    if content_type in ('audio', 'document'):
+        return Part(root=from_media_content(content))
+    if content_type == 'video':
+        return from_video_content(cast(VideoContent, content))
+    if content_type == 'thought':
+        return from_thought_content(cast(ThoughtContent, content))
+    if content_type == 'function_call':
+        return from_function_call_content(cast(FunctionCallContent, content))
+    if content_type == 'function_result':
+        return from_function_result_content(cast(FunctionResultContent, content))
+    return Part(root=CustomPart(custom={'unknownContent': content}))
+
+
+def _maybe_add_gemini_thought_signature(step: Step, part: Part) -> Part:
+    signature = step.get('signature') if isinstance(step, dict) else None
+    if signature:
+        root = part.root
+        metadata = dict(root.metadata or {})
+        metadata['thoughtSignature'] = signature
+        updated = root.model_copy(update={'metadata': metadata})
+        return Part(root=updated)
+    return part
+
+
+def from_google_search_call(step: GoogleSearchCallStep) -> Part:
+    """Convert a google_search_call step to a Genkit custom part."""
+    part = Part(
+        root=CustomPart(
+            custom={
+                'googleSearchCall': {
+                    'id': step['id'],
+                    'arguments': step['arguments'],
+                }
+            }
+        )
+    )
+    return _maybe_add_gemini_thought_signature(step, part)
+
+
+def from_google_search_result(step: GoogleSearchResultStep) -> Part:
+    """Convert a google_search_result step to a Genkit custom part."""
+    part = Part(
+        root=CustomPart(
+            custom={
+                'googleSearchResult': {
+                    'callId': step['call_id'],
+                    'result': step['result'],
+                }
+            }
+        )
+    )
+    return _maybe_add_gemini_thought_signature(step, part)
+
+
+def from_code_execution_call(step: CodeExecutionCallStep) -> Part:
+    """Convert a code_execution_call step to a Genkit custom part."""
+    arguments = step['arguments']
+    part = Part(
+        root=CustomPart(
+            custom={
+                'executableCode': {
+                    'code': arguments['code'],
+                    'language': arguments.get('language', 'PYTHON'),
+                }
+            },
+            metadata={'callId': step['id']},
+        )
+    )
+    return _maybe_add_gemini_thought_signature(step, part)
+
+
+def from_code_execution_result(step: CodeExecutionResultStep) -> Part:
+    """Convert a code_execution_result step to a Genkit custom part."""
+    result = step['result']
+    part = Part(
+        root=CustomPart(
+            custom={
+                'codeExecutionResult': {
+                    'output': result if isinstance(result, str) else json.dumps(result),
+                    'outcome': 'OUTCOME_OK',
+                }
+            },
+            metadata={'callId': step['call_id']},
+        )
+    )
+    return _maybe_add_gemini_thought_signature(step, part)
+
+
+def from_server_function_call(step: FunctionCallContent) -> Part:
+    """Convert a standalone function_call step to a Genkit custom part."""
+    return Part(
+        root=CustomPart(
+            custom={
+                'serverFunctionCall': {
+                    'id': step['id'],
+                    'name': step['name'],
+                    'arguments': step.get('arguments'),
+                }
+            }
+        )
+    )
+
+
+def from_server_function_result(step: FunctionResultContent) -> Part:
+    """Convert a standalone function_result step to a Genkit custom part."""
+    return Part(
+        root=CustomPart(
+            custom={
+                'serverFunctionResult': {
+                    'callId': step['call_id'],
+                    'name': step['name'],
+                    'result': step.get('result'),
+                    'isError': step.get('is_error'),
+                }
+            }
+        )
+    )
+
+
+def from_interaction_step(step: Step) -> list[Part]:
+    """Convert an Interactions step to Genkit parts."""
+    step_type = step.get('type')
+    if step_type == 'model_output':
+        model_output = cast(dict[str, Any], step)
+        return [from_interaction_content(content) for content in model_output['content']]
+    if step_type == 'user_input':
+        # The API echoes our prompt back; including it would duplicate the input.
+        return []
+    if step_type == 'google_search_call':
+        return [from_google_search_call(cast(GoogleSearchCallStep, step))]
+    if step_type == 'google_search_result':
+        return [from_google_search_result(cast(GoogleSearchResultStep, step))]
+    if step_type == 'code_execution_call':
+        return [from_code_execution_call(cast(CodeExecutionCallStep, step))]
+    if step_type == 'code_execution_result':
+        return [from_code_execution_result(cast(CodeExecutionResultStep, step))]
+    if step_type == 'thought':
+        return [from_thought_content(cast(ThoughtContent, step))]
+    if step_type == 'function_call':
+        return [from_server_function_call(cast(FunctionCallContent, step))]
+    if step_type == 'function_result':
+        return [from_server_function_result(cast(FunctionResultContent, step))]
+    return [Part(root=CustomPart(custom={'unknownStep': step}))]
+
+
+def from_media_content(content: ImageContent | AudioContent | VideoContent | DocumentContent) -> MediaPart:
+    """Convert wire media content to a Genkit media part."""
+    url = content.get('uri')
+    if content.get('data') and content.get('mime_type'):
+        url = f'data:{content["mime_type"]};base64,{content["data"]}'
+    return MediaPart(media=Media(url=url or '', content_type=content.get('mime_type')))
+
+
+def from_text_content(content: TextContent) -> Part:
+    """Convert wire text content to a Genkit text part."""
+    # Golden parity expects annotations metadata even when empty.
+    return Part(
+        root=TextPart(
+            text=content.get('text') or '',
+            metadata={'annotations': content.get('annotations')},
+        )
+    )
+
+
+def from_image_content(content: ImageContent) -> Part:
+    """Convert wire image content to a Genkit media part."""
+    part = Part(root=from_media_content(content))
+    if content.get('resolution') is not None:
+        root = part.root
+        metadata = dict(root.metadata or {})
+        metadata['resolution'] = content['resolution']
+        part = Part(root=root.model_copy(update={'metadata': metadata}))
+    return part
+
+
+def from_video_content(content: VideoContent) -> Part:
+    """Convert wire video content to a Genkit media part."""
+    part = Part(root=from_media_content(content))
+    if content.get('resolution') is not None:
+        root = part.root
+        metadata = dict(root.metadata or {})
+        metadata['resolution'] = content['resolution']
+        part = Part(root=root.model_copy(update={'metadata': metadata}))
+    return part
+
+
+def from_thought_content(content: ThoughtContent) -> Part:
+    """Convert wire thought content to a Genkit reasoning part."""
+    reasoning = ''
+    summary = content.get('summary')
+    if summary:
+        chunks: list[str] = []
+        for item in summary:
+            if item.get('type') == 'text':
+                chunks.append(item.get('text') or '')
+            else:
+                chunks.append('[Image]')
+        reasoning = '\n'.join(chunks)
+    return Part(
+        root=ReasoningPart(
+            reasoning=reasoning,
+            metadata={'thoughtSignature': content.get('signature')},
+            custom={'thought': content},
+        )
+    )
+
+
+def from_function_call_content(content: FunctionCallContent) -> Part:
+    """Convert wire function_call content to a Genkit tool request part."""
+    from genkit import ToolRequest
+
+    return Part(
+        root=ToolRequestPart(
+            tool_request=ToolRequest(
+                name=content['name'],
+                input=content.get('arguments'),
+                ref=content['id'],
+            )
+        )
+    )
+
+
+def from_function_result_content(content: FunctionResultContent) -> Part:
+    """Convert wire function_result content to a Genkit tool response part."""
+    from genkit import ToolResponse
+
+    return Part(
+        root=ToolResponsePart(
+            tool_response=ToolResponse(
+                name=content['name'],
+                output=content.get('result'),
+                ref=content['call_id'],
+            )
+        )
+    )
+
+
+def _interaction_message_metadata(interaction: GeminiInteraction) -> dict[str, Any] | None:
+    metadata: dict[str, Any] = {}
+    if interaction.get('id'):
+        metadata['interactionId'] = interaction['id']
+    if interaction.get('environment_id'):
+        metadata['environmentId'] = interaction['environment_id']
+    return metadata or None
+
+
+def _usage_from_interaction(usage: Usage) -> ModelUsage:
+    response_usage = ModelUsage(
+        input_tokens=usage.get('total_input_tokens'),
+        output_tokens=usage.get('total_output_tokens'),
+        total_tokens=usage.get('total_tokens'),
+        cached_content_tokens=usage.get('total_cached_tokens'),
+        thoughts_tokens=usage.get('total_thought_tokens'),
+    )
+    for modality_token in usage.get('input_tokens_by_modality') or []:
+        match modality_token.get('modality'):
+            case 'text':
+                response_usage.input_characters = modality_token.get('tokens')
+            case 'image':
+                response_usage.input_images = modality_token.get('tokens')
+            case 'audio':
+                response_usage.input_audio_files = modality_token.get('tokens')
+    for modality_token in usage.get('output_tokens_by_modality') or []:
+        match modality_token.get('modality'):
+            case 'text':
+                response_usage.output_characters = modality_token.get('tokens')
+            case 'image':
+                response_usage.output_images = modality_token.get('tokens')
+            case 'audio':
+                response_usage.output_audio_files = modality_token.get('tokens')
+    return response_usage
+
+
+def _parts_from_steps(steps: list[Step]) -> list[Part]:
+    return [
+        part
+        for part in (item for step in steps for item in from_interaction_step(step))
+        if part.model_dump(exclude_none=True)
+    ]
+
+
+def _cancelled_response(interaction: GeminiInteraction) -> ModelResponse:
+    message_metadata = _interaction_message_metadata(interaction)
+    message = Message(
+        role='model',
+        content=[Part(root=TextPart(text='Operation cancelled.'))],
+        metadata=message_metadata,
+    )
+    return ModelResponse.model_construct(
+        finish_reason=cast(FinishReason, 'aborted'),
+        finish_message='Operation cancelled',
+        message=message,
+    )
+
+
+def _completed_response(interaction: GeminiInteraction) -> ModelResponse | None:
+    steps = interaction.get('steps') or []
+    if not steps:
+        return None
+    content = _parts_from_steps(steps)
+    message_metadata = _interaction_message_metadata(interaction)
+    response = ModelResponse.model_construct(
+        finish_reason=FinishReason.STOP,
+        message=Message(role='model', content=content, metadata=message_metadata),
+        custom=dict(interaction),
+        raw=dict(interaction),
+    )
+    if interaction.get('usage'):
+        response.usage = _usage_from_interaction(interaction['usage'])
+    return response
+
+
+def from_interaction_sync(interaction: GeminiInteraction) -> ModelResponse:
+    """Convert a completed interaction to a synchronous model response."""
+    if interaction.get('status') == 'failed':
+        raise ValueError('Interaction failed')
+
+    message_metadata = _interaction_message_metadata(interaction)
+    response = ModelResponse.model_construct(
+        finish_reason=FinishReason.STOP,
+        message=Message(role='model', content=[], metadata=message_metadata),
+        custom=dict(interaction),
+        raw=dict(interaction),
+    )
+
+    if interaction.get('status') == 'cancelled':
+        response.finish_reason = cast(FinishReason, 'aborted')
+        response.finish_message = 'Operation cancelled'
+        response.message = Message(
+            role='model',
+            content=[Part(root=TextPart(text='Operation cancelled.'))],
+            metadata=message_metadata,
+        )
+        return response
+
+    steps = interaction.get('steps')
+    if steps:
+        response.message = Message(
+            role='model',
+            content=_parts_from_steps(steps),
+            metadata=message_metadata,
+        )
+        if interaction.get('usage'):
+            response.usage = _usage_from_interaction(interaction['usage'])
+    return response
+
+
+def from_interaction(
+    interaction: GeminiInteraction,
+    client_options: ClientOptions | None = None,
+) -> Operation:
+    """Convert an interaction poll result to a Genkit operation."""
+    op = Operation.model_construct(id=interaction.get('id') or '')
+    if client_options:
+        op.metadata = {'clientOptions': client_options}
+
+    status = interaction.get('status')
+    if status == 'in_progress':
+        op.done = False
+    elif status == 'cancelled':
+        op.done = True
+        op.output = _cancelled_response(interaction)
+    elif status == 'completed':
+        op.done = True
+        op.output = _completed_response(interaction)
+    elif status == 'failed':
+        op.done = True
+        error_payload = interaction.get('error') or {}
+        message = error_payload.get('message') if isinstance(error_payload, dict) else None
+        op.error = Error(message=message or 'Interaction failed')
+    elif status == 'requires_action':
+        op.done = True
+        op.output = from_interaction_sync(interaction)
+        metadata = dict(op.metadata or {})
+        metadata['interaction_status'] = 'requires_action'
+        op.metadata = metadata
+    return op

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
@@ -306,7 +306,7 @@ def from_interaction_content(content: Content) -> Part:
     if content_type == 'image':
         return from_image_content(cast(ImageContent, content))
     if content_type in ('audio', 'document'):
-        return Part(root=from_media_content(content))
+        return Part(root=from_media_content(cast(AudioContent | DocumentContent, content)))
     if content_type == 'video':
         return from_video_content(cast(VideoContent, content))
     if content_type == 'thought':
@@ -499,7 +499,7 @@ def from_thought_content(content: ThoughtContent) -> Part:
         chunks: list[str] = []
         for item in summary:
             if item.get('type') == 'text':
-                chunks.append(item.get('text') or '')
+                chunks.append(str(item.get('text') or ''))
             else:
                 chunks.append('[Image]')
         reasoning = '\n'.join(chunks)
@@ -567,6 +567,8 @@ def _usage_from_interaction(usage: Usage) -> ModelUsage:
                 response_usage.input_images = modality_token.get('tokens')
             case 'audio':
                 response_usage.input_audio_files = modality_token.get('tokens')
+            case _:
+                pass
     for modality_token in usage.get('output_tokens_by_modality') or []:
         match modality_token.get('modality'):
             case 'text':
@@ -575,6 +577,8 @@ def _usage_from_interaction(usage: Usage) -> ModelUsage:
                 response_usage.output_images = modality_token.get('tokens')
             case 'audio':
                 response_usage.output_audio_files = modality_token.get('tokens')
+            case _:
+                pass
     return response_usage
 
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
@@ -675,14 +675,11 @@ def from_interaction(
         op.done = True
         op.output = _completed_response(interaction)
     elif status == 'failed':
+        # Always exit the poll loop on failure; leaving done unset hangs forever.
         op.done = True
         error_payload = interaction.get('error') or {}
         message = error_payload.get('message') if isinstance(error_payload, dict) else None
         op.error = Error(message=message or 'Interaction failed')
-    elif status == 'requires_action':
-        op.done = True
-        op.output = from_interaction_sync(interaction)
-        metadata = dict(op.metadata or {})
-        metadata['interaction_status'] = 'requires_action'
-        op.metadata = metadata
+    # requires_action: leave done unset (same as the JS converter). Resuming that
+    # turn is a separate product decision; we don't invent interrupt/resume here.
     return op

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/types.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/types.py
@@ -1,0 +1,303 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wire types for the Google AI Interactions API."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+from genkit._core._typing import ToolChoice
+
+API_REVISION = '2026-05-20'
+
+ResponseModality = Literal['text', 'image', 'audio']
+MediaResolution = Literal['low', 'medium', 'high', 'ultra_high']
+InteractionStatus = Literal[
+    'in_progress',
+    'requires_action',
+    'completed',
+    'failed',
+    'cancelled',
+]
+ThinkingSummaries = Literal['auto', 'none']
+ThinkingLevel = Literal['minimal', 'low', 'medium', 'high']
+
+
+class InteractionFunctionTool(TypedDict, total=False):
+    type: Literal['function']
+    name: str
+    description: str
+    parameters: dict[str, Any]
+
+
+class InteractionGoogleSearchTool(TypedDict):
+    type: Literal['google_search']
+
+
+class InteractionCodeExecutionTool(TypedDict):
+    type: Literal['code_execution']
+
+
+class InteractionUrlContextTool(TypedDict):
+    type: Literal['url_context']
+
+
+class InteractionFileSearchTool(TypedDict, total=False):
+    type: Literal['file_search']
+    file_search_store_names: list[str]
+
+
+class InteractionMcpServerTool(TypedDict, total=False):
+    type: Literal['mcp_server']
+    name: str
+    url: str
+    headers: dict[str, str]
+    allowed_tools: list[str]
+
+
+InteractionTool = (
+    InteractionFunctionTool
+    | InteractionGoogleSearchTool
+    | InteractionCodeExecutionTool
+    | InteractionUrlContextTool
+    | InteractionFileSearchTool
+    | InteractionMcpServerTool
+)
+
+
+class TextAnnotation(TypedDict, total=False):
+    type: str
+    start_index: int
+    end_index: int
+    url: str
+    title: str
+    source: str
+
+
+class TextContent(TypedDict, total=False):
+    type: Literal['text']
+    text: str
+    annotations: list[TextAnnotation]
+
+
+class ImageContent(TypedDict, total=False):
+    type: Literal['image']
+    data: str
+    uri: str
+    mime_type: str
+    resolution: MediaResolution
+
+
+class AudioContent(TypedDict, total=False):
+    type: Literal['audio']
+    data: str
+    uri: str
+    mime_type: str
+
+
+class DocumentContent(TypedDict, total=False):
+    type: Literal['document']
+    data: str
+    uri: str
+    mime_type: str
+
+
+class VideoContent(TypedDict, total=False):
+    type: Literal['video']
+    data: str
+    uri: str
+    mime_type: str
+    resolution: MediaResolution
+
+
+class ThoughtContent(TypedDict, total=False):
+    type: Literal['thought']
+    signature: str
+    summary: list[TextContent | ImageContent]
+
+
+class FunctionCallContent(TypedDict, total=False):
+    type: Literal['function_call']
+    name: str
+    arguments: dict[str, Any]
+    id: str
+
+
+class FunctionResultContent(TypedDict, total=False):
+    type: Literal['function_result']
+    name: str
+    is_error: bool
+    result: dict[str, Any] | str
+    call_id: str
+
+
+Content = (
+    TextContent
+    | ImageContent
+    | AudioContent
+    | DocumentContent
+    | VideoContent
+    | ThoughtContent
+    | FunctionCallContent
+    | FunctionResultContent
+)
+
+
+class ModelOutputStep(TypedDict):
+    type: Literal['model_output']
+    content: list[Content]
+
+
+class UserInputStep(TypedDict):
+    type: Literal['user_input']
+    content: list[Content]
+
+
+class GoogleSearchCallStep(TypedDict, total=False):
+    type: Literal['google_search_call']
+    id: str
+    arguments: dict[str, list[str]]
+    signature: str
+
+
+class GoogleSearchResultStep(TypedDict, total=False):
+    type: Literal['google_search_result']
+    call_id: str
+    result: dict[str, Any]
+    signature: str
+
+
+class CodeExecutionCallStep(TypedDict, total=False):
+    type: Literal['code_execution_call']
+    id: str
+    arguments: dict[str, Any]
+    signature: str
+
+
+class CodeExecutionResultStep(TypedDict, total=False):
+    type: Literal['code_execution_result']
+    call_id: str
+    result: dict[str, Any] | str
+    signature: str
+
+
+Step = (
+    ModelOutputStep
+    | UserInputStep
+    | Content
+    | GoogleSearchCallStep
+    | GoogleSearchResultStep
+    | CodeExecutionCallStep
+    | CodeExecutionResultStep
+)
+
+
+class ModalityTokens(TypedDict, total=False):
+    modality: ResponseModality
+    tokens: int
+
+
+class Usage(TypedDict, total=False):
+    total_input_tokens: int
+    input_tokens_by_modality: list[ModalityTokens]
+    total_cached_tokens: int
+    cached_tokens_by_modality: list[ModalityTokens]
+    total_output_tokens: int
+    output_tokens_by_modality: list[ModalityTokens]
+    total_tool_use_tokens: int
+    tool_use_by_modality: list[ModalityTokens]
+    total_thought_tokens: int
+    total_tokens: int
+
+
+class SpeechConfig(TypedDict, total=False):
+    voice: str
+    language: str
+    speaker: str
+
+
+class ImageConfig(TypedDict, total=False):
+    aspect_ratio: str
+    image_size: str
+
+
+class ModelGenerationConfig(TypedDict, total=False):
+    temperature: float
+    top_p: float
+    seed: int
+    stop_sequences: list[str]
+    tool_choice: ToolChoice | dict[str, Any]
+    thinking_level: ThinkingLevel
+    thinking_summaries: ThinkingSummaries
+    max_output_tokens: int
+    speech_config: SpeechConfig
+    image_config: ImageConfig
+
+
+class DynamicAgentConfig(TypedDict):
+    type: Literal['dynamic']
+
+
+class DeepResearchAgentConfig(TypedDict, total=False):
+    type: Literal['deep-research']
+    thinking_summaries: ThinkingSummaries
+    visualization: Literal['auto', 'off']
+    collaborative_planning: bool
+
+
+InteractionsAgentConfig = DynamicAgentConfig | DeepResearchAgentConfig
+
+
+class CreateInteractionRequest(TypedDict, total=False):
+    previous_interaction_id: str
+    model: str
+    agent: str
+    environment: str | dict[str, Any]
+    # API also accepts str | Step; we only ever send a list of steps.
+    input: list[Step]
+    system_instruction: str
+    tools: list[InteractionTool]
+    response_format: dict[str, Any] | list[dict[str, Any]]
+    response_modalities: list[ResponseModality]
+    stream: bool
+    store: bool
+    background: bool
+    generation_config: ModelGenerationConfig
+    agent_config: InteractionsAgentConfig
+
+
+class GeminiInteraction(TypedDict, total=False):
+    model: str
+    agent: str
+    environment_id: str
+    id: str
+    previous_interaction_id: str
+    status: InteractionStatus
+    created: str
+    updated: str
+    role: str
+    steps: list[Step]
+    usage: Usage
+    error: dict[str, Any]
+
+
+class ClientOptions(TypedDict, total=False):
+    api_version: str
+    base_url: str
+    custom_headers: dict[str, str]
+    timeout: float
+    experimental_debug_traces: bool

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -111,7 +111,7 @@ from genkit._core._model import ModelRequest, ModelResponse
 from genkit._core._registry import Registry
 from genkit.embedder import embedder_action_metadata
 from genkit.evaluator import EvalFnResponse, EvalRequest
-from genkit.model import BackgroundAction, model_action_metadata
+from genkit.model import BackgroundAction, ModelRef, model_action_metadata
 from genkit.plugin_api import (
     GENKIT_CLIENT_HEADER,
     Action,
@@ -136,6 +136,7 @@ from genkit_google_genai.models.antigravity import (
 from genkit_google_genai.models.deep_research import (
     DeepResearchConfigSchema,
     create_deep_research_background_action,
+    deep_research_model,
     deep_research_model_info,
     is_deep_research_model_name,
     list_known_deep_research_models,
@@ -521,8 +522,8 @@ class GoogleAI(Plugin):
         # Interactions-backed models (known catalog)
         client_options = self._interactions_client_options()
         plugin_api_key = self._plugin_api_key()
-        for name in list_known_deep_research_models():
-            bg_action = self._resolve_deep_research_model(googleai_name(name), client_options, plugin_api_key)
+        for ref in list_known_deep_research_models():
+            bg_action = self._resolve_deep_research_model(ref, client_options, plugin_api_key)
             actions.append(bg_action.start_action)
             actions.append(bg_action.check_action)
             if bg_action.cancel_action is not None:
@@ -602,7 +603,8 @@ class GoogleAI(Plugin):
         if action_type == ActionKind.MODEL:
             prefix = GOOGLEAI_PLUGIN_NAME + '/'
             clean_name = name.replace(prefix, '') if name.startswith(prefix) else name
-            if is_veo_model(clean_name):
+            # Background-only families: leave MODEL empty so resolve_model falls back.
+            if is_veo_model(clean_name) or is_deep_research_model_name(clean_name):
                 return None
             return self._resolve_model(name)
         elif action_type == ActionKind.BACKGROUND_MODEL:
@@ -613,7 +615,7 @@ class GoogleAI(Plugin):
                 return bg_action.start_action
             if is_deep_research_model_name(clean_name):
                 bg_action = self._resolve_deep_research_model(
-                    name,
+                    deep_research_model(name),
                     self._interactions_client_options(),
                     self._plugin_api_key(),
                 )
@@ -629,7 +631,7 @@ class GoogleAI(Plugin):
                     return bg_action.check_action
                 if is_deep_research_model_name(clean_name):
                     bg_action = self._resolve_deep_research_model(
-                        model_name,
+                        deep_research_model(model_name),
                         self._interactions_client_options(),
                         self._plugin_api_key(),
                     )
@@ -642,7 +644,7 @@ class GoogleAI(Plugin):
                 clean_name = model_name.replace(prefix, '') if model_name.startswith(prefix) else model_name
                 if is_deep_research_model_name(clean_name):
                     bg_action = self._resolve_deep_research_model(
-                        model_name,
+                        deep_research_model(model_name),
                         self._interactions_client_options(),
                         self._plugin_api_key(),
                     )
@@ -664,7 +666,7 @@ class GoogleAI(Plugin):
         clean_name = name.replace(GOOGLEAI_PLUGIN_NAME + '/', '') if name.startswith(GOOGLEAI_PLUGIN_NAME) else name
         veo = VeoModel(clean_name, self._runtime_client())
         # Build actions via define_background_model; plugin init registers them on the app registry.
-        bg_action = define_background_model(
+        return define_background_model(
             registry=Registry(),
             name=name,
             start=veo.start,
@@ -673,26 +675,16 @@ class GoogleAI(Plugin):
             info=veo_model_info(clean_name),
             config_schema=VeoConfigSchema,
         )
-        # define_background_model stores supports with snake_case keys; generate_operation
-        # checks the camelCase wire name when metadata is a dict.
-        model_meta = bg_action.start_action.metadata
-        if model_meta:
-            model_block = model_meta.get('model')
-            if isinstance(model_block, dict):
-                supports = model_block.get('supports')
-                if isinstance(supports, dict) and supports.get('long_running'):
-                    supports['longRunning'] = supports['long_running']
-        return bg_action
 
     def _resolve_deep_research_model(
         self,
-        name: str,
+        ref: ModelRef,
         client_options: ClientOptions,
         plugin_api_key: str | None,
     ) -> BackgroundAction:
-        """Create a BackgroundAction for a Deep Research model."""
+        """Create a BackgroundAction for a Deep Research ModelRef (Interactions)."""
         return create_deep_research_background_action(
-            name,
+            ref,
             plugin_api_key=plugin_api_key,
             client_options=client_options,
         )
@@ -808,11 +800,11 @@ class GoogleAI(Plugin):
                 )
             )
 
-        for name in list_known_deep_research_models():
+        for ref in list_known_deep_research_models():
             actions_list.append(
                 model_action_metadata(
-                    name=googleai_name(name),
-                    info=deep_research_model_info(name).model_dump(by_alias=True),
+                    name=ref.name,
+                    info=deep_research_model_info(ref.name).model_dump(by_alias=True),
                     config_schema=DeepResearchConfigSchema,
                 )
             )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -106,7 +106,9 @@ from google.genai.types import HttpOptions, HttpOptionsDict
 import genkit_google_genai.constants as const
 from genkit import ModelInfo
 from genkit._core._action import ActionRunContext
+from genkit._core._background import define_background_model
 from genkit._core._model import ModelRequest, ModelResponse
+from genkit._core._registry import Registry
 from genkit.embedder import embedder_action_metadata
 from genkit.evaluator import EvalFnResponse, EvalRequest
 from genkit.model import BackgroundAction, model_action_metadata
@@ -533,6 +535,10 @@ class GoogleAI(Plugin):
             Action object if found, None otherwise.
         """
         if action_type == ActionKind.MODEL:
+            prefix = GOOGLEAI_PLUGIN_NAME + '/'
+            clean_name = name.replace(prefix, '') if name.startswith(prefix) else name
+            if is_veo_model(clean_name):
+                return None
             return self._resolve_model(name)
         elif action_type == ActionKind.BACKGROUND_MODEL:
             # For Veo models, return the start action
@@ -567,43 +573,27 @@ class GoogleAI(Plugin):
             BackgroundAction for the Veo model.
         """
         clean_name = name.replace(GOOGLEAI_PLUGIN_NAME + '/', '') if name.startswith(GOOGLEAI_PLUGIN_NAME) else name
-
-        # Create actions manually since we don't have registry access here
-
-        async def _start(request: Any, ctx: Any) -> Any:  # noqa: ANN401
-            veo = VeoModel(clean_name, self._runtime_client())
-            return await veo.start(request, ctx)
-
-        async def _check(op: Any, _ctx: Any) -> Any:  # noqa: ANN401
-            veo = VeoModel(clean_name, self._runtime_client())
-            return await veo.check(op)
-
-        # Prepare metadata matching model_action_metadata structure
-        info = veo_model_info(clean_name).model_dump(by_alias=True)
-        config_schema = VeoConfigSchema
-
-        start_action = Action(
-            kind=ActionKind.BACKGROUND_MODEL,
+        veo = VeoModel(clean_name, self._runtime_client())
+        # Build actions via define_background_model; plugin init registers them on the app registry.
+        bg_action = define_background_model(
+            registry=Registry(),
             name=name,
-            fn=_start,
-            metadata={
-                'model': {**info, 'customOptions': to_json_schema(config_schema)},
-                'type': 'background-model',
-            },
+            start=veo.start,
+            check=veo.check,
+            cancel=None,
+            info=veo_model_info(clean_name),
+            config_schema=VeoConfigSchema,
         )
-
-        check_action = Action(
-            kind=ActionKind.CHECK_OPERATION,
-            name=f'{name}/check',
-            fn=_check,
-            metadata={'type': 'check-operation'},
-        )
-
-        return BackgroundAction(
-            start_action=start_action,
-            check_action=check_action,
-            cancel_action=None,
-        )
+        # define_background_model stores supports with snake_case keys; generate_operation
+        # checks the camelCase wire name when metadata is a dict.
+        model_meta = bg_action.start_action.metadata
+        if model_meta:
+            model_block = model_meta.get('model')
+            if isinstance(model_block, dict):
+                supports = model_block.get('supports')
+                if isinstance(supports, dict) and supports.get('long_running'):
+                    supports['longRunning'] = supports['long_running']
+        return bg_action
 
     def _resolve_model(self, name: str) -> Action:
         """Create an Action object for a Google AI model.

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -406,13 +406,14 @@ class GoogleAI(Plugin):
         ... )
         >>>
         >>> # Video generation (background model)
-        >>> op = await ai.generate(
+        >>> operation = await ai.generate_operation(
         ...     model='googleai/veo-2.0-generate-001',
         ...     prompt='A sunset over mountains',
         ... )
-        >>> while not op.done:
+        >>> while not operation.done:
         ...     await asyncio.sleep(5)
-        ...     op = await ai.check_operation(op)
+        ...     operation = await ai.check_operation(operation)
+        >>> print(operation.output.message.content[0].root.media.url)
 
     Attributes:
         name: The plugin name ('googleai').

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -119,9 +119,24 @@ from genkit.plugin_api import (
     loop_local_client,
     to_json_schema,
 )
+from genkit_google_genai._interactions.types import ClientOptions
 from genkit_google_genai.evaluators import (
     VertexAIEvaluationMetricType,
     create_vertex_evaluators,
+)
+from genkit_google_genai.models.antigravity import (
+    AntigravityConfigSchema,
+    antigravity_model_info,
+    create_antigravity_action,
+    is_antigravity_model_name,
+    list_known_antigravity_models,
+)
+from genkit_google_genai.models.deep_research import (
+    DeepResearchConfigSchema,
+    create_deep_research_background_action,
+    deep_research_model_info,
+    is_deep_research_model_name,
+    list_known_deep_research_models,
 )
 from genkit_google_genai.models.embedder import (
     VERTEX_KNOWN_EMBEDDERS,
@@ -135,6 +150,13 @@ from genkit_google_genai.models.gemini import (
     get_model_config_schema,
     google_model_info,
     is_tuned_gemini_name,
+)
+from genkit_google_genai.models.googleai_lyria import (
+    GoogleAILyriaConfigSchema,
+    create_googleai_lyria_action,
+    googleai_lyria_model_info,
+    is_googleai_lyria_model_name,
+    list_known_googleai_lyria_models,
 )
 from genkit_google_genai.models.imagen import (
     SUPPORTED_MODELS as IMAGE_SUPPORTED_MODELS,
@@ -454,6 +476,22 @@ class GoogleAI(Plugin):
         self._runtime_client = loop_local_client(lambda: genai.client.Client(**self._client_kwargs))
         self._list_actions_cache: list[ActionMetadata] | None = None
 
+    def _interactions_client_options(self) -> ClientOptions:
+        """Build non-secret Interactions client options from plugin init settings."""
+        http_options = self._client_kwargs.get('http_options')
+        options: ClientOptions = {}
+        if http_options is not None:
+            if getattr(http_options, 'api_version', None):
+                options['api_version'] = http_options.api_version
+            if getattr(http_options, 'base_url', None):
+                options['base_url'] = http_options.base_url
+            if getattr(http_options, 'headers', None):
+                options['custom_headers'] = dict(http_options.headers)
+        return options
+
+    def _plugin_api_key(self) -> str | None:
+        return self._client_kwargs.get('api_key')
+
     async def init(self) -> list[Action]:
         """Initialize the plugin.
 
@@ -476,6 +514,32 @@ class GoogleAI(Plugin):
             bg_action = self._resolve_veo_model(googleai_name(name))
             actions.append(bg_action.start_action)
             actions.append(bg_action.check_action)
+
+        # Interactions-backed models (known catalog)
+        client_options = self._interactions_client_options()
+        plugin_api_key = self._plugin_api_key()
+        for name in list_known_deep_research_models():
+            bg_action = self._resolve_deep_research_model(googleai_name(name), client_options, plugin_api_key)
+            actions.append(bg_action.start_action)
+            actions.append(bg_action.check_action)
+            if bg_action.cancel_action is not None:
+                actions.append(bg_action.cancel_action)
+        for name in list_known_antigravity_models():
+            actions.append(
+                create_antigravity_action(
+                    googleai_name(name),
+                    plugin_api_key=plugin_api_key,
+                    client_options=client_options,
+                )
+            )
+        for name in list_known_googleai_lyria_models():
+            actions.append(
+                create_googleai_lyria_action(
+                    googleai_name(name),
+                    plugin_api_key=plugin_api_key,
+                    client_options=client_options,
+                )
+            )
 
         # Embedders
         for name in genai_models.embedders:
@@ -535,23 +599,47 @@ class GoogleAI(Plugin):
         if action_type == ActionKind.MODEL:
             return self._resolve_model(name)
         elif action_type == ActionKind.BACKGROUND_MODEL:
-            # For Veo models, return the start action
             prefix = GOOGLEAI_PLUGIN_NAME + '/'
             clean_name = name.replace(prefix, '') if name.startswith(prefix) else name
             if is_veo_model(clean_name):
                 bg_action = self._resolve_veo_model(name)
                 return bg_action.start_action
+            if is_deep_research_model_name(clean_name):
+                bg_action = self._resolve_deep_research_model(
+                    name,
+                    self._interactions_client_options(),
+                    self._plugin_api_key(),
+                )
+                return bg_action.start_action
             return None
         elif action_type == ActionKind.CHECK_OPERATION:
-            # Check action names are in format {model_name}/check
-            # Extract the model name and resolve if it's a Veo model
             if name.endswith('/check'):
-                model_name = name[:-6]  # Remove '/check' suffix
+                model_name = name[:-6]
                 prefix = GOOGLEAI_PLUGIN_NAME + '/'
                 clean_name = model_name.replace(prefix, '') if model_name.startswith(prefix) else model_name
                 if is_veo_model(clean_name):
                     bg_action = self._resolve_veo_model(model_name)
                     return bg_action.check_action
+                if is_deep_research_model_name(clean_name):
+                    bg_action = self._resolve_deep_research_model(
+                        model_name,
+                        self._interactions_client_options(),
+                        self._plugin_api_key(),
+                    )
+                    return bg_action.check_action
+            return None
+        elif action_type == ActionKind.CANCEL_OPERATION:
+            if name.endswith('/cancel'):
+                model_name = name[:-7]
+                prefix = GOOGLEAI_PLUGIN_NAME + '/'
+                clean_name = model_name.replace(prefix, '') if model_name.startswith(prefix) else model_name
+                if is_deep_research_model_name(clean_name):
+                    bg_action = self._resolve_deep_research_model(
+                        model_name,
+                        self._interactions_client_options(),
+                        self._plugin_api_key(),
+                    )
+                    return bg_action.cancel_action
             return None
         elif action_type == ActionKind.EMBEDDER:
             return self._resolve_embedder(name)
@@ -605,6 +693,19 @@ class GoogleAI(Plugin):
             cancel_action=None,
         )
 
+    def _resolve_deep_research_model(
+        self,
+        name: str,
+        client_options: ClientOptions,
+        plugin_api_key: str | None,
+    ) -> BackgroundAction:
+        """Create a BackgroundAction for a Deep Research model."""
+        return create_deep_research_background_action(
+            name,
+            plugin_api_key=plugin_api_key,
+            client_options=client_options,
+        )
+
     def _resolve_model(self, name: str) -> Action:
         """Create an Action object for a Google AI model.
 
@@ -616,6 +717,19 @@ class GoogleAI(Plugin):
         """
         # Extract local name (remove plugin prefix)
         clean_name = name.replace(GOOGLEAI_PLUGIN_NAME + '/', '') if name.startswith(GOOGLEAI_PLUGIN_NAME) else name
+
+        if is_antigravity_model_name(clean_name):
+            return create_antigravity_action(
+                name,
+                plugin_api_key=self._plugin_api_key(),
+                client_options=self._interactions_client_options(),
+            )
+        if is_googleai_lyria_model_name(clean_name):
+            return create_googleai_lyria_action(
+                name,
+                plugin_api_key=self._plugin_api_key(),
+                client_options=self._interactions_client_options(),
+            )
 
         # Determine model type and create model metadata/config schema
         if clean_name.lower().startswith('image'):
@@ -700,6 +814,33 @@ class GoogleAI(Plugin):
                     name=googleai_name(name),
                     info=veo_model_info(name).model_dump(by_alias=True),
                     config_schema=VeoConfigSchema,
+                )
+            )
+
+        for name in list_known_deep_research_models():
+            actions_list.append(
+                model_action_metadata(
+                    name=googleai_name(name),
+                    info=deep_research_model_info(name).model_dump(by_alias=True),
+                    config_schema=DeepResearchConfigSchema,
+                )
+            )
+
+        for name in list_known_antigravity_models():
+            actions_list.append(
+                model_action_metadata(
+                    name=googleai_name(name),
+                    info=antigravity_model_info(name).model_dump(by_alias=True),
+                    config_schema=AntigravityConfigSchema,
+                )
+            )
+
+        for name in list_known_googleai_lyria_models():
+            actions_list.append(
+                model_action_metadata(
+                    name=googleai_name(name),
+                    info=googleai_lyria_model_info(name).model_dump(by_alias=True),
+                    config_schema=GoogleAILyriaConfigSchema,
                 )
             )
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/antigravity.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/antigravity.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Antigravity foreground model via the Google AI Interactions API."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from genkit import ModelInfo, ModelRequest, ModelResponse, Supports
+from genkit.plugin_api import Action, ActionKind, ActionRunContext, model_action_metadata
+from genkit_google_genai._interactions.client import InteractionsClient
+from genkit_google_genai._interactions.converters import (
+    ensure_tool_ids,
+    from_interaction_sync,
+    to_interaction_steps,
+)
+from genkit_google_genai._interactions.types import ClientOptions, CreateInteractionRequest
+from genkit_google_genai.models.interactions_utils import (
+    calculate_api_key,
+    config_as_dict,
+    downgrade_system_messages,
+    extract_version,
+    merge_client_options,
+    remove_client_option_overrides,
+    response_modalities_from_config,
+)
+
+GENERIC_ANTIGRAVITY_INFO = ModelInfo(
+    label='Google AI - antigravity',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=False,
+        tool_choice=False,
+        system_role=False,
+        output=['text'],
+    ),
+)
+
+KNOWN_ANTIGRAVITY_MODELS: dict[str, ModelInfo] = {
+    'antigravity-preview-05-2026': GENERIC_ANTIGRAVITY_INFO,
+}
+
+
+class AntigravityConfigSchema(BaseModel):
+    """Antigravity model configuration."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    api_key: str | None = Field(default=None, alias='apiKey')
+    base_url: str | None = Field(default=None, alias='baseUrl')
+    api_version: str | None = Field(default=None, alias='apiVersion')
+    previous_interaction_id: str | None = Field(default=None, alias='previousInteractionId')
+    store: bool | None = None
+    environment: str | dict[str, Any] | None = None
+    response_modalities: list[Literal['TEXT', 'IMAGE']] | None = Field(
+        default=None,
+        alias='responseModalities',
+    )
+
+
+def is_antigravity_model_name(name: str | None) -> bool:
+    """Return True when the model name belongs to the Antigravity family."""
+    return bool(name and name.startswith('antigravity-'))
+
+
+def antigravity_model_info(version: str) -> ModelInfo:
+    """Return capability metadata for an Antigravity model."""
+    known = KNOWN_ANTIGRAVITY_MODELS.get(version)
+    if known is not None:
+        return ModelInfo(label=f'Google AI - {version}', supports=known.supports)
+    return ModelInfo(label=f'Google AI - {version}', supports=GENERIC_ANTIGRAVITY_INFO.supports)
+
+
+def list_known_antigravity_models() -> list[str]:
+    """Return statically known Antigravity model names."""
+    return list(KNOWN_ANTIGRAVITY_MODELS.keys())
+
+
+class AntigravityModel:
+    """Antigravity model backed by the Interactions API."""
+
+    def __init__(
+        self,
+        version: str,
+        *,
+        plugin_api_key: str | None,
+        client_options: ClientOptions,
+    ) -> None:
+        """Initialize Antigravity model."""
+        self._version = version
+        self._plugin_api_key = plugin_api_key
+        self._client_options = client_options
+
+    async def generate(self, request: ModelRequest, _ctx: ActionRunContext) -> ModelResponse:
+        """Run a synchronous Antigravity interaction."""
+        config = config_as_dict(request.config)
+        api_key = calculate_api_key(
+            self._plugin_api_key,
+            config.get('apiKey') or config.get('api_key'),
+        )
+        client_options = merge_client_options(self._client_options, config)
+        request_options = remove_client_option_overrides(config)
+
+        previous_interaction_id = request_options.pop('previousInteractionId', None) or request_options.pop(
+            'previous_interaction_id', None
+        )
+        store = request_options.pop('store', None)
+        environment = request_options.pop('environment', None)
+        request_options.pop('responseModalities', None)
+        request_options.pop('response_modalities', None)
+
+        messages = downgrade_system_messages(request.messages or [])
+        req: CreateInteractionRequest = {
+            'agent': extract_version(self._version),
+            'input': to_interaction_steps(ensure_tool_ids(messages)),
+            **({'previous_interaction_id': previous_interaction_id} if previous_interaction_id else {}),
+            **({'store': store} if store is not None else {}),
+            **({'environment': environment} if environment is not None else {}),
+            **request_options,
+        }
+
+        response_modalities = response_modalities_from_config(config)
+        if response_modalities is not None:
+            req['response_modalities'] = response_modalities
+
+        client = InteractionsClient(api_key=api_key, client_options=client_options)
+        try:
+            interaction = await client.create_interaction(req)
+        finally:
+            await client.aclose()
+        return from_interaction_sync(interaction)
+
+
+def create_antigravity_action(
+    name: str,
+    *,
+    plugin_api_key: str | None,
+    client_options: ClientOptions,
+) -> Action:
+    """Build a foreground model action for Antigravity."""
+    clean_name = extract_version(name)
+    model = AntigravityModel(clean_name, plugin_api_key=plugin_api_key, client_options=client_options)
+    info = antigravity_model_info(clean_name)
+
+    async def _run(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+        return await model.generate(request, ctx)
+
+    return Action(
+        kind=ActionKind.MODEL,
+        name=name,
+        fn=_run,
+        metadata=model_action_metadata(
+            name=name,
+            info=info.model_dump(by_alias=True),
+            config_schema=AntigravityConfigSchema,
+        ).metadata,
+    )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/antigravity.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/antigravity.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -126,19 +126,23 @@ class AntigravityModel:
         request_options.pop('response_modalities', None)
 
         messages = downgrade_system_messages(request.messages or [])
-        req: CreateInteractionRequest = {
+        req_dict: dict[str, Any] = {
             'agent': extract_version(self._version),
             'input': to_interaction_steps(ensure_tool_ids(messages)),
-            **({'previous_interaction_id': previous_interaction_id} if previous_interaction_id else {}),
-            **({'store': store} if store is not None else {}),
-            **({'environment': environment} if environment is not None else {}),
-            **request_options,
         }
+        if previous_interaction_id:
+            req_dict['previous_interaction_id'] = previous_interaction_id
+        if store is not None:
+            req_dict['store'] = store
+        if environment is not None:
+            req_dict['environment'] = environment
+        req_dict.update(request_options)
 
         response_modalities = response_modalities_from_config(config)
         if response_modalities is not None:
-            req['response_modalities'] = response_modalities
+            req_dict['response_modalities'] = response_modalities
 
+        req = cast(CreateInteractionRequest, req_dict)
         client = InteractionsClient(api_key=api_key, client_options=client_options)
         try:
             interaction = await client.create_interaction(req)

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
@@ -23,8 +23,10 @@ from typing import Any, Literal, cast
 from pydantic import BaseModel, ConfigDict, Field
 
 from genkit import ModelInfo, ModelRequest, Supports
-from genkit.model import BackgroundAction, Operation
-from genkit.plugin_api import Action, ActionKind, ActionRunContext, model_action_metadata, to_json_schema
+from genkit._core._background import define_background_model
+from genkit._core._registry import Registry
+from genkit.model import BackgroundAction, ModelRef, Operation, model_ref
+from genkit.plugin_api import ActionRunContext
 from genkit_google_genai._interactions.client import InteractionsClient
 from genkit_google_genai._interactions.converters import (
     clean_schema,
@@ -75,12 +77,6 @@ ADVANCED_DEEP_RESEARCH_INFO = ModelInfo(
     ),
 )
 
-KNOWN_DEEP_RESEARCH_MODELS: dict[str, ModelInfo] = {
-    'deep-research-pro-preview-12-2025': GENERIC_DEEP_RESEARCH_INFO,
-    'deep-research-preview-04-2026': ADVANCED_DEEP_RESEARCH_INFO,
-    'deep-research-max-preview-04-2026': ADVANCED_DEEP_RESEARCH_INFO,
-}
-
 
 class McpServerConfig(BaseModel):
     """MCP server configuration for Deep Research."""
@@ -122,28 +118,63 @@ class DeepResearchConfigSchema(BaseModel):
     mcp_servers: list[McpServerConfig | dict[str, Any]] | None = Field(default=None, alias='mcpServers')
 
 
+def _common_ref(name: str, info: ModelInfo | None = None) -> ModelRef:
+    """Build a googleai/ ModelRef for a Deep Research version."""
+    resolved = info or GENERIC_DEEP_RESEARCH_INFO
+    # Prefer a version-specific label when callers pass ADVANCED/GENERIC without one.
+    if resolved.label is None or resolved.label == GENERIC_DEEP_RESEARCH_INFO.label:
+        resolved = ModelInfo(label=f'Google AI - {name}', supports=resolved.supports)
+    return model_ref(
+        name=name,
+        namespace='googleai',
+        info=resolved,
+    ).model_copy(update={'config_schema': DeepResearchConfigSchema})
+
+
+KNOWN_DEEP_RESEARCH_MODELS: dict[str, ModelRef] = {
+    'deep-research-pro-preview-12-2025': _common_ref('deep-research-pro-preview-12-2025'),
+    'deep-research-preview-04-2026': _common_ref(
+        'deep-research-preview-04-2026',
+        ADVANCED_DEEP_RESEARCH_INFO,
+    ),
+    'deep-research-max-preview-04-2026': _common_ref(
+        'deep-research-max-preview-04-2026',
+        ADVANCED_DEEP_RESEARCH_INFO,
+    ),
+}
+
+
 def is_deep_research_model_name(name: str | None) -> bool:
     """Return True when the model name belongs to the Deep Research family."""
     return bool(name and name.startswith('deep-research-'))
 
 
+def deep_research_model(version: str) -> ModelRef:
+    """Return a ModelRef for a Deep Research version (namespaced or bare)."""
+    clean = extract_version(version)
+    known = KNOWN_DEEP_RESEARCH_MODELS.get(clean)
+    if known is not None:
+        return known
+    return _common_ref(clean)
+
+
 def deep_research_model_info(version: str) -> ModelInfo:
     """Return capability metadata for a Deep Research model."""
-    known = KNOWN_DEEP_RESEARCH_MODELS.get(version)
-    if known is not None:
-        return ModelInfo(
-            label=f'Google AI - {version}',
-            supports=known.supports,
-        )
+    ref = deep_research_model(version)
+    info = ref.info
+    if isinstance(info, ModelInfo):
+        return info
+    if isinstance(info, dict):
+        return ModelInfo.model_validate(info)
     return ModelInfo(
-        label=f'Google AI - {version}',
+        label=f'Google AI - {extract_version(version)}',
         supports=GENERIC_DEEP_RESEARCH_INFO.supports,
     )
 
 
-def list_known_deep_research_models() -> list[str]:
-    """Return statically known Deep Research model names."""
-    return list(KNOWN_DEEP_RESEARCH_MODELS.keys())
+def list_known_deep_research_models() -> list[ModelRef]:
+    """Return statically known Deep Research ModelRefs."""
+    return list(KNOWN_DEEP_RESEARCH_MODELS.values())
 
 
 def _build_tools(request: ModelRequest, config: dict[str, Any]) -> list[InteractionTool]:
@@ -334,51 +365,26 @@ class DeepResearchModel:
 
 
 def create_deep_research_background_action(
-    name: str,
+    ref: ModelRef,
     *,
     plugin_api_key: str | None,
     client_options: ClientOptions,
 ) -> BackgroundAction:
-    """Build start/check/cancel actions for a Deep Research model."""
-    clean_name = extract_version(name)
-    model = DeepResearchModel(clean_name, plugin_api_key=plugin_api_key, client_options=client_options)
-    info = deep_research_model_info(clean_name)
+    """Wire Deep Research Interactions start/check/cancel through define_background_model."""
+    version = extract_version(ref.name)
+    model = DeepResearchModel(version, plugin_api_key=plugin_api_key, client_options=client_options)
+    info = deep_research_model_info(version)
+    label = info.label or ref.name
 
-    async def _start(request: ModelRequest, ctx: ActionRunContext) -> Operation:
-        return await model.start(request, ctx)
-
-    async def _check(operation: Operation, _ctx: ActionRunContext) -> Operation:
-        return await model.check(operation)
-
-    async def _cancel(operation: Operation, _ctx: ActionRunContext) -> Operation:
-        return await model.cancel(operation)
-
-    metadata = model_action_metadata(
-        name=name,
-        info=info.model_dump(by_alias=True),
+    # Throwaway registry: plugin init re-registers the returned actions on the app registry.
+    # define_background_model stamps Operation.action so check_operation/cancel_operation work.
+    return define_background_model(
+        registry=Registry(),
+        name=ref.name,
+        start=model.start,
+        check=model.check,
+        cancel=model.cancel,
+        label=label,
+        info=info,
         config_schema=DeepResearchConfigSchema,
-    ).metadata
-
-    start_action = Action(
-        kind=ActionKind.BACKGROUND_MODEL,
-        name=name,
-        fn=_start,
-        metadata={**metadata, 'type': 'background-model'},
-    )
-    check_action = Action(
-        kind=ActionKind.CHECK_OPERATION,
-        name=f'{name}/check',
-        fn=_check,
-        metadata={'type': 'check-operation', 'outputSchema': to_json_schema(Operation)},
-    )
-    cancel_action = Action(
-        kind=ActionKind.CANCEL_OPERATION,
-        name=f'{name}/cancel',
-        fn=_cancel,
-        metadata={'type': 'cancel-operation', 'outputSchema': to_json_schema(Operation)},
-    )
-    return BackgroundAction(
-        start_action=start_action,
-        check_action=check_action,
-        cancel_action=cancel_action,
     )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
@@ -1,0 +1,384 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deep Research background model via the Google AI Interactions API."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from genkit import ModelInfo, ModelRequest, Supports
+from genkit.model import BackgroundAction, Operation
+from genkit.plugin_api import Action, ActionKind, ActionRunContext, model_action_metadata, to_json_schema
+from genkit_google_genai._interactions.client import InteractionsClient
+from genkit_google_genai._interactions.converters import (
+    clean_schema,
+    ensure_tool_ids,
+    from_interaction,
+    to_interaction_steps,
+    to_interaction_tool,
+)
+from genkit_google_genai._interactions.types import (
+    ClientOptions,
+    CreateInteractionRequest,
+    DeepResearchAgentConfig,
+    InteractionTool,
+)
+from genkit_google_genai.models.interactions_utils import (
+    calculate_api_key,
+    client_options_for_operation,
+    config_as_dict,
+    downgrade_system_messages,
+    extract_version,
+    merge_client_options,
+    remove_client_option_overrides,
+    response_modalities_from_config,
+)
+
+GENERIC_DEEP_RESEARCH_INFO = ModelInfo(
+    label='Google AI - deep-research',
+    supports=Supports(
+        multiturn=True,
+        media=False,
+        tools=False,
+        tool_choice=False,
+        system_role=False,
+        output=['text'],
+        long_running=True,
+    ),
+)
+
+ADVANCED_DEEP_RESEARCH_INFO = ModelInfo(
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=False,
+        system_role=False,
+        output=['text', 'media'],
+        long_running=True,
+    ),
+)
+
+KNOWN_DEEP_RESEARCH_MODELS: dict[str, ModelInfo] = {
+    'deep-research-pro-preview-12-2025': GENERIC_DEEP_RESEARCH_INFO,
+    'deep-research-preview-04-2026': ADVANCED_DEEP_RESEARCH_INFO,
+    'deep-research-max-preview-04-2026': ADVANCED_DEEP_RESEARCH_INFO,
+}
+
+
+class McpServerConfig(BaseModel):
+    """MCP server configuration for Deep Research."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    name: str | None = None
+    url: str | None = None
+    headers: dict[str, str] | None = None
+    allowed_tools: list[str] | None = Field(default=None, alias='allowedTools')
+
+
+class FileSearchConfig(BaseModel):
+    """File search store configuration for Deep Research."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    file_search_store_names: list[str] = Field(alias='fileSearchStoreNames')
+
+
+class DeepResearchConfigSchema(BaseModel):
+    """Deep Research model configuration."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    api_key: str | None = Field(default=None, alias='apiKey')
+    base_url: str | None = Field(default=None, alias='baseUrl')
+    api_version: str | None = Field(default=None, alias='apiVersion')
+    thinking_summaries: Literal['AUTO', 'NONE'] | None = Field(default=None, alias='thinkingSummaries')
+    previous_interaction_id: str | None = Field(default=None, alias='previousInteractionId')
+    store: bool | None = None
+    response_modalities: list[Literal['TEXT', 'IMAGE', 'AUDIO']] | None = Field(
+        default=None,
+        alias='responseModalities',
+    )
+    visualization: Literal['AUTO', 'OFF'] | None = None
+    collaborative_planning: bool | None = Field(default=None, alias='collaborativePlanning')
+    google_search: bool | dict[str, Any] | None = Field(default=None, alias='googleSearch')
+    url_context: bool | dict[str, Any] | None = Field(default=None, alias='urlContext')
+    code_execution: bool | dict[str, Any] | None = Field(default=None, alias='codeExecution')
+    file_search: FileSearchConfig | dict[str, Any] | None = Field(default=None, alias='fileSearch')
+    mcp_servers: list[McpServerConfig | dict[str, Any]] | None = Field(default=None, alias='mcpServers')
+
+
+def is_deep_research_model_name(name: str | None) -> bool:
+    """Return True when the model name belongs to the Deep Research family."""
+    return bool(name and name.startswith('deep-research-'))
+
+
+def deep_research_model_info(version: str) -> ModelInfo:
+    """Return capability metadata for a Deep Research model."""
+    known = KNOWN_DEEP_RESEARCH_MODELS.get(version)
+    if known is not None:
+        return ModelInfo(
+            label=f'Google AI - {version}',
+            supports=known.supports,
+        )
+    return ModelInfo(
+        label=f'Google AI - {version}',
+        supports=GENERIC_DEEP_RESEARCH_INFO.supports,
+    )
+
+
+def list_known_deep_research_models() -> list[str]:
+    """Return statically known Deep Research model names."""
+    return list(KNOWN_DEEP_RESEARCH_MODELS.keys())
+
+
+def _build_tools(request: ModelRequest, config: dict[str, Any]) -> list[InteractionTool]:
+    tools: list[InteractionTool] = []
+    if request.tools:
+        for tool in request.tools:
+            tools.append(to_interaction_tool(tool))
+
+    google_search = config.get('googleSearch') or config.get('google_search')
+    if google_search:
+        tool: InteractionTool = {'type': 'google_search'}
+        if isinstance(google_search, dict):
+            tool = cast(InteractionTool, {'type': 'google_search', **google_search})
+        tools.append(tool)
+
+    url_context = config.get('urlContext') or config.get('url_context')
+    if url_context:
+        tool = {'type': 'url_context'}
+        if isinstance(url_context, dict):
+            tool = cast(InteractionTool, {'type': 'url_context', **url_context})
+        tools.append(tool)
+
+    code_execution = config.get('codeExecution') or config.get('code_execution')
+    if code_execution:
+        tool = {'type': 'code_execution'}
+        if isinstance(code_execution, dict):
+            tool = cast(InteractionTool, {'type': 'code_execution', **code_execution})
+        tools.append(tool)
+
+    file_search = config.get('fileSearch') or config.get('file_search')
+    if isinstance(file_search, dict):
+        store_names = file_search.get('fileSearchStoreNames') or file_search.get('file_search_store_names')
+        rest = {
+            key: value
+            for key, value in file_search.items()
+            if key not in {'fileSearchStoreNames', 'file_search_store_names'}
+        }
+        tool = cast(
+            InteractionTool,
+            {
+                'type': 'file_search',
+                'file_search_store_names': store_names,
+                **rest,
+            },
+        )
+        tools.append(tool)
+
+    mcp_servers = config.get('mcpServers') or config.get('mcp_servers') or []
+    for mcp_server in mcp_servers:
+        if not isinstance(mcp_server, dict):
+            continue
+        allowed_tools = mcp_server.get('allowedTools') or mcp_server.get('allowed_tools')
+        rest_mcp = {key: value for key, value in mcp_server.items() if key not in {'allowedTools', 'allowed_tools'}}
+        tool = cast(
+            InteractionTool,
+            {
+                'type': 'mcp_server',
+                **rest_mcp,
+                **({'allowed_tools': allowed_tools} if allowed_tools else {}),
+            },
+        )
+        tools.append(tool)
+
+    return tools
+
+
+def _build_create_request(request: ModelRequest, version: str, config: dict[str, Any]) -> CreateInteractionRequest:
+    thinking_summaries = config.get('thinkingSummaries') or config.get('thinking_summaries')
+    visualization = config.get('visualization')
+    collaborative_planning = config.get('collaborativePlanning') or config.get('collaborative_planning')
+    previous_interaction_id = config.get('previousInteractionId') or config.get('previous_interaction_id')
+    store = config.get('store')
+
+    passthrough = remove_client_option_overrides(config)
+    for key in (
+        'thinkingSummaries',
+        'thinking_summaries',
+        'visualization',
+        'collaborativePlanning',
+        'collaborative_planning',
+        'previousInteractionId',
+        'previous_interaction_id',
+        'store',
+        'responseModalities',
+        'response_modalities',
+        'googleSearch',
+        'google_search',
+        'urlContext',
+        'url_context',
+        'codeExecution',
+        'code_execution',
+        'fileSearch',
+        'file_search',
+        'mcpServers',
+        'mcp_servers',
+    ):
+        passthrough.pop(key, None)
+
+    agent_config: DeepResearchAgentConfig = {'type': 'deep-research'}
+    if isinstance(thinking_summaries, str):
+        agent_config['thinking_summaries'] = thinking_summaries.lower()  # type: ignore[typeddict-item]
+    if isinstance(visualization, str):
+        agent_config['visualization'] = visualization.lower()  # type: ignore[typeddict-item]
+    if collaborative_planning is not None:
+        agent_config['collaborative_planning'] = bool(collaborative_planning)
+
+    response_format: dict[str, Any] | None = None
+    if request.output_format == 'json' or request.output_content_type == 'application/json':
+        response_format = {'type': 'text', 'mime_type': 'application/json'}
+        if request.output_schema:
+            response_format['schema'] = clean_schema(request.output_schema)
+
+    tools = _build_tools(request, config)
+    messages = downgrade_system_messages(request.messages or [])
+
+    req: CreateInteractionRequest = {
+        'agent': extract_version(version),
+        'input': to_interaction_steps(ensure_tool_ids(messages)),
+        'background': True,
+        'agent_config': agent_config,
+        **({'previous_interaction_id': previous_interaction_id} if previous_interaction_id else {}),
+        **({'store': store} if store is not None else {}),
+        **({'tools': tools} if tools else {}),
+        **({'response_format': response_format} if response_format else {}),
+        **passthrough,
+    }
+
+    response_modalities = response_modalities_from_config(config)
+    if response_modalities is not None:
+        req['response_modalities'] = response_modalities
+
+    return req
+
+
+class DeepResearchModel:
+    """Deep Research model backed by the Interactions API."""
+
+    def __init__(
+        self,
+        version: str,
+        *,
+        plugin_api_key: str | None,
+        client_options: ClientOptions,
+    ) -> None:
+        """Initialize Deep Research model."""
+        self._version = version
+        self._plugin_api_key = plugin_api_key
+        self._client_options = client_options
+
+    async def start(self, request: ModelRequest, _ctx: ActionRunContext) -> Operation:
+        """Start a background Deep Research interaction."""
+        config = config_as_dict(request.config)
+        api_key = calculate_api_key(
+            self._plugin_api_key,
+            config.get('apiKey') or config.get('api_key'),
+        )
+        client_options = merge_client_options(self._client_options, config)
+        client = InteractionsClient(api_key=api_key, client_options=client_options)
+        try:
+            interaction = await client.create_interaction(_build_create_request(request, self._version, config))
+        finally:
+            await client.aclose()
+        return from_interaction(interaction, client_options_for_operation(client_options))
+
+    async def check(self, operation: Operation) -> Operation:
+        """Poll a Deep Research interaction for completion."""
+        stored_options = cast(ClientOptions | None, (operation.metadata or {}).get('clientOptions'))
+        check_options = merge_client_options(self._client_options, dict(stored_options or {}))
+        api_key = calculate_api_key(self._plugin_api_key, None)
+        client = InteractionsClient(api_key=api_key, client_options=check_options)
+        try:
+            interaction = await client.get_interaction(operation.id)
+        finally:
+            await client.aclose()
+        return from_interaction(interaction, client_options_for_operation(check_options))
+
+    async def cancel(self, operation: Operation) -> Operation:
+        """Cancel an in-progress Deep Research interaction."""
+        stored_options = cast(ClientOptions | None, (operation.metadata or {}).get('clientOptions'))
+        cancel_options = merge_client_options(self._client_options, dict(stored_options or {}))
+        api_key = calculate_api_key(self._plugin_api_key, None)
+        client = InteractionsClient(api_key=api_key, client_options=cancel_options)
+        try:
+            interaction = await client.cancel_interaction(operation.id)
+        finally:
+            await client.aclose()
+        return from_interaction(interaction, client_options_for_operation(cancel_options))
+
+
+def create_deep_research_background_action(
+    name: str,
+    *,
+    plugin_api_key: str | None,
+    client_options: ClientOptions,
+) -> BackgroundAction:
+    """Build start/check/cancel actions for a Deep Research model."""
+    clean_name = extract_version(name)
+    model = DeepResearchModel(clean_name, plugin_api_key=plugin_api_key, client_options=client_options)
+    info = deep_research_model_info(clean_name)
+
+    async def _start(request: ModelRequest, ctx: ActionRunContext) -> Operation:
+        return await model.start(request, ctx)
+
+    async def _check(operation: Operation, _ctx: ActionRunContext) -> Operation:
+        return await model.check(operation)
+
+    async def _cancel(operation: Operation, _ctx: ActionRunContext) -> Operation:
+        return await model.cancel(operation)
+
+    metadata = model_action_metadata(
+        name=name,
+        info=info.model_dump(by_alias=True),
+        config_schema=DeepResearchConfigSchema,
+    ).metadata
+
+    start_action = Action(
+        kind=ActionKind.BACKGROUND_MODEL,
+        name=name,
+        fn=_start,
+        metadata={**metadata, 'type': 'background-model'},
+    )
+    check_action = Action(
+        kind=ActionKind.CHECK_OPERATION,
+        name=f'{name}/check',
+        fn=_check,
+        metadata={'type': 'check-operation', 'outputSchema': to_json_schema(Operation)},
+    )
+    cancel_action = Action(
+        kind=ActionKind.CANCEL_OPERATION,
+        name=f'{name}/cancel',
+        fn=_cancel,
+        metadata={'type': 'cancel-operation', 'outputSchema': to_json_schema(Operation)},
+    )
+    return BackgroundAction(
+        start_action=start_action,
+        check_action=check_action,
+        cancel_action=cancel_action,
+    )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
@@ -180,29 +180,29 @@ def list_known_deep_research_models() -> list[ModelRef]:
 def _build_tools(request: ModelRequest, config: dict[str, Any]) -> list[InteractionTool]:
     tools: list[InteractionTool] = []
     if request.tools:
-        for tool in request.tools:
-            tools.append(to_interaction_tool(tool))
+        for tool_def in request.tools:
+            tools.append(to_interaction_tool(tool_def))
 
     google_search = config.get('googleSearch') or config.get('google_search')
     if google_search:
-        tool: InteractionTool = {'type': 'google_search'}
+        builtin: InteractionTool = {'type': 'google_search'}
         if isinstance(google_search, dict):
-            tool = cast(InteractionTool, {'type': 'google_search', **google_search})
-        tools.append(tool)
+            builtin = cast(InteractionTool, {'type': 'google_search', **google_search})
+        tools.append(builtin)
 
     url_context = config.get('urlContext') or config.get('url_context')
     if url_context:
-        tool = {'type': 'url_context'}
+        builtin = {'type': 'url_context'}
         if isinstance(url_context, dict):
-            tool = cast(InteractionTool, {'type': 'url_context', **url_context})
-        tools.append(tool)
+            builtin = cast(InteractionTool, {'type': 'url_context', **url_context})
+        tools.append(builtin)
 
     code_execution = config.get('codeExecution') or config.get('code_execution')
     if code_execution:
-        tool = {'type': 'code_execution'}
+        builtin = {'type': 'code_execution'}
         if isinstance(code_execution, dict):
-            tool = cast(InteractionTool, {'type': 'code_execution', **code_execution})
-        tools.append(tool)
+            builtin = cast(InteractionTool, {'type': 'code_execution', **code_execution})
+        tools.append(builtin)
 
     file_search = config.get('fileSearch') or config.get('file_search')
     if isinstance(file_search, dict):
@@ -212,15 +212,16 @@ def _build_tools(request: ModelRequest, config: dict[str, Any]) -> list[Interact
             for key, value in file_search.items()
             if key not in {'fileSearchStoreNames', 'file_search_store_names'}
         }
-        tool = cast(
-            InteractionTool,
-            {
-                'type': 'file_search',
-                'file_search_store_names': store_names,
-                **rest,
-            },
+        tools.append(
+            cast(
+                InteractionTool,
+                {
+                    'type': 'file_search',
+                    'file_search_store_names': store_names,
+                    **rest,
+                },
+            )
         )
-        tools.append(tool)
 
     mcp_servers = config.get('mcpServers') or config.get('mcp_servers') or []
     for mcp_server in mcp_servers:
@@ -228,15 +229,16 @@ def _build_tools(request: ModelRequest, config: dict[str, Any]) -> list[Interact
             continue
         allowed_tools = mcp_server.get('allowedTools') or mcp_server.get('allowed_tools')
         rest_mcp = {key: value for key, value in mcp_server.items() if key not in {'allowedTools', 'allowed_tools'}}
-        tool = cast(
-            InteractionTool,
-            {
-                'type': 'mcp_server',
-                **rest_mcp,
-                **({'allowed_tools': allowed_tools} if allowed_tools else {}),
-            },
+        tools.append(
+            cast(
+                InteractionTool,
+                {
+                    'type': 'mcp_server',
+                    **rest_mcp,
+                    **({'allowed_tools': allowed_tools} if allowed_tools else {}),
+                },
+            )
         )
-        tools.append(tool)
 
     return tools
 
@@ -290,23 +292,27 @@ def _build_create_request(request: ModelRequest, version: str, config: dict[str,
     tools = _build_tools(request, config)
     messages = downgrade_system_messages(request.messages or [])
 
-    req: CreateInteractionRequest = {
+    req_dict: dict[str, Any] = {
         'agent': extract_version(version),
         'input': to_interaction_steps(ensure_tool_ids(messages)),
         'background': True,
         'agent_config': agent_config,
-        **({'previous_interaction_id': previous_interaction_id} if previous_interaction_id else {}),
-        **({'store': store} if store is not None else {}),
-        **({'tools': tools} if tools else {}),
-        **({'response_format': response_format} if response_format else {}),
-        **passthrough,
     }
+    if previous_interaction_id:
+        req_dict['previous_interaction_id'] = previous_interaction_id
+    if store is not None:
+        req_dict['store'] = store
+    if tools:
+        req_dict['tools'] = tools
+    if response_format is not None:
+        req_dict['response_format'] = response_format
+    req_dict.update(passthrough)
 
     response_modalities = response_modalities_from_config(config)
     if response_modalities is not None:
-        req['response_modalities'] = response_modalities
+        req_dict['response_modalities'] = response_modalities
 
-    return req
+    return cast(CreateInteractionRequest, req_dict)
 
 
 class DeepResearchModel:
@@ -341,8 +347,9 @@ class DeepResearchModel:
 
     async def check(self, operation: Operation) -> Operation:
         """Poll a Deep Research interaction for completion."""
-        stored_options = cast(ClientOptions | None, (operation.metadata or {}).get('clientOptions'))
-        check_options = merge_client_options(self._client_options, dict(stored_options or {}))
+        stored_raw = (operation.metadata or {}).get('clientOptions')
+        stored_dict: dict[str, Any] = cast(dict[str, Any], stored_raw) if isinstance(stored_raw, dict) else {}
+        check_options = merge_client_options(self._client_options, stored_dict)
         api_key = calculate_api_key(self._plugin_api_key, None)
         client = InteractionsClient(api_key=api_key, client_options=check_options)
         try:
@@ -353,8 +360,9 @@ class DeepResearchModel:
 
     async def cancel(self, operation: Operation) -> Operation:
         """Cancel an in-progress Deep Research interaction."""
-        stored_options = cast(ClientOptions | None, (operation.metadata or {}).get('clientOptions'))
-        cancel_options = merge_client_options(self._client_options, dict(stored_options or {}))
+        stored_raw = (operation.metadata or {}).get('clientOptions')
+        stored_dict: dict[str, Any] = cast(dict[str, Any], stored_raw) if isinstance(stored_raw, dict) else {}
+        cancel_options = merge_client_options(self._client_options, stored_dict)
         api_key = calculate_api_key(self._plugin_api_key, None)
         client = InteractionsClient(api_key=api_key, client_options=cancel_options)
         try:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/googleai_lyria.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/googleai_lyria.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google AI Interactions Lyria audio model (not the legacy Vertex Lyria)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from genkit import ModelInfo, ModelRequest, ModelResponse, Supports
+from genkit.plugin_api import Action, ActionKind, ActionRunContext, model_action_metadata
+from genkit_google_genai._interactions.client import InteractionsClient
+from genkit_google_genai._interactions.converters import (
+    ensure_tool_ids,
+    from_interaction_sync,
+    to_interaction_steps,
+)
+from genkit_google_genai._interactions.types import ClientOptions, CreateInteractionRequest, ResponseModality
+from genkit_google_genai.models.interactions_utils import (
+    calculate_api_key,
+    config_as_dict,
+    extract_version,
+    merge_client_options,
+    remove_client_option_overrides,
+    response_modalities_from_config,
+)
+
+GENERIC_GOOGLEAI_LYRIA_INFO = ModelInfo(
+    label='Google AI - lyria-3',
+    supports=Supports(
+        multiturn=False,
+        media=True,
+        tools=False,
+        tool_choice=False,
+        system_role=False,
+        output=['media', 'text'],
+    ),
+)
+
+KNOWN_GOOGLEAI_LYRIA_MODELS: dict[str, ModelInfo] = {
+    'lyria-3-clip-preview': GENERIC_GOOGLEAI_LYRIA_INFO,
+    'lyria-3-pro-preview': GENERIC_GOOGLEAI_LYRIA_INFO,
+}
+
+
+class GoogleAILyriaConfigSchema(BaseModel):
+    """Google AI Interactions Lyria model configuration."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    api_key: str | None = Field(default=None, alias='apiKey')
+    base_url: str | None = Field(default=None, alias='baseUrl')
+    api_version: str | None = Field(default=None, alias='apiVersion')
+    response_modalities: list[Literal['TEXT', 'IMAGE', 'AUDIO']] | None = Field(
+        default=None,
+        alias='responseModalities',
+    )
+
+
+def is_googleai_lyria_model_name(name: str | None) -> bool:
+    """Return True for Google AI Interactions Lyria models (lyria-3-*)."""
+    return bool(name and name.startswith('lyria-3'))
+
+
+def googleai_lyria_model_info(version: str) -> ModelInfo:
+    """Return capability metadata for an Interactions Lyria model."""
+    known = KNOWN_GOOGLEAI_LYRIA_MODELS.get(version)
+    if known is not None:
+        return ModelInfo(label=f'Google AI - {version}', supports=known.supports)
+    return ModelInfo(label=f'Google AI - {version}', supports=GENERIC_GOOGLEAI_LYRIA_INFO.supports)
+
+
+def list_known_googleai_lyria_models() -> list[str]:
+    """Return statically known Interactions Lyria model names."""
+    return list(KNOWN_GOOGLEAI_LYRIA_MODELS.keys())
+
+
+class GoogleAILyriaModel:
+    """Interactions Lyria model for Google AI."""
+
+    def __init__(
+        self,
+        version: str,
+        *,
+        plugin_api_key: str | None,
+        client_options: ClientOptions,
+    ) -> None:
+        """Initialize Interactions Lyria model."""
+        self._version = version
+        self._plugin_api_key = plugin_api_key
+        self._client_options = client_options
+
+    async def generate(self, request: ModelRequest, _ctx: ActionRunContext) -> ModelResponse:
+        """Run a synchronous Interactions Lyria generation."""
+        config = config_as_dict(request.config)
+        api_key = calculate_api_key(
+            self._plugin_api_key,
+            config.get('apiKey') or config.get('api_key'),
+        )
+        client_options = merge_client_options(self._client_options, config)
+        passthrough = remove_client_option_overrides(config)
+        passthrough.pop('responseModalities', None)
+        passthrough.pop('response_modalities', None)
+
+        messages = request.messages or []
+        default_modalities: list[ResponseModality] = ['audio', 'text']
+        req: CreateInteractionRequest = {
+            'model': extract_version(self._version),
+            'input': to_interaction_steps(ensure_tool_ids(messages)),
+            'response_modalities': response_modalities_from_config(config, default=default_modalities)
+            or default_modalities,
+            **passthrough,
+        }
+
+        client = InteractionsClient(api_key=api_key, client_options=client_options)
+        try:
+            interaction = await client.create_interaction(req)
+        finally:
+            await client.aclose()
+        return from_interaction_sync(interaction)
+
+
+def create_googleai_lyria_action(
+    name: str,
+    *,
+    plugin_api_key: str | None,
+    client_options: ClientOptions,
+) -> Action:
+    """Build a foreground model action for Interactions Lyria."""
+    clean_name = extract_version(name)
+    model = GoogleAILyriaModel(clean_name, plugin_api_key=plugin_api_key, client_options=client_options)
+    info = googleai_lyria_model_info(clean_name)
+
+    async def _run(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+        return await model.generate(request, ctx)
+
+    return Action(
+        kind=ActionKind.MODEL,
+        name=name,
+        fn=_run,
+        metadata=model_action_metadata(
+            name=name,
+            info=info.model_dump(by_alias=True),
+            config_schema=GoogleAILyriaConfigSchema,
+        ).metadata,
+    )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/googleai_lyria.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/googleai_lyria.py
@@ -72,8 +72,12 @@ class GoogleAILyriaConfigSchema(BaseModel):
 
 
 def is_googleai_lyria_model_name(name: str | None) -> bool:
-    """Return True for Google AI Interactions Lyria models (lyria-3-*)."""
-    return bool(name and name.startswith('lyria-3'))
+    """Return True for Google AI Interactions Lyria model name prefixes.
+
+    Known product models are lyria-3-*; the broader lyria-* prefix keeps legacy
+    names like lyria-002 from falling through to the Gemini catch-all.
+    """
+    return bool(name and name.startswith('lyria-'))
 
 
 def googleai_lyria_model_info(version: str) -> ModelInfo:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/googleai_lyria.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/googleai_lyria.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -118,13 +118,14 @@ class GoogleAILyriaModel:
 
         messages = request.messages or []
         default_modalities: list[ResponseModality] = ['audio', 'text']
-        req: CreateInteractionRequest = {
+        req_dict: dict[str, Any] = {
             'model': extract_version(self._version),
             'input': to_interaction_steps(ensure_tool_ids(messages)),
             'response_modalities': response_modalities_from_config(config, default=default_modalities)
             or default_modalities,
-            **passthrough,
         }
+        req_dict.update(passthrough)
+        req = cast(CreateInteractionRequest, req_dict)
 
         client = InteractionsClient(api_key=api_key, client_options=client_options)
         try:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel
 
@@ -95,7 +95,7 @@ def merge_client_options(
     config: dict[str, Any],
 ) -> ClientOptions:
     """Apply per-request client overrides from model config."""
-    merged: ClientOptions = dict(base)
+    merged = cast(ClientOptions, dict(base))
     if base_url := config.get('baseUrl') or config.get('base_url'):
         merged['base_url'] = str(base_url)
     if api_version := config.get('apiVersion') or config.get('api_version'):
@@ -114,7 +114,7 @@ def remove_client_option_overrides(config: dict[str, Any]) -> dict[str, Any]:
 
 def client_options_for_operation(client_options: ClientOptions) -> ClientOptions:
     """Persist only reconstructable client settings on an Operation (DB10)."""
-    return dict(client_options)
+    return cast(ClientOptions, dict(client_options))
 
 
 def response_modalities_from_config(

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for Google AI Interactions-backed models."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from pydantic import BaseModel
+
+from genkit import GenkitError, Message
+from genkit_google_genai._interactions.types import ClientOptions, ResponseModality
+
+_CLIENT_OPTION_KEYS = frozenset({
+    'api_key',
+    'apiKey',
+    'base_url',
+    'baseUrl',
+    'api_version',
+    'apiVersion',
+    'custom_headers',
+    'customHeaders',
+    'timeout',
+    'experimental_debug_traces',
+    'experimentalDebugTraces',
+})
+
+
+def get_api_key_from_env() -> str | None:
+    """Read a Gemini API key from common environment variables."""
+    return os.getenv('GEMINI_API_KEY') or os.getenv('GOOGLE_API_KEY') or os.getenv('GOOGLE_GENAI_API_KEY')
+
+
+def calculate_api_key(
+    plugin_api_key: str | None,
+    request_api_key: str | None,
+) -> str:
+    """Resolve the effective API key for an Interactions call."""
+    api_key = request_api_key or plugin_api_key or get_api_key_from_env()
+    if not api_key:
+        raise GenkitError(
+            status='FAILED_PRECONDITION',
+            message=(
+                'Please pass in the API key or set the GEMINI_API_KEY or GOOGLE_API_KEY environment variable.\n'
+                'For more details see https://genkit.dev/docs/plugins/google-genai/'
+            ),
+        )
+    return api_key
+
+
+def config_as_dict(config: Any) -> dict[str, Any]:  # noqa: ANN401
+    """Normalize model config to a plain dict."""
+    if config is None:
+        return {}
+    if isinstance(config, BaseModel):
+        return config.model_dump(by_alias=True, exclude_none=True)
+    if isinstance(config, dict):
+        return dict(config)
+    return {}
+
+
+def extract_version(model_name: str) -> str:
+    """Return the bare model version from a namespaced model name."""
+    if '/' in model_name:
+        return model_name.split('/', 1)[1]
+    return model_name
+
+
+def downgrade_system_messages(messages: list[Message]) -> list[Message]:
+    """Map system turns to user turns for agents that reject system instructions."""
+    downgraded = [message.model_copy(deep=True) for message in messages]
+    for message in downgraded:
+        if message.role == 'system':
+            message.role = 'user'
+    return downgraded
+
+
+def merge_client_options(
+    base: ClientOptions,
+    config: dict[str, Any],
+) -> ClientOptions:
+    """Apply per-request client overrides from model config."""
+    merged: ClientOptions = dict(base)
+    if base_url := config.get('baseUrl') or config.get('base_url'):
+        merged['base_url'] = str(base_url)
+    if api_version := config.get('apiVersion') or config.get('api_version'):
+        merged['api_version'] = str(api_version)
+    if custom_headers := config.get('customHeaders') or config.get('custom_headers'):
+        merged['custom_headers'] = dict(custom_headers)
+    if isinstance(config.get('timeout'), (int, float)):
+        merged['timeout'] = float(config['timeout'])
+    return merged
+
+
+def remove_client_option_overrides(config: dict[str, Any]) -> dict[str, Any]:
+    """Drop client-only config keys before passthrough to the wire payload."""
+    return {key: value for key, value in config.items() if key not in _CLIENT_OPTION_KEYS}
+
+
+def client_options_for_operation(client_options: ClientOptions) -> ClientOptions:
+    """Persist only reconstructable client settings on an Operation (DB10)."""
+    return dict(client_options)
+
+
+def response_modalities_from_config(
+    config: dict[str, Any],
+    *,
+    default: list[ResponseModality] | None = None,
+) -> list[ResponseModality] | None:
+    """Convert config responseModalities to wire lowercase modalities."""
+    raw = config.get('responseModalities') or config.get('response_modalities')
+    if raw is None:
+        return default
+    return [str(item).lower() for item in raw]  # type: ignore[misc]

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
@@ -59,7 +59,7 @@ Example:
     ...     operation = await ai.check_operation(operation)
     >>>
     >>> # Get the video URL
-    >>> print(operation.output)
+    >>> print(operation.output.message.content[0].root.media.url)
 
 See Also:
     - https://ai.google.dev/gemini-api/docs/video
@@ -80,6 +80,7 @@ from google.genai import types as genai_types
 from pydantic import BaseModel, ConfigDict, Field
 
 from genkit import (
+    FinishReason,
     Media,
     MediaPart,
     Message,
@@ -153,6 +154,7 @@ DEFAULT_VEO_SUPPORT = Supports(
     tools=False,
     system_role=True,
     output=['media'],
+    long_running=True,
 )
 
 
@@ -211,6 +213,49 @@ def _to_veo_parameters(config: Any) -> dict[str, Any]:  # noqa: ANN401
     return params
 
 
+def _video_parts_from_uris(uris: list[str]) -> list[Part]:
+    """Build model message parts for generated video URIs."""
+    return [
+        Part(
+            root=MediaPart(
+                media=Media(
+                    url=uri,
+                    content_type='video/mp4',
+                )
+            )
+        )
+        for uri in uris
+    ]
+
+
+def _extract_video_uris(response: Any) -> list[str]:  # noqa: ANN401
+    """Extract video URIs from a Veo API response payload."""
+    uris: list[str] = []
+    if hasattr(response, 'generated_videos'):
+        for gv in response.generated_videos or []:
+            if gv.video and gv.video.uri:
+                uris.append(gv.video.uri)
+    elif isinstance(response, dict):
+        video_response = response.get('generateVideoResponse', {})
+        for sample in video_response.get('generatedSamples', []):
+            video = sample.get('video', {})
+            uri = video.get('uri')
+            if uri:
+                uris.append(uri)
+    return uris
+
+
+def _response_raw_payload(response: Any) -> dict[str, Any] | None:  # noqa: ANN401
+    """Best-effort raw payload for completed Veo responses."""
+    if isinstance(response, dict):
+        return response
+    if hasattr(response, 'model_dump'):
+        dumped = response.model_dump(exclude_none=True)
+        if isinstance(dumped, dict):
+            return dumped
+    return None
+
+
 def _from_veo_operation(api_op: dict[str, Any]) -> Operation:
     """Convert Veo API operation to Genkit Operation.
 
@@ -243,31 +288,16 @@ def _from_veo_operation(api_op: dict[str, Any]) -> Operation:
     if response is None:
         return op
 
-    # Extract video URIs — response may be a Pydantic model or a dict.
-    uris: list[str] = []
-    if hasattr(response, 'generated_videos'):
-        # Pydantic GenerateVideosResponse from the SDK (check path).
-        for gv in response.generated_videos or []:
-            if gv.video and gv.video.uri:
-                uris.append(gv.video.uri)
-    elif isinstance(response, dict):
-        # Plain dict (start path or legacy REST).
-        video_response = response.get('generateVideoResponse', {})
-        for sample in video_response.get('generatedSamples', []):
-            video = sample.get('video', {})
-            uri = video.get('uri')
-            if uri:
-                uris.append(uri)
-
+    uris = _extract_video_uris(response)
     if uris:
-        content = [{'media': {'url': uri}} for uri in uris]
-        op.output = {
-            'finishReason': 'stop',
-            'message': {
-                'role': 'model',
-                'content': content,
-            },
-        }
+        op.output = ModelResponse(
+            finish_reason=FinishReason.STOP,
+            message=Message(
+                role=Role.MODEL,
+                content=_video_parts_from_uris(uris),
+            ),
+            raw=_response_raw_payload(response),
+        )
 
     return op
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/veo.py
@@ -273,9 +273,11 @@ def _from_veo_operation(api_op: dict[str, Any]) -> Operation:
     Returns:
         A Genkit Operation object.
     """
+    # LRO can omit or null `done` while the job is still running. Treat that as
+    # pending so typed clients don't see a missing/null flag mid-poll.
     op = Operation(
         id=api_op.get('name', ''),
-        done=api_op.get('done', False),
+        done=bool(api_op.get('done')),
     )
 
     # Handle error

--- a/py/packages/genkit-google-genai/tests/interactions/test_client.py
+++ b/py/packages/genkit-google-genai/tests/interactions/test_client.py
@@ -52,9 +52,10 @@ async def test_create_interaction_posts_with_headers() -> None:
     assert captured['method'] == 'POST'
     assert captured['url'] == 'https://generativelanguage.googleapis.com/v1beta/interactions'
     headers = captured['headers']
-    assert headers['x-goog-api-key'] == 'test-key'
-    assert headers['api-revision'] == API_REVISION
-    assert GENKIT_CLIENT_HEADER in headers['x-goog-api-client']
+    assert isinstance(headers, dict)
+    assert headers.get('x-goog-api-key') == 'test-key'
+    assert headers.get('api-revision') == API_REVISION
+    assert GENKIT_CLIENT_HEADER in str(headers.get('x-goog-api-client', ''))
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-google-genai/tests/interactions/test_client.py
+++ b/py/packages/genkit-google-genai/tests/interactions/test_client.py
@@ -1,0 +1,116 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Interactions HTTP client."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from genkit_google_genai._interactions.client import (
+    InteractionsClient,
+    get_google_ai_url,
+)
+from genkit_google_genai._interactions.types import API_REVISION
+
+from genkit import GenkitError
+from genkit.plugin_api import GENKIT_CLIENT_HEADER
+
+
+@pytest.mark.asyncio
+async def test_create_interaction_posts_with_headers() -> None:
+    captured: dict[str, object] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured['method'] = request.method
+        captured['url'] = str(request.url)
+        captured['headers'] = dict(request.headers)
+        captured['body'] = json.loads(request.content.decode())
+        return httpx.Response(200, json={'id': 'ix-1', 'status': 'in_progress'})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = InteractionsClient(api_key='test-key', http_client=http_client)
+        result = await client.create_interaction({'input': [{'type': 'user_input', 'content': []}]})
+
+    assert result == {'id': 'ix-1', 'status': 'in_progress'}
+    assert captured['method'] == 'POST'
+    assert captured['url'] == 'https://generativelanguage.googleapis.com/v1beta/interactions'
+    headers = captured['headers']
+    assert headers['x-goog-api-key'] == 'test-key'
+    assert headers['api-revision'] == API_REVISION
+    assert GENKIT_CLIENT_HEADER in headers['x-goog-api-client']
+
+
+@pytest.mark.asyncio
+async def test_get_interaction_uses_resource_url() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == 'GET'
+        assert str(request.url).endswith('/v1beta/interactions/ix-42')
+        return httpx.Response(200, json={'id': 'ix-42', 'status': 'completed'})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = InteractionsClient(api_key='test-key', http_client=http_client)
+        result = await client.get_interaction('ix-42')
+
+    assert result['status'] == 'completed'
+
+
+@pytest.mark.asyncio
+async def test_cancel_interaction_maps_success_to_cancelled() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == 'POST'
+        assert str(request.url).endswith('/interactions/ix-9/cancel')
+        return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = InteractionsClient(api_key='test-key', http_client=http_client)
+        result = await client.cancel_interaction('ix-9')
+
+    assert result == {'id': 'ix-9', 'status': 'cancelled'}
+
+
+@pytest.mark.asyncio
+async def test_error_mapping_includes_status_and_retry_after() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            429,
+            headers={'retry-after': '2'},
+            json={'error': {'message': 'rate limited'}},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        client = InteractionsClient(api_key='test-key', http_client=http_client)
+        with pytest.raises(GenkitError) as exc_info:
+            await client.get_interaction('ix-1')
+
+    error = exc_info.value
+    assert error.status == 'RESOURCE_EXHAUSTED'
+    assert 'rate limited' in error.original_message
+    assert error.response_metadata == {'retry_after_ms': 2000.0}
+
+
+def test_get_google_ai_url_honors_client_options() -> None:
+    url = get_google_ai_url(
+        resource_path='interactions/foo',
+        client_options={'api_version': 'v1', 'base_url': 'https://example.test'},
+    )
+    assert url == 'https://example.test/v1/interactions/foo'

--- a/py/packages/genkit-google-genai/tests/interactions/test_converters.py
+++ b/py/packages/genkit-google-genai/tests/interactions/test_converters.py
@@ -321,17 +321,17 @@ class TestFromInteractionStatusMapping:
         assert result.error is not None
         assert result.error.message == 'boom'
 
-    def test_requires_action_done_with_metadata(self) -> None:
+    def test_requires_action_leaves_done_unset(self) -> None:
         interaction: GeminiInteraction = {
             'id': '123',
             'status': 'requires_action',
             'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'approve plan'}]}],
         }
         result = from_interaction(interaction)
-        assert result.done is True
-        assert result.output is not None
-        assert result.metadata is not None
-        assert result.metadata['interaction_status'] == 'requires_action'
+        assert result.id == '123'
+        assert result.done is None
+        assert result.output is None
+        assert not (result.metadata or {}).get('interaction_status')
 
     def test_in_progress(self) -> None:
         result = from_interaction({'id': '123', 'status': 'in_progress'})

--- a/py/packages/genkit-google-genai/tests/interactions/test_converters.py
+++ b/py/packages/genkit-google-genai/tests/interactions/test_converters.py
@@ -1,0 +1,342 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Interactions API converters."""
+
+from __future__ import annotations
+
+import pytest
+from genkit_google_genai._interactions.converters import (
+    ensure_tool_ids,
+    from_interaction,
+    from_interaction_content,
+    from_interaction_step,
+    from_interaction_sync,
+    to_interaction_content,
+    to_interaction_role,
+    to_interaction_steps,
+    to_interaction_tool,
+)
+from genkit_google_genai._interactions.types import GeminiInteraction
+
+from genkit import (
+    CustomPart,
+    Media,
+    MediaPart,
+    Part,
+    TextPart,
+    ToolRequest,
+    ToolRequestPart,
+    ToolResponse,
+    ToolResponsePart,
+)
+from genkit.model import Message, ToolDefinition
+
+
+def _part_dict(part: Part) -> dict:
+    return part.root.model_dump(by_alias=True, exclude_none=True)
+
+
+class TestEnsureToolIds:
+    def test_assigns_ids_to_tool_requests_without_refs(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='tool1', input={}))),
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='tool2', input={}))),
+                ],
+            )
+        ]
+        result = ensure_tool_ids(messages)
+        req1 = result[0].content[0].root.tool_request
+        req2 = result[0].content[1].root.tool_request
+        assert req1 is not None and req1.ref and req1.ref.startswith('genkit-auto-id-')
+        assert req2 is not None and req2.ref and req2.ref.startswith('genkit-auto-id-')
+        assert req1.ref != req2.ref
+
+    def test_assigns_matching_ids_to_tool_responses(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='tool1', input={}))),
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='tool2', input={}))),
+                ],
+            ),
+            Message(
+                role='tool',
+                content=[
+                    Part(root=ToolResponsePart(tool_response=ToolResponse(name='tool1', output={}))),
+                    Part(root=ToolResponsePart(tool_response=ToolResponse(name='tool2', output={}))),
+                ],
+            ),
+        ]
+        result = ensure_tool_ids(messages)
+        req1 = result[0].content[0].root.tool_request
+        req2 = result[0].content[1].root.tool_request
+        res1 = result[1].content[0].root.tool_response
+        res2 = result[1].content[1].root.tool_response
+        assert req1 and req1.ref and res1 and res1.ref == req1.ref
+        assert req2 and req2.ref and res2 and res2.ref == req2.ref
+
+    def test_assigns_orphan_id_without_matching_request(self) -> None:
+        messages = [
+            Message(
+                role='tool',
+                content=[Part(root=ToolResponsePart(tool_response=ToolResponse(name='tool1', output={})))],
+            )
+        ]
+        result = ensure_tool_ids(messages)
+        res1 = result[0].content[0].root.tool_response
+        assert res1 and res1.ref and res1.ref.startswith('genkit-orphan-id-')
+
+    def test_preserves_existing_refs(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(root=ToolRequestPart(tool_request=ToolRequest(name='tool1', input={}, ref='existing-id')))
+                ],
+            )
+        ]
+        result = ensure_tool_ids(messages)
+        req1 = result[0].content[0].root.tool_request
+        assert req1 and req1.ref == 'existing-id'
+
+
+class TestToInteractionRole:
+    def test_user(self) -> None:
+        assert to_interaction_role('user') == 'user'
+
+    def test_model(self) -> None:
+        assert to_interaction_role('model') == 'model'
+
+    def test_tool_maps_to_user(self) -> None:
+        assert to_interaction_role('tool') == 'user'
+
+    def test_system_raises(self) -> None:
+        with pytest.raises(ValueError, match='system_instruction'):
+            to_interaction_role('system')
+
+
+class TestToInteractionTool:
+    def test_converts_tool_definition(self) -> None:
+        tool = ToolDefinition(
+            name='myFunc',
+            description='desc',
+            input_schema={'type': 'object', 'properties': {'arg': {'type': 'string'}}},
+        )
+        result = to_interaction_tool(tool)
+        assert result == {
+            'type': 'function',
+            'name': 'myFunc',
+            'description': 'desc',
+            'parameters': {'type': 'object', 'properties': {'arg': {'type': 'string'}}},
+        }
+
+
+class TestToInteractionContent:
+    def test_text(self) -> None:
+        result = to_interaction_content(Part(root=TextPart(text='Hello')))
+        assert result == {'type': 'text', 'text': 'Hello'}
+
+    def test_image_data(self) -> None:
+        result = to_interaction_content(
+            Part(root=MediaPart(media=Media(url='data:image/png;base64,DATA', content_type='image/png')))
+        )
+        assert result == {'type': 'image', 'data': 'DATA', 'mime_type': 'image/png'}
+
+    def test_image_uri(self) -> None:
+        result = to_interaction_content(
+            Part(root=MediaPart(media=Media(url='gs://bucket/image.png', content_type='image/png')))
+        )
+        assert result == {'type': 'image', 'uri': 'gs://bucket/image.png', 'mime_type': 'image/png'}
+
+    def test_audio(self) -> None:
+        result = to_interaction_content(
+            Part(root=MediaPart(media=Media(url='data:audio/mp3;base64,DATA', content_type='audio/mp3')))
+        )
+        assert result == {'type': 'audio', 'data': 'DATA', 'mime_type': 'audio/mp3'}
+
+    def test_document(self) -> None:
+        result = to_interaction_content(
+            Part(root=MediaPart(media=Media(url='gs://bucket/doc.pdf', content_type='application/pdf')))
+        )
+        assert result == {'type': 'document', 'uri': 'gs://bucket/doc.pdf', 'mime_type': 'application/pdf'}
+
+    def test_unsupported_media_raises(self) -> None:
+        with pytest.raises(ValueError, match='Unsupported media type'):
+            to_interaction_content(
+                Part(root=MediaPart(media=Media(url='https://example.com/x', content_type='text/plain')))
+            )
+
+
+class TestToInteractionSteps:
+    def test_tool_request(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[Part(root=ToolRequestPart(tool_request=ToolRequest(name='func', input={'a': 1}, ref='ref1')))],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {'type': 'function_call', 'name': 'func', 'arguments': {'a': 1}, 'id': 'ref1'}
+        ]
+
+    def test_tool_response(self) -> None:
+        messages = [
+            Message(
+                role='tool',
+                content=[
+                    Part(
+                        root=ToolResponsePart(
+                            tool_response=ToolResponse(name='func', output={'result': 'ok'}, ref='ref1')
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {'type': 'function_result', 'name': 'func', 'result': {'result': 'ok'}, 'call_id': 'ref1'}
+        ]
+
+    def test_model_output_grouping(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[Part(root=TextPart(text='Thinking')), Part(root=TextPart(text='Done'))],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'model_output',
+                'content': [{'type': 'text', 'text': 'Thinking'}, {'type': 'text', 'text': 'Done'}],
+            }
+        ]
+
+    def test_google_search_call(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        root=CustomPart(
+                            custom={'googleSearchCall': {'id': 'gs1', 'arguments': {'queries': ['genkit']}}},
+                            metadata={'thoughtSignature': 'sig'},
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'google_search_call',
+                'id': 'gs1',
+                'arguments': {'queries': ['genkit']},
+                'signature': 'sig',
+            }
+        ]
+
+
+class TestFromInteractionContent:
+    def test_text(self) -> None:
+        result = from_interaction_content({
+            'type': 'text',
+            'text': 'Hello world',
+            'annotations': [{'start_index': 0, 'end_index': 5, 'source': 'source'}],
+        })
+        assert _part_dict(result) == {
+            'text': 'Hello world',
+            'metadata': {'annotations': [{'start_index': 0, 'end_index': 5, 'source': 'source'}]},
+        }
+
+    def test_image_data(self) -> None:
+        result = from_interaction_content({'type': 'image', 'data': 'BASE64DATA', 'mime_type': 'image/png'})
+        assert _part_dict(result) == {'media': {'url': 'data:image/png;base64,BASE64DATA', 'contentType': 'image/png'}}
+
+    def test_image_resolution(self) -> None:
+        result = from_interaction_content({
+            'type': 'image',
+            'uri': 'gs://bucket/image.png',
+            'mime_type': 'image/png',
+            'resolution': 'high',
+        })
+        assert _part_dict(result) == {
+            'media': {'url': 'gs://bucket/image.png', 'contentType': 'image/png'},
+            'metadata': {'resolution': 'high'},
+        }
+
+    def test_thought(self) -> None:
+        content = {'type': 'thought', 'signature': 'SIG', 'summary': [{'type': 'text', 'text': 'Thinking...'}]}
+        result = from_interaction_content(content)
+        assert _part_dict(result) == {
+            'reasoning': 'Thinking...',
+            'metadata': {'thoughtSignature': 'SIG'},
+            'custom': {'thought': content},
+        }
+
+
+class TestFromInteractionStep:
+    def test_model_output_includes_empty_annotations(self) -> None:
+        result = from_interaction_step({'type': 'model_output', 'content': [{'type': 'text', 'text': 'Hello'}]})
+        root = result[0].root
+        assert isinstance(root, TextPart)
+        assert root.text == 'Hello'
+        assert root.metadata is not None
+        assert 'annotations' in root.metadata
+
+    def test_user_input_dropped(self) -> None:
+        result = from_interaction_step({'type': 'user_input', 'content': [{'type': 'text', 'text': 'Hello'}]})
+        assert result == []
+
+
+class TestFromInteractionStatusMapping:
+    def test_cancelled(self) -> None:
+        result = from_interaction({'id': '123', 'status': 'cancelled'})
+        assert result.done is True
+        assert result.output is not None
+        assert result.output.finish_reason == 'aborted'
+        assert result.output.finish_message == 'Operation cancelled'
+        assert _part_dict(result.output.message.content[0]) == {'text': 'Operation cancelled.'}
+
+    def test_failed_exits_poll_loop(self) -> None:
+        result = from_interaction({'id': '123', 'status': 'failed', 'error': {'message': 'boom'}})
+        assert result.done is True
+        assert result.error is not None
+        assert result.error.message == 'boom'
+
+    def test_requires_action_done_with_metadata(self) -> None:
+        interaction: GeminiInteraction = {
+            'id': '123',
+            'status': 'requires_action',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'approve plan'}]}],
+        }
+        result = from_interaction(interaction)
+        assert result.done is True
+        assert result.output is not None
+        assert result.metadata is not None
+        assert result.metadata['interaction_status'] == 'requires_action'
+
+    def test_in_progress(self) -> None:
+        result = from_interaction({'id': '123', 'status': 'in_progress'})
+        assert result.done is False
+
+
+class TestFromInteractionSync:
+    def test_failed_raises(self) -> None:
+        with pytest.raises(ValueError, match='Interaction failed'):
+            from_interaction_sync({'status': 'failed'})

--- a/py/packages/genkit-google-genai/tests/interactions/test_converters.py
+++ b/py/packages/genkit-google-genai/tests/interactions/test_converters.py
@@ -18,6 +18,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 from genkit_google_genai._interactions.converters import (
     ensure_tool_ids,
@@ -30,7 +32,7 @@ from genkit_google_genai._interactions.converters import (
     to_interaction_steps,
     to_interaction_tool,
 )
-from genkit_google_genai._interactions.types import GeminiInteraction
+from genkit_google_genai._interactions.types import Content, GeminiInteraction
 
 from genkit import (
     CustomPart,
@@ -282,7 +284,7 @@ class TestFromInteractionContent:
 
     def test_thought(self) -> None:
         content = {'type': 'thought', 'signature': 'SIG', 'summary': [{'type': 'text', 'text': 'Thinking...'}]}
-        result = from_interaction_content(content)
+        result = from_interaction_content(cast(Content, content))
         assert _part_dict(result) == {
             'reasoning': 'Thinking...',
             'metadata': {'thoughtSignature': 'SIG'},

--- a/py/packages/genkit-google-genai/tests/interactions/test_models.py
+++ b/py/packages/genkit-google-genai/tests/interactions/test_models.py
@@ -1,0 +1,273 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Interactions-backed Google AI models."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from genkit_google_genai.google import GoogleAI, googleai_name
+from genkit_google_genai.models.antigravity import AntigravityModel
+from genkit_google_genai.models.deep_research import DeepResearchModel
+from genkit_google_genai.models.googleai_lyria import GoogleAILyriaModel
+from genkit_google_genai.models.interactions_utils import downgrade_system_messages
+
+from genkit import ActionKind, Message, ModelRequest, Part, Role, TextPart
+
+
+def test_downgrade_system_messages_maps_system_to_user() -> None:
+    messages = [
+        Message(role=Role.SYSTEM, content=[Part(root=TextPart(text='Be helpful'))]),
+        Message(role=Role.USER, content=[Part(root=TextPart(text='Hi'))]),
+    ]
+    downgraded = downgrade_system_messages(messages)
+    assert downgraded[0].role == Role.USER
+    assert downgraded[1].role == Role.USER
+
+
+@pytest.mark.asyncio
+async def test_deep_research_start_sends_background_request() -> None:
+    captured: dict[str, object] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured['body'] = json.loads(request.content.decode())
+        return httpx.Response(200, json={'id': 'dr-1', 'status': 'in_progress'})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        model = DeepResearchModel(
+            'deep-research-preview-04-2026',
+            plugin_api_key='plugin-key',
+            client_options={},
+        )
+        request = ModelRequest(
+            messages=[
+                Message(role=Role.SYSTEM, content=[Part(root=TextPart(text='sys'))]),
+                Message(role=Role.USER, content=[Part(root=TextPart(text='research this'))]),
+            ],
+            config={'thinkingSummaries': 'AUTO', 'googleSearch': True},
+        )
+        with patch(
+            'genkit_google_genai.models.deep_research.InteractionsClient',
+            wraps=lambda **kwargs: __import__(
+                'genkit_google_genai._interactions.client', fromlist=['InteractionsClient']
+            ).InteractionsClient(http_client=http_client, **kwargs),
+        ):
+            operation = await model.start(request, MagicMock())
+
+    body = captured['body']
+    assert isinstance(body, dict)
+    assert body['background'] is True
+    assert body['agent'] == 'deep-research-preview-04-2026'
+    assert body['agent_config'] == {
+        'type': 'deep-research',
+        'thinking_summaries': 'auto',
+    }
+    assert body['tools'] == [{'type': 'google_search'}]
+    assert body['input'][0]['type'] == 'user_input'
+    assert operation.id == 'dr-1'
+    assert operation.done is False
+    assert 'apiKey' not in (operation.metadata or {}).get('clientOptions', {})
+    assert 'api_key' not in (operation.metadata or {}).get('clientOptions', {})
+
+
+@pytest.mark.asyncio
+async def test_deep_research_check_rederives_api_key() -> None:
+    captured: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured['api_key'] = request.headers.get('x-goog-api-key', '')
+        return httpx.Response(
+            200,
+            json={
+                'id': 'dr-1',
+                'status': 'completed',
+                'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'done'}]}],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        model = DeepResearchModel('deep-research-preview-04-2026', plugin_api_key='plugin-key', client_options={})
+        from genkit.model import Operation
+
+        operation = Operation.model_construct(
+            id='dr-1',
+            metadata={'clientOptions': {'base_url': 'https://example.test'}},
+        )
+        with patch(
+            'genkit_google_genai.models.deep_research.InteractionsClient',
+            wraps=lambda **kwargs: __import__(
+                'genkit_google_genai._interactions.client', fromlist=['InteractionsClient']
+            ).InteractionsClient(http_client=http_client, **kwargs),
+        ):
+            updated = await model.check(operation)
+
+    assert captured['api_key'] == 'plugin-key'
+    assert updated.done is True
+    assert updated.output is not None
+    assert updated.output.message is not None
+    assert updated.output.message.content[0].root.text == 'done'
+
+
+@pytest.mark.asyncio
+async def test_antigravity_generate_downgrades_system_and_uses_agent() -> None:
+    captured: dict[str, object] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured['body'] = json.loads(request.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                'id': 'ag-1',
+                'status': 'completed',
+                'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'hello'}]}],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        model = AntigravityModel('antigravity-preview-05-2026', plugin_api_key='key', client_options={})
+        request = ModelRequest(
+            messages=[
+                Message(role=Role.SYSTEM, content=[Part(root=TextPart(text='sys'))]),
+                Message(role=Role.USER, content=[Part(root=TextPart(text='build'))]),
+            ],
+            config={'responseModalities': ['TEXT', 'IMAGE']},
+        )
+        with patch(
+            'genkit_google_genai.models.antigravity.InteractionsClient',
+            wraps=lambda **kwargs: __import__(
+                'genkit_google_genai._interactions.client', fromlist=['InteractionsClient']
+            ).InteractionsClient(http_client=http_client, **kwargs),
+        ):
+            response = await model.generate(request, MagicMock())
+
+    body = captured['body']
+    assert isinstance(body, dict)
+    assert body['agent'] == 'antigravity-preview-05-2026'
+    assert body['response_modalities'] == ['text', 'image']
+    assert 'background' not in body
+    assert response.message is not None
+    assert response.message.content[0].root.text == 'hello'
+
+
+@pytest.mark.asyncio
+async def test_googleai_lyria_defaults_audio_and_text_modalities() -> None:
+    captured: dict[str, object] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured['body'] = json.loads(request.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                'id': 'ly-1',
+                'status': 'completed',
+                'steps': [
+                    {
+                        'type': 'model_output',
+                        'content': [{'type': 'audio', 'data': 'abc', 'mime_type': 'audio/wav'}],
+                    }
+                ],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        model = GoogleAILyriaModel('lyria-3-clip-preview', plugin_api_key='key', client_options={})
+        request = ModelRequest(
+            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='jazz riff'))])],
+        )
+        with patch(
+            'genkit_google_genai.models.googleai_lyria.InteractionsClient',
+            wraps=lambda **kwargs: __import__(
+                'genkit_google_genai._interactions.client', fromlist=['InteractionsClient']
+            ).InteractionsClient(http_client=http_client, **kwargs),
+        ):
+            response = await model.generate(request, MagicMock())
+
+    body = captured['body']
+    assert isinstance(body, dict)
+    assert body['model'] == 'lyria-3-clip-preview'
+    assert body['response_modalities'] == ['audio', 'text']
+    assert response.message is not None
+
+
+@pytest.mark.asyncio
+async def test_googleai_plugin_registers_interactions_models() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+        actions = await plugin.init()
+
+    kinds_by_name = {action.name: action.kind for action in actions}
+    dr_name = googleai_name('deep-research-preview-04-2026')
+    ag_name = googleai_name('antigravity-preview-05-2026')
+    ly_name = googleai_name('lyria-3-clip-preview')
+
+    assert kinds_by_name[dr_name] == ActionKind.BACKGROUND_MODEL
+    assert kinds_by_name[f'{dr_name}/check'] == ActionKind.CHECK_OPERATION
+    assert kinds_by_name[f'{dr_name}/cancel'] == ActionKind.CANCEL_OPERATION
+    assert kinds_by_name[ag_name] == ActionKind.MODEL
+    assert kinds_by_name[ly_name] == ActionKind.MODEL
+
+
+@pytest.mark.asyncio
+async def test_googleai_resolve_routes_interactions_models() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+
+    dr_name = googleai_name('deep-research-pro-preview-12-2025')
+    bg = await plugin.resolve(ActionKind.BACKGROUND_MODEL, dr_name)
+    assert bg is not None
+    assert bg.kind == ActionKind.BACKGROUND_MODEL
+
+    check = await plugin.resolve(ActionKind.CHECK_OPERATION, f'{dr_name}/check')
+    assert check is not None
+
+    cancel = await plugin.resolve(ActionKind.CANCEL_OPERATION, f'{dr_name}/cancel')
+    assert cancel is not None
+
+    ag = await plugin.resolve(ActionKind.MODEL, googleai_name('antigravity-preview-05-2026'))
+    assert ag is not None
+    assert ag.kind == ActionKind.MODEL
+
+    ly = await plugin.resolve(ActionKind.MODEL, googleai_name('lyria-3-pro-preview'))
+    assert ly is not None
+
+
+@pytest.mark.asyncio
+async def test_googleai_list_actions_includes_interactions_models() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+        actions = await plugin.list_actions()
+
+    names = {action.name for action in actions}
+    assert googleai_name('deep-research-max-preview-04-2026') in names
+    assert googleai_name('antigravity-preview-05-2026') in names
+    assert googleai_name('lyria-3-pro-preview') in names

--- a/py/packages/genkit-google-genai/tests/interactions/test_models.py
+++ b/py/packages/genkit-google-genai/tests/interactions/test_models.py
@@ -321,6 +321,16 @@ async def test_googleai_resolve_routes_interactions_models() -> None:
     ly = await plugin.resolve(ActionKind.MODEL, googleai_name('lyria-3-pro-preview'))
     assert ly is not None
 
+    # Legacy Vertex name must not fall through to Gemini capabilities metadata.
+    ly_legacy = await plugin.resolve(ActionKind.MODEL, googleai_name('lyria-002'))
+    assert ly_legacy is not None
+    model_meta = (ly_legacy.metadata or {}).get('model')
+    assert isinstance(model_meta, dict)
+    supports = model_meta.get('supports')
+    assert isinstance(supports, dict)
+    assert supports.get('media') is True
+    assert supports.get('multiturn') is not True
+
 
 @pytest.mark.asyncio
 async def test_googleai_list_actions_includes_interactions_models() -> None:

--- a/py/packages/genkit-google-genai/tests/interactions/test_models.py
+++ b/py/packages/genkit-google-genai/tests/interactions/test_models.py
@@ -86,7 +86,10 @@ async def test_deep_research_start_sends_background_request() -> None:
         'thinking_summaries': 'auto',
     }
     assert body['tools'] == [{'type': 'google_search'}]
-    assert body['input'][0]['type'] == 'user_input'
+    input_steps = body['input']
+    assert isinstance(input_steps, list)
+    assert isinstance(input_steps[0], dict)
+    assert input_steps[0]['type'] == 'user_input'
     assert operation.id == 'dr-1'
     assert operation.done is False
     assert 'apiKey' not in (operation.metadata or {}).get('clientOptions', {})
@@ -249,7 +252,10 @@ async def test_deep_research_define_background_model_sets_action() -> None:
     assert isinstance(operation, Operation)
     assert operation.action == f'/background-model/{ref.name}'
     assert operation.id == 'dr-action-1'
-    supports = (bg.start_action.metadata or {}).get('model', {}).get('supports', {})
+    model_meta = (bg.start_action.metadata or {}).get('model')
+    assert isinstance(model_meta, dict)
+    supports = model_meta.get('supports')
+    assert isinstance(supports, dict)
     assert supports.get('longRunning') is True
 
 

--- a/py/packages/genkit-google-genai/tests/interactions/test_models.py
+++ b/py/packages/genkit-google-genai/tests/interactions/test_models.py
@@ -25,11 +25,16 @@ import httpx
 import pytest
 from genkit_google_genai.google import GoogleAI, googleai_name
 from genkit_google_genai.models.antigravity import AntigravityModel
-from genkit_google_genai.models.deep_research import DeepResearchModel
+from genkit_google_genai.models.deep_research import (
+    DeepResearchModel,
+    create_deep_research_background_action,
+    deep_research_model,
+)
 from genkit_google_genai.models.googleai_lyria import GoogleAILyriaModel
 from genkit_google_genai.models.interactions_utils import downgrade_system_messages
 
 from genkit import ActionKind, Message, ModelRequest, Part, Role, TextPart
+from genkit.model import Operation
 
 
 def test_downgrade_system_messages_maps_system_to_user() -> None:
@@ -208,6 +213,59 @@ async def test_googleai_lyria_defaults_audio_and_text_modalities() -> None:
     assert body['model'] == 'lyria-3-clip-preview'
     assert body['response_modalities'] == ['audio', 'text']
     assert response.message is not None
+
+
+def test_deep_research_model_ref_is_namespaced() -> None:
+    ref = deep_research_model('deep-research-preview-04-2026')
+    assert ref.name == 'googleai/deep-research-preview-04-2026'
+    assert ref.config_schema is not None
+
+
+@pytest.mark.asyncio
+async def test_deep_research_define_background_model_sets_action() -> None:
+    """define_background_model must stamp Operation.action for check/cancel."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={'id': 'dr-action-1', 'status': 'in_progress'})
+
+    transport = httpx.MockTransport(handler)
+    ref = deep_research_model('deep-research-preview-04-2026')
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        bg = create_deep_research_background_action(
+            ref,
+            plugin_api_key='plugin-key',
+            client_options={},
+        )
+        with patch(
+            'genkit_google_genai.models.deep_research.InteractionsClient',
+            wraps=lambda **kwargs: __import__(
+                'genkit_google_genai._interactions.client', fromlist=['InteractionsClient']
+            ).InteractionsClient(http_client=http_client, **kwargs),
+        ):
+            operation = await bg.start(
+                ModelRequest(messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='q'))])]),
+            )
+
+    assert isinstance(operation, Operation)
+    assert operation.action == f'/background-model/{ref.name}'
+    assert operation.id == 'dr-action-1'
+    supports = (bg.start_action.metadata or {}).get('model', {}).get('supports', {})
+    assert supports.get('longRunning') is True
+
+
+@pytest.mark.asyncio
+async def test_googleai_resolve_model_skips_deep_research_foreground() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+
+    dr_name = googleai_name('deep-research-preview-04-2026')
+    assert await plugin.resolve(ActionKind.MODEL, dr_name) is None
+    bg = await plugin.resolve(ActionKind.BACKGROUND_MODEL, dr_name)
+    assert bg is not None
+    assert bg.kind == ActionKind.BACKGROUND_MODEL
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit-google-genai/tests/veo_test.py
+++ b/py/packages/genkit-google-genai/tests/veo_test.py
@@ -21,7 +21,11 @@ start path) and Pydantic GenerateVideosResponse objects (from the check
 path where the SDK returns a model instance).
 """
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
+from genkit_google_genai import GoogleAI
+from genkit_google_genai.google import GenaiModels
 from genkit_google_genai.models.veo import (
     VeoConfigSchema,
     VeoVersion,
@@ -30,6 +34,8 @@ from genkit_google_genai.models.veo import (
     is_veo_model,
 )
 from google.genai import types as genai_types
+
+from genkit import FinishReason, Genkit, ModelResponse
 
 
 class TestIsVeoModel:
@@ -146,12 +152,12 @@ class TestFromVeoOperation:
             },
         })
         assert op.done is True
-        assert op.output is not None
-        assert op.output['finishReason'] == 'stop'
-        content = op.output['message']['content']
+        assert isinstance(op.output, ModelResponse)
+        assert op.output.finish_reason == FinishReason.STOP
+        content = op.output.message.content if op.output.message else []
         assert len(content) == 2
-        assert content[0]['media']['url'] == 'https://example.com/v1.mp4'
-        assert content[1]['media']['url'] == 'https://example.com/v2.mp4'
+        assert content[0].root.media.url == 'https://example.com/v1.mp4'
+        assert content[1].root.media.url == 'https://example.com/v2.mp4'
 
     def test_pydantic_response_with_videos(self) -> None:
         """Pydantic GenerateVideosResponse extracts video URIs (check path).
@@ -178,12 +184,12 @@ class TestFromVeoOperation:
             'response': pydantic_response,
         })
         assert op.done is True
-        assert op.output is not None
-        assert op.output['finishReason'] == 'stop'
-        content = op.output['message']['content']
+        assert isinstance(op.output, ModelResponse)
+        assert op.output.finish_reason == FinishReason.STOP
+        content = op.output.message.content if op.output.message else []
         assert len(content) == 2
-        assert content[0]['media']['url'] == 'https://example.com/video_a.mp4'
-        assert content[1]['media']['url'] == 'https://example.com/video_b.mp4'
+        assert content[0].root.media.url == 'https://example.com/video_a.mp4'
+        assert content[1].root.media.url == 'https://example.com/video_b.mp4'
 
     def test_pydantic_response_empty_videos(self) -> None:
         """Pydantic response with no generated_videos produces no output."""
@@ -216,3 +222,80 @@ class TestFromVeoOperation:
         })
         assert op.done is True
         assert op.output is None
+
+
+def _mock_veo_client(start_done: bool = False) -> MagicMock:
+    """Build a mocked GenAI client for Veo background-model tests."""
+    client = MagicMock()
+    start_op = MagicMock()
+    start_op.name = 'operations/veo-start'
+    start_op.done = start_done
+
+    completed_response = genai_types.GenerateVideosResponse(
+        generated_videos=[
+            genai_types.GeneratedVideo(
+                video=genai_types.Video(uri='https://example.com/generated.mp4'),
+            ),
+        ],
+    )
+    check_op = MagicMock()
+    check_op.name = 'operations/veo-start'
+    check_op.done = True
+    check_op.error = None
+    check_op.response = completed_response
+
+    client.aio.models.generate_videos = AsyncMock(return_value=start_op)
+    client.aio.operations.get = AsyncMock(return_value=check_op)
+    return client
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_veo_generate_returns_operation(mock_list_models: MagicMock, mock_client_ctor: MagicMock) -> None:
+    """generate() on a Veo model returns an Operation to poll."""
+    models = GenaiModels()
+    models.veo = ['veo-2.0-generate-001']
+    mock_list_models.return_value = models
+    mock_client_ctor.return_value = _mock_veo_client()
+
+    ai = Genkit(plugins=[GoogleAI(api_key='test-key')])
+    response = await ai.generate(
+        model='googleai/veo-2.0-generate-001',
+        prompt='a cat surfing',
+    )
+
+    assert response.operation is not None
+    assert response.operation.id == 'operations/veo-start'
+    assert response.operation.done is False
+    assert response.operation.action == '/background-model/googleai/veo-2.0-generate-001'
+    assert response.message is None
+
+
+@patch('genkit_google_genai.google.genai.client.Client')
+@patch('genkit_google_genai.google._list_genai_models')
+@pytest.mark.asyncio
+async def test_veo_generate_operation_poll_loop(mock_list_models: MagicMock, mock_client_ctor: MagicMock) -> None:
+    """generate_operation + check_operation poll Veo to a ModelResponse output."""
+    models = GenaiModels()
+    models.veo = ['veo-2.0-generate-001']
+    mock_list_models.return_value = models
+    mock_client_ctor.return_value = _mock_veo_client()
+
+    ai = Genkit(plugins=[GoogleAI(api_key='test-key')])
+    operation = await ai.generate_operation(
+        model='googleai/veo-2.0-generate-001',
+        prompt='a cat surfing',
+    )
+
+    assert operation.id == 'operations/veo-start'
+    assert operation.done is False
+
+    operation = await ai.check_operation(operation)
+
+    assert operation.done is True
+    assert isinstance(operation.output, ModelResponse)
+    assert operation.output.finish_reason == FinishReason.STOP
+    content = operation.output.message.content if operation.output.message else []
+    assert len(content) == 1
+    assert content[0].root.media.url == 'https://example.com/generated.mp4'

--- a/py/packages/genkit-google-genai/tests/veo_test.py
+++ b/py/packages/genkit-google-genai/tests/veo_test.py
@@ -124,6 +124,16 @@ class TestFromVeoOperation:
         assert op.output is None
         assert op.error is None
 
+    def test_pending_operation_null_done_normalized(self) -> None:
+        """API null/omitted done is pending, not a missing flag."""
+        for api_op in (
+            {'name': 'operations/null-done', 'done': None},
+            {'name': 'operations/omitted-done'},
+        ):
+            op = _from_veo_operation(api_op)
+            assert op.done is False
+            assert op.output is None
+
     def test_error_operation(self) -> None:
         """An operation with an error populates op.error."""
         op = _from_veo_operation({

--- a/py/packages/genkit-google-genai/tests/veo_test.py
+++ b/py/packages/genkit-google-genai/tests/veo_test.py
@@ -156,8 +156,10 @@ class TestFromVeoOperation:
         assert op.output.finish_reason == FinishReason.STOP
         content = op.output.message.content if op.output.message else []
         assert len(content) == 2
-        assert content[0].root.media.url == 'https://example.com/v1.mp4'
-        assert content[1].root.media.url == 'https://example.com/v2.mp4'
+        media0 = content[0].root.media
+        media1 = content[1].root.media
+        assert media0 is not None and media0.url == 'https://example.com/v1.mp4'
+        assert media1 is not None and media1.url == 'https://example.com/v2.mp4'
 
     def test_pydantic_response_with_videos(self) -> None:
         """Pydantic GenerateVideosResponse extracts video URIs (check path).
@@ -188,8 +190,10 @@ class TestFromVeoOperation:
         assert op.output.finish_reason == FinishReason.STOP
         content = op.output.message.content if op.output.message else []
         assert len(content) == 2
-        assert content[0].root.media.url == 'https://example.com/video_a.mp4'
-        assert content[1].root.media.url == 'https://example.com/video_b.mp4'
+        media0 = content[0].root.media
+        media1 = content[1].root.media
+        assert media0 is not None and media0.url == 'https://example.com/video_a.mp4'
+        assert media1 is not None and media1.url == 'https://example.com/video_b.mp4'
 
     def test_pydantic_response_empty_videos(self) -> None:
         """Pydantic response with no generated_videos produces no output."""
@@ -298,4 +302,5 @@ async def test_veo_generate_operation_poll_loop(mock_list_models: MagicMock, moc
     assert operation.output.finish_reason == FinishReason.STOP
     content = operation.output.message.content if operation.output.message else []
     assert len(content) == 1
-    assert content[0].root.media.url == 'https://example.com/generated.mp4'
+    media = content[0].root.media
+    assert media is not None and media.url == 'https://example.com/generated.mp4'

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -1261,7 +1261,7 @@ class Genkit:
             )
 
         # Check if model supports long-running operations
-        if not _model_supports_long_running(model_action):
+        if not _model_supports_long_running(cast(Action, model_action)):
             raise GenkitError(
                 status='INVALID_ARGUMENT',
                 message=f"Model '{model_action.name}' does not support long running operations.",

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -75,7 +75,7 @@ from genkit._ai._resource import (
     define_resource,
 )
 from genkit._ai._tools import Tool, define_interrupt, define_tool
-from genkit._core._action import Action, ActionKind, get_current_context
+from genkit._core._action import Action, ActionKind, get_current_context  # noqa: F401 — re-exported via genkit.__init__
 from genkit._core._background import (
     BackgroundAction,
     CancelModelOpFn,
@@ -1253,7 +1253,7 @@ class Genkit:
                 message='No model specified for generate_operation.',
             )
 
-        model_action = await self.registry.resolve_action(ActionKind.MODEL, resolved_model)
+        model_action = await self.registry.resolve_model(resolved_model)
         if not model_action:
             raise GenkitError(
                 status='NOT_FOUND',

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -68,6 +68,7 @@ from genkit._core._typing import (
     FinishReason,
     MiddlewareRef,
     MultipartToolResponse,
+    Operation,
     Part,
     Role,
     TextPart,
@@ -702,6 +703,12 @@ async def _generate_action_turn(
                 ctx,
                 next_fn,
             )
+
+        # Background models return an Operation to poll, not a finished message.
+        # The tool loop below assumes response.message exists, so branch out first.
+        if model.kind == ActionKind.BACKGROUND_MODEL:
+            operation = cast(Operation, model_response)
+            return ModelResponse(operation=operation, request=request)
 
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
             if formatter is None:

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -250,7 +250,9 @@ def define_background_model(
     model_options: dict[str, Any] = {}
 
     if info:
-        model_options.update(info.model_dump())
+        # camelCase wire keys (e.g. longRunning) so generate_operation's
+        # metadata check sees the same shape Dev UI / JS expect.
+        model_options.update(info.model_dump(by_alias=True))
 
     model_options['label'] = label
     if config_schema:

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -767,6 +767,9 @@ class Registry:
         """
         action = await self.resolve_action(ActionKind.MODEL, name)
         if action is None:
+            # background-only models (Veo, Deep Research) live under a different kind
+            action = await self.resolve_action(ActionKind.BACKGROUND_MODEL, name)
+        if action is None:
             return None
         return cast(
             Action[ModelRequest, ModelResponse, ModelResponseChunk],

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for background model generate() and generate_operation() plumbing."""
+
+import pytest
+
+from genkit import Genkit
+from genkit._core._action import ActionRunContext
+from genkit._core._error import GenkitError
+from genkit._core._model import ModelRequest
+from genkit._core._typing import ModelInfo, Operation, Supports
+
+
+@pytest.fixture
+def ai() -> Genkit:
+    """Create a fresh Genkit instance for each test."""
+    return Genkit()
+
+
+async def _register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> None:
+    async def start(request: ModelRequest, ctx: ActionRunContext) -> Operation:
+        return Operation(id=op_id, done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    ai.define_background_model(
+        name='bg-model',
+        start=start,
+        check=check,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_operation_for_background_model(ai: Genkit) -> None:
+    """generate() wraps a background model Operation in ModelResponse."""
+    await _register_bg_model(ai)
+
+    response = await ai.generate(model='bg-model', prompt='a cat surfing')
+
+    assert response.operation is not None
+    assert response.operation.id == 'bg-op-123'
+    assert response.operation.done is False
+    assert response.operation.action == '/background-model/bg-model'
+    assert response.message is None
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_with_background_model(ai: Genkit) -> None:
+    """generate_operation resolves background models via resolve_model()."""
+    await _register_bg_model(ai, op_id='bg-op-456')
+
+    operation = await ai.generate_operation(model='bg-model', prompt='a cat surfing')
+
+    assert isinstance(operation, Operation)
+    assert operation.id == 'bg-op-456'
+    assert operation.action == '/background-model/bg-model'
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_rejects_foreground_model_without_lro(ai: Genkit) -> None:
+    """generate_operation rejects standard foreground models."""
+    from genkit import Message, ModelResponse
+    from genkit._core._typing import Part, Role, TextPart
+
+    async def model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+        return ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='Hello'))],
+            ),
+        )
+
+    ai.define_model(name='fg-model', fn=model_fn)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await ai.generate_operation(model='fg-model', prompt='Hi')
+
+    assert 'does not support long running operations' in str(exc_info.value)

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -432,6 +432,38 @@ async def test_list_actions_registered_canonical_coexists_with_qualified_dap_row
     assert provider_key in catalog
 
 
+@pytest.mark.asyncio
+async def test_resolve_model_falls_back_to_background_model() -> None:
+    """resolve_model finds models registered only under BACKGROUND_MODEL."""
+    from genkit._core._action import ActionRunContext
+    from genkit._core._background import define_background_model
+    from genkit._core._model import ModelRequest
+    from genkit._core._typing import ModelInfo, Operation, Supports
+
+    registry = Registry()
+
+    async def start(request: ModelRequest, ctx: ActionRunContext) -> Operation:
+        return Operation(id='bg-start', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    define_background_model(
+        registry=registry,
+        name='veo-model',
+        start=start,
+        check=check,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+    assert await registry.resolve_action(ActionKind.MODEL, 'veo-model') is None
+
+    resolved = await registry.resolve_model('veo-model')
+    assert resolved is not None
+    assert resolved.kind == ActionKind.BACKGROUND_MODEL
+    assert resolved.name == 'veo-model'
+
+
 def test_registry_satisfies_registry_like() -> None:
     """Registry must structurally satisfy RegistryLike so middleware can use it as such."""
     from genkit._core._protocols import RegistryLike

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -140,6 +140,7 @@ fastapi-bugbot       = { workspace = true }
 flask-hello          = { workspace = true }
 gemini-code-execution = { workspace = true }
 gemini-context-caching = { workspace = true }
+google-genai-deep-research = { workspace = true }
 google-genai-media   = { workspace = true }
 middleware           = { workspace = true }
 middleware-coding-agent = { workspace = true }

--- a/py/samples/README.md
+++ b/py/samples/README.md
@@ -32,6 +32,7 @@ Dev UI: http://localhost:4000. Most samples need `GEMINI_API_KEY`. See [plugins/
 | `flask-hello` | Expose Genkit flows through Flask |
 | `gemini-code-execution` | Ask Gemini to write and run code |
 | `gemini-context-caching` | Cache a large source document for follow-up prompts |
+| `google-genai-deep-research` | Background Deep Research with `generate_operation()` + polling |
 | `google-genai-media` | Speech, image, and video generation |
 | `middleware` | Observe or modify model requests |
 | `ollama-sample` | Local chat, streaming, tools, and embeddings via Ollama |

--- a/py/samples/google-genai-deep-research/README.md
+++ b/py/samples/google-genai-deep-research/README.md
@@ -1,0 +1,25 @@
+# Google Deep Research
+
+Start a background Deep Research job with `generate_operation()`, poll with `check_operation()`, and read the finished report from `operation.output`.
+
+```bash
+export GEMINI_API_KEY=your-api-key
+uv sync
+uv run src/main.py
+```
+
+To explore the flow in Dev UI instead:
+
+```bash
+genkit start -- uv run src/main.py
+```
+
+Flow: `deep_research`.
+
+Supported models (set `model` in flow input):
+
+- `googleai/deep-research-preview-04-2026`
+- `googleai/deep-research-max-preview-04-2026`
+- `googleai/deep-research-pro-preview-12-2025`
+
+Deep Research runs as a long-running background model — expect several minutes before `operation.done` is true.

--- a/py/samples/google-genai-deep-research/pyproject.toml
+++ b/py/samples/google-genai-deep-research/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "google-genai-deep-research"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "genkit",
+  "genkit-google-genai",
+  "pydantic",
+]
+
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/py/samples/google-genai-deep-research/src/main.py
+++ b/py/samples/google-genai-deep-research/src/main.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google GenAI Deep Research - start a background research job and poll to completion."""
+
+import asyncio
+import time
+from typing import Any, Literal
+
+from genkit_google_genai import GoogleAI
+from pydantic import BaseModel, Field
+
+from genkit import Genkit
+from genkit.model import Operation
+
+ai = Genkit(plugins=[GoogleAI()])
+
+
+class ResearchInput(BaseModel):
+    """Input for a Deep Research background model."""
+
+    model: Literal[
+        'googleai/deep-research-preview-04-2026',
+        'googleai/deep-research-max-preview-04-2026',
+        'googleai/deep-research-pro-preview-12-2025',
+    ] = Field(
+        default='googleai/deep-research-preview-04-2026',
+        description='Deep Research model for the background job',
+    )
+    prompt: str = Field(
+        default='Summarize recent advances in quantum error correction for a technical audience.',
+        description='Research question or topic',
+    )
+
+
+def _response_text(response: Any) -> str | None:
+    """Return text from a completed model response."""
+
+    text = getattr(response, 'text', None)
+    if text:
+        return text
+    return None
+
+
+async def _poll_operation(operation: Operation, *, timeout_seconds: float = 600) -> Operation:
+    """Poll a background operation until it completes or times out."""
+
+    started_at = time.monotonic()
+    while not operation.done:
+        if time.monotonic() - started_at > timeout_seconds:
+            raise TimeoutError('Timed out waiting for Deep Research output')
+        await asyncio.sleep(5)
+        operation = await ai.check_operation(operation)
+    return operation
+
+
+@ai.flow(name='deep_research')
+async def deep_research_flow(input: ResearchInput) -> dict[str, str | None]:
+    """Run Deep Research with generate_operation() and poll until the report is ready."""
+
+    operation = await ai.generate_operation(
+        model=input.model,
+        prompt=input.prompt,
+    )
+    operation = await _poll_operation(operation)
+
+    report = _response_text(operation.output) if operation.output else None
+
+    return {
+        'model': input.model,
+        'operation_id': operation.id,
+        'report': report,
+    }
+
+
+async def main() -> None:
+    """Run one Deep Research job."""
+    try:
+        print(await deep_research_flow(ResearchInput()))  # noqa: T201
+    except Exception as error:
+        print(f'Set GEMINI_API_KEY to a valid value before running this sample directly.\n{error}')  # noqa: T201
+
+
+if __name__ == '__main__':
+    ai.run_main(main())

--- a/py/samples/google-genai-media/README.md
+++ b/py/samples/google-genai-media/README.md
@@ -27,3 +27,5 @@ Flows: `generate_speech`, `generate_image`, `generate_video`.
 - `googleai/veo-2.0-generate-001`
 
 The flow input includes Veo config fields such as `aspect_ratio`, `duration_seconds`, `resolution`, and `seed`.
+
+`generate_video` uses `generate_operation()` to start Veo and `check_operation()` to poll until the video URL is ready in `operation.output`.

--- a/py/samples/google-genai-media/src/main.py
+++ b/py/samples/google-genai-media/src/main.py
@@ -24,9 +24,7 @@ from genkit_google_genai import GoogleAI
 from pydantic import BaseModel, Field
 
 from genkit import Genkit
-from genkit._core._background import lookup_background_action
-from genkit._core._typing import Operation, Part, Role, TextPart
-from genkit.model import Message, ModelRequest
+from genkit.model import Operation
 
 ai = Genkit(plugins=[GoogleAI()])
 
@@ -81,6 +79,18 @@ def _first_media_url(response: Any) -> str | None:
     return None
 
 
+async def _poll_operation(operation: Operation, *, timeout_seconds: float = 180) -> Operation:
+    """Poll a background operation until it completes or times out."""
+
+    started_at = time.monotonic()
+    while not operation.done:
+        if time.monotonic() - started_at > timeout_seconds:
+            raise TimeoutError('Timed out waiting for background model output')
+        await asyncio.sleep(3)
+        operation = await ai.check_operation(operation)
+    return operation
+
+
 @ai.flow(name='generate_speech')
 async def tts_speech_generator(input: SpeechInput) -> dict[str, str | None]:
     """Turn text into speech with one TTS call."""
@@ -105,45 +115,19 @@ async def imagen_image_generator(input: ImageInput) -> dict[str, str | None]:
     return {'model': 'googleai/imagen-3.0-generate-002', 'image_url': _first_media_url(response)}
 
 
-async def _poll_video(operation: Operation, model_name: str) -> Operation:
-    """Wait for a background video operation to finish."""
-
-    action = await lookup_background_action(ai.registry, f'/background-model/{model_name}')
-    if action is None:
-        raise ValueError(f'Veo background model not found: {model_name}')
-
-    started_at = time.monotonic()
-    while not operation.done:
-        if time.monotonic() - started_at > 180:
-            raise TimeoutError('Timed out waiting for Veo output')
-        await asyncio.sleep(3)
-        operation = await action.check(operation)
-    return operation
-
-
 @ai.flow(name='generate_video')
 async def veo_video_generator(input: VideoInput) -> dict[str, str | int | None]:
-    """Generate one video by starting and polling a background model."""
+    """Generate one Veo video with generate_operation() and poll to completion."""
 
-    action = await lookup_background_action(ai.registry, f'/background-model/{input.model}')
-    if action is None:
-        raise ValueError(f'Veo background model not found: {input.model}')
-
-    operation = await action.start(
-        ModelRequest(
-            messages=[Message(role=Role.USER, content=[Part(root=TextPart(text=input.prompt))])],
-            config=input.model_dump(exclude_none=True, exclude={'prompt', 'model'}),
-        )
+    config = input.model_dump(exclude_none=True, exclude={'prompt', 'model'})
+    operation = await ai.generate_operation(
+        model=input.model,
+        prompt=input.prompt,
+        config=config,
     )
-    operation = await _poll_video(operation, input.model)
+    operation = await _poll_operation(operation)
 
-    video_url = None
-    if isinstance(operation.output, dict):
-        message = operation.output.get('message', {})
-        content = message.get('content', [])
-        if content:
-            media = content[0].get('media', {})
-            video_url = media.get('url')
+    video_url = _first_media_url(operation.output) if operation.output else None
 
     return {
         'model': input.model,

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -33,6 +33,7 @@ members = [
     "genkit-openai",
     "genkit-vertexai",
     "genkit-workspace",
+    "google-genai-deep-research",
     "google-genai-media",
     "middleware",
     "middleware-coding-agent",
@@ -2272,6 +2273,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/46/d7/07ec5dadd0741f09e89f3ff5f0ce051ce2aa3a76797699d661dc88def077/google_genai-1.63.0.tar.gz", hash = "sha256:dc76cab810932df33cbec6c7ef3ce1538db5bef27aaf78df62ac38666c476294", size = 491970, upload-time = "2026-02-11T23:46:28.472Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/c8/ba32159e553fab787708c612cf0c3a899dafe7aca81115d841766e3bfe69/google_genai-1.63.0-py3-none-any.whl", hash = "sha256:6206c13fc20f332703ca7375bea7c191c82f95d6781c29936c6982d86599b359", size = 724747, upload-time = "2026-02-11T23:46:26.697Z" },
+]
+
+[[package]]
+name = "google-genai-deep-research"
+version = "0.1.0"
+source = { editable = "samples/google-genai-deep-research" }
+dependencies = [
+    { name = "genkit" },
+    { name = "genkit-google-genai" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-google-genai", editable = "packages/genkit-google-genai" },
+    { name = "pydantic" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Python port of googleAI Interactions + first-class background-model DX (`generate` / `generate_operation` / `check_operation`).

- **Veo** stays on `predictLongRunning` (Interactions has no video modality)
- **Deep Research** is a background model on Interactions
- **Antigravity** / **Lyria-3** are foreground Interactions models
- Core: `resolve_model` falls back to `BACKGROUND_MODEL`; generate short-circuits when the model is background-only

Assisted implementation; contracts and live smoke were owned/vetted. Prefer review on the decision points below over a line-by-line pass of converters.

## Intentional divergences / parity (please challenge)

1. **`failed` → `Operation.done=True` + `error`** — JS async `fromInteraction` leaves `done` unset (poll hang). We exit the loop.
2. **`requires_action` → fallthrough** — match JS (`done` unset). No interrupt/resume opinion yet; collaborative loop deferred.
3. **`CreateInteractionRequest.input` narrowed to `list[Step]`** — we only ever send that arm.
4. **Veo pending `done` null/omitted → `false`** — LRO quirk; typed clients shouldn't see a missing flag mid-poll.
5. **`lyria-*` prefix** (not only `lyria-3-*`) so `lyria-002` doesn't false-resolve as Gemini.

## Already vetted

- Live smoke: Veo `generate_operation` → HTTPS mp4 (~50s); Deep Research public path → report (~2min); no apiKey on Operations
- Earlier audit: DR was shadowed by Gemini catch-all / missing `action` — fixed via ModelRef + `define_background_model` + `resolve(MODEL)` skip; re-smoked
- Converter/unit tests for status mapping, registration, Veo output shape
- Preflight: ruff + ty + pytest 3.12 green; pyrefly at main's existing baseline (~55), no new Interactions debt

## Suggested review map (~30–45 min)

1. `from_interaction` status → `done`/`error` (`failed` vs `requires_action`)
2. Deep Research registration + `GoogleAI.resolve` MODEL skip for `deep-research-*` / Veo
3. `define_background_model` (`longRunning` via `model_dump(by_alias=True)`) + apiKey rederive on check/cancel
4. Samples: `google-genai-media` Veo + `google-genai-deep-research`

Skip bulk of `_interactions/types.py` + converters unless something above looks wrong.

## Known caveats

- Antigravity needs `config={'environment': 'remote', ...}` (verified live; same as JS samples — not defaulted)
- Full `requires_action` interactive / Genkit interrupt resume loop: out of scope
- Sparse HTTP→Genkit status map (same as JS: 400/429/499/500/503; else `UNKNOWN`)

## Test plan

- [ ] `uv run pytest packages/genkit-google-genai/tests/interactions packages/genkit-google-genai/tests/veo_test.py packages/genkit/tests/genkit/ai/background_generate_test.py --no-cov`
- [ ] Optional live: Veo + Deep Research samples with `GEMINI_API_KEY`
- [ ] Confirm Antigravity sample/docs show `environment: 'remote'`