### PR TITLE
feat(py/plugins/google-genai): Deep Research, Antigravity, and Lyria interaction models

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/__init__.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/__init__.py
@@ -89,7 +89,8 @@ from genkit_google_genai.models.gemini import (
     VertexAIGeminiVersion,
 )
 from genkit_google_genai.models.imagen import ImagenVersion
-from genkit_google_genai.models.lyria import LyriaConfig, LyriaVersion
+from genkit_google_genai.models.interactions_registry import LyriaVersion
+from genkit_google_genai.models.lyria import LyriaConfig
 from genkit_google_genai.models.veo import VeoConfig, VeoVersion
 
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/antigravity.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/antigravity.py
@@ -14,11 +14,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Google AI Interactions Lyria audio model action."""
+"""Google AI Interactions Antigravity model action."""
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
@@ -33,8 +33,8 @@ from genkit_google_genai._interactions.converters import (
     split_system_instruction,
     to_interaction_steps,
 )
-from genkit_google_genai._interactions.options import ClientOptions, ResponseModality
-from genkit_google_genai.models.interactions_registry import lyria_model_info
+from genkit_google_genai._interactions.options import ClientOptions
+from genkit_google_genai.models.interactions_registry import antigravity_model_info
 from genkit_google_genai.models.interactions_utils import (
     calculate_api_key,
     client_overrides_from_config,
@@ -44,11 +44,18 @@ from genkit_google_genai.models.interactions_utils import (
     require_interaction_steps,
 )
 
-CREATE_OPTION_KEYS = ('response_modalities',)
+DEFAULT_ENVIRONMENT: dict[str, str] = {'type': 'remote'}
+
+CREATE_OPTION_KEYS = (
+    'previous_interaction_id',
+    'store',
+    'environment',
+    'response_modalities',
+)
 
 
-class LyriaConfig(BaseModel):
-    """Google AI Interactions Lyria model configuration."""
+class AntigravityConfig(BaseModel):
+    """Antigravity model configuration."""
 
     # Per-request options arrive camelCased (apiKey).
     model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
@@ -58,21 +65,24 @@ class LyriaConfig(BaseModel):
     # Milliseconds — applied to the HTTP call, not the create body.
     timeout: float | None = None
     custom_headers: dict[str, str] | None = None
-    response_modalities: list[ResponseModality] | None = None
+    previous_interaction_id: str | None = None
+    store: bool | None = None
+    environment: str | dict[str, Any] | None = None
+    response_modalities: list[Literal['text', 'image']] | None = None
 
 
-def create_lyria_action(
+def create_antigravity_action(
     name: str,
     *,
     plugin_api_key: str | None,
     client_options: ClientOptions,
-) -> Action[ModelRequest[LyriaConfig], ModelResponse, Never]:
-    """Build a foreground model action for Interactions Lyria."""
+) -> Action[ModelRequest[AntigravityConfig], ModelResponse, Never]:
+    """Build a foreground model action for Antigravity."""
     version = extract_version(name)
-    info = lyria_model_info(version)
+    info = antigravity_model_info(version)
 
-    async def run(request: ModelRequest[LyriaConfig], _: ActionRunContext) -> ModelResponse:
-        config = request.config or LyriaConfig()
+    async def run(request: ModelRequest[AntigravityConfig], _: ActionRunContext) -> ModelResponse:
+        config = request.config or AntigravityConfig()
         api_key = calculate_api_key(plugin_api_key, config.api_key)
         merged_options = client_options.merge(
             client_overrides_from_config(
@@ -82,24 +92,31 @@ def create_lyria_action(
                 custom_headers=config.custom_headers,
             )
         )
-        # Known create fields vs undocumented passthrough (same as JS ...rest).
+
+        # Known create kwargs vs undocumented passthrough — non-mutating split.
         dumped = remove_client_option_overrides(config.model_dump(exclude_none=True))
         create_options, passthrough = partition_keys(dumped, CREATE_OPTION_KEYS)
-        modalities = create_options.get('response_modalities') or ['audio', 'text']
+        # Antigravity doesn't take system_instruction; fold system text into the
+        # leading user turn so guidance still reaches the model.
         system_instruction, turns = split_system_instruction(request.messages or [])
         steps = to_interaction_steps(ensure_tool_ids(turns))
+        if system_instruction:
+            steps.insert(
+                0,
+                {
+                    'type': 'user_input',
+                    'content': [{'type': 'text', 'text': system_instruction}],
+                },
+            )
+        require_interaction_steps(steps)
         create_kwargs: dict[str, Any] = {
-            'model': version,
+            'agent': version,
             'input': steps,
-            'response_modalities': modalities,
+            **create_options,
             **passthrough,
         }
-        if system_instruction:
-            create_kwargs['system_instruction'] = system_instruction
-        # Reject empty prompts before the round trip; system_instruction alone
-        # is enough for Lyria, so only require steps when there is no system text.
-        if not system_instruction:
-            require_interaction_steps(steps)
+        # Default missing environment to remote; the API rejects unsupported values.
+        create_kwargs.setdefault('environment', DEFAULT_ENVIRONMENT)
 
         created = await create_interaction(api_key, create_kwargs, merged_options)
         return from_interaction_sync(created)
@@ -111,6 +128,6 @@ def create_lyria_action(
         metadata=model_action_metadata(
             name=name,
             info=info.model_dump(by_alias=True),
-            config_schema=LyriaConfig,
+            config_schema=AntigravityConfig,
         ).metadata,
     )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/deep_research.py
@@ -1,0 +1,281 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google AI Interactions Deep Research background model action."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+from genkit import ModelInfo, ModelRequest
+from genkit._core._background import define_background_model
+from genkit._core._registry import Registry
+from genkit.model import BackgroundAction, ModelRef, Operation, model_ref
+from genkit.plugin_api import ActionRunContext
+from genkit_google_genai._interactions.client import (
+    cancel_interaction,
+    create_interaction,
+    get_interaction,
+)
+from genkit_google_genai._interactions.converters import (
+    clean_schema,
+    ensure_tool_ids,
+    from_interaction,
+    split_system_instruction,
+    to_interaction_steps,
+    to_interaction_tool,
+)
+from genkit_google_genai._interactions.options import ClientOptions
+from genkit_google_genai.models.interactions_registry import (
+    DEEP_RESEARCH_INFO,
+    KNOWN_DEEP_RESEARCH_MODELS,
+    deep_research_model_info,
+)
+from genkit_google_genai.models.interactions_utils import (
+    calculate_api_key,
+    client_options_for_operation,
+    client_overrides_from_config,
+    extract_version,
+    partition_keys,
+    remove_client_option_overrides,
+    require_interaction_steps,
+)
+
+AGENT_CONFIG_KEYS = (
+    'thinking_summaries',
+    'visualization',
+    'collaborative_planning',
+)
+TOOL_CONFIG_KEYS = (
+    'google_search',
+    'url_context',
+    'code_execution',
+    'file_search',
+    'mcp_servers',
+)
+CREATE_OPTION_KEYS = (
+    'previous_interaction_id',
+    'store',
+    'response_modalities',
+)
+
+
+class McpServerConfig(BaseModel):
+    """MCP server configuration for Deep Research."""
+
+    # Request config shows up camelCased on the wire (allowedTools, …).
+    model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
+    name: str | None = None
+    url: str | None = None
+    headers: dict[str, str] | None = None
+    allowed_tools: list[str] | None = None
+
+
+class FileSearchConfig(BaseModel):
+    """File search store configuration for Deep Research."""
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
+    file_search_store_names: list[str]
+
+
+class DeepResearchConfig(BaseModel):
+    """Deep Research model configuration."""
+
+    # Per-request options arrive camelCased (apiKey). Without accepting those
+    # names, the override silently disappears before check/cancel can reuse it.
+    model_config = ConfigDict(extra='allow', populate_by_name=True, alias_generator=to_camel)
+    api_key: str | None = None
+    base_url: str | None = None
+    api_version: str | None = None
+    # Milliseconds — applied to the HTTP call, not the create body.
+    timeout: float | None = None
+    custom_headers: dict[str, str] | None = None
+    thinking_summaries: Literal['auto', 'none'] | None = None
+    previous_interaction_id: str | None = None
+    store: bool | None = None
+    response_modalities: list[Literal['text', 'image', 'audio']] | None = None
+    visualization: Literal['auto', 'off'] | None = None
+    collaborative_planning: bool | None = None
+    google_search: bool | None = None
+    url_context: bool | None = None
+    code_execution: bool | None = None
+    file_search: FileSearchConfig | None = None
+    mcp_servers: list[McpServerConfig] | None = None
+
+
+def deep_research_model(version: str) -> ModelRef:
+    """Return a ModelRef for a Deep Research version (namespaced or bare)."""
+    clean = extract_version(version)
+    info = KNOWN_DEEP_RESEARCH_MODELS.get(clean) or DEEP_RESEARCH_INFO
+    # Prefer a version-specific label over the shared catalog default.
+    if info.label is None or info.label == DEEP_RESEARCH_INFO.label:
+        info = ModelInfo(label=f'Google AI - {clean}', supports=info.supports)
+    return model_ref(
+        name=clean,
+        namespace='googleai',
+        info=info,
+        config_schema=DeepResearchConfig,
+    )
+
+
+def build_tools(request: ModelRequest[DeepResearchConfig], config: DeepResearchConfig) -> list[dict[str, Any]]:
+    """Build Interactions API tool configurations for Deep Research."""
+    tools: list[dict[str, Any]] = []
+    if request.tools:
+        tools.extend(dict(to_interaction_tool(tool_def)) for tool_def in request.tools)
+
+    if config.google_search:
+        tools.append({'type': 'google_search'})
+    if config.url_context:
+        tools.append({'type': 'url_context'})
+    if config.code_execution:
+        tools.append({'type': 'code_execution'})
+    if config.file_search is not None:
+        tools.append({'type': 'file_search', **config.file_search.model_dump(exclude_none=True)})
+    for mcp_server in config.mcp_servers or []:
+        tools.append({'type': 'mcp_server', **mcp_server.model_dump(exclude_none=True)})
+
+    return tools
+
+
+def response_format_from_request(
+    request: ModelRequest[DeepResearchConfig],
+) -> dict[str, Any] | None:
+    """Build response_format when the caller asked for JSON output."""
+    if request.output_format != 'json' and request.output_content_type != 'application/json':
+        return None
+    response_format: dict[str, Any] = {'type': 'text', 'mime_type': 'application/json'}
+    if request.output_schema:
+        response_format['schema'] = clean_schema(request.output_schema)
+    return response_format
+
+
+def api_key_from_operation(
+    stored: ClientOptions,
+    *,
+    plugin_api_key: str | None,
+) -> str:
+    """Resolve the api key for check/cancel.
+
+    Prefer the key persisted on the operation at start. If metadata omitted it,
+    calculate_api_key falls through plugin → env (and errors if nothing is set).
+    """
+    return stored.api_key or calculate_api_key(plugin_api_key, None)
+
+
+def create_deep_research_background_action(
+    target: str | ModelRef,
+    *,
+    plugin_api_key: str | None,
+    client_options: ClientOptions,
+) -> BackgroundAction:
+    """Wire Deep Research Interactions start/check/cancel through define_background_model."""
+    name = target.name if isinstance(target, ModelRef) else target
+    version = extract_version(name)
+    info = deep_research_model_info(version)
+
+    async def start(request: ModelRequest[DeepResearchConfig], _: ActionRunContext) -> Operation:
+        config = request.config or DeepResearchConfig()
+        api_key = calculate_api_key(plugin_api_key, config.api_key)
+        options = client_options.merge(
+            client_overrides_from_config(
+                base_url=config.base_url,
+                api_version=config.api_version,
+                timeout=config.timeout,
+                custom_headers=config.custom_headers,
+            )
+        )
+
+        # Map dumped config into the buckets interactions.create expects without
+        # mutating the dump: agent fields, tool flags (via build_tools), create
+        # options, then undocumented passthrough leftovers.
+        dumped = remove_client_option_overrides(config.model_dump(exclude_none=True))
+        agent_fields, _tool_fields, create_options, passthrough = partition_keys(
+            dumped,
+            AGENT_CONFIG_KEYS,
+            TOOL_CONFIG_KEYS,
+            CREATE_OPTION_KEYS,
+        )
+        agent_config: dict[str, Any] = {'type': 'deep-research', **agent_fields}
+
+        tools = build_tools(request, config)
+        response_format = response_format_from_request(request)
+        # Deep Research rejects system_instruction and asks for guidance in the
+        # input prompt instead, so system turns become a leading user_input step.
+        system_instruction, turns = split_system_instruction(request.messages or [])
+        steps = to_interaction_steps(ensure_tool_ids(turns))
+        if system_instruction:
+            steps.insert(
+                0,
+                {
+                    'type': 'user_input',
+                    'content': [{'type': 'text', 'text': system_instruction}],
+                },
+            )
+        require_interaction_steps(steps)
+        create_kwargs: dict[str, Any] = {
+            'agent': version,
+            'input': steps,
+            'background': True,
+            'agent_config': agent_config,
+            **create_options,
+            **passthrough,
+        }
+        if tools:
+            create_kwargs['tools'] = tools
+        if response_format is not None:
+            create_kwargs['response_format'] = response_format
+
+        interaction = await create_interaction(api_key, create_kwargs, options)
+        return from_interaction(
+            interaction,
+            client_options_for_operation(options, api_key=api_key),
+        )
+
+    async def follow_up(operation: Operation, *, cancel: bool = False) -> Operation:
+        stored = ClientOptions.from_metadata(operation.metadata)
+        options = client_options.merge(stored)
+        api_key = api_key_from_operation(stored, plugin_api_key=plugin_api_key)
+        if cancel:
+            interaction = await cancel_interaction(api_key, operation.id, options)
+        else:
+            interaction = await get_interaction(api_key, operation.id, options)
+        return from_interaction(
+            interaction,
+            client_options_for_operation(options, api_key=api_key),
+        )
+
+    async def check(operation: Operation) -> Operation:
+        return await follow_up(operation)
+
+    async def cancel(operation: Operation) -> Operation:
+        return await follow_up(operation, cancel=True)
+
+    # Throwaway registry: plugin init re-registers the returned actions on the app registry.
+    # define_background_model stamps Operation.action so check_operation/cancel_operation work.
+    return define_background_model(
+        registry=Registry(),
+        name=name,
+        start=start,
+        check=check,
+        cancel=cancel,
+        label=info.label or name,
+        info=info,
+        config_schema=DeepResearchConfig,
+    )

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_registry.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/interactions_registry.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Curated catalogs of Google AI Interactions models.
+
+When Google ships a new Interactions model version, add it here — not in the
+individual action modules. Plugin registration, list_actions, and resolve all
+read from this file.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from genkit import ModelInfo, Supports
+from genkit._core._compat import StrEnum
+from genkit_google_genai.models.interactions_utils import extract_version
+
+
+def model_info(
+    version: str,
+    *,
+    fallback: ModelInfo,
+    known: Mapping[str, ModelInfo] | None = None,
+) -> ModelInfo:
+    """Build ModelInfo with a Google AI label and family (or per-version) supports."""
+    clean = extract_version(version)
+    entry = known.get(clean) if known else None
+    return ModelInfo(label=f'Google AI - {clean}', supports=(entry or fallback).supports)
+
+
+# ---------------------------------------------------------------------------
+# Lyria
+# ---------------------------------------------------------------------------
+
+LYRIA_INFO = ModelInfo(
+    label='Google AI - Lyria',
+    supports=Supports(
+        multiturn=False,
+        media=True,
+        tools=False,
+        tool_choice=False,
+        system_role=False,
+        output=['media', 'text'],
+    ),
+)
+
+
+class LyriaVersion(StrEnum):
+    """Lyria model version identifiers."""
+
+    LYRIA_3_CLIP = 'lyria-3-clip-preview'
+    LYRIA_3_PRO = 'lyria-3-pro-preview'
+
+
+KNOWN_LYRIA_MODELS: tuple[LyriaVersion, ...] = (
+    LyriaVersion.LYRIA_3_CLIP,
+    LyriaVersion.LYRIA_3_PRO,
+)
+
+
+def is_lyria_model_name(name: str | None) -> bool:
+    """Return True when the model name belongs to the Lyria family."""
+    return bool(name and name.startswith('lyria-'))
+
+
+def lyria_model_info(version: str) -> ModelInfo:
+    """Return capability metadata for an Interactions Lyria model."""
+    return model_info(version, fallback=LYRIA_INFO)
+
+
+def list_known_lyria_models() -> list[str]:
+    """Return statically known Interactions Lyria model names."""
+    return [str(version) for version in KNOWN_LYRIA_MODELS]
+
+
+# ---------------------------------------------------------------------------
+# Antigravity
+# ---------------------------------------------------------------------------
+
+ANTIGRAVITY_INFO = ModelInfo(
+    label='Google AI - Antigravity',
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=False,
+        tool_choice=False,
+        system_role=False,
+        output=['text'],
+    ),
+)
+
+KNOWN_ANTIGRAVITY_MODELS: dict[str, ModelInfo] = {
+    'antigravity-preview-05-2026': ANTIGRAVITY_INFO,
+}
+
+
+def is_antigravity_model_name(name: str | None) -> bool:
+    """Return True when the model name belongs to the Antigravity family."""
+    return bool(name and name.startswith('antigravity-'))
+
+
+def antigravity_model_info(version: str) -> ModelInfo:
+    """Return capability metadata for an Antigravity model."""
+    return model_info(version, known=KNOWN_ANTIGRAVITY_MODELS, fallback=ANTIGRAVITY_INFO)
+
+
+def list_known_antigravity_models() -> list[str]:
+    """Return statically known Antigravity model names."""
+    return list(KNOWN_ANTIGRAVITY_MODELS.keys())
+
+
+# ---------------------------------------------------------------------------
+# Deep Research
+# ---------------------------------------------------------------------------
+
+DEEP_RESEARCH_INFO = ModelInfo(
+    label='Google AI - Deep Research',
+    supports=Supports(
+        multiturn=True,
+        media=False,
+        tools=False,
+        tool_choice=False,
+        system_role=False,
+        output=['text'],
+        long_running=True,
+    ),
+)
+
+ADVANCED_DEEP_RESEARCH_INFO = ModelInfo(
+    supports=Supports(
+        multiturn=True,
+        media=True,
+        tools=True,
+        tool_choice=False,
+        system_role=False,
+        output=['text', 'media'],
+        long_running=True,
+    ),
+)
+
+KNOWN_DEEP_RESEARCH_MODELS: dict[str, ModelInfo] = {
+    'deep-research-pro-preview-12-2025': DEEP_RESEARCH_INFO,
+    'deep-research-preview-04-2026': ADVANCED_DEEP_RESEARCH_INFO,
+    'deep-research-max-preview-04-2026': ADVANCED_DEEP_RESEARCH_INFO,
+}
+
+
+def is_deep_research_model_name(name: str | None) -> bool:
+    """Return True when the model name belongs to the Deep Research family."""
+    return bool(name and name.startswith('deep-research-'))
+
+
+def deep_research_model_info(version: str) -> ModelInfo:
+    """Return capability metadata for a Deep Research model."""
+    return model_info(version, known=KNOWN_DEEP_RESEARCH_MODELS, fallback=DEEP_RESEARCH_INFO)
+
+
+def list_known_deep_research_models() -> list[str]:
+    """Return statically known Deep Research model names."""
+    return list(KNOWN_DEEP_RESEARCH_MODELS.keys())

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_models_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_models_test.py
@@ -1,0 +1,493 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Interactions-backed Google AI models."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from genkit_google_genai._interactions.converters import split_system_instruction
+from genkit_google_genai._interactions.options import ClientOptions
+from genkit_google_genai.models.antigravity import AntigravityConfig, create_antigravity_action
+from genkit_google_genai.models.deep_research import (
+    create_deep_research_background_action,
+    deep_research_model,
+)
+from genkit_google_genai.models.lyria import LyriaConfig, create_lyria_action
+from google.genai.interactions import Interaction
+
+from genkit import GenkitError, Message, ModelRequest, Part, Role, TextPart
+from genkit.model import Operation
+
+
+def test_split_system_instruction_folds_system_turns() -> None:
+    messages = [
+        Message(role=Role.SYSTEM, content=[Part(TextPart(text='Be helpful'))]),
+        Message(role=Role.USER, content=[Part(TextPart(text='Hi'))]),
+        Message(role=Role.SYSTEM, content=[Part(TextPart(text='Be terse'))]),
+    ]
+    instruction, turns = split_system_instruction(messages)
+    assert instruction == 'Be helpful\n\nBe terse'
+    assert [message.role for message in turns] == [Role.USER]
+
+
+def test_split_system_instruction_without_system_turns() -> None:
+    messages = [Message(role=Role.USER, content=[Part(TextPart(text='Hi'))])]
+    instruction, turns = split_system_instruction(messages)
+    assert instruction is None
+    assert turns == messages
+
+
+def patch_interactions(
+    module: str,
+    *,
+    create_result: dict[str, Any] | None = None,
+    get_result: dict[str, Any] | None = None,
+    cancel_result: dict[str, Any] | None = None,
+    captured: dict[str, Any] | None = None,
+):
+    """Patch raw HTTP Interactions helpers on a model module."""
+    create_calls: list[dict[str, Any]] = []
+    get_calls: list[str] = []
+    cancel_calls: list[str] = []
+
+    async def create(
+        api_key: str,
+        body: dict[str, Any],
+        client_options: ClientOptions | None = None,
+    ) -> Interaction:
+        create_calls.append(body)
+        if captured is not None:
+            captured['create'] = body
+            captured['api_key'] = api_key
+            captured['client_options'] = client_options
+        return Interaction.model_validate(create_result or {'id': 'ix-1', 'status': 'in_progress'})
+
+    async def get(
+        api_key: str,
+        interaction_id: str,
+        client_options: ClientOptions | None = None,
+    ) -> Interaction:
+        get_calls.append(interaction_id)
+        if captured is not None:
+            captured['get'] = interaction_id
+            captured['api_key'] = api_key
+            captured['client_options'] = client_options
+        return Interaction.model_validate(get_result or {'id': interaction_id, 'status': 'completed', 'steps': []})
+
+    async def cancel(
+        api_key: str,
+        interaction_id: str,
+        client_options: ClientOptions | None = None,
+    ) -> Interaction:
+        cancel_calls.append(interaction_id)
+        if captured is not None:
+            captured['cancel'] = interaction_id
+            captured['api_key'] = api_key
+            captured['client_options'] = client_options
+        return Interaction.model_validate(cancel_result or {'id': interaction_id, 'status': 'cancelled'})
+
+    patches: dict[str, Any] = {
+        'create_interaction': AsyncMock(side_effect=create),
+    }
+    # Only deep_research imports get/cancel; patch those when present.
+    if module.endswith('deep_research'):
+        patches['get_interaction'] = AsyncMock(side_effect=get)
+        patches['cancel_interaction'] = AsyncMock(side_effect=cancel)
+
+    return (
+        patch.multiple(module, **patches),
+        create_calls,
+        get_calls,
+        cancel_calls,
+    )
+
+
+@pytest.mark.asyncio
+async def test_deep_research_start_sends_background_request() -> None:
+    captured: dict[str, Any] = {}
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-1', 'status': 'in_progress'},
+        captured=captured,
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    request = ModelRequest(
+        messages=[
+            Message(role=Role.SYSTEM, content=[Part(TextPart(text='sys'))]),
+            Message(role=Role.USER, content=[Part(TextPart(text='research this'))]),
+        ],
+        config={'thinking_summaries': 'auto', 'google_search': True},
+    )
+    with patcher:
+        operation = await action.start(request)
+
+    body = create_calls[0]
+    assert body['background'] is True
+    assert body['agent'] == 'deep-research-preview-04-2026'
+    assert body['agent_config'] == {
+        'type': 'deep-research',
+        'thinking_summaries': 'auto',
+    }
+    assert body['tools'] == [{'type': 'google_search'}]
+    # Deep Research rejects system_instruction; system text lands as a leading input step.
+    assert 'system_instruction' not in body
+    assert body['input'] == [
+        {'type': 'user_input', 'content': [{'type': 'text', 'text': 'sys'}]},
+        {'type': 'user_input', 'content': [{'type': 'text', 'text': 'research this'}]},
+    ]
+    assert operation.id == 'dr-1'
+    assert operation.done is False
+    assert (operation.metadata or {}).get('clientOptions', {}).get('apiKey') == 'plugin-key'
+
+
+@pytest.mark.asyncio
+async def test_deep_research_check_uses_stored_api_key() -> None:
+    captured: dict[str, Any] = {}
+    patcher, _, get_calls, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        get_result={
+            'id': 'dr-1',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'done'}]}],
+        },
+        captured=captured,
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    operation = Operation.model_construct(
+        id='dr-1',
+        metadata={'clientOptions': {'baseUrl': 'https://example.test', 'apiKey': 'override-key'}},
+    )
+    with patcher:
+        updated = await action.check(operation)
+
+    assert captured['api_key'] == 'override-key'
+    assert get_calls == ['dr-1']
+    assert updated.done is True
+    assert updated.output is not None
+    assert updated.output.message is not None
+    assert updated.output.message.content[0].root.text == 'done'
+
+
+@pytest.mark.asyncio
+async def test_deep_research_cancel_uses_stored_api_key() -> None:
+    captured: dict[str, Any] = {}
+    patcher, _, _, cancel_calls = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        cancel_result={'id': 'dr-1', 'status': 'cancelled'},
+        captured=captured,
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    operation = Operation.model_construct(
+        id='dr-1',
+        metadata={'clientOptions': {'baseUrl': 'https://example.test', 'apiKey': 'override-key'}},
+    )
+    with patcher:
+        updated = await action.cancel(operation)
+
+    assert captured['api_key'] == 'override-key'
+    assert cancel_calls == ['dr-1']
+    assert updated.done is True
+    assert updated.id == 'dr-1'
+
+
+@pytest.mark.asyncio
+async def test_deep_research_check_falls_back_to_plugin_api_key() -> None:
+    captured: dict[str, Any] = {}
+    patcher, _, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        get_result={'id': 'dr-1', 'status': 'in_progress'},
+        captured=captured,
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    operation = Operation.model_construct(
+        id='dr-1',
+        metadata={'clientOptions': {'baseUrl': 'https://example.test'}},
+    )
+    with patcher:
+        await action.check(operation)
+
+    assert captured['api_key'] == 'plugin-key'
+
+
+@pytest.mark.asyncio
+async def test_deep_research_passes_previous_interaction_id() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-2', 'status': 'in_progress'},
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='follow up'))])],
+        config={'previous_interaction_id': 'v1_prior'},
+    )
+    with patcher:
+        await action.start(request)
+
+    assert create_calls[0]['previous_interaction_id'] == 'v1_prior'
+
+
+@pytest.mark.asyncio
+async def test_deep_research_start_stores_request_api_key_override() -> None:
+    """Per-request api_key wins and is what check will reuse from the Operation."""
+    patcher, _, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-key', 'status': 'in_progress'},
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        operation = await action.start(
+            ModelRequest(
+                messages=[Message(role=Role.USER, content=[Part(TextPart(text='q'))])],
+                config={'api_key': 'request-key'},
+            )
+        )
+
+    assert (operation.metadata or {}).get('clientOptions', {}).get('apiKey') == 'request-key'
+
+
+@pytest.mark.asyncio
+async def test_antigravity_passes_previous_interaction_id() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.antigravity',
+        create_result={
+            'id': 'ag-2',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'ok'}]}],
+        },
+    )
+    action = create_antigravity_action(
+        'antigravity-preview-05-2026',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        await action.run(
+            ModelRequest[AntigravityConfig](
+                messages=[Message(role=Role.USER, content=[Part(TextPart(text='continue'))])],
+                config=AntigravityConfig(previous_interaction_id='v1_prior'),
+            )
+        )
+
+    assert create_calls[0]['previous_interaction_id'] == 'v1_prior'
+
+
+@pytest.mark.asyncio
+async def test_antigravity_rejects_empty_messages() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.antigravity',
+        create_result={'id': 'ag-empty', 'status': 'completed', 'steps': []},
+    )
+    action = create_antigravity_action(
+        'antigravity-preview-05-2026',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        with pytest.raises(GenkitError, match='Missing input') as exc_info:
+            await action.run(ModelRequest(messages=[]))
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_deep_research_rejects_empty_messages() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-empty', 'status': 'in_progress'},
+    )
+    action = create_deep_research_background_action(
+        'deep-research-preview-04-2026',
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        with pytest.raises(GenkitError, match='Missing input') as exc_info:
+            await action.start(ModelRequest(messages=[]))
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_antigravity_generate_folds_system_and_uses_agent() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.antigravity',
+        create_result={
+            'id': 'ag-1',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'hello'}]}],
+        },
+    )
+    action = create_antigravity_action(
+        'antigravity-preview-05-2026',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    request = ModelRequest[AntigravityConfig](
+        messages=[
+            Message(role=Role.SYSTEM, content=[Part(TextPart(text='sys'))]),
+            Message(role=Role.USER, content=[Part(TextPart(text='build'))]),
+        ],
+        config=AntigravityConfig(response_modalities=['text', 'image']),
+    )
+    with patcher:
+        response = await action.run(request)
+
+    body = create_calls[0]
+    assert body['agent'] == 'antigravity-preview-05-2026'
+    assert body['response_modalities'] == ['text', 'image']
+    assert 'background' not in body
+    assert body['environment'] == {'type': 'remote'}
+    # Antigravity rejects system_instruction; system text lands as a leading input step.
+    assert 'system_instruction' not in body
+    assert body['input'] == [
+        {'type': 'user_input', 'content': [{'type': 'text', 'text': 'sys'}]},
+        {'type': 'user_input', 'content': [{'type': 'text', 'text': 'build'}]},
+    ]
+    assert response.response.message is not None
+    assert response.response.message.content[0].root.text == 'hello'
+
+
+def test_bare_model_request_accepts_lyria_config_instance() -> None:
+    """Bare ModelRequest(config=LyriaConfig(...)) should not reject the plugin schema."""
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='riff'))])],
+        config=LyriaConfig(api_key='k', response_modalities=['audio']),
+    )
+    assert isinstance(request.config, LyriaConfig)
+    assert request.config.api_key == 'k'
+
+
+@pytest.mark.asyncio
+async def test_lyria_defaults_audio_and_text_modalities() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.lyria',
+        create_result={
+            'id': 'ly-1',
+            'status': 'completed',
+            'steps': [
+                {
+                    'type': 'model_output',
+                    'content': [{'type': 'audio', 'data': 'abc', 'mime_type': 'audio/wav'}],
+                }
+            ],
+        },
+    )
+    action = create_lyria_action(
+        'lyria-3-clip-preview',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='jazz riff'))])],
+    )
+    with patcher:
+        response = await action.run(request)
+
+    body = create_calls[0]
+    assert body['model'] == 'lyria-3-clip-preview'
+    assert body['response_modalities'] == ['audio', 'text']
+    assert response.response.message is not None
+
+
+@pytest.mark.asyncio
+async def test_lyria_passes_through_unknown_config_fields() -> None:
+    patcher, create_calls, _, _ = patch_interactions(
+        'genkit_google_genai.models.lyria',
+        create_result={
+            'id': 'ly-2',
+            'status': 'completed',
+            'steps': [{'type': 'model_output', 'content': [{'type': 'text', 'text': 'ok'}]}],
+        },
+    )
+    action = create_lyria_action(
+        'lyria-3-clip-preview',
+        plugin_api_key='key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        await action.run(
+            ModelRequest(
+                messages=[Message(role=Role.USER, content=[Part(TextPart(text='riff'))])],
+                config={'temperature': 0.4, 'api_key': 'should-not-passthrough'},
+            )
+        )
+
+    body = create_calls[0]
+    assert body['temperature'] == 0.4
+    assert 'api_key' not in body
+    assert 'apiKey' not in body
+
+
+def test_deep_research_model_ref_is_namespaced() -> None:
+    ref = deep_research_model('deep-research-preview-04-2026')
+    assert ref.name == 'googleai/deep-research-preview-04-2026'
+    assert ref.config_schema is not None
+
+
+@pytest.mark.asyncio
+async def test_deep_research_define_background_model_sets_action() -> None:
+    """define_background_model must stamp Operation.action for check/cancel."""
+    patcher, _, _, _ = patch_interactions(
+        'genkit_google_genai.models.deep_research',
+        create_result={'id': 'dr-action-1', 'status': 'in_progress'},
+    )
+    ref = deep_research_model('deep-research-preview-04-2026')
+    bg = create_deep_research_background_action(
+        ref,
+        plugin_api_key='plugin-key',
+        client_options=ClientOptions(),
+    )
+    with patcher:
+        operation = await bg.start(
+            ModelRequest(messages=[Message(role=Role.USER, content=[Part(TextPart(text='q'))])]),
+        )
+
+    assert isinstance(operation, Operation)
+    assert operation.action == f'/background-model/{ref.name}'
+    assert operation.id == 'dr-action-1'
+    model_meta = (bg.start_action.metadata or {}).get('model')
+    assert isinstance(model_meta, dict)
+    supports = model_meta.get('supports')
+    assert isinstance(supports, dict)
+    assert supports.get('longRunning') is True


### PR DESCRIPTION
Third slice of the #5806 split: Deep Research background model with cancel support, Antigravity and Lyria foreground models on the Interactions transport, and a registry of known models with capability metadata. Rewrites lyria.py from the legacy Vertex-only LyriaModel. Model-level tests included here; plugin wiring and its integration tests land in the next slice.

Part of the stack splitting #5806; recombined it reproduces that PR byte-for-byte. Co-authored with @huangjeff5.

### Breaking changes

- `LyriaModel` is removed from `genkit_google_genai.models.lyria`; Lyria is now served by the Interactions-backed implementation (`create_lyria_action`). The package-level exports `LyriaConfig` and `LyriaVersion` are unchanged.
