### PR TITLE
fix(tools): allow analytics for help command

### DIFF
--- a/genkit-tools/cli/src/cli.ts
+++ b/genkit-tools/cli/src/cli.ts
@@ -91,7 +91,7 @@ export async function startCLI(): Promise<void> {
       // For now only record known command names, to avoid tools plugins causing
       // arbitrary text to get recorded. Once we launch tools plugins, we'll have
       // to give this more thought
-      const commandNames = commands.map((c) => c.name());
+      const commandNames = [...commands.map((c) => c.name()), 'help'];
       let commandName: string;
       if (commandNames.includes(actionCommand.name())) {
         commandName = actionCommand.name();

--- a/genkit-tools/cli/src/cli.ts
+++ b/genkit-tools/cli/src/cli.ts
@@ -91,7 +91,7 @@ export async function startCLI(): Promise<void> {
       // For now only record known command names, to avoid tools plugins causing
       // arbitrary text to get recorded. Once we launch tools plugins, we'll have
       // to give this more thought
-      const commandNames = [...commands.map((c) => c.name()), 'help'];
+      const commandNames = commands.map((c) => c.name()).concat('help');
       let commandName: string;
       if (commandNames.includes(actionCommand.name())) {
         commandName = actionCommand.name();


### PR DESCRIPTION
We have `unknown` commands in our CLI metrics. This should eliminate one source of them (and give us stats on when the explicit help command runs).

nota bene: it doesn't log "all" usage of help (e.g. `-h` or `--h`) but that's OK. we're just looking to reduce or eliminate "unknown" command metrics.