### PR TITLE
fix(js/core): allow Gemini propertyOrdering in schema validation

### DIFF
--- a/js/core/src/schema.ts
+++ b/js/core/src/schema.ts
@@ -25,6 +25,10 @@ import { GenkitError } from './error.js';
 import type { Registry } from './registry.js';
 const ajv = new Ajv();
 addFormats(ajv);
+// Gemini structured output uses the non-standard `propertyOrdering` keyword as a
+// field-order hint. Register it so Ajv strict mode does not reject those schemas.
+// See https://ai.google.dev/gemini-api/docs/structured-output#property-ordering
+ajv.addVocabulary(['propertyOrdering']);
 
 export { z }; // provide a consistent zod to use throughout genkit
 

--- a/js/core/tests/schema_test.ts
+++ b/js/core/tests/schema_test.ts
@@ -105,6 +105,38 @@ describe('validate()', () => {
         { path: '(root)', message: "must have required property 'foo'" },
       ],
     },
+    {
+      it: 'should allow Gemini propertyOrdering keyword in json schema',
+      jsonSchema: {
+        type: 'object',
+        properties: {
+          answer: { type: 'number' },
+          x: { type: 'number' },
+          y: { type: 'number' },
+        },
+        required: ['x', 'y', 'answer'],
+        propertyOrdering: ['x', 'y', 'answer'],
+        additionalProperties: false,
+      },
+      data: { x: 1, y: 2, answer: 3 },
+      valid: true,
+    },
+    {
+      it: 'should still validate data when propertyOrdering is present',
+      jsonSchema: {
+        type: 'object',
+        properties: {
+          x: { type: 'number' },
+          y: { type: 'number' },
+        },
+        required: ['x', 'y'],
+        propertyOrdering: ['x', 'y'],
+        additionalProperties: false,
+      },
+      data: { x: 'nope', y: 2 },
+      valid: false,
+      errors: [{ path: 'x', message: 'must be number' }],
+    },
   ];
   for (const test of tests) {
     it(test.it, () => {
@@ -369,6 +401,27 @@ describe('disableSchemaCodeGeneration()', () => {
           type: 'object',
           properties: { foo: { type: 'string' }, bar: { type: 'string' } },
           required: ['foo'],
+        },
+      }
+    );
+    assert.strictEqual(result.valid, true);
+  });
+
+  it('should allow Gemini propertyOrdering keyword in interpret mode', () => {
+    disableSchemaCodeGeneration();
+    const result = validateSchema(
+      { x: 1, y: 2, answer: 3 },
+      {
+        jsonSchema: {
+          type: 'object',
+          properties: {
+            answer: { type: 'number' },
+            x: { type: 'number' },
+            y: { type: 'number' },
+          },
+          required: ['x', 'y', 'answer'],
+          propertyOrdering: ['x', 'y', 'answer'],
+          additionalProperties: false,
         },
       }
     );


### PR DESCRIPTION
## Summary
- Register Gemini's non-standard `propertyOrdering` JSON Schema keyword with Ajv so structured-output schemas that include it no longer fail with `strict mode: unknown keyword`.
- Add unit coverage for compile and interpret validation modes, including a case that still rejects invalid data when `propertyOrdering` is present.

Fixes #3764

## Test plan
- [x] `npm test` in `js/core` (179 tests) — includes new compile/interpret cases with `propertyOrdering`
- [x] Confirms valid schemas with `propertyOrdering` no longer throw Ajv unknown-keyword; invalid data still rejected
- [ ] Manual (optional): reproduce original `ai.generate` + `output.jsonSchema.propertyOrdering` case

