### PR TITLE
fix(tools): harden reflection-v2 WS binding and CSRF-gate state-changing dev-server endpoints

### DIFF
--- a/genkit-tools/common/src/manager/manager-v2.ts
+++ b/genkit-tools/common/src/manager/manager-v2.ts
@@ -133,7 +133,28 @@ export class RuntimeManagerV2 extends BaseRuntimeManager {
     if (!port) {
       port = await getPort({ port: makeRange(3200, 3400) });
     }
-    this.wss = new WebSocketServer({ port });
+    this.wss = new WebSocketServer({
+      port,
+      // Bind to loopback and reject cross-origin (browser / DNS-rebinding)
+      // connections so the unauthenticated reflection control-plane is not
+      // exposed on the network. The runtime connects as a Node client with no
+      // Origin header; GENKIT_REFLECTION_HOST can override for container dev.
+      host: process.env.GENKIT_REFLECTION_HOST || '127.0.0.1',
+      verifyClient: ({ origin }, done) => {
+        if (!origin) return done(true);
+        try {
+          const hostname = new URL(origin).hostname;
+          done(
+            hostname === 'localhost' ||
+              hostname === '127.0.0.1' ||
+              hostname === '::1' ||
+              hostname === '[::1]'
+          );
+        } catch {
+          done(false);
+        }
+      },
+    });
 
     this._port = port;
     logger.info(`Starting reflection server: ws://localhost:${port}`);

--- a/genkit-tools/common/src/server/router.ts
+++ b/genkit-tools/common/src/server/router.ts
@@ -334,12 +334,12 @@ export const TOOLS_SERVER_ROUTER = (manager: BaseRuntimeManager) =>
       return manager.processManager.status();
     }),
 
-    restartAppProcess: t.procedure.query(async () => {
+    restartAppProcess: t.procedure.mutation(async () => {
       await manager.processManager?.restart();
       return true;
     }),
 
-    killAppProcess: t.procedure.query(async () => {
+    killAppProcess: t.procedure.mutation(async () => {
       await manager.processManager?.kill();
       return true;
     }),

--- a/js/core/src/reflection.ts
+++ b/js/core/src/reflection.ts
@@ -165,7 +165,7 @@ export class ReflectionServer {
       response.status(200).send('OK');
     });
 
-    server.get('/api/__quitquitquit', async (_, response) => {
+    server.post('/api/__quitquitquit', async (_, response) => {
       logger.debug('Received quitquitquit');
       response.status(200).send('OK');
       await this.stop();


### PR DESCRIPTION
## Summary

Follow-up hardening for the local dev servers, in the spirit of #5751 (which bound the js/core reflection server to loopback). This closes the parts that patch did not cover.

## Changes

1. `genkit-tools/common/src/manager/manager-v2.ts` - the reflection-v2 control-plane WebSocket server was created with `new WebSocketServer({ port })`: no `host` (so it binds all interfaces) and no `verifyClient` (no Origin check), while the `register` method is unauthenticated. A LAN peer, or a web page the developer visits (DNS-rebinding), can register a fake runtime and become the `getMostRecentRuntime()` fallback, hijacking proxied `runAction`/`listActions` calls and the inputs sent to them. Bind to `127.0.0.1` (with `GENKIT_REFLECTION_HOST` override for container/remote dev, mirroring the js/core reflection server) and reject cross-origin connections via `verifyClient` (the runtime connects as a Node client with no Origin header).

2. `genkit-tools/common/src/server/router.ts` - `restartAppProcess` and `killAppProcess` are state-changing but were tRPC `.query()` (HTTP GET), so any page the developer visits could trigger them with a simple GET (CSRF), killing or restarting the app under test. Converted to `.mutation()` so they are POST, preflighted, and gated by the existing CORS Origin allowlist.

3. `js/core/src/reflection.ts` - `/api/__quitquitquit` (which stops the reflection server) was a GET, so a bare `<img>` tag or a cross-origin `fetch` could shut it down. Changed to POST.

## Notes

Dev-only surface, so severity is low, but these mirror the same class the project already chose to fix in #5751. No behavior change for the legitimate CLI/runtime (Node clients send no Origin; the Dev UI already uses POST for mutations). Happy to add tests (a manager-v2 bind/Origin test and a router verb test) if wanted.