### PR TITLE
fix(py): Mute dev server HTTP and health poll logs

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import logging
 import os
 import signal
 import socket
@@ -102,7 +103,7 @@ from genkit._core._dap import (
 )
 from genkit._core._environment import is_dev_environment
 from genkit._core._error import GenkitError
-from genkit._core._logger import configure_logging, get_logger
+from genkit._core._logger import configure_logging, get_logger, resolve_level
 from genkit._core._middleware import (
     BaseMiddleware,
     GenerateMiddleware,
@@ -864,17 +865,10 @@ class Genkit:
                 sockets = [sock]
 
             app = create_reflection_asgi_app(registry=self.registry)
-            genkit_log = os.environ.get('GENKIT_LOG', '').strip().lower()
-            is_debug = genkit_log == 'debug'
-            log_level = {
-                'debug': 'debug',
-                'info': 'warning',
-                'warn': 'warning',
-                'warning': 'warning',
-                'error': 'error',
-                'critical': 'critical',
-                'fatal': 'critical',
-            }.get(genkit_log, 'warning')
+            level = resolve_level()
+            is_debug = level <= logging.DEBUG
+            level_name = logging.getLevelName(level).lower()
+            log_level = 'warning' if level_name in ('info', 'warning', 'warn') else level_name
             config = uvicorn.Config(
                 app,
                 host=spec.host,

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -876,6 +876,7 @@ class Genkit:
             else:
                 log_level = 'critical'
 
+            # Pass log_level explicitly so uvicorn's internal server engine doesn't default to INFO on startup.
             config = uvicorn.Config(
                 app,
                 host=spec.host,

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -864,13 +864,14 @@ class Genkit:
                 sockets = [sock]
 
             app = create_reflection_asgi_app(registry=self.registry)
+            is_debug = os.environ.get('GENKIT_LOG', '').strip().lower() == 'debug'
             config = uvicorn.Config(
                 app,
                 host=spec.host,
                 port=spec.port,
                 loop='asyncio',
-                access_log=False,
-                log_level='debug' if os.environ.get('GENKIT_LOG', '').lower() == 'debug' else 'warning',
+                access_log=is_debug,
+                log_level='debug' if is_debug else 'warning',
             )
             server = ReflectionServer(config, ready=self._reflection_ready)
             async with RuntimeManager(spec, lazy_write=True) as runtime_manager:

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -867,8 +867,15 @@ class Genkit:
             app = create_reflection_asgi_app(registry=self.registry)
             level = resolve_level()
             is_debug = level <= logging.DEBUG
-            level_name = logging.getLevelName(level).lower()
-            log_level = 'warning' if level_name in ('info', 'warning', 'warn') else level_name
+            if level <= logging.DEBUG:
+                log_level = 'debug'
+            elif level <= logging.WARNING:
+                log_level = 'warning'
+            elif level <= logging.ERROR:
+                log_level = 'error'
+            else:
+                log_level = 'critical'
+
             config = uvicorn.Config(
                 app,
                 host=spec.host,

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -102,7 +102,7 @@ from genkit._core._dap import (
 )
 from genkit._core._environment import is_dev_environment
 from genkit._core._error import GenkitError
-from genkit._core._logger import get_logger
+from genkit._core._logger import configure_logging, get_logger
 from genkit._core._middleware import (
     BaseMiddleware,
     GenerateMiddleware,
@@ -179,6 +179,7 @@ class Genkit:
         # Ensure the default generate action is registered for async usage.
         define_generate_action(self.registry)
         self._register_plugin_middleware(plugins)
+        configure_logging()
         # In dev mode, start the reflection server immediately in a background
         # daemon thread so it's available regardless of which web framework (or
         # none) the user chooses.
@@ -863,7 +864,14 @@ class Genkit:
                 sockets = [sock]
 
             app = create_reflection_asgi_app(registry=self.registry)
-            config = uvicorn.Config(app, host=spec.host, port=spec.port, loop='asyncio')
+            config = uvicorn.Config(
+                app,
+                host=spec.host,
+                port=spec.port,
+                loop='asyncio',
+                access_log=False,
+                log_level='debug' if os.environ.get('GENKIT_LOG', '').lower() == 'debug' else 'warning',
+            )
             server = ReflectionServer(config, ready=self._reflection_ready)
             async with RuntimeManager(spec, lazy_write=True) as runtime_manager:
                 server_task = asyncio.create_task(server.serve(sockets=sockets))

--- a/py/packages/genkit/src/genkit/_ai/_aio.py
+++ b/py/packages/genkit/src/genkit/_ai/_aio.py
@@ -864,14 +864,24 @@ class Genkit:
                 sockets = [sock]
 
             app = create_reflection_asgi_app(registry=self.registry)
-            is_debug = os.environ.get('GENKIT_LOG', '').strip().lower() == 'debug'
+            genkit_log = os.environ.get('GENKIT_LOG', '').strip().lower()
+            is_debug = genkit_log == 'debug'
+            log_level = {
+                'debug': 'debug',
+                'info': 'warning',
+                'warn': 'warning',
+                'warning': 'warning',
+                'error': 'error',
+                'critical': 'critical',
+                'fatal': 'critical',
+            }.get(genkit_log, 'warning')
             config = uvicorn.Config(
                 app,
                 host=spec.host,
                 port=spec.port,
                 loop='asyncio',
                 access_log=is_debug,
-                log_level='debug' if is_debug else 'warning',
+                log_level=log_level,
             )
             server = ReflectionServer(config, ready=self._reflection_ready)
             async with RuntimeManager(spec, lazy_write=True) as runtime_manager:

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -56,10 +56,6 @@ def configure_logging(*, shared_tty: bool | None = None) -> None:
         logging.getLogger(name).setLevel(quiet_level)
 
 
-# Configure logger levels on import
-configure_logging()
-
-
 def get_logger(name: str | None = None) -> FilteringBoundLogger:
     """Return a structlog bound logger with a concrete return type for checkers."""
     return structlog.get_logger(name)

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -12,6 +12,8 @@ import threading
 import structlog
 from structlog.typing import FilteringBoundLogger
 
+from genkit._core._environment import is_dev_environment
+
 CONFIGURED = False
 LOCK = threading.Lock()
 
@@ -37,7 +39,7 @@ def resolve_level() -> int:
     }.get(raw, logging.INFO)
 
 
-def configure_logging(*, force: bool = False) -> None:
+def configure_logging(*, shared_tty: bool | None = None, force: bool = False) -> None:
     """Configure genkit console logging and mute noisy HTTP/health poll loggers.
 
     Safe to call more than once. Default level is ``info``; override with
@@ -45,10 +47,16 @@ def configure_logging(*, force: bool = False) -> None:
     """
     global CONFIGURED
     with LOCK:
+        if shared_tty is None:
+            shared_tty = is_dev_environment()
+
         if CONFIGURED and not force:
             return
 
         CONFIGURED = True
+        if not shared_tty:
+            return
+
         level = resolve_level()
 
         for name in QUIET_LOGGERS:

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -53,7 +53,9 @@ def configure_logging(*, shared_tty: bool | None = None) -> None:
     quiet_level = level if level == logging.DEBUG else max(level, logging.WARNING)
 
     for name in QUIET_LOGGERS:
-        logging.getLogger(name).setLevel(quiet_level)
+        logger = logging.getLogger(name)
+        if logger.level == logging.NOTSET:
+            logger.setLevel(quiet_level)
 
 
 def get_logger(name: str | None = None) -> FilteringBoundLogger:

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -3,8 +3,60 @@
 
 """Internal logger for genkit core. Not part of public API."""
 
+from __future__ import annotations
+
+import logging
+import os
+import threading
+
 import structlog
 from structlog.typing import FilteringBoundLogger
+
+CONFIGURED = False
+LOCK = threading.Lock()
+
+# Libraries that log every HTTP request or poll. Under Dev UI, health checks
+# and span exports generate noise unless GENKIT_LOG=debug is explicitly set.
+QUIET_LOGGERS = (
+    'httpx',
+    'httpcore',
+    'uvicorn.access',
+    'uvicorn.error',
+)
+
+
+def resolve_level() -> int:
+    """Resolve logging level from GENKIT_LOG environment variable."""
+    raw = os.environ.get('GENKIT_LOG', 'info').strip().lower()
+    return {
+        'debug': logging.DEBUG,
+        'info': logging.INFO,
+        'warn': logging.WARNING,
+        'warning': logging.WARNING,
+        'error': logging.ERROR,
+    }.get(raw, logging.INFO)
+
+
+def configure_logging(*, force: bool = False) -> None:
+    """Configure genkit console logging and mute noisy HTTP/health poll loggers.
+
+    Safe to call more than once. Default level is ``info``; override with
+    ``GENKIT_LOG=debug|info|warn|error``.
+    """
+    global CONFIGURED
+    with LOCK:
+        if CONFIGURED and not force:
+            return
+
+        CONFIGURED = True
+        level = resolve_level()
+
+        for name in QUIET_LOGGERS:
+            logging.getLogger(name).setLevel(logging.DEBUG if level <= logging.DEBUG else logging.WARNING)
+
+
+# Configure logger levels on import
+configure_logging()
 
 
 def get_logger(name: str | None = None) -> FilteringBoundLogger:

--- a/py/packages/genkit/src/genkit/_core/_logger.py
+++ b/py/packages/genkit/src/genkit/_core/_logger.py
@@ -7,15 +7,11 @@ from __future__ import annotations
 
 import logging
 import os
-import threading
 
 import structlog
 from structlog.typing import FilteringBoundLogger
 
 from genkit._core._environment import is_dev_environment
-
-CONFIGURED = False
-LOCK = threading.Lock()
 
 # Libraries that log every HTTP request or poll. Under Dev UI, health checks
 # and span exports generate noise unless GENKIT_LOG=debug is explicitly set.
@@ -36,31 +32,28 @@ def resolve_level() -> int:
         'warn': logging.WARNING,
         'warning': logging.WARNING,
         'error': logging.ERROR,
+        'critical': logging.CRITICAL,
+        'fatal': logging.CRITICAL,
     }.get(raw, logging.INFO)
 
 
-def configure_logging(*, shared_tty: bool | None = None, force: bool = False) -> None:
+def configure_logging(*, shared_tty: bool | None = None) -> None:
     """Configure genkit console logging and mute noisy HTTP/health poll loggers.
 
     Safe to call more than once. Default level is ``info``; override with
     ``GENKIT_LOG=debug|info|warn|error``.
     """
-    global CONFIGURED
-    with LOCK:
-        if shared_tty is None:
-            shared_tty = is_dev_environment()
+    if shared_tty is None:
+        shared_tty = is_dev_environment()
 
-        if CONFIGURED and not force:
-            return
+    if not shared_tty:
+        return
 
-        CONFIGURED = True
-        if not shared_tty:
-            return
+    level = resolve_level()
+    quiet_level = level if level == logging.DEBUG else max(level, logging.WARNING)
 
-        level = resolve_level()
-
-        for name in QUIET_LOGGERS:
-            logging.getLogger(name).setLevel(logging.DEBUG if level <= logging.DEBUG else logging.WARNING)
+    for name in QUIET_LOGGERS:
+        logging.getLogger(name).setLevel(quiet_level)
 
 
 # Configure logger levels on import

--- a/py/packages/genkit/tests/genkit/core/logger_test.py
+++ b/py/packages/genkit/tests/genkit/core/logger_test.py
@@ -39,26 +39,41 @@ def test_resolve_level() -> None:
 
 def test_configure_logging_mutes_quiet_loggers() -> None:
     """Test that configure_logging sets QUIET_LOGGERS to WARNING in dev environment."""
-    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'info'}):
+    with (
+        mock.patch.dict(os.environ, {'GENKIT_LOG': 'info'}),
+        mock.patch('logging.getLogger') as mock_get_logger,
+    ):
         configure_logging(shared_tty=True)
         for name in QUIET_LOGGERS:
-            assert logging.getLogger(name).level == logging.WARNING
+            mock_get_logger.assert_any_call(name)
+        expected_calls = [mock.call(logging.WARNING)] * len(QUIET_LOGGERS)
+        mock_get_logger.return_value.setLevel.assert_has_calls(expected_calls, any_order=True)
 
 
 def test_configure_logging_allows_debug() -> None:
     """Test that GENKIT_LOG=debug sets QUIET_LOGGERS to DEBUG."""
-    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'debug'}):
+    with (
+        mock.patch.dict(os.environ, {'GENKIT_LOG': 'debug'}),
+        mock.patch('logging.getLogger') as mock_get_logger,
+    ):
         configure_logging(shared_tty=True)
         for name in QUIET_LOGGERS:
-            assert logging.getLogger(name).level == logging.DEBUG
+            mock_get_logger.assert_any_call(name)
+        expected_calls = [mock.call(logging.DEBUG)] * len(QUIET_LOGGERS)
+        mock_get_logger.return_value.setLevel.assert_has_calls(expected_calls, any_order=True)
 
 
 def test_configure_logging_respects_higher_levels() -> None:
     """Test that GENKIT_LOG=error sets QUIET_LOGGERS to ERROR."""
-    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'error'}):
+    with (
+        mock.patch.dict(os.environ, {'GENKIT_LOG': 'error'}),
+        mock.patch('logging.getLogger') as mock_get_logger,
+    ):
         configure_logging(shared_tty=True)
         for name in QUIET_LOGGERS:
-            assert logging.getLogger(name).level == logging.ERROR
+            mock_get_logger.assert_any_call(name)
+        expected_calls = [mock.call(logging.ERROR)] * len(QUIET_LOGGERS)
+        mock_get_logger.return_value.setLevel.assert_has_calls(expected_calls, any_order=True)
 
 
 def test_configure_logging_leaves_loggers_alone_in_prod() -> None:

--- a/py/packages/genkit/tests/genkit/core/logger_test.py
+++ b/py/packages/genkit/tests/genkit/core/logger_test.py
@@ -1,0 +1,47 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the logger module."""
+
+import logging
+import os
+from unittest import mock
+
+from genkit._core._logger import QUIET_LOGGERS, configure_logging, resolve_level
+
+
+def test_resolve_level() -> None:
+    """Test resolve_level with different GENKIT_LOG values."""
+    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'debug'}):
+        assert resolve_level() == logging.DEBUG
+
+    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'info'}):
+        assert resolve_level() == logging.INFO
+
+    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'warn'}):
+        assert resolve_level() == logging.WARNING
+
+    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'warning'}):
+        assert resolve_level() == logging.WARNING
+
+    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'error'}):
+        assert resolve_level() == logging.ERROR
+
+    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'invalid'}):
+        assert resolve_level() == logging.INFO
+
+
+def test_configure_logging_mutes_quiet_loggers() -> None:
+    """Test that configure_logging sets QUIET_LOGGERS to WARNING by default."""
+    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'info'}):
+        configure_logging(force=True)
+        for name in QUIET_LOGGERS:
+            assert logging.getLogger(name).level == logging.WARNING
+
+
+def test_configure_logging_allows_debug() -> None:
+    """Test that GENKIT_LOG=debug sets QUIET_LOGGERS to DEBUG."""
+    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'debug'}):
+        configure_logging(force=True)
+        for name in QUIET_LOGGERS:
+            assert logging.getLogger(name).level == logging.DEBUG

--- a/py/packages/genkit/tests/genkit/core/logger_test.py
+++ b/py/packages/genkit/tests/genkit/core/logger_test.py
@@ -27,6 +27,12 @@ def test_resolve_level() -> None:
     with mock.patch.dict(os.environ, {'GENKIT_LOG': 'error'}):
         assert resolve_level() == logging.ERROR
 
+    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'critical'}):
+        assert resolve_level() == logging.CRITICAL
+
+    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'fatal'}):
+        assert resolve_level() == logging.CRITICAL
+
     with mock.patch.dict(os.environ, {'GENKIT_LOG': 'invalid'}):
         assert resolve_level() == logging.INFO
 
@@ -34,7 +40,7 @@ def test_resolve_level() -> None:
 def test_configure_logging_mutes_quiet_loggers() -> None:
     """Test that configure_logging sets QUIET_LOGGERS to WARNING in dev environment."""
     with mock.patch.dict(os.environ, {'GENKIT_LOG': 'info'}):
-        configure_logging(shared_tty=True, force=True)
+        configure_logging(shared_tty=True)
         for name in QUIET_LOGGERS:
             assert logging.getLogger(name).level == logging.WARNING
 
@@ -42,13 +48,21 @@ def test_configure_logging_mutes_quiet_loggers() -> None:
 def test_configure_logging_allows_debug() -> None:
     """Test that GENKIT_LOG=debug sets QUIET_LOGGERS to DEBUG."""
     with mock.patch.dict(os.environ, {'GENKIT_LOG': 'debug'}):
-        configure_logging(shared_tty=True, force=True)
+        configure_logging(shared_tty=True)
         for name in QUIET_LOGGERS:
             assert logging.getLogger(name).level == logging.DEBUG
+
+
+def test_configure_logging_respects_higher_levels() -> None:
+    """Test that GENKIT_LOG=error sets QUIET_LOGGERS to ERROR."""
+    with mock.patch.dict(os.environ, {'GENKIT_LOG': 'error'}):
+        configure_logging(shared_tty=True)
+        for name in QUIET_LOGGERS:
+            assert logging.getLogger(name).level == logging.ERROR
 
 
 def test_configure_logging_leaves_loggers_alone_in_prod() -> None:
     """Test that configure_logging does not alter logger levels in non-dev env."""
     with mock.patch('logging.getLogger') as mock_get_logger:
-        configure_logging(shared_tty=False, force=True)
+        configure_logging(shared_tty=False)
         mock_get_logger.assert_not_called()

--- a/py/packages/genkit/tests/genkit/core/logger_test.py
+++ b/py/packages/genkit/tests/genkit/core/logger_test.py
@@ -32,9 +32,9 @@ def test_resolve_level() -> None:
 
 
 def test_configure_logging_mutes_quiet_loggers() -> None:
-    """Test that configure_logging sets QUIET_LOGGERS to WARNING by default."""
+    """Test that configure_logging sets QUIET_LOGGERS to WARNING in dev environment."""
     with mock.patch.dict(os.environ, {'GENKIT_LOG': 'info'}):
-        configure_logging(force=True)
+        configure_logging(shared_tty=True, force=True)
         for name in QUIET_LOGGERS:
             assert logging.getLogger(name).level == logging.WARNING
 
@@ -42,6 +42,13 @@ def test_configure_logging_mutes_quiet_loggers() -> None:
 def test_configure_logging_allows_debug() -> None:
     """Test that GENKIT_LOG=debug sets QUIET_LOGGERS to DEBUG."""
     with mock.patch.dict(os.environ, {'GENKIT_LOG': 'debug'}):
-        configure_logging(force=True)
+        configure_logging(shared_tty=True, force=True)
         for name in QUIET_LOGGERS:
             assert logging.getLogger(name).level == logging.DEBUG
+
+
+def test_configure_logging_leaves_loggers_alone_in_prod() -> None:
+    """Test that configure_logging does not alter logger levels in non-dev env."""
+    with mock.patch('logging.getLogger') as mock_get_logger:
+        configure_logging(shared_tty=False, force=True)
+        mock_get_logger.assert_not_called()

--- a/py/packages/genkit/tests/genkit/core/logger_test.py
+++ b/py/packages/genkit/tests/genkit/core/logger_test.py
@@ -43,6 +43,7 @@ def test_configure_logging_mutes_quiet_loggers() -> None:
         mock.patch.dict(os.environ, {'GENKIT_LOG': 'info'}),
         mock.patch('logging.getLogger') as mock_get_logger,
     ):
+        mock_get_logger.return_value.level = logging.NOTSET
         configure_logging(shared_tty=True)
         for name in QUIET_LOGGERS:
             mock_get_logger.assert_any_call(name)
@@ -56,6 +57,7 @@ def test_configure_logging_allows_debug() -> None:
         mock.patch.dict(os.environ, {'GENKIT_LOG': 'debug'}),
         mock.patch('logging.getLogger') as mock_get_logger,
     ):
+        mock_get_logger.return_value.level = logging.NOTSET
         configure_logging(shared_tty=True)
         for name in QUIET_LOGGERS:
             mock_get_logger.assert_any_call(name)
@@ -69,6 +71,7 @@ def test_configure_logging_respects_higher_levels() -> None:
         mock.patch.dict(os.environ, {'GENKIT_LOG': 'error'}),
         mock.patch('logging.getLogger') as mock_get_logger,
     ):
+        mock_get_logger.return_value.level = logging.NOTSET
         configure_logging(shared_tty=True)
         for name in QUIET_LOGGERS:
             mock_get_logger.assert_any_call(name)
@@ -81,3 +84,14 @@ def test_configure_logging_leaves_loggers_alone_in_prod() -> None:
     with mock.patch('logging.getLogger') as mock_get_logger:
         configure_logging(shared_tty=False)
         mock_get_logger.assert_not_called()
+
+
+def test_configure_logging_respects_user_configured_levels() -> None:
+    """Test that configure_logging does not overwrite explicitly set logger levels."""
+    with (
+        mock.patch.dict(os.environ, {'GENKIT_LOG': 'info'}),
+        mock.patch('logging.getLogger') as mock_get_logger,
+    ):
+        mock_get_logger.return_value.level = logging.DEBUG
+        configure_logging(shared_tty=True)
+        mock_get_logger.return_value.setLevel.assert_not_called()


### PR DESCRIPTION
## Summary
Under `genkit start` (`GENKIT_ENV=dev`), the Python process shares one terminal TTY with the CLI. The Dev UI frontend polls the runtime server (`GET /api/__health`) every 5 seconds. By default, `uvicorn.access` and `httpx` log every HTTP request at `INFO` level, flooding stdout/stderr with continuous health check polling:

```
INFO:     127.0.0.1:53925 - "GET /api/__health?id=58178-53811 HTTP/1.1" 200 OK
```

This PR silences third-party HTTP request and access logs by default during local dev mode while preserving opt-in `GENKIT_LOG=debug` troubleshooting and respecting user-configured log levels.

> **Note:** This **only impacts local development mode** (`genkit start`, which injects `GENKIT_ENV=dev`). In production environments, this logic does not kick in at all, leaving standard production application and server logging completely untouched.

## Verification
Verified with live reflection server polling:

**Default Dev Mode (`GENKIT_ENV=dev`):**
```
2026-07-30 14:26:30 [info     ] Genkit Dev UI reflection server running at http://127.0.0.1:57930
Removing file: /Users/huangjeff/Desktop/genkit/py/.genkit/runtimes/80253-57930-1785439590088.json
```
*(5 background `/api/__health` polling requests executed cleanly with 0 access log lines printed).*

**Debug Opt-In (`GENKIT_ENV=dev GENKIT_LOG=debug`):**
```
2026-07-30 14:25:46 [info     ] Genkit Dev UI reflection server running at http://127.0.0.1:57816
INFO:     127.0.0.1:57820 - "GET /api/__health HTTP/1.1" 200 OK
INFO:     127.0.0.1:57820 - "GET /api/__health HTTP/1.1" 200 OK
Removing file: /Users/huangjeff/Desktop/genkit/py/.genkit/runtimes/80182-57816-1785439546330.json
```
*(HTTP access logs print as expected when explicitly requested).*
