### PR TITLE
feat(go): add typed-config `New*Action` primitive constructors

### DIFF
--- a/go/ai/action_methods_test.go
+++ b/go/ai/action_methods_test.go
@@ -19,9 +19,11 @@ package ai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/core/status"
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
@@ -130,6 +132,92 @@ func TestPrimitiveMethodsForwardToEmbeddedAction(t *testing.T) {
 			}
 			if res == nil || len(res.Result) == 0 {
 				t.Error("RunJSONWithTelemetry() returned no result")
+			}
+		})
+	}
+}
+
+// A nil receiver reaches a forwarder whenever a caller holds an uninitialized
+// primitive, and dereferencing the embedded action would panic. Every
+// forwarder that can report an error returns INVALID_ARGUMENT instead, the way
+// Generate, Embed, Evaluate, Retrieve, and RunRawMultipart already do.
+func TestForwardersRejectNilReceivers(t *testing.T) {
+	ctx := context.Background()
+	in := json.RawMessage(`{}`)
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{"model RunJSON", func() error { var m *ModelAction; _, err := m.RunJSON(ctx, in, nil); return err }},
+		{"model RunJSONWithTelemetry", func() error {
+			var m *ModelAction
+			_, err := m.RunJSONWithTelemetry(ctx, in, nil)
+			return err
+		}},
+		{"embedder RunJSON", func() error { var e *EmbedderAction; _, err := e.RunJSON(ctx, in, nil); return err }},
+		{"embedder RunJSONWithTelemetry", func() error {
+			var e *EmbedderAction
+			_, err := e.RunJSONWithTelemetry(ctx, in, nil)
+			return err
+		}},
+		{"retriever RunJSON", func() error { var r *RetrieverAction; _, err := r.RunJSON(ctx, in, nil); return err }},
+		{"retriever RunJSONWithTelemetry", func() error {
+			var r *RetrieverAction
+			_, err := r.RunJSONWithTelemetry(ctx, in, nil)
+			return err
+		}},
+		{"evaluator RunJSON", func() error { var e *EvaluatorAction; _, err := e.RunJSON(ctx, in, nil); return err }},
+		{"evaluator RunJSONWithTelemetry", func() error {
+			var e *EvaluatorAction
+			_, err := e.RunJSONWithTelemetry(ctx, in, nil)
+			return err
+		}},
+		{"tool RunJSON", func() error {
+			var tl *ToolAction[any, any]
+			_, err := tl.RunJSON(ctx, in, nil)
+			return err
+		}},
+		{"tool RunJSONWithTelemetry", func() error {
+			var tl *ToolAction[any, any]
+			_, err := tl.RunJSONWithTelemetry(ctx, in, nil)
+			return err
+		}},
+		{"background RunJSON", func() error {
+			var b *BackgroundModelAction
+			_, err := b.RunJSON(ctx, in, nil)
+			return err
+		}},
+		{"background RunJSONWithTelemetry", func() error {
+			var b *BackgroundModelAction
+			_, err := b.RunJSONWithTelemetry(ctx, in, nil)
+			return err
+		}},
+		{"background Start", func() error {
+			var b *BackgroundModelAction
+			_, err := b.Start(ctx, &ModelRequest{})
+			return err
+		}},
+		{"background Check", func() error {
+			var b *BackgroundModelAction
+			_, err := b.Check(ctx, &ModelOperation{})
+			return err
+		}},
+		{"background Cancel", func() error {
+			var b *BackgroundModelAction
+			_, err := b.Cancel(ctx, &ModelOperation{})
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			if err == nil {
+				t.Fatal("got nil error, want an error on a nil receiver")
+			}
+			if !errors.Is(err, status.ErrInvalidArgument) {
+				t.Errorf("err = %v, want it to match status.ErrInvalidArgument", err)
 			}
 		})
 	}

--- a/go/ai/action_methods_test.go
+++ b/go/ai/action_methods_test.go
@@ -79,6 +79,14 @@ func TestPrimitiveMethodsForwardToEmbeddedAction(t *testing.T) {
 			input: `{"dataset":[{"testCaseId":"case-1","input":"x"}],"evalRunId":"run-1"}`,
 		},
 		{
+			name: "tool",
+			action: NewTool("test/tool", "a test tool", func(ctx *ToolContext, in string) (string, error) {
+				return in + "!", nil
+			}),
+			atype: api.ActionTypeToolV2,
+			input: `"hi"`,
+		},
+		{
 			name: "background model",
 			action: NewBackgroundModelAction("test/background", nil,
 				func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {

--- a/go/ai/action_methods_test.go
+++ b/go/ai/action_methods_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/internal/registry"
+)
+
+// The concrete primitives redeclare the methods promoted from their embedded
+// core action so that those methods, and the interfaces they satisfy, appear
+// in the package documentation. A redeclared method shadows the promoted one,
+// so a forwarder that calls itself instead of the embedded action recurses
+// until the stack overflows. Exercise every forwarder: Generate, Embed,
+// Retrieve, and Evaluate are covered elsewhere, but RunJSON and
+// RunJSONWithTelemetry are not called anywhere else in the suite, which is
+// exactly where such a mistake would survive.
+func TestPrimitiveMethodsForwardToEmbeddedAction(t *testing.T) {
+	modelFn := func(ctx context.Context, req *ModelRequest, _ any, cb ModelStreamCallback) (*ModelResponse, error) {
+		return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+	}
+
+	tests := []struct {
+		name   string
+		action api.Action
+		atype  api.ActionType
+		input  string
+	}{
+		{
+			name:   "model",
+			action: NewModelAction("test/model", nil, modelFn),
+			atype:  api.ActionTypeModel,
+			input:  `{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`,
+		},
+		{
+			name: "embedder",
+			action: NewEmbedderAction("test/embedder", nil, func(ctx context.Context, req *EmbedRequest, _ any) (*EmbedResponse, error) {
+				return &EmbedResponse{Embeddings: []*Embedding{{Embedding: []float32{1, 2}}}}, nil
+			}),
+			atype: api.ActionTypeEmbedder,
+			input: `{"input":[{"content":[{"text":"hi"}]}]}`,
+		},
+		{
+			name: "retriever",
+			action: NewRetrieverAction("test/retriever", nil, func(ctx context.Context, req *RetrieverRequest, _ any) (*RetrieverResponse, error) {
+				return &RetrieverResponse{Documents: []*Document{DocumentFromText("doc", nil)}}, nil
+			}),
+			atype: api.ActionTypeRetriever,
+			input: `{"query":{"content":[{"text":"hi"}]}}`,
+		},
+		{
+			name: "evaluator",
+			action: NewEvaluatorAction("test/evaluator", &EvaluatorOptions{DisplayName: "Test", Definition: "Test"},
+				func(ctx context.Context, req *EvaluatorCallbackRequest, _ any) (*EvaluatorCallbackResponse, error) {
+					return &EvaluatorCallbackResponse{
+						TestCaseId: req.Input.TestCaseId,
+						Evaluation: []Score{{Id: "score", Score: 1, Status: "PASS"}},
+					}, nil
+				}),
+			atype: api.ActionTypeEvaluator,
+			input: `{"dataset":[{"testCaseId":"case-1","input":"x"}],"evalRunId":"run-1"}`,
+		},
+		{
+			name: "background model",
+			action: NewBackgroundModelAction("test/background", nil,
+				func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
+					return &ModelOperation{ID: "op-1"}, nil
+				},
+				func(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
+					return &ModelOperation{ID: op.ID, Done: true}, nil
+				}),
+			atype: api.ActionTypeBackgroundModel,
+			input: `{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := registry.New()
+			tt.action.Register(r)
+
+			desc := tt.action.Desc()
+			if desc.Name != tt.action.Name() {
+				t.Errorf("Desc().Name = %q, Name() = %q; the two forwarders disagree", desc.Name, tt.action.Name())
+			}
+			if desc.Type != tt.atype {
+				t.Errorf("Desc().Type = %q, want %q", desc.Type, tt.atype)
+			}
+			if r.LookupAction(desc.Key) == nil {
+				t.Errorf("Register() did not reach the registry: no action at key %q", desc.Key)
+			}
+
+			out, err := tt.action.RunJSON(context.Background(), json.RawMessage(tt.input), nil)
+			if err != nil {
+				t.Fatalf("RunJSON() error: %v", err)
+			}
+			if len(out) == 0 {
+				t.Error("RunJSON() returned no output")
+			}
+
+			res, err := tt.action.RunJSONWithTelemetry(context.Background(), json.RawMessage(tt.input), nil)
+			if err != nil {
+				t.Fatalf("RunJSONWithTelemetry() error: %v", err)
+			}
+			if res == nil || len(res.Result) == 0 {
+				t.Error("RunJSONWithTelemetry() returned no result")
+			}
+		})
+	}
+}
+
+// A background model's lifecycle methods are forwarders too, and Cancel and
+// SupportsCancel have no other coverage on the concrete type.
+func TestBackgroundModelActionLifecycleForwarders(t *testing.T) {
+	startFn := func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
+		return &ModelOperation{ID: "op-1"}, nil
+	}
+	checkFn := func(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
+		return &ModelOperation{ID: op.ID, Done: true}, nil
+	}
+
+	t.Run("without cancel", func(t *testing.T) {
+		b := NewBackgroundModelAction("test/no-cancel", nil, startFn, checkFn)
+		if b.SupportsCancel() {
+			t.Error("SupportsCancel() = true, want false when no cancel function is given")
+		}
+		if _, err := b.Cancel(context.Background(), &ModelOperation{ID: "op-1"}); err == nil {
+			t.Error("Cancel() error = nil, want an error when cancellation is unsupported")
+		}
+	})
+
+	t.Run("with cancel", func(t *testing.T) {
+		b := NewBackgroundModelAction("test/cancel", &BackgroundModelOptions{
+			Cancel: func(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
+				return &ModelOperation{ID: op.ID, Done: true}, nil
+			},
+		}, startFn, checkFn)
+
+		if !b.SupportsCancel() {
+			t.Error("SupportsCancel() = false, want true")
+		}
+
+		op, err := b.Start(context.Background(), &ModelRequest{Messages: []*Message{NewUserTextMessage("hi")}})
+		if err != nil {
+			t.Fatalf("Start() error: %v", err)
+		}
+		if op.ID != "op-1" {
+			t.Errorf("Start() ID = %q, want %q", op.ID, "op-1")
+		}
+
+		checked, err := b.Check(context.Background(), op)
+		if err != nil {
+			t.Fatalf("Check() error: %v", err)
+		}
+		if !checked.Done {
+			t.Error("Check() Done = false, want true")
+		}
+
+		cancelled, err := b.Cancel(context.Background(), op)
+		if err != nil {
+			t.Fatalf("Cancel() error: %v", err)
+		}
+		if !cancelled.Done {
+			t.Error("Cancel() Done = false, want true")
+		}
+	})
+}

--- a/go/ai/action_test.go
+++ b/go/ai/action_test.go
@@ -71,7 +71,7 @@ func defineProgrammableModel(r api.Registry) *programmableModel {
 		Tools:     true,
 		Multiturn: true,
 	}
-	DefineModel(r, "programmableModel", &ModelOptions{Supports: supports}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+	defineModel(r, "programmableModel", &ModelOptions{Supports: supports}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		return pm.Generate(ctx, r, req, &ToolConfig{MaxTurns: 5}, cb)
 	})
 	return pm
@@ -97,7 +97,7 @@ func TestGenerateAction(t *testing.T) {
 
 			pm := defineProgrammableModel(r)
 
-			DefineTool(r, "testTool", "description",
+			defineTool(r, "testTool", "description",
 				func(ctx *ToolContext, input any) (any, error) {
 					return "tool called", nil
 				})

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -86,8 +86,8 @@ type CheckModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOpe
 type CancelModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOperation, error)
 
 // TypedBackgroundModelOptions configures a background model created with
-// [NewTypedBackgroundModel]. It holds descriptor data only; the cancel
-// function is a constructor argument.
+// [NewTypedBackgroundModel]. It holds descriptor data plus optional lifecycle
+// hooks; the required start and check functions are constructor arguments.
 type TypedBackgroundModelOptions struct {
 	ConfigSchema map[string]any // JSON schema for the model's config.
 	Label        string         // User-friendly name for the model.
@@ -95,6 +95,10 @@ type TypedBackgroundModelOptions struct {
 	Supports     *ModelSupports // Capabilities of the model.
 	Versions     []string       // Available versions of the model.
 	Metadata     map[string]any // Arbitrary key-value data attached to the action descriptor.
+
+	// Cancel cancels a running operation. Optional: nil means the model does
+	// not support canceling operations.
+	Cancel CancelModelOpFunc
 }
 
 // BackgroundModelOptions holds configuration for defining a background model.
@@ -124,9 +128,6 @@ func LookupBackgroundModel(r api.Registry, name string) BackgroundModel {
 // [BackgroundModelAction.Register] directly. Applications should define
 // background models with [genkit.DefineTypedBackgroundModel].
 //
-// cancelFn is optional; nil means the model does not support canceling
-// operations.
-//
 // Config is the model's typed configuration; it is usually inferred from
 // startFn's signature. See [NewTypedModel] for how the request's config
 // is deserialized.
@@ -135,7 +136,6 @@ func NewTypedBackgroundModel[Config any](
 	opts *TypedBackgroundModelOptions,
 	startFn TypedStartModelOpFunc[Config],
 	checkFn CheckModelOpFunc,
-	cancelFn CancelModelOpFunc,
 ) *BackgroundModelAction {
 	if name == "" {
 		panic("ai.NewTypedBackgroundModel: name is required")
@@ -235,7 +235,7 @@ func NewTypedBackgroundModel[Config any](
 		Description: description,
 		Metadata:    metadata,
 		InputSchema: inputSchema,
-	}, wrappedFn, checkFn, cancelFn)}
+	}, wrappedFn, checkFn, opts.Cancel)}
 }
 
 // NewBackgroundModel defines a new model that runs in the background.
@@ -257,9 +257,10 @@ func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn Start
 		Supports:     opts.Supports,
 		Versions:     opts.Versions,
 		Metadata:     opts.Metadata,
+		Cancel:       opts.Cancel,
 	}, func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
 		return startFn(ctx, req)
-	}, checkFn, opts.Cancel)
+	}, checkFn)
 }
 
 // GenerateOperation generates a model response as a long-running operation based on the provided options.

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -79,7 +79,7 @@ type BackgroundModelOptions struct {
 	Metadata map[string]any    // Additional metadata.
 }
 
-// LookupBackgroundModel looks up a BackgroundAction registered by [DefineBackgroundModel].
+// LookupBackgroundModel looks up a registered [BackgroundModel] by name.
 // It returns nil if the background model was not found.
 func LookupBackgroundModel(r api.Registry, name string) BackgroundModel {
 	key := api.KeyFromName(api.ActionTypeBackgroundModel, name)
@@ -204,16 +204,6 @@ func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn Start
 	return NewTypedBackgroundModel(name, opts, func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
 		return startFn(ctx, req)
 	}, checkFn)
-}
-
-// DefineBackgroundModel defines and registers a new model that runs in the background.
-//
-// Deprecated: Use [NewTypedBackgroundModel] and register the result with
-// [BackgroundModel.Register].
-func DefineBackgroundModel(r *registry.Registry, name string, opts *BackgroundModelOptions, fn StartModelOpFunc, checkFn CheckModelOpFunc) BackgroundModel {
-	m := NewBackgroundModel(name, opts, fn, checkFn)
-	m.Register(r)
-	return m
 }
 
 // GenerateOperation generates a model response as a long-running operation based on the provided options.

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -60,6 +60,12 @@ type ModelOperation = core.Operation[*ModelResponse]
 // StartModelOpFunc starts a background model operation.
 type StartModelOpFunc = func(ctx context.Context, req *ModelRequest) (*ModelOperation, error)
 
+// StartModelOpFuncWithConfig is a [StartModelOpFunc] that additionally
+// receives the request's typed Config: the framework deserializes the
+// request's raw config into it before calling the function (see
+// [NewBackgroundModelWithConfig]).
+type StartModelOpFuncWithConfig[Config any] = func(ctx context.Context, req *ModelRequest, config Config) (*ModelOperation, error)
+
 // CheckModelOpFunc checks the status of a background model operation.
 type CheckModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOperation, error)
 
@@ -84,16 +90,21 @@ func LookupBackgroundModel(r api.Registry, name string) BackgroundModel {
 	return &backgroundModel{*action}
 }
 
-// NewBackgroundModel defines a new model that runs in the background.
-func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn StartModelOpFunc, checkFn CheckModelOpFunc) BackgroundModel {
+// NewBackgroundModelWithConfig creates a new [BackgroundModel]. Register it
+// with [BackgroundModel.Register] to make it resolvable by name.
+//
+// Config is the model's typed configuration; it is usually inferred from
+// startFn's signature. See [NewModelWithConfig] for how the request's config
+// is deserialized.
+func NewBackgroundModelWithConfig[Config any](name string, opts *BackgroundModelOptions, startFn StartModelOpFuncWithConfig[Config], checkFn CheckModelOpFunc) BackgroundModel {
 	if name == "" {
-		panic("ai.NewBackgroundModel: name is required")
+		panic("ai.NewBackgroundModelWithConfig: name is required")
 	}
 	if startFn == nil {
-		panic("ai.NewBackgroundModel: startFn is required")
+		panic("ai.NewBackgroundModelWithConfig: startFn is required")
 	}
 	if checkFn == nil {
-		panic("ai.NewBackgroundModel: checkFn is required")
+		panic("ai.NewBackgroundModelWithConfig: checkFn is required")
 	}
 
 	if opts == nil {
@@ -106,6 +117,8 @@ func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn Start
 	if opts.Supports == nil {
 		opts.Supports = &ModelSupports{}
 	}
+
+	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, ModelRequest{}, "config")
 
 	// Seed from the caller's metadata, then stamp the built-in keys over it so
 	// they cannot be corrupted; registry discovery depends on them.
@@ -128,17 +141,27 @@ func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn Start
 		},
 		"versions":      opts.Versions,
 		"stage":         opts.Stage,
-		"customOptions": opts.ConfigSchema,
+		"customOptions": configSchema,
 	}
 
-	inputSchema := requestInputSchema(ModelRequest{}, "config", opts.ConfigSchema)
+	typedStartFn := func(ctx context.Context, req *ModelRequest) (*ModelOperation, error) {
+		// req.Config was normalized to the exact Config type by
+		// normalizeConfig below, so this hits the fast path.
+		cfg, err := resolveConfig[Config](req.Config)
+		if err != nil {
+			return nil, err
+		}
+		return startFn(ctx, req, cfg)
+	}
 
-	mws := []ModelMiddleware{
+	// normalizeConfig runs outermost so that the built-in wrappers and the
+	// start function all see the typed, converted config on the request.
+	fn := core.ChainMiddleware(
+		normalizeConfig[Config](name, opts.Versions),
 		simulateSystemPrompt(&opts.ModelOptions, nil),
 		augmentWithContext(&opts.ModelOptions, nil),
 		validateSupport(name, &opts.ModelOptions),
-	}
-	fn := core.ChainMiddleware(mws...)(backgroundModelToModelFn(startFn))
+	)(backgroundModelToModelFn(typedStartFn))
 
 	wrappedFn := func(ctx context.Context, req *ModelRequest) (*ModelOperation, error) {
 		resp, err := fn(ctx, req, nil)
@@ -169,7 +192,24 @@ func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn Start
 	}, wrappedFn)}
 }
 
+// NewBackgroundModel defines a new model that runs in the background.
+//
+// Deprecated: Use [NewBackgroundModelWithConfig], which passes the request's
+// config to startFn as a typed value instead of leaving it type-erased on the
+// request.
+func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn StartModelOpFunc, checkFn CheckModelOpFunc) BackgroundModel {
+	if startFn == nil {
+		panic("ai.NewBackgroundModel: startFn is required")
+	}
+	return NewBackgroundModelWithConfig(name, opts, func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
+		return startFn(ctx, req)
+	}, checkFn)
+}
+
 // DefineBackgroundModel defines and registers a new model that runs in the background.
+//
+// Deprecated: Use [NewBackgroundModelWithConfig] and register the result with
+// [BackgroundModel.Register].
 func DefineBackgroundModel(r *registry.Registry, name string, opts *BackgroundModelOptions, fn StartModelOpFunc, checkFn CheckModelOpFunc) BackgroundModel {
 	m := NewBackgroundModel(name, opts, fn, checkFn)
 	m.Register(r)

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -85,31 +85,21 @@ type CheckModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOpe
 // CancelModelOpFunc cancels a background model operation.
 type CancelModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOperation, error)
 
-// TypedBackgroundModelOptions configures a background model created with
-// [NewBackgroundModelAction]. It holds descriptor data plus optional lifecycle
-// hooks; the required start and check functions are constructor arguments.
-type TypedBackgroundModelOptions struct {
-	ConfigSchema map[string]any // JSON schema for the model's config.
-	Label        string         // User-friendly name for the model.
-	Stage        ModelStage     // Indicates the maturity stage of the model.
-	Supports     *ModelSupports // Capabilities of the model.
-	Versions     []string       // Available versions of the model.
-	Metadata     map[string]any // Arbitrary key-value data attached to the action descriptor.
+// BackgroundModelOptions configures a background model created with
+// [NewBackgroundModelAction]. It extends [ModelOptions] with the operation
+// lifecycle hooks a background model needs; the required start and check
+// functions are constructor arguments.
+type BackgroundModelOptions struct {
+	ModelOptions
 
 	// Cancel cancels a running operation. Optional: nil means the model does
 	// not support canceling operations.
 	Cancel CancelModelOpFunc
-}
 
-// BackgroundModelOptions holds configuration for defining a background model.
-//
-// Deprecated: Use [TypedBackgroundModelOptions] with
-// [NewBackgroundModelAction].
-type BackgroundModelOptions struct {
-	ModelOptions
-	// Cancel is the function that cancels a background model operation.
-	Cancel   CancelModelOpFunc
-	Metadata map[string]any // Additional metadata.
+	// Metadata is arbitrary key-value data attached to the action descriptor.
+	// It is merged over [ModelOptions.Metadata]; this field wins on key
+	// conflicts.
+	Metadata map[string]any
 }
 
 // LookupBackgroundModel looks up a registered [BackgroundModel] by name.
@@ -133,7 +123,7 @@ func LookupBackgroundModel(r api.Registry, name string) BackgroundModel {
 // is deserialized.
 func NewBackgroundModelAction[Config any](
 	name string,
-	opts *TypedBackgroundModelOptions,
+	opts *BackgroundModelOptions,
 	startFn BackgroundModelActionFunc[Config],
 	checkFn CheckModelOpFunc,
 ) *BackgroundModelAction {
@@ -148,7 +138,7 @@ func NewBackgroundModelAction[Config any](
 	}
 
 	if opts == nil {
-		opts = &TypedBackgroundModelOptions{}
+		opts = &BackgroundModelOptions{}
 	}
 	labelExplicit := opts.Label != ""
 	if !labelExplicit {
@@ -161,8 +151,11 @@ func NewBackgroundModelAction[Config any](
 	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, ModelRequest{}, "config")
 
 	// Seed from the caller's metadata, then stamp the built-in keys over it so
-	// they cannot be corrupted; registry discovery depends on them.
-	metadata := make(map[string]any, len(opts.Metadata)+2)
+	// they cannot be corrupted; registry discovery depends on them. The
+	// top-level Metadata wins over the embedded ModelOptions.Metadata on key
+	// conflicts.
+	metadata := make(map[string]any, len(opts.ModelOptions.Metadata)+len(opts.Metadata)+2)
+	maps.Copy(metadata, opts.ModelOptions.Metadata)
 	maps.Copy(metadata, opts.Metadata)
 	metadata["type"] = api.ActionTypeBackgroundModel
 	metadata["model"] = map[string]any{
@@ -194,13 +187,7 @@ func NewBackgroundModelAction[Config any](
 		return startFn(ctx, req, cfg)
 	}
 
-	mopts := &ModelOptions{
-		ConfigSchema: opts.ConfigSchema,
-		Label:        opts.Label,
-		Stage:        opts.Stage,
-		Supports:     opts.Supports,
-		Versions:     opts.Versions,
-	}
+	mopts := &opts.ModelOptions
 
 	// normalizeConfig runs outermost so that the built-in wrappers and the
 	// start function all see the typed, converted config on the request.
@@ -247,18 +234,7 @@ func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn Start
 	if startFn == nil {
 		panic("ai.NewBackgroundModel: startFn is required")
 	}
-	if opts == nil {
-		opts = &BackgroundModelOptions{}
-	}
-	return NewBackgroundModelAction(name, &TypedBackgroundModelOptions{
-		ConfigSchema: opts.ConfigSchema,
-		Label:        opts.Label,
-		Stage:        opts.Stage,
-		Supports:     opts.Supports,
-		Versions:     opts.Versions,
-		Metadata:     opts.Metadata,
-		Cancel:       opts.Cancel,
-	}, func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
+	return NewBackgroundModelAction(name, opts, func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
 		return startFn(ctx, req)
 	}, checkFn)
 }

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -19,7 +19,6 @@ package ai
 import (
 	"context"
 	"errors"
-	"maps"
 
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
@@ -148,34 +147,11 @@ func NewBackgroundModelAction[Config any](
 		opts.Supports = &ModelSupports{}
 	}
 
-	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, ModelRequest{}, "config")
+	configSchema, inputSchema := modelConfigSchemas[Config](opts.ConfigSchema)
 
-	// Seed from the caller's metadata, then stamp the built-in keys over it so
-	// they cannot be corrupted; registry discovery depends on them. The
-	// top-level Metadata wins over the embedded ModelOptions.Metadata on key
-	// conflicts.
-	metadata := make(map[string]any, len(opts.ModelOptions.Metadata)+len(opts.Metadata)+2)
-	maps.Copy(metadata, opts.ModelOptions.Metadata)
-	maps.Copy(metadata, opts.Metadata)
-	metadata["type"] = api.ActionTypeBackgroundModel
-	metadata["model"] = map[string]any{
-		"label": opts.Label,
-		"supports": map[string]any{
-			"media":       opts.Supports.Media,
-			"context":     opts.Supports.Context,
-			"multiturn":   opts.Supports.Multiturn,
-			"systemRole":  opts.Supports.SystemRole,
-			"tools":       opts.Supports.Tools,
-			"toolChoice":  opts.Supports.ToolChoice,
-			"constrained": opts.Supports.Constrained,
-			"output":      opts.Supports.Output,
-			"contentType": opts.Supports.ContentType,
-			"longRunning": opts.Supports.LongRunning,
-		},
-		"versions":      opts.Versions,
-		"stage":         opts.Stage,
-		"customOptions": configSchema,
-	}
+	// The top-level Metadata wins over the embedded ModelOptions.Metadata on
+	// key conflicts.
+	metadata := modelActionMetadata(api.ActionTypeBackgroundModel, &opts.ModelOptions, configSchema, opts.ModelOptions.Metadata, opts.Metadata)
 
 	typedStartFn := func(ctx context.Context, req *ModelRequest) (*ModelOperation, error) {
 		// req.Config was normalized to the exact Config type by
@@ -231,8 +207,14 @@ func NewBackgroundModelAction[Config any](
 // config to startFn as a typed value instead of leaving it type-erased on the
 // request.
 func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn StartModelOpFunc, checkFn CheckModelOpFunc) BackgroundModel {
+	if name == "" {
+		panic("ai.NewBackgroundModel: name is required")
+	}
 	if startFn == nil {
 		panic("ai.NewBackgroundModel: startFn is required")
+	}
+	if checkFn == nil {
+		panic("ai.NewBackgroundModel: checkFn is required")
 	}
 	return NewBackgroundModelAction(name, opts, func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
 		return startFn(ctx, req)

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -49,7 +49,7 @@ type BackgroundModel interface {
 type backgroundAction[In, Out any] = core.BackgroundAction[In, Out]
 
 // BackgroundModelAction is a background model backed by registry actions. It
-// is the concrete type returned by [NewTypedBackgroundModel]; return it from
+// is the concrete type returned by [NewBackgroundModelAction]; return it from
 // a plugin's Init for the framework to register.
 type BackgroundModelAction struct {
 	backgroundAction[*ModelRequest, *ModelResponse]
@@ -73,11 +73,11 @@ type ModelOperation = core.Operation[*ModelResponse]
 // StartModelOpFunc starts a background model operation.
 type StartModelOpFunc = func(ctx context.Context, req *ModelRequest) (*ModelOperation, error)
 
-// TypedStartModelOpFunc is a [StartModelOpFunc] that additionally
+// BackgroundModelActionFunc is a [StartModelOpFunc] that additionally
 // receives the request's typed Config: the framework deserializes the
 // request's raw config into it before calling the function (see
-// [NewTypedBackgroundModel]).
-type TypedStartModelOpFunc[Config any] = func(ctx context.Context, req *ModelRequest, config Config) (*ModelOperation, error)
+// [NewBackgroundModelAction]).
+type BackgroundModelActionFunc[Config any] = func(ctx context.Context, req *ModelRequest, config Config) (*ModelOperation, error)
 
 // CheckModelOpFunc checks the status of a background model operation.
 type CheckModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOperation, error)
@@ -86,7 +86,7 @@ type CheckModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOpe
 type CancelModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOperation, error)
 
 // TypedBackgroundModelOptions configures a background model created with
-// [NewTypedBackgroundModel]. It holds descriptor data plus optional lifecycle
+// [NewBackgroundModelAction]. It holds descriptor data plus optional lifecycle
 // hooks; the required start and check functions are constructor arguments.
 type TypedBackgroundModelOptions struct {
 	ConfigSchema map[string]any // JSON schema for the model's config.
@@ -104,7 +104,7 @@ type TypedBackgroundModelOptions struct {
 // BackgroundModelOptions holds configuration for defining a background model.
 //
 // Deprecated: Use [TypedBackgroundModelOptions] with
-// [NewTypedBackgroundModel].
+// [NewBackgroundModelAction].
 type BackgroundModelOptions struct {
 	ModelOptions
 	// Cancel is the function that cancels a background model operation.
@@ -123,28 +123,28 @@ func LookupBackgroundModel(r api.Registry, name string) BackgroundModel {
 	return &BackgroundModelAction{*action}
 }
 
-// NewTypedBackgroundModel creates an unregistered [BackgroundModelAction]:
+// NewBackgroundModelAction creates an unregistered [BackgroundModelAction]:
 // return it from a plugin's Init for the framework to register, or call
 // [BackgroundModelAction.Register] directly. Applications should define
-// background models with [genkit.DefineTypedBackgroundModel].
+// background models with [genkit.DefineBackgroundModelAction].
 //
 // Config is the model's typed configuration; it is usually inferred from
-// startFn's signature. See [NewTypedModel] for how the request's config
+// startFn's signature. See [NewModelAction] for how the request's config
 // is deserialized.
-func NewTypedBackgroundModel[Config any](
+func NewBackgroundModelAction[Config any](
 	name string,
 	opts *TypedBackgroundModelOptions,
-	startFn TypedStartModelOpFunc[Config],
+	startFn BackgroundModelActionFunc[Config],
 	checkFn CheckModelOpFunc,
 ) *BackgroundModelAction {
 	if name == "" {
-		panic("ai.NewTypedBackgroundModel: name is required")
+		panic("ai.NewBackgroundModelAction: name is required")
 	}
 	if startFn == nil {
-		panic("ai.NewTypedBackgroundModel: startFn is required")
+		panic("ai.NewBackgroundModelAction: startFn is required")
 	}
 	if checkFn == nil {
-		panic("ai.NewTypedBackgroundModel: checkFn is required")
+		panic("ai.NewBackgroundModelAction: checkFn is required")
 	}
 
 	if opts == nil {
@@ -240,7 +240,7 @@ func NewTypedBackgroundModel[Config any](
 
 // NewBackgroundModel defines a new model that runs in the background.
 //
-// Deprecated: Use [NewTypedBackgroundModel], which passes the request's
+// Deprecated: Use [NewBackgroundModelAction], which passes the request's
 // config to startFn as a typed value instead of leaving it type-erased on the
 // request.
 func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn StartModelOpFunc, checkFn CheckModelOpFunc) BackgroundModel {
@@ -250,7 +250,7 @@ func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn Start
 	if opts == nil {
 		opts = &BackgroundModelOptions{}
 	}
-	return NewTypedBackgroundModel(name, &TypedBackgroundModelOptions{
+	return NewBackgroundModelAction(name, &TypedBackgroundModelOptions{
 		ConfigSchema: opts.ConfigSchema,
 		Label:        opts.Label,
 		Stage:        opts.Stage,

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -194,11 +194,13 @@ func NewBackgroundModelAction[Config any](
 			description = ""
 		}
 	}
-	return &BackgroundModelAction{*core.NewBackgroundActionOf(api.ActionTypeBackgroundModel, name, &core.BackgroundActionOptions{
+	return &BackgroundModelAction{*core.NewBackgroundActionOf(api.ActionTypeBackgroundModel, name, &core.BackgroundActionOptions[*ModelRequest, *ModelResponse]{
 		Description: description,
 		Metadata:    metadata,
 		InputSchema: inputSchema,
-	}, wrappedFn, checkFn, opts.Cancel)}
+		Check:       checkFn,
+		Cancel:      opts.Cancel,
+	}, wrappedFn)}
 }
 
 // NewBackgroundModel defines a new model that runs in the background.

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -55,10 +55,12 @@ type BackgroundModelAction struct {
 	backgroundAction[*ModelRequest, *ModelResponse]
 }
 
-// BackgroundModelAction can be passed anywhere a [BackgroundModel] is
-// accepted. Plugin resolvers also assert it to [api.Action] (e.g.
+// BackgroundModelAction is a full registry action and can be passed anywhere
+// an [api.Action] is accepted as well as anywhere a [BackgroundModel] is
+// accepted. Its Register method registers the start, check, and cancel
+// actions together. Plugin resolvers rely on the [api.Action] side (e.g.
 // googlegenai's resolveAction returns the whole model as the resolved
-// action). That only holds through the embedded action's promoted methods,
+// action), which only holds through the embedded action's promoted methods,
 // so pin both here where the embedding lives.
 var (
 	_ api.Action      = (*BackgroundModelAction)(nil)
@@ -86,8 +88,12 @@ type CancelModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOp
 // BackgroundModelOptions holds configuration for defining a background model
 type BackgroundModelOptions struct {
 	ModelOptions
-	Cancel   CancelModelOpFunc // Function that cancels a background model operation.
-	Metadata map[string]any    // Additional metadata.
+	// Cancel is the function that cancels a background model operation.
+	//
+	// Deprecated: Pass cancelFn to [NewTypedBackgroundModel] instead;
+	// options hold descriptor data only.
+	Cancel   CancelModelOpFunc
+	Metadata map[string]any // Additional metadata.
 }
 
 // LookupBackgroundModel looks up a registered [BackgroundModel] by name.
@@ -106,10 +112,14 @@ func LookupBackgroundModel(r api.Registry, name string) BackgroundModel {
 // [BackgroundModelAction.Register] directly. Applications should define
 // background models with [genkit.DefineTypedBackgroundModel].
 //
+// cancelFn is optional; nil means the model does not support canceling
+// operations. When cancelFn is nil, the deprecated
+// [BackgroundModelOptions.Cancel] is used as a fallback.
+//
 // Config is the model's typed configuration; it is usually inferred from
 // startFn's signature. See [NewTypedModel] for how the request's config
 // is deserialized.
-func NewTypedBackgroundModel[Config any](name string, opts *BackgroundModelOptions, startFn TypedStartModelOpFunc[Config], checkFn CheckModelOpFunc) *BackgroundModelAction {
+func NewTypedBackgroundModel[Config any](name string, opts *BackgroundModelOptions, startFn TypedStartModelOpFunc[Config], checkFn CheckModelOpFunc, cancelFn CancelModelOpFunc) *BackgroundModelAction {
 	if name == "" {
 		panic("ai.NewTypedBackgroundModel: name is required")
 	}
@@ -185,6 +195,10 @@ func NewTypedBackgroundModel[Config any](name string, opts *BackgroundModelOptio
 		return modelOpFromResponse(resp)
 	}
 
+	if cancelFn == nil {
+		cancelFn = opts.Cancel
+	}
+
 	// The label doubles as the description on all three component actions,
 	// matching the JS background model surface. A label that was only
 	// defaulted from the name yields to an explicit caller
@@ -200,7 +214,7 @@ func NewTypedBackgroundModel[Config any](name string, opts *BackgroundModelOptio
 		Description: description,
 		Metadata:    metadata,
 		InputSchema: inputSchema,
-	}, wrappedFn, checkFn, opts.Cancel)}
+	}, wrappedFn, checkFn, cancelFn)}
 }
 
 // NewBackgroundModel defines a new model that runs in the background.
@@ -214,7 +228,7 @@ func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn Start
 	}
 	return NewTypedBackgroundModel(name, opts, func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
 		return startFn(ctx, req)
-	}, checkFn)
+	}, checkFn, nil)
 }
 
 // GenerateOperation generates a model response as a long-running operation based on the provided options.

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -85,13 +85,25 @@ type CheckModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOpe
 // CancelModelOpFunc cancels a background model operation.
 type CancelModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOperation, error)
 
-// BackgroundModelOptions holds configuration for defining a background model
+// TypedBackgroundModelOptions configures a background model created with
+// [NewTypedBackgroundModel]. It holds descriptor data only; the cancel
+// function is a constructor argument.
+type TypedBackgroundModelOptions struct {
+	ConfigSchema map[string]any // JSON schema for the model's config.
+	Label        string         // User-friendly name for the model.
+	Stage        ModelStage     // Indicates the maturity stage of the model.
+	Supports     *ModelSupports // Capabilities of the model.
+	Versions     []string       // Available versions of the model.
+	Metadata     map[string]any // Arbitrary key-value data attached to the action descriptor.
+}
+
+// BackgroundModelOptions holds configuration for defining a background model.
+//
+// Deprecated: Use [TypedBackgroundModelOptions] with
+// [NewTypedBackgroundModel].
 type BackgroundModelOptions struct {
 	ModelOptions
 	// Cancel is the function that cancels a background model operation.
-	//
-	// Deprecated: Pass cancelFn to [NewTypedBackgroundModel] instead;
-	// options hold descriptor data only.
 	Cancel   CancelModelOpFunc
 	Metadata map[string]any // Additional metadata.
 }
@@ -113,15 +125,14 @@ func LookupBackgroundModel(r api.Registry, name string) BackgroundModel {
 // background models with [genkit.DefineTypedBackgroundModel].
 //
 // cancelFn is optional; nil means the model does not support canceling
-// operations. When cancelFn is nil, the deprecated
-// [BackgroundModelOptions.Cancel] is used as a fallback.
+// operations.
 //
 // Config is the model's typed configuration; it is usually inferred from
 // startFn's signature. See [NewTypedModel] for how the request's config
 // is deserialized.
 func NewTypedBackgroundModel[Config any](
 	name string,
-	opts *BackgroundModelOptions,
+	opts *TypedBackgroundModelOptions,
 	startFn TypedStartModelOpFunc[Config],
 	checkFn CheckModelOpFunc,
 	cancelFn CancelModelOpFunc,
@@ -137,7 +148,7 @@ func NewTypedBackgroundModel[Config any](
 	}
 
 	if opts == nil {
-		opts = &BackgroundModelOptions{}
+		opts = &TypedBackgroundModelOptions{}
 	}
 	labelExplicit := opts.Label != ""
 	if !labelExplicit {
@@ -183,13 +194,21 @@ func NewTypedBackgroundModel[Config any](
 		return startFn(ctx, req, cfg)
 	}
 
+	mopts := &ModelOptions{
+		ConfigSchema: opts.ConfigSchema,
+		Label:        opts.Label,
+		Stage:        opts.Stage,
+		Supports:     opts.Supports,
+		Versions:     opts.Versions,
+	}
+
 	// normalizeConfig runs outermost so that the built-in wrappers and the
 	// start function all see the typed, converted config on the request.
 	fn := core.ChainMiddleware(
 		normalizeConfig[Config](name, opts.Versions),
-		simulateSystemPrompt(&opts.ModelOptions, nil),
-		augmentWithContext(&opts.ModelOptions, nil),
-		validateSupport(name, &opts.ModelOptions),
+		simulateSystemPrompt(mopts, nil),
+		augmentWithContext(mopts, nil),
+		validateSupport(name, mopts),
 	)(backgroundModelToModelFn(typedStartFn))
 
 	wrappedFn := func(ctx context.Context, req *ModelRequest) (*ModelOperation, error) {
@@ -199,10 +218,6 @@ func NewTypedBackgroundModel[Config any](
 		}
 
 		return modelOpFromResponse(resp)
-	}
-
-	if cancelFn == nil {
-		cancelFn = opts.Cancel
 	}
 
 	// The label doubles as the description on all three component actions,
@@ -232,9 +247,19 @@ func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn Start
 	if startFn == nil {
 		panic("ai.NewBackgroundModel: startFn is required")
 	}
-	return NewTypedBackgroundModel(name, opts, func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
+	if opts == nil {
+		opts = &BackgroundModelOptions{}
+	}
+	return NewTypedBackgroundModel(name, &TypedBackgroundModelOptions{
+		ConfigSchema: opts.ConfigSchema,
+		Label:        opts.Label,
+		Stage:        opts.Stage,
+		Supports:     opts.Supports,
+		Versions:     opts.Versions,
+		Metadata:     opts.Metadata,
+	}, func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
 		return startFn(ctx, req)
-	}, checkFn, nil)
+	}, checkFn, opts.Cancel)
 }
 
 // GenerateOperation generates a model response as a long-running operation based on the provided options.

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -119,7 +119,13 @@ func LookupBackgroundModel(r api.Registry, name string) BackgroundModel {
 // Config is the model's typed configuration; it is usually inferred from
 // startFn's signature. See [NewTypedModel] for how the request's config
 // is deserialized.
-func NewTypedBackgroundModel[Config any](name string, opts *BackgroundModelOptions, startFn TypedStartModelOpFunc[Config], checkFn CheckModelOpFunc, cancelFn CancelModelOpFunc) *BackgroundModelAction {
+func NewTypedBackgroundModel[Config any](
+	name string,
+	opts *BackgroundModelOptions,
+	startFn TypedStartModelOpFunc[Config],
+	checkFn CheckModelOpFunc,
+	cancelFn CancelModelOpFunc,
+) *BackgroundModelAction {
 	if name == "" {
 		panic("ai.NewTypedBackgroundModel: name is required")
 	}

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -43,16 +43,27 @@ type BackgroundModel interface {
 	SupportsCancel() bool
 }
 
-// backgroundModel is the concrete implementation of BackgroundModel interface.
-type backgroundModel struct {
-	core.BackgroundAction[*ModelRequest, *ModelResponse]
+// backgroundAction is an unexported alias of [core.BackgroundAction] used as
+// the embedded field in [BackgroundModelAction]; see the action alias in
+// generate.go for why.
+type backgroundAction[In, Out any] = core.BackgroundAction[In, Out]
+
+// BackgroundModelAction is a background model backed by registry actions. It
+// is the concrete type returned by [NewTypedBackgroundModel]; return it from
+// a plugin's Init for the framework to register.
+type BackgroundModelAction struct {
+	backgroundAction[*ModelRequest, *ModelResponse]
 }
 
-// Plugin resolvers assert the value returned by [NewBackgroundModel] to
-// [api.Action] (e.g. googlegenai's resolveAction returns the whole model as
-// the resolved action). That only holds through the embedded action's
-// promoted methods, so pin it here where the embedding lives.
-var _ api.Action = (*backgroundModel)(nil)
+// BackgroundModelAction can be passed anywhere a [BackgroundModel] is
+// accepted. Plugin resolvers also assert it to [api.Action] (e.g.
+// googlegenai's resolveAction returns the whole model as the resolved
+// action). That only holds through the embedded action's promoted methods,
+// so pin both here where the embedding lives.
+var (
+	_ api.Action      = (*BackgroundModelAction)(nil)
+	_ BackgroundModel = (*BackgroundModelAction)(nil)
+)
 
 // ModelOperation is a background operation for a model.
 type ModelOperation = core.Operation[*ModelResponse]
@@ -87,16 +98,18 @@ func LookupBackgroundModel(r api.Registry, name string) BackgroundModel {
 	if action == nil {
 		return nil
 	}
-	return &backgroundModel{*action}
+	return &BackgroundModelAction{*action}
 }
 
-// NewTypedBackgroundModel creates a new [BackgroundModel]. Register it
-// with [BackgroundModel.Register] to make it resolvable by name.
+// NewTypedBackgroundModel creates an unregistered [BackgroundModelAction]:
+// return it from a plugin's Init for the framework to register, or call
+// [BackgroundModelAction.Register] directly. Applications should define
+// background models with [genkit.DefineTypedBackgroundModel].
 //
 // Config is the model's typed configuration; it is usually inferred from
 // startFn's signature. See [NewTypedModel] for how the request's config
 // is deserialized.
-func NewTypedBackgroundModel[Config any](name string, opts *BackgroundModelOptions, startFn TypedStartModelOpFunc[Config], checkFn CheckModelOpFunc) BackgroundModel {
+func NewTypedBackgroundModel[Config any](name string, opts *BackgroundModelOptions, startFn TypedStartModelOpFunc[Config], checkFn CheckModelOpFunc) *BackgroundModelAction {
 	if name == "" {
 		panic("ai.NewTypedBackgroundModel: name is required")
 	}
@@ -183,13 +196,11 @@ func NewTypedBackgroundModel[Config any](name string, opts *BackgroundModelOptio
 			description = ""
 		}
 	}
-	return &backgroundModel{*core.NewBackgroundActionOf(api.ActionTypeBackgroundModel, name, &core.BackgroundActionOptions[*ModelRequest, *ModelResponse]{
+	return &BackgroundModelAction{*core.NewBackgroundActionOf(api.ActionTypeBackgroundModel, name, &core.BackgroundActionOptions{
 		Description: description,
 		Metadata:    metadata,
 		InputSchema: inputSchema,
-		Check:       checkFn,
-		Cancel:      opts.Cancel,
-	}, wrappedFn)}
+	}, wrappedFn, checkFn, opts.Cancel)}
 }
 
 // NewBackgroundModel defines a new model that runs in the background.

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -60,11 +60,11 @@ type ModelOperation = core.Operation[*ModelResponse]
 // StartModelOpFunc starts a background model operation.
 type StartModelOpFunc = func(ctx context.Context, req *ModelRequest) (*ModelOperation, error)
 
-// StartModelOpFuncWithConfig is a [StartModelOpFunc] that additionally
+// TypedStartModelOpFunc is a [StartModelOpFunc] that additionally
 // receives the request's typed Config: the framework deserializes the
 // request's raw config into it before calling the function (see
-// [NewBackgroundModelWithConfig]).
-type StartModelOpFuncWithConfig[Config any] = func(ctx context.Context, req *ModelRequest, config Config) (*ModelOperation, error)
+// [NewTypedBackgroundModel]).
+type TypedStartModelOpFunc[Config any] = func(ctx context.Context, req *ModelRequest, config Config) (*ModelOperation, error)
 
 // CheckModelOpFunc checks the status of a background model operation.
 type CheckModelOpFunc = func(ctx context.Context, op *ModelOperation) (*ModelOperation, error)
@@ -90,21 +90,21 @@ func LookupBackgroundModel(r api.Registry, name string) BackgroundModel {
 	return &backgroundModel{*action}
 }
 
-// NewBackgroundModelWithConfig creates a new [BackgroundModel]. Register it
+// NewTypedBackgroundModel creates a new [BackgroundModel]. Register it
 // with [BackgroundModel.Register] to make it resolvable by name.
 //
 // Config is the model's typed configuration; it is usually inferred from
-// startFn's signature. See [NewModelWithConfig] for how the request's config
+// startFn's signature. See [NewTypedModel] for how the request's config
 // is deserialized.
-func NewBackgroundModelWithConfig[Config any](name string, opts *BackgroundModelOptions, startFn StartModelOpFuncWithConfig[Config], checkFn CheckModelOpFunc) BackgroundModel {
+func NewTypedBackgroundModel[Config any](name string, opts *BackgroundModelOptions, startFn TypedStartModelOpFunc[Config], checkFn CheckModelOpFunc) BackgroundModel {
 	if name == "" {
-		panic("ai.NewBackgroundModelWithConfig: name is required")
+		panic("ai.NewTypedBackgroundModel: name is required")
 	}
 	if startFn == nil {
-		panic("ai.NewBackgroundModelWithConfig: startFn is required")
+		panic("ai.NewTypedBackgroundModel: startFn is required")
 	}
 	if checkFn == nil {
-		panic("ai.NewBackgroundModelWithConfig: checkFn is required")
+		panic("ai.NewTypedBackgroundModel: checkFn is required")
 	}
 
 	if opts == nil {
@@ -194,21 +194,21 @@ func NewBackgroundModelWithConfig[Config any](name string, opts *BackgroundModel
 
 // NewBackgroundModel defines a new model that runs in the background.
 //
-// Deprecated: Use [NewBackgroundModelWithConfig], which passes the request's
+// Deprecated: Use [NewTypedBackgroundModel], which passes the request's
 // config to startFn as a typed value instead of leaving it type-erased on the
 // request.
 func NewBackgroundModel(name string, opts *BackgroundModelOptions, startFn StartModelOpFunc, checkFn CheckModelOpFunc) BackgroundModel {
 	if startFn == nil {
 		panic("ai.NewBackgroundModel: startFn is required")
 	}
-	return NewBackgroundModelWithConfig(name, opts, func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
+	return NewTypedBackgroundModel(name, opts, func(ctx context.Context, req *ModelRequest, _ any) (*ModelOperation, error) {
 		return startFn(ctx, req)
 	}, checkFn)
 }
 
 // DefineBackgroundModel defines and registers a new model that runs in the background.
 //
-// Deprecated: Use [NewBackgroundModelWithConfig] and register the result with
+// Deprecated: Use [NewTypedBackgroundModel] and register the result with
 // [BackgroundModel.Register].
 func DefineBackgroundModel(r *registry.Registry, name string, opts *BackgroundModelOptions, fn StartModelOpFunc, checkFn CheckModelOpFunc) BackgroundModel {
 	m := NewBackgroundModel(name, opts, fn, checkFn)

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -18,6 +18,7 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	"github.com/firebase/genkit/go/core"
@@ -26,7 +27,10 @@ import (
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
-// BackgroundModel represents a model that can run operations in the background.
+// BackgroundModel represents a model that can run operations in the
+// background. It is the type to accept as an argument and to look up by name;
+// implementations are created with [NewBackgroundModelAction], or
+// [genkit.DefineBackgroundModelAction] in an application.
 type BackgroundModel interface {
 	// Name returns the registry name of the background model.
 	Name() string
@@ -44,27 +48,75 @@ type BackgroundModel interface {
 
 // backgroundAction is an unexported alias of [core.BackgroundAction] used as
 // the embedded field in [BackgroundModelAction]; see the action alias in
-// generate.go for why.
+// generate.go for why, including why the promoted methods are redeclared
+// below.
 type backgroundAction[In, Out any] = core.BackgroundAction[In, Out]
 
 // BackgroundModelAction is a background model backed by registry actions. It
 // is the concrete type returned by [NewBackgroundModelAction]; return it from
 // a plugin's Init for the framework to register.
+//
+// It implements [BackgroundModel] and [api.Action], so it can be passed
+// anywhere either is accepted. The [api.Action] side is what lets a plugin
+// resolver return the whole model as the resolved action (googlegenai's
+// resolveAction does this), and the three component actions register
+// together through [BackgroundModelAction.Register].
 type BackgroundModelAction struct {
 	backgroundAction[*ModelRequest, *ModelResponse]
 }
 
-// BackgroundModelAction is a full registry action and can be passed anywhere
-// an [api.Action] is accepted as well as anywhere a [BackgroundModel] is
-// accepted. Its Register method registers the start, check, and cancel
-// actions together. Plugin resolvers rely on the [api.Action] side (e.g.
-// googlegenai's resolveAction returns the whole model as the resolved
-// action), which only holds through the embedded action's promoted methods,
-// so pin both here where the embedding lives.
+// Pinned here so that breaking either interface fails the build at the type
+// rather than during plugin resolution.
 var (
 	_ api.Action      = (*BackgroundModelAction)(nil)
 	_ BackgroundModel = (*BackgroundModelAction)(nil)
 )
+
+// Name returns the registry name of the background model.
+func (b *BackgroundModelAction) Name() string { return b.backgroundAction.Name() }
+
+// Register registers the model's start, check, and cancel actions with r. The
+// cancel action is registered only if the model supports cancellation. A
+// plugin that returns the model from its Init does not need to call this.
+func (b *BackgroundModelAction) Register(r api.Registry) { b.backgroundAction.Register(r) }
+
+// Desc returns the start action's descriptor: its name, schemas, and metadata.
+func (b *BackgroundModelAction) Desc() api.ActionDesc { return b.backgroundAction.Desc() }
+
+// Start starts a background operation and returns it without waiting for
+// completion. Poll it with [BackgroundModelAction.Check].
+func (b *BackgroundModelAction) Start(ctx context.Context, req *ModelRequest) (*ModelOperation, error) {
+	return b.backgroundAction.Start(ctx, req)
+}
+
+// Check returns the current state of a background operation.
+func (b *BackgroundModelAction) Check(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
+	return b.backgroundAction.Check(ctx, op)
+}
+
+// Cancel cancels a running background operation. It fails with UNAVAILABLE if
+// the model does not support cancellation; see
+// [BackgroundModelAction.SupportsCancel].
+func (b *BackgroundModelAction) Cancel(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
+	return b.backgroundAction.Cancel(ctx, op)
+}
+
+// SupportsCancel reports whether the model was defined with a cancel
+// function.
+func (b *BackgroundModelAction) SupportsCancel() bool { return b.backgroundAction.SupportsCancel() }
+
+// RunJSON starts an operation from a JSON-encoded [ModelRequest] and returns
+// the JSON-encoded operation. The framework uses it to serve reflection and
+// registry-driven calls; prefer [BackgroundModelAction.Start].
+func (b *BackgroundModelAction) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	return b.backgroundAction.RunJSON(ctx, input, cb)
+}
+
+// RunJSONWithTelemetry is [BackgroundModelAction.RunJSON] with the run's
+// telemetry returned alongside the output.
+func (b *BackgroundModelAction) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	return b.backgroundAction.RunJSONWithTelemetry(ctx, input, cb)
+}
 
 // ModelOperation is a background operation for a model.
 type ModelOperation = core.Operation[*ModelResponse]

--- a/go/ai/background_model.go
+++ b/go/ai/background_model.go
@@ -86,11 +86,17 @@ func (b *BackgroundModelAction) Desc() api.ActionDesc { return b.backgroundActio
 // Start starts a background operation and returns it without waiting for
 // completion. Poll it with [BackgroundModelAction.Check].
 func (b *BackgroundModelAction) Start(ctx context.Context, req *ModelRequest) (*ModelOperation, error) {
+	if b == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "BackgroundModel.Start: start called on a nil background model; check that all background models are defined")
+	}
 	return b.backgroundAction.Start(ctx, req)
 }
 
 // Check returns the current state of a background operation.
 func (b *BackgroundModelAction) Check(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
+	if b == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "BackgroundModel.Check: check called on a nil background model; check that all background models are defined")
+	}
 	return b.backgroundAction.Check(ctx, op)
 }
 
@@ -98,6 +104,9 @@ func (b *BackgroundModelAction) Check(ctx context.Context, op *ModelOperation) (
 // the model does not support cancellation; see
 // [BackgroundModelAction.SupportsCancel].
 func (b *BackgroundModelAction) Cancel(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
+	if b == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "BackgroundModel.Cancel: cancel called on a nil background model; check that all background models are defined")
+	}
 	return b.backgroundAction.Cancel(ctx, op)
 }
 
@@ -109,12 +118,18 @@ func (b *BackgroundModelAction) SupportsCancel() bool { return b.backgroundActio
 // the JSON-encoded operation. The framework uses it to serve reflection and
 // registry-driven calls; prefer [BackgroundModelAction.Start].
 func (b *BackgroundModelAction) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	if b == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "BackgroundModel.RunJSON: model called on a nil background model; check that all background models are defined")
+	}
 	return b.backgroundAction.RunJSON(ctx, input, cb)
 }
 
 // RunJSONWithTelemetry is [BackgroundModelAction.RunJSON] with the run's
 // telemetry returned alongside the output.
 func (b *BackgroundModelAction) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	if b == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "BackgroundModel.RunJSONWithTelemetry: model called on a nil background model; check that all background models are defined")
+	}
 	return b.backgroundAction.RunJSONWithTelemetry(ctx, input, cb)
 }
 

--- a/go/ai/background_model_test.go
+++ b/go/ai/background_model_test.go
@@ -57,9 +57,19 @@ func TestNewBackgroundModelInputSchema(t *testing.T) {
 		if !ok {
 			t.Fatalf("input schema has no config property: %v", props)
 		}
-		configProps, ok := config["properties"].(map[string]any)
+		// The config slot is advertised as the schema or an explicit null so
+		// that a typed-nil config passes input validation.
+		anyOf, ok := config["anyOf"].([]any)
+		if !ok || len(anyOf) != 2 {
+			t.Fatalf("config property is not null-tolerant: %v", config)
+		}
+		schema, ok := anyOf[0].(map[string]any)
 		if !ok {
-			t.Fatalf("config property is not the supplied schema: %v", config)
+			t.Fatalf("config property is not the supplied schema: %v", anyOf[0])
+		}
+		configProps, ok := schema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("config property is not the supplied schema: %v", schema)
 		}
 		if configProps["temperature"] == nil {
 			t.Errorf("config schema was not carried through, got %v", configProps)

--- a/go/ai/config.go
+++ b/go/ai/config.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/internal/base"
+)
+
+// This file holds the typed-config plumbing shared by models, embedders, and
+// evaluators. Requests carry config as `any` on the wire; the
+// Define*/New*WithConfig constructors wrap the user's typed function so that
+// the raw value is deserialized into the Config type parameter before the
+// function runs, and the request's type-erased config slot is normalized to
+// that same converted value so the two views never disagree.
+
+// nullableConfigSchema wraps a config schema for the request input-schema
+// slot so that an explicit JSON null is accepted on the wire: a typed-nil Go
+// config marshals to null and resolves to the zero Config value, so it must
+// not be rejected by input validation. The advertised config schema (the
+// customOptions metadata) stays unwrapped.
+func nullableConfigSchema(schema map[string]any) map[string]any {
+	if schema == nil {
+		return nil
+	}
+	return map[string]any{"anyOf": []any{schema, map[string]any{"type": "null"}}}
+}
+
+// normalizeConfig returns a model middleware that resolves the request's raw
+// config into Config and writes the converted value back into the request.
+// It runs as the outermost step of a model's built-in chain so that every
+// wrapper after it, and the model function itself, sees the typed value; by
+// then the config has already been validated against the model's config
+// schema at the action boundary.
+//
+// Version validation runs here, against the raw config, because conversion is
+// lossy: a "version" key sent by a JSON caller would be silently dropped when
+// deserializing into a Config type that has no such field.
+func normalizeConfig[Config any](model string, versions []string) ModelMiddleware {
+	return func(next ModelFunc) ModelFunc {
+		return func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			if err := validateVersion(model, versions, req.Config); err != nil {
+				return nil, err
+			}
+			cfg, err := resolveConfig[Config](req.Config)
+			if err != nil {
+				return nil, err
+			}
+			req.Config = cfg
+			return next(ctx, req, cb)
+		}
+	}
+}
+
+// actionConfigSchemas returns the action's effective config schema (the
+// explicit override when set, otherwise the schema inferred from Config) and
+// the request input schema with its config slot replaced by the null-tolerant
+// wrapping of that schema. reqZero is the zero request value to infer the
+// input schema from and key is the config slot's wire name ("config" for
+// models, "options" for embedders and evaluators).
+func actionConfigSchemas[Config any](override map[string]any, reqZero any, key string) (configSchema, inputSchema map[string]any) {
+	configSchema = override
+	if configSchema == nil {
+		configSchema = base.SchemaMapFor[Config]()
+	}
+	return configSchema, requestInputSchema(reqZero, key, nullableConfigSchema(configSchema))
+}
+
+// resolveConfig converts the raw config value carried by a request into the
+// typed Config the action was defined with. It accepts the exact Config type
+// (or a pointer to it, which is dereferenced), a map[string]any (as sent by
+// the Dev UI and other JSON callers, deserialized via a JSON round-trip), or
+// nil (yielding the zero value). Any other type is rejected so one provider's
+// config cannot be silently passed to another provider's action.
+func resolveConfig[Config any](raw any) (Config, error) {
+	cfg, err := base.ConvertToExact[Config](raw)
+	if err != nil {
+		if errors.Is(err, base.ErrTypeMismatch) {
+			return cfg, core.NewPublicError(core.INVALID_ARGUMENT, fmt.Sprintf("invalid config type %T, want %T or map[string]any", raw, cfg), nil)
+		}
+		return cfg, core.NewPublicError(core.INVALID_ARGUMENT, fmt.Sprintf("invalid config for %T; check that field names and value types match: %v", cfg, err), nil)
+	}
+	return cfg, nil
+}

--- a/go/ai/config.go
+++ b/go/ai/config.go
@@ -27,7 +27,7 @@ import (
 
 // This file holds the typed-config plumbing shared by models, embedders, and
 // evaluators. Requests carry config as `any` on the wire; the
-// NewTyped* constructors wrap the user's typed function so that
+// New*Action constructors wrap the user's typed function so that
 // the raw value is deserialized into the Config type parameter before the
 // function runs, and the request's type-erased config slot is normalized to
 // that same converted value so the two views never disagree.

--- a/go/ai/config.go
+++ b/go/ai/config.go
@@ -27,7 +27,7 @@ import (
 
 // This file holds the typed-config plumbing shared by models, embedders, and
 // evaluators. Requests carry config as `any` on the wire; the
-// Define*/New*WithConfig constructors wrap the user's typed function so that
+// NewTyped* constructors wrap the user's typed function so that
 // the raw value is deserialized into the Config type parameter before the
 // function runs, and the request's type-erased config slot is normalized to
 // that same converted value so the two views never disagree.

--- a/go/ai/config.go
+++ b/go/ai/config.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/internal/base"
@@ -45,11 +46,14 @@ func nullableConfigSchema(schema map[string]any) map[string]any {
 }
 
 // normalizeConfig returns a model middleware that resolves the request's raw
-// config into Config and writes the converted value back into the request.
-// It runs as the outermost step of a model's built-in chain so that every
-// wrapper after it, and the model function itself, sees the typed value; by
-// then the config has already been validated against the model's config
-// schema at the action boundary.
+// config into Config and passes the request on with its config slot
+// normalized to the converted value. It runs as the outermost step of a
+// model's built-in chain so that every wrapper after it, and the model
+// function itself, sees the typed value; by then the config has already been
+// validated against the model's config schema at the action boundary. The
+// normalization happens on a shallow copy: the incoming request is
+// caller-owned memory that may be reused across actions or turns, so it must
+// keep carrying the raw config.
 //
 // Version validation runs here, against the raw config, because conversion is
 // lossy: a "version" key sent by a JSON caller would be silently dropped when
@@ -60,28 +64,91 @@ func normalizeConfig[Config any](model string, versions []string) ModelMiddlewar
 			if err := validateVersion(model, versions, req.Config); err != nil {
 				return nil, err
 			}
-			cfg, err := resolveConfig[Config](req.Config)
-			if err != nil {
+			reqCopy := *req
+			req = &reqCopy
+			if _, err := resolveConfigInto[Config](&req.Config); err != nil {
 				return nil, err
 			}
-			req.Config = cfg
 			return next(ctx, req, cb)
 		}
 	}
 }
 
-// actionConfigSchemas returns the action's effective config schema (the
-// explicit override when set, otherwise the schema inferred from Config) and
-// the request input schema with its config slot replaced by the null-tolerant
-// wrapping of that schema. reqZero is the zero request value to infer the
-// input schema from and key is the config slot's wire name ("config" for
-// models, "options" for embedders and evaluators).
+// actionConfigSchemas returns the action's effective config schema (see
+// effectiveConfigSchema) and the request input schema with its config slot
+// replaced by the null-tolerant wrapping of that schema. reqZero is the zero
+// request value to infer the input schema from and key is the config slot's
+// wire name ("options" for embedders, retrievers, and evaluators; models go
+// through [modelConfigSchemas]).
 func actionConfigSchemas[Config any](override map[string]any, reqZero any, key string) (configSchema, inputSchema map[string]any) {
-	configSchema = override
-	if configSchema == nil {
-		configSchema = base.SchemaMapFor[Config]()
-	}
+	configSchema = effectiveConfigSchema[Config](override)
 	return configSchema, requestInputSchema(reqZero, key, nullableConfigSchema(configSchema))
+}
+
+// modelConfigSchemas is [actionConfigSchemas] for the model config slot. It
+// additionally keeps the framework-level "version" key admissible: callers
+// pin a model version through the config, validateVersion consumes the key on
+// the raw value, and conversion drops it, so the schema must not reject it.
+// The property is added to the advertised schema as well, which is honest:
+// the key is accepted on the wire.
+func modelConfigSchemas[Config any](override map[string]any) (configSchema, inputSchema map[string]any) {
+	configSchema = withVersionProperty(effectiveConfigSchema[Config](override))
+	return configSchema, requestInputSchema(ModelRequest{}, "config", nullableConfigSchema(configSchema))
+}
+
+// effectiveConfigSchema returns the explicit override when set, otherwise the
+// schema inferred from Config. Inferred schemas have their "required" lists
+// stripped: a config is partial by nature (callers set only the fields they
+// want to override), so a struct field lacking omitempty must not become a
+// mandatory config key. An explicit override is the caller's contract and
+// passes through untouched.
+func effectiveConfigSchema[Config any](override map[string]any) map[string]any {
+	if override != nil {
+		return override
+	}
+	schema := base.SchemaMapFor[Config]()
+	stripRequired(schema)
+	return schema
+}
+
+// stripRequired removes "required" lists from schema and its nested object
+// schemas (properties, items, and schema-valued additionalProperties).
+func stripRequired(schema map[string]any) {
+	if schema == nil {
+		return
+	}
+	delete(schema, "required")
+	if props, ok := schema["properties"].(map[string]any); ok {
+		for _, sub := range props {
+			if m, ok := sub.(map[string]any); ok {
+				stripRequired(m)
+			}
+		}
+	}
+	if items, ok := schema["items"].(map[string]any); ok {
+		stripRequired(items)
+	}
+	if extra, ok := schema["additionalProperties"].(map[string]any); ok {
+		stripRequired(extra)
+	}
+}
+
+// withVersionProperty returns schema with a string "version" property added
+// unless one is already declared or the schema constrains no properties. The
+// maps are cloned before modification since an override is caller-owned.
+func withVersionProperty(schema map[string]any) map[string]any {
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return schema
+	}
+	if _, ok := props["version"]; ok {
+		return schema
+	}
+	schema = maps.Clone(schema)
+	props = maps.Clone(props)
+	props["version"] = map[string]any{"type": "string"}
+	schema["properties"] = props
+	return schema
 }
 
 // resolveConfig converts the raw config value carried by a request into the
@@ -97,6 +164,24 @@ func resolveConfig[Config any](raw any) (Config, error) {
 			return cfg, core.NewPublicError(core.INVALID_ARGUMENT, fmt.Sprintf("invalid config type %T, want %T or map[string]any", raw, cfg), nil)
 		}
 		return cfg, core.NewPublicError(core.INVALID_ARGUMENT, fmt.Sprintf("invalid config for %T; check that field names and value types match: %v", cfg, err), nil)
+	}
+	return cfg, nil
+}
+
+// resolveConfigInto resolves the type-erased config slot at *slot into the
+// typed Config (see [resolveConfig]) and normalizes the slot to the converted
+// value so the request's two views of the config never disagree. The slot is
+// left untouched when the resolved value is a nil pointer, map, or slice:
+// boxing a typed nil would make the slot compare non-nil for a request that
+// carried no config, flipping every `== nil` default check downstream while
+// dereferences still panic.
+func resolveConfigInto[Config any](slot *any) (Config, error) {
+	cfg, err := resolveConfig[Config](*slot)
+	if err != nil {
+		return cfg, err
+	}
+	if !base.IsNil(cfg) {
+		*slot = cfg
 	}
 	return cfg, nil
 }

--- a/go/ai/config.go
+++ b/go/ai/config.go
@@ -101,7 +101,8 @@ func modelConfigSchemas[Config any](override map[string]any) (configSchema, inpu
 // stripped: a config is partial by nature (callers set only the fields they
 // want to override), so a struct field lacking omitempty must not become a
 // mandatory config key. An explicit override is the caller's contract and
-// passes through untouched.
+// passes through untouched, which is also what keeps the in-place strip safe:
+// it only ever reaches the fresh map [base.SchemaMapFor] allocates per call.
 func effectiveConfigSchema[Config any](override map[string]any) map[string]any {
 	if override != nil {
 		return override

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
@@ -113,6 +114,34 @@ func TestModelConfigNormalizedBeforeBuiltins(t *testing.T) {
 	_, err := m.Generate(context.Background(), req, nil)
 	if err == nil || !strings.Contains(err.Error(), "invalid config type") {
 		t.Fatalf("Generate() error = %v, want config type error before media support error", err)
+	}
+}
+
+func TestTypedBackgroundModelMetadata(t *testing.T) {
+	bm := NewTypedBackgroundModel("test/bg-metadata",
+		&TypedBackgroundModelOptions{
+			Metadata: map[string]any{
+				"custom": "value",
+				"model":  "caller values must not clobber the reserved keys",
+			},
+		},
+		func(ctx context.Context, req *ModelRequest, cfg testTypedConfig) (*ModelOperation, error) {
+			return &ModelOperation{ID: "op1"}, nil
+		},
+		func(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
+			return op, nil
+		},
+		nil)
+
+	metadata := bm.Desc().Metadata
+	if got := metadata["custom"]; got != "value" {
+		t.Errorf(`Metadata["custom"] = %v, want "value"`, got)
+	}
+	if got := metadata["type"]; got != api.ActionTypeBackgroundModel {
+		t.Errorf(`Metadata["type"] = %v, want %v`, got, api.ActionTypeBackgroundModel)
+	}
+	if _, ok := metadata["model"].(map[string]any); !ok {
+		t.Errorf(`Metadata["model"] = %v, want the built model info map`, metadata["model"])
 	}
 }
 

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // testTypedConfig is a provider-style config struct used to exercise the
-// typed-config deserialization that NewTyped* constructors wrap around user
+// typed-config deserialization that New*Action constructors wrap around user
 // functions.
 type testTypedConfig struct {
 	Temperature float64 `json:"temperature,omitempty"`
@@ -46,7 +46,7 @@ func TestModelTypedConfig(t *testing.T) {
 
 	var got testTypedConfig
 	var gotReqConfig any
-	m := NewTypedModel("test/typed-config", nil, func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
+	m := NewModelAction("test/typed-config", nil, func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
 		got = cfg
 		gotReqConfig = req.Config
 		return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
@@ -100,7 +100,7 @@ func TestModelTypedConfig(t *testing.T) {
 func TestModelConfigNormalizedBeforeBuiltins(t *testing.T) {
 	r := registry.New()
 
-	m := NewTypedModel("test/config-order", &ModelOptions{
+	m := NewModelAction("test/config-order", &ModelOptions{
 		Supports: &ModelSupports{Multiturn: true}, // no media support
 	}, func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
 		return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
@@ -117,8 +117,8 @@ func TestModelConfigNormalizedBeforeBuiltins(t *testing.T) {
 	}
 }
 
-func TestTypedModelMetadata(t *testing.T) {
-	m := NewTypedModel("test/model-metadata",
+func TestModelActionMetadata(t *testing.T) {
+	m := NewModelAction("test/model-metadata",
 		&ModelOptions{
 			Metadata: map[string]any{
 				"custom": "value",
@@ -141,8 +141,8 @@ func TestTypedModelMetadata(t *testing.T) {
 	}
 }
 
-func TestTypedEmbedderMetadata(t *testing.T) {
-	e := NewTypedEmbedder("test/embedder-metadata",
+func TestEmbedderActionMetadata(t *testing.T) {
+	e := NewEmbedderAction("test/embedder-metadata",
 		&EmbedderOptions{
 			Metadata: map[string]any{
 				"custom": "value",
@@ -165,8 +165,8 @@ func TestTypedEmbedderMetadata(t *testing.T) {
 	}
 }
 
-func TestTypedEvaluatorMetadata(t *testing.T) {
-	e := NewTypedEvaluator("test/evaluator-metadata",
+func TestEvaluatorActionMetadata(t *testing.T) {
+	e := NewEvaluatorAction("test/evaluator-metadata",
 		&EvaluatorOptions{
 			Metadata: map[string]any{
 				"custom":    "value",
@@ -189,8 +189,8 @@ func TestTypedEvaluatorMetadata(t *testing.T) {
 	}
 }
 
-func TestTypedBackgroundModelMetadata(t *testing.T) {
-	bm := NewTypedBackgroundModel("test/bg-metadata",
+func TestBackgroundModelActionMetadata(t *testing.T) {
+	bm := NewBackgroundModelAction("test/bg-metadata",
 		&TypedBackgroundModelOptions{
 			Metadata: map[string]any{
 				"custom": "value",
@@ -219,7 +219,7 @@ func TestTypedBackgroundModelMetadata(t *testing.T) {
 func TestBackgroundModelConfigValidation(t *testing.T) {
 	r := registry.New()
 
-	bm := NewTypedBackgroundModel("test/bg-typed-config", nil,
+	bm := NewBackgroundModelAction("test/bg-typed-config", nil,
 		func(ctx context.Context, req *ModelRequest, cfg testTypedConfig) (*ModelOperation, error) {
 			return &ModelOperation{ID: "op1", Done: false}, nil
 		},
@@ -249,7 +249,7 @@ func TestBackgroundModelConfigValidation(t *testing.T) {
 }
 
 func TestModelConfigSchemaInference(t *testing.T) {
-	newFn := func() TypedModelFunc[testTypedConfig] {
+	newFn := func() ModelActionFunc[testTypedConfig] {
 		return func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
 			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
 		}
@@ -266,7 +266,7 @@ func TestModelConfigSchemaInference(t *testing.T) {
 	}
 
 	t.Run("inferred from Config type", func(t *testing.T) {
-		m := NewTypedModel("test/inferred-schema", nil, newFn())
+		m := NewModelAction("test/inferred-schema", nil, newFn())
 		schema, ok := configSchemaOf(t, m).(map[string]any)
 		if !ok {
 			t.Fatalf("customOptions = %v, want inferred schema map", configSchemaOf(t, m))
@@ -282,7 +282,7 @@ func TestModelConfigSchemaInference(t *testing.T) {
 
 	t.Run("explicit ConfigSchema wins", func(t *testing.T) {
 		override := map[string]any{"type": "object", "properties": map[string]any{"custom": map[string]any{"type": "string"}}}
-		m := NewTypedModel("test/override-schema", &ModelOptions{ConfigSchema: override}, newFn())
+		m := NewModelAction("test/override-schema", &ModelOptions{ConfigSchema: override}, newFn())
 		schema, ok := configSchemaOf(t, m).(map[string]any)
 		if !ok {
 			t.Fatalf("customOptions missing")
@@ -294,7 +294,7 @@ func TestModelConfigSchemaInference(t *testing.T) {
 	})
 
 	t.Run("any config infers no schema", func(t *testing.T) {
-		m := NewTypedModel("test/any-schema", nil, func(ctx context.Context, req *ModelRequest, cfg any, cb ModelStreamCallback) (*ModelResponse, error) {
+		m := NewModelAction("test/any-schema", nil, func(ctx context.Context, req *ModelRequest, cfg any, cb ModelStreamCallback) (*ModelResponse, error) {
 			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
 		})
 		if s, _ := configSchemaOf(t, m).(map[string]any); len(s) != 0 {
@@ -342,7 +342,7 @@ func TestEmbedderTypedConfig(t *testing.T) {
 
 	var got testTypedConfig
 	var gotReqOptions any
-	e := NewTypedEmbedder("test/typed-config-embedder", nil, func(ctx context.Context, req *EmbedRequest, cfg testTypedConfig) (*EmbedResponse, error) {
+	e := NewEmbedderAction("test/typed-config-embedder", nil, func(ctx context.Context, req *EmbedRequest, cfg testTypedConfig) (*EmbedResponse, error) {
 		got = cfg
 		gotReqOptions = req.Options
 		return &EmbedResponse{}, nil
@@ -370,7 +370,7 @@ func TestEvaluatorTypedConfig(t *testing.T) {
 	r := registry.New()
 
 	var got testTypedConfig
-	e := NewTypedEvaluator("test/typed-config-evaluator", nil, func(ctx context.Context, req *EvaluatorCallbackRequest, cfg testTypedConfig) (*EvaluatorCallbackResponse, error) {
+	e := NewEvaluatorAction("test/typed-config-evaluator", nil, func(ctx context.Context, req *EvaluatorCallbackRequest, cfg testTypedConfig) (*EvaluatorCallbackResponse, error) {
 		got = cfg
 		return &EvaluatorCallbackResponse{
 			TestCaseId: req.Input.TestCaseId,
@@ -392,7 +392,7 @@ func TestEvaluatorTypedConfig(t *testing.T) {
 	}
 
 	var gotBatch testTypedConfig
-	be := NewTypedBatchEvaluator("test/typed-config-batch-evaluator", nil, func(ctx context.Context, req *EvaluatorRequest, cfg testTypedConfig) (*EvaluatorResponse, error) {
+	be := NewBatchEvaluatorAction("test/typed-config-batch-evaluator", nil, func(ctx context.Context, req *EvaluatorRequest, cfg testTypedConfig) (*EvaluatorResponse, error) {
 		gotBatch = cfg
 		return &EvaluatorResponse{}, nil
 	})
@@ -415,7 +415,7 @@ func TestRetrieverTypedConfig(t *testing.T) {
 
 	var got testTypedConfig
 	var gotReqOptions any
-	ret := NewTypedRetriever("test/typed-config-retriever", nil, func(ctx context.Context, req *RetrieverRequest, cfg testTypedConfig) (*RetrieverResponse, error) {
+	ret := NewRetrieverAction("test/typed-config-retriever", nil, func(ctx context.Context, req *RetrieverRequest, cfg testTypedConfig) (*RetrieverResponse, error) {
 		got = cfg
 		gotReqOptions = req.Options
 		return &RetrieverResponse{}, nil
@@ -440,7 +440,7 @@ func TestRetrieverTypedConfig(t *testing.T) {
 }
 
 func TestRetrieverConfigSchemaInference(t *testing.T) {
-	ret := NewTypedRetriever("test/inferred-retriever", nil, func(ctx context.Context, req *RetrieverRequest, cfg testTypedConfig) (*RetrieverResponse, error) {
+	ret := NewRetrieverAction("test/inferred-retriever", nil, func(ctx context.Context, req *RetrieverRequest, cfg testTypedConfig) (*RetrieverResponse, error) {
 		return &RetrieverResponse{}, nil
 	})
 
@@ -458,8 +458,8 @@ func TestRetrieverConfigSchemaInference(t *testing.T) {
 	}
 }
 
-func TestTypedRetrieverMetadata(t *testing.T) {
-	ret := NewTypedRetriever("test/retriever-metadata",
+func TestRetrieverActionMetadata(t *testing.T) {
+	ret := NewRetrieverAction("test/retriever-metadata",
 		&RetrieverOptions{
 			Metadata: map[string]any{
 				"custom":    "value",

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -117,6 +117,78 @@ func TestModelConfigNormalizedBeforeBuiltins(t *testing.T) {
 	}
 }
 
+func TestTypedModelMetadata(t *testing.T) {
+	m := NewTypedModel("test/model-metadata",
+		&ModelOptions{
+			Metadata: map[string]any{
+				"custom": "value",
+				"model":  "caller values must not clobber the reserved keys",
+			},
+		},
+		func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
+			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+		})
+
+	metadata := m.Desc().Metadata
+	if got := metadata["custom"]; got != "value" {
+		t.Errorf(`Metadata["custom"] = %v, want "value"`, got)
+	}
+	if got := metadata["type"]; got != api.ActionTypeModel {
+		t.Errorf(`Metadata["type"] = %v, want %v`, got, api.ActionTypeModel)
+	}
+	if _, ok := metadata["model"].(map[string]any); !ok {
+		t.Errorf(`Metadata["model"] = %v, want the built model info map`, metadata["model"])
+	}
+}
+
+func TestTypedEmbedderMetadata(t *testing.T) {
+	e := NewTypedEmbedder("test/embedder-metadata",
+		&EmbedderOptions{
+			Metadata: map[string]any{
+				"custom": "value",
+				"info":   "caller values must not clobber the reserved keys",
+			},
+		},
+		func(ctx context.Context, req *EmbedRequest, cfg testTypedConfig) (*EmbedResponse, error) {
+			return &EmbedResponse{}, nil
+		})
+
+	metadata := e.Desc().Metadata
+	if got := metadata["custom"]; got != "value" {
+		t.Errorf(`Metadata["custom"] = %v, want "value"`, got)
+	}
+	if got := metadata["type"]; got != api.ActionTypeEmbedder {
+		t.Errorf(`Metadata["type"] = %v, want %v`, got, api.ActionTypeEmbedder)
+	}
+	if _, ok := metadata["info"].(map[string]any); !ok {
+		t.Errorf(`Metadata["info"] = %v, want the built embedder info map`, metadata["info"])
+	}
+}
+
+func TestTypedEvaluatorMetadata(t *testing.T) {
+	e := NewTypedEvaluator("test/evaluator-metadata",
+		&EvaluatorOptions{
+			Metadata: map[string]any{
+				"custom":    "value",
+				"evaluator": "caller values must not clobber the reserved keys",
+			},
+		},
+		func(ctx context.Context, req *EvaluatorCallbackRequest, cfg testTypedConfig) (*EvaluatorCallbackResponse, error) {
+			return &EvaluatorCallbackResponse{}, nil
+		})
+
+	metadata := e.Desc().Metadata
+	if got := metadata["custom"]; got != "value" {
+		t.Errorf(`Metadata["custom"] = %v, want "value"`, got)
+	}
+	if got := metadata["type"]; got != api.ActionTypeEvaluator {
+		t.Errorf(`Metadata["type"] = %v, want %v`, got, api.ActionTypeEvaluator)
+	}
+	if _, ok := metadata["evaluator"].(map[string]any); !ok {
+		t.Errorf(`Metadata["evaluator"] = %v, want the built evaluator info map`, metadata["evaluator"])
+	}
+}
+
 func TestTypedBackgroundModelMetadata(t *testing.T) {
 	bm := NewTypedBackgroundModel("test/bg-metadata",
 		&TypedBackgroundModelOptions{

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -409,3 +409,75 @@ func TestEvaluatorTypedConfig(t *testing.T) {
 		t.Errorf("config = %+v, want Temperature 0.8", gotBatch)
 	}
 }
+
+func TestRetrieverTypedConfig(t *testing.T) {
+	r := registry.New()
+
+	var got testTypedConfig
+	var gotReqOptions any
+	ret := NewTypedRetriever("test/typed-config-retriever", nil, func(ctx context.Context, req *RetrieverRequest, cfg testTypedConfig) (*RetrieverResponse, error) {
+		got = cfg
+		gotReqOptions = req.Options
+		return &RetrieverResponse{}, nil
+	})
+	ret.Register(r)
+
+	req := &RetrieverRequest{Query: DocumentFromText("q", nil), Options: map[string]any{"maxTokens": 7}}
+	if _, err := ret.Retrieve(context.Background(), req); err != nil {
+		t.Fatalf("Retrieve() unexpected error: %v", err)
+	}
+	if got.MaxTokens != 7 {
+		t.Errorf("config = %+v, want MaxTokens 7", got)
+	}
+	if gotReqOptions != any(got) {
+		t.Errorf("req.Options = %#v, want normalized to %#v", gotReqOptions, got)
+	}
+
+	req = &RetrieverRequest{Query: DocumentFromText("q", nil), Options: otherProviderConfig{Temperature: 0.1}}
+	if _, err := ret.Retrieve(context.Background(), req); err == nil || !strings.Contains(err.Error(), "invalid config type") {
+		t.Fatalf("Retrieve() error = %v, want invalid config type error", err)
+	}
+}
+
+func TestRetrieverConfigSchemaInference(t *testing.T) {
+	ret := NewTypedRetriever("test/inferred-retriever", nil, func(ctx context.Context, req *RetrieverRequest, cfg testTypedConfig) (*RetrieverResponse, error) {
+		return &RetrieverResponse{}, nil
+	})
+
+	md, ok := ret.Desc().Metadata["retriever"].(map[string]any)
+	if !ok {
+		t.Fatalf("retriever metadata missing: %v", ret.Desc().Metadata)
+	}
+	schema, ok := md["customOptions"].(map[string]any)
+	if !ok {
+		t.Fatalf("customOptions is not an inferred schema: %v", md["customOptions"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok || props["temperature"] == nil || props["maxTokens"] == nil {
+		t.Errorf("inferred config schema = %v, want temperature and maxTokens", schema)
+	}
+}
+
+func TestTypedRetrieverMetadata(t *testing.T) {
+	ret := NewTypedRetriever("test/retriever-metadata",
+		&RetrieverOptions{
+			Metadata: map[string]any{
+				"custom":    "value",
+				"retriever": "caller values must not clobber the reserved keys",
+			},
+		},
+		func(ctx context.Context, req *RetrieverRequest, cfg testTypedConfig) (*RetrieverResponse, error) {
+			return &RetrieverResponse{}, nil
+		})
+
+	metadata := ret.Desc().Metadata
+	if got := metadata["custom"]; got != "value" {
+		t.Errorf(`Metadata["custom"] = %v, want "value"`, got)
+	}
+	if got := metadata["type"]; got != api.ActionTypeRetriever {
+		t.Errorf(`Metadata["type"] = %v, want %v`, got, api.ActionTypeRetriever)
+	}
+	if _, ok := metadata["retriever"].(map[string]any); !ok {
+		t.Errorf(`Metadata["retriever"] = %v, want the built retriever info map`, metadata["retriever"])
+	}
+}

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -202,8 +202,7 @@ func TestTypedBackgroundModelMetadata(t *testing.T) {
 		},
 		func(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
 			return op, nil
-		},
-		nil)
+		})
 
 	metadata := bm.Desc().Metadata
 	if got := metadata["custom"]; got != "value" {
@@ -226,8 +225,7 @@ func TestBackgroundModelConfigValidation(t *testing.T) {
 		},
 		func(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
 			return op, nil
-		},
-		nil)
+		})
 	bm.Register(r)
 
 	// A config that violates the inferred schema is rejected by input

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -1,0 +1,312 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/core/api"
+	"github.com/firebase/genkit/go/internal/registry"
+)
+
+// testTypedConfig is a provider-style config struct used to exercise the
+// typed-config deserialization that New*WithConfig wraps around user
+// functions.
+type testTypedConfig struct {
+	Temperature float64 `json:"temperature,omitempty"`
+	MaxTokens   int     `json:"maxTokens,omitempty"`
+}
+
+// otherProviderConfig stands in for a different provider's config type. Its
+// JSON shape is compatible with testTypedConfig so that requests carrying it
+// pass the action's input schema validation and rejection happens on the Go
+// type itself.
+type otherProviderConfig struct {
+	Temperature float64 `json:"temperature,omitempty"`
+}
+
+func TestModelTypedConfig(t *testing.T) {
+	r := registry.New()
+
+	var got testTypedConfig
+	var gotReqConfig any
+	m := NewModelWithConfig("test/typed-config", nil, func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
+		got = cfg
+		gotReqConfig = req.Config
+		return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+	})
+	m.Register(r)
+
+	tests := []struct {
+		name    string
+		config  any
+		want    testTypedConfig
+		wantErr string
+	}{
+		{name: "nil config yields zero value", config: nil, want: testTypedConfig{}},
+		{name: "exact type", config: testTypedConfig{Temperature: 0.5, MaxTokens: 10}, want: testTypedConfig{Temperature: 0.5, MaxTokens: 10}},
+		{name: "pointer to exact type", config: &testTypedConfig{Temperature: 0.7}, want: testTypedConfig{Temperature: 0.7}},
+		{name: "map is deserialized", config: map[string]any{"temperature": 0.9, "maxTokens": 5}, want: testTypedConfig{Temperature: 0.9, MaxTokens: 5}},
+		{name: "mismatched struct type is rejected", config: otherProviderConfig{Temperature: 0.2}, wantErr: "invalid config type"},
+		{name: "mismatched pointer type is rejected", config: &otherProviderConfig{Temperature: 0.2}, wantErr: "invalid config type"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got = testTypedConfig{}
+			req := &ModelRequest{
+				Messages: []*Message{NewUserTextMessage("hi")},
+				Config:   tt.config,
+			}
+			_, err := m.Generate(context.Background(), req, nil)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Generate() error = %v, want error containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Generate() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("config = %+v, want %+v", got, tt.want)
+			}
+			if gotReqConfig != any(tt.want) {
+				t.Errorf("req.Config = %#v, want normalized to %#v", gotReqConfig, tt.want)
+			}
+		})
+	}
+}
+
+// TestModelConfigNormalizedBeforeBuiltins pins the boundary ordering: config
+// resolution runs outermost in the model's built-in chain, so a mismatched
+// config type is reported before capability validation (which would otherwise
+// reject this request for containing unsupported media).
+func TestModelConfigNormalizedBeforeBuiltins(t *testing.T) {
+	r := registry.New()
+
+	m := NewModelWithConfig("test/config-order", &ModelOptions{
+		Supports: &ModelSupports{Multiturn: true}, // no media support
+	}, func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
+		return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+	})
+	m.Register(r)
+
+	req := &ModelRequest{
+		Messages: []*Message{NewUserMessage(NewMediaPart("image/png", "data:image/png;base64,aGk="))},
+		Config:   otherProviderConfig{Temperature: 0.2},
+	}
+	_, err := m.Generate(context.Background(), req, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid config type") {
+		t.Fatalf("Generate() error = %v, want config type error before media support error", err)
+	}
+}
+
+func TestBackgroundModelConfigValidation(t *testing.T) {
+	r := registry.New()
+
+	bm := NewBackgroundModelWithConfig("test/bg-typed-config", nil,
+		func(ctx context.Context, req *ModelRequest, cfg testTypedConfig) (*ModelOperation, error) {
+			return &ModelOperation{ID: "op1", Done: false}, nil
+		},
+		func(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
+			return op, nil
+		})
+	bm.Register(r)
+
+	// A config that violates the inferred schema is rejected by input
+	// validation at the action boundary, before conversion.
+	req := &ModelRequest{
+		Messages: []*Message{NewUserTextMessage("hi")},
+		Config:   map[string]any{"unknownOption": true},
+	}
+	if _, err := bm.Start(context.Background(), req); err == nil || !strings.Contains(err.Error(), "schema") {
+		t.Fatalf("Start() error = %v, want schema validation error", err)
+	}
+
+	// A valid map config passes validation and is converted.
+	req = &ModelRequest{
+		Messages: []*Message{NewUserTextMessage("hi")},
+		Config:   map[string]any{"temperature": 0.5},
+	}
+	if _, err := bm.Start(context.Background(), req); err != nil {
+		t.Fatalf("Start() unexpected error: %v", err)
+	}
+}
+
+func TestModelConfigSchemaInference(t *testing.T) {
+	newFn := func() ModelFuncWithConfig[testTypedConfig] {
+		return func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
+			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+		}
+	}
+
+	configSchemaOf := func(t *testing.T, m Model) any {
+		t.Helper()
+		desc := m.(api.Action).Desc()
+		modelMeta, ok := desc.Metadata["model"].(map[string]any)
+		if !ok {
+			t.Fatalf("missing model metadata: %+v", desc.Metadata)
+		}
+		return modelMeta["customOptions"]
+	}
+
+	t.Run("inferred from Config type", func(t *testing.T) {
+		m := NewModelWithConfig("test/inferred-schema", nil, newFn())
+		schema, ok := configSchemaOf(t, m).(map[string]any)
+		if !ok {
+			t.Fatalf("customOptions = %v, want inferred schema map", configSchemaOf(t, m))
+		}
+		props, ok := schema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("schema has no properties: %v", schema)
+		}
+		if _, ok := props["temperature"]; !ok {
+			t.Errorf("inferred schema missing temperature property: %v", props)
+		}
+	})
+
+	t.Run("explicit ConfigSchema wins", func(t *testing.T) {
+		override := map[string]any{"type": "object", "properties": map[string]any{"custom": map[string]any{"type": "string"}}}
+		m := NewModelWithConfig("test/override-schema", &ModelOptions{ConfigSchema: override}, newFn())
+		schema, ok := configSchemaOf(t, m).(map[string]any)
+		if !ok {
+			t.Fatalf("customOptions missing")
+		}
+		props := schema["properties"].(map[string]any)
+		if _, ok := props["custom"]; !ok {
+			t.Errorf("override schema not used: %v", schema)
+		}
+	})
+
+	t.Run("any config infers no schema", func(t *testing.T) {
+		m := NewModelWithConfig("test/any-schema", nil, func(ctx context.Context, req *ModelRequest, cfg any, cb ModelStreamCallback) (*ModelResponse, error) {
+			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+		})
+		if s, _ := configSchemaOf(t, m).(map[string]any); len(s) != 0 {
+			t.Errorf("customOptions = %v, want no inferred schema for any config", s)
+		}
+	})
+
+	t.Run("deprecated NewModel behaves like any config", func(t *testing.T) {
+		m := NewModel("test/legacy-schema", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+		})
+		if s, _ := configSchemaOf(t, m).(map[string]any); len(s) != 0 {
+			t.Errorf("customOptions = %v, want no inferred schema for legacy models", s)
+		}
+	})
+}
+
+// TestDeprecatedModelPassesConfigThrough pins the compatibility contract of
+// the deprecated untyped constructors: any config value, including another
+// provider's struct, still reaches the model function unconverted.
+func TestDeprecatedModelPassesConfigThrough(t *testing.T) {
+	r := registry.New()
+
+	var gotConfig any
+	m := DefineModel(r, "test/legacy-config", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+		gotConfig = req.Config
+		return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+	})
+
+	cfg := otherProviderConfig{Temperature: 0.4}
+	req := &ModelRequest{
+		Messages: []*Message{NewUserTextMessage("hi")},
+		Config:   cfg,
+	}
+	if _, err := m.Generate(context.Background(), req, nil); err != nil {
+		t.Fatalf("Generate() unexpected error: %v", err)
+	}
+	if gotConfig != any(cfg) {
+		t.Errorf("req.Config = %#v, want passed through as %#v", gotConfig, cfg)
+	}
+}
+
+func TestEmbedderTypedConfig(t *testing.T) {
+	r := registry.New()
+
+	var got testTypedConfig
+	var gotReqOptions any
+	e := NewEmbedderWithConfig("test/typed-config-embedder", nil, func(ctx context.Context, req *EmbedRequest, cfg testTypedConfig) (*EmbedResponse, error) {
+		got = cfg
+		gotReqOptions = req.Options
+		return &EmbedResponse{}, nil
+	})
+	e.Register(r)
+
+	req := &EmbedRequest{Options: map[string]any{"maxTokens": 7}}
+	if _, err := e.Embed(context.Background(), req); err != nil {
+		t.Fatalf("Embed() unexpected error: %v", err)
+	}
+	if got.MaxTokens != 7 {
+		t.Errorf("config = %+v, want MaxTokens 7", got)
+	}
+	if gotReqOptions != any(got) {
+		t.Errorf("req.Options = %#v, want normalized to %#v", gotReqOptions, got)
+	}
+
+	req = &EmbedRequest{Options: otherProviderConfig{Temperature: 0.1}}
+	if _, err := e.Embed(context.Background(), req); err == nil || !strings.Contains(err.Error(), "invalid config type") {
+		t.Fatalf("Embed() error = %v, want invalid config type error", err)
+	}
+}
+
+func TestEvaluatorTypedConfig(t *testing.T) {
+	r := registry.New()
+
+	var got testTypedConfig
+	e := NewEvaluatorWithConfig("test/typed-config-evaluator", nil, func(ctx context.Context, req *EvaluatorCallbackRequest, cfg testTypedConfig) (*EvaluatorCallbackResponse, error) {
+		got = cfg
+		return &EvaluatorCallbackResponse{
+			TestCaseId: req.Input.TestCaseId,
+			Evaluation: []Score{{Id: "s", Score: 1, Status: ScoreStatusPass.String()}},
+		}, nil
+	})
+	e.Register(r)
+
+	req := &EvaluatorRequest{
+		Dataset:      []*Example{{TestCaseId: "tc1", Input: "in"}},
+		EvaluationId: "run1",
+		Options:      &testTypedConfig{Temperature: 0.3},
+	}
+	if _, err := e.Evaluate(context.Background(), req); err != nil {
+		t.Fatalf("Evaluate() unexpected error: %v", err)
+	}
+	if got.Temperature != 0.3 {
+		t.Errorf("config = %+v, want Temperature 0.3", got)
+	}
+
+	var gotBatch testTypedConfig
+	be := NewBatchEvaluatorWithConfig("test/typed-config-batch-evaluator", nil, func(ctx context.Context, req *EvaluatorRequest, cfg testTypedConfig) (*EvaluatorResponse, error) {
+		gotBatch = cfg
+		return &EvaluatorResponse{}, nil
+	})
+	be.Register(r)
+	breq := &EvaluatorRequest{
+		Dataset:      []*Example{{TestCaseId: "tc1", Input: "in"}},
+		EvaluationId: "run2",
+		Options:      map[string]any{"temperature": 0.8},
+	}
+	if _, err := be.Evaluate(context.Background(), breq); err != nil {
+		t.Fatalf("Evaluate() unexpected error: %v", err)
+	}
+	if gotBatch.Temperature != 0.8 {
+		t.Errorf("config = %+v, want Temperature 0.8", gotBatch)
+	}
+}

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // testTypedConfig is a provider-style config struct used to exercise the
-// typed-config deserialization that New*WithConfig wraps around user
+// typed-config deserialization that NewTyped* constructors wrap around user
 // functions.
 type testTypedConfig struct {
 	Temperature float64 `json:"temperature,omitempty"`
@@ -46,7 +46,7 @@ func TestModelTypedConfig(t *testing.T) {
 
 	var got testTypedConfig
 	var gotReqConfig any
-	m := NewModelWithConfig("test/typed-config", nil, func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
+	m := NewTypedModel("test/typed-config", nil, func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
 		got = cfg
 		gotReqConfig = req.Config
 		return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
@@ -100,7 +100,7 @@ func TestModelTypedConfig(t *testing.T) {
 func TestModelConfigNormalizedBeforeBuiltins(t *testing.T) {
 	r := registry.New()
 
-	m := NewModelWithConfig("test/config-order", &ModelOptions{
+	m := NewTypedModel("test/config-order", &ModelOptions{
 		Supports: &ModelSupports{Multiturn: true}, // no media support
 	}, func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
 		return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
@@ -120,7 +120,7 @@ func TestModelConfigNormalizedBeforeBuiltins(t *testing.T) {
 func TestBackgroundModelConfigValidation(t *testing.T) {
 	r := registry.New()
 
-	bm := NewBackgroundModelWithConfig("test/bg-typed-config", nil,
+	bm := NewTypedBackgroundModel("test/bg-typed-config", nil,
 		func(ctx context.Context, req *ModelRequest, cfg testTypedConfig) (*ModelOperation, error) {
 			return &ModelOperation{ID: "op1", Done: false}, nil
 		},
@@ -150,7 +150,7 @@ func TestBackgroundModelConfigValidation(t *testing.T) {
 }
 
 func TestModelConfigSchemaInference(t *testing.T) {
-	newFn := func() ModelFuncWithConfig[testTypedConfig] {
+	newFn := func() TypedModelFunc[testTypedConfig] {
 		return func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
 			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
 		}
@@ -167,7 +167,7 @@ func TestModelConfigSchemaInference(t *testing.T) {
 	}
 
 	t.Run("inferred from Config type", func(t *testing.T) {
-		m := NewModelWithConfig("test/inferred-schema", nil, newFn())
+		m := NewTypedModel("test/inferred-schema", nil, newFn())
 		schema, ok := configSchemaOf(t, m).(map[string]any)
 		if !ok {
 			t.Fatalf("customOptions = %v, want inferred schema map", configSchemaOf(t, m))
@@ -183,7 +183,7 @@ func TestModelConfigSchemaInference(t *testing.T) {
 
 	t.Run("explicit ConfigSchema wins", func(t *testing.T) {
 		override := map[string]any{"type": "object", "properties": map[string]any{"custom": map[string]any{"type": "string"}}}
-		m := NewModelWithConfig("test/override-schema", &ModelOptions{ConfigSchema: override}, newFn())
+		m := NewTypedModel("test/override-schema", &ModelOptions{ConfigSchema: override}, newFn())
 		schema, ok := configSchemaOf(t, m).(map[string]any)
 		if !ok {
 			t.Fatalf("customOptions missing")
@@ -195,7 +195,7 @@ func TestModelConfigSchemaInference(t *testing.T) {
 	})
 
 	t.Run("any config infers no schema", func(t *testing.T) {
-		m := NewModelWithConfig("test/any-schema", nil, func(ctx context.Context, req *ModelRequest, cfg any, cb ModelStreamCallback) (*ModelResponse, error) {
+		m := NewTypedModel("test/any-schema", nil, func(ctx context.Context, req *ModelRequest, cfg any, cb ModelStreamCallback) (*ModelResponse, error) {
 			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
 		})
 		if s, _ := configSchemaOf(t, m).(map[string]any); len(s) != 0 {
@@ -243,7 +243,7 @@ func TestEmbedderTypedConfig(t *testing.T) {
 
 	var got testTypedConfig
 	var gotReqOptions any
-	e := NewEmbedderWithConfig("test/typed-config-embedder", nil, func(ctx context.Context, req *EmbedRequest, cfg testTypedConfig) (*EmbedResponse, error) {
+	e := NewTypedEmbedder("test/typed-config-embedder", nil, func(ctx context.Context, req *EmbedRequest, cfg testTypedConfig) (*EmbedResponse, error) {
 		got = cfg
 		gotReqOptions = req.Options
 		return &EmbedResponse{}, nil
@@ -271,7 +271,7 @@ func TestEvaluatorTypedConfig(t *testing.T) {
 	r := registry.New()
 
 	var got testTypedConfig
-	e := NewEvaluatorWithConfig("test/typed-config-evaluator", nil, func(ctx context.Context, req *EvaluatorCallbackRequest, cfg testTypedConfig) (*EvaluatorCallbackResponse, error) {
+	e := NewTypedEvaluator("test/typed-config-evaluator", nil, func(ctx context.Context, req *EvaluatorCallbackRequest, cfg testTypedConfig) (*EvaluatorCallbackResponse, error) {
 		got = cfg
 		return &EvaluatorCallbackResponse{
 			TestCaseId: req.Input.TestCaseId,
@@ -293,7 +293,7 @@ func TestEvaluatorTypedConfig(t *testing.T) {
 	}
 
 	var gotBatch testTypedConfig
-	be := NewBatchEvaluatorWithConfig("test/typed-config-batch-evaluator", nil, func(ctx context.Context, req *EvaluatorRequest, cfg testTypedConfig) (*EvaluatorResponse, error) {
+	be := NewTypedBatchEvaluator("test/typed-config-batch-evaluator", nil, func(ctx context.Context, req *EvaluatorRequest, cfg testTypedConfig) (*EvaluatorResponse, error) {
 		gotBatch = cfg
 		return &EvaluatorResponse{}, nil
 	})

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -191,9 +191,13 @@ func TestEvaluatorActionMetadata(t *testing.T) {
 
 func TestBackgroundModelActionMetadata(t *testing.T) {
 	bm := NewBackgroundModelAction("test/bg-metadata",
-		&TypedBackgroundModelOptions{
+		&BackgroundModelOptions{
+			ModelOptions: ModelOptions{
+				Metadata: map[string]any{"inner": "kept", "shared": "inner"},
+			},
 			Metadata: map[string]any{
 				"custom": "value",
+				"shared": "outer",
 				"model":  "caller values must not clobber the reserved keys",
 			},
 		},
@@ -207,6 +211,12 @@ func TestBackgroundModelActionMetadata(t *testing.T) {
 	metadata := bm.Desc().Metadata
 	if got := metadata["custom"]; got != "value" {
 		t.Errorf(`Metadata["custom"] = %v, want "value"`, got)
+	}
+	if got := metadata["inner"]; got != "kept" {
+		t.Errorf(`Metadata["inner"] = %v, want the embedded ModelOptions metadata carried through`, got)
+	}
+	if got := metadata["shared"]; got != "outer" {
+		t.Errorf(`Metadata["shared"] = %v, want the top-level Metadata to win`, got)
 	}
 	if got := metadata["type"]; got != api.ActionTypeBackgroundModel {
 		t.Errorf(`Metadata["type"] = %v, want %v`, got, api.ActionTypeBackgroundModel)

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -220,7 +220,7 @@ func TestDeprecatedModelPassesConfigThrough(t *testing.T) {
 	r := registry.New()
 
 	var gotConfig any
-	m := DefineModel(r, "test/legacy-config", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+	m := defineModel(r, "test/legacy-config", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		gotConfig = req.Config
 		return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
 	})

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -184,8 +184,11 @@ func TestEvaluatorActionMetadata(t *testing.T) {
 	if got := metadata["type"]; got != api.ActionTypeEvaluator {
 		t.Errorf(`Metadata["type"] = %v, want %v`, got, api.ActionTypeEvaluator)
 	}
-	if _, ok := metadata["evaluator"].(map[string]any); !ok {
+	evalInfo, ok := metadata["evaluator"].(map[string]any)
+	if !ok {
 		t.Errorf(`Metadata["evaluator"] = %v, want the built evaluator info map`, metadata["evaluator"])
+	} else if evalInfo["customOptions"] == nil {
+		t.Errorf(`Metadata["evaluator"]["customOptions"] = nil, want the inferred config schema advertised`)
 	}
 }
 
@@ -255,6 +258,151 @@ func TestBackgroundModelConfigValidation(t *testing.T) {
 	}
 	if _, err := bm.Start(context.Background(), req); err != nil {
 		t.Fatalf("Start() unexpected error: %v", err)
+	}
+}
+
+// TestModelVersionWithTypedConfig pins that the framework-level "version" key
+// stays admissible on the config slot even when the inferred Config type has
+// no version field: version validation must see the key before conversion
+// drops it, not have it rejected by the closed inferred schema.
+func TestModelVersionWithTypedConfig(t *testing.T) {
+	r := registry.New()
+	m := NewModelAction("test/versioned", &ModelOptions{Versions: []string{"v1"}},
+		func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
+			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+		})
+	m.Register(r)
+
+	req := &ModelRequest{
+		Messages: []*Message{NewUserTextMessage("hi")},
+		Config:   map[string]any{"version": "v1", "temperature": 0.5},
+	}
+	if _, err := m.Generate(context.Background(), req, nil); err != nil {
+		t.Fatalf("Generate() with a valid version: %v", err)
+	}
+
+	req = &ModelRequest{
+		Messages: []*Message{NewUserTextMessage("hi")},
+		Config:   map[string]any{"version": "v9"},
+	}
+	_, err := m.Generate(context.Background(), req, nil)
+	if err == nil || !strings.Contains(err.Error(), "version") {
+		t.Fatalf("Generate() error = %v, want a version validation error", err)
+	}
+	if strings.Contains(err.Error(), "schema") {
+		t.Fatalf("Generate() error = %v, want the version error, not a schema rejection", err)
+	}
+}
+
+// strictFieldConfig has fields without omitempty; the inferred schema must
+// not turn them into required config keys, since a config is partial by
+// nature.
+type strictFieldConfig struct {
+	Temperature float64 `json:"temperature"`
+	MaxTokens   int     `json:"maxTokens"`
+}
+
+func TestPartialConfigNotRequired(t *testing.T) {
+	r := registry.New()
+	m := NewModelAction("test/partial-config", nil,
+		func(ctx context.Context, req *ModelRequest, cfg strictFieldConfig, cb ModelStreamCallback) (*ModelResponse, error) {
+			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+		})
+	m.Register(r)
+
+	req := &ModelRequest{
+		Messages: []*Message{NewUserTextMessage("hi")},
+		Config:   map[string]any{"temperature": 0.5},
+	}
+	if _, err := m.Generate(context.Background(), req, nil); err != nil {
+		t.Fatalf("Generate() with a partial config: %v", err)
+	}
+
+	// Stripping required must not open the schema: unknown keys stay rejected.
+	req = &ModelRequest{
+		Messages: []*Message{NewUserTextMessage("hi")},
+		Config:   map[string]any{"unknownOption": true},
+	}
+	if _, err := m.Generate(context.Background(), req, nil); err == nil || !strings.Contains(err.Error(), "schema") {
+		t.Fatalf("Generate() error = %v, want schema validation error for an unknown key", err)
+	}
+}
+
+// TestPointerConfigNilStaysNil pins that a request carrying no config keeps a
+// nil config slot when Config is a pointer type: boxing the typed nil would
+// make req.Config compare non-nil while dereferencing it still panics.
+func TestPointerConfigNilStaysNil(t *testing.T) {
+	r := registry.New()
+	var gotCfg *testTypedConfig
+	var gotReqConfig any
+	m := NewModelAction("test/pointer-config", nil,
+		func(ctx context.Context, req *ModelRequest, cfg *testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
+			gotCfg = cfg
+			gotReqConfig = req.Config
+			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+		})
+	m.Register(r)
+
+	req := &ModelRequest{Messages: []*Message{NewUserTextMessage("hi")}}
+	if _, err := m.Generate(context.Background(), req, nil); err != nil {
+		t.Fatalf("Generate() unexpected error: %v", err)
+	}
+	if gotCfg != nil {
+		t.Errorf("cfg = %v, want nil pointer for a request without config", gotCfg)
+	}
+	if gotReqConfig != nil {
+		t.Errorf("req.Config = %#v, want nil for a request without config", gotReqConfig)
+	}
+
+	// A populated map still resolves and normalizes to the pointer type.
+	req = &ModelRequest{
+		Messages: []*Message{NewUserTextMessage("hi")},
+		Config:   map[string]any{"temperature": 0.5},
+	}
+	if _, err := m.Generate(context.Background(), req, nil); err != nil {
+		t.Fatalf("Generate() unexpected error: %v", err)
+	}
+	if gotCfg == nil || gotCfg.Temperature != 0.5 {
+		t.Errorf("cfg = %+v, want Temperature 0.5", gotCfg)
+	}
+	if _, ok := gotReqConfig.(*testTypedConfig); !ok {
+		t.Errorf("req.Config = %#v, want normalized to *testTypedConfig", gotReqConfig)
+	}
+}
+
+// TestCallerRequestNotMutated pins that config normalization happens on the
+// action's shallow copy of the request: the caller's struct keeps its raw
+// config, so one request can be fanned out to actions with different Config
+// types.
+func TestCallerRequestNotMutated(t *testing.T) {
+	r := registry.New()
+	m := NewModelAction("test/no-mutation", nil,
+		func(ctx context.Context, req *ModelRequest, cfg testTypedConfig, cb ModelStreamCallback) (*ModelResponse, error) {
+			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
+		})
+	m.Register(r)
+
+	raw := map[string]any{"temperature": 0.5}
+	req := &ModelRequest{Messages: []*Message{NewUserTextMessage("hi")}, Config: raw}
+	if _, err := m.Generate(context.Background(), req, nil); err != nil {
+		t.Fatalf("Generate() unexpected error: %v", err)
+	}
+	if got, ok := req.Config.(map[string]any); !ok || got["temperature"] != 0.5 {
+		t.Errorf("req.Config = %#v, want the caller's raw map left untouched", req.Config)
+	}
+
+	ret := NewRetrieverAction("test/no-mutation-retriever", nil,
+		func(ctx context.Context, req *RetrieverRequest, cfg testTypedConfig) (*RetrieverResponse, error) {
+			return &RetrieverResponse{}, nil
+		})
+	ret.Register(r)
+
+	rreq := &RetrieverRequest{Query: DocumentFromText("q", nil), Options: raw}
+	if _, err := ret.Retrieve(context.Background(), rreq); err != nil {
+		t.Fatalf("Retrieve() unexpected error: %v", err)
+	}
+	if got, ok := rreq.Options.(map[string]any); !ok || got["temperature"] != 0.5 {
+		t.Errorf("req.Options = %#v, want the caller's raw map left untouched", rreq.Options)
 	}
 }
 

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -125,7 +125,8 @@ func TestBackgroundModelConfigValidation(t *testing.T) {
 		},
 		func(ctx context.Context, op *ModelOperation) (*ModelOperation, error) {
 			return op, nil
-		})
+		},
+		nil)
 	bm.Register(r)
 
 	// A config that violates the inferred schema is rejected by input

--- a/go/ai/config_test.go
+++ b/go/ai/config_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
@@ -156,9 +155,9 @@ func TestModelConfigSchemaInference(t *testing.T) {
 		}
 	}
 
-	configSchemaOf := func(t *testing.T, m Model) any {
+	configSchemaOf := func(t *testing.T, m *ModelAction) any {
 		t.Helper()
-		desc := m.(api.Action).Desc()
+		desc := m.Desc()
 		modelMeta, ok := desc.Metadata["model"].(map[string]any)
 		if !ok {
 			t.Fatalf("missing model metadata: %+v", desc.Metadata)
@@ -207,7 +206,7 @@ func TestModelConfigSchemaInference(t *testing.T) {
 		m := NewModel("test/legacy-schema", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			return &ModelResponse{Message: NewModelTextMessage("ok"), Request: req}, nil
 		})
-		if s, _ := configSchemaOf(t, m).(map[string]any); len(s) != 0 {
+		if s, _ := configSchemaOf(t, m.(*ModelAction)).(map[string]any); len(s) != 0 {
 			t.Errorf("customOptions = %v, want no inferred schema for legacy models", s)
 		}
 	})

--- a/go/ai/define_test.go
+++ b/go/ai/define_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ai
+
+import (
+	"github.com/firebase/genkit/go/core/api"
+)
+
+// Test-local define helpers: New* + Register in one call, mirroring the
+// removed registry-taking Define functions so tests stay concise.
+
+func defineModel(r api.Registry, name string, opts *ModelOptions, fn ModelFunc) Model {
+	m := NewModel(name, opts, fn)
+	m.Register(r)
+	return m
+}
+
+func defineEmbedder(r api.Registry, name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
+	e := NewEmbedder(name, opts, fn)
+	e.Register(r)
+	return e
+}
+
+func defineEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluator {
+	e := NewEvaluator(name, opts, fn)
+	e.Register(r)
+	return e
+}
+
+func defineBatchEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn BatchEvaluatorFunc) Evaluator {
+	e := NewBatchEvaluator(name, opts, fn)
+	e.Register(r)
+	return e
+}
+
+func defineTool[In, Out any](r api.Registry, name, description string, fn ToolFunc[In, Out], opts ...ToolOption) *ToolDef[In, Out] {
+	t := NewTool(name, description, fn, opts...)
+	t.Register(r)
+	return t
+}
+
+func defineMultipartTool[In any](r api.Registry, name, description string, fn MultipartToolFunc[In], opts ...ToolOption) *ToolDef[In, *MultipartToolResponse] {
+	t := NewMultipartTool(name, description, fn, opts...)
+	t.Register(r)
+	return t
+}
+
+func defineResource(r api.Registry, name string, opts *ResourceOptions, fn ResourceFunc) Resource {
+	res := NewResource(name, opts, fn)
+	res.Register(r)
+	return res
+}
+
+func defineToolWithInputSchema[Out any](r api.Registry, name, description string, inputSchema map[string]any, fn ToolFunc[any, Out]) *ToolDef[any, Out] {
+	return defineTool(r, name, description, fn, WithInputSchema(inputSchema))
+}

--- a/go/ai/define_test.go
+++ b/go/ai/define_test.go
@@ -47,13 +47,13 @@ func defineBatchEvaluator(r api.Registry, name string, opts *EvaluatorOptions, f
 	return e
 }
 
-func defineTool[In, Out any](r api.Registry, name, description string, fn ToolFunc[In, Out], opts ...ToolOption) *ToolDef[In, Out] {
+func defineTool[In, Out any](r api.Registry, name, description string, fn ToolFunc[In, Out], opts ...ToolOption) *ToolAction[In, Out] {
 	t := NewTool(name, description, fn, opts...)
 	t.Register(r)
 	return t
 }
 
-func defineMultipartTool[In any](r api.Registry, name, description string, fn MultipartToolFunc[In], opts ...ToolOption) *ToolDef[In, *MultipartToolResponse] {
+func defineMultipartTool[In any](r api.Registry, name, description string, fn MultipartToolFunc[In], opts ...ToolOption) *ToolAction[In, *MultipartToolResponse] {
 	t := NewMultipartTool(name, description, fn, opts...)
 	t.Register(r)
 	return t
@@ -71,6 +71,6 @@ func defineResource(r api.Registry, name string, opts *ResourceOptions, fn Resou
 	return res
 }
 
-func defineToolWithInputSchema[Out any](r api.Registry, name, description string, inputSchema map[string]any, fn ToolFunc[any, Out]) *ToolDef[any, Out] {
+func defineToolWithInputSchema[Out any](r api.Registry, name, description string, inputSchema map[string]any, fn ToolFunc[any, Out]) *ToolAction[any, Out] {
 	return defineTool(r, name, description, fn, WithInputSchema(inputSchema))
 }

--- a/go/ai/define_test.go
+++ b/go/ai/define_test.go
@@ -59,6 +59,12 @@ func defineMultipartTool[In any](r api.Registry, name, description string, fn Mu
 	return t
 }
 
+func defineRetriever(r api.Registry, name string, opts *RetrieverOptions, fn RetrieverFunc) Retriever {
+	ret := NewRetriever(name, opts, fn)
+	ret.Register(r)
+	return ret
+}
+
 func defineResource(r api.Registry, name string, opts *ResourceOptions, fn ResourceFunc) Resource {
 	res := NewResource(name, opts, fn)
 	res.Register(r)

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -118,7 +118,11 @@ var (
 // normalized to the converted value, so it always matches the typed
 // parameter. The config's JSON schema is inferred from Config unless
 // [EmbedderOptions.ConfigSchema] overrides it.
-func NewTypedEmbedder[Config any](name string, opts *EmbedderOptions, fn TypedEmbedderFunc[Config]) *EmbedderAction {
+func NewTypedEmbedder[Config any](
+	name string,
+	opts *EmbedderOptions,
+	fn TypedEmbedderFunc[Config],
+) *EmbedderAction {
 	if name == "" {
 		panic("ai.NewTypedEmbedder: name is required")
 	}

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -90,13 +90,25 @@ type EmbedderOptions struct {
 	Dimensions int `json:"dimensions,omitempty"`
 }
 
-// embedder is an action with functions specific to converting documents to multidimensional vectors such as Embed().
-type embedder struct {
-	core.Action[*EmbedRequest, *EmbedResponse, struct{}]
+// EmbedderAction is an embedder backed by a registry action. It is the
+// concrete type returned by [NewTypedEmbedder]; pass it to [WithEmbedder] to
+// use it for embedding, or return it from a plugin's Init for the framework
+// to register.
+type EmbedderAction struct {
+	action[*EmbedRequest, *EmbedResponse, struct{}]
 }
 
-// NewTypedEmbedder creates a new [Embedder]. Register it with
-// [Embedder.Register] to make it resolvable by name.
+// EmbedderAction is a full registry action and can be passed anywhere an
+// [api.Action] is accepted as well as anywhere an [Embedder] is accepted.
+var (
+	_ api.Action = (*EmbedderAction)(nil)
+	_ Embedder   = (*EmbedderAction)(nil)
+)
+
+// NewTypedEmbedder creates an unregistered [EmbedderAction]: return it from a
+// plugin's Init for the framework to register, or call
+// [EmbedderAction.Register] directly. Applications should define embedders
+// with [genkit.DefineTypedEmbedder].
 //
 // Config is the embedder's typed configuration; it is usually inferred from
 // fn's signature. The framework deserializes the request's raw options into
@@ -106,7 +118,7 @@ type embedder struct {
 // normalized to the converted value, so it always matches the typed
 // parameter. The config's JSON schema is inferred from Config unless
 // [EmbedderOptions.ConfigSchema] overrides it.
-func NewTypedEmbedder[Config any](name string, opts *EmbedderOptions, fn TypedEmbedderFunc[Config]) Embedder {
+func NewTypedEmbedder[Config any](name string, opts *EmbedderOptions, fn TypedEmbedderFunc[Config]) *EmbedderAction {
 	if name == "" {
 		panic("ai.NewTypedEmbedder: name is required")
 	}
@@ -149,8 +161,8 @@ func NewTypedEmbedder[Config any](name string, opts *EmbedderOptions, fn TypedEm
 		return fn(ctx, req, cfg)
 	}
 
-	return &embedder{
-		Action: *core.NewActionOf(api.ActionTypeEmbedder, name, &core.ActionOptions{
+	return &EmbedderAction{
+		action: *core.NewActionOf(api.ActionTypeEmbedder, name, &core.ActionOptions{
 			Metadata:    metadata,
 			InputSchema: inputSchema,
 		}, rawFn),
@@ -178,13 +190,11 @@ func LookupEmbedder(r api.Registry, name string) Embedder {
 	if action == nil {
 		return nil
 	}
-	return &embedder{
-		Action: *action,
-	}
+	return &EmbedderAction{*action}
 }
 
 // Embed runs the given [Embedder].
-func (e *embedder) Embed(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+func (e *EmbedderAction) Embed(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 	if e == nil {
 		return nil, status.Errorf(status.ErrInvalidArgument, "Embedder.Embed: embedder called on a nil embedder; check that all embedders are defined")
 	}

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -160,13 +160,14 @@ func NewEmbedderAction[Config any](
 	}
 
 	rawFn := func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
-		cfg, err := resolveConfig[Config](req.Options)
+		// Normalize a shallow copy so the type-erased Options and the typed
+		// parameter always agree without clobbering the caller-owned request.
+		reqCopy := *req
+		req = &reqCopy
+		cfg, err := resolveConfigInto[Config](&req.Options)
 		if err != nil {
 			return nil, err
 		}
-		// Normalize the request so its type-erased Options always carries the
-		// same converted value the typed parameter does.
-		req.Options = cfg
 		return fn(ctx, req, cfg)
 	}
 

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -19,6 +19,7 @@ package ai
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
@@ -88,6 +89,8 @@ type EmbedderOptions struct {
 	Supports *EmbedderSupports `json:"supports,omitempty"`
 	// Dimensions specifies the number of dimensions in the embedding vector.
 	Dimensions int `json:"dimensions,omitempty"`
+	// Metadata is arbitrary key-value data attached to the action descriptor.
+	Metadata map[string]any `json:"-"`
 }
 
 // EmbedderAction is an embedder backed by a registry action. It is the
@@ -138,20 +141,22 @@ func NewTypedEmbedder[Config any](
 
 	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EmbedRequest{}, "options")
 
-	metadata := map[string]any{
-		"type": api.ActionTypeEmbedder,
-		// TODO: This should be under "embedder" but JS has it as "info".
-		"info": map[string]any{
-			"label":      opts.Label,
-			"dimensions": opts.Dimensions,
-			"supports": map[string]any{
-				"input":        opts.Supports.Input,
-				"multilingual": opts.Supports.Multilingual,
-			},
+	// Seed from the caller's metadata, then stamp the built-in keys over it so
+	// they cannot be corrupted; registry discovery depends on them.
+	metadata := make(map[string]any, len(opts.Metadata)+3)
+	maps.Copy(metadata, opts.Metadata)
+	metadata["type"] = api.ActionTypeEmbedder
+	// TODO: This should be under "embedder" but JS has it as "info".
+	metadata["info"] = map[string]any{
+		"label":      opts.Label,
+		"dimensions": opts.Dimensions,
+		"supports": map[string]any{
+			"input":        opts.Supports.Input,
+			"multilingual": opts.Supports.Multilingual,
 		},
-		"embedder": map[string]any{
-			"customOptions": configSchema,
-		},
+	}
+	metadata["embedder"] = map[string]any{
+		"customOptions": configSchema,
 	}
 
 	rawFn := func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -29,6 +29,11 @@ import (
 // EmbedderFunc is the function type for embedding documents.
 type EmbedderFunc = func(context.Context, *EmbedRequest) (*EmbedResponse, error)
 
+// EmbedderFuncWithConfig is an [EmbedderFunc] that additionally receives the
+// request's typed Config: the framework deserializes the request's raw
+// options into it before calling the function (see [NewEmbedderWithConfig]).
+type EmbedderFuncWithConfig[Config any] = func(context.Context, *EmbedRequest, Config) (*EmbedResponse, error)
+
 // Embedder represents an embedder that can perform content embedding.
 type Embedder interface {
 	// Name returns the registry name of the embedder.
@@ -90,10 +95,20 @@ type embedder struct {
 	core.Action[*EmbedRequest, *EmbedResponse, struct{}]
 }
 
-// NewEmbedder creates a new [Embedder].
-func NewEmbedder(name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
+// NewEmbedderWithConfig creates a new [Embedder]. Register it with
+// [Embedder.Register] to make it resolvable by name.
+//
+// Config is the embedder's typed configuration; it is usually inferred from
+// fn's signature. The framework deserializes the request's raw options into
+// Config before calling fn: the exact Config type (or a pointer to it) and
+// map[string]any (from the Dev UI and other JSON callers) are accepted, and
+// mismatched types are rejected. The request's [EmbedRequest.Options] is
+// normalized to the converted value, so it always matches the typed
+// parameter. The config's JSON schema is inferred from Config unless
+// [EmbedderOptions.ConfigSchema] overrides it.
+func NewEmbedderWithConfig[Config any](name string, opts *EmbedderOptions, fn EmbedderFuncWithConfig[Config]) Embedder {
 	if name == "" {
-		panic("ai.NewEmbedder: name is required")
+		panic("ai.NewEmbedderWithConfig: name is required")
 	}
 
 	if opts == nil {
@@ -104,6 +119,8 @@ func NewEmbedder(name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
 	if opts.Supports == nil {
 		opts.Supports = &EmbedderSupports{}
 	}
+
+	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EmbedRequest{}, "options")
 
 	metadata := map[string]any{
 		"type": api.ActionTypeEmbedder,
@@ -117,22 +134,47 @@ func NewEmbedder(name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
 			},
 		},
 		"embedder": map[string]any{
-			"customOptions": opts.ConfigSchema,
+			"customOptions": configSchema,
 		},
 	}
 
-	inputSchema := requestInputSchema(EmbedRequest{}, "options", opts.ConfigSchema)
+	rawFn := func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		cfg, err := resolveConfig[Config](req.Options)
+		if err != nil {
+			return nil, err
+		}
+		// Normalize the request so its type-erased Options always carries the
+		// same converted value the typed parameter does.
+		req.Options = cfg
+		return fn(ctx, req, cfg)
+	}
 
 	return &embedder{
 		Action: *core.NewActionOf(api.ActionTypeEmbedder, name, &core.ActionOptions{
 			Metadata:    metadata,
 			InputSchema: inputSchema,
-		}, fn),
+		}, rawFn),
 	}
+}
+
+// NewEmbedder creates a new [Embedder].
+//
+// Deprecated: Use [NewEmbedderWithConfig], which passes the request's options
+// to fn as a typed value instead of leaving them type-erased on the request.
+func NewEmbedder(name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
+	if name == "" {
+		panic("ai.NewEmbedder: name is required")
+	}
+	return NewEmbedderWithConfig(name, opts, func(ctx context.Context, req *EmbedRequest, _ any) (*EmbedResponse, error) {
+		return fn(ctx, req)
+	})
 }
 
 // DefineEmbedder registers the given embed function as an action, and returns an
 // [Embedder] that runs it.
+//
+// Deprecated: Use [NewEmbedderWithConfig] and register the result with
+// [Embedder.Register].
 func DefineEmbedder(r api.Registry, name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
 	e := NewEmbedder(name, opts, fn)
 	e.Register(r)

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -29,10 +29,10 @@ import (
 // EmbedderFunc is the function type for embedding documents.
 type EmbedderFunc = func(context.Context, *EmbedRequest) (*EmbedResponse, error)
 
-// EmbedderFuncWithConfig is an [EmbedderFunc] that additionally receives the
+// TypedEmbedderFunc is an [EmbedderFunc] that additionally receives the
 // request's typed Config: the framework deserializes the request's raw
-// options into it before calling the function (see [NewEmbedderWithConfig]).
-type EmbedderFuncWithConfig[Config any] = func(context.Context, *EmbedRequest, Config) (*EmbedResponse, error)
+// options into it before calling the function (see [NewTypedEmbedder]).
+type TypedEmbedderFunc[Config any] = func(context.Context, *EmbedRequest, Config) (*EmbedResponse, error)
 
 // Embedder represents an embedder that can perform content embedding.
 type Embedder interface {
@@ -95,7 +95,7 @@ type embedder struct {
 	core.Action[*EmbedRequest, *EmbedResponse, struct{}]
 }
 
-// NewEmbedderWithConfig creates a new [Embedder]. Register it with
+// NewTypedEmbedder creates a new [Embedder]. Register it with
 // [Embedder.Register] to make it resolvable by name.
 //
 // Config is the embedder's typed configuration; it is usually inferred from
@@ -106,9 +106,9 @@ type embedder struct {
 // normalized to the converted value, so it always matches the typed
 // parameter. The config's JSON schema is inferred from Config unless
 // [EmbedderOptions.ConfigSchema] overrides it.
-func NewEmbedderWithConfig[Config any](name string, opts *EmbedderOptions, fn EmbedderFuncWithConfig[Config]) Embedder {
+func NewTypedEmbedder[Config any](name string, opts *EmbedderOptions, fn TypedEmbedderFunc[Config]) Embedder {
 	if name == "" {
-		panic("ai.NewEmbedderWithConfig: name is required")
+		panic("ai.NewTypedEmbedder: name is required")
 	}
 
 	if opts == nil {
@@ -159,13 +159,13 @@ func NewEmbedderWithConfig[Config any](name string, opts *EmbedderOptions, fn Em
 
 // NewEmbedder creates a new [Embedder].
 //
-// Deprecated: Use [NewEmbedderWithConfig], which passes the request's options
+// Deprecated: Use [NewTypedEmbedder], which passes the request's options
 // to fn as a typed value instead of leaving them type-erased on the request.
 func NewEmbedder(name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
 	if name == "" {
 		panic("ai.NewEmbedder: name is required")
 	}
-	return NewEmbedderWithConfig(name, opts, func(ctx context.Context, req *EmbedRequest, _ any) (*EmbedResponse, error) {
+	return NewTypedEmbedder(name, opts, func(ctx context.Context, req *EmbedRequest, _ any) (*EmbedResponse, error) {
 		return fn(ctx, req)
 	})
 }
@@ -173,7 +173,7 @@ func NewEmbedder(name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
 // DefineEmbedder registers the given embed function as an action, and returns an
 // [Embedder] that runs it.
 //
-// Deprecated: Use [NewEmbedderWithConfig] and register the result with
+// Deprecated: Use [NewTypedEmbedder] and register the result with
 // [Embedder.Register].
 func DefineEmbedder(r api.Registry, name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
 	e := NewEmbedder(name, opts, fn)

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -170,18 +170,7 @@ func NewEmbedder(name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
 	})
 }
 
-// DefineEmbedder registers the given embed function as an action, and returns an
-// [Embedder] that runs it.
-//
-// Deprecated: Use [NewTypedEmbedder] and register the result with
-// [Embedder.Register].
-func DefineEmbedder(r api.Registry, name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
-	e := NewEmbedder(name, opts, fn)
-	e.Register(r)
-	return e
-}
-
-// LookupEmbedder looks up an [Embedder] registered by [DefineEmbedder].
+// LookupEmbedder looks up a registered [Embedder] by name.
 // It will try to resolve the embedder dynamically if the embedder is not found.
 // It returns nil if the embedder was not resolved.
 func LookupEmbedder(r api.Registry, name string) Embedder {

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -30,10 +30,10 @@ import (
 // EmbedderFunc is the function type for embedding documents.
 type EmbedderFunc = func(context.Context, *EmbedRequest) (*EmbedResponse, error)
 
-// TypedEmbedderFunc is an [EmbedderFunc] that additionally receives the
+// EmbedderActionFunc is an [EmbedderFunc] that additionally receives the
 // request's typed Config: the framework deserializes the request's raw
-// options into it before calling the function (see [NewTypedEmbedder]).
-type TypedEmbedderFunc[Config any] = func(context.Context, *EmbedRequest, Config) (*EmbedResponse, error)
+// options into it before calling the function (see [NewEmbedderAction]).
+type EmbedderActionFunc[Config any] = func(context.Context, *EmbedRequest, Config) (*EmbedResponse, error)
 
 // Embedder represents an embedder that can perform content embedding.
 type Embedder interface {
@@ -94,7 +94,7 @@ type EmbedderOptions struct {
 }
 
 // EmbedderAction is an embedder backed by a registry action. It is the
-// concrete type returned by [NewTypedEmbedder]; pass it to [WithEmbedder] to
+// concrete type returned by [NewEmbedderAction]; pass it to [WithEmbedder] to
 // use it for embedding, or return it from a plugin's Init for the framework
 // to register.
 type EmbedderAction struct {
@@ -108,10 +108,10 @@ var (
 	_ Embedder   = (*EmbedderAction)(nil)
 )
 
-// NewTypedEmbedder creates an unregistered [EmbedderAction]: return it from a
+// NewEmbedderAction creates an unregistered [EmbedderAction]: return it from a
 // plugin's Init for the framework to register, or call
 // [EmbedderAction.Register] directly. Applications should define embedders
-// with [genkit.DefineTypedEmbedder].
+// with [genkit.DefineEmbedderAction].
 //
 // Config is the embedder's typed configuration; it is usually inferred from
 // fn's signature. The framework deserializes the request's raw options into
@@ -121,13 +121,13 @@ var (
 // normalized to the converted value, so it always matches the typed
 // parameter. The config's JSON schema is inferred from Config unless
 // [EmbedderOptions.ConfigSchema] overrides it.
-func NewTypedEmbedder[Config any](
+func NewEmbedderAction[Config any](
 	name string,
 	opts *EmbedderOptions,
-	fn TypedEmbedderFunc[Config],
+	fn EmbedderActionFunc[Config],
 ) *EmbedderAction {
 	if name == "" {
-		panic("ai.NewTypedEmbedder: name is required")
+		panic("ai.NewEmbedderAction: name is required")
 	}
 
 	if opts == nil {
@@ -180,13 +180,13 @@ func NewTypedEmbedder[Config any](
 
 // NewEmbedder creates a new [Embedder].
 //
-// Deprecated: Use [NewTypedEmbedder], which passes the request's options
+// Deprecated: Use [NewEmbedderAction], which passes the request's options
 // to fn as a typed value instead of leaving them type-erased on the request.
 func NewEmbedder(name string, opts *EmbedderOptions, fn EmbedderFunc) Embedder {
 	if name == "" {
 		panic("ai.NewEmbedder: name is required")
 	}
-	return NewTypedEmbedder(name, opts, func(ctx context.Context, req *EmbedRequest, _ any) (*EmbedResponse, error) {
+	return NewEmbedderAction(name, opts, func(ctx context.Context, req *EmbedRequest, _ any) (*EmbedResponse, error) {
 		return fn(ctx, req)
 	})
 }

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -18,6 +18,7 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 
@@ -35,7 +36,10 @@ type EmbedderFunc = func(context.Context, *EmbedRequest) (*EmbedResponse, error)
 // options into it before calling the function (see [NewEmbedderAction]).
 type EmbedderActionFunc[Config any] = func(context.Context, *EmbedRequest, Config) (*EmbedResponse, error)
 
-// Embedder represents an embedder that can perform content embedding.
+// Embedder represents an embedder that can perform content embedding. It is
+// the type to accept as an argument and to look up by name; implementations
+// are created with [NewEmbedderAction], or [genkit.DefineEmbedderAction] in an
+// application.
 type Embedder interface {
 	// Name returns the registry name of the embedder.
 	Name() string
@@ -97,16 +101,45 @@ type EmbedderOptions struct {
 // concrete type returned by [NewEmbedderAction]; pass it to [WithEmbedder] to
 // use it for embedding, or return it from a plugin's Init for the framework
 // to register.
+//
+// It implements [Embedder] and [api.Action], so it can be passed anywhere
+// either is accepted. It also promotes [core.Action.Run], the typed
+// equivalent of [EmbedderAction.Embed].
 type EmbedderAction struct {
 	action[*EmbedRequest, *EmbedResponse, struct{}]
 }
 
-// EmbedderAction is a full registry action and can be passed anywhere an
-// [api.Action] is accepted as well as anywhere an [Embedder] is accepted.
+// Pinned here so that breaking either interface fails the build at the type
+// rather than at a call site.
 var (
 	_ api.Action = (*EmbedderAction)(nil)
 	_ Embedder   = (*EmbedderAction)(nil)
 )
+
+// Name returns the registry name of the embedder.
+func (e *EmbedderAction) Name() string { return e.action.Name() }
+
+// Register registers the embedder with r, making it available to lookups and
+// to the Dev UI. A plugin that returns the embedder from its Init does not
+// need to call this.
+func (e *EmbedderAction) Register(r api.Registry) { e.action.Register(r) }
+
+// Desc returns the embedder's action descriptor: its name, schemas, and
+// metadata.
+func (e *EmbedderAction) Desc() api.ActionDesc { return e.action.Desc() }
+
+// RunJSON runs the embedder on a JSON-encoded [EmbedRequest] and returns a
+// JSON-encoded [EmbedResponse]. The framework uses it to serve reflection and
+// registry-driven calls; prefer [EmbedderAction.Embed].
+func (e *EmbedderAction) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	return e.action.RunJSON(ctx, input, cb)
+}
+
+// RunJSONWithTelemetry is [EmbedderAction.RunJSON] with the run's telemetry
+// returned alongside the output.
+func (e *EmbedderAction) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	return e.action.RunJSONWithTelemetry(ctx, input, cb)
+}
 
 // NewEmbedderAction creates an unregistered [EmbedderAction]: return it from a
 // plugin's Init for the framework to register, or call

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -132,12 +132,18 @@ func (e *EmbedderAction) Desc() api.ActionDesc { return e.action.Desc() }
 // JSON-encoded [EmbedResponse]. The framework uses it to serve reflection and
 // registry-driven calls; prefer [EmbedderAction.Embed].
 func (e *EmbedderAction) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	if e == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "Embedder.RunJSON: embedder called on a nil embedder; check that all embedders are defined")
+	}
 	return e.action.RunJSON(ctx, input, cb)
 }
 
 // RunJSONWithTelemetry is [EmbedderAction.RunJSON] with the run's telemetry
 // returned alongside the output.
 func (e *EmbedderAction) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	if e == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "Embedder.RunJSONWithTelemetry: embedder called on a nil embedder; check that all embedders are defined")
+	}
 	return e.action.RunJSONWithTelemetry(ctx, input, cb)
 }
 

--- a/go/ai/embedder_test.go
+++ b/go/ai/embedder_test.go
@@ -112,7 +112,7 @@ func TestDefineEmbedder(t *testing.T) {
 		r := newTestRegistry(t)
 		called := false
 
-		e := DefineEmbedder(r, "test/defineEmbedder", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		e := defineEmbedder(r, "test/defineEmbedder", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 			called = true
 			return &EmbedResponse{
 				Embeddings: []*Embedding{{Embedding: []float32{0.1, 0.2, 0.3}}},
@@ -146,7 +146,7 @@ func TestDefineEmbedder(t *testing.T) {
 func TestLookupEmbedder(t *testing.T) {
 	t.Run("returns embedder when found", func(t *testing.T) {
 		r := newTestRegistry(t)
-		DefineEmbedder(r, "test/lookupEmbedder", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		defineEmbedder(r, "test/lookupEmbedder", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 			return &EmbedResponse{}, nil
 		})
 
@@ -171,7 +171,7 @@ func TestEmbedderEmbed(t *testing.T) {
 		r := newTestRegistry(t)
 		var capturedReq *EmbedRequest
 
-		e := DefineEmbedder(r, "test/embedDocuments", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		e := defineEmbedder(r, "test/embedDocuments", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 			capturedReq = req
 			embeddings := make([]*Embedding, len(req.Input))
 			for i := range req.Input {
@@ -210,7 +210,7 @@ func TestEmbedderEmbed(t *testing.T) {
 		r := newTestRegistry(t)
 		expectedErr := errors.New("embedding failed")
 
-		e := DefineEmbedder(r, "test/embedError", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		e := defineEmbedder(r, "test/embedError", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 			return nil, expectedErr
 		})
 
@@ -226,7 +226,7 @@ func TestEmbedderEmbed(t *testing.T) {
 		r := newTestRegistry(t)
 		var capturedOpts any
 
-		e := DefineEmbedder(r, "test/embedOpts", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		e := defineEmbedder(r, "test/embedOpts", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 			capturedOpts = req.Options
 			return &EmbedResponse{Embeddings: []*Embedding{{Embedding: []float32{0.1}}}}, nil
 		})
@@ -247,7 +247,7 @@ func TestEmbedderEmbed(t *testing.T) {
 func TestEmbedFunction(t *testing.T) {
 	t.Run("embeds with embedder directly", func(t *testing.T) {
 		r := newTestRegistry(t)
-		e := DefineEmbedder(r, "test/embedFunc", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		e := defineEmbedder(r, "test/embedFunc", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 			return &EmbedResponse{
 				Embeddings: []*Embedding{{Embedding: []float32{0.1, 0.2, 0.3}}},
 			}, nil
@@ -266,7 +266,7 @@ func TestEmbedFunction(t *testing.T) {
 
 	t.Run("embeds with embedder ref", func(t *testing.T) {
 		r := newTestRegistry(t)
-		DefineEmbedder(r, "test/embedFuncRef", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		defineEmbedder(r, "test/embedFuncRef", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 			return &EmbedResponse{
 				Embeddings: []*Embedding{{Embedding: []float32{0.1, 0.2, 0.3}}},
 			}, nil
@@ -286,7 +286,7 @@ func TestEmbedFunction(t *testing.T) {
 
 	t.Run("embeds with embedder name", func(t *testing.T) {
 		r := newTestRegistry(t)
-		DefineEmbedder(r, "test/embedFuncName", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		defineEmbedder(r, "test/embedFuncName", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 			return &EmbedResponse{
 				Embeddings: []*Embedding{{Embedding: []float32{0.1, 0.2, 0.3}}},
 			}, nil
@@ -307,7 +307,7 @@ func TestEmbedFunction(t *testing.T) {
 		r := newTestRegistry(t)
 		var capturedOpts any
 
-		DefineEmbedder(r, "test/embedRefConfig", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		defineEmbedder(r, "test/embedRefConfig", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 			capturedOpts = req.Options
 			return &EmbedResponse{Embeddings: []*Embedding{{Embedding: []float32{0.1}}}}, nil
 		})
@@ -330,7 +330,7 @@ func TestEmbedFunction(t *testing.T) {
 		r := newTestRegistry(t)
 		var capturedOpts any
 
-		DefineEmbedder(r, "test/embedOverrideConfig", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		defineEmbedder(r, "test/embedOverrideConfig", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 			capturedOpts = req.Options
 			return &EmbedResponse{Embeddings: []*Embedding{{Embedding: []float32{0.1}}}}, nil
 		})
@@ -374,7 +374,7 @@ func TestEmbedFunction(t *testing.T) {
 		r := newTestRegistry(t)
 		var capturedDocs []*Document
 
-		DefineEmbedder(r, "test/embedDocs", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+		defineEmbedder(r, "test/embedDocs", nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 			capturedDocs = req.Input
 			embeddings := make([]*Embedding, len(req.Input))
 			for i := range req.Input {

--- a/go/ai/embedder_test.go
+++ b/go/ai/embedder_test.go
@@ -199,7 +199,7 @@ func TestEmbedderEmbed(t *testing.T) {
 	})
 
 	t.Run("returns error on nil embedder", func(t *testing.T) {
-		var e *embedder
+		var e *EmbedderAction
 		_, err := e.Embed(context.Background(), &EmbedRequest{})
 		if err == nil {
 			t.Error("expected error for nil embedder")

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -33,19 +33,19 @@ import (
 // EvaluatorFunc is the function type for evaluator implementations.
 type EvaluatorFunc = func(context.Context, *EvaluatorCallbackRequest) (*EvaluatorCallbackResponse, error)
 
-// EvaluatorFuncWithConfig is an [EvaluatorFunc] that additionally receives
+// TypedEvaluatorFunc is an [EvaluatorFunc] that additionally receives
 // the request's typed Config: the framework deserializes the request's raw
-// options into it before calling the function (see [NewEvaluatorWithConfig]).
-type EvaluatorFuncWithConfig[Config any] = func(context.Context, *EvaluatorCallbackRequest, Config) (*EvaluatorCallbackResponse, error)
+// options into it before calling the function (see [NewTypedEvaluator]).
+type TypedEvaluatorFunc[Config any] = func(context.Context, *EvaluatorCallbackRequest, Config) (*EvaluatorCallbackResponse, error)
 
 // BatchEvaluatorFunc is the function type for batch evaluator implementations.
 type BatchEvaluatorFunc = func(context.Context, *EvaluatorRequest) (*EvaluatorResponse, error)
 
-// BatchEvaluatorFuncWithConfig is a [BatchEvaluatorFunc] that additionally
+// TypedBatchEvaluatorFunc is a [BatchEvaluatorFunc] that additionally
 // receives the request's typed Config: the framework deserializes the
 // request's raw options into it before calling the function (see
-// [NewBatchEvaluatorWithConfig]).
-type BatchEvaluatorFuncWithConfig[Config any] = func(context.Context, *EvaluatorRequest, Config) (*EvaluatorResponse, error)
+// [NewTypedBatchEvaluator]).
+type TypedBatchEvaluatorFunc[Config any] = func(context.Context, *EvaluatorRequest, Config) (*EvaluatorResponse, error)
 
 // Evaluator represents a evaluator action.
 type Evaluator interface {
@@ -187,7 +187,7 @@ func evaluatorMetadata(opts *EvaluatorOptions) map[string]any {
 	}
 }
 
-// NewEvaluatorWithConfig creates a new [Evaluator]. Register it with
+// NewTypedEvaluator creates a new [Evaluator]. Register it with
 // [Evaluator.Register] to make it resolvable by name.
 // This method processes the input dataset one-by-one.
 //
@@ -197,9 +197,9 @@ func evaluatorMetadata(opts *EvaluatorOptions) map[string]any {
 // map[string]any (from the Dev UI and other JSON callers) are accepted, and
 // mismatched types are rejected. The config's JSON schema is inferred from
 // Config unless [EvaluatorOptions.ConfigSchema] overrides it.
-func NewEvaluatorWithConfig[Config any](name string, opts *EvaluatorOptions, fn EvaluatorFuncWithConfig[Config]) Evaluator {
+func NewTypedEvaluator[Config any](name string, opts *EvaluatorOptions, fn TypedEvaluatorFunc[Config]) Evaluator {
 	if name == "" {
-		panic("ai.NewEvaluatorWithConfig: evaluator name is required")
+		panic("ai.NewTypedEvaluator: evaluator name is required")
 	}
 
 	if opts == nil {
@@ -275,17 +275,17 @@ func NewEvaluatorWithConfig[Config any](name string, opts *EvaluatorOptions, fn 
 	}
 }
 
-// NewBatchEvaluatorWithConfig creates a new [Evaluator]. Register it with
+// NewTypedBatchEvaluator creates a new [Evaluator]. Register it with
 // [Evaluator.Register] to make it resolvable by name.
 // This method provides the full [EvaluatorRequest] to the callback function,
 // giving more flexibility to the user for processing the data, such as batching or parallelization.
 //
 // Config is the evaluator's typed configuration; it is usually inferred from
-// fn's signature. See [NewEvaluatorWithConfig] for how the request's options
+// fn's signature. See [NewTypedEvaluator] for how the request's options
 // are deserialized.
-func NewBatchEvaluatorWithConfig[Config any](name string, opts *EvaluatorOptions, fn BatchEvaluatorFuncWithConfig[Config]) Evaluator {
+func NewTypedBatchEvaluator[Config any](name string, opts *EvaluatorOptions, fn TypedBatchEvaluatorFunc[Config]) Evaluator {
 	if name == "" {
-		panic("ai.NewBatchEvaluatorWithConfig: batch evaluator name is required")
+		panic("ai.NewTypedBatchEvaluator: batch evaluator name is required")
 	}
 
 	if opts == nil {
@@ -316,14 +316,14 @@ func NewBatchEvaluatorWithConfig[Config any](name string, opts *EvaluatorOptions
 // NewEvaluator creates a new [Evaluator].
 // This method processes the input dataset one-by-one.
 //
-// Deprecated: Use [NewEvaluatorWithConfig], which passes the request's
+// Deprecated: Use [NewTypedEvaluator], which passes the request's
 // options to fn as a typed value instead of leaving them type-erased on the
 // request.
 func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluator {
 	if name == "" {
 		panic("ai.NewEvaluator: evaluator name is required")
 	}
-	return NewEvaluatorWithConfig(name, opts, func(ctx context.Context, req *EvaluatorCallbackRequest, _ any) (*EvaluatorCallbackResponse, error) {
+	return NewTypedEvaluator(name, opts, func(ctx context.Context, req *EvaluatorCallbackRequest, _ any) (*EvaluatorCallbackResponse, error) {
 		return fn(ctx, req)
 	})
 }
@@ -331,7 +331,7 @@ func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluat
 // DefineEvaluator creates a new [Evaluator] and registers it.
 // This method processes the input dataset one-by-one.
 //
-// Deprecated: Use [NewEvaluatorWithConfig] and register the result with
+// Deprecated: Use [NewTypedEvaluator] and register the result with
 // [Evaluator.Register].
 func DefineEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluator {
 	e := NewEvaluator(name, opts, fn)
@@ -343,14 +343,14 @@ func DefineEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn Eva
 // This method provides the full [EvaluatorRequest] to the callback function,
 // giving more flexibility to the user for processing the data, such as batching or parallelization.
 //
-// Deprecated: Use [NewBatchEvaluatorWithConfig], which passes the request's
+// Deprecated: Use [NewTypedBatchEvaluator], which passes the request's
 // options to fn as a typed value instead of leaving them type-erased on the
 // request.
 func NewBatchEvaluator(name string, opts *EvaluatorOptions, fn BatchEvaluatorFunc) Evaluator {
 	if name == "" {
 		panic("ai.NewBatchEvaluator: batch evaluator name is required")
 	}
-	return NewBatchEvaluatorWithConfig(name, opts, func(ctx context.Context, req *EvaluatorRequest, _ any) (*EvaluatorResponse, error) {
+	return NewTypedBatchEvaluator(name, opts, func(ctx context.Context, req *EvaluatorRequest, _ any) (*EvaluatorResponse, error) {
 		return fn(ctx, req)
 	})
 }
@@ -359,7 +359,7 @@ func NewBatchEvaluator(name string, opts *EvaluatorOptions, fn BatchEvaluatorFun
 // This method provides the full [EvaluatorRequest] to the callback function,
 // giving more flexibility to the user for processing the data, such as batching or parallelization.
 //
-// Deprecated: Use [NewBatchEvaluatorWithConfig] and register the result with
+// Deprecated: Use [NewTypedBatchEvaluator] and register the result with
 // [Evaluator.Register].
 func DefineBatchEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn BatchEvaluatorFunc) Evaluator {
 	e := NewBatchEvaluator(name, opts, fn)

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -33,8 +33,19 @@ import (
 // EvaluatorFunc is the function type for evaluator implementations.
 type EvaluatorFunc = func(context.Context, *EvaluatorCallbackRequest) (*EvaluatorCallbackResponse, error)
 
+// EvaluatorFuncWithConfig is an [EvaluatorFunc] that additionally receives
+// the request's typed Config: the framework deserializes the request's raw
+// options into it before calling the function (see [NewEvaluatorWithConfig]).
+type EvaluatorFuncWithConfig[Config any] = func(context.Context, *EvaluatorCallbackRequest, Config) (*EvaluatorCallbackResponse, error)
+
 // BatchEvaluatorFunc is the function type for batch evaluator implementations.
 type BatchEvaluatorFunc = func(context.Context, *EvaluatorRequest) (*EvaluatorResponse, error)
+
+// BatchEvaluatorFuncWithConfig is a [BatchEvaluatorFunc] that additionally
+// receives the request's typed Config: the framework deserializes the
+// request's raw options into it before calling the function (see
+// [NewBatchEvaluatorWithConfig]).
+type BatchEvaluatorFuncWithConfig[Config any] = func(context.Context, *EvaluatorRequest, Config) (*EvaluatorResponse, error)
 
 // Evaluator represents a evaluator action.
 type Evaluator interface {
@@ -163,19 +174,10 @@ type EvaluatorCallbackRequest struct {
 // EvaluatorCallbackResponse is the result on evaluating a single [Example]
 type EvaluatorCallbackResponse = EvaluationResult
 
-// NewEvaluator creates a new [Evaluator].
-// This method processes the input dataset one-by-one.
-func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluator {
-	if name == "" {
-		panic("ai.NewEvaluator: evaluator name is required")
-	}
-
-	if opts == nil {
-		opts = &EvaluatorOptions{}
-	}
-
+// evaluatorMetadata builds the shared action metadata for an evaluator.
+func evaluatorMetadata(opts *EvaluatorOptions) map[string]any {
 	// TODO(ssbushi): Set this on `evaluator` key on action metadata
-	metadata := map[string]any{
+	return map[string]any{
 		"type": api.ActionTypeEvaluator,
 		"evaluator": map[string]any{
 			"evaluatorIsBilled":    opts.IsBilled,
@@ -183,14 +185,42 @@ func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluat
 			"evaluatorDefinition":  opts.Definition,
 		},
 	}
+}
 
-	inputSchema := requestInputSchema(EvaluatorRequest{}, "options", opts.ConfigSchema)
+// NewEvaluatorWithConfig creates a new [Evaluator]. Register it with
+// [Evaluator.Register] to make it resolvable by name.
+// This method processes the input dataset one-by-one.
+//
+// Config is the evaluator's typed configuration; it is usually inferred from
+// fn's signature. The framework deserializes the request's raw options into
+// Config before calling fn: the exact Config type (or a pointer to it) and
+// map[string]any (from the Dev UI and other JSON callers) are accepted, and
+// mismatched types are rejected. The config's JSON schema is inferred from
+// Config unless [EvaluatorOptions.ConfigSchema] overrides it.
+func NewEvaluatorWithConfig[Config any](name string, opts *EvaluatorOptions, fn EvaluatorFuncWithConfig[Config]) Evaluator {
+	if name == "" {
+		panic("ai.NewEvaluatorWithConfig: evaluator name is required")
+	}
+
+	if opts == nil {
+		opts = &EvaluatorOptions{}
+	}
+
+	_, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EvaluatorRequest{}, "options")
 
 	return &evaluator{
 		Action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
-			Metadata:    metadata,
+			Metadata:    evaluatorMetadata(opts),
 			InputSchema: inputSchema,
 		}, func(ctx context.Context, req *EvaluatorRequest) (output *EvaluatorResponse, err error) {
+			cfg, err := resolveConfig[Config](req.Options)
+			if err != nil {
+				return nil, err
+			}
+			// Normalize the request so its type-erased Options always carries
+			// the same converted value the typed parameter does.
+			req.Options = cfg
+
 			var results []EvaluationResult
 			for _, datapoint := range req.Dataset {
 				if datapoint.TestCaseId == "" {
@@ -208,10 +238,10 @@ func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluat
 
 						callbackRequest := EvaluatorCallbackRequest{
 							Input:   *input,
-							Options: req.Options,
+							Options: cfg,
 						}
 
-						result, err := fn(ctx, &callbackRequest)
+						result, err := fn(ctx, &callbackRequest, cfg)
 						if err != nil {
 							failedScore := Score{
 								Status: ScoreStatusFail.String(),
@@ -245,8 +275,64 @@ func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluat
 	}
 }
 
+// NewBatchEvaluatorWithConfig creates a new [Evaluator]. Register it with
+// [Evaluator.Register] to make it resolvable by name.
+// This method provides the full [EvaluatorRequest] to the callback function,
+// giving more flexibility to the user for processing the data, such as batching or parallelization.
+//
+// Config is the evaluator's typed configuration; it is usually inferred from
+// fn's signature. See [NewEvaluatorWithConfig] for how the request's options
+// are deserialized.
+func NewBatchEvaluatorWithConfig[Config any](name string, opts *EvaluatorOptions, fn BatchEvaluatorFuncWithConfig[Config]) Evaluator {
+	if name == "" {
+		panic("ai.NewBatchEvaluatorWithConfig: batch evaluator name is required")
+	}
+
+	if opts == nil {
+		opts = &EvaluatorOptions{}
+	}
+
+	_, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EvaluatorRequest{}, "options")
+
+	rawFn := func(ctx context.Context, req *EvaluatorRequest) (*EvaluatorResponse, error) {
+		cfg, err := resolveConfig[Config](req.Options)
+		if err != nil {
+			return nil, err
+		}
+		// Normalize the request so its type-erased Options always carries the
+		// same converted value the typed parameter does.
+		req.Options = cfg
+		return fn(ctx, req, cfg)
+	}
+
+	return &evaluator{
+		Action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
+			Metadata:    evaluatorMetadata(opts),
+			InputSchema: inputSchema,
+		}, rawFn),
+	}
+}
+
+// NewEvaluator creates a new [Evaluator].
+// This method processes the input dataset one-by-one.
+//
+// Deprecated: Use [NewEvaluatorWithConfig], which passes the request's
+// options to fn as a typed value instead of leaving them type-erased on the
+// request.
+func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluator {
+	if name == "" {
+		panic("ai.NewEvaluator: evaluator name is required")
+	}
+	return NewEvaluatorWithConfig(name, opts, func(ctx context.Context, req *EvaluatorCallbackRequest, _ any) (*EvaluatorCallbackResponse, error) {
+		return fn(ctx, req)
+	})
+}
+
 // DefineEvaluator creates a new [Evaluator] and registers it.
 // This method processes the input dataset one-by-one.
+//
+// Deprecated: Use [NewEvaluatorWithConfig] and register the result with
+// [Evaluator.Register].
 func DefineEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluator {
 	e := NewEvaluator(name, opts, fn)
 	e.Register(r)
@@ -256,37 +342,28 @@ func DefineEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn Eva
 // NewBatchEvaluator creates a new [Evaluator].
 // This method provides the full [EvaluatorRequest] to the callback function,
 // giving more flexibility to the user for processing the data, such as batching or parallelization.
+//
+// Deprecated: Use [NewBatchEvaluatorWithConfig], which passes the request's
+// options to fn as a typed value instead of leaving them type-erased on the
+// request.
 func NewBatchEvaluator(name string, opts *EvaluatorOptions, fn BatchEvaluatorFunc) Evaluator {
 	if name == "" {
 		panic("ai.NewBatchEvaluator: batch evaluator name is required")
 	}
-
-	if opts == nil {
-		opts = &EvaluatorOptions{}
-	}
-
-	metadata := map[string]any{
-		"type": api.ActionTypeEvaluator,
-		"evaluator": map[string]any{
-			"evaluatorIsBilled":    opts.IsBilled,
-			"evaluatorDisplayName": opts.DisplayName,
-			"evaluatorDefinition":  opts.Definition,
-		},
-	}
-
-	return &evaluator{
-		Action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
-			Metadata: metadata,
-		}, fn),
-	}
+	return NewBatchEvaluatorWithConfig(name, opts, func(ctx context.Context, req *EvaluatorRequest, _ any) (*EvaluatorResponse, error) {
+		return fn(ctx, req)
+	})
 }
 
 // DefineBatchEvaluator creates a new [Evaluator] and registers it.
 // This method provides the full [EvaluatorRequest] to the callback function,
 // giving more flexibility to the user for processing the data, such as batching or parallelization.
+//
+// Deprecated: Use [NewBatchEvaluatorWithConfig] and register the result with
+// [Evaluator.Register].
 func DefineBatchEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn BatchEvaluatorFunc) Evaluator {
 	e := NewBatchEvaluator(name, opts, fn)
-	e.(*evaluator).Register(r)
+	e.Register(r)
 	return e
 }
 

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -34,19 +34,19 @@ import (
 // EvaluatorFunc is the function type for evaluator implementations.
 type EvaluatorFunc = func(context.Context, *EvaluatorCallbackRequest) (*EvaluatorCallbackResponse, error)
 
-// TypedEvaluatorFunc is an [EvaluatorFunc] that additionally receives
+// EvaluatorActionFunc is an [EvaluatorFunc] that additionally receives
 // the request's typed Config: the framework deserializes the request's raw
-// options into it before calling the function (see [NewTypedEvaluator]).
-type TypedEvaluatorFunc[Config any] = func(context.Context, *EvaluatorCallbackRequest, Config) (*EvaluatorCallbackResponse, error)
+// options into it before calling the function (see [NewEvaluatorAction]).
+type EvaluatorActionFunc[Config any] = func(context.Context, *EvaluatorCallbackRequest, Config) (*EvaluatorCallbackResponse, error)
 
 // BatchEvaluatorFunc is the function type for batch evaluator implementations.
 type BatchEvaluatorFunc = func(context.Context, *EvaluatorRequest) (*EvaluatorResponse, error)
 
-// TypedBatchEvaluatorFunc is a [BatchEvaluatorFunc] that additionally
+// BatchEvaluatorActionFunc is a [BatchEvaluatorFunc] that additionally
 // receives the request's typed Config: the framework deserializes the
 // request's raw options into it before calling the function (see
-// [NewTypedBatchEvaluator]).
-type TypedBatchEvaluatorFunc[Config any] = func(context.Context, *EvaluatorRequest, Config) (*EvaluatorResponse, error)
+// [NewBatchEvaluatorAction]).
+type BatchEvaluatorActionFunc[Config any] = func(context.Context, *EvaluatorRequest, Config) (*EvaluatorResponse, error)
 
 // Evaluator represents a evaluator action.
 type Evaluator interface {
@@ -85,7 +85,7 @@ func (e EvaluatorRef) Config() any {
 }
 
 // EvaluatorAction is an evaluator backed by a registry action. It is the
-// concrete type returned by [NewTypedEvaluator] and [NewTypedBatchEvaluator];
+// concrete type returned by [NewEvaluatorAction] and [NewBatchEvaluatorAction];
 // pass it to [WithEvaluator], or return it from a plugin's Init for the
 // framework to register.
 type EvaluatorAction struct {
@@ -203,10 +203,10 @@ func evaluatorMetadata(opts *EvaluatorOptions) map[string]any {
 	return metadata
 }
 
-// NewTypedEvaluator creates an unregistered [EvaluatorAction]: return it from
+// NewEvaluatorAction creates an unregistered [EvaluatorAction]: return it from
 // a plugin's Init for the framework to register, or call
 // [EvaluatorAction.Register] directly. Applications should define evaluators
-// with [genkit.DefineTypedEvaluator].
+// with [genkit.DefineEvaluatorAction].
 // This method processes the input dataset one-by-one.
 //
 // Config is the evaluator's typed configuration; it is usually inferred from
@@ -215,13 +215,13 @@ func evaluatorMetadata(opts *EvaluatorOptions) map[string]any {
 // map[string]any (from the Dev UI and other JSON callers) are accepted, and
 // mismatched types are rejected. The config's JSON schema is inferred from
 // Config unless [EvaluatorOptions.ConfigSchema] overrides it.
-func NewTypedEvaluator[Config any](
+func NewEvaluatorAction[Config any](
 	name string,
 	opts *EvaluatorOptions,
-	fn TypedEvaluatorFunc[Config],
+	fn EvaluatorActionFunc[Config],
 ) *EvaluatorAction {
 	if name == "" {
-		panic("ai.NewTypedEvaluator: evaluator name is required")
+		panic("ai.NewEvaluatorAction: evaluator name is required")
 	}
 
 	if opts == nil {
@@ -297,23 +297,23 @@ func NewTypedEvaluator[Config any](
 	}
 }
 
-// NewTypedBatchEvaluator creates an unregistered [EvaluatorAction]: return it
+// NewBatchEvaluatorAction creates an unregistered [EvaluatorAction]: return it
 // from a plugin's Init for the framework to register, or call
 // [EvaluatorAction.Register] directly. Applications should define batch
-// evaluators with [genkit.DefineTypedBatchEvaluator].
+// evaluators with [genkit.DefineBatchEvaluatorAction].
 // This method provides the full [EvaluatorRequest] to the callback function,
 // giving more flexibility to the user for processing the data, such as batching or parallelization.
 //
 // Config is the evaluator's typed configuration; it is usually inferred from
-// fn's signature. See [NewTypedEvaluator] for how the request's options
+// fn's signature. See [NewEvaluatorAction] for how the request's options
 // are deserialized.
-func NewTypedBatchEvaluator[Config any](
+func NewBatchEvaluatorAction[Config any](
 	name string,
 	opts *EvaluatorOptions,
-	fn TypedBatchEvaluatorFunc[Config],
+	fn BatchEvaluatorActionFunc[Config],
 ) *EvaluatorAction {
 	if name == "" {
-		panic("ai.NewTypedBatchEvaluator: batch evaluator name is required")
+		panic("ai.NewBatchEvaluatorAction: batch evaluator name is required")
 	}
 
 	if opts == nil {
@@ -344,14 +344,14 @@ func NewTypedBatchEvaluator[Config any](
 // NewEvaluator creates a new [Evaluator].
 // This method processes the input dataset one-by-one.
 //
-// Deprecated: Use [NewTypedEvaluator], which passes the request's
+// Deprecated: Use [NewEvaluatorAction], which passes the request's
 // options to fn as a typed value instead of leaving them type-erased on the
 // request.
 func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluator {
 	if name == "" {
 		panic("ai.NewEvaluator: evaluator name is required")
 	}
-	return NewTypedEvaluator(name, opts, func(ctx context.Context, req *EvaluatorCallbackRequest, _ any) (*EvaluatorCallbackResponse, error) {
+	return NewEvaluatorAction(name, opts, func(ctx context.Context, req *EvaluatorCallbackRequest, _ any) (*EvaluatorCallbackResponse, error) {
 		return fn(ctx, req)
 	})
 }
@@ -360,14 +360,14 @@ func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluat
 // This method provides the full [EvaluatorRequest] to the callback function,
 // giving more flexibility to the user for processing the data, such as batching or parallelization.
 //
-// Deprecated: Use [NewTypedBatchEvaluator], which passes the request's
+// Deprecated: Use [NewBatchEvaluatorAction], which passes the request's
 // options to fn as a typed value instead of leaving them type-erased on the
 // request.
 func NewBatchEvaluator(name string, opts *EvaluatorOptions, fn BatchEvaluatorFunc) Evaluator {
 	if name == "" {
 		panic("ai.NewBatchEvaluator: batch evaluator name is required")
 	}
-	return NewTypedBatchEvaluator(name, opts, func(ctx context.Context, req *EvaluatorRequest, _ any) (*EvaluatorResponse, error) {
+	return NewBatchEvaluatorAction(name, opts, func(ctx context.Context, req *EvaluatorRequest, _ any) (*EvaluatorResponse, error) {
 		return fn(ctx, req)
 	})
 }

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -328,17 +328,6 @@ func NewEvaluator(name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluat
 	})
 }
 
-// DefineEvaluator creates a new [Evaluator] and registers it.
-// This method processes the input dataset one-by-one.
-//
-// Deprecated: Use [NewTypedEvaluator] and register the result with
-// [Evaluator.Register].
-func DefineEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn EvaluatorFunc) Evaluator {
-	e := NewEvaluator(name, opts, fn)
-	e.Register(r)
-	return e
-}
-
 // NewBatchEvaluator creates a new [Evaluator].
 // This method provides the full [EvaluatorRequest] to the callback function,
 // giving more flexibility to the user for processing the data, such as batching or parallelization.
@@ -355,19 +344,7 @@ func NewBatchEvaluator(name string, opts *EvaluatorOptions, fn BatchEvaluatorFun
 	})
 }
 
-// DefineBatchEvaluator creates a new [Evaluator] and registers it.
-// This method provides the full [EvaluatorRequest] to the callback function,
-// giving more flexibility to the user for processing the data, such as batching or parallelization.
-//
-// Deprecated: Use [NewTypedBatchEvaluator] and register the result with
-// [Evaluator.Register].
-func DefineBatchEvaluator(r api.Registry, name string, opts *EvaluatorOptions, fn BatchEvaluatorFunc) Evaluator {
-	e := NewBatchEvaluator(name, opts, fn)
-	e.Register(r)
-	return e
-}
-
-// LookupEvaluator looks up an [Evaluator] registered by [DefineEvaluator].
+// LookupEvaluator looks up a registered [Evaluator] by name.
 // It returns nil if the evaluator was not defined.
 func LookupEvaluator(r api.Registry, name string) Evaluator {
 	action := core.ResolveActionFor[*EvaluatorRequest, *EvaluatorResponse, struct{}](r, api.ActionTypeEvaluator, name)

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -209,7 +209,11 @@ func evaluatorMetadata(opts *EvaluatorOptions) map[string]any {
 // map[string]any (from the Dev UI and other JSON callers) are accepted, and
 // mismatched types are rejected. The config's JSON schema is inferred from
 // Config unless [EvaluatorOptions.ConfigSchema] overrides it.
-func NewTypedEvaluator[Config any](name string, opts *EvaluatorOptions, fn TypedEvaluatorFunc[Config]) *EvaluatorAction {
+func NewTypedEvaluator[Config any](
+	name string,
+	opts *EvaluatorOptions,
+	fn TypedEvaluatorFunc[Config],
+) *EvaluatorAction {
 	if name == "" {
 		panic("ai.NewTypedEvaluator: evaluator name is required")
 	}
@@ -297,7 +301,11 @@ func NewTypedEvaluator[Config any](name string, opts *EvaluatorOptions, fn Typed
 // Config is the evaluator's typed configuration; it is usually inferred from
 // fn's signature. See [NewTypedEvaluator] for how the request's options
 // are deserialized.
-func NewTypedBatchEvaluator[Config any](name string, opts *EvaluatorOptions, fn TypedBatchEvaluatorFunc[Config]) *EvaluatorAction {
+func NewTypedBatchEvaluator[Config any](
+	name string,
+	opts *EvaluatorOptions,
+	fn TypedBatchEvaluatorFunc[Config],
+) *EvaluatorAction {
 	if name == "" {
 		panic("ai.NewTypedBatchEvaluator: batch evaluator name is required")
 	}

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -188,7 +188,7 @@ type EvaluatorCallbackRequest struct {
 type EvaluatorCallbackResponse = EvaluationResult
 
 // evaluatorMetadata builds the shared action metadata for an evaluator.
-func evaluatorMetadata(opts *EvaluatorOptions) map[string]any {
+func evaluatorMetadata(opts *EvaluatorOptions, configSchema map[string]any) map[string]any {
 	// Seed from the caller's metadata, then stamp the built-in keys over it so
 	// they cannot be corrupted; registry discovery depends on them.
 	metadata := make(map[string]any, len(opts.Metadata)+2)
@@ -199,6 +199,7 @@ func evaluatorMetadata(opts *EvaluatorOptions) map[string]any {
 		"evaluatorIsBilled":    opts.IsBilled,
 		"evaluatorDisplayName": opts.DisplayName,
 		"evaluatorDefinition":  opts.Definition,
+		"customOptions":        configSchema,
 	}
 	return metadata
 }
@@ -228,20 +229,22 @@ func NewEvaluatorAction[Config any](
 		opts = &EvaluatorOptions{}
 	}
 
-	_, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EvaluatorRequest{}, "options")
+	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EvaluatorRequest{}, "options")
 
 	return &EvaluatorAction{
 		action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
-			Metadata:    evaluatorMetadata(opts),
+			Metadata:    evaluatorMetadata(opts, configSchema),
 			InputSchema: inputSchema,
 		}, func(ctx context.Context, req *EvaluatorRequest) (output *EvaluatorResponse, err error) {
-			cfg, err := resolveConfig[Config](req.Options)
+			// Normalize a shallow copy so the type-erased Options and the
+			// typed parameter always agree without clobbering the caller-owned
+			// request.
+			reqCopy := *req
+			req = &reqCopy
+			cfg, err := resolveConfigInto[Config](&req.Options)
 			if err != nil {
 				return nil, err
 			}
-			// Normalize the request so its type-erased Options always carries
-			// the same converted value the typed parameter does.
-			req.Options = cfg
 
 			var results []EvaluationResult
 			for _, datapoint := range req.Dataset {
@@ -320,22 +323,23 @@ func NewBatchEvaluatorAction[Config any](
 		opts = &EvaluatorOptions{}
 	}
 
-	_, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EvaluatorRequest{}, "options")
+	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EvaluatorRequest{}, "options")
 
 	rawFn := func(ctx context.Context, req *EvaluatorRequest) (*EvaluatorResponse, error) {
-		cfg, err := resolveConfig[Config](req.Options)
+		// Normalize a shallow copy so the type-erased Options and the typed
+		// parameter always agree without clobbering the caller-owned request.
+		reqCopy := *req
+		req = &reqCopy
+		cfg, err := resolveConfigInto[Config](&req.Options)
 		if err != nil {
 			return nil, err
 		}
-		// Normalize the request so its type-erased Options always carries the
-		// same converted value the typed parameter does.
-		req.Options = cfg
 		return fn(ctx, req, cfg)
 	}
 
 	return &EvaluatorAction{
 		action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
-			Metadata:    evaluatorMetadata(opts),
+			Metadata:    evaluatorMetadata(opts, configSchema),
 			InputSchema: inputSchema,
 		}, rawFn),
 	}

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -83,10 +83,20 @@ func (e EvaluatorRef) Config() any {
 	return e.config
 }
 
-// evaluator is an action with functions specific to evaluating a dataset.
-type evaluator struct {
-	core.Action[*EvaluatorRequest, *EvaluatorResponse, struct{}]
+// EvaluatorAction is an evaluator backed by a registry action. It is the
+// concrete type returned by [NewTypedEvaluator] and [NewTypedBatchEvaluator];
+// pass it to [WithEvaluator], or return it from a plugin's Init for the
+// framework to register.
+type EvaluatorAction struct {
+	action[*EvaluatorRequest, *EvaluatorResponse, struct{}]
 }
+
+// EvaluatorAction is a full registry action and can be passed anywhere an
+// [api.Action] is accepted as well as anywhere an [Evaluator] is accepted.
+var (
+	_ api.Action = (*EvaluatorAction)(nil)
+	_ Evaluator  = (*EvaluatorAction)(nil)
+)
 
 // Example is a single example that requires evaluation
 type Example struct {
@@ -187,8 +197,10 @@ func evaluatorMetadata(opts *EvaluatorOptions) map[string]any {
 	}
 }
 
-// NewTypedEvaluator creates a new [Evaluator]. Register it with
-// [Evaluator.Register] to make it resolvable by name.
+// NewTypedEvaluator creates an unregistered [EvaluatorAction]: return it from
+// a plugin's Init for the framework to register, or call
+// [EvaluatorAction.Register] directly. Applications should define evaluators
+// with [genkit.DefineTypedEvaluator].
 // This method processes the input dataset one-by-one.
 //
 // Config is the evaluator's typed configuration; it is usually inferred from
@@ -197,7 +209,7 @@ func evaluatorMetadata(opts *EvaluatorOptions) map[string]any {
 // map[string]any (from the Dev UI and other JSON callers) are accepted, and
 // mismatched types are rejected. The config's JSON schema is inferred from
 // Config unless [EvaluatorOptions.ConfigSchema] overrides it.
-func NewTypedEvaluator[Config any](name string, opts *EvaluatorOptions, fn TypedEvaluatorFunc[Config]) Evaluator {
+func NewTypedEvaluator[Config any](name string, opts *EvaluatorOptions, fn TypedEvaluatorFunc[Config]) *EvaluatorAction {
 	if name == "" {
 		panic("ai.NewTypedEvaluator: evaluator name is required")
 	}
@@ -208,8 +220,8 @@ func NewTypedEvaluator[Config any](name string, opts *EvaluatorOptions, fn Typed
 
 	_, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, EvaluatorRequest{}, "options")
 
-	return &evaluator{
-		Action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
+	return &EvaluatorAction{
+		action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
 			Metadata:    evaluatorMetadata(opts),
 			InputSchema: inputSchema,
 		}, func(ctx context.Context, req *EvaluatorRequest) (output *EvaluatorResponse, err error) {
@@ -275,15 +287,17 @@ func NewTypedEvaluator[Config any](name string, opts *EvaluatorOptions, fn Typed
 	}
 }
 
-// NewTypedBatchEvaluator creates a new [Evaluator]. Register it with
-// [Evaluator.Register] to make it resolvable by name.
+// NewTypedBatchEvaluator creates an unregistered [EvaluatorAction]: return it
+// from a plugin's Init for the framework to register, or call
+// [EvaluatorAction.Register] directly. Applications should define batch
+// evaluators with [genkit.DefineTypedBatchEvaluator].
 // This method provides the full [EvaluatorRequest] to the callback function,
 // giving more flexibility to the user for processing the data, such as batching or parallelization.
 //
 // Config is the evaluator's typed configuration; it is usually inferred from
 // fn's signature. See [NewTypedEvaluator] for how the request's options
 // are deserialized.
-func NewTypedBatchEvaluator[Config any](name string, opts *EvaluatorOptions, fn TypedBatchEvaluatorFunc[Config]) Evaluator {
+func NewTypedBatchEvaluator[Config any](name string, opts *EvaluatorOptions, fn TypedBatchEvaluatorFunc[Config]) *EvaluatorAction {
 	if name == "" {
 		panic("ai.NewTypedBatchEvaluator: batch evaluator name is required")
 	}
@@ -305,8 +319,8 @@ func NewTypedBatchEvaluator[Config any](name string, opts *EvaluatorOptions, fn 
 		return fn(ctx, req, cfg)
 	}
 
-	return &evaluator{
-		Action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
+	return &EvaluatorAction{
+		action: *core.NewActionOf(api.ActionTypeEvaluator, name, &core.ActionOptions{
 			Metadata:    evaluatorMetadata(opts),
 			InputSchema: inputSchema,
 		}, rawFn),
@@ -351,13 +365,11 @@ func LookupEvaluator(r api.Registry, name string) Evaluator {
 	if action == nil {
 		return nil
 	}
-	return &evaluator{
-		Action: *action,
-	}
+	return &EvaluatorAction{*action}
 }
 
 // Evaluate runs the given [Evaluator].
-func (e *evaluator) Evaluate(ctx context.Context, req *EvaluatorRequest) (*EvaluatorResponse, error) {
+func (e *EvaluatorAction) Evaluate(ctx context.Context, req *EvaluatorRequest) (*EvaluatorResponse, error) {
 	if e == nil {
 		return nil, status.Errorf(status.ErrInvalidArgument, "Evaluator.Evaluate: evaluator called on a nil evaluator; check that all evaluators are defined")
 	}

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -19,6 +19,7 @@ package ai
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
@@ -165,6 +166,8 @@ type EvaluatorResponse = []EvaluationResult
 type EvaluatorOptions struct {
 	// ConfigSchema is the JSON schema for the evaluator's config.
 	ConfigSchema map[string]any `json:"configSchema,omitempty"`
+	// Metadata is arbitrary key-value data attached to the action descriptor.
+	Metadata map[string]any `json:"-"`
 	// DisplayName is the name of the evaluator as it appears in the UI.
 	DisplayName string `json:"displayName"`
 	// Definition is the definition of the evaluator.
@@ -186,15 +189,18 @@ type EvaluatorCallbackResponse = EvaluationResult
 
 // evaluatorMetadata builds the shared action metadata for an evaluator.
 func evaluatorMetadata(opts *EvaluatorOptions) map[string]any {
+	// Seed from the caller's metadata, then stamp the built-in keys over it so
+	// they cannot be corrupted; registry discovery depends on them.
+	metadata := make(map[string]any, len(opts.Metadata)+2)
+	maps.Copy(metadata, opts.Metadata)
 	// TODO(ssbushi): Set this on `evaluator` key on action metadata
-	return map[string]any{
-		"type": api.ActionTypeEvaluator,
-		"evaluator": map[string]any{
-			"evaluatorIsBilled":    opts.IsBilled,
-			"evaluatorDisplayName": opts.DisplayName,
-			"evaluatorDefinition":  opts.Definition,
-		},
+	metadata["type"] = api.ActionTypeEvaluator
+	metadata["evaluator"] = map[string]any{
+		"evaluatorIsBilled":    opts.IsBilled,
+		"evaluatorDisplayName": opts.DisplayName,
+		"evaluatorDefinition":  opts.Definition,
 	}
+	return metadata
 }
 
 // NewTypedEvaluator creates an unregistered [EvaluatorAction]: return it from

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -18,6 +18,7 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 
@@ -48,7 +49,11 @@ type BatchEvaluatorFunc = func(context.Context, *EvaluatorRequest) (*EvaluatorRe
 // [NewBatchEvaluatorAction]).
 type BatchEvaluatorActionFunc[Config any] = func(context.Context, *EvaluatorRequest, Config) (*EvaluatorResponse, error)
 
-// Evaluator represents a evaluator action.
+// Evaluator represents an evaluator. It is the type to accept as an argument
+// and to look up by name; implementations are created with
+// [NewEvaluatorAction] or [NewBatchEvaluatorAction], or their
+// [genkit.DefineEvaluatorAction] and [genkit.DefineBatchEvaluatorAction]
+// counterparts in an application.
 type Evaluator interface {
 	// Name returns the name of the evaluator.
 	Name() string
@@ -88,16 +93,45 @@ func (e EvaluatorRef) Config() any {
 // concrete type returned by [NewEvaluatorAction] and [NewBatchEvaluatorAction];
 // pass it to [WithEvaluator], or return it from a plugin's Init for the
 // framework to register.
+//
+// It implements [Evaluator] and [api.Action], so it can be passed anywhere
+// either is accepted. It also promotes [core.Action.Run], the typed
+// equivalent of [EvaluatorAction.Evaluate].
 type EvaluatorAction struct {
 	action[*EvaluatorRequest, *EvaluatorResponse, struct{}]
 }
 
-// EvaluatorAction is a full registry action and can be passed anywhere an
-// [api.Action] is accepted as well as anywhere an [Evaluator] is accepted.
+// Pinned here so that breaking either interface fails the build at the type
+// rather than at a call site.
 var (
 	_ api.Action = (*EvaluatorAction)(nil)
 	_ Evaluator  = (*EvaluatorAction)(nil)
 )
+
+// Name returns the registry name of the evaluator.
+func (e *EvaluatorAction) Name() string { return e.action.Name() }
+
+// Register registers the evaluator with r, making it available to lookups and
+// to the Dev UI. A plugin that returns the evaluator from its Init does not
+// need to call this.
+func (e *EvaluatorAction) Register(r api.Registry) { e.action.Register(r) }
+
+// Desc returns the evaluator's action descriptor: its name, schemas, and
+// metadata.
+func (e *EvaluatorAction) Desc() api.ActionDesc { return e.action.Desc() }
+
+// RunJSON runs the evaluator on a JSON-encoded [EvaluatorRequest] and returns
+// a JSON-encoded [EvaluatorResponse]. The framework uses it to serve
+// reflection and registry-driven calls; prefer [EvaluatorAction.Evaluate].
+func (e *EvaluatorAction) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	return e.action.RunJSON(ctx, input, cb)
+}
+
+// RunJSONWithTelemetry is [EvaluatorAction.RunJSON] with the run's telemetry
+// returned alongside the output.
+func (e *EvaluatorAction) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	return e.action.RunJSONWithTelemetry(ctx, input, cb)
+}
 
 // Example is a single example that requires evaluation
 type Example struct {

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -124,12 +124,18 @@ func (e *EvaluatorAction) Desc() api.ActionDesc { return e.action.Desc() }
 // a JSON-encoded [EvaluatorResponse]. The framework uses it to serve
 // reflection and registry-driven calls; prefer [EvaluatorAction.Evaluate].
 func (e *EvaluatorAction) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	if e == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "Evaluator.RunJSON: evaluator called on a nil evaluator; check that all evaluators are defined")
+	}
 	return e.action.RunJSON(ctx, input, cb)
 }
 
 // RunJSONWithTelemetry is [EvaluatorAction.RunJSON] with the run's telemetry
 // returned alongside the output.
 func (e *EvaluatorAction) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	if e == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "Evaluator.RunJSONWithTelemetry: evaluator called on a nil evaluator; check that all evaluators are defined")
+	}
 	return e.action.RunJSONWithTelemetry(ctx, input, cb)
 }
 

--- a/go/ai/evaluator_test.go
+++ b/go/ai/evaluator_test.go
@@ -90,7 +90,7 @@ var testRequest = EvaluatorRequest{
 func TestSimpleEvaluator(t *testing.T) {
 	r := registry.New()
 
-	evaluator := DefineEvaluator(r, "test/testEvaluator", &evalOpts, testEvalFunc)
+	evaluator := defineEvaluator(r, "test/testEvaluator", &evalOpts, testEvalFunc)
 
 	resp, err := evaluator.Evaluate(context.Background(), &testRequest)
 	if err != nil {
@@ -117,14 +117,14 @@ func TestSimpleEvaluator(t *testing.T) {
 func TestOptionsRequired(t *testing.T) {
 	r := registry.New()
 
-	_ = DefineEvaluator(r, "test/testEvaluator", &evalOpts, testEvalFunc)
-	_ = DefineBatchEvaluator(r, "test/testBatchEvaluator", &evalOpts, testBatchEvalFunc)
+	_ = defineEvaluator(r, "test/testEvaluator", &evalOpts, testEvalFunc)
+	_ = defineBatchEvaluator(r, "test/testBatchEvaluator", &evalOpts, testBatchEvalFunc)
 }
 
 func TestFailingEvaluator(t *testing.T) {
 	r := registry.New()
 
-	evalAction := DefineEvaluator(r, "test/testEvaluator", &evalOpts, testFailingEvalFunc)
+	evalAction := defineEvaluator(r, "test/testEvaluator", &evalOpts, testFailingEvalFunc)
 
 	resp, err := evalAction.Evaluate(context.Background(), &testRequest)
 	if err != nil {
@@ -142,8 +142,8 @@ func TestFailingEvaluator(t *testing.T) {
 func TestLookupEvaluator(t *testing.T) {
 	r := registry.New()
 
-	DefineEvaluator(r, "test/testEvaluator", &evalOpts, testEvalFunc)
-	DefineBatchEvaluator(r, "test/testBatchEvaluator", &evalOpts, testBatchEvalFunc)
+	defineEvaluator(r, "test/testEvaluator", &evalOpts, testEvalFunc)
+	defineBatchEvaluator(r, "test/testBatchEvaluator", &evalOpts, testBatchEvalFunc)
 
 	if LookupEvaluator(r, "test/testEvaluator") == nil {
 		t.Errorf("LookupEvaluator(r, \"test/testEvaluator\") is nil")
@@ -156,7 +156,7 @@ func TestLookupEvaluator(t *testing.T) {
 func TestEvaluate(t *testing.T) {
 	r := registry.New()
 
-	evalAction := DefineEvaluator(r, "test/testEvaluator", &evalOpts, testEvalFunc)
+	evalAction := defineEvaluator(r, "test/testEvaluator", &evalOpts, testEvalFunc)
 
 	resp, err := Evaluate(context.Background(), r,
 		WithEvaluator(evalAction),
@@ -184,7 +184,7 @@ func TestEvaluate(t *testing.T) {
 func TestBatchEvaluator(t *testing.T) {
 	r := registry.New()
 
-	evalAction := DefineBatchEvaluator(r, "test/testBatchEvaluator", &evalOpts, testBatchEvalFunc)
+	evalAction := defineBatchEvaluator(r, "test/testBatchEvaluator", &evalOpts, testBatchEvalFunc)
 
 	resp, err := evalAction.Evaluate(context.Background(), &testRequest)
 	if err != nil {
@@ -249,7 +249,7 @@ func TestEvaluatorRefUsedWithEvaluate(t *testing.T) {
 	r := registry.New()
 
 	// Define evaluator that uses config
-	DefineEvaluator(r, "test/configEvaluator", &evalOpts, func(ctx context.Context, req *EvaluatorCallbackRequest) (*EvaluatorCallbackResponse, error) {
+	defineEvaluator(r, "test/configEvaluator", &evalOpts, func(ctx context.Context, req *EvaluatorCallbackRequest) (*EvaluatorCallbackResponse, error) {
 		score := Score{
 			Id:      "configScore",
 			Score:   1,

--- a/go/ai/exp/agent.go
+++ b/go/ai/exp/agent.go
@@ -2938,8 +2938,8 @@ func (c *AgentConnection[State]) SendText(text string) error {
 }
 
 // SendResume sends a resume payload to continue an interrupted generation.
-// Construct the payload with [ai.ToolDef.RestartWith] or
-// [ai.ToolDef.RespondWith] parts.
+// Construct the payload with [ai.ToolAction.RestartWith] or
+// [ai.ToolAction.RespondWith] parts.
 func (c *AgentConnection[State]) SendResume(resume *ToolResume) error {
 	return c.conn.Send(&AgentInput{Resume: resume})
 }

--- a/go/ai/exp/agent_history_test.go
+++ b/go/ai/exp/agent_history_test.go
@@ -41,7 +41,7 @@ func recordingModel(t *testing.T, r api.Registry, name string, replies ...string
 	ai.DefineGenerateAction(context.Background(), r)
 	var requests []*ai.ModelRequest
 	turn := 0
-	ai.DefineModel(r, name, &ai.ModelOptions{
+	defineTestModel(r, name, &ai.ModelOptions{
 		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true},
 	}, func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 		requests = append(requests, req)
@@ -310,7 +310,7 @@ func TestPromptAgent_StateReachesContentFunction(t *testing.T) {
 
 	// A tool is the write side: it reaches the live session from its context
 	// and updates the custom state, which the next turn's render sees.
-	bump := ai.DefineTool(reg, "bump", "increments the counter",
+	bump := defineTestTool(reg, "bump", "increments the counter",
 		func(tc *ai.ToolContext, _ struct{}) (string, error) {
 			sess := SessionFromContext[testState](tc)
 			if sess == nil {
@@ -326,7 +326,7 @@ func TestPromptAgent_StateReachesContentFunction(t *testing.T) {
 	// Calls bump once per turn, then answers on the pass that carries the
 	// tool's response.
 	var systemSeen []string
-	ai.DefineModel(reg, "test/statefn", &ai.ModelOptions{
+	defineTestModel(reg, "test/statefn", &ai.ModelOptions{
 		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true},
 	}, func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 		for _, m := range req.Messages {

--- a/go/ai/exp/agent_test.go
+++ b/go/ai/exp/agent_test.go
@@ -1652,7 +1652,7 @@ func setupPromptTestRegistry(t *testing.T) *registry.Registry {
 	ctx := context.Background()
 
 	ai.ConfigureFormats(reg)
-	ai.DefineModel(reg, "test/echo", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true}},
+	defineTestModel(reg, "test/echo", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true}},
 		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 			// Echo back the last user message text.
 			var text string
@@ -1702,7 +1702,7 @@ func TestPromptAgent_NamedPromptSharedAcrossAgents(t *testing.T) {
 
 	var mu sync.Mutex
 	var renderedSystems []string
-	ai.DefineModel(reg, "test/capture", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true}},
+	defineTestModel(reg, "test/capture", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true}},
 		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 			mu.Lock()
 			for _, m := range req.Messages {
@@ -1766,7 +1766,7 @@ func TestDefinePromptAgent_DefaultAndNamed(t *testing.T) {
 
 	var mu sync.Mutex
 	var renderedSystems []string
-	ai.DefineModel(reg, "test/capture", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true}},
+	defineTestModel(reg, "test/capture", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true}},
 		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 			mu.Lock()
 			for _, m := range req.Messages {
@@ -1909,7 +1909,7 @@ func TestPromptAgent_MultiTurnHistory(t *testing.T) {
 	reg := setupPromptTestRegistry(t)
 
 	// Use a model that echoes all message count so we can verify history grows.
-	ai.DefineModel(reg, "test/history", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true}},
+	defineTestModel(reg, "test/history", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true}},
 		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 			// Count total messages received (includes prompt-rendered + history).
 			var parts []string
@@ -2056,14 +2056,14 @@ func TestPromptAgent_ToolLoopMessages(t *testing.T) {
 	ai.ConfigureFormats(reg)
 
 	// Define two tools so the model can call them across multiple rounds.
-	ai.DefineTool(reg, "greet", "returns a greeting",
+	defineTestTool(reg, "greet", "returns a greeting",
 		func(ctx *ai.ToolContext, input struct {
 			Name string `json:"name"`
 		}) (string, error) {
 			return "hello " + input.Name, nil
 		},
 	)
-	ai.DefineTool(reg, "farewell", "returns a farewell",
+	defineTestTool(reg, "farewell", "returns a farewell",
 		func(ctx *ai.ToolContext, input struct {
 			Name string `json:"name"`
 		}) (string, error) {
@@ -2075,7 +2075,7 @@ func TestPromptAgent_ToolLoopMessages(t *testing.T) {
 	//   Round 1: request "greet" tool
 	//   Round 2: after seeing greet response, request "farewell" tool
 	//   Round 3: after seeing farewell response, return final text
-	ai.DefineModel(reg, "test/toolmodel", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true}},
+	defineTestModel(reg, "test/toolmodel", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true}},
 		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 			// Count tool responses to determine which round we're in.
 			toolResps := 0
@@ -2363,7 +2363,7 @@ func TestPromptAgent_RejectsInvalidInputMessage(t *testing.T) {
 	ctx := context.Background()
 	reg := setupPromptTestRegistry(t)
 	var modelCalls atomic.Int64
-	ai.DefineModel(reg, "test/reject", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true}},
+	defineTestModel(reg, "test/reject", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true}},
 		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 			modelCalls.Add(1)
 			return &ai.ModelResponse{Message: ai.NewModelTextMessage("unexpected")}, nil
@@ -2656,7 +2656,7 @@ func TestPromptAgent_RejectsResumeForUnrequestedTool(t *testing.T) {
 	ai.ConfigureFormats(reg)
 
 	var modelCalls atomic.Int32
-	ai.DefineModel(reg, "test/plain", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
+	defineTestModel(reg, "test/plain", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
 		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 			modelCalls.Add(1)
 			return &ai.ModelResponse{Request: req, Message: ai.NewModelTextMessage("hello")}, nil
@@ -5708,7 +5708,7 @@ func TestPromptAgent_ForwardsFinishReason(t *testing.T) {
 	ctx := context.Background()
 	reg := registry.New()
 	ai.ConfigureFormats(reg)
-	ai.DefineModel(reg, "test/length", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true}},
+	defineTestModel(reg, "test/length", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true}},
 		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 			return &ai.ModelResponse{
 				Request:      req,
@@ -6100,14 +6100,14 @@ func TestPromptAgent_ForwardsInterruptedFinishReason(t *testing.T) {
 	reg := registry.New()
 	ai.ConfigureFormats(reg)
 
-	interruptTool := ai.DefineTool(reg, "interruptor", "always interrupts",
+	interruptTool := defineTestTool(reg, "interruptor", "always interrupts",
 		func(tc *ai.ToolContext, input any) (any, error) {
 			return nil, tc.Interrupt(&ai.InterruptOptions{
 				Metadata: map[string]any{"reason": "needs approval"},
 			})
 		},
 	)
-	ai.DefineModel(reg, "test/interrupt", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
+	defineTestModel(reg, "test/interrupt", &ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
 		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 			return &ai.ModelResponse{
 				Request: req,

--- a/go/ai/exp/agents_conformance_test.go
+++ b/go/ai/exp/agents_conformance_test.go
@@ -1137,7 +1137,7 @@ func defineTestModel(r api.Registry, name string, opts *ai.ModelOptions, fn ai.M
 	return m
 }
 
-func defineTestTool[In, Out any](r api.Registry, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolDef[In, Out] {
+func defineTestTool[In, Out any](r api.Registry, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolAction[In, Out] {
 	t := ai.NewTool(name, description, fn, opts...)
 	t.Register(r)
 	return t

--- a/go/ai/exp/agents_conformance_test.go
+++ b/go/ai/exp/agents_conformance_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/firebase/genkit/go/ai/exp"
 	"github.com/firebase/genkit/go/ai/exp/localstore"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/internal/registry"
 )
 
@@ -141,28 +142,28 @@ func setupHarness(t *testing.T) *harness {
 	ai.ConfigureFormats(reg)
 
 	pm := &programmableModel{}
-	ai.DefineModel(reg, "programmableModel",
+	defineTestModel(reg, "programmableModel",
 		&ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true}},
 		pm.generate)
 	ai.DefineGenerateAction(context.Background(), reg)
 
 	// --- Tools ---
 
-	testTool := ai.DefineTool(reg, "testTool", "A simple test tool",
+	testTool := defineTestTool(reg, "testTool", "A simple test tool",
 		func(tc *ai.ToolContext, _ struct{}) (string, error) {
 			return "tool called", nil
 		})
 
 	// interruptTool always pauses the turn, returning the tool request to the
 	// client for external resolution (resume.respond).
-	interruptTool := ai.DefineTool(reg, "interruptTool", "An interrupt tool",
+	interruptTool := defineTestTool(reg, "interruptTool", "An interrupt tool",
 		func(tc *ai.ToolContext, _ interruptIn) (interruptOut, error) {
 			return interruptOut{}, tc.Interrupt(&ai.InterruptOptions{})
 		})
 
 	// restartTool interrupts on first call and succeeds when restarted with
 	// resumed metadata (resume.restart).
-	restartTool := ai.DefineTool(reg, "restartTool", "A tool that requires confirmation before executing",
+	restartTool := defineTestTool(reg, "restartTool", "A tool that requires confirmation before executing",
 		func(tc *ai.ToolContext, in restartIn) (restartOut, error) {
 			if tc.Resumed == nil {
 				return restartOut{}, tc.Interrupt(&ai.InterruptOptions{
@@ -1126,4 +1127,18 @@ func toFloat(v any) float64 {
 	default:
 		return 0
 	}
+}
+
+// defineTestModel and defineTestTool register actions in one call, mirroring
+// the removed registry-taking ai.Define* helpers.
+func defineTestModel(r api.Registry, name string, opts *ai.ModelOptions, fn ai.ModelFunc) ai.Model {
+	m := ai.NewModel(name, opts, fn)
+	m.Register(r)
+	return m
+}
+
+func defineTestTool[In, Out any](r api.Registry, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolDef[In, Out] {
+	t := ai.NewTool(name, description, fn, opts...)
+	t.Register(r)
+	return t
 }

--- a/go/ai/exp/define_test.go
+++ b/go/ai/exp/define_test.go
@@ -30,7 +30,7 @@ func defineTestModel(r api.Registry, name string, opts *ai.ModelOptions, fn ai.M
 	return m
 }
 
-func defineTestTool[In, Out any](r api.Registry, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolDef[In, Out] {
+func defineTestTool[In, Out any](r api.Registry, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolAction[In, Out] {
 	t := ai.NewTool(name, description, fn, opts...)
 	t.Register(r)
 	return t

--- a/go/ai/exp/define_test.go
+++ b/go/ai/exp/define_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package exp
+
+import (
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+)
+
+// Test-local define helpers: New* + Register in one call, mirroring the
+// removed registry-taking ai.Define* helpers so tests stay concise.
+
+func defineTestModel(r api.Registry, name string, opts *ai.ModelOptions, fn ai.ModelFunc) ai.Model {
+	m := ai.NewModel(name, opts, fn)
+	m.Register(r)
+	return m
+}
+
+func defineTestTool[In, Out any](r api.Registry, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolDef[In, Out] {
+	t := ai.NewTool(name, description, fn, opts...)
+	t.Register(r)
+	return t
+}
+
+func defineTestExpTool[In, Out any](r api.Registry, name, description string, fn ToolFunc[In, Out], opts ...ai.ToolOption) *Tool[In, Out] {
+	t := NewTool(name, description, fn, opts...)
+	t.Register(r)
+	return t
+}
+
+func defineTestInterruptibleTool[In, Out, Res any](r api.Registry, name, description string, fn InterruptibleToolFunc[In, Out, Res], opts ...ai.ToolOption) *InterruptibleTool[In, Out, Res] {
+	t := NewInterruptibleTool(name, description, fn, opts...)
+	t.Register(r)
+	return t
+}

--- a/go/ai/exp/gen.go
+++ b/go/ai/exp/gen.go
@@ -128,7 +128,7 @@ type AgentInput struct {
 	// Message is the user's input for this turn.
 	Message *ai.Message `json:"message,omitempty"`
 	// Resume provides options for resuming an interrupted generation.
-	// Construct using [ai.ToolDef.RestartWith] / [ai.ToolDef.RespondWith]
+	// Construct using [ai.ToolAction.RestartWith] / [ai.ToolAction.RespondWith]
 	// parts. When set, the generate call resumes with these parts instead
 	// of treating Message as a tool response.
 	Resume *ToolResume `json:"resume,omitempty"`

--- a/go/ai/exp/tools.go
+++ b/go/ai/exp/tools.go
@@ -40,15 +40,15 @@ type InterruptibleToolFunc[In, Out, Resume any] = func(ctx context.Context, inpu
 // Tool wraps an [ai.Tool] with experimental x package features
 // such as a plain [context.Context] function signature and [tool.AttachParts].
 //
-// DEPRECATED(breaking): With breaking changes, Tool would not wrap ai.ToolDef.
+// DEPRECATED(breaking): With breaking changes, Tool would not wrap ai.ToolAction.
 // It would be the primary tool type, backed directly by core.NewActionOf,
 // eliminating the inner field and all delegation methods below.
 type Tool[In, Out any] struct {
-	inner *ai.ToolDef[In, *ai.MultipartToolResponse] // DEPRECATED(breaking): remove wrapper; Tool owns the action directly.
+	inner *ai.ToolAction[In, *ai.MultipartToolResponse] // DEPRECATED(breaking): remove wrapper; Tool owns the action directly.
 }
 
 // DEPRECATED(breaking): The methods below exist to implement ai.Tool on top of
-// the wrapped ai.ToolDef. Most are pure delegation; Definition additionally
+// the wrapped ai.ToolAction. Most are pure delegation; Definition additionally
 // restores the real output schema (see its comment). With breaking changes, Tool
 // would own the action directly and implement these natively, inferring the
 // output schema from Out without the override.

--- a/go/ai/exp/tools.go
+++ b/go/ai/exp/tools.go
@@ -29,7 +29,7 @@ import (
 	"github.com/firebase/genkit/go/internal/base"
 )
 
-// ToolFunc is the function signature for tools created with [DefineTool] and [NewTool].
+// ToolFunc is the function signature for tools created with [NewTool].
 type ToolFunc[In, Out any] = func(ctx context.Context, input In) (Out, error)
 
 // InterruptibleToolFunc is the function signature for tools created with
@@ -172,20 +172,6 @@ func requireAnyOutForSchemaOptions[Out any](ctor, name string, opts []ai.ToolOpt
 	}
 }
 
-// DefineTool creates a new tool with a simple function signature and registers it.
-// The function receives a plain [context.Context] instead of [ai.ToolContext].
-// Use [tool.AttachParts] inside the function to return additional content parts.
-func DefineTool[In, Out any](
-	r api.Registry,
-	name, description string,
-	fn ToolFunc[In, Out],
-	opts ...ai.ToolOption,
-) *Tool[In, Out] {
-	t := NewTool(name, description, fn, opts...)
-	t.Register(r)
-	return t
-}
-
 // NewTool creates a new unregistered tool with a simple function signature.
 // Use [tool.AttachParts] inside the function to return additional content parts.
 func NewTool[In, Out any](
@@ -197,21 +183,6 @@ func NewTool[In, Out any](
 	// DEPRECATED(breaking): Call core.NewActionOf directly instead of wrapping ai.NewMultipartTool.
 	inner := ai.NewMultipartTool(name, description, wrapSimpleFunc(fn), opts...)
 	return &Tool[In, Out]{inner: inner}
-}
-
-// DefineInterruptibleTool creates a new interruptible tool and registers it.
-// The resumed parameter is non-nil when the tool is being resumed after an
-// interrupt. Use [tool.Interrupt] inside the function to interrupt execution
-// and send data to the caller.
-func DefineInterruptibleTool[In, Out, Res any](
-	r api.Registry,
-	name, description string,
-	fn InterruptibleToolFunc[In, Out, Res],
-	opts ...ai.ToolOption,
-) *InterruptibleTool[In, Out, Res] {
-	t := NewInterruptibleTool(name, description, fn, opts...)
-	t.Register(r)
-	return t
 }
 
 // NewInterruptibleTool creates a new unregistered interruptible tool.

--- a/go/ai/exp/tools_test.go
+++ b/go/ai/exp/tools_test.go
@@ -105,7 +105,7 @@ func TestToolOutputSchemaOptions(t *testing.T) {
 // reqs (typically tool requests), and once a tool response is in history it
 // returns the final text "done". This drives a single tool round per Generate.
 func defineToolThenFinishModel(reg *registry.Registry, reqs ...*ai.Part) {
-	ai.DefineModel(reg, "test/model",
+	defineTestModel(reg, "test/model",
 		&ai.ModelOptions{Supports: &ai.ModelSupports{Multiturn: true, Tools: true}},
 		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 			for _, m := range req.Messages {
@@ -139,7 +139,7 @@ func TestDefineTool_PlainContext(t *testing.T) {
 	}))
 
 	var gotCity string
-	weather := DefineTool(reg, "getWeather", "fetches the weather",
+	weather := defineTestExpTool(reg, "getWeather", "fetches the weather",
 		func(ctx context.Context, in weatherIn) (string, error) {
 			gotCity = in.City
 			return "Sunny", nil
@@ -164,7 +164,7 @@ func TestDefineTool_PlainContext(t *testing.T) {
 // multipart response without changing the function signature.
 func TestTool_AttachParts(t *testing.T) {
 	reg := newToolTestRegistry(t)
-	shot := DefineTool(reg, "screenshot", "takes a screenshot",
+	shot := defineTestExpTool(reg, "screenshot", "takes a screenshot",
 		func(ctx context.Context, _ struct{}) (string, error) {
 			tool.AttachParts(ctx, ai.NewMediaPart("image/png", "pngbytes"))
 			return "captured", nil
@@ -237,7 +237,7 @@ func TestTool_OutputSchemaMatchesClassic(t *testing.T) {
 // when no streaming callback is wired (here, a direct RunRaw).
 func TestTool_SendPartialNoOpWithoutStreaming(t *testing.T) {
 	reg := newToolTestRegistry(t)
-	tl := DefineTool(reg, "noop", "streams when it can",
+	tl := defineTestExpTool(reg, "noop", "streams when it can",
 		func(ctx context.Context, _ struct{}) (string, error) {
 			tool.SendPartial(ctx, map[string]any{"progress": 50})
 			return "ok", nil
@@ -274,7 +274,7 @@ func TestDefineInterruptibleTool_TypedRoundTrip(t *testing.T) {
 	}))
 
 	var gotResume *confirmation
-	transfer := DefineInterruptibleTool(reg, "transfer", "transfers money",
+	transfer := defineTestInterruptibleTool(reg, "transfer", "transfers money",
 		func(ctx context.Context, in transferIn, res *confirmation) (string, error) {
 			if res == nil {
 				return "", tool.Interrupt(transferInterrupt{Reason: "large_amount", Amount: in.Amount})
@@ -365,7 +365,7 @@ func TestResume_NonObjectData_ReturnsClearError(t *testing.T) {
 // the tool runs.
 func TestInterrupt_NonObjectData_ReturnsClearError(t *testing.T) {
 	reg := newToolTestRegistry(t)
-	tl := DefineInterruptibleTool(reg, "bad", "interrupts with a scalar",
+	tl := defineTestInterruptibleTool(reg, "bad", "interrupts with a scalar",
 		func(ctx context.Context, _ struct{}, _ *struct{}) (string, error) {
 			return "", tool.Interrupt("not an object")
 		})
@@ -386,7 +386,7 @@ func TestSendPartial_StreamsPartialToolResponse(t *testing.T) {
 	reg := newToolTestRegistry(t)
 	defineToolThenFinishModel(reg, ai.NewToolRequestPart(&ai.ToolRequest{Name: "progressTool", Input: map[string]any{}}))
 
-	DefineTool(reg, "progressTool", "streams progress",
+	defineTestExpTool(reg, "progressTool", "streams progress",
 		func(ctx context.Context, _ struct{}) (string, error) {
 			tool.SendPartial(ctx, map[string]any{"progress": 50})
 			return "complete", nil
@@ -444,8 +444,8 @@ func TestConcurrentStreamingTools_NoDataRace(t *testing.T) {
 		}
 		return "ok", nil
 	}
-	DefineTool(reg, "toolA", "streams", streamer)
-	DefineTool(reg, "toolB", "streams", streamer)
+	defineTestExpTool(reg, "toolA", "streams", streamer)
+	defineTestExpTool(reg, "toolB", "streams", streamer)
 
 	for _, err := range ai.GenerateStream(context.Background(), reg,
 		ai.WithModelName("test/model"),

--- a/go/ai/format_test.go
+++ b/go/ai/format_test.go
@@ -1079,7 +1079,7 @@ func TestConstrainedGenerateWithFormats(t *testing.T) {
 		},
 	}
 
-	formatModel := DefineModel(r, "test/format", &modelOpts, func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
+	formatModel := defineModel(r, "test/format", &modelOpts, func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
 		return &ModelResponse{
 			Request: gr,
 			Message: NewModelTextMessage(JSONmd),

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -72,10 +72,10 @@ type ToolConfig struct {
 // ModelFunc is a streaming function that takes in a ModelRequest and generates a ModelResponse, optionally streaming ModelResponseChunks.
 type ModelFunc = core.StreamingFunc[*ModelRequest, *ModelResponse, *ModelResponseChunk]
 
-// TypedModelFunc is a [ModelFunc] that additionally receives the
+// ModelActionFunc is a [ModelFunc] that additionally receives the
 // request's typed Config: the framework deserializes the request's raw config
-// into it before calling the function (see [NewTypedModel]).
-type TypedModelFunc[Config any] = func(context.Context, *ModelRequest, Config, ModelStreamCallback) (*ModelResponse, error)
+// into it before calling the function (see [NewModelAction]).
+type ModelActionFunc[Config any] = func(context.Context, *ModelRequest, Config, ModelStreamCallback) (*ModelResponse, error)
 
 // ModelStreamCallback is a stream callback of a ModelAction.
 type ModelStreamCallback = func(context.Context, *ModelResponseChunk) error
@@ -92,7 +92,7 @@ type ModelMiddleware = core.Middleware[*ModelRequest, *ModelResponse, *ModelResp
 type action[In, Out, Stream any] = core.Action[In, Out, Stream]
 
 // ModelAction is a generative model backed by a registry action. It is the
-// concrete type returned by [NewTypedModel]; pass it to [WithModel] to use it
+// concrete type returned by [NewModelAction]; pass it to [WithModel] to use it
 // for generation, or return it from a plugin's Init for the framework to
 // register.
 type ModelAction struct {
@@ -160,10 +160,10 @@ func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
 	return (*generateAction)(a)
 }
 
-// NewTypedModel creates an unregistered [ModelAction]: return it from a
+// NewModelAction creates an unregistered [ModelAction]: return it from a
 // plugin's Init for the framework to register, or call
 // [ModelAction.Register] directly. Applications should define models with
-// [genkit.DefineTypedModel].
+// [genkit.DefineModelAction].
 //
 // Config is the model's typed configuration; it is usually inferred from fn's
 // signature. The framework deserializes the request's raw config into Config
@@ -179,13 +179,13 @@ func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
 // wrapper types like Opt[float64] that marshal to primitives but reflect as
 // objects), set [ModelOptions.ConfigSchema] explicitly or requests will be
 // rejected at the action boundary.
-func NewTypedModel[Config any](
+func NewModelAction[Config any](
 	name string,
 	opts *ModelOptions,
-	fn TypedModelFunc[Config],
+	fn ModelActionFunc[Config],
 ) *ModelAction {
 	if name == "" {
-		panic("ai.NewTypedModel: name is required")
+		panic("ai.NewModelAction: name is required")
 	}
 
 	if opts == nil {
@@ -250,13 +250,13 @@ func NewTypedModel[Config any](
 
 // NewModel creates a new [Model].
 //
-// Deprecated: Use [NewTypedModel], which passes the request's config to
+// Deprecated: Use [NewModelAction], which passes the request's config to
 // fn as a typed value instead of leaving it type-erased on the request.
 func NewModel(name string, opts *ModelOptions, fn ModelFunc) Model {
 	if name == "" {
 		panic("ai.NewModel: name is required")
 	}
-	return NewTypedModel(name, opts, func(ctx context.Context, req *ModelRequest, _ any, cb ModelStreamCallback) (*ModelResponse, error) {
+	return NewModelAction(name, opts, func(ctx context.Context, req *ModelRequest, _ any, cb ModelStreamCallback) (*ModelResponse, error) {
 		return fn(ctx, req, cb)
 	})
 }

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -197,30 +197,8 @@ func NewModelAction[Config any](
 		opts.Supports = &ModelSupports{}
 	}
 
-	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, ModelRequest{}, "config")
-
-	// The reserved type and model keys win over caller-provided metadata.
-	metadata := make(map[string]any, len(opts.Metadata)+2)
-	maps.Copy(metadata, opts.Metadata)
-	metadata["type"] = api.ActionTypeModel
-	metadata["model"] = map[string]any{
-		"label": opts.Label,
-		"supports": map[string]any{
-			"media":       opts.Supports.Media,
-			"context":     opts.Supports.Context,
-			"multiturn":   opts.Supports.Multiturn,
-			"systemRole":  opts.Supports.SystemRole,
-			"tools":       opts.Supports.Tools,
-			"toolChoice":  opts.Supports.ToolChoice,
-			"constrained": opts.Supports.Constrained,
-			"output":      opts.Supports.Output,
-			"contentType": opts.Supports.ContentType,
-			"longRunning": opts.Supports.LongRunning,
-		},
-		"versions":      opts.Versions,
-		"stage":         opts.Stage,
-		"customOptions": configSchema,
-	}
+	configSchema, inputSchema := modelConfigSchemas[Config](opts.ConfigSchema)
+	metadata := modelActionMetadata(api.ActionTypeModel, opts, configSchema, opts.Metadata)
 
 	typedFn := func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		// req.Config was normalized to the exact Config type by
@@ -246,6 +224,41 @@ func NewModelAction[Config any](
 		Metadata:    metadata,
 		InputSchema: inputSchema,
 	}, rawFn)}
+}
+
+// modelActionMetadata builds the descriptor metadata shared by model and
+// background-model actions: the caller metadata maps are merged in order,
+// then the reserved type and model keys are stamped over them so they cannot
+// be corrupted; registry discovery depends on them.
+func modelActionMetadata(actionType api.ActionType, opts *ModelOptions, configSchema map[string]any, callerMetadata ...map[string]any) map[string]any {
+	size := 2
+	for _, m := range callerMetadata {
+		size += len(m)
+	}
+	metadata := make(map[string]any, size)
+	for _, m := range callerMetadata {
+		maps.Copy(metadata, m)
+	}
+	metadata["type"] = actionType
+	metadata["model"] = map[string]any{
+		"label": opts.Label,
+		"supports": map[string]any{
+			"media":       opts.Supports.Media,
+			"context":     opts.Supports.Context,
+			"multiturn":   opts.Supports.Multiturn,
+			"systemRole":  opts.Supports.SystemRole,
+			"tools":       opts.Supports.Tools,
+			"toolChoice":  opts.Supports.ToolChoice,
+			"constrained": opts.Supports.Constrained,
+			"output":      opts.Supports.Output,
+			"contentType": opts.Supports.ContentType,
+			"longRunning": opts.Supports.LongRunning,
+		},
+		"versions":      opts.Versions,
+		"stage":         opts.Stage,
+		"customOptions": configSchema,
+	}
+	return metadata
 }
 
 // NewModel creates a new [Model].

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -177,7 +177,11 @@ func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
 // wrapper types like Opt[float64] that marshal to primitives but reflect as
 // objects), set [ModelOptions.ConfigSchema] explicitly or requests will be
 // rejected at the action boundary.
-func NewTypedModel[Config any](name string, opts *ModelOptions, fn TypedModelFunc[Config]) *ModelAction {
+func NewTypedModel[Config any](
+	name string,
+	opts *ModelOptions,
+	fn TypedModelFunc[Config],
+) *ModelAction {
 	if name == "" {
 		panic("ai.NewTypedModel: name is required")
 	}

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -71,6 +71,11 @@ type ToolConfig struct {
 // ModelFunc is a streaming function that takes in a ModelRequest and generates a ModelResponse, optionally streaming ModelResponseChunks.
 type ModelFunc = core.StreamingFunc[*ModelRequest, *ModelResponse, *ModelResponseChunk]
 
+// ModelFuncWithConfig is a [ModelFunc] that additionally receives the
+// request's typed Config: the framework deserializes the request's raw config
+// into it before calling the function (see [NewModelWithConfig]).
+type ModelFuncWithConfig[Config any] = func(context.Context, *ModelRequest, Config, ModelStreamCallback) (*ModelResponse, error)
+
 // ModelStreamCallback is a stream callback of a ModelAction.
 type ModelStreamCallback = func(context.Context, *ModelResponseChunk) error
 
@@ -137,10 +142,26 @@ func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
 	return (*generateAction)(a)
 }
 
-// NewModel creates a new [Model].
-func NewModel(name string, opts *ModelOptions, fn ModelFunc) Model {
+// NewModelWithConfig creates a new [Model]. Register it with
+// [Model.Register] to make it resolvable by name.
+//
+// Config is the model's typed configuration; it is usually inferred from fn's
+// signature. The framework deserializes the request's raw config into Config
+// before calling fn: the exact Config type (or a pointer to it) and
+// map[string]any (from the Dev UI and other JSON callers) are accepted, and
+// mismatched types are rejected. The request's [ModelRequest.Config] is
+// normalized to the converted value, so it always matches the typed
+// parameter. The config's JSON schema is inferred from Config unless
+// [ModelOptions.ConfigSchema] overrides it.
+//
+// The config schema is enforced by input validation on every call, so if
+// Config's JSON marshaling diverges from its reflected schema (e.g. SDK
+// wrapper types like Opt[float64] that marshal to primitives but reflect as
+// objects), set [ModelOptions.ConfigSchema] explicitly or requests will be
+// rejected at the action boundary.
+func NewModelWithConfig[Config any](name string, opts *ModelOptions, fn ModelFuncWithConfig[Config]) Model {
 	if name == "" {
-		panic("ai.NewModel: name is required")
+		panic("ai.NewModelWithConfig: name is required")
 	}
 
 	if opts == nil {
@@ -151,6 +172,8 @@ func NewModel(name string, opts *ModelOptions, fn ModelFunc) Model {
 	if opts.Supports == nil {
 		opts.Supports = &ModelSupports{}
 	}
+
+	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, ModelRequest{}, "config")
 
 	metadata := map[string]any{
 		"type": api.ActionTypeModel,
@@ -170,27 +193,53 @@ func NewModel(name string, opts *ModelOptions, fn ModelFunc) Model {
 			},
 			"versions":      opts.Versions,
 			"stage":         opts.Stage,
-			"customOptions": opts.ConfigSchema,
+			"customOptions": configSchema,
 		},
 	}
 
-	inputSchema := requestInputSchema(ModelRequest{}, "config", opts.ConfigSchema)
+	typedFn := func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+		// req.Config was normalized to the exact Config type by
+		// normalizeConfig below, so this hits the fast path.
+		cfg, err := resolveConfig[Config](req.Config)
+		if err != nil {
+			return nil, err
+		}
+		return fn(ctx, req, cfg, cb)
+	}
 
-	mws := []ModelMiddleware{
+	// normalizeConfig runs outermost so that the built-in wrappers and the
+	// model function all see the typed, converted config on the request.
+	rawFn := core.ChainMiddleware(
+		normalizeConfig[Config](name, opts.Versions),
 		simulateSystemPrompt(opts, nil),
 		augmentWithContext(opts, nil),
 		validateSupport(name, opts),
 		addAutomaticTelemetry(),
-	}
-	fn = core.ChainMiddleware(mws...)(fn)
+	)(typedFn)
 
 	return &model{*core.NewStreamingActionOf(api.ActionTypeModel, name, &core.ActionOptions{
 		Metadata:    metadata,
 		InputSchema: inputSchema,
-	}, fn)}
+	}, rawFn)}
+}
+
+// NewModel creates a new [Model].
+//
+// Deprecated: Use [NewModelWithConfig], which passes the request's config to
+// fn as a typed value instead of leaving it type-erased on the request.
+func NewModel(name string, opts *ModelOptions, fn ModelFunc) Model {
+	if name == "" {
+		panic("ai.NewModel: name is required")
+	}
+	return NewModelWithConfig(name, opts, func(ctx context.Context, req *ModelRequest, _ any, cb ModelStreamCallback) (*ModelResponse, error) {
+		return fn(ctx, req, cb)
+	})
 }
 
 // DefineModel creates a new [Model] and registers it.
+//
+// Deprecated: Use [NewModelWithConfig] and register the result with
+// [Model.Register].
 func DefineModel(r api.Registry, name string, opts *ModelOptions, fn ModelFunc) Model {
 	m := NewModel(name, opts, fn)
 	m.Register(r)

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -71,10 +71,10 @@ type ToolConfig struct {
 // ModelFunc is a streaming function that takes in a ModelRequest and generates a ModelResponse, optionally streaming ModelResponseChunks.
 type ModelFunc = core.StreamingFunc[*ModelRequest, *ModelResponse, *ModelResponseChunk]
 
-// ModelFuncWithConfig is a [ModelFunc] that additionally receives the
+// TypedModelFunc is a [ModelFunc] that additionally receives the
 // request's typed Config: the framework deserializes the request's raw config
-// into it before calling the function (see [NewModelWithConfig]).
-type ModelFuncWithConfig[Config any] = func(context.Context, *ModelRequest, Config, ModelStreamCallback) (*ModelResponse, error)
+// into it before calling the function (see [NewTypedModel]).
+type TypedModelFunc[Config any] = func(context.Context, *ModelRequest, Config, ModelStreamCallback) (*ModelResponse, error)
 
 // ModelStreamCallback is a stream callback of a ModelAction.
 type ModelStreamCallback = func(context.Context, *ModelResponseChunk) error
@@ -142,7 +142,7 @@ func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
 	return (*generateAction)(a)
 }
 
-// NewModelWithConfig creates a new [Model]. Register it with
+// NewTypedModel creates a new [Model]. Register it with
 // [Model.Register] to make it resolvable by name.
 //
 // Config is the model's typed configuration; it is usually inferred from fn's
@@ -159,9 +159,9 @@ func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
 // wrapper types like Opt[float64] that marshal to primitives but reflect as
 // objects), set [ModelOptions.ConfigSchema] explicitly or requests will be
 // rejected at the action boundary.
-func NewModelWithConfig[Config any](name string, opts *ModelOptions, fn ModelFuncWithConfig[Config]) Model {
+func NewTypedModel[Config any](name string, opts *ModelOptions, fn TypedModelFunc[Config]) Model {
 	if name == "" {
-		panic("ai.NewModelWithConfig: name is required")
+		panic("ai.NewTypedModel: name is required")
 	}
 
 	if opts == nil {
@@ -225,20 +225,20 @@ func NewModelWithConfig[Config any](name string, opts *ModelOptions, fn ModelFun
 
 // NewModel creates a new [Model].
 //
-// Deprecated: Use [NewModelWithConfig], which passes the request's config to
+// Deprecated: Use [NewTypedModel], which passes the request's config to
 // fn as a typed value instead of leaving it type-erased on the request.
 func NewModel(name string, opts *ModelOptions, fn ModelFunc) Model {
 	if name == "" {
 		panic("ai.NewModel: name is required")
 	}
-	return NewModelWithConfig(name, opts, func(ctx context.Context, req *ModelRequest, _ any, cb ModelStreamCallback) (*ModelResponse, error) {
+	return NewTypedModel(name, opts, func(ctx context.Context, req *ModelRequest, _ any, cb ModelStreamCallback) (*ModelResponse, error) {
 		return fn(ctx, req, cb)
 	})
 }
 
 // DefineModel creates a new [Model] and registers it.
 //
-// Deprecated: Use [NewModelWithConfig] and register the result with
+// Deprecated: Use [NewTypedModel] and register the result with
 // [Model.Register].
 func DefineModel(r api.Registry, name string, opts *ModelOptions, fn ModelFunc) Model {
 	m := NewModel(name, opts, fn)

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -136,6 +137,7 @@ type ModelOptions struct {
 	Stage        ModelStage     // Indicates the maturity stage of the model.
 	Supports     *ModelSupports // Capabilities of the model.
 	Versions     []string       // Available versions of the model.
+	Metadata     map[string]any // Arbitrary key-value data attached to the action descriptor.
 }
 
 // DefineGenerateAction defines a utility generate action.
@@ -197,26 +199,27 @@ func NewTypedModel[Config any](
 
 	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, ModelRequest{}, "config")
 
-	metadata := map[string]any{
-		"type": api.ActionTypeModel,
-		"model": map[string]any{
-			"label": opts.Label,
-			"supports": map[string]any{
-				"media":       opts.Supports.Media,
-				"context":     opts.Supports.Context,
-				"multiturn":   opts.Supports.Multiturn,
-				"systemRole":  opts.Supports.SystemRole,
-				"tools":       opts.Supports.Tools,
-				"toolChoice":  opts.Supports.ToolChoice,
-				"constrained": opts.Supports.Constrained,
-				"output":      opts.Supports.Output,
-				"contentType": opts.Supports.ContentType,
-				"longRunning": opts.Supports.LongRunning,
-			},
-			"versions":      opts.Versions,
-			"stage":         opts.Stage,
-			"customOptions": configSchema,
+	// The reserved type and model keys win over caller-provided metadata.
+	metadata := make(map[string]any, len(opts.Metadata)+2)
+	maps.Copy(metadata, opts.Metadata)
+	metadata["type"] = api.ActionTypeModel
+	metadata["model"] = map[string]any{
+		"label": opts.Label,
+		"supports": map[string]any{
+			"media":       opts.Supports.Media,
+			"context":     opts.Supports.Context,
+			"multiturn":   opts.Supports.Multiturn,
+			"systemRole":  opts.Supports.SystemRole,
+			"tools":       opts.Supports.Tools,
+			"toolChoice":  opts.Supports.ToolChoice,
+			"constrained": opts.Supports.Constrained,
+			"output":      opts.Supports.Output,
+			"contentType": opts.Supports.ContentType,
+			"longRunning": opts.Supports.LongRunning,
 		},
+		"versions":      opts.Versions,
+		"stage":         opts.Stage,
+		"customOptions": configSchema,
 	}
 
 	typedFn := func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -236,17 +236,7 @@ func NewModel(name string, opts *ModelOptions, fn ModelFunc) Model {
 	})
 }
 
-// DefineModel creates a new [Model] and registers it.
-//
-// Deprecated: Use [NewTypedModel] and register the result with
-// [Model.Register].
-func DefineModel(r api.Registry, name string, opts *ModelOptions, fn ModelFunc) Model {
-	m := NewModel(name, opts, fn)
-	m.Register(r)
-	return m
-}
-
-// LookupModel looks up a [Model] registered by [DefineModel].
+// LookupModel looks up a registered [Model] by name.
 // It will try to resolve the model dynamically if the model is not found.
 // It returns nil if the model was not resolved.
 func LookupModel(r api.Registry, name string) Model {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -134,12 +134,18 @@ func (m *ModelAction) Desc() api.ActionDesc { return m.action.Desc() }
 // JSON-encoded [ModelResponse]. The framework uses it to serve reflection and
 // registry-driven calls; prefer [ModelAction.Generate].
 func (m *ModelAction) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	if m == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "Model.RunJSON: model called on a nil model; check that all models are defined")
+	}
 	return m.action.RunJSON(ctx, input, cb)
 }
 
 // RunJSONWithTelemetry is [ModelAction.RunJSON] with the run's telemetry
 // returned alongside the output.
 func (m *ModelAction) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	if m == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "Model.RunJSONWithTelemetry: model called on a nil model; check that all models are defined")
+	}
 	return m.action.RunJSONWithTelemetry(ctx, input, cb)
 }
 

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -38,7 +38,10 @@ import (
 	"github.com/firebase/genkit/go/internal/base"
 )
 
-// Model represents a model that can generate content based on a request.
+// Model represents a model that can generate content based on a request. It
+// is the type to accept as an argument and to look up by name; implementations
+// are created with [NewModelAction], or [genkit.DefineModelAction] in an
+// application.
 type Model interface {
 	// Name returns the registry name of the model.
 	Name() string
@@ -89,22 +92,56 @@ type ModelMiddleware = core.Middleware[*ModelRequest, *ModelResponse, *ModelResp
 // in the ai primitives (ModelAction, EmbedderAction, EvaluatorAction).
 // Embedding via the alias promotes Action's methods without exporting the
 // field itself, so the containment stays an internal detail of each primitive.
+//
+// Each primitive redeclares the promoted methods that satisfy its interfaces,
+// forwarding to the embedded action. Promotion alone would compile, but godoc
+// cannot see through an alias into another package: a promoted method appears
+// in no documentation and no doc link to it resolves, so a reader would find
+// a model with one method that nonetheless claims to be an [api.Action].
 type action[In, Out, Stream any] = core.Action[In, Out, Stream]
 
 // ModelAction is a generative model backed by a registry action. It is the
 // concrete type returned by [NewModelAction]; pass it to [WithModel] to use it
 // for generation, or return it from a plugin's Init for the framework to
 // register.
+//
+// It implements [Model] and [api.Action], so it can be passed anywhere either
+// is accepted. It also promotes [core.Action.Run], the typed equivalent of
+// [ModelAction.Generate].
 type ModelAction struct {
 	action[*ModelRequest, *ModelResponse, *ModelResponseChunk]
 }
 
-// ModelAction is a full registry action and can be passed anywhere an
-// [api.Action] is accepted as well as anywhere a [Model] is accepted.
+// Pinned here so that breaking either interface fails the build at the type
+// rather than at a call site.
 var (
 	_ api.Action = (*ModelAction)(nil)
 	_ Model      = (*ModelAction)(nil)
 )
+
+// Name returns the registry name of the model.
+func (m *ModelAction) Name() string { return m.action.Name() }
+
+// Register registers the model with r, making it available to lookups and to
+// the Dev UI. A plugin that returns the model from its Init does not need to
+// call this.
+func (m *ModelAction) Register(r api.Registry) { m.action.Register(r) }
+
+// Desc returns the model's action descriptor: its name, schemas, and metadata.
+func (m *ModelAction) Desc() api.ActionDesc { return m.action.Desc() }
+
+// RunJSON runs the model on a JSON-encoded [ModelRequest] and returns a
+// JSON-encoded [ModelResponse]. The framework uses it to serve reflection and
+// registry-driven calls; prefer [ModelAction.Generate].
+func (m *ModelAction) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	return m.action.RunJSON(ctx, input, cb)
+}
+
+// RunJSONWithTelemetry is [ModelAction.RunJSON] with the run's telemetry
+// returned alongside the output.
+func (m *ModelAction) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	return m.action.RunJSONWithTelemetry(ctx, input, cb)
+}
 
 // generateAction is the type for a utility model generation action that takes in a GenerateActionOptions instead of a ModelRequest.
 type generateAction = core.Action[*GenerateActionOptions, *ModelResponse, *ModelResponseChunk]

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -84,10 +84,26 @@ type ModelStreamCallback = func(context.Context, *ModelResponseChunk) error
 // Deprecated: Use [Middleware] interface with [WithUse] instead, which supports Generate, Model, and Tool hooks.
 type ModelMiddleware = core.Middleware[*ModelRequest, *ModelResponse, *ModelResponseChunk]
 
-// model is an action with functions specific to model generation such as Generate().
-type model struct {
-	core.Action[*ModelRequest, *ModelResponse, *ModelResponseChunk]
+// action is an unexported alias of [core.Action] used as the embedded field
+// in the ai primitives (ModelAction, EmbedderAction, EvaluatorAction).
+// Embedding via the alias promotes Action's methods without exporting the
+// field itself, so the containment stays an internal detail of each primitive.
+type action[In, Out, Stream any] = core.Action[In, Out, Stream]
+
+// ModelAction is a generative model backed by a registry action. It is the
+// concrete type returned by [NewTypedModel]; pass it to [WithModel] to use it
+// for generation, or return it from a plugin's Init for the framework to
+// register.
+type ModelAction struct {
+	action[*ModelRequest, *ModelResponse, *ModelResponseChunk]
 }
+
+// ModelAction is a full registry action and can be passed anywhere an
+// [api.Action] is accepted as well as anywhere a [Model] is accepted.
+var (
+	_ api.Action = (*ModelAction)(nil)
+	_ Model      = (*ModelAction)(nil)
+)
 
 // generateAction is the type for a utility model generation action that takes in a GenerateActionOptions instead of a ModelRequest.
 type generateAction = core.Action[*GenerateActionOptions, *ModelResponse, *ModelResponseChunk]
@@ -142,8 +158,10 @@ func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
 	return (*generateAction)(a)
 }
 
-// NewTypedModel creates a new [Model]. Register it with
-// [Model.Register] to make it resolvable by name.
+// NewTypedModel creates an unregistered [ModelAction]: return it from a
+// plugin's Init for the framework to register, or call
+// [ModelAction.Register] directly. Applications should define models with
+// [genkit.DefineTypedModel].
 //
 // Config is the model's typed configuration; it is usually inferred from fn's
 // signature. The framework deserializes the request's raw config into Config
@@ -159,7 +177,7 @@ func DefineGenerateAction(ctx context.Context, r api.Registry) *generateAction {
 // wrapper types like Opt[float64] that marshal to primitives but reflect as
 // objects), set [ModelOptions.ConfigSchema] explicitly or requests will be
 // rejected at the action boundary.
-func NewTypedModel[Config any](name string, opts *ModelOptions, fn TypedModelFunc[Config]) Model {
+func NewTypedModel[Config any](name string, opts *ModelOptions, fn TypedModelFunc[Config]) *ModelAction {
 	if name == "" {
 		panic("ai.NewTypedModel: name is required")
 	}
@@ -217,7 +235,7 @@ func NewTypedModel[Config any](name string, opts *ModelOptions, fn TypedModelFun
 		addAutomaticTelemetry(),
 	)(typedFn)
 
-	return &model{*core.NewStreamingActionOf(api.ActionTypeModel, name, &core.ActionOptions{
+	return &ModelAction{*core.NewStreamingActionOf(api.ActionTypeModel, name, &core.ActionOptions{
 		Metadata:    metadata,
 		InputSchema: inputSchema,
 	}, rawFn)}
@@ -244,9 +262,7 @@ func LookupModel(r api.Registry, name string) Model {
 	if action == nil {
 		return nil
 	}
-	return &model{
-		Action: *action,
-	}
+	return &ModelAction{*action}
 }
 
 // GenerateWithRequest is the central generation implementation for ai.Generate(), prompt.Execute(), and the GenerateAction direct call.
@@ -343,7 +359,7 @@ func GenerateWithRequest(ctx context.Context, r api.Registry, opts *GenerateActi
 		// Native constrained output is enabled only when the user has
 		// requested it, the model supports it, and there's a JSON schema.
 		outputCfg.Constrained = opts.Output.JsonSchema != nil &&
-			opts.Output.Constrained && outputCfg.Constrained && m != nil && m.(*model).supportsConstrained(len(toolDefs) > 0)
+			opts.Output.Constrained && outputCfg.Constrained && m != nil && m.(*ModelAction).supportsConstrained(len(toolDefs) > 0)
 
 		// Add schema instructions to prompt when not using native constraints.
 		// This is a no-op for unstructured output requests.
@@ -981,21 +997,21 @@ func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...Ge
 }
 
 // Generate applies the [Action] to provided request.
-func (m *model) Generate(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+func (m *ModelAction) Generate(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 	if m == nil {
 		return nil, status.Errorf(status.ErrInvalidArgument, "Model.Generate: generate called on a nil model; check that all models are defined")
 	}
 
-	return m.Action.Run(ctx, req, cb)
+	return m.Run(ctx, req, cb)
 }
 
 // supportsConstrained returns whether the model supports constrained output.
-func (m *model) supportsConstrained(hasTools bool) bool {
+func (m *ModelAction) supportsConstrained(hasTools bool) bool {
 	if m == nil {
 		return false
 	}
 
-	metadata := m.Action.Desc().Metadata
+	metadata := m.Desc().Metadata
 	if metadata == nil {
 		return false
 	}

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -1515,7 +1515,7 @@ func (m *Message) Text() string {
 // NewResume constructs a [GenerateActionResume] from Part slices.
 // This is useful when building [GenerateActionOptions] directly (e.g., from a
 // rendered prompt) and need to set the Resume field from [*Part] values
-// produced by [ToolDef.RestartWith] or [ToolDef.RespondWith].
+// produced by [ToolAction.RestartWith] or [ToolAction.RespondWith].
 func NewResume(restarts, responds []*Part) *GenerateActionResume {
 	return &GenerateActionResume{
 		Restart: restarts,
@@ -1637,14 +1637,14 @@ func handleResumedToolRequest(ctx context.Context, r api.Registry, genOpts *Gene
 					return nil, status.Errorf(ErrToolNotFound, "handleResumedToolRequest: tool %q not found", toolReq.Name)
 				}
 
-				toolDef := tool.Definition()
-				if len(toolDef.OutputSchema) > 0 {
+				toolDefinition := tool.Definition()
+				if len(toolDefinition.OutputSchema) > 0 {
 					outputBytes, err := json.Marshal(respondPart.ToolResponse.Output)
 					if err != nil {
 						return nil, status.Errorf(status.ErrInvalidArgument, "handleResumedToolRequest: failed to marshal tool output for validation: %w", err)
 					}
 
-					schemaBytes, err := json.Marshal(toolDef.OutputSchema)
+					schemaBytes, err := json.Marshal(toolDefinition.OutputSchema)
 					if err != nil {
 						return nil, status.Errorf(status.ErrInternal, "handleResumedToolRequest: tool %q has invalid output schema: %w", toolReq.Name, err)
 					}

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -61,7 +61,7 @@ var (
 		Stage:    ModelStageDeprecated,
 	}
 
-	echoModel = DefineModel(r, "test/"+modelName, &metadata, func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
+	echoModel = defineModel(r, "test/"+modelName, &metadata, func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
 		if msc != nil {
 			msc(ctx, &ModelResponseChunk{
 				Content: []*Part{NewTextPart("stream!")},
@@ -81,7 +81,7 @@ var (
 )
 
 // with tools
-var gablorkenTool = DefineTool(r, "gablorken", "use when need to calculate a gablorken",
+var gablorkenTool = defineTool(r, "gablorken", "use when need to calculate a gablorken",
 	func(ctx *ToolContext, input struct {
 		Value float64
 		Over  float64
@@ -97,7 +97,7 @@ func TestStreamingChunksHaveRoleAndIndex(t *testing.T) {
 	r := childRegistry(t)
 	ctx := context.Background()
 
-	convertTempTool := DefineTool(r, "convertTemp", "converts temperature",
+	convertTempTool := defineTool(r, "convertTemp", "converts temperature",
 		func(ctx *ToolContext, input struct {
 			From        string
 			To          string
@@ -111,7 +111,7 @@ func TestStreamingChunksHaveRoleAndIndex(t *testing.T) {
 		},
 	)
 
-	toolModel := DefineModel(r, "test/toolModel", &metadata, func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
+	toolModel := defineModel(r, "test/toolModel", &metadata, func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
 		hasToolResponse := false
 		for _, msg := range gr.Messages {
 			if msg.Role == RoleTool {
@@ -366,7 +366,7 @@ func TestGenerate(t *testing.T) {
 	JSON := "{\"subject\": \"bananas\", \"location\": \"tropics\"}"
 	JSONmd := "```json" + JSON + "```"
 
-	bananaModel := DefineModel(r, "test/banana", &metadata, func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
+	bananaModel := defineModel(r, "test/banana", &metadata, func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
 		if msc != nil {
 			msc(ctx, &ModelResponseChunk{
 				Content: []*Part{NewTextPart("stream!")},
@@ -480,7 +480,7 @@ func TestGenerate(t *testing.T) {
 	})
 
 	t.Run("handles tool interrupts", func(t *testing.T) {
-		interruptTool := DefineTool(r, "interruptor", "always interrupts",
+		interruptTool := defineTool(r, "interruptor", "always interrupts",
 			func(ctx *ToolContext, input any) (any, error) {
 				return nil, ctx.Interrupt(&InterruptOptions{
 					Metadata: map[string]any{
@@ -496,7 +496,7 @@ func TestGenerate(t *testing.T) {
 				Tools:     true,
 			},
 		}
-		interruptModel := DefineModel(r, "test/interrupt", info,
+		interruptModel := defineModel(r, "test/interrupt", info,
 			func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
 				return &ModelResponse{
 					Request: gr,
@@ -555,7 +555,7 @@ func TestGenerate(t *testing.T) {
 				Tools:     true,
 			},
 		}
-		parallelModel := DefineModel(r, "test/parallel", info,
+		parallelModel := defineModel(r, "test/parallel", info,
 			func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
 				roundCount++
 				if roundCount == 1 {
@@ -620,7 +620,7 @@ func TestGenerate(t *testing.T) {
 				Tools:     true,
 			},
 		}
-		multiRoundModel := DefineModel(r, "test/multiround", info,
+		multiRoundModel := defineModel(r, "test/multiround", info,
 			func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
 				roundCount++
 				if roundCount == 1 {
@@ -688,7 +688,7 @@ func TestGenerate(t *testing.T) {
 				Tools:     true,
 			},
 		}
-		infiniteModel := DefineModel(r, "test/infinite", info,
+		infiniteModel := defineModel(r, "test/infinite", info,
 			func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
 				return &ModelResponse{
 					Request: gr,
@@ -777,7 +777,7 @@ func TestGenerate(t *testing.T) {
 				Tools:     true,
 			},
 		}
-		toolCallModel := DefineModel(r, "test/toolcall", info,
+		toolCallModel := defineModel(r, "test/toolcall", info,
 			func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
 				roundCount++
 				if roundCount == 1 {
@@ -878,7 +878,7 @@ func TestGenerateWithOutputSchemaName(t *testing.T) {
 	ConfigureFormats(r)
 
 	// Define a model that supports constrained output
-	model := DefineModel(r, "test/constrained", &ModelOptions{
+	model := defineModel(r, "test/constrained", &ModelOptions{
 		Supports: &ModelSupports{Constrained: ConstrainedSupportAll},
 	}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		// Mock response
@@ -1013,7 +1013,7 @@ type resumableToolInput struct {
 
 func TestToolInterruptsAndResume(t *testing.T) {
 	r := childRegistry(t)
-	conditionalTool := DefineTool(r, "conditional", "tool that may interrupt based on input",
+	conditionalTool := defineTool(r, "conditional", "tool that may interrupt based on input",
 		func(ctx *ToolContext, input conditionalToolInput) (string, error) {
 			if input.Interrupt {
 				return "", ctx.Interrupt(&InterruptOptions{
@@ -1028,7 +1028,7 @@ func TestToolInterruptsAndResume(t *testing.T) {
 		},
 	)
 
-	resumableTool := DefineTool(r, "resumable", "tool that can be resumed",
+	resumableTool := defineTool(r, "resumable", "tool that can be resumed",
 		func(ctx *ToolContext, input resumableToolInput) (string, error) {
 			if ctx.Resumed != nil {
 				resumedData, ok := ctx.Resumed["data"].(string)
@@ -1048,7 +1048,7 @@ func TestToolInterruptsAndResume(t *testing.T) {
 		},
 	}
 
-	toolModel := DefineModel(r, "test/toolmodel", info,
+	toolModel := defineModel(r, "test/toolmodel", info,
 		func(ctx context.Context, mr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
 			return &ModelResponse{
 				Request: mr,
@@ -1287,14 +1287,14 @@ func TestResourceProcessing(t *testing.T) {
 	r := registry.New()
 
 	// Create test resources using DefineResource
-	DefineResource(r, "test-file", &ResourceOptions{
+	defineResource(r, "test-file", &ResourceOptions{
 		URI:         "file:///test.txt",
 		Description: "Test file resource",
 	}, func(ctx context.Context, input *ResourceInput) (*ResourceOutput, error) {
 		return &ResourceOutput{Content: []*Part{NewTextPart("FILE CONTENT")}}, nil
 	})
 
-	DefineResource(r, "test-api", &ResourceOptions{
+	defineResource(r, "test-api", &ResourceOptions{
 		URI:         "api://data/123",
 		Description: "Test API resource",
 	}, func(ctx context.Context, input *ResourceInput) (*ResourceOutput, error) {
@@ -1587,7 +1587,7 @@ func TestMultipartTools(t *testing.T) {
 	t.Run("define multipart tool registers as tool.v2 only", func(t *testing.T) {
 		r := registry.New()
 
-		DefineMultipartTool(r, "multipartTest", "a multipart tool",
+		defineMultipartTool(r, "multipartTest", "a multipart tool",
 			func(ctx *ToolContext, input struct{ Query string }) (*MultipartToolResponse, error) {
 				return &MultipartToolResponse{
 					Output:  "main output",
@@ -1615,7 +1615,7 @@ func TestMultipartTools(t *testing.T) {
 	t.Run("regular tool registers as both tool and tool.v2", func(t *testing.T) {
 		r := registry.New()
 
-		DefineTool(r, "regularTestTool", "a regular tool",
+		defineTool(r, "regularTestTool", "a regular tool",
 			func(ctx *ToolContext, input struct{ Value int }) (int, error) {
 				return input.Value * 2, nil
 			},
@@ -1642,7 +1642,7 @@ func TestMultipartTools(t *testing.T) {
 		ConfigureFormats(r)
 		DefineGenerateAction(context.Background(), r)
 
-		multipartTool := DefineMultipartTool(r, "imageGenerator", "generates images",
+		multipartTool := defineMultipartTool(r, "imageGenerator", "generates images",
 			func(ctx *ToolContext, input struct{ Prompt string }) (*MultipartToolResponse, error) {
 				return &MultipartToolResponse{
 					Output:   map[string]any{"description": "generated image"},
@@ -1655,7 +1655,7 @@ func TestMultipartTools(t *testing.T) {
 		)
 
 		// Create a model that requests the tool
-		multipartToolModel := DefineModel(r, "test/multipartToolModel", &metadata, func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
+		multipartToolModel := defineModel(r, "test/multipartToolModel", &metadata, func(ctx context.Context, gr *ModelRequest, msc ModelStreamCallback) (*ModelResponse, error) {
 			// Check if we already have a tool response
 			for _, msg := range gr.Messages {
 				if msg.Role == RoleTool {
@@ -1708,7 +1708,7 @@ func TestMultipartTools(t *testing.T) {
 	t.Run("RunRawMultipart returns MultipartToolResponse for regular tool", func(t *testing.T) {
 		r := registry.New()
 
-		tool := DefineTool(r, "multipartWrapperTest", "test multipart wrapper",
+		tool := defineTool(r, "multipartWrapperTest", "test multipart wrapper",
 			func(ctx *ToolContext, input struct{ Value int }) (int, error) {
 				return input.Value * 3, nil
 			},
@@ -1737,7 +1737,7 @@ func TestMultipartTools(t *testing.T) {
 	t.Run("RunRawMultipart returns full response for multipart tool", func(t *testing.T) {
 		r := registry.New()
 
-		tool := DefineMultipartTool(r, "multipartFullTest", "test multipart",
+		tool := defineMultipartTool(r, "multipartFullTest", "test multipart",
 			func(ctx *ToolContext, input struct{ Query string }) (*MultipartToolResponse, error) {
 				return &MultipartToolResponse{
 					Output:  "result",
@@ -1780,7 +1780,7 @@ func TestGenerateStream(t *testing.T) {
 		chunkTexts := []string{"Hello", " ", "World"}
 		chunkIndex := 0
 
-		streamModel := DefineModel(r, "test/streamModel", &ModelOptions{
+		streamModel := defineModel(r, "test/streamModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			if cb != nil {
@@ -1833,7 +1833,7 @@ func TestGenerateStream(t *testing.T) {
 	})
 
 	t.Run("handles no streaming callback gracefully", func(t *testing.T) {
-		noStreamModel := DefineModel(r, "test/noStreamModel", &ModelOptions{
+		noStreamModel := defineModel(r, "test/noStreamModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			return &ModelResponse{
@@ -1873,7 +1873,7 @@ func TestGenerateStream(t *testing.T) {
 	t.Run("propagates generation errors", func(t *testing.T) {
 		expectedErr := errors.New("generation failed")
 
-		errorModel := DefineModel(r, "test/errorModel", &ModelOptions{
+		errorModel := defineModel(r, "test/errorModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			return nil, expectedErr
@@ -1902,7 +1902,7 @@ func TestGenerateStream(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		streamModel := DefineModel(r, "test/cancelModel", &ModelOptions{
+		streamModel := defineModel(r, "test/cancelModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			if cb != nil {
@@ -1948,7 +1948,7 @@ func TestGenerateStream(t *testing.T) {
 	})
 
 	t.Run("should not yield after stop", func(t *testing.T) {
-		streamModel := DefineModel(r, "test/breakStreamModel", &ModelOptions{
+		streamModel := defineModel(r, "test/breakStreamModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn: true,
 			},
@@ -1979,7 +1979,7 @@ func TestGenerateDataStream(t *testing.T) {
 	DefineGenerateAction(context.Background(), r)
 
 	t.Run("yields typed chunks and final output", func(t *testing.T) {
-		streamModel := DefineModel(r, "test/typedStreamModel", &ModelOptions{
+		streamModel := defineModel(r, "test/typedStreamModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Constrained: ConstrainedSupportAll,
@@ -2034,7 +2034,7 @@ func TestGenerateDataStream(t *testing.T) {
 	})
 
 	t.Run("final output is correctly typed", func(t *testing.T) {
-		streamModel := DefineModel(r, "test/finalTypedModel", &ModelOptions{
+		streamModel := defineModel(r, "test/finalTypedModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Constrained: ConstrainedSupportAll,
@@ -2076,7 +2076,7 @@ func TestGenerateDataStream(t *testing.T) {
 	t.Run("automatically sets output type", func(t *testing.T) {
 		var capturedRequest *ModelRequest
 
-		streamModel := DefineModel(r, "test/autoOutputModel", &ModelOptions{
+		streamModel := defineModel(r, "test/autoOutputModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Constrained: ConstrainedSupportAll,
@@ -2107,7 +2107,7 @@ func TestGenerateDataStream(t *testing.T) {
 	})
 
 	t.Run("handles tool interrupts", func(t *testing.T) {
-		interruptTool := DefineTool(r, "streamInterruptor", "always interrupts",
+		interruptTool := defineTool(r, "streamInterruptor", "always interrupts",
 			func(ctx *ToolContext, input any) (any, error) {
 				return nil, ctx.Interrupt(&InterruptOptions{
 					Metadata: map[string]any{
@@ -2117,7 +2117,7 @@ func TestGenerateDataStream(t *testing.T) {
 			},
 		)
 
-		streamModel := DefineModel(r, "test/streamInterruptModel", &ModelOptions{
+		streamModel := defineModel(r, "test/streamInterruptModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Tools:       true,
@@ -2175,13 +2175,13 @@ func TestGenerateDataStream(t *testing.T) {
 	})
 
 	t.Run("handles returnToolRequests", func(t *testing.T) {
-		greetTool := DefineTool(r, "streamGreeter", "greets",
+		greetTool := defineTool(r, "streamGreeter", "greets",
 			func(ctx *ToolContext, input any) (any, error) {
 				return "hello", nil
 			},
 		)
 
-		streamModel := DefineModel(r, "test/streamReturnToolModel", &ModelOptions{
+		streamModel := defineModel(r, "test/streamReturnToolModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Tools:       true,
@@ -2232,7 +2232,7 @@ func TestGenerateDataStream(t *testing.T) {
 	})
 
 	t.Run("propagates chunk parsing errors", func(t *testing.T) {
-		streamModel := DefineModel(r, "test/parseErrorModel", &ModelOptions{
+		streamModel := defineModel(r, "test/parseErrorModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Constrained: ConstrainedSupportAll,
@@ -2266,7 +2266,7 @@ func TestGenerateDataStream(t *testing.T) {
 	})
 
 	t.Run("should not yield after stop", func(t *testing.T) {
-		streamModel := DefineModel(r, "test/breakDataStreamModel", &ModelOptions{
+		streamModel := defineModel(r, "test/breakDataStreamModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Constrained: ConstrainedSupportAll,
@@ -2298,7 +2298,7 @@ func TestGenerateDataStream(t *testing.T) {
 func TestGenerateText(t *testing.T) {
 	r := newTestRegistry(t)
 
-	echoModel := DefineModel(r, "test/echoTextModel", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+	echoModel := defineModel(r, "test/echoTextModel", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		return &ModelResponse{
 			Request: req,
 			Message: NewModelTextMessage("echo: " + req.Messages[0].Content[0].Text),
@@ -2326,7 +2326,7 @@ func TestGenerateData(t *testing.T) {
 		Value int `json:"value"`
 	}
 
-	jsonModel := DefineModel(r, "test/jsonDataModel", &ModelOptions{
+	jsonModel := defineModel(r, "test/jsonDataModel", &ModelOptions{
 		Supports: &ModelSupports{
 			Constrained: ConstrainedSupportAll,
 		},
@@ -2685,7 +2685,7 @@ func TestGenerateWithMarkdownJSON(t *testing.T) {
 	DefineGenerateAction(context.Background(), r)
 
 	// A model that returns JSON wrapped in markdown
-	markdownModel := DefineModel(r, "test/markdownJson", &ModelOptions{
+	markdownModel := defineModel(r, "test/markdownJson", &ModelOptions{
 		Supports: &ModelSupports{Constrained: ConstrainedSupportAll},
 	}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		jsonContent := "{\"name\": \"test\", \"value\": 123}"
@@ -2696,7 +2696,7 @@ func TestGenerateWithMarkdownJSON(t *testing.T) {
 	})
 
 	// A model that returns JSON wrapped in markdown with loose formatting (spaces)
-	looseMarkdownModel := DefineModel(r, "test/looseMarkdownJson", &ModelOptions{
+	looseMarkdownModel := defineModel(r, "test/looseMarkdownJson", &ModelOptions{
 		Supports: &ModelSupports{Constrained: ConstrainedSupportAll},
 	}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		jsonContent := "{\"name\": \"test\", \"value\": 123}"
@@ -2759,20 +2759,20 @@ func TestGenerateNoGoroutineLeak(t *testing.T) {
 
 	done := make(chan struct{})
 
-	slowTool := DefineTool(r, "slow", "slow",
+	slowTool := defineTool(r, "slow", "slow",
 		func(*ToolContext, any) (any, error) {
 			<-done
 			return nil, nil
 		},
 	)
 
-	failTool := DefineTool(r, "fail", "fail",
+	failTool := defineTool(r, "fail", "fail",
 		func(*ToolContext, any) (any, error) {
 			return nil, errors.New("boom")
 		},
 	)
 
-	testModel := DefineModel(r, "test/testModel", &ModelOptions{
+	testModel := defineModel(r, "test/testModel", &ModelOptions{
 		Supports: &ModelSupports{
 			Multiturn: true,
 			Tools:     true,

--- a/go/ai/middleware.go
+++ b/go/ai/middleware.go
@@ -153,13 +153,6 @@ func NewMiddleware[M Middleware](description string, prototype M) *MiddlewareDes
 	}
 }
 
-// DefineMiddleware creates and registers a middleware descriptor in one step.
-func DefineMiddleware[M Middleware](r api.Registry, description string, prototype M) *MiddlewareDesc {
-	d := NewMiddleware(description, prototype)
-	d.Register(r)
-	return d
-}
-
 // MiddlewareFunc adapts a per-call factory closure to the [Middleware]
 // interface for ad-hoc inline use, without a registered descriptor or plugin
 // wiring. The adapted middleware does not appear in the Dev UI.

--- a/go/ai/middleware_test.go
+++ b/go/ai/middleware_test.go
@@ -594,7 +594,7 @@ func TestWrapToolInterrupts(t *testing.T) {
 // body ran, so a test can tell a short-circuited call from a real one.
 func defineCountingTool(t *testing.T, r api.Registry, name string, calls *int32) Tool {
 	t.Helper()
-	return DefineTool(r, name, "A test tool",
+	return defineTool(r, name, "A test tool",
 		func(ctx *ToolContext, input struct {
 			Value string `json:"value"`
 		}) (string, error) {
@@ -792,7 +792,7 @@ func TestWrapToolValidationErrorReturnedToModel(t *testing.T) {
 		handler: modelHandler,
 	})
 
-	DefineTool(r, "validateMe", "A tool that requires a numeric value",
+	defineTool(r, "validateMe", "A tool that requires a numeric value",
 		func(ctx *ToolContext, input any) (string, error) {
 			m := input.(map[string]any)
 			return fmt.Sprintf("success: %v", m["value"]), nil
@@ -920,7 +920,7 @@ func TestMiddlewareHookOrderOnToolRestart(t *testing.T) {
 		Interrupt bool `json:"interrupt"`
 	}
 
-	tool := DefineTool(r, "restartable", "interrupts, then runs on resume",
+	tool := defineTool(r, "restartable", "interrupts, then runs on resume",
 		func(ctx *ToolContext, in restartInput) (string, error) {
 			if in.Interrupt {
 				return "", ctx.Interrupt(&InterruptOptions{})
@@ -931,7 +931,7 @@ func TestMiddlewareHookOrderOnToolRestart(t *testing.T) {
 
 	// Requests the tool on the first turn, returns a final text response once a
 	// tool response is present in history.
-	model := DefineModel(r, "test/restartModel", &ModelOptions{
+	model := defineModel(r, "test/restartModel", &ModelOptions{
 		Supports: &ModelSupports{Multiturn: true, Tools: true},
 	}, func(ctx context.Context, req *ModelRequest, _ ModelStreamCallback) (*ModelResponse, error) {
 		for _, msg := range req.Messages {

--- a/go/ai/model_middleware.go
+++ b/go/ai/model_middleware.go
@@ -265,16 +265,15 @@ func validateSupport(model string, opts *ModelOptions) ModelMiddleware {
 				return nil, status.Errorf(ErrUnsupportedByModel, "model %q does not support native constrained output, but constrained output was requested. Request: %+v", model, input)
 			}
 
-			if err := validateVersion(model, opts.Versions, input.Config); err != nil {
-				return nil, err
-			}
-
 			return next(ctx, input, cb)
 		}
 	}
 }
 
 // validateVersion validates that the requested model version is supported.
+// It runs against the raw, pre-conversion config (see [normalizeConfig])
+// because conversion into a Config type without a version field would
+// silently drop the key.
 func validateVersion(model string, versions []string, config any) error {
 	var configMap map[string]any
 

--- a/go/ai/model_middleware_test.go
+++ b/go/ai/model_middleware_test.go
@@ -23,6 +23,8 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"github.com/firebase/genkit/go/core"
 )
 
 func TestValidateSupport(t *testing.T) {
@@ -254,7 +256,17 @@ func TestValidateSupport(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := validateSupport("test-model", tt.opts)(mockModelFunc)
+			// Version validation moved from validateSupport to
+			// normalizeConfig (it must see the raw, pre-conversion config),
+			// so chain both here the way model construction does.
+			var versions []string
+			if tt.opts != nil {
+				versions = tt.opts.Versions
+			}
+			handler := core.ChainMiddleware(
+				normalizeConfig[any]("test-model", versions),
+				validateSupport("test-model", tt.opts),
+			)(mockModelFunc)
 			_, err := handler(context.Background(), tt.input, nil)
 
 			if (err != nil) != tt.wantErr {

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -36,7 +36,7 @@ type InputOutput struct {
 }
 
 func testTool(reg api.Registry, name string) Tool {
-	return DefineTool(reg, name, "use when need to execute a test",
+	return defineTool(reg, name, "use when need to execute a test",
 		func(ctx *ToolContext, input struct {
 			Test string
 		},
@@ -150,7 +150,7 @@ type HelloPromptInput struct {
 }
 
 func definePromptModel(reg api.Registry) Model {
-	return DefineModel(reg, "test/chat",
+	return defineModel(reg, "test/chat",
 		&ModelOptions{Supports: &ModelSupports{
 			Tools:      true,
 			Multiturn:  true,
@@ -690,7 +690,7 @@ func TestOptionsPatternExecute(t *testing.T) {
 
 	ConfigureFormats(reg)
 
-	testModel := DefineModel(reg, "options/test", nil, testGenerate)
+	testModel := defineModel(reg, "options/test", nil, testGenerate)
 
 	t.Run("Streaming", func(t *testing.T) {
 		p := DefinePrompt(reg, "TestExecute", WithInputType(InputOutput{}), WithPrompt("TestExecute"))
@@ -742,7 +742,7 @@ func TestDefaultsOverride(t *testing.T) {
 	// Set up default formats
 	ConfigureFormats(reg)
 
-	testModel := DefineModel(reg, "defineoptions/test", nil, testGenerate)
+	testModel := defineModel(reg, "defineoptions/test", nil, testGenerate)
 	model := definePromptModel(reg)
 
 	tests := []struct {
@@ -1573,7 +1573,7 @@ Generate a recipe for {{food}}.
 	reg := registry.New()
 	ConfigureFormats(reg)
 
-	DefineModel(reg, "test-model", &ModelOptions{
+	defineModel(reg, "test-model", &ModelOptions{
 		Supports: &ModelSupports{Constrained: ConstrainedSupportAll},
 	}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		// Mock response that matches the expected schema structure
@@ -1683,7 +1683,7 @@ Generate a recipe.
 	reg := registry.New()
 	ConfigureFormats(reg)
 
-	DefineModel(reg, "test-model", &ModelOptions{
+	defineModel(reg, "test-model", &ModelOptions{
 		Supports: &ModelSupports{Constrained: ConstrainedSupportAll},
 	}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		return &ModelResponse{
@@ -1711,7 +1711,7 @@ func TestWithOutputSchemaName_DefinePrompt(t *testing.T) {
 	reg := registry.New()
 	ConfigureFormats(reg)
 
-	DefineModel(reg, "test-model", &ModelOptions{
+	defineModel(reg, "test-model", &ModelOptions{
 		Supports: &ModelSupports{Constrained: ConstrainedSupportAll},
 	}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		return &ModelResponse{
@@ -1749,7 +1749,7 @@ func TestWithOutputSchemaName_DefinePrompt_Missing(t *testing.T) {
 	reg := registry.New()
 	ConfigureFormats(reg)
 
-	DefineModel(reg, "test-model", &ModelOptions{
+	defineModel(reg, "test-model", &ModelOptions{
 		Supports: &ModelSupports{Constrained: ConstrainedSupportAll},
 	}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		return &ModelResponse{
@@ -1791,7 +1791,7 @@ func TestDataPromptExecute(t *testing.T) {
 	t.Run("typed input and output", func(t *testing.T) {
 		var capturedInput any
 
-		testModel := DefineModel(r, "test/dataPromptModel", &ModelOptions{
+		testModel := defineModel(r, "test/dataPromptModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Constrained: ConstrainedSupportAll,
@@ -1833,7 +1833,7 @@ func TestDataPromptExecute(t *testing.T) {
 	})
 
 	t.Run("string output type", func(t *testing.T) {
-		testModel := DefineModel(r, "test/stringDataPromptModel", &ModelOptions{
+		testModel := defineModel(r, "test/stringDataPromptModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			return &ModelResponse{
@@ -1872,7 +1872,7 @@ func TestDataPromptExecute(t *testing.T) {
 	t.Run("additional options passed through", func(t *testing.T) {
 		var capturedConfig any
 
-		testModel := DefineModel(r, "test/optionsDataPromptModel", &ModelOptions{
+		testModel := defineModel(r, "test/optionsDataPromptModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Constrained: ConstrainedSupportAll,
@@ -1910,7 +1910,7 @@ func TestDataPromptExecute(t *testing.T) {
 	})
 
 	t.Run("returns error for invalid output parsing", func(t *testing.T) {
-		testModel := DefineModel(r, "test/parseFailDataPromptModel", &ModelOptions{
+		testModel := defineModel(r, "test/parseFailDataPromptModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Constrained: ConstrainedSupportAll,
@@ -1949,7 +1949,7 @@ func TestDataPromptExecuteStream(t *testing.T) {
 	}
 
 	t.Run("typed streaming with struct output", func(t *testing.T) {
-		testModel := DefineModel(r, "test/streamDataPromptModel", &ModelOptions{
+		testModel := defineModel(r, "test/streamDataPromptModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Constrained: ConstrainedSupportAll,
@@ -2006,7 +2006,7 @@ func TestDataPromptExecuteStream(t *testing.T) {
 	})
 
 	t.Run("string output streaming", func(t *testing.T) {
-		testModel := DefineModel(r, "test/stringStreamDataPromptModel", &ModelOptions{
+		testModel := defineModel(r, "test/stringStreamDataPromptModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			if cb != nil {
@@ -2076,7 +2076,7 @@ func TestDataPromptExecuteStream(t *testing.T) {
 	t.Run("handles options passed at execute time", func(t *testing.T) {
 		var capturedConfig any
 
-		testModel := DefineModel(r, "test/optionsStreamModel", &ModelOptions{
+		testModel := defineModel(r, "test/optionsStreamModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Constrained: ConstrainedSupportAll,
@@ -2119,7 +2119,7 @@ func TestDataPromptExecuteStream(t *testing.T) {
 	t.Run("propagates errors", func(t *testing.T) {
 		expectedErr := errors.New("stream failed")
 
-		testModel := DefineModel(r, "test/errorStreamDataPromptModel", &ModelOptions{
+		testModel := defineModel(r, "test/errorStreamDataPromptModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			return nil, expectedErr
@@ -2147,7 +2147,7 @@ func TestDataPromptExecuteStream(t *testing.T) {
 	})
 
 	t.Run("should not yield after stop", func(t *testing.T) {
-		testModel := DefineModel(r, "test/breakDataPromptStreamModel", &ModelOptions{
+		testModel := defineModel(r, "test/breakDataPromptStreamModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn:   true,
 				Constrained: ConstrainedSupportAll,
@@ -2189,7 +2189,7 @@ func TestPromptExecuteStream(t *testing.T) {
 	t.Run("yields chunks then final response", func(t *testing.T) {
 		chunkTexts := []string{"A", "B", "C"}
 
-		testModel := DefineModel(r, "test/promptStreamModel", &ModelOptions{
+		testModel := defineModel(r, "test/promptStreamModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			if cb != nil {
@@ -2260,7 +2260,7 @@ func TestPromptExecuteStream(t *testing.T) {
 	t.Run("handles execution options", func(t *testing.T) {
 		var capturedConfig any
 
-		testModel := DefineModel(r, "test/optionsPromptExecModel", &ModelOptions{
+		testModel := defineModel(r, "test/optionsPromptExecModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			capturedConfig = req.Config
@@ -2295,7 +2295,7 @@ func TestPromptExecuteStream(t *testing.T) {
 	})
 
 	t.Run("should not yield after stop", func(t *testing.T) {
-		testModel := DefineModel(r, "test/breakPromptStreamModel", &ModelOptions{
+		testModel := defineModel(r, "test/breakPromptStreamModel", &ModelOptions{
 			Supports: &ModelSupports{
 				Multiturn: true,
 			},
@@ -2337,7 +2337,7 @@ func TestSessionStateInjection(t *testing.T) {
 	t.Run("state accessible in prompt template", func(t *testing.T) {
 		var capturedPrompt string
 
-		testModel := DefineModel(r, "test/sessionStateModel", &ModelOptions{
+		testModel := defineModel(r, "test/sessionStateModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			capturedPrompt = req.Messages[0].Text()
@@ -2376,7 +2376,7 @@ func TestSessionStateInjection(t *testing.T) {
 	t.Run("prompt works without state in context", func(t *testing.T) {
 		var capturedPrompt string
 
-		testModel := DefineModel(r, "test/noSessionModel", &ModelOptions{
+		testModel := defineModel(r, "test/noSessionModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			capturedPrompt = req.Messages[0].Text()
@@ -2411,7 +2411,7 @@ func TestSessionStateInjection(t *testing.T) {
 	t.Run("state and input variables can be used together", func(t *testing.T) {
 		var capturedPrompt string
 
-		testModel := DefineModel(r, "test/mixedModel", &ModelOptions{
+		testModel := defineModel(r, "test/mixedModel", &ModelOptions{
 			Supports: &ModelSupports{Multiturn: true},
 		}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 			capturedPrompt = req.Messages[0].Text()

--- a/go/ai/prompt_test.go
+++ b/go/ai/prompt_test.go
@@ -1591,8 +1591,8 @@ Generate a recipe for {{food}}.
 
 	// verify the prompt is loaded with a schema reference
 	// the internal representation stores the schema with $ref for lazy resolution
-	actionDef := prompt.(api.Action).Desc()
-	outputSchema := actionDef.Metadata["prompt"].(map[string]any)["output"].(map[string]any)["schema"]
+	desc := prompt.(api.Action).Desc()
+	outputSchema := desc.Metadata["prompt"].(map[string]any)["output"].(map[string]any)["schema"]
 	if outputSchema == nil {
 		t.Fatal("Output schema should not be nil")
 	}

--- a/go/ai/resource.go
+++ b/go/ai/resource.go
@@ -126,14 +126,6 @@ type Resource interface {
 	Register(r api.Registry)
 }
 
-// DefineResource creates a resource and registers it with the given Registry.
-func DefineResource(r api.Registry, name string, opts *ResourceOptions, fn ResourceFunc) Resource {
-	metadata := resourceMetadata(name, opts)
-	a := core.NewActionOf(api.ActionTypeResource, name, &core.ActionOptions{Metadata: metadata}, fn)
-	a.Register(r)
-	return &resource{Action: *a}
-}
-
 // NewResource creates a resource but does not register it in the registry.
 // It can be registered later via the Register method.
 func NewResource(name string, opts *ResourceOptions, fn ResourceFunc) Resource {

--- a/go/ai/resource_test.go
+++ b/go/ai/resource_test.go
@@ -26,7 +26,7 @@ func TestStaticResource(t *testing.T) {
 	g := registry.New()
 
 	// Define static resource
-	DefineResource(g, "test-doc", &ResourceOptions{
+	defineResource(g, "test-doc", &ResourceOptions{
 		URI: "file:///test.txt",
 	}, func(ctx context.Context, input *ResourceInput) (*ResourceOutput, error) {
 		return &ResourceOutput{
@@ -107,7 +107,7 @@ func TestResourceInGeneration(t *testing.T) {
 	ConfigureFormats(r)
 
 	// Define mock model
-	DefineModel(r, "test", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+	defineModel(r, "test", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		// Extract resource parts from the prompt
 		var responseText strings.Builder
 		for _, msg := range req.Messages {
@@ -128,7 +128,7 @@ func TestResourceInGeneration(t *testing.T) {
 	})
 
 	// Define resource
-	DefineResource(r, "policy", &ResourceOptions{
+	defineResource(r, "policy", &ResourceOptions{
 		URI: "file:///policy.txt",
 	}, func(ctx context.Context, input *ResourceInput) (*ResourceOutput, error) {
 		return &ResourceOutput{
@@ -163,7 +163,7 @@ func TestDynamicResourceInGeneration(t *testing.T) {
 	ConfigureFormats(r)
 
 	// Define mock model
-	DefineModel(r, "test", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+	defineModel(r, "test", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		var responseText strings.Builder
 		for _, msg := range req.Messages {
 			for _, part := range msg.Content {
@@ -219,7 +219,7 @@ func TestMultipleDynamicResourcesInGeneration(t *testing.T) {
 	ConfigureFormats(r)
 
 	// Define mock model
-	DefineModel(r, "test", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+	defineModel(r, "test", nil, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
 		return &ModelResponse{
 			Request: req,
 			Message: &Message{
@@ -276,7 +276,7 @@ func contains(s, substr string) bool {
 func TestLookupResource(t *testing.T) {
 	t.Run("finds registered resource", func(t *testing.T) {
 		r := registry.New()
-		DefineResource(r, "test/lookup", &ResourceOptions{
+		defineResource(r, "test/lookup", &ResourceOptions{
 			URI: "lookup://test",
 		}, func(ctx context.Context, input *ResourceInput) (*ResourceOutput, error) {
 			return &ResourceOutput{
@@ -304,7 +304,7 @@ func TestLookupResource(t *testing.T) {
 
 	t.Run("resource can be executed after lookup", func(t *testing.T) {
 		r := registry.New()
-		DefineResource(r, "test/executable", &ResourceOptions{
+		defineResource(r, "test/executable", &ResourceOptions{
 			URI: "exec://test",
 		}, func(ctx context.Context, input *ResourceInput) (*ResourceOutput, error) {
 			return &ResourceOutput{
@@ -328,7 +328,7 @@ func TestLookupResource(t *testing.T) {
 
 	t.Run("resource matches and extracts variables after lookup", func(t *testing.T) {
 		r := registry.New()
-		DefineResource(r, "test/template", &ResourceOptions{
+		defineResource(r, "test/template", &ResourceOptions{
 			Template: "template://item/{id}",
 		}, func(ctx context.Context, input *ResourceInput) (*ResourceOutput, error) {
 			return &ResourceOutput{

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -31,10 +31,10 @@ import (
 // RetrieverFunc is the function type for retriever implementations.
 type RetrieverFunc = func(context.Context, *RetrieverRequest) (*RetrieverResponse, error)
 
-// TypedRetrieverFunc is a [RetrieverFunc] that additionally receives the
+// RetrieverActionFunc is a [RetrieverFunc] that additionally receives the
 // request's typed Config: the framework deserializes the request's raw
-// options into it before calling the function (see [NewTypedRetriever]).
-type TypedRetrieverFunc[Config any] = func(context.Context, *RetrieverRequest, Config) (*RetrieverResponse, error)
+// options into it before calling the function (see [NewRetrieverAction]).
+type RetrieverActionFunc[Config any] = func(context.Context, *RetrieverRequest, Config) (*RetrieverResponse, error)
 
 // Retriever represents a document retriever.
 type Retriever interface {
@@ -47,7 +47,7 @@ type Retriever interface {
 }
 
 // RetrieverAction is a retriever backed by a registry action. It is the
-// concrete type returned by [NewTypedRetriever]; pass it to [WithRetriever] to
+// concrete type returned by [NewRetrieverAction]; pass it to [WithRetriever] to
 // retrieve with it, or return it from a plugin's Init for the framework to
 // register.
 type RetrieverAction struct {
@@ -105,10 +105,10 @@ type RetrieverOptions struct {
 	Metadata map[string]any `json:"-"`
 }
 
-// NewTypedRetriever creates an unregistered [RetrieverAction]: return it from
+// NewRetrieverAction creates an unregistered [RetrieverAction]: return it from
 // a plugin's Init for the framework to register, or call
 // [RetrieverAction.Register] directly. Applications should define retrievers
-// with [genkit.DefineTypedRetriever].
+// with [genkit.DefineRetrieverAction].
 //
 // Config is the retriever's typed configuration; it is usually inferred from
 // fn's signature. The framework deserializes the request's raw options into
@@ -118,13 +118,13 @@ type RetrieverOptions struct {
 // normalized to the converted value, so it always matches the typed
 // parameter. The config's JSON schema is inferred from Config unless
 // [RetrieverOptions.ConfigSchema] overrides it.
-func NewTypedRetriever[Config any](
+func NewRetrieverAction[Config any](
 	name string,
 	opts *RetrieverOptions,
-	fn TypedRetrieverFunc[Config],
+	fn RetrieverActionFunc[Config],
 ) *RetrieverAction {
 	if name == "" {
-		panic("ai.NewTypedRetriever: retriever name is required")
+		panic("ai.NewRetrieverAction: retriever name is required")
 	}
 
 	if opts == nil {
@@ -174,13 +174,13 @@ func NewTypedRetriever[Config any](
 
 // NewRetriever creates a new [Retriever].
 //
-// Deprecated: Use [NewTypedRetriever], which passes the request's options to
+// Deprecated: Use [NewRetrieverAction], which passes the request's options to
 // fn as a typed value instead of leaving them type-erased on the request.
 func NewRetriever(name string, opts *RetrieverOptions, fn RetrieverFunc) Retriever {
 	if name == "" {
 		panic("ai.NewRetriever: retriever name is required")
 	}
-	return NewTypedRetriever(name, opts, func(ctx context.Context, req *RetrieverRequest, _ any) (*RetrieverResponse, error) {
+	return NewRetrieverAction(name, opts, func(ctx context.Context, req *RetrieverRequest, _ any) (*RetrieverResponse, error) {
 		return fn(ctx, req)
 	})
 }

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -154,13 +154,14 @@ func NewRetrieverAction[Config any](
 	}
 
 	rawFn := func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
-		cfg, err := resolveConfig[Config](req.Options)
+		// Normalize a shallow copy so the type-erased Options and the typed
+		// parameter always agree without clobbering the caller-owned request.
+		reqCopy := *req
+		req = &reqCopy
+		cfg, err := resolveConfigInto[Config](&req.Options)
 		if err != nil {
 			return nil, err
 		}
-		// Normalize the request so its type-erased Options always carries the
-		// same converted value the typed parameter does.
-		req.Options = cfg
 		return fn(ctx, req, cfg)
 	}
 

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -122,14 +122,7 @@ func NewRetriever(name string, opts *RetrieverOptions, fn RetrieverFunc) Retriev
 	}
 }
 
-// DefineRetriever creates a new [Retriever] and registers it.
-func DefineRetriever(r api.Registry, name string, opts *RetrieverOptions, fn RetrieverFunc) Retriever {
-	ret := NewRetriever(name, opts, fn)
-	ret.Register(r)
-	return ret
-}
-
-// LookupRetriever looks up a [Retriever] registered by [DefineRetriever].
+// LookupRetriever looks up a registered [Retriever] by name.
 // It will try to resolve the retriever dynamically if the retriever is not found.
 // It returns nil if the retriever was not resolved.
 func LookupRetriever(r api.Registry, name string) Retriever {

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
@@ -29,6 +30,11 @@ import (
 
 // RetrieverFunc is the function type for retriever implementations.
 type RetrieverFunc = func(context.Context, *RetrieverRequest) (*RetrieverResponse, error)
+
+// TypedRetrieverFunc is a [RetrieverFunc] that additionally receives the
+// request's typed Config: the framework deserializes the request's raw
+// options into it before calling the function (see [NewTypedRetriever]).
+type TypedRetrieverFunc[Config any] = func(context.Context, *RetrieverRequest, Config) (*RetrieverResponse, error)
 
 // Retriever represents a document retriever.
 type Retriever interface {
@@ -40,10 +46,20 @@ type Retriever interface {
 	Register(r api.Registry)
 }
 
-// retriever is an action with functions specific to document retrieval such as Retrieve().
-type retriever struct {
-	core.Action[*RetrieverRequest, *RetrieverResponse, struct{}]
+// RetrieverAction is a retriever backed by a registry action. It is the
+// concrete type returned by [NewTypedRetriever]; pass it to [WithRetriever] to
+// retrieve with it, or return it from a plugin's Init for the framework to
+// register.
+type RetrieverAction struct {
+	action[*RetrieverRequest, *RetrieverResponse, struct{}]
 }
+
+// RetrieverAction is a full registry action and can be passed anywhere an
+// [api.Action] is accepted as well as anywhere a [Retriever] is accepted.
+var (
+	_ api.Action = (*RetrieverAction)(nil)
+	_ Retriever  = (*RetrieverAction)(nil)
+)
 
 // RetrieverArg is the interface for retriever arguments. It can either be the retriever action itself or a reference to be looked up.
 type RetrieverArg interface {
@@ -85,12 +101,30 @@ type RetrieverOptions struct {
 	Label string `json:"label,omitempty"`
 	// Supports defines the capabilities of the retriever, such as media support.
 	Supports *RetrieverSupports `json:"supports,omitempty"`
+	// Metadata is arbitrary key-value data attached to the action descriptor.
+	Metadata map[string]any `json:"-"`
 }
 
-// NewRetriever creates a new [Retriever].
-func NewRetriever(name string, opts *RetrieverOptions, fn RetrieverFunc) Retriever {
+// NewTypedRetriever creates an unregistered [RetrieverAction]: return it from
+// a plugin's Init for the framework to register, or call
+// [RetrieverAction.Register] directly. Applications should define retrievers
+// with [genkit.DefineTypedRetriever].
+//
+// Config is the retriever's typed configuration; it is usually inferred from
+// fn's signature. The framework deserializes the request's raw options into
+// Config before calling fn: the exact Config type (or a pointer to it) and
+// map[string]any (from the Dev UI and other JSON callers) are accepted, and
+// mismatched types are rejected. The request's [RetrieverRequest.Options] is
+// normalized to the converted value, so it always matches the typed
+// parameter. The config's JSON schema is inferred from Config unless
+// [RetrieverOptions.ConfigSchema] overrides it.
+func NewTypedRetriever[Config any](
+	name string,
+	opts *RetrieverOptions,
+	fn TypedRetrieverFunc[Config],
+) *RetrieverAction {
 	if name == "" {
-		panic("ai.NewRetriever: retriever name is required")
+		panic("ai.NewTypedRetriever: retriever name is required")
 	}
 
 	if opts == nil {
@@ -102,24 +136,53 @@ func NewRetriever(name string, opts *RetrieverOptions, fn RetrieverFunc) Retriev
 		opts.Supports = &RetrieverSupports{}
 	}
 
-	metadata := map[string]any{
-		"type": api.ActionTypeRetriever,
-		"info": map[string]any{
-			"label": opts.Label,
-			"supports": map[string]any{
-				"media": opts.Supports.Media,
-			},
-		},
-		"retriever": map[string]any{
-			"customOptions": opts.ConfigSchema,
+	configSchema, inputSchema := actionConfigSchemas[Config](opts.ConfigSchema, RetrieverRequest{}, "options")
+
+	// Seed from the caller's metadata, then stamp the built-in keys over it so
+	// they cannot be corrupted; registry discovery depends on them.
+	metadata := make(map[string]any, len(opts.Metadata)+3)
+	maps.Copy(metadata, opts.Metadata)
+	metadata["type"] = api.ActionTypeRetriever
+	metadata["info"] = map[string]any{
+		"label": opts.Label,
+		"supports": map[string]any{
+			"media": opts.Supports.Media,
 		},
 	}
-
-	inputSchema := requestInputSchema(RetrieverRequest{}, "options", opts.ConfigSchema)
-
-	return &retriever{
-		Action: *core.NewActionOf(api.ActionTypeRetriever, name, &core.ActionOptions{Metadata: metadata, InputSchema: inputSchema}, fn),
+	metadata["retriever"] = map[string]any{
+		"customOptions": configSchema,
 	}
+
+	rawFn := func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		cfg, err := resolveConfig[Config](req.Options)
+		if err != nil {
+			return nil, err
+		}
+		// Normalize the request so its type-erased Options always carries the
+		// same converted value the typed parameter does.
+		req.Options = cfg
+		return fn(ctx, req, cfg)
+	}
+
+	return &RetrieverAction{
+		action: *core.NewActionOf(api.ActionTypeRetriever, name, &core.ActionOptions{
+			Metadata:    metadata,
+			InputSchema: inputSchema,
+		}, rawFn),
+	}
+}
+
+// NewRetriever creates a new [Retriever].
+//
+// Deprecated: Use [NewTypedRetriever], which passes the request's options to
+// fn as a typed value instead of leaving them type-erased on the request.
+func NewRetriever(name string, opts *RetrieverOptions, fn RetrieverFunc) Retriever {
+	if name == "" {
+		panic("ai.NewRetriever: retriever name is required")
+	}
+	return NewTypedRetriever(name, opts, func(ctx context.Context, req *RetrieverRequest, _ any) (*RetrieverResponse, error) {
+		return fn(ctx, req)
+	})
 }
 
 // LookupRetriever looks up a registered [Retriever] by name.
@@ -130,13 +193,11 @@ func LookupRetriever(r api.Registry, name string) Retriever {
 	if action == nil {
 		return nil
 	}
-	return &retriever{
-		Action: *action,
-	}
+	return &RetrieverAction{*action}
 }
 
 // Retrieve runs the given [Retriever].
-func (r *retriever) Retrieve(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+func (r *RetrieverAction) Retrieve(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 	if r == nil {
 		return nil, status.Errorf(status.ErrInvalidArgument, "Retriever.Retrieve: retriever called on a nil retriever; check that all retrievers are defined")
 	}

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -84,12 +84,18 @@ func (r *RetrieverAction) Desc() api.ActionDesc { return r.action.Desc() }
 // a JSON-encoded [RetrieverResponse]. The framework uses it to serve
 // reflection and registry-driven calls; prefer [RetrieverAction.Retrieve].
 func (r *RetrieverAction) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	if r == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "Retriever.RunJSON: retriever called on a nil retriever; check that all retrievers are defined")
+	}
 	return r.action.RunJSON(ctx, input, cb)
 }
 
 // RunJSONWithTelemetry is [RetrieverAction.RunJSON] with the run's telemetry
 // returned alongside the output.
 func (r *RetrieverAction) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	if r == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "Retriever.RunJSONWithTelemetry: retriever called on a nil retriever; check that all retrievers are defined")
+	}
 	return r.action.RunJSONWithTelemetry(ctx, input, cb)
 }
 

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -18,6 +18,7 @@ package ai
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -36,7 +37,9 @@ type RetrieverFunc = func(context.Context, *RetrieverRequest) (*RetrieverRespons
 // options into it before calling the function (see [NewRetrieverAction]).
 type RetrieverActionFunc[Config any] = func(context.Context, *RetrieverRequest, Config) (*RetrieverResponse, error)
 
-// Retriever represents a document retriever.
+// Retriever represents a document retriever. It is the type to accept as an
+// argument and to look up by name; implementations are created with
+// [NewRetrieverAction], or [genkit.DefineRetrieverAction] in an application.
 type Retriever interface {
 	// Name returns the name of the retriever.
 	Name() string
@@ -50,16 +53,45 @@ type Retriever interface {
 // concrete type returned by [NewRetrieverAction]; pass it to [WithRetriever] to
 // retrieve with it, or return it from a plugin's Init for the framework to
 // register.
+//
+// It implements [Retriever] and [api.Action], so it can be passed anywhere
+// either is accepted. It also promotes [core.Action.Run], the typed
+// equivalent of [RetrieverAction.Retrieve].
 type RetrieverAction struct {
 	action[*RetrieverRequest, *RetrieverResponse, struct{}]
 }
 
-// RetrieverAction is a full registry action and can be passed anywhere an
-// [api.Action] is accepted as well as anywhere a [Retriever] is accepted.
+// Pinned here so that breaking either interface fails the build at the type
+// rather than at a call site.
 var (
 	_ api.Action = (*RetrieverAction)(nil)
 	_ Retriever  = (*RetrieverAction)(nil)
 )
+
+// Name returns the registry name of the retriever.
+func (r *RetrieverAction) Name() string { return r.action.Name() }
+
+// Register registers the retriever with reg, making it available to lookups
+// and to the Dev UI. A plugin that returns the retriever from its Init does
+// not need to call this.
+func (r *RetrieverAction) Register(reg api.Registry) { r.action.Register(reg) }
+
+// Desc returns the retriever's action descriptor: its name, schemas, and
+// metadata.
+func (r *RetrieverAction) Desc() api.ActionDesc { return r.action.Desc() }
+
+// RunJSON runs the retriever on a JSON-encoded [RetrieverRequest] and returns
+// a JSON-encoded [RetrieverResponse]. The framework uses it to serve
+// reflection and registry-driven calls; prefer [RetrieverAction.Retrieve].
+func (r *RetrieverAction) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	return r.action.RunJSON(ctx, input, cb)
+}
+
+// RunJSONWithTelemetry is [RetrieverAction.RunJSON] with the run's telemetry
+// returned alongside the output.
+func (r *RetrieverAction) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	return r.action.RunJSONWithTelemetry(ctx, input, cb)
+}
 
 // RetrieverArg is the interface for retriever arguments. It can either be the retriever action itself or a reference to be looked up.
 type RetrieverArg interface {

--- a/go/ai/retriever_test.go
+++ b/go/ai/retriever_test.go
@@ -114,7 +114,7 @@ func TestDefineRetriever(t *testing.T) {
 			DocumentFromText("result 2", nil),
 		}
 
-		r := DefineRetriever(reg, "test/defineRetriever", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		r := defineRetriever(reg, "test/defineRetriever", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			called = true
 			return &RetrieverResponse{Documents: expectedDocs}, nil
 		})
@@ -146,7 +146,7 @@ func TestDefineRetriever(t *testing.T) {
 func TestLookupRetriever(t *testing.T) {
 	t.Run("returns retriever when found", func(t *testing.T) {
 		reg := newTestRegistry(t)
-		DefineRetriever(reg, "test/lookupRetriever", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		defineRetriever(reg, "test/lookupRetriever", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			return &RetrieverResponse{}, nil
 		})
 
@@ -176,7 +176,7 @@ func TestRetrieverRetrieve(t *testing.T) {
 			DocumentFromText("relevant result 2", map[string]any{"score": 0.8}),
 		}
 
-		r := DefineRetriever(reg, "test/retrieveDocs", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		r := defineRetriever(reg, "test/retrieveDocs", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			capturedReq = req
 			return &RetrieverResponse{Documents: expectedDocs}, nil
 		})
@@ -203,7 +203,7 @@ func TestRetrieverRetrieve(t *testing.T) {
 
 	t.Run("Retrieve errors instead of panicking when no document is given", func(t *testing.T) {
 		reg := newTestRegistry(t)
-		r := DefineRetriever(reg, "test/retrieveNoDocs", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		r := defineRetriever(reg, "test/retrieveNoDocs", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			return &RetrieverResponse{}, nil
 		})
 
@@ -215,7 +215,7 @@ func TestRetrieverRetrieve(t *testing.T) {
 		reg := newTestRegistry(t)
 		expectedErr := errors.New("retrieval failed")
 
-		r := DefineRetriever(reg, "test/retrieveError", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		r := defineRetriever(reg, "test/retrieveError", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			return nil, expectedErr
 		})
 
@@ -231,7 +231,7 @@ func TestRetrieverRetrieve(t *testing.T) {
 		reg := newTestRegistry(t)
 		var capturedOpts any
 
-		r := DefineRetriever(reg, "test/retrieveOpts", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		r := defineRetriever(reg, "test/retrieveOpts", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			capturedOpts = req.Options
 			return &RetrieverResponse{Documents: []*Document{}}, nil
 		})
@@ -252,7 +252,7 @@ func TestRetrieverRetrieve(t *testing.T) {
 func TestRetrieveFunction(t *testing.T) {
 	t.Run("retrieves with retriever directly", func(t *testing.T) {
 		reg := newTestRegistry(t)
-		r := DefineRetriever(reg, "test/retrieveFunc", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		r := defineRetriever(reg, "test/retrieveFunc", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			return &RetrieverResponse{
 				Documents: []*Document{DocumentFromText("result", nil)},
 			}, nil
@@ -271,7 +271,7 @@ func TestRetrieveFunction(t *testing.T) {
 
 	t.Run("retrieves with retriever ref", func(t *testing.T) {
 		reg := newTestRegistry(t)
-		DefineRetriever(reg, "test/retrieveFuncRef", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		defineRetriever(reg, "test/retrieveFuncRef", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			return &RetrieverResponse{
 				Documents: []*Document{DocumentFromText("result", nil)},
 			}, nil
@@ -291,7 +291,7 @@ func TestRetrieveFunction(t *testing.T) {
 
 	t.Run("retrieves with retriever name", func(t *testing.T) {
 		reg := newTestRegistry(t)
-		DefineRetriever(reg, "test/retrieveFuncName", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		defineRetriever(reg, "test/retrieveFuncName", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			return &RetrieverResponse{
 				Documents: []*Document{DocumentFromText("result", nil)},
 			}, nil
@@ -312,7 +312,7 @@ func TestRetrieveFunction(t *testing.T) {
 		reg := newTestRegistry(t)
 		var capturedOpts any
 
-		DefineRetriever(reg, "test/retrieveRefConfig", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		defineRetriever(reg, "test/retrieveRefConfig", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			capturedOpts = req.Options
 			return &RetrieverResponse{Documents: []*Document{}}, nil
 		})
@@ -335,7 +335,7 @@ func TestRetrieveFunction(t *testing.T) {
 		reg := newTestRegistry(t)
 		var capturedOpts any
 
-		DefineRetriever(reg, "test/retrieveOverrideConfig", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		defineRetriever(reg, "test/retrieveOverrideConfig", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			capturedOpts = req.Options
 			return &RetrieverResponse{Documents: []*Document{}}, nil
 		})
@@ -377,7 +377,7 @@ func TestRetrieveFunction(t *testing.T) {
 
 	t.Run("returns error with multiple documents", func(t *testing.T) {
 		reg := newTestRegistry(t)
-		DefineRetriever(reg, "test/retrieveMultiDoc", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		defineRetriever(reg, "test/retrieveMultiDoc", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			return &RetrieverResponse{Documents: []*Document{}}, nil
 		})
 
@@ -395,7 +395,7 @@ func TestRetrieveFunction(t *testing.T) {
 		reg := newTestRegistry(t)
 		var capturedQuery *Document
 
-		DefineRetriever(reg, "test/retrieveDocOpts", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+		defineRetriever(reg, "test/retrieveDocOpts", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 			capturedQuery = req.Query
 			return &RetrieverResponse{Documents: []*Document{}}, nil
 		})

--- a/go/ai/retriever_test.go
+++ b/go/ai/retriever_test.go
@@ -194,7 +194,7 @@ func TestRetrieverRetrieve(t *testing.T) {
 	})
 
 	t.Run("returns error on nil retriever", func(t *testing.T) {
-		var r *retriever
+		var r *RetrieverAction
 		_, err := r.Retrieve(context.Background(), &RetrieverRequest{})
 		if err == nil {
 			t.Error("expected error for nil retriever")

--- a/go/ai/testutil_test.go
+++ b/go/ai/testutil_test.go
@@ -87,7 +87,7 @@ func defineFakeModel(t *testing.T, r api.Registry, cfg fakeModelConfig) Model {
 			}, nil
 		}
 	}
-	return DefineModel(r, cfg.name, &ModelOptions{Supports: cfg.supports}, cfg.handler)
+	return defineModel(r, cfg.name, &ModelOptions{Supports: cfg.supports}, cfg.handler)
 }
 
 // echoModelHandler creates a handler that echoes back information about the request.
@@ -292,7 +292,7 @@ func assertNoPanic(t *testing.T, fn func()) {
 // defineFakeTool creates a simple tool for testing.
 func defineFakeTool(t *testing.T, r api.Registry, name, description string) Tool {
 	t.Helper()
-	return DefineTool(r, name, description,
+	return defineTool(r, name, description,
 		func(ctx *ToolContext, input struct {
 			Value string `json:"value"`
 		}) (string, error) {
@@ -369,7 +369,7 @@ func assertSpanAttr(t *testing.T, span sdktrace.ReadOnlySpan, key, want string) 
 // defineFakeEmbedder creates a simple embedder for testing.
 func defineFakeEmbedder(t *testing.T, r api.Registry, name string) Embedder {
 	t.Helper()
-	return DefineEmbedder(r, name, nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
+	return defineEmbedder(r, name, nil, func(ctx context.Context, req *EmbedRequest) (*EmbedResponse, error) {
 		embeddings := make([]*Embedding, len(req.Input))
 		for i := range req.Input {
 			embeddings[i] = &Embedding{

--- a/go/ai/testutil_test.go
+++ b/go/ai/testutil_test.go
@@ -383,7 +383,7 @@ func defineFakeEmbedder(t *testing.T, r api.Registry, name string) Embedder {
 // defineFakeRetriever creates a simple retriever for testing.
 func defineFakeRetriever(t *testing.T, r api.Registry, name string, docs []*Document) Retriever {
 	t.Helper()
-	return DefineRetriever(r, name, nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+	return defineRetriever(r, name, nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
 		return &RetrieverResponse{Documents: docs}, nil
 	})
 }

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -57,14 +57,22 @@ func (t ToolName) Name() string {
 	return (string)(t)
 }
 
-// ToolDef is an action with functions specific to tools.
+// ToolAction is a tool backed by a registry action. It is the concrete type
+// returned by [NewTool] and [NewMultipartTool].
 // Internally, all tools use the v2 format (returning MultipartToolResponse).
 // For regular tools, RunRaw unwraps the Output field for backward compatibility.
-type ToolDef[In, Out any] struct {
+type ToolAction[In, Out any] struct {
 	action    api.Action   // The underlying action.
 	multipart bool         // Whether this is a multipart-only tool.
 	registry  api.Registry // Registry for schema resolution. Set when registered.
 }
+
+// ToolDef is the previous name for [ToolAction]. It was renamed because it
+// read as a sibling of [ToolDefinition], the wire type a tool advertises to
+// the model, which it is not.
+//
+// Deprecated: use [ToolAction].
+type ToolDef[In, Out any] = ToolAction[In, Out]
 
 // Tool represents a tool that can be called by a model.
 type Tool interface {
@@ -138,7 +146,7 @@ type RespondOptions struct {
 	Metadata map[string]any
 }
 
-// RespondWithOption is a functional option for [ToolDef.RespondWith].
+// RespondWithOption is a functional option for [ToolAction.RespondWith].
 type RespondWithOption[Out any] interface {
 	applyRespondWith(*RespondOptions)
 }
@@ -157,7 +165,7 @@ func WithResponseMetadata[Out any](meta map[string]any) RespondWithOption[Out] {
 	return &RespondOptions{Metadata: meta}
 }
 
-// RestartWithOption is a functional option for [ToolDef.RestartWith].
+// RestartWithOption is a functional option for [ToolAction.RestartWith].
 type RestartWithOption[In any] interface {
 	applyRestartWith(*RestartOptions)
 }
@@ -297,7 +305,7 @@ func applyStrictMetadata(metadata map[string]any, strict *bool) {
 
 // applyToolOutputSchema records a custom output schema as the tool's
 // advertised (original) output schema. The action's own output type stays the
-// multipart envelope; [ToolDef.Definition] surfaces the original schema to the
+// multipart envelope; [ToolAction.Definition] surfaces the original schema to the
 // model and the Dev UI.
 func applyToolOutputSchema(metadata map[string]any, schema map[string]any) {
 	if schema != nil {
@@ -317,10 +325,10 @@ func requireAnyTypeParam[T any](ctor, name, requirement string) {
 	}
 }
 
-// NewTool creates a new [ToolDef]. It can be passed directly to [Generate].
+// NewTool creates a new [ToolAction]. It can be passed directly to [Generate].
 // Use [WithInputSchema] or [WithOutputSchema] to provide custom JSON schemas
 // instead of inferring them from the type parameters.
-func NewTool[In, Out any](name, description string, fn ToolFunc[In, Out], opts ...ToolOption) *ToolDef[In, Out] {
+func NewTool[In, Out any](name, description string, fn ToolFunc[In, Out], opts ...ToolOption) *ToolAction[In, Out] {
 	toolOpts := &toolOptions{}
 	for _, opt := range opts {
 		opt.applyTool(toolOpts)
@@ -338,23 +346,23 @@ func NewTool[In, Out any](name, description string, fn ToolFunc[In, Out], opts .
 	applyToolOutputSchema(metadata, toolOpts.OutputSchema)
 	applyStrictMetadata(metadata, toolOpts.StrictSchema)
 	action := core.NewActionOf(api.ActionTypeToolV2, name, &core.ActionOptions{Metadata: metadata, InputSchema: toolOpts.InputSchema}, wrappedFn)
-	return &ToolDef[In, Out]{action: action, multipart: false}
+	return &ToolAction[In, Out]{action: action, multipart: false}
 }
 
-// NewToolWithInputSchema creates a new [ToolDef] with a custom input schema. It can be passed directly to [Generate].
+// NewToolWithInputSchema creates a new [ToolAction] with a custom input schema. It can be passed directly to [Generate].
 //
 // Deprecated: Use [NewTool] with [WithInputSchema] instead.
-func NewToolWithInputSchema[Out any](name, description string, inputSchema map[string]any, fn ToolFunc[any, Out]) *ToolDef[any, Out] {
+func NewToolWithInputSchema[Out any](name, description string, inputSchema map[string]any, fn ToolFunc[any, Out]) *ToolAction[any, Out] {
 	return NewTool(name, description, fn, WithInputSchema(inputSchema))
 }
 
-// NewMultipartTool creates a new multipart [ToolDef]. It can be passed directly to [Generate].
+// NewMultipartTool creates a new multipart [ToolAction]. It can be passed directly to [Generate].
 // Multipart tools can return both output data and additional content parts (like media).
 // Use [WithInputSchema] to provide a custom JSON schema instead of inferring from the type parameter.
 // Use [WithOutputSchema] or [WithOutputSchemaName] to advertise the logical
 // output the tool produces (the envelope's output field); the wire format
 // stays the multipart response envelope.
-func NewMultipartTool[In any](name, description string, fn MultipartToolFunc[In], opts ...ToolOption) *ToolDef[In, *MultipartToolResponse] {
+func NewMultipartTool[In any](name, description string, fn MultipartToolFunc[In], opts ...ToolOption) *ToolAction[In, *MultipartToolResponse] {
 	toolOpts := &toolOptions{}
 	for _, opt := range opts {
 		opt.applyTool(toolOpts)
@@ -365,7 +373,7 @@ func NewMultipartTool[In any](name, description string, fn MultipartToolFunc[In]
 	applyToolOutputSchema(metadata, toolOpts.OutputSchema)
 	applyStrictMetadata(metadata, toolOpts.StrictSchema)
 	action := core.NewActionOf(api.ActionTypeToolV2, name, &core.ActionOptions{Metadata: metadata, InputSchema: toolOpts.InputSchema}, wrappedFn)
-	return &ToolDef[In, *MultipartToolResponse]{action: action, multipart: true}
+	return &ToolAction[In, *MultipartToolResponse]{action: action, multipart: true}
 }
 
 // wrapToolFunc wraps a regular tool function to return MultipartToolResponse.
@@ -421,12 +429,12 @@ func wrapMultipartToolFunc[In any](name, description string, fn MultipartToolFun
 }
 
 // Name returns the name of the tool.
-func (t *ToolDef[In, Out]) Name() string {
+func (t *ToolAction[In, Out]) Name() string {
 	return t.action.Name()
 }
 
 // Definition returns [ToolDefinition] for for this tool.
-func (t *ToolDef[In, Out]) Definition() *ToolDefinition {
+func (t *ToolAction[In, Out]) Definition() *ToolDefinition {
 	desc := t.action.Desc()
 
 	// Resolve the input schema if it contains a $ref.
@@ -472,7 +480,7 @@ func (t *ToolDef[In, Out]) Definition() *ToolDefinition {
 }
 
 // Register registers the tool with the given registry.
-func (t *ToolDef[In, Out]) Register(r api.Registry) {
+func (t *ToolAction[In, Out]) Register(r api.Registry) {
 	t.registry = r
 	t.action.Register(r)
 	if !t.multipart {
@@ -483,7 +491,7 @@ func (t *ToolDef[In, Out]) Register(r api.Registry) {
 }
 
 // RunRaw runs this tool using the provided raw map format data (JSON parsed as map[string]any).
-func (t *ToolDef[In, Out]) RunRaw(ctx context.Context, input any) (any, error) {
+func (t *ToolAction[In, Out]) RunRaw(ctx context.Context, input any) (any, error) {
 	resp, err := t.RunRawMultipart(ctx, input)
 	if err != nil {
 		return nil, err
@@ -493,7 +501,7 @@ func (t *ToolDef[In, Out]) RunRaw(ctx context.Context, input any) (any, error) {
 
 // RunRawMultipart runs this tool using the provided raw map format data (JSON parsed as map[string]any).
 // It returns the full multipart response.
-func (t *ToolDef[In, Out]) RunRawMultipart(ctx context.Context, input any) (*MultipartToolResponse, error) {
+func (t *ToolAction[In, Out]) RunRawMultipart(ctx context.Context, input any) (*MultipartToolResponse, error) {
 	if t == nil {
 		return nil, status.Errorf(status.ErrInvalidArgument, "ai.Tool.RunRawMultipart: tool called on a nil tool; check that all tools are defined")
 	}
@@ -545,19 +553,19 @@ func LookupTool(r api.Registry, name string) Tool {
 		}
 	}
 
-	return &ToolDef[any, any]{action: action, multipart: multipart, registry: r}
+	return &ToolAction[any, any]{action: action, multipart: multipart, registry: r}
 }
 
 // IsMultipart returns true if the tool is a multipart tool (tool.v2 only).
-func (t *ToolDef[In, Out]) IsMultipart() bool {
+func (t *ToolAction[In, Out]) IsMultipart() bool {
 	return t.multipart
 }
 
 // Respond creates a part for [WithToolResponses] to provide a resolved response for an interrupted tool call.
 // Returns nil if the part is not a tool request.
 //
-// Deprecated: Use [ToolDef.RespondWith] instead for strongly-typed options.
-func (t *ToolDef[In, Out]) Respond(toolReq *Part, output any, opts *RespondOptions) *Part {
+// Deprecated: Use [ToolAction.RespondWith] instead for strongly-typed options.
+func (t *ToolAction[In, Out]) Respond(toolReq *Part, output any, opts *RespondOptions) *Part {
 	if toolReq == nil || !toolReq.IsToolRequest() {
 		return nil
 	}
@@ -580,8 +588,8 @@ func (t *ToolDef[In, Out]) Respond(toolReq *Part, output any, opts *RespondOptio
 // Restart creates a part for [WithToolRestarts] to re-execute an interrupted tool call with additional context.
 // Returns nil if the part is not a tool request.
 //
-// Deprecated: Use [ToolDef.RestartWith] instead for strongly-typed options.
-func (t *ToolDef[In, Out]) Restart(p *Part, opts *RestartOptions) *Part {
+// Deprecated: Use [ToolAction.RestartWith] instead for strongly-typed options.
+func (t *ToolAction[In, Out]) Restart(p *Part, opts *RestartOptions) *Part {
 	if p == nil || !p.IsToolRequest() {
 		return nil
 	}
@@ -629,7 +637,7 @@ func (t *ToolDef[In, Out]) Restart(p *Part, opts *RestartOptions) *Part {
 // Example:
 //
 //	part, err := myTool.RespondWith(toolReq, output, WithResponseMetadata[MyOutput](meta))
-func (t *ToolDef[In, Out]) RespondWith(toolReq *Part, output Out, opts ...RespondWithOption[Out]) (*Part, error) {
+func (t *ToolAction[In, Out]) RespondWith(toolReq *Part, output Out, opts ...RespondWithOption[Out]) (*Part, error) {
 	if toolReq == nil {
 		return nil, status.Errorf(status.ErrInvalidArgument, "ai.RespondWith: toolReq is nil")
 	}
@@ -661,7 +669,7 @@ func (t *ToolDef[In, Out]) RespondWith(toolReq *Part, output Out, opts ...Respon
 // Example:
 //
 //	part, err := myTool.RestartWith(toolReq, WithNewInput(newInput), WithResumedMetadata[MyInput](meta))
-func (t *ToolDef[In, Out]) RestartWith(toolReq *Part, opts ...RestartWithOption[In]) (*Part, error) {
+func (t *ToolAction[In, Out]) RestartWith(toolReq *Part, opts ...RestartWithOption[In]) (*Part, error) {
 	if toolReq == nil {
 		return nil, status.Errorf(status.ErrInvalidArgument, "ai.RestartWith: toolReq is nil")
 	}

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -317,52 +317,6 @@ func requireAnyTypeParam[T any](ctor, name, requirement string) {
 	}
 }
 
-// DefineTool creates a new [ToolDef] and registers it.
-// Use [WithInputSchema] or [WithOutputSchema] to provide custom JSON schemas
-// instead of inferring them from the type parameters.
-func DefineTool[In, Out any](
-	r api.Registry,
-	name, description string,
-	fn ToolFunc[In, Out],
-	opts ...ToolOption,
-) *ToolDef[In, Out] {
-	toolOpts := &toolOptions{}
-	for _, opt := range opts {
-		opt.applyTool(toolOpts)
-	}
-
-	if toolOpts.InputSchema != nil {
-		requireAnyTypeParam[In]("ai.DefineTool", name, "WithInputSchema requires In")
-	}
-	if toolOpts.OutputSchema != nil {
-		requireAnyTypeParam[Out]("ai.DefineTool", name, "WithOutputSchema and WithOutputSchemaName require Out")
-	}
-
-	metadata, wrappedFn := wrapToolFunc(name, description, fn)
-	applyToolOutputSchema(metadata, toolOpts.OutputSchema)
-	applyStrictMetadata(metadata, toolOpts.StrictSchema)
-	action := core.NewActionOf(api.ActionTypeToolV2, name, &core.ActionOptions{Metadata: metadata, InputSchema: toolOpts.InputSchema}, wrappedFn)
-	action.Register(r)
-
-	// Also register under the "tool" action type for backward compatibility.
-	provider, id := api.ParseName(name)
-	r.RegisterAction(api.NewKey(api.ActionTypeTool, provider, id), action)
-
-	return &ToolDef[In, Out]{action: action, multipart: false, registry: r}
-}
-
-// DefineToolWithInputSchema creates a new [ToolDef] with a custom input schema and registers it.
-//
-// Deprecated: Use [DefineTool] with [WithInputSchema] instead.
-func DefineToolWithInputSchema[Out any](
-	r api.Registry,
-	name, description string,
-	inputSchema map[string]any,
-	fn ToolFunc[any, Out],
-) *ToolDef[any, Out] {
-	return DefineTool(r, name, description, fn, WithInputSchema(inputSchema))
-}
-
 // NewTool creates a new [ToolDef]. It can be passed directly to [Generate].
 // Use [WithInputSchema] or [WithOutputSchema] to provide custom JSON schemas
 // instead of inferring them from the type parameters.
@@ -392,31 +346,6 @@ func NewTool[In, Out any](name, description string, fn ToolFunc[In, Out], opts .
 // Deprecated: Use [NewTool] with [WithInputSchema] instead.
 func NewToolWithInputSchema[Out any](name, description string, inputSchema map[string]any, fn ToolFunc[any, Out]) *ToolDef[any, Out] {
 	return NewTool(name, description, fn, WithInputSchema(inputSchema))
-}
-
-// DefineMultipartTool creates a new multipart [ToolDef] and registers it.
-// Multipart tools can return both output data and additional content parts (like media).
-// Use [WithInputSchema] to provide a custom JSON schema instead of inferring from the type parameter.
-// Use [WithOutputSchema] or [WithOutputSchemaName] to advertise the logical
-// output the tool produces (the envelope's output field); the wire format
-// stays the multipart response envelope.
-func DefineMultipartTool[In any](
-	r api.Registry,
-	name, description string,
-	fn MultipartToolFunc[In],
-	opts ...ToolOption,
-) *ToolDef[In, *MultipartToolResponse] {
-	toolOpts := &toolOptions{}
-	for _, opt := range opts {
-		opt.applyTool(toolOpts)
-	}
-
-	metadata, wrappedFn := wrapMultipartToolFunc(name, description, fn)
-	applyToolOutputSchema(metadata, toolOpts.OutputSchema)
-	applyStrictMetadata(metadata, toolOpts.StrictSchema)
-	action := core.NewActionOf(api.ActionTypeToolV2, name, &core.ActionOptions{Metadata: metadata, InputSchema: toolOpts.InputSchema}, wrappedFn)
-	action.Register(r)
-	return &ToolDef[In, *MultipartToolResponse]{action: action, multipart: true, registry: r}
 }
 
 // NewMultipartTool creates a new multipart [ToolDef]. It can be passed directly to [Generate].

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -513,12 +513,18 @@ func (t *ToolAction[In, Out]) Desc() api.ActionDesc { return t.action.Desc() }
 // tool. Prefer [ToolAction.RunRaw], which unwraps the envelope's output for a
 // regular tool.
 func (t *ToolAction[In, Out]) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	if t == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "ai.Tool.RunJSON: tool called on a nil tool; check that all tools are defined")
+	}
 	return t.action.RunJSON(ctx, input, cb)
 }
 
 // RunJSONWithTelemetry is [ToolAction.RunJSON] with the run's telemetry
 // returned alongside the output.
 func (t *ToolAction[In, Out]) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	if t == nil {
+		return nil, status.Errorf(status.ErrInvalidArgument, "ai.Tool.RunJSONWithTelemetry: tool called on a nil tool; check that all tools are defined")
+	}
 	return t.action.RunJSONWithTelemetry(ctx, input, cb)
 }
 

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -62,7 +62,8 @@ func (t ToolName) Name() string {
 // Internally, all tools use the v2 format (returning MultipartToolResponse).
 // For regular tools, RunRaw unwraps the Output field for backward compatibility.
 //
-// It implements [Tool], so it can be passed anywhere one is accepted. Unlike
+// It implements [Tool] and [api.Action], so it can be passed anywhere either
+// is accepted, including the action slice a plugin returns from Init. Unlike
 // the other primitives it holds its action in a named field rather than
 // embedding it, so its documented methods are its whole surface.
 type ToolAction[In, Out any] struct {
@@ -71,9 +72,12 @@ type ToolAction[In, Out any] struct {
 	registry  api.Registry // Registry for schema resolution. Set when registered.
 }
 
-// Pinned here so that breaking the interface fails the build at the type
+// Pinned here so that breaking either interface fails the build at the type
 // rather than at a call site.
-var _ Tool = (*ToolAction[any, any])(nil)
+var (
+	_ Tool       = (*ToolAction[any, any])(nil)
+	_ api.Action = (*ToolAction[any, any])(nil)
+)
 
 // ToolDef is the previous name for [ToolAction]. It was renamed because it
 // read as a sibling of [ToolDefinition], the wire type a tool advertises to
@@ -499,6 +503,23 @@ func (t *ToolAction[In, Out]) Register(r api.Registry) {
 		provider, id := api.ParseName(t.action.Name())
 		r.RegisterAction(api.NewKey(api.ActionTypeTool, provider, id), t.action)
 	}
+}
+
+// Desc returns the tool's action descriptor: its name, schemas, and metadata.
+func (t *ToolAction[In, Out]) Desc() api.ActionDesc { return t.action.Desc() }
+
+// RunJSON runs the tool on JSON-encoded input and returns the JSON-encoded
+// multipart response envelope, which is what the registry serves for this
+// tool. Prefer [ToolAction.RunRaw], which unwraps the envelope's output for a
+// regular tool.
+func (t *ToolAction[In, Out]) RunJSON(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (json.RawMessage, error) {
+	return t.action.RunJSON(ctx, input, cb)
+}
+
+// RunJSONWithTelemetry is [ToolAction.RunJSON] with the run's telemetry
+// returned alongside the output.
+func (t *ToolAction[In, Out]) RunJSONWithTelemetry(ctx context.Context, input json.RawMessage, cb core.StreamCallback[json.RawMessage]) (*api.ActionRunResult[json.RawMessage], error) {
+	return t.action.RunJSONWithTelemetry(ctx, input, cb)
 }
 
 // RunRaw runs this tool using the provided raw map format data (JSON parsed as map[string]any).

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -61,11 +61,19 @@ func (t ToolName) Name() string {
 // returned by [NewTool] and [NewMultipartTool].
 // Internally, all tools use the v2 format (returning MultipartToolResponse).
 // For regular tools, RunRaw unwraps the Output field for backward compatibility.
+//
+// It implements [Tool], so it can be passed anywhere one is accepted. Unlike
+// the other primitives it holds its action in a named field rather than
+// embedding it, so its documented methods are its whole surface.
 type ToolAction[In, Out any] struct {
 	action    api.Action   // The underlying action.
 	multipart bool         // Whether this is a multipart-only tool.
 	registry  api.Registry // Registry for schema resolution. Set when registered.
 }
+
+// Pinned here so that breaking the interface fails the build at the type
+// rather than at a call site.
+var _ Tool = (*ToolAction[any, any])(nil)
 
 // ToolDef is the previous name for [ToolAction]. It was renamed because it
 // read as a sibling of [ToolDefinition], the wire type a tool advertises to
@@ -74,7 +82,10 @@ type ToolAction[In, Out any] struct {
 // Deprecated: use [ToolAction].
 type ToolDef[In, Out any] = ToolAction[In, Out]
 
-// Tool represents a tool that can be called by a model.
+// Tool represents a tool that can be called by a model. It is the type to
+// accept as an argument and to look up by name; implementations are created
+// with [NewTool] or [NewMultipartTool], or their [genkit.DefineTool] and
+// [genkit.DefineMultipartTool] counterparts in an application.
 type Tool interface {
 	// Name returns the name of the tool.
 	Name() string

--- a/go/ai/tools_test.go
+++ b/go/ai/tools_test.go
@@ -136,7 +136,7 @@ func (e *wrappedInterruptError) Unwrap() error {
 func TestDefineTool(t *testing.T) {
 	t.Run("creates and registers tool", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "provider/addNumbers", "Adds two numbers", func(ctx *ToolContext, input struct {
+		tl := defineTool(r, "provider/addNumbers", "Adds two numbers", func(ctx *ToolContext, input struct {
 			A int `json:"a"`
 			B int `json:"b"`
 		}) (int, error) {
@@ -158,7 +158,7 @@ func TestDefineTool(t *testing.T) {
 
 	t.Run("tool can be looked up after registration", func(t *testing.T) {
 		r := newTestRegistry(t)
-		DefineTool(r, "provider/multiply", "Multiplies", func(ctx *ToolContext, input struct {
+		defineTool(r, "provider/multiply", "Multiplies", func(ctx *ToolContext, input struct {
 			X int `json:"x"`
 			Y int `json:"y"`
 		}) (int, error) {
@@ -173,7 +173,7 @@ func TestDefineTool(t *testing.T) {
 
 	t.Run("tool executes correctly", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "provider/concat", "Concatenates strings", func(ctx *ToolContext, input struct {
+		tl := defineTool(r, "provider/concat", "Concatenates strings", func(ctx *ToolContext, input struct {
 			A string `json:"a"`
 			B string `json:"b"`
 		}) (string, error) {
@@ -205,7 +205,7 @@ func TestDefineToolWithInputSchema(t *testing.T) {
 			"required": []any{"query"},
 		}
 
-		tl := DefineToolWithInputSchema(r, "provider/search", "Searches", customSchema,
+		tl := defineToolWithInputSchema(r, "provider/search", "Searches", customSchema,
 			func(ctx *ToolContext, input any) (string, error) {
 				m := input.(map[string]any)
 				return "results for: " + m["query"].(string), nil
@@ -298,7 +298,7 @@ func TestNewToolWithInputSchema(t *testing.T) {
 func TestDefineMultipartTool(t *testing.T) {
 	t.Run("creates multipart tool", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineMultipartTool(r, "provider/imageGen", "Generates images",
+		tl := defineMultipartTool(r, "provider/imageGen", "Generates images",
 			func(ctx *ToolContext, input struct {
 				Prompt string `json:"prompt"`
 			}) (*MultipartToolResponse, error) {
@@ -326,7 +326,7 @@ func TestDefineMultipartTool(t *testing.T) {
 
 	t.Run("multipart tool returns parts", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineMultipartTool(r, "provider/multiOut", "Returns multiple parts",
+		tl := defineMultipartTool(r, "provider/multiOut", "Returns multiple parts",
 			func(ctx *ToolContext, input struct{}) (*MultipartToolResponse, error) {
 				return &MultipartToolResponse{
 					Output: map[string]any{"status": "ok"},
@@ -384,7 +384,7 @@ func TestNewMultipartTool(t *testing.T) {
 func TestToolDefinition(t *testing.T) {
 	t.Run("includes all fields", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "provider/complete", "A complete tool", func(ctx *ToolContext, input struct {
+		tl := defineTool(r, "provider/complete", "A complete tool", func(ctx *ToolContext, input struct {
 			Query string `json:"query"`
 		}) (struct {
 			Result string `json:"result"`
@@ -430,7 +430,7 @@ func TestLookupTool(t *testing.T) {
 
 	t.Run("finds registered tool", func(t *testing.T) {
 		r := newTestRegistry(t)
-		DefineTool(r, "test/findMe", "Find me", func(ctx *ToolContext, input struct{}) (bool, error) {
+		defineTool(r, "test/findMe", "Find me", func(ctx *ToolContext, input struct{}) (bool, error) {
 			return true, nil
 		})
 
@@ -449,7 +449,7 @@ func TestWithStrictSchema(t *testing.T) {
 
 	t.Run("absent by default", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "strict/default", "no strict opt", func(ctx *ToolContext, input struct{}) (string, error) {
+		tl := defineTool(r, "strict/default", "no strict opt", func(ctx *ToolContext, input struct{}) (string, error) {
 			return "", nil
 		})
 		def := tl.Definition()
@@ -474,7 +474,7 @@ func TestWithStrictSchema(t *testing.T) {
 
 	t.Run("DefineTool with WithStrictSchema(true) is surfaced on Definition", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "strict/registered-true", "registered strict",
+		tl := defineTool(r, "strict/registered-true", "registered strict",
 			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
 			WithStrictSchema(true),
 		)
@@ -483,7 +483,7 @@ func TestWithStrictSchema(t *testing.T) {
 
 	t.Run("DefineTool with WithStrictSchema(false) is surfaced on Definition", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "strict/registered-false", "registered loose",
+		tl := defineTool(r, "strict/registered-false", "registered loose",
 			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
 			WithStrictSchema(false),
 		)
@@ -492,7 +492,7 @@ func TestWithStrictSchema(t *testing.T) {
 
 	t.Run("LookupTool round-trips the strict flag for registered tools", func(t *testing.T) {
 		r := newTestRegistry(t)
-		DefineTool(r, "strict/lookup-true", "registered strict",
+		defineTool(r, "strict/lookup-true", "registered strict",
 			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
 			WithStrictSchema(true),
 		)
@@ -521,7 +521,7 @@ func TestWithStrictSchema(t *testing.T) {
 
 	t.Run("DefineMultipartTool plumbs strict the same way", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineMultipartTool(r, "strict/multipart", "multipart strict",
+		tl := defineMultipartTool(r, "strict/multipart", "multipart strict",
 			func(ctx *ToolContext, input struct{}) (*MultipartToolResponse, error) {
 				return &MultipartToolResponse{}, nil
 			},
@@ -534,7 +534,7 @@ func TestWithStrictSchema(t *testing.T) {
 		// WithStrictSchema fills a single slot, so repeating it overwrites
 		// rather than failing.
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "strict/double-set", "double set",
+		tl := defineTool(r, "strict/double-set", "double set",
 			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
 			WithStrictSchema(true),
 			WithStrictSchema(false),
@@ -546,7 +546,7 @@ func TestWithStrictSchema(t *testing.T) {
 func TestToolIsMultipart(t *testing.T) {
 	t.Run("regular tool is not multipart", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "provider/regular", "Regular tool", func(ctx *ToolContext, input struct{}) (string, error) {
+		tl := defineTool(r, "provider/regular", "Regular tool", func(ctx *ToolContext, input struct{}) (string, error) {
 			return "ok", nil
 		})
 
@@ -558,7 +558,7 @@ func TestToolIsMultipart(t *testing.T) {
 
 	t.Run("multipart tool is multipart", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineMultipartTool(r, "provider/multi", "Multi tool",
+		tl := defineMultipartTool(r, "provider/multi", "Multi tool",
 			func(ctx *ToolContext, input struct{}) (*MultipartToolResponse, error) {
 				return &MultipartToolResponse{}, nil
 			})
@@ -573,7 +573,7 @@ func TestToolIsMultipart(t *testing.T) {
 func TestToolRunRaw(t *testing.T) {
 	t.Run("returns output from regular tool", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "provider/sum", "Sums numbers", func(ctx *ToolContext, input struct {
+		tl := defineTool(r, "provider/sum", "Sums numbers", func(ctx *ToolContext, input struct {
 			Nums []int `json:"nums"`
 		}) (int, error) {
 			sum := 0
@@ -598,7 +598,7 @@ func TestToolRunRaw(t *testing.T) {
 
 	t.Run("returns error from tool", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "provider/fail", "Always fails", func(ctx *ToolContext, input struct{}) (string, error) {
+		tl := defineTool(r, "provider/fail", "Always fails", func(ctx *ToolContext, input struct{}) (string, error) {
 			return "", errors.New("intentional failure")
 		})
 
@@ -612,7 +612,7 @@ func TestToolRunRaw(t *testing.T) {
 func TestToolRunRawMultipart(t *testing.T) {
 	t.Run("returns full response from multipart tool", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineMultipartTool(r, "provider/fullResp", "Full response",
+		tl := defineMultipartTool(r, "provider/fullResp", "Full response",
 			func(ctx *ToolContext, input struct{}) (*MultipartToolResponse, error) {
 				return &MultipartToolResponse{
 					Output: "main output",
@@ -638,7 +638,7 @@ func TestToolRunRawMultipart(t *testing.T) {
 
 func TestToolRespond(t *testing.T) {
 	r := newTestRegistry(t)
-	tl := DefineTool(r, "provider/responder", "Test responder", func(ctx *ToolContext, input struct{}) (string, error) {
+	tl := defineTool(r, "provider/responder", "Test responder", func(ctx *ToolContext, input struct{}) (string, error) {
 		return "ok", nil
 	})
 
@@ -706,7 +706,7 @@ func TestToolRespond(t *testing.T) {
 
 func TestToolRestart(t *testing.T) {
 	r := newTestRegistry(t)
-	tl := DefineTool(r, "provider/restarter", "Test restarter", func(ctx *ToolContext, input struct {
+	tl := defineTool(r, "provider/restarter", "Test restarter", func(ctx *ToolContext, input struct {
 		Value int `json:"value"`
 	}) (int, error) {
 		return input.Value, nil
@@ -804,7 +804,7 @@ func TestToolRestart(t *testing.T) {
 func TestToolInterrupt(t *testing.T) {
 	t.Run("tool can interrupt execution", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "provider/interrupter", "Can interrupt",
+		tl := defineTool(r, "provider/interrupter", "Can interrupt",
 			func(ctx *ToolContext, input struct {
 				ShouldInterrupt bool `json:"shouldInterrupt"`
 			}) (string, error) {
@@ -835,7 +835,7 @@ func TestToolInterrupt(t *testing.T) {
 
 	t.Run("tool completes without interrupt", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "provider/noInterrupt", "No interrupt",
+		tl := defineTool(r, "provider/noInterrupt", "No interrupt",
 			func(ctx *ToolContext, input struct {
 				ShouldInterrupt bool `json:"shouldInterrupt"`
 			}) (string, error) {
@@ -868,7 +868,7 @@ func TestToolWithInputSchemaOption(t *testing.T) {
 			},
 		}
 
-		tl := DefineTool(r, "provider/customInput", "Custom input schema",
+		tl := defineTool(r, "provider/customInput", "Custom input schema",
 			func(ctx *ToolContext, input any) (string, error) {
 				m := input.(map[string]any)
 				return m["customField"].(string), nil
@@ -910,10 +910,10 @@ func TestToolWithOutputSchemaOptions(t *testing.T) {
 		},
 	}
 
-	t.Run("DefineTool with WithOutputSchema", func(t *testing.T) {
+	t.Run("registered tool with WithOutputSchema", func(t *testing.T) {
 		r := newTestRegistry(t)
 
-		tl := DefineTool(r, "provider/customOutput", "Custom output schema",
+		tl := defineTool(r, "provider/customOutput", "Custom output schema",
 			func(ctx *ToolContext, input struct{}) (any, error) { return nil, nil },
 			WithOutputSchema(customSchema))
 
@@ -940,7 +940,7 @@ func TestToolWithOutputSchemaOptions(t *testing.T) {
 		r := newTestRegistry(t)
 		r.RegisterSchema("Answer", customSchema)
 
-		tl := DefineTool(r, "provider/namedOutput", "Named output schema",
+		tl := defineTool(r, "provider/namedOutput", "Named output schema",
 			func(ctx *ToolContext, input struct{}) (any, error) { return nil, nil },
 			WithOutputSchemaName("Answer"))
 
@@ -991,10 +991,10 @@ func TestToolWithOutputSchemaOptions(t *testing.T) {
 func TestResolveUniqueTools(t *testing.T) {
 	t.Run("resolves tools from registry", func(t *testing.T) {
 		r := newTestRegistry(t)
-		DefineTool(r, "provider/tool1", "Tool 1", func(ctx *ToolContext, input struct{}) (bool, error) {
+		defineTool(r, "provider/tool1", "Tool 1", func(ctx *ToolContext, input struct{}) (bool, error) {
 			return true, nil
 		})
-		DefineTool(r, "provider/tool2", "Tool 2", func(ctx *ToolContext, input struct{}) (bool, error) {
+		defineTool(r, "provider/tool2", "Tool 2", func(ctx *ToolContext, input struct{}) (bool, error) {
 			return true, nil
 		})
 
@@ -1055,7 +1055,7 @@ func TestResolveUniqueTools(t *testing.T) {
 func TestIsMultipart(t *testing.T) {
 	t.Run("returns false for standard tool", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineTool(r, "provider/standard", "Standard tool",
+		tl := defineTool(r, "provider/standard", "Standard tool",
 			func(ctx *ToolContext, input struct{}) (string, error) {
 				return "result", nil
 			})
@@ -1078,7 +1078,7 @@ func TestIsMultipart(t *testing.T) {
 
 	t.Run("returns true for multipart tool", func(t *testing.T) {
 		r := newTestRegistry(t)
-		tl := DefineMultipartTool(r, "provider/multipart", "Multipart tool",
+		tl := defineMultipartTool(r, "provider/multipart", "Multipart tool",
 			func(ctx *ToolContext, input struct{}) (*MultipartToolResponse, error) {
 				return &MultipartToolResponse{
 					Content: []*Part{NewTextPart("hello"), NewTextPart("world")},

--- a/go/core/doc.go
+++ b/go/core/doc.go
@@ -160,7 +160,7 @@ and other capabilities. Implement the [api.Plugin] interface:
 
 	func (p *MyPlugin) Init(ctx context.Context) []api.Action {
 		// Initialize the plugin and return actions to register
-		model := ai.NewTypedModel(...)
+		model := ai.NewModelAction(...)
 		tool := ai.NewTool(...)
 		return []api.Action{model, tool}
 	}

--- a/go/core/doc.go
+++ b/go/core/doc.go
@@ -160,7 +160,7 @@ and other capabilities. Implement the [api.Plugin] interface:
 
 	func (p *MyPlugin) Init(ctx context.Context) []api.Action {
 		// Initialize the plugin and return actions to register
-		model := ai.NewModel(...)
+		model := ai.NewTypedModel(...)
 		tool := ai.NewTool(...)
 		return []api.Action{model, tool}
 	}

--- a/go/core/schemas.config
+++ b/go/core/schemas.config
@@ -1224,7 +1224,7 @@ Message is the user's input for this turn.
 
 AgentInput.resume doc
 Resume provides options for resuming an interrupted generation.
-Construct using [ai.ToolDef.RestartWith] / [ai.ToolDef.RespondWith]
+Construct using [ai.ToolAction.RestartWith] / [ai.ToolAction.RespondWith]
 parts. When set, the generate call resumes with these parts instead
 of treating Message as a tool response.
 .

--- a/go/genkit/doc.go
+++ b/go/genkit/doc.go
@@ -419,9 +419,9 @@ components without registering them in Genkit. This is useful for plugins
 or when you need to pass components directly:
 
   - [ai.NewTool]: Create an unregistered tool
-  - [ai.NewTypedModel]: Create an unregistered model
-  - [ai.NewTypedRetriever]: Create an unregistered retriever
-  - [ai.NewTypedEmbedder]: Create an unregistered embedder
+  - [ai.NewModelAction]: Create an unregistered model
+  - [ai.NewRetrieverAction]: Create an unregistered retriever
+  - [ai.NewEmbedderAction]: Create an unregistered embedder
 
 Use the corresponding Define* functions in this package to create and register
 components for use with Genkit's action system, tracing, and Dev UI.

--- a/go/genkit/doc.go
+++ b/go/genkit/doc.go
@@ -419,9 +419,9 @@ components without registering them in Genkit. This is useful for plugins
 or when you need to pass components directly:
 
   - [ai.NewTool]: Create an unregistered tool
-  - [ai.NewModel]: Create an unregistered model
-  - [ai.NewRetriever]: Create an unregistered retriever
-  - [ai.NewEmbedder]: Create an unregistered embedder
+  - [ai.NewTypedModel]: Create an unregistered model
+  - [ai.NewTypedRetriever]: Create an unregistered retriever
+  - [ai.NewTypedEmbedder]: Create an unregistered embedder
 
 Use the corresponding Define* functions in this package to create and register
 components for use with Genkit's action system, tracing, and Dev UI.

--- a/go/genkit/exp/tools.go
+++ b/go/genkit/exp/tools.go
@@ -63,7 +63,9 @@ import (
 //	fmt.Println(resp.Text())
 func DefineTool[In, Out any](g *genkit.Genkit, name, description string, fn aix.ToolFunc[In, Out], opts ...ai.ToolOption) *aix.Tool[In, Out] {
 	requireExperimental(g, "DefineTool")
-	return aix.DefineTool(genkitbridge.RegistryOf(g), name, description, fn, opts...)
+	t := aix.NewTool(name, description, fn, opts...)
+	t.Register(genkitbridge.RegistryOf(g))
+	return t
 }
 
 // DefineInterruptibleTool defines a tool that supports typed interrupt/resume,
@@ -146,5 +148,7 @@ func DefineTool[In, Out any](g *genkit.Genkit, name, description string, fn aix.
 //	}
 func DefineInterruptibleTool[In, Out, Resume any](g *genkit.Genkit, name, description string, fn aix.InterruptibleToolFunc[In, Out, Resume], opts ...ai.ToolOption) *aix.InterruptibleTool[In, Out, Resume] {
 	requireExperimental(g, "DefineInterruptibleTool")
-	return aix.DefineInterruptibleTool(genkitbridge.RegistryOf(g), name, description, fn, opts...)
+	t := aix.NewInterruptibleTool(name, description, fn, opts...)
+	t.Register(genkitbridge.RegistryOf(g))
+	return t
 }

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -588,8 +588,6 @@ func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc)
 // The `name` is the identifier the model uses to request the background model. The `opts`
 // are the options for the background model. The `startFn` is the function that starts the background model.
 // The `checkFn` is the function that checks the status of the background model.
-// The `cancelFn` is optional; nil means the model does not support canceling
-// operations.
 //
 // Config is the model's typed configuration; it is usually inferred from
 // startFn's signature. See [ai.NewTypedModel] for how the request's
@@ -600,9 +598,8 @@ func DefineTypedBackgroundModel[Config any](
 	opts *ai.TypedBackgroundModelOptions,
 	startFn ai.TypedStartModelOpFunc[Config],
 	checkFn ai.CheckModelOpFunc,
-	cancelFn ai.CancelModelOpFunc,
 ) *ai.BackgroundModelAction {
-	m := ai.NewTypedBackgroundModel(name, opts, startFn, checkFn, cancelFn)
+	m := ai.NewTypedBackgroundModel(name, opts, startFn, checkFn)
 	m.Register(g.reg)
 	return m
 }

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -595,7 +595,7 @@ func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc)
 func DefineBackgroundModelAction[Config any](
 	g *Genkit,
 	name string,
-	opts *ai.TypedBackgroundModelOptions,
+	opts *ai.BackgroundModelOptions,
 	startFn ai.BackgroundModelActionFunc[Config],
 	checkFn ai.CheckModelOpFunc,
 ) *ai.BackgroundModelAction {

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -675,14 +675,14 @@ func LookupBackgroundModel(g *Genkit, name string) ai.BackgroundModel {
 //	}
 //
 //	fmt.Println(resp.Text()) // Might output something like "The weather in Paris is Sunny, 25°C."
-func DefineTool[In, Out any](g *Genkit, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolDef[In, Out] {
+func DefineTool[In, Out any](g *Genkit, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolAction[In, Out] {
 	t := ai.NewTool(name, description, fn, opts...)
 	t.Register(g.reg)
 	return t
 }
 
 // DefineToolWithInputSchema defines a tool with a custom input schema that can be used by models during generation,
-// registers it as a [core.Action] of type Tool, and returns an [*ai.ToolDef].
+// registers it as a [core.Action] of type Tool, and returns an [*ai.ToolAction].
 //
 // This variant of [DefineTool] allows specifying a JSON Schema for the tool's input, providing more
 // control over input validation and model guidance. The input parameter to the tool function will be
@@ -726,14 +726,14 @@ func DefineTool[In, Out any](g *Genkit, name, description string, fn ai.ToolFunc
 //		},
 //		ai.WithToolInputSchema(inputSchema),
 //	)
-func DefineToolWithInputSchema[Out any](g *Genkit, name, description string, inputSchema map[string]any, fn ai.ToolFunc[any, Out]) *ai.ToolDef[any, Out] {
+func DefineToolWithInputSchema[Out any](g *Genkit, name, description string, inputSchema map[string]any, fn ai.ToolFunc[any, Out]) *ai.ToolAction[any, Out] {
 	t := ai.NewTool(name, description, fn, ai.WithInputSchema(inputSchema))
 	t.Register(g.reg)
 	return t
 }
 
 // DefineMultipartTool defines a multipart tool that can be used by models during generation,
-// registers it as a [core.Action] of type Tool, and returns an [*ai.ToolDef].
+// registers it as a [core.Action] of type Tool, and returns an [*ai.ToolAction].
 // Unlike regular tools that return just an output value, multipart tools can return
 // both an output value and additional content parts (like images or other media).
 //
@@ -788,7 +788,7 @@ func DefineToolWithInputSchema[Out any](g *Genkit, name, description string, inp
 //	}
 //
 //	fmt.Println(resp.Text())
-func DefineMultipartTool[In any](g *Genkit, name, description string, fn ai.MultipartToolFunc[In], opts ...ai.ToolOption) *ai.ToolDef[In, *ai.MultipartToolResponse] {
+func DefineMultipartTool[In any](g *Genkit, name, description string, fn ai.MultipartToolFunc[In], opts ...ai.ToolOption) *ai.ToolAction[In, *ai.MultipartToolResponse] {
 	t := ai.NewMultipartTool(name, description, fn, opts...)
 	t.Register(g.reg)
 	return t

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -597,7 +597,7 @@ func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc)
 func DefineTypedBackgroundModel[Config any](
 	g *Genkit,
 	name string,
-	opts *ai.BackgroundModelOptions,
+	opts *ai.TypedBackgroundModelOptions,
 	startFn ai.TypedStartModelOpFunc[Config],
 	checkFn ai.CheckModelOpFunc,
 	cancelFn ai.CancelModelOpFunc,

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -577,18 +577,20 @@ func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc)
 	return m
 }
 
-// DefineTypedBackgroundModel defines a background model, registers it as
-// an [ai.BackgroundModel], and returns an [ai.BackgroundModel].
+// DefineTypedBackgroundModel defines a background model, registers it, and
+// returns the concrete [ai.BackgroundModelAction].
 //
 // The `name` is the identifier the model uses to request the background model. The `opts`
 // are the options for the background model. The `startFn` is the function that starts the background model.
 // The `checkFn` is the function that checks the status of the background model.
+// The `cancelFn` is optional; nil means the model does not support canceling
+// operations.
 //
 // Config is the model's typed configuration; it is usually inferred from
 // startFn's signature. See [ai.NewTypedModel] for how the request's
 // config is deserialized and validated.
-func DefineTypedBackgroundModel[Config any](g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.TypedStartModelOpFunc[Config], checkFn ai.CheckModelOpFunc) *ai.BackgroundModelAction {
-	m := ai.NewTypedBackgroundModel(name, opts, startFn, checkFn)
+func DefineTypedBackgroundModel[Config any](g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.TypedStartModelOpFunc[Config], checkFn ai.CheckModelOpFunc, cancelFn ai.CancelModelOpFunc) *ai.BackgroundModelAction {
+	m := ai.NewTypedBackgroundModel(name, opts, startFn, checkFn, cancelFn)
 	m.Register(g.reg)
 	return m
 }

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -1475,7 +1475,9 @@ func Embed(ctx context.Context, g *Genkit, opts ...ai.EmbedderOption) (*ai.Embed
 // For retrievers that don't need to be registered (e.g., for plugin development),
 // use [ai.NewRetriever] instead.
 func DefineRetriever(g *Genkit, name string, opts *ai.RetrieverOptions, fn ai.RetrieverFunc) ai.Retriever {
-	return ai.DefineRetriever(g.reg, name, opts, fn)
+	ret := ai.NewRetriever(name, opts, fn)
+	ret.Register(g.reg)
+	return ret
 }
 
 // LookupRetriever retrieves a registered [ai.Retriever] by its provider and name.

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -500,7 +500,7 @@ func ListTools(g *Genkit) []ai.Tool {
 }
 
 // DefineModelAction defines a custom model implementation, registers it
-// as a [core.Action] of type Model, and returns an [ai.Model] interface.
+// as a [core.Action] of type Model, and returns the concrete [ai.ModelAction].
 //
 // The `name` argument is the unique identifier for the model (e.g., "myProvider/myModel").
 // The `opts` argument provides metadata about the model's capabilities ([ai.ModelOptions]).
@@ -633,7 +633,8 @@ func LookupBackgroundModel(g *Genkit, name string) ai.BackgroundModel {
 }
 
 // DefineTool defines a tool that can be used by models during generation,
-// registers it as a [core.Action] of type Tool, and returns an [ai.Tool].
+// registers it as a [core.Action] of type Tool, and returns the concrete
+// [ai.ToolAction].
 // Tools allow models to interact with external systems or perform specific computations.
 //
 // The `name` is the identifier the model uses to request the tool. The `description`
@@ -682,7 +683,7 @@ func DefineTool[In, Out any](g *Genkit, name, description string, fn ai.ToolFunc
 }
 
 // DefineToolWithInputSchema defines a tool with a custom input schema that can be used by models during generation,
-// registers it as a [core.Action] of type Tool, and returns an [*ai.ToolAction].
+// registers it as a [core.Action] of type Tool, and returns the concrete [ai.ToolAction].
 //
 // This variant of [DefineTool] allows specifying a JSON Schema for the tool's input, providing more
 // control over input validation and model guidance. The input parameter to the tool function will be
@@ -724,7 +725,7 @@ func DefineTool[In, Out any](g *Genkit, name, description string, fn ai.ToolFunc
 //			// Implementation...
 //			return fmt.Sprintf("Weather in %s: 25°%s", city, unit), nil
 //		},
-//		ai.WithToolInputSchema(inputSchema),
+//		ai.WithInputSchema(inputSchema),
 //	)
 func DefineToolWithInputSchema[Out any](g *Genkit, name, description string, inputSchema map[string]any, fn ai.ToolFunc[any, Out]) *ai.ToolAction[any, Out] {
 	t := ai.NewTool(name, description, fn, ai.WithInputSchema(inputSchema))
@@ -733,7 +734,8 @@ func DefineToolWithInputSchema[Out any](g *Genkit, name, description string, inp
 }
 
 // DefineMultipartTool defines a multipart tool that can be used by models during generation,
-// registers it as a [core.Action] of type Tool, and returns an [*ai.ToolAction].
+// registers it as a [core.Action] of type Tool, and returns the concrete
+// [ai.ToolAction].
 // Unlike regular tools that return just an output value, multipart tools can return
 // both an output value and additional content parts (like images or other media).
 //
@@ -1464,7 +1466,8 @@ func Embed(ctx context.Context, g *Genkit, opts ...ai.EmbedderOption) (*ai.Embed
 }
 
 // DefineRetrieverAction defines a custom retriever implementation, registers it
-// as a [core.Action] of type Retriever, and returns an [ai.RetrieverAction].
+// as a [core.Action] of type Retriever, and returns the concrete
+// [ai.RetrieverAction].
 // Retrievers are used to find documents relevant to a given query, often by
 // performing similarity searches in a vector database.
 //
@@ -1508,9 +1511,9 @@ func LookupRetriever(g *Genkit, name string) ai.Retriever {
 }
 
 // DefineEmbedderAction defines a custom text embedding implementation,
-// registers it as a [core.Action] of type Embedder, and returns an
-// [ai.Embedder]. Embedders convert text documents or queries into numerical
-// vector representations (embeddings).
+// registers it as a [core.Action] of type Embedder, and returns the concrete
+// [ai.EmbedderAction]. Embedders convert text documents or queries into
+// numerical vector representations (embeddings).
 //
 // The `name` is the unique identifier for the embedder.
 // The `fn` function contains the logic to process an [ai.EmbedRequest] (containing documents or a query)
@@ -1564,8 +1567,8 @@ func LookupPlugin(g *Genkit, name string) api.Plugin {
 
 // DefineEvaluatorAction defines an evaluator that processes test cases
 // one by one, registers it as a [core.Action] of type Evaluator, and returns
-// an [ai.Evaluator]. Evaluators are used to assess the quality or performance
-// of AI models or flows based on a dataset of test cases.
+// the concrete [ai.EvaluatorAction]. Evaluators are used to assess the quality
+// or performance of AI models or flows based on a dataset of test cases.
 //
 // This variant calls the provided `fn` function for each individual test case
 // ([ai.EvaluatorCallbackRequest]) in the evaluation dataset.
@@ -1598,7 +1601,7 @@ func DefineEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.Ev
 
 // DefineBatchEvaluatorAction defines an evaluator that processes the
 // entire dataset at once, registers it as a [core.Action] of type Evaluator,
-// and returns an [ai.Evaluator].
+// and returns the concrete [ai.EvaluatorAction].
 //
 // This variant provides the full evaluation request ([ai.EvaluatorRequest]), including
 // the entire dataset, to the `fn` function. This allows for more flexible processing,

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -560,7 +560,7 @@ func ListTools(g *Genkit) []ai.Tool {
 //			return resp, nil
 //		},
 //	)
-func DefineTypedModel[Config any](g *Genkit, name string, opts *ai.ModelOptions, fn ai.TypedModelFunc[Config]) ai.Model {
+func DefineTypedModel[Config any](g *Genkit, name string, opts *ai.ModelOptions, fn ai.TypedModelFunc[Config]) *ai.ModelAction {
 	m := ai.NewTypedModel(name, opts, fn)
 	m.Register(g.reg)
 	return m
@@ -587,7 +587,7 @@ func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc)
 // Config is the model's typed configuration; it is usually inferred from
 // startFn's signature. See [ai.NewTypedModel] for how the request's
 // config is deserialized and validated.
-func DefineTypedBackgroundModel[Config any](g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.TypedStartModelOpFunc[Config], checkFn ai.CheckModelOpFunc) ai.BackgroundModel {
+func DefineTypedBackgroundModel[Config any](g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.TypedStartModelOpFunc[Config], checkFn ai.CheckModelOpFunc) *ai.BackgroundModelAction {
 	m := ai.NewTypedBackgroundModel(name, opts, startFn, checkFn)
 	m.Register(g.reg)
 	return m
@@ -1489,7 +1489,7 @@ func LookupRetriever(g *Genkit, name string) ai.Retriever {
 //
 // For embedders that don't need to be registered (e.g., for plugin development),
 // use [ai.NewTypedEmbedder] instead.
-func DefineTypedEmbedder[Config any](g *Genkit, name string, opts *ai.EmbedderOptions, fn ai.TypedEmbedderFunc[Config]) ai.Embedder {
+func DefineTypedEmbedder[Config any](g *Genkit, name string, opts *ai.EmbedderOptions, fn ai.TypedEmbedderFunc[Config]) *ai.EmbedderAction {
 	e := ai.NewTypedEmbedder(name, opts, fn)
 	e.Register(g.reg)
 	return e
@@ -1535,7 +1535,7 @@ func LookupPlugin(g *Genkit, name string) api.Plugin {
 // Config is the evaluator's typed configuration; it is usually inferred from
 // fn's signature. See [ai.NewTypedEvaluator] for how the request's
 // options are deserialized.
-func DefineTypedEvaluator[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.TypedEvaluatorFunc[Config]) ai.Evaluator {
+func DefineTypedEvaluator[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.TypedEvaluatorFunc[Config]) *ai.EvaluatorAction {
 	e := ai.NewTypedEvaluator(name, opts, fn)
 	e.Register(g.reg)
 	return e
@@ -1564,7 +1564,7 @@ func DefineEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.Ev
 // Config is the evaluator's typed configuration; it is usually inferred from
 // fn's signature. See [ai.NewTypedEvaluator] for how the request's
 // options are deserialized.
-func DefineTypedBatchEvaluator[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.TypedBatchEvaluatorFunc[Config]) ai.Evaluator {
+func DefineTypedBatchEvaluator[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.TypedBatchEvaluatorFunc[Config]) *ai.EvaluatorAction {
 	e := ai.NewTypedBatchEvaluator(name, opts, fn)
 	e.Register(g.reg)
 	return e

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -499,25 +499,25 @@ func ListTools(g *Genkit) []ai.Tool {
 	return tools
 }
 
-// DefineTypedModel defines a custom model implementation, registers it
+// DefineModelAction defines a custom model implementation, registers it
 // as a [core.Action] of type Model, and returns an [ai.Model] interface.
 //
 // The `name` argument is the unique identifier for the model (e.g., "myProvider/myModel").
 // The `opts` argument provides metadata about the model's capabilities ([ai.ModelOptions]).
-// The `fn` argument ([ai.TypedModelFunc]) implements the actual generation logic,
+// The `fn` argument ([ai.ModelActionFunc]) implements the actual generation logic,
 // handling input requests ([ai.ModelRequest]) and producing responses ([ai.ModelResponse]),
 // potentially streaming chunks ([ai.ModelResponseChunk]) via the callback.
 //
 // Config is the model's typed configuration; it is usually inferred from fn's
-// signature. See [ai.NewTypedModel] for how the request's config is
+// signature. See [ai.NewModelAction] for how the request's config is
 // deserialized and validated.
 //
 // For models that don't need to be registered (e.g., for plugin development or testing),
-// use [ai.NewTypedModel] instead.
+// use [ai.NewModelAction] instead.
 //
 // Example:
 //
-//	echoModel := genkit.DefineTypedModel(g, "custom/echo",
+//	echoModel := genkit.DefineModelAction(g, "custom/echo",
 //		&ai.ModelOptions{
 //			Label:    "Echo Model",
 //			Supports: &ai.ModelSupports{Multiturn: true},
@@ -560,13 +560,13 @@ func ListTools(g *Genkit) []ai.Tool {
 //			return resp, nil
 //		},
 //	)
-func DefineTypedModel[Config any](
+func DefineModelAction[Config any](
 	g *Genkit,
 	name string,
 	opts *ai.ModelOptions,
-	fn ai.TypedModelFunc[Config],
+	fn ai.ModelActionFunc[Config],
 ) *ai.ModelAction {
-	m := ai.NewTypedModel(name, opts, fn)
+	m := ai.NewModelAction(name, opts, fn)
 	m.Register(g.reg)
 	return m
 }
@@ -574,7 +574,7 @@ func DefineTypedModel[Config any](
 // DefineModel defines a custom model implementation, registers it as a [core.Action]
 // of type Model, and returns an [ai.Model] interface.
 //
-// Deprecated: Use [DefineTypedModel], which passes the request's config
+// Deprecated: Use [DefineModelAction], which passes the request's config
 // to fn as a typed value instead of leaving it type-erased on the request.
 func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc) ai.Model {
 	m := ai.NewModel(name, opts, fn)
@@ -582,7 +582,7 @@ func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc)
 	return m
 }
 
-// DefineTypedBackgroundModel defines a background model, registers it, and
+// DefineBackgroundModelAction defines a background model, registers it, and
 // returns the concrete [ai.BackgroundModelAction].
 //
 // The `name` is the identifier the model uses to request the background model. The `opts`
@@ -590,16 +590,16 @@ func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc)
 // The `checkFn` is the function that checks the status of the background model.
 //
 // Config is the model's typed configuration; it is usually inferred from
-// startFn's signature. See [ai.NewTypedModel] for how the request's
+// startFn's signature. See [ai.NewModelAction] for how the request's
 // config is deserialized and validated.
-func DefineTypedBackgroundModel[Config any](
+func DefineBackgroundModelAction[Config any](
 	g *Genkit,
 	name string,
 	opts *ai.TypedBackgroundModelOptions,
-	startFn ai.TypedStartModelOpFunc[Config],
+	startFn ai.BackgroundModelActionFunc[Config],
 	checkFn ai.CheckModelOpFunc,
 ) *ai.BackgroundModelAction {
-	m := ai.NewTypedBackgroundModel(name, opts, startFn, checkFn)
+	m := ai.NewBackgroundModelAction(name, opts, startFn, checkFn)
 	m.Register(g.reg)
 	return m
 }
@@ -607,7 +607,7 @@ func DefineTypedBackgroundModel[Config any](
 // DefineBackgroundModel defines a background model, registers it as a [ai.BackgroundModel],
 // and returns an [ai.BackgroundModel].
 //
-// Deprecated: Use [DefineTypedBackgroundModel], which passes the
+// Deprecated: Use [DefineBackgroundModelAction], which passes the
 // request's config to startFn as a typed value instead of leaving it
 // type-erased on the request.
 func DefineBackgroundModel(g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.StartModelOpFunc, checkFn ai.CheckModelOpFunc) ai.BackgroundModel {
@@ -1463,7 +1463,7 @@ func Embed(ctx context.Context, g *Genkit, opts ...ai.EmbedderOption) (*ai.Embed
 	return ai.Embed(ctx, g.reg, opts...)
 }
 
-// DefineTypedRetriever defines a custom retriever implementation, registers it
+// DefineRetrieverAction defines a custom retriever implementation, registers it
 // as a [core.Action] of type Retriever, and returns an [ai.RetrieverAction].
 // Retrievers are used to find documents relevant to a given query, often by
 // performing similarity searches in a vector database.
@@ -1473,18 +1473,18 @@ func Embed(ctx context.Context, g *Genkit, opts ...ai.EmbedderOption) (*ai.Embed
 // and return an [ai.RetrieverResponse] (containing the relevant documents).
 //
 // Config is the retriever's typed configuration; it is usually inferred from
-// fn's signature. See [ai.NewTypedRetriever] for how the request's options are
+// fn's signature. See [ai.NewRetrieverAction] for how the request's options are
 // deserialized.
 //
 // For retrievers that don't need to be registered (e.g., for plugin development),
-// use [ai.NewTypedRetriever] instead.
-func DefineTypedRetriever[Config any](
+// use [ai.NewRetrieverAction] instead.
+func DefineRetrieverAction[Config any](
 	g *Genkit,
 	name string,
 	opts *ai.RetrieverOptions,
-	fn ai.TypedRetrieverFunc[Config],
+	fn ai.RetrieverActionFunc[Config],
 ) *ai.RetrieverAction {
-	ret := ai.NewTypedRetriever(name, opts, fn)
+	ret := ai.NewRetrieverAction(name, opts, fn)
 	ret.Register(g.reg)
 	return ret
 }
@@ -1492,7 +1492,7 @@ func DefineTypedRetriever[Config any](
 // DefineRetriever defines a custom retriever implementation, registers it as a
 // [core.Action] of type Retriever, and returns an [ai.Retriever].
 //
-// Deprecated: Use [DefineTypedRetriever], which passes the request's options
+// Deprecated: Use [DefineRetrieverAction], which passes the request's options
 // to fn as a typed value instead of leaving them type-erased on the request.
 func DefineRetriever(g *Genkit, name string, opts *ai.RetrieverOptions, fn ai.RetrieverFunc) ai.Retriever {
 	ret := ai.NewRetriever(name, opts, fn)
@@ -1507,7 +1507,7 @@ func LookupRetriever(g *Genkit, name string) ai.Retriever {
 	return ai.LookupRetriever(g.reg, name)
 }
 
-// DefineTypedEmbedder defines a custom text embedding implementation,
+// DefineEmbedderAction defines a custom text embedding implementation,
 // registers it as a [core.Action] of type Embedder, and returns an
 // [ai.Embedder]. Embedders convert text documents or queries into numerical
 // vector representations (embeddings).
@@ -1517,18 +1517,18 @@ func LookupRetriever(g *Genkit, name string) ai.Retriever {
 // and return an [ai.EmbedResponse] (containing the corresponding embeddings).
 //
 // Config is the embedder's typed configuration; it is usually inferred from
-// fn's signature. See [ai.NewTypedEmbedder] for how the request's
+// fn's signature. See [ai.NewEmbedderAction] for how the request's
 // options are deserialized.
 //
 // For embedders that don't need to be registered (e.g., for plugin development),
-// use [ai.NewTypedEmbedder] instead.
-func DefineTypedEmbedder[Config any](
+// use [ai.NewEmbedderAction] instead.
+func DefineEmbedderAction[Config any](
 	g *Genkit,
 	name string,
 	opts *ai.EmbedderOptions,
-	fn ai.TypedEmbedderFunc[Config],
+	fn ai.EmbedderActionFunc[Config],
 ) *ai.EmbedderAction {
-	e := ai.NewTypedEmbedder(name, opts, fn)
+	e := ai.NewEmbedderAction(name, opts, fn)
 	e.Register(g.reg)
 	return e
 }
@@ -1536,7 +1536,7 @@ func DefineTypedEmbedder[Config any](
 // DefineEmbedder defines a custom text embedding implementation, registers it as a
 // [core.Action] of type Embedder, and returns an [ai.Embedder].
 //
-// Deprecated: Use [DefineTypedEmbedder], which passes the request's
+// Deprecated: Use [DefineEmbedderAction], which passes the request's
 // options to fn as a typed value instead of leaving them type-erased on the
 // request.
 func DefineEmbedder(g *Genkit, name string, opts *ai.EmbedderOptions, fn ai.EmbedderFunc) ai.Embedder {
@@ -1562,7 +1562,7 @@ func LookupPlugin(g *Genkit, name string) api.Plugin {
 	return g.reg.LookupPlugin(name)
 }
 
-// DefineTypedEvaluator defines an evaluator that processes test cases
+// DefineEvaluatorAction defines an evaluator that processes test cases
 // one by one, registers it as a [core.Action] of type Evaluator, and returns
 // an [ai.Evaluator]. Evaluators are used to assess the quality or performance
 // of AI models or flows based on a dataset of test cases.
@@ -1571,15 +1571,15 @@ func LookupPlugin(g *Genkit, name string) api.Plugin {
 // ([ai.EvaluatorCallbackRequest]) in the evaluation dataset.
 //
 // Config is the evaluator's typed configuration; it is usually inferred from
-// fn's signature. See [ai.NewTypedEvaluator] for how the request's
+// fn's signature. See [ai.NewEvaluatorAction] for how the request's
 // options are deserialized.
-func DefineTypedEvaluator[Config any](
+func DefineEvaluatorAction[Config any](
 	g *Genkit,
 	name string,
 	opts *ai.EvaluatorOptions,
-	fn ai.TypedEvaluatorFunc[Config],
+	fn ai.EvaluatorActionFunc[Config],
 ) *ai.EvaluatorAction {
-	e := ai.NewTypedEvaluator(name, opts, fn)
+	e := ai.NewEvaluatorAction(name, opts, fn)
 	e.Register(g.reg)
 	return e
 }
@@ -1587,7 +1587,7 @@ func DefineTypedEvaluator[Config any](
 // DefineEvaluator defines an evaluator that processes test cases one by one,
 // registers it as a [core.Action] of type Evaluator, and returns an [ai.Evaluator].
 //
-// Deprecated: Use [DefineTypedEvaluator], which passes the request's
+// Deprecated: Use [DefineEvaluatorAction], which passes the request's
 // options to fn as a typed value instead of leaving them type-erased on the
 // request.
 func DefineEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.EvaluatorFunc) ai.Evaluator {
@@ -1596,7 +1596,7 @@ func DefineEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.Ev
 	return e
 }
 
-// DefineTypedBatchEvaluator defines an evaluator that processes the
+// DefineBatchEvaluatorAction defines an evaluator that processes the
 // entire dataset at once, registers it as a [core.Action] of type Evaluator,
 // and returns an [ai.Evaluator].
 //
@@ -1605,15 +1605,15 @@ func DefineEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.Ev
 // such as batching calls to external services or parallelizing computations.
 //
 // Config is the evaluator's typed configuration; it is usually inferred from
-// fn's signature. See [ai.NewTypedEvaluator] for how the request's
+// fn's signature. See [ai.NewEvaluatorAction] for how the request's
 // options are deserialized.
-func DefineTypedBatchEvaluator[Config any](
+func DefineBatchEvaluatorAction[Config any](
 	g *Genkit,
 	name string,
 	opts *ai.EvaluatorOptions,
-	fn ai.TypedBatchEvaluatorFunc[Config],
+	fn ai.BatchEvaluatorActionFunc[Config],
 ) *ai.EvaluatorAction {
-	e := ai.NewTypedBatchEvaluator(name, opts, fn)
+	e := ai.NewBatchEvaluatorAction(name, opts, fn)
 	e.Register(g.reg)
 	return e
 }
@@ -1621,7 +1621,7 @@ func DefineTypedBatchEvaluator[Config any](
 // DefineBatchEvaluator defines an evaluator that processes the entire dataset at once,
 // registers it as a [core.Action] of type Evaluator, and returns an [ai.Evaluator].
 //
-// Deprecated: Use [DefineTypedBatchEvaluator], which passes the
+// Deprecated: Use [DefineBatchEvaluatorAction], which passes the
 // request's options to fn as a typed value instead of leaving them
 // type-erased on the request.
 func DefineBatchEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.BatchEvaluatorFunc) ai.Evaluator {

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -499,25 +499,25 @@ func ListTools(g *Genkit) []ai.Tool {
 	return tools
 }
 
-// DefineModelWithConfig defines a custom model implementation, registers it
+// DefineTypedModel defines a custom model implementation, registers it
 // as a [core.Action] of type Model, and returns an [ai.Model] interface.
 //
 // The `name` argument is the unique identifier for the model (e.g., "myProvider/myModel").
 // The `opts` argument provides metadata about the model's capabilities ([ai.ModelOptions]).
-// The `fn` argument ([ai.ModelFuncWithConfig]) implements the actual generation logic,
+// The `fn` argument ([ai.TypedModelFunc]) implements the actual generation logic,
 // handling input requests ([ai.ModelRequest]) and producing responses ([ai.ModelResponse]),
 // potentially streaming chunks ([ai.ModelResponseChunk]) via the callback.
 //
 // Config is the model's typed configuration; it is usually inferred from fn's
-// signature. See [ai.NewModelWithConfig] for how the request's config is
+// signature. See [ai.NewTypedModel] for how the request's config is
 // deserialized and validated.
 //
 // For models that don't need to be registered (e.g., for plugin development or testing),
-// use [ai.NewModelWithConfig] instead.
+// use [ai.NewTypedModel] instead.
 //
 // Example:
 //
-//	echoModel := genkit.DefineModelWithConfig(g, "custom/echo",
+//	echoModel := genkit.DefineTypedModel(g, "custom/echo",
 //		&ai.ModelOptions{
 //			Label:    "Echo Model",
 //			Supports: &ai.ModelSupports{Multiturn: true},
@@ -560,8 +560,8 @@ func ListTools(g *Genkit) []ai.Tool {
 //			return resp, nil
 //		},
 //	)
-func DefineModelWithConfig[Config any](g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFuncWithConfig[Config]) ai.Model {
-	m := ai.NewModelWithConfig(name, opts, fn)
+func DefineTypedModel[Config any](g *Genkit, name string, opts *ai.ModelOptions, fn ai.TypedModelFunc[Config]) ai.Model {
+	m := ai.NewTypedModel(name, opts, fn)
 	m.Register(g.reg)
 	return m
 }
@@ -569,13 +569,13 @@ func DefineModelWithConfig[Config any](g *Genkit, name string, opts *ai.ModelOpt
 // DefineModel defines a custom model implementation, registers it as a [core.Action]
 // of type Model, and returns an [ai.Model] interface.
 //
-// Deprecated: Use [DefineModelWithConfig], which passes the request's config
+// Deprecated: Use [DefineTypedModel], which passes the request's config
 // to fn as a typed value instead of leaving it type-erased on the request.
 func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc) ai.Model {
 	return ai.DefineModel(g.reg, name, opts, fn)
 }
 
-// DefineBackgroundModelWithConfig defines a background model, registers it as
+// DefineTypedBackgroundModel defines a background model, registers it as
 // an [ai.BackgroundModel], and returns an [ai.BackgroundModel].
 //
 // The `name` is the identifier the model uses to request the background model. The `opts`
@@ -583,10 +583,10 @@ func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc)
 // The `checkFn` is the function that checks the status of the background model.
 //
 // Config is the model's typed configuration; it is usually inferred from
-// startFn's signature. See [ai.NewModelWithConfig] for how the request's
+// startFn's signature. See [ai.NewTypedModel] for how the request's
 // config is deserialized and validated.
-func DefineBackgroundModelWithConfig[Config any](g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.StartModelOpFuncWithConfig[Config], checkFn ai.CheckModelOpFunc) ai.BackgroundModel {
-	m := ai.NewBackgroundModelWithConfig(name, opts, startFn, checkFn)
+func DefineTypedBackgroundModel[Config any](g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.TypedStartModelOpFunc[Config], checkFn ai.CheckModelOpFunc) ai.BackgroundModel {
+	m := ai.NewTypedBackgroundModel(name, opts, startFn, checkFn)
 	m.Register(g.reg)
 	return m
 }
@@ -594,7 +594,7 @@ func DefineBackgroundModelWithConfig[Config any](g *Genkit, name string, opts *a
 // DefineBackgroundModel defines a background model, registers it as a [ai.BackgroundModel],
 // and returns an [ai.BackgroundModel].
 //
-// Deprecated: Use [DefineBackgroundModelWithConfig], which passes the
+// Deprecated: Use [DefineTypedBackgroundModel], which passes the
 // request's config to startFn as a typed value instead of leaving it
 // type-erased on the request.
 func DefineBackgroundModel(g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.StartModelOpFunc, checkFn ai.CheckModelOpFunc) ai.BackgroundModel {
@@ -1462,7 +1462,7 @@ func LookupRetriever(g *Genkit, name string) ai.Retriever {
 	return ai.LookupRetriever(g.reg, name)
 }
 
-// DefineEmbedderWithConfig defines a custom text embedding implementation,
+// DefineTypedEmbedder defines a custom text embedding implementation,
 // registers it as a [core.Action] of type Embedder, and returns an
 // [ai.Embedder]. Embedders convert text documents or queries into numerical
 // vector representations (embeddings).
@@ -1472,13 +1472,13 @@ func LookupRetriever(g *Genkit, name string) ai.Retriever {
 // and return an [ai.EmbedResponse] (containing the corresponding embeddings).
 //
 // Config is the embedder's typed configuration; it is usually inferred from
-// fn's signature. See [ai.NewEmbedderWithConfig] for how the request's
+// fn's signature. See [ai.NewTypedEmbedder] for how the request's
 // options are deserialized.
 //
 // For embedders that don't need to be registered (e.g., for plugin development),
-// use [ai.NewEmbedderWithConfig] instead.
-func DefineEmbedderWithConfig[Config any](g *Genkit, name string, opts *ai.EmbedderOptions, fn ai.EmbedderFuncWithConfig[Config]) ai.Embedder {
-	e := ai.NewEmbedderWithConfig(name, opts, fn)
+// use [ai.NewTypedEmbedder] instead.
+func DefineTypedEmbedder[Config any](g *Genkit, name string, opts *ai.EmbedderOptions, fn ai.TypedEmbedderFunc[Config]) ai.Embedder {
+	e := ai.NewTypedEmbedder(name, opts, fn)
 	e.Register(g.reg)
 	return e
 }
@@ -1486,7 +1486,7 @@ func DefineEmbedderWithConfig[Config any](g *Genkit, name string, opts *ai.Embed
 // DefineEmbedder defines a custom text embedding implementation, registers it as a
 // [core.Action] of type Embedder, and returns an [ai.Embedder].
 //
-// Deprecated: Use [DefineEmbedderWithConfig], which passes the request's
+// Deprecated: Use [DefineTypedEmbedder], which passes the request's
 // options to fn as a typed value instead of leaving them type-erased on the
 // request.
 func DefineEmbedder(g *Genkit, name string, opts *ai.EmbedderOptions, fn ai.EmbedderFunc) ai.Embedder {
@@ -1510,7 +1510,7 @@ func LookupPlugin(g *Genkit, name string) api.Plugin {
 	return g.reg.LookupPlugin(name)
 }
 
-// DefineEvaluatorWithConfig defines an evaluator that processes test cases
+// DefineTypedEvaluator defines an evaluator that processes test cases
 // one by one, registers it as a [core.Action] of type Evaluator, and returns
 // an [ai.Evaluator]. Evaluators are used to assess the quality or performance
 // of AI models or flows based on a dataset of test cases.
@@ -1519,10 +1519,10 @@ func LookupPlugin(g *Genkit, name string) api.Plugin {
 // ([ai.EvaluatorCallbackRequest]) in the evaluation dataset.
 //
 // Config is the evaluator's typed configuration; it is usually inferred from
-// fn's signature. See [ai.NewEvaluatorWithConfig] for how the request's
+// fn's signature. See [ai.NewTypedEvaluator] for how the request's
 // options are deserialized.
-func DefineEvaluatorWithConfig[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.EvaluatorFuncWithConfig[Config]) ai.Evaluator {
-	e := ai.NewEvaluatorWithConfig(name, opts, fn)
+func DefineTypedEvaluator[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.TypedEvaluatorFunc[Config]) ai.Evaluator {
+	e := ai.NewTypedEvaluator(name, opts, fn)
 	e.Register(g.reg)
 	return e
 }
@@ -1530,14 +1530,14 @@ func DefineEvaluatorWithConfig[Config any](g *Genkit, name string, opts *ai.Eval
 // DefineEvaluator defines an evaluator that processes test cases one by one,
 // registers it as a [core.Action] of type Evaluator, and returns an [ai.Evaluator].
 //
-// Deprecated: Use [DefineEvaluatorWithConfig], which passes the request's
+// Deprecated: Use [DefineTypedEvaluator], which passes the request's
 // options to fn as a typed value instead of leaving them type-erased on the
 // request.
 func DefineEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.EvaluatorFunc) ai.Evaluator {
 	return ai.DefineEvaluator(g.reg, name, opts, fn)
 }
 
-// DefineBatchEvaluatorWithConfig defines an evaluator that processes the
+// DefineTypedBatchEvaluator defines an evaluator that processes the
 // entire dataset at once, registers it as a [core.Action] of type Evaluator,
 // and returns an [ai.Evaluator].
 //
@@ -1546,10 +1546,10 @@ func DefineEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.Ev
 // such as batching calls to external services or parallelizing computations.
 //
 // Config is the evaluator's typed configuration; it is usually inferred from
-// fn's signature. See [ai.NewEvaluatorWithConfig] for how the request's
+// fn's signature. See [ai.NewTypedEvaluator] for how the request's
 // options are deserialized.
-func DefineBatchEvaluatorWithConfig[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.BatchEvaluatorFuncWithConfig[Config]) ai.Evaluator {
-	e := ai.NewBatchEvaluatorWithConfig(name, opts, fn)
+func DefineTypedBatchEvaluator[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.TypedBatchEvaluatorFunc[Config]) ai.Evaluator {
+	e := ai.NewTypedBatchEvaluator(name, opts, fn)
 	e.Register(g.reg)
 	return e
 }
@@ -1557,7 +1557,7 @@ func DefineBatchEvaluatorWithConfig[Config any](g *Genkit, name string, opts *ai
 // DefineBatchEvaluator defines an evaluator that processes the entire dataset at once,
 // registers it as a [core.Action] of type Evaluator, and returns an [ai.Evaluator].
 //
-// Deprecated: Use [DefineBatchEvaluatorWithConfig], which passes the
+// Deprecated: Use [DefineTypedBatchEvaluator], which passes the
 // request's options to fn as a typed value instead of leaving them
 // type-erased on the request.
 func DefineBatchEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.BatchEvaluatorFunc) ai.Evaluator {

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -560,7 +560,12 @@ func ListTools(g *Genkit) []ai.Tool {
 //			return resp, nil
 //		},
 //	)
-func DefineTypedModel[Config any](g *Genkit, name string, opts *ai.ModelOptions, fn ai.TypedModelFunc[Config]) *ai.ModelAction {
+func DefineTypedModel[Config any](
+	g *Genkit,
+	name string,
+	opts *ai.ModelOptions,
+	fn ai.TypedModelFunc[Config],
+) *ai.ModelAction {
 	m := ai.NewTypedModel(name, opts, fn)
 	m.Register(g.reg)
 	return m
@@ -589,7 +594,14 @@ func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc)
 // Config is the model's typed configuration; it is usually inferred from
 // startFn's signature. See [ai.NewTypedModel] for how the request's
 // config is deserialized and validated.
-func DefineTypedBackgroundModel[Config any](g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.TypedStartModelOpFunc[Config], checkFn ai.CheckModelOpFunc, cancelFn ai.CancelModelOpFunc) *ai.BackgroundModelAction {
+func DefineTypedBackgroundModel[Config any](
+	g *Genkit,
+	name string,
+	opts *ai.BackgroundModelOptions,
+	startFn ai.TypedStartModelOpFunc[Config],
+	checkFn ai.CheckModelOpFunc,
+	cancelFn ai.CancelModelOpFunc,
+) *ai.BackgroundModelAction {
 	m := ai.NewTypedBackgroundModel(name, opts, startFn, checkFn, cancelFn)
 	m.Register(g.reg)
 	return m
@@ -1491,7 +1503,12 @@ func LookupRetriever(g *Genkit, name string) ai.Retriever {
 //
 // For embedders that don't need to be registered (e.g., for plugin development),
 // use [ai.NewTypedEmbedder] instead.
-func DefineTypedEmbedder[Config any](g *Genkit, name string, opts *ai.EmbedderOptions, fn ai.TypedEmbedderFunc[Config]) *ai.EmbedderAction {
+func DefineTypedEmbedder[Config any](
+	g *Genkit,
+	name string,
+	opts *ai.EmbedderOptions,
+	fn ai.TypedEmbedderFunc[Config],
+) *ai.EmbedderAction {
 	e := ai.NewTypedEmbedder(name, opts, fn)
 	e.Register(g.reg)
 	return e
@@ -1537,7 +1554,12 @@ func LookupPlugin(g *Genkit, name string) api.Plugin {
 // Config is the evaluator's typed configuration; it is usually inferred from
 // fn's signature. See [ai.NewTypedEvaluator] for how the request's
 // options are deserialized.
-func DefineTypedEvaluator[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.TypedEvaluatorFunc[Config]) *ai.EvaluatorAction {
+func DefineTypedEvaluator[Config any](
+	g *Genkit,
+	name string,
+	opts *ai.EvaluatorOptions,
+	fn ai.TypedEvaluatorFunc[Config],
+) *ai.EvaluatorAction {
 	e := ai.NewTypedEvaluator(name, opts, fn)
 	e.Register(g.reg)
 	return e
@@ -1566,7 +1588,12 @@ func DefineEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.Ev
 // Config is the evaluator's typed configuration; it is usually inferred from
 // fn's signature. See [ai.NewTypedEvaluator] for how the request's
 // options are deserialized.
-func DefineTypedBatchEvaluator[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.TypedBatchEvaluatorFunc[Config]) *ai.EvaluatorAction {
+func DefineTypedBatchEvaluator[Config any](
+	g *Genkit,
+	name string,
+	opts *ai.EvaluatorOptions,
+	fn ai.TypedBatchEvaluatorFunc[Config],
+) *ai.EvaluatorAction {
 	e := ai.NewTypedBatchEvaluator(name, opts, fn)
 	e.Register(g.reg)
 	return e

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -1463,8 +1463,8 @@ func Embed(ctx context.Context, g *Genkit, opts ...ai.EmbedderOption) (*ai.Embed
 	return ai.Embed(ctx, g.reg, opts...)
 }
 
-// DefineRetriever defines a custom retriever implementation, registers it as a
-// [core.Action] of type Retriever, and returns an [ai.Retriever].
+// DefineTypedRetriever defines a custom retriever implementation, registers it
+// as a [core.Action] of type Retriever, and returns an [ai.RetrieverAction].
 // Retrievers are used to find documents relevant to a given query, often by
 // performing similarity searches in a vector database.
 //
@@ -1472,8 +1472,28 @@ func Embed(ctx context.Context, g *Genkit, opts ...ai.EmbedderOption) (*ai.Embed
 // contains the logic to process an [ai.RetrieverRequest] (containing the query)
 // and return an [ai.RetrieverResponse] (containing the relevant documents).
 //
+// Config is the retriever's typed configuration; it is usually inferred from
+// fn's signature. See [ai.NewTypedRetriever] for how the request's options are
+// deserialized.
+//
 // For retrievers that don't need to be registered (e.g., for plugin development),
-// use [ai.NewRetriever] instead.
+// use [ai.NewTypedRetriever] instead.
+func DefineTypedRetriever[Config any](
+	g *Genkit,
+	name string,
+	opts *ai.RetrieverOptions,
+	fn ai.TypedRetrieverFunc[Config],
+) *ai.RetrieverAction {
+	ret := ai.NewTypedRetriever(name, opts, fn)
+	ret.Register(g.reg)
+	return ret
+}
+
+// DefineRetriever defines a custom retriever implementation, registers it as a
+// [core.Action] of type Retriever, and returns an [ai.Retriever].
+//
+// Deprecated: Use [DefineTypedRetriever], which passes the request's options
+// to fn as a typed value instead of leaving them type-erased on the request.
 func DefineRetriever(g *Genkit, name string, opts *ai.RetrieverOptions, fn ai.RetrieverFunc) ai.Retriever {
 	ret := ai.NewRetriever(name, opts, fn)
 	ret.Register(g.reg)

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -572,7 +572,9 @@ func DefineTypedModel[Config any](g *Genkit, name string, opts *ai.ModelOptions,
 // Deprecated: Use [DefineTypedModel], which passes the request's config
 // to fn as a typed value instead of leaving it type-erased on the request.
 func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc) ai.Model {
-	return ai.DefineModel(g.reg, name, opts, fn)
+	m := ai.NewModel(name, opts, fn)
+	m.Register(g.reg)
+	return m
 }
 
 // DefineTypedBackgroundModel defines a background model, registers it as
@@ -598,7 +600,9 @@ func DefineTypedBackgroundModel[Config any](g *Genkit, name string, opts *ai.Bac
 // request's config to startFn as a typed value instead of leaving it
 // type-erased on the request.
 func DefineBackgroundModel(g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.StartModelOpFunc, checkFn ai.CheckModelOpFunc) ai.BackgroundModel {
-	return ai.DefineBackgroundModel(g.reg, name, opts, startFn, checkFn)
+	m := ai.NewBackgroundModel(name, opts, startFn, checkFn)
+	m.Register(g.reg)
+	return m
 }
 
 // LookupModel retrieves a registered [ai.Model] by its provider and name.
@@ -661,7 +665,9 @@ func LookupBackgroundModel(g *Genkit, name string) ai.BackgroundModel {
 //
 //	fmt.Println(resp.Text()) // Might output something like "The weather in Paris is Sunny, 25°C."
 func DefineTool[In, Out any](g *Genkit, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolDef[In, Out] {
-	return ai.DefineTool(g.reg, name, description, fn, opts...)
+	t := ai.NewTool(name, description, fn, opts...)
+	t.Register(g.reg)
+	return t
 }
 
 // DefineToolWithInputSchema defines a tool with a custom input schema that can be used by models during generation,
@@ -710,7 +716,9 @@ func DefineTool[In, Out any](g *Genkit, name, description string, fn ai.ToolFunc
 //		ai.WithToolInputSchema(inputSchema),
 //	)
 func DefineToolWithInputSchema[Out any](g *Genkit, name, description string, inputSchema map[string]any, fn ai.ToolFunc[any, Out]) *ai.ToolDef[any, Out] {
-	return ai.DefineTool(g.reg, name, description, fn, ai.WithInputSchema(inputSchema))
+	t := ai.NewTool(name, description, fn, ai.WithInputSchema(inputSchema))
+	t.Register(g.reg)
+	return t
 }
 
 // DefineMultipartTool defines a multipart tool that can be used by models during generation,
@@ -770,7 +778,9 @@ func DefineToolWithInputSchema[Out any](g *Genkit, name, description string, inp
 //
 //	fmt.Println(resp.Text())
 func DefineMultipartTool[In any](g *Genkit, name, description string, fn ai.MultipartToolFunc[In], opts ...ai.ToolOption) *ai.ToolDef[In, *ai.MultipartToolResponse] {
-	return ai.DefineMultipartTool(g.reg, name, description, fn, opts...)
+	t := ai.NewMultipartTool(name, description, fn, opts...)
+	t.Register(g.reg)
+	return t
 }
 
 // LookupTool retrieves a registered tool by its name.
@@ -832,7 +842,9 @@ func LookupTool(g *Genkit, name string) ai.Tool {
 //		ai.WithUse(Trace{Label: "debug"}),
 //	)
 func DefineMiddleware[M ai.Middleware](g *Genkit, description string, prototype M) *ai.MiddlewareDesc {
-	return ai.DefineMiddleware(g.reg, description, prototype)
+	d := ai.NewMiddleware(description, prototype)
+	d.Register(g.reg)
+	return d
 }
 
 // LookupMiddleware retrieves a registered middleware descriptor by its name.
@@ -1490,7 +1502,9 @@ func DefineTypedEmbedder[Config any](g *Genkit, name string, opts *ai.EmbedderOp
 // options to fn as a typed value instead of leaving them type-erased on the
 // request.
 func DefineEmbedder(g *Genkit, name string, opts *ai.EmbedderOptions, fn ai.EmbedderFunc) ai.Embedder {
-	return ai.DefineEmbedder(g.reg, name, opts, fn)
+	e := ai.NewEmbedder(name, opts, fn)
+	e.Register(g.reg)
+	return e
 }
 
 // LookupEmbedder retrieves a registered [ai.Embedder] by its provider and name.
@@ -1534,7 +1548,9 @@ func DefineTypedEvaluator[Config any](g *Genkit, name string, opts *ai.Evaluator
 // options to fn as a typed value instead of leaving them type-erased on the
 // request.
 func DefineEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.EvaluatorFunc) ai.Evaluator {
-	return ai.DefineEvaluator(g.reg, name, opts, fn)
+	e := ai.NewEvaluator(name, opts, fn)
+	e.Register(g.reg)
+	return e
 }
 
 // DefineTypedBatchEvaluator defines an evaluator that processes the
@@ -1561,7 +1577,9 @@ func DefineTypedBatchEvaluator[Config any](g *Genkit, name string, opts *ai.Eval
 // request's options to fn as a typed value instead of leaving them
 // type-erased on the request.
 func DefineBatchEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.BatchEvaluatorFunc) ai.Evaluator {
-	return ai.DefineBatchEvaluator(g.reg, name, opts, fn)
+	e := ai.NewBatchEvaluator(name, opts, fn)
+	e.Register(g.reg)
+	return e
 }
 
 // LookupEvaluator retrieves a registered [ai.Evaluator] by its provider and name.
@@ -1866,7 +1884,9 @@ func (f renamedFormatter) Name() string { return f.name }
 //	  }, nil
 //	})
 func DefineResource(g *Genkit, name string, opts *ai.ResourceOptions, fn ai.ResourceFunc) ai.Resource {
-	return ai.DefineResource(g.reg, name, opts, fn)
+	res := ai.NewResource(name, opts, fn)
+	res.Register(g.reg)
+	return res
 }
 
 // FindMatchingResource finds a resource that matches the given URI.

--- a/go/genkit/genkit.go
+++ b/go/genkit/genkit.go
@@ -499,26 +499,30 @@ func ListTools(g *Genkit) []ai.Tool {
 	return tools
 }
 
-// DefineModel defines a custom model implementation, registers it as a [core.Action]
-// of type Model, and returns an [ai.Model] interface.
+// DefineModelWithConfig defines a custom model implementation, registers it
+// as a [core.Action] of type Model, and returns an [ai.Model] interface.
 //
 // The `name` argument is the unique identifier for the model (e.g., "myProvider/myModel").
 // The `opts` argument provides metadata about the model's capabilities ([ai.ModelOptions]).
-// The `fn` argument ([ai.ModelFunc]) implements the actual generation logic, handling
-// input requests ([ai.ModelRequest]) and producing responses ([ai.ModelResponse]),
+// The `fn` argument ([ai.ModelFuncWithConfig]) implements the actual generation logic,
+// handling input requests ([ai.ModelRequest]) and producing responses ([ai.ModelResponse]),
 // potentially streaming chunks ([ai.ModelResponseChunk]) via the callback.
 //
+// Config is the model's typed configuration; it is usually inferred from fn's
+// signature. See [ai.NewModelWithConfig] for how the request's config is
+// deserialized and validated.
+//
 // For models that don't need to be registered (e.g., for plugin development or testing),
-// use [ai.NewModel] instead.
+// use [ai.NewModelWithConfig] instead.
 //
 // Example:
 //
-//	echoModel := genkit.DefineModel(g, "custom/echo",
+//	echoModel := genkit.DefineModelWithConfig(g, "custom/echo",
 //		&ai.ModelOptions{
 //			Label:    "Echo Model",
 //			Supports: &ai.ModelSupports{Multiturn: true},
 //		},
-//		func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+//		func(ctx context.Context, req *ai.ModelRequest, config MyConfig, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 //			// Simple echo implementation
 //			resp := &ai.ModelResponse{
 //				Message: &ai.Message{
@@ -556,16 +560,43 @@ func ListTools(g *Genkit) []ai.Tool {
 //			return resp, nil
 //		},
 //	)
+func DefineModelWithConfig[Config any](g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFuncWithConfig[Config]) ai.Model {
+	m := ai.NewModelWithConfig(name, opts, fn)
+	m.Register(g.reg)
+	return m
+}
+
+// DefineModel defines a custom model implementation, registers it as a [core.Action]
+// of type Model, and returns an [ai.Model] interface.
+//
+// Deprecated: Use [DefineModelWithConfig], which passes the request's config
+// to fn as a typed value instead of leaving it type-erased on the request.
 func DefineModel(g *Genkit, name string, opts *ai.ModelOptions, fn ai.ModelFunc) ai.Model {
 	return ai.DefineModel(g.reg, name, opts, fn)
+}
+
+// DefineBackgroundModelWithConfig defines a background model, registers it as
+// an [ai.BackgroundModel], and returns an [ai.BackgroundModel].
+//
+// The `name` is the identifier the model uses to request the background model. The `opts`
+// are the options for the background model. The `startFn` is the function that starts the background model.
+// The `checkFn` is the function that checks the status of the background model.
+//
+// Config is the model's typed configuration; it is usually inferred from
+// startFn's signature. See [ai.NewModelWithConfig] for how the request's
+// config is deserialized and validated.
+func DefineBackgroundModelWithConfig[Config any](g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.StartModelOpFuncWithConfig[Config], checkFn ai.CheckModelOpFunc) ai.BackgroundModel {
+	m := ai.NewBackgroundModelWithConfig(name, opts, startFn, checkFn)
+	m.Register(g.reg)
+	return m
 }
 
 // DefineBackgroundModel defines a background model, registers it as a [ai.BackgroundModel],
 // and returns an [ai.BackgroundModel].
 //
-// The `name` is the identifier the model uses to request the background model. The `opts`
-// are the options for the background model. The `startFn` is the function that starts the background model.
-// The `checkFn` is the function that checks the status of the background model.
+// Deprecated: Use [DefineBackgroundModelWithConfig], which passes the
+// request's config to startFn as a typed value instead of leaving it
+// type-erased on the request.
 func DefineBackgroundModel(g *Genkit, name string, opts *ai.BackgroundModelOptions, startFn ai.StartModelOpFunc, checkFn ai.CheckModelOpFunc) ai.BackgroundModel {
 	return ai.DefineBackgroundModel(g.reg, name, opts, startFn, checkFn)
 }
@@ -1431,16 +1462,33 @@ func LookupRetriever(g *Genkit, name string) ai.Retriever {
 	return ai.LookupRetriever(g.reg, name)
 }
 
-// DefineEmbedder defines a custom text embedding implementation, registers it as a
-// [core.Action] of type Embedder, and returns an [ai.Embedder].
-// Embedders convert text documents or queries into numerical vector representations (embeddings).
+// DefineEmbedderWithConfig defines a custom text embedding implementation,
+// registers it as a [core.Action] of type Embedder, and returns an
+// [ai.Embedder]. Embedders convert text documents or queries into numerical
+// vector representations (embeddings).
 //
 // The `name` is the unique identifier for the embedder.
 // The `fn` function contains the logic to process an [ai.EmbedRequest] (containing documents or a query)
 // and return an [ai.EmbedResponse] (containing the corresponding embeddings).
 //
+// Config is the embedder's typed configuration; it is usually inferred from
+// fn's signature. See [ai.NewEmbedderWithConfig] for how the request's
+// options are deserialized.
+//
 // For embedders that don't need to be registered (e.g., for plugin development),
-// use [ai.NewEmbedder] instead.
+// use [ai.NewEmbedderWithConfig] instead.
+func DefineEmbedderWithConfig[Config any](g *Genkit, name string, opts *ai.EmbedderOptions, fn ai.EmbedderFuncWithConfig[Config]) ai.Embedder {
+	e := ai.NewEmbedderWithConfig(name, opts, fn)
+	e.Register(g.reg)
+	return e
+}
+
+// DefineEmbedder defines a custom text embedding implementation, registers it as a
+// [core.Action] of type Embedder, and returns an [ai.Embedder].
+//
+// Deprecated: Use [DefineEmbedderWithConfig], which passes the request's
+// options to fn as a typed value instead of leaving them type-erased on the
+// request.
 func DefineEmbedder(g *Genkit, name string, opts *ai.EmbedderOptions, fn ai.EmbedderFunc) ai.Embedder {
 	return ai.DefineEmbedder(g.reg, name, opts, fn)
 }
@@ -1462,33 +1510,56 @@ func LookupPlugin(g *Genkit, name string) api.Plugin {
 	return g.reg.LookupPlugin(name)
 }
 
-// DefineEvaluator defines an evaluator that processes test cases one by one,
-// registers it as a [core.Action] of type Evaluator, and returns an [ai.Evaluator].
-// Evaluators are used to assess the quality or performance of AI models or flows
-// based on a dataset of test cases.
+// DefineEvaluatorWithConfig defines an evaluator that processes test cases
+// one by one, registers it as a [core.Action] of type Evaluator, and returns
+// an [ai.Evaluator]. Evaluators are used to assess the quality or performance
+// of AI models or flows based on a dataset of test cases.
 //
-// This variant calls the provided `eval` function for each individual test case
+// This variant calls the provided `fn` function for each individual test case
 // ([ai.EvaluatorCallbackRequest]) in the evaluation dataset.
 //
-// The `provider` and `name` form the unique identifier. `options` provide
-// metadata about the evaluator ([ai.EvaluatorOptions]). The `eval` function
-// implements the logic to score a single test case and returns the results
-// in an [ai.EvaluatorCallbackResponse].
+// Config is the evaluator's typed configuration; it is usually inferred from
+// fn's signature. See [ai.NewEvaluatorWithConfig] for how the request's
+// options are deserialized.
+func DefineEvaluatorWithConfig[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.EvaluatorFuncWithConfig[Config]) ai.Evaluator {
+	e := ai.NewEvaluatorWithConfig(name, opts, fn)
+	e.Register(g.reg)
+	return e
+}
+
+// DefineEvaluator defines an evaluator that processes test cases one by one,
+// registers it as a [core.Action] of type Evaluator, and returns an [ai.Evaluator].
+//
+// Deprecated: Use [DefineEvaluatorWithConfig], which passes the request's
+// options to fn as a typed value instead of leaving them type-erased on the
+// request.
 func DefineEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.EvaluatorFunc) ai.Evaluator {
 	return ai.DefineEvaluator(g.reg, name, opts, fn)
+}
+
+// DefineBatchEvaluatorWithConfig defines an evaluator that processes the
+// entire dataset at once, registers it as a [core.Action] of type Evaluator,
+// and returns an [ai.Evaluator].
+//
+// This variant provides the full evaluation request ([ai.EvaluatorRequest]), including
+// the entire dataset, to the `fn` function. This allows for more flexible processing,
+// such as batching calls to external services or parallelizing computations.
+//
+// Config is the evaluator's typed configuration; it is usually inferred from
+// fn's signature. See [ai.NewEvaluatorWithConfig] for how the request's
+// options are deserialized.
+func DefineBatchEvaluatorWithConfig[Config any](g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.BatchEvaluatorFuncWithConfig[Config]) ai.Evaluator {
+	e := ai.NewBatchEvaluatorWithConfig(name, opts, fn)
+	e.Register(g.reg)
+	return e
 }
 
 // DefineBatchEvaluator defines an evaluator that processes the entire dataset at once,
 // registers it as a [core.Action] of type Evaluator, and returns an [ai.Evaluator].
 //
-// This variant provides the full evaluation request ([ai.EvaluatorRequest]), including
-// the entire dataset, to the `eval` function. This allows for more flexible processing,
-// such as batching calls to external services or parallelizing computations.
-//
-// The `provider` and `name` form the unique identifier. `options` provide
-// metadata about the evaluator ([ai.EvaluatorOptions]). The `eval` function
-// implements the logic to score the dataset and returns the aggregated results
-// in an [ai.EvaluatorResponse].
+// Deprecated: Use [DefineBatchEvaluatorWithConfig], which passes the
+// request's options to fn as a typed value instead of leaving them
+// type-erased on the request.
 func DefineBatchEvaluator(g *Genkit, name string, opts *ai.EvaluatorOptions, fn ai.BatchEvaluatorFunc) ai.Evaluator {
 	return ai.DefineBatchEvaluator(g.reg, name, opts, fn)
 }

--- a/go/genkit/genkit_test.go
+++ b/go/genkit/genkit_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/api"
 )
 
 func TestStreamFlow(t *testing.T) {
@@ -357,5 +358,47 @@ input:
 				t.Fatalf("Expected prompt %q to be loaded", tt.promptName)
 			}
 		})
+	}
+}
+
+// pluginWithTool returns one of each primitive that a plugin is expected to be
+// able to ship, matching the plugin-authoring example in the core package
+// documentation.
+type pluginWithTool struct{}
+
+func (p *pluginWithTool) Name() string { return "toolplugin" }
+
+func (p *pluginWithTool) Init(ctx context.Context) []api.Action {
+	model := ai.NewModelAction("toolplugin/model", nil,
+		func(ctx context.Context, req *ai.ModelRequest, _ any, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+			return &ai.ModelResponse{Message: ai.NewModelTextMessage("ok")}, nil
+		})
+	tool := ai.NewTool("toolplugin/tool", "a tool shipped by a plugin",
+		func(ctx *ai.ToolContext, in string) (string, error) {
+			return in + "!", nil
+		})
+	return []api.Action{model, tool}
+}
+
+// A plugin ships tools the same way it ships models: by returning them in its
+// action slice. This is the shape the core package documentation prescribes,
+// and it only compiles because *ai.ToolAction satisfies api.Action.
+func TestPluginCanReturnTools(t *testing.T) {
+	g := Init(context.Background(), WithPlugins(&pluginWithTool{}))
+
+	if m := LookupModel(g, "toolplugin/model"); m == nil {
+		t.Error("LookupModel() = nil, want the model the plugin returned")
+	}
+
+	tool := LookupTool(g, "toolplugin/tool")
+	if tool == nil {
+		t.Fatal("LookupTool() = nil, want the tool the plugin returned")
+	}
+	out, err := tool.RunRaw(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("RunRaw() error: %v", err)
+	}
+	if out != "hi!" {
+		t.Errorf("RunRaw() = %v, want %q", out, "hi!")
 	}
 }

--- a/go/internal/fakeembedder/fakeembedder_test.go
+++ b/go/internal/fakeembedder/fakeembedder_test.go
@@ -37,7 +37,8 @@ func TestFakeEmbedder(t *testing.T) {
 		},
 		ConfigSchema: nil,
 	}
-	emb := ai.DefineEmbedder(r, "fake/embed", emdOpts, embed.Embed)
+	emb := ai.NewEmbedder("fake/embed", emdOpts, embed.Embed)
+	emb.Register(r)
 	d := ai.DocumentFromText("fakeembedder test", nil)
 
 	vals := []float32{1, 2}

--- a/go/plugins/anthropic/anthropic.go
+++ b/go/plugins/anthropic/anthropic.go
@@ -133,8 +133,8 @@ func (a *Anthropic) ListActions(ctx context.Context) []api.ActionDesc {
 		// When listing discovered models, the Genkit action name and the
 		// Anthropic API model ID are identical.
 		model := newModel(a.aclient, name, name, modelOptions(name))
-		if actionDef, ok := model.(api.Action); ok {
-			actions = append(actions, actionDef.Desc())
+		if action, ok := model.(api.Action); ok {
+			actions = append(actions, action.Desc())
 		}
 	}
 

--- a/go/plugins/googlegenai/actions.go
+++ b/go/plugins/googlegenai/actions.go
@@ -33,8 +33,8 @@ func listActions(ctx context.Context, client *genai.Client, provider string) []a
 	for _, name := range models.gemini {
 		opts := GetModelOptions(name, provider)
 		model := newModel(client, name, opts)
-		if actionDef, ok := model.(api.Action); ok {
-			actions = append(actions, actionDef.Desc())
+		if action, ok := model.(api.Action); ok {
+			actions = append(actions, action.Desc())
 		}
 	}
 
@@ -42,8 +42,8 @@ func listActions(ctx context.Context, client *genai.Client, provider string) []a
 	for _, name := range models.imagen {
 		opts := GetModelOptions(name, provider)
 		model := newModel(client, name, opts)
-		if actionDef, ok := model.(api.Action); ok {
-			actions = append(actions, actionDef.Desc())
+		if action, ok := model.(api.Action); ok {
+			actions = append(actions, action.Desc())
 		}
 	}
 
@@ -51,8 +51,8 @@ func listActions(ctx context.Context, client *genai.Client, provider string) []a
 	for _, name := range models.veo {
 		opts := GetModelOptions(name, provider)
 		veoModel := newVeoModel(client, name, opts)
-		if actionDef, ok := veoModel.(api.Action); ok {
-			actions = append(actions, actionDef.Desc())
+		if action, ok := veoModel.(api.Action); ok {
+			actions = append(actions, action.Desc())
 		}
 	}
 
@@ -60,8 +60,8 @@ func listActions(ctx context.Context, client *genai.Client, provider string) []a
 	for _, name := range models.embedders {
 		opts := GetEmbedderOptions(name, provider)
 		embedder := newEmbedder(client, name, &opts)
-		if actionDef, ok := embedder.(api.Action); ok {
-			actions = append(actions, actionDef.Desc())
+		if action, ok := embedder.(api.Action); ok {
+			actions = append(actions, action.Desc())
 		}
 	}
 

--- a/go/plugins/middleware/define_test.go
+++ b/go/plugins/middleware/define_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/api"
+)
+
+// Test-local define helpers: New* + Register in one call, mirroring the
+// removed registry-taking ai.Define* helpers so tests stay concise.
+
+func registerTestModel(r api.Registry, name string, opts *ai.ModelOptions, fn ai.ModelFunc) ai.Model {
+	m := ai.NewModel(name, opts, fn)
+	m.Register(r)
+	return m
+}
+
+func registerTestTool[In, Out any](r api.Registry, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolDef[In, Out] {
+	t := ai.NewTool(name, description, fn, opts...)
+	t.Register(r)
+	return t
+}
+
+func registerTestMiddleware[M ai.Middleware](r api.Registry, description string, prototype M) *ai.MiddlewareDesc {
+	d := ai.NewMiddleware(description, prototype)
+	d.Register(r)
+	return d
+}

--- a/go/plugins/middleware/define_test.go
+++ b/go/plugins/middleware/define_test.go
@@ -30,7 +30,7 @@ func registerTestModel(r api.Registry, name string, opts *ai.ModelOptions, fn ai
 	return m
 }
 
-func registerTestTool[In, Out any](r api.Registry, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolDef[In, Out] {
+func registerTestTool[In, Out any](r api.Registry, name, description string, fn ai.ToolFunc[In, Out], opts ...ai.ToolOption) *ai.ToolAction[In, Out] {
 	t := ai.NewTool(name, description, fn, opts...)
 	t.Register(r)
 	return t

--- a/go/plugins/middleware/filesystem_test.go
+++ b/go/plugins/middleware/filesystem_test.go
@@ -72,7 +72,7 @@ func scriptedModel(t *testing.T, r *registry.Registry, name string, script []mod
 	t.Helper()
 	var seen []*ai.ModelRequest
 	idx := 0
-	m := ai.DefineModel(r, name, &ai.ModelOptions{
+	m := registerTestModel(r, name, &ai.ModelOptions{
 		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true, Media: true},
 	}, func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 		seen = append(seen, req)
@@ -106,7 +106,7 @@ func TestFilesystemListFilesNonRecursive(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs))
 	if err != nil {
@@ -162,7 +162,7 @@ func TestFilesystemListFilesRecursive(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs))
 	if err != nil {
@@ -203,7 +203,7 @@ func TestFilesystemReadFileInjectsUserMessage(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
 		t.Fatal(err)
@@ -258,7 +258,7 @@ func TestFilesystemReadFileInjectsImageAsMedia(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
 		t.Fatal(err)
@@ -294,7 +294,7 @@ func TestFilesystemStreamsInjectedFileContents(t *testing.T) {
 	// Streaming model that emits the same payload it returns, so each turn
 	// produces at least one chunk.
 	turn := 0
-	m := ai.DefineModel(r, "test/fs-stream", &ai.ModelOptions{
+	m := registerTestModel(r, "test/fs-stream", &ai.ModelOptions{
 		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true, Media: true},
 	}, func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 		turn++
@@ -320,7 +320,7 @@ func TestFilesystemStreamsInjectedFileContents(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 
 	var chunks []*ai.ModelResponseChunk
 	if _, err := ai.Generate(ctx, r,
@@ -386,7 +386,7 @@ func TestFilesystemWriteFileRequiresAllowWriteAccess(t *testing.T) {
 
 	// Only list_files/read_file should be registered; write_file must not be.
 	fs := &Filesystem{RootDir: root}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 
 	hooks, err := fs.New(ctx)
 	if err != nil {
@@ -420,7 +420,7 @@ func TestFilesystemWriteFileCreatesAndOverwrites(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root, AllowWriteAccess: true}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
 		t.Fatal(err)
@@ -460,7 +460,7 @@ func TestFilesystemEditFile(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root, AllowWriteAccess: true}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
 		t.Fatal(err)
@@ -503,7 +503,7 @@ func TestFilesystemEditFileNotFound(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root, AllowWriteAccess: true}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs))
 	if err != nil {
@@ -564,7 +564,7 @@ func TestFilesystemRejectsTraversal(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
 		t.Fatal(err)
@@ -630,7 +630,7 @@ func TestFilesystemRespectsConfigOverride(t *testing.T) {
 	}
 
 	// Register the middleware with the proto root.
-	ai.DefineMiddleware(r, "filesystem", &Filesystem{RootDir: protoRoot})
+	registerTestMiddleware(r, "filesystem", &Filesystem{RootDir: protoRoot})
 
 	m, seen := scriptedModel(t, r, "test/fs-devui", []modelTurn{
 		{Tools: []*ai.ToolRequest{{Name: "read_file", Input: map[string]any{"filePath": "marker.txt"}}}},
@@ -679,7 +679,7 @@ func TestFilesystemMissingRootDirIsAnError(t *testing.T) {
 	})
 
 	fs := &Filesystem{}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 
 	_, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs))
 	if err == nil {
@@ -705,7 +705,7 @@ func TestFilesystemListFilesIncludesSize(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs))
 	if err != nil {
 		t.Fatal(err)
@@ -766,7 +766,7 @@ func TestFilesystemReadFileIncludesLineMetadata(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
 		t.Fatal(err)
 	}
@@ -825,7 +825,7 @@ func TestFilesystemEditFileRequiresPriorRead(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root, AllowWriteAccess: true}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
 		t.Fatal(err)
 	}
@@ -868,7 +868,7 @@ func TestFilesystemEditFileDetectsExternalModification(t *testing.T) {
 	}
 
 	turn := 0
-	m := ai.DefineModel(r, "test/fs-edit-stale", &ai.ModelOptions{
+	m := registerTestModel(r, "test/fs-edit-stale", &ai.ModelOptions{
 		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true},
 	}, func(ctx context.Context, req *ai.ModelRequest, _ ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 		// Between the read and the edit, simulate the user editing the file.
@@ -892,7 +892,7 @@ func TestFilesystemEditFileDetectsExternalModification(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root, AllowWriteAccess: true}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
 		t.Fatal(err)
 	}
@@ -926,7 +926,7 @@ func TestFilesystemReadFileDedupsUnchanged(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
 		t.Fatal(err)
 	}
@@ -986,7 +986,7 @@ func TestFilesystemWriteFileRequiresReadOnOverwrite(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root, AllowWriteAccess: true}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
 		t.Fatal(err)
 	}
@@ -1019,7 +1019,7 @@ func TestFilesystemReadFileOffsetLimit(t *testing.T) {
 	})
 
 	fs := &Filesystem{RootDir: root}
-	ai.DefineMiddleware(r, "filesystem", fs)
+	registerTestMiddleware(r, "filesystem", fs)
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("go"), ai.WithUse(fs)); err != nil {
 		t.Fatal(err)
 	}

--- a/go/plugins/middleware/retry_test.go
+++ b/go/plugins/middleware/retry_test.go
@@ -36,7 +36,7 @@ func newTestRegistry(t *testing.T) *registry.Registry {
 
 func defineModel(t *testing.T, r *registry.Registry, name string, fn ai.ModelFunc) ai.Model {
 	t.Helper()
-	return ai.DefineModel(r, name, &ai.ModelOptions{
+	return registerTestModel(r, name, &ai.ModelOptions{
 		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true},
 	}, fn)
 }
@@ -55,7 +55,7 @@ func TestRetrySucceedsOnFirstAttempt(t *testing.T) {
 	})
 
 	retry := &Retry{}
-	ai.DefineMiddleware(r, "retry", retry)
+	registerTestMiddleware(r, "retry", retry)
 
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(retry))
 	if err != nil {
@@ -81,7 +81,7 @@ func TestRetryRecoversAfterTransientError(t *testing.T) {
 	})
 
 	retry := &Retry{}
-	ai.DefineMiddleware(r, "retry", retry)
+	registerTestMiddleware(r, "retry", retry)
 
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(retry))
 	if err != nil {
@@ -104,7 +104,7 @@ func TestRetryExhaustsMaxRetries(t *testing.T) {
 	})
 
 	retry := &Retry{MaxRetries: 2}
-	ai.DefineMiddleware(r, "retry", retry)
+	registerTestMiddleware(r, "retry", retry)
 
 	_, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(retry))
 	if err == nil {
@@ -125,7 +125,7 @@ func TestRetryDoesNotRetryNonMatchingGenkitError(t *testing.T) {
 	})
 
 	retry := &Retry{}
-	ai.DefineMiddleware(r, "retry", retry)
+	registerTestMiddleware(r, "retry", retry)
 
 	_, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(retry))
 	if err == nil {
@@ -148,7 +148,7 @@ func TestRetryRetriesNonGenkitErrors(t *testing.T) {
 	})
 
 	retry := &Retry{}
-	ai.DefineMiddleware(r, "retry", retry)
+	registerTestMiddleware(r, "retry", retry)
 
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(retry))
 	if err != nil {
@@ -176,7 +176,7 @@ func TestRetryRetriesUnclassifiedErrorWithNarrowedStatuses(t *testing.T) {
 	})
 
 	retry := &Retry{Statuses: []core.StatusName{core.UNAVAILABLE}}
-	ai.DefineMiddleware(r, "retry", retry)
+	registerTestMiddleware(r, "retry", retry)
 
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(retry))
 	if err != nil {
@@ -202,7 +202,7 @@ func TestRetryCustomStatuses(t *testing.T) {
 		Statuses:   []core.StatusName{core.PERMISSION_DENIED},
 		MaxRetries: 1,
 	}
-	ai.DefineMiddleware(r, "retry", retry)
+	registerTestMiddleware(r, "retry", retry)
 
 	_, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(retry))
 	if err == nil {
@@ -231,7 +231,7 @@ func TestRetryBackoffDelays(t *testing.T) {
 		BackoffFactor:  2,
 		NoJitter:       true,
 	}
-	ai.DefineMiddleware(r, "retry", retry)
+	registerTestMiddleware(r, "retry", retry)
 
 	_, _ = ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(retry))
 
@@ -265,7 +265,7 @@ func TestRetryMaxDelayClamp(t *testing.T) {
 		BackoffFactor:  2,
 		NoJitter:       true,
 	}
-	ai.DefineMiddleware(r, "retry", retry)
+	registerTestMiddleware(r, "retry", retry)
 
 	_, _ = ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(retry))
 
@@ -300,7 +300,7 @@ func TestRetryStopsWhenContextCanceledDuringBackoff(t *testing.T) {
 	defer func() { sleepFunc = origSleep }()
 
 	retry := &Retry{MaxRetries: 5}
-	ai.DefineMiddleware(r, "retry", retry)
+	registerTestMiddleware(r, "retry", retry)
 
 	_, err := ai.Generate(reqCtx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(retry))
 	if err == nil {

--- a/go/plugins/middleware/skills_test.go
+++ b/go/plugins/middleware/skills_test.go
@@ -63,7 +63,7 @@ func setupSkillsDir(t *testing.T) string {
 func captureModel(t *testing.T, r *registry.Registry, name string) (ai.Model, *[]*ai.Message) {
 	t.Helper()
 	var captured []*ai.Message
-	m := ai.DefineModel(r, name, &ai.ModelOptions{
+	m := registerTestModel(r, name, &ai.ModelOptions{
 		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true},
 	}, func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 		captured = req.Messages
@@ -77,7 +77,7 @@ func captureModel(t *testing.T, r *registry.Registry, name string) (ai.Model, *[
 // messages.
 func toolCallingModel(t *testing.T, r *registry.Registry, name, toolName string, input map[string]any) ai.Model {
 	t.Helper()
-	return ai.DefineModel(r, name, &ai.ModelOptions{
+	return registerTestModel(r, name, &ai.ModelOptions{
 		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true},
 	}, func(ctx context.Context, req *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
 		for _, msg := range req.Messages {
@@ -106,7 +106,7 @@ func TestSkillsInjectsSystemPrompt(t *testing.T) {
 	m, captured := captureModel(t, r, "test/capture")
 
 	s := &Skills{SkillPaths: []string{skillsDir}}
-	ai.DefineMiddleware(r, "skills", s)
+	registerTestMiddleware(r, "skills", s)
 
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(s)); err != nil {
 		t.Fatal(err)
@@ -139,7 +139,7 @@ func TestSkillsRegistersUseSkillTool(t *testing.T) {
 	m := toolCallingModel(t, r, "test/toolcaller", useSkillToolName, map[string]any{"skillName": "python"})
 
 	s := &Skills{SkillPaths: []string{skillsDir}}
-	ai.DefineMiddleware(r, "skills", s)
+	registerTestMiddleware(r, "skills", s)
 
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("use python"), ai.WithUse(s))
 	if err != nil {
@@ -172,7 +172,7 @@ func TestSkillsUnknownSkillReturnsError(t *testing.T) {
 	m := toolCallingModel(t, r, "test/unknown", useSkillToolName, map[string]any{"skillName": "nonexistent"})
 
 	s := &Skills{SkillPaths: []string{skillsDir}}
-	ai.DefineMiddleware(r, "skills", s)
+	registerTestMiddleware(r, "skills", s)
 
 	_, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("use skill"), ai.WithUse(s))
 	if err == nil {
@@ -190,7 +190,7 @@ func TestSkillsPromptInjectionIsIdempotent(t *testing.T) {
 	m, captured := captureModel(t, r, "test/idempotent")
 
 	s := &Skills{SkillPaths: []string{skillsDir}}
-	ai.DefineMiddleware(r, "skills", s)
+	registerTestMiddleware(r, "skills", s)
 
 	// First call produces a system message with a single <skills> block.
 	resp, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(s))
@@ -238,7 +238,7 @@ func TestSkillsNoopWhenNoSkillsFound(t *testing.T) {
 	// Point at an empty directory — no skills, so the middleware should
 	// leave the request untouched.
 	s := &Skills{SkillPaths: []string{t.TempDir()}}
-	ai.DefineMiddleware(r, "skills", s)
+	registerTestMiddleware(r, "skills", s)
 
 	if _, err := ai.Generate(ctx, r, ai.WithModel(m), ai.WithPrompt("hello"), ai.WithUse(s)); err != nil {
 		t.Fatal(err)

--- a/go/plugins/middleware/tool_approval_test.go
+++ b/go/plugins/middleware/tool_approval_test.go
@@ -30,14 +30,14 @@ import (
 
 func defineToolModel(t *testing.T, r *registry.Registry, name string, fn ai.ModelFunc) ai.Model {
 	t.Helper()
-	return ai.DefineModel(r, name, &ai.ModelOptions{
+	return registerTestModel(r, name, &ai.ModelOptions{
 		Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true, Tools: true},
 	}, fn)
 }
 
 func defineTool(t *testing.T, r api.Registry, name string) ai.Tool {
 	t.Helper()
-	return ai.DefineTool(r, name, "test tool",
+	return registerTestTool(r, name, "test tool",
 		func(ctx *ai.ToolContext, input struct {
 			V string `json:"v"`
 		}) (string, error) {
@@ -119,7 +119,7 @@ func TestToolApprovalAllowsApprovedTools(t *testing.T) {
 	alsoAllowed := defineTool(t, r, "alsoAllowed")
 
 	ta := &ToolApproval{AllowedTools: []string{"allowed", "alsoAllowed"}}
-	ai.DefineMiddleware(r, "toolApproval", ta)
+	registerTestMiddleware(r, "toolApproval", ta)
 
 	resp, err := ai.Generate(ctx, r,
 		ai.WithModel(m),
@@ -146,7 +146,7 @@ func TestToolApprovalInterruptsUnapprovedTools(t *testing.T) {
 	dangerous := defineTool(t, r, "dangerous")
 
 	ta := &ToolApproval{AllowedTools: []string{"safe"}}
-	ai.DefineMiddleware(r, "toolApproval", ta)
+	registerTestMiddleware(r, "toolApproval", ta)
 
 	resp, err := ai.Generate(ctx, r,
 		ai.WithModel(m),
@@ -247,7 +247,7 @@ func TestToolApprovalEmptyListInterruptsAll(t *testing.T) {
 	myTool := defineTool(t, r, "myTool")
 
 	ta := &ToolApproval{}
-	ai.DefineMiddleware(r, "toolApproval", ta)
+	registerTestMiddleware(r, "toolApproval", ta)
 
 	resp, err := ai.Generate(ctx, r,
 		ai.WithModel(m),
@@ -287,7 +287,7 @@ func TestToolApprovalResumedCallRuns(t *testing.T) {
 	needsApproval := defineTool(t, r, "needsApproval")
 
 	ta := &ToolApproval{} // deny all
-	ai.DefineMiddleware(r, "toolApproval", ta)
+	registerTestMiddleware(r, "toolApproval", ta)
 
 	resp, err := ai.Generate(ctx, r,
 		ai.WithModel(m),
@@ -351,7 +351,7 @@ func TestToolApprovalResumedWithoutApprovalInterrupts(t *testing.T) {
 	needsApproval := defineTool(t, r, "needsApproval")
 
 	ta := &ToolApproval{}
-	ai.DefineMiddleware(r, "toolApproval", ta)
+	registerTestMiddleware(r, "toolApproval", ta)
 
 	resp, err := ai.Generate(ctx, r,
 		ai.WithModel(m),


### PR DESCRIPTION
Adds a typed-config constructor family for the `ai` primitives: models, embedders, evaluators, batch evaluators, background models, and retrievers. Every new function lands alongside its existing counterpart under a new name (`ai.New*Action`, `genkit.Define*Action`), so nothing breaks; the old constructors are deprecated and delegate to the new ones, leaving one code path. Builds on the `core.New*ActionOf` options-struct constructors these compose over, merged in #5862, and now targets main directly. Next in the plugin migration train: once providers move to `NewModelAction` (googlegenai in #5869, anthropic in #5874), their hand-rolled `configFromRequest` mapping and its missing validation go away.

## The framework deserializes config, not the plugin

**Before:** every provider hand-rolls the config mapping and reflects its own config schema; neither is validated.

```go
func configToMap(config any) map[string]any {
    r := jsonschema.Reflector{
        DoNotReference: true,
        ExpandedStruct: true,
        IgnoredTypes:   []any{genai.Schema{}}, // recursion-prone fields tracked by hand
    }
    ...
}

func configFromRequest(input *ai.ModelRequest) (*genai.GenerateContentConfig, error) {
    switch config := input.Config.(type) {
    case genai.GenerateContentConfig:  return &config, nil
    case *genai.GenerateContentConfig: return config, nil
    case map[string]any:               return base.MapToStruct[genai.GenerateContentConfig](config)
    case nil:                          return &genai.GenerateContentConfig{}, nil
    default:
        return nil, core.NewPublicError(core.INVALID_ARGUMENT, "Invalid configuration type ...", nil)
    }
}

fn := func(ctx context.Context, input *ai.ModelRequest, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
    gcc, err := configFromRequest(input)
    ...
}
ai.NewModel(name, &ai.ModelOptions{
    ConfigSchema: configToMap(genai.GenerateContentConfig{}),
    ...
}, fn)
```

**After:** `Config` is inferred from the function signature and arrives converted; the schema is derived from it.

```go
fn := func(ctx context.Context, input *ai.ModelRequest, config genai.GenerateContentConfig, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
    ...
}
ai.NewModelAction(name, opts, fn) // config schema inferred from Config
```

The framework validates the raw config against the config schema at the action boundary, converts it (exact type, `*Config`, or `map[string]any`; anything else is `INVALID_ARGUMENT`), and hands the function a shallow copy of the request whose type-erased slot carries the converted value, so the two views cannot disagree. The caller's request keeps its raw config, so one request can fan out across providers, and a pointer `Config` with no config stays `nil` rather than boxing a typed nil.

- The config JSON schema is inferred from `Config` unless `ConfigSchema` overrides it. Inferred schemas drop `required` (a config is partial by nature), and the model config slot always admits the framework-level `version` key so `Versions` keeps working. The override stays the escape hatch for types whose reflection does not match their JSON marshaling (SDK wrapper generics like `Opt[float64]`); those plugins use the new constructors and supply the schema by hand.
- The request input schema's config slot is wrapped as `anyOf [schema, null]`, because a typed-nil config marshals to JSON `null` and would otherwise fail input validation.
- Conversion runs outermost in the model's built-in middleware chain (`normalizeConfig`), so the built-in wrappers and the model function all see the typed value. Version validation moved there out of `validateSupport`: it has to run on the raw config, since converting into a `Config` with no `version` field silently drops the key.

## Constructors return concrete `*Action` types

The constructors and the `genkit.Define*Action` wrappers return `*ModelAction`, `*EmbedderAction`, `*EvaluatorAction`, `*RetrieverAction`, and `*BackgroundModelAction` instead of the interfaces. This leaves room to add methods later without the interface-growth break, and satisfies `api.Action` structurally, so a plugin `Init` can append models to its returned action slice without a type assertion. The constructors are named for the types they return, the way `NewModelRef` returns a `ModelRef`; the plain names stay occupied by the deprecated constructors. The implementation function types follow the same stem: `ModelActionFunc[Config]` is the fn a `ModelAction` is built from.

Each type embeds `core.Action` (or `core.BackgroundAction`) through an unexported package-level alias, which promotes `Desc`, `Register`, `RunJSON`, and the rest without exporting the embedded field. `Model`, `Embedder`, `Evaluator`, `Retriever`, and `BackgroundModel` are unchanged and stay the accepted-argument and lookup types; the concrete types satisfy them, and the deprecated constructors keep returning interfaces.

Those promoted methods are then redeclared on each type as forwarders. The callable surface is identical either way, but godoc cannot see through an alias into another package: without them `ModelAction` documented one method while claiming to implement `api.Action`, `BackgroundModelAction` documented none at all, and every `[ModelAction.Register]` link in the constructor docs failed to resolve. A forwarder that calls itself rather than the embedded action recurses instead of failing to compile, so each one is exercised, `RunJSON` and `RunJSONWithTelemetry` included. Each forwarder that can report an error also rejects a nil receiver with `INVALID_ARGUMENT`, matching `Generate`, `Embed`, `Evaluate`, `Retrieve`, and `RunRawMultipart`; `Name`, `Desc`, `Register`, and `SupportsCancel` cannot, so they still panic rather than report a zero value as truth.

`ToolDef` is renamed to `ToolAction` to join that family, keeping `ToolDef` as a deprecated alias. The old name read as a sibling of `ToolDefinition`, the wire type a tool advertises to the model, when it is in fact the action a tool is backed by. It is an alias rather than a deletion because nothing about the type is framework-internal: an application can hold one, so `ai.NewTool`, `NewMultipartTool`, `NewToolWithInputSchema` and their three `genkit.Define*` counterparts stay source-compatible even though their return type is now spelled `*ToolAction`.

`ToolAction` also gains `Desc`, `RunJSON`, and `RunJSONWithTelemetry`, which makes it an `api.Action` like the rest of the family. It holds its action in a named field instead of embedding one, so it never inherited them, and a plugin returns `[]api.Action`: shipping a tool from a plugin did not compile, though core's package documentation has always shown exactly that. The three forward to the action the type already holds, so they serve what the registry already serves for the tool, `RunJSON` returning the multipart envelope registered under both the tool and action keys.

## One options struct for background models

`NewBackgroundModelAction` takes the same `BackgroundModelOptions` the deprecated constructor takes: `ModelOptions` embedded plus the background extras, the Go counterpart of JS's `DefineBackgroundModelOptions`, which extends `DefineModelOptions` the same way. Embedding means every future `ModelOptions` field applies to background models without mirroring, and a plugin that already holds a `ModelOptions` drops it in wholesale. The rule on the provider surface: required functions are positional (`startFn`, `checkFn`), so the compiler enforces them and they drive type inference, and the optional `Cancel` hook lives in the options struct, so a future addition is a field rather than a signature break. `core.NewBackgroundActionOf` instead takes only `startFn` positionally, with check and cancel as fields of its generic `BackgroundActionOptions[In, Out]` (#5862): the substrate's required set is expected to evolve, while a background model is defined by its pollable check.

`ModelOptions`, `EmbedderOptions`, `EvaluatorOptions`, and `RetrieverOptions` gain a `Metadata` slot. Caller values merge into the action descriptor with the reserved keys (`type`, and the per-kind info map) stamped over them, since registry discovery depends on those. `BackgroundModelOptions` ends up with two slots, its own predating the `ModelOptions` one; both merge into the descriptor, and the top-level field wins on key conflicts.

## Registry-taking `Define*` helpers deleted

Continuing #5862's cleanup into the `ai` layer. A registry is unobtainable outside the framework, so these had no reachable external callers and are deleted rather than deprecated; the `genkit.Define*` wrappers stay as the user touchpoints.

Deleted: `DefineModel`, `DefineEmbedder`, `DefineEvaluator`, `DefineBatchEvaluator`, `DefineBackgroundModel`, `DefineRetriever`, `DefineMiddleware`, `DefineTool`, `DefineToolWithInputSchema`, `DefineMultipartTool`, `DefineResource`, plus the experimental `exp.DefineTool` and `exp.DefineInterruptibleTool`.

Kept, because the registry is a structural input rather than a registration target: `ai.DefinePrompt`, `ai.DefineDataPrompt`, `ai.DefineFormat`, `ai.DefineGenerateAction` (init bootstrap), and the exp agent constructors.

## Four behavior changes reach existing callers

Observable through the deprecated constructors:

- A `version` error surfaces before capability errors, since version validation now runs outermost instead of inside `validateSupport`.
- With `ConfigSchema` set, the request input schema's config slot is the null-tolerant `anyOf` wrapping instead of the raw schema.
- Batch evaluators advertise an inferred input schema, having previously advertised none at all.
- A background model's embedded `ModelOptions.Metadata` reaches the action descriptor; it was ignored on the background path before, and the top-level `BackgroundModelOptions.Metadata` still wins on key conflicts.

`Config` resolves to `any` on the deprecated path, which infers no schema and passes the raw config through untouched, so nothing else moves.

## API reference

```go
// Added: ai
ai.NewModelAction[Config](name, opts, fn) *ModelAction
ai.NewEmbedderAction[Config](name, opts, fn) *EmbedderAction
ai.NewEvaluatorAction[Config](name, opts, fn) *EvaluatorAction
ai.NewBatchEvaluatorAction[Config](name, opts, fn) *EvaluatorAction
ai.NewRetrieverAction[Config](name, opts, fn) *RetrieverAction
ai.NewBackgroundModelAction[Config](name, opts, startFn, checkFn) *BackgroundModelAction

ai.ModelAction, ai.EmbedderAction, ai.EvaluatorAction, ai.RetrieverAction, ai.BackgroundModelAction
ai.ModelActionFunc[Config], ai.EmbedderActionFunc[Config], ai.EvaluatorActionFunc[Config],
ai.BatchEvaluatorActionFunc[Config], ai.RetrieverActionFunc[Config], ai.BackgroundModelActionFunc[Config]
ai.ModelOptions.Metadata, ai.EmbedderOptions.Metadata,
ai.EvaluatorOptions.Metadata, ai.RetrieverOptions.Metadata

// Added: genkit
genkit.DefineModelAction, genkit.DefineEmbedderAction, genkit.DefineEvaluatorAction,
genkit.DefineBatchEvaluatorAction, genkit.DefineRetrieverAction, genkit.DefineBackgroundModelAction

ai.ToolAction.Desc, ai.ToolAction.RunJSON, ai.ToolAction.RunJSONWithTelemetry

// Renamed, deprecated alias kept
ai.ToolDef -> ai.ToolAction

// Deprecated, delegating to the new constructors
ai.NewModel, ai.NewEmbedder, ai.NewEvaluator, ai.NewBatchEvaluator,
ai.NewRetriever, ai.NewBackgroundModel
genkit.DefineModel, genkit.DefineEmbedder, genkit.DefineEvaluator,
genkit.DefineBatchEvaluator, genkit.DefineRetriever, genkit.DefineBackgroundModel
```

## Scope

- **No `Define*Action` at the `ai` layer.** Registration is one `Register` call, so a define-wrapper there would only shadow the `genkit` one applications already have.
- **No plugin migrations here.** googlegenai (#5869) and anthropic (#5874) move on top of this, so this PR reviews as pure framework surface.

## Verification

Go 1.26.3, `go build ./...` and `go test ./...` in `go/`: 41 packages with tests pass, no failures.

New coverage in `ai/config_test.go`: a typed model receives its config deserialized from each accepted shape and rejects the rest with `INVALID_ARGUMENT`; the config is normalized before the built-in wrappers run, so they see the typed value; the schema is inferred from `Config`, overridden by an explicit `ConfigSchema`, and absent for `Config=any`; the deprecated constructors pass the raw config through unchanged; and caller `Metadata` reaches the descriptor without displacing the reserved keys, for the typed model, embedder, evaluator, retriever, and background model, including the background model's two-slot merge. Embedders, evaluators, and retrievers get the same shape-by-shape config coverage. `ai/define_test.go`, `ai/exp/define_test.go`, and `plugins/middleware/define_test.go` hold test-local `New* + Register` helpers standing in for the deleted `Define*`. `ai/action_methods_test.go` runs every forwarder on all six primitives; pointing one at itself makes it fail with a stack overflow rather than passing quietly. `genkit/genkit_test.go` pins the documented plugin shape: a plugin returning `[]api.Action{model, tool}` registers both, and the tool runs through a registry lookup.




