### PR TITLE
fix(py): seed span attrs at start so Dev UI shows live traces immediately

### DIFF
--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -4,5 +4,9 @@
 """Internal logger for genkit core. Not part of public API."""
 
 import structlog
+from structlog.typing import FilteringBoundLogger
 
-get_logger = structlog.get_logger
+
+def get_logger(name: str | None = None) -> FilteringBoundLogger:
+    """Return a structlog bound logger with a concrete return type for checkers."""
+    return structlog.get_logger(name)

--- a/py/packages/genkit/src/genkit/_core/_trace/_adjusting_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_adjusting_exporter.py
@@ -27,6 +27,8 @@ from opentelemetry.trace import StatusCode
 
 from genkit._core._compat import override
 
+from ._attrs import Attr, Subtype
+
 
 def _copy_attrs(span: ReadableSpan) -> dict[str, Any]:
     """Return a mutable copy of span attributes."""
@@ -112,7 +114,7 @@ class AdjustingTraceExporter(SpanExporter):
         if self._log_input_and_output:
             return span
         attrs = _copy_attrs(span)
-        keys_to_redact = [k for k in ('genkit:input', 'genkit:output') if k in attrs]
+        keys_to_redact = [k for k in (Attr.INPUT, Attr.OUTPUT) if k in attrs]
         if not keys_to_redact:
             return span
         for key in keys_to_redact:
@@ -128,24 +130,24 @@ class AdjustingTraceExporter(SpanExporter):
 
     def _mark_failure_source(self, span: ReadableSpan) -> ReadableSpan:
         attrs = _copy_attrs(span)
-        if not attrs.get('genkit:isFailureSource'):
+        if not attrs.get(Attr.IS_FAILURE_SOURCE):
             return span
-        attrs['genkit:failedSpan'] = attrs.get('genkit:name', '')
-        attrs['genkit:failedPath'] = attrs.get('genkit:path', '')
+        attrs[Attr.FAILED_SPAN] = attrs.get(Attr.NAME, '')
+        attrs[Attr.FAILED_PATH] = attrs.get(Attr.PATH, '')
         return RedactedSpan(span, attrs)
 
     def _mark_feature(self, span: ReadableSpan) -> ReadableSpan:
         attrs = _copy_attrs(span)
-        if not attrs.get('genkit:isRoot') or not attrs.get('genkit:name'):
+        if not attrs.get(Attr.IS_ROOT) or not attrs.get(Attr.NAME):
             return span
-        attrs['genkit:feature'] = attrs['genkit:name']
+        attrs[Attr.FEATURE] = attrs[Attr.NAME]
         return RedactedSpan(span, attrs)
 
     def _mark_model(self, span: ReadableSpan) -> ReadableSpan:
         attrs = _copy_attrs(span)
-        if attrs.get('genkit:metadata:subtype') != 'model' or not attrs.get('genkit:name'):
+        if attrs.get(Attr.SUBTYPE) != Subtype.MODEL or not attrs.get(Attr.NAME):
             return span
-        attrs['genkit:model'] = attrs['genkit:name']
+        attrs[Attr.MODEL] = attrs[Attr.NAME]
         return RedactedSpan(span, attrs)
 
     def _normalize_labels(self, span: ReadableSpan) -> ReadableSpan:

--- a/py/packages/genkit/src/genkit/_core/_trace/_attrs.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_attrs.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical Genkit span attribute keys and value enums.
+
+``Attr`` members are the wire names Dev UI / exporters read. ``State`` /
+``Subtype`` hold allowed values for those keys so callers don't mix a key
+(``Attr.STATE``) with a value (``State.ERROR``).
+"""
+
+from typing import Final
+
+from genkit._core._compat import StrEnum
+
+PREFIX: Final[str] = 'genkit'
+METADATA_PREFIX: Final[str] = f'{PREFIX}:metadata:'
+
+
+class Attr(StrEnum):
+    """Span attribute keys."""
+
+    NAME = f'{PREFIX}:name'
+    PATH = f'{PREFIX}:path'
+    QUALIFIED_PATH = f'{PREFIX}:qualifiedPath'
+    TYPE = f'{PREFIX}:type'
+    INPUT = f'{PREFIX}:input'
+    OUTPUT = f'{PREFIX}:output'
+    STATE = f'{PREFIX}:state'
+    ERROR = f'{PREFIX}:error'
+    IS_ROOT = f'{PREFIX}:isRoot'
+    IS_FAILURE_SOURCE = f'{PREFIX}:isFailureSource'
+    FAILED_SPAN = f'{PREFIX}:failedSpan'
+    FAILED_PATH = f'{PREFIX}:failedPath'
+    FEATURE = f'{PREFIX}:feature'
+    MODEL = f'{PREFIX}:model'
+    SUBTYPE = f'{METADATA_PREFIX}subtype'
+
+
+class State(StrEnum):
+    """Values for :attr:`Attr.STATE`."""
+
+    SUCCESS = 'success'
+    ERROR = 'error'
+
+
+class Subtype(StrEnum):
+    """Common values for :attr:`Attr.SUBTYPE` (not exhaustive)."""
+
+    MODEL = 'model'
+    PROMPT = 'prompt'
+    TOOL = 'tool'
+    FLOW = 'flow'
+
+
+def metadata_key(key: str) -> str:
+    """Prefix a short metadata key: ``flow:name`` → ``genkit:metadata:flow:name``."""
+    return f'{METADATA_PREFIX}{key}'

--- a/py/packages/genkit/src/genkit/_core/_trace/_attrs.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_attrs.py
@@ -67,4 +67,6 @@ class Subtype(StrEnum):
 
 def metadata_key(key: str) -> str:
     """Prefix a short metadata key: ``flow:name`` → ``genkit:metadata:flow:name``."""
+    if key.startswith(METADATA_PREFIX):
+        return key
     return f'{METADATA_PREFIX}{key}'

--- a/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
@@ -37,6 +37,7 @@ from genkit._core._compat import override
 from genkit._core._environment import is_dev_environment
 from genkit._core._logger import get_logger
 
+from ._attrs import Attr, Subtype
 from ._realtime_processor import RealtimeSpanProcessor
 
 logger = get_logger(__name__)
@@ -77,13 +78,13 @@ def _ensure_exception_message_for_dev_ui(span_entry: dict[str, Any]) -> None:
     TraceData SpanStatusSchema uses `message` (not OTel's `description`). Dev UI and
     evaluate.ts read the first `exception` timeEvent's `exception.message` and fall
     back to the literal "Error" if missing. Synthesize from status.message or
-    genkit:error when events are empty or incomplete.
+    the error attr when events are empty or incomplete.
     """
     st = span_entry.get('status')
     if not st or st.get('code') != 2:
         return
     attrs = span_entry.get('attributes') or {}
-    msg = st.get('message') or attrs.get('genkit:error')
+    msg = st.get('message') or attrs.get(Attr.ERROR)
     if not msg:
         return
     if not st.get('message'):
@@ -181,7 +182,7 @@ def extract_span_data(span: ReadableSpan) -> dict[str, Any]:
 
 DEFAULT_SPAN_FILTERS: dict[str, str] = {
     # Suppress prompt runner preview traces (triggered on every keystroke in Dev UI)
-    'genkit:metadata:subtype': 'prompt',
+    Attr.SUBTYPE: Subtype.PROMPT,
 }
 
 

--- a/py/packages/genkit/src/genkit/_core/_tracing.py
+++ b/py/packages/genkit/src/genkit/_core/_tracing.py
@@ -156,13 +156,14 @@ def start_attributes(
     in-progress entry until the span ends. State/output are excluded — they
     aren't known until the body finishes.
     """
-    attrs: dict[str, str | bool] = {
+    attrs: dict[str, str | bool] = {}
+    if metadata.telemetry_labels:
+        attrs.update(metadata.telemetry_labels)
+    attrs.update({
         Attr.NAME: metadata.name,
         Attr.PATH: qualified_path,
         Attr.QUALIFIED_PATH: qualified_path,
-    }
-    if metadata.telemetry_labels:
-        attrs.update(metadata.telemetry_labels)
+    })
     if metadata.type:
         attrs[Attr.TYPE] = metadata.type
     if metadata.subtype:

--- a/py/packages/genkit/src/genkit/_core/_tracing.py
+++ b/py/packages/genkit/src/genkit/_core/_tracing.py
@@ -31,12 +31,13 @@ from opentelemetry.sdk.trace.export import SpanExporter
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
-from genkit._core._base import GenkitModel
-from genkit._core._environment import is_dev_environment
-from genkit._core._error import GenkitError
-from genkit._core._logger import get_logger
-from genkit._core._trace._default_exporter import create_span_processor, init_telemetry_server_exporter
-from genkit._core._trace._path import build_path
+from ._base import GenkitModel
+from ._environment import is_dev_environment
+from ._error import GenkitError
+from ._logger import get_logger
+from ._trace._attrs import Attr, State, metadata_key
+from ._trace._default_exporter import create_span_processor, init_telemetry_server_exporter
+from ._trace._path import build_path
 
 logger = get_logger(__name__)
 
@@ -44,12 +45,12 @@ logger = get_logger(__name__)
 class SpanMetadata(GenkitModel):
     """Input parameters for opening a Genkit span via :func:`run_in_new_span`.
 
-    Mapping from SpanMetadata to span attributes:
-      - name                 -> genkit:name (and span name)
-      - input / output       -> genkit:input / genkit:output (JSON-serialized)
-      - type                 -> genkit:type
-      - subtype              -> genkit:metadata:subtype
-      - metadata[k]          -> genkit:metadata:<k> (auto-prefixed)
+    Mapping from SpanMetadata to span attributes (see ``Attr`` for wire names):
+      - name                 -> Attr.NAME (and span name)
+      - input / output       -> Attr.INPUT / Attr.OUTPUT (JSON-serialized)
+      - type                 -> Attr.TYPE
+      - subtype              -> Attr.SUBTYPE
+      - metadata[k]          -> metadata_key(k)
       - telemetry_labels[k]  -> <k> verbatim (caller-controlled keys)
 
     """
@@ -79,13 +80,13 @@ _parent_path_context: ContextVar[str] = ContextVar('genkit_parent_path', default
 
 
 @contextmanager
-def save_parent_path() -> Generator[None, None, None]:
-    """Save the parent path on entry and restore it on exit."""
-    saved = _parent_path_context.get()
+def push_parent_path(path: str) -> Generator[None, None, None]:
+    """Push ``path`` as the active parent path for nested spans; restore on exit."""
+    token = _parent_path_context.set(path)
     try:
         yield
     finally:
-        _parent_path_context.set(saved)
+        _parent_path_context.reset(token)
 
 
 def init_provider() -> TracerProvider:
@@ -134,13 +135,69 @@ if is_dev_environment():
 
 
 def _to_json_attr(value: object) -> str:
-    """Serialize an arbitrary object for a ``genkit:input``/``genkit:output`` attribute."""
+    """Serialize an arbitrary object for an input/output span attribute."""
     if isinstance(value, BaseModel):
         return value.model_dump_json(by_alias=True, exclude_none=True)
     try:
         return json.dumps(value)
     except (TypeError, ValueError):
         return str(value)
+
+
+def start_attributes(
+    metadata: SpanMetadata,
+    *,
+    qualified_path: str,
+) -> dict[str, str | bool]:
+    """Attrs known when the span begins (identity/shape + input).
+
+    Live-trace export snapshots the span the instant it starts, so these have to
+    be on the span *before* start returns; otherwise Dev UI shows a blank
+    in-progress entry until the span ends. State/output are excluded — they
+    aren't known until the body finishes.
+    """
+    attrs: dict[str, str | bool] = {
+        Attr.NAME: metadata.name,
+        Attr.PATH: qualified_path,
+        Attr.QUALIFIED_PATH: qualified_path,
+    }
+    if metadata.telemetry_labels:
+        attrs.update(metadata.telemetry_labels)
+    if metadata.type:
+        attrs[Attr.TYPE] = metadata.type
+    if metadata.subtype:
+        attrs[Attr.SUBTYPE] = metadata.subtype
+    if metadata.is_root:
+        attrs[Attr.IS_ROOT] = True
+    if metadata.metadata:
+        for meta_key, meta_value in metadata.metadata.items():
+            attrs[metadata_key(meta_key)] = str(meta_value)
+    if metadata.input is not None:
+        attrs[Attr.INPUT] = _to_json_attr(metadata.input)
+    return attrs
+
+
+@contextmanager
+def record_span_outcome(
+    span: trace_api.Span,
+    metadata: SpanMetadata,
+) -> Generator[None, None, None]:
+    """Write success or error attrs after the span body finishes."""
+    try:
+        yield
+    except Exception as e:
+        logger.debug(f'Error in run_in_new_span: {e!s}')
+        logger.debug(traceback.format_exc())
+        span.set_attribute(Attr.STATE, State.ERROR)
+        err_text = e.original_message if isinstance(e, GenkitError) else str(e)
+        span.set_attribute(Attr.ERROR, err_text)
+        span.set_status(status=trace_api.StatusCode.ERROR, description=str(e))
+        span.record_exception(e)
+        raise
+
+    if metadata.output is not None:
+        span.set_attribute(Attr.OUTPUT, _to_json_attr(metadata.output))
+    span.set_attribute(Attr.STATE, State.SUCCESS)
 
 
 @contextmanager
@@ -161,37 +218,11 @@ def run_in_new_span(
         The OpenTelemetry Span object.
     """
     qualified_path = build_path(metadata.name, _parent_path_context.get(), metadata.type or '', metadata.subtype)
+    # Seed start-known attrs as span-start options so RealtimeSpanProcessor's
+    # on_start export already carries them for the Dev UI.
+    start_attrs = start_attributes(metadata, qualified_path=qualified_path)
 
-    with save_parent_path():
-        with tracer.start_as_current_span(name=metadata.name, links=links) as span:
-            if metadata.telemetry_labels:
-                span.set_attributes(metadata.telemetry_labels)
-            span.set_attribute('genkit:name', metadata.name)
-            span.set_attribute('genkit:path', qualified_path)
-            span.set_attribute('genkit:qualifiedPath', qualified_path)
-            if metadata.type:
-                span.set_attribute('genkit:type', metadata.type)
-            if metadata.subtype:
-                span.set_attribute('genkit:metadata:subtype', metadata.subtype)
-            if metadata.input is not None:
-                span.set_attribute('genkit:input', _to_json_attr(metadata.input))
-            if metadata.metadata:
-                for meta_key, meta_value in metadata.metadata.items():
-                    span.set_attribute(f'genkit:metadata:{meta_key}', str(meta_value))
-            _parent_path_context.set(qualified_path)
-
-            try:
+    with push_parent_path(qualified_path):
+        with tracer.start_as_current_span(name=metadata.name, links=links, attributes=start_attrs) as span:
+            with record_span_outcome(span, metadata):
                 yield span
-            except Exception as e:
-                logger.debug(f'Error in run_in_new_span: {e!s}')
-                logger.debug(traceback.format_exc())
-                span.set_attribute('genkit:state', 'error')
-                err_text = e.original_message if isinstance(e, GenkitError) else str(e)
-                span.set_attribute('genkit:error', err_text)
-                span.set_status(status=trace_api.StatusCode.ERROR, description=str(e))
-                span.record_exception(e)
-                raise
-
-            if metadata.output is not None:
-                span.set_attribute('genkit:output', _to_json_attr(metadata.output))
-            span.set_attribute('genkit:state', 'success')

--- a/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
+++ b/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
@@ -110,43 +110,37 @@ def test_realtime_on_start_export_carries_identity_attrs(
                 self.snapshots.append(dict(span.attributes or {}))
             return super().export(spans)
 
-    provider = trace_api.get_tracer_provider()
-    if not isinstance(provider, TracerProvider):
-        provider = TracerProvider()
-        trace_api.set_tracer_provider(provider)
-
+    provider = TracerProvider()
     snap_exporter = SnapshotExporter()
     processor = RealtimeSpanProcessor(snap_exporter)
     provider.add_span_processor(processor)
+
+    tracer = provider.get_tracer('test_tracer')
+    meta = SpanMetadata(
+        name='liveAction',
+        type='action',
+        subtype='flow',
+        input={'prompt': 'hi'},
+        metadata={'flow:name': 'liveAction'},
+    )
+    start_attrs = start_attributes(meta, qualified_path='/{liveAction,t:action,s:flow}')
+
     try:
-        with run_in_new_span(
-            SpanMetadata(
-                name='liveAction',
-                type='action',
-                subtype='flow',
-                input={'prompt': 'hi'},
-                metadata={'flow:name': 'liveAction'},
-            )
-        ):
+        with tracer.start_as_current_span('liveAction', attributes=start_attrs):
             # on_start already fired; first snapshot is the live export.
             assert snap_exporter.snapshots, 'expected RealtimeSpanProcessor on_start export'
-            start_attrs = snap_exporter.snapshots[0]
-            assert start_attrs['genkit:name'] == 'liveAction'
-            assert start_attrs['genkit:type'] == 'action'
-            assert start_attrs['genkit:metadata:subtype'] == 'flow'
-            assert start_attrs['genkit:path'] == '/{liveAction,t:action,s:flow}'
-            assert start_attrs['genkit:metadata:flow:name'] == 'liveAction'
-            assert start_attrs['genkit:input'] == '{"prompt": "hi"}'
+            start_attrs_snapshot = snap_exporter.snapshots[0]
+            assert start_attrs_snapshot['genkit:name'] == 'liveAction'
+            assert start_attrs_snapshot['genkit:type'] == 'action'
+            assert start_attrs_snapshot['genkit:metadata:subtype'] == 'flow'
+            assert start_attrs_snapshot['genkit:path'] == '/{liveAction,t:action,s:flow}'
+            assert start_attrs_snapshot['genkit:metadata:flow:name'] == 'liveAction'
+            assert start_attrs_snapshot['genkit:input'] == '{"prompt": "hi"}'
             # Run-determined attrs must not leak into the start write.
-            assert 'genkit:state' not in start_attrs
-            assert 'genkit:output' not in start_attrs
+            assert 'genkit:state' not in start_attrs_snapshot
+            assert 'genkit:output' not in start_attrs_snapshot
     finally:
-        snap_exporter.clear()
-        if hasattr(provider, '_active_span_processor'):
-            try:
-                provider._active_span_processor._span_processors.remove(processor)
-            except ValueError:
-                pass
+        provider.shutdown()
 
 
 def test_writes_name_path_and_state_success(exporter: InMemorySpanExporter) -> None:

--- a/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
+++ b/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
@@ -142,6 +142,11 @@ def test_realtime_on_start_export_carries_identity_attrs(
             assert 'genkit:output' not in start_attrs
     finally:
         snap_exporter.clear()
+        if hasattr(provider, '_active_span_processor'):
+            try:
+                provider._active_span_processor._span_processors.remove(processor)
+            except ValueError:
+                pass
 
 
 def test_writes_name_path_and_state_success(exporter: InMemorySpanExporter) -> None:

--- a/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
+++ b/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
@@ -15,13 +15,14 @@ from collections.abc import Generator, Sequence
 import pytest
 from opentelemetry import trace as trace_api
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from pydantic import BaseModel
 
 from genkit._core._action import Action, ActionKind
 from genkit._core._error import GenkitError
-from genkit._core._tracing import SpanMetadata, _parent_path_context, run_in_new_span
+from genkit._core._trace._realtime_processor import RealtimeSpanProcessor
+from genkit._core._tracing import SpanMetadata, _parent_path_context, run_in_new_span, start_attributes
 
 
 @pytest.fixture(autouse=True)
@@ -54,6 +55,92 @@ def _by_name(spans: Sequence[ReadableSpan], name: str) -> ReadableSpan:
     matches = [s for s in spans if s.name == name]
     assert matches, f'no span named {name!r} in {[s.name for s in spans]}'
     return matches[-1]
+
+
+def test_start_attributes_includes_input_excludes_outcome() -> None:
+    """Start-known attrs include input; state/output wait until the body finishes."""
+    attrs = start_attributes(
+        SpanMetadata(
+            name='myTool',
+            type='action',
+            subtype='tool',
+            input='in',
+            output='out',
+            is_root=True,
+            metadata={'key': 'value'},
+        ),
+        qualified_path='/{chatFlow,t:flow}/{myTool,t:action,s:tool}',
+    )
+    assert attrs == {
+        'genkit:name': 'myTool',
+        'genkit:path': '/{chatFlow,t:flow}/{myTool,t:action,s:tool}',
+        'genkit:qualifiedPath': '/{chatFlow,t:flow}/{myTool,t:action,s:tool}',
+        'genkit:type': 'action',
+        'genkit:metadata:subtype': 'tool',
+        'genkit:isRoot': True,
+        'genkit:metadata:key': 'value',
+        'genkit:input': '"in"',
+    }
+    for forbidden in ('genkit:state', 'genkit:output'):
+        assert forbidden not in attrs
+
+
+def test_start_attributes_json_input() -> None:
+    attrs = start_attributes(
+        SpanMetadata(name='echo', type='action', input={'msg': 'hi'}),
+        qualified_path='/{echo,t:action}',
+    )
+    assert attrs['genkit:input'] == '{"msg": "hi"}'
+
+
+def test_realtime_on_start_export_carries_identity_attrs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RealtimeSpanProcessor.on_start must see name/type/path so Dev UI populates immediately."""
+    monkeypatch.setenv('GENKIT_ENV', 'dev')
+
+    class SnapshotExporter(InMemorySpanExporter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.snapshots: list[dict[str, object]] = []
+
+        def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+            for span in spans:
+                self.snapshots.append(dict(span.attributes or {}))
+            return super().export(spans)
+
+    provider = trace_api.get_tracer_provider()
+    if not isinstance(provider, TracerProvider):
+        provider = TracerProvider()
+        trace_api.set_tracer_provider(provider)
+
+    snap_exporter = SnapshotExporter()
+    processor = RealtimeSpanProcessor(snap_exporter)
+    provider.add_span_processor(processor)
+    try:
+        with run_in_new_span(
+            SpanMetadata(
+                name='liveAction',
+                type='action',
+                subtype='flow',
+                input={'prompt': 'hi'},
+                metadata={'flow:name': 'liveAction'},
+            )
+        ):
+            # on_start already fired; first snapshot is the live export.
+            assert snap_exporter.snapshots, 'expected RealtimeSpanProcessor on_start export'
+            start_attrs = snap_exporter.snapshots[0]
+            assert start_attrs['genkit:name'] == 'liveAction'
+            assert start_attrs['genkit:type'] == 'action'
+            assert start_attrs['genkit:metadata:subtype'] == 'flow'
+            assert start_attrs['genkit:path'] == '/{liveAction,t:action,s:flow}'
+            assert start_attrs['genkit:metadata:flow:name'] == 'liveAction'
+            assert start_attrs['genkit:input'] == '{"prompt": "hi"}'
+            # Run-determined attrs must not leak into the start write.
+            assert 'genkit:state' not in start_attrs
+            assert 'genkit:output' not in start_attrs
+    finally:
+        snap_exporter.clear()
 
 
 def test_writes_name_path_and_state_success(exporter: InMemorySpanExporter) -> None:

--- a/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
+++ b/py/packages/genkit/tests/genkit/core/run_in_new_span_test.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel
 
 from genkit._core._action import Action, ActionKind
 from genkit._core._error import GenkitError
+from genkit._core._trace._attrs import metadata_key
 from genkit._core._trace._realtime_processor import RealtimeSpanProcessor
 from genkit._core._tracing import SpanMetadata, _parent_path_context, run_in_new_span, start_attributes
 
@@ -363,3 +364,24 @@ async def test_action_context_telemetry_circular_references(exporter: InMemorySp
 
     # 'key' is serializable, and 'self' circular reference should be safely cut off with '[Circular]'
     assert context_json == {'key': 'val', 'self': '[Circular]'}
+
+
+def test_metadata_key_prevents_double_prefix() -> None:
+    assert metadata_key('flow:name') == 'genkit:metadata:flow:name'
+    assert metadata_key('genkit:metadata:flow:name') == 'genkit:metadata:flow:name'
+
+
+def test_start_attributes_precedence_over_telemetry_labels() -> None:
+    meta = SpanMetadata(
+        name='realName',
+        telemetry_labels={
+            'genkit:name': 'fakeName',
+            'genkit:path': 'fakePath',
+            'user:label': 'custom',
+        },
+    )
+    attrs = start_attributes(meta, qualified_path='/realPath')
+    assert attrs['genkit:name'] == 'realName'
+    assert attrs['genkit:path'] == '/realPath'
+    assert attrs['genkit:qualifiedPath'] == '/realPath'
+    assert attrs['user:label'] == 'custom'


### PR DESCRIPTION
## Summary
- Seed start-known span attributes (name, path, type, subtype, metadata, input) as OTel span-start options so `RealtimeSpanProcessor.on_start` exports a useful in-progress span — Dev UI no longer waits for the span to end to show identity/input.
- Centralize wire attribute keys/values in `Attr` / `State` / `Subtype` (`StrEnum`) and share them across tracing + exporters.
- Tighten `run_in_new_span` (push parent path, record outcome helpers).

## Test plan
- [x] `pytest packages/genkit/tests/genkit/core/run_in_new_span_test.py packages/genkit/tests/genkit/core/trace/`

Tested manually:
<img width="1127" height="624" alt="Screenshot 2026-07-27 at 2 15 46 PM" src="https://github.com/user-attachments/assets/394226a2-2010-4c0e-8a58-637425822b04" />
