### PR TITLE
fix(py): set PyPI as explicit default index for uv

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -128,6 +128,11 @@ source = ["packages"]
 default-groups = ["dev", "lint"]
 override-dependencies = ["werkzeug>=3.1.6"]
 
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
+default = true
+
 [tool.uv.sources]
 # Samples (alphabetical by package name from pyproject.toml)
 agents               = { workspace = true }


### PR DESCRIPTION
### Summary
Explicitly configures PyPI (`https://pypi.org/simple`) as the default package index in `py/pyproject.toml`.

### Rationale
Developer laptops (especially corporate machines) often have global `pip` / `uv` configs or fallbacks pointing to internal Google Artifact Registry instances (`us-python.pkg.dev/artifact-foundry-prod/...`). When running `uv sync` on a fresh clone of `genkit/py`, `uv` attempts to query that internal Artifact Registry without credentials, resulting in a `401 Unauthorized` error when resolving public dependencies like `dotpromptz`.

Configuring `[[tool.uv.index]]` with `default = true` in `pyproject.toml`:
1. Instructs `uv` to always resolve dependencies from public PyPI out-of-the-box.
2. Eliminates 401 authentication errors for developers with custom global `pip` / `uv` configurations.
3. Removes the need for setting `UV_DEFAULT_INDEX=https://pypi.org/simple` manual environment variables during onboarding.

### Verification
Ran `uv sync` in `py/` without any extra environment variables or flags; resolved and audited all packages in 26ms.