### PR TITLE
feat(py/plugins/google-genai): raw Interactions HTTP client, converters, and options

### DIFF
--- a/genkit-tools/common/src/types/model.ts
+++ b/genkit-tools/common/src/types/model.ts
@@ -343,6 +343,7 @@ export const FinishReasonSchema = z.enum([
   'stop',
   'length',
   'blocked',
+  'aborted',
   'interrupted',
   'other',
   'unknown',

--- a/genkit-tools/genkit-schema.json
+++ b/genkit-tools/genkit-schema.json
@@ -788,6 +788,7 @@
         "stop",
         "length",
         "blocked",
+        "aborted",
         "interrupted",
         "other",
         "unknown"

--- a/go/ai/gen.go
+++ b/go/ai/gen.go
@@ -78,6 +78,7 @@ const (
 	FinishReasonStop        FinishReason = "stop"
 	FinishReasonLength      FinishReason = "length"
 	FinishReasonBlocked     FinishReason = "blocked"
+	FinishReasonAborted     FinishReason = "aborted"
 	FinishReasonInterrupted FinishReason = "interrupted"
 	FinishReasonOther       FinishReason = "other"
 	FinishReasonUnknown     FinishReason = "unknown"

--- a/py/packages/genkit-google-genai/pyproject.toml
+++ b/py/packages/genkit-google-genai/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
   "genkit",
-  "google-genai>=1.63.0",
+  "google-genai>=2.14.0,<3",
   "google-cloud-aiplatform>=1.77.0",
   "structlog>=25.2.0",
   "strenum>=0.4.15; python_version < '3.11'",

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/client.py
@@ -1,0 +1,257 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Raw HTTP helpers for the Google AI Interactions API."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import cast
+
+import httpx
+from genkit_google_genai._interactions.options import ClientOptions
+from google.genai.interactions import Interaction
+
+from genkit import GenkitError
+from genkit._core._error import ErrorResponseMetadata, StatusName
+from genkit._core._logger import get_logger
+from genkit.plugin_api import GENKIT_CLIENT_HEADER, get_cached_client
+
+logger = get_logger(__name__)
+
+DEFAULT_API_VERSION = 'v1beta'
+DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com'
+API_REVISION = '2026-05-20'
+# Interactions creates (esp. Antigravity/Lyria) can run far longer than the
+# shared client's 60s default, so this transport opts out of a wall clock.
+CACHE_KEY = 'googleai-interactions'
+NO_TIMEOUT = httpx.Timeout(None)
+
+
+def google_ai_url(
+    resource_path: str,
+    *,
+    client_options: ClientOptions | None = None,
+) -> str:
+    """Build a Google AI REST URL for the given resource path."""
+    opts = client_options or ClientOptions()
+    api_version = opts.api_version or DEFAULT_API_VERSION
+    base_url = (opts.base_url or DEFAULT_BASE_URL).rstrip('/')
+    return f'{base_url}/{api_version}/{resource_path}'
+
+
+def headers(*, api_key: str, client_options: ClientOptions | None) -> dict[str, str]:
+    """Build request headers; api key and Genkit client attribution win over custom."""
+    custom = dict((client_options or ClientOptions()).custom_headers or {})
+    # Not allowed in user settings — same as the JS Google AI client.
+    custom.pop('x-goog-api-key', None)
+    custom.pop('x-goog-api-client', None)
+    return {
+        **custom,
+        'Content-Type': 'application/json',
+        'x-goog-api-client': GENKIT_CLIENT_HEADER,
+        'Api-Revision': API_REVISION,
+        'x-goog-api-key': api_key,
+    }
+
+
+def timeout_seconds(client_options: ClientOptions | None) -> float | None:
+    """Convert ClientOptions.timeout (milliseconds) to httpx seconds."""
+    opts = client_options or ClientOptions()
+    if opts.timeout is not None and opts.timeout >= 0:
+        return opts.timeout / 1000.0
+    return None
+
+
+def parse_retry_after_ms(value: str | None) -> float | None:
+    """Read a Retry-After header, which may be a delay in seconds or an HTTP date."""
+    if not value or not value.strip():
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        seconds = -1.0
+    if seconds >= 0:
+        return seconds * 1000
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+    return max(0.0, (retry_at - datetime.now(timezone.utc)).total_seconds() * 1000)
+
+
+def status_for_http_code(status_code: int) -> StatusName:
+    """Map an HTTP status onto the Genkit error status callers switch on."""
+    match status_code:
+        case 429:
+            return 'RESOURCE_EXHAUSTED'
+        case 400:
+            return 'INVALID_ARGUMENT'
+        case 401:
+            return 'UNAUTHENTICATED'
+        case 403:
+            return 'PERMISSION_DENIED'
+        case 404:
+            return 'NOT_FOUND'
+        case 499:
+            return 'CANCELLED'
+        case 500:
+            return 'INTERNAL'
+        case 503:
+            return 'UNAVAILABLE'
+        case _:
+            return 'UNKNOWN'
+
+
+async def create_interaction(
+    api_key: str,
+    body: dict[str, object],
+    client_options: ClientOptions | None = None,
+) -> Interaction:
+    """POST /interactions and return the parsed Interaction."""
+    url = google_ai_url('interactions', client_options=client_options)
+    return await request(
+        method='POST',
+        url=url,
+        api_key=api_key,
+        client_options=client_options,
+        json_body=body,
+    )
+
+
+async def get_interaction(
+    api_key: str,
+    interaction_id: str,
+    client_options: ClientOptions | None = None,
+) -> Interaction:
+    """GET /interactions/{id} and return the parsed Interaction."""
+    url = google_ai_url(f'interactions/{interaction_id}', client_options=client_options)
+    return await request(
+        method='GET',
+        url=url,
+        api_key=api_key,
+        client_options=client_options,
+    )
+
+
+async def cancel_interaction(
+    api_key: str,
+    interaction_id: str,
+    client_options: ClientOptions | None = None,
+) -> Interaction:
+    """POST /interactions/{id}/cancel and return a cancelled Interaction."""
+    url = google_ai_url(f'interactions/{interaction_id}/cancel', client_options=client_options)
+    try:
+        await request(
+            method='POST',
+            url=url,
+            api_key=api_key,
+            client_options=client_options,
+        )
+        # Successful cancel often surfaces as CANCELLED; normalize both paths.
+        raise GenkitError(status='CANCELLED', message='successfully cancelled')
+    except GenkitError as error:
+        if error.status == 'CANCELLED':
+            return Interaction.model_validate({'id': interaction_id, 'status': 'cancelled'})
+        raise
+
+
+async def request(
+    *,
+    method: str,
+    url: str,
+    api_key: str,
+    client_options: ClientOptions | None,
+    json_body: dict[str, object] | None = None,
+) -> Interaction:
+    """Issue one Interactions HTTP call and parse the Interaction body."""
+    # Auth/key headers are per-request; the loop-local client is just the transport.
+    client = get_cached_client(cache_key=CACHE_KEY, timeout=NO_TIMEOUT)
+    request_headers = headers(api_key=api_key, client_options=client_options)
+    timeout = timeout_seconds(client_options)
+
+    try:
+        if timeout is not None:
+            response = await client.request(
+                method,
+                url,
+                headers=request_headers,
+                json=json_body,
+                timeout=timeout,
+            )
+        else:
+            response = await client.request(
+                method,
+                url,
+                headers=request_headers,
+                json=json_body,
+            )
+    except httpx.TimeoutException as error:
+        raise GenkitError(
+            status='DEADLINE_EXCEEDED',
+            message=f'Request to {url} exceeded the configured timeout: {error}',
+        ) from error
+    except GenkitError:
+        raise
+    except Exception as error:
+        logger.exception('Interactions request failed')
+        raise GenkitError(
+            status='UNKNOWN',
+            message=f'Unable to complete request to {url}: {error}',
+        ) from error
+
+    if response.is_success:
+        if not response.content:
+            raise GenkitError(
+                status='INTERNAL',
+                message=f'Received an empty response from {url}',
+            )
+        try:
+            return Interaction.model_validate(response.json())
+        except Exception as error:
+            raise GenkitError(
+                status='INTERNAL',
+                message=f'Unable to parse Interaction response from {url}: {error}',
+            ) from error
+
+    error_message = response.text
+    error_detail: object | None = None
+    try:
+        payload: object = response.json()
+        error_detail = payload
+        if isinstance(payload, Mapping):
+            api_error = payload.get('error')
+            if isinstance(api_error, Mapping) and api_error.get('message') is not None:
+                error_message = str(api_error['message'])
+    except json.JSONDecodeError:
+        pass
+
+    retry_after_ms = parse_retry_after_ms(response.headers.get('retry-after'))
+    response_metadata: ErrorResponseMetadata | None = None
+    if retry_after_ms is not None:
+        response_metadata = cast(ErrorResponseMetadata, {'retry_after_ms': retry_after_ms})
+
+    raise GenkitError(
+        status=status_for_http_code(response.status_code),
+        message=(f'Request to {url} failed with HTTP {response.status_code} {response.reason_phrase}: {error_message}'),
+        details=error_detail,
+        response_metadata=response_metadata,
+    )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
@@ -1,0 +1,714 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Converters between Genkit message parts and Interactions API wire shapes."""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from typing import Any, Literal, cast
+
+from genkit_google_genai._interactions.options import ClientOptions
+from google.genai.interactions import (
+    AudioContent,
+    CodeExecutionCallStep,
+    CodeExecutionCallStepParam,
+    CodeExecutionResultStep,
+    CodeExecutionResultStepParam,
+    Content,
+    ContentParam,
+    DocumentContent,
+    FunctionCallStep,
+    FunctionCallStepParam,
+    FunctionParam,
+    FunctionResultStep,
+    FunctionResultStepParam,
+    FunctionResultStepResultUnionParam,
+    GoogleSearchCallStep,
+    GoogleSearchCallStepParam,
+    GoogleSearchResultStep,
+    GoogleSearchResultStepParam,
+    ImageContent,
+    Interaction,
+    ModelOutputStep,
+    ModelOutputStepParam,
+    Step,
+    StepParam,
+    TextContent,
+    TextContentParam,
+    ThoughtStep,
+    ThoughtStepParam,
+    UnknownContent,
+    Usage,
+    UserInputStep,
+    UserInputStepParam,
+    VideoContent,
+)
+from pydantic import BaseModel
+
+from genkit import (
+    CustomPart,
+    Media,
+    MediaPart,
+    Part,
+    ReasoningPart,
+    TextPart,
+    ToolRequest,
+    ToolRequestPart,
+    ToolResponse,
+    ToolResponsePart,
+)
+from genkit.model import Error, FinishReason, Message, ModelResponse, ModelUsage, Operation, ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+InteractionRole = Literal['user', 'model']
+
+# Keys we round-trip through Genkit custom parts and metadata for wire concepts
+# Genkit has no first-class part for. Both directions read them, so a typo in
+# one place would silently break pairing — keep them defined once.
+THOUGHT_SIGNATURE = 'thoughtSignature'
+CALL_ID = 'callId'
+GOOGLE_SEARCH_CALL = 'googleSearchCall'
+GOOGLE_SEARCH_RESULT = 'googleSearchResult'
+EXECUTABLE_CODE = 'executableCode'
+CODE_EXECUTION_RESULT = 'codeExecutionResult'
+# Code execution only ever runs Python, and the wire rejects any other value.
+CODE_LANGUAGE: Literal['python'] = 'python'
+
+FAILED_MESSAGE = 'Interaction failed'
+
+# Interactions splits media into typed content blocks, chosen by mime prefix.
+MEDIA_CONTENT_TYPES: tuple[tuple[str, str], ...] = (
+    ('image/', 'image'),
+    ('audio/', 'audio'),
+    ('video/', 'video'),
+    ('application/pdf', 'document'),
+)
+
+# Turns a Genkit role into the side of the transcript it belongs on. Tool
+# results are part of the user's side; system prompts aren't turns at all.
+INTERACTION_ROLES: dict[str, InteractionRole] = {
+    'user': 'user',
+    'model': 'model',
+    'tool': 'user',
+}
+
+# Terminal statuses that can still carry partial output worth surfacing.
+PARTIAL_TERMINAL_STATUSES: dict[str, tuple[FinishReason, str]] = {
+    'incomplete': (FinishReason.LENGTH, 'Interaction incomplete (truncated output)'),
+    'budget_exceeded': (FinishReason.ABORTED, 'Interaction exceeded its budget'),
+}
+
+
+def interaction_error_message(interaction: Interaction) -> str | None:
+    """Read the failure message a failed Interaction reports on its output step."""
+    for step in interaction.steps or []:
+        if isinstance(step, ModelOutputStep) and step.error is not None and step.error.message:
+            return step.error.message
+    return None
+
+
+def clean_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Strip schema keys the Interactions API rejects."""
+    out = copy.deepcopy(schema)
+    for key in list(out):
+        if key in ('$schema', 'additionalProperties'):
+            del out[key]
+            continue
+        value = out[key]
+        if isinstance(value, dict):
+            out[key] = clean_schema(value)
+        elif isinstance(value, list):
+            if key == 'type':
+                out[key] = next((item for item in value if item != 'null'), value[0] if value else value)
+            else:
+                out[key] = [clean_schema(item) if isinstance(item, dict) else item for item in value]
+    return out
+
+
+def ensure_tool_ids(messages: list[Message]) -> list[Message]:
+    """Assign stable tool call IDs so wire payloads stay pairable."""
+    generated_ids: list[str] = []
+    next_id_counter = 0
+
+    new_messages = [message.model_copy(deep=True) for message in messages]
+
+    for message in new_messages:
+        for part in message.content:
+            root = part.root
+            if isinstance(root, ToolRequestPart) and root.tool_request and not root.tool_request.ref:
+                new_id = f'genkit-auto-id-{next_id_counter}'
+                next_id_counter += 1
+                root.tool_request.ref = new_id
+                generated_ids.append(new_id)
+
+    # Responses without refs reuse request IDs in order; unmatched ones get orphan IDs.
+    for message in new_messages:
+        for part in message.content:
+            root = part.root
+            if isinstance(root, ToolResponsePart) and root.tool_response and not root.tool_response.ref:
+                matched_id = generated_ids.pop(0) if generated_ids else None
+                if matched_id:
+                    root.tool_response.ref = matched_id
+                else:
+                    root.tool_response.ref = f'genkit-orphan-id-{next_id_counter}'
+                    next_id_counter += 1
+
+    return new_messages
+
+
+def to_interaction_tool(tool: ToolDefinition) -> FunctionParam:
+    """Convert a Genkit tool definition to an Interactions function tool."""
+    func: FunctionParam = {
+        'type': 'function',
+        'name': tool.name,
+    }
+    if tool.description is not None:
+        func['description'] = tool.description
+    if tool.input_schema is not None:
+        if isinstance(tool.input_schema, dict):
+            func['parameters'] = clean_schema(tool.input_schema)
+        else:
+            func['parameters'] = clean_schema(dict(tool.input_schema))
+    return func
+
+
+def to_interaction_content(part: Part) -> ContentParam | None:
+    """Convert a Genkit part to an Interactions content block."""
+    root = part.root
+    if isinstance(root, TextPart):
+        text: TextContentParam = {'type': 'text', 'text': root.text}
+        return text
+    if isinstance(root, MediaPart) and root.media is not None:
+        return to_interaction_media(root)
+    logger.warning('Unsupported part type for Interaction input: %s', part.model_dump(by_alias=True))
+    return None
+
+
+def to_interaction_media(part: MediaPart) -> ContentParam:
+    """Convert a media part to an Interactions image/audio/video/document block."""
+    if part.media is None:
+        raise ValueError('Media part missing media')
+    content_type = part.media.content_type
+    if not content_type:
+        raise ValueError('Media part missing contentType')
+    block_type = next((name for prefix, name in MEDIA_CONTENT_TYPES if content_type.startswith(prefix)), None)
+    if block_type is None:
+        raise ValueError(f'Unsupported media type: {content_type}')
+
+    block: dict[str, Any] = {'type': block_type, 'mime_type': content_type}
+    # Inline data URLs travel as base64; anything else is a reference the API fetches.
+    url = part.media.url
+    if url.startswith('data:'):
+        block['data'] = url[url.index(',') + 1 :]
+    else:
+        block['uri'] = url
+    return cast(ContentParam, block)
+
+
+def to_interaction_role(role: str) -> InteractionRole:
+    """Map a Genkit message role to the Interactions API role."""
+    if role == 'system':
+        raise ValueError('System role should be handled as system_instruction, not part of turns.')
+    return INTERACTION_ROLES.get(role, 'user')
+
+
+def split_system_instruction(messages: list[Message]) -> tuple[str | None, list[Message]]:
+    """Lift system turns out of the transcript into the interaction's instruction.
+
+    An interaction carries one system instruction that governs the whole thing
+    rather than a turn in the tape, so however many system messages a prompt
+    has, they fold into a single block of text ahead of the conversation.
+    """
+    instructions: list[str] = []
+    turns: list[Message] = []
+    for message in messages:
+        if message.role != 'system':
+            turns.append(message)
+            continue
+        if any(not isinstance(part.root, TextPart) for part in message.content):
+            logger.warning('Dropping non-text content from a system message; system instructions are text only.')
+        if message.text:
+            instructions.append(message.text)
+    return '\n\n'.join(instructions) or None, turns
+
+
+def with_signature(step: StepParam, metadata: dict[str, Any]) -> StepParam:
+    """Carry a thought signature from part metadata back onto its step."""
+    signature = metadata.get(THOUGHT_SIGNATURE)
+    if signature is not None:
+        cast(dict[str, Any], step)['signature'] = signature
+    return step
+
+
+def to_function_call_step(request: ToolRequest) -> FunctionCallStepParam:
+    """Compile a Genkit tool request into a function_call step."""
+    return {
+        'type': 'function_call',
+        'name': request.name,
+        'arguments': request.input if isinstance(request.input, dict) else {},
+        'id': request.ref or '',
+    }
+
+
+def to_function_result_step(response: ToolResponse) -> FunctionResultStepParam:
+    """Compile a Genkit tool response into a function_result step."""
+    output = response.output
+    if isinstance(output, (str, dict, list)):
+        result = cast(FunctionResultStepResultUnionParam, output)
+    elif output is None:
+        result = cast(FunctionResultStepResultUnionParam, {})
+    else:
+        # Bare scalars aren't a result shape the API accepts, so box them.
+        result = cast(FunctionResultStepResultUnionParam, {'result': output})
+    return {
+        'type': 'function_result',
+        'name': response.name,
+        'result': result,
+        'call_id': response.ref or '',
+    }
+
+
+def to_thought_step(part: ReasoningPart) -> StepParam:
+    """Compile a Genkit reasoning part into a thought step."""
+    thought: ThoughtStepParam = {
+        'type': 'thought',
+        'summary': [{'type': 'text', 'text': part.reasoning}],
+    }
+    return with_signature(thought, part.metadata or {})
+
+
+def to_server_tool_step(custom: dict[str, Any], metadata: dict[str, Any]) -> StepParam | None:
+    """Compile the custom parts that stand in for Google-side tool activity.
+
+    Search and code execution run on Google's side, so Genkit has no first-class
+    part for them and we round-trip them through custom parts instead.
+    """
+    if GOOGLE_SEARCH_CALL in custom:
+        call = custom[GOOGLE_SEARCH_CALL]
+        search_call: GoogleSearchCallStepParam = {
+            'type': 'google_search_call',
+            'id': call.get('id', ''),
+            'arguments': call.get('arguments'),
+        }
+        return search_call
+    if GOOGLE_SEARCH_RESULT in custom:
+        result = custom[GOOGLE_SEARCH_RESULT]
+        search_result: GoogleSearchResultStepParam = {
+            'type': 'google_search_result',
+            'call_id': result.get(CALL_ID, ''),
+            'result': result.get('result'),
+        }
+        return search_result
+    if EXECUTABLE_CODE in custom:
+        code = custom[EXECUTABLE_CODE]
+        code_call: CodeExecutionCallStepParam = {
+            'type': 'code_execution_call',
+            'id': metadata.get(CALL_ID, ''),
+            'arguments': {'code': code.get('code'), 'language': CODE_LANGUAGE},
+        }
+        return code_call
+    if CODE_EXECUTION_RESULT in custom:
+        code_result: CodeExecutionResultStepParam = {
+            'type': 'code_execution_result',
+            'call_id': metadata.get(CALL_ID, ''),
+            'result': custom[CODE_EXECUTION_RESULT].get('output'),
+        }
+        return code_result
+    return None
+
+
+def to_standalone_step(part: Part) -> StepParam | None:
+    """Return the step a part compiles to on its own, or None if it is inline content."""
+    root = part.root
+    if isinstance(root, ToolRequestPart) and root.tool_request:
+        return to_function_call_step(root.tool_request)
+    if isinstance(root, ToolResponsePart) and root.tool_response:
+        return to_function_result_step(root.tool_response)
+    if isinstance(root, ReasoningPart):
+        return to_thought_step(root)
+    if isinstance(root, CustomPart):
+        metadata = root.metadata or {}
+        step = to_server_tool_step(root.custom or {}, metadata)
+        return with_signature(step, metadata) if step is not None else None
+    return None
+
+
+def to_content_step(role: InteractionRole, content: list[ContentParam]) -> StepParam:
+    """Wrap a turn's inline content in the step for whoever produced it."""
+    if role == 'model':
+        model_step: ModelOutputStepParam = {'type': 'model_output', 'content': content}
+        return model_step
+    user_step: UserInputStepParam = {'type': 'user_input', 'content': content}
+    return user_step
+
+
+def to_interaction_steps(messages: list[Message]) -> list[StepParam]:
+    """Convert Genkit messages to Interactions API steps.
+
+    A message's plain text and media collapse into one content step for the
+    turn, but tool calls, thoughts, and Google-side tool activity are steps in
+    their own right on the wire, so they get spliced in where they occurred.
+    """
+    steps: list[StepParam] = []
+    for message in messages:
+        role = to_interaction_role(message.role)
+        inline: list[ContentParam] = []
+        for part in message.content:
+            step = to_standalone_step(part)
+            if step is not None:
+                steps.append(step)
+                continue
+            content = to_interaction_content(part)
+            if content is not None:
+                inline.append(content)
+        if inline:
+            steps.append(to_content_step(role, inline))
+    return steps
+
+
+def with_metadata(part: Part, key: str, value: object) -> Part:
+    """Return a copy of the part carrying one more metadata entry."""
+    if not value:
+        return part
+    root = part.root
+    updated = root.model_copy(update={'metadata': {**(root.metadata or {}), key: value}})
+    return Part(root=updated)
+
+
+def plain(value: object) -> object:
+    """Unwrap SDK models into plain data so parts stay JSON-serializable."""
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode='python')
+    if isinstance(value, list):
+        return [plain(item) for item in value]
+    return value
+
+
+def server_tool_part(key: str, payload: dict[str, Any], *, signature: str | None, call_id: str | None = None) -> Part:
+    """Wrap Google-side tool activity in the custom part Genkit round-trips."""
+    part = Part(root=CustomPart(custom={key: payload}, metadata={CALL_ID: call_id} if call_id else None))
+    return with_metadata(part, THOUGHT_SIGNATURE, signature)
+
+
+def from_google_search_call(step: GoogleSearchCallStep) -> Part:
+    """Convert a google_search_call step to a Genkit custom part."""
+    return server_tool_part(
+        GOOGLE_SEARCH_CALL,
+        {'id': step.id, 'arguments': plain(step.arguments)},
+        signature=step.signature,
+    )
+
+
+def from_google_search_result(step: GoogleSearchResultStep) -> Part:
+    """Convert a google_search_result step to a Genkit custom part."""
+    return server_tool_part(
+        GOOGLE_SEARCH_RESULT,
+        {CALL_ID: step.call_id, 'result': plain(step.result or [])},
+        signature=step.signature,
+    )
+
+
+def from_code_execution_call(step: CodeExecutionCallStep) -> Part:
+    """Convert a code_execution_call step to a Genkit custom part."""
+    arguments = step.arguments
+    return server_tool_part(
+        EXECUTABLE_CODE,
+        {
+            'code': arguments.code if arguments else None,
+            'language': (arguments.language if arguments else None) or CODE_LANGUAGE,
+        },
+        signature=step.signature,
+        call_id=step.id,
+    )
+
+
+def from_code_execution_result(step: CodeExecutionResultStep) -> Part:
+    """Convert a code_execution_result step to a Genkit custom part."""
+    result = step.result
+    return server_tool_part(
+        CODE_EXECUTION_RESULT,
+        {
+            'output': result if isinstance(result, str) else json.dumps(result),
+            'outcome': 'OUTCOME_OK',
+        },
+        signature=step.signature,
+        call_id=step.call_id,
+    )
+
+
+def from_function_call_step(step: FunctionCallStep) -> Part:
+    """Convert a function_call step to a Genkit tool request part.
+
+    Fresh create/get steps with client tool calls are pending work for Genkit's
+    tool loop, so they use ToolRequestPart — not an opaque custom blob.
+    """
+    return Part(
+        root=ToolRequestPart(
+            tool_request=ToolRequest(
+                name=step.name or '',
+                input=plain(step.arguments) if step.arguments is not None else {},
+                ref=step.id,
+            )
+        )
+    )
+
+
+def from_function_result_step(step: FunctionResultStep) -> Part:
+    """Convert a function_result step to a Genkit tool response part."""
+    return Part(
+        root=ToolResponsePart(
+            tool_response=ToolResponse(
+                name=step.name or '',
+                output=plain(step.result),
+                ref=step.call_id,
+            ),
+            metadata={'isError': step.is_error} if step.is_error is not None else None,
+        )
+    )
+
+
+def from_media_content(content: ImageContent | AudioContent | DocumentContent | VideoContent) -> MediaPart:
+    """Convert wire media content to a Genkit media part."""
+    url = content.uri
+    if content.data and content.mime_type:
+        url = f'data:{content.mime_type};base64,{content.data}'
+    return MediaPart(media=Media(url=url or '', content_type=content.mime_type))
+
+
+def from_text_content(content: TextContent) -> Part:
+    """Convert wire text content to a Genkit text part."""
+    # Empty annotations still show up in metadata so round-trips stay stable.
+    return Part(
+        root=TextPart(
+            text=content.text or '',
+            metadata={'annotations': content.annotations},
+        )
+    )
+
+
+def from_visual_content(content: ImageContent | VideoContent) -> Part:
+    """Convert wire image or video content, keeping the resolution it came back at."""
+    return with_metadata(Part(root=from_media_content(content)), 'resolution', content.resolution)
+
+
+def from_thought_step(step: ThoughtStep) -> Part:
+    """Convert a thought step to a Genkit reasoning part."""
+    summary = step.summary or []
+    reasoning = '\n'.join(item.text or '' if isinstance(item, TextContent) else '[Image]' for item in summary)
+    return Part(
+        root=ReasoningPart(
+            reasoning=reasoning,
+            metadata={THOUGHT_SIGNATURE: step.signature},
+            custom={'thought': step.model_dump(mode='python')},
+        )
+    )
+
+
+def from_interaction_content(content: Content) -> Part:
+    """Convert an Interactions content block back to a Genkit part."""
+    if isinstance(content, TextContent):
+        return from_text_content(content)
+    if isinstance(content, (ImageContent, VideoContent)):
+        return from_visual_content(content)
+    if isinstance(content, (AudioContent, DocumentContent)):
+        return Part(root=from_media_content(content))
+    if isinstance(content, UnknownContent):
+        return Part(root=CustomPart(custom={'unknownContent': content.model_dump(mode='python')}))
+    return Part(root=CustomPart(custom={'unknownContent': content}))
+
+
+def from_interaction_step(step: Step) -> list[Part]:
+    """Convert an Interactions step to Genkit parts."""
+    if isinstance(step, ModelOutputStep):
+        return [from_interaction_content(content) for content in (step.content or [])]
+    if isinstance(step, UserInputStep):
+        # The API echoes our prompt back; including it would duplicate the input.
+        return []
+    if isinstance(step, GoogleSearchCallStep):
+        return [from_google_search_call(step)]
+    if isinstance(step, GoogleSearchResultStep):
+        return [from_google_search_result(step)]
+    if isinstance(step, CodeExecutionCallStep):
+        return [from_code_execution_call(step)]
+    if isinstance(step, CodeExecutionResultStep):
+        return [from_code_execution_result(step)]
+    if isinstance(step, ThoughtStep):
+        return [from_thought_step(step)]
+    if isinstance(step, FunctionCallStep):
+        return [from_function_call_step(step)]
+    if isinstance(step, FunctionResultStep):
+        return [from_function_result_step(step)]
+    if isinstance(step, BaseModel):
+        return [Part(root=CustomPart(custom={'unknownStep': step.model_dump(mode='python')}))]
+    return [Part(root=CustomPart(custom={'unknownStep': step}))]
+
+
+def interaction_message_metadata(interaction: Interaction) -> dict[str, Any] | None:
+    """Build message.metadata fields that identify the source Interaction."""
+    metadata: dict[str, Any] = {}
+    if interaction.id:
+        metadata['interactionId'] = interaction.id
+    if interaction.environment_id:
+        metadata['environmentId'] = interaction.environment_id
+    if interaction.status:
+        # Preserve the wire status when finish_reason is a coarser Genkit enum.
+        metadata['interactionStatus'] = interaction.status
+    return metadata or None
+
+
+def usage_from_interaction(usage: Usage) -> ModelUsage:
+    """Map Interactions Usage onto Genkit ModelUsage."""
+    response_usage = ModelUsage(
+        input_tokens=usage.total_input_tokens,
+        output_tokens=usage.total_output_tokens,
+        total_tokens=usage.total_tokens,
+        cached_content_tokens=usage.total_cached_tokens,
+        thoughts_tokens=usage.total_thought_tokens,
+    )
+    for modality_token in usage.input_tokens_by_modality or []:
+        match modality_token.modality:
+            case 'text':
+                response_usage.input_characters = modality_token.tokens
+            case 'image':
+                response_usage.input_images = modality_token.tokens
+            case 'audio':
+                response_usage.input_audio_files = modality_token.tokens
+            case _:
+                pass
+    for modality_token in usage.output_tokens_by_modality or []:
+        match modality_token.modality:
+            case 'text':
+                response_usage.output_characters = modality_token.tokens
+            case 'image':
+                response_usage.output_images = modality_token.tokens
+            case 'audio':
+                response_usage.output_audio_files = modality_token.tokens
+            case _:
+                pass
+    return response_usage
+
+
+def parts_from_steps(steps: list[Step]) -> list[Part]:
+    """Flatten interaction steps into Genkit parts, dropping empty ones."""
+    return [
+        part
+        for part in (item for step in steps for item in from_interaction_step(step))
+        if part.model_dump(exclude_none=True)
+    ]
+
+
+def model_response(
+    interaction: Interaction,
+    *,
+    content: list[Part],
+    finish_reason: FinishReason,
+    finish_message: str | None = None,
+) -> ModelResponse:
+    """Build a ModelResponse that carries the raw interaction alongside its parts."""
+    dumped = interaction.model_dump(mode='python')
+    response = ModelResponse.model_construct(
+        finish_reason=finish_reason,
+        finish_message=finish_message,
+        message=Message(role='model', content=content, metadata=interaction_message_metadata(interaction)),
+        custom=dumped,
+        raw=dumped,
+    )
+    if interaction.usage is not None:
+        response.usage = usage_from_interaction(interaction.usage)
+    return response
+
+
+def cancelled_response(interaction: Interaction) -> ModelResponse:
+    """Build the ModelResponse for a cancelled Interaction."""
+    return model_response(
+        interaction,
+        content=[Part(root=TextPart(text='Operation cancelled.'))],
+        finish_reason=FinishReason.ABORTED,
+        finish_message='Operation cancelled',
+    )
+
+
+def steps_response(
+    interaction: Interaction,
+    *,
+    finish_reason: FinishReason,
+    finish_message: str | None = None,
+) -> ModelResponse | None:
+    """Build a ModelResponse from interaction steps, or None when there are none."""
+    steps = list(interaction.steps or [])
+    if not steps:
+        return None
+    return model_response(
+        interaction,
+        content=parts_from_steps(steps),
+        finish_reason=finish_reason,
+        finish_message=finish_message,
+    )
+
+
+def completed_response(interaction: Interaction) -> ModelResponse | None:
+    """Build the ModelResponse for a completed Interaction, if it has steps."""
+    return steps_response(interaction, finish_reason=FinishReason.STOP)
+
+
+def from_interaction_sync(interaction: Interaction) -> ModelResponse:
+    """Convert a completed interaction to a synchronous model response."""
+    if interaction.status == 'failed':
+        raise ValueError(interaction_error_message(interaction) or FAILED_MESSAGE)
+    if interaction.status == 'cancelled':
+        return cancelled_response(interaction)
+    return completed_response(interaction) or model_response(interaction, content=[], finish_reason=FinishReason.STOP)
+
+
+def from_interaction(
+    interaction: Interaction,
+    client_options: ClientOptions | None = None,
+) -> Operation:
+    """Convert an interaction poll result to a Genkit operation."""
+    op = Operation.model_construct(id=interaction.id or '')
+    if client_options is not None:
+        dumped = client_options.to_metadata_dict()
+        if dumped:
+            op.metadata = {'clientOptions': dumped}
+
+    status = interaction.status
+    if status in ('in_progress', 'queued'):
+        # Keep polling — still running or waiting on the server.
+        op.done = False
+    elif status == 'cancelled':
+        op.done = True
+        op.output = cancelled_response(interaction)
+    elif status == 'completed':
+        op.done = True
+        op.output = completed_response(interaction)
+    elif partial := PARTIAL_TERMINAL_STATUSES.get(cast(str, status)):
+        # Halted for length or budget. Prefer whatever landed over a bare error.
+        finish_reason, message = partial
+        op.done = True
+        op.output = steps_response(interaction, finish_reason=finish_reason, finish_message=message)
+        if op.output is None:
+            op.error = Error(message=message)
+    elif status == 'failed':
+        # Always exit the poll loop on failure; leaving done unset hangs forever.
+        op.done = True
+        op.error = Error(message=interaction_error_message(interaction) or FAILED_MESSAGE)
+    # requires_action: leave done unset. Resuming that turn is a separate product
+    # decision; we don't invent interrupt/resume here.
+    return op

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/converters.py
@@ -216,7 +216,9 @@ def to_interaction_media(part: MediaPart) -> ContentParam:
     # Inline data URLs travel as base64; anything else is a reference the API fetches.
     url = part.media.url
     if url.startswith('data:'):
-        block['data'] = url[url.index(',') + 1 :]
+        if ',' not in url:
+            raise ValueError('Malformed data URL for media part: missing payload separator')
+        block['data'] = url.split(',', 1)[1]
     else:
         block['uri'] = url
     return cast(ContentParam, block)

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/options.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/_interactions/options.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small option types for Interactions-backed Google AI models."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+from typing_extensions import Self
+
+ResponseModality = Literal['text', 'image', 'audio']
+
+
+class ClientOptions(BaseModel):
+    """HTTP settings reconstructed across background poll calls.
+
+    Stored on Operation.metadata['clientOptions'] so check/cancel can reuse
+    per-request overrides (including apiKey) from start. Wire keys are
+    camelCase like the rest of operation metadata.
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, extra='ignore', populate_by_name=True)
+
+    api_key: str | None = None
+    api_version: str | None = None
+    base_url: str | None = None
+    custom_headers: dict[str, str] | None = None
+    # Milliseconds — same unit as the JS Google AI client option / HttpOptions.
+    timeout: float | None = None
+
+    def merge(self, overrides: ClientOptions | dict[str, Any] | None) -> Self:
+        """Return a copy with non-null override fields applied."""
+        if not overrides:
+            return self
+        if isinstance(overrides, dict):
+            overrides = ClientOptions.model_validate(overrides)
+        # Field names (not aliases) — model_copy(update=...) keys off Python attrs.
+        update = overrides.model_dump(exclude_none=True)
+        return self.model_copy(update=update) if update else self
+
+    @classmethod
+    def from_metadata(cls, metadata: dict[str, Any] | None) -> Self:
+        """Load options previously persisted on an Operation."""
+        raw = (metadata or {}).get('clientOptions')
+        if isinstance(raw, cls):
+            return raw
+        if isinstance(raw, dict):
+            return cls.model_validate(raw)
+        return cls()
+
+    def to_metadata_dict(self) -> dict[str, Any]:
+        """Serialize for Operation.metadata (omit unset fields)."""
+        return self.model_dump(by_alias=True, exclude_none=True)

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
@@ -233,7 +233,7 @@ class Embedder:
         if api_client is None or not hasattr(api_client, 'async_request'):
             raise RuntimeError(
                 'Multimodal embedding relies on google-genai client internals that are '
-                'unavailable in the installed google-genai version; install google-genai>=1.63.0.'
+                'unavailable in the installed google-genai version; install google-genai>=2.3.0.'
             )
         http_response = await api_client.async_request(
             http_method='post',

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/embedder.py
@@ -233,7 +233,7 @@ class Embedder:
         if api_client is None or not hasattr(api_client, 'async_request'):
             raise RuntimeError(
                 'Multimodal embedding relies on google-genai client internals that are '
-                'unavailable in the installed google-genai version; install google-genai>=2.3.0.'
+                'unavailable in the installed google-genai version; install google-genai>=2.14.0.'
             )
         http_response = await api_client.async_request(
             http_method='post',

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
@@ -175,7 +175,12 @@ def status_from_api_error(error: APIError) -> StatusName:
         }
         if candidate in valid:
             return cast(StatusName, candidate)
-    return status_for_http_code(int(error.code or 0))
+    # APIError.code comes straight from response JSON, so it may not be numeric.
+    try:
+        code = int(error.code or 0)
+    except (TypeError, ValueError):
+        code = 0
+    return status_for_http_code(code)
 
 
 def map_genai_error(exc: BaseException) -> GenkitError:

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_utils.py
@@ -1,0 +1,215 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for Google AI Interactions-backed models."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, cast
+
+from google.genai.errors import APIError
+
+from genkit import GenkitError
+from genkit._core._error import ErrorResponseMetadata, StatusName
+from genkit_google_genai._interactions.client import parse_retry_after_ms, status_for_http_code
+from genkit_google_genai._interactions.options import ClientOptions
+
+# Snake_case: callers dump config with by_alias=False before we strip these.
+CLIENT_OPTION_KEYS = frozenset({
+    'api_key',
+    'base_url',
+    'api_version',
+    'custom_headers',
+    'timeout',
+    'experimental_debug_traces',
+})
+
+
+def get_api_key_from_env() -> str | None:
+    """Read a Gemini API key from common environment variables."""
+    return os.getenv('GEMINI_API_KEY') or os.getenv('GOOGLE_API_KEY') or os.getenv('GOOGLE_GENAI_API_KEY')
+
+
+def calculate_api_key(
+    plugin_api_key: str | None,
+    request_api_key: str | None,
+) -> str:
+    """Resolve the effective API key for an Interactions call."""
+    api_key = request_api_key or plugin_api_key or get_api_key_from_env()
+    if not api_key:
+        raise GenkitError(
+            status='FAILED_PRECONDITION',
+            message=(
+                'Please pass in the API key or set the GEMINI_API_KEY or GOOGLE_API_KEY environment variable.\n'
+                'For more details see https://genkit.dev/docs/plugins/google-genai/'
+            ),
+        )
+    return api_key
+
+
+def extract_version(model_name: str) -> str:
+    """Return the bare model version from a namespaced model name."""
+    if '/' in model_name:
+        return model_name.split('/', 1)[1]
+    return model_name
+
+
+def remove_client_option_overrides(config: dict[str, Any]) -> dict[str, Any]:
+    """Drop client-only config keys before passthrough to the wire payload."""
+    return {key: value for key, value in config.items() if key not in CLIENT_OPTION_KEYS}
+
+
+def client_overrides_from_config(
+    *,
+    base_url: str | None = None,
+    api_version: str | None = None,
+    timeout: float | None = None,
+    custom_headers: dict[str, str] | None = None,
+) -> ClientOptions:
+    """Lift per-request transport knobs out of a model config into ClientOptions."""
+    return ClientOptions(
+        base_url=base_url,
+        api_version=api_version,
+        timeout=timeout,
+        custom_headers=custom_headers,
+    )
+
+
+def partition_keys(
+    payload: dict[str, Any],
+    *groups: tuple[str, ...],
+) -> tuple[dict[str, Any], ...]:
+    """Split payload into one dict per key group, then a remainder of leftovers.
+
+    Does not mutate payload. Keys listed in any group are claimed for that group
+    (or dropped from the remainder even when absent), so callers can peel a
+    dumped model config into agent_config / create options / tool fields /
+    passthrough extras without colliding.
+    """
+    claimed: set[str] = set()
+    for keys in groups:
+        claimed.update(keys)
+    parts = tuple({key: payload[key] for key in keys if key in payload} for keys in groups)
+    remainder = {key: value for key, value in payload.items() if key not in claimed}
+    return (*parts, remainder)
+
+
+def require_interaction_steps(steps: list[Any]) -> list[Any]:
+    """Reject an empty Interactions input before we pay for a round trip."""
+    if not steps:
+        raise GenkitError(
+            status='INVALID_ARGUMENT',
+            message='Missing input.',
+        )
+    return steps
+
+
+def http_status_code_from_exception(exc: BaseException) -> int | None:
+    """Read an HTTP status from SDK errors that aren't google.genai.errors.APIError.
+
+    Interactions (gaos) raises its own BadRequestError hierarchy with
+    status_code, which doesn't subclass google.genai.errors.APIError.
+    """
+    for attr in ('status_code', 'code'):
+        raw = getattr(exc, attr, None)
+        if raw is None:
+            continue
+        try:
+            code = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if code > 0:
+            return code
+    return None
+
+
+def client_options_for_operation(
+    client_options: ClientOptions,
+    *,
+    api_key: str | None = None,
+) -> ClientOptions:
+    """Persist client settings on an Operation for later check/cancel calls."""
+    if api_key:
+        return client_options.model_copy(update={'api_key': api_key})
+    return client_options
+
+
+def status_from_api_error(error: APIError) -> StatusName:
+    """Pick the Genkit error status for an SDK error, preferring the status it names."""
+    raw_status = error.status
+    if isinstance(raw_status, str):
+        candidate = raw_status.upper()
+        # API sometimes returns gRPC status names directly.
+        valid: set[str] = {
+            'OK',
+            'CANCELLED',
+            'UNKNOWN',
+            'INVALID_ARGUMENT',
+            'DEADLINE_EXCEEDED',
+            'NOT_FOUND',
+            'ALREADY_EXISTS',
+            'PERMISSION_DENIED',
+            'UNAUTHENTICATED',
+            'RESOURCE_EXHAUSTED',
+            'FAILED_PRECONDITION',
+            'ABORTED',
+            'OUT_OF_RANGE',
+            'UNIMPLEMENTED',
+            'INTERNAL',
+            'UNAVAILABLE',
+            'DATA_LOSS',
+        }
+        if candidate in valid:
+            return cast(StatusName, candidate)
+    return status_for_http_code(int(error.code or 0))
+
+
+def map_genai_error(exc: BaseException) -> GenkitError:
+    """Map a google-genai SDK error onto GenkitError for callers/poll backoff."""
+    if isinstance(exc, GenkitError):
+        return exc
+    if isinstance(exc, APIError):
+        retry_after_ms: float | None = None
+        headers: dict[str, str] = {}
+        response = getattr(exc, 'response', None)
+        raw_headers = getattr(response, 'headers', None)
+        if raw_headers is not None:
+            try:
+                headers = {str(key).lower(): str(value) for key, value in raw_headers.items()}
+            except Exception:  # noqa: BLE001 - headers shape varies by transport
+                headers = {}
+            retry_after_ms = parse_retry_after_ms(headers.get('retry-after'))
+        response_metadata: ErrorResponseMetadata | None = None
+        if retry_after_ms is not None or headers:
+            meta: ErrorResponseMetadata = {}
+            if retry_after_ms is not None:
+                meta['retry_after_ms'] = retry_after_ms
+            if headers:
+                meta['headers'] = headers
+            response_metadata = meta
+        return GenkitError(
+            status=status_from_api_error(exc),
+            message=exc.message or str(exc),
+            details=getattr(exc, 'details', None),
+            response_metadata=response_metadata,
+        )
+    # Interactions path: gaos BadRequestError etc. carry status_code but aren't APIError.
+    status_code = http_status_code_from_exception(exc)
+    if status_code is not None:
+        message = getattr(exc, 'message', None) or str(exc)
+        return GenkitError(status=status_for_http_code(status_code), message=message)
+    return GenkitError(status='UNKNOWN', message=str(exc))

--- a/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
@@ -438,5 +438,5 @@ async def test_multimodal_embedding_guards_missing_private_transport(mocker: Moc
     client_mock = mocker.Mock(spec=[])  # no _api_client attribute at all
 
     embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
-    with pytest.raises(RuntimeError, match='google-genai>=1.63.0'):
+    with pytest.raises(RuntimeError, match='google-genai>=2.3.0'):
         await embedder.generate(request)

--- a/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_embedder_test.py
@@ -438,5 +438,5 @@ async def test_multimodal_embedding_guards_missing_private_transport(mocker: Moc
     client_mock = mocker.Mock(spec=[])  # no _api_client attribute at all
 
     embedder = Embedder('multimodalembedding', client_mock, is_vertex=True)
-    with pytest.raises(RuntimeError, match='google-genai>=2.3.0'):
+    with pytest.raises(RuntimeError, match='google-genai>=2.14.0'):
         await embedder.generate(request)

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_client_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_client_test.py
@@ -1,0 +1,214 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the raw HTTP Interactions client."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from genkit_google_genai._interactions import client as interactions_client
+from genkit_google_genai._interactions.client import (
+    API_REVISION,
+    cancel_interaction,
+    create_interaction,
+    get_interaction,
+    google_ai_url,
+    headers,
+    timeout_seconds,
+)
+from genkit_google_genai._interactions.options import ClientOptions
+from google.genai.interactions import Interaction
+
+from genkit import GenkitError
+from genkit.plugin_api import GENKIT_CLIENT_HEADER
+
+
+def test_google_ai_url_defaults() -> None:
+    assert google_ai_url('interactions') == ('https://generativelanguage.googleapis.com/v1beta/interactions')
+
+
+def test_google_ai_url_respects_overrides() -> None:
+    url = google_ai_url(
+        'interactions/abc',
+        client_options=ClientOptions(base_url='https://example.test/', api_version='v1alpha'),
+    )
+    assert url == 'https://example.test/v1alpha/interactions/abc'
+
+
+def test_headers_set_api_revision_and_strip_reserved_custom() -> None:
+    result = headers(
+        api_key='k',
+        client_options=ClientOptions(
+            custom_headers={
+                'x-custom': '1',
+                'x-goog-api-key': 'stolen',
+                'x-goog-api-client': 'wrapper',
+            }
+        ),
+    )
+    assert result['Api-Revision'] == API_REVISION
+    assert result['x-goog-api-key'] == 'k'
+    assert result['x-goog-api-client'] == GENKIT_CLIENT_HEADER
+    assert result['x-custom'] == '1'
+
+
+def test_timeout_seconds_converts_milliseconds() -> None:
+    assert timeout_seconds(ClientOptions(timeout=1500)) == 1.5
+    assert timeout_seconds(ClientOptions()) is None
+
+
+def mock_response(
+    *,
+    status_code: int = 200,
+    json_body: dict[str, Any] | None = None,
+    text: str = '',
+    headers_map: dict[str, str] | None = None,
+    content: bytes | None = None,
+) -> httpx.Response:
+    if json_body is not None:
+        return httpx.Response(status_code, json=json_body, headers=headers_map or {})
+    if content is not None:
+        return httpx.Response(status_code, content=content, headers=headers_map or {})
+    return httpx.Response(status_code, text=text, headers=headers_map or {})
+
+
+@pytest.fixture
+def http_client() -> MagicMock:
+    client = MagicMock()
+    client.request = AsyncMock()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_create_interaction_posts_body(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        json_body={'id': 'ix-1', 'status': 'in_progress'},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        result = await create_interaction(
+            'key',
+            {'agent': 'deep-research', 'background': True},
+            ClientOptions(base_url='https://example.test'),
+        )
+
+    assert isinstance(result, Interaction)
+    assert result.id == 'ix-1'
+    method, url = http_client.request.call_args.args[:2]
+    assert method == 'POST'
+    assert url == 'https://example.test/v1beta/interactions'
+    kwargs = http_client.request.call_args.kwargs
+    assert kwargs['json'] == {'agent': 'deep-research', 'background': True}
+    assert kwargs['headers']['Api-Revision'] == API_REVISION
+    assert kwargs['headers']['x-goog-api-key'] == 'key'
+
+
+@pytest.mark.asyncio
+async def test_get_interaction_gets_by_id(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        json_body={'id': 'ix-9', 'status': 'completed', 'steps': []},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        result = await get_interaction('key', 'ix-9')
+
+    assert result.id == 'ix-9'
+    method, url = http_client.request.call_args.args[:2]
+    assert method == 'GET'
+    assert url.endswith('/interactions/ix-9')
+
+
+@pytest.mark.asyncio
+async def test_cancel_interaction_normalizes_http_cancelled(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        status_code=499,
+        json_body={'error': {'message': 'cancelled'}},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        result = await cancel_interaction('key', 'ix-cancel')
+
+    assert result.id == 'ix-cancel'
+    assert result.status == 'cancelled'
+
+
+@pytest.mark.asyncio
+async def test_cancel_interaction_normalizes_success_as_cancelled(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        json_body={'id': 'ix-cancel', 'status': 'completed'},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        result = await cancel_interaction('key', 'ix-cancel')
+
+    assert result.status == 'cancelled'
+
+
+@pytest.mark.asyncio
+async def test_cancel_interaction_rethrows_non_cancelled_errors(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        status_code=404,
+        json_body={'error': {'message': 'missing'}},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        with pytest.raises(GenkitError) as exc_info:
+            await cancel_interaction('key', 'ix-missing')
+    assert exc_info.value.status == 'NOT_FOUND'
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_includes_retry_after_ms(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        status_code=429,
+        json_body={'error': {'message': 'slow down'}},
+        headers_map={'retry-after': '1.5'},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        with pytest.raises(GenkitError) as exc_info:
+            await create_interaction('key', {'model': 'lyria'})
+    assert exc_info.value.status == 'RESOURCE_EXHAUSTED'
+    assert exc_info.value.response_metadata is not None
+    assert exc_info.value.response_metadata.get('retry_after_ms') == 1500.0
+
+
+@pytest.mark.asyncio
+async def test_empty_success_body_is_internal_error(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(content=b'')
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        with pytest.raises(GenkitError, match='empty response') as exc_info:
+            await get_interaction('key', 'ix-1')
+    assert exc_info.value.status == 'INTERNAL'
+
+
+@pytest.mark.asyncio
+async def test_timeout_maps_to_deadline_exceeded(http_client: MagicMock) -> None:
+    http_client.request.side_effect = httpx.TimeoutException('late')
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client):
+        with pytest.raises(GenkitError) as exc_info:
+            await create_interaction('key', {'model': 'lyria'}, ClientOptions(timeout=1000))
+    assert exc_info.value.status == 'DEADLINE_EXCEEDED'
+
+
+@pytest.mark.asyncio
+async def test_request_timeout_converted_from_ms(http_client: MagicMock) -> None:
+    http_client.request.return_value = mock_response(
+        json_body={'id': 'ix-1', 'status': 'completed', 'steps': []},
+    )
+    with patch.object(interactions_client, 'get_cached_client', return_value=http_client) as cached:
+        await create_interaction('key', {'model': 'lyria'}, ClientOptions(timeout=2500))
+
+    assert cached.call_args.kwargs['timeout'] == interactions_client.NO_TIMEOUT
+    assert http_client.request.call_args.kwargs['timeout'] == 2.5

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_converters_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_converters_test.py
@@ -166,6 +166,12 @@ class TestToInteractionContent:
         )
         assert result == {'type': 'image', 'data': 'DATA', 'mime_type': 'image/png'}
 
+    def test_image_data_missing_separator(self) -> None:
+        with pytest.raises(ValueError, match='missing payload separator'):
+            to_interaction_content(
+                Part(MediaPart(media=Media(url='data:image/png;base64GARBAGE', content_type='image/png')))
+            )
+
     def test_image_uri(self) -> None:
         result = to_interaction_content(
             Part(MediaPart(media=Media(url='gs://bucket/image.png', content_type='image/png')))

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_converters_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_converters_test.py
@@ -1,0 +1,713 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Interactions API converters."""
+
+from __future__ import annotations
+
+import pytest
+from genkit_google_genai._interactions.converters import (
+    ensure_tool_ids,
+    from_interaction,
+    from_interaction_content,
+    from_interaction_step,
+    from_interaction_sync,
+    from_thought_step,
+    parts_from_steps,
+    to_interaction_content,
+    to_interaction_role,
+    to_interaction_steps,
+    to_interaction_tool,
+)
+from genkit_google_genai._interactions.options import ClientOptions
+from google.genai.interactions import Content, Interaction, Step, ThoughtStep
+from pydantic import TypeAdapter
+
+from genkit import (
+    CustomPart,
+    Media,
+    MediaPart,
+    Part,
+    ReasoningPart,
+    TextPart,
+    ToolRequest,
+    ToolRequestPart,
+    ToolResponse,
+    ToolResponsePart,
+)
+from genkit.model import Message, ToolDefinition
+
+ContentAdapter: TypeAdapter[Content] = TypeAdapter(Content)
+StepAdapter: TypeAdapter[Step] = TypeAdapter(Step)
+
+
+def part_dict(part: Part) -> dict:
+    return part.root.model_dump(by_alias=True, exclude_none=True)
+
+
+class TestEnsureToolIds:
+    def test_assigns_ids_to_tool_requests_without_refs(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='tool1', input={}))),
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='tool2', input={}))),
+                ],
+            )
+        ]
+        result = ensure_tool_ids(messages)
+        req1 = result[0].content[0].root.tool_request
+        req2 = result[0].content[1].root.tool_request
+        assert req1 is not None and req1.ref and req1.ref.startswith('genkit-auto-id-')
+        assert req2 is not None and req2.ref and req2.ref.startswith('genkit-auto-id-')
+        assert req1.ref != req2.ref
+
+    def test_assigns_matching_ids_to_tool_responses(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='tool1', input={}))),
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='tool2', input={}))),
+                ],
+            ),
+            Message(
+                role='tool',
+                content=[
+                    Part(ToolResponsePart(tool_response=ToolResponse(name='tool1', output={}))),
+                    Part(ToolResponsePart(tool_response=ToolResponse(name='tool2', output={}))),
+                ],
+            ),
+        ]
+        result = ensure_tool_ids(messages)
+        req1 = result[0].content[0].root.tool_request
+        req2 = result[0].content[1].root.tool_request
+        res1 = result[1].content[0].root.tool_response
+        res2 = result[1].content[1].root.tool_response
+        assert req1 and req1.ref and res1 and res1.ref == req1.ref
+        assert req2 and req2.ref and res2 and res2.ref == req2.ref
+
+    def test_assigns_orphan_id_without_matching_request(self) -> None:
+        messages = [
+            Message(
+                role='tool',
+                content=[Part(ToolResponsePart(tool_response=ToolResponse(name='tool1', output={})))],
+            )
+        ]
+        result = ensure_tool_ids(messages)
+        res1 = result[0].content[0].root.tool_response
+        assert res1 and res1.ref and res1.ref.startswith('genkit-orphan-id-')
+
+    def test_preserves_existing_refs(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[Part(ToolRequestPart(tool_request=ToolRequest(name='tool1', input={}, ref='existing-id')))],
+            )
+        ]
+        result = ensure_tool_ids(messages)
+        req1 = result[0].content[0].root.tool_request
+        assert req1 and req1.ref == 'existing-id'
+
+
+class TestToInteractionRole:
+    def test_user(self) -> None:
+        assert to_interaction_role('user') == 'user'
+
+    def test_model(self) -> None:
+        assert to_interaction_role('model') == 'model'
+
+    def test_tool_maps_to_user(self) -> None:
+        assert to_interaction_role('tool') == 'user'
+
+    def test_system_raises(self) -> None:
+        with pytest.raises(ValueError, match='system_instruction'):
+            to_interaction_role('system')
+
+
+class TestToInteractionTool:
+    def test_converts_tool_definition(self) -> None:
+        tool = ToolDefinition(
+            name='myFunc',
+            description='desc',
+            input_schema={'type': 'object', 'properties': {'arg': {'type': 'string'}}},
+        )
+        result = to_interaction_tool(tool)
+        assert result == {
+            'type': 'function',
+            'name': 'myFunc',
+            'description': 'desc',
+            'parameters': {'type': 'object', 'properties': {'arg': {'type': 'string'}}},
+        }
+
+
+class TestToInteractionContent:
+    def test_text(self) -> None:
+        result = to_interaction_content(Part(TextPart(text='Hello')))
+        assert result == {'type': 'text', 'text': 'Hello'}
+
+    def test_image_data(self) -> None:
+        result = to_interaction_content(
+            Part(MediaPart(media=Media(url='data:image/png;base64,DATA', content_type='image/png')))
+        )
+        assert result == {'type': 'image', 'data': 'DATA', 'mime_type': 'image/png'}
+
+    def test_image_uri(self) -> None:
+        result = to_interaction_content(
+            Part(MediaPart(media=Media(url='gs://bucket/image.png', content_type='image/png')))
+        )
+        assert result == {'type': 'image', 'uri': 'gs://bucket/image.png', 'mime_type': 'image/png'}
+
+    def test_audio(self) -> None:
+        result = to_interaction_content(
+            Part(MediaPart(media=Media(url='data:audio/mp3;base64,DATA', content_type='audio/mp3')))
+        )
+        assert result == {'type': 'audio', 'data': 'DATA', 'mime_type': 'audio/mp3'}
+
+    def test_document(self) -> None:
+        result = to_interaction_content(
+            Part(MediaPart(media=Media(url='gs://bucket/doc.pdf', content_type='application/pdf')))
+        )
+        assert result == {'type': 'document', 'uri': 'gs://bucket/doc.pdf', 'mime_type': 'application/pdf'}
+
+    def test_unsupported_media_raises(self) -> None:
+        with pytest.raises(ValueError, match='Unsupported media type'):
+            to_interaction_content(Part(MediaPart(media=Media(url='https://example.com/x', content_type='text/plain'))))
+
+
+class TestToInteractionSteps:
+    def test_tool_request(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[Part(ToolRequestPart(tool_request=ToolRequest(name='func', input={'a': 1}, ref='ref1')))],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {'type': 'function_call', 'name': 'func', 'arguments': {'a': 1}, 'id': 'ref1'}
+        ]
+
+    def test_tool_response(self) -> None:
+        messages = [
+            Message(
+                role='tool',
+                content=[
+                    Part(
+                        root=ToolResponsePart(
+                            tool_response=ToolResponse(name='func', output={'result': 'ok'}, ref='ref1')
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {'type': 'function_result', 'name': 'func', 'result': {'result': 'ok'}, 'call_id': 'ref1'}
+        ]
+
+    def test_model_output_grouping(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[Part(TextPart(text='Thinking')), Part(TextPart(text='Done'))],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'model_output',
+                'content': [{'type': 'text', 'text': 'Thinking'}, {'type': 'text', 'text': 'Done'}],
+            }
+        ]
+
+    def test_system_role_rejected(self) -> None:
+        messages = [Message(role='system', content=[Part(TextPart(text='be terse'))])]
+        with pytest.raises(ValueError, match='system_instruction'):
+            to_interaction_steps(messages)
+
+    def test_code_execution_call_always_sends_python(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        root=CustomPart(
+                            custom={'executableCode': {'code': 'print(1)', 'language': 'PYTHON'}},
+                            metadata={'callId': 'c1'},
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'code_execution_call',
+                'id': 'c1',
+                'arguments': {'code': 'print(1)', 'language': 'python'},
+            }
+        ]
+
+    def test_google_search_call(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        root=CustomPart(
+                            custom={'googleSearchCall': {'id': 'gs1', 'arguments': {'queries': ['genkit']}}},
+                            metadata={'thoughtSignature': 'sig'},
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'google_search_call',
+                'id': 'gs1',
+                'arguments': {'queries': ['genkit']},
+                'signature': 'sig',
+            }
+        ]
+
+    def test_thought_becomes_its_own_step(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        root=ReasoningPart(
+                            reasoning='plan the answer',
+                            metadata={'thoughtSignature': 'sig-t'},
+                        )
+                    )
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'thought',
+                'summary': [{'type': 'text', 'text': 'plan the answer'}],
+                'signature': 'sig-t',
+            }
+        ]
+
+    def test_mixed_model_turn_flushes_standalone_steps_before_inline_text(self) -> None:
+        """Standalone steps (thought/tool) emit immediately; text waits until end of turn.
+
+        That means [thought, text, tool_request] becomes thought, function_call,
+        then model_output(text) — not thought, model_output, function_call.
+        """
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(root=ReasoningPart(reasoning='think', metadata={'thoughtSignature': 's'})),
+                    Part(TextPart(text='calling tool')),
+                    Part(ToolRequestPart(tool_request=ToolRequest(name='lookup', input={'q': 1}, ref='c1'))),
+                ],
+            )
+        ]
+        assert to_interaction_steps(messages) == [
+            {
+                'type': 'thought',
+                'summary': [{'type': 'text', 'text': 'think'}],
+                'signature': 's',
+            },
+            {'type': 'function_call', 'name': 'lookup', 'arguments': {'q': 1}, 'id': 'c1'},
+            {
+                'type': 'model_output',
+                'content': [{'type': 'text', 'text': 'calling tool'}],
+            },
+        ]
+
+
+class TestFromInteractionContent:
+    def test_text(self) -> None:
+        result = from_interaction_content(
+            ContentAdapter.validate_python({
+                'type': 'text',
+                'text': 'Hello world',
+                'annotations': [{'start_index': 0, 'end_index': 5, 'source': 'source'}],
+            })
+        )
+        assert part_dict(result) == {
+            'text': 'Hello world',
+            'metadata': {
+                'annotations': [{'start_index': 0, 'end_index': 5, 'source': 'source', 'type': 'file_citation'}]
+            },
+        }
+
+    def test_image_data(self) -> None:
+        result = from_interaction_content(
+            ContentAdapter.validate_python({'type': 'image', 'data': 'BASE64DATA', 'mime_type': 'image/png'})
+        )
+        assert part_dict(result) == {'media': {'url': 'data:image/png;base64,BASE64DATA', 'contentType': 'image/png'}}
+
+    def test_image_resolution(self) -> None:
+        result = from_interaction_content(
+            ContentAdapter.validate_python({
+                'type': 'image',
+                'uri': 'gs://bucket/image.png',
+                'mime_type': 'image/png',
+                'resolution': 'high',
+            })
+        )
+        assert part_dict(result) == {
+            'media': {'url': 'gs://bucket/image.png', 'contentType': 'image/png'},
+            'metadata': {'resolution': 'high'},
+        }
+
+    def test_thought(self) -> None:
+        step = ThoughtStep.model_validate({
+            'type': 'thought',
+            'signature': 'SIG',
+            'summary': [{'type': 'text', 'text': 'Thinking...'}],
+        })
+        result = from_thought_step(step)
+        assert part_dict(result) == {
+            'reasoning': 'Thinking...',
+            'metadata': {'thoughtSignature': 'SIG'},
+            'custom': {'thought': step.model_dump(mode='python')},
+        }
+
+
+class TestFromInteractionStep:
+    def test_model_output_includes_empty_annotations(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({'type': 'model_output', 'content': [{'type': 'text', 'text': 'Hello'}]})
+        )
+        root = result[0].root
+        assert isinstance(root, TextPart)
+        assert root.text == 'Hello'
+        assert root.metadata is not None
+        assert 'annotations' in root.metadata
+
+    def test_user_input_dropped(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({'type': 'user_input', 'content': [{'type': 'text', 'text': 'Hello'}]})
+        )
+        assert result == []
+
+    def test_function_call_is_tool_request(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({
+                'type': 'function_call',
+                'id': 'c1',
+                'name': 'get_weather',
+                'arguments': {'city': 'Austin'},
+            })
+        )
+        root = result[0].root
+        assert isinstance(root, ToolRequestPart)
+        assert root.tool_request is not None
+        assert root.tool_request.name == 'get_weather'
+        assert root.tool_request.input == {'city': 'Austin'}
+        assert root.tool_request.ref == 'c1'
+
+    def test_function_result_is_tool_response(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({
+                'type': 'function_result',
+                'call_id': 'c1',
+                'name': 'get_weather',
+                'result': {'temp': 92},
+                'is_error': False,
+            })
+        )
+        root = result[0].root
+        assert isinstance(root, ToolResponsePart)
+        assert root.tool_response is not None
+        assert root.tool_response.name == 'get_weather'
+        assert root.tool_response.output == {'temp': 92}
+        assert root.tool_response.ref == 'c1'
+        assert root.metadata == {'isError': False}
+
+    def test_google_search_call_is_custom_part(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({
+                'type': 'google_search_call',
+                'id': 'gs1',
+                'arguments': {'queries': ['genkit']},
+                'signature': 'sig',
+            })
+        )
+        root = result[0].root
+        assert isinstance(root, CustomPart)
+        assert root.custom == {'googleSearchCall': {'id': 'gs1', 'arguments': {'queries': ['genkit']}}}
+        assert root.metadata == {'thoughtSignature': 'sig'}
+
+    def test_code_execution_call_is_custom_part(self) -> None:
+        result = from_interaction_step(
+            StepAdapter.validate_python({
+                'type': 'code_execution_call',
+                'id': 'ce1',
+                'arguments': {'code': 'print(1)', 'language': 'python'},
+            })
+        )
+        root = result[0].root
+        assert isinstance(root, CustomPart)
+        assert root.custom == {'executableCode': {'code': 'print(1)', 'language': 'python'}}
+        assert root.metadata == {'callId': 'ce1'}
+
+
+class TestInboundFlattensToSingleModelMessage:
+    """Every Interaction response becomes one role=model Message of flattened parts."""
+
+    def test_mixed_tape_drops_user_input_and_keeps_order(self) -> None:
+        interaction = Interaction.model_validate({
+            'id': 'ix-1',
+            'status': 'completed',
+            'environment_id': 'env-1',
+            'steps': [
+                {'type': 'user_input', 'content': [{'type': 'text', 'text': 'weather?'}]},
+                {
+                    'type': 'thought',
+                    'signature': 'sig',
+                    'summary': [{'type': 'text', 'text': 'need a tool'}],
+                },
+                {'type': 'model_output', 'content': [{'type': 'text', 'text': 'checking'}]},
+                {
+                    'type': 'function_call',
+                    'id': 'c1',
+                    'name': 'get_weather',
+                    'arguments': {'city': 'Austin'},
+                },
+            ],
+        })
+        op = from_interaction(interaction)
+        assert op.done is True
+        assert op.output is not None
+        message = op.output.message
+        assert message is not None
+        assert message.role == 'model'
+        assert message.metadata == {
+            'interactionId': 'ix-1',
+            'environmentId': 'env-1',
+            'interactionStatus': 'completed',
+        }
+        assert [type(part.root).__name__ for part in message.content] == [
+            'ReasoningPart',
+            'TextPart',
+            'ToolRequestPart',
+        ]
+        assert message.content[0].root.reasoning == 'need a tool'
+        assert message.content[1].root.text == 'checking'
+        assert message.content[2].root.tool_request.ref == 'c1'
+
+    def test_already_resolved_tool_pair_stays_inside_model_message(self) -> None:
+        """A tape that already has function_result still flattens into one model turn."""
+        steps = [
+            StepAdapter.validate_python({
+                'type': 'function_call',
+                'id': 'c1',
+                'name': 'get_weather',
+                'arguments': {'city': 'Austin'},
+            }),
+            StepAdapter.validate_python({
+                'type': 'function_result',
+                'call_id': 'c1',
+                'name': 'get_weather',
+                'result': {'temp': 92},
+            }),
+            StepAdapter.validate_python({
+                'type': 'model_output',
+                'content': [{'type': 'text', 'text': '92F'}],
+            }),
+        ]
+        parts = parts_from_steps(steps)
+        assert [type(part.root).__name__ for part in parts] == [
+            'ToolRequestPart',
+            'ToolResponsePart',
+            'TextPart',
+        ]
+
+
+class TestFunctionCallRoundTrip:
+    """The bug we hit: function_call must be ToolRequestPart, not CustomPart."""
+
+    def test_outbound_then_inbound_preserves_tool_request(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        ToolRequestPart(
+                            tool_request=ToolRequest(name='get_weather', input={'city': 'Austin'}, ref='c1')
+                        )
+                    )
+                ],
+            )
+        ]
+        steps = to_interaction_steps(messages)
+        assert steps == [{'type': 'function_call', 'name': 'get_weather', 'arguments': {'city': 'Austin'}, 'id': 'c1'}]
+        inbound = from_interaction_step(StepAdapter.validate_python(steps[0]))
+        root = inbound[0].root
+        assert isinstance(root, ToolRequestPart)
+        assert root.tool_request is not None
+        assert root.tool_request.name == 'get_weather'
+        assert root.tool_request.input == {'city': 'Austin'}
+        assert root.tool_request.ref == 'c1'
+
+    def test_inbound_then_outbound_preserves_function_call(self) -> None:
+        step = StepAdapter.validate_python({
+            'type': 'function_call',
+            'id': 'c1',
+            'name': 'get_weather',
+            'arguments': {'city': 'Austin'},
+        })
+        part = from_interaction_step(step)[0]
+        assert isinstance(part.root, ToolRequestPart)
+        again = to_interaction_steps([Message(role='model', content=[part])])
+        assert again == [{'type': 'function_call', 'name': 'get_weather', 'arguments': {'city': 'Austin'}, 'id': 'c1'}]
+
+    def test_thought_round_trip_keeps_signature(self) -> None:
+        messages = [
+            Message(
+                role='model',
+                content=[
+                    Part(
+                        root=ReasoningPart(
+                            reasoning='plan',
+                            metadata={'thoughtSignature': 'sig'},
+                        )
+                    )
+                ],
+            )
+        ]
+        steps = to_interaction_steps(messages)
+        inbound = from_interaction_step(StepAdapter.validate_python(steps[0]))
+        root = inbound[0].root
+        assert isinstance(root, ReasoningPart)
+        assert root.reasoning == 'plan'
+        assert root.metadata == {'thoughtSignature': 'sig'}
+
+
+class TestClientOptionsWireFormat:
+    def test_operation_metadata_uses_camel_case_keys(self) -> None:
+        op = from_interaction(
+            Interaction.model_validate({'id': '123', 'status': 'in_progress'}),
+            ClientOptions(api_key='k', base_url='https://example.test', api_version='v1beta'),
+        )
+        assert op.metadata == {
+            'clientOptions': {
+                'apiKey': 'k',
+                'baseUrl': 'https://example.test',
+                'apiVersion': 'v1beta',
+            }
+        }
+
+
+class TestFromInteractionStatusMapping:
+    def test_cancelled(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'cancelled'}))
+        assert result.done is True
+        assert result.output is not None
+        assert result.output.finish_reason == 'aborted'
+        assert result.output.finish_message == 'Operation cancelled'
+        assert part_dict(result.output.message.content[0]) == {'text': 'Operation cancelled.'}
+
+    def test_failed_exits_poll_loop(self) -> None:
+        result = from_interaction(
+            Interaction.model_validate({
+                'id': '123',
+                'status': 'failed',
+                'steps': [{'type': 'model_output', 'error': {'code': 3, 'message': 'boom'}}],
+            })
+        )
+        assert result.done is True
+        assert result.error is not None
+        assert result.error.message == 'boom'
+
+    def test_failed_without_step_error_falls_back(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'failed'}))
+        assert result.done is True
+        assert result.error is not None
+        assert result.error.message == 'Interaction failed'
+
+    def test_requires_action_leaves_done_unset(self) -> None:
+        interaction = Interaction.model_validate({
+            'id': '123',
+            'status': 'requires_action',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'approve plan'}]}],
+        })
+        result = from_interaction(interaction)
+        assert result.id == '123'
+        assert result.done is None
+        assert result.output is None
+        assert not (result.metadata or {}).get('interaction_status')
+
+    def test_in_progress(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'in_progress'}))
+        assert result.done is False
+
+    def test_queued_keeps_polling(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'queued'}))
+        assert result.done is False
+
+    def test_incomplete_surfaces_partial_steps(self) -> None:
+        result = from_interaction(
+            Interaction.model_validate({
+                'id': '123',
+                'status': 'incomplete',
+                'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'partial'}]}],
+            })
+        )
+        assert result.done is True
+        assert result.error is None
+        assert result.output is not None
+        assert result.output.finish_reason == 'length'
+        assert result.output.finish_message == 'Interaction incomplete (truncated output)'
+        assert result.output.message is not None
+        assert result.output.message.content[0].root.text == 'partial'
+        assert result.output.message.metadata is not None
+        assert result.output.message.metadata.get('interactionStatus') == 'incomplete'
+
+    def test_incomplete_without_steps_errors(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'incomplete'}))
+        assert result.done is True
+        assert result.output is None
+        assert result.error is not None
+
+    def test_budget_exceeded_surfaces_partial_steps(self) -> None:
+        result = from_interaction(
+            Interaction.model_validate({
+                'id': '123',
+                'status': 'budget_exceeded',
+                'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'draft'}]}],
+            })
+        )
+        assert result.done is True
+        assert result.error is None
+        assert result.output is not None
+        assert result.output.finish_reason == 'aborted'
+        assert result.output.finish_message == 'Interaction exceeded its budget'
+        assert result.output.message is not None
+        assert result.output.message.content[0].root.text == 'draft'
+        assert result.output.message.metadata is not None
+        assert result.output.message.metadata.get('interactionStatus') == 'budget_exceeded'
+
+    def test_budget_exceeded_without_steps_errors(self) -> None:
+        result = from_interaction(Interaction.model_validate({'id': '123', 'status': 'budget_exceeded'}))
+        assert result.done is True
+        assert result.output is None
+        assert result.error is not None
+        assert 'budget' in (result.error.message or '').lower()
+
+
+class TestFromInteractionSync:
+    def test_failed_raises(self) -> None:
+        with pytest.raises(ValueError, match='Interaction failed'):
+            from_interaction_sync(Interaction.model_validate({'status': 'failed'}))

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
@@ -58,6 +58,13 @@ def test_map_genai_error_maps_gaos_status_code() -> None:
     assert mapped.original_message == 'Missing input.'
 
 
+def test_map_genai_error_tolerates_non_numeric_code() -> None:
+    """APIError.code comes from response JSON, so it may be a non-numeric string."""
+    error = APIError('boom', {'error': {'message': 'weird proxy error', 'code': 'boom'}})
+    mapped = map_genai_error(error)
+    assert mapped.status == 'UNKNOWN'
+
+
 def test_map_genai_error_maps_gaos_not_found() -> None:
     error = SimpleNamespace(status_code=404, message="Did you mean 'lyria-3-pro-preview'?")
     mapped = map_genai_error(error)

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_utils_test.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Interactions shared helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from genkit_google_genai.models.interactions_utils import (
+    map_genai_error,
+    partition_keys,
+    require_interaction_steps,
+)
+from google.genai.errors import APIError
+
+from genkit import GenkitError
+
+
+def test_map_genai_error_maps_rate_limit_and_retry_after() -> None:
+    response = SimpleNamespace(headers={'retry-after': '1.5'})
+    error = APIError(429, {'error': {'message': 'slow down', 'status': 'RESOURCE_EXHAUSTED'}}, response=response)
+
+    mapped = map_genai_error(error)
+
+    assert isinstance(mapped, GenkitError)
+    assert mapped.status == 'RESOURCE_EXHAUSTED'
+    assert mapped.original_message == 'slow down'
+    assert mapped.response_metadata is not None
+    assert mapped.response_metadata.get('retry_after_ms') == 1500.0
+
+
+def test_map_genai_error_maps_unauthenticated() -> None:
+    error = APIError(401, {'error': {'message': 'bad key'}})
+    mapped = map_genai_error(error)
+    assert mapped.status == 'UNAUTHENTICATED'
+
+
+def test_map_genai_error_maps_gaos_status_code() -> None:
+    """Interactions gaos errors aren't google.genai.errors.APIError but carry status_code."""
+    error = SimpleNamespace(status_code=400, message='Missing input.')
+    mapped = map_genai_error(error)
+    assert mapped.status == 'INVALID_ARGUMENT'
+    assert mapped.original_message == 'Missing input.'
+
+
+def test_map_genai_error_maps_gaos_not_found() -> None:
+    error = SimpleNamespace(status_code=404, message="Did you mean 'lyria-3-pro-preview'?")
+    mapped = map_genai_error(error)
+    assert mapped.status == 'NOT_FOUND'
+
+
+def test_partition_keys_is_non_mutating() -> None:
+    payload = {
+        'thinking_summaries': 'auto',
+        'google_search': True,
+        'store': True,
+        'extra': 1,
+    }
+    agent, tools, create, rest = partition_keys(
+        payload,
+        ('thinking_summaries',),
+        ('google_search',),
+        ('store', 'response_modalities'),
+    )
+
+    assert agent == {'thinking_summaries': 'auto'}
+    assert tools == {'google_search': True}
+    assert create == {'store': True}
+    assert rest == {'extra': 1}
+    # Original dump is untouched.
+    assert payload == {
+        'thinking_summaries': 'auto',
+        'google_search': True,
+        'store': True,
+        'extra': 1,
+    }
+
+
+def test_require_interaction_steps_rejects_empty() -> None:
+    with pytest.raises(GenkitError, match='Missing input') as exc_info:
+        require_interaction_steps([])
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+
+
+def test_require_interaction_steps_passes_through() -> None:
+    steps = [{'type': 'user_input', 'content': [{'type': 'text', 'text': 'hi'}]}]
+    assert require_interaction_steps(steps) is steps

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -85,11 +85,12 @@ from genkit._ai._resource import (
     define_resource,
 )
 from genkit._ai._tools import Tool, define_interrupt, define_tool
-from genkit._core._action import Action, ActionKind, get_current_context
+from genkit._core._action import Action, ActionKind, get_current_context  # noqa: F401 — re-exported via genkit.__init__
 from genkit._core._background import (
     BackgroundAction,
     CancelModelOpFn,
     CheckModelOpFn,
+    ConfigT,
     StartModelOpFn,
     check_operation,
     define_background_model,
@@ -146,7 +147,7 @@ T = TypeVar('T')
 MiddlewareT = TypeVar('MiddlewareT', bound=BaseMiddleware)
 
 
-def _model_supports_long_running(model_action: Action) -> bool:
+def model_supports_long_running(model_action: Action) -> bool:
     """Check if a model action supports long-running operations."""
     model_info = model_action.metadata.get('model') if model_action.metadata else None
     if not model_info:
@@ -423,12 +424,12 @@ class Genkit:
     def define_background_model(
         self,
         name: str,
-        start: StartModelOpFn,
+        start: StartModelOpFn[ConfigT],
         check: CheckModelOpFn,
         cancel: CancelModelOpFn | None = None,
         label: str | None = None,
         info: ModelInfo | None = None,
-        config_schema: type[BaseModel] | dict[str, object] | None = None,
+        config_schema: type[ConfigT] | dict[str, object] | None = None,
         metadata: dict[str, object] | None = None,
         description: str | None = None,
     ) -> BackgroundAction:
@@ -1412,7 +1413,7 @@ class Genkit:
                 message='No model specified for generate_operation.',
             )
 
-        model_action = await self.registry.resolve_action(ActionKind.MODEL, resolved_model)
+        model_action = await self.registry.resolve_model(resolved_model)
         if not model_action:
             raise GenkitError(
                 status='NOT_FOUND',
@@ -1420,7 +1421,7 @@ class Genkit:
             )
 
         # Check if model supports long-running operations
-        if not _model_supports_long_running(model_action):
+        if not model_supports_long_running(cast(Action, model_action)):
             raise GenkitError(
                 status='INVALID_ARGUMENT',
                 message=f"Model '{model_action.name}' does not support long running operations.",

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -70,6 +70,7 @@ from genkit._core._typing import (
     FinishReason,
     MiddlewareRef,
     MultipartToolResponse,
+    Operation,
     Part,
     Role,
     TextPart,
@@ -747,6 +748,12 @@ async def _generate_action_turn(
                 next_fn,
             )
 
+        # Background models return an Operation to poll, not a finished message.
+        # The tool loop below assumes response.message exists, so branch out first.
+        if model.kind == ActionKind.BACKGROUND_MODEL:
+            operation = cast(Operation, model_response)
+            return ModelResponse(operation=operation, request=request)
+
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
             if formatter is None:
                 return None
@@ -755,10 +762,11 @@ async def _generate_action_turn(
         # Extract schema_type for runtime Pydantic validation
         schema_type = turn_options.output.schema_type if turn_options.output else None
 
-        # Plugin returns ModelResponse directly. Framework sets request and
-        # any output format context (message_parser, schema_type) as private attrs.
+        # Plugin returns ModelResponse directly. Framework fills request when the
+        # plugin didn't already attach one (e.g. with a normalized config echo).
         response = model_response
-        response.request = request
+        if response.request is None:
+            response.request = request
         if formatter:
             response._message_parser = message_parser
         if schema_type:
@@ -1079,11 +1087,17 @@ async def resolve_parameters(
         else cast(str | None, registry.lookup_value('defaultModel', 'defaultModel'))
     )
     if not model:
-        raise Exception('No model configured.')
+        raise GenkitError(status='INVALID_ARGUMENT', message='No model configured.')
 
     model_action = await registry.resolve_model(model)
     if model_action is None:
-        raise Exception(f'Failed to to resolve model {model}')
+        hint = ''
+        if isinstance(model, str) and '/' not in model:
+            hint = f" Did you mean 'googleai/{model}' or 'vertexai/{model}'?"
+        raise GenkitError(
+            status='NOT_FOUND',
+            message=f"Failed to resolve model '{model}'.{hint}",
+        )
 
     # Resolve tools up front to fail fast on invalid caller-supplied tool names or
     # duplicate short names before running side effects or middleware.

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1093,7 +1093,10 @@ async def resolve_parameters(
     if model_action is None:
         hint = ''
         if isinstance(model, str) and '/' not in model:
-            hint = f" Did you mean 'googleai/{model}' or 'vertexai/{model}'?"
+            namespaces = registry.plugin_names()
+            if namespaces:
+                suggestions = ' or '.join(f"'{ns}/{model}'" for ns in namespaces)
+                hint = f' Did you mean {suggestions}?'
         raise GenkitError(
             status='NOT_FOUND',
             message=f"Failed to resolve model '{model}'.{hint}",

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -71,12 +71,19 @@ def model_ref(
     info: ModelInfo | None = None,
     version: str | None = None,
     config: dict[str, object] | None = None,
+    config_schema: object | None = None,
 ) -> ModelRef:
     """Create a ModelRef, optionally prefixing name with namespace."""
     # Logic: if (options.namespace && !name.startsWith(options.namespace + '/'))
     final_name = f'{namespace}/{name}' if namespace and not name.startswith(f'{namespace}/') else name
 
-    return ModelRef(name=final_name, info=info, version=version, config=config)
+    return ModelRef(
+        name=final_name,
+        info=info,
+        version=version,
+        config=config,
+        config_schema=config_schema,
+    )
 
 
 def define_model(

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -695,8 +695,16 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         # signal that "no input" is a legitimate way to invoke this action.
         if input is None and self._first_arg_optional:
             return input
+        # When a BaseModel instance fails (e.g. generate hands ModelRequest with
+        # GenerationCommonConfig into an action typed as ModelRequest[PluginConfig]),
+        # dump to plain data and retry so the action's schema wins.
         try:
-            return self._input_type.validate_python(input)
+            try:
+                return self._input_type.validate_python(input)
+            except ValidationError:
+                if not isinstance(input, BaseModel):
+                    raise
+                return self._input_type.validate_python(input.model_dump(mode='python'))
         except ValidationError as e:
             if input is None:
                 raise GenkitError(

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -20,12 +20,12 @@ from __future__ import annotations
 
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
 
 from pydantic import BaseModel
 
 from genkit._core._action import Action, ActionKind, ActionRunContext
-from genkit._core._model import ModelRequest, ModelResponse
+from genkit._core._model import ConfigT, ModelRequest, ModelResponse
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
@@ -37,7 +37,7 @@ from genkit._core._typing import (
 OutputT = TypeVar('OutputT')
 
 
-def _make_action_key(action_type: ActionKind | str, name: str) -> str:
+def make_action_key(action_type: ActionKind | str, name: str) -> str:
     """Create an action key matching JS format: /{actionType}/{name}.
 
     Args:
@@ -50,12 +50,9 @@ def _make_action_key(action_type: ActionKind | str, name: str) -> str:
     return f'/{action_type}/{name}'
 
 
-# Type aliases for background model functions matching JS signatures
-# JS: start: (input, options) => Promise<Operation<OutputT>>
-StartModelOpFn = Callable[[ModelRequest, ActionRunContext], Awaitable[Operation]]
-# JS: check: (input: Operation<OutputT>) => Promise<Operation<OutputT>>
+# Type aliases for background model start/check/cancel handlers.
+StartModelOpFn = Callable[[ModelRequest[ConfigT], ActionRunContext], Awaitable[Operation]]
 CheckModelOpFn = Callable[[Operation], Awaitable[Operation]]
-# JS: cancel?: (input: Operation<OutputT>) => Promise<Operation<OutputT>>
 CancelModelOpFn = Callable[[Operation], Awaitable[Operation]]
 
 
@@ -128,7 +125,7 @@ class BackgroundAction(Generic[OutputT]):
             An Operation with an ID to track the job.
         """
         result = await self.start_action.run(input)
-        return _ensure_operation(result.response)
+        return ensure_operation(result.response)
 
     async def check(self, operation: Operation) -> Operation:
         """Check the status of a background operation.
@@ -142,7 +139,7 @@ class BackgroundAction(Generic[OutputT]):
             Updated Operation with current status.
         """
         result = await self.check_action.run(operation)
-        return _ensure_operation(result.response)
+        return ensure_operation(result.response)
 
     async def cancel(self, operation: Operation) -> Operation:
         """Cancel a background operation.
@@ -162,10 +159,10 @@ class BackgroundAction(Generic[OutputT]):
             # Match JS behavior: return operation unchanged if cancel not supported
             return operation
         result = await self.cancel_action.run(operation)
-        return _ensure_operation(result.response)
+        return ensure_operation(result.response)
 
 
-def _ensure_operation(response: Any) -> Operation:  # noqa: ANN401
+def ensure_operation(response: Any) -> Operation:  # noqa: ANN401
     """Convert response to Operation type."""
     if isinstance(response, Operation):
         return response
@@ -197,12 +194,12 @@ class DefineBackgroundModelOptions(BaseModel):
 def define_background_model(
     registry: Registry,
     name: str,
-    start: StartModelOpFn,
+    start: StartModelOpFn[ConfigT],
     check: CheckModelOpFn,
     cancel: CancelModelOpFn | None = None,
     label: str | None = None,
     info: ModelInfo | None = None,
-    config_schema: type | dict[str, Any] | None = None,
+    config_schema: type[ConfigT] | dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
     description: str | None = None,
 ) -> BackgroundAction[ModelResponse]:
@@ -243,14 +240,16 @@ def define_background_model(
         ...     op = await action.check(op)
     """
     label = label or name
-    action_key = _make_action_key(ActionKind.BACKGROUND_MODEL, name)
+    action_key = make_action_key(ActionKind.BACKGROUND_MODEL, name)
 
     # Build model metadata matching JS structure
     model_meta: dict[str, Any] = metadata.copy() if metadata else {}
     model_options: dict[str, Any] = {}
 
     if info:
-        model_options.update(info.model_dump())
+        # camelCase wire keys (e.g. longRunning) so generate_operation's
+        # metadata check sees the same shape Dev UI / JS expect.
+        model_options.update(info.model_dump(by_alias=True))
 
     model_options['label'] = label
     if config_schema:
@@ -262,10 +261,12 @@ def define_background_model(
     output_schema_meta = to_json_schema(ModelResponse)
     model_meta['outputSchema'] = output_schema_meta
 
-    # Wrap the start function to add the action key and timing (matching JS)
+    # Wrap the start function to add the action key and timing.
+    # Annotate as bare ModelRequest so Action doesn't build TypeAdapter(ModelRequest[TypeVar]);
+    # when config_schema is set we override to ModelRequest[that schema] below.
     async def wrapped_start(request: ModelRequest, ctx: ActionRunContext) -> Operation:
         start_time = time.perf_counter()
-        op = await start(request, ctx)
+        op = await start(cast(ModelRequest[ConfigT], request), ctx)
         # Set action key matching JS format: /{actionType}/{name}
         op.action = action_key
         latency_ms = (time.perf_counter() - start_time) * 1000
@@ -275,7 +276,7 @@ def define_background_model(
         return op
 
     # Wrap the check function (matching JS - no ctx parameter)
-    async def wrapped_check(op: Operation, ctx: ActionRunContext) -> Operation:
+    async def wrapped_check(op: Operation, _: ActionRunContext) -> Operation:
         updated = await check(op)
         # Preserve action key
         updated.action = action_key
@@ -291,6 +292,12 @@ def define_background_model(
         metadata=model_meta,
         description=description or f'Background model: {label}',
     )
+    # wrapped_start is annotated as bare ModelRequest so Action doesn't build
+    # TypeAdapter(ModelRequest[TypeVar]). When callers pass a concrete config
+    # class, validate start input as ModelRequest[ConfigT].
+    if isinstance(config_schema, type):
+        # Parameterizing at runtime, so the subscript can't be a type expression.
+        start_action._override_input_schema(cast(type, cast(Any, ModelRequest)[config_schema]))
 
     # Register the check action
     # JS: actionType: 'check-operation'
@@ -311,7 +318,7 @@ def define_background_model(
         # Capture cancel in local scope for the nested function
         cancel_fn = cancel
 
-        async def wrapped_cancel(op: Operation, ctx: ActionRunContext) -> Operation:
+        async def wrapped_cancel(op: Operation, _: ActionRunContext) -> Operation:
             cancelled = await cancel_fn(op)
             cancelled.action = action_key
             return cancelled

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -297,7 +297,7 @@ def define_background_model(
     # class, validate start input as ModelRequest[ConfigT].
     if isinstance(config_schema, type):
         # Parameterizing at runtime, so the subscript can't be a type expression.
-        start_action._override_input_schema(cast(type, cast(Any, ModelRequest)[config_schema]))
+        start_action._override_input_schema(cast('type[BaseModel]', cast(Any, ModelRequest)[config_schema]))
 
     # Register the check action
     # JS: actionType: 'check-operation'

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -64,7 +64,9 @@ ModelUsage = GenerationUsage  # public name for GenerationUsage
 
 # TypeVars for generic types
 OutputT = TypeVar('OutputT', default=object)
-ConfigT = TypeVar('ConfigT', bound=ModelConfig, default=ModelConfig)
+# No default — callers/actions bind ModelRequest[TheirConfig]. A ModelConfig
+# default would reject plugin config instances on bare ModelRequest.
+ConfigT = TypeVar('ConfigT', bound=BaseModel)
 
 
 class ModelRef(BaseModel):
@@ -254,6 +256,27 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
     output_schema: dict[str, Any] | None = None
     output_constrained: bool | None = None
     output_content_type: str | None = None
+
+    @field_validator('config', mode='plain')
+    @classmethod
+    def _validate_config(cls, v: object) -> object:
+        """Accept plugin config models and dicts without forcing ModelConfig.
+
+        Bare ModelRequest(config={...}) keeps the dict; ModelRequest[PluginConfig]
+        coerces that dict into the plugin schema. Plugin config instances pass through.
+        """
+        if v is None:
+            return None
+        if isinstance(v, BaseModel):
+            return v
+        if isinstance(v, dict):
+            args = cls.__pydantic_generic_metadata__['args']
+            if args:
+                schema = args[0]
+                if isinstance(schema, type) and issubclass(schema, BaseModel):
+                    return schema.model_validate(v)
+            return v
+        raise TypeError(f'config must be a BaseModel or dict, got {type(v).__name__}')
 
     @field_validator('messages', mode='before')
     @classmethod

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -25,9 +25,18 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from functools import cached_property
-from typing import Any, ClassVar, Generic, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_serializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    SerializeAsAny,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 from pydantic.alias_generators import to_camel
 from typing_extensions import TypeVar
 
@@ -248,7 +257,15 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
     # Veneer types for IDE/typing (validators wrap MessageData->Message, DocumentData->Document)
     messages: list[Message]  # pyright: ignore[reportIncompatibleVariableOverride]
     docs: list[Document] | None = None  # pyright: ignore[reportIncompatibleVariableOverride]
-    config: ConfigT | None = None
+    if TYPE_CHECKING:
+        # Reads are typed as the bound schema: after validation a parametrized
+        # request can only hold ConfigT (dicts are coerced, mismatches rejected).
+        # The runtime union is what pydantic validates and serializes against.
+        config: ConfigT | None = None
+    else:
+        # dict arm first + left_to_right: smart union would lax-coerce bare dict
+        # configs into an empty BaseModel via the unresolved ConfigT arm.
+        config: dict[str, Any] | SerializeAsAny[ConfigT] | None = Field(default=None, union_mode='left_to_right')
     tools: list[ToolDefinition] | None = None
     tool_choice: ToolChoice | None = Field(default=None)
     # Flat output fields (no nested OutputConfig)
@@ -257,17 +274,33 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
     output_constrained: bool | None = None
     output_content_type: str | None = None
 
-    @field_validator('config', mode='plain')
+    if TYPE_CHECKING:
+
+        def __init__(
+            self,
+            *,
+            messages: list[Message],
+            docs: list[Document] | None = None,
+            config: ConfigT | dict[str, Any] | None = None,
+            tools: list[ToolDefinition] | None = None,
+            tool_choice: ToolChoice | None = None,
+            output_format: str | None = None,
+            output_schema: dict[str, Any] | None = None,
+            output_constrained: bool | None = None,
+            output_content_type: str | None = None,
+            **extras: Any,  # noqa: ANN401
+        ) -> None: ...
+
+    @field_validator('config', mode='before')
     @classmethod
     def _validate_config(cls, v: object) -> object:
-        """Accept plugin config models and dicts without forcing ModelConfig.
+        """Coerce dict configs into the bound plugin schema when parametrized.
 
         Bare ModelRequest(config={...}) keeps the dict; ModelRequest[PluginConfig]
-        coerces that dict into the plugin schema. Plugin config instances pass through.
+        coerces that dict into the plugin schema. Plugin config instances pass
+        through here, then union validation rejects mismatched schemas.
         """
-        if v is None:
-            return None
-        if isinstance(v, BaseModel):
+        if v is None or isinstance(v, BaseModel):
             return v
         if isinstance(v, dict):
             args = cls.__pydantic_generic_metadata__['args']
@@ -277,6 +310,26 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
                     return schema.model_validate(v)
             return v
         raise TypeError(f'config must be a BaseModel or dict, got {type(v).__name__}')
+
+    @model_validator(mode='before')
+    @classmethod
+    def _flatten_output(cls, data: object) -> object:
+        """Accept spec wire format: unnest output into the flat output_* fields."""
+        if not isinstance(data, dict):
+            return data
+        flat = cast('dict[str, Any]', dict(data))
+        output = flat.pop('output', None)
+        if not isinstance(output, dict):
+            return data
+        for src, camel, snake in (
+            ('format', 'outputFormat', 'output_format'),
+            ('schema', 'outputSchema', 'output_schema'),
+            ('constrained', 'outputConstrained', 'output_constrained'),
+            ('contentType', 'outputContentType', 'output_content_type'),
+        ):
+            if src in output and camel not in flat and snake not in flat:
+                flat[camel] = output[src]
+        return flat
 
     @field_validator('messages', mode='before')
     @classmethod

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -767,6 +767,9 @@ class Registry:
         """
         action = await self.resolve_action(ActionKind.MODEL, name)
         if action is None:
+            # background-only models (Veo, Deep Research) live under a different kind
+            action = await self.resolve_action(ActionKind.BACKGROUND_MODEL, name)
+        if action is None:
             return None
         return cast(
             Action[ModelRequest, ModelResponse, ModelResponseChunk],

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -405,6 +405,14 @@ class Registry:
             return local
         return {**self._parent.list_values(kind), **local}
 
+    def plugin_names(self) -> list[str]:
+        """Names of registered plugins, parent-first, deduplicated."""
+        with self._lock:
+            local = list(self._plugins)
+        if self._parent is None:
+            return local
+        return list(dict.fromkeys([*self._parent.plugin_names(), *local]))
+
     def register_plugin(self, plugin: Plugin) -> None:
         """Register a plugin with the registry.
 

--- a/py/packages/genkit/src/genkit/_core/_typing.py
+++ b/py/packages/genkit/src/genkit/_core/_typing.py
@@ -90,6 +90,7 @@ class FinishReason(StrEnum):
     STOP = 'stop'
     LENGTH = 'length'
     BLOCKED = 'blocked'
+    ABORTED = 'aborted'
     INTERRUPTED = 'interrupted'
     OTHER = 'other'
     UNKNOWN = 'unknown'

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for background model generate() and generate_operation() plumbing."""
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from genkit import Genkit, Message, ModelResponse, Part, Role, TextPart
+from genkit._core._action import ActionRunContext
+from genkit._core._error import GenkitError
+from genkit._core._model import ModelRequest
+from genkit._core._typing import ModelInfo, Operation, Supports
+
+
+@pytest.fixture
+def ai() -> Genkit:
+    """Create a fresh Genkit instance for each test."""
+    return Genkit()
+
+
+async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> None:
+    async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
+        return Operation(id=op_id, done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    ai.define_background_model(
+        name='bg-model',
+        start=start,
+        check=check,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+
+class PluginConfig(BaseModel):
+    thinking_summaries: str | None = None
+    google_search: bool | None = None
+
+
+@pytest.mark.asyncio
+async def test_background_start_receives_plugin_config_schema(ai: Genkit) -> None:
+    """Bare ModelRequest configs are re-validated as the plugin config schema."""
+    seen: dict[str, Any] = {}
+
+    async def start(request: ModelRequest[PluginConfig], _: ActionRunContext) -> Operation:
+        seen['config'] = request.config
+        return Operation(id='cfg-op', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    action = ai.define_background_model(
+        name='cfg-model',
+        start=start,
+        check=check,
+        config_schema=PluginConfig,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+    # Mimic generate: bare ModelRequest keeps a dict; Action coerces to the plugin schema.
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='go'))])],
+        config={'thinking_summaries': 'auto', 'google_search': True},
+    )
+    assert request.config == {'thinking_summaries': 'auto', 'google_search': True}
+
+    await action.start(request)
+
+    config = seen['config']
+    assert isinstance(config, PluginConfig)
+    assert config.thinking_summaries == 'auto'
+    assert config.google_search is True
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_operation_for_background_model(ai: Genkit) -> None:
+    """generate() wraps a background model Operation in ModelResponse."""
+    await register_bg_model(ai)
+
+    response = await ai.generate(model='bg-model', prompt='a cat surfing')
+
+    assert response.operation is not None
+    assert response.operation.id == 'bg-op-123'
+    assert response.operation.done is False
+    assert response.operation.action == '/background-model/bg-model'
+    assert response.message is None
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_with_background_model(ai: Genkit) -> None:
+    """generate_operation resolves background models via resolve_model()."""
+    await register_bg_model(ai, op_id='bg-op-456')
+
+    operation = await ai.generate_operation(model='bg-model', prompt='a cat surfing')
+
+    assert isinstance(operation, Operation)
+    assert operation.id == 'bg-op-456'
+    assert operation.action == '/background-model/bg-model'
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_rejects_foreground_model_without_lro(ai: Genkit) -> None:
+    """generate_operation rejects standard foreground models."""
+
+    async def model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
+        return ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='Hello'))],
+            ),
+        )
+
+    ai.define_model(name='fg-model', fn=model_fn)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await ai.generate_operation(model='fg-model', prompt='Hi')
+
+    assert 'does not support long running operations' in str(exc_info.value)

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -22,7 +22,8 @@ import pytest
 from pydantic import BaseModel
 
 from genkit import Genkit, Message, ModelResponse, Part, Role, TextPart
-from genkit._core._action import ActionRunContext
+from genkit._core._action import ActionKind, ActionRunContext
+from genkit._core._background import BackgroundAction
 from genkit._core._error import GenkitError
 from genkit._core._model import ModelRequest
 from genkit._core._typing import ModelInfo, Operation, Supports
@@ -34,14 +35,14 @@ def ai() -> Genkit:
     return Genkit()
 
 
-async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> None:
+async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> BackgroundAction:
     async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
         return Operation(id=op_id, done=False)
 
     async def check(op: Operation) -> Operation:
         return op
 
-    ai.define_background_model(
+    return ai.define_background_model(
         name='bg-model',
         start=start,
         check=check,
@@ -133,3 +134,60 @@ async def test_generate_operation_rejects_foreground_model_without_lro(ai: Genki
         await ai.generate_operation(model='fg-model', prompt='Hi')
 
     assert 'does not support long running operations' in str(exc_info.value)
+
+
+def register_cancellable_model(ai: Genkit, cancelled: list[str]) -> BackgroundAction:
+    async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
+        return Operation(id='op-1', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    async def cancel(op: Operation) -> Operation:
+        cancelled.append(op.id)
+        return Operation(id=op.id, done=True)
+
+    return ai.define_background_model(
+        name='cancellable-model',
+        start=start,
+        check=check,
+        cancel=cancel,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_runs_handler_and_preserves_action_key(ai: Genkit) -> None:
+    """cancel() invokes the handler and stamps the background action key."""
+    cancelled: list[str] = []
+    action = register_cancellable_model(ai, cancelled)
+
+    assert action.supports_cancel
+
+    result = await action.cancel(Operation(id='op-1', done=False))
+
+    assert cancelled == ['op-1']
+    assert result.done is True
+    assert result.action == '/background-model/cancellable-model'
+
+
+@pytest.mark.asyncio
+async def test_cancel_action_resolvable_via_registry(ai: Genkit) -> None:
+    """Cancel registers under cancel-operation kind at {name}/cancel."""
+    action = register_cancellable_model(ai, [])
+
+    resolved = await ai.registry.resolve_action(ActionKind.CANCEL_OPERATION, 'cancellable-model/cancel')
+
+    assert resolved is action.cancel_action
+
+
+@pytest.mark.asyncio
+async def test_cancel_without_handler_returns_operation_unchanged(ai: Genkit) -> None:
+    """Without a cancel handler the operation comes back untouched (JS parity)."""
+    action = await register_bg_model(ai)
+
+    assert not action.supports_cancel
+    assert await ai.registry.resolve_action(ActionKind.CANCEL_OPERATION, 'bg-model/cancel') is None
+
+    op = Operation(id='bg-op-123', done=False)
+    assert await action.cancel(op) is op

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -5,11 +5,14 @@
 
 """Tests for the action module."""
 
+import warnings
+
 import pytest
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from genkit import Message, ModelRequest, ModelResponse, ModelResponseChunk, ModelUsage
 from genkit._ai._model import text_from_content
+from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
     ActionMetadata,
     DocumentPart,
@@ -414,3 +417,54 @@ def test_parameterized_model_request_coerces_dict_to_plugin_config() -> None:
     )
     assert isinstance(request.config, PluginConfig)
     assert request.config.api_key == 'k'
+
+
+def test_parameterized_model_request_rejects_mismatched_config_instance() -> None:
+    class OtherConfig(BaseModel):
+        top_k: int | None = None
+
+    with pytest.raises(ValidationError):
+        ModelRequest[PluginConfig](
+            messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+            config=OtherConfig(top_k=3),  # pyright: ignore[reportArgumentType]
+        )
+
+
+def test_model_request_rejects_non_model_non_dict_config() -> None:
+    with pytest.raises(TypeError, match='config must be a BaseModel or dict'):
+        ModelRequest(
+            messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+            config='not-a-config',  # pyright: ignore[reportArgumentType]
+        )
+
+
+def test_parameterized_model_request_config_json_schema_refs_plugin_schema() -> None:
+    schema = to_json_schema(ModelRequest[PluginConfig])
+    config_prop = schema['properties']['config']
+    assert any('$ref' in arm for arm in config_prop.get('anyOf', [])), config_prop
+
+
+def test_model_request_dump_round_trip_preserves_output_config() -> None:
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'temperature': 0.5},
+        output_format='json',
+        output_schema={'type': 'object'},
+        output_constrained=True,
+    )
+    round_tripped = ModelRequest.model_validate(request.model_dump(mode='python'))
+    assert round_tripped.output_format == 'json'
+    assert round_tripped.output_schema == {'type': 'object'}
+    assert round_tripped.output_constrained is True
+    assert round_tripped.config == {'temperature': 0.5}
+
+
+def test_model_request_dump_emits_no_serializer_warnings() -> None:
+    request = ModelRequest[PluginConfig](
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'api_key': 'k'},
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        request.model_dump(mode='python')
+        request.model_dump_json()

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -6,6 +6,7 @@
 """Tests for the action module."""
 
 import pytest
+from pydantic import BaseModel, ConfigDict
 
 from genkit import Message, ModelRequest, ModelResponse, ModelResponseChunk, ModelUsage
 from genkit._ai._model import text_from_content
@@ -20,6 +21,14 @@ from genkit._core._typing import (
     ToolRequestPart,
 )
 from genkit.model import get_basic_usage_stats, model_action_metadata
+
+
+class PluginConfig(BaseModel):
+    """Stand-in for a plugin-specific config schema (e.g. LyriaConfig)."""
+
+    model_config = ConfigDict(extra='allow')
+    api_key: str | None = None
+    response_modalities: list[str] | None = None
 
 
 def test_message_wrapper_text() -> None:
@@ -376,3 +385,32 @@ def test_text_from_content_with_none_text() -> None:
         Part(root=TextPart(text=' world')),
     ]
     assert text_from_content(content) == 'hello world'
+
+
+def test_bare_model_request_accepts_plugin_config_instance() -> None:
+    """Bare ModelRequest(config=PluginConfig) keeps the plugin schema instance."""
+    plugin_config = PluginConfig(api_key='k', response_modalities=['audio'])
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config=plugin_config,
+    )
+    assert request.config is plugin_config
+    assert isinstance(request.config, PluginConfig)
+
+
+def test_bare_model_request_keeps_dict_config() -> None:
+    """Dict configs stay dicts on bare ModelRequest; Action coerces to the plugin schema."""
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'temperature': 0.5, 'api_key': 'k'},
+    )
+    assert request.config == {'temperature': 0.5, 'api_key': 'k'}
+
+
+def test_parameterized_model_request_coerces_dict_to_plugin_config() -> None:
+    request = ModelRequest[PluginConfig](
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'api_key': 'k'},
+    )
+    assert isinstance(request.config, PluginConfig)
+    assert request.config.api_key == 'k'

--- a/py/packages/genkit/tests/genkit/ai/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/ai/prompt_test.py
@@ -100,7 +100,7 @@ async def test_simple_prompt() -> None:
     """Test simple prompt rendering."""
     ai, *_ = setup_test()
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     my_prompt = ai.define_prompt(prompt='hi', config={'temperature': 11})
 
@@ -123,7 +123,7 @@ async def test_simple_prompt_with_override_config() -> None:
     ai, *_ = setup_test()
 
     # Config is MERGED: prompt config (banana: true) + opts config (temperature: 12)
-    want_txt = '[ECHO] user: "hi" {"temperature":12.0,"banana":true}'
+    want_txt = '[ECHO] user: "hi" {"banana":true,"temperature":12}'
 
     my_prompt = ai.define_prompt(prompt='hi', config={'banana': True})
 
@@ -221,7 +221,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] system: "hello foo (bar)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] system: "hello foo (bar)" {"banana":"ripe","temperature":11.0}""",
     ),
     (
         'renders user prompt',
@@ -241,7 +241,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] user: "hello foo (bar_system)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] user: "hello foo (bar_system)" {"banana":"ripe","temperature":11.0}""",
     ),
     (
         'renders user prompt with context',
@@ -261,7 +261,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {'auth': {'email': 'a@b.c'}},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] user: "hello foo (bar, a@b.c)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] user: "hello foo (bar, a@b.c)" {"banana":"ripe","temperature":11.0}""",
     ),
 ]
 

--- a/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for generate-path model resolution errors."""
+
+import pytest
+
+from genkit import GenkitError
+from genkit._ai._generate import resolve_parameters
+from genkit._core._model import GenerateActionOptions
+from genkit._core._registry import Registry
+
+
+@pytest.mark.asyncio
+async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> None:
+    registry = Registry()
+    with pytest.raises(GenkitError) as exc_info:
+        await resolve_parameters(
+            registry,
+            GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
+        )
+    assert exc_info.value.status == 'NOT_FOUND'
+    assert 'googleai/lyria-3-clip-preview' in str(exc_info.value)
+    assert 'vertexai/lyria-3-clip-preview' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_resolve_parameters_no_model_is_invalid_argument() -> None:
+    registry = Registry()
+    with pytest.raises(GenkitError) as exc_info:
+        await resolve_parameters(registry, GenerateActionOptions(messages=[]))
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'No model configured' in str(exc_info.value)

--- a/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
@@ -18,14 +18,44 @@
 
 import pytest
 
-from genkit import GenkitError
+from genkit import GenkitError, Plugin
 from genkit._ai._generate import resolve_parameters
+from genkit._core._action import Action, ActionKind
 from genkit._core._model import GenerateActionOptions
 from genkit._core._registry import Registry
+from genkit._core._typing import ActionMetadata
+
+
+class _NamespacePlugin(Plugin):
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def init(self) -> list[Action]:
+        return []
+
+    async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
+        return None
+
+    async def list_actions(self) -> list[ActionMetadata]:
+        return []
 
 
 @pytest.mark.asyncio
-async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> None:
+async def test_resolve_parameters_missing_prefix_hints_registered_namespaces() -> None:
+    registry = Registry()
+    registry.register_plugin(_NamespacePlugin('ollama'))
+    registry.register_plugin(_NamespacePlugin('openai'))
+    with pytest.raises(GenkitError) as exc_info:
+        await resolve_parameters(
+            registry,
+            GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
+        )
+    assert exc_info.value.status == 'NOT_FOUND'
+    assert "'ollama/lyria-3-clip-preview' or 'openai/lyria-3-clip-preview'" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_resolve_parameters_no_plugins_no_namespace_hint() -> None:
     registry = Registry()
     with pytest.raises(GenkitError) as exc_info:
         await resolve_parameters(
@@ -33,8 +63,7 @@ async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> Non
             GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
         )
     assert exc_info.value.status == 'NOT_FOUND'
-    assert 'googleai/lyria-3-clip-preview' in str(exc_info.value)
-    assert 'vertexai/lyria-3-clip-preview' in str(exc_info.value)
+    assert 'Did you mean' not in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -12,10 +12,13 @@ functionality, ensuring proper registration and management of Genkit resources.
 import pytest
 
 from genkit import Genkit, Plugin
-from genkit._core._action import Action, ActionKind, create_action_key
+from genkit._core._action import Action, ActionKind, ActionRunContext, create_action_key
+from genkit._core._background import define_background_model
 from genkit._core._dap import DapValue, define_dynamic_action_provider
+from genkit._core._model import ModelRequest
+from genkit._core._protocols import RegistryLike
 from genkit._core._registry import Registry
-from genkit._core._typing import ActionMetadata
+from genkit._core._typing import ActionMetadata, ModelInfo, Operation, Supports
 
 
 async def _identity(x: object) -> object:
@@ -432,9 +435,33 @@ async def test_list_actions_registered_canonical_coexists_with_qualified_dap_row
     assert provider_key in catalog
 
 
+@pytest.mark.asyncio
+async def test_resolve_model_falls_back_to_background_model() -> None:
+    """resolve_model finds models registered only under BACKGROUND_MODEL."""
+    registry = Registry()
+
+    async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
+        return Operation(id='bg-start', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    define_background_model(
+        registry=registry,
+        name='veo-model',
+        start=start,
+        check=check,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+    assert await registry.resolve_action(ActionKind.MODEL, 'veo-model') is None
+
+    resolved = await registry.resolve_model('veo-model')
+    assert resolved is not None
+    assert resolved.kind == ActionKind.BACKGROUND_MODEL
+    assert resolved.name == 'veo-model'
+
+
 def test_registry_satisfies_registry_like() -> None:
     """Registry must structurally satisfy RegistryLike so middleware can use it as such."""
-    from genkit._core._protocols import RegistryLike
-    from genkit._core._registry import Registry
-
     assert isinstance(Registry(None), RegistryLike)

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -75,7 +75,7 @@ async def test_generate_uses_default_model(setup_test: SetupFixture) -> None:
     """Test that the generate function uses the default model."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     response = await ai.generate(prompt='hi', config={'temperature': 11})
 
@@ -125,11 +125,11 @@ async def test_generate_with_explicit_model(setup_test: SetupFixture) -> None:
 
     response = await ai.generate(model='echoModel', prompt='hi', config={'temperature': 11})
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
     stream_result = ai.generate_stream(model='echoModel', prompt='hi', config={'temperature': 11})
 
-    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -139,7 +139,7 @@ async def test_generate_with_str_prompt(setup_test: SetupFixture) -> None:
 
     response = await ai.generate(prompt='hi', config={'temperature': 11})
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -147,7 +147,7 @@ async def test_generate_with_part_prompt(setup_test: SetupFixture) -> None:
     """Test that the generate function with a part prompt works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     response = await ai.generate(prompt=[Part(root=TextPart(text='hi'))], config={'temperature': 11})
 
@@ -163,7 +163,7 @@ async def test_generate_with_part_list_prompt(setup_test: SetupFixture) -> None:
     """Test that the generate function with a list of parts prompt works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hello","world" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hello","world" {"temperature":11}'
 
     response = await ai.generate(
         prompt=[Part(root=TextPart(text='hello')), Part(root=TextPart(text='world'))],
@@ -185,7 +185,7 @@ async def test_generate_with_str_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a string system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(system='talk like pirate', prompt='hi', config={'temperature': 11})
 
@@ -201,7 +201,7 @@ async def test_generate_with_part_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a part system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(
         system=[Part(root=TextPart(text='talk like pirate'))],
@@ -225,7 +225,7 @@ async def test_generate_with_part_list_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a list of parts system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk","like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk","like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(
         system=[Part(root=TextPart(text='talk')), Part(root=TextPart(text='like pirate'))],
@@ -259,7 +259,7 @@ async def test_generate_with_messages(setup_test: SetupFixture) -> None:
         config={'temperature': 11},
     )
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
     stream_result = ai.generate_stream(
         messages=[
@@ -271,7 +271,7 @@ async def test_generate_with_messages(setup_test: SetupFixture) -> None:
         config={'temperature': 11},
     )
 
-    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -1506,7 +1506,7 @@ def test_define_model_default_metadata(setup_test: SetupFixture) -> None:
     """Test that the define model function works."""
     ai, _, _, *_ = setup_test
 
-    async def foo_model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+    async def foo_model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
         return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='banana!'))]))
 
     action = ai.define_model(
@@ -1527,7 +1527,7 @@ def test_define_model_with_schema(setup_test: SetupFixture) -> None:
         field_a: str = Field(description='a field')
         field_b: str = Field(description='b field')
 
-    async def foo_model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+    async def foo_model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
         return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='banana!'))]))
 
     action = ai.define_model(
@@ -1564,7 +1564,7 @@ def test_define_model_with_info(setup_test: SetupFixture) -> None:
     """Test that the define model function with info works."""
     ai, _, _, *_ = setup_test
 
-    async def foo_model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+    async def foo_model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
         return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='banana!'))]))
 
     action = ai.define_model(

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1756,7 +1756,7 @@ dependencies = [
 requires-dist = [
     { name = "genkit", editable = "packages/genkit" },
     { name = "google-cloud-aiplatform", specifier = ">=1.77.0" },
-    { name = "google-genai", specifier = ">=1.63.0" },
+    { name = "google-genai", specifier = ">=2.14.0,<3" },
     { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
     { name = "structlog", specifier = ">=25.2.0" },
 ]
@@ -2087,16 +2087,15 @@ grpc = [
 
 [[package]]
 name = "google-auth"
-version = "2.48.0"
+version = "2.56.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/33/dbc946a407401b975f0719658f18e664ece2109f79ffd1ff3bf226c205f4/google_auth-2.56.2.tar.gz", hash = "sha256:e28f103ca8091fb7012b99c44243d7366c29863713b8e34a220c3322b7a07051", size = 365820, upload-time = "2026-07-21T21:53:28.188Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
+    { url = "https://files.pythonhosted.org/packages/88/63/50636aae68c9bf17c891c7eb18b49baa9bd6b31d2a97b8de4813a9fc8d1c/google_auth-2.56.2-py3-none-any.whl", hash = "sha256:c8270ea95b2697b74e3d8438ae9c5b898e38b623b915c7b5c5635921e7de68a6", size = 258588, upload-time = "2026-07-21T21:53:26.399Z" },
 ]
 
 [package.optional-dependencies]
@@ -2106,15 +2105,17 @@ requests = [
 
 [[package]]
 name = "google-cloud-aiplatform"
-version = "1.137.0"
+version = "1.162.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "certifi" },
     { name = "docstring-parser" },
     { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-resource-manager" },
-    { name = "google-cloud-storage" },
+    { name = "google-cloud-storage", version = "3.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "google-cloud-storage", version = "3.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "google-genai" },
     { name = "packaging" },
     { name = "proto-plus" },
@@ -2122,9 +2123,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/76/0da98f663f5c58239900fa8f99488d01439b1ca7846c9667217a3aee20b1/google_cloud_aiplatform-1.137.0.tar.gz", hash = "sha256:76e66e2c3879936e51039d8bbd82581451510b4c7a840a588daaecee893d7d1e", size = 9947045, upload-time = "2026-02-11T16:23:18.435Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/fa/20a86701f1d3bcbedfe03a965bd4ae000ba79863fb1c2b4b658965f1057d/google_cloud_aiplatform-1.162.0.tar.gz", hash = "sha256:2403f75e6e44e879aecc0eab2d8c26e972507e4b4414d873b31cd4f4b49c9edb", size = 11218765, upload-time = "2026-07-21T23:17:44.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/b5/795c410120cb350058b9328f051b57a49a897514ba1bc65677ade0f6c1be/google_cloud_aiplatform-1.137.0-py2.py3-none-any.whl", hash = "sha256:e99dd235c237cbbeb0e73b0fc4b1ca9588b4144ac243a6242b2005b339b40ce8", size = 8204286, upload-time = "2026-02-11T16:23:15.462Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b8/6f10db46713d03d4e889d569b8b0e10e4334d2cab26b9f865c78b1e4e4d9/google_cloud_aiplatform-1.162.0-py2.py3-none-any.whl", hash = "sha256:07ac79932b8f7a683c3bec6dcc21dd05234b55d01636b5a622ec93c18aad15fd", size = 9391054, upload-time = "2026-07-21T23:17:41.173Z" },
 ]
 
 [[package]]
@@ -2260,17 +2261,43 @@ wheels = [
 name = "google-cloud-storage"
 version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "google-api-core" },
-    { name = "google-auth" },
-    { name = "google-cloud-core" },
-    { name = "google-crc32c" },
-    { name = "google-resumable-media" },
-    { name = "requests" },
+    { name = "google-api-core", marker = "python_full_version < '3.13'" },
+    { name = "google-auth", marker = "python_full_version < '3.13'" },
+    { name = "google-cloud-core", marker = "python_full_version < '3.13'" },
+    { name = "google-crc32c", marker = "python_full_version < '3.13'" },
+    { name = "google-resumable-media", marker = "python_full_version < '3.13'" },
+    { name = "requests", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/b1/4f0798e88285b50dfc60ed3a7de071def538b358db2da468c2e0deecbb40/google_cloud_storage-3.9.0.tar.gz", hash = "sha256:f2d8ca7db2f652be757e92573b2196e10fbc09649b5c016f8b422ad593c641cc", size = 17298544, upload-time = "2026-02-02T13:36:34.119Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/0b/816a6ae3c9fd096937d2e5f9670558908811d57d59ddf69dd4b83b326fd1/google_cloud_storage-3.9.0-py3-none-any.whl", hash = "sha256:2dce75a9e8b3387078cbbdad44757d410ecdb916101f8ba308abf202b6968066", size = 321324, upload-time = "2026-02-02T13:36:32.271Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.13.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+]
+dependencies = [
+    { name = "google-api-core", marker = "python_full_version >= '3.13'" },
+    { name = "google-auth", marker = "python_full_version >= '3.13'" },
+    { name = "google-cloud-core", marker = "python_full_version >= '3.13'" },
+    { name = "google-crc32c", marker = "python_full_version >= '3.13'" },
+    { name = "google-resumable-media", marker = "python_full_version >= '3.13'" },
+    { name = "requests", marker = "python_full_version >= '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/25/355ed97c1723c787dfaa888808d55db18371f82c38ff862357b1e902cd19/google_cloud_storage-3.13.0.tar.gz", hash = "sha256:d11d8706ea1520fba0f21043bcb7897caf7015d76ce1ad9a4f60237e4d7a9f6c", size = 17340960, upload-time = "2026-07-13T19:10:07.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e8/b3678a0931ee7d4b3fdaf0813e6206d66e0922b2c26d912f308728b5b95a/google_cloud_storage-3.13.0-py3-none-any.whl", hash = "sha256:648af3ef8a6acc674e1359d3c920c67eb89a7a5ab66b336bd3ac43fed6b5ab84", size = 341428, upload-time = "2026-07-13T19:09:52.39Z" },
 ]
 
 [[package]]
@@ -2326,7 +2353,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.63.0"
+version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2340,9 +2367,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/d7/07ec5dadd0741f09e89f3ff5f0ce051ce2aa3a76797699d661dc88def077/google_genai-1.63.0.tar.gz", hash = "sha256:dc76cab810932df33cbec6c7ef3ce1538db5bef27aaf78df62ac38666c476294", size = 491970, upload-time = "2026-02-11T23:46:28.472Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/df/4f820054c99f29f2fe3de4a8a7c9534dd795302e4a07483a0cb07c3a29b6/google_genai-2.14.0.tar.gz", hash = "sha256:a9d1f4f362d76280f1be1340fcb3c86e63dbca128f6a4ae09d86ab47ff7148e8", size = 641055, upload-time = "2026-07-22T21:35:44.717Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/c8/ba32159e553fab787708c612cf0c3a899dafe7aca81115d841766e3bfe69/google_genai-1.63.0-py3-none-any.whl", hash = "sha256:6206c13fc20f332703ca7375bea7c191c82f95d6781c29936c6982d86599b359", size = 724747, upload-time = "2026-02-11T23:46:26.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/86/5ac5fb53e44cca4a6607fb917eb331fa237c65a103b9ec2e8e8acc8a42db/google_genai-2.14.0-py3-none-any.whl", hash = "sha256:ae7172cdd35695189b516b33a878e4132e5daa2dbc03a5b44cddfa8a82fad664", size = 1030738, upload-time = "2026-07-22T21:35:42.785Z" },
 ]
 
 [[package]]
@@ -6112,18 +6139,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Second slice of the #5806 split (stacked on #5854): minimal async HTTP client for the Google AI Interactions API, request/response converters between Genkit and Interactions wire types, ClientOptions resolution, shared error-mapping utilities, and the google-genai >=2.14.0,<3 bump.

Part of the stack splitting #5806; recombined it reproduces that PR byte-for-byte. Co-authored with @huangjeff5.

### Breaking changes

- `google-genai` dependency floor moves from `>=1.63.0` to `>=2.14.0,<3` (major version bump) for the Interactions SDK types. Downstream projects pinned below 2.x will fail to resolve.
