### PR TITLE
feat(py/plugins/google-genai): wire Interactions models into GoogleAI plugin

### DIFF
--- a/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/google.py
@@ -63,7 +63,7 @@ from genkit._core._action import ActionRunContext
 from genkit._core._model import ModelRequest, ModelResponse
 from genkit.embedder import embedder_action_metadata
 from genkit.evaluator import EvalFnResponse, EvalRequest
-from genkit.model import BackgroundAction, model_action_metadata
+from genkit.model import BackgroundAction, ModelRef, model_action_metadata
 from genkit.plugin_api import (
     GENKIT_CLIENT_HEADER,
     Action,
@@ -73,9 +73,19 @@ from genkit.plugin_api import (
     loop_local_client,
     to_json_schema,
 )
+from genkit_google_genai._interactions.options import ClientOptions
 from genkit_google_genai.evaluators import (
     VertexAIEvaluationMetricType,
     create_vertex_evaluators,
+)
+from genkit_google_genai.models.antigravity import (
+    AntigravityConfig,
+    create_antigravity_action,
+)
+from genkit_google_genai.models.deep_research import (
+    DeepResearchConfig,
+    create_deep_research_background_action,
+    deep_research_model,
 )
 from genkit_google_genai.models.embedder import (
     VERTEX_KNOWN_EMBEDDERS,
@@ -95,6 +105,21 @@ from genkit_google_genai.models.imagen import (
     ImagenConfigSchema,
     ImagenModel,
     vertexai_image_model_info,
+)
+from genkit_google_genai.models.interactions_registry import (
+    antigravity_model_info,
+    deep_research_model_info,
+    is_antigravity_model_name,
+    is_deep_research_model_name,
+    is_lyria_model_name,
+    list_known_antigravity_models,
+    list_known_deep_research_models,
+    list_known_lyria_models,
+    lyria_model_info,
+)
+from genkit_google_genai.models.lyria import (
+    LyriaConfig,
+    create_lyria_action,
 )
 from genkit_google_genai.models.veo import (
     VeoConfig,
@@ -414,6 +439,34 @@ class GoogleAI(Plugin):
         self._runtime_client = loop_local_client(lambda: genai.client.Client(**self._client_kwargs))
         self._list_actions_cache: list[ActionMetadata] | None = None
 
+    def _interactions_client_options(self) -> ClientOptions:
+        """Extract baseline non-secret HTTP options from plugin init settings.
+
+        These settings (base_url, api_version, custom_headers) serve as the
+        plugin-level fallback defaults for Google AI Interactions-backed models
+        (Deep Research, Antigravity, Lyria).
+
+        Resolution Hierarchy for Client Settings:
+            1. Per-request override: Options passed in request config (highest priority).
+            2. Operation metadata: Stored options on Operation.metadata['clientOptions']
+               (for background check/cancel calls across processes).
+            3. Plugin-level init: Baseline settings from self._client_kwargs.
+            4. Environment variables: E.g., GEMINI_API_KEY / GOOGLE_API_KEY (lowest fallback).
+        """
+        http_options: HttpOptions | None = self._client_kwargs.get('http_options')
+        if http_options is None:
+            return ClientOptions()
+        return ClientOptions(
+            api_version=http_options.api_version,
+            base_url=http_options.base_url,
+            custom_headers=dict(http_options.headers) if http_options.headers else None,
+            # HttpOptions.timeout is milliseconds; ClientOptions uses the same unit.
+            timeout=float(http_options.timeout) if http_options.timeout is not None else None,
+        )
+
+    def _plugin_api_key(self) -> str | None:
+        return self._client_kwargs.get('api_key')
+
     async def init(self) -> list[Action]:
         """Initialize the plugin.
 
@@ -436,6 +489,32 @@ class GoogleAI(Plugin):
             bg_action = self._resolve_veo_model(googleai_name(name))
             actions.append(bg_action.start_action)
             actions.append(bg_action.check_action)
+
+        # Interactions-backed models (known catalog)
+        client_options = self._interactions_client_options()
+        plugin_api_key = self._plugin_api_key()
+        for name in list_known_deep_research_models():
+            bg_action = self._resolve_deep_research_model(googleai_name(name), client_options, plugin_api_key)
+            actions.append(bg_action.start_action)
+            actions.append(bg_action.check_action)
+            if bg_action.cancel_action is not None:
+                actions.append(bg_action.cancel_action)
+        for name in list_known_antigravity_models():
+            actions.append(
+                create_antigravity_action(
+                    googleai_name(name),
+                    plugin_api_key=plugin_api_key,
+                    client_options=client_options,
+                )
+            )
+        for name in list_known_lyria_models():
+            actions.append(
+                create_lyria_action(
+                    googleai_name(name),
+                    plugin_api_key=plugin_api_key,
+                    client_options=client_options,
+                )
+            )
 
         # Embedders
         for name in genai_models.embedders:
@@ -496,7 +575,7 @@ class GoogleAI(Plugin):
             prefix = GOOGLEAI_PLUGIN_NAME + '/'
             clean_name = name.replace(prefix, '') if name.startswith(prefix) else name
             # Background-only families: leave MODEL empty so resolve_model falls back.
-            if is_veo_model(clean_name):
+            if is_veo_model(clean_name) or is_deep_research_model_name(clean_name):
                 return None
             return self._resolve_model(name)
         elif action_type == ActionKind.BACKGROUND_MODEL:
@@ -504,6 +583,13 @@ class GoogleAI(Plugin):
             clean_name = name.replace(prefix, '') if name.startswith(prefix) else name
             if is_veo_model(clean_name):
                 bg_action = self._resolve_veo_model(name)
+                return bg_action.start_action
+            if is_deep_research_model_name(clean_name):
+                bg_action = self._resolve_deep_research_model(
+                    deep_research_model(name),
+                    self._interactions_client_options(),
+                    self._plugin_api_key(),
+                )
                 return bg_action.start_action
             return None
         elif action_type == ActionKind.CHECK_OPERATION:
@@ -514,6 +600,26 @@ class GoogleAI(Plugin):
                 if is_veo_model(clean_name):
                     bg_action = self._resolve_veo_model(model_name)
                     return bg_action.check_action
+                if is_deep_research_model_name(clean_name):
+                    bg_action = self._resolve_deep_research_model(
+                        deep_research_model(model_name),
+                        self._interactions_client_options(),
+                        self._plugin_api_key(),
+                    )
+                    return bg_action.check_action
+            return None
+        elif action_type == ActionKind.CANCEL_OPERATION:
+            if name.endswith('/cancel'):
+                model_name = name[:-7]
+                prefix = GOOGLEAI_PLUGIN_NAME + '/'
+                clean_name = model_name.replace(prefix, '') if model_name.startswith(prefix) else model_name
+                if is_deep_research_model_name(clean_name):
+                    bg_action = self._resolve_deep_research_model(
+                        deep_research_model(model_name),
+                        self._interactions_client_options(),
+                        self._plugin_api_key(),
+                    )
+                    return bg_action.cancel_action
             return None
         elif action_type == ActionKind.EMBEDDER:
             return self._resolve_embedder(name)
@@ -522,6 +628,19 @@ class GoogleAI(Plugin):
     def _resolve_veo_model(self, name: str) -> BackgroundAction:
         """Create a BackgroundAction for a Veo video generation model."""
         return create_veo_background_action(name, self._runtime_client())
+
+    def _resolve_deep_research_model(
+        self,
+        target: str | ModelRef,
+        client_options: ClientOptions,
+        plugin_api_key: str | None,
+    ) -> BackgroundAction:
+        """Create a BackgroundAction for a Deep Research ModelRef (Interactions)."""
+        return create_deep_research_background_action(
+            target,
+            plugin_api_key=plugin_api_key,
+            client_options=client_options,
+        )
 
     def _resolve_model(self, name: str) -> Action:
         """Create an Action object for a Google AI model.
@@ -534,6 +653,19 @@ class GoogleAI(Plugin):
         """
         # Extract local name (remove plugin prefix)
         clean_name = name.replace(GOOGLEAI_PLUGIN_NAME + '/', '') if name.startswith(GOOGLEAI_PLUGIN_NAME) else name
+
+        if is_antigravity_model_name(clean_name):
+            return create_antigravity_action(
+                name,
+                plugin_api_key=self._plugin_api_key(),
+                client_options=self._interactions_client_options(),
+            )
+        if is_lyria_model_name(clean_name):
+            return create_lyria_action(
+                name,
+                plugin_api_key=self._plugin_api_key(),
+                client_options=self._interactions_client_options(),
+            )
 
         # Determine model type and create model metadata/config schema
         if clean_name.lower().startswith('image'):
@@ -618,6 +750,33 @@ class GoogleAI(Plugin):
                     name=googleai_name(name),
                     info=veo_model_info(name).model_dump(by_alias=True),
                     config_schema=VeoConfig,
+                )
+            )
+
+        for name in list_known_deep_research_models():
+            actions_list.append(
+                model_action_metadata(
+                    name=googleai_name(name),
+                    info=deep_research_model_info(name).model_dump(by_alias=True),
+                    config_schema=DeepResearchConfig,
+                )
+            )
+
+        for name in list_known_antigravity_models():
+            actions_list.append(
+                model_action_metadata(
+                    name=googleai_name(name),
+                    info=antigravity_model_info(name).model_dump(by_alias=True),
+                    config_schema=AntigravityConfig,
+                )
+            )
+
+        for name in list_known_lyria_models():
+            actions_list.append(
+                model_action_metadata(
+                    name=googleai_name(name),
+                    info=lyria_model_info(name).model_dump(by_alias=True),
+                    config_schema=LyriaConfig,
                 )
             )
 

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/imagen.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/imagen.py
@@ -45,6 +45,7 @@ from genkit import (
     TextPart,
 )
 from genkit.plugin_api import ActionRunContext, tracer
+from genkit_google_genai.models.interactions_utils import map_genai_error
 
 
 def _to_dict(obj: Any) -> Any:  # noqa: ANN401
@@ -183,7 +184,12 @@ class ImagenModel:
                     'model': self._version,
                 }),
             )
-            response = await self._client.aio.models.generate_images(model=self._version, prompt=prompt, config=config)
+            try:
+                response = await self._client.aio.models.generate_images(
+                    model=self._version, prompt=prompt, config=config
+                )
+            except Exception as error:
+                raise map_genai_error(error) from error
             span.set_attribute('genkit:output', json.dumps(_to_dict(response), default=str))
 
         content = self._contents_from_response(response)

--- a/py/packages/genkit-google-genai/tests/interactions/interactions_models_test.py
+++ b/py/packages/genkit-google-genai/tests/interactions/interactions_models_test.py
@@ -19,11 +19,12 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from genkit_google_genai._interactions.converters import split_system_instruction
 from genkit_google_genai._interactions.options import ClientOptions
+from genkit_google_genai.google import GoogleAI, googleai_name
 from genkit_google_genai.models.antigravity import AntigravityConfig, create_antigravity_action
 from genkit_google_genai.models.deep_research import (
     create_deep_research_background_action,
@@ -32,7 +33,7 @@ from genkit_google_genai.models.deep_research import (
 from genkit_google_genai.models.lyria import LyriaConfig, create_lyria_action
 from google.genai.interactions import Interaction
 
-from genkit import GenkitError, Message, ModelRequest, Part, Role, TextPart
+from genkit import ActionKind, GenkitError, Message, ModelRequest, Part, Role, TextPart
 from genkit.model import Operation
 
 
@@ -491,3 +492,91 @@ async def test_deep_research_define_background_model_sets_action() -> None:
     supports = model_meta.get('supports')
     assert isinstance(supports, dict)
     assert supports.get('longRunning') is True
+
+
+@pytest.mark.asyncio
+async def test_googleai_resolve_model_skips_deep_research_foreground() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+
+    dr_name = googleai_name('deep-research-preview-04-2026')
+    assert await plugin.resolve(ActionKind.MODEL, dr_name) is None
+    bg = await plugin.resolve(ActionKind.BACKGROUND_MODEL, dr_name)
+    assert bg is not None
+    assert bg.kind == ActionKind.BACKGROUND_MODEL
+
+
+@pytest.mark.asyncio
+async def test_googleai_plugin_registers_interactions_models() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+        actions = await plugin.init()
+
+    kinds_by_name = {action.name: action.kind for action in actions}
+    dr_name = googleai_name('deep-research-preview-04-2026')
+    ag_name = googleai_name('antigravity-preview-05-2026')
+    ly_name = googleai_name('lyria-3-clip-preview')
+
+    assert kinds_by_name[dr_name] == ActionKind.BACKGROUND_MODEL
+    assert kinds_by_name[f'{dr_name}/check'] == ActionKind.CHECK_OPERATION
+    assert kinds_by_name[f'{dr_name}/cancel'] == ActionKind.CANCEL_OPERATION
+    assert kinds_by_name[ag_name] == ActionKind.MODEL
+    assert kinds_by_name[ly_name] == ActionKind.MODEL
+
+
+@pytest.mark.asyncio
+async def test_googleai_resolve_routes_interactions_models() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+
+    dr_name = googleai_name('deep-research-pro-preview-12-2025')
+    bg = await plugin.resolve(ActionKind.BACKGROUND_MODEL, dr_name)
+    assert bg is not None
+    assert bg.kind == ActionKind.BACKGROUND_MODEL
+
+    check = await plugin.resolve(ActionKind.CHECK_OPERATION, f'{dr_name}/check')
+    assert check is not None
+
+    cancel = await plugin.resolve(ActionKind.CANCEL_OPERATION, f'{dr_name}/cancel')
+    assert cancel is not None
+
+    ag = await plugin.resolve(ActionKind.MODEL, googleai_name('antigravity-preview-05-2026'))
+    assert ag is not None
+    assert ag.kind == ActionKind.MODEL
+
+    ly = await plugin.resolve(ActionKind.MODEL, googleai_name('lyria-3-pro-preview'))
+    assert ly is not None
+
+    # Legacy Vertex name must not fall through to Gemini capabilities metadata.
+    ly_legacy = await plugin.resolve(ActionKind.MODEL, googleai_name('lyria-002'))
+    assert ly_legacy is not None
+    model_meta = (ly_legacy.metadata or {}).get('model')
+    assert isinstance(model_meta, dict)
+    supports = model_meta.get('supports')
+    assert isinstance(supports, dict)
+    assert supports.get('media') is True
+    assert supports.get('multiturn') is not True
+
+
+@pytest.mark.asyncio
+async def test_googleai_list_actions_includes_interactions_models() -> None:
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = iter([])
+
+    with patch('genkit_google_genai.google.genai.client.Client', return_value=mock_client):
+        plugin = GoogleAI(api_key='test-key')
+        actions = await plugin.list_actions()
+
+    names = {action.name for action in actions}
+    assert googleai_name('deep-research-max-preview-04-2026') in names
+    assert googleai_name('antigravity-preview-05-2026') in names
+    assert googleai_name('lyria-3-pro-preview') in names

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -146,6 +146,7 @@ fastapi-bugbot       = { workspace = true }
 flask-hello          = { workspace = true }
 gemini-code-execution = { workspace = true }
 gemini-context-caching = { workspace = true }
+google-genai-deep-research = { workspace = true }
 google-genai-media   = { workspace = true }
 middleware           = { workspace = true }
 middleware-coding-agent = { workspace = true }

--- a/py/samples/README.md
+++ b/py/samples/README.md
@@ -32,6 +32,7 @@ Dev UI: http://localhost:4000. Most samples need `GEMINI_API_KEY`. See [plugins/
 | `flask-hello` | Expose Genkit flows through Flask |
 | `gemini-code-execution` | Ask Gemini to write and run code |
 | `gemini-context-caching` | Cache a large source document for follow-up prompts |
+| `google-genai-deep-research` | Background Deep Research with `generate_operation()` + polling |
 | `google-genai-media` | Speech, image, and video generation |
 | `middleware` | Observe or modify model requests |
 | `ollama-sample` | Local chat, streaming, tools, and embeddings via Ollama |

--- a/py/samples/google-genai-deep-research/README.md
+++ b/py/samples/google-genai-deep-research/README.md
@@ -1,0 +1,25 @@
+# Google Deep Research
+
+Start a background Deep Research job with `generate_operation()`, poll with `check_operation()`, and read the finished report from `operation.output`.
+
+```bash
+export GEMINI_API_KEY=your-api-key
+uv sync
+uv run src/main.py
+```
+
+To explore the flow in Dev UI instead:
+
+```bash
+genkit start -- uv run src/main.py
+```
+
+Flow: `deep_research`.
+
+Supported models (set `model` in flow input):
+
+- `googleai/deep-research-preview-04-2026`
+- `googleai/deep-research-max-preview-04-2026`
+- `googleai/deep-research-pro-preview-12-2025`
+
+Deep Research runs as a long-running background model — expect several minutes before `operation.done` is true.

--- a/py/samples/google-genai-deep-research/pyproject.toml
+++ b/py/samples/google-genai-deep-research/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "google-genai-deep-research"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "genkit",
+  "genkit-google-genai",
+  "pydantic",
+]
+
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/py/samples/google-genai-deep-research/src/main.py
+++ b/py/samples/google-genai-deep-research/src/main.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Google GenAI Deep Research - start a background research job and poll to completion."""
+
+import asyncio
+
+from genkit_google_genai import GoogleAI
+from pydantic import BaseModel, Field
+
+from genkit import Genkit
+
+ai = Genkit(plugins=[GoogleAI()])
+
+
+class ResearchInput(BaseModel):
+    """Input for a Deep Research background model."""
+
+    model: str = Field(
+        default='googleai/deep-research-preview-04-2026',
+        description='Deep Research model for the background job',
+    )
+    prompt: str = Field(
+        default='Summarize recent advances in quantum error correction for a technical audience.',
+        description='Research question or topic',
+    )
+
+
+@ai.flow(name='deep_research')
+async def deep_research_flow(input: ResearchInput) -> str | None:
+    """Run Deep Research with generate_operation() and poll until the report is ready."""
+    operation = await ai.generate_operation(
+        model=input.model,
+        prompt=input.prompt,
+    )
+    while not operation.done:
+        await asyncio.sleep(5)
+        operation = await ai.check_operation(operation)
+
+    return operation.output.text if operation.output else None
+
+
+async def main() -> None:
+    """Run one Deep Research job."""
+    try:
+        print(await deep_research_flow(ResearchInput()))  # noqa: T201
+    except Exception as error:
+        print(f'Set GEMINI_API_KEY to a valid value before running this sample directly.\n{error}')  # noqa: T201
+
+
+if __name__ == '__main__':
+    ai.run_main(main())

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -34,6 +34,7 @@ members = [
     "genkit-openai",
     "genkit-vertexai",
     "genkit-workspace",
+    "google-genai-deep-research",
     "google-genai-media",
     "middleware",
     "middleware-coding-agent",
@@ -2370,6 +2371,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dc/df/4f820054c99f29f2fe3de4a8a7c9534dd795302e4a07483a0cb07c3a29b6/google_genai-2.14.0.tar.gz", hash = "sha256:a9d1f4f362d76280f1be1340fcb3c86e63dbca128f6a4ae09d86ab47ff7148e8", size = 641055, upload-time = "2026-07-22T21:35:44.717Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/86/5ac5fb53e44cca4a6607fb917eb331fa237c65a103b9ec2e8e8acc8a42db/google_genai-2.14.0-py3-none-any.whl", hash = "sha256:ae7172cdd35695189b516b33a878e4132e5daa2dbc03a5b44cddfa8a82fad664", size = 1030738, upload-time = "2026-07-22T21:35:42.785Z" },
+]
+
+[[package]]
+name = "google-genai-deep-research"
+version = "0.1.0"
+source = { editable = "samples/google-genai-deep-research" }
+dependencies = [
+    { name = "genkit" },
+    { name = "genkit-google-genai" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "genkit", editable = "packages/genkit" },
+    { name = "genkit-google-genai", editable = "packages/genkit-google-genai" },
+    { name = "pydantic" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fifth slice of the #5806 split: registers the Deep Research, Antigravity, and Lyria catalogs in GoogleAI init/resolve/list_actions (including cancel-operation routing), threads plugin-level ClientOptions and API key into the Interactions models, maps genai errors in Imagen, restores the wiring integration tests, and adds the google-genai-deep-research sample.

Final slice of the interactions chain; with #5854-#5856 and the Veo slice merged, plus the parallel gemini finish_message PR, the tree is byte-identical to #5806. Co-authored with @huangjeff5.