### PR TITLE
fix(py): record session state on runTurn spans and mint client-managed sessionIds

### DIFF
--- a/py/packages/genkit/src/genkit/_ai/_agents/_base.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_base.py
@@ -71,6 +71,7 @@ from genkit._core._error import GenkitError
 from genkit._core._middleware import BaseMiddleware
 from genkit._core._model import ModelConfig
 from genkit._core._registry import Registry
+from genkit._core._trace._attrs import metadata_key
 from genkit._core._typing import (
     AgentAbortRequest,
     AgentAbortResponse,
@@ -249,7 +250,7 @@ def define_custom_agent(
         if state.session_id:
             span = trace_api.get_current_span()
             if span.is_recording():
-                span.set_attribute('genkit:metadata:agent:sessionId', state.session_id)
+                span.set_attribute(metadata_key('agent:sessionId'), state.session_id)
 
         rt = AgentRuntime(
             name=name,

--- a/py/packages/genkit/src/genkit/_ai/_agents/_client.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_client.py
@@ -249,7 +249,7 @@ class AgentResponse(Generic[StateT]):
 
     @property
     def session_id(self) -> str | None:
-        """Server session id this turn belongs to, if store-backed."""
+        """Session id this turn belongs to (store- or client-managed)."""
         return self.raw.session_id
 
     @property
@@ -1232,10 +1232,9 @@ class AgentChat(Generic[StateT]):
         """
         if raw.state is not None:
             # Client-managed: the whole session round-trips, so the output is
-            # authoritative for the custom state and artifacts. There's no server
-            # store to key a session on, so session_id has no meaning here and is
-            # always None.
-            self._session_id = None
+            # authoritative for session id, custom state, and artifacts. Keep the
+            # id so the next turn's state blob stays self-describing.
+            self._session_id = raw.state.session_id
             self._custom = copy.deepcopy(raw.state.custom)
             self._artifacts = [a.model_copy(deep=True) for a in raw.state.artifacts] if raw.state.artifacts else []
             return

--- a/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
@@ -47,6 +47,7 @@ from genkit._core._error import GenkitError
 from genkit._core._logger import get_logger
 from genkit._core._model import GenerateActionOptions, Message, ModelResponse, ModelResponseChunk
 from genkit._core._registry import Registry
+from genkit._core._trace._attrs import metadata_key
 from genkit._core._tracing import SpanMetadata, run_in_new_span
 from genkit._core._typing import (
     AgentFinishReason,
@@ -91,7 +92,7 @@ class SessionRunner(Generic[StateT]):
         store: SessionStore | None = None,
         get_parent_snapshot_id: Callable[[], str | None] | None = None,
         on_begin_turn: Callable[[], Awaitable[None]] | None = None,
-        on_end_turn: Callable[[AgentFinishReason | None], Awaitable[None]] | None = None,
+        on_end_turn: Callable[[AgentFinishReason | None], Awaitable[str | None]] | None = None,
     ) -> None:
         self.session = session
         self.turn_inputs = turn_inputs
@@ -163,18 +164,27 @@ class SessionRunner(Generic[StateT]):
                 input=inp,
             )
             try:
-                with run_in_new_span(span_meta):
+                with run_in_new_span(span_meta) as span:
                     turn_result = await fn(inp, turn_ctx)
                     finish_reason = turn_result.finish_reason if turn_result else None
                     self.last_turn_finish_reason = finish_reason
                     self.last_turn_error = None
 
+                    snapshot_id: str | None = None
                     if self.on_end_turn is not None:
-                        await self.on_end_turn(finish_reason)
+                        snapshot_id = await self.on_end_turn(finish_reason)
 
-                    span_meta.output = {'finishReason': finish_reason}
-                    if turn_snapshot_id:
-                        span_meta.metadata = {'agent:snapshotId': turn_snapshot_id}
+                    # Span output is the session state this turn committed
+                    # (messages, artifacts, custom) so a trace can show what
+                    # changed without reading the client response.
+                    state = await self.session.state()
+                    span_meta.output = {
+                        'state': state.model_dump(by_alias=True, exclude_none=True, mode='json'),
+                    }
+                    # Tag with the id this turn actually persisted under
+                    # (server-managed only; omitted when nothing was written).
+                    if snapshot_id:
+                        span.set_attribute(metadata_key('agent:snapshotId'), snapshot_id)
 
                 self.last_good_state = await self.session.state()
                 self.last_good_state_version = self.session.version
@@ -578,10 +588,15 @@ class AgentRuntime:
             return snap.snapshot_id
         return self.last_snapshot.snapshot_id if self.last_snapshot else None
 
-    async def emit_turn_end(self, finish_reason: AgentFinishReason | None = None) -> None:
-        """Called by SessionRunner after each turn: snapshot + TurnEnd chunk."""
+    async def emit_turn_end(self, finish_reason: AgentFinishReason | None = None) -> str | None:
+        """Called by SessionRunner after each turn: snapshot + TurnEnd chunk.
+
+        Returns the snapshot id this turn persisted under (or None when
+        client-managed / detached / nothing written) so the turn span can
+        tag the same id.
+        """
         if self.detached:
-            return
+            return None
         is_failed = finish_reason == AgentFinishReason.FAILED
         snapshot_id = await self.maybe_snapshot(
             finish_reason=finish_reason,
@@ -600,6 +615,7 @@ class AgentRuntime:
                 )
             )
         )
+        return snapshot_id
 
     async def failed_agent_output(self, result: AgentResult | None) -> AgentOutput:
         last_good = self.session_runner.last_good_state or await self.session.state()
@@ -866,10 +882,15 @@ class AgentRuntime:
             t1.add_done_callback(self.background_tasks.discard)
             heartbeat_task.add_done_callback(self.background_tasks.discard)
             t2.add_done_callback(self.background_tasks.discard)
-            return AgentOutput(
+            state = await self.session.state()
+            out = AgentOutput(
+                session_id=state.session_id,
                 snapshot_id=pending_snap.snapshot_id,
                 finish_reason=AgentFinishReason.DETACHED,
             )
+            if self.store is None:
+                out.state = self.transform_state(state)
+            return out
 
         # --- Normal completion path ---
         await fn_task

--- a/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
@@ -183,7 +183,7 @@ class SessionRunner(Generic[StateT]):
                     }
                     # Tag with the id this turn actually persisted under
                     # (server-managed only; omitted when nothing was written).
-                    if snapshot_id:
+                    if snapshot_id and span.is_recording():
                         span.set_attribute(metadata_key('agent:snapshotId'), snapshot_id)
 
                 self.last_good_state = await self.session.state()

--- a/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
@@ -883,14 +883,11 @@ class AgentRuntime:
             heartbeat_task.add_done_callback(self.background_tasks.discard)
             t2.add_done_callback(self.background_tasks.discard)
             state = await self.session.state()
-            out = AgentOutput(
+            return AgentOutput(
                 session_id=state.session_id,
                 snapshot_id=pending_snap.snapshot_id,
                 finish_reason=AgentFinishReason.DETACHED,
             )
-            if self.store is None:
-                out.state = self.transform_state(state)
-            return out
 
         # --- Normal completion path ---
         await fn_task

--- a/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_runtime.py
@@ -882,7 +882,6 @@ class AgentRuntime:
             t1.add_done_callback(self.background_tasks.discard)
             heartbeat_task.add_done_callback(self.background_tasks.discard)
             t2.add_done_callback(self.background_tasks.discard)
-            state = await self.session.state()
             return AgentOutput(
                 session_id=state.session_id,
                 snapshot_id=pending_snap.snapshot_id,

--- a/py/packages/genkit/src/genkit/_ai/_agents/_session.py
+++ b/py/packages/genkit/src/genkit/_ai/_agents/_session.py
@@ -192,7 +192,14 @@ class Session(Generic[StateT]):
 
     def __init__(self, initial_state: SessionState | None = None) -> None:
         self.lock = asyncio.Lock()
-        self.session_state: SessionState = initial_state or SessionState()
+        # Own a copy so minting session_id (or later mutations) never reaches
+        # back into a caller's AgentInit.state / snapshot blob.
+        state = initial_state.model_copy(deep=True) if initial_state is not None else SessionState()
+        # Every conversation needs a stable id for trace correlation and so
+        # client-managed state is self-describing from the first turn.
+        if not state.session_id:
+            state.session_id = str(uuid4())
+        self.session_state: SessionState = state
         self.version: int = 0
         self.custom_changed_listeners: list[Callable[[], Awaitable[None]]] = []
         self.artifact_changed_listeners: list[Callable[[Artifact], Awaitable[None]]] = []

--- a/py/packages/genkit/tests/genkit/ai/agent_chat_client_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_chat_client_test.py
@@ -463,11 +463,11 @@ async def test_client_managed_stitches_tool_messages_from_chunks_not_output_stat
 
     # The output round-trips state, but its messages deliberately omit the tool
     # steps so the test proves the view is stitched from chunks, not raw.state.
-    # A stray session_id here must be ignored: client-managed has no server store
-    # to key a session on, so the id stays None.
+    # session_id inside the round-tripped state is adopted so the next turn's
+    # state blob stays self-describing.
     transport.final_output = AgentOutput(
         message=MessageData(role='model', content=[Part(root=TextPart(text='It is 12C in Tokyo.'))]),
-        state=SessionState(session_id='ignored', custom={'unit': 'celsius'}),
+        state=SessionState(session_id='sess-client-1', custom={'unit': 'celsius'}),
         finish_reason=AgentFinishReason.STOP,
     )
     turn = chat.send('Weather in Tokyo?')
@@ -514,12 +514,12 @@ async def test_client_managed_stitches_tool_messages_from_chunks_not_output_stat
     assert chat.messages[-1].content[0].root.text == 'It is 12C in Tokyo.'
     # Custom is adopted from the round-tripped output.
     assert chat.state == {'unit': 'celsius'}
-    # session_id stays None for client-managed, even when the output carries one.
-    assert chat.session_id is None
+    assert chat.session_id == 'sess-client-1'
     # The running view is what ships back as state for a client-managed resume.
     init_state = chat._wire_init().state
     assert init_state is not None
     assert init_state.messages == chat.messages
+    assert init_state.session_id == 'sess-client-1'
 
 
 @pytest.mark.asyncio
@@ -632,13 +632,19 @@ async def test_no_store_inprocess_transport_assembles_output_message() -> None:
     assert out.text == 'Hi there!'
     assert len(chat.messages) == 2
     assert chat.messages[1].content[0].root.text == 'Hi there!'
-    assert chat.session_id is None
+    assert chat.session_id is not None
     assert chat.snapshot_id is None
 
     # You assemble the resume blob yourself from the chat's tracked fields.
-    saved = SessionState(messages=chat.messages, custom=chat.state, artifacts=chat.artifacts)
+    saved = SessionState(
+        session_id=chat.session_id,
+        messages=chat.messages,
+        custom=chat.state,
+        artifacts=chat.artifacts,
+    )
     assert saved.messages == chat.messages
     assert saved.custom == chat.state
+    assert saved.session_id == chat.session_id
 
 
 class _ServerEmulatingClientManagedTransport(AgentTransport[Any]):

--- a/py/packages/genkit/tests/genkit/ai/agent_turn_span_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_turn_span_test.py
@@ -50,11 +50,16 @@ def exporter() -> Generator[InMemorySpanExporter, None, None]:
         provider = TracerProvider()
         trace_api.set_tracer_provider(provider)
     exp = InMemorySpanExporter()
-    provider.add_span_processor(SimpleSpanProcessor(exp))
+    processor = SimpleSpanProcessor(exp)
+    provider.add_span_processor(processor)
     try:
         yield exp
     finally:
         exp.clear()
+        if hasattr(provider, '_active_span_processor'):
+            provider._active_span_processor._span_processors = tuple(
+                p for p in provider._active_span_processor._span_processors if p is not processor
+            )
 
 
 def _by_name(spans: Sequence[ReadableSpan], name: str) -> ReadableSpan:

--- a/py/packages/genkit/tests/genkit/ai/agent_turn_span_test.py
+++ b/py/packages/genkit/tests/genkit/ai/agent_turn_span_test.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""runTurn / root agent span telemetry for store and client-managed agents."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Generator, Sequence
+
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from genkit._ai._agents._base import define_custom_agent
+from genkit._ai._agents._runtime import SessionRunner
+from genkit._ai._agents._session import Session
+from genkit._ai._agents._types import TurnContext, TurnResult
+from genkit._core._action import ActionRunContext
+from genkit._core._registry import Registry
+from genkit._core._trace._attrs import Attr, metadata_key
+from genkit._core._typing import AgentInput, AgentResult, MessageData, Part, SessionState, TextPart
+from genkit.agent import AgentFinishReason, InMemorySessionStore
+
+UUID_RE = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', re.I)
+SESSION_ID_ATTR = metadata_key('agent:sessionId')
+SNAPSHOT_ID_ATTR = metadata_key('agent:snapshotId')
+
+
+@pytest.fixture
+def exporter() -> Generator[InMemorySpanExporter, None, None]:
+    provider = trace_api.get_tracer_provider()
+    if not isinstance(provider, TracerProvider):
+        provider = TracerProvider()
+        trace_api.set_tracer_provider(provider)
+    exp = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exp))
+    try:
+        yield exp
+    finally:
+        exp.clear()
+
+
+def _by_name(spans: Sequence[ReadableSpan], name: str) -> ReadableSpan:
+    matches = [s for s in spans if s.name == name]
+    assert matches, f'no span named {name!r} in {[s.name for s in spans]}'
+    return matches[-1]
+
+
+def _counter_agent(
+    *,
+    registry: Registry,
+    name: str,
+    store: InMemorySessionStore | None,
+):
+    async def fn(session_runner: SessionRunner, _: ActionRunContext) -> AgentResult:
+        async def handle_turn(_: AgentInput, __: TurnContext) -> TurnResult | None:
+            def bump(custom: dict | None) -> dict:
+                return {'count': (custom or {}).get('count', 0) + 1}
+
+            await session_runner.update_custom(bump)
+            await session_runner.add_messages(MessageData(role='model', content=[Part(root=TextPart(text='done'))]))
+            return TurnResult(finish_reason=AgentFinishReason.STOP)
+
+        await session_runner.run(handle_turn)
+        return await session_runner.result()
+
+    return define_custom_agent(registry, name, fn, store=store)
+
+
+def test_session_mints_session_id_when_missing() -> None:
+    session = Session()
+    assert session.session_state.session_id
+    assert UUID_RE.match(session.session_state.session_id)
+
+
+def test_session_preserves_existing_session_id() -> None:
+    session = Session(SessionState(session_id='keep-me', custom={'x': 1}))
+    assert session.session_state.session_id == 'keep-me'
+    assert session.session_state.custom == {'x': 1}
+
+
+def test_session_does_not_mutate_caller_state() -> None:
+    seed = SessionState(custom={'n': 1})
+    session = Session(seed)
+    assert session.session_state.session_id
+    assert seed.session_id is None
+
+
+@pytest.mark.asyncio
+async def test_run_turn_span_output_is_session_state_with_store(
+    exporter: InMemorySpanExporter,
+) -> None:
+    registry = Registry()
+    store = InMemorySessionStore()
+    agent = _counter_agent(registry=registry, name='turnSpanStore', store=store)
+
+    out = await agent.chat().send('hi').response
+    assert out.snapshot_id
+    assert out.session_id
+    assert UUID_RE.match(out.session_id)
+
+    spans = exporter.get_finished_spans()
+    root = _by_name(spans, 'turnSpanStore')
+    assert root.attributes is not None
+    assert root.attributes[SESSION_ID_ATTR] == out.session_id
+
+    turn_span = _by_name(spans, 'runTurn-1')
+    assert turn_span.attributes is not None
+    assert turn_span.attributes[SNAPSHOT_ID_ATTR] == out.snapshot_id
+    assert SESSION_ID_ATTR not in turn_span.attributes
+
+    payload = json.loads(turn_span.attributes[Attr.OUTPUT])
+    assert payload['state']['custom'] == {'count': 1}
+    assert payload['state']['sessionId'] == out.session_id
+    assert 'messages' in payload['state']
+    assert 'finishReason' not in payload
+
+
+@pytest.mark.asyncio
+async def test_run_turn_span_output_is_session_state_client_managed(
+    exporter: InMemorySpanExporter,
+) -> None:
+    registry = Registry()
+    agent = _counter_agent(registry=registry, name='turnSpanClient', store=None)
+
+    out = await agent.chat().send('hi').response
+    assert out.raw.state is not None
+    assert out.raw.state.session_id
+    assert UUID_RE.match(out.raw.state.session_id)
+    assert out.session_id == out.raw.state.session_id
+
+    spans = exporter.get_finished_spans()
+    root = _by_name(spans, 'turnSpanClient')
+    assert root.attributes is not None
+    assert root.attributes[SESSION_ID_ATTR] == out.session_id
+
+    turn_span = _by_name(spans, 'runTurn-1')
+    assert turn_span.attributes is not None
+    assert SNAPSHOT_ID_ATTR not in turn_span.attributes
+    assert SESSION_ID_ATTR not in turn_span.attributes
+
+    payload = json.loads(turn_span.attributes[Attr.OUTPUT])
+    assert payload['state']['custom'] == {'count': 1}
+    assert payload['state']['sessionId'] == out.session_id
+    assert 'finishReason' not in payload
+
+
+@pytest.mark.asyncio
+async def test_client_managed_preserves_session_id_across_turns() -> None:
+    registry = Registry()
+    agent = _counter_agent(registry=registry, name='preserveClientSid', store=None)
+
+    chat = agent.chat()
+    out1 = await chat.send('one').response
+    assert out1.raw.state is not None
+    sid = out1.raw.state.session_id
+    assert sid
+
+    out2 = await chat.send('two').response
+    assert out2.raw.state is not None
+    assert out2.raw.state.session_id == sid


### PR DESCRIPTION
## Summary
- Fix `runTurn` span `genkit:output` to record `{ state: <session state> }` (messages/artifacts/custom) instead of only `{ finishReason }`, so Dev UI matches the JS/Go turn span shape.
- Tag `agent:snapshotId` with the id actually returned from turn-end persistence (not a reserved id that may never have been written).
- Mint a `sessionId` on fresh client-managed sessions and stamp the root agent span with `agent:sessionId`; have the chat client adopt that id from round-tripped state so multi-turn traces stay correlatable.
- Include `session_id` on detach `AgentOutput` (and `state` when there is no store).