### PR TITLE
fix(py): use model call ID for Gemini tool request refs instead of part index

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -1788,8 +1788,8 @@ class GeminiModel:
             for i, c in enumerate(response.candidates):
                 c_content = []
                 if c.content and c.content.parts:
-                    for j, part in enumerate(c.content.parts):
-                        converted = PartConverter.from_gemini(part=part, ref=str(j))
+                    for part in c.content.parts:
+                        converted = PartConverter.from_gemini(part=part)
                         if converted:
                             c_content.append(converted)
 
@@ -1976,8 +1976,8 @@ class GeminiModel:
         if response.candidates:
             for candidate in response.candidates:
                 if candidate.content and candidate.content.parts:
-                    for i, part in enumerate(candidate.content.parts):
-                        converted = PartConverter.from_gemini(part=part, ref=str(i))
+                    for part in candidate.content.parts:
+                        converted = PartConverter.from_gemini(part=part)
                         if converted:  # Only append if conversion succeeded
                             content.append(converted)
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/utils.py
@@ -125,12 +125,17 @@ class PartConverter:
         if isinstance(part.root, TextPart):
             return genai.types.Part(text=part.root.text or ' ')
         if isinstance(part.root, ToolRequestPart):
+            # Round-trip the call id when we have one so the model can correlate
+            # tool responses to the original request.
+            function_call = genai.types.FunctionCall(
+                # Gemini throws on '/' in tool name
+                name=part.root.tool_request.name.replace('/', '__'),
+                args=part.root.tool_request.input,
+            )
+            if part.root.tool_request.ref:
+                function_call.id = part.root.tool_request.ref
             return genai.types.Part(
-                function_call=genai.types.FunctionCall(
-                    # Gemini throws on '/' in tool name
-                    name=part.root.tool_request.name.replace('/', '__'),
-                    args=part.root.tool_request.input,
-                ),
+                function_call=function_call,
                 thought_signature=cls._extract_thought_signature(part.root.metadata),
             )
         if isinstance(part.root, ReasoningPart):
@@ -285,7 +290,7 @@ class PartConverter:
         return genai.types.Part()
 
     @classmethod
-    def from_gemini(cls, part: genai.types.Part, ref: str | None = None) -> Part:
+    def from_gemini(cls, part: genai.types.Part) -> Part:
         """Maps a Gemini Part back to a Genkit Part.
 
         This method inspects the type of the Gemini Part and converts it into
@@ -294,7 +299,6 @@ class PartConverter:
 
         Args:
             part: The `genai.types.Part` object to convert.
-            ref: The tool call reference ID.
 
         Returns:
             A Genkit `Part` object representing the converted content.
@@ -309,10 +313,13 @@ class PartConverter:
         if part.text is not None:
             return Part(root=TextPart(text=part.text))
         if part.function_call:
+            # Tool refs come only from the model's call id. A synthetic part
+            # index isn't unique across turns, so resume can't tell repeated
+            # calls to the same tool apart.
             return Part(
                 root=ToolRequestPart(
                     tool_request=ToolRequest(
-                        ref=ref or getattr(part.function_call, 'id', None),
+                        ref=getattr(part.function_call, 'id', None),
                         # restore slashes
                         name=(part.function_call.name or '').replace('__', '/'),
                         input=part.function_call.args if part.function_call.args is not None else {},

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/utils.py
@@ -127,13 +127,13 @@ class PartConverter:
         if isinstance(part.root, ToolRequestPart):
             # Round-trip the call id when we have one so the model can correlate
             # tool responses to the original request.
-            function_call = genai.types.FunctionCall(
-                # Gemini throws on '/' in tool name
-                name=part.root.tool_request.name.replace('/', '__'),
-                args=part.root.tool_request.input,
-            )
+            fc_args = {
+                'name': part.root.tool_request.name.replace('/', '__'),
+                'args': part.root.tool_request.input,
+            }
             if part.root.tool_request.ref:
-                function_call.id = part.root.tool_request.ref
+                fc_args['id'] = part.root.tool_request.ref
+            function_call = genai.types.FunctionCall(**fc_args)
             return genai.types.Part(
                 function_call=function_call,
                 thought_signature=cls._extract_thought_signature(part.root.metadata),

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/utils.py
@@ -127,15 +127,13 @@ class PartConverter:
         if isinstance(part.root, ToolRequestPart):
             # Round-trip the call id when we have one so the model can correlate
             # tool responses to the original request.
-            fc_args = {
-                'name': part.root.tool_request.name.replace('/', '__'),
-                'args': part.root.tool_request.input,
-            }
-            if part.root.tool_request.ref:
-                fc_args['id'] = part.root.tool_request.ref
-            function_call = genai.types.FunctionCall(**fc_args)
             return genai.types.Part(
-                function_call=function_call,
+                function_call=genai.types.FunctionCall(
+                    # Gemini throws on '/' in tool name
+                    name=part.root.tool_request.name.replace('/', '__'),
+                    args=part.root.tool_request.input,
+                    id=part.root.tool_request.ref,
+                ),
                 thought_signature=cls._extract_thought_signature(part.root.metadata),
             )
         if isinstance(part.root, ReasoningPart):

--- a/py/packages/genkit-google-genai/tests/part_converter_test.py
+++ b/py/packages/genkit-google-genai/tests/part_converter_test.py
@@ -26,7 +26,7 @@ import pytest
 from genkit_google_genai.models.utils import PartConverter
 from google import genai
 
-from genkit import Media, MediaPart, Part
+from genkit import Media, MediaPart, Part, ToolRequest, ToolRequestPart
 
 
 class TestIsGeminiNativeUrl:
@@ -178,3 +178,67 @@ class TestToGeminiMediaPart:
             pytest.fail(f'inline_data.data = {result.inline_data.data!r}, want {raw!r}')
         if result.inline_data.mime_type != 'text/plain':
             pytest.fail(f'mime_type = {result.inline_data.mime_type}, want text/plain')
+
+
+class TestFunctionCallRef:
+    """Tool-request refs come from the model's call id, not a part index."""
+
+    def test_from_gemini_uses_function_call_id(self) -> None:
+        part = genai.types.Part(
+            function_call=genai.types.FunctionCall(
+                id='call-abc',
+                name='write_file',
+                args={'file_path': 'a.py', 'content': 'hi'},
+            )
+        )
+        got = PartConverter.from_gemini(part)
+        assert isinstance(got.root, ToolRequestPart)
+        if got.root.tool_request.ref != 'call-abc':
+            pytest.fail(f'ref = {got.root.tool_request.ref!r}, want call-abc')
+        if got.root.tool_request.name != 'write_file':
+            pytest.fail(f'name = {got.root.tool_request.name!r}, want write_file')
+
+    def test_from_gemini_leaves_ref_unset_when_model_omits_id(self) -> None:
+        part = genai.types.Part(
+            function_call=genai.types.FunctionCall(
+                name='write_file',
+                args={'file_path': 'a.py', 'content': 'hi'},
+            )
+        )
+        got = PartConverter.from_gemini(part)
+        assert isinstance(got.root, ToolRequestPart)
+        if got.root.tool_request.ref is not None:
+            pytest.fail(f'ref = {got.root.tool_request.ref!r}, want None')
+
+    @pytest.mark.asyncio
+    async def test_to_gemini_round_trips_ref_as_function_call_id(self) -> None:
+        part = Part(
+            root=ToolRequestPart(
+                tool_request=ToolRequest(
+                    name='write_file',
+                    ref='call-abc',
+                    input={'file_path': 'a.py', 'content': 'hi'},
+                )
+            )
+        )
+        got = await PartConverter.to_gemini(part)
+        assert isinstance(got, genai.types.Part)
+        assert got.function_call is not None
+        if got.function_call.id != 'call-abc':
+            pytest.fail(f'function_call.id = {got.function_call.id!r}, want call-abc')
+
+    @pytest.mark.asyncio
+    async def test_to_gemini_omits_id_when_ref_unset(self) -> None:
+        part = Part(
+            root=ToolRequestPart(
+                tool_request=ToolRequest(
+                    name='write_file',
+                    input={'file_path': 'a.py', 'content': 'hi'},
+                )
+            )
+        )
+        got = await PartConverter.to_gemini(part)
+        assert isinstance(got, genai.types.Part)
+        assert got.function_call is not None
+        if got.function_call.id is not None:
+            pytest.fail(f'function_call.id = {got.function_call.id!r}, want None')


### PR DESCRIPTION
When converting Gemini tool call responses to Genkit `Part` instances in `genkit-google-genai`, synthetic part index offsets (`ref="0"`) were previously generated when no call ID was provided. Synthetic indices are not unique across multi-turn sessions, breaking tool call matching when repeated calls to the same tool occur.

This PR updates `genkit-google-genai` to use the model's actual tool call ID (`part.function_call.id`) for tool request `ref`s and round-trip `ref` back to `function_call.id`, matching the behavior of the JS and Go SDKs.