### PR TITLE
fix(agents): add resume.metadata to AgentInput wire schema

### DIFF
--- a/genkit-tools/common/src/types/agent.ts
+++ b/genkit-tools/common/src/types/agent.ts
@@ -141,6 +141,7 @@ export const AgentInputSchema = z.object({
     .object({
       respond: z.array(ToolResponsePartSchema).optional(),
       restart: z.array(ToolRequestPartSchema).optional(),
+      metadata: z.record(z.any()).optional(),
     })
     .optional(),
 });

--- a/genkit-tools/genkit-schema.json
+++ b/genkit-tools/genkit-schema.json
@@ -80,6 +80,10 @@
               "items": {
                 "$ref": "#/$defs/ToolRequestPart"
               }
+            },
+            "metadata": {
+              "type": "object",
+              "additionalProperties": {}
             }
           },
           "additionalProperties": false

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -2542,8 +2542,9 @@ func agentLoop[State any](r api.Registry, prompt ai.Prompt, defaultInput any) Ag
 					return nil, err
 				}
 				actionOpts.Resume = &ai.GenerateActionResume{
-					Respond: input.Resume.Respond,
-					Restart: input.Resume.Restart,
+					Respond:  input.Resume.Respond,
+					Restart:  input.Resume.Restart,
+					Metadata: input.Resume.Metadata,
 				}
 			}
 

--- a/go/ai/exp/gen.go
+++ b/go/ai/exp/gen.go
@@ -142,6 +142,8 @@ type ToolResume struct {
 	Respond []*ai.Part `json:"respond,omitempty"`
 	// Restart contains tool request parts to restart when resuming.
 	Restart []*ai.Part `json:"restart,omitempty"`
+	// Metadata contains additional context for resuming the generation.
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 // AgentMetadata is the value placed under metadata["agent"] on an agent's

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -1236,6 +1236,7 @@ AgentInputResume pkg ai/exp
 AgentInputResume name ToolResume
 AgentInputResume.respond type []*ai.Part
 AgentInputResume.restart type []*ai.Part
+AgentInputResume.metadata type map[string]any
 
 AgentInputResume doc
 ToolResume holds the parts that resume an interrupted agent turn.
@@ -1249,6 +1250,10 @@ Respond contains tool response parts to send to the model when resuming.
 
 AgentInputResume.restart doc
 Restart contains tool request parts to restart when resuming.
+.
+
+AgentInputResume.metadata doc
+Metadata contains additional context for resuming the generation.
 .
 
 # ----------------------------------------------------------------------------

--- a/js/ai/src/agent-types.ts
+++ b/js/ai/src/agent-types.ts
@@ -166,6 +166,7 @@ export const AgentInputSchema = z.object({
     .object({
       respond: z.array(ToolResponsePartSchema).optional(),
       restart: z.array(ToolRequestPartSchema).optional(),
+      metadata: z.record(z.any()).optional(),
     })
     .optional(),
   detach: z.boolean().optional(),

--- a/js/ai/src/agent.ts
+++ b/js/ai/src/agent.ts
@@ -1540,6 +1540,9 @@ export function definePromptAgent<
           ...(input.resume.respond?.length && {
             respond: input.resume.respond as ToolResponsePart[],
           }),
+          ...(input.resume.metadata && {
+            metadata: input.resume.metadata,
+          }),
         };
       }
 

--- a/js/ai/tests/agent_test.ts
+++ b/js/ai/tests/agent_test.ts
@@ -25,6 +25,7 @@ import { GenkitError, z } from '@genkit-ai/core';
 import { TestSpanExporter } from '../../core/tests/utils.js';
 import { AgentError } from '../src/agent-core.js';
 import {
+  AgentInputSchema,
   AgentStreamChunk,
   SessionRunner,
   defineAgent,
@@ -4167,6 +4168,42 @@ Now respond to the latest message.`,
       assert.ok(task.snapshotId);
       const snap = await task.wait({ intervalMs: 1 });
       assert.ok(snap.status);
+    });
+
+    it('AgentInputSchema parses resume metadata without stripping it', () => {
+      const parsed = AgentInputSchema.parse({
+        resume: {
+          metadata: { approvedBy: 'jeff', ticket: 'INC-123' },
+        },
+      });
+      assert.deepEqual(parsed.resume?.metadata, {
+        approvedBy: 'jeff',
+        ticket: 'INC-123',
+      });
+    });
+
+    it('chat.resume forwards resume.metadata to agent execution', async () => {
+      const store = new InMemorySessionStore<{}>();
+      let lastGenOptsResume: any = undefined;
+
+      const agent = defineCustomAgent<{}>(
+        new Registry(),
+        { name: 'apiResumeMetadata', store },
+        async (sess) => {
+          await sess.run(async (input) => {
+            lastGenOptsResume = input?.resume;
+            return { finishReason: 'stop' as const };
+          });
+          return {
+            message: { role: 'model', content: [{ text: 'resumed' }] },
+            finishReason: 'stop' as const,
+          };
+        }
+      );
+
+      const chat = agent.chat();
+      await chat.resume({ metadata: { approvedBy: 'jeff' } });
+      assert.deepEqual(lastGenOptsResume?.metadata, { approvedBy: 'jeff' });
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR addresses issue #5826 by adding `metadata` to `AgentInput.resume` on the shared agent wire, aligning it with `GenerateActionOptions.resume.metadata`.

## Changes Made

1. **Schema Definitions**:
   - `genkit-tools/genkit-schema.json`: Added `metadata` object property under `.AgentInput.properties.resume.properties`.
   - `js/ai/src/agent-types.ts`: Added `metadata: z.record(z.any()).optional()` to `AgentInputSchema.resume`.
   - `genkit-tools/common/src/types/agent.ts`: Added `metadata: z.record(z.any()).optional()` to `AgentInputSchema.resume`.
   - `go/ai/exp/gen.go` & `go/core/schemas.config`: Added `Metadata map[string]any` to `ToolResume`.

2. **Runtime Wiring**:
   - `js/ai/src/agent.ts`: Forwarded `input.resume.metadata` into `genOpts.resume.metadata` during agent execution.
   - `go/ai/exp/agent.go`: Forwarded `input.Resume.Metadata` into `actionOpts.Resume.Metadata`.
   - Python (`py/packages/genkit/src/genkit/_core/_typing.py`): Verified and regenerated schema typings via `./py/bin/generate_schema_typing`.

3. **Tests**:
   - `js/ai/tests/agent_test.ts`: Added unit tests for parsing `resume.metadata` on `AgentInputSchema` and verifying `chat.resume({ metadata: ... })` / `chat.send({ resume: ... })` metadata forwarding.

Closes #5826