### PR TITLE
fix(go/plugins/anthropic): correct message conversion and honor tool choice

### DIFF
--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
@@ -37,7 +38,54 @@ import (
 
 const (
 	ToolNameRegex = `^[a-zA-Z0-9_-]{1,64}$`
+
+	// DefaultMaxOutputTokens is used when the request config does not set
+	// MaxTokens, which the Anthropic API requires. It matches the JS plugin's
+	// DEFAULT_MAX_OUTPUT_TOKENS and is low enough for every Claude model.
+	DefaultMaxOutputTokens = 4096
 )
+
+// metadataSignature extracts a reasoning signature from part metadata. It
+// handles both []byte (the value [ai.NewReasoningPart] stores) and string
+// (base64-encoded, after the part has been through a JSON roundtrip such as
+// persisted session history). Without the string case the signature is dropped
+// and Anthropic rejects the replayed thinking block.
+func metadataSignature(metadata map[string]any) []byte {
+	switch sig := metadata["signature"].(type) {
+	case []byte:
+		return sig
+	case string:
+		decoded, err := base64.StdEncoding.DecodeString(sig)
+		if err != nil {
+			return nil
+		}
+		return decoded
+	}
+	return nil
+}
+
+// toAnthropicMediaBlock converts a media or data [ai.Part] to the content block
+// its media type calls for. Anthropic only accepts images in an image block;
+// PDFs and plain text must be sent as document blocks.
+func toAnthropicMediaBlock(p *ai.Part, kind string) (anthropic.ContentBlockParamUnion, error) {
+	contentType, data, err := uri.Data(p)
+	if err != nil {
+		return anthropic.ContentBlockParamUnion{}, fmt.Errorf("unable to parse %s part: %w", kind, err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(data)
+	switch {
+	case strings.HasPrefix(contentType, "image/"):
+		return anthropic.NewImageBlockBase64(contentType, encoded), nil
+	case contentType == "application/pdf":
+		return anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{Data: encoded}), nil
+	case contentType == "text/plain":
+		return anthropic.NewDocumentBlock(anthropic.PlainTextSourceParam{Data: string(data)}), nil
+	default:
+		return anthropic.ContentBlockParamUnion{}, fmt.Errorf(
+			"unsupported %s content type %q: Anthropic accepts image/*, application/pdf, and text/plain", kind, contentType)
+	}
+}
 
 func DefineModel(client anthropic.Client, provider, name string, info ai.ModelOptions) ai.Model {
 	label := "Anthropic"
@@ -217,8 +265,11 @@ func toAnthropicRequest(provider string, i *ai.ModelRequest) (*anthropic.Message
 		return nil, err
 	}
 
+	// max_tokens is required by the Anthropic API. Fall back to a conservative
+	// default that every Claude model accepts, mirroring the JS plugin's
+	// DEFAULT_MAX_OUTPUT_TOKENS, so a bare Generate call works without config.
 	if req.MaxTokens == 0 {
-		return nil, errors.New("maxTokens not set")
+		req.MaxTokens = DefaultMaxOutputTokens
 	}
 
 	// configure system prompt (if given)
@@ -227,51 +278,82 @@ func toAnthropicRequest(provider string, i *ai.ModelRequest) (*anthropic.Message
 		if message.Role == ai.RoleSystem {
 			// only text is supported for system messages
 			sysBlocks = append(sysBlocks, anthropic.TextBlockParam{Text: message.Text()})
-		} else if message.Content[len(message.Content)-1].IsToolResponse() {
+			continue
+		}
+
+		parts, err := toAnthropicParts(message.Content)
+		if err != nil {
+			return nil, err
+		}
+		// Anthropic rejects messages with an empty content array.
+		if len(parts) == 0 {
+			continue
+		}
+
+		if lastPart := message.Content[len(message.Content)-1]; lastPart.IsToolResponse() {
 			// if the last message is a ToolResponse, the conversation must continue
 			// and the ToolResponse message must be sent as a user
 			// see: https://docs.anthropic.com/en/docs/build-with-claude/tool-use#handling-tool-use-and-tool-result-content-blocks
-			parts, err := toAnthropicParts(message.Content)
-			if err != nil {
-				return nil, err
-			}
 			messages = append(messages, anthropic.NewUserMessage(parts...))
-		} else {
-			parts, err := toAnthropicParts(message.Content)
-			if err != nil {
-				return nil, err
-			}
-			role, err := toAnthropicRole(message.Role)
-			if err != nil {
-				return nil, err
-			}
-			messages = append(messages, anthropic.MessageParam{
-				Role:    role,
-				Content: parts,
-			})
+			continue
 		}
+
+		role, err := toAnthropicRole(message.Role)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, anthropic.MessageParam{
+			Role:    role,
+			Content: parts,
+		})
 	}
 
-	req.System = sysBlocks
+	// Only overwrite the config-provided system prompt when the request
+	// actually carries system messages, and never send an empty array.
+	if len(sysBlocks) > 0 {
+		req.System = sysBlocks
+	}
 	req.Messages = messages
 
 	tools, err := toAnthropicTools(provider, i.Tools)
 	if err != nil {
 		return nil, err
 	}
-	req.Tools = tools
+	// Append rather than assign: server-side tools (web search, code execution,
+	// ...) can only be expressed through the config, and assigning here would
+	// silently drop them.
+	req.Tools = append(req.Tools, tools...)
+
+	if toolChoice, ok := toAnthropicToolChoice(i.ToolChoice); ok {
+		req.ToolChoice = toolChoice
+	}
 
 	if i.Output != nil && i.Output.Format == "json" && i.Output.Schema != nil && i.Output.Constrained {
-		// Native structured output via OutputConfig.
-		req.OutputConfig = anthropic.OutputConfigParam{
-			Format: anthropic.JSONOutputFormatParam{
-				Schema: pluginjsonschema.EnforceStrict(i.Output.Schema),
-				// Type is elided, defaults to "json_schema"
-			},
+		// Native structured output via OutputConfig. Set only the format so a
+		// config-provided OutputConfig.Effort survives.
+		req.OutputConfig.Format = anthropic.JSONOutputFormatParam{
+			Schema: pluginjsonschema.EnforceStrict(i.Output.Schema),
+			// Type is elided, defaults to "json_schema"
 		}
 	}
 
 	return req, nil
+}
+
+// toAnthropicToolChoice translates [ai.ToolChoice] to the Anthropic tool_choice
+// union. The second return value reports whether a choice was set; when false
+// the caller leaves any config-provided tool_choice untouched.
+func toAnthropicToolChoice(choice ai.ToolChoice) (anthropic.ToolChoiceUnionParam, bool) {
+	switch choice {
+	case ai.ToolChoiceAuto:
+		return anthropic.ToolChoiceUnionParam{OfAuto: &anthropic.ToolChoiceAutoParam{}}, true
+	case ai.ToolChoiceRequired:
+		return anthropic.ToolChoiceUnionParam{OfAny: &anthropic.ToolChoiceAnyParam{}}, true
+	case ai.ToolChoiceNone:
+		return anthropic.ToolChoiceUnionParam{OfNone: &anthropic.ToolChoiceNoneParam{}}, true
+	default:
+		return anthropic.ToolChoiceUnionParam{}, false
+	}
 }
 
 // configFromRequest converts any supported config type to [anthropic.MessageNewParams]
@@ -299,7 +381,10 @@ func configFromRequest(input *ai.ModelRequest) (*anthropic.MessageNewParams, err
 
 // toAnthropicTools translates [ai.ToolDefinition] to an anthropic.ToolParam type
 func toAnthropicTools(provider string, tools []*ai.ToolDefinition) ([]anthropic.ToolUnionParam, error) {
-	resp := make([]anthropic.ToolUnionParam, 0)
+	if len(tools) == 0 {
+		return nil, nil
+	}
+	resp := make([]anthropic.ToolUnionParam, 0, len(tools))
 	regex := regexp.MustCompile(ToolNameRegex)
 
 	for _, t := range tools {
@@ -370,17 +455,17 @@ func toAnthropicParts(parts []*ai.Part) ([]anthropic.ContentBlockParamUnion, err
 		case p.IsText():
 			blocks = append(blocks, anthropic.NewTextBlock(p.Text))
 		case p.IsMedia():
-			contentType, data, err := uri.Data(p)
+			block, err := toAnthropicMediaBlock(p, "media")
 			if err != nil {
-				return nil, fmt.Errorf("unable to parse media part: %w", err)
+				return nil, err
 			}
-			blocks = append(blocks, anthropic.NewImageBlockBase64(contentType, base64.StdEncoding.EncodeToString(data)))
+			blocks = append(blocks, block)
 		case p.IsData():
-			contentType, data, err := uri.Data(p)
+			block, err := toAnthropicMediaBlock(p, "data")
 			if err != nil {
-				return nil, fmt.Errorf("unable to parse data part: %w", err)
+				return nil, err
 			}
-			blocks = append(blocks, anthropic.NewImageBlockBase64(contentType, base64.RawStdEncoding.EncodeToString(data)))
+			blocks = append(blocks, block)
 		case p.IsToolRequest():
 			toolReq := p.ToolRequest
 			blocks = append(blocks, anthropic.NewToolUseBlock(toolReq.Ref, toolReq.Input, toolReq.Name))
@@ -392,13 +477,7 @@ func toAnthropicParts(parts []*ai.Part) ([]anthropic.ContentBlockParamUnion, err
 			}
 			blocks = append(blocks, anthropic.NewToolResultBlock(toolResp.Ref, string(output), false))
 		case p.IsReasoning():
-			signature := []byte{}
-			if p.Metadata != nil {
-				if sig, ok := p.Metadata["signature"].([]byte); ok {
-					signature = sig
-				}
-			}
-			blocks = append(blocks, anthropic.NewThinkingBlock(string(signature), p.Text))
+			blocks = append(blocks, anthropic.NewThinkingBlock(string(metadataSignature(p.Metadata)), p.Text))
 		default:
 			return nil, errors.New("unknown part type in the request")
 		}

--- a/go/plugins/internal/anthropic/anthropic.go
+++ b/go/plugins/internal/anthropic/anthropic.go
@@ -73,12 +73,11 @@ func toAnthropicMediaBlock(p *ai.Part, kind string) (anthropic.ContentBlockParam
 		return anthropic.ContentBlockParamUnion{}, fmt.Errorf("unable to parse %s part: %w", kind, err)
 	}
 
-	encoded := base64.StdEncoding.EncodeToString(data)
 	switch {
 	case strings.HasPrefix(contentType, "image/"):
-		return anthropic.NewImageBlockBase64(contentType, encoded), nil
+		return anthropic.NewImageBlockBase64(contentType, base64.StdEncoding.EncodeToString(data)), nil
 	case contentType == "application/pdf":
-		return anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{Data: encoded}), nil
+		return anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{Data: base64.StdEncoding.EncodeToString(data)}), nil
 	case contentType == "text/plain":
 		return anthropic.NewDocumentBlock(anthropic.PlainTextSourceParam{Data: string(data)}), nil
 	default:

--- a/go/plugins/internal/anthropic/anthropic_test.go
+++ b/go/plugins/internal/anthropic/anthropic_test.go
@@ -17,6 +17,7 @@
 package anthropic
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -475,7 +476,9 @@ func TestToAnthropicRequest(t *testing.T) {
 			},
 		},
 		{
-			name: "no max tokens",
+			// max_tokens is required by the API, so an unset value falls back to
+			// DefaultMaxOutputTokens rather than failing the request.
+			name: "no max tokens falls back to the default",
 			req: &ai.ModelRequest{
 				Messages: []*ai.Message{
 					{
@@ -484,7 +487,12 @@ func TestToAnthropicRequest(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "maxTokens not set",
+			expected: &anthropic.MessageNewParams{
+				MaxTokens: DefaultMaxOutputTokens,
+				Messages: []anthropic.MessageParam{
+					anthropic.NewUserMessage(anthropic.NewTextBlock("hello")),
+				},
+			},
 		},
 	}
 
@@ -554,6 +562,232 @@ func TestToAnthropicRequest_StructuredOutput(t *testing.T) {
 
 	if diff := cmp.Diff(wantSchema, got.OutputConfig.Format.Schema); diff != "" {
 		t.Errorf("OutputConfig schema mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// userRequest builds a minimal request carrying a single user message.
+func userRequest(config any) *ai.ModelRequest {
+	return &ai.ModelRequest{
+		Config:   config,
+		Messages: []*ai.Message{ai.NewUserMessage(ai.NewTextPart("hi"))},
+	}
+}
+
+// wireJSON marshals v the way it would be sent to the Anthropic API.
+func wireJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func TestToAnthropicPartsMediaTypes(t *testing.T) {
+	tests := []struct {
+		name        string
+		part        *ai.Part
+		want        string
+		expectedErr string
+	}{
+		{
+			name: "png stays an image block",
+			part: ai.NewMediaPart("image/png", "data:image/png;base64,iVBORw0KGgo="),
+			want: `"type":"image"`,
+		},
+		{
+			// Anthropic only accepts images in an image block; a PDF sent as one
+			// is rejected by the API.
+			name: "pdf becomes a document block",
+			part: ai.NewMediaPart("application/pdf", "data:application/pdf;base64,JVBERi0xLjQK"),
+			want: `"type":"document"`,
+		},
+		{
+			name: "plain text becomes a document block",
+			part: ai.NewMediaPart("text/plain", "data:text/plain;base64,aGVsbG8="),
+			want: `"type":"document"`,
+		},
+		{
+			name:        "unsupported type is rejected",
+			part:        ai.NewMediaPart("audio/mpeg", "data:audio/mpeg;base64,SUQzAw=="),
+			expectedErr: `unsupported media content type "audio/mpeg"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toAnthropicParts([]*ai.Part{tt.part})
+			if checkError(t, err, tt.expectedErr) {
+				return
+			}
+			if wire := wireJSON(t, got); !strings.Contains(wire, tt.want) {
+				t.Errorf("got %s, want it to contain %s", wire, tt.want)
+			}
+		})
+	}
+}
+
+func TestToAnthropicPartsReasoningSignature(t *testing.T) {
+	part := ai.NewReasoningPart("thinking...", []byte("sig-abc"))
+
+	t.Run("in process", func(t *testing.T) {
+		got, err := toAnthropicParts([]*ai.Part{part})
+		if err != nil {
+			t.Fatalf("toAnthropicParts: %v", err)
+		}
+		if wire := wireJSON(t, got); !strings.Contains(wire, `"signature":"sig-abc"`) {
+			t.Errorf("signature missing: %s", wire)
+		}
+	})
+
+	// A part read back from persisted history holds the signature as a base64
+	// string rather than []byte. Dropping it makes Anthropic reject the
+	// replayed thinking block.
+	t.Run("after a JSON roundtrip", func(t *testing.T) {
+		raw, err := json.Marshal(part)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var restored ai.Part
+		if err := json.Unmarshal(raw, &restored); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		got, err := toAnthropicParts([]*ai.Part{&restored})
+		if err != nil {
+			t.Fatalf("toAnthropicParts: %v", err)
+		}
+		if wire := wireJSON(t, got); !strings.Contains(wire, `"signature":"sig-abc"`) {
+			t.Errorf("signature lost across roundtrip: %s", wire)
+		}
+	})
+}
+
+func TestToAnthropicRequestPreservesConfig(t *testing.T) {
+	// Server-side tools can only be expressed through the config, so the
+	// genkit tool list must merge with them rather than replace them.
+	t.Run("config tools survive", func(t *testing.T) {
+		config := &anthropic.MessageNewParams{
+			MaxTokens: 100,
+			Tools: []anthropic.ToolUnionParam{
+				{OfWebSearchTool20250305: &anthropic.WebSearchTool20250305Param{}},
+			},
+		}
+		got, err := toAnthropicRequest("anthropic", userRequest(config))
+		if err != nil {
+			t.Fatalf("toAnthropicRequest: %v", err)
+		}
+		if len(got.Tools) != 1 {
+			t.Fatalf("got %d tools, want the config tool preserved", len(got.Tools))
+		}
+
+		req := userRequest(config)
+		req.Tools = []*ai.ToolDefinition{{
+			Name:        "my_tool",
+			Description: "d",
+			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+		}}
+		got, err = toAnthropicRequest("anthropic", req)
+		if err != nil {
+			t.Fatalf("toAnthropicRequest: %v", err)
+		}
+		if len(got.Tools) != 2 {
+			t.Errorf("got %d tools, want the config tool plus the genkit tool", len(got.Tools))
+		}
+	})
+
+	// Assigning a fresh OutputConfig would drop a config-provided effort.
+	t.Run("output config effort survives structured output", func(t *testing.T) {
+		req := userRequest(&anthropic.MessageNewParams{
+			MaxTokens:    100,
+			OutputConfig: anthropic.OutputConfigParam{Effort: anthropic.OutputConfigEffort("high")},
+		})
+		req.Output = &ai.ModelOutputConfig{
+			Format:      "json",
+			Constrained: true,
+			Schema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"a": map[string]any{"type": "string"}},
+			},
+		}
+		got, err := toAnthropicRequest("anthropic", req)
+		if err != nil {
+			t.Fatalf("toAnthropicRequest: %v", err)
+		}
+		wire := wireJSON(t, got.OutputConfig)
+		if !strings.Contains(wire, `"effort":"high"`) {
+			t.Errorf("effort dropped: %s", wire)
+		}
+		if !strings.Contains(wire, `"json_schema"`) {
+			t.Errorf("format missing: %s", wire)
+		}
+	})
+
+	t.Run("config tool choice survives when unset", func(t *testing.T) {
+		got, err := toAnthropicRequest("anthropic", userRequest(&anthropic.MessageNewParams{
+			MaxTokens:  100,
+			ToolChoice: anthropic.ToolChoiceUnionParam{OfTool: &anthropic.ToolChoiceToolParam{Name: "pinned"}},
+		}))
+		if err != nil {
+			t.Fatalf("toAnthropicRequest: %v", err)
+		}
+		if wire := wireJSON(t, got.ToolChoice); !strings.Contains(wire, "pinned") {
+			t.Errorf("config tool choice dropped: %s", wire)
+		}
+	})
+
+	// Anthropic rejects an empty content array, and an empty tools array
+	// conflicts with a config-provided tool_choice.
+	t.Run("no empty arrays on the wire", func(t *testing.T) {
+		got, err := toAnthropicRequest("anthropic", userRequest(nil))
+		if err != nil {
+			t.Fatalf("toAnthropicRequest: %v", err)
+		}
+		wire := wireJSON(t, got)
+		if strings.Contains(wire, `"tools":[]`) || strings.Contains(wire, `"system":[]`) {
+			t.Errorf("empty arrays present: %s", wire)
+		}
+	})
+}
+
+func TestToAnthropicRequestToolChoice(t *testing.T) {
+	tests := []struct {
+		choice ai.ToolChoice
+		want   string
+	}{
+		{ai.ToolChoiceAuto, `"type":"auto"`},
+		{ai.ToolChoiceRequired, `"type":"any"`},
+		{ai.ToolChoiceNone, `"type":"none"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.choice), func(t *testing.T) {
+			req := userRequest(nil)
+			req.ToolChoice = tt.choice
+			got, err := toAnthropicRequest("anthropic", req)
+			if err != nil {
+				t.Fatalf("toAnthropicRequest: %v", err)
+			}
+			if wire := wireJSON(t, got.ToolChoice); !strings.Contains(wire, tt.want) {
+				t.Errorf("got %s, want it to contain %s", wire, tt.want)
+			}
+		})
+	}
+}
+
+// A message whose content is empty must be skipped rather than indexed into.
+func TestToAnthropicRequestSkipsEmptyMessages(t *testing.T) {
+	got, err := toAnthropicRequest("anthropic", &ai.ModelRequest{
+		Config: &anthropic.MessageNewParams{MaxTokens: 100},
+		Messages: []*ai.Message{
+			{Role: ai.RoleModel, Content: nil},
+			ai.NewUserMessage(ai.NewTextPart("hi")),
+		},
+	})
+	if err != nil {
+		t.Fatalf("toAnthropicRequest: %v", err)
+	}
+	if len(got.Messages) != 1 {
+		t.Errorf("got %d messages, want the empty one skipped", len(got.Messages))
 	}
 }
 


### PR DESCRIPTION
Fixes seven defects in the Anthropic request path, all in `plugins/internal/anthropic` and therefore shared with `vertexai/modelgarden`.

## Bugs fixed

**PDFs were sent as image blocks.** Every media part became `NewImageBlockBase64`, but Anthropic only accepts jpeg/png/gif/webp there. PDF input failed outright. Media now routes by content type: `image/*` to an image block, `application/pdf` and `text/plain` to document blocks.

**Reasoning signatures were dropped after a JSON roundtrip.** `NewReasoningPart` stores the signature as `[]byte`, and the conversion asserted `.([]byte)`. Once history is serialized and reloaded (persisted sessions, flow state) the value is a base64 `string`, the assertion failed, and the thinking block shipped with `signature: ""` — which Anthropic rejects, breaking multi-turn extended thinking. Now accepts either form, matching the helper the Gemini plugin already uses.

**Config-provided tools were silently wiped.** `req.Tools` was assigned unconditionally from the Genkit tool list. Server-side tools (web search, code execution, and friends) can only be expressed through `MessageNewParams`, so setting one and then generating dropped it. The two lists now merge.

**`OutputConfig.Effort` was clobbered by constrained JSON output.** Structured output replaced the whole `OutputConfigParam`, discarding a config-provided effort. Only `.Format` is set now.

**Empty message content panicked.** `Content[len(Content)-1]` was indexed without a length check, so a message with no parts caused an index-out-of-range. Parts are built first, and messages that yield no content blocks are skipped — Anthropic rejects empty content arrays anyway.

**`ai.ModelRequest.ToolChoice` was ignored.** The plugin advertises `ToolChoice: true` in its `Supports`, but never read the field, so `ai.WithToolChoice(...)` silently did nothing. Now mapped: auto to `auto`, required to `any`, none to `none`. Leaving it unset no longer disturbs a config-provided `tool_choice`.

**`maxTokens` was mandatory.** An unset value returned `maxTokens not set`, so a plain `Generate` call against a Claude model failed until the caller supplied config. It now falls back to `DefaultMaxOutputTokens = 4096`, matching the JS plugin's `DEFAULT_MAX_OUTPUT_TOKENS`, which every Claude model accepts. An explicit value still wins.

Two smaller things in the same code path: the data-part branch used unpadded `RawStdEncoding` where the adjacent media branch used `StdEncoding`, and empty `system: []` / `tools: []` arrays were sent on every request.

## Behavior change worth noting

Unsupported media types (for example `audio/mpeg`) now return a local error naming the accepted types, instead of silently sending a malformed image block and getting an opaque API 400. Clearer, but it is a new error path rather than a previously-working case.

## Verification

Regression tests added for all seven fixes, plus coverage for the merge and no-clobber cases. One existing case asserted the old `maxTokens not set` error and was updated to assert the default.

Go 1.26.3, full `go test ./...` in `go/`: 40 packages pass, no new failures.

## Scope

No dependency changes; this builds against the currently required `anthropic-sdk-go` v1.23.0. Prompt caching, citations, server-tool result round-tripping, and streaming fidelity are known gaps left for follow-ups.
