### PR TITLE
chore(py): Reduce noisy logging in python SDK

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -102,7 +102,7 @@ from genkit._core._dap import (
 )
 from genkit._core._environment import is_dev_environment
 from genkit._core._error import GenkitError
-from genkit._core._logger import get_logger
+from genkit._core._logger import configure_logging, get_logger
 from genkit._core._middleware import (
     BaseMiddleware,
     GenerateMiddleware,
@@ -179,6 +179,10 @@ class Genkit:
         # Ensure the default generate action is registered for async usage.
         define_generate_action(self.registry)
         self._register_plugin_middleware(plugins)
+        # Put the log floor in place for plain scripts too (INFO unless
+        # GENKIT_LOG says otherwise). Shared-TTY takeover happens when
+        # GENKIT_ENV=dev was set before import.
+        configure_logging()
         # In dev mode, start the reflection server immediately in a background
         # daemon thread so it's available regardless of which web framework (or
         # none) the user chooses.
@@ -844,7 +848,7 @@ class Genkit:
         async def _run_server() -> None:
             v2_url = os.environ.get('GENKIT_REFLECTION_V2_SERVER')
             if v2_url:
-                await logger.ainfo(f'Genkit Dev UI reflection v2 client connecting to {v2_url}')
+                await logger.adebug(f'Genkit Dev UI reflection v2 client connecting to {v2_url}')
                 server_v2 = ReflectionServerV2(self.registry, v2_url)
                 self._reflection_ready.set()
                 await server_v2.run_forever()
@@ -863,7 +867,17 @@ class Genkit:
                 sockets = [sock]
 
             app = create_reflection_asgi_app(registry=self.registry)
-            config = uvicorn.Config(app, host=spec.host, port=spec.port, loop='asyncio')
+            # Reflection is an internal control plane for the Dev UI. Access logs
+            # and uvicorn lifecycle INFO would drip into the user's terminal on
+            # every 5s health poll — keep them off unless GENKIT_LOG=debug.
+            config = uvicorn.Config(
+                app,
+                host=spec.host,
+                port=spec.port,
+                loop='asyncio',
+                access_log=False,
+                log_level='debug' if os.environ.get('GENKIT_LOG', '').lower() == 'debug' else 'warning',
+            )
             server = ReflectionServer(config, ready=self._reflection_ready)
             async with RuntimeManager(spec, lazy_write=True) as runtime_manager:
                 server_task = asyncio.create_task(server.serve(sockets=sockets))
@@ -874,7 +888,7 @@ class Genkit:
                     return
 
                 runtime_manager.write_runtime_file()
-                await logger.ainfo(f'Genkit Dev UI reflection server running at {spec.url}')
+                await logger.adebug(f'Genkit Dev UI reflection server running at {spec.url}')
                 await server_task
 
         threading.Thread(
@@ -891,7 +905,7 @@ class Genkit:
             self.define_format(fmt)
 
         if not plugins:
-            logger.warning('No plugins provided to Genkit')
+            logger.debug('No plugins provided to Genkit')
         else:
             for plugin in plugins:
                 if isinstance(plugin, Plugin):  # pyright: ignore[reportUnnecessaryIsInstance]
@@ -910,22 +924,22 @@ class Genkit:
     def run_main(self, coro: Coroutine[Any, Any, T]) -> T | None:
         """Run the user's main coroutine, blocking in dev mode for the reflection server."""
         if not is_dev_environment():
-            logger.info('Running in production mode.')
             return run_loop(coro)
-
-        logger.info('Running in development mode.')
 
         async def dev_runner() -> T | None:
             user_result: T | None = None
             try:
                 user_result = await coro
                 logger.debug('User coroutine completed successfully.')
-            except Exception:
-                logger.exception('User coroutine failed')
+            except Exception as e:
+                # Script entrypoint failed — there's no Dev UI panel for this run,
+                # so keep a headline + a debug traceback.
+                logger.error('Startup failed: %s: %s', type(e).__name__, e)
+                logger.debug('Startup failure details', exc_info=True)
 
             # Block until Ctrl+C (SIGINT handled by anyio) or SIGTERM, keeping
             # the daemon reflection thread alive.
-            logger.info('Script done — Dev UI running. Press Ctrl+C to stop.')
+            logger.info('Dev UI ready. Press Ctrl+C to stop.')
             try:
                 async with anyio.create_task_group() as tg:
 
@@ -940,7 +954,7 @@ class Genkit:
             except anyio.get_cancelled_exc_class():
                 pass
 
-            logger.info('Dev UI server stopped.')
+            logger.debug('Dev UI server stopped.')
             return user_result
 
         return anyio.run(dev_runner)

--- a/py/packages/genkit/src/genkit/_ai/_prompt.py
+++ b/py/packages/genkit/src/genkit/_ai/_prompt.py
@@ -19,18 +19,13 @@
 
 import asyncio
 import os
+import warnings
 import weakref
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, Generic, TypedDict, TypeVar, cast
 
-from dotpromptz.typing import (
-    DataArgument,
-    PromptFunction,
-    PromptInputConfig,
-    PromptMetadata,
-)
 from pydantic import BaseModel, ConfigDict
 from typing_extensions import Never, Unpack
 
@@ -73,6 +68,22 @@ from genkit._core._typing import (
     ToolChoice,
     ToolRequestPart,
     ToolResponsePart,
+)
+
+# Fires at import time for every genkit app; not actionable for app authors.
+# Must run before ``dotpromptz.typing`` class bodies execute.
+warnings.filterwarnings(
+    'ignore',
+    message='Field name "schema" .* shadows an attribute in parent',
+    category=UserWarning,
+    module=r'dotpromptz(\.|$)',
+)
+
+from dotpromptz.typing import (  # noqa: E402
+    DataArgument,
+    PromptFunction,
+    PromptInputConfig,
+    PromptMetadata,
 )
 
 ModelStreamingCallback = StreamingCallback

--- a/py/packages/genkit/src/genkit/_ai/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_runtime.py
@@ -88,18 +88,13 @@ def _remove_file(file_path: Path | None) -> bool:
     Returns:
         True if cleanup was successful or file didn't exist, False on error.
     """
-    # NOTE: Neither print nor logger appears to work during atexit, so print is intentional here.
+    # Logger is unreliable during atexit; only print on failure.
     if not file_path:
         return True
     try:
         if file_path.exists():
-            print(f'Removing file: {file_path}')  # noqa: T201 - atexit handler, logger unavailable
             file_path.unlink()
-            # Consider success if unlink didn't raise error
-            return True
-        else:
-            # Consider success if file already gone
-            return True
+        return True
     except Exception as e:
         print(f'Error deleting {file_path}: {e}')  # noqa: T201 - atexit handler, logger unavailable
         return False
@@ -158,7 +153,7 @@ def _create_and_write_runtime_file(runtime_dir: Path, spec: ServerSpec) -> Path:
     with Path(runtime_file_path).open('w', encoding='utf-8') as f:
         _ = f.write(metadata)
 
-    logger.info(f'Initialized runtime file: {runtime_file_path}')
+    logger.debug(f'Initialized runtime file: {runtime_file_path}')
     _ = sys.stdout.flush()
     _ = sys.stderr.flush()
     return runtime_file_path

--- a/py/packages/genkit/src/genkit/_core/_error.py
+++ b/py/packages/genkit/src/genkit/_core/_error.py
@@ -16,11 +16,14 @@
 
 """Error classes and utilities for the Genkit framework."""
 
+import traceback
 from enum import IntEnum
 from typing import Any, ClassVar, Literal, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
+
+from genkit._core._environment import is_dev_environment
 
 
 class StatusCodes(IntEnum):
@@ -333,15 +336,13 @@ def get_callable_json(error: object) -> dict[str, Any]:
 def get_error_stack(error: object) -> str | None:
     """Extract stack trace from an error object.
 
-    Args:
-        error: The error to get the stack trace from.
-
-    Returns:
-        The stack trace string if available, None otherwise.
+    In development, the Dev UI needs the real stack to debug playground runs.
+    In production we omit it so callable/HTTP error payloads stay lean.
     """
-    if isinstance(error, Exception):
-        # Stack traces are valuable for debugging; consider making this configurable
-        # to enable them in development/staging and suppress in production.
-        # For now, return an empty string to keep Dev UI clean as per requirements.
+    if not isinstance(error, Exception):
+        return None
+    if not is_dev_environment():
         return ''
-    return None
+    if error.__traceback__ is None:
+        return ''
+    return ''.join(traceback.format_exception(type(error), error, error.__traceback__))

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -1,12 +1,172 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Internal logger for genkit core. Not part of public API."""
+"""Internal logger for genkit core. Not part of public API.
+
+Under ``genkit start`` (``GENKIT_ENV=dev``), the Python process shares one
+terminal with the CLI. This module keeps that stream readable: message-first
+lines, a real log-level floor, and quiet third-party request spam.
+
+For plain scripts, we still put an INFO floor on genkit's own structlog so
+``logger.debug('generate response', ...)`` payload dumps stay off unless the
+caller opts in with ``GENKIT_LOG=debug`` — without rewriting the process root
+logger an app may already own.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from collections.abc import MutableMapping
+from typing import Any
 
 import structlog
 from structlog.typing import FilteringBoundLogger
+
+from genkit._core._environment import is_dev_environment
+
+CONFIGURED = False
+LOCK = threading.Lock()
+
+# Libraries that log every HTTP hop. Under Dev UI those hops are health checks
+# and span exports — useful in GENKIT_LOG=debug, noise otherwise.
+QUIET_LOGGERS = (
+    'httpx',
+    'httpcore',
+    'uvicorn.access',
+    'uvicorn.error',
+    'opentelemetry',
+    'opentelemetry.sdk',
+    'opentelemetry.instrumentation',
+    # google-genai logs "AFC is enabled with max remote calls: N" at INFO on
+    # every tool-using generate — fine for debug, noisy in the shared TTY.
+    'google.genai',
+    'google_genai',
+)
+
+
+def resolve_level() -> int:
+    raw = os.environ.get('GENKIT_LOG', 'info').strip().lower()
+    return {
+        'debug': logging.DEBUG,
+        'info': logging.INFO,
+        'warn': logging.WARNING,
+        'warning': logging.WARNING,
+        'error': logging.ERROR,
+    }.get(raw, logging.INFO)
+
+
+def configure_logging(*, shared_tty: bool | None = None, force: bool = False) -> None:
+    """Configure genkit console logging.
+
+    Safe to call more than once. Default level is ``info``; override with
+    ``GENKIT_LOG=debug|info|warn|error``.
+
+    When ``shared_tty`` is true (``genkit start`` / ``GENKIT_ENV=dev``), take over
+    the process console: message-first lines, quiet third-party request loggers,
+    and ``basicConfig(force=True)``. When false, only ensure genkit's structlog
+    has an INFO floor so debug payload dumps don't print — leave the caller's
+    root logger alone.
+    """
+    global CONFIGURED
+    with LOCK:
+        if shared_tty is None:
+            shared_tty = is_dev_environment()
+
+        if CONFIGURED and not force:
+            return
+
+        level = resolve_level()
+
+        if shared_tty:
+            CONFIGURED = True
+            logging.basicConfig(
+                format='%(message)s',
+                stream=sys.stderr,
+                level=level,
+                force=True,
+            )
+
+            for name in QUIET_LOGGERS:
+                # Keep a little headroom when the user asked for debug.
+                logging.getLogger(name).setLevel(logging.DEBUG if level <= logging.DEBUG else logging.WARNING)
+
+            structlog.configure(
+                processors=[
+                    structlog.contextvars.merge_contextvars,
+                    structlog.stdlib.add_log_level,
+                    structlog.stdlib.PositionalArgumentsFormatter(),
+                    structlog.processors.StackInfoRenderer(),
+                    structlog.processors.format_exc_info,
+                    structlog.processors.UnicodeDecoder(),
+                    console_renderer,
+                ],
+                wrapper_class=structlog.make_filtering_bound_logger(level),
+                logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+                cache_logger_on_first_use=True,
+            )
+            return
+
+        # Plain scripts / production: don't stomp apps that already configured
+        # structlog themselves.
+        if structlog.is_configured() and not force:
+            CONFIGURED = True
+            return
+
+        CONFIGURED = True
+        structlog.configure(
+            processors=[
+                structlog.contextvars.merge_contextvars,
+                structlog.stdlib.PositionalArgumentsFormatter(),
+                structlog.processors.add_log_level,
+                structlog.processors.StackInfoRenderer(),
+                structlog.dev.set_exc_info,
+                structlog.processors.format_exc_info,
+                structlog.processors.UnicodeDecoder(),
+                structlog.dev.ConsoleRenderer(),
+            ],
+            wrapper_class=structlog.make_filtering_bound_logger(level),
+            cache_logger_on_first_use=True,
+        )
+
+
+def console_renderer(
+    _logger: object,
+    _method_name: str,
+    event_dict: MutableMapping[str, Any],
+) -> str:
+    """Render a short, message-first line for a human watching the terminal."""
+    level = str(event_dict.pop('level', 'info')).lower()
+    event = event_dict.pop('event', '')
+    # Exception text already appended by format_exc_info when present.
+    exc_info = event_dict.pop('exception', None)
+    extras = ' '.join(f'{key}={value!r}' for key, value in event_dict.items() if value is not None)
+    message = str(event)
+    if extras:
+        message = f'{message} ({extras})' if message else extras
+
+    if level in ('warning', 'warn'):
+        line = f'Warn: {message}'
+    elif level == 'error':
+        line = f'Error: {message}'
+    elif level == 'debug':
+        line = f'Debug: {message}'
+    else:
+        # info stays bare so readiness lines don't look like framework chatter
+        line = message
+
+    if exc_info:
+        return f'{line}\n{exc_info}'
+    return line
 
 
 def get_logger(name: str | None = None) -> FilteringBoundLogger:
     """Return a structlog bound logger with a concrete return type for checkers."""
     return structlog.get_logger(name)
+
+
+# Install the floor before other genkit modules cache loggers at import time.
+# Shared-TTY takeover only when this process is the genkit start runtime.
+configure_logging(shared_tty=is_dev_environment())

--- a/py/packages/genkit/src/genkit/_core/_reflection.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection.py
@@ -163,7 +163,10 @@ class ActionRunner:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            logger.exception('Error executing action')
+            # Dev UI already shows the error + stack from the reflection response.
+            # Dumping a full traceback here turns every playground failure into
+            # terminal noise.
+            logger.debug('Action failed: %s: %s', type(e).__name__, e, exc_info=True)
             self.queue.put_nowait(json.dumps({'error': get_reflection_json(e).model_dump(by_alias=True)}))
         finally:
             self.trace_ready.set()
@@ -204,7 +207,7 @@ def create_reflection_asgi_app(
         return JSONResponse({'status': 'OK'})
 
     async def terminate(_: Request) -> JSONResponse:
-        logger.info('Shutting down...')
+        logger.debug('Shutting down...')
         asyncio.get_running_loop().call_soon(os.kill, os.getpid(), signal.SIGTERM)
         return JSONResponse({'status': 'OK'})
 
@@ -248,10 +251,11 @@ def create_reflection_asgi_app(
                     serialized[key] = val.model_dump(by_alias=True, exclude_none=True, mode='json')
                 raw_values = serialized
             return JSONResponse(raw_values, headers={'x-genkit-version': version})
-        except Exception:
-            logger.exception('Reflection /api/values failed')
+        except Exception as e:
+            logger.error(f'Failed to list values: {type(e).__name__}: {e}')
+            logger.debug('Reflection /api/values failed', exc_info=e)
             return JSONResponse(
-                {'error': 'Failed to list values', 'detail': 'See Python process logs for the traceback.'},
+                {'error': 'Failed to list values', 'detail': str(e)},
                 status_code=500,
                 headers={'x-genkit-version': version},
             )

--- a/py/packages/genkit/src/genkit/_core/_reflection_v2.py
+++ b/py/packages/genkit/src/genkit/_core/_reflection_v2.py
@@ -363,8 +363,9 @@ class ReflectionServerV2:
                     )
                 else:
                     logger.debug('reflection V2: unknown notification', method=method)
-        except Exception:
-            logger.exception('reflection V2: handler error', method=method)
+        except Exception as e:
+            logger.error(f'Reflection error in {method}: {type(e).__name__}: {e}')
+            logger.debug('reflection V2: handler error', method=method, exc_info=e)
             if req_id is not None:
                 await self.send_error(str(req_id), JSON_RPC_SERVER_ERROR, 'internal error')
 
@@ -490,7 +491,8 @@ class ReflectionServerV2:
             await self.send_error(sid, JSON_RPC_SERVER_ERROR, 'Action was cancelled', err_data)
             return
 
-        logger.exception('reflection V2: runAction error')
+        # Dev UI already shows the error + stack from the JSON-RPC response.
+        logger.debug('Action failed: %s: %s', type(exc).__name__, exc, exc_info=True)
         # Wire contract requires ``details`` to carry only ``stack`` and ``traceId``
         # (see ``GenkitErrorSchema.data.genkitErrorDetails`` in genkit-tools); anything
         # else in ``GenkitError.details`` is runtime-internal and gets dropped.

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -165,6 +165,8 @@ class Registry:
         #   we key both the in-flight task cache and the "all done" flag by the
         #   running loop.
         self._plugins: dict[str, Plugin] = {}
+        # Plugin names whose init failure was already reported at error level.
+        self._plugin_init_error_logged: set[str] = set()
         self._plugin_init_tasks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Task[None]]] = (
             weakref.WeakKeyDictionary()
         )
@@ -306,8 +308,9 @@ class Registry:
         for plugin_name, plugin in plugins:
             try:
                 advertised = await plugin.list_actions()
-            except Exception:
-                logger.exception('Error listing actions for plugin %s', plugin_name)
+            except Exception as e:
+                logger.error('Error listing actions for plugin %s: %s', plugin_name, e)
+                logger.debug('Plugin list_actions failed', plugin=plugin_name, exc_info=True)
                 continue
             for meta in advertised or []:
                 if not meta.name:
@@ -330,11 +333,13 @@ class Registry:
                     # DAP action keys are prefixed with the provider action's ``name``;
                     # see :meth:`DynamicActionProvider.list_action_metadata_by_key`.
                     dap_actions = await dap.list_action_metadata_by_key(action.name)
-                except Exception:
-                    logger.exception(
-                        'Error listing actions for Dynamic Action Provider %s',
+                except Exception as e:
+                    logger.error(
+                        'Error listing actions for Dynamic Action Provider %s: %s',
                         action.name,
+                        e,
                     )
+                    logger.debug('DAP list_actions failed', provider=action.name, exc_info=True)
                     continue
                 # ``list_action_metadata_by_key`` already populates each entry's ``meta.key``
                 # to match its DAP action key, so we can merge straight into the catalog.
@@ -436,7 +441,22 @@ class Registry:
         with self._lock:
             plugin_names = list(self._plugins.keys())
         for name in plugin_names:
-            await self._ensure_plugin_initialized(name)
+            try:
+                await self._ensure_plugin_initialized(name)
+            except Exception as e:
+                # One bad plugin (bad API key, network down) must not take down
+                # the Dev UI reflection server or spam a traceback every health poll.
+                with self._lock:
+                    already_logged = name in self._plugin_init_error_logged
+                    if not already_logged:
+                        self._plugin_init_error_logged.add(name)
+                if not already_logged:
+                    # Keep the headline short — provider error payloads are often huge JSON.
+                    detail = str(e).replace('\n', ' ')
+                    if len(detail) > 180:
+                        detail = detail[:177] + '...'
+                    logger.error('Failed to initialize plugin %s: %s: %s', name, type(e).__name__, detail)
+                    logger.debug('Plugin initialization failed', plugin=name, exc_info=True)
         with self._lock:
             if len(self._plugins) == len(plugin_names):
                 self._all_plugins_initialized[loop] = True
@@ -530,7 +550,13 @@ class Registry:
             try:
                 await async_factory()
             except Exception as e:
-                logger.warning(f'Failed to load lazy action {action.name}: {e}')
+                # Prompt/schema load failures show up when Dev UI lists actions;
+                # keep one short line, not an ExceptionGroup wall.
+                detail = str(e).replace('\n', ' ')
+                if len(detail) > 160:
+                    detail = detail[:157] + '...'
+                logger.warning('Failed to load lazy action %s: %s', action.name, detail)
+                logger.debug('Lazy action load failed', action=action.name, exc_info=True)
             finally:
                 self._loading_actions.discard(action_id)
         return action

--- a/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_default_exporter.py
@@ -211,11 +211,17 @@ class TraceServerExporter(SpanExporter):
 
         url = urljoin(self.telemetry_server_url, self.telemetry_server_endpoint)
         headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
-        with httpx.Client() as client:
-            for span in spans:
-                if span.context and format(span.context.trace_id, '032x') in filtered_trace_ids:
-                    continue
-                client.post(url, json=extract_span_data(span), headers=headers)
+        try:
+            with httpx.Client() as client:
+                for span in spans:
+                    if span.context and format(span.context.trace_id, '032x') in filtered_trace_ids:
+                        continue
+                    client.post(url, json=extract_span_data(span), headers=headers)
+        except Exception as e:
+            # Network blips / proxy misconfig must not dump httpx tracebacks into
+            # the shared genkit start terminal. Traces are best-effort in dev.
+            logger.debug('Telemetry export failed: %s: %s', type(e).__name__, e)
+            return SpanExportResult.FAILURE
         return SpanExportResult.SUCCESS
 
     @override

--- a/py/packages/genkit/src/genkit/_core/_trace/_realtime_processor.py
+++ b/py/packages/genkit/src/genkit/_core/_trace/_realtime_processor.py
@@ -37,14 +37,13 @@ class RealtimeSpanProcessor(SimpleSpanProcessor):
             return
         try:
             self.span_exporter.export([span])
-        except ConnectionError:
+        except Exception as e:  # noqa: BLE001 — must never crash the caller
+            # httpx.ConnectError isn't a builtins.ConnectionError; treat all export
+            # failures as best-effort and keep the shared terminal clean.
             logger.debug(
-                'RealtimeSpanProcessor: export failed on_start (collector unreachable)',
-                exc_info=True,
-            )
-        except Exception:  # noqa: BLE001 — must never crash the caller
-            logger.warning(
-                'RealtimeSpanProcessor: unexpected error during export on_start',
+                'RealtimeSpanProcessor: export failed on_start: %s: %s',
+                type(e).__name__,
+                e,
                 exc_info=True,
             )
 

--- a/py/packages/genkit/src/genkit/_core/_tracing.py
+++ b/py/packages/genkit/src/genkit/_core/_tracing.py
@@ -97,8 +97,11 @@ def init_provider() -> TracerProvider:
     if tracer_provider is None or not isinstance(tracer_provider, TracerProvider):  # pyright: ignore[reportUnnecessaryComparison]
         tracer_provider = TracerProvider()
         trace_api.set_tracer_provider(tracer_provider)
+        # Correlate logs with spans when someone opts into debug, but don't rewrite
+        # the global log format — that turns every httpx/uvicorn line into a wall
+        # of trace_id/span_id noise in the shared genkit start terminal.
         # pyrefly: ignore[missing-attribute] - LoggingInstrumentor has instrument() method
-        LoggingInstrumentor().instrument(set_logging_format=True)
+        LoggingInstrumentor().instrument(set_logging_format=False)
         logger.debug('Creating a new global tracer provider for telemetry.')
 
     if not isinstance(tracer_provider, TracerProvider):  # pyright: ignore[reportUnnecessaryIsInstance]

--- a/py/packages/genkit/tests/genkit/core/error_test.py
+++ b/py/packages/genkit/tests/genkit/core/error_test.py
@@ -16,6 +16,8 @@
 
 """Unit tests for the error module."""
 
+import os
+
 from genkit import ErrorResponseMetadata
 from genkit._core._error import (
     GenkitError,
@@ -122,4 +124,8 @@ def test_get_error_stack() -> None:
         raise ValueError('Example Error')
     except ValueError as e:
         tb = get_error_stack(e)
-        assert tb == ''
+        if os.environ.get('GENKIT_ENV') == 'dev':
+            assert tb is not None
+            assert 'ValueError: Example Error' in tb
+        else:
+            assert tb == ''


### PR DESCRIPTION
## Summary
Under `genkit start`, the Python process shares one TTY with the CLI. Before this change that stream was a dump — health polls, telemetry failures, playground errors, and full model payloads — so you couldn’t tell whether *your app* was healthy. Plain `uv run` scripts had the same payload spam, and “raise the log level” didn’t work.

Here's what we did:
- Quiet shared `genkit start` terminal by default (message-first logs, muted httpx/otel/google-genai/uvicorn access).
- `GENKIT_LOG=debug|info|warn|error` opt-in for internals.
- Plugin init failures: one short Error line; reflection stays up.
- Telemetry export failures best-effort (debug only).
- Playground action failures: stack on Dev UI wire, not terminal spam.
- Structlog INFO floor so plain scripts don't dump generate payloads by default.

