### PR TITLE
fix(js): set a message on ToolInterruptError

### DIFF
--- a/js/ai/src/tool.ts
+++ b/js/ai/src/tool.ts
@@ -523,10 +523,15 @@ export function defineInterrupt<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
  */
 export class ToolInterruptError extends Error {
   constructor(readonly metadata?: Record<string, any>) {
-    const message =
-      metadata !== undefined
-        ? `tool execution interrupted: \n\n${JSON.stringify(metadata, null, 2)}`
-        : 'tool execution interrupted';
+    let message = 'tool execution interrupted';
+    if (metadata !== undefined) {
+      try {
+        message += `: \n\n${JSON.stringify(metadata, null, 2)}`;
+      } catch {
+        // Keep construction safe if metadata has cycles / BigInt / etc.
+        message += ': \n\n[unserializable metadata]';
+      }
+    }
     super(message);
     this.name = 'ToolInterruptError';
   }

--- a/js/ai/src/tool.ts
+++ b/js/ai/src/tool.ts
@@ -516,11 +516,18 @@ export function defineInterrupt<I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
 }
 
 /**
- * Thrown when tools execution is interrupted. It's meant to be caugh by the framework, not public API.
+ * Thrown when tool execution is interrupted. Intended to be caught by the
+ * generate loop as a yield mechanism, but may also surface when tools are
+ * invoked outside of generate (e.g. manually or via the Dev UI), so the error
+ * includes a message for debugging and logging.
  */
 export class ToolInterruptError extends Error {
   constructor(readonly metadata?: Record<string, any>) {
-    super();
+    const message =
+      metadata !== undefined
+        ? `tool execution interrupted: \n\n${JSON.stringify(metadata, null, 2)}`
+        : 'tool execution interrupted';
+    super(message);
     this.name = 'ToolInterruptError';
   }
 }

--- a/js/ai/tests/tool_test.ts
+++ b/js/ai/tests/tool_test.ts
@@ -53,6 +53,18 @@ describe('ToolInterruptError', () => {
     assert.ok(String(err).includes('tool execution interrupted'));
     assert.ok(String(err).includes('"key": "value"'));
   });
+
+  it('falls back when metadata cannot be serialized', () => {
+    const metadata: Record<string, any> = { key: 'value' };
+    metadata.self = metadata;
+    const err = new ToolInterruptError(metadata);
+    assert.strictEqual(err.name, 'ToolInterruptError');
+    assert.strictEqual(err.metadata, metadata);
+    assert.strictEqual(
+      err.message,
+      'tool execution interrupted: \n\n[unserializable metadata]'
+    );
+  });
 });
 
 describe('defineInterrupt', () => {

--- a/js/ai/tests/tool_test.ts
+++ b/js/ai/tests/tool_test.ts
@@ -20,6 +20,7 @@ import { Registry } from '@genkit-ai/core/registry';
 import * as assert from 'assert';
 import { afterEach, describe, it } from 'node:test';
 import {
+  ToolInterruptError,
   defineInterrupt,
   defineTool,
   interrupt,
@@ -31,6 +32,28 @@ import {
 } from '../src/tool.js';
 
 initNodeFeatures();
+
+describe('ToolInterruptError', () => {
+  it('sets a message when no metadata is provided', () => {
+    const err = new ToolInterruptError();
+    assert.strictEqual(err.name, 'ToolInterruptError');
+    assert.strictEqual(err.message, 'tool execution interrupted');
+    assert.strictEqual(String(err), 'ToolInterruptError: tool execution interrupted');
+  });
+
+  it('includes metadata in the message when provided', () => {
+    const metadata = { key: 'value' };
+    const err = new ToolInterruptError(metadata);
+    assert.strictEqual(err.name, 'ToolInterruptError');
+    assert.strictEqual(err.metadata, metadata);
+    assert.strictEqual(
+      err.message,
+      'tool execution interrupted: \n\n{\n  "key": "value"\n}'
+    );
+    assert.ok(String(err).includes('tool execution interrupted'));
+    assert.ok(String(err).includes('"key": "value"'));
+  });
+});
 
 describe('defineInterrupt', () => {
   let registry = new Registry();


### PR DESCRIPTION
## Summary
- Set a `message` on `ToolInterruptError` so `String(error)` / logging produce a useful representation when tools are invoked outside the generate loop (manual calls, Dev UI, observability).
- Align the JS message format with the existing Go `toolInterruptError.Error()` behavior: `"tool execution interrupted"` with optional pretty-printed metadata.
- Add unit tests covering both the no-metadata and metadata message cases.

Fixes #5821

## Test plan
- [x] `js/ai` `tool_test.ts` — new coverage for `ToolInterruptError` message with and without metadata
- [x] Aligns stringification with Go `toolInterruptError.Error()` behavior
- [ ] Manual: invoke an interrupt tool outside `generate` and confirm `error.message` / `String(error)` is non-empty
- [ ] Manual: confirm Dev UI / logs show a readable interrupt error string

