### PR TITLE
feat(py/plugins/google-genai): finish_message for image models and effective config echo

### DIFF
--- a/genkit-tools/common/src/types/model.ts
+++ b/genkit-tools/common/src/types/model.ts
@@ -343,6 +343,7 @@ export const FinishReasonSchema = z.enum([
   'stop',
   'length',
   'blocked',
+  'aborted',
   'interrupted',
   'other',
   'unknown',

--- a/genkit-tools/genkit-schema.json
+++ b/genkit-tools/genkit-schema.json
@@ -788,6 +788,7 @@
         "stop",
         "length",
         "blocked",
+        "aborted",
         "interrupted",
         "other",
         "unknown"

--- a/go/ai/gen.go
+++ b/go/ai/gen.go
@@ -78,6 +78,7 @@ const (
 	FinishReasonStop        FinishReason = "stop"
 	FinishReasonLength      FinishReason = "length"
 	FinishReasonBlocked     FinishReason = "blocked"
+	FinishReasonAborted     FinishReason = "aborted"
 	FinishReasonInterrupted FinishReason = "interrupted"
 	FinishReasonOther       FinishReason = "other"
 	FinishReasonUnknown     FinishReason = "unknown"

--- a/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
+++ b/py/packages/genkit-google-genai/src/genkit_google_genai/models/gemini.py
@@ -157,6 +157,7 @@ from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema
 from genkit import (
     Constrained,
     GenkitError,
+    MediaPart,
     Message,
     ModelConfig,
     ModelInfo,
@@ -183,9 +184,19 @@ def _to_dict(obj: JsonAny) -> JsonAny:  # noqa: ANN401
     return obj.model_dump() if isinstance(obj, BaseModel) else obj
 
 
+def _finish_reason_name(fr: Any) -> str | None:  # noqa: ANN401
+    """Normalize a google-genai finish reason to an uppercase name string."""
+    if fr is None:
+        return None
+    name = getattr(fr, 'name', fr)
+    if isinstance(name, str):
+        return name.upper()
+    return str(name).upper() if name is not None else None
+
+
 def _to_finish_reason(fr: Any) -> FinishReason:  # noqa: ANN401
     """Map a google-genai finish reason onto Genkit's FinishReason."""
-    fr_name = getattr(fr, 'name', fr) if fr is not None else None
+    fr_name = _finish_reason_name(fr)
     if fr_name == 'STOP':
         return FinishReason.STOP
     if fr_name == 'MAX_TOKENS':
@@ -201,9 +212,40 @@ def _to_finish_reason(fr: Any) -> FinishReason:  # noqa: ANN401
         'IMAGE_SAFETY',
     ):
         return FinishReason.BLOCKED
-    if fr_name in ('OTHER', 'MALFORMED_FUNCTION_CALL', 'MISSING_THOUGHT_SIGNATURE'):
+    # NO_IMAGE: request accepted but no image bytes. IMAGE_OTHER: generation
+    # stopped for a non-safety reason (often prompt/content policy adjacent).
+    if fr_name in (
+        'OTHER',
+        'MALFORMED_FUNCTION_CALL',
+        'MISSING_THOUGHT_SIGNATURE',
+        'NO_IMAGE',
+        'IMAGE_OTHER',
+    ):
         return FinishReason.OTHER
     return FinishReason.UNKNOWN
+
+
+def _content_has_media(content: list[Part]) -> bool:
+    """Return True when any part carries media (image/audio/video bytes or URL)."""
+    return any(isinstance(part.root, MediaPart) for part in content)
+
+
+def _finish_message_for_image_response(
+    *,
+    fr_name: str | None,
+    content: list[Part],
+) -> str | None:
+    """Explain empty/no-image outcomes so callers don't treat them as silent success."""
+    if _content_has_media(content):
+        return None
+    if fr_name == 'IMAGE_SAFETY':
+        return 'Image blocked by safety filters.'
+    if fr_name == 'IMAGE_OTHER':
+        return 'Image generation stopped (IMAGE_OTHER). Try revising the prompt.'
+    if fr_name == 'NO_IMAGE':
+        return 'No image was returned. Try a clearer image prompt (for example, "draw a red circle on white").'
+    # Ambiguous prompts sometimes come back as STOP/OTHER/UNKNOWN with empty parts.
+    return 'No image was returned. Try a clearer image prompt (for example, "draw a red circle on white").'
 
 
 def _to_float(obj: Any, attr: str) -> float | None:  # noqa: ANN401
@@ -998,7 +1040,6 @@ class VertexAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     | `gemini-3-pro-image`                 | Gemini 3 Pro Image                   | Supported    |
     | `gemini-3.1-flash-image`             | Gemini 3.1 Flash Image               | Supported    |
     | `gemini-3-pro-image-preview`         | Gemini 3 Pro Image Preview           | Supported    |
-    | `gemini-2.5-flash-image-preview`     | Gemini 2.5 Flash Image Preview       | Supported    |
     | `gemini-2.5-flash-image`             | Gemini 2.5 Flash Image               | Supported    |
     | `gemma-3-12b-it`                     | Gemma 3 12B IT                       | Supported    |
     | `gemma-3-1b-it`                      | Gemma 3 1B IT                        | Supported    |
@@ -1064,7 +1105,6 @@ class GoogleAIGeminiVersion(StrEnum, metaclass=Deprecations):  # pyrefly: ignore
     | `gemini-3.1-flash-image`             | Gemini 3.1 Flash Image               | Supported  |
     | `gemini-3.1-flash-image-preview`     | Gemini 3.1 Flash Image Preview       | Supported  |
     | `gemini-3-pro-image-preview`         | Gemini 3 Pro Image Preview           | Supported  |
-    | `gemini-2.5-flash-image-preview`     | Gemini 2.5 Flash Image Preview       | Supported  |
     | `gemini-2.5-flash-image`             | Gemini 2.5 Flash Image               | Supported  |
     | `gemini-3.1-pro-preview`             | Gemini 3.1 Pro Preview               | Supported  |
     | `gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools  | Supported  |
@@ -1141,7 +1181,6 @@ _add_model(GEMINI_3_PRO_IMAGE, ['gemini-3-pro-image'])
 _add_model(GEMINI_3_1_FLASH_IMAGE, ['gemini-3.1-flash-image'])
 _add_model(GEMINI_3_1_FLASH_IMAGE_PREVIEW, ['gemini-3.1-flash-image-preview'])
 _add_model(GEMINI_3_PRO_IMAGE_PREVIEW, ['gemini-3-pro-image-preview'])
-_add_model(GEMINI_2_5_FLASH_IMAGE_PREVIEW, ['gemini-2.5-flash-image-preview'])
 _add_model(GEMINI_2_5_FLASH_IMAGE, ['gemini-2.5-flash-image'])
 
 
@@ -1624,8 +1663,45 @@ class GeminiModel:
             )
 
         response.usage = self._create_usage_stats(request=request, response=response)
+        # Put normalized config on a request copy so callers debugging
+        # response.request see what drove the call, without mutating the
+        # original ModelRequest.
+        effective = self.effective_config(request, model_name=model_name, request_cfg=request_cfg)
+        response.request = request.model_copy(update={'config': effective})
 
         return response
+
+    def effective_config(
+        self,
+        request: ModelRequest,
+        *,
+        model_name: str,
+        request_cfg: genai_types.GenerateContentConfig | None,
+    ) -> dict[str, Any] | None:
+        """Return the coerced config used for this call (snake_case + injections).
+
+        Accepts camelCase or snake_case on the way in; includes plugin-injected
+        fields (e.g. image/TTS ``response_modalities``). Does not mutate request.
+        """
+        effective: dict[str, Any] = {}
+        if request.config is not None:
+            normalized = self._normalize_config_to_dict(request.config)
+            if normalized:
+                effective.update(normalized)
+
+        if request_cfg is not None and request_cfg.response_modalities:
+            effective['response_modalities'] = list(request_cfg.response_modalities)
+        elif is_tts_model(model_name):
+            effective['response_modalities'] = ['AUDIO']
+        elif is_image_model(model_name):
+            effective['response_modalities'] = ['TEXT', 'IMAGE']
+
+        # api_key is Field(exclude=True) on the schema dump, but strip anyway
+        # in case the caller handed us a raw dict.
+        effective.pop('api_key', None)
+        effective.pop('apiKey', None)
+
+        return effective or None
 
     async def _resolve_request_client(self, request: ModelRequest) -> genai.Client:
         """Resolve the client to use for a request.
@@ -1783,6 +1859,8 @@ class GeminiModel:
             content = [Part(root=TextPart(text=''))]
 
         finish_reason = FinishReason.OTHER
+        finish_message: str | None = None
+        primary_fr_name: str | None = None
         candidates = []
         if response.candidates:
             for i, c in enumerate(response.candidates):
@@ -1796,18 +1874,34 @@ class GeminiModel:
                 if not c_content:
                     c_content = [Part(root=TextPart(text=''))]
 
+                c_fr_name = _finish_reason_name(c.finish_reason)
                 c_finish_reason = _to_finish_reason(c.finish_reason)
+                c_finish_message = getattr(c, 'finish_message', None) or None
+                if is_image_model(model_name) and not c_finish_message:
+                    c_finish_message = _finish_message_for_image_response(
+                        fr_name=c_fr_name,
+                        content=c_content,
+                    )
 
                 if i == 0:
                     finish_reason = c_finish_reason
+                    finish_message = c_finish_message
+                    primary_fr_name = c_fr_name
 
                 candidates.append(
                     Candidate(
                         index=float(i),
                         message=Message(role=Role.MODEL, content=c_content),
                         finish_reason=c_finish_reason,
+                        finish_message=c_finish_message,
                     )
                 )
+
+        if is_image_model(model_name) and finish_message is None:
+            finish_message = _finish_message_for_image_response(
+                fr_name=primary_fr_name,
+                content=content,
+            )
 
         return ModelResponse(
             message=Message(
@@ -1815,6 +1909,7 @@ class GeminiModel:
                 role=Role.MODEL,
             ),
             finish_reason=finish_reason,
+            finish_message=finish_message,
             candidates=candidates,
             usage=_usage_from_metadata(response.usage_metadata),
         )
@@ -1867,6 +1962,8 @@ class GeminiModel:
 
         accumulated_content: list[Part] = []
         finish_reason = FinishReason.UNKNOWN
+        finish_message: str | None = None
+        primary_fr_name: str | None = None
         usage_metadata: Any = None
         async for response_chunk in generator:
             content = await self._contents_from_response(response_chunk)
@@ -1882,11 +1979,22 @@ class GeminiModel:
             # chunks, so hold onto the latest values we see as the stream drains —
             # otherwise a streamed turn reports no finish reason and no usage at all.
             if response_chunk.candidates and response_chunk.candidates[0] is not None:
-                fr = response_chunk.candidates[0].finish_reason
+                candidate = response_chunk.candidates[0]
+                fr = candidate.finish_reason
                 if fr:
+                    primary_fr_name = _finish_reason_name(fr)
                     finish_reason = _to_finish_reason(fr)
+                candidate_finish_message = getattr(candidate, 'finish_message', None)
+                if candidate_finish_message:
+                    finish_message = candidate_finish_message
             if response_chunk.usage_metadata is not None:
                 usage_metadata = response_chunk.usage_metadata
+
+        if is_image_model(model_name) and finish_message is None:
+            finish_message = _finish_message_for_image_response(
+                fr_name=primary_fr_name,
+                content=accumulated_content,
+            )
 
         return ModelResponse(
             message=Message(
@@ -1894,6 +2002,7 @@ class GeminiModel:
                 content=accumulated_content,
             ),
             finish_reason=finish_reason,
+            finish_message=finish_message,
             usage=_usage_from_metadata(usage_metadata),
         )
 

--- a/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
+++ b/py/packages/genkit-google-genai/test/models/googlegenai_gemini_test.py
@@ -301,6 +301,66 @@ async def test_generate_media_response(mocker: MockerFixture, version: str) -> N
     assert base64.b64decode(encoded_data) == response_byte_string
 
 
+@pytest.mark.asyncio
+async def test_generate_echoes_normalized_effective_config(mocker: MockerFixture) -> None:
+    """response.request.config is snake_case + injected modalities; caller request untouched."""
+    candidate = genai.types.Candidate(
+        content=genai.types.Content(parts=[genai.types.Part(text='ok')]),
+        finish_reason='STOP',
+    )
+    resp = genai.types.GenerateContentResponse(candidates=[candidate])
+    client = mocker.AsyncMock()
+    client.aio.models.generate_content.return_value = resp
+
+    original_config = {
+        'imageConfig': {'aspectRatio': '16:9'},
+        'apiKey': 'should-not-echo',
+        'temperature': 0.2,
+    }
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='draw a red circle'))])],
+        config=dict(original_config),
+    )
+    gemini = GeminiModel('gemini-2.5-flash-image', client)
+    response = await gemini.generate(request, ActionRunContext())
+
+    assert request.config == original_config
+    assert response.request is not None
+    assert response.request is not request
+    echoed = response.request.config
+    assert isinstance(echoed, dict)
+    assert echoed['image_config']['aspect_ratio'] == '16:9'
+    assert echoed['temperature'] == 0.2
+    assert echoed['response_modalities'] == ['TEXT', 'IMAGE']
+    assert 'api_key' not in echoed
+    assert 'apiKey' not in echoed
+    assert 'imageConfig' not in echoed
+
+
+@pytest.mark.asyncio
+async def test_generate_echoes_injected_modalities_when_config_omitted(
+    mocker: MockerFixture,
+) -> None:
+    """Image models still surface effective response_modalities with no caller config."""
+    candidate = genai.types.Candidate(
+        content=genai.types.Content(parts=[genai.types.Part(text='ok')]),
+        finish_reason='STOP',
+    )
+    resp = genai.types.GenerateContentResponse(candidates=[candidate])
+    client = mocker.AsyncMock()
+    client.aio.models.generate_content.return_value = resp
+
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(root=TextPart(text='draw a blue square'))])],
+    )
+    gemini = GeminiModel('gemini-2.5-flash-image', client)
+    response = await gemini.generate(request, ActionRunContext())
+
+    assert request.config is None
+    assert response.request is not None
+    assert response.request.config == {'response_modalities': ['TEXT', 'IMAGE']}
+
+
 def test_convert_schema_property(mocker: MockerFixture) -> None:
     """Test _convert_schema_property."""
     googleai_client_mock = mocker.AsyncMock()
@@ -504,20 +564,6 @@ async def test_generate_with_system_instructions(mocker: MockerFixture) -> None:
             'gemini-2.5-flash-image',
             ModelInfo(
                 label='Google AI - Gemini 2.5 Flash Image',
-                supports=Supports(
-                    multiturn=True,
-                    media=True,
-                    tools=True,
-                    tool_choice=True,
-                    system_role=True,
-                    constrained=Constrained.ALL,
-                ),
-            ),
-        ),
-        (
-            'gemini-2.5-flash-image-preview',
-            ModelInfo(
-                label='Google AI - Gemini 2.5 Flash Image Preview',
                 supports=Supports(
                     multiturn=True,
                     media=True,

--- a/py/packages/genkit-google-genai/tests/gemini_finish_reason_test.py
+++ b/py/packages/genkit-google-genai/tests/gemini_finish_reason_test.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for Gemini finish-reason mapping and empty-image messaging."""
+
+from types import SimpleNamespace
+
+import pytest
+from genkit_google_genai.models.gemini import (
+    SUPPORTED_MODELS,
+    _finish_message_for_image_response,
+    _to_finish_reason,
+    is_image_model,
+)
+
+from genkit import FinishReason, Media, MediaPart, Part, TextPart
+
+
+@pytest.mark.parametrize(
+    ('reason', 'expected'),
+    [
+        ('STOP', FinishReason.STOP),
+        ('MAX_TOKENS', FinishReason.LENGTH),
+        ('SAFETY', FinishReason.BLOCKED),
+        ('IMAGE_SAFETY', FinishReason.BLOCKED),
+        ('NO_IMAGE', FinishReason.OTHER),
+        ('IMAGE_OTHER', FinishReason.OTHER),
+        ('OTHER', FinishReason.OTHER),
+        ('TOTALLY_MADE_UP', FinishReason.UNKNOWN),
+        (None, FinishReason.UNKNOWN),
+        (SimpleNamespace(name='no_image'), FinishReason.OTHER),
+    ],
+)
+def test_to_finish_reason(reason: object, expected: FinishReason) -> None:
+    assert _to_finish_reason(reason) == expected
+
+
+def test_finish_message_for_missing_image() -> None:
+    empty = [Part(root=TextPart(text=''))]
+    msg = _finish_message_for_image_response(fr_name='NO_IMAGE', content=empty)
+    assert msg is not None
+    assert 'No image was returned' in msg
+
+    with_media = [
+        Part(root=MediaPart(media=Media(url='data:image/png;base64,xx', content_type='image/png'))),
+    ]
+    assert _finish_message_for_image_response(fr_name='STOP', content=with_media) is None
+
+
+def test_stale_flash_image_preview_not_in_supported_models() -> None:
+    assert 'gemini-2.5-flash-image-preview' not in SUPPORTED_MODELS
+    assert is_image_model('gemini-2.5-flash-image-preview')

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -85,11 +85,12 @@ from genkit._ai._resource import (
     define_resource,
 )
 from genkit._ai._tools import Tool, define_interrupt, define_tool
-from genkit._core._action import Action, ActionKind, get_current_context
+from genkit._core._action import Action, ActionKind, get_current_context  # noqa: F401 — re-exported via genkit.__init__
 from genkit._core._background import (
     BackgroundAction,
     CancelModelOpFn,
     CheckModelOpFn,
+    ConfigT,
     StartModelOpFn,
     check_operation,
     define_background_model,
@@ -146,7 +147,7 @@ T = TypeVar('T')
 MiddlewareT = TypeVar('MiddlewareT', bound=BaseMiddleware)
 
 
-def _model_supports_long_running(model_action: Action) -> bool:
+def model_supports_long_running(model_action: Action) -> bool:
     """Check if a model action supports long-running operations."""
     model_info = model_action.metadata.get('model') if model_action.metadata else None
     if not model_info:
@@ -423,12 +424,12 @@ class Genkit:
     def define_background_model(
         self,
         name: str,
-        start: StartModelOpFn,
+        start: StartModelOpFn[ConfigT],
         check: CheckModelOpFn,
         cancel: CancelModelOpFn | None = None,
         label: str | None = None,
         info: ModelInfo | None = None,
-        config_schema: type[BaseModel] | dict[str, object] | None = None,
+        config_schema: type[ConfigT] | dict[str, object] | None = None,
         metadata: dict[str, object] | None = None,
         description: str | None = None,
     ) -> BackgroundAction:
@@ -1412,7 +1413,7 @@ class Genkit:
                 message='No model specified for generate_operation.',
             )
 
-        model_action = await self.registry.resolve_action(ActionKind.MODEL, resolved_model)
+        model_action = await self.registry.resolve_model(resolved_model)
         if not model_action:
             raise GenkitError(
                 status='NOT_FOUND',
@@ -1420,7 +1421,7 @@ class Genkit:
             )
 
         # Check if model supports long-running operations
-        if not _model_supports_long_running(model_action):
+        if not model_supports_long_running(cast(Action, model_action)):
             raise GenkitError(
                 status='INVALID_ARGUMENT',
                 message=f"Model '{model_action.name}' does not support long running operations.",

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -70,6 +70,7 @@ from genkit._core._typing import (
     FinishReason,
     MiddlewareRef,
     MultipartToolResponse,
+    Operation,
     Part,
     Role,
     TextPart,
@@ -747,6 +748,12 @@ async def _generate_action_turn(
                 next_fn,
             )
 
+        # Background models return an Operation to poll, not a finished message.
+        # The tool loop below assumes response.message exists, so branch out first.
+        if model.kind == ActionKind.BACKGROUND_MODEL:
+            operation = cast(Operation, model_response)
+            return ModelResponse(operation=operation, request=request)
+
         def message_parser(msg: Message) -> Any:  # noqa: ANN401
             if formatter is None:
                 return None
@@ -755,10 +762,11 @@ async def _generate_action_turn(
         # Extract schema_type for runtime Pydantic validation
         schema_type = turn_options.output.schema_type if turn_options.output else None
 
-        # Plugin returns ModelResponse directly. Framework sets request and
-        # any output format context (message_parser, schema_type) as private attrs.
+        # Plugin returns ModelResponse directly. Framework fills request when the
+        # plugin didn't already attach one (e.g. with a normalized config echo).
         response = model_response
-        response.request = request
+        if response.request is None:
+            response.request = request
         if formatter:
             response._message_parser = message_parser
         if schema_type:
@@ -1079,11 +1087,17 @@ async def resolve_parameters(
         else cast(str | None, registry.lookup_value('defaultModel', 'defaultModel'))
     )
     if not model:
-        raise Exception('No model configured.')
+        raise GenkitError(status='INVALID_ARGUMENT', message='No model configured.')
 
     model_action = await registry.resolve_model(model)
     if model_action is None:
-        raise Exception(f'Failed to to resolve model {model}')
+        hint = ''
+        if isinstance(model, str) and '/' not in model:
+            hint = f" Did you mean 'googleai/{model}' or 'vertexai/{model}'?"
+        raise GenkitError(
+            status='NOT_FOUND',
+            message=f"Failed to resolve model '{model}'.{hint}",
+        )
 
     # Resolve tools up front to fail fast on invalid caller-supplied tool names or
     # duplicate short names before running side effects or middleware.

--- a/py/packages/genkit/src/genkit/_ai/_generate.py
+++ b/py/packages/genkit/src/genkit/_ai/_generate.py
@@ -1093,7 +1093,10 @@ async def resolve_parameters(
     if model_action is None:
         hint = ''
         if isinstance(model, str) and '/' not in model:
-            hint = f" Did you mean 'googleai/{model}' or 'vertexai/{model}'?"
+            namespaces = registry.plugin_names()
+            if namespaces:
+                suggestions = ' or '.join(f"'{ns}/{model}'" for ns in namespaces)
+                hint = f' Did you mean {suggestions}?'
         raise GenkitError(
             status='NOT_FOUND',
             message=f"Failed to resolve model '{model}'.{hint}",

--- a/py/packages/genkit/src/genkit/_ai/_model.py
+++ b/py/packages/genkit/src/genkit/_ai/_model.py
@@ -71,12 +71,19 @@ def model_ref(
     info: ModelInfo | None = None,
     version: str | None = None,
     config: dict[str, object] | None = None,
+    config_schema: object | None = None,
 ) -> ModelRef:
     """Create a ModelRef, optionally prefixing name with namespace."""
     # Logic: if (options.namespace && !name.startsWith(options.namespace + '/'))
     final_name = f'{namespace}/{name}' if namespace and not name.startswith(f'{namespace}/') else name
 
-    return ModelRef(name=final_name, info=info, version=version, config=config)
+    return ModelRef(
+        name=final_name,
+        info=info,
+        version=version,
+        config=config,
+        config_schema=config_schema,
+    )
 
 
 def define_model(

--- a/py/packages/genkit/src/genkit/_core/_action.py
+++ b/py/packages/genkit/src/genkit/_core/_action.py
@@ -695,8 +695,16 @@ class Action(Generic[InputT, OutputT, ChunkT, InitT]):
         # signal that "no input" is a legitimate way to invoke this action.
         if input is None and self._first_arg_optional:
             return input
+        # When a BaseModel instance fails (e.g. generate hands ModelRequest with
+        # GenerationCommonConfig into an action typed as ModelRequest[PluginConfig]),
+        # dump to plain data and retry so the action's schema wins.
         try:
-            return self._input_type.validate_python(input)
+            try:
+                return self._input_type.validate_python(input)
+            except ValidationError:
+                if not isinstance(input, BaseModel):
+                    raise
+                return self._input_type.validate_python(input.model_dump(mode='python'))
         except ValidationError as e:
             if input is None:
                 raise GenkitError(

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -20,12 +20,12 @@ from __future__ import annotations
 
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
 
 from pydantic import BaseModel
 
 from genkit._core._action import Action, ActionKind, ActionRunContext
-from genkit._core._model import ModelRequest, ModelResponse
+from genkit._core._model import ConfigT, ModelRequest, ModelResponse
 from genkit._core._registry import Registry
 from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
@@ -37,7 +37,7 @@ from genkit._core._typing import (
 OutputT = TypeVar('OutputT')
 
 
-def _make_action_key(action_type: ActionKind | str, name: str) -> str:
+def make_action_key(action_type: ActionKind | str, name: str) -> str:
     """Create an action key matching JS format: /{actionType}/{name}.
 
     Args:
@@ -50,12 +50,9 @@ def _make_action_key(action_type: ActionKind | str, name: str) -> str:
     return f'/{action_type}/{name}'
 
 
-# Type aliases for background model functions matching JS signatures
-# JS: start: (input, options) => Promise<Operation<OutputT>>
-StartModelOpFn = Callable[[ModelRequest, ActionRunContext], Awaitable[Operation]]
-# JS: check: (input: Operation<OutputT>) => Promise<Operation<OutputT>>
+# Type aliases for background model start/check/cancel handlers.
+StartModelOpFn = Callable[[ModelRequest[ConfigT], ActionRunContext], Awaitable[Operation]]
 CheckModelOpFn = Callable[[Operation], Awaitable[Operation]]
-# JS: cancel?: (input: Operation<OutputT>) => Promise<Operation<OutputT>>
 CancelModelOpFn = Callable[[Operation], Awaitable[Operation]]
 
 
@@ -128,7 +125,7 @@ class BackgroundAction(Generic[OutputT]):
             An Operation with an ID to track the job.
         """
         result = await self.start_action.run(input)
-        return _ensure_operation(result.response)
+        return ensure_operation(result.response)
 
     async def check(self, operation: Operation) -> Operation:
         """Check the status of a background operation.
@@ -142,7 +139,7 @@ class BackgroundAction(Generic[OutputT]):
             Updated Operation with current status.
         """
         result = await self.check_action.run(operation)
-        return _ensure_operation(result.response)
+        return ensure_operation(result.response)
 
     async def cancel(self, operation: Operation) -> Operation:
         """Cancel a background operation.
@@ -162,10 +159,10 @@ class BackgroundAction(Generic[OutputT]):
             # Match JS behavior: return operation unchanged if cancel not supported
             return operation
         result = await self.cancel_action.run(operation)
-        return _ensure_operation(result.response)
+        return ensure_operation(result.response)
 
 
-def _ensure_operation(response: Any) -> Operation:  # noqa: ANN401
+def ensure_operation(response: Any) -> Operation:  # noqa: ANN401
     """Convert response to Operation type."""
     if isinstance(response, Operation):
         return response
@@ -197,12 +194,12 @@ class DefineBackgroundModelOptions(BaseModel):
 def define_background_model(
     registry: Registry,
     name: str,
-    start: StartModelOpFn,
+    start: StartModelOpFn[ConfigT],
     check: CheckModelOpFn,
     cancel: CancelModelOpFn | None = None,
     label: str | None = None,
     info: ModelInfo | None = None,
-    config_schema: type | dict[str, Any] | None = None,
+    config_schema: type[ConfigT] | dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
     description: str | None = None,
 ) -> BackgroundAction[ModelResponse]:
@@ -243,14 +240,16 @@ def define_background_model(
         ...     op = await action.check(op)
     """
     label = label or name
-    action_key = _make_action_key(ActionKind.BACKGROUND_MODEL, name)
+    action_key = make_action_key(ActionKind.BACKGROUND_MODEL, name)
 
     # Build model metadata matching JS structure
     model_meta: dict[str, Any] = metadata.copy() if metadata else {}
     model_options: dict[str, Any] = {}
 
     if info:
-        model_options.update(info.model_dump())
+        # camelCase wire keys (e.g. longRunning) so generate_operation's
+        # metadata check sees the same shape Dev UI / JS expect.
+        model_options.update(info.model_dump(by_alias=True))
 
     model_options['label'] = label
     if config_schema:
@@ -262,10 +261,12 @@ def define_background_model(
     output_schema_meta = to_json_schema(ModelResponse)
     model_meta['outputSchema'] = output_schema_meta
 
-    # Wrap the start function to add the action key and timing (matching JS)
+    # Wrap the start function to add the action key and timing.
+    # Annotate as bare ModelRequest so Action doesn't build TypeAdapter(ModelRequest[TypeVar]);
+    # when config_schema is set we override to ModelRequest[that schema] below.
     async def wrapped_start(request: ModelRequest, ctx: ActionRunContext) -> Operation:
         start_time = time.perf_counter()
-        op = await start(request, ctx)
+        op = await start(cast(ModelRequest[ConfigT], request), ctx)
         # Set action key matching JS format: /{actionType}/{name}
         op.action = action_key
         latency_ms = (time.perf_counter() - start_time) * 1000
@@ -275,7 +276,7 @@ def define_background_model(
         return op
 
     # Wrap the check function (matching JS - no ctx parameter)
-    async def wrapped_check(op: Operation, ctx: ActionRunContext) -> Operation:
+    async def wrapped_check(op: Operation, _: ActionRunContext) -> Operation:
         updated = await check(op)
         # Preserve action key
         updated.action = action_key
@@ -291,6 +292,12 @@ def define_background_model(
         metadata=model_meta,
         description=description or f'Background model: {label}',
     )
+    # wrapped_start is annotated as bare ModelRequest so Action doesn't build
+    # TypeAdapter(ModelRequest[TypeVar]). When callers pass a concrete config
+    # class, validate start input as ModelRequest[ConfigT].
+    if isinstance(config_schema, type):
+        # Parameterizing at runtime, so the subscript can't be a type expression.
+        start_action._override_input_schema(cast(type, cast(Any, ModelRequest)[config_schema]))
 
     # Register the check action
     # JS: actionType: 'check-operation'
@@ -311,7 +318,7 @@ def define_background_model(
         # Capture cancel in local scope for the nested function
         cancel_fn = cancel
 
-        async def wrapped_cancel(op: Operation, ctx: ActionRunContext) -> Operation:
+        async def wrapped_cancel(op: Operation, _: ActionRunContext) -> Operation:
             cancelled = await cancel_fn(op)
             cancelled.action = action_key
             return cancelled

--- a/py/packages/genkit/src/genkit/_core/_background.py
+++ b/py/packages/genkit/src/genkit/_core/_background.py
@@ -297,7 +297,7 @@ def define_background_model(
     # class, validate start input as ModelRequest[ConfigT].
     if isinstance(config_schema, type):
         # Parameterizing at runtime, so the subscript can't be a type expression.
-        start_action._override_input_schema(cast(type, cast(Any, ModelRequest)[config_schema]))
+        start_action._override_input_schema(cast('type[BaseModel]', cast(Any, ModelRequest)[config_schema]))
 
     # Register the check action
     # JS: actionType: 'check-operation'

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -64,7 +64,9 @@ ModelUsage = GenerationUsage  # public name for GenerationUsage
 
 # TypeVars for generic types
 OutputT = TypeVar('OutputT', default=object)
-ConfigT = TypeVar('ConfigT', bound=ModelConfig, default=ModelConfig)
+# No default — callers/actions bind ModelRequest[TheirConfig]. A ModelConfig
+# default would reject plugin config instances on bare ModelRequest.
+ConfigT = TypeVar('ConfigT', bound=BaseModel)
 
 
 class ModelRef(BaseModel):
@@ -254,6 +256,27 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
     output_schema: dict[str, Any] | None = None
     output_constrained: bool | None = None
     output_content_type: str | None = None
+
+    @field_validator('config', mode='plain')
+    @classmethod
+    def _validate_config(cls, v: object) -> object:
+        """Accept plugin config models and dicts without forcing ModelConfig.
+
+        Bare ModelRequest(config={...}) keeps the dict; ModelRequest[PluginConfig]
+        coerces that dict into the plugin schema. Plugin config instances pass through.
+        """
+        if v is None:
+            return None
+        if isinstance(v, BaseModel):
+            return v
+        if isinstance(v, dict):
+            args = cls.__pydantic_generic_metadata__['args']
+            if args:
+                schema = args[0]
+                if isinstance(schema, type) and issubclass(schema, BaseModel):
+                    return schema.model_validate(v)
+            return v
+        raise TypeError(f'config must be a BaseModel or dict, got {type(v).__name__}')
 
     @field_validator('messages', mode='before')
     @classmethod

--- a/py/packages/genkit/src/genkit/_core/_model.py
+++ b/py/packages/genkit/src/genkit/_core/_model.py
@@ -25,9 +25,18 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from functools import cached_property
-from typing import Any, ClassVar, Generic, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_serializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    SerializeAsAny,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 from pydantic.alias_generators import to_camel
 from typing_extensions import TypeVar
 
@@ -248,7 +257,15 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
     # Veneer types for IDE/typing (validators wrap MessageData->Message, DocumentData->Document)
     messages: list[Message]  # pyright: ignore[reportIncompatibleVariableOverride]
     docs: list[Document] | None = None  # pyright: ignore[reportIncompatibleVariableOverride]
-    config: ConfigT | None = None
+    if TYPE_CHECKING:
+        # Reads are typed as the bound schema: after validation a parametrized
+        # request can only hold ConfigT (dicts are coerced, mismatches rejected).
+        # The runtime union is what pydantic validates and serializes against.
+        config: ConfigT | None = None
+    else:
+        # dict arm first + left_to_right: smart union would lax-coerce bare dict
+        # configs into an empty BaseModel via the unresolved ConfigT arm.
+        config: dict[str, Any] | SerializeAsAny[ConfigT] | None = Field(default=None, union_mode='left_to_right')
     tools: list[ToolDefinition] | None = None
     tool_choice: ToolChoice | None = Field(default=None)
     # Flat output fields (no nested OutputConfig)
@@ -257,17 +274,33 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
     output_constrained: bool | None = None
     output_content_type: str | None = None
 
-    @field_validator('config', mode='plain')
+    if TYPE_CHECKING:
+
+        def __init__(
+            self,
+            *,
+            messages: list[Message],
+            docs: list[Document] | None = None,
+            config: ConfigT | dict[str, Any] | None = None,
+            tools: list[ToolDefinition] | None = None,
+            tool_choice: ToolChoice | None = None,
+            output_format: str | None = None,
+            output_schema: dict[str, Any] | None = None,
+            output_constrained: bool | None = None,
+            output_content_type: str | None = None,
+            **extras: Any,  # noqa: ANN401
+        ) -> None: ...
+
+    @field_validator('config', mode='before')
     @classmethod
     def _validate_config(cls, v: object) -> object:
-        """Accept plugin config models and dicts without forcing ModelConfig.
+        """Coerce dict configs into the bound plugin schema when parametrized.
 
         Bare ModelRequest(config={...}) keeps the dict; ModelRequest[PluginConfig]
-        coerces that dict into the plugin schema. Plugin config instances pass through.
+        coerces that dict into the plugin schema. Plugin config instances pass
+        through here, then union validation rejects mismatched schemas.
         """
-        if v is None:
-            return None
-        if isinstance(v, BaseModel):
+        if v is None or isinstance(v, BaseModel):
             return v
         if isinstance(v, dict):
             args = cls.__pydantic_generic_metadata__['args']
@@ -277,6 +310,26 @@ class ModelRequest(GenkitModel, Generic[ConfigT]):
                     return schema.model_validate(v)
             return v
         raise TypeError(f'config must be a BaseModel or dict, got {type(v).__name__}')
+
+    @model_validator(mode='before')
+    @classmethod
+    def _flatten_output(cls, data: object) -> object:
+        """Accept spec wire format: unnest output into the flat output_* fields."""
+        if not isinstance(data, dict):
+            return data
+        flat = cast('dict[str, Any]', dict(data))
+        output = flat.pop('output', None)
+        if not isinstance(output, dict):
+            return data
+        for src, camel, snake in (
+            ('format', 'outputFormat', 'output_format'),
+            ('schema', 'outputSchema', 'output_schema'),
+            ('constrained', 'outputConstrained', 'output_constrained'),
+            ('contentType', 'outputContentType', 'output_content_type'),
+        ):
+            if src in output and camel not in flat and snake not in flat:
+                flat[camel] = output[src]
+        return flat
 
     @field_validator('messages', mode='before')
     @classmethod

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -767,6 +767,9 @@ class Registry:
         """
         action = await self.resolve_action(ActionKind.MODEL, name)
         if action is None:
+            # background-only models (Veo, Deep Research) live under a different kind
+            action = await self.resolve_action(ActionKind.BACKGROUND_MODEL, name)
+        if action is None:
             return None
         return cast(
             Action[ModelRequest, ModelResponse, ModelResponseChunk],

--- a/py/packages/genkit/src/genkit/_core/_registry.py
+++ b/py/packages/genkit/src/genkit/_core/_registry.py
@@ -405,6 +405,14 @@ class Registry:
             return local
         return {**self._parent.list_values(kind), **local}
 
+    def plugin_names(self) -> list[str]:
+        """Names of registered plugins, parent-first, deduplicated."""
+        with self._lock:
+            local = list(self._plugins)
+        if self._parent is None:
+            return local
+        return list(dict.fromkeys([*self._parent.plugin_names(), *local]))
+
     def register_plugin(self, plugin: Plugin) -> None:
         """Register a plugin with the registry.
 

--- a/py/packages/genkit/src/genkit/_core/_typing.py
+++ b/py/packages/genkit/src/genkit/_core/_typing.py
@@ -90,6 +90,7 @@ class FinishReason(StrEnum):
     STOP = 'stop'
     LENGTH = 'length'
     BLOCKED = 'blocked'
+    ABORTED = 'aborted'
     INTERRUPTED = 'interrupted'
     OTHER = 'other'
     UNKNOWN = 'unknown'

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for background model generate() and generate_operation() plumbing."""
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from genkit import Genkit, Message, ModelResponse, Part, Role, TextPart
+from genkit._core._action import ActionRunContext
+from genkit._core._error import GenkitError
+from genkit._core._model import ModelRequest
+from genkit._core._typing import ModelInfo, Operation, Supports
+
+
+@pytest.fixture
+def ai() -> Genkit:
+    """Create a fresh Genkit instance for each test."""
+    return Genkit()
+
+
+async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> None:
+    async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
+        return Operation(id=op_id, done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    ai.define_background_model(
+        name='bg-model',
+        start=start,
+        check=check,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+
+class PluginConfig(BaseModel):
+    thinking_summaries: str | None = None
+    google_search: bool | None = None
+
+
+@pytest.mark.asyncio
+async def test_background_start_receives_plugin_config_schema(ai: Genkit) -> None:
+    """Bare ModelRequest configs are re-validated as the plugin config schema."""
+    seen: dict[str, Any] = {}
+
+    async def start(request: ModelRequest[PluginConfig], _: ActionRunContext) -> Operation:
+        seen['config'] = request.config
+        return Operation(id='cfg-op', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    action = ai.define_background_model(
+        name='cfg-model',
+        start=start,
+        check=check,
+        config_schema=PluginConfig,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+    # Mimic generate: bare ModelRequest keeps a dict; Action coerces to the plugin schema.
+    request = ModelRequest(
+        messages=[Message(role=Role.USER, content=[Part(TextPart(text='go'))])],
+        config={'thinking_summaries': 'auto', 'google_search': True},
+    )
+    assert request.config == {'thinking_summaries': 'auto', 'google_search': True}
+
+    await action.start(request)
+
+    config = seen['config']
+    assert isinstance(config, PluginConfig)
+    assert config.thinking_summaries == 'auto'
+    assert config.google_search is True
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_operation_for_background_model(ai: Genkit) -> None:
+    """generate() wraps a background model Operation in ModelResponse."""
+    await register_bg_model(ai)
+
+    response = await ai.generate(model='bg-model', prompt='a cat surfing')
+
+    assert response.operation is not None
+    assert response.operation.id == 'bg-op-123'
+    assert response.operation.done is False
+    assert response.operation.action == '/background-model/bg-model'
+    assert response.message is None
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_with_background_model(ai: Genkit) -> None:
+    """generate_operation resolves background models via resolve_model()."""
+    await register_bg_model(ai, op_id='bg-op-456')
+
+    operation = await ai.generate_operation(model='bg-model', prompt='a cat surfing')
+
+    assert isinstance(operation, Operation)
+    assert operation.id == 'bg-op-456'
+    assert operation.action == '/background-model/bg-model'
+
+
+@pytest.mark.asyncio
+async def test_generate_operation_rejects_foreground_model_without_lro(ai: Genkit) -> None:
+    """generate_operation rejects standard foreground models."""
+
+    async def model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
+        return ModelResponse(
+            message=Message(
+                role=Role.MODEL,
+                content=[Part(root=TextPart(text='Hello'))],
+            ),
+        )
+
+    ai.define_model(name='fg-model', fn=model_fn)
+
+    with pytest.raises(GenkitError) as exc_info:
+        await ai.generate_operation(model='fg-model', prompt='Hi')
+
+    assert 'does not support long running operations' in str(exc_info.value)

--- a/py/packages/genkit/tests/genkit/ai/background_generate_test.py
+++ b/py/packages/genkit/tests/genkit/ai/background_generate_test.py
@@ -22,7 +22,8 @@ import pytest
 from pydantic import BaseModel
 
 from genkit import Genkit, Message, ModelResponse, Part, Role, TextPart
-from genkit._core._action import ActionRunContext
+from genkit._core._action import ActionKind, ActionRunContext
+from genkit._core._background import BackgroundAction
 from genkit._core._error import GenkitError
 from genkit._core._model import ModelRequest
 from genkit._core._typing import ModelInfo, Operation, Supports
@@ -34,14 +35,14 @@ def ai() -> Genkit:
     return Genkit()
 
 
-async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> None:
+async def register_bg_model(ai: Genkit, *, op_id: str = 'bg-op-123') -> BackgroundAction:
     async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
         return Operation(id=op_id, done=False)
 
     async def check(op: Operation) -> Operation:
         return op
 
-    ai.define_background_model(
+    return ai.define_background_model(
         name='bg-model',
         start=start,
         check=check,
@@ -133,3 +134,60 @@ async def test_generate_operation_rejects_foreground_model_without_lro(ai: Genki
         await ai.generate_operation(model='fg-model', prompt='Hi')
 
     assert 'does not support long running operations' in str(exc_info.value)
+
+
+def register_cancellable_model(ai: Genkit, cancelled: list[str]) -> BackgroundAction:
+    async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
+        return Operation(id='op-1', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    async def cancel(op: Operation) -> Operation:
+        cancelled.append(op.id)
+        return Operation(id=op.id, done=True)
+
+    return ai.define_background_model(
+        name='cancellable-model',
+        start=start,
+        check=check,
+        cancel=cancel,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_runs_handler_and_preserves_action_key(ai: Genkit) -> None:
+    """cancel() invokes the handler and stamps the background action key."""
+    cancelled: list[str] = []
+    action = register_cancellable_model(ai, cancelled)
+
+    assert action.supports_cancel
+
+    result = await action.cancel(Operation(id='op-1', done=False))
+
+    assert cancelled == ['op-1']
+    assert result.done is True
+    assert result.action == '/background-model/cancellable-model'
+
+
+@pytest.mark.asyncio
+async def test_cancel_action_resolvable_via_registry(ai: Genkit) -> None:
+    """Cancel registers under cancel-operation kind at {name}/cancel."""
+    action = register_cancellable_model(ai, [])
+
+    resolved = await ai.registry.resolve_action(ActionKind.CANCEL_OPERATION, 'cancellable-model/cancel')
+
+    assert resolved is action.cancel_action
+
+
+@pytest.mark.asyncio
+async def test_cancel_without_handler_returns_operation_unchanged(ai: Genkit) -> None:
+    """Without a cancel handler the operation comes back untouched (JS parity)."""
+    action = await register_bg_model(ai)
+
+    assert not action.supports_cancel
+    assert await ai.registry.resolve_action(ActionKind.CANCEL_OPERATION, 'bg-model/cancel') is None
+
+    op = Operation(id='bg-op-123', done=False)
+    assert await action.cancel(op) is op

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -5,11 +5,14 @@
 
 """Tests for the action module."""
 
+import warnings
+
 import pytest
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from genkit import Message, ModelRequest, ModelResponse, ModelResponseChunk, ModelUsage
 from genkit._ai._model import text_from_content
+from genkit._core._schema import to_json_schema
 from genkit._core._typing import (
     ActionMetadata,
     DocumentPart,
@@ -414,3 +417,54 @@ def test_parameterized_model_request_coerces_dict_to_plugin_config() -> None:
     )
     assert isinstance(request.config, PluginConfig)
     assert request.config.api_key == 'k'
+
+
+def test_parameterized_model_request_rejects_mismatched_config_instance() -> None:
+    class OtherConfig(BaseModel):
+        top_k: int | None = None
+
+    with pytest.raises(ValidationError):
+        ModelRequest[PluginConfig](
+            messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+            config=OtherConfig(top_k=3),  # pyright: ignore[reportArgumentType]
+        )
+
+
+def test_model_request_rejects_non_model_non_dict_config() -> None:
+    with pytest.raises(TypeError, match='config must be a BaseModel or dict'):
+        ModelRequest(
+            messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+            config='not-a-config',  # pyright: ignore[reportArgumentType]
+        )
+
+
+def test_parameterized_model_request_config_json_schema_refs_plugin_schema() -> None:
+    schema = to_json_schema(ModelRequest[PluginConfig])
+    config_prop = schema['properties']['config']
+    assert any('$ref' in arm for arm in config_prop.get('anyOf', [])), config_prop
+
+
+def test_model_request_dump_round_trip_preserves_output_config() -> None:
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'temperature': 0.5},
+        output_format='json',
+        output_schema={'type': 'object'},
+        output_constrained=True,
+    )
+    round_tripped = ModelRequest.model_validate(request.model_dump(mode='python'))
+    assert round_tripped.output_format == 'json'
+    assert round_tripped.output_schema == {'type': 'object'}
+    assert round_tripped.output_constrained is True
+    assert round_tripped.config == {'temperature': 0.5}
+
+
+def test_model_request_dump_emits_no_serializer_warnings() -> None:
+    request = ModelRequest[PluginConfig](
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'api_key': 'k'},
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        request.model_dump(mode='python')
+        request.model_dump_json()

--- a/py/packages/genkit/tests/genkit/ai/model_test.py
+++ b/py/packages/genkit/tests/genkit/ai/model_test.py
@@ -6,6 +6,7 @@
 """Tests for the action module."""
 
 import pytest
+from pydantic import BaseModel, ConfigDict
 
 from genkit import Message, ModelRequest, ModelResponse, ModelResponseChunk, ModelUsage
 from genkit._ai._model import text_from_content
@@ -20,6 +21,14 @@ from genkit._core._typing import (
     ToolRequestPart,
 )
 from genkit.model import get_basic_usage_stats, model_action_metadata
+
+
+class PluginConfig(BaseModel):
+    """Stand-in for a plugin-specific config schema (e.g. LyriaConfig)."""
+
+    model_config = ConfigDict(extra='allow')
+    api_key: str | None = None
+    response_modalities: list[str] | None = None
 
 
 def test_message_wrapper_text() -> None:
@@ -376,3 +385,32 @@ def test_text_from_content_with_none_text() -> None:
         Part(root=TextPart(text=' world')),
     ]
     assert text_from_content(content) == 'hello world'
+
+
+def test_bare_model_request_accepts_plugin_config_instance() -> None:
+    """Bare ModelRequest(config=PluginConfig) keeps the plugin schema instance."""
+    plugin_config = PluginConfig(api_key='k', response_modalities=['audio'])
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config=plugin_config,
+    )
+    assert request.config is plugin_config
+    assert isinstance(request.config, PluginConfig)
+
+
+def test_bare_model_request_keeps_dict_config() -> None:
+    """Dict configs stay dicts on bare ModelRequest; Action coerces to the plugin schema."""
+    request = ModelRequest(
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'temperature': 0.5, 'api_key': 'k'},
+    )
+    assert request.config == {'temperature': 0.5, 'api_key': 'k'}
+
+
+def test_parameterized_model_request_coerces_dict_to_plugin_config() -> None:
+    request = ModelRequest[PluginConfig](
+        messages=[Message(role='user', content=[Part(root=TextPart(text='hi'))])],
+        config={'api_key': 'k'},
+    )
+    assert isinstance(request.config, PluginConfig)
+    assert request.config.api_key == 'k'

--- a/py/packages/genkit/tests/genkit/ai/prompt_test.py
+++ b/py/packages/genkit/tests/genkit/ai/prompt_test.py
@@ -100,7 +100,7 @@ async def test_simple_prompt() -> None:
     """Test simple prompt rendering."""
     ai, *_ = setup_test()
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     my_prompt = ai.define_prompt(prompt='hi', config={'temperature': 11})
 
@@ -123,7 +123,7 @@ async def test_simple_prompt_with_override_config() -> None:
     ai, *_ = setup_test()
 
     # Config is MERGED: prompt config (banana: true) + opts config (temperature: 12)
-    want_txt = '[ECHO] user: "hi" {"temperature":12.0,"banana":true}'
+    want_txt = '[ECHO] user: "hi" {"banana":true,"temperature":12}'
 
     my_prompt = ai.define_prompt(prompt='hi', config={'banana': True})
 
@@ -221,7 +221,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] system: "hello foo (bar)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] system: "hello foo (bar)" {"banana":"ripe","temperature":11.0}""",
     ),
     (
         'renders user prompt',
@@ -241,7 +241,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] user: "hello foo (bar_system)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] user: "hello foo (bar_system)" {"banana":"ripe","temperature":11.0}""",
     ),
     (
         'renders user prompt with context',
@@ -261,7 +261,7 @@ test_cases_parse_partial_json = [
         ModelConfig.model_validate({'temperature': 11}),
         {'auth': {'email': 'a@b.c'}},
         # Config is MERGED: prompt config (banana: ripe) + opts config (temperature: 11)
-        """[ECHO] user: "hello foo (bar, a@b.c)" {"temperature":11.0,"banana":"ripe"}""",
+        """[ECHO] user: "hello foo (bar, a@b.c)" {"banana":"ripe","temperature":11.0}""",
     ),
 ]
 

--- a/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for generate-path model resolution errors."""
+
+import pytest
+
+from genkit import GenkitError
+from genkit._ai._generate import resolve_parameters
+from genkit._core._model import GenerateActionOptions
+from genkit._core._registry import Registry
+
+
+@pytest.mark.asyncio
+async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> None:
+    registry = Registry()
+    with pytest.raises(GenkitError) as exc_info:
+        await resolve_parameters(
+            registry,
+            GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
+        )
+    assert exc_info.value.status == 'NOT_FOUND'
+    assert 'googleai/lyria-3-clip-preview' in str(exc_info.value)
+    assert 'vertexai/lyria-3-clip-preview' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_resolve_parameters_no_model_is_invalid_argument() -> None:
+    registry = Registry()
+    with pytest.raises(GenkitError) as exc_info:
+        await resolve_parameters(registry, GenerateActionOptions(messages=[]))
+    assert exc_info.value.status == 'INVALID_ARGUMENT'
+    assert 'No model configured' in str(exc_info.value)

--- a/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
+++ b/py/packages/genkit/tests/genkit/ai/resolve_model_error_test.py
@@ -18,14 +18,44 @@
 
 import pytest
 
-from genkit import GenkitError
+from genkit import GenkitError, Plugin
 from genkit._ai._generate import resolve_parameters
+from genkit._core._action import Action, ActionKind
 from genkit._core._model import GenerateActionOptions
 from genkit._core._registry import Registry
+from genkit._core._typing import ActionMetadata
+
+
+class _NamespacePlugin(Plugin):
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def init(self) -> list[Action]:
+        return []
+
+    async def resolve(self, action_type: ActionKind, name: str) -> Action | None:
+        return None
+
+    async def list_actions(self) -> list[ActionMetadata]:
+        return []
 
 
 @pytest.mark.asyncio
-async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> None:
+async def test_resolve_parameters_missing_prefix_hints_registered_namespaces() -> None:
+    registry = Registry()
+    registry.register_plugin(_NamespacePlugin('ollama'))
+    registry.register_plugin(_NamespacePlugin('openai'))
+    with pytest.raises(GenkitError) as exc_info:
+        await resolve_parameters(
+            registry,
+            GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
+        )
+    assert exc_info.value.status == 'NOT_FOUND'
+    assert "'ollama/lyria-3-clip-preview' or 'openai/lyria-3-clip-preview'" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_resolve_parameters_no_plugins_no_namespace_hint() -> None:
     registry = Registry()
     with pytest.raises(GenkitError) as exc_info:
         await resolve_parameters(
@@ -33,8 +63,7 @@ async def test_resolve_parameters_missing_prefix_hints_plugin_namespace() -> Non
             GenerateActionOptions(model='lyria-3-clip-preview', messages=[]),
         )
     assert exc_info.value.status == 'NOT_FOUND'
-    assert 'googleai/lyria-3-clip-preview' in str(exc_info.value)
-    assert 'vertexai/lyria-3-clip-preview' in str(exc_info.value)
+    assert 'Did you mean' not in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/py/packages/genkit/tests/genkit/core/registry_test.py
+++ b/py/packages/genkit/tests/genkit/core/registry_test.py
@@ -12,10 +12,13 @@ functionality, ensuring proper registration and management of Genkit resources.
 import pytest
 
 from genkit import Genkit, Plugin
-from genkit._core._action import Action, ActionKind, create_action_key
+from genkit._core._action import Action, ActionKind, ActionRunContext, create_action_key
+from genkit._core._background import define_background_model
 from genkit._core._dap import DapValue, define_dynamic_action_provider
+from genkit._core._model import ModelRequest
+from genkit._core._protocols import RegistryLike
 from genkit._core._registry import Registry
-from genkit._core._typing import ActionMetadata
+from genkit._core._typing import ActionMetadata, ModelInfo, Operation, Supports
 
 
 async def _identity(x: object) -> object:
@@ -432,9 +435,33 @@ async def test_list_actions_registered_canonical_coexists_with_qualified_dap_row
     assert provider_key in catalog
 
 
+@pytest.mark.asyncio
+async def test_resolve_model_falls_back_to_background_model() -> None:
+    """resolve_model finds models registered only under BACKGROUND_MODEL."""
+    registry = Registry()
+
+    async def start(request: ModelRequest, _: ActionRunContext) -> Operation:
+        return Operation(id='bg-start', done=False)
+
+    async def check(op: Operation) -> Operation:
+        return op
+
+    define_background_model(
+        registry=registry,
+        name='veo-model',
+        start=start,
+        check=check,
+        info=ModelInfo(supports=Supports(long_running=True)),
+    )
+
+    assert await registry.resolve_action(ActionKind.MODEL, 'veo-model') is None
+
+    resolved = await registry.resolve_model('veo-model')
+    assert resolved is not None
+    assert resolved.kind == ActionKind.BACKGROUND_MODEL
+    assert resolved.name == 'veo-model'
+
+
 def test_registry_satisfies_registry_like() -> None:
     """Registry must structurally satisfy RegistryLike so middleware can use it as such."""
-    from genkit._core._protocols import RegistryLike
-    from genkit._core._registry import Registry
-
     assert isinstance(Registry(None), RegistryLike)

--- a/py/packages/genkit/tests/genkit/veneer/veneer_test.py
+++ b/py/packages/genkit/tests/genkit/veneer/veneer_test.py
@@ -75,7 +75,7 @@ async def test_generate_uses_default_model(setup_test: SetupFixture) -> None:
     """Test that the generate function uses the default model."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     response = await ai.generate(prompt='hi', config={'temperature': 11})
 
@@ -125,11 +125,11 @@ async def test_generate_with_explicit_model(setup_test: SetupFixture) -> None:
 
     response = await ai.generate(model='echoModel', prompt='hi', config={'temperature': 11})
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
     stream_result = ai.generate_stream(model='echoModel', prompt='hi', config={'temperature': 11})
 
-    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -139,7 +139,7 @@ async def test_generate_with_str_prompt(setup_test: SetupFixture) -> None:
 
     response = await ai.generate(prompt='hi', config={'temperature': 11})
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -147,7 +147,7 @@ async def test_generate_with_part_prompt(setup_test: SetupFixture) -> None:
     """Test that the generate function with a part prompt works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hi" {"temperature":11}'
 
     response = await ai.generate(prompt=[Part(root=TextPart(text='hi'))], config={'temperature': 11})
 
@@ -163,7 +163,7 @@ async def test_generate_with_part_list_prompt(setup_test: SetupFixture) -> None:
     """Test that the generate function with a list of parts prompt works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] user: "hello","world" {"temperature":11.0}'
+    want_txt = '[ECHO] user: "hello","world" {"temperature":11}'
 
     response = await ai.generate(
         prompt=[Part(root=TextPart(text='hello')), Part(root=TextPart(text='world'))],
@@ -185,7 +185,7 @@ async def test_generate_with_str_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a string system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(system='talk like pirate', prompt='hi', config={'temperature': 11})
 
@@ -201,7 +201,7 @@ async def test_generate_with_part_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a part system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(
         system=[Part(root=TextPart(text='talk like pirate'))],
@@ -225,7 +225,7 @@ async def test_generate_with_part_list_system(setup_test: SetupFixture) -> None:
     """Test that the generate function with a list of parts system works."""
     ai, *_ = setup_test
 
-    want_txt = '[ECHO] system: "talk","like pirate" user: "hi" {"temperature":11.0}'
+    want_txt = '[ECHO] system: "talk","like pirate" user: "hi" {"temperature":11}'
 
     response = await ai.generate(
         system=[Part(root=TextPart(text='talk')), Part(root=TextPart(text='like pirate'))],
@@ -259,7 +259,7 @@ async def test_generate_with_messages(setup_test: SetupFixture) -> None:
         config={'temperature': 11},
     )
 
-    assert response.text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert response.text == '[ECHO] user: "hi" {"temperature":11}'
 
     stream_result = ai.generate_stream(
         messages=[
@@ -271,7 +271,7 @@ async def test_generate_with_messages(setup_test: SetupFixture) -> None:
         config={'temperature': 11},
     )
 
-    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11.0}'
+    assert (await stream_result.response).text == '[ECHO] user: "hi" {"temperature":11}'
 
 
 @pytest.mark.asyncio
@@ -1506,7 +1506,7 @@ def test_define_model_default_metadata(setup_test: SetupFixture) -> None:
     """Test that the define model function works."""
     ai, _, _, *_ = setup_test
 
-    async def foo_model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+    async def foo_model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
         return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='banana!'))]))
 
     action = ai.define_model(
@@ -1527,7 +1527,7 @@ def test_define_model_with_schema(setup_test: SetupFixture) -> None:
         field_a: str = Field(description='a field')
         field_b: str = Field(description='b field')
 
-    async def foo_model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+    async def foo_model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
         return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='banana!'))]))
 
     action = ai.define_model(
@@ -1564,7 +1564,7 @@ def test_define_model_with_info(setup_test: SetupFixture) -> None:
     """Test that the define model function with info works."""
     ai, _, _, *_ = setup_test
 
-    async def foo_model_fn(request: ModelRequest, ctx: ActionRunContext) -> ModelResponse:
+    async def foo_model_fn(request: ModelRequest, _: ActionRunContext) -> ModelResponse:
         return ModelResponse(message=Message(role=Role.MODEL, content=[Part(root=TextPart(text='banana!'))]))
 
     action = ai.define_model(


### PR DESCRIPTION
Parallel slice of the #5806 split (based on #5854, independent of the Interactions chain): normalizes finish reasons (NO_IMAGE, IMAGE_OTHER), synthesizes finish_message when image models return no media so empty results are not silent successes, propagates finish_message onto candidates, echoes the normalized effective config on response.request, and drops the retired gemini-2.5-flash-image-preview registration.

Part of the stack splitting #5806; recombined it reproduces that PR byte-for-byte. Co-authored with @huangjeff5.

### Breaking changes

- `gemini-2.5-flash-image-preview` is no longer registered as a model (the `GEMINI_2_5_FLASH_IMAGE_PREVIEW` enum members remain, but the model name stops resolving). Use `gemini-2.5-flash-image`.
