### PR TITLE
feat(py): core support for background model operations and typed model refs

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -90,7 +90,7 @@ from genkit._core._background import (
     BackgroundAction,
     CancelModelOpFn,
     CheckModelOpFn,
-    ConfigT,
+    ModelRequestConfigT,
     StartModelOpFn,
     check_operation,
     define_background_model,
@@ -424,12 +424,12 @@ class Genkit:
     def define_background_model(
         self,
         name: str,
-        start: StartModelOpFn[ConfigT],
+        start: StartModelOpFn[ModelRequestConfigT],
         check: CheckModelOpFn,
         cancel: CancelModelOpFn | None = None,
         label: str | None = None,
         info: ModelInfo | None = None,
-        config_schema: type[ConfigT] | dict[str, object] | None = None,
+        config_schema: type[ModelRequestConfigT] | dict[str, object] | None = None,
         metadata: dict[str, object] | None = None,
         description: str | None = None,
     ) -> BackgroundAction:

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -85,11 +85,12 @@ from genkit._ai._resource import (
     define_resource,
 )
 from genkit._ai._tools import Tool, define_interrupt, define_tool
-from genkit._core._action import Action, ActionKind, get_current_context
+from genkit._core._action import Action, ActionKind, get_current_context  # noqa: F401 — re-exported via genkit.__init__
 from genkit._core._background import (
     BackgroundAction,
     CancelModelOpFn,
     CheckModelOpFn,
+    ConfigT,
     StartModelOpFn,
     check_operation,
     define_background_model,
@@ -146,7 +147,7 @@ T = TypeVar('T')
 MiddlewareT = TypeVar('MiddlewareT', bound=BaseMiddleware)
 
 
-def _model_supports_long_running(model_action: Action) -> bool:
+def model_supports_long_running(model_action: Action) -> bool:
     """Check if a model action supports long-running operations."""
     model_info = model_action.metadata.get('model') if model_action.metadata else None
     if not model_info:
@@ -423,12 +424,12 @@ class Genkit:
     def define_background_model(
         self,
         name: str,
-        start: StartModelOpFn,
+        start: StartModelOpFn[ConfigT],
         check: CheckModelOpFn,
         cancel: CancelModelOpFn | None = None,
         label: str | None = None,
         info: ModelInfo | None = None,
-        config_schema: type[BaseModel] | dict[str, object] | None = None,
+        config_schema: type[ConfigT] | dict[str, object] | None = None,
         metadata: dict[str, object] | None = None,
         description: str | None = None,
     ) -> BackgroundAction:
@@ -1412,7 +1413,7 @@ class Genkit:
                 message='No model specified for generate_operation.',
             )
 
-        model_action = await self.registry.resolve_action(ActionKind.MODEL, resolved_model)
+        model_action = await self.registry.resolve_model(resolved_model)
         if not model_action:
             raise GenkitError(
                 status='NOT_FOUND',
@@ -1420,7 +1421,7 @@ class Genkit:
             )
 
         # Check if model supports long-running operations
-        if not _model_supports_long_running(model_action):
+        if not model_supports_long_running(cast(Action, model_action)):
             raise GenkitError(
                 status='INVALID_ARGUMENT',
                 message=f"Model '{model_action.name}' does not support long running operations.",

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -1421,7 +1421,7 @@ class Genkit:
             )
 
         # Check if model supports long-running operations
-        if not model_supports_long_running(cast(Action, model_action)):
+        if not model_supports_long_running(model_action):
             raise GenkitError(
                 status='INVALID_ARGUMENT',
                 message=f"Model '{model_action.name}' does not support long running operations.",

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -85,7 +85,7 @@ from genkit._ai._resource import (
     define_resource,
 )
 from genkit._ai._tools import Tool, define_interrupt, define_tool
-from genkit._core._action import Action, ActionKind, get_current_context  # noqa: F401 — re-exported via genkit.__init__
+from genkit._core._action import Action, ActionKind, get_current_context
 from genkit._core._background import (
     BackgroundAction,
     CancelModelOpFn,

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -70,6 +70,7 @@ from genkit._core._typing import (
     FinishReason,
     MiddlewareRef,
     MultipartToolResponse,
+    Operation,
     Part,
     Role,
     TextPart,
@@ -747,6 +748,12 @@ async def _generate_action_turn(
                 next_fn,
             )
 
+        # Background models return an Operation to poll, not a finished message.
+        # The tool loop below assumes response.message exists, so branch out first.
+        if model.kind == ActionKind.BACKGROUND_MODEL:
+            operation = cast(Operation, model_response)
+            return ModelResponse(operation=operation, request=request)
+
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
             if formatter is None:
                 return None
@@ -755,10 +762,11 @@ async def _generate_action_turn(
         # Extract schema_type for runtime Pydantic validation
         schema_type = turn_options.output.schema_type if turn_options.output else None
 
-        # Plugin returns ModelResponse directly. Framework sets request and
-        # any output format context (message_parser, schema_type) as private attrs.
+        # Plugin returns ModelResponse directly. Framework fills request when the
+        # plugin didn't already attach one (e.g. with a normalized config echo).
         response = model_response
-        response.request = request
+        if response.request is None:
+            response.request = request
         if formatter:
             response._message_parser = message_parser
         if schema_type:
@@ -1079,11 +1087,17 @@ async def resolve_parameters(
         else cast(str | None, registry.lookup_value('defaultModel', 'defaultModel'))
     )
     if not model:
-        raise Exception('No model configured.')
+        raise GenkitError(status='INVALID_ARGUMENT', message='No model configured.')
 
     model_action = await registry.resolve_model(model)
     if model_action is None:
-        raise Exception(f'Failed to to resolve model {model}')
+        hint = ''
+        if isinstance(model, str) and '/' not in model:
+            hint = f" Did you mean 'googleai/{model}' or 'vertexai/{model}'?"
+        raise GenkitError(
+            status='NOT_FOUND',
+            message=f"Failed to resolve model '{model}'.{hint}",
+        )
 
     # Resolve tools up front to fail fast on invalid caller-supplied tool names or
     # duplicate short names before running side effects or middleware.

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1091,12 +1091,12 @@ async def resolve_parameters(
 
     model_action = await registry.resolve_model(model)
     if model_action is None:
-        hint = ''
+        message = f"Failed to resolve model '{model}'."
         if isinstance(model, str) and '/' not in model:
-            hint = f" Did you mean 'googleai/{model}' or 'vertexai/{model}'?"
+            message += f" Ensure the model name includes a provider prefix (e.g., 'googleai/{model}' or 'vertexai/{model}')."
         raise GenkitError(
             status='NOT_FOUND',
-            message=f"Failed to resolve model '{model}'.{hint}",
+            message=message,
         )
 
     # Resolve tools up front to fail fast on invalid caller-supplied tool names or

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1093,7 +1093,7 @@ async def resolve_parameters(
     if model_action is None:
         message = f"Failed to resolve model '{model}'."
         if isinstance(model, str) and '/' not in model:
-            message += ' Ensure the model name includes a plugin prefix.'
+            message += ' Ensure the model name includes the plugin namespace.'
         raise GenkitError(
             status='NOT_FOUND',
             message=message,

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1093,9 +1093,7 @@ async def resolve_parameters(
     if model_action is None:
         message = f"Failed to resolve model '{model}'."
         if isinstance(model, str) and '/' not in model:
-            message += (
-                f" Ensure the model name includes a provider prefix (e.g., 'googleai/{model}' or 'vertexai/{model}')."
-            )
+            message += ' Ensure the model name includes a plugin prefix.'
         raise GenkitError(
             status='NOT_FOUND',
             message=message,

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -765,8 +765,7 @@ async def _generate_action_turn(
         # Extract schema_type for runtime Pydantic validation
         schema_type = turn_options.output.schema_type if turn_options.output else None
 
-        # Plugin returns ModelResponse directly. Framework fills request when the
-        # plugin didn't already attach one (e.g. with a normalized config echo).
+        # Attach the request to the response if the model plugin did not already include one.
         response = model_response
         if response.request is None:
             response.request = request

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1093,7 +1093,9 @@ async def resolve_parameters(
     if model_action is None:
         message = f"Failed to resolve model '{model}'."
         if isinstance(model, str) and '/' not in model:
-            message += f" Ensure the model name includes a provider prefix (e.g., 'googleai/{model}' or 'vertexai/{model}')."
+            message += (
+                f" Ensure the model name includes a provider prefix (e.g., 'googleai/{model}' or 'vertexai/{model}')."
+            )
         raise GenkitError(
             status='NOT_FOUND',
             message=message,

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1093,10 +1093,7 @@ async def resolve_parameters(
     if model_action is None:
         hint = ''
         if isinstance(model, str) and '/' not in model:
-            namespaces = registry.plugin_names()
-            if namespaces:
-                suggestions = ' or '.join(f"'{ns}/{model}'" for ns in namespaces)
-                hint = f' Did you mean {suggestions}?'
+            hint = f" Did you mean 'googleai/{model}' or 'vertexai/{model}'?"
         raise GenkitError(
             status='NOT_FOUND',
             message=f"Failed to resolve model '{model}'.{hint}",

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1093,7 +1093,10 @@ async def resolve_parameters(
     if model_action is None:
         hint = ''
         if isinstance(model, str) and '/' not in model:
-            hint = f" Did you mean 'googleai/{model}' or 'vertexai/{model}'?"
+            namespaces = registry.plugin_names()
+            if namespaces:
+                suggestions = ' or '.join(f"'{ns}/{model}'" for ns in namespaces)
+                hint = f' Did you mean {suggestions}?'
         raise GenkitError(
             status='NOT_FOUND',
             message=f"Failed to resolve model '{model}'.{hint}",

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -684,10 +684,10 @@ async def _generate_action_turn(
     async def dispatch_model(
         params: ModelHookParams,
         ctx: GenerateMiddlewareContext,
-        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
-    ) -> ModelResponse:
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse | Operation]],
+    ) -> ModelResponse | Operation:
         """Chain wrap_model middleware and call next_fn."""
-        runner: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = next_fn
+        runner: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse | Operation]] = next_fn
         for mw in reversed(middleware):
             _mw = mw
             _inner = runner
@@ -696,11 +696,15 @@ async def _generate_action_turn(
                 params: ModelHookParams,
                 c: GenerateMiddlewareContext,
                 _mw: MiddlewareDef = _mw,
-                _inner: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]] = _inner,
-            ) -> ModelResponse:
+                _inner: Callable[
+                    [ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse | Operation]
+                ] = _inner,
+            ) -> ModelResponse | Operation:
                 return await _mw.wrap_model(params, c, _inner)
 
-            runner = cast(Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]], run_next)
+            runner = cast(
+                Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse | Operation]], run_next
+            )
         return await runner(params, ctx)
 
     # if resolving the 'resume' option above generated a tool message, stream it.
@@ -731,7 +735,7 @@ async def _generate_action_turn(
         if request.docs:
             request = _augment_with_context(request)
 
-        async def next_fn(params: ModelHookParams, c: GenerateMiddlewareContext) -> ModelResponse:
+        async def next_fn(params: ModelHookParams, c: GenerateMiddlewareContext) -> ModelResponse | Operation:
             return (
                 await model.run(
                     input=params.request,
@@ -750,9 +754,8 @@ async def _generate_action_turn(
 
         # Background models return an Operation to poll, not a finished message.
         # The tool loop below assumes response.message exists, so branch out first.
-        if model.kind == ActionKind.BACKGROUND_MODEL:
-            operation = cast(Operation, model_response)
-            return ModelResponse(operation=operation, request=request)
+        if isinstance(model_response, Operation):
+            return ModelResponse(operation=model_response, request=request)
 
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
             if formatter is None:

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -71,12 +71,19 @@ def model_ref(
     info: ModelInfo | None = None,
     version: str | None = None,
     config: dict[str, object] | None = None,
+    config_schema: object | None = None,
 ) -> ModelRef:
     """Create a ModelRef, optionally prefixing name with namespace."""
     # Logic: if (options.namespace && !name.startsWith(options.namespace + '/'))
     final_name = f'{namespace}/{name}' if namespace and not name.startswith(f'{namespace}/') else name
 
-    return ModelRef(name=final_name, info=info, version=version, config=config)
+    return ModelRef(
+        name=final_name,
+        info=info,
+        version=version,
+        config=config,
+        config_schema=config_schema,
+    )
 
 
 def define_model(

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -78,12 +78,6 @@ def model_ref(
     """Create a ModelRef, optionally prefixing name with namespace."""
     final_name = f'{namespace}/{name}' if namespace and not name.startswith(f'{namespace}/') else name
 
-    if config is not None:
-        if isinstance(config, dict):
-            config = config_schema.model_validate(config)
-        elif not isinstance(config, config_schema):
-            raise TypeError(f'config must conform to {config_schema.__name__}, got {type(config).__name__}')
-
     return ModelRef[ModelRefConfigT](
         name=final_name,
         config_schema=config_schema,

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -33,6 +33,7 @@ from genkit._core._model import (
     Message,
     ModelConfig,
     ModelRef,
+    ModelRefConfigT,
     ModelRequest,
     ModelResponse,
     ModelResponseChunk,
@@ -67,22 +68,28 @@ def model_action_metadata(
 
 def model_ref(
     name: str,
+    *,
+    config_schema: type[ModelRefConfigT],
     namespace: str | None = None,
     info: ModelInfo | None = None,
     version: str | None = None,
-    config: dict[str, object] | None = None,
-    config_schema: object | None = None,
-) -> ModelRef:
+    config: ModelRefConfigT | None = None,
+) -> ModelRef[ModelRefConfigT]:
     """Create a ModelRef, optionally prefixing name with namespace."""
-    # Logic: if (options.namespace && !name.startsWith(options.namespace + '/'))
     final_name = f'{namespace}/{name}' if namespace and not name.startswith(f'{namespace}/') else name
 
-    return ModelRef(
+    if config is not None:
+        if isinstance(config, dict):
+            config = config_schema.model_validate(config)
+        elif not isinstance(config, config_schema):
+            raise TypeError(f'config must conform to {config_schema.__name__}, got {type(config).__name__}')
+
+    return ModelRef[ModelRefConfigT](
         name=final_name,
+        config_schema=config_schema,
         info=info,
         version=version,
         config=config,
-        config_schema=config_schema,
     )
 
 

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -696,10 +696,9 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         if input is None and self._first_arg_optional:
             return input
         payload: object = input
-        # If input is a BaseModel instance of a different generic type (e.g. caller passes
-        # ModelRequest[dict] to an action typed as ModelRequest[PluginConfig]), Pydantic rejects
-        # direct validation due to class mismatch. Try validating directly first; if it fails,
-        # dump to a plain dict so the action's target schema wins.
+        # If input is a BaseModel of a different type (e.g. ModelRequest[dict] vs ModelRequest[PluginConfig]),
+        # Pydantic rejects direct class validation. We dump it to a plain dict so Pydantic can re-parse
+        # the raw fields into the action's schema.
         if isinstance(input, BaseModel):
             try:
                 return self._input_type.validate_python(input)

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -695,30 +695,25 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         # signal that "no input" is a legitimate way to invoke this action.
         if input is None and self._first_arg_optional:
             return input
+        payload: object = input
         # When a BaseModel instance fails (e.g. generate hands ModelRequest with
         # GenerationCommonConfig into an action typed as ModelRequest[PluginConfig]),
         # dump to plain data and retry so the action's schema wins.
-        try:
+        if isinstance(input, BaseModel):
             try:
                 return self._input_type.validate_python(input)
             except ValidationError:
-                if not isinstance(input, BaseModel):
-                    raise
-                return self._input_type.validate_python(input.model_dump(mode='python'))
+                payload = input.model_dump(mode='python')
+
+        try:
+            return self._input_type.validate_python(payload)
         except ValidationError as e:
-            if input is None:
-                raise GenkitError(
-                    message=(
-                        f"Action '{self.name}' requires input but none was provided. "
-                        'Please supply a valid input payload.'
-                    ),
-                    status='INVALID_ARGUMENT',
-                ) from e
-            raise GenkitError(
-                message=f"Invalid input for action '{self.name}': {e}",
-                status='INVALID_ARGUMENT',
-                cause=e,
-            ) from e
+            msg = (
+                f"Action '{self.name}' requires input but none was provided. Please supply a valid input payload."
+                if input is None
+                else f"Invalid input for action '{self.name}': {e}"
+            )
+            raise GenkitError(message=msg, status='INVALID_ARGUMENT', cause=e) from e
 
     async def _run_with_telemetry(
         self,

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -695,8 +695,16 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         # signal that "no input" is a legitimate way to invoke this action.
         if input is None and self._first_arg_optional:
             return input
+        # When a BaseModel instance fails (e.g. generate hands ModelRequest with
+        # GenerationCommonConfig into an action typed as ModelRequest[PluginConfig]),
+        # dump to plain data and retry so the action's schema wins.
         try:
-            return self._input_type.validate_python(input)
+            try:
+                return self._input_type.validate_python(input)
+            except ValidationError:
+                if not isinstance(input, BaseModel):
+                    raise
+                return self._input_type.validate_python(input.model_dump(mode='python'))
         except ValidationError as e:
             if input is None:
                 raise GenkitError(

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -696,9 +696,10 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         if input is None and self._first_arg_optional:
             return input
         payload: object = input
-        # When a BaseModel instance fails (e.g. generate hands ModelRequest with
-        # GenerationCommonConfig into an action typed as ModelRequest[PluginConfig]),
-        # dump to plain data and retry so the action's schema wins.
+        # If input is a BaseModel instance of a different generic type (e.g. caller passes
+        # ModelRequest[dict] to an action typed as ModelRequest[PluginConfig]), Pydantic rejects
+        # direct validation due to class mismatch. Try validating directly first; if it fails,
+        # dump to a plain dict so the action's target schema wins.
         if isinstance(input, BaseModel):
             try:
                 return self._input_type.validate_python(input)

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -25,7 +25,7 @@ from typing import Any, Generic, TypeVar, cast
 from pydantic import BaseModel
 
 from genkit._core._action import Action, ActionKind, ActionRunContext
-from genkit._core._model import ConfigT, ModelRequest, ModelResponse
+from genkit._core._model import ModelRequestConfigT, ModelRequest, ModelResponse
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
@@ -51,7 +51,7 @@ def make_action_key(action_type: ActionKind | str, name: str) -> str:
 
 
 # Type aliases for background model start/check/cancel handlers.
-StartModelOpFn = Callable[[ModelRequest[ConfigT], ActionRunContext], Awaitable[Operation]]
+StartModelOpFn = Callable[[ModelRequest[ModelRequestConfigT], ActionRunContext], Awaitable[Operation]]
 CheckModelOpFn = Callable[[Operation], Awaitable[Operation]]
 CancelModelOpFn = Callable[[Operation], Awaitable[Operation]]
 
@@ -194,12 +194,12 @@ class DefineBackgroundModelOptions(BaseModel):
 def define_background_model(
     registry: Registry,
     name: str,
-    start: StartModelOpFn[ConfigT],
+    start: StartModelOpFn[ModelRequestConfigT],
     check: CheckModelOpFn,
     cancel: CancelModelOpFn | None = None,
     label: str | None = None,
     info: ModelInfo | None = None,
-    config_schema: type[ConfigT] | dict[str, Any] | None = None,
+    config_schema: type[ModelRequestConfigT] | dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
     description: str | None = None,
 ) -> BackgroundAction[ModelResponse]:
@@ -269,7 +269,7 @@ def define_background_model(
     # when config_schema is set we override to ModelRequest[that schema] below.
     async def wrapped_start(request: ModelRequest, ctx: ActionRunContext) -> Operation:
         start_time = time.perf_counter()
-        op = await start(cast(ModelRequest[ConfigT], request), ctx)
+        op = await start(cast(ModelRequest[ModelRequestConfigT], request), ctx)
         # Set action key matching JS format: /{actionType}/{name}
         op.action = action_key
         latency_ms = (time.perf_counter() - start_time) * 1000

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -246,9 +246,9 @@ def define_background_model(
     # Wrap the start function to add the action key and timing.
     # Annotate as bare ModelRequest so Action doesn't build TypeAdapter(ModelRequest[TypeVar]);
     # when config_schema is set we override to ModelRequest[that schema] below.
-    async def wrapped_start(request: ModelRequest, ctx: ActionRunContext) -> Operation:
+    async def wrapped_start(request: ModelRequest[ModelRequestConfigT], ctx: ActionRunContext) -> Operation:
         start_time = time.perf_counter()
-        op = await start(cast(ModelRequest[ModelRequestConfigT], request), ctx)
+        op = await start(request, ctx)
         # Set action key in format: /{actionType}/{name}
         op.action = action_key
         latency_ms = (time.perf_counter() - start_time) * 1000

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -38,7 +38,7 @@ OutputT = TypeVar('OutputT')
 
 
 def make_action_key(action_type: ActionKind | str, name: str) -> str:
-    """Create an action key matching JS format: /{actionType}/{name}.
+    """Create an action key in format: /{actionType}/{name}.
 
     Args:
         action_type: The action type (e.g., 'background-model').
@@ -62,11 +62,8 @@ class BackgroundAction(Generic[OutputT]):
     Unlike regular actions, background actions can run for extended periods.
     The returned operation can be used to check status and retrieve the response.
 
-    This class matches the JS BackgroundAction interface from
-    js/core/src/background-action.ts.
-
     Attributes:
-        __action: Action metadata (matches JS __action property).
+        __action: Action metadata.
         start_action: Action to start the operation.
         check_action: Action to check operation status.
         cancel_action: Optional action to cancel operations.
@@ -90,7 +87,7 @@ class BackgroundAction(Generic[OutputT]):
         self.check_action = check_action
         self.cancel_action = cancel_action
 
-        # Match JS __action property structure
+        # Store action metadata
         self.__action = {
             'name': start_action.name,
             'description': start_action.description,
@@ -115,8 +112,6 @@ class BackgroundAction(Generic[OutputT]):
     ) -> Operation:
         """Start a background operation.
 
-        Matches JS: start(input?, options?) => Promise<Operation<OutputT>>
-
         Args:
             input: The input request.
             options: Optional run options.
@@ -131,8 +126,6 @@ class BackgroundAction(Generic[OutputT]):
     async def check(self, operation: Operation) -> Operation:
         """Check the status of a background operation.
 
-        Matches JS: check(operation) => Promise<Operation<OutputT>>
-
         Args:
             operation: The operation to check.
 
@@ -146,10 +139,7 @@ class BackgroundAction(Generic[OutputT]):
     async def cancel(self, operation: Operation) -> Operation:
         """Cancel a background operation.
 
-        Matches JS: cancel(operation) => Promise<Operation<OutputT>>
-
-        If cancellation is not supported, returns the operation unchanged
-        (matching JS behavior).
+        If cancellation is not supported, returns the operation unchanged.
 
         Args:
             operation: The operation to cancel.
@@ -158,7 +148,7 @@ class BackgroundAction(Generic[OutputT]):
             Updated Operation reflecting cancellation attempt.
         """
         if self.cancel_action is None:
-            # Match JS behavior: return operation unchanged if cancel not supported
+            # Return operation unchanged if cancel not supported
             return operation
         result = await self.cancel_action.run(operation)
         res = result.response
@@ -167,8 +157,6 @@ class BackgroundAction(Generic[OutputT]):
 
 class DefineBackgroundModelOptions(BaseModel):
     """Options for defining a background model.
-
-    Matches JS DefineBackgroundModelOptions from js/ai/src/model.ts.
 
     Attributes:
         name: Unique name for this background model.
@@ -198,8 +186,6 @@ def define_background_model(
     description: str | None = None,
 ) -> BackgroundAction[ModelResponse]:
     """Define and register a background model.
-
-    This matches the JS defineBackgroundModel function from js/ai/src/model.ts.
 
     A background model consists of three actions:
     - Start action: /{background-model}/{name}
@@ -236,13 +222,12 @@ def define_background_model(
     label = label or name
     action_key = make_action_key(ActionKind.BACKGROUND_MODEL, name)
 
-    # Build model metadata matching JS structure
+    # Build model metadata
     model_meta: dict[str, Any] = metadata.copy() if metadata else {}
     model_options: dict[str, Any] = {}
 
     if info:
-        # camelCase wire keys (e.g. longRunning) so generate_operation's
-        # metadata check sees the same shape Dev UI / JS expect.
+        # Export camelCase wire keys (e.g. longRunning) for Dev UI compatibility.
         model_options.update(info.model_dump(by_alias=True, exclude_none=True))
 
     # Precedence: explicit label argument > info.label > fallback to model name
@@ -254,7 +239,7 @@ def define_background_model(
 
     model_meta['model'] = model_options
 
-    # Build output schema metadata (matching JS)
+    # Build output schema metadata
     output_schema_meta = to_json_schema(ModelResponse)
     model_meta['outputSchema'] = output_schema_meta
 
@@ -264,7 +249,7 @@ def define_background_model(
     async def wrapped_start(request: ModelRequest, ctx: ActionRunContext) -> Operation:
         start_time = time.perf_counter()
         op = await start(cast(ModelRequest[ModelRequestConfigT], request), ctx)
-        # Set action key matching JS format: /{actionType}/{name}
+        # Set action key in format: /{actionType}/{name}
         op.action = action_key
         latency_ms = (time.perf_counter() - start_time) * 1000
         if op.metadata is None:
@@ -272,7 +257,7 @@ def define_background_model(
         op.metadata['latencyMs'] = latency_ms
         return op
 
-    # Wrap the check function (matching JS - no ctx parameter)
+    # Wrap the check function
     async def wrapped_check(op: Operation, _: ActionRunContext) -> Operation:
         updated = await check(op)
         # Preserve action key
@@ -280,8 +265,6 @@ def define_background_model(
         return updated
 
     # Register the start action
-    # JS: actionType: config.actionType (background-model)
-    # JS: name: config.name
     start_action = registry.register_action(
         name=name,
         kind=ActionKind.BACKGROUND_MODEL,
@@ -297,8 +280,6 @@ def define_background_model(
         start_action._override_input_schema(cast('type[BaseModel]', cast(Any, ModelRequest)[config_schema]))
 
     # Register the check action
-    # JS: actionType: 'check-operation'
-    # JS: name: `${config.name}/check`
     check_action = registry.register_action(
         name=f'{name}/check',
         kind=ActionKind.CHECK_OPERATION,
@@ -308,8 +289,6 @@ def define_background_model(
     )
 
     # Register the cancel action if provided
-    # JS: actionType: 'cancel-operation'
-    # JS: name: `${config.name}/cancel`
     cancel_action = None
     if cancel is not None:
         # Capture cancel in local scope for the nested function
@@ -341,8 +320,6 @@ async def lookup_background_action(
 ) -> BackgroundAction[ModelResponse] | None:
     """Look up a background action by its action key.
 
-    Matches JS lookupBackgroundAction from js/core/src/background-action.ts.
-
     The key format is /{actionType}/{name}, e.g., /background-model/video-gen.
 
     Args:
@@ -358,7 +335,6 @@ async def lookup_background_action(
         return None
 
     # Extract action name from key: /{actionType}/{name} -> {name}
-    # JS: const actionName = key.substring(key.indexOf('/', 1) + 1);
     parts = key.split('/', 2)  # ['', 'background-model', 'name']
     if len(parts) < 3:
         return None
@@ -386,8 +362,6 @@ async def check_operation(
     operation: Operation,
 ) -> Operation:
     """Check the status of a background operation.
-
-    Matches JS checkOperation from js/ai/src/check-operation.ts.
 
     Args:
         registry: The registry to look up actions from.

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -20,12 +20,12 @@ from __future__ import annotations
 
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
 
 from pydantic import BaseModel
 
 from genkit._core._action import Action, ActionKind, ActionRunContext
-from genkit._core._model import ModelRequest, ModelResponse
+from genkit._core._model import ConfigT, ModelRequest, ModelResponse
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
@@ -37,7 +37,7 @@ from genkit._core._typing import (
 OutputT = TypeVar('OutputT')
 
 
-def _make_action_key(action_type: ActionKind | str, name: str) -> str:
+def make_action_key(action_type: ActionKind | str, name: str) -> str:
     """Create an action key matching JS format: /{actionType}/{name}.
 
     Args:
@@ -50,12 +50,9 @@ def _make_action_key(action_type: ActionKind | str, name: str) -> str:
     return f'/{action_type}/{name}'
 
 
-# Type aliases for background model functions matching JS signatures
-# JS: start: (input, options) => Promise<Operation<OutputT>>
-StartModelOpFn = Callable[[ModelRequest, ActionRunContext], Awaitable[Operation]]
-# JS: check: (input: Operation<OutputT>) => Promise<Operation<OutputT>>
+# Type aliases for background model start/check/cancel handlers.
+StartModelOpFn = Callable[[ModelRequest[ConfigT], ActionRunContext], Awaitable[Operation]]
 CheckModelOpFn = Callable[[Operation], Awaitable[Operation]]
-# JS: cancel?: (input: Operation<OutputT>) => Promise<Operation<OutputT>>
 CancelModelOpFn = Callable[[Operation], Awaitable[Operation]]
 
 
@@ -128,7 +125,7 @@ class BackgroundAction(Generic[OutputT]):
             An Operation with an ID to track the job.
         """
         result = await self.start_action.run(input)
-        return _ensure_operation(result.response)
+        return ensure_operation(result.response)
 
     async def check(self, operation: Operation) -> Operation:
         """Check the status of a background operation.
@@ -142,7 +139,7 @@ class BackgroundAction(Generic[OutputT]):
             Updated Operation with current status.
         """
         result = await self.check_action.run(operation)
-        return _ensure_operation(result.response)
+        return ensure_operation(result.response)
 
     async def cancel(self, operation: Operation) -> Operation:
         """Cancel a background operation.
@@ -162,10 +159,10 @@ class BackgroundAction(Generic[OutputT]):
             # Match JS behavior: return operation unchanged if cancel not supported
             return operation
         result = await self.cancel_action.run(operation)
-        return _ensure_operation(result.response)
+        return ensure_operation(result.response)
 
 
-def _ensure_operation(response: Any) -> Operation:  # noqa: ANN401
+def ensure_operation(response: Any) -> Operation:  # noqa: ANN401
     """Convert response to Operation type."""
     if isinstance(response, Operation):
         return response
@@ -197,12 +194,12 @@ class DefineBackgroundModelOptions(BaseModel):
 def define_background_model(
     registry: Registry,
     name: str,
-    start: StartModelOpFn,
+    start: StartModelOpFn[ConfigT],
     check: CheckModelOpFn,
     cancel: CancelModelOpFn | None = None,
     label: str | None = None,
     info: ModelInfo | None = None,
-    config_schema: type | dict[str, Any] | None = None,
+    config_schema: type[ConfigT] | dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
     description: str | None = None,
 ) -> BackgroundAction[ModelResponse]:
@@ -242,13 +239,16 @@ def define_background_model(
         ...     await asyncio.sleep(5)
         ...     op = await action.check(op)
     """
-    action_key = _make_action_key(ActionKind.BACKGROUND_MODEL, name)
+    label = label or name
+    action_key = make_action_key(ActionKind.BACKGROUND_MODEL, name)
 
     # Build model metadata matching JS structure
     model_meta: dict[str, Any] = metadata.copy() if metadata else {}
     model_options: dict[str, Any] = {}
 
     if info:
+        # camelCase wire keys (e.g. longRunning) so generate_operation's
+        # metadata check sees the same shape Dev UI / JS expect.
         model_options.update(info.model_dump(by_alias=True, exclude_none=True))
 
     # Precedence: explicit label argument > info.label > fallback to model name
@@ -264,10 +264,12 @@ def define_background_model(
     output_schema_meta = to_json_schema(ModelResponse)
     model_meta['outputSchema'] = output_schema_meta
 
-    # Wrap the start function to add the action key and timing (matching JS)
+    # Wrap the start function to add the action key and timing.
+    # Annotate as bare ModelRequest so Action doesn't build TypeAdapter(ModelRequest[TypeVar]);
+    # when config_schema is set we override to ModelRequest[that schema] below.
     async def wrapped_start(request: ModelRequest, ctx: ActionRunContext) -> Operation:
         start_time = time.perf_counter()
-        op = await start(request, ctx)
+        op = await start(cast(ModelRequest[ConfigT], request), ctx)
         # Set action key matching JS format: /{actionType}/{name}
         op.action = action_key
         latency_ms = (time.perf_counter() - start_time) * 1000
@@ -277,7 +279,7 @@ def define_background_model(
         return op
 
     # Wrap the check function (matching JS - no ctx parameter)
-    async def wrapped_check(op: Operation, ctx: ActionRunContext) -> Operation:
+    async def wrapped_check(op: Operation, _: ActionRunContext) -> Operation:
         updated = await check(op)
         # Preserve action key
         updated.action = action_key
@@ -293,6 +295,12 @@ def define_background_model(
         metadata=model_meta,
         description=description or f'Background model: {label}',
     )
+    # wrapped_start is annotated as bare ModelRequest so Action doesn't build
+    # TypeAdapter(ModelRequest[TypeVar]). When callers pass a concrete config
+    # class, validate start input as ModelRequest[ConfigT].
+    if isinstance(config_schema, type):
+        # Parameterizing at runtime, so the subscript can't be a type expression.
+        start_action._override_input_schema(cast(type, cast(Any, ModelRequest)[config_schema]))
 
     # Register the check action
     # JS: actionType: 'check-operation'
@@ -313,7 +321,7 @@ def define_background_model(
         # Capture cancel in local scope for the nested function
         cancel_fn = cancel
 
-        async def wrapped_cancel(op: Operation, ctx: ActionRunContext) -> Operation:
+        async def wrapped_cancel(op: Operation, _: ActionRunContext) -> Operation:
             cancelled = await cancel_fn(op)
             cancelled.action = action_key
             return cancelled

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -125,7 +125,8 @@ class BackgroundAction(Generic[OutputT]):
             An Operation with an ID to track the job.
         """
         result = await self.start_action.run(input)
-        return ensure_operation(result.response)
+        res = result.response
+        return Operation.model_validate(res) if isinstance(res, dict) else res
 
     async def check(self, operation: Operation) -> Operation:
         """Check the status of a background operation.
@@ -139,7 +140,8 @@ class BackgroundAction(Generic[OutputT]):
             Updated Operation with current status.
         """
         result = await self.check_action.run(operation)
-        return ensure_operation(result.response)
+        res = result.response
+        return Operation.model_validate(res) if isinstance(res, dict) else res
 
     async def cancel(self, operation: Operation) -> Operation:
         """Cancel a background operation.
@@ -159,16 +161,8 @@ class BackgroundAction(Generic[OutputT]):
             # Match JS behavior: return operation unchanged if cancel not supported
             return operation
         result = await self.cancel_action.run(operation)
-        return ensure_operation(result.response)
-
-
-def ensure_operation(response: object) -> Operation:
-    """Convert response to Operation type."""
-    if isinstance(response, Operation):
-        return response
-    if isinstance(response, dict):
-        return Operation.model_validate(response)
-    raise TypeError(f'Expected Operation, got {type(response)}')
+        res = result.response
+        return Operation.model_validate(res) if isinstance(res, dict) else res
 
 
 class DefineBackgroundModelOptions(BaseModel):

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
 
@@ -276,7 +276,7 @@ def define_background_model(
     # TypeAdapter(ModelRequest[TypeVar]). When callers pass a concrete config
     # class, validate start input as ModelRequest[ConfigT].
     if isinstance(config_schema, type):
-        start_action._override_input_schema(cast(Any, ModelRequest)[config_schema])
+        start_action._override_input_schema(ModelRequest[config_schema])  # ty: ignore[invalid-type-form]
 
     # Register the check action
     check_action = registry.register_action(

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -276,8 +276,7 @@ def define_background_model(
     # TypeAdapter(ModelRequest[TypeVar]). When callers pass a concrete config
     # class, validate start input as ModelRequest[ConfigT].
     if isinstance(config_schema, type):
-        # Parameterizing at runtime, so the subscript can't be a type expression.
-        start_action._override_input_schema(cast('type[BaseModel]', cast(Any, ModelRequest)[config_schema]))
+        start_action._override_input_schema(cast(Any, ModelRequest)[config_schema])
 
     # Register the check action
     check_action = registry.register_action(

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -25,7 +25,7 @@ from typing import Any, Generic, TypeVar, cast
 from pydantic import BaseModel
 
 from genkit._core._action import Action, ActionKind, ActionRunContext
-from genkit._core._model import ModelRequestConfigT, ModelRequest, ModelResponse
+from genkit._core._model import ModelRequest, ModelRequestConfigT, ModelResponse
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
 from genkit._core._typing import (

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -162,7 +162,7 @@ class BackgroundAction(Generic[OutputT]):
         return ensure_operation(result.response)
 
 
-def ensure_operation(response: Any) -> Operation:  # noqa: ANN401
+def ensure_operation(response: object) -> Operation:
     """Convert response to Operation type."""
     if isinstance(response, Operation):
         return response

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -300,7 +300,7 @@ def define_background_model(
     # class, validate start input as ModelRequest[ConfigT].
     if isinstance(config_schema, type):
         # Parameterizing at runtime, so the subscript can't be a type expression.
-        start_action._override_input_schema(cast(type, cast(Any, ModelRequest)[config_schema]))
+        start_action._override_input_schema(cast('type[BaseModel]', cast(Any, ModelRequest)[config_schema]))
 
     # Register the check action
     # JS: actionType: 'check-operation'

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -219,7 +219,6 @@ def define_background_model(
         ...     await asyncio.sleep(5)
         ...     op = await action.check(op)
     """
-    label = label or name
     action_key = make_action_key(ActionKind.BACKGROUND_MODEL, name)
 
     # Build model metadata

--- a/py/packages/genkit/src/genkit/_core/_middleware.py
+++ b/py/packages/genkit/src/genkit/_core/_middleware.py
@@ -36,7 +36,7 @@ from genkit._core._model import (
     ModelResponseChunk,
 )
 from genkit._core._protocols import GenkitLike, RegistryLike
-from genkit._core._typing import MiddlewareDesc, MultipartToolResponse, ToolRequestPart
+from genkit._core._typing import MiddlewareDesc, MultipartToolResponse, Operation, ToolRequestPart
 
 logger = get_logger(__name__)
 
@@ -268,8 +268,8 @@ class BaseMiddleware(Generic[TConfig]):
         self,
         params: ModelHookParams,
         ctx: GenerateMiddlewareContext,
-        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
-    ) -> ModelResponse:
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse | Operation]],
+    ) -> ModelResponse | Operation:
         """Wrap each model API call."""
         return await next_fn(params, ctx)
 
@@ -317,8 +317,8 @@ class MiddlewareDef(Protocol):
         self,
         params: ModelHookParams,
         ctx: GenerateMiddlewareContext,
-        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse]],
-    ) -> ModelResponse:
+        next_fn: Callable[[ModelHookParams, GenerateMiddlewareContext], Awaitable[ModelResponse | Operation]],
+    ) -> ModelResponse | Operation:
         """Wrap each model API call."""
         ...
 

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -309,7 +309,7 @@ class ModelRequest(GenkitModel, Generic[ModelRequestConfigT]):
 
     @model_serializer(mode='wrap')
     def _serialize_for_spec(self, serializer: Callable[..., dict[str, Any]]) -> dict[str, Any]:
-        """Serialize to spec wire format with nested output (matches JS/Go)."""
+        """Serialize to spec wire format with nested output."""
         data = serializer(self)
         # Build nested output from flat fields - spec expects output key always present
         output: dict[str, Any] = {}

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -64,7 +64,9 @@ ModelUsage = GenerationUsage  # public name for GenerationUsage
 
 # TypeVars for generic types
 OutputT = TypeVar('OutputT', default=object)
-ConfigT = TypeVar('ConfigT', bound=ModelConfig, default=ModelConfig)
+# No default — callers/actions bind ModelRequest[TheirConfig]. A ModelConfig
+# default would reject plugin config instances on bare ModelRequest.
+ConfigT = TypeVar('ConfigT', bound=BaseModel)
 
 
 class ModelRef(BaseModel):
@@ -254,6 +256,27 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
     output_schema: dict[str, Any] | None = None
     output_constrained: bool | None = None
     output_content_type: str | None = None
+
+    @field_validator('config', mode='plain')
+    @classmethod
+    def _validate_config(cls, v: object) -> object:
+        """Accept plugin config models and dicts without forcing ModelConfig.
+
+        Bare ModelRequest(config={...}) keeps the dict; ModelRequest[PluginConfig]
+        coerces that dict into the plugin schema. Plugin config instances pass through.
+        """
+        if v is None:
+            return None
+        if isinstance(v, BaseModel):
+            return v
+        if isinstance(v, dict):
+            args = cls.__pydantic_generic_metadata__['args']
+            if args:
+                schema = args[0]
+                if isinstance(schema, type) and issubclass(schema, BaseModel):
+                    return schema.model_validate(v)
+            return v
+        raise TypeError(f'config must be a BaseModel or dict, got {type(v).__name__}')
 
     @field_validator('messages', mode='before')
     @classmethod

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -263,13 +263,10 @@ class ModelRequest(GenkitModel, Generic[ModelRequestConfigT]):
     output_constrained: bool | None = None
     output_content_type: str | None = None
 
-    @field_validator('config', mode='before')
-    @classmethod
-    def _validate_config(cls, v: object) -> object:
+    def model_post_init(self, __context: object) -> None:
         """Ensure config is None, a dict, or a BaseModel instance."""
-        if v is None or isinstance(v, (BaseModel, dict)):
-            return v
-        raise TypeError(f'config must be a BaseModel or dict, got {type(v).__name__}')
+        if self.config is not None and not isinstance(self.config, (BaseModel, dict)):
+            raise TypeError(f'config must be a BaseModel or dict, got {type(self.config).__name__}')
 
     @model_validator(mode='before')
     @classmethod

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, ClassVar, Generic, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_serializer, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_serializer
 from pydantic.alias_generators import to_camel
 from typing_extensions import TypeVar
 
@@ -267,8 +267,6 @@ class ModelRequest(GenkitModel, Generic[ModelRequestConfigT]):
         """Ensure config is None, a dict, or a BaseModel instance."""
         if self.config is not None and not isinstance(self.config, (BaseModel, dict)):
             raise TypeError(f'config must be a BaseModel or dict, got {type(self.config).__name__}')
-
-
 
     @field_validator('messages', mode='before')
     @classmethod

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -25,18 +25,9 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, cast
+from typing import Any, ClassVar, Generic, cast
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    PrivateAttr,
-    SerializeAsAny,
-    field_validator,
-    model_serializer,
-    model_validator,
-)
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_serializer, model_validator
 from pydantic.alias_generators import to_camel
 from typing_extensions import TypeVar
 
@@ -75,7 +66,9 @@ ModelUsage = GenerationUsage  # public name for GenerationUsage
 OutputT = TypeVar('OutputT', default=object)
 # No default — callers/actions bind ModelRequest[TheirConfig]. A ModelConfig
 # default would reject plugin config instances on bare ModelRequest.
-ConfigT = TypeVar('ConfigT', bound=BaseModel)
+# Unbounded so ModelRequest supports any config payload (BaseModel instances, dicts, custom options)
+# across action execution boundaries without forcing assumptions.
+ModelRequestConfigT = TypeVar('ModelRequestConfigT', covariant=True)
 
 
 class ModelRef(BaseModel):
@@ -234,7 +227,7 @@ class Document(DocumentData):
         return None
 
 
-class ModelRequest(GenkitModel, Generic[ConfigT]):
+class ModelRequest(GenkitModel, Generic[ModelRequestConfigT]):
     """Hand-written model request with flat output fields and veneer types.
 
     Output config is inlined as flat fields (output_format, output_schema, etc.)
@@ -257,15 +250,7 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
     # Veneer types for IDE/typing (validators wrap MessageData->Message, DocumentData->Document)
     messages: list[Message]  # pyright: ignore[reportIncompatibleVariableOverride]
     docs: list[Document] | None = None  # pyright: ignore[reportIncompatibleVariableOverride]
-    if TYPE_CHECKING:
-        # Reads are typed as the bound schema: after validation a parametrized
-        # request can only hold ConfigT (dicts are coerced, mismatches rejected).
-        # The runtime union is what pydantic validates and serializes against.
-        config: ConfigT | None = None
-    else:
-        # dict arm first + left_to_right: smart union would lax-coerce bare dict
-        # configs into an empty BaseModel via the unresolved ConfigT arm.
-        config: dict[str, Any] | SerializeAsAny[ConfigT] | None = Field(default=None, union_mode='left_to_right')
+    config: ModelRequestConfigT | None = None
     tools: list[ToolDefinition] | None = None
     tool_choice: ToolChoice | None = Field(default=None)
     # Flat output fields (no nested OutputConfig)
@@ -274,40 +259,11 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
     output_constrained: bool | None = None
     output_content_type: str | None = None
 
-    if TYPE_CHECKING:
-
-        def __init__(
-            self,
-            *,
-            messages: list[Message],
-            docs: list[Document] | None = None,
-            config: ConfigT | dict[str, Any] | None = None,
-            tools: list[ToolDefinition] | None = None,
-            tool_choice: ToolChoice | None = None,
-            output_format: str | None = None,
-            output_schema: dict[str, Any] | None = None,
-            output_constrained: bool | None = None,
-            output_content_type: str | None = None,
-            **extras: Any,  # noqa: ANN401
-        ) -> None: ...
-
     @field_validator('config', mode='before')
     @classmethod
     def _validate_config(cls, v: object) -> object:
-        """Coerce dict configs into the bound plugin schema when parametrized.
-
-        Bare ModelRequest(config={...}) keeps the dict; ModelRequest[PluginConfig]
-        coerces that dict into the plugin schema. Plugin config instances pass
-        through here, then union validation rejects mismatched schemas.
-        """
-        if v is None or isinstance(v, BaseModel):
-            return v
-        if isinstance(v, dict):
-            args = cls.__pydantic_generic_metadata__['args']
-            if args:
-                schema = args[0]
-                if isinstance(schema, type) and issubclass(schema, BaseModel):
-                    return schema.model_validate(v)
+        """Ensure config is None, a dict, or a BaseModel instance."""
+        if v is None or isinstance(v, (BaseModel, dict)):
             return v
         raise TypeError(f'config must be a BaseModel or dict, got {type(v).__name__}')
 

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -268,25 +268,7 @@ class ModelRequest(GenkitModel, Generic[ModelRequestConfigT]):
         if self.config is not None and not isinstance(self.config, (BaseModel, dict)):
             raise TypeError(f'config must be a BaseModel or dict, got {type(self.config).__name__}')
 
-    @model_validator(mode='before')
-    @classmethod
-    def _flatten_output(cls, data: object) -> object:
-        """Accept spec wire format: unnest output into the flat output_* fields."""
-        if not isinstance(data, dict):
-            return data
-        flat = cast('dict[str, Any]', dict(data))
-        output = flat.pop('output', None)
-        if not isinstance(output, dict):
-            return data
-        for src, camel, snake in (
-            ('format', 'outputFormat', 'output_format'),
-            ('schema', 'outputSchema', 'output_schema'),
-            ('constrained', 'outputConstrained', 'output_constrained'),
-            ('contentType', 'outputContentType', 'output_content_type'),
-        ):
-            if src in output and camel not in flat and snake not in flat:
-                flat[camel] = output[src]
-        return flat
+
 
     @field_validator('messages', mode='before')
     @classmethod

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from copy import deepcopy
+from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, ClassVar, Generic, cast
 
@@ -47,6 +48,7 @@ from genkit._core._typing import (
     MediaPart,
     MessageData,
     MiddlewareRef,
+    ModelInfo,
     ModelResponseChunk as ModelResponseChunkSchema,
     Operation,
     Part,
@@ -64,21 +66,23 @@ ModelUsage = GenerationUsage  # public name for GenerationUsage
 
 # TypeVars for generic types
 OutputT = TypeVar('OutputT', default=object)
-# No default — callers/actions bind ModelRequest[TheirConfig]. A ModelConfig
-# default would reject plugin config instances on bare ModelRequest.
+# Bound to BaseModel so ModelRef is always parameterized with a concrete Pydantic config schema.
+# Covariant so ModelRef[GeminiConfig] is assignable to ModelRef[BaseModel] or ModelRef[Any].
+ModelRefConfigT = TypeVar('ModelRefConfigT', bound=BaseModel, covariant=True)
 # Unbounded so ModelRequest supports any config payload (BaseModel instances, dicts, custom options)
 # across action execution boundaries without forcing assumptions.
 ModelRequestConfigT = TypeVar('ModelRequestConfigT', covariant=True)
 
 
-class ModelRef(BaseModel):
-    """Reference to a model with configuration."""
+@dataclass(frozen=True, kw_only=True)
+class ModelRef(Generic[ModelRefConfigT]):
+    """Frozen reference to a model, optionally tied to a config schema."""
 
     name: str
-    config_schema: object | None = None
-    info: object | None = None
+    config_schema: type[ModelRefConfigT]
+    info: ModelInfo | None = None
     version: str | None = None
-    config: dict[str, object] | None = None
+    config: ModelRefConfigT | None = None
 
 
 class Message(MessageData):

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -25,9 +25,18 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from functools import cached_property
-from typing import Any, ClassVar, Generic, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_serializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    SerializeAsAny,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 from pydantic.alias_generators import to_camel
 from typing_extensions import TypeVar
 
@@ -248,7 +257,15 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
     # Veneer types for IDE/typing (validators wrap MessageData->Message, DocumentData->Document)
     messages: list[Message]  # pyright: ignore[reportIncompatibleVariableOverride]
     docs: list[Document] | None = None  # pyright: ignore[reportIncompatibleVariableOverride]
-    config: ConfigT | None = None
+    if TYPE_CHECKING:
+        # Reads are typed as the bound schema: after validation a parametrized
+        # request can only hold ConfigT (dicts are coerced, mismatches rejected).
+        # The runtime union is what pydantic validates and serializes against.
+        config: ConfigT | None = None
+    else:
+        # dict arm first + left_to_right: smart union would lax-coerce bare dict
+        # configs into an empty BaseModel via the unresolved ConfigT arm.
+        config: dict[str, Any] | SerializeAsAny[ConfigT] | None = Field(default=None, union_mode='left_to_right')
     tools: list[ToolDefinition] | None = None
     tool_choice: ToolChoice | None = Field(default=None)
     # Flat output fields (no nested OutputConfig)
@@ -257,17 +274,33 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
     output_constrained: bool | None = None
     output_content_type: str | None = None
 
-    @field_validator('config', mode='plain')
+    if TYPE_CHECKING:
+
+        def __init__(
+            self,
+            *,
+            messages: list[Message],
+            docs: list[Document] | None = None,
+            config: ConfigT | dict[str, Any] | None = None,
+            tools: list[ToolDefinition] | None = None,
+            tool_choice: ToolChoice | None = None,
+            output_format: str | None = None,
+            output_schema: dict[str, Any] | None = None,
+            output_constrained: bool | None = None,
+            output_content_type: str | None = None,
+            **extras: Any,  # noqa: ANN401
+        ) -> None: ...
+
+    @field_validator('config', mode='before')
     @classmethod
     def _validate_config(cls, v: object) -> object:
-        """Accept plugin config models and dicts without forcing ModelConfig.
+        """Coerce dict configs into the bound plugin schema when parametrized.
 
         Bare ModelRequest(config={...}) keeps the dict; ModelRequest[PluginConfig]
-        coerces that dict into the plugin schema. Plugin config instances pass through.
+        coerces that dict into the plugin schema. Plugin config instances pass
+        through here, then union validation rejects mismatched schemas.
         """
-        if v is None:
-            return None
-        if isinstance(v, BaseModel):
+        if v is None or isinstance(v, BaseModel):
             return v
         if isinstance(v, dict):
             args = cls.__pydantic_generic_metadata__['args']
@@ -277,6 +310,26 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
                     return schema.model_validate(v)
             return v
         raise TypeError(f'config must be a BaseModel or dict, got {type(v).__name__}')
+
+    @model_validator(mode='before')
+    @classmethod
+    def _flatten_output(cls, data: object) -> object:
+        """Accept spec wire format: unnest output into the flat output_* fields."""
+        if not isinstance(data, dict):
+            return data
+        flat = cast('dict[str, Any]', dict(data))
+        output = flat.pop('output', None)
+        if not isinstance(output, dict):
+            return data
+        for src, camel, snake in (
+            ('format', 'outputFormat', 'output_format'),
+            ('schema', 'outputSchema', 'output_schema'),
+            ('constrained', 'outputConstrained', 'output_constrained'),
+            ('contentType', 'outputContentType', 'output_content_type'),
+        ):
+            if src in output and camel not in flat and snake not in flat:
+                flat[camel] = output[src]
+        return flat
 
     @field_validator('messages', mode='before')
     @classmethod

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -767,6 +767,9 @@ class Registry:
         """
         action = await self.resolve_action(ActionKind.MODEL, name)
         if action is None:
+            # background-only models (Veo, Deep Research) live under a different kind
+            action = await self.resolve_action(ActionKind.BACKGROUND_MODEL, name)
+        if action is None:
             return None
         return cast(
             Action[ModelRequest, ModelResponse, ModelResponseChunk],

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -405,6 +405,14 @@ class Registry:
             return local
         return {**self._parent.list_values(kind), **local}
 
+    def plugin_names(self) -> list[str]:
+        """Names of registered plugins, parent-first, deduplicated."""
+        with self._lock:
+            local = list(self._plugins)
+        if self._parent is None:
+            return local
+        return list(dict.fromkeys([*self._parent.plugin_names(), *local]))
+
     def register_plugin(self, plugin: Plugin) -> None:
         """Register a plugin with the registry.
 

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -405,14 +405,6 @@ class Registry:
             return local
         return {**self._parent.list_values(kind), **local}
 
-    def plugin_names(self) -> list[str]:
-        """Names of registered plugins, parent-first, deduplicated."""
-        with self._lock:
-            local = list(self._plugins)
-        if self._parent is None:
-            return local
-        return list(dict.fromkeys([*self._parent.plugin_names(), *local]))
-
     def register_plugin(self, plugin: Plugin) -> None:
         """Register a plugin with the registry.
 

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for background model generate() and generate_operation() plumbing."""
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from genkit import Genkit, Message, ModelResponse, Part, Role, TextPart
+from genkit._core._action import ActionRunContext
+from genkit._core._error import GenkitError
+from genkit._core._model import ModelRequest
+from genkit._core._typing import ModelInfo, Operation, Supports
+
+
+@pytest.fixture
+def ai() -> Genkit:
+    """Create a fresh Genkit instance for each test."""
+    return Genkit()
+
+
+async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> None:
+    async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
+        return Operation(id=op_id, done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    ai.define_background_model(
+        name='bg-model',
+        start=start,
+        check=check,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+
+class PluginConfig(BaseModel):
+    thinking_summaries: str | None = None
+    google_search: bool | None = None
+
+
+@pytest.mark.asyncio
+async def test_background_start_receives_plugin_config_schema(ai: Genkit) -> None:
+    """Bare ModelRequest configs are re-validated as the plugin config schema."""
+    seen: dict[str, Any] = {}
+
+    async def start(request: ModelRequest[PluginConfig], _: ActionRunContext) -> Operation:
+        seen['config'] = request.config
+        return Operation(id='cfg-op', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    action = ai.define_background_model(
+        name='cfg-model',
+        start=start,
+        check=check,
+        config_schema=PluginConfig,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+    # Mimic generate: bare ModelRequest keeps a dict; Action coerces to the plugin schema.
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='go'))])],
+        config={'thinking_summaries': 'auto', 'google_search': True},
+    )
+    assert request.config == {'thinking_summaries': 'auto', 'google_search': True}
+
+    await action.start(request)
+
+    config = seen['config']
+    assert isinstance(config, PluginConfig)
+    assert config.thinking_summaries == 'auto'
+    assert config.google_search is True
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_operation_for_background_model(ai: Genkit) -> None:
+    """generate() wraps a background model Operation in ModelResponse."""
+    await register_bg_model(ai)
+
+    response = await ai.generate(model='bg-model', prompt='a cat surfing')
+
+    assert response.operation is not None
+    assert response.operation.id == 'bg-op-123'
+    assert response.operation.done is False
+    assert response.operation.action == '/background-model/bg-model'
+    assert response.message is None
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_with_background_model(ai: Genkit) -> None:
+    """generate_operation resolves background models via resolve_model()."""
+    await register_bg_model(ai, op_id='bg-op-456')
+
+    operation = await ai.generate_operation(model='bg-model', prompt='a cat surfing')
+
+    assert isinstance(operation, Operation)
+    assert operation.id == 'bg-op-456'
+    assert operation.action == '/background-model/bg-model'
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_rejects_foreground_model_without_lro(ai: Genkit) -> None:
+    """generate_operation rejects standard foreground models."""
+
+    async def model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
+        return ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='Hello'))],
+            ),
+        )
+
+    ai.define_model(name='fg-model', fn=model_fn)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await ai.generate_operation(model='fg-model', prompt='Hi')
+
+    assert 'does not support long running operations' in str(exc_info.value)

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -22,7 +22,8 @@ import pytest
 from pydantic import BaseModel
 
 from genkit import Genkit, Message, ModelResponse, Part, Role, TextPart
-from genkit._core._action import ActionRunContext
+from genkit._core._action import ActionKind, ActionRunContext
+from genkit._core._background import BackgroundAction
 from genkit._core._error import GenkitError
 from genkit._core._model import ModelRequest
 from genkit._core._typing import ModelInfo, Operation, Supports
@@ -34,14 +35,14 @@ def ai() -> Genkit:
     return Genkit()
 
 
-async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> None:
+async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> BackgroundAction:
     async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
         return Operation(id=op_id, done=False)
 
     async def check(op: Operation) -> Operation:
         return op
 
-    ai.define_background_model(
+    return ai.define_background_model(
         name='bg-model',
         start=start,
         check=check,
@@ -133,3 +134,60 @@ async def test_generate_operation_rejects_foreground_model_without_lro(ai: Genki
         await ai.generate_operation(model='fg-model', prompt='Hi')
 
     assert 'does not support long running operations' in str(exc_info.value)
+
+
+def register_cancellable_model(ai: Genkit, cancelled: list[str]) -> BackgroundAction:
+    async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
+        return Operation(id='op-1', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    async def cancel(op: Operation) -> Operation:
+        cancelled.append(op.id)
+        return Operation(id=op.id, done=True)
+
+    return ai.define_background_model(
+        name='cancellable-model',
+        start=start,
+        check=check,
+        cancel=cancel,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_runs_handler_and_preserves_action_key(ai: Genkit) -> None:
+    """cancel() invokes the handler and stamps the background action key."""
+    cancelled: list[str] = []
+    action = register_cancellable_model(ai, cancelled)
+
+    assert action.supports_cancel
+
+    result = await action.cancel(Operation(id='op-1', done=False))
+
+    assert cancelled == ['op-1']
+    assert result.done is True
+    assert result.action == '/background-model/cancellable-model'
+
+
+@pytest.mark.asyncio
+async def test_cancel_action_resolvable_via_registry(ai: Genkit) -> None:
+    """Cancel registers under cancel-operation kind at {name}/cancel."""
+    action = register_cancellable_model(ai, [])
+
+    resolved = await ai.registry.resolve_action(ActionKind.CANCEL_OPERATION, 'cancellable-model/cancel')
+
+    assert resolved is action.cancel_action
+
+
+@pytest.mark.asyncio
+async def test_cancel_without_handler_returns_operation_unchanged(ai: Genkit) -> None:
+    """Without a cancel handler the operation comes back untouched (JS parity)."""
+    action = await register_bg_model(ai)
+
+    assert not action.supports_cancel
+    assert await ai.registry.resolve_action(ActionKind.CANCEL_OPERATION, 'bg-model/cancel') is None
+
+    op = Operation(id='bg-op-123', done=False)
+    assert await action.cancel(op) is op

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -5,11 +5,14 @@
 
 """Tests for the action module."""
 
+import warnings
+
 import pytest
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from genkit import Message, ModelRequest, ModelResponse, ModelResponseChunk, ModelUsage
 from genkit._ai._model import text_from_content
+from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
     ActionMetadata,
     DocumentPart,
@@ -414,3 +417,54 @@ def test_parameterized_model_request_coerces_dict_to_plugin_config() -> None:
     )
     assert isinstance(request.config, PluginConfig)
     assert request.config.api_key == 'k'
+
+
+def test_parameterized_model_request_rejects_mismatched_config_instance() -> None:
+    class OtherConfig(BaseModel):
+        top_k: int | None = None
+
+    with pytest.raises(ValidationError):
+        ModelRequest[PluginConfig](
+            messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+            config=OtherConfig(top_k=3),  # pyright: ignore[reportArgumentType]
+        )
+
+
+def test_model_request_rejects_non_model_non_dict_config() -> None:
+    with pytest.raises(TypeError, match='config must be a BaseModel or dict'):
+        ModelRequest(
+            messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+            config='not-a-config',  # pyright: ignore[reportArgumentType]
+        )
+
+
+def test_parameterized_model_request_config_json_schema_refs_plugin_schema() -> None:
+    schema = to_json_schema(ModelRequest[PluginConfig])
+    config_prop = schema['properties']['config']
+    assert any('$ref' in arm for arm in config_prop.get('anyOf', [])), config_prop
+
+
+def test_model_request_dump_round_trip_preserves_output_config() -> None:
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'temperature': 0.5},
+        output_format='json',
+        output_schema={'type': 'object'},
+        output_constrained=True,
+    )
+    round_tripped = ModelRequest.model_validate(request.model_dump(mode='python'))
+    assert round_tripped.output_format == 'json'
+    assert round_tripped.output_schema == {'type': 'object'}
+    assert round_tripped.output_constrained is True
+    assert round_tripped.config == {'temperature': 0.5}
+
+
+def test_model_request_dump_emits_no_serializer_warnings() -> None:
+    request = ModelRequest[PluginConfig](
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'api_key': 'k'},
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        request.model_dump(mode='python')
+        request.model_dump_json()

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -451,6 +451,7 @@ def test_model_request_dump_emits_no_serializer_warnings() -> None:
         messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
         config={'api_key': 'k'},
     )
+    # Convert all Python/Pydantic warnings into hard errors so silent serialization warnings fail the test.
     with warnings.catch_warnings():
         warnings.simplefilter('error')
         request.model_dump(mode='python')

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -6,6 +6,7 @@
 """Tests for the action module."""
 
 import pytest
+from pydantic import BaseModel, ConfigDict
 
 from genkit import Message, ModelRequest, ModelResponse, ModelResponseChunk, ModelUsage
 from genkit._ai._model import text_from_content
@@ -20,6 +21,14 @@ from genkit._core._typing import (
     ToolRequestPart,
 )
 from genkit.model import get_basic_usage_stats, model_action_metadata
+
+
+class PluginConfig(BaseModel):
+    """Stand-in for a plugin-specific config schema (e.g. LyriaConfig)."""
+
+    model_config = ConfigDict(extra='allow')
+    api_key: str | None = None
+    response_modalities: list[str] | None = None
 
 
 def test_message_wrapper_text() -> None:
@@ -376,3 +385,32 @@ def test_text_from_content_with_none_text() -> None:
         Part(root=TextPart(text=' world')),
     ]
     assert text_from_content(content) == 'hello world'
+
+
+def test_bare_model_request_accepts_plugin_config_instance() -> None:
+    """Bare ModelRequest(config=PluginConfig) keeps the plugin schema instance."""
+    plugin_config = PluginConfig(api_key='k', response_modalities=['audio'])
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config=plugin_config,
+    )
+    assert request.config is plugin_config
+    assert isinstance(request.config, PluginConfig)
+
+
+def test_bare_model_request_keeps_dict_config() -> None:
+    """Dict configs stay dicts on bare ModelRequest; Action coerces to the plugin schema."""
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'temperature': 0.5, 'api_key': 'k'},
+    )
+    assert request.config == {'temperature': 0.5, 'api_key': 'k'}
+
+
+def test_parameterized_model_request_coerces_dict_to_plugin_config() -> None:
+    request = ModelRequest[PluginConfig](
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'api_key': 'k'},
+    )
+    assert isinstance(request.config, PluginConfig)
+    assert request.config.api_key == 'k'

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -444,20 +444,6 @@ def test_parameterized_model_request_config_json_schema_refs_plugin_schema() -> 
     assert any('$ref' in arm for arm in config_prop.get('anyOf', [])), config_prop
 
 
-def test_model_request_dump_round_trip_preserves_output_config() -> None:
-    request = ModelRequest(
-        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
-        config={'temperature': 0.5},
-        output_format='json',
-        output_schema={'type': 'object'},
-        output_constrained=True,
-    )
-    round_tripped = ModelRequest.model_validate(request.model_dump(mode='python'))
-    assert round_tripped.output_format == 'json'
-    assert round_tripped.output_schema == {'type': 'object'}
-    assert round_tripped.output_constrained is True
-    assert round_tripped.config == {'temperature': 0.5}
-
 
 def test_model_request_dump_emits_no_serializer_warnings() -> None:
     request = ModelRequest[PluginConfig](

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -439,13 +439,14 @@ def test_model_request_rejects_non_model_non_dict_config() -> None:
 
 
 def test_parameterized_model_request_config_json_schema_refs_plugin_schema() -> None:
+    """Verify JSON schema for ModelRequest[PluginConfig] includes a $ref to PluginConfig for Reflection API / Dev UI."""
     schema = to_json_schema(ModelRequest[PluginConfig])
     config_prop = schema['properties']['config']
     assert any('$ref' in arm for arm in config_prop.get('anyOf', [])), config_prop
 
 
-
 def test_model_request_dump_emits_no_serializer_warnings() -> None:
+    """Verify model_dump() and model_dump_json() execute without triggering Pydantic serialization warnings."""
     request = ModelRequest[PluginConfig](
         messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
         config={'api_key': 'k'},

--- a/py/packages/genkit/tests/genkit/ai/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/ai/prompt_test.py
@@ -100,7 +100,7 @@ async def test_simple_prompt() -> None:
     """Test simple prompt rendering."""
     ai, *_ = setup_test()
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     my_prompt = ai.define_prompt(prompt='hi', config={'temperature': 11})
 
@@ -123,7 +123,7 @@ async def test_simple_prompt_with_override_config() -> None:
     ai, *_ = setup_test()
 
     # Config is MERGED: prompt config (banana: true) + opts config (temperature: 12)
-    want_txt = '[ECHO] user: "hi" {"temperature":12.0,"banana":true}'
+    want_txt = '[ECHO] user: "hi" {"banana":true,"temperature":12}'
 
     my_prompt = ai.define_prompt(prompt='hi', config={'banana': True})
 
@@ -221,7 +221,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] system: "hello foo (bar)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] system: "hello foo (bar)" {"banana":"ripe","temperature":11.0}""",
     ),
     (
         'renders user prompt',
@@ -241,7 +241,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] user: "hello foo (bar_system)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] user: "hello foo (bar_system)" {"banana":"ripe","temperature":11.0}""",
     ),
     (
         'renders user prompt with context',
@@ -261,7 +261,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {'auth': {'email': 'a@b.c'}},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] user: "hello foo (bar, a@b.c)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] user: "hello foo (bar, a@b.c)" {"banana":"ripe","temperature":11.0}""",
     ),
 ]
 

--- a/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
@@ -18,44 +18,14 @@
 
 import pytest
 
-from genkit import GenkitError, Plugin
+from genkit import GenkitError
 from genkit._ai._generate import resolve_parameters
-from genkit._core._action import Action, ActionKind
 from genkit._core._model import GenerateActionOptions
 from genkit._core._registry import Registry
-from genkit._core._typing import ActionMetadata
-
-
-class _NamespacePlugin(Plugin):
-    def __init__(self, name: str) -> None:
-        self.name = name
-
-    async def init(self) -> list[Action]:
-        return []
-
-    async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
-        return None
-
-    async def list_actions(self) -> list[ActionMetadata]:
-        return []
 
 
 @pytest.mark.asyncio
-async def test_resolve_parameters_missing_prefix_hints_registered_namespaces() -> None:
-    registry = Registry()
-    registry.register_plugin(_NamespacePlugin('ollama'))
-    registry.register_plugin(_NamespacePlugin('openai'))
-    with pytest.raises(GenkitError) as exc_info:
-        await resolve_parameters(
-            registry,
-            GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
-        )
-    assert exc_info.value.status == 'NOT_FOUND'
-    assert "'ollama/lyria-3-clip-preview' or 'openai/lyria-3-clip-preview'" in str(exc_info.value)
-
-
-@pytest.mark.asyncio
-async def test_resolve_parameters_no_plugins_no_namespace_hint() -> None:
+async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> None:
     registry = Registry()
     with pytest.raises(GenkitError) as exc_info:
         await resolve_parameters(
@@ -63,7 +33,8 @@ async def test_resolve_parameters_no_plugins_no_namespace_hint() -> None:
             GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
         )
     assert exc_info.value.status == 'NOT_FOUND'
-    assert 'Did you mean' not in str(exc_info.value)
+    assert 'googleai/lyria-3-clip-preview' in str(exc_info.value)
+    assert 'vertexai/lyria-3-clip-preview' in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
@@ -33,8 +33,8 @@ async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> Non
             GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
         )
     assert exc_info.value.status == 'NOT_FOUND'
-    assert 'googleai/lyria-3-clip-preview' in str(exc_info.value)
-    assert 'vertexai/lyria-3-clip-preview' in str(exc_info.value)
+    assert "Failed to resolve model 'lyria-3-clip-preview'." in str(exc_info.value)
+    assert 'Ensure the model name includes a plugin prefix' in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for generate-path model resolution errors."""
+
+import pytest
+
+from genkit import GenkitError
+from genkit._ai._generate import resolve_parameters
+from genkit._core._model import GenerateActionOptions
+from genkit._core._registry import Registry
+
+
+@pytest.mark.asyncio
+async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> None:
+    registry = Registry()
+    with pytest.raises(GenkitError) as exc_info:
+        await resolve_parameters(
+            registry,
+            GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
+        )
+    assert exc_info.value.status == 'NOT_FOUND'
+    assert 'googleai/lyria-3-clip-preview' in str(exc_info.value)
+    assert 'vertexai/lyria-3-clip-preview' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_resolve_parameters_no_model_is_invalid_argument() -> None:
+    registry = Registry()
+    with pytest.raises(GenkitError) as exc_info:
+        await resolve_parameters(registry, GenerateActionOptions(messages=[]))
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'No model configured' in str(exc_info.value)

--- a/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
@@ -18,14 +18,44 @@
 
 import pytest
 
-from genkit import GenkitError
+from genkit import GenkitError, Plugin
 from genkit._ai._generate import resolve_parameters
+from genkit._core._action import Action, ActionKind
 from genkit._core._model import GenerateActionOptions
 from genkit._core._registry import Registry
+from genkit._core._typing import ActionMetadata
+
+
+class _NamespacePlugin(Plugin):
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def init(self) -> list[Action]:
+        return []
+
+    async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
+        return None
+
+    async def list_actions(self) -> list[ActionMetadata]:
+        return []
 
 
 @pytest.mark.asyncio
-async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> None:
+async def test_resolve_parameters_missing_prefix_hints_registered_namespaces() -> None:
+    registry = Registry()
+    registry.register_plugin(_NamespacePlugin('ollama'))
+    registry.register_plugin(_NamespacePlugin('openai'))
+    with pytest.raises(GenkitError) as exc_info:
+        await resolve_parameters(
+            registry,
+            GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
+        )
+    assert exc_info.value.status == 'NOT_FOUND'
+    assert "'ollama/lyria-3-clip-preview' or 'openai/lyria-3-clip-preview'" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_resolve_parameters_no_plugins_no_namespace_hint() -> None:
     registry = Registry()
     with pytest.raises(GenkitError) as exc_info:
         await resolve_parameters(
@@ -33,8 +63,7 @@ async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> Non
             GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
         )
     assert exc_info.value.status == 'NOT_FOUND'
-    assert 'googleai/lyria-3-clip-preview' in str(exc_info.value)
-    assert 'vertexai/lyria-3-clip-preview' in str(exc_info.value)
+    assert 'Did you mean' not in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
@@ -34,7 +34,7 @@ async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> Non
         )
     assert exc_info.value.status == 'NOT_FOUND'
     assert "Failed to resolve model 'lyria-3-clip-preview'." in str(exc_info.value)
-    assert 'Ensure the model name includes a plugin prefix' in str(exc_info.value)
+    assert 'Ensure the model name includes the plugin namespace' in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -12,10 +12,13 @@ functionality, ensuring proper registration and management of Genkit resources.
 import pytest
 
 from genkit import Genkit, Plugin
-from genkit._core._action import Action, ActionKind, create_action_key
+from genkit._core._action import Action, ActionKind, ActionRunContext, create_action_key
+from genkit._core._background import define_background_model
 from genkit._core._dap import DapValue, define_dynamic_action_provider
+from genkit._core._model import ModelRequest
+from genkit._core._protocols import RegistryLike
 from genkit._core._registry import Registry
-from genkit._core._typing import ActionMetadata
+from genkit._core._typing import ActionMetadata, ModelInfo, Operation, Supports
 
 
 async def _identity(x: object) -> object:
@@ -432,9 +435,33 @@ async def test_list_actions_registered_canonical_coexists_with_qualified_dap_row
     assert provider_key in catalog
 
 
+@pytest.mark.asyncio
+async def test_resolve_model_falls_back_to_background_model() -> None:
+    """resolve_model finds models registered only under BACKGROUND_MODEL."""
+    registry = Registry()
+
+    async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
+        return Operation(id='bg-start', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    define_background_model(
+        registry=registry,
+        name='veo-model',
+        start=start,
+        check=check,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+    assert await registry.resolve_action(ActionKind.MODEL, 'veo-model') is None
+
+    resolved = await registry.resolve_model('veo-model')
+    assert resolved is not None
+    assert resolved.kind == ActionKind.BACKGROUND_MODEL
+    assert resolved.name == 'veo-model'
+
+
 def test_registry_satisfies_registry_like() -> None:
     """Registry must structurally satisfy RegistryLike so middleware can use it as such."""
-    from genkit._core._protocols import RegistryLike
-    from genkit._core._registry import Registry
-
     assert isinstance(Registry(None), RegistryLike)

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -76,7 +76,7 @@ async def test_generate_uses_default_model(setup_test: SetupFixture) -> None:
     """Test that the generate function uses the default model."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     response = await ai.generate(prompt='hi', config={'temperature': 11})
 
@@ -126,11 +126,11 @@ async def test_generate_with_explicit_model(setup_test: SetupFixture) -> None:
 
     response = await ai.generate(model='echoModel', prompt='hi', config={'temperature': 11})
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
     stream_result = ai.generate_stream(model='echoModel', prompt='hi', config={'temperature': 11})
 
-    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -140,7 +140,7 @@ async def test_generate_with_str_prompt(setup_test: SetupFixture) -> None:
 
     response = await ai.generate(prompt='hi', config={'temperature': 11})
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -148,7 +148,7 @@ async def test_generate_with_part_prompt(setup_test: SetupFixture) -> None:
     """Test that the generate function with a part prompt works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     response = await ai.generate(prompt=[Part(root=TextPart(text='hi'))], config={'temperature': 11})
 
@@ -164,7 +164,7 @@ async def test_generate_with_part_list_prompt(setup_test: SetupFixture) -> None:
     """Test that the generate function with a list of parts prompt works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hello","world" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hello","world" {"temperature":11}'
 
     response = await ai.generate(
         prompt=[Part(root=TextPart(text='hello')), Part(root=TextPart(text='world'))],
@@ -186,7 +186,7 @@ async def test_generate_with_str_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a string system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(system='talk like pirate', prompt='hi', config={'temperature': 11})
 
@@ -202,7 +202,7 @@ async def test_generate_with_part_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a part system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(
         system=[Part(root=TextPart(text='talk like pirate'))],
@@ -226,7 +226,7 @@ async def test_generate_with_part_list_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a list of parts system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk","like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk","like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(
         system=[Part(root=TextPart(text='talk')), Part(root=TextPart(text='like pirate'))],
@@ -260,7 +260,7 @@ async def test_generate_with_messages(setup_test: SetupFixture) -> None:
         config={'temperature': 11},
     )
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
     stream_result = ai.generate_stream(
         messages=[
@@ -272,7 +272,7 @@ async def test_generate_with_messages(setup_test: SetupFixture) -> None:
         config={'temperature': 11},
     )
 
-    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -1507,7 +1507,7 @@ def test_define_model_default_metadata(setup_test: SetupFixture) -> None:
     """Test that the define model function works."""
     ai, _, _, *_ = setup_test
 
-    async def foo_model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+    async def foo_model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
         return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='banana!'))]))
 
     action = ai.define_model(
@@ -1528,7 +1528,7 @@ def test_define_model_with_schema(setup_test: SetupFixture) -> None:
         field_a: str = Field(description='a field')
         field_b: str = Field(description='b field')
 
-    async def foo_model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+    async def foo_model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
         return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='banana!'))]))
 
     action = ai.define_model(
@@ -1565,7 +1565,7 @@ def test_define_model_with_info(setup_test: SetupFixture) -> None:
     """Test that the define model function with info works."""
     ai, _, _, *_ = setup_test
 
-    async def foo_model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+    async def foo_model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
         return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='banana!'))]))
 
     action = ai.define_model(


### PR DESCRIPTION
First slice of the #5806 split: `FinishReason.ABORTED` (typing + genkit-schema.json), a cancel-operation action kind with registry lookup, background operation lifecycle updates, generate_operation/check_operation plumbing, and a `config_schema` parameter on `model_ref`.

## Stack (split of #5806)

1. #5854 core support for background model operations and typed model refs
2. #5855 Interactions HTTP client, converters, and options
3. #5856 Deep Research, Antigravity, and Lyria interaction models
4. #5857 move Veo to background model actions
5. #5858 wire Interactions models into GoogleAI plugin
6. #5859 gemini finish_message (parallel, based on this PR)

The split originally reproduced #5806 byte-for-byte; this slice has since picked up review fixes. Work co-authored with @huangjeff5.

### Breaking changes

- `ModelRequest(config={...})` keeps the dict instead of coercing into `ModelConfig`; `ModelRequest[PluginConfig]` coerces dicts into the plugin schema and rejects mismatched config instances. Values that are neither `BaseModel` nor dict raise `TypeError`.
- Bare `ModelRequest.config` is no longer typed `ModelConfig | None`: it resolves to `Unknown | None` under pyright, so attribute access on it is unchecked. Bind `ModelRequest[YourConfig]` for typed access.

### Cross-language files

The `aborted` finish reason already exists in the JS runtime; this PR syncs the tools zod source, the generated `genkit-schema.json`, and Go's generated `go/ai/gen.go` (CI enforces all three). No hand-written Go or tools changes.
