### PR TITLE
feat(go): relax option merging to accumulate or last-win

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -416,6 +416,11 @@ if terse {
 response, _ := genkit.Generate(ctx, g, append(opts, ai.WithPrompt("What should I pack for Tokyo?"))...)
 ```
 
+Tool names must be unique across the merged list: repeating the same tool in
+two helpers is rejected when the request runs. These rules cover a single
+options list; APIs that layer two lists, like a prompt's define-time options
+against `Execute`-time options, document their own precedence.
+
 ### Generate Structured Data
 
 Get type-safe JSON output that maps directly to your Go structs:

--- a/go/README.md
+++ b/go/README.md
@@ -395,7 +395,26 @@ Options compose, so you can build a request up from several helpers. Options
 carrying multiple items (`ai.WithMessages`, `ai.WithTools`, `ai.WithDocs`,
 `ai.WithUse`) accumulate across repeats, while single-value options
 (`ai.WithConfig`, `ai.WithModelName`, `ai.WithSystem`) take the last one set.
-Repeating an option is never an error.
+Repeating an option is never an error, so a request can be assembled in pieces:
+
+```go
+opts := []ai.GenerateOption{
+    ai.WithModelName("googleai/gemini-flash-latest"),
+    ai.WithSystem("You are a helpful assistant."),
+    ai.WithTools(searchTool, weatherTool),
+}
+
+if isAdmin {
+    // Appends to the tools above; the model sees all of them.
+    opts = append(opts, ai.WithTools(adminTools...))
+}
+if terse {
+    // Fills the same slot as the system prompt above, so this one wins.
+    opts = append(opts, ai.WithSystem("You are a terse assistant. One sentence."))
+}
+
+response, _ := genkit.Generate(ctx, g, append(opts, ai.WithPrompt("What should I pack for Tokyo?"))...)
+```
 
 ### Generate Structured Data
 

--- a/go/README.md
+++ b/go/README.md
@@ -391,6 +391,12 @@ text, _ := genkit.GenerateText(ctx, g,
 fmt.Println(text)
 ```
 
+Options compose, so you can build a request up from several helpers. Options
+carrying multiple items (`ai.WithMessages`, `ai.WithTools`, `ai.WithDocs`,
+`ai.WithUse`) accumulate across repeats, while single-value options
+(`ai.WithConfig`, `ai.WithModelName`, `ai.WithSystem`) take the last one set.
+Repeating an option is never an error.
+
 ### Generate Structured Data
 
 Get type-safe JSON output that maps directly to your Go structs:

--- a/go/README.md
+++ b/go/README.md
@@ -561,18 +561,24 @@ resp, _ := genkit.Generate(ctx, g,
     ai.WithTools(transferTool),
 )
 
-if resp.FinishReason == ai.FinishReasonInterrupted {
-    for _, interrupt := range resp.Interrupts() {
-        meta, _ := ai.InterruptAs[TransferInterrupt](interrupt)
+// Interrupts() yields nothing unless the tool paused for input.
+var restarts []*ai.Part
+for _, interrupt := range resp.Interrupts() {
+    meta, _ := ai.InterruptAs[TransferInterrupt](interrupt)
 
-        // Get user confirmation, then resume
-        part, _ := transferTool.RestartWith(interrupt)
-        resp, _ = genkit.Generate(ctx, g,
-            ai.WithMessages(resp.History()...),
-            ai.WithTools(transferTool),
-            ai.WithToolRestarts(part),
-        )
-    }
+    // Use meta to get user confirmation, then resume with their answer.
+    part, _ := transferTool.RestartWith(interrupt)
+    restarts = append(restarts, part)
+}
+
+// Collect every restart first, then resume once: generating inside the loop
+// would resume later interrupts against a history that already moved on.
+if len(restarts) > 0 {
+    resp, _ = genkit.Generate(ctx, g,
+        ai.WithMessages(resp.History()...),
+        ai.WithTools(transferTool),
+        ai.WithToolRestarts(restarts...),
+    )
 }
 ```
 

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -166,9 +166,7 @@ func (e *embedder) Embed(ctx context.Context, req *EmbedRequest) (*EmbedResponse
 func Embed(ctx context.Context, r api.Registry, opts ...EmbedderOption) (*EmbedResponse, error) {
 	embedOpts := &embedderOptions{}
 	for _, opt := range opts {
-		if err := opt.applyEmbedder(embedOpts); err != nil {
-			return nil, fmt.Errorf("ai.Embed: error applying options: %w", err)
-		}
+		opt.applyEmbedder(embedOpts)
 	}
 
 	if embedOpts.Embedder == nil {

--- a/go/ai/embedder.go
+++ b/go/ai/embedder.go
@@ -23,6 +23,7 @@ import (
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/internal/base"
 )
 
 // EmbedderFunc is the function type for embedding documents.
@@ -181,7 +182,9 @@ func Embed(ctx context.Context, r api.Registry, opts ...EmbedderOption) (*EmbedR
 	}
 
 	if embedRef, ok := embedOpts.Embedder.(EmbedderRef); ok && embedOpts.Config == nil {
-		embedOpts.Config = embedRef.Config()
+		if cfg := embedRef.Config(); !base.IsNil(cfg) {
+			embedOpts.Config = cfg
+		}
 	}
 
 	req := &EmbedRequest{

--- a/go/ai/evaluator.go
+++ b/go/ai/evaluator.go
@@ -315,9 +315,7 @@ func (e *evaluator) Evaluate(ctx context.Context, req *EvaluatorRequest) (*Evalu
 func Evaluate(ctx context.Context, r api.Registry, opts ...EvaluatorOption) (*EvaluatorResponse, error) {
 	evalOpts := &evaluatorOptions{}
 	for _, opt := range opts {
-		if err := opt.applyEvaluator(evalOpts); err != nil {
-			return nil, err
-		}
+		opt.applyEvaluator(evalOpts)
 	}
 
 	if evalOpts.Evaluator == nil {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -592,9 +592,7 @@ func buildToolRunner(mws []*Hooks) func(ctx context.Context, tool Tool, req *Too
 func Generate(ctx context.Context, r api.Registry, opts ...GenerateOption) (*ModelResponse, error) {
 	genOpts := &generateOptions{}
 	for _, opt := range opts {
-		if err := opt.applyGenerate(genOpts); err != nil {
-			return nil, status.Errorf(status.ErrInvalidArgument, "ai.Generate: error applying options: %w", err)
-		}
+		opt.applyGenerate(genOpts)
 	}
 
 	if genOpts.OutputSchema != nil {
@@ -726,7 +724,11 @@ func GenerateText(ctx context.Context, r api.Registry, opts ...GenerateOption) (
 // Check resp.Interrupts() or resp.ToolRequests() to handle these cases.
 func GenerateData[Out any](ctx context.Context, r api.Registry, opts ...GenerateOption) (*Out, *ModelResponse, error) {
 	var value Out
-	opts = append(opts, WithOutputType(value))
+	// Prepend the inferred output type so an explicit WithOutputSchema or
+	// WithOutputSchemaName passed by the caller wins the schema slot (last set
+	// wins). The typed Out still drives value extraction below, so structured
+	// output keeps working whether or not the caller overrode the schema.
+	opts = append([]GenerateOption{WithOutputType(value)}, opts...)
 
 	resp, err := Generate(ctx, r, opts...)
 	if err != nil {

--- a/go/ai/generate.go
+++ b/go/ai/generate.go
@@ -722,6 +722,12 @@ func GenerateText(ctx context.Context, r api.Registry, opts ...GenerateOption) (
 // If the response doesn't contain text output (e.g., contains tool requests
 // or interrupts instead), the output will be nil and no error is returned.
 // Check resp.Interrupts() or resp.ToolRequests() to handle these cases.
+//
+// The output format is JSON with a schema inferred from Out; an explicit
+// [WithOutputSchema] or [WithOutputSchemaName] overrides the schema while
+// extraction into Out keeps working. Overriding the format itself with a
+// non-JSON [WithOutputFormat] or [WithOutputEnums] breaks that extraction:
+// the response text will not parse into Out.
 func GenerateData[Out any](ctx context.Context, r api.Registry, opts ...GenerateOption) (*Out, *ModelResponse, error) {
 	var value Out
 	// Prepend the inferred output type so an explicit WithOutputSchema or
@@ -793,7 +799,9 @@ func GenerateStream(ctx context.Context, r api.Registry, opts ...GenerateOption)
 			return nil
 		}
 
-		allOpts := append(slices.Clone(opts), WithStreaming(cb))
+		// Chain rather than set the callback so a caller-supplied
+		// WithStreaming still receives every chunk.
+		allOpts := append(slices.Clone(opts), withChainedStreaming(cb))
 
 		resp, err := Generate(ctx, r, allOpts...)
 		if done || errors.Is(err, errStop) {
@@ -818,6 +826,10 @@ func GenerateStream(ctx context.Context, r api.Registry, opts ...GenerateOption)
 // will not be called again.
 //
 // Otherwise the Chunk field of the passed [StreamValue] holds a streamed chunk.
+//
+// Like [GenerateData], the output format is JSON with a schema inferred from
+// Out; overriding the format with a non-JSON [WithOutputFormat] or
+// [WithOutputEnums] breaks typed extraction.
 func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...GenerateOption) iter.Seq2[*StreamValue[Out, Out], error] {
 	return func(yield func(*StreamValue[Out, Out], error) bool) {
 		done := false
@@ -845,10 +857,12 @@ func GenerateDataStream[Out any](ctx context.Context, r api.Registry, opts ...Ge
 			return nil
 		}
 
-		// Prepend WithOutputType so the user can override the output format.
+		// Prepend WithOutputType so the user can override the output format,
+		// and chain the iterator callback so a caller-supplied WithStreaming
+		// still receives every chunk.
 		var value Out
 		allOpts := append([]GenerateOption{WithOutputType(value)}, opts...)
-		allOpts = append(allOpts, WithStreaming(cb))
+		allOpts = append(allOpts, withChainedStreaming(cb))
 
 		resp, err := Generate(ctx, r, allOpts...)
 		if done || errors.Is(err, errStop) {

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -2344,6 +2344,59 @@ func TestGenerateData(t *testing.T) {
 	})
 }
 
+// TestGenerateDataCallerSchemaOverride verifies that GenerateData injects the
+// output type inferred from Out but still lets a caller-supplied
+// WithOutputSchema win the schema slot, while typed extraction keeps working.
+func TestGenerateDataCallerSchemaOverride(t *testing.T) {
+	r := newTestRegistry(t)
+
+	type TestOutput struct {
+		Value int `json:"value"`
+	}
+
+	var capturedSchema map[string]any
+	model := DefineModel(r, "test/captureSchema", &ModelOptions{
+		Supports: &ModelSupports{
+			Constrained: ConstrainedSupportAll,
+		},
+	}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+		if req.Output != nil {
+			capturedSchema = req.Output.Schema
+		}
+		return &ModelResponse{
+			Request: req,
+			Message: NewModelTextMessage(`{"value": 42}`),
+		}, nil
+	})
+
+	// A distinctive schema the inferred one would never produce.
+	customSchema := map[string]any{
+		"type":  "object",
+		"title": "CallerProvided",
+		"properties": map[string]any{
+			"value": map[string]any{"type": "integer"},
+		},
+	}
+
+	output, _, err := GenerateData[TestOutput](context.Background(), r,
+		WithModel(model),
+		WithPrompt("get value"),
+		WithOutputSchema(customSchema),
+	)
+	if err != nil {
+		t.Fatalf("GenerateData error: %v", err)
+	}
+
+	// The caller's schema reaches the model, overriding the type-inferred one.
+	if capturedSchema["title"] != "CallerProvided" {
+		t.Errorf("request output schema = %v, want caller-provided schema (title CallerProvided)", capturedSchema)
+	}
+	// Typed extraction from Out still works.
+	if output.Value != 42 {
+		t.Errorf("output.Value = %d, want 42", output.Value)
+	}
+}
+
 func TestModelResponseReasoning(t *testing.T) {
 	t.Run("returns reasoning from response", func(t *testing.T) {
 		resp := &ModelResponse{

--- a/go/ai/generate_test.go
+++ b/go/ai/generate_test.go
@@ -2355,18 +2355,17 @@ func TestGenerateDataCallerSchemaOverride(t *testing.T) {
 	}
 
 	var capturedSchema map[string]any
-	model := DefineModel(r, "test/captureSchema", &ModelOptions{
-		Supports: &ModelSupports{
-			Constrained: ConstrainedSupportAll,
+	model := defineFakeModel(t, r, fakeModelConfig{
+		name: "test/captureSchema",
+		handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			if req.Output != nil {
+				capturedSchema = req.Output.Schema
+			}
+			return &ModelResponse{
+				Request: req,
+				Message: NewModelTextMessage(`{"value": 42}`),
+			}, nil
 		},
-	}, func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
-		if req.Output != nil {
-			capturedSchema = req.Output.Schema
-		}
-		return &ModelResponse{
-			Request: req,
-			Message: NewModelTextMessage(`{"value": 42}`),
-		}, nil
 	})
 
 	// A distinctive schema the inferred one would never produce.
@@ -2395,6 +2394,56 @@ func TestGenerateDataCallerSchemaOverride(t *testing.T) {
 	if output.Value != 42 {
 		t.Errorf("output.Value = %d, want 42", output.Value)
 	}
+}
+
+// TestGenerateStreamChainsUserCallback verifies that the stream-returning
+// wrappers chain a caller-supplied WithStreaming callback with their internal
+// iterator callback instead of displacing it: both must see every chunk.
+func TestGenerateStreamChainsUserCallback(t *testing.T) {
+	r := newTestRegistry(t)
+
+	model := defineFakeModel(t, r, fakeModelConfig{
+		name: "test/chunkedModel",
+		handler: func(ctx context.Context, req *ModelRequest, cb ModelStreamCallback) (*ModelResponse, error) {
+			if cb != nil {
+				if err := cb(ctx, &ModelResponseChunk{Content: []*Part{NewTextPart("one")}}); err != nil {
+					return nil, err
+				}
+				if err := cb(ctx, &ModelResponseChunk{Content: []*Part{NewTextPart("two")}}); err != nil {
+					return nil, err
+				}
+			}
+			return &ModelResponse{
+				Request: req,
+				Message: NewModelTextMessage("onetwo"),
+			}, nil
+		},
+	})
+
+	var userChunks []string
+	userCB := func(ctx context.Context, chunk *ModelResponseChunk) error {
+		userChunks = append(userChunks, chunk.Text())
+		return nil
+	}
+
+	var iterChunks []string
+	for v, err := range GenerateStream(context.Background(), r,
+		WithModel(model),
+		WithPrompt("count"),
+		WithStreaming(userCB),
+	) {
+		if err != nil {
+			t.Fatalf("GenerateStream error: %v", err)
+		}
+		if v.Done {
+			break
+		}
+		iterChunks = append(iterChunks, v.Chunk.Text())
+	}
+
+	want := []string{"one", "two"}
+	assertEqual(t, userChunks, want)
+	assertEqual(t, iterChunks, want)
 }
 
 func TestModelResponseReasoning(t *testing.T) {

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -69,8 +69,8 @@ func appendMessagesFn(existing, next MessagesFn) MessagesFn {
 			return nil, err
 		}
 		// Copy rather than append onto before: WithMessages(history...) hands
-		// the caller's slice straight through, so appending in place could
-		// scribble over the array backing their history.
+		// the caller's slice straight through, so appending in place would
+		// write into the spare capacity of the array backing their history.
 		msgs := make([]*Message, 0, len(before)+len(after))
 		msgs = append(msgs, before...)
 		msgs = append(msgs, after...)

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -19,17 +19,64 @@ package ai
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/firebase/genkit/go/core"
 )
+
+// Options follow the standard Go functional-options pattern: pass as many as
+// you like, in any order, and they merge left to right. Two rules govern how
+// repeats combine, so composing a request from several helpers is predictable:
+//
+//   - Collection options accumulate. Repeating one, or mixing its variants,
+//     appends in call order: WithMessages(a), WithMessages(b) sends [a, b], and
+//     WithTools, WithResources, WithUse, WithMiddleware, WithDocs, and
+//     WithDataset behave the same.
+//   - Single-value options take the last one set. WithConfig, WithModel /
+//     WithModelName, WithSystem, WithPrompt, the output-schema options, and the
+//     like each fill one slot, so the final call wins and earlier ones are
+//     overwritten rather than rejected.
+//
+// Applying options therefore never fails on a "set more than once" conflict.
+// The only failures are genuinely invalid arguments (for example a type that
+// WithInputType cannot turn into a schema), which panic at the call site where
+// the mistake is.
 
 // PromptFn is a function that generates a prompt.
 type PromptFn = func(context.Context, any) (string, error)
 
 // MessagesFn is a function that generates messages.
 type MessagesFn = func(context.Context, any) ([]*Message, error)
+
+// appendMessagesFn composes two message-producing functions so their outputs
+// concatenate in call order. It backs the accumulate semantics of
+// [WithMessages] and [WithMessagesFn]: passing several of them (in any mix)
+// appends their messages instead of overwriting.
+func appendMessagesFn(existing, next MessagesFn) MessagesFn {
+	if existing == nil {
+		return next
+	}
+	if next == nil {
+		return existing
+	}
+	return func(ctx context.Context, input any) ([]*Message, error) {
+		before, err := existing(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		after, err := next(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		// Copy rather than append onto before: WithMessages(history...) hands
+		// the caller's slice straight through, so appending in place could
+		// scribble over the array backing their history.
+		msgs := make([]*Message, 0, len(before)+len(after))
+		msgs = append(msgs, before...)
+		msgs = append(msgs, after...)
+		return msgs, nil
+	}
+}
 
 // configOptions holds configuration options.
 type configOptions struct {
@@ -38,63 +85,60 @@ type configOptions struct {
 
 // ConfigOption is an option for model configuration.
 type ConfigOption interface {
-	applyConfig(*configOptions) error
-	applyCommonGen(*commonGenOptions) error
-	applyPrompt(*promptOptions) error
-	applyGenerate(*generateOptions) error
-	applyPromptExecute(*promptExecutionOptions) error
-	applyEmbedder(*embedderOptions) error
-	applyRetriever(*retrieverOptions) error
-	applyEvaluator(*evaluatorOptions) error
+	applyConfig(*configOptions)
+	applyCommonGen(*commonGenOptions)
+	applyPrompt(*promptOptions)
+	applyGenerate(*generateOptions)
+	applyPromptExecute(*promptExecutionOptions)
+	applyEmbedder(*embedderOptions)
+	applyRetriever(*retrieverOptions)
+	applyEvaluator(*evaluatorOptions)
 }
 
 // applyConfig applies the option to the config options.
-func (o *configOptions) applyConfig(opts *configOptions) error {
+func (o *configOptions) applyConfig(opts *configOptions) {
 	if o.Config != nil {
-		if opts.Config != nil {
-			return errors.New("cannot set config more than once (WithConfig)")
-		}
 		opts.Config = o.Config
 	}
-	return nil
 }
 
 // applyCommonGen applies the option to the common options.
-func (o *configOptions) applyCommonGen(opts *commonGenOptions) error {
-	return o.applyConfig(&opts.configOptions)
+func (o *configOptions) applyCommonGen(opts *commonGenOptions) {
+	o.applyConfig(&opts.configOptions)
 }
 
 // applyPrompt applies the option to the prompt options.
-func (o *configOptions) applyPrompt(opts *promptOptions) error {
-	return o.applyConfig(&opts.configOptions)
+func (o *configOptions) applyPrompt(opts *promptOptions) {
+	o.applyConfig(&opts.configOptions)
 }
 
 // applyGenerate applies the option to the generate options.
-func (o *configOptions) applyGenerate(opts *generateOptions) error {
-	return o.applyConfig(&opts.configOptions)
+func (o *configOptions) applyGenerate(opts *generateOptions) {
+	o.applyConfig(&opts.configOptions)
 }
 
 // applyPromptExecute applies the option to the prompt generate options.
-func (o *configOptions) applyPromptExecute(opts *promptExecutionOptions) error {
-	return o.applyConfig(&opts.configOptions)
+func (o *configOptions) applyPromptExecute(opts *promptExecutionOptions) {
+	o.applyConfig(&opts.configOptions)
 }
 
 // applyEmbedder applies the option to the embed options.
-func (o *configOptions) applyEmbedder(opts *embedderOptions) error {
-	return o.applyConfig(&opts.configOptions)
+func (o *configOptions) applyEmbedder(opts *embedderOptions) {
+	o.applyConfig(&opts.configOptions)
 }
 
 // applyRetriever applies the option to the retrieve options.
-func (o *configOptions) applyRetriever(opts *retrieverOptions) error {
-	return o.applyConfig(&opts.configOptions)
+func (o *configOptions) applyRetriever(opts *retrieverOptions) {
+	o.applyConfig(&opts.configOptions)
 }
 
 // applyEvaluator applies the option to the evaluate options.
-func (o *configOptions) applyEvaluator(opts *evaluatorOptions) error {
-	return o.applyConfig(&opts.configOptions)
+func (o *configOptions) applyEvaluator(opts *evaluatorOptions) {
+	o.applyConfig(&opts.configOptions)
 }
 
-// WithConfig sets the configuration.
+// WithConfig sets the configuration. Repeating this option takes the last
+// config set.
 func WithConfig(config any) ConfigOption {
 	return &configOptions{Config: config}
 }
@@ -114,101 +158,55 @@ type commonGenOptions struct {
 }
 
 type CommonGenOption interface {
-	applyCommonGen(*commonGenOptions) error
-	applyPrompt(*promptOptions) error
-	applyGenerate(*generateOptions) error
-	applyPromptExecute(*promptExecutionOptions) error
+	applyCommonGen(*commonGenOptions)
+	applyPrompt(*promptOptions)
+	applyGenerate(*generateOptions)
+	applyPromptExecute(*promptExecutionOptions)
 }
 
 // applyCommonGen applies the option to the common options.
-func (o *commonGenOptions) applyCommonGen(opts *commonGenOptions) error {
-	if err := o.configOptions.applyConfig(&opts.configOptions); err != nil {
-		return err
-	}
+func (o *commonGenOptions) applyCommonGen(opts *commonGenOptions) {
+	o.configOptions.applyConfig(&opts.configOptions)
 
 	if o.MessagesFn != nil {
-		if opts.MessagesFn != nil {
-			return errors.New("cannot set messages more than once (either WithMessages or WithMessagesFn)")
-		}
-		opts.MessagesFn = o.MessagesFn
+		opts.MessagesFn = appendMessagesFn(opts.MessagesFn, o.MessagesFn)
 	}
-
 	if o.Model != nil {
-		if opts.Model != nil {
-			return errors.New("cannot set model more than once (either WithModel or WithModelName)")
-		}
 		opts.Model = o.Model
 	}
-
-	if o.Tools != nil {
-		if opts.Tools != nil {
-			return errors.New("cannot set tools more than once (WithTools)")
-		}
-		opts.Tools = o.Tools
-	}
-
-	if o.Resources != nil {
-		if opts.Resources != nil {
-			return errors.New("cannot set resources more than once (WithResources)")
-		}
-		opts.Resources = o.Resources
-	}
-
+	opts.Tools = append(opts.Tools, o.Tools...)
+	opts.Resources = append(opts.Resources, o.Resources...)
 	if o.ToolChoice != "" {
-		if opts.ToolChoice != "" {
-			return errors.New("cannot set tool choice more than once (WithToolChoice)")
-		}
 		opts.ToolChoice = o.ToolChoice
 	}
-
 	if o.MaxTurns > 0 {
-		if opts.MaxTurns > 0 {
-			return errors.New("cannot set max turns more than once (WithMaxTurns)")
-		}
 		opts.MaxTurns = o.MaxTurns
 	}
-
 	if o.ReturnToolRequests != nil {
-		if opts.ReturnToolRequests != nil {
-			return errors.New("cannot configure returning tool requests more than once (WithReturnToolRequests)")
-		}
 		opts.ReturnToolRequests = o.ReturnToolRequests
 	}
-
-	if o.Middleware != nil {
-		if opts.Middleware != nil {
-			return errors.New("cannot set middleware more than once (WithMiddleware)")
-		}
-		opts.Middleware = o.Middleware
-	}
-
-	if o.Use != nil {
-		if opts.Use != nil {
-			return errors.New("cannot set middleware more than once (WithUse)")
-		}
-		opts.Use = o.Use
-	}
-
-	return nil
+	opts.Middleware = append(opts.Middleware, o.Middleware...)
+	opts.Use = append(opts.Use, o.Use...)
 }
 
 // applyPromptExecute applies the option to the prompt request options.
-func (o *commonGenOptions) applyPromptExecute(reqOpts *promptExecutionOptions) error {
-	return o.applyCommonGen(&reqOpts.commonGenOptions)
+func (o *commonGenOptions) applyPromptExecute(reqOpts *promptExecutionOptions) {
+	o.applyCommonGen(&reqOpts.commonGenOptions)
 }
 
 // applyPrompt applies the option to the prompt options.
-func (o *commonGenOptions) applyPrompt(pOpts *promptOptions) error {
-	return o.applyCommonGen(&pOpts.commonGenOptions)
+func (o *commonGenOptions) applyPrompt(pOpts *promptOptions) {
+	o.applyCommonGen(&pOpts.commonGenOptions)
 }
 
 // applyGenerate applies the option to the generate options.
-func (o *commonGenOptions) applyGenerate(genOpts *generateOptions) error {
-	return o.applyCommonGen(&genOpts.commonGenOptions)
+func (o *commonGenOptions) applyGenerate(genOpts *generateOptions) {
+	o.applyCommonGen(&genOpts.commonGenOptions)
 }
 
-// WithMessages sets the messages.
-// These messages will be sandwiched between the system and user prompts.
+// WithMessages adds messages to the request, placed between the system and
+// user prompts. Repeating this option, or mixing it with [WithMessagesFn],
+// appends: messages accumulate in the order the options are passed.
 func WithMessages(messages ...*Message) CommonGenOption {
 	return &commonGenOptions{
 		MessagesFn: func(ctx context.Context, _ any) ([]*Message, error) {
@@ -217,38 +215,45 @@ func WithMessages(messages ...*Message) CommonGenOption {
 	}
 }
 
-// WithMessagesFn sets the request messages to the result of the function.
-// These messages will be sandwiched between the system and user messages.
+// WithMessagesFn adds messages produced by fn at request time, placed between
+// the system and user prompts. Like [WithMessages], repeating this option (or
+// mixing the two) appends the produced messages in call order.
 func WithMessagesFn(fn MessagesFn) CommonGenOption {
 	return &commonGenOptions{MessagesFn: fn}
 }
 
-// WithTools sets the tools to use for the generate request.
+// WithTools adds tools to use for the generate request. Repeating this option
+// appends; duplicate tools (by name) are rejected when the request runs.
 func WithTools(tools ...ToolRef) CommonGenOption {
 	return &commonGenOptions{Tools: tools}
 }
 
 // WithModel sets either a [Model] or a [ModelRef] that may contain a config.
 // Passing [WithConfig] will take precedence over the config in WithModel.
+// Repeating this option, or mixing it with [WithModelName], takes the last
+// model set.
 func WithModel(model ModelArg) CommonGenOption {
 	return &commonGenOptions{Model: model}
 }
 
 // WithModelName sets the model name to call for generation.
 // The model name will be resolved to a [Model] and may error if the reference is invalid.
+// Repeating this option, or mixing it with [WithModel], takes the last model set.
 func WithModelName(name string) CommonGenOption {
 	return &commonGenOptions{Model: NewModelRef(name, nil)}
 }
 
-// WithMiddleware sets middleware to apply to the model request.
+// WithMiddleware adds middleware to apply to the model request. Repeating this
+// option appends to the chain.
 //
 // Deprecated: Use [WithUse] instead, which supports Generate, Model, and Tool hooks.
 func WithMiddleware(middleware ...ModelMiddleware) CommonGenOption {
 	return &commonGenOptions{Middleware: middleware}
 }
 
-// WithUse sets middleware to apply to generation. Middleware hooks wrap
-// the generate loop, model calls, and tool executions.
+// WithUse adds middleware to apply to generation. Middleware hooks wrap the
+// generate loop, model calls, and tool executions. Repeating this option
+// appends to the chain.
 //
 // Accepts either a middleware config struct (produced by a plugin) or an
 // inline adapter via [MiddlewareFunc]. The chain applies outer-to-inner, so
@@ -279,9 +284,10 @@ func WithToolChoice(toolChoice ToolChoice) CommonGenOption {
 	return &commonGenOptions{ToolChoice: toolChoice}
 }
 
-// WithResources specifies resources to be temporarily available during generation.
-// Resources are unregistered resources that get attached to a temporary registry
-// during the generation request and cleaned up afterward.
+// WithResources specifies resources to be temporarily available during
+// generation. Repeating this option appends. Resources are unregistered
+// resources that get attached to a temporary registry during the generation
+// request and cleaned up afterward.
 func WithResources(resources ...Resource) CommonGenOption {
 	return &commonGenOptions{Resources: resources}
 }
@@ -295,38 +301,31 @@ type inputOptions struct {
 // InputOption is an option for the input of a prompt.
 // It applies only to DefinePrompt().
 type InputOption interface {
-	applyInput(*inputOptions) error
-	applyPrompt(*promptOptions) error
-	applyTool(*toolOptions) error
+	applyInput(*inputOptions)
+	applyPrompt(*promptOptions)
+	applyTool(*toolOptions)
 }
 
-// applyInput applies the option to the input options.
-func (o *inputOptions) applyInput(opts *inputOptions) error {
+// applyInput applies the option to the input options. The schema and the
+// default input are independent single-value slots, so the last option to set
+// each one wins.
+func (o *inputOptions) applyInput(opts *inputOptions) {
 	if o.InputSchema != nil {
-		if opts.InputSchema != nil {
-			return errors.New("cannot set input schema more than once (WithInputType, WithInputSchema, or WithInputSchemaName)")
-		}
 		opts.InputSchema = o.InputSchema
 	}
-
 	if o.DefaultInput != nil {
-		if opts.DefaultInput != nil {
-			return errors.New("cannot set default input more than once (WithInputType)")
-		}
 		opts.DefaultInput = o.DefaultInput
 	}
-
-	return nil
 }
 
 // applyPrompt applies the option to the prompt options.
-func (o *inputOptions) applyPrompt(pOpts *promptOptions) error {
-	return o.applyInput(&pOpts.inputOptions)
+func (o *inputOptions) applyPrompt(pOpts *promptOptions) {
+	o.applyInput(&pOpts.inputOptions)
 }
 
 // applyTool applies the option to the tool options.
-func (o *inputOptions) applyTool(tOpts *toolOptions) error {
-	return o.applyInput(&tOpts.inputOptions)
+func (o *inputOptions) applyTool(tOpts *toolOptions) {
+	o.applyInput(&tOpts.inputOptions)
 }
 
 // WithInputType uses the type provided to derive the input schema.
@@ -380,50 +379,32 @@ type promptOptions struct {
 // PromptOption is an option for defining a prompt.
 // It applies only to DefinePrompt().
 type PromptOption interface {
-	applyPrompt(*promptOptions) error
+	applyPrompt(*promptOptions)
 }
 
 // applyPrompt applies the option to the prompt options.
-func (o *promptOptions) applyPrompt(opts *promptOptions) error {
-	if err := o.commonGenOptions.applyPrompt(opts); err != nil {
-		return err
-	}
-
-	if err := o.promptingOptions.applyPrompt(opts); err != nil {
-		return err
-	}
-
-	if err := o.inputOptions.applyPrompt(opts); err != nil {
-		return err
-	}
-
-	if err := o.outputOptions.applyPrompt(opts); err != nil {
-		return err
-	}
+func (o *promptOptions) applyPrompt(opts *promptOptions) {
+	o.commonGenOptions.applyPrompt(opts)
+	o.promptingOptions.applyPrompt(opts)
+	o.inputOptions.applyPrompt(opts)
+	o.outputOptions.applyPrompt(opts)
 
 	if o.Description != "" {
-		if opts.Description != "" {
-			return errors.New("cannot set description more than once (WithDescription)")
-		}
 		opts.Description = o.Description
 	}
-
 	if o.Metadata != nil {
-		if opts.Metadata != nil {
-			return errors.New("cannot set metadata more than once (WithMetadata)")
-		}
 		opts.Metadata = o.Metadata
 	}
-
-	return nil
 }
 
-// WithDescription sets the description of the prompt.
+// WithDescription sets the description of the prompt. Repeating this option
+// takes the last description set.
 func WithDescription(description string) PromptOption {
 	return &promptOptions{Description: description}
 }
 
-// WithMetadata sets arbitrary metadata for the prompt.
+// WithMetadata sets arbitrary metadata for the prompt. Repeating this option
+// replaces the metadata rather than merging it.
 func WithMetadata(metadata map[string]any) PromptOption {
 	return &promptOptions{Metadata: metadata}
 }
@@ -437,38 +418,31 @@ type promptingOptions struct {
 // PromptingOption is an option for the system and user prompts of a prompt or generate request.
 // It applies only to DefinePrompt() and Generate().
 type PromptingOption interface {
-	applyPrompting(*promptingOptions) error
-	applyPrompt(*promptOptions) error
-	applyGenerate(*generateOptions) error
+	applyPrompting(*promptingOptions)
+	applyPrompt(*promptOptions)
+	applyGenerate(*generateOptions)
 }
 
-// applyPrompting applies the option to the prompting options.
-func (o *promptingOptions) applyPrompting(opts *promptingOptions) error {
+// applyPrompting applies the option to the prompting options. The system and
+// user prompts are independent single-value slots, so the last option to set
+// each one wins.
+func (o *promptingOptions) applyPrompting(opts *promptingOptions) {
 	if o.SystemFn != nil {
-		if opts.SystemFn != nil {
-			return errors.New("cannot set system text more than once (either WithSystem or WithSystemFn)")
-		}
 		opts.SystemFn = o.SystemFn
 	}
-
 	if o.PromptFn != nil {
-		if opts.PromptFn != nil {
-			return errors.New("cannot set prompt text more than once (either WithPrompt or WithPromptFn)")
-		}
 		opts.PromptFn = o.PromptFn
 	}
-
-	return nil
 }
 
 // applyPrompt applies the option to the prompt options.
-func (o *promptingOptions) applyPrompt(opts *promptOptions) error {
-	return o.applyPrompting(&opts.promptingOptions)
+func (o *promptingOptions) applyPrompt(opts *promptOptions) {
+	o.applyPrompting(&opts.promptingOptions)
 }
 
 // applyGenerate applies the option to the generate options.
-func (o *promptingOptions) applyGenerate(opts *generateOptions) error {
-	return o.applyPrompting(&opts.promptingOptions)
+func (o *promptingOptions) applyGenerate(opts *generateOptions) {
+	o.applyPrompting(&opts.promptingOptions)
 }
 
 // WithSystem sets the system prompt message.
@@ -518,46 +492,38 @@ type outputOptions struct {
 // OutputOption is an option for the output of a prompt or generate request.
 // It applies only to DefinePrompt() and Generate().
 type OutputOption interface {
-	applyOutput(*outputOptions) error
-	applyPrompt(*promptOptions) error
-	applyGenerate(*generateOptions) error
+	applyOutput(*outputOptions)
+	applyPrompt(*promptOptions)
+	applyGenerate(*generateOptions)
 }
 
-// applyOutput applies the option to the output options.
-func (o *outputOptions) applyOutput(opts *outputOptions) error {
+// applyOutput applies the option to the output options. The schema, format,
+// and instructions are independent single-value slots, so the last option to
+// set each one wins. This is what lets a caller-supplied [WithOutputSchema]
+// override the schema [GenerateData] injects while still using JSON output.
+func (o *outputOptions) applyOutput(opts *outputOptions) {
 	if o.OutputSchema != nil {
-		if opts.OutputSchema != nil {
-			return errors.New("cannot set output schema more than once (WithOutputType, WithOutputSchema, or WithOutputSchemaName)")
-		}
 		opts.OutputSchema = o.OutputSchema
 	}
-
-	if o.OutputInstructions != nil {
-		if opts.OutputInstructions != nil {
-			return errors.New("cannot set output instructions more than once (WithOutputFormat)")
-		}
-		opts.OutputInstructions = o.OutputInstructions
-	}
-
 	if o.OutputFormat != "" {
 		opts.OutputFormat = o.OutputFormat
 	}
-
-	if o.CustomConstrained {
-		opts.CustomConstrained = o.CustomConstrained
+	if o.OutputInstructions != nil {
+		opts.OutputInstructions = o.OutputInstructions
 	}
-
-	return nil
+	if o.CustomConstrained {
+		opts.CustomConstrained = true
+	}
 }
 
 // applyPrompt applies the option to the prompt options.
-func (o *outputOptions) applyPrompt(pOpts *promptOptions) error {
-	return o.applyOutput(&pOpts.outputOptions)
+func (o *outputOptions) applyPrompt(pOpts *promptOptions) {
+	o.applyOutput(&pOpts.outputOptions)
 }
 
 // applyGenerate applies the option to the generate options.
-func (o *outputOptions) applyGenerate(genOpts *generateOptions) error {
-	return o.applyOutput(&genOpts.outputOptions)
+func (o *outputOptions) applyGenerate(genOpts *generateOptions) {
+	o.applyOutput(&genOpts.outputOptions)
 }
 
 // WithOutputType sets the output format to JSON and the schema derived from the given value.
@@ -635,35 +601,31 @@ type executionOptions struct {
 
 // ExecutionOption is an option for the execution of a prompt or generate request. It applies only to Generate() and prompt.Execute().
 type ExecutionOption interface {
-	applyExecution(*executionOptions) error
-	applyGenerate(*generateOptions) error
-	applyPromptExecute(*promptExecutionOptions) error
+	applyExecution(*executionOptions)
+	applyGenerate(*generateOptions)
+	applyPromptExecute(*promptExecutionOptions)
 }
 
 // applyExecution applies the option to the runtime options.
-func (o *executionOptions) applyExecution(execOpts *executionOptions) error {
+func (o *executionOptions) applyExecution(execOpts *executionOptions) {
 	if o.Stream != nil {
-		if execOpts.Stream != nil {
-			return errors.New("cannot set stream callback more than once (WithStream)")
-		}
 		execOpts.Stream = o.Stream
 	}
-
-	return nil
 }
 
 // applyGenerate applies the option to the generate options.
-func (o *executionOptions) applyGenerate(genOpts *generateOptions) error {
-	return o.applyExecution(&genOpts.executionOptions)
+func (o *executionOptions) applyGenerate(genOpts *generateOptions) {
+	o.applyExecution(&genOpts.executionOptions)
 }
 
 // applyPromptExecute applies the option to the prompt request options.
-func (o *executionOptions) applyPromptExecute(pgOpts *promptExecutionOptions) error {
-	return o.applyExecution(&pgOpts.executionOptions)
+func (o *executionOptions) applyPromptExecute(pgOpts *promptExecutionOptions) {
+	o.applyExecution(&pgOpts.executionOptions)
 }
 
 // WithStreaming sets the stream callback for the generate request.
 // A callback is a function that is called with each chunk of the generated response before the final response is returned.
+// Repeating this option takes the last callback set.
 func WithStreaming(callback ModelStreamCallback) ExecutionOption {
 	return &executionOptions{Stream: callback}
 }
@@ -676,46 +638,40 @@ type documentOptions struct {
 // DocumentOption is an option for providing context or input documents.
 // It applies only to [Generate] and [prompt.Execute].
 type DocumentOption interface {
-	applyDocument(*documentOptions) error
-	applyGenerate(*generateOptions) error
-	applyPromptExecute(*promptExecutionOptions) error
-	applyEmbedder(*embedderOptions) error
-	applyRetriever(*retrieverOptions) error
+	applyDocument(*documentOptions)
+	applyGenerate(*generateOptions)
+	applyPromptExecute(*promptExecutionOptions)
+	applyEmbedder(*embedderOptions)
+	applyRetriever(*retrieverOptions)
 }
 
 // applyDocument applies the option to the context options.
-func (o *documentOptions) applyDocument(docOpts *documentOptions) error {
-	if o.Documents != nil {
-		if docOpts.Documents != nil {
-			return errors.New("cannot set documents more than once (WithDocs)")
-		}
-		docOpts.Documents = o.Documents
-	}
-
-	return nil
+func (o *documentOptions) applyDocument(docOpts *documentOptions) {
+	docOpts.Documents = append(docOpts.Documents, o.Documents...)
 }
 
 // applyGenerate applies the option to the generate options.
-func (o *documentOptions) applyGenerate(genOpts *generateOptions) error {
-	return o.applyDocument(&genOpts.documentOptions)
+func (o *documentOptions) applyGenerate(genOpts *generateOptions) {
+	o.applyDocument(&genOpts.documentOptions)
 }
 
 // applyPromptExecute applies the option to the prompt generate options.
-func (o *documentOptions) applyPromptExecute(pgOpts *promptExecutionOptions) error {
-	return o.applyDocument(&pgOpts.documentOptions)
+func (o *documentOptions) applyPromptExecute(pgOpts *promptExecutionOptions) {
+	o.applyDocument(&pgOpts.documentOptions)
 }
 
 // applyEmbedder applies the option to the embed options.
-func (o *documentOptions) applyEmbedder(embedOpts *embedderOptions) error {
-	return o.applyDocument(&embedOpts.documentOptions)
+func (o *documentOptions) applyEmbedder(embedOpts *embedderOptions) {
+	o.applyDocument(&embedOpts.documentOptions)
 }
 
 // applyRetriever applies the option to the retrieve options.
-func (o *documentOptions) applyRetriever(retOpts *retrieverOptions) error {
-	return o.applyDocument(&retOpts.documentOptions)
+func (o *documentOptions) applyRetriever(retOpts *retrieverOptions) {
+	o.applyDocument(&retOpts.documentOptions)
 }
 
-// WithTextDocs sets the text to be used as context documents for generation or as input to an embedder.
+// WithTextDocs adds text as context documents for generation or as input to an
+// embedder. Repeating this option (or mixing it with [WithDocs]) appends.
 func WithTextDocs(text ...string) DocumentOption {
 	docs := make([]*Document, len(text))
 	for i, t := range text {
@@ -724,7 +680,8 @@ func WithTextDocs(text ...string) DocumentOption {
 	return &documentOptions{Documents: docs}
 }
 
-// WithDocs sets the documents to be used as context for generation or as input to an embedder.
+// WithDocs adds documents as context for generation or as input to an
+// embedder. Repeating this option (or mixing it with [WithTextDocs]) appends.
 func WithDocs(docs ...*Document) DocumentOption {
 	return &documentOptions{Documents: docs}
 }
@@ -740,45 +697,30 @@ type evaluatorOptions struct {
 // EvaluatorOption is an option for providing a dataset to evaluate.
 // It applies only to [Evaluator.Evaluate].
 type EvaluatorOption interface {
-	applyEvaluator(*evaluatorOptions) error
+	applyEvaluator(*evaluatorOptions)
 }
 
 // applyEvaluator applies the option to the evaluator options.
-func (o *evaluatorOptions) applyEvaluator(evalOpts *evaluatorOptions) error {
-	if err := o.applyConfig(&evalOpts.configOptions); err != nil {
-		return err
-	}
+func (o *evaluatorOptions) applyEvaluator(evalOpts *evaluatorOptions) {
+	o.applyConfig(&evalOpts.configOptions)
 
-	if o.Dataset != nil {
-		if evalOpts.Dataset != nil {
-			return errors.New("cannot set dataset more than once (WithDataset)")
-		}
-		evalOpts.Dataset = o.Dataset
-	}
-
+	evalOpts.Dataset = append(evalOpts.Dataset, o.Dataset...)
 	if o.ID != "" {
-		if evalOpts.ID != "" {
-			return errors.New("cannot set ID more than once (WithID)")
-		}
 		evalOpts.ID = o.ID
 	}
-
 	if o.Evaluator != nil {
-		if evalOpts.Evaluator != nil {
-			return errors.New("cannot set evaluator more than once (WithEvaluator or WithEvaluatorName)")
-		}
 		evalOpts.Evaluator = o.Evaluator
 	}
-
-	return nil
 }
 
-// WithDataset sets the dataset to do evaluation on.
+// WithDataset adds examples to the dataset to evaluate. Repeating this option
+// appends.
 func WithDataset(examples ...*Example) EvaluatorOption {
 	return &evaluatorOptions{Dataset: examples}
 }
 
 // WithID sets the ID of the evaluation to uniquely identify it.
+// Repeating this option takes the last ID set.
 func WithID(ID string) EvaluatorOption {
 	return &evaluatorOptions{ID: ID}
 }
@@ -805,27 +747,17 @@ type embedderOptions struct {
 // EmbedderOption is an option for configuring an embedder request.
 // It applies only to [Embed].
 type EmbedderOption interface {
-	applyEmbedder(*embedderOptions) error
+	applyEmbedder(*embedderOptions)
 }
 
 // applyEmbedder applies the option to the embed options.
-func (o *embedderOptions) applyEmbedder(embedOpts *embedderOptions) error {
-	if err := o.applyConfig(&embedOpts.configOptions); err != nil {
-		return err
-	}
-
-	if err := o.applyDocument(&embedOpts.documentOptions); err != nil {
-		return err
-	}
+func (o *embedderOptions) applyEmbedder(embedOpts *embedderOptions) {
+	o.applyConfig(&embedOpts.configOptions)
+	o.applyDocument(&embedOpts.documentOptions)
 
 	if o.Embedder != nil {
-		if embedOpts.Embedder != nil {
-			return errors.New("cannot set embedder more than once (WithEmbedder or WithEmbedderName)")
-		}
 		embedOpts.Embedder = o.Embedder
 	}
-
-	return nil
 }
 
 // WithEmbedder sets either a [Embedder] or a [EmbedderRef] that may contain a config.
@@ -850,27 +782,17 @@ type retrieverOptions struct {
 // RetrieverOption is an option for configuring a retriever request.
 // It applies only to [Retriever.Retrieve].
 type RetrieverOption interface {
-	applyRetriever(*retrieverOptions) error
+	applyRetriever(*retrieverOptions)
 }
 
 // applyRetriever applies the option to the retrieve options.
-func (o *retrieverOptions) applyRetriever(retOpts *retrieverOptions) error {
-	if err := o.applyConfig(&retOpts.configOptions); err != nil {
-		return err
-	}
-
-	if err := o.applyDocument(&retOpts.documentOptions); err != nil {
-		return err
-	}
+func (o *retrieverOptions) applyRetriever(retOpts *retrieverOptions) {
+	o.applyConfig(&retOpts.configOptions)
+	o.applyDocument(&retOpts.documentOptions)
 
 	if o.Retriever != nil {
-		if retOpts.Retriever != nil {
-			return errors.New("cannot set retriever more than once (WithRetriever or WithRetrieverName)")
-		}
 		retOpts.Retriever = o.Retriever
 	}
-
-	return nil
 }
 
 // WithRetriever sets either a [Retriever] or a [RetrieverRef] that may contain a config.
@@ -899,64 +821,35 @@ type generateOptions struct {
 
 // GenerateOption is an option for generating a model response. It applies only to Generate().
 type GenerateOption interface {
-	applyGenerate(*generateOptions) error
+	applyGenerate(*generateOptions)
 }
 
 // applyGenerate applies the option to the generate options.
-func (o *generateOptions) applyGenerate(genOpts *generateOptions) error {
-	if err := o.commonGenOptions.applyGenerate(genOpts); err != nil {
-		return err
-	}
+func (o *generateOptions) applyGenerate(genOpts *generateOptions) {
+	o.commonGenOptions.applyGenerate(genOpts)
+	o.promptingOptions.applyGenerate(genOpts)
+	o.outputOptions.applyGenerate(genOpts)
+	o.executionOptions.applyGenerate(genOpts)
+	o.documentOptions.applyGenerate(genOpts)
 
-	if err := o.promptingOptions.applyGenerate(genOpts); err != nil {
-		return err
-	}
-
-	if err := o.outputOptions.applyGenerate(genOpts); err != nil {
-		return err
-	}
-
-	if err := o.executionOptions.applyGenerate(genOpts); err != nil {
-		return err
-	}
-
-	if err := o.documentOptions.applyGenerate(genOpts); err != nil {
-		return err
-	}
-
-	if o.RespondParts != nil {
-		if genOpts.RespondParts != nil {
-			return errors.New("cannot set respond parts more than once (WithToolResponses)")
-		}
-		genOpts.RespondParts = o.RespondParts
-	}
-
-	if o.RestartParts != nil {
-		if genOpts.RestartParts != nil {
-			return errors.New("cannot set restart parts more than once (WithToolRestarts)")
-		}
-		genOpts.RestartParts = o.RestartParts
-	}
-
+	genOpts.RespondParts = append(genOpts.RespondParts, o.RespondParts...)
+	genOpts.RestartParts = append(genOpts.RestartParts, o.RestartParts...)
 	if o.StepName != "" {
-		if genOpts.StepName != "" {
-			return errors.New("cannot set step name more than once (WithStepName)")
-		}
 		genOpts.StepName = o.StepName
 	}
-
-	return nil
 }
 
 // WithToolResponses provides resolved responses for interrupted tool calls.
-// Use this when you already have the result and want to skip re-executing the tool.
+// Use this when you already have the result and want to skip re-executing the
+// tool. Repeating this option appends.
 func WithToolResponses(parts ...*Part) GenerateOption {
 	return &generateOptions{RespondParts: parts}
 }
 
 // WithToolRestarts re-executes interrupted tool calls with additional metadata.
-// Use this when the original call lacked required context (e.g., auth, user confirmation)
-// that should now allow the tool to complete successfully.
+// Use this when the original call lacked required context (e.g., auth, user
+// confirmation) that should now allow the tool to complete successfully.
+// Repeating this option appends.
 func WithToolRestarts(parts ...*Part) GenerateOption {
 	return &generateOptions{RestartParts: parts}
 }
@@ -969,18 +862,15 @@ type toolOptions struct {
 
 // ToolOption is an option for defining a tool.
 type ToolOption interface {
-	applyTool(*toolOptions) error
+	applyTool(*toolOptions)
 }
 
 // applyTool applies the option to the tool options.
-func (o *toolOptions) applyTool(opts *toolOptions) error {
+func (o *toolOptions) applyTool(opts *toolOptions) {
 	if o.StrictSchema != nil {
-		if opts.StrictSchema != nil {
-			return errors.New("cannot set strict schema more than once (WithStrictSchema)")
-		}
 		opts.StrictSchema = o.StrictSchema
 	}
-	return o.inputOptions.applyTool(opts)
+	o.inputOptions.applyTool(opts)
 }
 
 // WithStrictSchema controls whether the provider enforces strict JSON schema
@@ -1004,35 +894,23 @@ type promptExecutionOptions struct {
 
 // PromptExecuteOption is an option for executing a prompt. It applies only to [prompt.Execute].
 type PromptExecuteOption interface {
-	applyPromptExecute(*promptExecutionOptions) error
+	applyPromptExecute(*promptExecutionOptions)
 }
 
 // applyPromptExecute applies the option to the prompt request options.
-func (o *promptExecutionOptions) applyPromptExecute(pgOpts *promptExecutionOptions) error {
-	if err := o.commonGenOptions.applyPromptExecute(pgOpts); err != nil {
-		return err
-	}
-
-	if err := o.executionOptions.applyPromptExecute(pgOpts); err != nil {
-		return err
-	}
-
-	if err := o.documentOptions.applyPromptExecute(pgOpts); err != nil {
-		return err
-	}
+func (o *promptExecutionOptions) applyPromptExecute(pgOpts *promptExecutionOptions) {
+	o.commonGenOptions.applyPromptExecute(pgOpts)
+	o.executionOptions.applyPromptExecute(pgOpts)
+	o.documentOptions.applyPromptExecute(pgOpts)
 
 	if o.Input != nil {
-		if pgOpts.Input != nil {
-			return errors.New("cannot set input more than once (WithInput)")
-		}
 		pgOpts.Input = o.Input
 	}
-
-	return nil
 }
 
 // WithInput sets the input for the prompt request. Input must conform to the
 // prompt's input schema and can either be a map[string]any or a struct of the same api.
+// Repeating this option takes the last input set.
 func WithInput(input any) PromptExecuteOption {
 	return &promptExecutionOptions{Input: input}
 }

--- a/go/ai/option.go
+++ b/go/ai/option.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/firebase/genkit/go/core"
 )
@@ -37,6 +38,12 @@ import (
 //     like each fill one slot, so the final call wins and earlier ones are
 //     overwritten rather than rejected.
 //
+// A zero value does not fill a slot: WithMaxTurns(0), WithToolChoice(""), or
+// WithConfig(nil) is a no-op, so an earlier non-zero value cannot be un-set by
+// a later zero one. The rules apply within a single options list; APIs that
+// layer two lists (a prompt's define-time options against Execute-time
+// options) document their own precedence.
+//
 // Applying options therefore never fails on a "set more than once" conflict.
 // The only failures are genuinely invalid arguments (for example a type that
 // WithInputType cannot turn into a schema), which panic at the call site where
@@ -51,7 +58,8 @@ type MessagesFn = func(context.Context, any) ([]*Message, error)
 // appendMessagesFn composes two message-producing functions so their outputs
 // concatenate in call order. It backs the accumulate semantics of
 // [WithMessages] and [WithMessagesFn]: passing several of them (in any mix)
-// appends their messages instead of overwriting.
+// appends their messages instead of overwriting. Either side may be nil, in
+// which case the other is returned unwrapped.
 func appendMessagesFn(existing, next MessagesFn) MessagesFn {
 	if existing == nil {
 		return next
@@ -68,13 +76,11 @@ func appendMessagesFn(existing, next MessagesFn) MessagesFn {
 		if err != nil {
 			return nil, err
 		}
-		// Copy rather than append onto before: WithMessages(history...) hands
-		// the caller's slice straight through, so appending in place would
-		// write into the spare capacity of the array backing their history.
-		msgs := make([]*Message, 0, len(before)+len(after))
-		msgs = append(msgs, before...)
-		msgs = append(msgs, after...)
-		return msgs, nil
+		// Concat rather than append onto before: WithMessages(history...)
+		// hands the caller's slice straight through, so appending in place
+		// would write into the spare capacity of the array backing their
+		// history. Concat always allocates a fresh slice.
+		return slices.Concat(before, after), nil
 	}
 }
 
@@ -168,9 +174,7 @@ type CommonGenOption interface {
 func (o *commonGenOptions) applyCommonGen(opts *commonGenOptions) {
 	o.configOptions.applyConfig(&opts.configOptions)
 
-	if o.MessagesFn != nil {
-		opts.MessagesFn = appendMessagesFn(opts.MessagesFn, o.MessagesFn)
-	}
+	opts.MessagesFn = appendMessagesFn(opts.MessagesFn, o.MessagesFn)
 	if o.Model != nil {
 		opts.Model = o.Model
 	}
@@ -306,14 +310,14 @@ type InputOption interface {
 	applyTool(*toolOptions)
 }
 
-// applyInput applies the option to the input options. The schema and the
-// default input are independent single-value slots, so the last option to set
-// each one wins.
+// applyInput applies the option to the input options. The input configuration
+// is one slot: the last option to set it replaces both the schema and the
+// default input together, so overriding [WithInputType] with [WithInputSchema]
+// or [WithInputSchemaName] does not leave the old type's defaults behind to be
+// rendered against the new schema.
 func (o *inputOptions) applyInput(opts *inputOptions) {
-	if o.InputSchema != nil {
+	if o.InputSchema != nil || o.DefaultInput != nil {
 		opts.InputSchema = o.InputSchema
-	}
-	if o.DefaultInput != nil {
 		opts.DefaultInput = o.DefaultInput
 	}
 }
@@ -625,9 +629,53 @@ func (o *executionOptions) applyPromptExecute(pgOpts *promptExecutionOptions) {
 
 // WithStreaming sets the stream callback for the generate request.
 // A callback is a function that is called with each chunk of the generated response before the final response is returned.
-// Repeating this option takes the last callback set.
+// Repeating this option takes the last callback set. The stream-returning
+// APIs ([GenerateStream], [Prompt.ExecuteStream], and their typed variants)
+// attach their own iterator callback without displacing one set here; both
+// receive every chunk.
 func WithStreaming(callback ModelStreamCallback) ExecutionOption {
 	return &executionOptions{Stream: callback}
+}
+
+// chainedStreamingOption installs a stream callback without displacing one the
+// caller already set: any existing callback runs first, then this one. The
+// stream-returning wrappers use it to attach their iterator callback while
+// keeping a caller-supplied [WithStreaming] observable; a plain WithStreaming
+// appended after the caller's options would win the last-win slot and
+// silently drop theirs.
+type chainedStreamingOption struct {
+	callback ModelStreamCallback
+}
+
+// applyExecution chains the callback after any existing one.
+func (o *chainedStreamingOption) applyExecution(execOpts *executionOptions) {
+	if prev := execOpts.Stream; prev != nil {
+		next := o.callback
+		execOpts.Stream = func(ctx context.Context, chunk *ModelResponseChunk) error {
+			if err := prev(ctx, chunk); err != nil {
+				return err
+			}
+			return next(ctx, chunk)
+		}
+		return
+	}
+	execOpts.Stream = o.callback
+}
+
+// applyGenerate applies the option to the generate options.
+func (o *chainedStreamingOption) applyGenerate(genOpts *generateOptions) {
+	o.applyExecution(&genOpts.executionOptions)
+}
+
+// applyPromptExecute applies the option to the prompt request options.
+func (o *chainedStreamingOption) applyPromptExecute(pgOpts *promptExecutionOptions) {
+	o.applyExecution(&pgOpts.executionOptions)
+}
+
+// withChainedStreaming returns an option that adds callback after any
+// already-set stream callback instead of replacing it.
+func withChainedStreaming(callback ModelStreamCallback) ExecutionOption {
+	return &chainedStreamingOption{callback: callback}
 }
 
 // documentOptions are options for providing context documents to a prompt or generate request or as input to an embedder.
@@ -910,7 +958,9 @@ func (o *promptExecutionOptions) applyPromptExecute(pgOpts *promptExecutionOptio
 
 // WithInput sets the input for the prompt request. Input must conform to the
 // prompt's input schema and can either be a map[string]any or a struct of the same api.
-// Repeating this option takes the last input set.
+// Repeating this option takes the last input set. APIs that take the input as
+// a typed argument ([DataPrompt.Execute], [DataPrompt.ExecuteStream]) apply
+// that argument after these options, so the typed argument wins.
 func WithInput(input any) PromptExecuteOption {
 	return &promptExecutionOptions{Input: input}
 }

--- a/go/ai/option_test.go
+++ b/go/ai/option_test.go
@@ -25,339 +25,266 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-func TestCommonOptions(t *testing.T) {
-	tests := []struct {
-		name    string
-		opts    []CommonGenOption
-		wantErr bool
-	}{
-		{
-			name: "valid options",
-			opts: []CommonGenOption{
-				WithMessages(NewUserTextMessage("test")),
-				WithConfig(&GenerationCommonConfig{Temperature: 0.7}),
-				WithModel(&mockModel{name: "test/model"}),
-				WithTools(&mockTool{name: "test/tool"}),
-				WithToolChoice(ToolChoiceAuto),
-				WithMaxTurns(3),
-				WithReturnToolRequests(true),
-				WithMiddleware(func(next ModelFunc) ModelFunc { return next }),
-			},
-			wantErr: false,
-		},
-		{
-			name: "mutually exclusive - messages",
-			opts: []CommonGenOption{
-				WithMessages(NewUserTextMessage("test")),
-				WithMessagesFn(func(context.Context, any) ([]*Message, error) { return nil, nil }),
-			},
-			wantErr: true,
-		},
-		{
-			name: "mutually exclusive - model",
-			opts: []CommonGenOption{
-				WithModel(&mockModel{name: "test/model"}),
-				WithModelName("test/model"),
-			},
-			wantErr: true,
-		},
+// applyGen builds a generateOptions from the given options, mirroring what
+// Generate does internally.
+func applyGen(opts ...GenerateOption) *generateOptions {
+	g := &generateOptions{}
+	for _, o := range opts {
+		o.applyGenerate(g)
 	}
+	return g
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			genOpts := &generateOptions{}
-			promptOpts := &promptOptions{}
-			pgOpts := &promptExecutionOptions{}
+// messageText renders the concatenated text of a MessagesFn's output, for
+// asserting on accumulation order.
+func messageText(t *testing.T, fn MessagesFn) []string {
+	t.Helper()
+	if fn == nil {
+		return nil
+	}
+	msgs, err := fn(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("MessagesFn error: %v", err)
+	}
+	out := make([]string, len(msgs))
+	for i, m := range msgs {
+		out[i] = m.Text()
+	}
+	return out
+}
 
-			var err error
-			for _, opt := range tt.opts {
-				err = opt.applyGenerate(genOpts)
-				if err != nil {
-					break
-				}
-			}
+// TestCollectionOptionsAccumulate verifies that options carrying multiple items
+// append across repeated calls (and across their variants) rather than
+// erroring or overwriting.
+func TestCollectionOptionsAccumulate(t *testing.T) {
+	t.Run("messages append across WithMessages and WithMessagesFn", func(t *testing.T) {
+		g := applyGen(
+			WithMessages(NewUserTextMessage("a")),
+			WithMessages(NewUserTextMessage("b"), NewUserTextMessage("c")),
+			WithMessagesFn(func(context.Context, any) ([]*Message, error) {
+				return []*Message{NewUserTextMessage("d")}, nil
+			}),
+		)
+		want := []string{"a", "b", "c", "d"}
+		if diff := cmp.Diff(want, messageText(t, g.MessagesFn)); diff != "" {
+			t.Errorf("messages diff (-want +got):\n%s", diff)
+		}
+	})
 
-			if (err != nil) != tt.wantErr {
-				t.Errorf("applyGenerate() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+	t.Run("messages do not alias the caller's slice", func(t *testing.T) {
+		// WithMessages(history...) hands the caller's slice straight through,
+		// so appending onto it in place would corrupt their history.
+		history := make([]*Message, 1, 4)
+		history[0] = NewUserTextMessage("original")
+		g := applyGen(
+			WithMessages(history...),
+			WithMessages(NewUserTextMessage("appended")),
+		)
+		if got := messageText(t, g.MessagesFn); len(got) != 2 {
+			t.Fatalf("messages = %v, want 2 entries", got)
+		}
+		if history[0].Text() != "original" {
+			t.Errorf("caller history was mutated: got %q, want %q", history[0].Text(), "original")
+		}
+		if len(history) != 1 {
+			t.Errorf("len(history) = %d, want 1", len(history))
+		}
+	})
 
-			if tt.wantErr {
-				return
-			}
+	t.Run("tools append", func(t *testing.T) {
+		t1 := &mockTool{name: "t/1"}
+		t2 := &mockTool{name: "t/2"}
+		t3 := &mockTool{name: "t/3"}
+		g := applyGen(WithTools(t1, t2), WithTools(t3))
+		if diff := cmp.Diff([]ToolRef{t1, t2, t3}, g.Tools,
+			cmpopts.IgnoreUnexported(mockTool{})); diff != "" {
+			t.Errorf("tools diff (-want +got):\n%s", diff)
+		}
+	})
 
-			for _, opt := range tt.opts {
-				if err = opt.applyPrompt(promptOpts); err != nil {
-					t.Errorf("applyPrompt() unexpected error = %v", err)
-					return
-				}
-			}
+	t.Run("docs append across WithDocs and WithTextDocs", func(t *testing.T) {
+		g := applyGen(WithDocs(DocumentFromText("doc", nil)), WithTextDocs("text"))
+		if len(g.Documents) != 2 {
+			t.Fatalf("len(Documents) = %d, want 2", len(g.Documents))
+		}
+	})
 
-			for _, opt := range tt.opts {
-				if err = opt.applyPromptExecute(pgOpts); err != nil {
-					t.Errorf("applyPromptExecute() unexpected error = %v", err)
-					return
-				}
-			}
-		})
+	t.Run("resources append", func(t *testing.T) {
+		res := func(name string) Resource {
+			return NewResource(name, &ResourceOptions{URI: "res://" + name},
+				func(context.Context, *ResourceInput) (*ResourceOutput, error) { return nil, nil })
+		}
+		g := applyGen(WithResources(res("a")), WithResources(res("b"), res("c")))
+		if len(g.Resources) != 3 {
+			t.Errorf("len(Resources) = %d, want 3", len(g.Resources))
+		}
+	})
+
+	t.Run("middleware appends in order", func(t *testing.T) {
+		g := applyGen(
+			WithMiddleware(func(next ModelFunc) ModelFunc { return next }),
+			WithMiddleware(
+				func(next ModelFunc) ModelFunc { return next },
+				func(next ModelFunc) ModelFunc { return next },
+			),
+		)
+		if len(g.Middleware) != 3 {
+			t.Errorf("len(Middleware) = %d, want 3", len(g.Middleware))
+		}
+	})
+
+	t.Run("tool responses and restarts append", func(t *testing.T) {
+		g := applyGen(
+			WithToolResponses(NewTextPart("r1")),
+			WithToolResponses(NewTextPart("r2")),
+			WithToolRestarts(NewTextPart("s1")),
+			WithToolRestarts(NewTextPart("s2")),
+		)
+		if len(g.RespondParts) != 2 {
+			t.Errorf("len(RespondParts) = %d, want 2", len(g.RespondParts))
+		}
+		if len(g.RestartParts) != 2 {
+			t.Errorf("len(RestartParts) = %d, want 2", len(g.RestartParts))
+		}
+	})
+
+	t.Run("dataset appends", func(t *testing.T) {
+		e := &evaluatorOptions{}
+		for _, o := range []EvaluatorOption{
+			WithDataset(&Example{}),
+			WithDataset(&Example{}, &Example{}),
+		} {
+			o.applyEvaluator(e)
+		}
+		if len(e.Dataset) != 3 {
+			t.Errorf("len(Dataset) = %d, want 3", len(e.Dataset))
+		}
+	})
+}
+
+// TestSingleValueOptionsLastWins verifies that options filling a single slot
+// take the last value set instead of erroring on repeats.
+func TestSingleValueOptionsLastWins(t *testing.T) {
+	t.Run("model: WithModel then WithModelName", func(t *testing.T) {
+		g := applyGen(WithModel(&mockModel{name: "first/model"}), WithModelName("second/model"))
+		if g.Model == nil || g.Model.Name() != "second/model" {
+			t.Errorf("Model = %v, want name second/model", g.Model)
+		}
+	})
+
+	t.Run("config: last wins", func(t *testing.T) {
+		last := &GenerationCommonConfig{Temperature: 0.9}
+		g := applyGen(WithConfig(&GenerationCommonConfig{Temperature: 0.1}), WithConfig(last))
+		if g.Config != last {
+			t.Errorf("Config = %v, want %v", g.Config, last)
+		}
+	})
+
+	t.Run("tool choice, max turns, return tool requests: last wins", func(t *testing.T) {
+		g := applyGen(
+			WithToolChoice(ToolChoiceAuto), WithToolChoice(ToolChoiceRequired),
+			WithMaxTurns(2), WithMaxTurns(7),
+			WithReturnToolRequests(true), WithReturnToolRequests(false),
+		)
+		if g.ToolChoice != ToolChoiceRequired {
+			t.Errorf("ToolChoice = %q, want %q", g.ToolChoice, ToolChoiceRequired)
+		}
+		if g.MaxTurns != 7 {
+			t.Errorf("MaxTurns = %d, want 7", g.MaxTurns)
+		}
+		if g.ReturnToolRequests == nil || *g.ReturnToolRequests {
+			t.Errorf("ReturnToolRequests = %v, want false", g.ReturnToolRequests)
+		}
+	})
+
+	t.Run("system and prompt: last wins across text and fn", func(t *testing.T) {
+		g := applyGen(
+			WithSystem("sys one"),
+			WithSystemFn(func(context.Context, any) (string, error) { return "sys two", nil }),
+			WithPrompt("usr one"),
+			WithPrompt("usr two"),
+		)
+		if sys, _ := g.SystemFn(context.Background(), nil); sys != "sys two" {
+			t.Errorf("system = %q, want %q", sys, "sys two")
+		}
+		if usr, _ := g.PromptFn(context.Background(), nil); usr != "usr two" {
+			t.Errorf("prompt = %q, want %q", usr, "usr two")
+		}
+	})
+
+	t.Run("streaming: last wins, no error on repeat", func(t *testing.T) {
+		g := applyGen(
+			WithStreaming(func(context.Context, *ModelResponseChunk) error { return nil }),
+			WithStreaming(func(context.Context, *ModelResponseChunk) error { return nil }),
+		)
+		if g.Stream == nil {
+			t.Error("Stream is nil, want non-nil")
+		}
+	})
+
+	t.Run("prompt input: last wins", func(t *testing.T) {
+		opts := &promptExecutionOptions{}
+		for _, o := range []PromptExecuteOption{WithInput("input1"), WithInput("input2")} {
+			o.applyPromptExecute(opts)
+		}
+		if opts.Input != "input2" {
+			t.Errorf("Input = %v, want input2", opts.Input)
+		}
+	})
+
+	t.Run("input schema: last wins across variants", func(t *testing.T) {
+		opts := &promptOptions{}
+		for _, o := range []InputOption{
+			WithInputType(struct {
+				Test string `json:"test"`
+			}{}),
+			WithInputSchemaName("Override"),
+		} {
+			o.applyPrompt(opts)
+		}
+		if ref, _ := opts.InputSchema["$ref"].(string); ref != "genkit:Override" {
+			t.Errorf("InputSchema.$ref = %v, want genkit:Override", opts.InputSchema["$ref"])
+		}
+	})
+}
+
+// TestOutputSchemaLastWins verifies the output-schema slot behaves as last-wins,
+// which is what lets GenerateData inject a schema that a caller can override.
+func TestOutputSchemaLastWins(t *testing.T) {
+	custom := map[string]any{"type": "object", "properties": map[string]any{"n": map[string]any{"type": "string"}}}
+
+	// Simulate GenerateData's prepend: the inferred type is applied first, the
+	// caller's explicit schema second.
+	g := applyGen(
+		WithOutputType(struct {
+			Value int `json:"value"`
+		}{}),
+		WithOutputSchema(custom),
+	)
+	if diff := cmp.Diff(custom, g.OutputSchema); diff != "" {
+		t.Errorf("OutputSchema not overridden by caller (-want +got):\n%s", diff)
+	}
+	if g.OutputFormat != OutputFormatJSON {
+		t.Errorf("OutputFormat = %q, want %q", g.OutputFormat, OutputFormatJSON)
 	}
 }
 
 func TestPromptOptions(t *testing.T) {
-	tests := []struct {
-		name    string
-		opts    []PromptOption
-		wantErr bool
-	}{
-		{
-			name: "valid options",
-			opts: []PromptOption{
-				WithDescription("test description"),
-				WithMetadata(map[string]any{"key": "value"}),
-				WithInputType(struct {
-					Test string `json:"test"`
-				}{}),
-			},
-			wantErr: false,
-		},
+	opts := &promptOptions{}
+	for _, o := range []PromptOption{
+		WithDescription("test description"),
+		WithMetadata(map[string]any{"key": "value"}),
+		WithInputType(struct {
+			Test string `json:"test"`
+		}{}),
+	} {
+		o.applyPrompt(opts)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			opts := &promptOptions{}
-			var err error
-			for _, opt := range tt.opts {
-				err = opt.applyPrompt(opts)
-				if err != nil {
-					break
-				}
-			}
-			if (err != nil) != tt.wantErr {
-				t.Errorf("applyPrompt() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
+	if opts.Description != "test description" {
+		t.Errorf("Description = %q, want %q", opts.Description, "test description")
 	}
-}
-
-func TestPromptingOptions(t *testing.T) {
-	tests := []struct {
-		name    string
-		opts    []PromptingOption
-		wantErr bool
-	}{
-		{
-			name: "valid options",
-			opts: []PromptingOption{
-				WithSystem("system instruction"),
-				WithPrompt("user prompt"),
-			},
-			wantErr: false,
-		},
-		{
-			name: "mutually exclusive - system",
-			opts: []PromptingOption{
-				WithSystem("system instruction"),
-				WithSystemFn(func(context.Context, any) (string, error) { return "system", nil }),
-			},
-			wantErr: true,
-		},
-		{
-			name: "mutually exclusive - prompt",
-			opts: []PromptingOption{
-				WithPrompt("user prompt"),
-				WithPromptFn(func(context.Context, any) (string, error) { return "prompt", nil }),
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			genOpts := &generateOptions{}
-			promptOpts := &promptOptions{}
-
-			var err error
-			for _, opt := range tt.opts {
-				err = opt.applyGenerate(genOpts)
-				if err != nil {
-					break
-				}
-			}
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("applyGenerate() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
-			if tt.wantErr {
-				return
-			}
-
-			for _, opt := range tt.opts {
-				if err = opt.applyPrompt(promptOpts); err != nil {
-					t.Errorf("applyPrompt() unexpected error = %v", err)
-					return
-				}
-			}
-		})
-	}
-}
-
-func TestOutputOptions(t *testing.T) {
-	tests := []struct {
-		name    string
-		opts    []OutputOption
-		wantErr bool
-	}{
-		{
-			name: "valid - output type",
-			opts: []OutputOption{
-				WithOutputType(struct {
-					Test string `json:"test"`
-				}{}),
-			},
-			wantErr: false,
-		},
-		{
-			name: "valid - output format",
-			opts: []OutputOption{
-				WithOutputFormat(OutputFormatText),
-			},
-			wantErr: false,
-		},
-		{
-			name: "valid - output instruction",
-			opts: []OutputOption{
-				WithOutputInstructions(""),
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			genOpts := &generateOptions{}
-			promptOpts := &promptOptions{}
-
-			var err error
-			for _, opt := range tt.opts {
-				err = opt.applyGenerate(genOpts)
-				if err != nil {
-					break
-				}
-			}
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("applyGenerate() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
-			if tt.wantErr {
-				return
-			}
-
-			for _, opt := range tt.opts {
-				if err = opt.applyPrompt(promptOpts); err != nil {
-					t.Errorf("applyPrompt() unexpected error = %v", err)
-					return
-				}
-			}
-		})
-	}
-}
-
-func TestExecutionOptions(t *testing.T) {
-	tests := []struct {
-		name    string
-		opts    []ExecutionOption
-		wantErr bool
-	}{
-		{
-			name: "valid options",
-			opts: []ExecutionOption{
-				WithStreaming(func(context.Context, *ModelResponseChunk) error { return nil }),
-			},
-			wantErr: false,
-		},
-		{
-			name: "duplicate - streaming",
-			opts: []ExecutionOption{
-				WithStreaming(func(context.Context, *ModelResponseChunk) error { return nil }),
-				WithStreaming(func(context.Context, *ModelResponseChunk) error { return nil }),
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			genOpts := &generateOptions{}
-			pgOpts := &promptExecutionOptions{}
-
-			var err error
-			for _, opt := range tt.opts {
-				err = opt.applyGenerate(genOpts)
-				if err != nil {
-					break
-				}
-			}
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("applyGenerate() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
-			if tt.wantErr {
-				return
-			}
-
-			for _, opt := range tt.opts {
-				if err = opt.applyPromptExecute(pgOpts); err != nil {
-					t.Errorf("applyPromptExecute() unexpected error = %v", err)
-					return
-				}
-			}
-		})
-	}
-}
-
-func TestPromptGenerateOptions(t *testing.T) {
-	tests := []struct {
-		name    string
-		opts    []PromptExecuteOption
-		wantErr bool
-	}{
-		{
-			name: "valid options",
-			opts: []PromptExecuteOption{
-				WithInput(map[string]string{"key": "value"}),
-			},
-			wantErr: false,
-		},
-		{
-			name: "duplicate - input",
-			opts: []PromptExecuteOption{
-				WithInput("input1"),
-				WithInput("input2"),
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			opts := &promptExecutionOptions{}
-			var err error
-			for _, opt := range tt.opts {
-				err = opt.applyPromptExecute(opts)
-				if err != nil {
-					break
-				}
-			}
-			if (err != nil) != tt.wantErr {
-				t.Errorf("applyPromptExecute() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
+	if opts.InputSchema == nil {
+		t.Error("InputSchema is nil")
 	}
 }
 
@@ -388,9 +315,7 @@ func TestGenerateOptionsComplete(t *testing.T) {
 	}
 
 	for _, opt := range options {
-		if err := opt.applyGenerate(opts); err != nil {
-			t.Fatalf("Failed to apply option: %v", err)
-		}
+		opt.applyGenerate(opts)
 	}
 
 	returnToolRequests := true
@@ -485,9 +410,7 @@ func TestPromptOptionsComplete(t *testing.T) {
 	}
 
 	for _, opt := range options {
-		if err := opt.applyPrompt(opts); err != nil {
-			t.Fatalf("Failed to apply option: %v", err)
-		}
+		opt.applyPrompt(opts)
 	}
 
 	returnToolRequests := true
@@ -580,9 +503,7 @@ func TestPromptExecuteOptionsComplete(t *testing.T) {
 	}
 
 	for _, opt := range options {
-		if err := opt.applyPromptExecute(opts); err != nil {
-			t.Fatalf("Failed to apply option: %v", err)
-		}
+		opt.applyPromptExecute(opts)
 	}
 
 	returnToolRequests := true
@@ -666,10 +587,7 @@ func TestWithInputSchemaName(t *testing.T) {
 	t.Run("creates input option with schema reference", func(t *testing.T) {
 		opt := WithInputSchemaName("MyInputType")
 		opts := &promptOptions{}
-
-		if err := opt.applyPrompt(opts); err != nil {
-			t.Fatalf("applyPrompt() error: %v", err)
-		}
+		opt.applyPrompt(opts)
 
 		if opts.InputSchema == nil {
 			t.Fatal("InputSchema is nil")
@@ -695,10 +613,7 @@ func TestWithOutputSchema(t *testing.T) {
 		}
 		opt := WithOutputSchema(schema)
 		opts := &generateOptions{}
-
-		if err := opt.applyGenerate(opts); err != nil {
-			t.Fatalf("applyGenerate() error: %v", err)
-		}
+		opt.applyGenerate(opts)
 
 		if opts.OutputSchema == nil {
 			t.Fatal("OutputSchema is nil")
@@ -713,10 +628,7 @@ func TestWithOutputEnums(t *testing.T) {
 	t.Run("creates enum output with string values", func(t *testing.T) {
 		opt := WithOutputEnums("red", "green", "blue")
 		opts := &generateOptions{}
-
-		if err := opt.applyGenerate(opts); err != nil {
-			t.Fatalf("applyGenerate() error: %v", err)
-		}
+		opt.applyGenerate(opts)
 
 		if opts.OutputSchema == nil {
 			t.Fatal("OutputSchema is nil")
@@ -743,10 +655,7 @@ func TestWithOutputEnums(t *testing.T) {
 		type Color string
 		opt := WithOutputEnums(Color("red"), Color("green"))
 		opts := &generateOptions{}
-
-		if err := opt.applyGenerate(opts); err != nil {
-			t.Fatalf("applyGenerate() error: %v", err)
-		}
+		opt.applyGenerate(opts)
 
 		enumVals := opts.OutputSchema["enum"].([]string)
 		if enumVals[0] != "red" || enumVals[1] != "green" {
@@ -759,10 +668,7 @@ func TestWithEvaluatorName(t *testing.T) {
 	t.Run("creates evaluator option with reference", func(t *testing.T) {
 		opt := WithEvaluatorName("test/myEvaluator")
 		opts := &evaluatorOptions{}
-
-		if err := opt.applyEvaluator(opts); err != nil {
-			t.Fatalf("applyEvaluator() error: %v", err)
-		}
+		opt.applyEvaluator(opts)
 
 		if opts.Evaluator == nil {
 			t.Fatal("Evaluator is nil")

--- a/go/ai/option_test.go
+++ b/go/ai/option_test.go
@@ -35,12 +35,12 @@ func applyGen(opts ...GenerateOption) *generateOptions {
 	return g
 }
 
-// messageText renders the concatenated text of a MessagesFn's output, for
+// messageText returns the text of each message a MessagesFn produces, for
 // asserting on accumulation order.
 func messageText(t *testing.T, fn MessagesFn) []string {
 	t.Helper()
 	if fn == nil {
-		return nil
+		t.Fatal("MessagesFn is nil")
 	}
 	msgs, err := fn(context.Background(), nil)
 	if err != nil {
@@ -65,10 +65,7 @@ func TestCollectionOptionsAccumulate(t *testing.T) {
 				return []*Message{NewUserTextMessage("d")}, nil
 			}),
 		)
-		want := []string{"a", "b", "c", "d"}
-		if diff := cmp.Diff(want, messageText(t, g.MessagesFn)); diff != "" {
-			t.Errorf("messages diff (-want +got):\n%s", diff)
-		}
+		assertEqual(t, messageText(t, g.MessagesFn), []string{"a", "b", "c", "d"})
 	})
 
 	t.Run("messages do not alias the caller's slice", func(t *testing.T) {
@@ -109,10 +106,7 @@ func TestCollectionOptionsAccumulate(t *testing.T) {
 		t2 := &mockTool{name: "t/2"}
 		t3 := &mockTool{name: "t/3"}
 		g := applyGen(WithTools(t1, t2), WithTools(t3))
-		if diff := cmp.Diff([]ToolRef{t1, t2, t3}, g.Tools,
-			cmpopts.IgnoreUnexported(mockTool{})); diff != "" {
-			t.Errorf("tools diff (-want +got):\n%s", diff)
-		}
+		assertEqual(t, g.Tools, []ToolRef{t1, t2, t3}, cmpopts.IgnoreUnexported(mockTool{}))
 	})
 
 	t.Run("docs append across WithDocs and WithTextDocs", func(t *testing.T) {
@@ -245,12 +239,12 @@ func TestSingleValueOptionsLastWins(t *testing.T) {
 		}
 	})
 
-	t.Run("input schema: last wins across variants", func(t *testing.T) {
+	t.Run("input config: last wins as one slot, stale defaults cleared", func(t *testing.T) {
 		opts := &promptOptions{}
 		for _, o := range []InputOption{
 			WithInputType(struct {
 				Test string `json:"test"`
-			}{}),
+			}{Test: "stale"}),
 			WithInputSchemaName("Override"),
 		} {
 			o.applyPrompt(opts)
@@ -258,28 +252,30 @@ func TestSingleValueOptionsLastWins(t *testing.T) {
 		if ref, _ := opts.InputSchema["$ref"].(string); ref != "genkit:Override" {
 			t.Errorf("InputSchema.$ref = %v, want genkit:Override", opts.InputSchema["$ref"])
 		}
+		// The schema override replaces the whole input config: the default
+		// input inferred from the overridden type must not survive to be
+		// rendered against the new schema.
+		if opts.DefaultInput != nil {
+			t.Errorf("DefaultInput = %v, want nil after schema override", opts.DefaultInput)
+		}
 	})
-}
 
-// TestOutputSchemaLastWins verifies the output-schema slot behaves as last-wins,
-// which is what lets GenerateData inject a schema that a caller can override.
-func TestOutputSchemaLastWins(t *testing.T) {
-	custom := map[string]any{"type": "object", "properties": map[string]any{"n": map[string]any{"type": "string"}}}
+	t.Run("output schema: last wins, keeping JSON format", func(t *testing.T) {
+		custom := map[string]any{"type": "object", "properties": map[string]any{"n": map[string]any{"type": "string"}}}
 
-	// Simulate GenerateData's prepend: the inferred type is applied first, the
-	// caller's explicit schema second.
-	g := applyGen(
-		WithOutputType(struct {
-			Value int `json:"value"`
-		}{}),
-		WithOutputSchema(custom),
-	)
-	if diff := cmp.Diff(custom, g.OutputSchema); diff != "" {
-		t.Errorf("OutputSchema not overridden by caller (-want +got):\n%s", diff)
-	}
-	if g.OutputFormat != OutputFormatJSON {
-		t.Errorf("OutputFormat = %q, want %q", g.OutputFormat, OutputFormatJSON)
-	}
+		// Mirrors GenerateData's prepend: the inferred type is applied first,
+		// the caller's explicit schema second.
+		g := applyGen(
+			WithOutputType(struct {
+				Value int `json:"value"`
+			}{}),
+			WithOutputSchema(custom),
+		)
+		assertEqual(t, g.OutputSchema, custom)
+		if g.OutputFormat != OutputFormatJSON {
+			t.Errorf("OutputFormat = %q, want %q", g.OutputFormat, OutputFormatJSON)
+		}
+	})
 }
 
 func TestPromptOptions(t *testing.T) {

--- a/go/ai/option_test.go
+++ b/go/ai/option_test.go
@@ -72,22 +72,35 @@ func TestCollectionOptionsAccumulate(t *testing.T) {
 	})
 
 	t.Run("messages do not alias the caller's slice", func(t *testing.T) {
-		// WithMessages(history...) hands the caller's slice straight through,
-		// so appending onto it in place would corrupt their history.
+		// WithMessages(history...) hands the caller's slice straight through.
+		// Appending onto it would land in the spare capacity of the array
+		// backing history, which is invisible until the caller appends to
+		// their own slice and silently rewrites the messages we produced.
 		history := make([]*Message, 1, 4)
 		history[0] = NewUserTextMessage("original")
+
 		g := applyGen(
 			WithMessages(history...),
 			WithMessages(NewUserTextMessage("appended")),
 		)
-		if got := messageText(t, g.MessagesFn); len(got) != 2 {
-			t.Fatalf("messages = %v, want 2 entries", got)
+		msgs, err := g.MessagesFn(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("MessagesFn error: %v", err)
+		}
+		if len(msgs) != 2 {
+			t.Fatalf("len(msgs) = %d, want 2", len(msgs))
+		}
+
+		// The caller keeps building their own history, reusing index 1 of the
+		// shared array. Our already-produced messages must not change.
+		history = append(history, NewUserTextMessage("caller's next turn"))
+
+		if msgs[1].Text() != "appended" {
+			t.Errorf("produced messages aliased the caller's array: msgs[1] = %q, want %q",
+				msgs[1].Text(), "appended")
 		}
 		if history[0].Text() != "original" {
 			t.Errorf("caller history was mutated: got %q, want %q", history[0].Text(), "original")
-		}
-		if len(history) != 1 {
-			t.Errorf("len(history) = %d, want 1", len(history))
 		}
 	})
 

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -73,9 +73,7 @@ func DefinePrompt(r api.Registry, name string, opts ...PromptOption) Prompt {
 
 	pOpts := &promptOptions{}
 	for _, opt := range opts {
-		if err := opt.applyPrompt(pOpts); err != nil {
-			panic(fmt.Errorf("ai.DefinePrompt: error applying options: %w", err))
-		}
+		opt.applyPrompt(pOpts)
 	}
 
 	p := &prompt{
@@ -161,9 +159,7 @@ func (p *prompt) Execute(ctx context.Context, opts ...PromptExecuteOption) (*Mod
 
 	execOpts := &promptExecutionOptions{}
 	for _, opt := range opts {
-		if err := opt.applyPromptExecute(execOpts); err != nil {
-			return nil, fmt.Errorf("Prompt.Execute: error applying options: %w", err)
-		}
+		opt.applyPromptExecute(execOpts)
 	}
 	// Render() should populate all data from the prompt. Prompt fields should
 	// *not* be referenced in this function as it may have been loaded from

--- a/go/ai/prompt.go
+++ b/go/ai/prompt.go
@@ -87,7 +87,9 @@ func DefinePrompt(r api.Registry, name string, opts ...PromptOption) Prompt {
 	}
 
 	if modelRef, ok := pOpts.Model.(ModelRef); ok && pOpts.Config == nil {
-		pOpts.Config = modelRef.Config()
+		if cfg := modelRef.Config(); !base.IsNil(cfg) {
+			pOpts.Config = cfg
+		}
 	}
 
 	var tools []string
@@ -170,7 +172,9 @@ func (p *prompt) Execute(ctx context.Context, opts ...PromptExecuteOption) (*Mod
 	}
 
 	if modelRef, ok := execOpts.Model.(ModelRef); ok && execOpts.Config == nil {
-		execOpts.Config = modelRef.Config()
+		if cfg := modelRef.Config(); !base.IsNil(cfg) {
+			execOpts.Config = cfg
+		}
 	}
 
 	if execOpts.Config != nil {
@@ -297,7 +301,9 @@ func (p *prompt) ExecuteStream(ctx context.Context, opts ...PromptExecuteOption)
 			return nil
 		}
 
-		allOpts := append(slices.Clone(opts), WithStreaming(cb))
+		// Chain rather than set the callback so a caller-supplied
+		// WithStreaming still receives every chunk.
+		allOpts := append(slices.Clone(opts), withChainedStreaming(cb))
 		resp, err := p.Execute(ctx, allOpts...)
 		if done || errors.Is(err, errStop) {
 			return
@@ -1000,6 +1006,8 @@ func AsDataPrompt[In, Out any](p Prompt) *DataPrompt[In, Out] {
 // Execute executes the typed prompt and returns the strongly-typed output along with the full model response.
 // For structured output types (non-string Out), the prompt must be configured with the appropriate
 // output schema, either through [DefineDataPrompt] or by using [WithOutputType] when defining the prompt.
+// The typed input argument fills the input slot last, so it wins over any
+// [WithInput] passed in opts.
 func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...PromptExecuteOption) (Out, *ModelResponse, error) {
 	if dp == nil {
 		return base.Zero[Out](), nil, status.Errorf(status.ErrInvalidArgument, "DataPrompt.Execute: prompt is nil")
@@ -1032,6 +1040,8 @@ func (dp *DataPrompt[In, Out]) Execute(ctx context.Context, input In, opts ...Pr
 //
 // For structured output types (non-string Out), the prompt must be configured with the appropriate
 // output schema, either through [DefineDataPrompt] or by using [WithOutputType] when defining the prompt.
+// The typed input argument fills the input slot last, so it wins over any
+// [WithInput] passed in opts.
 func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts ...PromptExecuteOption) iter.Seq2[*StreamValue[Out, Out], error] {
 	return func(yield func(*StreamValue[Out, Out], error) bool) {
 		if dp == nil {
@@ -1064,7 +1074,10 @@ func (dp *DataPrompt[In, Out]) ExecuteStream(ctx context.Context, input In, opts
 			return nil
 		}
 
-		allOpts := append(slices.Clone(opts), WithInput(input), WithStreaming(cb))
+		// The typed input is applied last so it wins the input slot; the
+		// iterator callback is chained so a caller-supplied WithStreaming
+		// still receives every chunk.
+		allOpts := append(slices.Clone(opts), WithInput(input), withChainedStreaming(cb))
 		resp, err := dp.prompt.Execute(ctx, allOpts...)
 		if done || errors.Is(err, errStop) {
 			return

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -24,6 +24,7 @@ import (
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/core/api"
 	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/internal/base"
 )
 
 // RetrieverFunc is the function type for retriever implementations.
@@ -162,6 +163,9 @@ func Retrieve(ctx context.Context, r api.Registry, opts ...RetrieverOption) (*Re
 		opt.applyRetriever(retOpts)
 	}
 
+	if len(retOpts.Documents) == 0 {
+		return nil, errors.New("ai.Retrieve: a query document is required (WithDocs or WithTextDocs)")
+	}
 	if len(retOpts.Documents) > 1 {
 		return nil, errors.New("ai.Retrieve: only supports a single document as input")
 	}
@@ -179,7 +183,9 @@ func Retrieve(ctx context.Context, r api.Registry, opts ...RetrieverOption) (*Re
 	}
 
 	if retRef, ok := retOpts.Retriever.(RetrieverRef); ok && retOpts.Config == nil {
-		retOpts.Config = retRef.Config()
+		if cfg := retRef.Config(); !base.IsNil(cfg) {
+			retOpts.Config = cfg
+		}
 	}
 
 	req := &RetrieverRequest{

--- a/go/ai/retriever.go
+++ b/go/ai/retriever.go
@@ -159,9 +159,7 @@ func (r *retriever) Retrieve(ctx context.Context, req *RetrieverRequest) (*Retri
 func Retrieve(ctx context.Context, r api.Registry, opts ...RetrieverOption) (*RetrieverResponse, error) {
 	retOpts := &retrieverOptions{}
 	for _, opt := range opts {
-		if err := opt.applyRetriever(retOpts); err != nil {
-			return nil, fmt.Errorf("ai.Retrieve: error applying options: %w", err)
-		}
+		opt.applyRetriever(retOpts)
 	}
 
 	if len(retOpts.Documents) > 1 {

--- a/go/ai/retriever_test.go
+++ b/go/ai/retriever_test.go
@@ -201,6 +201,16 @@ func TestRetrieverRetrieve(t *testing.T) {
 		}
 	})
 
+	t.Run("Retrieve errors instead of panicking when no document is given", func(t *testing.T) {
+		reg := newTestRegistry(t)
+		r := DefineRetriever(reg, "test/retrieveNoDocs", nil, func(ctx context.Context, req *RetrieverRequest) (*RetrieverResponse, error) {
+			return &RetrieverResponse{}, nil
+		})
+
+		_, err := Retrieve(context.Background(), reg, WithRetriever(r))
+		assertError(t, err, "a query document is required")
+	})
+
 	t.Run("propagates function errors", func(t *testing.T) {
 		reg := newTestRegistry(t)
 		expectedErr := errors.New("retrieval failed")

--- a/go/ai/tools.go
+++ b/go/ai/tools.go
@@ -140,54 +140,49 @@ type RespondOptions struct {
 
 // RespondWithOption is a functional option for [ToolDef.RespondWith].
 type RespondWithOption[Out any] interface {
-	applyRespondWith(*RespondOptions) error
+	applyRespondWith(*RespondOptions)
 }
 
-// applyRespondWith applies the option to the respond options.
-func (o *RespondOptions) applyRespondWith(opts *RespondOptions) error {
+// applyRespondWith applies the option to the respond options. Metadata is a
+// single-value slot, so the last [WithResponseMetadata] set wins.
+func (o *RespondOptions) applyRespondWith(opts *RespondOptions) {
 	if o.Metadata != nil {
-		if opts.Metadata != nil {
-			return errors.New("cannot set metadata more than once (WithResponseMetadata)")
-		}
 		opts.Metadata = o.Metadata
 	}
-	return nil
 }
 
-// WithResponseMetadata sets metadata for the response.
+// WithResponseMetadata sets metadata for the response. Repeating this option
+// replaces the metadata rather than merging it.
 func WithResponseMetadata[Out any](meta map[string]any) RespondWithOption[Out] {
 	return &RespondOptions{Metadata: meta}
 }
 
 // RestartWithOption is a functional option for [ToolDef.RestartWith].
 type RestartWithOption[In any] interface {
-	applyRestartWith(*RestartOptions) error
+	applyRestartWith(*RestartOptions)
 }
 
-// applyRestartWith applies the option to the restart options.
-func (o *RestartOptions) applyRestartWith(opts *RestartOptions) error {
+// applyRestartWith applies the option to the restart options. The replacement
+// input and the resumed metadata are independent single-value slots, so the
+// last option to set each one wins.
+func (o *RestartOptions) applyRestartWith(opts *RestartOptions) {
 	if o.ReplaceInput != nil {
-		if opts.ReplaceInput != nil {
-			return errors.New("cannot set new input more than once (WithNewInput)")
-		}
 		opts.ReplaceInput = o.ReplaceInput
 	}
 	if o.ResumedMetadata != nil {
-		if opts.ResumedMetadata != nil {
-			return errors.New("cannot set resumed metadata more than once (WithResumedMetadata)")
-		}
 		opts.ResumedMetadata = o.ResumedMetadata
 	}
-	return nil
 }
 
 // WithNewInput sets a new input value to replace the original tool request input.
+// Repeating this option takes the last input set.
 func WithNewInput[In any](input In) RestartWithOption[In] {
 	return &RestartOptions{ReplaceInput: input}
 }
 
 // WithResumedMetadata sets metadata to pass to the resumed tool execution.
 // The metadata will be available in the tool's [ToolContext.Resumed] field.
+// Repeating this option replaces the metadata rather than merging it.
 func WithResumedMetadata[In any](meta map[string]any) RestartWithOption[In] {
 	return &RestartOptions{ResumedMetadata: meta}
 }
@@ -310,9 +305,7 @@ func DefineTool[In, Out any](
 ) *ToolDef[In, Out] {
 	toolOpts := &toolOptions{}
 	for _, opt := range opts {
-		if err := opt.applyTool(toolOpts); err != nil {
-			panic(fmt.Errorf("ai.DefineTool %q: %w", name, err))
-		}
+		opt.applyTool(toolOpts)
 	}
 
 	// If the user provided a custom input schema, enforce that In is 'any'
@@ -351,9 +344,7 @@ func DefineToolWithInputSchema[Out any](
 func NewTool[In, Out any](name, description string, fn ToolFunc[In, Out], opts ...ToolOption) *ToolDef[In, Out] {
 	toolOpts := &toolOptions{}
 	for _, opt := range opts {
-		if err := opt.applyTool(toolOpts); err != nil {
-			panic(fmt.Errorf("ai.NewTool %q: %w", name, err))
-		}
+		opt.applyTool(toolOpts)
 	}
 
 	// If the user provided a custom input schema, enforce that In is 'any'
@@ -390,9 +381,7 @@ func DefineMultipartTool[In any](
 ) *ToolDef[In, *MultipartToolResponse] {
 	toolOpts := &toolOptions{}
 	for _, opt := range opts {
-		if err := opt.applyTool(toolOpts); err != nil {
-			panic(fmt.Errorf("ai.DefineMultipartTool %q: %w", name, err))
-		}
+		opt.applyTool(toolOpts)
 	}
 
 	metadata, wrappedFn := wrapMultipartToolFunc(name, description, fn)
@@ -407,9 +396,7 @@ func DefineMultipartTool[In any](
 func NewMultipartTool[In any](name, description string, fn MultipartToolFunc[In], opts ...ToolOption) *ToolDef[In, *MultipartToolResponse] {
 	toolOpts := &toolOptions{}
 	for _, opt := range opts {
-		if err := opt.applyTool(toolOpts); err != nil {
-			panic(fmt.Errorf("ai.NewMultipartTool %q: %w", name, err))
-		}
+		opt.applyTool(toolOpts)
 	}
 
 	metadata, wrappedFn := wrapMultipartToolFunc(name, description, fn)
@@ -690,9 +677,7 @@ func (t *ToolDef[In, Out]) RespondWith(toolReq *Part, output Out, opts ...Respon
 
 	cfg := &RespondOptions{}
 	for _, opt := range opts {
-		if err := opt.applyRespondWith(cfg); err != nil {
-			return nil, status.Errorf(status.ErrInvalidArgument, "ai.RespondWith: %w", err)
-		}
+		opt.applyRespondWith(cfg)
 	}
 
 	newToolResp := NewResponseForToolRequest(toolReq, output)
@@ -724,9 +709,7 @@ func (t *ToolDef[In, Out]) RestartWith(toolReq *Part, opts ...RestartWithOption[
 
 	cfg := &RestartOptions{}
 	for _, opt := range opts {
-		if err := opt.applyRestartWith(cfg); err != nil {
-			return nil, status.Errorf(status.ErrInvalidArgument, "ai.RestartWith: %w", err)
-		}
+		opt.applyRestartWith(cfg)
 	}
 
 	newInput := toolReq.ToolRequest.Input

--- a/go/ai/tools_test.go
+++ b/go/ai/tools_test.go
@@ -19,7 +19,6 @@ package ai
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -531,27 +530,16 @@ func TestWithStrictSchema(t *testing.T) {
 		check(true)(t, tl)
 	})
 
-	t.Run("setting strict twice returns an error via panic", func(t *testing.T) {
-		// DefineTool surfaces applyTool errors as a panic.
-		defer func() {
-			r := recover()
-			if r == nil {
-				t.Fatal("expected panic from setting WithStrictSchema twice, got none")
-			}
-			msg, ok := r.(error)
-			if !ok {
-				t.Fatalf("expected error from panic, got %T: %v", r, r)
-			}
-			if got := msg.Error(); !strings.Contains(got, "strict schema") {
-				t.Errorf("expected panic to mention strict schema, got %q", got)
-			}
-		}()
+	t.Run("setting strict twice takes the last value", func(t *testing.T) {
+		// WithStrictSchema fills a single slot, so repeating it overwrites
+		// rather than failing.
 		r := newTestRegistry(t)
-		DefineTool(r, "strict/double-set", "double set",
+		tl := DefineTool(r, "strict/double-set", "double set",
 			func(ctx *ToolContext, input struct{}) (string, error) { return "", nil },
 			WithStrictSchema(true),
 			WithStrictSchema(false),
 		)
+		check(false)(t, tl)
 	})
 }
 


### PR DESCRIPTION
Every option in `ai/option.go` returned an error when it was set more than once, or combined with a sibling variant (`WithMessages` with `WithMessagesFn`, `WithModel` with `WithModelName`, and so on). That made options impossible to compose: a caller could not build a request up from several helpers, and `GenerateData` could not inject its output type without conflicting with a caller-supplied `WithOutputSchema`.

Options now follow the standard Go functional-options pattern, merging left to right under two rules, and applying them never fails.

```go
// Before: rejected with "cannot set messages more than once"
// After:  messages accumulate in call order
genkit.Generate(ctx, g,
    ai.WithMessages(history...),
    ai.WithMessages(turn...),
)
```

**Options carrying multiple items accumulate** across repeats and across their variants: `WithMessages`/`WithMessagesFn`, `WithTools`, `WithResources`, `WithUse`, `WithMiddleware`, `WithDocs`/`WithTextDocs`, `WithDataset`, `WithToolResponses`, `WithToolRestarts`.

**Options filling a single slot take the last one set**: `WithConfig`, `WithModel`/`WithModelName`, `WithSystem`/`WithPrompt`, the output schema and format options, `WithStreaming`, `WithInput*`, `WithStrictSchema`, and the tool restart/respond options. The input configuration is one such slot as a whole: schema and default input replace together, so overriding `WithInputType` with `WithInputSchema` or `WithInputSchemaName` does not leave the old type's defaults behind to be rendered against the new schema.

A zero value does not fill a slot, so an earlier non-zero value cannot be un-set by a later `WithMaxTurns(0)` or `WithConfig(nil)`; the package doc states this. Only genuinely invalid arguments still fail, and they panic at the call site (a type `WithInputType` cannot turn into a schema). The unexported `apply*` methods drop their `error` return accordingly.

## Stream wrappers chain a caller's WithStreaming

`GenerateStream`, `GenerateDataStream`, `Prompt.ExecuteStream`, and `DataPrompt.ExecuteStream` attach an internal callback to feed their iterator. Appending it after the caller's options would let it win the last-win slot and silently discard a caller-supplied `WithStreaming` (previously a loud conflict error). The wrappers instead chain the two: the caller's callback runs first, then the iterator's, and both receive every chunk.

`DataPrompt.Execute` and `ExecuteStream` apply their typed input argument after caller options, so it wins the input slot over an `ai.WithInput` passed in opts; the docs on both methods and on `WithInput` state that precedence.

## Not a breaking change

**Compile-time.** Every `apply*` method is unexported and takes unexported parameter types, so `ai.GenerateOption` and its siblings were only ever implementable inside `package ai`. No consumer can have implemented them. Every exported constructor keeps its signature. This was verified by building a package outside `genkit/go` that holds each option interface, constructs each one, directly constructs the two exported option structs (`ai.RestartOptions`, `ai.RespondOptions`), and embeds one in a user type.

**Runtime.** The change is a relaxation, not a redefinition. "Valid today" means each slot was set at most once, and with exactly one setter both merge rules reduce to that same one value. The only inputs whose behavior changes are the ones that return an error today.

Two deltas worth naming:

- `GenerateData` now **prepends** its inferred `WithOutputType` instead of appending it, so a caller-supplied `WithOutputSchema` wins the schema slot while typed extraction keeps working. This matches what `GenerateDataStream` and `DefineDataPrompt` already did. It changes one currently-valid combination: `GenerateData[T](..., ai.WithOutputFormat("text"))` previously ended up as JSON because the injected option applied last; the caller's format now wins, and the godoc warns that a non-JSON format breaks typed extraction.
- A few genuinely-bad inputs report a different error. `WithTools(a), WithTools(a)` now accumulates and trips the existing duplicate check, so the message moves from `cannot set tools more than once` to `duplicate tool "a"`, surfacing at request time rather than at option application.

## Examples

Build a request in pieces, exercising both rules:

```go
opts := []ai.GenerateOption{
    ai.WithModelName("googleai/gemini-flash-latest"),
    ai.WithSystem("You are a helpful assistant."),
    ai.WithTools(searchTool),
}

opts = append(opts, ai.WithTools(adminTools...))   // Concatenates onto searchTool.
opts = append(opts, ai.WithSystem("Be terse."))    // Fills the same slot, so this wins.

resp, err := genkit.Generate(ctx, g, append(opts, ai.WithPrompt("What should I pack for Tokyo?"))...)
```

Keep typed extraction while supplying your own schema:

```go
// The caller's schema wins; the value is still parsed into Recipe.
recipe, _, err := genkit.GenerateData[Recipe](ctx, g,
    ai.WithPrompt("Invent a recipe."),
    ai.WithOutputSchemaName("StrictRecipe"),
)
```

## Scope

**Options outside `go/ai` keep rejecting repeats.** `genkit.Init` options (`WithPlugins`, `WithDefaultModel`, `WithPromptDir`), `ai/exp` agent options, and the firebase/localstore plugin options are untouched. Whether those should follow, particularly whether `WithPlugins` should accumulate, is a separate design question.

## Notes

Message accumulation composes the `MessagesFn` closures and concatenates into a fresh slice (`slices.Concat`) rather than appending in place. `ai.WithMessages(history...)` hands the caller's slice straight through, so appending would land in that array's spare capacity, invisible until the caller appends to their own history and silently rewrites messages already produced for the request.

Reviewing the touched functions also fixed two pre-existing defects riding along: `Retrieve` called with no document option now returns an error instead of panicking on `Documents[0]`, and prompt definition/execution, `Retrieve`, and `Embed` now guard ref-carried configs with the same typed-nil check `Generate` already had, so a ref holding a `(*T)(nil)` config no longer clobbers a real one.

Unrelated to the option change: the Tool Interrupts example in `go/README.md` called `Generate` inside the loop over `resp.Interrupts()` while reassigning `resp`, so with two or more interrupts the later ones resumed against a history that had already advanced past them. It now collects the restart parts and resumes once, matching the shape the interruptible-tools section further down already used.

## Testing

Go 1.26.3: `go build ./...` and `go vet ./...` clean across the module, `go test ./...` passes all 41 packages with tests with no failures, and `go test -race ./ai/` passes.

New coverage: collection options accumulate (messages across both variants, tools, docs, resources, middleware, tool responses/restarts, dataset), single-value options take last-win, the input config replaces as one slot with stale defaults cleared, `GenerateData` reaches the model with a caller-supplied schema while still extracting into the typed output, and `Retrieve` with no documents errors instead of panicking. Two of the tests are negative-checked, verified to fail against the unfixed code: the aliasing test appends to the caller's own history after the composed messages are materialized, and the streaming test asserts a caller's `WithStreaming` and the iterator both observe every chunk.
